### PR TITLE
[IMP] html_editor: selection placeholder to counter selection blockers

### DIFF
--- a/addons/html_builder/static/src/core/remove_plugin.js
+++ b/addons/html_builder/static/src/core/remove_plugin.js
@@ -4,6 +4,7 @@ import { _t } from "@web/core/l10n/translation";
 import { unremovableNodePredicates as deletePluginPredicates } from "@html_editor/core/delete_plugin";
 import { isUnremovableQWebElement as qwebPluginPredicate } from "@html_editor/others/qweb_plugin";
 import { isEditable } from "@html_builder/utils/utils";
+import { closestElement } from "@html_editor/utils/dom_traversal";
 
 const unremovableNodePredicates = [
     (node) => !isEditable(node.parentNode),
@@ -15,14 +16,6 @@ const unremovableNodePredicates = [
 export function isRemovable(el) {
     return !unremovableNodePredicates.some((p) => p(el));
 }
-
-const layoutElementsSelector = [
-    ".o_we_shape",
-    ".o_we_bg_filter",
-    // Website only
-    ".s_parallax_bg",
-    ".o_bg_video_container",
-].join(",");
 
 export class RemovePlugin extends Plugin {
     static id = "remove";
@@ -76,13 +69,15 @@ export class RemovePlugin extends Plugin {
             childrenEls.length === 1 &&
             childrenEls[0].matches("figcaption");
 
+        const systemNodeSelectors = this.getResource("system_node_selectors").join(",");
         const isEmpty =
             isEmptyFigureEl ||
             (el.textContent.trim() === "" &&
-                childrenEls.every((el) =>
-                    // Consider layout-only elements (like bg-shapes) as empty
-                    el.matches(layoutElementsSelector)
-                ));
+                (!systemNodeSelectors ||
+                    childrenEls.every((el) =>
+                        // Consider layout-only elements (like bg-shapes) as empty
+                        closestElement(el, systemNodeSelectors)
+                    )));
 
         return (
             isEmpty &&

--- a/addons/html_builder/static/src/plugins/background_option/background_image_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/background_option/background_image_option_plugin.js
@@ -26,6 +26,7 @@ export class BackgroundImageOptionPlugin extends Plugin {
             DynamicColorAction,
         },
         content_not_editable_selectors: ".o_we_bg_filter",
+        system_node_selectors: ".o_we_bg_filter",
         get_target_element_providers: withSequence(5, (el) => el),
     };
     /**

--- a/addons/html_builder/static/src/plugins/background_option/background_shape_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/background_option/background_shape_option_plugin.js
@@ -28,6 +28,7 @@ export class BackgroundShapeOptionPlugin extends Plugin {
             editingElement.querySelector(":scope > .o_we_bg_filter")
         ),
         content_not_editable_selectors: ".o_we_shape",
+        system_node_selectors: ".o_we_shape",
     };
     static shared = [
         "getShapeStyleUrl",

--- a/addons/html_builder/static/src/plugins/layout_column_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/layout_column_option_plugin.js
@@ -15,6 +15,16 @@ class LayoutColumnOptionPlugin extends Plugin {
         builder_actions: {
             ChangeColumnCountAction,
         },
+        selection_placeholder_container_predicates: (container) => {
+            if (container.nodeName === "DIV" && container.parentElement.classList.contains("row")) {
+                return true;
+            }
+        },
+        selection_blocker_predicates: (blocker) => {
+            if (blocker.classList.contains("row")) {
+                return false;
+            }
+        },
     };
     onCloned({ cloneEl }) {
         const cloneElClassList = cloneEl.classList;

--- a/addons/html_editor/__manifest__.py
+++ b/addons/html_editor/__manifest__.py
@@ -29,6 +29,7 @@ This addon provides an extensible, maintainable editor.
             'html_editor/static/src/scss/html_editor.common.scss',
             'html_editor/static/src/scss/html_editor.frontend.scss',
             'html_editor/static/src/scss/base_style.scss',
+            'html_editor/static/src/main/selection_placeholder_plugin.scss',
         ],
         'web.assets_backend': [
             ('include', 'html_editor.assets_editor'),

--- a/addons/html_editor/static/src/core/delete_plugin.js
+++ b/addons/html_editor/static/src/core/delete_plugin.js
@@ -1172,6 +1172,12 @@ export class DeletePlugin extends Plugin {
     }
 
     shouldSkip(leaf, blockSwitch) {
+        // A system node is a node that should be ignored by the editor. In
+        // other words, if the editor had a VDOM, it would be absent from it.
+        const systemNodeSelectors = this.getResource("system_node_selectors").join(",");
+        if (systemNodeSelectors && closestElement(leaf, systemNodeSelectors)) {
+            return true;
+        }
         if (leaf.nodeType === Node.TEXT_NODE) {
             return false;
         }

--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -347,9 +347,7 @@ export class DomPlugin extends Plugin {
                             fillShrunkPhrasingParent(otherNode);
                         }
                         // After the content insertion, the right-part of a
-                        // split is evaluated for removal, if it is unnecessary
-                        // (to guarantee a paragraph-related element
-                        // after the last unsplittable inserted element).
+                        // split is evaluated for removal.
                         candidatesForRemoval.push(right);
                     } else {
                         if (isBlock(currentNode)) {
@@ -410,41 +408,16 @@ export class DomPlugin extends Plugin {
                 !(isProtected(parent) && !isUnprotecting(parent)) &&
                 parent.isContentEditable
             ) {
-                cleanTrailingBR(parent, [
-                    (node) => {
-                        // Don't remove the last BR in cases where the
-                        // previous sibling is an unsplittable block
-                        // (i.e. a table, a non-editable div, ...)
-                        // to allow placing the cursor after that unsplittable
-                        // element. This can be removed when the cursor
-                        // is properly handled around these elements.
-                        const previousSibling = node.previousSibling;
-                        return (
-                            previousSibling &&
-                            isBlock(previousSibling) &&
-                            this.dependencies.split.isUnsplittable(previousSibling)
-                        );
-                    },
-                ]);
+                cleanTrailingBR(parent);
             }
         }
         for (const candidateForRemoval of candidatesForRemoval) {
-            // Ensure that a paragraph related element is present after the last
-            // unsplittable inserted element
             if (
                 candidateForRemoval.isConnected &&
                 (isParagraphRelatedElement(candidateForRemoval) ||
                     isListItemElement(candidateForRemoval)) &&
                 candidateForRemoval.parentElement.isContentEditable &&
-                isEmptyBlock(candidateForRemoval) &&
-                ((candidateForRemoval.previousElementSibling &&
-                    !this.dependencies.split.isUnsplittable(
-                        candidateForRemoval.previousElementSibling
-                    )) ||
-                    (candidateForRemoval.nextElementSibling &&
-                        !this.dependencies.split.isUnsplittable(
-                            candidateForRemoval.nextElementSibling
-                        )))
+                isEmptyBlock(candidateForRemoval)
             ) {
                 candidateForRemoval.remove();
             }
@@ -467,6 +440,7 @@ export class DomPlugin extends Plugin {
             // Correct the position if it happens to be in the editable root.
             lastPosition = getDeepestPosition(...lastPosition);
         }
+        // TODO: check if position is editable?
         this.dependencies.selection.setSelection(
             { anchorNode: lastPosition[0], anchorOffset: lastPosition[1] },
             { normalize: false }

--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -440,7 +440,6 @@ export class DomPlugin extends Plugin {
             // Correct the position if it happens to be in the editable root.
             lastPosition = getDeepestPosition(...lastPosition);
         }
-        // TODO: check if position is editable?
         this.dependencies.selection.setSelection(
             { anchorNode: lastPosition[0], anchorOffset: lastPosition[1] },
             { normalize: false }

--- a/addons/html_editor/static/src/core/no_inline_root_plugin.js
+++ b/addons/html_editor/static/src/core/no_inline_root_plugin.js
@@ -46,10 +46,7 @@ export class NoInlineRootPlugin extends Plugin {
         if (key?.startsWith("Arrow")) {
             return this.fixSelectionOnEditableRootArrowKeys(nodeAfterCursor, nodeBeforeCursor, key);
         }
-        return (
-            this.fixSelectionOnEditableRootGeneric(nodeAfterCursor, nodeBeforeCursor) ||
-            this.fixSelectionOnEditableRootCreateP(nodeAfterCursor, nodeBeforeCursor)
-        );
+        return this.fixSelectionOnEditableRootGeneric(nodeAfterCursor, nodeBeforeCursor);
     }
     /**
      * @param {Node} nodeAfterCursor
@@ -91,39 +88,5 @@ export class NoInlineRootPlugin extends Plugin {
             return true;
         }
         return false;
-    }
-    /**
-     * Handle cursor not next to a 'P'.
-     * Insert a new 'P' if selection resulted from a mouse click.
-     *
-     * In some situations (notably around tables and horizontal
-     * separators), the cursor could be placed having its anchorNode at
-     * the editable root, allowing the user to insert inlined text at
-     * it.
-     *
-     * @param {Node} nodeAfterCursor
-     * @param {Node} nodeBeforeCursor
-     * @returns {boolean} Whether the selection was fixed
-     */
-    fixSelectionOnEditableRootCreateP(nodeAfterCursor, nodeBeforeCursor) {
-        if (!this.isPointerDown) {
-            return false;
-        }
-
-        const baseContainer = this.dependencies.baseContainer.createBaseContainer();
-        baseContainer.append(this.document.createElement("br"));
-        if (!nodeAfterCursor) {
-            // Cursor is at the end of the editable.
-            this.editable.append(baseContainer);
-        } else if (!nodeBeforeCursor) {
-            // Cursor is at the beginning of the editable.
-            this.editable.prepend(baseContainer);
-        } else {
-            // Cursor is between two non-p blocks
-            nodeAfterCursor.before(baseContainer);
-        }
-        this.dependencies.selection.setCursorStart(baseContainer);
-        this.dependencies.history.addStep();
-        return true;
     }
 }

--- a/addons/html_editor/static/src/core/split_plugin.js
+++ b/addons/html_editor/static/src/core/split_plugin.js
@@ -70,6 +70,11 @@ export class SplitPlugin extends Plugin {
             },
             (node) => node.nodeName === "SECTION",
         ],
+        selection_blocker_predicates: (blocker) => {
+            if (this.isUnsplittable(blocker)) {
+                return true;
+            }
+        },
     };
 
     // --------------------------------------------------------------------------

--- a/addons/html_editor/static/src/main/banner_plugin.js
+++ b/addons/html_editor/static/src/main/banner_plugin.js
@@ -1,5 +1,5 @@
 import { Plugin } from "@html_editor/plugin";
-import { fillShrunkPhrasingParent, fixNonEditableFirstChild } from "@html_editor/utils/dom";
+import { fillShrunkPhrasingParent } from "@html_editor/utils/dom";
 import { closestElement } from "@html_editor/utils/dom_traversal";
 import { parseHTML } from "@html_editor/utils/html";
 import { withSequence } from "@html_editor/utils/resource";
@@ -133,15 +133,13 @@ export class BannerPlugin extends Plugin {
             </div>`
         ).childNodes[0];
         this.dependencies.dom.insert(bannerElement);
-        const baseContainerNodeName = this.dependencies.baseContainer.getDefaultNodeName();
-        const nextNode = this.dependencies.baseContainer.isCandidateForBaseContainer(blockEl)
-            ? blockEl.nodeName
-            : baseContainerNodeName;
-        this.dependencies.dom.setBlock({ tagName: nextNode });
-        fixNonEditableFirstChild(this.editable, bannerElement, baseContainerNodeName);
         this.dependencies.selection.setCursorEnd(
             bannerElement.querySelector(`.o_editor_banner_content > ${baseContainer.tagName}`)
         );
+        // Remove the old element.
+        if (bannerElement.nextSibling?.nodeName === blockEl.nodeName) {
+            bannerElement.nextSibling.remove();
+        }
         this.dependencies.history.addStep();
     }
 

--- a/addons/html_editor/static/src/main/column_plugin.js
+++ b/addons/html_editor/static/src/main/column_plugin.js
@@ -50,7 +50,7 @@ export class ColumnPlugin extends Plugin {
                 categoryId: "structure",
                 isAvailable: columnIsAvailable(2),
                 commandId: "columnize",
-                commandParams: { numberOfColumns: 2 },
+                commandParams: 2,
             },
             {
                 title: _t("3 columns"),
@@ -58,7 +58,7 @@ export class ColumnPlugin extends Plugin {
                 categoryId: "structure",
                 isAvailable: columnIsAvailable(3),
                 commandId: "columnize",
-                commandParams: { numberOfColumns: 3 },
+                commandParams: 3,
             },
             {
                 title: _t("4 columns"),
@@ -66,7 +66,7 @@ export class ColumnPlugin extends Plugin {
                 categoryId: "structure",
                 isAvailable: columnIsAvailable(4),
                 commandId: "columnize",
-                commandParams: { numberOfColumns: 4 },
+                commandParams: 4,
             },
             {
                 title: _t("Remove columns"),
@@ -75,7 +75,7 @@ export class ColumnPlugin extends Plugin {
                 isAvailable: (selection) =>
                     !!closestElement(selection.anchorNode, ".o_text_columns .row"),
                 commandId: "columnize",
-                commandParams: { numberOfColumns: 0 },
+                commandParams: 0,
             },
         ],
         hints: [
@@ -110,7 +110,7 @@ export class ColumnPlugin extends Plugin {
         },
     };
 
-    columnize({ numberOfColumns, addParagraphAfter = true } = {}) {
+    columnize(numberOfColumns) {
         const selectionToRestore = this.dependencies.selection.getEditableSelection();
         const anchor = selectionToRestore.anchorNode;
         const hasColumns = !!closestElement(anchor, ".o_text_columns");
@@ -121,7 +121,7 @@ export class ColumnPlugin extends Plugin {
                 this.removeColumns(anchor);
             }
         } else if (numberOfColumns) {
-            this.createColumns(anchor, numberOfColumns, addParagraphAfter);
+            this.createColumns(anchor, numberOfColumns);
         }
         this.dependencies.selection.setSelection(selectionToRestore);
         this.dependencies.history.addStep();
@@ -142,7 +142,7 @@ export class ColumnPlugin extends Plugin {
         }
     }
 
-    createColumns(anchor, numberOfColumns, addParagraphAfter) {
+    createColumns(anchor, numberOfColumns) {
         const container = this.document.createElement("div");
         if (!closestElement(anchor, ".container")) {
             container.classList.add("container");
@@ -160,11 +160,6 @@ export class ColumnPlugin extends Plugin {
             column.classList.add(`col-${columnSize}`, "o-contenteditable-true");
             row.append(column);
             columns.push(column);
-        }
-        if (addParagraphAfter) {
-            const baseContainer = this.dependencies.baseContainer.createBaseContainer();
-            baseContainer.append(this.document.createElement("br"));
-            block.after(baseContainer);
         }
         columns.shift().append(block);
         for (const column of columns) {

--- a/addons/html_editor/static/src/main/selection_placeholder_plugin.js
+++ b/addons/html_editor/static/src/main/selection_placeholder_plugin.js
@@ -1,0 +1,248 @@
+import { Plugin } from "@html_editor/plugin";
+import { closestBlock, isBlock } from "@html_editor/utils/blocks";
+import { fillEmpty } from "@html_editor/utils/dom";
+import {
+    allowsParagraphRelatedElements,
+    isEmpty,
+    isNotEditableNode,
+} from "@html_editor/utils/dom_info";
+import {
+    closestElement,
+    getAdjacentNextSiblings,
+    getAdjacentPreviousSiblings,
+} from "@html_editor/utils/dom_traversal";
+import { withSequence } from "@html_editor/utils/resource";
+
+const BLINKER_CLASS = "o-horizontal-caret";
+const PLACEHOLDER_ATTRIBUTE = "data-selection-placeholder";
+const PLACEHOLDER_SELECTOR = `[${PLACEHOLDER_ATTRIBUTE}]`;
+
+export class SelectionPlaceholderPlugin extends Plugin {
+    static id = "selectionPlaceholder";
+    static dependencies = ["baseContainer", "history", "selection"];
+    resources = {
+        external_history_step_handlers: this.updatePlaceholders.bind(this),
+        normalize_handlers: this.updatePlaceholders.bind(this),
+        step_added_handlers: this.updatePlaceholders.bind(this),
+        selectionchange_handlers: (selectionData) => this.onSelectionChange(selectionData),
+        clean_for_save_handlers: withSequence(0, ({ root }) => {
+            for (const placeholder of root.querySelectorAll(PLACEHOLDER_SELECTOR)) {
+                placeholder.remove();
+            }
+        }),
+        split_element_block_overrides: ({ blockToSplit }) => {
+            if (blockToSplit.hasAttribute(PLACEHOLDER_ATTRIBUTE)) {
+                this.persistPlaceholder(blockToSplit);
+                return true;
+            }
+        },
+        selection_blocker_predicates: (blocker) => {
+            if (blocker.hasAttribute(PLACEHOLDER_ATTRIBUTE) || !isBlock(blocker)) {
+                return false;
+            } else if (isNotEditableNode(blocker)) {
+                return true;
+            }
+        },
+        selection_placeholder_container_predicates: (container) => {
+            if (!container.isContentEditable || !allowsParagraphRelatedElements(container)) {
+                return false;
+            } else if (container.getAttribute("contenteditable") === "true") {
+                return true;
+            }
+        },
+        power_buttons_visibility_predicates: ({ anchorNode }) =>
+            !closestElement(anchorNode, PLACEHOLDER_SELECTOR),
+        move_node_blacklist_selectors: PLACEHOLDER_SELECTOR,
+        system_node_selectors: PLACEHOLDER_SELECTOR,
+        system_classes: BLINKER_CLASS,
+    };
+
+    setup() {
+        this.addDomListener(
+            this.editable,
+            "focusout",
+            () => this.editable.querySelectorAll(`.${BLINKER_CLASS}`).forEach(this.cleanBlinker),
+            { isGlobal: true }
+        );
+        this.addDomListener(this.editable, "focusin", () => this.resetBlinkerClasses(), {
+            isGlobal: true,
+        });
+    }
+
+    /**
+     * Update all placeholders and blinker classes so they are present
+     * everywhere we need them, and absent wherever they are not useful.
+     */
+    updatePlaceholders() {
+        const checkPredicate = (resourceId, node) => {
+            const results = this.getResource(resourceId)
+                .map((p) => p(node))
+                .filter((result) => result !== undefined);
+            return !!results.length && results.every(Boolean);
+        };
+        const isSelectionBlocker = (node) => checkPredicate("selection_blocker_predicates", node);
+        const placeholderParents = [this.editable, ...this.editable.querySelectorAll("*")].filter(
+            (container) => checkPredicate("selection_placeholder_container_predicates", container)
+        );
+
+        // 1. Update current placeholders.
+        for (const placeholder of this.editable.querySelectorAll(PLACEHOLDER_SELECTOR)) {
+            const siblings = ["before", "after"].map((side) =>
+                getNonWhitespaceSibling(side, placeholder)
+            );
+            if (!isEmpty(placeholder) || !siblings.filter(Boolean).length) {
+                // Persist non-empty placeholders and any suddenly lonely placeholder.
+                this.persistPlaceholder(placeholder);
+            } else if (
+                !placeholderParents.includes(placeholder.parentElement) ||
+                !siblings.every((sibling) => !sibling || isSelectionBlocker(sibling))
+            ) {
+                // Remove illegitimate placeholders.
+                placeholder.remove();
+            } else {
+                // Update the margins.
+                this.applyMargin(placeholder, ...siblings);
+            }
+        }
+
+        // Get the blocks to check.
+        const blockers = [
+            ...new Set(placeholderParents.flatMap((element) => [...element.children])),
+        ].filter((element) => isSelectionBlocker(element));
+
+        // 2. Add placeholders before and after every blocker where necessary.
+        for (const blocker of blockers) {
+            for (const side of ["before", "after"]) {
+                // Get the first non-whitespace sibling.
+                const sibling = getNonWhitespaceSibling(side, blocker);
+                // Insert a placeholder if there is no such sibling or if it's a
+                // selection blocker.
+                if (!sibling || isSelectionBlocker(sibling)) {
+                    // Create the placeholder.
+                    const placeholder = this.dependencies.baseContainer.createBaseContainer();
+                    fillEmpty(placeholder);
+                    placeholder.setAttribute(PLACEHOLDER_ATTRIBUTE, "");
+                    // Position the placeholder.
+                    const siblings = side === "before" ? [sibling, blocker] : [blocker, sibling];
+                    this.applyMargin(placeholder, ...siblings);
+                    // Insert the placeholder.
+                    blocker[side](placeholder);
+                }
+            }
+        }
+        // 3. Reset blinker classes.
+        this.resetBlinkerClasses();
+    }
+
+    /**
+     * Position a placeholder between its siblings.
+     *
+     * @param {Element} placeholder
+     * @param {Element} previous
+     * @param {Element} next
+     */
+    applyMargin(placeholder, previous, next) {
+        const marginBefore = previous ? getMargin(previous, "bottom") : 0;
+        const marginAfter = next ? getMargin(next, "top") : 0;
+        const middleMargin = Math.abs(marginBefore - marginAfter) / 2;
+        if (middleMargin) {
+            const positiveMargin = Math.abs(
+                middleMargin - (marginAfter >= marginBefore ? marginAfter : marginBefore)
+            );
+            const negativeMargin = -1 - middleMargin;
+            const marginTop = marginAfter >= marginBefore ? positiveMargin : negativeMargin;
+            const marginBottom = marginAfter >= marginBefore ? negativeMargin : positiveMargin;
+            placeholder.style.margin = `${marginTop}px 0 ${marginBottom}px`;
+        }
+    }
+
+    /**
+     * Turn a selection placeholder into a real block.
+     *
+     * @param {Element} placeholder
+     */
+    persistPlaceholder(placeholder) {
+        placeholder.removeAttribute(PLACEHOLDER_ATTRIBUTE);
+        this.cleanBlinker(placeholder);
+        placeholder.removeAttribute("style");
+    }
+
+    /**
+     * Remove the horizontal caret class from a placeholder element.
+     *
+     * @param {Element} blinker
+     */
+    cleanBlinker(blinker) {
+        if (blinker.className === BLINKER_CLASS) {
+            blinker.removeAttribute("class");
+        } else {
+            blinker.classList.remove(BLINKER_CLASS);
+        }
+    }
+
+    /**
+     * Remove any irrelevant blinker class (horizontal caret) and make sure
+     * there is one on the placeholder in collapsed selection, if any.
+     *
+     * @param {import("@html_editor/core/selection_plugin").EditorSelection} selection
+     */
+    resetBlinkerClasses(selection = this.dependencies.selection.getEditableSelection()) {
+        const anchorPlaceholder =
+            selection.isCollapsed && closestElement(selection.anchorNode, PLACEHOLDER_SELECTOR);
+        if (anchorPlaceholder && this.document.activeElement.contains(anchorPlaceholder)) {
+            anchorPlaceholder.classList.add(BLINKER_CLASS);
+        }
+        for (const blinker of this.editable.querySelectorAll(`.${BLINKER_CLASS}`)) {
+            if (blinker !== anchorPlaceholder || !this.document.activeElement.contains(blinker)) {
+                this.cleanBlinker(blinker);
+            }
+        }
+    }
+
+    /**
+     * Update the placeholders' states in function of the selection, by
+     * potentially persisting one, and by reseting the blinker classes.
+     *
+     * @param {import("@html_editor/core/selection_plugin").SelectionData} selectionData
+     */
+    onSelectionChange(selectionData) {
+        const selection = selectionData.editableSelection;
+        this.resetBlinkerClasses(selection);
+        if (selection.isCollapsed) {
+            const anchor = closestElement(selection.anchorNode);
+            if (
+                closestBlock(anchor.parentElement) === this.editable &&
+                anchor?.hasAttribute(PLACEHOLDER_ATTRIBUTE) &&
+                !getNonWhitespaceSibling("next", anchor)
+            ) {
+                // If it's at the bottom of the document, just persist immediately.
+                this.persistPlaceholder(anchor);
+                this.dependencies.history.addStep();
+            }
+        }
+    }
+}
+
+/**
+ * @param {"before"|"after"} side
+ * @param {Node} node
+ * @returns {Node|undefined}
+ */
+const getNonWhitespaceSibling = (side, node) => {
+    const siblings =
+        side === "before" ? getAdjacentPreviousSiblings(node) : getAdjacentNextSiblings(node);
+    return siblings.find(
+        (sibling) => !(sibling.nodeType === Node.TEXT_NODE && !sibling.textContent.trim())
+    );
+};
+/**
+ * Get an element's top or bottom margin as a number.
+ *
+ * @param {Element} element
+ * @param {"top"|"bottom"} side
+ * @returns {Number}
+ */
+const getMargin = (element, side) =>
+    +element.ownerDocument.defaultView
+        .getComputedStyle(element)
+        [side === "top" ? "marginTop" : "marginBottom"].replace("px", "");

--- a/addons/html_editor/static/src/main/selection_placeholder_plugin.scss
+++ b/addons/html_editor/static/src/main/selection_placeholder_plugin.scss
@@ -1,0 +1,23 @@
+@keyframes blink-caret {
+    0%, 49% { opacity: 1; }
+    50%, 100% { opacity: 0; }
+}
+
+*[data-selection-placeholder] {
+    height: 0;
+    margin: 0 0 -1px; // Compensate for the border.
+    border-top: solid transparent 1px;
+    caret-color: transparent;
+    position: relative;
+
+    &.o-horizontal-caret {
+        border-top-color: gray;
+        z-index: 1;
+        animation: blink-caret 1.3s infinite;
+    }
+
+    // Disable hints:
+    &:after {
+        content: none !important;
+    }
+}

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -128,6 +128,16 @@ export class TablePlugin extends Plugin {
         move_node_whitelist_selectors: "table",
         collapsed_selection_toolbar_predicate: (selectionData) =>
             !!closestElement(selectionData.editableSelection.anchorNode, ".o_selected_td"),
+        selection_blocker_predicates: (node) => {
+            if (node.nodeName === "TABLE") {
+                return true;
+            }
+        },
+        selection_placeholder_container_predicates: (container) => {
+            if (container.nodeName === "TABLE") {
+                return false;
+            }
+        },
         normalize_handlers: this.distributeTableColorsToAllCells.bind(this),
     };
 

--- a/addons/html_editor/static/src/others/embedded_component_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_component_plugin.js
@@ -1,5 +1,6 @@
 import { nodeToTree } from "@html_editor/core/history_plugin";
 import { Plugin } from "@html_editor/plugin";
+import { withSequence } from "@html_editor/utils/resource";
 import { memoize } from "@web/core/utils/functions";
 
 /**
@@ -11,7 +12,7 @@ export class EmbeddedComponentPlugin extends Plugin {
     static dependencies = ["history", "protectedNode"];
     resources = {
         /** Handlers */
-        normalize_handlers: this.normalize.bind(this),
+        normalize_handlers: withSequence(0, this.normalize.bind(this)),
         clean_for_save_handlers: ({ root }) => this.cleanForSave(root),
         attribute_change_handlers: this.onChangeAttribute.bind(this),
         restore_savepoint_handlers: () => this.handleComponents(this.editable),

--- a/addons/html_editor/static/src/others/embedded_components/plugins/caption_plugin/caption_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/caption_plugin/caption_plugin.js
@@ -1,10 +1,10 @@
 import { Plugin } from "@html_editor/plugin";
 import { _t } from "@web/core/l10n/translation";
-import { closestBlock } from "@html_editor/utils/blocks";
+import { closestBlock, isBlock } from "@html_editor/utils/blocks";
 import { renderToElement } from "@web/core/utils/render";
-import { fillEmpty, unwrapContents } from "@html_editor/utils/dom";
+import { unwrapContents } from "@html_editor/utils/dom";
 import { closestElement } from "@html_editor/utils/dom_traversal";
-import { EDITABLE_MEDIA_CLASS, isShrunkBlock } from "@html_editor/utils/dom_info";
+import { EDITABLE_MEDIA_CLASS, isVisible } from "@html_editor/utils/dom_info";
 import { boundariesOut, rightPos } from "@html_editor/utils/position";
 import { findInSelection } from "@html_editor/utils/selection";
 import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
@@ -124,7 +124,13 @@ export class CaptionPlugin extends Plugin {
             closestBlock(image) !== this.editable
         ) {
             // <p>wx<img/>yz</p> => <p>wx</p><p><img/></p><p>yz</p>
-            this.dependencies.split.splitAroundUntil(image, closestBlock(image));
+            const block = this.dependencies.split.splitAroundUntil(image, closestBlock(image));
+            if (isBlock(block.previousSibling) && !isVisible(block.previousSibling)) {
+                block.previousSibling.remove();
+            }
+            if (isBlock(block.nextSibling) && !isVisible(block.nextSibling)) {
+                block.nextSibling.remove();
+            }
         }
         // => <p><figure><img/></figure></p>
         // or <p><a><figure><img/></figure></a></p>
@@ -143,22 +149,6 @@ export class CaptionPlugin extends Plugin {
         // Ensure it's not possible to write inside the figure.
         figure.setAttribute("contenteditable", "false");
         image.classList.add(EDITABLE_MEDIA_CLASS);
-        // Ensure it's possible to write before and after the figure.
-        const block = closestBlock(link || image);
-        if (!block.previousSibling) {
-            const baseContainer = this.dependencies.baseContainer.createBaseContainer();
-            block.before(baseContainer);
-            fillEmpty(baseContainer);
-        } else if (isShrunkBlock(block.previousSibling)) {
-            fillEmpty(block.previousSibling);
-        }
-        if (!block.nextSibling) {
-            const baseContainer = this.dependencies.baseContainer.createBaseContainer();
-            block.after(baseContainer);
-            fillEmpty(baseContainer);
-        } else if (isShrunkBlock(block.nextSibling)) {
-            fillEmpty(block.nextSibling);
-        }
         // Add the caption component.
         // => <p><figure><img/><figcaption>...</figcaption></figure></p>
         // or <p><a><figure><img/><figcaption>...</figcaption></figure></a></p>

--- a/addons/html_editor/static/src/others/embedded_components/plugins/caption_plugin/caption_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/caption_plugin/caption_plugin.js
@@ -49,6 +49,13 @@ export class CaptionPlugin extends Plugin {
         ],
         image_name_predicates: [this.getImageName.bind(this)],
         link_compatible_selection_predicates: [this.isLinkAllowedOnSelection.bind(this)],
+        // Consider a <figure> element as empty if it only contains a
+        // <figcaption> element (e.g. when its image has just been
+        // removed).
+        empty_node_predicates: (el) =>
+            el.matches?.("figure") &&
+            el.children.length === 1 &&
+            el.children[0].matches("figcaption"),
         move_node_whitelist_selectors: "figure",
     };
 

--- a/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin.scss
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin.scss
@@ -1,12 +1,12 @@
 .o_syntax_highlighting {
     position: relative;
     padding: 0;
-    margin: 0;
+    margin: 0 0 16px;
     tab-size: 4;
     font: 13px / 19.5px SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 
     pre, textarea.o_prism_source {
-        margin: 0px 0px 16px;
+        margin: 0;
         padding: 8px 16px;
     }
 

--- a/addons/html_editor/static/src/others/embedded_components/plugins/table_of_content_plugin/table_of_content_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/table_of_content_plugin/table_of_content_plugin.js
@@ -6,18 +6,10 @@ import {
     TableOfContentManager,
 } from "@html_editor/others/embedded_components/core/table_of_content/table_of_content_manager";
 import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
-import { fixNonEditableFirstChild } from "@html_editor/utils/dom";
 
 export class TableOfContentPlugin extends Plugin {
     static id = "tableOfContent";
-    static dependencies = [
-        "dom",
-        "selection",
-        "embeddedComponents",
-        "link",
-        "history",
-        "baseContainer",
-    ];
+    static dependencies = ["dom", "selection", "embeddedComponents", "link", "history"];
     resources = {
         user_commands: [
             {
@@ -59,11 +51,6 @@ export class TableOfContentPlugin extends Plugin {
     insertTableOfContent() {
         const tableOfContentBlueprint = renderToElement("html_editor.TableOfContentBlueprint");
         this.dependencies.dom.insert(tableOfContentBlueprint);
-        fixNonEditableFirstChild(
-            this.editable,
-            tableOfContentBlueprint,
-            this.dependencies.baseContainer.getDefaultNodeName()
-        );
         this.dependencies.history.addStep();
     }
 

--- a/addons/html_editor/static/src/others/embedded_components/plugins/toggle_block_plugin/toggle_block_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/toggle_block_plugin/toggle_block_plugin.js
@@ -51,6 +51,12 @@ export class ToggleBlockPlugin extends Plugin {
             ),
         ],
         move_node_blacklist_selectors: `${toggleSelector} ${titleSelector} *`,
+        selection_blocker_predicates: (blocker) => {
+            // Prevent the insertion of selection placeholders around toggle blocks.
+            if (blocker.dataset.embedded === "toggleBlock") {
+                return false;
+            }
+        },
         powerbox_items: [
             {
                 commandId: "insertToggleBlock",

--- a/addons/html_editor/static/src/others/qweb_plugin.js
+++ b/addons/html_editor/static/src/others/qweb_plugin.js
@@ -45,7 +45,7 @@ export class QWebPlugin extends Plugin {
                 delete element.dataset.oeProtected;
             }
         },
-        normalize_handlers: this.normalize.bind(this),
+        normalize_handlers: withSequence(0, this.normalize.bind(this)),
 
         system_attributes: QWEB_DATA_ATTRIBUTES,
         unremovable_node_predicates: isUnremovableQWebElement,

--- a/addons/html_editor/static/src/plugin_sets.js
+++ b/addons/html_editor/static/src/plugin_sets.js
@@ -77,6 +77,7 @@ import { ImagePostProcessPlugin } from "./main/media/image_post_process_plugin";
 import { DoubleClickImagePreviewPlugin } from "./main/media/dblclick_image_preview_plugin";
 import { StylePlugin } from "./core/style_plugin";
 import { ContentEditablePlugin } from "./core/content_editable_plugin";
+import { SelectionPlaceholderPlugin } from "./main/selection_placeholder_plugin";
 
 /**
  * @typedef { Object } SharedMethods
@@ -191,6 +192,7 @@ export const MAIN_PLUGINS = [
     InlineCodePlugin,
     TableResizePlugin,
     PlaceholderPlugin,
+    SelectionPlaceholderPlugin,
 ];
 
 export const COLLABORATION_PLUGINS = [

--- a/addons/html_editor/static/src/utils/dom.js
+++ b/addons/html_editor/static/src/utils/dom.js
@@ -300,24 +300,3 @@ export function splitTextNode(textNode, offset, originalNodeSide = DIRECTIONS.RI
     }
     return parentOffset;
 }
-
-/**
- * Ensures that the first child of the editable container is editable.
- *
- * A Chromium bug prevents selecting the container if editable's first child
- * is contenteditable= false element. To avoid this, a base container is
- * inserted before the non-editable node so it no longer appears as
- * the first child.
- *
- * @param {HTMLElement} editable
- * @param {Node} node The non-editable first child of the editable container.
- * @param {string} baseContainerNodeName
- */
-export function fixNonEditableFirstChild(editable, node, baseContainerNodeName) {
-    if (editable.firstChild === node) {
-        const ownerDocument = node.ownerDocument;
-        const firstBaseContainer = createBaseContainer(baseContainerNodeName, ownerDocument);
-        firstBaseContainer.append(ownerDocument.createElement("br"));
-        node.before(firstBaseContainer);
-    }
-}

--- a/addons/html_editor/static/tests/align.test.js
+++ b/addons/html_editor/static/tests/align.test.js
@@ -36,9 +36,13 @@ describe("left", () => {
     test("should not align left a non-editable node", async () => {
         await testEditor({
             contentBefore: '<p>ab</p><div contenteditable="false"><p>c[]d</p></div>',
-            contentBeforeEdit: '<p>ab</p><div contenteditable="false"><p>c[]d</p></div>',
+            contentBeforeEdit:
+                '<p>ab</p><div contenteditable="false"><p>c[]d</p></div>' +
+                '<p data-selection-placeholder=""><br></p>',
             stepFunction: alignLeft,
-            contentAfterEdit: '<p>ab</p><div contenteditable="false"><p>c[]d</p></div>',
+            contentAfterEdit:
+                '<p>ab</p><div contenteditable="false"><p>c[]d</p></div>' +
+                '<p data-selection-placeholder=""><br></p>',
             contentAfter: '<p>ab</p><div contenteditable="false"><p>c[]d</p></div>',
         });
     });

--- a/addons/html_editor/static/tests/banner.test.js
+++ b/addons/html_editor/static/tests/banner.test.js
@@ -1,5 +1,5 @@
 import { expect, test } from "@odoo/hoot";
-import { click, manuallyDispatchProgrammaticEvent, press, tick, waitFor } from "@odoo/hoot-dom";
+import { click, manuallyDispatchProgrammaticEvent, press, waitFor } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import { setupEditor } from "./_helpers/editor";
 import { getContent, setSelection } from "./_helpers/selection";
@@ -16,7 +16,6 @@ test("should insert a banner with focus inside followed by a paragraph", async (
     expect(".active .o-we-command-name").toHaveText("Banner Info");
 
     await press("enter");
-    await tick(); // Wait for selectionchange to update hints.
     expect(unformat(getContent(el))).toBe(
         unformat(
             `<p data-selection-placeholder=""><br></p><div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
@@ -24,7 +23,7 @@ test("should insert a banner with focus inside followed by a paragraph", async (
                     <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true">
                         <p>Test[]</p>
                     </div>
-                </div><p><br></p>`
+                </div><p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         )
     );
 
@@ -57,7 +56,7 @@ test("press 'ctrl+a' inside a banner should select all the banner content", asyn
                     <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true">
                         <p>[Test</p><p>Test1</p><p>Test2]</p>
                     </div>
-                </div><p><br></p>`
+                </div><p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         )
     );
 });
@@ -82,7 +81,7 @@ test("remove all content should preserve the first paragraph tag inside the bann
                     <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true">
                         <p>[Test</p><p>Test1</p><p>Test2]</p>
                     </div>
-                </div><p><br></p>`
+                </div><p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         )
     );
 
@@ -92,7 +91,7 @@ test("remove all content should preserve the first paragraph tag inside the bann
             `<p data-selection-placeholder=""><br></p><div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
                     <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info" aria-label="Banner Info">💡</i>
                     <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true"><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p></div>
-                </div><p><br></p>`
+                </div><p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         )
     );
 });
@@ -101,7 +100,6 @@ test("Inserting a banner at the top of the editable also inserts a paragraph abo
     const { el, editor } = await setupEditor("<p>test[]</p>");
     await insertText(editor, "/bannerinfo");
     await press("enter");
-    await tick(); // Wait for selectionchange to update hints.
     expect(unformat(getContent(el))).toBe(
         unformat(
             `<p data-selection-placeholder=""><br></p>
@@ -111,7 +109,7 @@ test("Inserting a banner at the top of the editable also inserts a paragraph abo
                     <p>test[]</p>
                 </div>
             </div>
-            <p><br></p>`
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         )
     );
 });
@@ -276,13 +274,12 @@ test("should move heading element inside the banner, with paragraph element afte
     expect(".active .o-we-command-name").toHaveText("Banner Info");
 
     await press("enter");
-    await tick(); // Wait for selectionchange to update hints.
     expect(getContent(el)).toBe(
         `<p data-selection-placeholder=""><br></p><div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
                 <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info" aria-label="Banner Info">💡</i>
                 <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true">
                     <h1>Test[]</h1>
                 </div>
-            </div><p><br></p>`
+            </div><p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
     );
 });

--- a/addons/html_editor/static/tests/banner.test.js
+++ b/addons/html_editor/static/tests/banner.test.js
@@ -1,5 +1,5 @@
 import { expect, test } from "@odoo/hoot";
-import { click, manuallyDispatchProgrammaticEvent, press, waitFor } from "@odoo/hoot-dom";
+import { click, manuallyDispatchProgrammaticEvent, press, tick, waitFor } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import { setupEditor } from "./_helpers/editor";
 import { getContent, setSelection } from "./_helpers/selection";
@@ -16,9 +16,10 @@ test("should insert a banner with focus inside followed by a paragraph", async (
     expect(".active .o-we-command-name").toHaveText("Banner Info");
 
     await press("enter");
+    await tick(); // Wait for selectionchange to update hints.
     expect(unformat(getContent(el))).toBe(
         unformat(
-            `<p><br></p><div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+            `<p data-selection-placeholder=""><br></p><div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
                     <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info" aria-label="Banner Info">💡</i>
                     <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true">
                         <p>Test[]</p>
@@ -51,7 +52,7 @@ test("press 'ctrl+a' inside a banner should select all the banner content", asyn
     await press(["ctrl", "a"]);
     expect(unformat(getContent(el))).toBe(
         unformat(
-            `<p><br></p><div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+            `<p data-selection-placeholder=""><br></p><div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
                     <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info" aria-label="Banner Info">💡</i>
                     <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true">
                         <p>[Test</p><p>Test1</p><p>Test2]</p>
@@ -76,7 +77,7 @@ test("remove all content should preserve the first paragraph tag inside the bann
     await press(["ctrl", "a"]);
     expect(unformat(getContent(el))).toBe(
         unformat(
-            `<p><br></p><div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+            `<p data-selection-placeholder=""><br></p><div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
                     <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info" aria-label="Banner Info">💡</i>
                     <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true">
                         <p>[Test</p><p>Test1</p><p>Test2]</p>
@@ -88,7 +89,7 @@ test("remove all content should preserve the first paragraph tag inside the bann
     await press("Backspace");
     expect(unformat(getContent(el))).toBe(
         unformat(
-            `<p><br></p><div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+            `<p data-selection-placeholder=""><br></p><div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
                     <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info" aria-label="Banner Info">💡</i>
                     <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true"><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p></div>
                 </div><p><br></p>`
@@ -100,9 +101,10 @@ test("Inserting a banner at the top of the editable also inserts a paragraph abo
     const { el, editor } = await setupEditor("<p>test[]</p>");
     await insertText(editor, "/bannerinfo");
     await press("enter");
+    await tick(); // Wait for selectionchange to update hints.
     expect(unformat(getContent(el))).toBe(
         unformat(
-            `<p><br></p>
+            `<p data-selection-placeholder=""><br></p>
             <div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
                 <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info" aria-label="Banner Info">💡</i>
                 <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true">
@@ -126,8 +128,8 @@ test("Everything gets selected with ctrl+a, including a contenteditable=false as
     await press(["ctrl", "a"]);
     await animationFrame();
     expect(getContent(el)).toBe(
-        `<div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
-                <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info" aria-label="Banner Info">[💡</i>
+        `<p data-selection-placeholder="">[<br></p><div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+                <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info" aria-label="Banner Info">💡</i>
                 <div class="w-100 px-3" contenteditable="true">
                     <p><br></p>
                 </div>
@@ -148,7 +150,7 @@ test("Everything gets selected with ctrl+a, including a banner", async () => {
     await insertText(editor, "Test2");
     await press(["ctrl", "a"]);
     expect(getContent(el)).toBe(
-        `<p>[<br></p><div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+        `<p data-selection-placeholder="">[<br></p><div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
                 <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info" aria-label="Banner Info">💡</i>
                 <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true">
                     <p>test</p>
@@ -168,7 +170,7 @@ test("Everything gets selected with ctrl+a, including a contenteditable=false as
     );
     await press(["ctrl", "a"]);
     expect(getContent(el)).toBe(
-        '<div data-oe-role="status" contenteditable="false" role="status">[a</div><div data-oe-role="status" contenteditable="false" role="status">b</div><p>cd]</p>'
+        '<p data-selection-placeholder="">[<br></p><div data-oe-role="status" contenteditable="false" role="status">a</div><p data-selection-placeholder=""><br></p><div data-oe-role="status" contenteditable="false" role="status">b</div><p>cd]</p>'
     );
 
     await press("Backspace");
@@ -274,8 +276,9 @@ test("should move heading element inside the banner, with paragraph element afte
     expect(".active .o-we-command-name").toHaveText("Banner Info");
 
     await press("enter");
+    await tick(); // Wait for selectionchange to update hints.
     expect(getContent(el)).toBe(
-        `<p><br></p><div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+        `<p data-selection-placeholder=""><br></p><div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
                 <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info" aria-label="Banner Info">💡</i>
                 <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true">
                     <h1>Test[]</h1>

--- a/addons/html_editor/static/tests/banner.test.js
+++ b/addons/html_editor/static/tests/banner.test.js
@@ -245,7 +245,7 @@ test("add banner inside empty list", async () => {
                     <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true">
                         <p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>
                     </div>
-                </div><br></li></ul>`
+                </div></li></ul>`
         )
     );
 });
@@ -262,7 +262,7 @@ test("add banner inside non-empty list", async () => {
                     <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true">
                         <p>Test[]</p>
                     </div>
-                </div><br></li></ul>`
+                </div></li></ul>`
         )
     );
 });

--- a/addons/html_editor/static/tests/caption.test.js
+++ b/addons/html_editor/static/tests/caption.test.js
@@ -121,14 +121,14 @@ test("add a caption to an image and focus it", async () => {
             cleanHints(editor);
         },
         contentAfterEdit: unformat(
-            `<p><br></p>
+            `<p data-selection-placeholder=""><br></p>
             <figure contenteditable="false">
                 <img class="img-fluid test-image o_editable_media" src="${base64Img}" data-caption-id="${captionId}" data-caption="">
                 <figcaption ${getFigcaptionAttributes(captionId, "", true)}>
                     <input ${CAPTION_INPUT_ATTRIBUTES}>
                 </figcaption>
             </figure>
-            <p><br></p>`
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         ),
     });
 });
@@ -175,37 +175,34 @@ test("saving an image with a caption replaces the input with plain text", async 
             </figure>`
         ),
         contentBeforeEdit: unformat(
-            // Paragraphs get added to ensure we can write before/after the figure.
-            `<p><br></p>
+            `<p data-selection-placeholder=""><br></p>
             <figure contenteditable="false">
                 <img class="img-fluid test-image o_editable_media" src="${base64Img}" data-caption-id="${captionId}" data-caption="${caption}">
                 <figcaption ${getFigcaptionAttributes(captionId, caption)}>
                     <input ${CAPTION_INPUT_ATTRIBUTES}>
                 </figcaption>
             </figure>
-            <p><br></p>`
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         ),
         // Unchanged.
         contentAfterEdit: unformat(
-            `<p><br></p>
+            `<p data-selection-placeholder=""><br></p>
             <figure contenteditable="false">
                 <img class="img-fluid test-image o_editable_media" src="${base64Img}" data-caption-id="${captionId}" data-caption="${caption}">
                 <figcaption ${getFigcaptionAttributes(captionId, caption)}>
                     <input ${CAPTION_INPUT_ATTRIBUTES}>
                 </figcaption>
             </figure>
-            <p><br></p>`
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         ),
         // Cleaned up for screen readers.
         contentAfter: unformat(
-            `<p><br></p>
-            <figure>
+            `<figure>
                 <img class="img-fluid test-image" src="${base64Img}">
                 <figcaption>
                     ${caption}
                 </figcaption>
-            </figure>
-            <p><br></p>`
+            </figure>`
         ),
     });
 });
@@ -244,15 +241,11 @@ test("clicking the caption button on an image with a caption removes the caption
             await expectElementCount(".o-we-toolbar", 1);
         },
         contentAfterEdit: unformat(
-            `<p><br></p>
-            <p>[<img class="img-fluid test-image" src="${base64Img}" data-caption="${caption}">]</p>
-            <p><br></p>`
+            `<p>[<img class="img-fluid test-image" src="${base64Img}" data-caption="${caption}">]</p>`
         ),
         // Unchanged
         contentAfter: unformat(
-            `<p><br></p>
-            <p>[<img class="img-fluid test-image" src="${base64Img}" data-caption="${caption}">]</p>
-            <p><br></p>`
+            `<p>[<img class="img-fluid test-image" src="${base64Img}" data-caption="${caption}">]</p>`
         ),
     });
 });
@@ -281,7 +274,7 @@ test("leaving the caption persists its value", async () => {
             await animationFrame(); // Wait for the selection to change.
         },
         contentAfterEdit: unformat(
-            `<p><br></p>
+            `<p data-selection-placeholder=""><br></p>
             <figure contenteditable="false">
                 <img class="img-fluid test-image o_editable_media" src="${base64Img}" data-caption="${caption}ab" data-caption-id="${captionId}">
                 <figcaption ${getFigcaptionAttributes(captionId, caption + "ab", true)}>
@@ -291,8 +284,7 @@ test("leaving the caption persists its value", async () => {
             <h1>[]Heading</h1>`
         ),
         contentAfter: unformat(
-            `<p><br></p>
-            <figure>
+            `<figure>
                 <img class="img-fluid test-image" src="${base64Img}">
                 <figcaption>
                     ${caption}ab
@@ -321,8 +313,7 @@ test("can't use the powerbox in a caption", async () => {
             await animationFrame(); // Wait for the selection to change.
         },
         contentAfter: unformat(
-            `<p><br></p>
-            <figure>
+            `<figure>
                 <img class="img-fluid test-image" src="${base64Img}">
                 <figcaption>
                     /
@@ -356,8 +347,7 @@ test("can't use the toolbar in a caption", async () => {
             editor.shared.selection.setCursorStart(queryOne("h1"));
         },
         contentAfter: unformat(
-            `<p><br></p>
-            <figure>
+            `<figure>
                 <img class="img-fluid test-image" src="${base64Img}">
                 <figcaption>a</figcaption>
             </figure>
@@ -488,10 +478,7 @@ test("remove an image with a caption", async () => {
             await waitFor(".o-we-toolbar button[name='image_delete']");
             await click(".o-we-toolbar button[name='image_delete']");
         },
-        contentAfter: unformat(
-            `<p><br></p>
-            <h1>[]Heading</h1>`
-        ),
+        contentAfter: "<h1>[]Heading</h1>",
     });
 });
 
@@ -511,7 +498,7 @@ const getDeleteImageTestData = () => {
             // Check that we indeed have a proper figure structure.
             expect(getContent(editor.editable).replace("[]", "")).toBe(
                 unformat(
-                    `<p><br></p>
+                    `<p data-selection-placeholder=""><br></p>
                             <figure contenteditable="false">
                             <img class="img-fluid test-image o_editable_media" data-caption="${caption}" src="${base64Img}" data-caption-id="${captionId}">
                             <figcaption ${getFigcaptionAttributes(
@@ -530,10 +517,7 @@ const getDeleteImageTestData = () => {
             await click("h1");
             await click("img");
         },
-        contentAfter: unformat(
-            `<p><br></p>
-            <h1>[]Heading</h1>`
-        ),
+        contentAfter: "<h1>[]Heading</h1>",
     };
 };
 
@@ -599,8 +583,7 @@ test("replace an image with a caption", async () => {
         },
         // TODO: fix the weird final selection
         contentAfter: unformat(
-            `<p><br></p>
-            <figure>
+            `<figure>
                 <img src="/web/static/img/logo2.png" alt="" data-attachment-id="1" class="img img-fluid o_we_custom_image">
                 <figcaption>Hello</figcaption>
             </figure>
@@ -650,8 +633,7 @@ test("edit caption after replacing image", async () => {
             await animationFrame();
         },
         contentAfter: unformat(
-            `<p><br></p>
-            <figure>
+            `<figure>
                 [<img src="/web/static/img/logo2.png" alt="" data-attachment-id="1" class="img img-fluid o_we_custom_image">]
                 <figcaption>abc</figcaption>
             </figure>
@@ -697,8 +679,7 @@ test("after replacing a captioned image, undo should revert to the original imag
             expect("img[src='/web/static/img/logo2.png']").toHaveCount(0);
         },
         contentAfter: unformat(
-            `<p><br></p>
-            <figure>
+            `<figure>
                 [<img src="/web/static/img/logo.png" class="img-fluid test-image">]
                 <figcaption></figcaption>
             </figure>
@@ -723,8 +704,7 @@ test("add a link to an image with a caption", async () => {
             await expectElementCount(".o-we-toolbar", 1);
         },
         contentAfter: unformat(
-            `<p><br></p>
-            <p>
+            `<p>
                 <a href="https://odoo.com">
                     <figure>
                         [<img class="img-fluid test-image" src="${base64Img}">]
@@ -758,8 +738,7 @@ test("add a caption to an image with a link", async () => {
             selection.removeAllRanges();
         },
         contentAfter: unformat(
-            `<p><br></p>
-            <div>
+            `<div>
                 <a href="https://odoo.com">
                     <figure>
                         <img class="img-fluid test-image" src="${base64Img}">
@@ -984,14 +963,14 @@ test("should properly parse figure without fig caption", async () => {
             </figure>`
         ),
         contentBeforeEdit: unformat(
-            `<p><br></p>
+            `<p data-selection-placeholder=""><br></p>
             <figure contenteditable="false">
                 <img class="img-fluid test-image o_editable_media" src="${base64Img}" data-caption-id="1" data-caption="">
                 <figcaption data-embedded="caption" data-oe-protected="true" contenteditable="false" class="mt-2" data-embedded-props='{"id":"1","focusInput":false}'>
                 <input type="text" maxlength="100" class="border-0 p-0" placeholder="Write your caption here">
                 </figcaption>
             </figure>
-            <p><br></p>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
             `
         ),
     });

--- a/addons/html_editor/static/tests/collaboration.test.js
+++ b/addons/html_editor/static/tests/collaboration.test.js
@@ -648,6 +648,7 @@ describe("data-oe-protected", () => {
                 await animationFrame();
                 expect(getContent(peerInfos.c1.editor.editable, { sortAttrs: true })).toBe(
                     unformat(`
+                        <p data-selection-placeholder=""><br></p>
                         <div contenteditable="false" data-oe-protected="true">
                             <p id="true">a<br></p>
                             <div contenteditable="true" data-oe-protected="false">
@@ -659,6 +660,7 @@ describe("data-oe-protected", () => {
                 );
                 expect(getContent(peerInfos.c2.editor.editable, { sortAttrs: true })).toBe(
                     unformat(`
+                        <p data-selection-placeholder=""><br></p>
                         <div contenteditable="false" data-oe-protected="true">
                             <p id="true"><br></p>
                             <div contenteditable="true" data-oe-protected="false">
@@ -695,6 +697,7 @@ describe("data-oe-protected", () => {
         mergePeersSteps(peerInfos);
         expect(getContent(e1.editable, { sortAttrs: true })).toBe(
             unformat(`
+                <p data-selection-placeholder=""><br></p>
                 <div contenteditable="false" data-oe-protected="true">
                     <div contenteditable="true" data-oe-protected="false">
                         <p>d</p>
@@ -705,6 +708,7 @@ describe("data-oe-protected", () => {
         );
         expect(getContent(e2.editable, { sortAttrs: true })).toBe(
             unformat(`
+                <p data-selection-placeholder=""><br></p>
                 <div contenteditable="false" data-oe-protected="true">
                     <div contenteditable="true" data-oe-protected="false">
                         <p>d</p>
@@ -784,13 +788,14 @@ describe("Collaboration with embedded components", () => {
         validateSameHistory(peerInfos);
         cleanHints(e2);
         expect(getContent(e2.editable, { sortAttrs: true })).toBe(
-            `<div contenteditable="false" data-embedded="counter" data-oe-protected="true"></div><p>[]<br></p>`
+            `<p data-selection-placeholder=""><br></p><div contenteditable="false" data-embedded="counter" data-oe-protected="true"></div><p>[]<br></p>`
         );
         await animationFrame();
         cleanHints(e1);
         cleanHints(e2);
         expect(getContent(e1.editable, { sortAttrs: true })).toBe(
             unformat(`
+                <p data-selection-placeholder=""><br></p>
                 <div contenteditable="false" data-embedded="counter" data-oe-protected="true">
                     <span class="counter">Counter:0</span>
                 </div>
@@ -799,6 +804,7 @@ describe("Collaboration with embedded components", () => {
         );
         expect(getContent(e2.editable, { sortAttrs: true })).toBe(
             unformat(`
+                <p data-selection-placeholder=""><br></p>
                 <div contenteditable="false" data-embedded="counter" data-oe-protected="true">
                     <span class="counter">Counter:0</span>
                 </div>
@@ -962,6 +968,7 @@ describe("Collaboration with embedded components", () => {
         mergePeersSteps(peerInfos);
         // Before mount:
         let editable = unformat(`
+            <p data-selection-placeholder=""><br></p>
             <div contenteditable="false" data-embedded="wrapper" data-oe-protected="true">
                 <div contenteditable="true" data-embedded-editable="deep" data-oe-protected="false">
                     <p>deep12</p>
@@ -974,6 +981,7 @@ describe("Collaboration with embedded components", () => {
         await animationFrame();
         // After mount:
         editable = unformat(`
+            <p data-selection-placeholder=""><br></p>
             <div contenteditable="false" data-embedded="wrapper" data-oe-protected="true">
                 <div>
                     <div class="deep">
@@ -994,6 +1002,7 @@ describe("Collaboration with embedded components", () => {
         e2.shared.history.addStep();
         mergePeersSteps(peerInfos);
         editable = unformat(`
+            <p data-selection-placeholder=""><br></p>
             <div contenteditable="false" data-embedded="wrapper" data-oe-protected="true">
                 <div>
                     <div class="deep">
@@ -1063,6 +1072,7 @@ describe("Collaboration with embedded components", () => {
         mergePeersSteps(peerInfos);
         expect(getContent(e1.editable, { sortAttrs: true })).toBe(
             unformat(`
+                <p data-selection-placeholder=""><br></p>
                 <div contenteditable="false" data-embedded="wrapper" data-oe-protected="true">
                     <div>
                         <div class="switched">
@@ -1079,6 +1089,7 @@ describe("Collaboration with embedded components", () => {
         );
         expect(getContent(e2.editable, { sortAttrs: true })).toBe(
             unformat(`
+                <p data-selection-placeholder=""><br></p>
                 <div contenteditable="false" data-embedded="wrapper" data-oe-protected="true">
                     <div>
                         <div class="deep">
@@ -1139,6 +1150,7 @@ describe("Collaboration with embedded components", () => {
         e2.shared.history.addStep();
         mergePeersSteps(peerInfos);
         const editable = unformat(`
+            <p data-selection-placeholder=""><br></p>
             <div contenteditable="false" data-embedded="wrapper" data-oe-protected="true">
                 <div class="deep">
                     <div contenteditable="true" data-embedded-editable="deep" data-oe-protected="false">
@@ -1203,6 +1215,7 @@ describe("Collaboration with embedded components", () => {
         e2.shared.history.addStep();
         mergePeersSteps(peerInfos);
         const editable = unformat(`
+            <p data-selection-placeholder=""><br></p>
             <div contenteditable="false" data-embedded="wrapper" data-oe-protected="true">
                 <div class="deep">
                     <div contenteditable="true" data-embedded-editable="deep" data-oe-protected="false">
@@ -1214,6 +1227,7 @@ describe("Collaboration with embedded components", () => {
                                 </div>
                             </div>
                         </div>
+                        <p data-selection-placeholder=""><br></p>
                     </div>
                 </div>
             </div>
@@ -1381,20 +1395,20 @@ describe("Collaboration with embedded components", () => {
             const obj2 = [...peerInfos.c2.plugins.get("embeddedComponents").components][0].root.node
                 .component;
             expect(getContent(e1.editable, { sortAttrs: true })).toBe(
-                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1}}' data-oe-protected="true"><div class="obj">1_1</div></div>`
+                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1}}' data-oe-protected="true"><div class="obj">1_1</div></div><p data-selection-placeholder=""><br></p>`
             );
             expect(getContent(e2.editable, { sortAttrs: true })).toBe(
-                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1}}' data-oe-protected="true"><div class="obj">1_1</div></div>`
+                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1}}' data-oe-protected="true"><div class="obj">1_1</div></div><p data-selection-placeholder=""><br></p>`
             );
             obj2.embeddedState.obj["2"] = 2;
             await animationFrame();
             mergePeersSteps(peerInfos);
             await animationFrame();
             expect(getContent(e1.editable, { sortAttrs: true })).toBe(
-                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1,"2":2}}' data-embedded-state='{"stateChangeId":1,"previous":{"obj":{"1":1}},"next":{"obj":{"1":1,"2":2}}}' data-oe-protected="true"><div class="obj">1_1,2_2</div></div>`
+                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1,"2":2}}' data-embedded-state='{"stateChangeId":1,"previous":{"obj":{"1":1}},"next":{"obj":{"1":1,"2":2}}}' data-oe-protected="true"><div class="obj">1_1,2_2</div></div><p data-selection-placeholder=""><br></p>`
             );
             expect(getContent(e2.editable, { sortAttrs: true })).toBe(
-                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1,"2":2}}' data-embedded-state='{"stateChangeId":1,"previous":{"obj":{"1":1}},"next":{"obj":{"1":1,"2":2}}}' data-oe-protected="true"><div class="obj">1_1,2_2</div></div>`
+                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1,"2":2}}' data-embedded-state='{"stateChangeId":1,"previous":{"obj":{"1":1}},"next":{"obj":{"1":1,"2":2}}}' data-oe-protected="true"><div class="obj">1_1,2_2</div></div><p data-selection-placeholder=""><br></p>`
             );
             const savepoint = e1.shared.history.makeSavePoint();
             delete obj2.embeddedState.obj["1"];
@@ -1402,10 +1416,10 @@ describe("Collaboration with embedded components", () => {
             mergePeersSteps(peerInfos);
             await animationFrame();
             expect(getContent(e1.editable, { sortAttrs: true })).toBe(
-                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"2":2}}' data-embedded-state='{"stateChangeId":2,"previous":{"obj":{"1":1,"2":2}},"next":{"obj":{"2":2}}}' data-oe-protected="true"><div class="obj">2_2</div></div>`
+                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"2":2}}' data-embedded-state='{"stateChangeId":2,"previous":{"obj":{"1":1,"2":2}},"next":{"obj":{"2":2}}}' data-oe-protected="true"><div class="obj">2_2</div></div><p data-selection-placeholder=""><br></p>`
             );
             expect(getContent(e2.editable, { sortAttrs: true })).toBe(
-                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"2":2}}' data-embedded-state='{"stateChangeId":2,"previous":{"obj":{"1":1,"2":2}},"next":{"obj":{"2":2}}}' data-oe-protected="true"><div class="obj">2_2</div></div>`
+                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"2":2}}' data-embedded-state='{"stateChangeId":2,"previous":{"obj":{"1":1,"2":2}},"next":{"obj":{"2":2}}}' data-oe-protected="true"><div class="obj">2_2</div></div><p data-selection-placeholder=""><br></p>`
             );
             obj1.embeddedState.obj["3"] = 3;
             await animationFrame();
@@ -1416,10 +1430,10 @@ describe("Collaboration with embedded components", () => {
             mergePeersSteps(peerInfos);
             await animationFrame();
             expect(getContent(e1.editable, { sortAttrs: true })).toBe(
-                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"2":2,"3":3,"4":4}}' data-embedded-state='{"stateChangeId":4,"previous":{"obj":{"2":2,"3":3}},"next":{"obj":{"2":2,"3":3,"4":4}}}' data-oe-protected="true"><div class="obj">2_2,3_3,4_4</div></div>`
+                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"2":2,"3":3,"4":4}}' data-embedded-state='{"stateChangeId":4,"previous":{"obj":{"2":2,"3":3}},"next":{"obj":{"2":2,"3":3,"4":4}}}' data-oe-protected="true"><div class="obj">2_2,3_3,4_4</div></div><p data-selection-placeholder=""><br></p>`
             );
             expect(getContent(e2.editable, { sortAttrs: true })).toBe(
-                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"2":2,"3":3,"4":4}}' data-embedded-state='{"stateChangeId":4,"previous":{"obj":{"2":2,"3":3}},"next":{"obj":{"2":2,"3":3,"4":4}}}' data-oe-protected="true"><div class="obj">2_2,3_3,4_4</div></div>`
+                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"2":2,"3":3,"4":4}}' data-embedded-state='{"stateChangeId":4,"previous":{"obj":{"2":2,"3":3}},"next":{"obj":{"2":2,"3":3,"4":4}}}' data-oe-protected="true"><div class="obj">2_2,3_3,4_4</div></div><p data-selection-placeholder=""><br></p>`
             );
             savepoint();
             await animationFrame();
@@ -1435,10 +1449,10 @@ describe("Collaboration with embedded components", () => {
             // {2, 3, 4} to {2, 4}, and that is why it is applied correctly
             // for both users.
             expect(getContent(e1.editable, { sortAttrs: true })).toBe(
-                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"2":2,"4":4}}' data-embedded-state='{"stateChangeId":9,"previous":{"obj":{"2":2}},"next":{"obj":{"2":2,"4":4}}}' data-oe-protected="true"><div class="obj">2_2,4_4</div></div>`
+                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"2":2,"4":4}}' data-embedded-state='{"stateChangeId":9,"previous":{"obj":{"2":2}},"next":{"obj":{"2":2,"4":4}}}' data-oe-protected="true"><div class="obj">2_2,4_4</div></div><p data-selection-placeholder=""><br></p>`
             );
             expect(getContent(e2.editable, { sortAttrs: true })).toBe(
-                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"2":2,"4":4}}' data-embedded-state='{"stateChangeId":9,"previous":{"obj":{"2":2}},"next":{"obj":{"2":2,"4":4}}}' data-oe-protected="true"><div class="obj">2_2,4_4</div></div>`
+                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"2":2,"4":4}}' data-embedded-state='{"stateChangeId":9,"previous":{"obj":{"2":2}},"next":{"obj":{"2":2,"4":4}}}' data-oe-protected="true"><div class="obj">2_2,4_4</div></div><p data-selection-placeholder=""><br></p>`
             );
         });
 
@@ -1506,20 +1520,20 @@ describe("Collaboration with embedded components", () => {
             mergePeersSteps(peerInfos);
             await animationFrame();
             expect(getContent(e1.editable, { sortAttrs: true })).toBe(
-                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1,"2":2,"3":3,"4":4}}' data-embedded-state='{"stateChangeId":2,"previous":{"obj":{"1":1}},"next":{"obj":{"1":1,"3":3,"4":4}}}' data-oe-protected="true"><div class="obj">1_1,2_2,3_3,4_4</div></div>`
+                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1,"2":2,"3":3,"4":4}}' data-embedded-state='{"stateChangeId":2,"previous":{"obj":{"1":1}},"next":{"obj":{"1":1,"3":3,"4":4}}}' data-oe-protected="true"><div class="obj">1_1,2_2,3_3,4_4</div></div><p data-selection-placeholder=""><br></p>`
             );
             expect(getContent(e2.editable, { sortAttrs: true })).toBe(
-                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1,"2":2,"3":3,"4":4}}' data-embedded-state='{"stateChangeId":2,"previous":{"obj":{"1":1}},"next":{"obj":{"1":1,"3":3,"4":4}}}' data-oe-protected="true"><div class="obj">1_1,2_2,3_3,4_4</div></div>`
+                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1,"2":2,"3":3,"4":4}}' data-embedded-state='{"stateChangeId":2,"previous":{"obj":{"1":1}},"next":{"obj":{"1":1,"3":3,"4":4}}}' data-oe-protected="true"><div class="obj">1_1,2_2,3_3,4_4</div></div><p data-selection-placeholder=""><br></p>`
             );
             undo(e2);
             await animationFrame();
             mergePeersSteps(peerInfos);
             await animationFrame();
             expect(getContent(e1.editable, { sortAttrs: true })).toBe(
-                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1,"2":2}}' data-embedded-state='{"stateChangeId":3,"previous":{"obj":{"1":1,"2":2,"3":3,"4":4}},"next":{"obj":{"1":1,"2":2}}}' data-oe-protected="true"><div class="obj">1_1,2_2</div></div>`
+                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1,"2":2}}' data-embedded-state='{"stateChangeId":3,"previous":{"obj":{"1":1,"2":2,"3":3,"4":4}},"next":{"obj":{"1":1,"2":2}}}' data-oe-protected="true"><div class="obj">1_1,2_2</div></div><p data-selection-placeholder=""><br></p>`
             );
             expect(getContent(e2.editable, { sortAttrs: true })).toBe(
-                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1,"2":2}}' data-embedded-state='{"stateChangeId":3,"previous":{"obj":{"1":1,"2":2,"3":3,"4":4}},"next":{"obj":{"1":1,"2":2}}}' data-oe-protected="true"><div class="obj">1_1,2_2</div></div>`
+                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1,"2":2}}' data-embedded-state='{"stateChangeId":3,"previous":{"obj":{"1":1,"2":2,"3":3,"4":4}},"next":{"obj":{"1":1,"2":2}}}' data-oe-protected="true"><div class="obj">1_1,2_2</div></div><p data-selection-placeholder=""><br></p>`
             );
         });
 
@@ -1550,10 +1564,10 @@ describe("Collaboration with embedded components", () => {
             // When steps were merged, both users updated their state with
             // both changes, even if the component was outside of the dom.
             expect(getContent(e1.editable, { sortAttrs: true })).toBe(
-                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1,"2":2,"3":3}}' data-embedded-state='{"stateChangeId":2,"previous":{"obj":{"1":1}},"next":{"obj":{"1":1,"3":3}}}' data-oe-protected="true"><div class="obj">1_1,2_2,3_3</div></div>`
+                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1,"2":2,"3":3}}' data-embedded-state='{"stateChangeId":2,"previous":{"obj":{"1":1}},"next":{"obj":{"1":1,"3":3}}}' data-oe-protected="true"><div class="obj">1_1,2_2,3_3</div></div><p data-selection-placeholder=""><br></p>`
             );
             expect(getContent(e2.editable, { sortAttrs: true })).toBe(
-                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1,"2":2,"3":3}}' data-embedded-state='{"stateChangeId":2,"previous":{"obj":{"1":1}},"next":{"obj":{"1":1,"3":3}}}' data-oe-protected="true"><div class="obj">1_1,2_2,3_3</div></div>`
+                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1,"2":2,"3":3}}' data-embedded-state='{"stateChangeId":2,"previous":{"obj":{"1":1}},"next":{"obj":{"1":1,"3":3}}}' data-oe-protected="true"><div class="obj">1_1,2_2,3_3</div></div><p data-selection-placeholder=""><br></p>`
             );
         });
 
@@ -1696,10 +1710,10 @@ describe("Collaboration with embedded components", () => {
             mergePeersSteps(peerInfos);
             await animationFrame();
             expect(getContent(e1.editable, { sortAttrs: true })).toBe(
-                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1}}' data-embedded-state='{"stateChangeId":2,"previous":{"obj":{"1":1,"2":2}},"next":{"obj":{"1":1}}}' data-oe-protected="true"><div class="obj">1_1</div></div>`
+                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1}}' data-embedded-state='{"stateChangeId":2,"previous":{"obj":{"1":1,"2":2}},"next":{"obj":{"1":1}}}' data-oe-protected="true"><div class="obj">1_1</div></div><p data-selection-placeholder=""><br></p>`
             );
             expect(getContent(e2.editable, { sortAttrs: true })).toBe(
-                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1}}' data-embedded-state='{"stateChangeId":2,"previous":{"obj":{"1":1,"2":2}},"next":{"obj":{"1":1}}}' data-oe-protected="true"><div class="obj">1_1</div></div>`
+                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1}}' data-embedded-state='{"stateChangeId":2,"previous":{"obj":{"1":1,"2":2}},"next":{"obj":{"1":1}}}' data-oe-protected="true"><div class="obj">1_1</div></div><p data-selection-placeholder=""><br></p>`
             );
         });
 
@@ -1769,21 +1783,71 @@ describe("Collaboration with embedded components", () => {
             mergePeersSteps(peerInfos);
             await animationFrame();
             expect(getContent(e1.editable, { sortAttrs: true })).toBe(
-                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1,"2":2}}' data-embedded-state='{"stateChangeId":2,"previous":{"obj":{"1":1}},"next":{"obj":{"1":1,"2":2}}}' data-oe-protected="true"><div class="obj">1_1,2_2</div></div>`
+                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1,"2":2}}' data-embedded-state='{"stateChangeId":2,"previous":{"obj":{"1":1}},"next":{"obj":{"1":1,"2":2}}}' data-oe-protected="true"><div class="obj">1_1,2_2</div></div><p data-selection-placeholder=""><br></p>`
             );
             expect(getContent(e2.editable, { sortAttrs: true })).toBe(
-                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1,"2":2}}' data-embedded-state='{"stateChangeId":2,"previous":{"obj":{"1":1}},"next":{"obj":{"1":1,"2":2}}}' data-oe-protected="true"><div class="obj">1_1,2_2</div></div>`
+                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1,"2":2}}' data-embedded-state='{"stateChangeId":2,"previous":{"obj":{"1":1}},"next":{"obj":{"1":1,"2":2}}}' data-oe-protected="true"><div class="obj">1_1,2_2</div></div><p data-selection-placeholder=""><br></p>`
             );
             undo(e1);
             await animationFrame();
             mergePeersSteps(peerInfos);
             await animationFrame();
             expect(getContent(e1.editable, { sortAttrs: true })).toBe(
-                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"2":2}}' data-embedded-state='{"stateChangeId":3,"previous":{"obj":{"1":1,"2":2}},"next":{"obj":{"2":2}}}' data-oe-protected="true"><div class="obj">2_2</div></div>`
+                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"2":2}}' data-embedded-state='{"stateChangeId":3,"previous":{"obj":{"1":1,"2":2}},"next":{"obj":{"2":2}}}' data-oe-protected="true"><div class="obj">2_2</div></div><p data-selection-placeholder=""><br></p>`
             );
             expect(getContent(e2.editable, { sortAttrs: true })).toBe(
-                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"2":2}}' data-embedded-state='{"stateChangeId":3,"previous":{"obj":{"1":1,"2":2}},"next":{"obj":{"2":2}}}' data-oe-protected="true"><div class="obj">2_2</div></div>`
+                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"2":2}}' data-embedded-state='{"stateChangeId":3,"previous":{"obj":{"1":1,"2":2}},"next":{"obj":{"2":2}}}' data-oe-protected="true"><div class="obj">2_2</div></div><p data-selection-placeholder=""><br></p>`
             );
         });
     });
+
+    test("Should not duplicate selection placeholders", async () => {
+        const peerInfos = await setupMultiEditor({
+            peerIds: ["c1", "c2"],
+            contentBefore: '<p>a[c1}{c1][c2}{c2]</p><div data-embedded="obj"></div>',
+            Plugins: [EmbeddedComponentPlugin],
+            resources: {
+                embedded_components: [collaborativeObject],
+            },
+        });
+        const e1 = peerInfos.c1.editor;
+        const e2 = peerInfos.c2.editor;
+        const contentBefore =
+            '<p>a[]</p><div data-embedded="obj" data-oe-protected="true" contenteditable="false"><div class="obj"></div></div>' +
+            '<p data-selection-placeholder=""><br></p>';
+        await animationFrame();
+        expect(getContent(e1.editable)).toBe(contentBefore);
+        expect(getContent(e2.editable)).toBe(contentBefore);
+        e1.shared.dom.insert("b");
+        addStep(e1);
+        await animationFrame();
+        expect(getContent(e1.editable)).toBe(contentBefore.replace("a[]", "ab[]"));
+        expect(getContent(e2.editable)).toBe(contentBefore);
+        await animationFrame();
+        mergePeersSteps(peerInfos);
+        expect(getContent(e1.editable)).toBe(contentBefore.replace("a[]", "ab[]"));
+        expect(getContent(e2.editable)).toBe(contentBefore.replace("a[]", "a[]b"));
+    });
+});
+
+test("Should not duplicate selection placeholders", async () => {
+    const peerInfos = await setupMultiEditor({
+        peerIds: ["c1", "c2"],
+        contentBefore: '<p>a[c1}{c1][c2}{c2]</p><div contenteditable="false">c</div>',
+    });
+    const e1 = peerInfos.c1.editor;
+    const e2 = peerInfos.c2.editor;
+    const contentBefore =
+        '<p>a[]</p><div contenteditable="false">c</div>' +
+        '<p data-selection-placeholder=""><br></p>';
+    expect(getContent(e1.editable)).toBe(contentBefore);
+    expect(getContent(e2.editable)).toBe(contentBefore);
+    e1.shared.dom.insert("b");
+    addStep(e1);
+    expect(getContent(e1.editable)).toBe(contentBefore.replace("a[]", "ab[]"));
+    expect(getContent(e2.editable)).toBe(contentBefore);
+    await animationFrame();
+    mergePeersSteps(peerInfos);
+    expect(getContent(e1.editable)).toBe(contentBefore.replace("a[]", "ab[]"));
+    expect(getContent(e2.editable)).toBe(contentBefore.replace("a[]", "a[]b"));
 });

--- a/addons/html_editor/static/tests/collaboration.test.js
+++ b/addons/html_editor/static/tests/collaboration.test.js
@@ -261,10 +261,14 @@ test("wrapInlinesInBlocks should not create impossible mutations in a collaborat
     e1.shared.history.addStep();
     mergePeersSteps(peerInfos);
     expect(getContent(e1.editable, { sortAttrs: true })).toBe(
-        `<div class="oe_unbreakable"><p>myNode[]</p></div>`
+        '<p data-selection-placeholder=""><br></p>' +
+            '<div class="oe_unbreakable"><p>myNode[]</p></div>' +
+            '<p data-selection-placeholder=""><br></p>'
     );
     expect(getContent(e2.editable, { sortAttrs: true })).toBe(
-        `<div class="oe_unbreakable"><p>myNode[]</p></div>`
+        '<p data-selection-placeholder=""><br></p>' +
+            '<div class="oe_unbreakable"><p>myNode[]</p></div>' +
+            '<p data-selection-placeholder=""><br></p>'
     );
 });
 test("should reset from snapshot", async () => {
@@ -730,14 +734,17 @@ describe("serialize/unserialize", () => {
                 const divA = editor.document.createElement("div");
                 divA.textContent = "a";
                 editor.editable.append(divA);
-                const p = editor.editable.querySelector("p");
+                const p = editor.editable.querySelector("p:not([data-selection-placeholder])");
                 divA.append(p);
                 editor.shared.history.addStep();
             },
         });
         mergePeersSteps(peerInfos);
         validateSameHistory(peerInfos);
-        validateContent(peerInfos, "<div>a<p>x</p></div>");
+        validateContent(
+            peerInfos,
+            '<p data-selection-placeholder=""><br></p><div>a<p>x</p></div><p data-selection-placeholder=""><br></p>'
+        );
     });
     test("Should add a new node that contain another node created in the same mutation stack", async () => {
         const peerInfos = await setupMultiEditor({
@@ -758,7 +765,10 @@ describe("serialize/unserialize", () => {
         });
         mergePeersSteps(peerInfos);
         validateSameHistory(peerInfos);
-        validateContent(peerInfos, `<p>x</p><div>b<div class="o-paragraph">a</div></div>`);
+        validateContent(
+            peerInfos,
+            `<p>x</p><div>b<div class="o-paragraph">a</div></div><p data-selection-placeholder=""><br></p>`
+        );
     });
 });
 

--- a/addons/html_editor/static/tests/color.test.js
+++ b/addons/html_editor/static/tests/color.test.js
@@ -919,10 +919,10 @@ test("doesn't change the color of the whole section when there's an icon next to
         </section>`,
         stepFunction: setColor("rgb(0, 0, 255)", "color"),
         contentAfterEdit: `
-        <section style="color: rgb(255, 0, 0);">
+        <p data-selection-placeholder=""><br></p><section style="color: rgb(255, 0, 0);">
             <p>a<font style="color: rgb(0, 0, 255);">[bc]</font>d</p>
             <span class="fa fa-glass" contenteditable="false">\u200b</span>
-        </section>`,
+        </section><p data-selection-placeholder=""><br></p>`,
         contentAfter: `
         <section style="color: rgb(255, 0, 0);">
             <p>a<font style="color: rgb(0, 0, 255);">[bc]</font>d</p>

--- a/addons/html_editor/static/tests/color_selector.test.js
+++ b/addons/html_editor/static/tests/color_selector.test.js
@@ -970,7 +970,7 @@ describe("color preview", () => {
         // Hover a color
         await hover(queryOne("button[data-color='#CE0000']"));
         expect(getContent(el)).toBe(`
-            <table class="table table-bordered o_table o_selected_table">
+            <p data-selection-placeholder=""><br></p><table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr>
                         <td class="o_selected_td o_selected_td_bg_color_preview" style="background-color: rgba(206, 0, 0, 0.6); ${defaultTextColor}">
@@ -983,13 +983,13 @@ describe("color preview", () => {
                         </td>
                     </tr>
                 </tbody>
-            </table>
+            </table><p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
         `);
         // Hover out
         await hover(queryOne(".o-we-toolbar .o-select-color-foreground"));
         await animationFrame();
         expect(getContent(el)).toBe(`
-            <table class="table table-bordered o_table o_selected_table">
+            <p data-selection-placeholder=""><br></p><table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr>
                         <td class="o_selected_td">
@@ -1002,7 +1002,7 @@ describe("color preview", () => {
                         </td>
                     </tr>
                 </tbody>
-            </table>
+            </table><p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
         `);
         await expectElementCount(".o-we-toolbar", 1);
     });
@@ -1038,7 +1038,7 @@ describe("color preview", () => {
         // Hover a color
         await hover(queryOne("button[data-color='black']"));
         expect(getContent(el)).toBe(`
-            <table class="table table-bordered o_table o_selected_table">
+            <p data-selection-placeholder=""><br></p><table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr>
                         <td class="o_selected_td o_selected_td_bg_color_preview bg-black" style="${defaultTextColor}">
@@ -1051,13 +1051,13 @@ describe("color preview", () => {
                         </td>
                     </tr>
                 </tbody>
-            </table>
+            </table><p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
         `);
         // Hover out
         await hover(queryOne(".o-we-toolbar .o-select-color-foreground"));
         await animationFrame();
         expect(getContent(el)).toBe(`
-            <table class="table table-bordered o_table o_selected_table">
+            <p data-selection-placeholder=""><br></p><table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr>
                         <td class="o_selected_td">
@@ -1070,7 +1070,7 @@ describe("color preview", () => {
                         </td>
                     </tr>
                 </tbody>
-            </table>
+            </table><p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
         `);
         await expectElementCount(".o-we-toolbar", 1);
     });

--- a/addons/html_editor/static/tests/columnize.test.js
+++ b/addons/html_editor/static/tests/columnize.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "@odoo/hoot";
-import { press, queryAllTexts } from "@odoo/hoot-dom";
+import { press, queryAllTexts, tick } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import { setupEditor, testEditor } from "./_helpers/editor";
 import { getContent, setSelection } from "./_helpers/selection";
@@ -16,7 +16,7 @@ function column(size, contents) {
 }
 
 function columsDuringEditContainer(contents) {
-    return `<div class="container o_text_columns o-contenteditable-false" contenteditable="false"><div class="row">${contents}</div></div>`;
+    return `<p data-selection-placeholder=""><br></p><div class="container o_text_columns o-contenteditable-false" contenteditable="false"><div class="row">${contents}</div></div>`;
 }
 
 function columnDuringEdit(size, contents) {
@@ -42,7 +42,7 @@ describe("2 columns", () => {
                 columsDuringEditContainer(
                     columnDuringEdit(6, `<p o-we-hint-text="Empty column" class="o-we-hint">[]<br></p>`) +
                     columnDuringEdit(6, `<p o-we-hint-text="Empty column" class="o-we-hint"><br></p>`)
-                ),
+                ) + '<p data-selection-placeholder=""><br></p>',
             /* eslint-enable */
         });
     });
@@ -57,9 +57,9 @@ describe("2 columns", () => {
                 ),
             contentAfterEdit:
                 columsDuringEditContainer(
-                    columnDuringEdit(6, `<table><tbody><tr><td><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p></td><td><p><br></p></td></tr></tbody></table>`) +
+                    columnDuringEdit(6, `<p data-selection-placeholder=""><br></p><table><tbody><tr><td><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p></td><td><p><br></p></td></tr></tbody></table><p data-selection-placeholder=""><br></p>`) +
                     columnDuringEdit(6, `<p o-we-hint-text="Empty column" class="o-we-hint"><br></p>`)
-                ),
+                ) + '<p data-selection-placeholder=""><br></p>',
             /* eslint-enable */
         });
     });
@@ -134,7 +134,7 @@ describe("2 columns", () => {
 
         await press("enter");
         expect(getContent(el)).toBe(
-            `<div class="container o_text_columns o-contenteditable-false" contenteditable="false"><div class="row"><div class="col-6 o-contenteditable-true" contenteditable="true"><p>ab[]cd</p></div><div class="col-6 o-contenteditable-true" contenteditable="true"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div></div></div><p><br></p>`
+            `<p data-selection-placeholder=""><br></p><div class="container o_text_columns o-contenteditable-false" contenteditable="false"><div class="row"><div class="col-6 o-contenteditable-true" contenteditable="true"><p>ab[]cd</p></div><div class="col-6 o-contenteditable-true" contenteditable="true"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div></div></div><p><br></p>`
         );
 
         await insertText(editor, "/columns");
@@ -158,7 +158,7 @@ describe("3 columns", () => {
                     columnDuringEdit(4, "<p>abcd</p>") +
                     columnDuringEdit(4, `<p o-we-hint-text="Empty column" class="o-we-hint"><br></p>`) +
                     columnDuringEdit(4, `<p o-we-hint-text="Empty column" class="o-we-hint">[]<br></p>`)
-                ),
+                ) + '<p data-selection-placeholder=""><br></p>',
             /* eslint-enable */
             stepFunction: columnize(3),
             contentAfter: columnsContainer(
@@ -227,7 +227,7 @@ describe("3 columns", () => {
 
         await press("enter");
         expect(getContent(el)).toBe(
-            `<div class="container o_text_columns o-contenteditable-false" contenteditable="false"><div class="row"><div class="col-4 o-contenteditable-true" contenteditable="true"><p>ab[]cd</p></div><div class="col-4 o-contenteditable-true" contenteditable="true"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div><div class="col-4 o-contenteditable-true" contenteditable="true"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div></div></div><p><br></p>`
+            `<p data-selection-placeholder=""><br></p><div class="container o_text_columns o-contenteditable-false" contenteditable="false"><div class="row"><div class="col-4 o-contenteditable-true" contenteditable="true"><p>ab[]cd</p></div><div class="col-4 o-contenteditable-true" contenteditable="true"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div><div class="col-4 o-contenteditable-true" contenteditable="true"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div></div></div><p><br></p>`
         );
 
         await insertText(editor, "/columns");
@@ -313,7 +313,7 @@ describe("4 columns", () => {
 
         await press("enter");
         expect(getContent(el)).toBe(
-            `<div class="container o_text_columns o-contenteditable-false" contenteditable="false"><div class="row"><div class="col-3 o-contenteditable-true" contenteditable="true"><p>ab[]cd</p></div><div class="col-3 o-contenteditable-true" contenteditable="true"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div><div class="col-3 o-contenteditable-true" contenteditable="true"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div><div class="col-3 o-contenteditable-true" contenteditable="true"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div></div></div><p><br></p>`
+            `<p data-selection-placeholder=""><br></p><div class="container o_text_columns o-contenteditable-false" contenteditable="false"><div class="row"><div class="col-3 o-contenteditable-true" contenteditable="true"><p>ab[]cd</p></div><div class="col-3 o-contenteditable-true" contenteditable="true"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div><div class="col-3 o-contenteditable-true" contenteditable="true"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div><div class="col-3 o-contenteditable-true" contenteditable="true"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div></div></div><p><br></p>`
         );
 
         await insertText(editor, "/columns");
@@ -383,7 +383,7 @@ describe("remove columns", () => {
         // add 2 columns
         await press("enter");
         expect(getContent(el)).toBe(
-            `<div class="container o_text_columns o-contenteditable-false" contenteditable="false"><div class="row"><div class="col-6 o-contenteditable-true" contenteditable="true"><p>ab[]cd</p></div><div class="col-6 o-contenteditable-true" contenteditable="true"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div></div></div><p><br></p>`
+            `<p data-selection-placeholder=""><br></p><div class="container o_text_columns o-contenteditable-false" contenteditable="false"><div class="row"><div class="col-6 o-contenteditable-true" contenteditable="true"><p>ab[]cd</p></div><div class="col-6 o-contenteditable-true" contenteditable="true"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div></div></div><p><br></p>`
         );
 
         await insertText(editor, "/removecolumns");
@@ -473,6 +473,7 @@ describe("selection", () => {
                 const lastP = children[children.length - 1];
                 lastP.innerHTML = "ab";
                 setSelection({ anchorNode: lastP.firstChild, anchorOffset: 0 });
+                await tick(); // wait for trailing placeholder to be persisted via selectionchange
                 await press(["shift", "arrowUp"]);
             },
             contentAfter:
@@ -490,6 +491,9 @@ describe("selection", () => {
                 const children = editable.querySelectorAll("p");
                 const lastP = children[children.length - 1];
                 lastP.innerHTML = "ab";
+                // Persist the trailing placeholder
+                setSelection({ anchorNode: lastP.lastChild, anchorOffset: nodeSize(lastP) });
+                await tick();
                 const firstP = children[0];
                 setSelection({ anchorNode: firstP.lastChild, anchorOffset: nodeSize(firstP) });
                 await press(["shift", "arrowDown"]);
@@ -517,7 +521,7 @@ describe("helper hint", () => {
                     columnDuringEdit(4, `<p o-we-hint-text="Empty column" class="o-we-hint">[]<br></p>`) +
                     columnDuringEdit(4, `<h1 o-we-hint-text="Heading 1" class="o-we-hint"><br></h1>` + "<h2><br></h2>") +
                     columnDuringEdit(4, `<p o-we-hint-text="Empty column" class="o-we-hint"><br></p>`)
-                ),
+                ) + '<p data-selection-placeholder=""><br></p>',
             /* eslint-enable */
         });
     });
@@ -536,7 +540,7 @@ describe("helper hint", () => {
                     columnDuringEdit(4, `<p o-we-hint-text="Empty column" class="o-we-hint"><br></p>`) +
                     columnDuringEdit(4, "<h1><br></h1>" + `<h2 o-we-hint-text="Heading 2" class="o-we-hint">[]<br></h2>`) +
                     columnDuringEdit(4, `<p o-we-hint-text="Empty column" class="o-we-hint"><br></p>`)
-                ),
+                ) + '<p data-selection-placeholder=""><br></p>',
             /* eslint-enable */
         });
     });
@@ -555,7 +559,7 @@ describe("helper hint", () => {
                     columnDuringEdit(4, "<p><br></p>" + `<p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`) +
                     columnDuringEdit(4, `<p o-we-hint-text="Empty column" class="o-we-hint"><br></p>`) +
                     columnDuringEdit(4, `<p o-we-hint-text="Empty column" class="o-we-hint"><br></p>`)
-                ),
+                ) + '<p data-selection-placeholder=""><br></p>',
             /* eslint-enable */
         });
     });

--- a/addons/html_editor/static/tests/columnize.test.js
+++ b/addons/html_editor/static/tests/columnize.test.js
@@ -16,7 +16,7 @@ function column(size, contents) {
 }
 
 function columsDuringEditContainer(contents) {
-    return `<p data-selection-placeholder=""><br></p><div class="container o_text_columns o-contenteditable-false" contenteditable="false"><div class="row">${contents}</div></div>`;
+    return `<p data-selection-placeholder=""><br></p><div class="container o_text_columns o-contenteditable-false" contenteditable="false"><div class="row">${contents}</div></div><p data-selection-placeholder=""><br></p>`;
 }
 
 function columnDuringEdit(size, contents) {
@@ -25,7 +25,7 @@ function columnDuringEdit(size, contents) {
 
 function columnize(numberOfColumns) {
     return (editor) => {
-        execCommand(editor, "columnize", { numberOfColumns });
+        execCommand(editor, "columnize", numberOfColumns);
     };
 }
 
@@ -42,7 +42,7 @@ describe("2 columns", () => {
                 columsDuringEditContainer(
                     columnDuringEdit(6, `<p o-we-hint-text="Empty column" class="o-we-hint">[]<br></p>`) +
                     columnDuringEdit(6, `<p o-we-hint-text="Empty column" class="o-we-hint"><br></p>`)
-                ) + '<p data-selection-placeholder=""><br></p>',
+                ),
             /* eslint-enable */
         });
     });
@@ -59,7 +59,7 @@ describe("2 columns", () => {
                 columsDuringEditContainer(
                     columnDuringEdit(6, `<p data-selection-placeholder=""><br></p><table><tbody><tr><td><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p></td><td><p><br></p></td></tr></tbody></table><p data-selection-placeholder=""><br></p>`) +
                     columnDuringEdit(6, `<p o-we-hint-text="Empty column" class="o-we-hint"><br></p>`)
-                ) + '<p data-selection-placeholder=""><br></p>',
+                ),
             /* eslint-enable */
         });
     });
@@ -85,14 +85,12 @@ describe("2 columns", () => {
                 columsDuringEditContainer(
                     columnDuringEdit(6, "<p>[]abcd</p>") +
                     columnDuringEdit(6, `<p o-we-hint-text="Empty column" class="o-we-hint"><br></p>`)
-                ) +
-                "<p><br></p>",
+                ),
             contentAfter:
                 columnsContainer(
                     column(6, "<p>[]abcd</p>") +
                     column(6, "<p><br></p>")
-                ) +
-                "<p><br></p>",
+                )
             /* eslint-enable */
         });
     });
@@ -134,7 +132,7 @@ describe("2 columns", () => {
 
         await press("enter");
         expect(getContent(el)).toBe(
-            `<p data-selection-placeholder=""><br></p><div class="container o_text_columns o-contenteditable-false" contenteditable="false"><div class="row"><div class="col-6 o-contenteditable-true" contenteditable="true"><p>ab[]cd</p></div><div class="col-6 o-contenteditable-true" contenteditable="true"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div></div></div><p><br></p>`
+            `<p data-selection-placeholder=""><br></p><div class="container o_text_columns o-contenteditable-false" contenteditable="false"><div class="row"><div class="col-6 o-contenteditable-true" contenteditable="true"><p>ab[]cd</p></div><div class="col-6 o-contenteditable-true" contenteditable="true"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div></div></div><p data-selection-placeholder=""><br></p>`
         );
 
         await insertText(editor, "/columns");
@@ -158,7 +156,7 @@ describe("3 columns", () => {
                     columnDuringEdit(4, "<p>abcd</p>") +
                     columnDuringEdit(4, `<p o-we-hint-text="Empty column" class="o-we-hint"><br></p>`) +
                     columnDuringEdit(4, `<p o-we-hint-text="Empty column" class="o-we-hint">[]<br></p>`)
-                ) + '<p data-selection-placeholder=""><br></p>',
+                ),
             /* eslint-enable */
             stepFunction: columnize(3),
             contentAfter: columnsContainer(
@@ -177,13 +175,13 @@ describe("3 columns", () => {
                     columnDuringEdit(4, "<p>ab[]cd</p>") +
                     columnDuringEdit(4, `<p o-we-hint-text="Empty column" class="o-we-hint"><br></p>`) +
                     columnDuringEdit(4, `<p o-we-hint-text="Empty column" class="o-we-hint"><br></p>`)
-                ) + "<p><br></p>",
+                ),
             contentAfter:
                 columnsContainer(
                     column(4, "<p>ab[]cd</p>") +
                     column(4, "<p><br></p>") +
                     column(4, "<p><br></p>")
-                ) + "<p><br></p>",
+                ),
             /* eslint-enable */
         });
     });
@@ -227,7 +225,7 @@ describe("3 columns", () => {
 
         await press("enter");
         expect(getContent(el)).toBe(
-            `<p data-selection-placeholder=""><br></p><div class="container o_text_columns o-contenteditable-false" contenteditable="false"><div class="row"><div class="col-4 o-contenteditable-true" contenteditable="true"><p>ab[]cd</p></div><div class="col-4 o-contenteditable-true" contenteditable="true"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div><div class="col-4 o-contenteditable-true" contenteditable="true"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div></div></div><p><br></p>`
+            `<p data-selection-placeholder=""><br></p><div class="container o_text_columns o-contenteditable-false" contenteditable="false"><div class="row"><div class="col-4 o-contenteditable-true" contenteditable="true"><p>ab[]cd</p></div><div class="col-4 o-contenteditable-true" contenteditable="true"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div><div class="col-4 o-contenteditable-true" contenteditable="true"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div></div></div><p data-selection-placeholder=""><br></p>`
         );
 
         await insertText(editor, "/columns");
@@ -263,13 +261,12 @@ describe("4 columns", () => {
         await testEditor({
             contentBefore: "<p>abcd[]</p>",
             stepFunction: columnize(4),
-            contentAfter:
-                columnsContainer(
-                    column(3, "<p>abcd[]</p>") +
-                        column(3, "<p><br></p>") +
-                        column(3, "<p><br></p>") +
-                        column(3, "<p><br></p>")
-                ) + "<p><br></p>",
+            contentAfter: columnsContainer(
+                column(3, "<p>abcd[]</p>") +
+                    column(3, "<p><br></p>") +
+                    column(3, "<p><br></p>") +
+                    column(3, "<p><br></p>")
+            ),
         });
     });
 
@@ -313,7 +310,7 @@ describe("4 columns", () => {
 
         await press("enter");
         expect(getContent(el)).toBe(
-            `<p data-selection-placeholder=""><br></p><div class="container o_text_columns o-contenteditable-false" contenteditable="false"><div class="row"><div class="col-3 o-contenteditable-true" contenteditable="true"><p>ab[]cd</p></div><div class="col-3 o-contenteditable-true" contenteditable="true"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div><div class="col-3 o-contenteditable-true" contenteditable="true"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div><div class="col-3 o-contenteditable-true" contenteditable="true"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div></div></div><p><br></p>`
+            `<p data-selection-placeholder=""><br></p><div class="container o_text_columns o-contenteditable-false" contenteditable="false"><div class="row"><div class="col-3 o-contenteditable-true" contenteditable="true"><p>ab[]cd</p></div><div class="col-3 o-contenteditable-true" contenteditable="true"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div><div class="col-3 o-contenteditable-true" contenteditable="true"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div><div class="col-3 o-contenteditable-true" contenteditable="true"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div></div></div><p data-selection-placeholder=""><br></p>`
         );
 
         await insertText(editor, "/columns");
@@ -383,14 +380,14 @@ describe("remove columns", () => {
         // add 2 columns
         await press("enter");
         expect(getContent(el)).toBe(
-            `<p data-selection-placeholder=""><br></p><div class="container o_text_columns o-contenteditable-false" contenteditable="false"><div class="row"><div class="col-6 o-contenteditable-true" contenteditable="true"><p>ab[]cd</p></div><div class="col-6 o-contenteditable-true" contenteditable="true"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div></div></div><p><br></p>`
+            `<p data-selection-placeholder=""><br></p><div class="container o_text_columns o-contenteditable-false" contenteditable="false"><div class="row"><div class="col-6 o-contenteditable-true" contenteditable="true"><p>ab[]cd</p></div><div class="col-6 o-contenteditable-true" contenteditable="true"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div></div></div><p data-selection-placeholder=""><br></p>`
         );
 
         await insertText(editor, "/removecolumns");
         await animationFrame();
         expect(".active .o-we-command-name").toHaveText("Remove columns");
         await press("enter");
-        expect(getContent(el)).toBe(`<p>ab[]cd</p><p><br></p><p><br></p>`);
+        expect(getContent(el)).toBe(`<p>ab[]cd</p><p><br></p>`);
     });
 });
 
@@ -408,7 +405,7 @@ describe("complex", () => {
             },
             // A paragraph was created for each column + after them and
             // they were all kept.
-            contentAfter: "<p>ab[]cd</p><p><br></p><p><br></p><p><br></p><p><br></p>",
+            contentAfter: "<p>ab[]cd</p><p><br></p><p><br></p><p><br></p>",
         });
     });
 
@@ -427,7 +424,6 @@ describe("complex", () => {
                 "</div>" +
                 '<div class="col-6 o-contenteditable-true"><p><br></p></div>' +
                 "</div></div>" +
-                "<p><br></p>" +
                 "</div></div></div>",
         });
     });
@@ -455,9 +451,7 @@ describe("undo", () => {
                 redo(editor);
                 await insertText(editor, "x");
             },
-            contentAfter:
-                columnsContainer(column(6, "<p>x[]</p>") + column(6, "<p><br></p>")) +
-                "<p><br></p>",
+            contentAfter: columnsContainer(column(6, "<p>x[]</p>") + column(6, "<p><br></p>")),
         });
     });
 });
@@ -521,7 +515,7 @@ describe("helper hint", () => {
                     columnDuringEdit(4, `<p o-we-hint-text="Empty column" class="o-we-hint">[]<br></p>`) +
                     columnDuringEdit(4, `<h1 o-we-hint-text="Heading 1" class="o-we-hint"><br></h1>` + "<h2><br></h2>") +
                     columnDuringEdit(4, `<p o-we-hint-text="Empty column" class="o-we-hint"><br></p>`)
-                ) + '<p data-selection-placeholder=""><br></p>',
+                ),
             /* eslint-enable */
         });
     });
@@ -540,7 +534,7 @@ describe("helper hint", () => {
                     columnDuringEdit(4, `<p o-we-hint-text="Empty column" class="o-we-hint"><br></p>`) +
                     columnDuringEdit(4, "<h1><br></h1>" + `<h2 o-we-hint-text="Heading 2" class="o-we-hint">[]<br></h2>`) +
                     columnDuringEdit(4, `<p o-we-hint-text="Empty column" class="o-we-hint"><br></p>`)
-                ) + '<p data-selection-placeholder=""><br></p>',
+                ),
             /* eslint-enable */
         });
     });
@@ -559,7 +553,7 @@ describe("helper hint", () => {
                     columnDuringEdit(4, "<p><br></p>" + `<p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`) +
                     columnDuringEdit(4, `<p o-we-hint-text="Empty column" class="o-we-hint"><br></p>`) +
                     columnDuringEdit(4, `<p o-we-hint-text="Empty column" class="o-we-hint"><br></p>`)
-                ) + '<p data-selection-placeholder=""><br></p>',
+                ),
             /* eslint-enable */
         });
     });

--- a/addons/html_editor/static/tests/copy.test.js
+++ b/addons/html_editor/static/tests/copy.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "@odoo/hoot";
 import { press } from "@odoo/hoot-dom";
 import { setupEditor } from "./_helpers/editor";
+import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
 
 describe("range collapsed", () => {
     test("should ignore copying an empty selection with empty clipboardData", async () => {
@@ -43,7 +44,10 @@ describe("range not collapsed", () => {
     test.tags("focus required");
     test("should copy a selection as text/plain, text/html and application/vnd.odoo.odoo-editor in table", async () => {
         await setupEditor(
-            `]<table><tbody><tr><td><ul><li>a[</li><li>b</li><li>c</li></ul></td><td><br></td></tr></tbody></table>`
+            `]<table><tbody><tr><td><ul><li>a[</li><li>b</li><li>c</li></ul></td><td><br></td></tr></tbody></table>`,
+            // Exclude the selection placeholder plugin so we have a DOM that
+            // really starts with a table.
+            { config: { Plugins: MAIN_PLUGINS.filter((p) => p.id !== "selectionPlaceholder") } }
         );
         const clipboardData = new DataTransfer();
         await press(["ctrl", "c"], { dataTransfer: clipboardData });

--- a/addons/html_editor/static/tests/data-oe/protected.test.js
+++ b/addons/html_editor/static/tests/data-oe/protected.test.js
@@ -25,7 +25,9 @@ test("should ignore protected elements children mutations (true)", async () => {
             execCommand(editor, "historyUndo");
         },
         contentAfterEdit: unformat(`
+                <p data-selection-placeholder=""><br></p>
                 <div><p>ab[]</p></div>
+                <p data-selection-placeholder=""><br></p>
                 <div data-oe-protected="true" contenteditable="false"><p>ab</p></div>
                 <p data-selection-placeholder=""><br></p>
                 `),
@@ -48,7 +50,9 @@ test("should not ignore unprotected elements children mutations (false)", async 
             execCommand(editor, "historyUndo");
         },
         contentAfterEdit: unformat(`
+                <p data-selection-placeholder=""><br></p>
                 <div><p>abc</p></div>
+                <p data-selection-placeholder=""><br></p>
                 <div data-oe-protected="true" contenteditable="false"><div data-oe-protected="false" contenteditable="true"><p>ab[]</p></div></div>
                 <p data-selection-placeholder=""><br></p>
                 `),
@@ -86,10 +90,12 @@ test("should not normalize protected elements children (true)", async () => {
                 </div>
                 `),
         contentAfterEdit: unformat(`
+                <p data-selection-placeholder=""><br></p>
                 <div>
                     <p>\ufeff<i class="fa" contenteditable="false">\u200B</i>\ufeff</p>
                     <ul><li><p>abc</p><p><br></p></li></ul>
                 </div>
+                <p data-selection-placeholder=""><br></p>
                 <div data-oe-protected="true" contenteditable="false">
                     <p><i class="fa"></i></p>
                     <ul><li>abc<p><br></p></li></ul>

--- a/addons/html_editor/static/tests/data-oe/protected.test.js
+++ b/addons/html_editor/static/tests/data-oe/protected.test.js
@@ -27,6 +27,7 @@ test("should ignore protected elements children mutations (true)", async () => {
         contentAfterEdit: unformat(`
                 <div><p>ab[]</p></div>
                 <div data-oe-protected="true" contenteditable="false"><p>ab</p></div>
+                <p data-selection-placeholder=""><br></p>
                 `),
     });
 });
@@ -49,6 +50,7 @@ test("should not ignore unprotected elements children mutations (false)", async 
         contentAfterEdit: unformat(`
                 <div><p>abc</p></div>
                 <div data-oe-protected="true" contenteditable="false"><div data-oe-protected="false" contenteditable="true"><p>ab[]</p></div></div>
+                <p data-selection-placeholder=""><br></p>
                 `),
     });
 });
@@ -92,6 +94,7 @@ test("should not normalize protected elements children (true)", async () => {
                     <p><i class="fa"></i></p>
                     <ul><li>abc<p><br></p></li></ul>
                 </div>
+                <p data-selection-placeholder=""><br></p>
                 `),
     });
 });
@@ -122,8 +125,9 @@ test("should normalize unprotected elements children (false)", async () => {
                     </div>
                 </div>
                 `),
-        contentAfterEdit: unformat(`
-                <div data-oe-protected="true" contenteditable="false">
+        contentAfterEdit: unformat(
+            `<p data-selection-placeholder=""><br></p>
+            <div data-oe-protected="true" contenteditable="false">
                     <p><i class="fa"></i></p>
                     <ul><li>abc<p><br></p></li></ul>
                     <div data-oe-protected="false" contenteditable="true">
@@ -131,7 +135,8 @@ test("should normalize unprotected elements children (false)", async () => {
                         <ul><li><p>abc</p><p><br></p></li></ul>
                     </div>
                 </div>
-                `),
+                <p data-selection-placeholder=""><br></p>`
+        ),
     });
 });
 
@@ -142,11 +147,13 @@ test("should not handle table selection in protected elements children (true)", 
                     <p>a[bc</p><table><tbody><tr><td>a]b</td><td>cd</td><td>ef</td></tr></tbody></table>
                 </div>
                 `),
-        contentAfterEdit: unformat(`
-                <div data-oe-protected="true" contenteditable="false">
+        contentAfterEdit: unformat(
+            `<p data-selection-placeholder=""><br></p>
+            <div data-oe-protected="true" contenteditable="false">
                     <p>a[bc</p><table><tbody><tr><td>a]b</td><td>cd</td><td>ef</td></tr></tbody></table>
                 </div>
-                `),
+                <p data-selection-placeholder=""><br></p>`
+        ),
     });
 });
 
@@ -159,8 +166,9 @@ test("should handle table selection in unprotected elements", async () => {
                     </div>
                 </div>
                 `),
-        contentAfterEdit: unformat(`
-                <div data-oe-protected="true" contenteditable="false">
+        contentAfterEdit: unformat(
+            `<p data-selection-placeholder=""><br></p>
+            <div data-oe-protected="true" contenteditable="false">
                     <div data-oe-protected="false" contenteditable="true">
                         <p>a[bc</p>
                         <table class="o_selected_table"><tbody><tr>
@@ -168,9 +176,11 @@ test("should handle table selection in unprotected elements", async () => {
                             <td class="o_selected_td">cd</td>
                             <td class="o_selected_td">ef]</td>
                         </tr></tbody></table>
+                        <p data-selection-placeholder=""><br></p>
                     </div>
                 </div>
-                `),
+                <p data-selection-placeholder=""><br></p>`
+        ),
     });
 });
 
@@ -187,8 +197,9 @@ test("should not remove contenteditable attribute of a protected node", async ()
                     </div>
                 </div>
             `),
-        contentAfterEdit: unformat(`
-                <div data-oe-protected="true" contenteditable="false">
+        contentAfterEdit: unformat(
+            `<p data-selection-placeholder=""><br></p>
+            <div data-oe-protected="true" contenteditable="false">
                     <p contenteditable="true">content</p>
                     <table contenteditable="true">
                         <tbody><tr><td>ab</td></tr></tbody>
@@ -197,7 +208,8 @@ test("should not remove contenteditable attribute of a protected node", async ()
                         <p>content</p>
                     </div>
                 </div>
-            `),
+                <p data-selection-placeholder=""><br></p>`
+        ),
     });
 });
 
@@ -215,8 +227,9 @@ test("should not select a protected table even if it is contenteditable='true'",
                     </tr></tbody></table>
                 </div>
             `),
-        contentAfterEdit: unformat(`
-                <div data-oe-protected="true" contenteditable="false">
+        contentAfterEdit: unformat(
+            `<p data-selection-placeholder=""><br></p>
+            <div data-oe-protected="true" contenteditable="false">
                     <table contenteditable="true"><tbody><tr>
                         <td>[ab</td>
                     </tr></tbody></table>
@@ -224,7 +237,8 @@ test("should not select a protected table even if it is contenteditable='true'",
                         <td>cd]</td>
                     </tr></tbody></table>
                 </div>
-            `),
+                <p data-selection-placeholder=""><br></p>`
+        ),
     });
 });
 
@@ -247,9 +261,14 @@ test("select a protected element shouldn't open the toolbar", async () => {
     await expectElementCount(".o-we-toolbar", 1);
 });
 
+const configWithoutSelectionPlaceholder = {
+    config: { Plugins: MAIN_PLUGINS.filter((p) => p.id !== "selectionPlaceholder") },
+};
+
 test("should protect disconnected nodes", async () => {
     const { editor, el, plugins } = await setupEditor(
-        `<div data-oe-protected="true"><p>a</p></div><p>a</p>`
+        `<div data-oe-protected="true"><p>a</p></div><p>a</p>`,
+        configWithoutSelectionPlaceholder
     );
     const div = el.querySelector("div");
     const protectedP = div.querySelector("p");
@@ -266,7 +285,8 @@ test("should protect disconnected nodes", async () => {
 
 test("should not crash when changing attributes and removing a protecting anchor", async () => {
     const { editor, el, plugins } = await setupEditor(
-        `<div data-oe-protected="true" data-attr="value"><p>a</p></div><p>a</p>`
+        `<div data-oe-protected="true" data-attr="value"><p>a</p></div><p>a</p>`,
+        configWithoutSelectionPlaceholder
     );
     const div = el.querySelector("div");
     div.dataset.attr = "other";
@@ -291,7 +311,7 @@ test("removing a protected node should be undo-able", async () => {
     expect(getContent(el)).toBe(`<p>[]a</p>`);
     undo(editor);
     expect(getContent(el)).toBe(
-        `<div data-oe-protected="true" contenteditable="false"><p>a</p></div><p>[]a</p>`
+        `<p data-selection-placeholder=""><br></p><div data-oe-protected="true" contenteditable="false"><p>a</p></div><p>[]a</p>`
     );
 });
 
@@ -336,6 +356,7 @@ test("removing a recursively protected then unprotected node should be undo-able
     undo(editor);
     expect(getContent(el)).toBe(
         unformat(`
+            <p data-selection-placeholder=""><br></p>
             <div data-oe-protected="true" contenteditable="false">
                 <p>a</p>
                 <div data-oe-protected="false" contenteditable="true">
@@ -376,7 +397,9 @@ test("removing a protected node and then removing its protected parent should be
     editor.shared.history.addStep();
     expect(editor.shared.history.getHistorySteps().length).toBe(1);
     expect(historyPlugin.currentStep.mutations).toEqual([]);
-    expect(getContent(el)).toBe(`<div data-oe-protected="true" contenteditable="false"></div>`);
+    expect(getContent(el)).toBe(
+        `<p data-selection-placeholder=""><br></p><div data-oe-protected="true" contenteditable="false"></div><p data-selection-placeholder=""><br></p>`
+    );
 });
 
 test("removing a protected ancestor, then a protected descendant, then its protected parent should be ignored", async () => {
@@ -403,7 +426,9 @@ test("removing a protected ancestor, then a protected descendant, then its prote
     editor.shared.history.addStep();
     expect(editor.shared.history.getHistorySteps().length).toBe(1);
     expect(historyPlugin.currentStep.mutations).toEqual([]);
-    expect(getContent(el)).toBe(`<div data-oe-protected="true" contenteditable="false"></div>`);
+    expect(getContent(el)).toBe(
+        `<p data-selection-placeholder=""><br></p><div data-oe-protected="true" contenteditable="false"></div><p data-selection-placeholder=""><br></p>`
+    );
 });
 
 test("moving a protected node at an unprotected location, only remove should be ignored", async () => {
@@ -432,12 +457,15 @@ test("moving a protected node at an unprotected location, only remove should be 
     expect(historyPlugin.nodeMap.getNode(lastStep.mutations[0].nodeId)).toBe(a);
     expect(getContent(el)).toBe(
         unformat(`
+            <p data-selection-placeholder=""><br></p>
             <div data-oe-protected="true" contenteditable="false">
                 <div class="b" data-oe-protected="false" contenteditable="true">
                     <p class="a"></p>
                 </div>
             </div>
+            <p data-selection-placeholder=""><br></p>
             <div data-oe-protected="true" contenteditable="false"></div>
+            <p data-selection-placeholder=""><br></p>
         `)
     );
 });
@@ -468,12 +496,15 @@ test("moving an unprotected node at a protected location, only add should be ign
     expect(historyPlugin.nodeMap.getNode(lastStep.mutations[0].nodeId)).toBe(a);
     expect(getContent(el)).toBe(
         unformat(`
+            <p data-selection-placeholder=""><br></p>
             <div data-oe-protected="true" contenteditable="false">
                 <div data-oe-protected="false" contenteditable="true"></div>
             </div>
+            <p data-selection-placeholder=""><br></p>
             <div class="b" data-oe-protected="true" contenteditable="false">
                 <p class="a">content</p>
             </div>
+            <p data-selection-placeholder=""><br></p>
         `)
     );
 });
@@ -498,20 +529,24 @@ test("sequentially added nodes under a protecting parent are correctly protected
     expect(protectedPlugin.protectedNodes.has(node)).toBe(true);
     expect(getContent(el)).toBe(
         unformat(`
+            <p data-selection-placeholder=""><br></p>
             <div data-oe-protected="true" contenteditable="false">
                 <div>a</div>
                 content
             </div>
+            <p data-selection-placeholder=""><br></p>
         `)
     );
     node.remove();
     editor.shared.history.addStep();
     expect(getContent(el)).toBe(
         unformat(`
+            <p data-selection-placeholder=""><br></p>
             <div data-oe-protected="true" contenteditable="false">
                 <div></div>
                 content
             </div>
+            <p data-selection-placeholder=""><br></p>
         `)
     );
     expect(editor.shared.history.getHistorySteps().length).toBe(1);
@@ -541,6 +576,7 @@ test("don't protect a node under data-oe-protected='false' through delete and un
     expect(protectedPlugin.protectedNodes.has(node)).toBe(false);
     expect(getContent(el)).toBe(
         unformat(`
+            <p data-selection-placeholder=""><br></p>
             <div data-oe-protected="true" contenteditable="false">
                 <div data-oe-protected="false" contenteditable="true">
                     <p>b</p>
@@ -554,6 +590,7 @@ test("don't protect a node under data-oe-protected='false' through delete and un
     undo(editor);
     expect(getContent(el)).toBe(
         unformat(`
+            <p data-selection-placeholder=""><br></p>
             <div data-oe-protected="true" contenteditable="false">
                 <div data-oe-protected="false" contenteditable="true">
                     <p>b</p>
@@ -606,5 +643,7 @@ test("protected plugin is robust against other plugins which can filter mutation
     editor.shared.history.addStep();
     expect(editor.shared.history.getHistorySteps().length).toBe(1);
     expect(historyPlugin.currentStep.mutations).toEqual([]);
-    expect(getContent(el)).toBe(`<div data-oe-protected="true" contenteditable="false"></div>`);
+    expect(getContent(el)).toBe(
+        `<p data-selection-placeholder=""><br></p><div data-oe-protected="true" contenteditable="false"></div><p data-selection-placeholder=""><br></p>`
+    );
 });

--- a/addons/html_editor/static/tests/delete/backward.test.js
+++ b/addons/html_editor/static/tests/delete/backward.test.js
@@ -109,14 +109,18 @@ describe("Selection collapsed", () => {
                 contentBefore: "<div><p>ab</p><br><i>c[]</i></div>",
                 stepFunction: deleteBackward,
                 contentAfterEdit:
-                    '<div><p>ab</p><br><i data-oe-zws-empty-inline="">[]\u200B</i></div>',
+                    '<p data-selection-placeholder=""><br></p>' +
+                    '<div><p>ab</p><br><i data-oe-zws-empty-inline="">[]\u200B</i></div>' +
+                    '<p data-selection-placeholder=""><br></p>',
                 contentAfter: "<div><p>ab</p><br><br>[]</div>",
             });
             await testEditor({
                 contentBefore: '<div><p>uv</p><br><span class="style">w[]</span></div>',
                 stepFunction: deleteBackward,
                 contentAfterEdit:
-                    '<div><p>uv</p><br><span class="style" data-oe-zws-empty-inline="">[]\u200B</span></div>',
+                    '<p data-selection-placeholder=""><br></p>' +
+                    '<div><p>uv</p><br><span class="style" data-oe-zws-empty-inline="">[]\u200B</span></div>' +
+                    '<p data-selection-placeholder=""><br></p>',
                 contentAfter: '<div><p>uv</p><br><span class="style">[]\u200B</span></div>',
             });
             await testEditor({
@@ -125,7 +129,10 @@ describe("Selection collapsed", () => {
                     deleteBackward(editor);
                     await insertText(editor, "x");
                 },
-                contentAfterEdit: '<div><p>cd</p><br><span class="a">x[]</span></div>',
+                contentAfterEdit:
+                    '<p data-selection-placeholder=""><br></p>' +
+                    '<div><p>cd</p><br><span class="a">x[]</span></div>' +
+                    '<p data-selection-placeholder=""><br></p>',
                 contentAfter: '<div><p>cd</p><br><span class="a">x[]</span></div>',
             });
         });
@@ -1584,7 +1591,9 @@ describe("Selection not collapsed", () => {
                 deleteBackward(editor);
             },
             contentAfterEdit:
-                '<div><p>ab <span class="style" data-oe-zws-empty-inline="">[]\u200B</span> d</p></div>',
+                '<p data-selection-placeholder=""><br></p>' +
+                '<div><p>ab <span class="style" data-oe-zws-empty-inline="">[]\u200B</span> d</p></div>' +
+                '<p data-selection-placeholder=""><br></p>',
             contentAfter: '<div><p>ab <span class="style">[]\u200B</span> d</p></div>',
         });
         await testEditor({
@@ -1593,7 +1602,10 @@ describe("Selection not collapsed", () => {
                 deleteBackward(editor);
                 await insertText(editor, "x");
             },
-            contentAfterEdit: '<div><p>ab <span class="style">x[]</span> d</p></div>',
+            contentAfterEdit:
+                '<p data-selection-placeholder=""><br></p>' +
+                '<div><p>ab <span class="style">x[]</span> d</p></div>' +
+                '<p data-selection-placeholder=""><br></p>',
             contentAfter: '<div><p>ab <span class="style">x[]</span> d</p></div>',
         });
         await testEditor({
@@ -1602,7 +1614,9 @@ describe("Selection not collapsed", () => {
                 deleteBackward(editor);
             },
             contentAfterEdit:
-                '<div><p>ab <span data-oe-zws-empty-inline="">[]\u200B</span> d</p></div>',
+                '<p data-selection-placeholder=""><br></p>' +
+                '<div><p>ab <span data-oe-zws-empty-inline="">[]\u200B</span> d</p></div>' +
+                '<p data-selection-placeholder=""><br></p>',
             contentAfter: "<div><p>ab []&nbsp;d</p></div>",
         });
         await testEditor({
@@ -1611,7 +1625,10 @@ describe("Selection not collapsed", () => {
                 deleteBackward(editor);
                 await insertText(editor, "x");
             },
-            contentAfterEdit: '<div><p>ab<span class="style">x[]</span>d</p></div>',
+            contentAfterEdit:
+                '<p data-selection-placeholder=""><br></p>' +
+                '<div><p>ab<span class="style">x[]</span>d</p></div>' +
+                '<p data-selection-placeholder=""><br></p>',
             contentAfter: '<div><p>ab<span class="style">x[]</span>d</p></div>',
         });
         await testEditor({
@@ -1620,7 +1637,10 @@ describe("Selection not collapsed", () => {
                 deleteBackward(editor);
                 await insertText(editor, "x");
             },
-            contentAfterEdit: '<div><p>ab <span class="style">x[]</span> f</p></div>',
+            contentAfterEdit:
+                '<p data-selection-placeholder=""><br></p>' +
+                '<div><p>ab <span class="style">x[]</span> f</p></div>' +
+                '<p data-selection-placeholder=""><br></p>',
             contentAfter: '<div><p>ab <span class="style">x[]</span> f</p></div>',
         });
     });

--- a/addons/html_editor/static/tests/delete/backward.test.js
+++ b/addons/html_editor/static/tests/delete/backward.test.js
@@ -848,9 +848,15 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     compareFunction: compareHighlightedContent,
                     contentBefore: "<pre>abcd</pre>",
-                    contentBeforeEdit: highlightedPre({ value: "abcd" }),
+                    contentBeforeEdit:
+                        '<p data-selection-placeholder=""><br></p>' +
+                        highlightedPre({ value: "abcd" }) +
+                        '<p data-selection-placeholder=""><br></p>',
                     stepFunction: testDeleteInCodeBlock(2),
-                    contentAfterEdit: highlightedPre({ value: "acd", textareaRange: 1 }),
+                    contentAfterEdit:
+                        '<p data-selection-placeholder=""><br></p>' +
+                        highlightedPre({ value: "acd", textareaRange: 1 }) +
+                        '<p data-selection-placeholder=""><br></p>',
                     contentAfter: `<pre data-language-id="plaintext">acd</pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -860,9 +866,15 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     compareFunction: compareHighlightedContent,
                     contentBefore: "<pre>     abcd</pre>",
-                    contentBeforeEdit: highlightedPre({ value: "     abcd" }),
+                    contentBeforeEdit:
+                        '<p data-selection-placeholder=""><br></p>' +
+                        highlightedPre({ value: "     abcd" }) +
+                        '<p data-selection-placeholder=""><br></p>',
                     stepFunction: testDeleteInCodeBlock(7), // ab[]cd
-                    contentAfterEdit: highlightedPre({ value: "     acd", textareaRange: 6 }),
+                    contentAfterEdit:
+                        '<p data-selection-placeholder=""><br></p>' +
+                        highlightedPre({ value: "     acd", textareaRange: 6 }) +
+                        '<p data-selection-placeholder=""><br></p>',
                     contentAfter: `<pre data-language-id="plaintext">     acd</pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -872,9 +884,15 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     compareFunction: compareHighlightedContent,
                     contentBefore: "<pre>abcd     </pre>",
-                    contentBeforeEdit: highlightedPre({ value: "abcd     " }),
+                    contentBeforeEdit:
+                        '<p data-selection-placeholder=""><br></p>' +
+                        highlightedPre({ value: "abcd     " }) +
+                        '<p data-selection-placeholder=""><br></p>',
                     stepFunction: testDeleteInCodeBlock(2),
-                    contentAfterEdit: highlightedPre({ value: "acd     ", textareaRange: 1 }),
+                    contentAfterEdit:
+                        '<p data-selection-placeholder=""><br></p>' +
+                        highlightedPre({ value: "acd     ", textareaRange: 1 }) +
+                        '<p data-selection-placeholder=""><br></p>',
                     contentAfter: `<pre data-language-id="plaintext">acd     </pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -884,9 +902,15 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     compareFunction: compareHighlightedContent,
                     contentBefore: "<pre>     abcd     </pre>",
-                    contentBeforeEdit: highlightedPre({ value: "     abcd     " }),
+                    contentBeforeEdit:
+                        '<p data-selection-placeholder=""><br></p>' +
+                        highlightedPre({ value: "     abcd     " }) +
+                        '<p data-selection-placeholder=""><br></p>',
                     stepFunction: testDeleteInCodeBlock(7), // ab[]cd
-                    contentAfterEdit: highlightedPre({ value: "     acd     ", textareaRange: 6 }),
+                    contentAfterEdit:
+                        '<p data-selection-placeholder=""><br></p>' +
+                        highlightedPre({ value: "     acd     ", textareaRange: 6 }) +
+                        '<p data-selection-placeholder=""><br></p>',
                     contentAfter: `<pre data-language-id="plaintext">     acd     </pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -896,9 +920,15 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     compareFunction: compareHighlightedContent,
                     contentBefore: "<pre>     ab</pre>",
-                    contentBeforeEdit: highlightedPre({ value: "     ab" }),
+                    contentBeforeEdit:
+                        '<p data-selection-placeholder=""><br></p>' +
+                        highlightedPre({ value: "     ab" }) +
+                        '<p data-selection-placeholder=""><br></p>',
                     stepFunction: testDeleteInCodeBlock(3), // "   []  ab"
-                    contentAfterEdit: highlightedPre({ value: "    ab", textareaRange: 2 }),
+                    contentAfterEdit:
+                        '<p data-selection-placeholder=""><br></p>' +
+                        highlightedPre({ value: "    ab", textareaRange: 2 }) +
+                        '<p data-selection-placeholder=""><br></p>',
                     contentAfter: `<pre data-language-id="plaintext">    ab</pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -908,9 +938,15 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     compareFunction: compareHighlightedContent,
                     contentBefore: "<pre>ab\ncd</pre>",
-                    contentBeforeEdit: highlightedPre({ value: "ab\ncd" }),
+                    contentBeforeEdit:
+                        '<p data-selection-placeholder=""><br></p>' +
+                        highlightedPre({ value: "ab\ncd" }) +
+                        '<p data-selection-placeholder=""><br></p>',
                     stepFunction: testDeleteInCodeBlock(3), // ab\n[]cd
-                    contentAfterEdit: highlightedPre({ value: "abcd", textareaRange: 2 }),
+                    contentAfterEdit:
+                        '<p data-selection-placeholder=""><br></p>' +
+                        highlightedPre({ value: "abcd", textareaRange: 2 }) +
+                        '<p data-selection-placeholder=""><br></p>',
                     contentAfter: `<pre data-language-id="plaintext">abcd</pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -920,7 +956,10 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     compareFunction: compareHighlightedContent,
                     contentBefore: "<pre>     ab</pre>",
-                    contentBeforeEdit: highlightedPre({ value: "     ab" }),
+                    contentBeforeEdit:
+                        '<p data-selection-placeholder=""><br></p>' +
+                        highlightedPre({ value: "     ab" }) +
+                        '<p data-selection-placeholder=""><br></p>',
                     stepFunction: async (editor) => {
                         await testDeleteInCodeBlock(5)(editor); // "     []ab"
                         await testDeleteInCodeBlock(4)(editor); // "    []ab"
@@ -928,7 +967,10 @@ describe("Selection collapsed", () => {
                         await testDeleteInCodeBlock(2)(editor); // "  []ab"
                         await testDeleteInCodeBlock(1)(editor); // " []ab"
                     },
-                    contentAfterEdit: highlightedPre({ value: "ab", textareaRange: 0 }),
+                    contentAfterEdit:
+                        '<p data-selection-placeholder=""><br></p>' +
+                        highlightedPre({ value: "ab", textareaRange: 0 }) +
+                        '<p data-selection-placeholder=""><br></p>',
                     contentAfter: `<pre data-language-id="plaintext">ab</pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -938,7 +980,10 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     compareFunction: compareHighlightedContent,
                     contentBefore: "<pre>ab     </pre>",
-                    contentBeforeEdit: highlightedPre({ value: "ab     " }),
+                    contentBeforeEdit:
+                        '<p data-selection-placeholder=""><br></p>' +
+                        highlightedPre({ value: "ab     " }) +
+                        '<p data-selection-placeholder=""><br></p>',
                     stepFunction: async (editor) => {
                         await testDeleteInCodeBlock(7)(editor); // "ab     []"
                         await testDeleteInCodeBlock(6)(editor); // "ab    []"
@@ -946,7 +991,10 @@ describe("Selection collapsed", () => {
                         await testDeleteInCodeBlock(4)(editor); // "ab  []"
                         await testDeleteInCodeBlock(3)(editor); // "ab []"
                     },
-                    contentAfterEdit: highlightedPre({ value: "ab", textareaRange: 2 }),
+                    contentAfterEdit:
+                        '<p data-selection-placeholder=""><br></p>' +
+                        highlightedPre({ value: "ab", textareaRange: 2 }) +
+                        '<p data-selection-placeholder=""><br></p>',
                     contentAfter: `<pre data-language-id="plaintext">ab</pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -1274,6 +1322,7 @@ describe("Selection collapsed", () => {
         test("should remove the uneditable nesting zone from the outside", async () => {
             await testEditor({
                 contentBefore: unformat(`
+                        <p data-selection-placeholder=""><br></p>
                         <div contenteditable="false">
                             <div contenteditable="true">
                                 <p>content</p>
@@ -2025,10 +2074,12 @@ describe("Selection not collapsed", () => {
                 </tbody></table>`
             ),
             contentBeforeEdit: unformat(
-                `[<table class="o_selected_table"><tbody>
+                `[<p data-selection-placeholder=""><br></p>
+                <table class="o_selected_table"><tbody>
                     <tr><td class="o_selected_td"><br></td><td class="o_selected_td"><br></td></tr>
                     <tr><td class="o_selected_td"><br></td><td class="o_selected_td">]<br></td></tr>
-                </tbody></table>`
+                </tbody></table>
+                <p data-selection-placeholder=""><br></p>`
             ),
             stepFunction: deleteBackward,
             contentAfter: unformat("<p>[]<br></p>"),

--- a/addons/html_editor/static/tests/delete/backward.test.js
+++ b/addons/html_editor/static/tests/delete/backward.test.js
@@ -858,12 +858,12 @@ describe("Selection collapsed", () => {
                     contentBeforeEdit:
                         '<p data-selection-placeholder=""><br></p>' +
                         highlightedPre({ value: "abcd" }) +
-                        '<p data-selection-placeholder=""><br></p>',
+                        '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
                     stepFunction: testDeleteInCodeBlock(2),
                     contentAfterEdit:
                         '<p data-selection-placeholder=""><br></p>' +
                         highlightedPre({ value: "acd", textareaRange: 1 }) +
-                        '<p data-selection-placeholder=""><br></p>',
+                        '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
                     contentAfter: `<pre data-language-id="plaintext">acd</pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -876,12 +876,12 @@ describe("Selection collapsed", () => {
                     contentBeforeEdit:
                         '<p data-selection-placeholder=""><br></p>' +
                         highlightedPre({ value: "     abcd" }) +
-                        '<p data-selection-placeholder=""><br></p>',
+                        '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
                     stepFunction: testDeleteInCodeBlock(7), // ab[]cd
                     contentAfterEdit:
                         '<p data-selection-placeholder=""><br></p>' +
                         highlightedPre({ value: "     acd", textareaRange: 6 }) +
-                        '<p data-selection-placeholder=""><br></p>',
+                        '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
                     contentAfter: `<pre data-language-id="plaintext">     acd</pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -894,12 +894,12 @@ describe("Selection collapsed", () => {
                     contentBeforeEdit:
                         '<p data-selection-placeholder=""><br></p>' +
                         highlightedPre({ value: "abcd     " }) +
-                        '<p data-selection-placeholder=""><br></p>',
+                        '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
                     stepFunction: testDeleteInCodeBlock(2),
                     contentAfterEdit:
                         '<p data-selection-placeholder=""><br></p>' +
                         highlightedPre({ value: "acd     ", textareaRange: 1 }) +
-                        '<p data-selection-placeholder=""><br></p>',
+                        '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
                     contentAfter: `<pre data-language-id="plaintext">acd     </pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -912,12 +912,12 @@ describe("Selection collapsed", () => {
                     contentBeforeEdit:
                         '<p data-selection-placeholder=""><br></p>' +
                         highlightedPre({ value: "     abcd     " }) +
-                        '<p data-selection-placeholder=""><br></p>',
+                        '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
                     stepFunction: testDeleteInCodeBlock(7), // ab[]cd
                     contentAfterEdit:
                         '<p data-selection-placeholder=""><br></p>' +
                         highlightedPre({ value: "     acd     ", textareaRange: 6 }) +
-                        '<p data-selection-placeholder=""><br></p>',
+                        '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
                     contentAfter: `<pre data-language-id="plaintext">     acd     </pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -930,12 +930,12 @@ describe("Selection collapsed", () => {
                     contentBeforeEdit:
                         '<p data-selection-placeholder=""><br></p>' +
                         highlightedPre({ value: "     ab" }) +
-                        '<p data-selection-placeholder=""><br></p>',
+                        '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
                     stepFunction: testDeleteInCodeBlock(3), // "   []  ab"
                     contentAfterEdit:
                         '<p data-selection-placeholder=""><br></p>' +
                         highlightedPre({ value: "    ab", textareaRange: 2 }) +
-                        '<p data-selection-placeholder=""><br></p>',
+                        '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
                     contentAfter: `<pre data-language-id="plaintext">    ab</pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -948,12 +948,12 @@ describe("Selection collapsed", () => {
                     contentBeforeEdit:
                         '<p data-selection-placeholder=""><br></p>' +
                         highlightedPre({ value: "ab\ncd" }) +
-                        '<p data-selection-placeholder=""><br></p>',
+                        '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
                     stepFunction: testDeleteInCodeBlock(3), // ab\n[]cd
                     contentAfterEdit:
                         '<p data-selection-placeholder=""><br></p>' +
                         highlightedPre({ value: "abcd", textareaRange: 2 }) +
-                        '<p data-selection-placeholder=""><br></p>',
+                        '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
                     contentAfter: `<pre data-language-id="plaintext">abcd</pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -966,7 +966,7 @@ describe("Selection collapsed", () => {
                     contentBeforeEdit:
                         '<p data-selection-placeholder=""><br></p>' +
                         highlightedPre({ value: "     ab" }) +
-                        '<p data-selection-placeholder=""><br></p>',
+                        '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
                     stepFunction: async (editor) => {
                         await testDeleteInCodeBlock(5)(editor); // "     []ab"
                         await testDeleteInCodeBlock(4)(editor); // "    []ab"
@@ -977,7 +977,7 @@ describe("Selection collapsed", () => {
                     contentAfterEdit:
                         '<p data-selection-placeholder=""><br></p>' +
                         highlightedPre({ value: "ab", textareaRange: 0 }) +
-                        '<p data-selection-placeholder=""><br></p>',
+                        '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
                     contentAfter: `<pre data-language-id="plaintext">ab</pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -990,7 +990,7 @@ describe("Selection collapsed", () => {
                     contentBeforeEdit:
                         '<p data-selection-placeholder=""><br></p>' +
                         highlightedPre({ value: "ab     " }) +
-                        '<p data-selection-placeholder=""><br></p>',
+                        '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
                     stepFunction: async (editor) => {
                         await testDeleteInCodeBlock(7)(editor); // "ab     []"
                         await testDeleteInCodeBlock(6)(editor); // "ab    []"
@@ -1001,7 +1001,7 @@ describe("Selection collapsed", () => {
                     contentAfterEdit:
                         '<p data-selection-placeholder=""><br></p>' +
                         highlightedPre({ value: "ab", textareaRange: 2 }) +
-                        '<p data-selection-placeholder=""><br></p>',
+                        '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
                     contentAfter: `<pre data-language-id="plaintext">ab</pre>[]`,
                     config: configWithEmbeddings,
                 });

--- a/addons/html_editor/static/tests/delete/delete_range.test.js
+++ b/addons/html_editor/static/tests/delete/delete_range.test.js
@@ -245,7 +245,8 @@ describe("deleteRange method", () => {
                 `[<table><tbody>
                     <tr><td><br></td><td><br></td></tr>
                     <tr><td>]<br></td><td><br></td></tr>
-                </tbody></table>`
+                </tbody></table>
+                <p data-selection-placeholder=""><br></p>`
             );
             expect(getContent(el)).toBe(contentAfter);
         });
@@ -254,7 +255,7 @@ describe("deleteRange method", () => {
         test("should not fill a HR with BR", async () => {
             const { editor, el } = await setupEditor("<hr><p>abc[</p><p>]def</p>");
             deleteRange(editor);
-            const hr = el.firstElementChild;
+            const hr = el.querySelector("hr");
             expect(hr.childNodes.length).toBe(0);
         });
     });
@@ -408,7 +409,8 @@ describe("deleteSelection", () => {
                     ),
                     stepFunction: deleteSelection,
                     contentAfterEdit: unformat(
-                        `<div class="container o_text_columns o-contenteditable-false" contenteditable="false">
+                        `<p data-selection-placeholder=""><br></p>
+                        <div class="container o_text_columns o-contenteditable-false" contenteditable="false">
                             <div class="row">
                                 <div class="col-6 o-contenteditable-true" contenteditable="true">a[]</div>
                                 <div class="col-6 o-contenteditable-true" contenteditable="true"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div>

--- a/addons/html_editor/static/tests/delete/delete_range.test.js
+++ b/addons/html_editor/static/tests/delete/delete_range.test.js
@@ -264,7 +264,8 @@ describe("deleteRange method", () => {
             await testEditor({
                 contentBefore: `[<div class="container o_text_columns"><div class="row"><div class="col-4"><p>a</p></div><div class="col-4"><p>b</p></div><div class="col-4"><p>c</p></div></div></div>]`,
                 stepFunction: deleteRange,
-                contentAfter: `[]<p><br></p>`,
+                // TODO: should an empty editable be allowed without allowInlineAtRoot?
+                contentAfter: `[]`,
             });
         });
         test("should delete columns when all selected along with text from an outer node", async () => {

--- a/addons/html_editor/static/tests/delete/find_adjacent_position.test.js
+++ b/addons/html_editor/static/tests/delete/find_adjacent_position.test.js
@@ -140,6 +140,7 @@ describe("findAdjacentPosition method", () => {
     describe("Different editable zones", () => {
         test("should find adjacent character", async () => {
             const previous = unformat(`
+                <p data-selection-placeholder=""><br></p>
                 <div contenteditable="false">
                     <p>abc</p>
                     <p contenteditable="true">[]def</p>
@@ -147,6 +148,7 @@ describe("findAdjacentPosition method", () => {
                 <p>fgh</p>
             `);
             const next = unformat(`
+                <p data-selection-placeholder=""><br></p>
                 <div contenteditable="false">
                     <p>abc</p>
                     <p contenteditable="true">d[]ef</p>
@@ -201,6 +203,7 @@ describe("findAdjacentPosition method", () => {
                 // it's the desirable one to compose a range for deletion,
                 // allowing to remove the div with deleteBackward
                 unformat(`
+                    <p data-selection-placeholder=""><br></p>
                     []<div contenteditable="false">
                         <p>abc</p>
                         <p contenteditable="true">def</p>
@@ -231,6 +234,7 @@ describe("findAdjacentPosition method", () => {
                         <p>abc</p>
                         <p contenteditable="true">def</p>
                     </div>[]
+                    <p data-selection-placeholder=""><br></p>
                 `)
             );
         });

--- a/addons/html_editor/static/tests/delete/find_adjacent_position.test.js
+++ b/addons/html_editor/static/tests/delete/find_adjacent_position.test.js
@@ -92,7 +92,15 @@ describe("findAdjacentPosition method", () => {
                 const previous = '<div><p>a[]</p><span contenteditable="false">b</span></div>';
                 const next = '<div><p>a</p>[]<span contenteditable="false">b</span></div>';
                 const { editor } = await setupEditor(previous);
-                assertAdjacentPositions(editor, previous, next);
+                assertAdjacentPositions(
+                    editor,
+                    '<p data-selection-placeholder=""><br></p>' +
+                        previous +
+                        '<p data-selection-placeholder=""><br></p>',
+                    '<p data-selection-placeholder=""><br></p>' +
+                        next +
+                        '<p data-selection-placeholder=""><br></p>'
+                );
             });
             test("Should find position before filebox", async () => {
                 const content = `<div>\ufeff<span contenteditable="false" class="o_file_box"></span>\ufeff[]</div>`;

--- a/addons/html_editor/static/tests/delete/fix_base_container.test.js
+++ b/addons/html_editor/static/tests/delete/fix_base_container.test.js
@@ -29,9 +29,11 @@ describe("Adjust base container on delete", () => {
                 deleteBackward(editor);
             },
             contentAfterEdit: unformat(`
+                <p data-selection-placeholder=""><br></p>
                 <div>
                     <div class="o-paragraph o-we-hint" o-we-hint-text='Type "/" for commands'>[]<br></div>
                 </div>
+                <p data-selection-placeholder=""><br></p>
             `),
             config: { cleanEmptyStructuralContainers: false },
         });
@@ -79,7 +81,9 @@ describe("Adjust base container on delete", () => {
                 deleteBackward(editor);
             },
             contentAfterEdit: unformat(`
+                <p data-selection-placeholder=""><br></p>
                 <div><div class="o-paragraph o-we-hint" o-we-hint-text='Type "/" for commands'>[]<br></div></div>
+                <p data-selection-placeholder=""><br></p>
             `),
         });
     });
@@ -108,7 +112,9 @@ describe("Adjust base container on delete", () => {
                 deleteBackward(editor);
             },
             contentAfterEdit: unformat(`
+                <p data-selection-placeholder=""><br></p>
                 <div class="oe_unremovable">[]<br></div>
+                <p data-selection-placeholder=""><br></p>
             `),
         });
     });
@@ -123,9 +129,11 @@ describe("Adjust base container on delete", () => {
                 deleteBackward(editor);
             },
             contentAfterEdit: unformat(`
+                <p data-selection-placeholder=""><br></p>
                 <div class="oe_unremovable">
                     <p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>
                 </div>
+                <p data-selection-placeholder=""><br></p>
             `),
         });
     });
@@ -187,9 +195,11 @@ describe("Adjust base container on delete", () => {
                 deleteBackward(editor);
             },
             contentAfterEdit: unformat(`
+                <p data-selection-placeholder=""><br></p>
                 <div>
                     <div class="o-paragraph o-we-hint" o-we-hint-text='Type "/" for commands'>[]</div>
                 </div>
+                <p data-selection-placeholder=""><br></p>
             `),
         });
     });
@@ -205,9 +215,11 @@ describe("Adjust base container on delete", () => {
                 deleteBackward(editor);
             },
             contentAfterEdit: unformat(`
+                <p data-selection-placeholder=""><br></p>
                 <div>
                     <div class="o-paragraph o-we-hint" o-we-hint-text='Type "/" for commands'>[]<br></div>
                 </div>
+                <p data-selection-placeholder=""><br></p>
             `),
         });
     });
@@ -222,9 +234,11 @@ describe("Adjust base container on delete", () => {
                 deleteBackward(editor);
             },
             contentAfterEdit: unformat(`
+                <p data-selection-placeholder=""><br></p>
                 <div>
                     <div class="o-paragraph">[]text</div>
                 </div>
+                <p data-selection-placeholder=""><br></p>
             `),
         });
     });

--- a/addons/html_editor/static/tests/delete/fix_base_container.test.js
+++ b/addons/html_editor/static/tests/delete/fix_base_container.test.js
@@ -141,11 +141,13 @@ describe("Adjust base container on delete", () => {
             },
             // The P is added by the deletion, not by `cleanEmptyStructuralContainers`.
             contentAfterEdit: unformat(`
+                <p data-selection-placeholder=""><br></p>
                 <div contenteditable="false">
                     <div contenteditable="true">
                         <p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>
                     </div>
                 </div>
+                <p data-selection-placeholder=""><br></p>
             `),
         });
     });
@@ -162,11 +164,13 @@ describe("Adjust base container on delete", () => {
                 deleteBackward(editor);
             },
             contentAfterEdit: unformat(`
+                <p data-selection-placeholder=""><br></p>
                 <div contenteditable="false">
                     <div contenteditable="true">
                         <div class="o-paragraph o-we-hint" o-we-hint-text='Type "/" for commands'>[]<br></div>
                     </div>
                 </div>
+                <p data-selection-placeholder=""><br></p>
             `),
         });
     });
@@ -253,11 +257,13 @@ describe("Adjust base container on delete", () => {
                 deleteBackward(editor);
             },
             contentAfterEdit: unformat(`
+                <p data-selection-placeholder=""><br></p>
                 <div contenteditable="false">
                     <div contenteditable="true">
                         <div class="o-paragraph o-we-hint" o-we-hint-text='Type "/" for commands'>[]<br></div>
                     </div>
                 </div>
+                <p data-selection-placeholder=""><br></p>
             `),
         });
     });

--- a/addons/html_editor/static/tests/delete/forward.test.js
+++ b/addons/html_editor/static/tests/delete/forward.test.js
@@ -752,9 +752,15 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     compareFunction: compareHighlightedContent,
                     contentBefore: "<pre>abcd</pre>",
-                    contentBeforeEdit: highlightedPre({ value: "abcd" }),
+                    contentBeforeEdit:
+                        '<p data-selection-placeholder=""><br></p>' +
+                        highlightedPre({ value: "abcd" }) +
+                        '<p data-selection-placeholder=""><br></p>',
                     stepFunction: testDeleteInCodeBlock(2), // "ab[]cd"
-                    contentAfterEdit: highlightedPre({ value: "abd", textareaRange: 2 }),
+                    contentAfterEdit:
+                        '<p data-selection-placeholder=""><br></p>' +
+                        highlightedPre({ value: "abd", textareaRange: 2 }) +
+                        '<p data-selection-placeholder=""><br></p>',
                     contentAfter: `<pre data-language-id="plaintext">abd</pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -764,9 +770,15 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     compareFunction: compareHighlightedContent,
                     contentBefore: "<pre>     abcd</pre>",
-                    contentBeforeEdit: highlightedPre({ value: "     abcd" }),
+                    contentBeforeEdit:
+                        '<p data-selection-placeholder=""><br></p>' +
+                        highlightedPre({ value: "     abcd" }) +
+                        '<p data-selection-placeholder=""><br></p>',
                     stepFunction: testDeleteInCodeBlock(7), // "     ab[]cd"
-                    contentAfterEdit: highlightedPre({ value: "     abd", textareaRange: 7 }),
+                    contentAfterEdit:
+                        '<p data-selection-placeholder=""><br></p>' +
+                        highlightedPre({ value: "     abd", textareaRange: 7 }) +
+                        '<p data-selection-placeholder=""><br></p>',
                     contentAfter: `<pre data-language-id="plaintext">     abd</pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -776,9 +788,15 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     compareFunction: compareHighlightedContent,
                     contentBefore: "<pre>abcd     </pre>",
-                    contentBeforeEdit: highlightedPre({ value: "abcd     " }),
+                    contentBeforeEdit:
+                        '<p data-selection-placeholder=""><br></p>' +
+                        highlightedPre({ value: "abcd     " }) +
+                        '<p data-selection-placeholder=""><br></p>',
                     stepFunction: testDeleteInCodeBlock(2), // "ab[]cd     "
-                    contentAfterEdit: highlightedPre({ value: "abd     ", textareaRange: 2 }),
+                    contentAfterEdit:
+                        '<p data-selection-placeholder=""><br></p>' +
+                        highlightedPre({ value: "abd     ", textareaRange: 2 }) +
+                        '<p data-selection-placeholder=""><br></p>',
                     contentAfter: `<pre data-language-id="plaintext">abd     </pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -788,9 +806,15 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     compareFunction: compareHighlightedContent,
                     contentBefore: "<pre>     abcd     </pre>",
-                    contentBeforeEdit: highlightedPre({ value: "     abcd     " }),
+                    contentBeforeEdit:
+                        '<p data-selection-placeholder=""><br></p>' +
+                        highlightedPre({ value: "     abcd     " }) +
+                        '<p data-selection-placeholder=""><br></p>',
                     stepFunction: testDeleteInCodeBlock(7), // "     ab[]cd     "
-                    contentAfterEdit: highlightedPre({ value: "     abd     ", textareaRange: 7 }),
+                    contentAfterEdit:
+                        '<p data-selection-placeholder=""><br></p>' +
+                        highlightedPre({ value: "     abd     ", textareaRange: 7 }) +
+                        '<p data-selection-placeholder=""><br></p>',
                     contentAfter: `<pre data-language-id="plaintext">     abd     </pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -800,9 +824,15 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     compareFunction: compareHighlightedContent,
                     contentBefore: "<pre>     ab</pre>",
-                    contentBeforeEdit: highlightedPre({ value: "     ab" }),
+                    contentBeforeEdit:
+                        '<p data-selection-placeholder=""><br></p>' +
+                        highlightedPre({ value: "     ab" }) +
+                        '<p data-selection-placeholder=""><br></p>',
                     stepFunction: testDeleteInCodeBlock(2), // "  []   ab"
-                    contentAfterEdit: highlightedPre({ value: "    ab", textareaRange: 2 }),
+                    contentAfterEdit:
+                        '<p data-selection-placeholder=""><br></p>' +
+                        highlightedPre({ value: "    ab", textareaRange: 2 }) +
+                        '<p data-selection-placeholder=""><br></p>',
                     contentAfter: `<pre data-language-id="plaintext">    ab</pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -812,9 +842,15 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     compareFunction: compareHighlightedContent,
                     contentBefore: "<pre>ab\ncd</pre>",
-                    contentBeforeEdit: highlightedPre({ value: "ab\ncd" }),
+                    contentBeforeEdit:
+                        '<p data-selection-placeholder=""><br></p>' +
+                        highlightedPre({ value: "ab\ncd" }) +
+                        '<p data-selection-placeholder=""><br></p>',
                     stepFunction: testDeleteInCodeBlock(2), // "ab[]\ncd"
-                    contentAfterEdit: highlightedPre({ value: "abcd", textareaRange: 2 }),
+                    contentAfterEdit:
+                        '<p data-selection-placeholder=""><br></p>' +
+                        highlightedPre({ value: "abcd", textareaRange: 2 }) +
+                        '<p data-selection-placeholder=""><br></p>',
                     contentAfter: `<pre data-language-id="plaintext">abcd</pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -824,7 +860,10 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     compareFunction: compareHighlightedContent,
                     contentBefore: "<pre>     ab</pre>",
-                    contentBeforeEdit: highlightedPre({ value: "     ab" }),
+                    contentBeforeEdit:
+                        '<p data-selection-placeholder=""><br></p>' +
+                        highlightedPre({ value: "     ab" }) +
+                        '<p data-selection-placeholder=""><br></p>',
                     stepFunction: async (editor) => {
                         await testDeleteInCodeBlock(0)(editor); // "[]     ab"
                         await testDeleteInCodeBlock(0)(editor); // "[]    ab"
@@ -832,7 +871,10 @@ describe("Selection collapsed", () => {
                         await testDeleteInCodeBlock(0)(editor); // "[]  ab"
                         await testDeleteInCodeBlock(0)(editor); // "[] ab"
                     },
-                    contentAfterEdit: highlightedPre({ value: "ab", textareaRange: 0 }),
+                    contentAfterEdit:
+                        '<p data-selection-placeholder=""><br></p>' +
+                        highlightedPre({ value: "ab", textareaRange: 0 }) +
+                        '<p data-selection-placeholder=""><br></p>',
                     contentAfter: `<pre data-language-id="plaintext">ab</pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -842,7 +884,10 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     compareFunction: compareHighlightedContent,
                     contentBefore: "<pre>ab     </pre>",
-                    contentBeforeEdit: highlightedPre({ value: "ab     " }),
+                    contentBeforeEdit:
+                        '<p data-selection-placeholder=""><br></p>' +
+                        highlightedPre({ value: "ab     " }) +
+                        '<p data-selection-placeholder=""><br></p>',
                     stepFunction: async (editor) => {
                         await testDeleteInCodeBlock(2)(editor); // "ab[]     "
                         await testDeleteInCodeBlock(2)(editor); // "ab[]    "
@@ -850,7 +895,10 @@ describe("Selection collapsed", () => {
                         await testDeleteInCodeBlock(2)(editor); // "ab[]  "
                         await testDeleteInCodeBlock(2)(editor); // "ab[] "
                     },
-                    contentAfterEdit: highlightedPre({ value: "ab", textareaRange: 2 }),
+                    contentAfterEdit:
+                        '<p data-selection-placeholder=""><br></p>' +
+                        highlightedPre({ value: "ab", textareaRange: 2 }) +
+                        '<p data-selection-placeholder=""><br></p>',
                     contentAfter: `<pre data-language-id="plaintext">ab</pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -1131,6 +1179,7 @@ describe("Selection collapsed", () => {
                                 <p>content</p>
                             </div>
                         </div>
+                        <p data-selection-placeholder=""><br></p>
                     `),
                 stepFunction: deleteForward,
                 contentAfter: unformat(`

--- a/addons/html_editor/static/tests/delete/forward.test.js
+++ b/addons/html_editor/static/tests/delete/forward.test.js
@@ -755,12 +755,12 @@ describe("Selection collapsed", () => {
                     contentBeforeEdit:
                         '<p data-selection-placeholder=""><br></p>' +
                         highlightedPre({ value: "abcd" }) +
-                        '<p data-selection-placeholder=""><br></p>',
+                        '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
                     stepFunction: testDeleteInCodeBlock(2), // "ab[]cd"
                     contentAfterEdit:
                         '<p data-selection-placeholder=""><br></p>' +
                         highlightedPre({ value: "abd", textareaRange: 2 }) +
-                        '<p data-selection-placeholder=""><br></p>',
+                        '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
                     contentAfter: `<pre data-language-id="plaintext">abd</pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -773,12 +773,12 @@ describe("Selection collapsed", () => {
                     contentBeforeEdit:
                         '<p data-selection-placeholder=""><br></p>' +
                         highlightedPre({ value: "     abcd" }) +
-                        '<p data-selection-placeholder=""><br></p>',
+                        '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
                     stepFunction: testDeleteInCodeBlock(7), // "     ab[]cd"
                     contentAfterEdit:
                         '<p data-selection-placeholder=""><br></p>' +
                         highlightedPre({ value: "     abd", textareaRange: 7 }) +
-                        '<p data-selection-placeholder=""><br></p>',
+                        '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
                     contentAfter: `<pre data-language-id="plaintext">     abd</pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -791,12 +791,12 @@ describe("Selection collapsed", () => {
                     contentBeforeEdit:
                         '<p data-selection-placeholder=""><br></p>' +
                         highlightedPre({ value: "abcd     " }) +
-                        '<p data-selection-placeholder=""><br></p>',
+                        '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
                     stepFunction: testDeleteInCodeBlock(2), // "ab[]cd     "
                     contentAfterEdit:
                         '<p data-selection-placeholder=""><br></p>' +
                         highlightedPre({ value: "abd     ", textareaRange: 2 }) +
-                        '<p data-selection-placeholder=""><br></p>',
+                        '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
                     contentAfter: `<pre data-language-id="plaintext">abd     </pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -809,12 +809,12 @@ describe("Selection collapsed", () => {
                     contentBeforeEdit:
                         '<p data-selection-placeholder=""><br></p>' +
                         highlightedPre({ value: "     abcd     " }) +
-                        '<p data-selection-placeholder=""><br></p>',
+                        '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
                     stepFunction: testDeleteInCodeBlock(7), // "     ab[]cd     "
                     contentAfterEdit:
                         '<p data-selection-placeholder=""><br></p>' +
                         highlightedPre({ value: "     abd     ", textareaRange: 7 }) +
-                        '<p data-selection-placeholder=""><br></p>',
+                        '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
                     contentAfter: `<pre data-language-id="plaintext">     abd     </pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -827,12 +827,12 @@ describe("Selection collapsed", () => {
                     contentBeforeEdit:
                         '<p data-selection-placeholder=""><br></p>' +
                         highlightedPre({ value: "     ab" }) +
-                        '<p data-selection-placeholder=""><br></p>',
+                        '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
                     stepFunction: testDeleteInCodeBlock(2), // "  []   ab"
                     contentAfterEdit:
                         '<p data-selection-placeholder=""><br></p>' +
                         highlightedPre({ value: "    ab", textareaRange: 2 }) +
-                        '<p data-selection-placeholder=""><br></p>',
+                        '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
                     contentAfter: `<pre data-language-id="plaintext">    ab</pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -845,12 +845,12 @@ describe("Selection collapsed", () => {
                     contentBeforeEdit:
                         '<p data-selection-placeholder=""><br></p>' +
                         highlightedPre({ value: "ab\ncd" }) +
-                        '<p data-selection-placeholder=""><br></p>',
+                        '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
                     stepFunction: testDeleteInCodeBlock(2), // "ab[]\ncd"
                     contentAfterEdit:
                         '<p data-selection-placeholder=""><br></p>' +
                         highlightedPre({ value: "abcd", textareaRange: 2 }) +
-                        '<p data-selection-placeholder=""><br></p>',
+                        '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
                     contentAfter: `<pre data-language-id="plaintext">abcd</pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -863,7 +863,7 @@ describe("Selection collapsed", () => {
                     contentBeforeEdit:
                         '<p data-selection-placeholder=""><br></p>' +
                         highlightedPre({ value: "     ab" }) +
-                        '<p data-selection-placeholder=""><br></p>',
+                        '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
                     stepFunction: async (editor) => {
                         await testDeleteInCodeBlock(0)(editor); // "[]     ab"
                         await testDeleteInCodeBlock(0)(editor); // "[]    ab"
@@ -874,7 +874,7 @@ describe("Selection collapsed", () => {
                     contentAfterEdit:
                         '<p data-selection-placeholder=""><br></p>' +
                         highlightedPre({ value: "ab", textareaRange: 0 }) +
-                        '<p data-selection-placeholder=""><br></p>',
+                        '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
                     contentAfter: `<pre data-language-id="plaintext">ab</pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -887,7 +887,7 @@ describe("Selection collapsed", () => {
                     contentBeforeEdit:
                         '<p data-selection-placeholder=""><br></p>' +
                         highlightedPre({ value: "ab     " }) +
-                        '<p data-selection-placeholder=""><br></p>',
+                        '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
                     stepFunction: async (editor) => {
                         await testDeleteInCodeBlock(2)(editor); // "ab[]     "
                         await testDeleteInCodeBlock(2)(editor); // "ab[]    "
@@ -898,7 +898,7 @@ describe("Selection collapsed", () => {
                     contentAfterEdit:
                         '<p data-selection-placeholder=""><br></p>' +
                         highlightedPre({ value: "ab", textareaRange: 2 }) +
-                        '<p data-selection-placeholder=""><br></p>',
+                        '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
                     contentAfter: `<pre data-language-id="plaintext">ab</pre>[]`,
                     config: configWithEmbeddings,
                 });

--- a/addons/html_editor/static/tests/editor.test.js
+++ b/addons/html_editor/static/tests/editor.test.js
@@ -154,7 +154,9 @@ test("Convert self closing t elements to opening/closing tags", async () => {
         </div>
     `);
     expect(el.innerHTML.trim().replace(/\s+/g, " ")).toBe(
-        `<div> <t t-out="object.partner_id" data-oe-t-inline="true" contenteditable="false"></t> </div>`
+        '<p data-selection-placeholder=""><br></p>' +
+            `<div> <t t-out="object.partner_id" data-oe-t-inline="true" contenteditable="false"></t> </div>` +
+            '<p data-selection-placeholder=""><br></p>'
     );
     expect(editor.getContent().trim().replace(/\s+/g, " ")).toBe(
         '<div> <t t-out="object.partner_id" data-oe-t-inline="true" contenteditable="false"></t> </div>'

--- a/addons/html_editor/static/tests/embedded_components.test.js
+++ b/addons/html_editor/static/tests/embedded_components.test.js
@@ -387,7 +387,7 @@ describe("Mount and Destroy embedded components", () => {
             unformat(`
                 <p data-selection-placeholder=""><br></p>
                 <div data-embedded="recursiveComponent" data-oe-protected="true" contenteditable="false">
-                    <div>
+                    []<div>
                         <div class="click count-2">Count:2</div>
                         <div class="innerEditable-2">
                             <div data-prop-name="innerValue" data-oe-protected="false" contenteditable="true">
@@ -418,7 +418,7 @@ describe("Mount and Destroy embedded components", () => {
                         </div>
                     </div>
                 </div>
-                <p class="target o-we-hint" o-we-hint-text='Type "/" for commands'>[]<br></p>
+                <p data-selection-placeholder=""><br></p>
             `)
         );
         for (const index of indexOrder) {
@@ -444,8 +444,8 @@ describe("Mount and Destroy embedded components", () => {
         expect(getContent(el)).toBe(
             unformat(`
                 <p data-selection-placeholder=""><br></p>
-                <div data-embedded="recursiveComponent" data-oe-protected="true" contenteditable="false"></div>
-                <p class="target o-we-hint" o-we-hint-text='Type "/" for commands'>[]<br></p>
+                <div data-embedded="recursiveComponent" data-oe-protected="true" contenteditable="false">[]</div>
+                <p data-selection-placeholder=""><br></p>
             `)
         );
         // Verify that there is no potential host outside of the editable,
@@ -586,8 +586,8 @@ describe("Selection after embedded component insertion", () => {
         expect(getContent(el)).toBe(
             unformat(`
                 <p data-selection-placeholder=""><br></p>
-                <div data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></div>
-                <p>[]<br></p>`)
+                <div data-embedded="counter" data-oe-protected="true" contenteditable="false">[]<span class="counter">Counter:0</span></div>
+                <p data-selection-placeholder=""><br></p>`)
         );
     });
     test("block at the end of paragraph", async () => {
@@ -601,8 +601,8 @@ describe("Selection after embedded component insertion", () => {
         expect(getContent(el)).toBe(
             unformat(`
                 <p>a</p>
-                <div data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></div>
-                <p>[]<br></p>`)
+                <div data-embedded="counter" data-oe-protected="true" contenteditable="false">[]<span class="counter">Counter:0</span></div>
+                <p data-selection-placeholder=""><br></p>`)
         );
     });
     test("block at the start of paragraph", async () => {
@@ -846,7 +846,9 @@ describe("Mount processing", () => {
         // "unknown" data-embedded should be considered once during the first
         // mounting wave.
         expect.verifySteps(["unknown handled"]);
-        expect(getContent(el)).toBe(`<div data-embedded="unknown"><p>UNKNOWN</p></div>`);
+        expect(getContent(el)).toBe(
+            `<p data-selection-placeholder=""><br></p><div data-embedded="unknown"><p>UNKNOWN</p></div><p data-selection-placeholder=""><br></p>`
+        );
     });
     test("Mount a component with a plugin that modifies the Component's env", async () => {
         let setSelection;
@@ -904,7 +906,7 @@ describe("In-editor manipulations", () => {
         await animationFrame();
         await expectElementCount(".o-we-toolbar", 1);
         expect(getContent(el)).toBe(
-            `<div><p>[a]</p><span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></span></div>`
+            `<p data-selection-placeholder=""><br></p><div><p>[a]</p><span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></span></div><p data-selection-placeholder=""><br></p>`
         );
 
         const node = queryFirst(".counter", {}).firstChild;
@@ -912,7 +914,7 @@ describe("In-editor manipulations", () => {
         await tick();
         await animationFrame();
         expect(getContent(el)).toBe(
-            `<div><p>a</p><span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">C[ou]nter:0</span></span></div>`
+            `<p data-selection-placeholder=""><br></p><div><p>a</p><span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">C[ou]nter:0</span></span></div><p data-selection-placeholder=""><br></p>`
         );
         await expectElementCount(".o-we-toolbar", 0);
     });
@@ -938,7 +940,7 @@ describe("In-editor manipulations", () => {
         );
         cleanHints(editor);
         expect(getContent(el)).toBe(
-            `<div><p>a</p></div><div data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></div><p data-selection-placeholder=""><br></p>`
+            `<p data-selection-placeholder=""><br></p><div><p>a</p></div><p data-selection-placeholder=""><br></p><div data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></div><p data-selection-placeholder=""><br></p>`
         );
     });
 
@@ -952,7 +954,7 @@ describe("In-editor manipulations", () => {
         const historyPlugin = plugins.get("history");
         const node = historyPlugin._unserializeNode(historyPlugin.serializeNode(el))[0];
         expect(getContent(node, { sortAttrs: true })).toBe(
-            `<div><p>a</p></div><div contenteditable="false" data-embedded="counter" data-oe-protected="true"></div><p data-selection-placeholder=""><br></p>`
+            `<p data-selection-placeholder=""><br></p><div><p>a</p></div><p data-selection-placeholder=""><br></p><div contenteditable="false" data-embedded="counter" data-oe-protected="true"></div><p data-selection-placeholder=""><br></p>`
         );
     });
 
@@ -972,7 +974,9 @@ describe("In-editor manipulations", () => {
         );
         const historyPlugin = plugins.get("history");
         const node = historyPlugin._unserializeNode(historyPlugin.serializeNode(el))[0];
-        expect(getContent(node)).toBe(`<div data-embedded="unknown"><p>UNKNOWN</p></div>`);
+        expect(getContent(node)).toBe(
+            `<p data-selection-placeholder=""><br></p><div data-embedded="unknown"><p>UNKNOWN</p></div><p data-selection-placeholder=""><br></p>`
+        );
     });
 
     test("Don't remove empty inline-block data-embedded elements during initElementForEdition, but wrap them in div instead", async () => {
@@ -981,7 +985,7 @@ describe("In-editor manipulations", () => {
             { config: getConfig([embedding("counter", Counter)]) }
         );
         expect(getContent(el, { sortAttrs: true })).toBe(
-            `<div><div contenteditable="false" data-embedded="counter" data-oe-protected="true" style="display:inline-block;"><span class="counter">Counter:0</span></div></div>`
+            `<p data-selection-placeholder=""><br></p><div><div contenteditable="false" data-embedded="counter" data-oe-protected="true" style="display:inline-block;"><span class="counter">Counter:0</span></div></div><p data-selection-placeholder=""><br></p>`
         );
     });
 });

--- a/addons/html_editor/static/tests/embedded_components.test.js
+++ b/addons/html_editor/static/tests/embedded_components.test.js
@@ -385,16 +385,19 @@ describe("Mount and Destroy embedded components", () => {
         expect.verifySteps(["mount 1", "mount 2", "mount 3"]);
         expect(getContent(el)).toBe(
             unformat(`
+                <p data-selection-placeholder=""><br></p>
                 <div data-embedded="recursiveComponent" data-oe-protected="true" contenteditable="false">
                     <div>
                         <div class="click count-2">Count:2</div>
                         <div class="innerEditable-2">
                             <div data-prop-name="innerValue" data-oe-protected="false" contenteditable="true">
+                                <p data-selection-placeholder=""><br></p>
                                 <div data-embedded="recursiveComponent" data-oe-protected="true" contenteditable="false">
                                     <div>
                                         <div class="click count-1">Count:1</div>
                                         <div class="innerEditable-1">
                                             <div data-prop-name="innerValue" data-oe-protected="false" contenteditable="true">
+                                                <p data-selection-placeholder=""><br></p>
                                                 <div data-embedded="recursiveComponent" data-oe-protected="true" contenteditable="false">
                                                     <div>
                                                         <div class="click count-3">Count:3</div>
@@ -405,10 +408,12 @@ describe("Mount and Destroy embedded components", () => {
                                                         </div>
                                                     </div>
                                                 </div>
+                                                <p data-selection-placeholder=""><br></p>
                                             </div>
                                         </div>
                                     </div>
                                 </div>
+                                <p data-selection-placeholder=""><br></p>
                             </div>
                         </div>
                     </div>
@@ -438,6 +443,7 @@ describe("Mount and Destroy embedded components", () => {
         // outermost host.
         expect(getContent(el)).toBe(
             unformat(`
+                <p data-selection-placeholder=""><br></p>
                 <div data-embedded="recursiveComponent" data-oe-protected="true" contenteditable="false"></div>
                 <p class="target o-we-hint" o-we-hint-text='Type "/" for commands'>[]<br></p>
             `)
@@ -579,6 +585,7 @@ describe("Selection after embedded component insertion", () => {
         cleanHints(editor);
         expect(getContent(el)).toBe(
             unformat(`
+                <p data-selection-placeholder=""><br></p>
                 <div data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></div>
                 <p>[]<br></p>`)
         );
@@ -608,6 +615,7 @@ describe("Selection after embedded component insertion", () => {
         cleanHints(editor);
         expect(getContent(el)).toBe(
             unformat(`
+                <p data-selection-placeholder=""><br></p>
                 <div data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></div>
                 <p>[]a</p>`)
         );
@@ -930,7 +938,7 @@ describe("In-editor manipulations", () => {
         );
         cleanHints(editor);
         expect(getContent(el)).toBe(
-            `<div><p>a</p></div><div data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></div>`
+            `<div><p>a</p></div><div data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></div><p data-selection-placeholder=""><br></p>`
         );
     });
 
@@ -944,7 +952,7 @@ describe("In-editor manipulations", () => {
         const historyPlugin = plugins.get("history");
         const node = historyPlugin._unserializeNode(historyPlugin.serializeNode(el))[0];
         expect(getContent(node, { sortAttrs: true })).toBe(
-            `<div><p>a</p></div><div contenteditable="false" data-embedded="counter" data-oe-protected="true"></div>`
+            `<div><p>a</p></div><div contenteditable="false" data-embedded="counter" data-oe-protected="true"></div><p data-selection-placeholder=""><br></p>`
         );
     });
 
@@ -1001,6 +1009,7 @@ describe("editable descendants", () => {
         );
         expect(getContent(el)).toBe(
             unformat(`
+                <p data-selection-placeholder=""><br></p>
                 <div data-embedded="wrapper" data-oe-protected="true" contenteditable="false">
                     <div class="shallow">
                         <div data-embedded-editable="shallow" data-oe-protected="false" contenteditable="true">
@@ -1015,6 +1024,7 @@ describe("editable descendants", () => {
                         </div>
                     </div>
                 </div>
+                <p data-selection-placeholder=""><br></p>
             `)
         );
     });
@@ -1048,9 +1058,11 @@ describe("editable descendants", () => {
         await animationFrame();
         expect(getContent(el)).toBe(
             unformat(`
+                <p data-selection-placeholder=""><br></p>
                 <div data-embedded="wrapper" data-oe-protected="true" contenteditable="false">
                     <div class="deep">
                         <div data-embedded-editable="deep" data-oe-protected="false" contenteditable="true">
+                            <p data-selection-placeholder=""><br></p>
                             <div data-embedded="wrapper" data-oe-protected="true" contenteditable="false">
                                 <div class="deep">
                                     <div data-embedded-editable="deep" data-oe-protected="false" contenteditable="true">
@@ -1058,6 +1070,7 @@ describe("editable descendants", () => {
                                     </div>
                                 </div>
                             </div>
+                            <p data-selection-placeholder=""><br></p>
                         </div>
                     </div>
                 </div>
@@ -1105,6 +1118,7 @@ describe("editable descendants", () => {
         expect.verifySteps(["patched"]);
         expect(getContent(el)).toBe(
             unformat(`
+                <p data-selection-placeholder=""><br></p>
                 <div data-embedded="wrapper" data-oe-protected="true" contenteditable="false">
                     <div class="shallow">
                         <div data-embedded-editable="shallow" data-oe-protected="false" contenteditable="true">
@@ -1121,6 +1135,7 @@ describe("editable descendants", () => {
                         </div>
                     </div>
                 </div>
+                <p data-selection-placeholder=""><br></p>
             `)
         );
         // No mutation should be added to the next step
@@ -1191,6 +1206,7 @@ describe("editable descendants", () => {
         const node = historyPlugin._unserializeNode(historyPlugin.serializeNode(el))[0];
         expect(getContent(node, { sortAttrs: true })).toBe(
             unformat(`
+                <p data-selection-placeholder=""><br></p>
                 <div contenteditable="false" data-embedded="wrapper" data-oe-protected="true">
                     <div contenteditable="true" data-embedded-editable="shallow" data-oe-protected="false">
                         <p>shallow</p>
@@ -1199,6 +1215,7 @@ describe("editable descendants", () => {
                         <p>deep</p>
                     </div>
                 </div>
+                <p data-selection-placeholder=""><br></p>
             `)
         );
     });
@@ -1233,9 +1250,11 @@ describe("editable descendants", () => {
         );
         expect(getContent(el)).toBe(
             unformat(`
+                <p data-selection-placeholder=""><br></p>
                 <div data-embedded="wrapper" data-oe-protected="true" contenteditable="false">
                     <div class="shallow">
                         <div data-embedded-editable="shallow" data-oe-protected="false" contenteditable="true">
+                            <p data-selection-placeholder=""><br></p>
                             <div data-embedded="simpleWrapper" data-oe-protected="true" contenteditable="false">
                                 <div class="deep">
                                     <div data-embedded-editable="deep" data-oe-protected="false" contenteditable="true">
@@ -1243,6 +1262,7 @@ describe("editable descendants", () => {
                                     </div>
                                 </div>
                             </div>
+                            <p data-selection-placeholder=""><br></p>
                         </div>
                     </div>
                     <div>
@@ -1253,6 +1273,7 @@ describe("editable descendants", () => {
                         </div>
                     </div>
                 </div>
+                <p data-selection-placeholder=""><br></p>
             `)
         );
         const wrapper = el.querySelector(`[data-embedded="wrapper"]`);

--- a/addons/html_editor/static/tests/font_awesome.test.js
+++ b/addons/html_editor/static/tests/font_awesome.test.js
@@ -161,7 +161,9 @@ describe("parse/render", () => {
         await testEditor({
             contentBefore: '<div><i class="fa fa-pastafarianism"></i><div><p>abc</p></div></div>',
             contentBeforeEdit:
-                '<div><i class="fa fa-pastafarianism" contenteditable="false">\u200b</i><div><p>abc</p></div></div>',
+                '<p data-selection-placeholder=""><br></p>' +
+                '<div><i class="fa fa-pastafarianism" contenteditable="false">\u200b</i><div><p>abc</p></div></div>' +
+                '<p data-selection-placeholder=""><br></p>',
             contentAfter: '<div><i class="fa fa-pastafarianism"></i><div><p>abc</p></div></div>',
         });
     });

--- a/addons/html_editor/static/tests/format/bold.test.js
+++ b/addons/html_editor/static/tests/format/bold.test.js
@@ -69,7 +69,9 @@ test("should make qweb tag bold and create a step even with partial selection in
     );
     bold(editor);
     expect(getContent(el)).toBe(
-        `<div>[<p t-esc="'Test'" contenteditable="false" style="font-weight: bolder;">Test</p>]</div>`
+        '<p data-selection-placeholder=""><br></p>' +
+            `<div>[<p t-esc="'Test'" contenteditable="false" style="font-weight: bolder;">Test</p>]</div>` +
+            '<p data-selection-placeholder=""><br></p>'
     );
     expect(queryOne(`p[contenteditable="false"]`).childNodes.length).toBe(1);
     const historySteps = editor.shared.history.getHistorySteps();

--- a/addons/html_editor/static/tests/format/bold.test.js
+++ b/addons/html_editor/static/tests/format/bold.test.js
@@ -213,6 +213,7 @@ test("should make a few characters bold inside table (bold)", async () => {
             </table>`),
         stepFunction: bold,
         contentAfterEdit: unformat(`
+            <p data-selection-placeholder=""><br></p>
             <table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr>
@@ -231,7 +232,8 @@ test("should make a few characters bold inside table (bold)", async () => {
                         <td><p><br></p></td>
                     </tr>
             </tbody>
-            </table>`),
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`),
     });
 });
 

--- a/addons/html_editor/static/tests/format/italic.test.js
+++ b/addons/html_editor/static/tests/format/italic.test.js
@@ -213,6 +213,7 @@ test("should make a few characters italic inside table (italic)", async () => {
             </table>`),
         stepFunction: italic,
         contentAfterEdit: unformat(`
+            <p data-selection-placeholder=""><br></p>
             <table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr>
@@ -231,7 +232,8 @@ test("should make a few characters italic inside table (italic)", async () => {
                         <td><p><br></p></td>
                     </tr>
                 </tbody>
-            </table>`),
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`),
     });
 });
 

--- a/addons/html_editor/static/tests/format/remove_format.test.js
+++ b/addons/html_editor/static/tests/format/remove_format.test.js
@@ -973,7 +973,7 @@ describe("Toolbar", () => {
         );
         await removeFormatClick();
         expect(getContent(el)).toBe(
-            `<table class="table table-bordered o_table o_selected_table"><tbody><tr><td class="o_selected_td"><p>[abc</p></td><td class="o_selected_td"><p>\u200b</p></td></tr></tbody></table><p>]\u200b</p>`
+            `<p data-selection-placeholder=""><br></p><table class="table table-bordered o_table o_selected_table"><tbody><tr><td class="o_selected_td"><p>[abc</p></td><td class="o_selected_td"><p>\u200b</p></td></tr></tbody></table><p>]\u200b</p>`
         );
     });
 
@@ -983,7 +983,7 @@ describe("Toolbar", () => {
         );
         await removeFormatClick();
         expect(getContent(el)).toBe(
-            `<table class="table table-bordered o_table o_selected_table"><tbody><tr><td style="" class="o_selected_td"><p>[\u200b</p></td><td style="" class="o_selected_td"><p>]\u200b</p></td></tr></tbody></table>`
+            `<p data-selection-placeholder=""><br></p><table class="table table-bordered o_table o_selected_table"><tbody><tr><td style="" class="o_selected_td"><p>[\u200b</p></td><td style="" class="o_selected_td"><p>]\u200b</p></td></tr></tbody></table><p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         );
     });
 
@@ -1007,6 +1007,7 @@ describe("Toolbar", () => {
         await removeFormatClick();
         expect(getContent(el)).toBe(
             unformat(`
+                <p data-selection-placeholder=""><br></p>
                 <table class="table table-bordered o_table o_selected_table">
                     <tbody>
                         <tr style="height: 100px;">
@@ -1019,6 +1020,7 @@ describe("Toolbar", () => {
                         </tr>
                     </tbody>
                 </table>
+                <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
             `)
         );
     });

--- a/addons/html_editor/static/tests/format/strike_through.test.js
+++ b/addons/html_editor/static/tests/format/strike_through.test.js
@@ -231,6 +231,7 @@ test("should make a few characters strikeThrough inside table (strikeThrough)", 
             </table>`),
         stepFunction: strikeThrough,
         contentAfterEdit: unformat(`
+            <p data-selection-placeholder=""><br></p>
             <table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr>
@@ -249,7 +250,8 @@ test("should make a few characters strikeThrough inside table (strikeThrough)", 
                         <td><p><br></p></td>
                     </tr>
                 </tbody>
-            </table>`),
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`),
     });
 });
 

--- a/addons/html_editor/static/tests/format/underline.test.js
+++ b/addons/html_editor/static/tests/format/underline.test.js
@@ -199,6 +199,7 @@ test("should make a few characters underline inside table (underline)", async ()
             </table>`),
         stepFunction: underline,
         contentAfterEdit: unformat(`
+            <p data-selection-placeholder=""><br></p>
             <table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr>
@@ -217,7 +218,8 @@ test("should make a few characters underline inside table (underline)", async ()
                         <td><p><br></p></td>
                     </tr>
                 </tbody>
-            </table>`),
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`),
     });
 });
 

--- a/addons/html_editor/static/tests/hint.test.js
+++ b/addons/html_editor/static/tests/hint.test.js
@@ -76,7 +76,11 @@ test("should not display hint in a non-editable paragraph", async () => {
     const content = '<div contenteditable="false"><p>[]</p></div>';
     const { el } = await setupEditor(content);
     // Unchanged, no empty paragraph hint.
-    expect(getContent(el)).toBe(content);
+    expect(getContent(el)).toBe(
+        '<p data-selection-placeholder=""><br></p>' +
+            content +
+            '<p data-selection-placeholder=""><br></p>'
+    );
 });
 
 test("should not lose track of temporary hints on split block", async () => {

--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -2574,7 +2574,7 @@ describe("codeview enabled", () => {
     });
 });
 
-test("should never insert Table of Contents as the first child of the editable", async () => {
+test("should always have a block before a Table of Contents", async () => {
     Partner._records = [
         {
             id: 1,
@@ -2598,5 +2598,7 @@ test("should never insert Table of Contents as the first child of the editable",
     await animationFrame();
     const firstChild = htmlEditor.editable.firstChild;
     expect(firstChild.getAttribute("data-embedded")).not.toBe("tableOfContent");
-    expect(firstChild).toHaveOuterHTML('<div class="o-paragraph"><br></div>');
+    expect(firstChild).toHaveOuterHTML(
+        '<div class="o-paragraph" data-selection-placeholder="" style="margin: 8px 0px -9px;"><br></div>'
+    );
 });

--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -469,7 +469,8 @@ test("edit and save a html field containing JSON as some attribute values should
     pasteOdooEditorHtml(htmlEditor, `<div data-value=${value}><p>content</p></div>`);
     const txtField = queryOne('.o_field_html[name="txt"] .odoo-editor-editable');
     expect(txtField).toHaveInnerHTML(
-        `<div data-value="{&quot;myString&quot;:&quot;myString&quot;}"><p>content</p></div><p>first</p>`
+        '<div class="o-paragraph" data-selection-placeholder=""><br></div>' +
+            `<div data-value="{&quot;myString&quot;:&quot;myString&quot;}"><p>content</p></div><p>first</p>`
     );
     expect.verifySteps(["Setup Wysiwyg"]);
 
@@ -930,7 +931,7 @@ test("Embed video by pasting video URL", async () => {
     await animationFrame();
     const videoIframe = queryOne("div.media_iframe_video");
     expect(videoIframe.nextElementSibling).toHaveOuterHTML(
-        `<p o-we-hint-text='Type "/" for commands' class="o-we-hint"><br></p>`
+        '<div class="o-paragraph" data-selection-placeholder=""><br></div>'
     );
     expect(
         `div.media_iframe_video iframe[data-src="https://www.youtube.com/embed/${videoId}"]`

--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -640,10 +640,18 @@ test("edit a html field with `o-contenteditable-true` or `o-contenteditable-fals
             </form>`,
     });
     expect.verifySteps(["setup_wysiwyg"]);
-    expect(`[name="txt"] .odoo-editor-editable`).toHaveInnerHTML(getTxtValue("inside", true));
+    expect(`[name="txt"] .odoo-editor-editable`).toHaveInnerHTML(
+        '<div class="o-paragraph" data-selection-placeholder=""><br></div>' +
+            getTxtValue("inside", true) +
+            '<div class="o-paragraph" data-selection-placeholder=""><br></div>'
+    );
     setSelectionInHtmlField();
     pasteOdooEditorHtml(htmlEditor, "addon");
-    expect(`[name="txt"] .odoo-editor-editable`).toHaveInnerHTML(getTxtValue("addoninside", true));
+    expect(`[name="txt"] .odoo-editor-editable`).toHaveInnerHTML(
+        '<div class="o-paragraph" data-selection-placeholder=""><br></div>' +
+            getTxtValue("addoninside", true) +
+            '<div class="o-paragraph" data-selection-placeholder=""><br></div>'
+    );
     await clickSave();
     expect.verifySteps(["update_value", "web_save"]);
 });

--- a/addons/html_editor/static/tests/html_migrations.test.js
+++ b/addons/html_editor/static/tests/html_migrations.test.js
@@ -81,7 +81,8 @@ describe("test the migration process", () => {
                     <div class="w-100 px-3 o_editor_banner_content o-contenteditable-true" contenteditable="true">
                         <p>content</p>
                     </div>
-                </div>`
+                </div>
+                <div class="o-paragraph" data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></div>`
             );
             expect(htmlFieldComponent.editor.getContent()).toBe(
                 `<p data-oe-version="${CURRENT_VERSION}">test</p>

--- a/addons/html_editor/static/tests/icon.test.js
+++ b/addons/html_editor/static/tests/icon.test.js
@@ -422,7 +422,9 @@ describe("selection", () => {
         setSelection({ anchorNode: icon, anchorOffset: 0 });
         await tick();
         expect(getContent(el)).toBe(
-            `<p contenteditable="false">abc[<span class="fa fa-glass" contenteditable="false">\u200b</span>]def</p>`
+            '<p data-selection-placeholder=""><br></p>' +
+                '<p contenteditable="false">abc[<span class="fa fa-glass" contenteditable="false">\u200b</span>]def</p>' +
+                '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>'
         );
     });
 });

--- a/addons/html_editor/static/tests/insert/html.test.js
+++ b/addons/html_editor/static/tests/insert/html.test.js
@@ -72,11 +72,13 @@ describe("collapsed selection", () => {
         });
     });
 
-    test("should keep a paragraph after a div block", async () => {
+    test("should wrap a div block in selection placeholders", async () => {
         await testEditor({
             contentBefore: "<p>[]<br></p>",
             stepFunction: insertHTML("<div><p>content</p></div>"),
-            contentAfter: "<div><p>content</p></div><p>[]<br></p>",
+            contentAfterEdit:
+                '<p data-selection-placeholder=""><br></p><div><p>content[]</p></div><p data-selection-placeholder=""><br></p>',
+            contentAfter: "<div><p>content[]</p></div>",
         });
     });
 
@@ -160,8 +162,9 @@ describe("collapsed selection", () => {
         // https://developer.mozilla.org/en-US/docs/Web/HTML/Content_categories#phrasing_content
         const { editor } = await setupEditor(`<p class="oe_unbreakable">cont[]ent</p>`, {});
         insertHTML("<table><tbody><tr><td/></tr></tbody></table>")(editor);
+        await tick();
         expect(getContent(editor.editable)).toBe(
-            `<p class="oe_unbreakable">content[]</p><table><tbody><tr><td></td></tr></tbody></table><p data-selection-placeholder=""><br></p>`
+            `<p data-selection-placeholder=""><br></p><p class="oe_unbreakable">content</p><p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p><table><tbody><tr><td></td></tr></tbody></table><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`
         );
     });
 
@@ -177,7 +180,9 @@ describe("collapsed selection", () => {
 
         insertHTML("<table><tbody><tr><td/></tr></tbody></table>")(editor);
         expect(getContent(editor.editable)).toBe(
-            `<div><p class="oe_unbreakable" contenteditable="true"><b class="oe_unbreakable">content[]</b><table><tbody><tr><td></td></tr></tbody></table></p></div>`
+            '<p data-selection-placeholder=""><br></p>' +
+                `<div><p class="oe_unbreakable" contenteditable="true"><b class="oe_unbreakable">content[]</b><table><tbody><tr><td></td></tr></tbody></table></p></div>` +
+                '<p data-selection-placeholder=""><br></p>'
         );
     });
 
@@ -185,7 +190,8 @@ describe("collapsed selection", () => {
         const { editor } = await setupEditor(`<p>cont[]</p>`, {});
         insertHTML(`<p class="oe_unbreakable">1</p>`)(editor);
         expect(getContent(editor.editable)).toBe(
-            `<p>cont</p><p class="oe_unbreakable">1[]</p><p><br></p>`
+            `<p>cont</p><p class="oe_unbreakable">1[]</p>` +
+                '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>'
         );
     });
 
@@ -205,8 +211,12 @@ describe("collapsed selection", () => {
                 `<p class="oe_unbreakable">1</p><p class="oe_unbreakable">2</p>`
             )
         );
+        editor.shared.history.addStep();
         expect(getContent(editor.editable)).toBe(
-            `<p>cont</p><p class="oe_unbreakable">1</p><p class="oe_unbreakable">2[]</p><p><br></p>`
+            `<p>cont</p><p class="oe_unbreakable">1</p>` +
+                `<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>` +
+                `<p class="oe_unbreakable">2[]</p>` +
+                `<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         );
     });
 
@@ -259,7 +269,7 @@ describe("collapsed selection", () => {
         editor.shared.history.addStep();
         cleanHints(editor);
         expect(getContent(editor.editable, { sortAttrs: true })).toBe(
-            `<p data-selection-placeholder=""><br></p><p contenteditable="false" data-oe-protected="true">in</p><p>[]<br></p>`
+            `<p data-selection-placeholder=""><br></p><p contenteditable="false" data-oe-protected="true">in[]</p><p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         );
     });
 
@@ -291,20 +301,28 @@ describe("collapsed selection", () => {
         const { el, editor } = await setupEditor(`<p>[]<br></p>`);
         insertHTML(`<div class="oe_unbreakable">a</div>`)(editor);
         cleanHints(editor);
-        expect(getContent(el)).toBe(`<div class="oe_unbreakable">a</div><p>[]<br></p>`);
+        expect(getContent(el)).toBe(
+            '<p data-selection-placeholder=""><br></p>' +
+                '<div class="oe_unbreakable">a[]</div>' +
+                '<p data-selection-placeholder=""><br></p>'
+        );
     });
 
     test("insert block at the end of a paragraph", async () => {
         const { el, editor } = await setupEditor(`<p>b[]</p>`);
         insertHTML(`<div class="oe_unbreakable">a</div>`)(editor);
         cleanHints(editor);
-        expect(getContent(el)).toBe(`<p>b</p><div class="oe_unbreakable">a</div><p>[]<br></p>`);
+        expect(getContent(el)).toBe(
+            `<p>b</p><div class="oe_unbreakable">a[]</div><p data-selection-placeholder=""><br></p>`
+        );
     });
 
     test("insert block at the start of a paragraph", async () => {
         const { el, editor } = await setupEditor(`<p>[]b</p>`);
         insertHTML(`<div class="oe_unbreakable">a</div>`)(editor);
-        expect(getContent(el)).toBe(`<div class="oe_unbreakable">a</div><p>[]b</p>`);
+        expect(getContent(el)).toBe(
+            `<p data-selection-placeholder=""><br></p><div class="oe_unbreakable">a</div><p>[]b</p>`
+        );
     });
 
     test("insert block at the middle of a paragraph", async () => {

--- a/addons/html_editor/static/tests/insert/html.test.js
+++ b/addons/html_editor/static/tests/insert/html.test.js
@@ -161,7 +161,7 @@ describe("collapsed selection", () => {
         const { editor } = await setupEditor(`<p class="oe_unbreakable">cont[]ent</p>`, {});
         insertHTML("<table><tbody><tr><td/></tr></tbody></table>")(editor);
         expect(getContent(editor.editable)).toBe(
-            `<p class="oe_unbreakable">content[]</p><table><tbody><tr><td></td></tr></tbody></table>`
+            `<p class="oe_unbreakable">content[]</p><table><tbody><tr><td></td></tr></tbody></table><p data-selection-placeholder=""><br></p>`
         );
     });
 
@@ -259,7 +259,7 @@ describe("collapsed selection", () => {
         editor.shared.history.addStep();
         cleanHints(editor);
         expect(getContent(editor.editable, { sortAttrs: true })).toBe(
-            `<p contenteditable="false" data-oe-protected="true">in</p><p>[]<br></p>`
+            `<p data-selection-placeholder=""><br></p><p contenteditable="false" data-oe-protected="true">in</p><p>[]<br></p>`
         );
     });
 

--- a/addons/html_editor/static/tests/insert/paragraph_break.test.js
+++ b/addons/html_editor/static/tests/insert/paragraph_break.test.js
@@ -137,6 +137,7 @@ describe("Selection collapsed", () => {
                 // highlighted and the focus is in the textarea.
                 await animationFrame();
             };
+
             beforeEach(patchPrism);
 
             test("should insert a line break within the pre", async () => {
@@ -146,7 +147,7 @@ describe("Selection collapsed", () => {
                     contentBeforeEdit:
                         '<p data-selection-placeholder=""><br></p>' +
                         highlightedPre({ value: "abcd" }) +
-                        '<p data-selection-placeholder=""><br></p>',
+                        '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
                     stepFunction: testEnterInCodeBlock(2), // "ab[]cd"
                     contentAfterEdit:
                         '<p data-selection-placeholder=""><br></p>' +
@@ -154,7 +155,7 @@ describe("Selection collapsed", () => {
                             value: "ab\ncd",
                             textareaRange: 3, // "ab\n[]cd"
                         }) +
-                        '<p data-selection-placeholder=""><br></p>',
+                        '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
                     contentAfter: `<pre data-language-id="plaintext">ab<br>cd</pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -166,7 +167,7 @@ describe("Selection collapsed", () => {
                     contentBeforeEdit:
                         '<p data-selection-placeholder=""><br></p>' +
                         highlightedPre({ value: "abc" }) +
-                        '<p data-selection-placeholder=""><br></p>',
+                        '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
                     stepFunction: testEnterInCodeBlock(3), // "abc[]"
                     contentAfterEdit:
                         '<p data-selection-placeholder=""><br></p>' +
@@ -175,7 +176,7 @@ describe("Selection collapsed", () => {
                             preHtml: "abc<br><br>",
                             textareaRange: 4, // "abc\n[]"
                         }) +
-                        '<p data-selection-placeholder=""><br></p>',
+                        '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
                     contentAfter: `<pre data-language-id="plaintext">abc<br><br></pre>[]`,
                     config: configWithEmbeddings,
                 });

--- a/addons/html_editor/static/tests/insert/paragraph_break.test.js
+++ b/addons/html_editor/static/tests/insert/paragraph_break.test.js
@@ -143,12 +143,18 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     compareFunction: compareHighlightedContent,
                     contentBefore: "<pre>abcd</pre>",
-                    contentBeforeEdit: highlightedPre({ value: "abcd" }),
+                    contentBeforeEdit:
+                        '<p data-selection-placeholder=""><br></p>' +
+                        highlightedPre({ value: "abcd" }) +
+                        '<p data-selection-placeholder=""><br></p>',
                     stepFunction: testEnterInCodeBlock(2), // "ab[]cd"
-                    contentAfterEdit: highlightedPre({
-                        value: "ab\ncd",
-                        textareaRange: 3, // "ab\n[]cd"
-                    }),
+                    contentAfterEdit:
+                        '<p data-selection-placeholder=""><br></p>' +
+                        highlightedPre({
+                            value: "ab\ncd",
+                            textareaRange: 3, // "ab\n[]cd"
+                        }) +
+                        '<p data-selection-placeholder=""><br></p>',
                     contentAfter: `<pre data-language-id="plaintext">ab<br>cd</pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -157,13 +163,19 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     compareFunction: compareHighlightedContent,
                     contentBefore: "<pre>abc</pre>",
-                    contentBeforeEdit: highlightedPre({ value: "abc" }),
+                    contentBeforeEdit:
+                        '<p data-selection-placeholder=""><br></p>' +
+                        highlightedPre({ value: "abc" }) +
+                        '<p data-selection-placeholder=""><br></p>',
                     stepFunction: testEnterInCodeBlock(3), // "abc[]"
-                    contentAfterEdit: highlightedPre({
-                        value: "abc\n",
-                        preHtml: "abc<br><br>",
-                        textareaRange: 4, // "abc\n[]"
-                    }),
+                    contentAfterEdit:
+                        '<p data-selection-placeholder=""><br></p>' +
+                        highlightedPre({
+                            value: "abc\n",
+                            preHtml: "abc<br><br>",
+                            textareaRange: 4, // "abc\n[]"
+                        }) +
+                        '<p data-selection-placeholder=""><br></p>',
                     contentAfter: `<pre data-language-id="plaintext">abc<br><br></pre>[]`,
                     config: configWithEmbeddings,
                 });

--- a/addons/html_editor/static/tests/insert/separator.test.js
+++ b/addons/html_editor/static/tests/insert/separator.test.js
@@ -111,7 +111,7 @@ describe("insert separator", () => {
         el.append(div);
         editor.shared.history.addStep();
         expect(getContent(el)).toBe(
-            `<p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p><div><hr contenteditable="false"></div>`
+            `<p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p><div><hr contenteditable="false"></div><p data-selection-placeholder=""><br></p>`
         );
     });
 

--- a/addons/html_editor/static/tests/insert/separator.test.js
+++ b/addons/html_editor/static/tests/insert/separator.test.js
@@ -14,7 +14,7 @@ describe("insert separator", () => {
         await testEditor({
             contentBefore: "<p>[]<br></p>",
             stepFunction: insertSeparator,
-            contentAfterEdit: `<hr contenteditable="false"><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`,
+            contentAfterEdit: `<p data-selection-placeholder="" style="margin: 8px 0px -9px;"><br></p><hr contenteditable="false"><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`,
             contentAfter: "<hr><p>[]<br></p>",
         });
     });
@@ -23,7 +23,7 @@ describe("insert separator", () => {
         await testEditor({
             contentBefore: "<p>[]abc<br></p>",
             stepFunction: insertSeparator,
-            contentAfterEdit: `<hr contenteditable="false"><p>[]abc<br></p>`,
+            contentAfterEdit: `<p data-selection-placeholder="" style="margin: 8px 0px -9px;"><br></p><hr contenteditable="false"><p>[]abc<br></p>`,
             contentAfter: "<hr><p>[]abc<br></p>",
         });
     });

--- a/addons/html_editor/static/tests/list/automatic_list_detection.test.js
+++ b/addons/html_editor/static/tests/list/automatic_list_detection.test.js
@@ -95,6 +95,7 @@ test("creating list directly inside table column (td)", async () => {
     await insertText(editor, "A. ");
     expect(getContent(el)).toBe(
         unformat(`
+            <p data-selection-placeholder=""><br></p>
             <table class="table table-bordered o_table">
                 <tbody>
                     <tr>

--- a/addons/html_editor/static/tests/list/automatic_list_detection.test.js
+++ b/addons/html_editor/static/tests/list/automatic_list_detection.test.js
@@ -115,7 +115,7 @@ test("creating list directly inside table column (td)", async () => {
                     </tr>
                 </tbody>
             </table>
-            <p><br></p>`)
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`)
     );
 });
 

--- a/addons/html_editor/static/tests/list/toggle_cl.test.js
+++ b/addons/html_editor/static/tests/list/toggle_cl.test.js
@@ -201,6 +201,7 @@ describe("Range collapsed", () => {
                 `),
                 stepFunction: toggleCheckList,
                 contentAfterEdit: unformat(`
+                    <p data-selection-placeholder=""><br></p>
                     <table class="table table-bordered o_selected_table">
                         <tbody>
                             <tr>
@@ -215,6 +216,7 @@ describe("Range collapsed", () => {
                             </tr>
                         </tbody>
                     </table>
+                    <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
                 `),
                 contentAfter: unformat(`
                     <table class="table table-bordered">
@@ -366,6 +368,7 @@ describe("Range collapsed", () => {
                 `),
                 stepFunction: toggleCheckList,
                 contentAfterEdit: unformat(`
+                    <p data-selection-placeholder=""><br></p>
                     <table class="table table-bordered o_selected_table">
                         <tbody>
                             <tr>
@@ -380,6 +383,7 @@ describe("Range collapsed", () => {
                             </tr>
                         </tbody>
                     </table>
+                    <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
                 `),
                 contentAfter: unformat(`
                     <table class="table table-bordered">

--- a/addons/html_editor/static/tests/list/toggle_ol.test.js
+++ b/addons/html_editor/static/tests/list/toggle_ol.test.js
@@ -93,6 +93,7 @@ describe("Range collapsed", () => {
                 `),
                 stepFunction: toggleOrderedList,
                 contentAfterEdit: unformat(`
+                    <p data-selection-placeholder=""><br></p>
                     <table class="table table-bordered o_selected_table">
                         <tbody>
                             <tr>
@@ -107,6 +108,7 @@ describe("Range collapsed", () => {
                             </tr>
                         </tbody>
                     </table>
+                    <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
                 `),
                 contentAfter: unformat(`
                     <table class="table table-bordered">
@@ -224,6 +226,7 @@ describe("Range collapsed", () => {
                 `),
                 stepFunction: toggleOrderedList,
                 contentAfterEdit: unformat(`
+                    <p data-selection-placeholder=""><br></p>
                     <table class="table table-bordered o_selected_table">
                         <tbody>
                             <tr>
@@ -238,6 +241,7 @@ describe("Range collapsed", () => {
                             </tr>
                         </tbody>
                     </table>
+                    <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
                 `),
                 contentAfter: unformat(`
                     <table class="table table-bordered">

--- a/addons/html_editor/static/tests/list/toggle_ul.test.js
+++ b/addons/html_editor/static/tests/list/toggle_ul.test.js
@@ -101,6 +101,7 @@ describe("Range collapsed", () => {
                 `),
                 stepFunction: toggleUnorderedList,
                 contentAfterEdit: unformat(`
+                    <p data-selection-placeholder=""><br></p>
                     <table class="table table-bordered o_selected_table">
                         <tbody>
                             <tr>
@@ -115,6 +116,7 @@ describe("Range collapsed", () => {
                             </tr>
                         </tbody>
                     </table>
+                    <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
                 `),
                 contentAfter: unformat(`
                     <table class="table table-bordered">
@@ -265,6 +267,7 @@ describe("Range collapsed", () => {
                 `),
                 stepFunction: toggleUnorderedList,
                 contentAfterEdit: unformat(`
+                    <p data-selection-placeholder=""><br></p>
                     <table class="table table-bordered o_selected_table">
                         <tbody>
                             <tr>
@@ -279,6 +282,7 @@ describe("Range collapsed", () => {
                             </tr>
                         </tbody>
                     </table>
+                    <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
                 `),
                 contentAfter: unformat(`
                     <table class="table table-bordered">

--- a/addons/html_editor/static/tests/media.test.js
+++ b/addons/html_editor/static/tests/media.test.js
@@ -177,7 +177,7 @@ describe("(non-)editable media", () => {
             await animationFrame();
             await expectElementCount(".o-we-toolbar", 0);
             expect(getContent(editor.editable)).toBe(
-                `<div contenteditable="false">[<img src="${base64Img}">]</div>`
+                `<p data-selection-placeholder=""><br></p><div contenteditable="false">[<img src="${base64Img}">]</div><p data-selection-placeholder=""><br></p>`
             );
         });
         test("toolbar should open when clicking on an editable image in a non-editable context", async () => {
@@ -189,7 +189,9 @@ describe("(non-)editable media", () => {
             await expectElementCount(".o-we-toolbar", 1);
             // Now pressing the delete button should remove the image.
             await click(".o-we-toolbar button[name='image_delete']");
-            expect(getContent(editor.editable)).toBe(`<div contenteditable="false">[]<br></div>`);
+            expect(getContent(editor.editable)).toBe(
+                `<p data-selection-placeholder=""><br></p><div contenteditable="false">[]<br></div><p data-selection-placeholder=""><br></p>`
+            );
         });
     });
     describe("delete", () => {

--- a/addons/html_editor/static/tests/misc.test.js
+++ b/addons/html_editor/static/tests/misc.test.js
@@ -1,7 +1,7 @@
 import { Plugin } from "@html_editor/plugin";
 import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
 import { expect, test } from "@odoo/hoot";
-import { click, waitFor } from "@odoo/hoot-dom";
+import { click, tick, waitFor } from "@odoo/hoot-dom";
 import { setupEditor, testEditor } from "./_helpers/editor";
 import { getContent, setContent } from "./_helpers/selection";
 import { withSequence } from "@html_editor/utils/resource";
@@ -78,11 +78,21 @@ test("with an empty selector and a <br>", async () => {
 test("no arrow key press or mouse click should keep selection near a contenteditable='false'", async () => {
     await testEditor({
         contentBefore: '[]<hr contenteditable="false">',
+        contentAfterEdit:
+            `<p data-selection-placeholder="" style="margin: 8px 0px -9px;" o-we-hint-text='Type "/" for commands' class="o-we-hint o-horizontal-caret">[]<br></p>` +
+            '<hr contenteditable="false">' +
+            '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
         contentAfter: "[]<hr>",
     });
     await testEditor({
         contentBefore: '<hr contenteditable="false">[]',
-        contentAfter: "<hr>[]",
+        // Wait for selectionchange listener:
+        stepFunction: async () => await tick(),
+        contentAfterEdit:
+            '<p data-selection-placeholder="" style="margin: 8px 0px -9px;"><br></p>' +
+            '<hr contenteditable="false">' +
+            `<p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`,
+        contentAfter: "<hr><p>[]<br></p>",
     });
 });
 

--- a/addons/html_editor/static/tests/misc.test.js
+++ b/addons/html_editor/static/tests/misc.test.js
@@ -58,14 +58,30 @@ test("with an empty selector", async () => {
 
 test("with a part of the selector in an empty HTMLElement", async () => {
     const { el } = await setupEditor("<div>a[bc<div>]</div></div>", {});
-    expect(el.innerHTML).toBe(`<div>abc<div class="o-paragraph"><br></div></div>`);
-    expect(getContent(el)).toBe(`<div>a[bc<div class="o-paragraph">]<br></div></div>`);
+    expect(el.innerHTML).toBe(
+        '<p data-selection-placeholder=""><br></p>' +
+            `<div>abc<div class="o-paragraph"><br></div></div>` +
+            '<p data-selection-placeholder=""><br></p>'
+    );
+    expect(getContent(el)).toBe(
+        '<p data-selection-placeholder=""><br></p>' +
+            `<div>a[bc<div class="o-paragraph">]<br></div></div>` +
+            '<p data-selection-placeholder=""><br></p>'
+    );
 });
 
 test("inverse selection", async () => {
     const { el } = await setupEditor("<div>a]bc<div>[</div></div>", {});
-    expect(el.innerHTML).toBe(`<div>abc<div class="o-paragraph"><br></div></div>`);
-    expect(getContent(el)).toBe(`<div>a]bc<div class="o-paragraph">[<br></div></div>`);
+    expect(el.innerHTML).toBe(
+        '<p data-selection-placeholder=""><br></p>' +
+            `<div>abc<div class="o-paragraph"><br></div></div>` +
+            '<p data-selection-placeholder=""><br></p>'
+    );
+    expect(getContent(el)).toBe(
+        '<p data-selection-placeholder=""><br></p>' +
+            `<div>a]bc<div class="o-paragraph">[<br></div></div>` +
+            '<p data-selection-placeholder=""><br></p>'
+    );
 });
 
 test("with an empty selector and a <br>", async () => {

--- a/addons/html_editor/static/tests/mouse/click.test.js
+++ b/addons/html_editor/static/tests/mouse/click.test.js
@@ -4,6 +4,7 @@ import { animationFrame, pointerDown, pointerUp, waitForNone } from "@odoo/hoot-
 import { tick } from "@odoo/hoot-mock";
 import { setupEditor, testEditor } from "../_helpers/editor";
 import { getContent, setSelection } from "../_helpers/selection";
+import { unformat } from "../_helpers/format";
 
 /**
  * Simulates placing the cursor at the editable root after a mouse click.
@@ -22,82 +23,116 @@ async function simulateMouseClick(node, before = false) {
     });
     await tick();
     await pointerUp(node);
+    await tick();
 }
 
-test.skip("should insert a paragraph at end of editable and place cursor in it (hr)", async () => {
+test("should insert a paragraph at end of editable and place cursor in it (hr)", async () => {
     await testEditor({
         contentBefore: '<hr contenteditable="false">',
         stepFunction: async (editor) => {
             const hr = editor.editable.querySelector("hr");
             await simulateMouseClick(hr);
         },
+        contentAfterEdit: unformat(
+            `<p data-selection-placeholder="" style="margin: 8px 0px -9px;"><br></p>
+            <hr contenteditable="false">
+            <p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`
+        ),
         contentAfter: "<hr><p>[]<br></p>",
     });
 });
 
-test.skip("should insert a paragraph at end of editable and place cursor in it (table)", async () => {
+test("should insert a paragraph at end of editable and place cursor in it (table)", async () => {
     await testEditor({
         contentBefore: "<table></table>",
         stepFunction: async (editor) => {
             const table = editor.editable.querySelector("table");
             await simulateMouseClick(table);
         },
+        contentAfterEdit: unformat(
+            `<p data-selection-placeholder=""><br></p>
+            <table></table>
+            <p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`
+        ),
         contentAfter: "<table></table><p>[]<br></p>",
     });
 });
 
-test.skip("should insert a paragraph at beginning of editable and place cursor in it (1)", async () => {
+test("should insert a paragraph at beginning of editable and place cursor in it (1)", async () => {
     await testEditor({
         contentBefore: '<hr contenteditable="false">',
         stepFunction: async (editor) => {
             const hr = editor.editable.querySelector("hr");
             await simulateMouseClick(hr, true);
         },
-        contentAfter: "<p>[]<br></p><hr>",
+        contentAfterEdit: unformat(`
+            <p data-selection-placeholder="" style="margin: 8px 0px -9px;" o-we-hint-text='Type "/" for commands' class="o-we-hint o-horizontal-caret">[]<br></p>
+            <hr contenteditable="false">
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`),
+        contentAfter: "[]<hr>",
     });
 });
-test.skip("should insert a paragraph at beginning of editable and place cursor in it (2)", async () => {
+test("should insert a paragraph at beginning of editable and place cursor in it (2)", async () => {
     await testEditor({
         contentBefore: "<table></table>",
         stepFunction: async (editor) => {
             const table = editor.editable.querySelector("table");
             await simulateMouseClick(table, true);
         },
-        contentAfter: "<p>[]<br></p><table></table>",
+        contentAfterEdit: unformat(`
+            <p data-selection-placeholder="" o-we-hint-text='Type "/" for commands' class="o-we-hint o-horizontal-caret">[]<br></p>
+            <table></table>
+            <p data-selection-placeholder=""><br></p>
+        `),
+        contentAfter: "[]<table></table>",
     });
 });
 
-test.skip("should insert a paragraph between the two non-P blocks and place cursor in it (1)", async () => {
+test("should insert a paragraph between the two non-P blocks and place cursor in it (1)", async () => {
     await testEditor({
         contentBefore: '<hr contenteditable="false"><hr contenteditable="false">',
         stepFunction: async (editor) => {
             const firstHR = editor.editable.querySelector("hr");
             await simulateMouseClick(firstHR);
         },
-        contentAfter: "<hr><p>[]<br></p><hr>",
+        contentAfterEdit: unformat(
+            `<p data-selection-placeholder="" style="margin: 8px 0px -9px;"><br></p>
+            <hr contenteditable="false">
+            <p data-selection-placeholder="" o-we-hint-text='Type "/" for commands' class="o-we-hint o-horizontal-caret">[]<br></p>
+            <hr contenteditable="false">
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+        ),
+        contentAfter: "<hr>[]<hr>",
     });
 });
-test.skip("should insert a paragraph between the two non-P blocks and place cursor in it (2)", async () => {
+test("should insert a paragraph between the two non-P blocks and place cursor in it (2)", async () => {
     await testEditor({
         contentBefore: "<table></table><table></table>",
         stepFunction: async (editor) => {
             const firstTable = editor.editable.querySelector("table");
             await simulateMouseClick(firstTable);
         },
-        contentAfter: "<table></table><p>[]<br></p><table></table>",
+        contentAfterEdit: unformat(
+            `<p data-selection-placeholder=""><br></p>
+            <table></table>
+            <p data-selection-placeholder="" o-we-hint-text='Type "/" for commands' class="o-we-hint o-horizontal-caret">[]<br></p>
+            <table></table>
+            <p data-selection-placeholder=""><br></p>`
+        ),
+        contentAfter: "<table></table>[]<table></table>",
     });
 });
 
-test.skip("should insert a paragraph before the table, then one after it", async () => {
+test("should insert a paragraph before the table, then one after it", async () => {
     const { el } = await setupEditor("<table></table>");
     const table = el.querySelector("table");
     await simulateMouseClick(table, true);
     expect(getContent(el)).toBe(
-        `<p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p><table></table>`
+        `<p data-selection-placeholder="" o-we-hint-text='Type "/" for commands' class="o-we-hint o-horizontal-caret">[]<br></p><table></table><p data-selection-placeholder=""><br></p>`
     );
     await simulateMouseClick(table);
     expect(getContent(el)).toBe(
-        `<p><br></p><table></table><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`
+        `<p data-selection-placeholder=""><br></p><table></table><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`
     );
 });
 

--- a/addons/html_editor/static/tests/mouse/click.test.js
+++ b/addons/html_editor/static/tests/mouse/click.test.js
@@ -24,7 +24,7 @@ async function simulateMouseClick(node, before = false) {
     await pointerUp(node);
 }
 
-test("should insert a paragraph at end of editable and place cursor in it (hr)", async () => {
+test.skip("should insert a paragraph at end of editable and place cursor in it (hr)", async () => {
     await testEditor({
         contentBefore: '<hr contenteditable="false">',
         stepFunction: async (editor) => {
@@ -35,7 +35,7 @@ test("should insert a paragraph at end of editable and place cursor in it (hr)",
     });
 });
 
-test("should insert a paragraph at end of editable and place cursor in it (table)", async () => {
+test.skip("should insert a paragraph at end of editable and place cursor in it (table)", async () => {
     await testEditor({
         contentBefore: "<table></table>",
         stepFunction: async (editor) => {
@@ -46,7 +46,7 @@ test("should insert a paragraph at end of editable and place cursor in it (table
     });
 });
 
-test("should insert a paragraph at beginning of editable and place cursor in it (1)", async () => {
+test.skip("should insert a paragraph at beginning of editable and place cursor in it (1)", async () => {
     await testEditor({
         contentBefore: '<hr contenteditable="false">',
         stepFunction: async (editor) => {
@@ -56,7 +56,7 @@ test("should insert a paragraph at beginning of editable and place cursor in it 
         contentAfter: "<p>[]<br></p><hr>",
     });
 });
-test("should insert a paragraph at beginning of editable and place cursor in it (2)", async () => {
+test.skip("should insert a paragraph at beginning of editable and place cursor in it (2)", async () => {
     await testEditor({
         contentBefore: "<table></table>",
         stepFunction: async (editor) => {
@@ -67,7 +67,7 @@ test("should insert a paragraph at beginning of editable and place cursor in it 
     });
 });
 
-test("should insert a paragraph between the two non-P blocks and place cursor in it (1)", async () => {
+test.skip("should insert a paragraph between the two non-P blocks and place cursor in it (1)", async () => {
     await testEditor({
         contentBefore: '<hr contenteditable="false"><hr contenteditable="false">',
         stepFunction: async (editor) => {
@@ -77,7 +77,7 @@ test("should insert a paragraph between the two non-P blocks and place cursor in
         contentAfter: "<hr><p>[]<br></p><hr>",
     });
 });
-test("should insert a paragraph between the two non-P blocks and place cursor in it (2)", async () => {
+test.skip("should insert a paragraph between the two non-P blocks and place cursor in it (2)", async () => {
     await testEditor({
         contentBefore: "<table></table><table></table>",
         stepFunction: async (editor) => {
@@ -88,7 +88,7 @@ test("should insert a paragraph between the two non-P blocks and place cursor in
     });
 });
 
-test("should insert a paragraph before the table, then one after it", async () => {
+test.skip("should insert a paragraph before the table, then one after it", async () => {
     const { el } = await setupEditor("<table></table>");
     const table = el.querySelector("table");
     await simulateMouseClick(table, true);

--- a/addons/html_editor/static/tests/movenode.test.js
+++ b/addons/html_editor/static/tests/movenode.test.js
@@ -314,6 +314,7 @@ describe("click", () => {
         await animationFrame();
         expect(getContent(el)).toBe(
             unformat(`
+                <p data-selection-placeholder=""><br></p>
                 <table class="o_selected_table">
                     <tbody>
                         <tr>

--- a/addons/html_editor/static/tests/movenode.test.js
+++ b/addons/html_editor/static/tests/movenode.test.js
@@ -117,7 +117,7 @@ describe("drag", () => {
         expect(".oe-dropzone-box-side").toHaveCount(8);
         await drop(".oe-dropzone-box-side:eq(2)");
         expect(getContent(el)).toBe(
-            `<div class="oe_unbreakable"><br></div><p>a[]</p><div class="o-paragraph">d</div><p>b</p><p>c</p>`
+            `<p data-selection-placeholder=""><br></p><div class="oe_unbreakable"><br></div><p>a[]</p><div class="o-paragraph">d</div><p>b</p><p>c</p>`
         );
     });
     test("should drop after the next baseContainer", async () => {
@@ -136,7 +136,7 @@ describe("drag", () => {
         expect(".oe-dropzone-box-side").toHaveCount(8);
         await drop(".oe-dropzone-box-side:eq(3)");
         expect(getContent(el)).toBe(
-            `<div class="oe_unbreakable"><br></div><div class="o-paragraph">d</div><p>a[]</p><p>b</p><p>c</p>`
+            `<p data-selection-placeholder=""><br></p><div class="oe_unbreakable"><br></div><div class="o-paragraph">d</div><p>a[]</p><p>b</p><p>c</p>`
         );
     });
     test("should drop LI at correct position within list", async () => {

--- a/addons/html_editor/static/tests/normalize.test.js
+++ b/addons/html_editor/static/tests/normalize.test.js
@@ -19,12 +19,14 @@ test("should remove `style.color` from table and apply it to tds", async () => {
                 </tbody></table>
             `),
         contentBeforeEdit: unformat(`
+            <p data-selection-placeholder=""><br></p>
             <table style="" class="o_selected_table">
                 <tbody>
                     <tr><td class="o_selected_td" style="color: red;">ab</td></tr>
                     <tr><td style="color: red;">ab</td></tr>
                 </tbody>
             </table>
+            <p data-selection-placeholder=""><br></p>
         `),
     });
 });
@@ -38,12 +40,14 @@ test("should remove `style.color` from table and apply it to td without `style.c
                 </tbody></table>
             `),
         contentBeforeEdit: unformat(`
+            <p data-selection-placeholder=""><br></p>
             <table style="">
                 <tbody>
                     <tr><td style="color: red;">ab</td></tr>
                     <tr><td style="color: green;">ab</td></tr>
                 </tbody>
             </table>
+            <p data-selection-placeholder=""><br></p>
         `),
     });
 });

--- a/addons/html_editor/static/tests/paste.test.js
+++ b/addons/html_editor/static/tests/paste.test.js
@@ -101,11 +101,10 @@ describe("Html Paste cleaning - whitelist", () => {
                 <table class="table table-bordered o_table">
                     <tbody>
                         <tr>
-                            <td><p><br></p></td>
+                            <td><p>[]<br></p></td>
                         </tr>
                     </tbody>
                 </table>
-                <p>[]<br></p>
             `),
         });
     });
@@ -3884,9 +3883,9 @@ ${"            "}
             </tr>
             <tr>
                 <td>14pt MONO TEXT
-                </td>
+                []</td>
             </tr>
-        </tbody></table><p>[]<br></p>`,
+        </tbody></table>`,
         });
     });
 
@@ -3994,10 +3993,10 @@ ${"        "}
                     text on color background</td>
             </tr>
             <tr>
-                <td>14pt MONO TEXT</td>
+                <td>14pt MONO TEXT[]</td>
             </tr>
         </tbody>
-    </table><p>[]<br></p>`,
+    </table>`,
         });
     });
 
@@ -4123,10 +4122,10 @@ ${"        "}
         </tr>
         <tr>
             <td>
-                14pt MONO TEXT
+                14pt MONO TEXT[]
             </td>
         </tr>
-    </tbody></table><p>[]<br></p>`,
+    </tbody></table>`,
         });
     });
 
@@ -4153,11 +4152,10 @@ ${"        "}
                 <table class="table table-bordered o_table">
                     <tbody>
                         <tr>
-                            <td><p><br></p></td>
+                            <td><p>[]<br></p></td>
                         </tr>
                     </tbody>
                 </table>
-                <p>[]<br></p>
             `),
         });
     });
@@ -4203,11 +4201,10 @@ ${"        "}
                                 </tr>
                                 <tr>
                                     <td>1</td>
-                                    <td>2</td>
+                                    <td>2[]</td>
                                 </tr>
                             </tbody>
                         </table>
-                        <p>[]<br></p>
                     `),
         });
     });
@@ -4234,11 +4231,10 @@ ${"        "}
                             <tbody>
                                 <tr>
                                     <th>1</th>
-                                    <th>2</th>
+                                    <th>2[]</th>
                                 </tr>
                             </tbody>
                         </table>
-                        <p>[]<br></p>
                     `),
         });
     });

--- a/addons/html_editor/static/tests/powerbox.test.js
+++ b/addons/html_editor/static/tests/powerbox.test.js
@@ -507,7 +507,7 @@ test("should insert a 3x3 table on type `/table`", async () => {
     await press("Enter");
     await tick();
     expect(getContent(el)).toBe(
-        `<table class="table table-bordered o_table"><tbody><tr><td><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p></td><td><p><br></p></td><td><p><br></p></td></tr><tr><td><p><br></p></td><td><p><br></p></td><td><p><br></p></td></tr><tr><td><p><br></p></td><td><p><br></p></td><td><p><br></p></td></tr></tbody></table><p><br></p>`
+        `<p data-selection-placeholder=""><br></p><table class="table table-bordered o_table"><tbody><tr><td><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p></td><td><p><br></p></td><td><p><br></p></td></tr><tr><td><p><br></p></td><td><p><br></p></td><td><p><br></p></td></tr><tr><td><p><br></p></td><td><p><br></p></td><td><p><br></p></td></tr></tbody></table><p><br></p>`
     );
 });
 
@@ -519,7 +519,7 @@ test("should insert a 3x3 table on type `/table` in mobile view", async () => {
     await press("Enter");
     await tick();
     expect(getContent(el)).toBe(
-        `<table class="table table-bordered o_table"><tbody><tr><td><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p></td><td><p><br></p></td><td><p><br></p></td></tr><tr><td><p><br></p></td><td><p><br></p></td><td><p><br></p></td></tr><tr><td><p><br></p></td><td><p><br></p></td><td><p><br></p></td></tr></tbody></table><p><br></p>`
+        `<p data-selection-placeholder=""><br></p><table class="table table-bordered o_table"><tbody><tr><td><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p></td><td><p><br></p></td><td><p><br></p></td></tr><tr><td><p><br></p></td><td><p><br></p></td><td><p><br></p></td></tr><tr><td><p><br></p></td><td><p><br></p></td><td><p><br></p></td></tr></tbody></table><p><br></p>`
     );
 });
 

--- a/addons/html_editor/static/tests/powerbox.test.js
+++ b/addons/html_editor/static/tests/powerbox.test.js
@@ -507,7 +507,7 @@ test("should insert a 3x3 table on type `/table`", async () => {
     await press("Enter");
     await tick();
     expect(getContent(el)).toBe(
-        `<p data-selection-placeholder=""><br></p><table class="table table-bordered o_table"><tbody><tr><td><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p></td><td><p><br></p></td><td><p><br></p></td></tr><tr><td><p><br></p></td><td><p><br></p></td><td><p><br></p></td></tr><tr><td><p><br></p></td><td><p><br></p></td><td><p><br></p></td></tr></tbody></table><p><br></p>`
+        `<p data-selection-placeholder=""><br></p><table class="table table-bordered o_table"><tbody><tr><td><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p></td><td><p><br></p></td><td><p><br></p></td></tr><tr><td><p><br></p></td><td><p><br></p></td><td><p><br></p></td></tr><tr><td><p><br></p></td><td><p><br></p></td><td><p><br></p></td></tr></tbody></table><p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
     );
 });
 
@@ -519,7 +519,7 @@ test("should insert a 3x3 table on type `/table` in mobile view", async () => {
     await press("Enter");
     await tick();
     expect(getContent(el)).toBe(
-        `<p data-selection-placeholder=""><br></p><table class="table table-bordered o_table"><tbody><tr><td><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p></td><td><p><br></p></td><td><p><br></p></td></tr><tr><td><p><br></p></td><td><p><br></p></td><td><p><br></p></td></tr><tr><td><p><br></p></td><td><p><br></p></td><td><p><br></p></td></tr></tbody></table><p><br></p>`
+        `<p data-selection-placeholder=""><br></p><table class="table table-bordered o_table"><tbody><tr><td><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p></td><td><p><br></p></td><td><p><br></p></td></tr><tr><td><p><br></p></td><td><p><br></p></td><td><p><br></p></td></tr><tr><td><p><br></p></td><td><p><br></p></td><td><p><br></p></td></tr></tbody></table><p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
     );
 });
 

--- a/addons/html_editor/static/tests/qweb.test.js
+++ b/addons/html_editor/static/tests/qweb.test.js
@@ -318,7 +318,7 @@ test("cleaning does not remove t-out links", async () => {
         { config }
     );
     expect(el.innerHTML.trim().replace(/\s+/g, " ")).toBe(
-        `<ul> <li> <a href="xyz" t-out="xyz" data-oe-protected="true" contenteditable="false"> </a> </li> </ul>`
+        `<ul> <li><a href="xyz" t-out="xyz" data-oe-protected="true" contenteditable="false"></a></li> </ul>`
     );
     expect(editor.getContent().trim().replace(/\s+/g, " ")).toBe(
         '<ul> <li><a href="xyz" t-out="xyz"></a></li> </ul>'

--- a/addons/html_editor/static/tests/qweb.test.js
+++ b/addons/html_editor/static/tests/qweb.test.js
@@ -15,7 +15,9 @@ describe("qweb picker", () => {
             { config }
         );
         expect(getContent(el)).toBe(
-            `<div><t t-if="test" data-oe-t-inline="true" data-oe-t-group="0" data-oe-t-selectable="true" data-oe-t-group-active="true">yes</t><t t-else="" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="0">no</t></div>`
+            '<p data-selection-placeholder=""><br></p>' +
+                `<div><t t-if="test" data-oe-t-inline="true" data-oe-t-group="0" data-oe-t-selectable="true" data-oe-t-group-active="true">yes</t><t t-else="" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="0">no</t></div>` +
+                '<p data-selection-placeholder=""><br></p>'
         );
         await click(queryOne(`[data-oe-t-group-active="true"]`));
         await animationFrame();
@@ -29,7 +31,9 @@ describe("qweb picker", () => {
         expect(".o-we-qweb-picker").toHaveCount(1);
         expect(".o-we-qweb-picker select option:selected").toHaveText("else");
         expect(getContent(el)).toBe(
-            `<div><t t-if="test" data-oe-t-inline="true" data-oe-t-group="0" data-oe-t-selectable="true">yes</t><t t-else="" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="0" data-oe-t-group-active="true">no</t></div>`
+            '<p data-selection-placeholder=""><br></p>' +
+                `<div><t t-if="test" data-oe-t-inline="true" data-oe-t-group="0" data-oe-t-selectable="true">yes</t><t t-else="" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="0" data-oe-t-group-active="true">no</t></div>` +
+                '<p data-selection-placeholder=""><br></p>'
         );
 
         dispatchCleanForSave(editor, { root: el });
@@ -53,7 +57,9 @@ describe("qweb picker", () => {
             config,
         });
         expect(getContent(el)).toBe(
-            `<div><t t-if="test" data-oe-t-inline="true" data-oe-t-group="0" data-oe-t-selectable="true" data-oe-t-group-active="true">yes</t><t t-else="" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="0">no</t></div>`
+            '<p data-selection-placeholder=""><br></p>' +
+                `<div><t t-if="test" data-oe-t-inline="true" data-oe-t-group="0" data-oe-t-selectable="true" data-oe-t-group-active="true">yes</t><t t-else="" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="0">no</t></div>` +
+                '<p data-selection-placeholder=""><br></p>'
         );
         await click(queryOne(`[data-oe-t-group-active="true"]`));
         await animationFrame();
@@ -67,7 +73,9 @@ describe("qweb picker", () => {
         expect(".o-we-qweb-picker").toHaveCount(1);
         expect(".o-we-qweb-picker select option:selected").toHaveText("if: test");
         expect(getContent(el)).toBe(
-            `<div><t t-if="test" data-oe-t-inline="true" data-oe-t-group="0" data-oe-t-selectable="true" data-oe-t-group-active="true">yes</t><t t-else="" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="0">no</t></div>`
+            '<p data-selection-placeholder=""><br></p>' +
+                `<div><t t-if="test" data-oe-t-inline="true" data-oe-t-group="0" data-oe-t-selectable="true" data-oe-t-group-active="true">yes</t><t t-else="" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="0">no</t></div>` +
+                '<p data-selection-placeholder=""><br></p>'
         );
     });
 
@@ -77,7 +85,9 @@ describe("qweb picker", () => {
             { config }
         );
         expect(getContent(el)).toBe(
-            `<div><t t-if="test" data-oe-t-inline="true" data-oe-t-group="0" data-oe-t-selectable="true" data-oe-t-group-active="true">if</t><t t-elif="test2" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="0">elif</t><t t-elif="test3" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="0">elif 3</t><t t-else="" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="0">else</t></div>`
+            '<p data-selection-placeholder=""><br></p>' +
+                `<div><t t-if="test" data-oe-t-inline="true" data-oe-t-group="0" data-oe-t-selectable="true" data-oe-t-group-active="true">if</t><t t-elif="test2" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="0">elif</t><t t-elif="test3" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="0">elif 3</t><t t-else="" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="0">else</t></div>` +
+                '<p data-selection-placeholder=""><br></p>'
         );
         await click(queryOne(`[data-oe-t-group-active="true"]`));
         await animationFrame();
@@ -96,7 +106,9 @@ describe("qweb picker", () => {
         expect(".o-we-qweb-picker").toHaveCount(1);
         expect(".o-we-qweb-picker select option:selected").toHaveText("elif: test2");
         expect(getContent(el)).toBe(
-            `<div><t t-if="test" data-oe-t-inline="true" data-oe-t-group="0" data-oe-t-selectable="true">if</t><t t-elif="test2" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="0" data-oe-t-group-active="true">elif</t><t t-elif="test3" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="0">elif 3</t><t t-else="" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="0">else</t></div>`
+            '<p data-selection-placeholder=""><br></p>' +
+                `<div><t t-if="test" data-oe-t-inline="true" data-oe-t-group="0" data-oe-t-selectable="true">if</t><t t-elif="test2" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="0" data-oe-t-group-active="true">elif</t><t t-elif="test3" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="0">elif 3</t><t t-else="" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="0">else</t></div>` +
+                '<p data-selection-placeholder=""><br></p>'
         );
 
         await click(".o-we-qweb-picker select");
@@ -105,7 +117,9 @@ describe("qweb picker", () => {
         expect(".o-we-qweb-picker").toHaveCount(1);
         expect(".o-we-qweb-picker select option:selected").toHaveText("elif: test3");
         expect(getContent(el)).toBe(
-            `<div><t t-if="test" data-oe-t-inline="true" data-oe-t-group="0" data-oe-t-selectable="true">if</t><t t-elif="test2" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="0">elif</t><t t-elif="test3" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="0" data-oe-t-group-active="true">elif 3</t><t t-else="" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="0">else</t></div>`
+            '<p data-selection-placeholder=""><br></p>' +
+                `<div><t t-if="test" data-oe-t-inline="true" data-oe-t-group="0" data-oe-t-selectable="true">if</t><t t-elif="test2" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="0">elif</t><t t-elif="test3" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="0" data-oe-t-group-active="true">elif 3</t><t t-else="" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="0">else</t></div>` +
+                '<p data-selection-placeholder=""><br></p>'
         );
 
         await click(".o-we-qweb-picker select");
@@ -114,7 +128,9 @@ describe("qweb picker", () => {
         expect(".o-we-qweb-picker").toHaveCount(1);
         expect(".o-we-qweb-picker select option:selected").toHaveText("else");
         expect(getContent(el)).toBe(
-            `<div><t t-if="test" data-oe-t-inline="true" data-oe-t-group="0" data-oe-t-selectable="true">if</t><t t-elif="test2" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="0">elif</t><t t-elif="test3" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="0">elif 3</t><t t-else="" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="0" data-oe-t-group-active="true">else</t></div>`
+            '<p data-selection-placeholder=""><br></p>' +
+                `<div><t t-if="test" data-oe-t-inline="true" data-oe-t-group="0" data-oe-t-selectable="true">if</t><t t-elif="test2" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="0">elif</t><t t-elif="test3" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="0">elif 3</t><t t-else="" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="0" data-oe-t-group-active="true">else</t></div>` +
+                '<p data-selection-placeholder=""><br></p>'
         );
     });
 
@@ -124,7 +140,9 @@ describe("qweb picker", () => {
             { config }
         );
         expect(getContent(el)).toBe(
-            `<div><t t-if="test" data-oe-t-inline="true" data-oe-t-group="0" data-oe-t-selectable="true" data-oe-t-group-active="true">yes</t><t t-else="" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="0">no</t><t t-if="test2" data-oe-t-inline="true" data-oe-t-group="1" data-oe-t-selectable="true" data-oe-t-group-active="true">hello</t><t t-else="" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="1">bye</t></div>`
+            '<p data-selection-placeholder=""><br></p>' +
+                `<div><t t-if="test" data-oe-t-inline="true" data-oe-t-group="0" data-oe-t-selectable="true" data-oe-t-group-active="true">yes</t><t t-else="" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="0">no</t><t t-if="test2" data-oe-t-inline="true" data-oe-t-group="1" data-oe-t-selectable="true" data-oe-t-group-active="true">hello</t><t t-else="" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="1">bye</t></div>` +
+                '<p data-selection-placeholder=""><br></p>'
         );
         expect('[data-oe-t-group-active="true"]').toHaveCount(2);
 
@@ -140,7 +158,9 @@ describe("qweb picker", () => {
         expect(".o-we-qweb-picker").toHaveCount(1);
         expect(".o-we-qweb-picker select option:selected").toHaveText("else");
         expect(getContent(el)).toBe(
-            `<div><t t-if="test" data-oe-t-inline="true" data-oe-t-group="0" data-oe-t-selectable="true" data-oe-t-group-active="true">yes</t><t t-else="" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="0">no</t><t t-if="test2" data-oe-t-inline="true" data-oe-t-group="1" data-oe-t-selectable="true">hello</t><t t-else="" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="1" data-oe-t-group-active="true">bye</t></div>`
+            '<p data-selection-placeholder=""><br></p>' +
+                `<div><t t-if="test" data-oe-t-inline="true" data-oe-t-group="0" data-oe-t-selectable="true" data-oe-t-group-active="true">yes</t><t t-else="" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="0">no</t><t t-if="test2" data-oe-t-inline="true" data-oe-t-group="1" data-oe-t-selectable="true">hello</t><t t-else="" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="1" data-oe-t-group-active="true">bye</t></div>` +
+                '<p data-selection-placeholder=""><br></p>'
         );
     });
 
@@ -149,7 +169,9 @@ describe("qweb picker", () => {
             config,
         });
         expect(getContent(el)).toBe(
-            `<div><t t-if="test" data-oe-t-inline="true" data-oe-t-group="0" data-oe-t-selectable="true" data-oe-t-group-active="true">yes</t><t t-else="" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="0">no</t></div>`
+            '<p data-selection-placeholder=""><br></p>' +
+                `<div><t t-if="test" data-oe-t-inline="true" data-oe-t-group="0" data-oe-t-selectable="true" data-oe-t-group-active="true">yes</t><t t-else="" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="0">no</t></div>` +
+                '<p data-selection-placeholder=""><br></p>'
         );
 
         // Open picker
@@ -171,7 +193,9 @@ describe("qweb picker", () => {
             }
         );
         expect(getContent(el)).toBe(
-            `<div><t t-if="test" data-oe-t-inline="true" data-oe-t-group="0" data-oe-t-selectable="true" data-oe-t-group-active="true"><t t-if="sub-test" data-oe-t-inline="true" data-oe-t-group="1" data-oe-t-selectable="true" data-oe-t-group-active="true">Sub if</t><t t-else="" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="1">Sub Else</t></t><t t-else="" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="0">Else</t></div>`
+            '<p data-selection-placeholder=""><br></p>' +
+                `<div><t t-if="test" data-oe-t-inline="true" data-oe-t-group="0" data-oe-t-selectable="true" data-oe-t-group-active="true"><t t-if="sub-test" data-oe-t-inline="true" data-oe-t-group="1" data-oe-t-selectable="true" data-oe-t-group-active="true">Sub if</t><t t-else="" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="1">Sub Else</t></t><t t-else="" data-oe-t-inline="true" data-oe-t-selectable="true" data-oe-t-group="0">Else</t></div>` +
+                '<p data-selection-placeholder=""><br></p>'
         );
 
         // Open picker on sub condition
@@ -223,18 +247,24 @@ test("select text inside t-out", async () => {
         config,
     });
     expect(getContent(el)).toBe(
-        `<div><t t-out="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">Hello</t></div>`
+        '<p data-selection-placeholder=""><br></p>' +
+            `<div><t t-out="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">Hello</t></div>` +
+            '<p data-selection-placeholder=""><br></p>'
     );
 
     setSelection({ anchorNode: el.querySelector("t[t-out]").childNodes[0], anchorOffset: 1 });
 
     await tick();
     expect(getContent(el)).toBe(
-        `<div><t t-out="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">H[]ello</t></div>`
+        '<p data-selection-placeholder=""><br></p>' +
+            `<div><t t-out="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">H[]ello</t></div>` +
+            '<p data-selection-placeholder=""><br></p>'
     );
     await dblclick("t");
     expect(getContent(el)).toBe(
-        `<div>[<t t-out="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">Hello</t>]</div>`
+        '<p data-selection-placeholder=""><br></p>' +
+            `<div>[<t t-out="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">Hello</t>]</div>` +
+            '<p data-selection-placeholder=""><br></p>'
     );
 });
 
@@ -243,18 +273,24 @@ test("select text inside t-esc", async () => {
         config,
     });
     expect(getContent(el)).toBe(
-        `<div><t t-esc="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">Hello</t></div>`
+        '<p data-selection-placeholder=""><br></p>' +
+            `<div><t t-esc="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">Hello</t></div>` +
+            '<p data-selection-placeholder=""><br></p>'
     );
 
     setSelection({ anchorNode: el.querySelector("t[t-esc]").childNodes[0], anchorOffset: 1 });
 
     await tick();
     expect(getContent(el)).toBe(
-        `<div><t t-esc="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">H[]ello</t></div>`
+        '<p data-selection-placeholder=""><br></p>' +
+            `<div><t t-esc="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">H[]ello</t></div>` +
+            '<p data-selection-placeholder=""><br></p>'
     );
     await dblclick("t");
     expect(getContent(el)).toBe(
-        `<div>[<t t-esc="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">Hello</t>]</div>`
+        '<p data-selection-placeholder=""><br></p>' +
+            `<div>[<t t-esc="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">Hello</t>]</div>` +
+            '<p data-selection-placeholder=""><br></p>'
     );
 });
 
@@ -263,18 +299,24 @@ test("select text inside t-field", async () => {
         config,
     });
     expect(getContent(el)).toBe(
-        `<div><t t-field="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">Hello</t></div>`
+        '<p data-selection-placeholder=""><br></p>' +
+            `<div><t t-field="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">Hello</t></div>` +
+            '<p data-selection-placeholder=""><br></p>'
     );
 
     setSelection({ anchorNode: el.querySelector("t[t-field]").childNodes[0], anchorOffset: 1 });
 
     await tick();
     expect(getContent(el)).toBe(
-        `<div><t t-field="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">H[]ello</t></div>`
+        '<p data-selection-placeholder=""><br></p>' +
+            `<div><t t-field="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">H[]ello</t></div>` +
+            '<p data-selection-placeholder=""><br></p>'
     );
     await dblclick("t");
     expect(getContent(el)).toBe(
-        `<div>[<t t-field="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">Hello</t>]</div>`
+        '<p data-selection-placeholder=""><br></p>' +
+            `<div>[<t t-field="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">Hello</t>]</div>` +
+            '<p data-selection-placeholder=""><br></p>'
     );
 });
 
@@ -292,12 +334,12 @@ test("cleaning removes content editable", async () => {
         }
     );
     expect(getContent(el)).toBe(`
-        <div>
+        <p data-selection-placeholder=""><br></p><div>
             <t t-field="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">Hello</t>
             <t t-out="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">Hello</t>
             <t t-esc="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">Hello</t>
             <t t-raw="test" data-oe-t-inline="true" data-oe-protected="true" contenteditable="false">Hello</t>
-        </div>`);
+        </div><p data-selection-placeholder=""><br></p>`);
 
     expect(editor.getContent()).toBe(`
         <div>

--- a/addons/html_editor/static/tests/sanitize.test.js
+++ b/addons/html_editor/static/tests/sanitize.test.js
@@ -32,7 +32,7 @@ test("sanitize should leave t-field, t-out, t-esc as is", async () => {
 test("sanitize plugin should handle contenteditable attribute with o-contenteditable-[true/false] class", async () => {
     await testEditor({
         contentBefore: `<p class="o-contenteditable-true">a[]</p><p class="o-contenteditable-false">b</p>`,
-        contentAfterEdit: `<p class="o-contenteditable-true" contenteditable="true">a[]</p><p class="o-contenteditable-false" contenteditable="false">b</p>`,
+        contentAfterEdit: `<p class="o-contenteditable-true" contenteditable="true">a[]</p><p class="o-contenteditable-false" contenteditable="false">b</p><p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`,
         contentAfter: `<p class="o-contenteditable-true">a[]</p><p class="o-contenteditable-false">b</p>`,
     });
 });

--- a/addons/html_editor/static/tests/selection.test.js
+++ b/addons/html_editor/static/tests/selection.test.js
@@ -188,7 +188,7 @@ test("press 'ctrl+a' in 'contenteditable' should only select his content", async
     );
     await press(["ctrl", "a"]);
     expect(getContent(el)).toBe(
-        `<div contenteditable="false"><p contenteditable="true">[ab]</p><p contenteditable="true">cd</p></div>`
+        `<p data-selection-placeholder=""><br></p><div contenteditable="false"><p contenteditable="true">[ab]</p><p contenteditable="true">cd</p></div><p data-selection-placeholder=""><br></p>`
     );
 });
 

--- a/addons/html_editor/static/tests/selection.test.js
+++ b/addons/html_editor/static/tests/selection.test.js
@@ -75,8 +75,12 @@ test("correct selection after triple click with bold", async () => {
 test.tags("desktop");
 test("selection on triple click should be contained in the paragraph", async () => {
     const { el } = await setupEditor("<div><p>[]abc</p><br><br><h2>def</h2></div>");
-    await tripleClick(el.querySelector("p"));
-    expect(getContent(el)).toBe("<div><p>[abc]</p><br><br><h2>def</h2></div>");
+    await tripleClick(el.querySelector("p:not([data-selection-placeholder])"));
+    expect(getContent(el)).toBe(
+        '<p data-selection-placeholder=""><br></p>' +
+            "<div><p>[abc]</p><br><br><h2>def</h2></div>" +
+            '<p data-selection-placeholder=""><br></p>'
+    );
 });
 
 test.tags("desktop");
@@ -89,7 +93,7 @@ test("correct selection after triple click in multi-line block (1)", async () =>
 test.tags("desktop");
 test("correct selection after triple click in multi-line block (2)", async () => {
     const { el } = await setupEditor("<p>block1</p><p>[]block2<br>block2</p><p>block3</p>", {});
-    await tripleClick(queryFirst("p").nextSibling.firstChild); // we triple click inside block2
+    await tripleClick(queryFirst("p:not([data-selection-placeholder])").nextSibling.firstChild); // we triple click inside block2
     expect(getContent(el)).toBe("<p>block1</p><p>[block2<br>block2]</p><p>block3</p>");
 });
 
@@ -179,7 +183,11 @@ test("setSelection should not set the selection outside the editable", async () 
 test("press 'ctrl+a' in 'oe_structure' child should only select his content", async () => {
     const { el } = await setupEditor(`<div class="oe_structure"><p>a[]b</p><p>cd</p></div>`);
     await press(["ctrl", "a"]);
-    expect(getContent(el)).toBe(`<div class="oe_structure"><p>[ab]</p><p>cd</p></div>`);
+    expect(getContent(el)).toBe(
+        '<p data-selection-placeholder=""><br></p>' +
+            `<div class="oe_structure"><p>[ab]</p><p>cd</p></div>` +
+            '<p data-selection-placeholder=""><br></p>'
+    );
 });
 
 test("press 'ctrl+a' in 'contenteditable' should only select his content", async () => {
@@ -388,12 +396,14 @@ describe("getTargetedNodes", () => {
                 const { el: editable, editor } = await setupEditor(
                     "<div><p>a[bc</p><div>d]ef</div></div>"
                 );
-                const outerDiv = editable.firstChild;
+                const outerDiv = editable.querySelector("div");
                 const p1 = outerDiv.firstChild; // The selection crossed `</p>` -> include it.
                 const abc = p1.firstChild;
                 const innerDiv = p1.nextSibling; // The selection crossed `<div>` -> include it.
                 const def = innerDiv.firstChild;
-                const result = editor.shared.selection.getTargetedNodes();
+                const result = editor.shared.selection
+                    .getTargetedNodes()
+                    .filter((node) => !node.hasAttribute?.("data-selection-placeholder"));
                 expect(result).toEqual([p1, abc, innerDiv, def]);
             });
 
@@ -420,14 +430,16 @@ describe("getTargetedNodes", () => {
                 const span1 = p1.firstChild; // The selection crossed `</span>` -> include it.
                 // "ab" isn't included because no part of it is selected.
                 const cd = p1.lastChild;
-                const div = editable.lastChild;
+                const div = editable.querySelector("div");
                 const p2 = div.firstChild;
                 const span2 = p2.firstChild; // The selection crossed `<span class="b">` -> include it.
                 const b = span2.firstChild;
                 const e = b.firstChild;
                 const i = b.nextSibling; // The selection crossed `<i>` -> include it.
                 const fg = i.firstChild;
-                const result = editor.shared.selection.getTargetedNodes();
+                const result = editor.shared.selection
+                    .getTargetedNodes()
+                    .filter((node) => !node.hasAttribute?.("data-selection-placeholder"));
                 expect(result).toEqual([p1, span1, cd, div, p2, span2, b, e, i, fg]);
             });
         });

--- a/addons/html_editor/static/tests/selection_placeholder.test.js
+++ b/addons/html_editor/static/tests/selection_placeholder.test.js
@@ -1,0 +1,582 @@
+import { expect, test } from "@odoo/hoot";
+import { testEditor } from "./_helpers/editor";
+import { unformat } from "./_helpers/format";
+import { animationFrame, press, tick } from "@odoo/hoot-dom";
+import { insertText, simulateArrowKeyPress, splitBlock } from "./_helpers/user_actions";
+import { getContent } from "./_helpers/selection";
+import { closestElement } from "@html_editor/utils/dom_traversal";
+import { isTableCell } from "@html_editor/utils/dom_info";
+import { parseHTML } from "@html_editor/utils/html";
+
+const pressArrowKey = async (editor, key) => {
+    const selection = editor.shared.selection.getSelectionData().deepEditableSelection;
+    if (
+        !key.includes("Shift") &&
+        selection.isCollapsed &&
+        closestElement(selection.anchorNode, isTableCell)
+    ) {
+        // Since the selection is in a table, the table plugin handles the
+        // arrow key so we use `press` instead of `simulateArrowKeyPress`
+        // (which would then change the selection twice).
+        // TODO: detect this without relying on implementation if possible.
+        await press(key);
+    } else {
+        await simulateArrowKeyPress(editor, key);
+        // Wait an extra tick in case of selection in root correction, so the
+        // extra selectionchange event is triggered.
+        await tick();
+    }
+    // Wait for selectionchange event.
+    await tick();
+};
+
+test("a selection placeholder is inserted before a contenteditable=false as first element, and removed on clean", async () => {
+    await testEditor({
+        contentBefore: `<div contenteditable="false">a</div><p>b</p>`,
+        contentBeforeEdit: `<p data-selection-placeholder=""><br></p><div contenteditable="false">a</div><p>b</p>`,
+        contentAfter: `<div contenteditable="false">a</div><p>b</p>`,
+    });
+});
+
+test("a selection placeholder is inserted before a table as first element, and removed on clean", async () => {
+    await testEditor({
+        contentBefore: `<table><tbody><tr><td>a</td></tr></tbody></table><p>b</p>`,
+        contentBeforeEdit: `<p data-selection-placeholder=""><br></p><table><tbody><tr><td>a</td></tr></tbody></table><p>b</p>`,
+        contentAfter: `<table><tbody><tr><td>a</td></tr></tbody></table><p>b</p>`,
+    });
+});
+
+test("a selection placeholder is inserted after a contenteditable=false as last element, and removed on clean", async () => {
+    await testEditor({
+        contentBefore: `<p>a</p><div contenteditable="false">b</div>`,
+        contentBeforeEdit: `<p>a</p><div contenteditable="false">b</div><p data-selection-placeholder=""><br></p>`,
+        contentAfter: `<p>a</p><div contenteditable="false">b</div>`,
+    });
+});
+
+test("a selection placeholder is inserted after a table as last element, and removed on clean", async () => {
+    await testEditor({
+        contentBefore: `<p>a</p><table><tbody><tr><td>b</td></tr></tbody></table>`,
+        contentBeforeEdit: `<p>a</p><table><tbody><tr><td>b</td></tr></tbody></table><p data-selection-placeholder=""><br></p>`,
+        contentAfter: `<p>a</p><table><tbody><tr><td>b</td></tr></tbody></table>`,
+    });
+});
+
+test("a selection placeholder is inserted between two tables, and removed on clean", async () => {
+    await testEditor({
+        contentBefore: unformat(
+            `<table><tbody><tr><td>a</td></tr></tbody></table>
+            <table><tbody><tr><td>b</td></tr></tbody></table>`
+        ),
+        contentBeforeEdit: unformat(
+            `<p data-selection-placeholder=""><br></p>
+            <table><tbody><tr><td>a</td></tr></tbody></table>
+            <p data-selection-placeholder=""><br></p>
+            <table><tbody><tr><td>b</td></tr></tbody></table>
+            <p data-selection-placeholder=""><br></p>`
+        ),
+        contentAfter: unformat(
+            `<table><tbody><tr><td>a</td></tr></tbody></table>
+            <table><tbody><tr><td>b</td></tr></tbody></table>`
+        ),
+    });
+});
+
+test.tags("focus required");
+test("can navigate in and out of selection placeholders", async () => {
+    await testEditor({
+        contentBefore: unformat(
+            `<p>a</p>
+            <table><tbody><tr><td>b[]</td></tr></tbody></table>
+            <table><tbody><tr><td>d</td></tr></tbody></table>
+            <p>e</p>`
+        ),
+        contentBeforeEdit: unformat(
+            `<p>a</p>
+            <table><tbody><tr><td>b[]</td></tr></tbody></table>
+            <p data-selection-placeholder=""><br></p>
+            <table><tbody><tr><td>d</td></tr></tbody></table>
+            <p>e</p>`
+        ),
+        stepFunction: async (editor) => {
+            await pressArrowKey(editor, "ArrowDown");
+            expect(getContent(editor.editable)).toBe(
+                unformat(
+                    `<p>a</p>
+                    <table><tbody><tr><td>b</td></tr></tbody></table>
+                    <p data-selection-placeholder="" o-we-hint-text='Type "/" for commands' class="o-we-hint o-horizontal-caret">[]<br></p>
+                    <table><tbody><tr><td>d</td></tr></tbody></table>
+                    <p>e</p>`
+                ),
+                { message: "Stepped down into the placeholder." }
+            );
+            await pressArrowKey(editor, "ArrowRight");
+            expect(getContent(editor.editable)).toBe(
+                unformat(
+                    `<p>a</p>
+                    <table><tbody><tr><td>b</td></tr></tbody></table>
+                    <p data-selection-placeholder=""><br></p>
+                    <table><tbody><tr><td>[]d</td></tr></tbody></table>
+                    <p>e</p>`
+                ),
+                { message: "Stepped down out of the placeholder." }
+            );
+            await pressArrowKey(editor, "ArrowUp");
+            expect(getContent(editor.editable)).toBe(
+                unformat(
+                    `<p>a</p>
+                    <table><tbody><tr><td>b</td></tr></tbody></table>
+                    <p data-selection-placeholder="" o-we-hint-text='Type "/" for commands' class="o-we-hint o-horizontal-caret">[]<br></p>
+                    <table><tbody><tr><td>d</td></tr></tbody></table>
+                    <p>e</p>`
+                ),
+                { message: "Stepped up into the placeholder." }
+            );
+            await pressArrowKey(editor, "ArrowLeft");
+            expect(getContent(editor.editable)).toBe(
+                unformat(
+                    `<p>a</p>
+                    <table><tbody><tr><td>b[]</td></tr></tbody></table>
+                    <p data-selection-placeholder=""><br></p>
+                    <table><tbody><tr><td>d</td></tr></tbody></table>
+                    <p>e</p>`
+                ),
+                { message: "Stepped up out of the placeholder." }
+            );
+        },
+        contentAfterEdit: unformat(
+            `<p>a</p>
+            <table><tbody><tr><td>b[]</td></tr></tbody></table>
+            <p data-selection-placeholder=""><br></p>
+            <table><tbody><tr><td>d</td></tr></tbody></table>
+            <p>e</p>`
+        ),
+        contentAfter: unformat(
+            `<p>a</p>
+            <table><tbody><tr><td>b[]</td></tr></tbody></table>
+            <table><tbody><tr><td>d</td></tr></tbody></table>
+            <p>e</p>`
+        ),
+    });
+});
+
+test.tags("focus required");
+test("moving the caret into a selection placeholder shows a horizontal caret", async () => {
+    const focusedResult = unformat(
+        `<p data-selection-placeholder=""><br></p>
+        <table><tbody><tr><td>a</td></tr></tbody></table>
+        <p data-selection-placeholder="" o-we-hint-text='Type "/" for commands' class="o-we-hint o-horizontal-caret">[]<br></p>
+        <table><tbody><tr><td><textarea></textarea></td></tr></tbody></table>
+        <p data-selection-placeholder=""><br></p>`
+    );
+    await testEditor({
+        contentBefore: unformat(
+            `<table><tbody><tr><td>a[]</td></tr></tbody></table>
+            <table><tbody><tr><td><textarea></textarea></td></tr></tbody></table>`
+        ),
+        contentBeforeEdit: unformat(
+            `<p data-selection-placeholder=""><br></p>
+            <table><tbody><tr><td>a[]</td></tr></tbody></table>
+            <p data-selection-placeholder=""><br></p>
+            <table><tbody><tr><td><textarea></textarea></td></tr></tbody></table>
+            <p data-selection-placeholder=""><br></p>`
+        ),
+        stepFunction: async (editor) => {
+            await pressArrowKey(editor, "ArrowDown");
+            expect(getContent(editor.editable)).toBe(focusedResult, {
+                message: "The placeholder was selected.",
+            });
+            // Blur the editable.
+            editor.editable.blur();
+            await animationFrame();
+            expect(getContent(editor.editable)).toBe(
+                unformat(
+                    `<p data-selection-placeholder=""><br></p>
+                    <table><tbody><tr><td>a</td></tr></tbody></table>
+                    <p data-selection-placeholder="" o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>
+                    <table><tbody><tr><td><textarea></textarea></td></tr></tbody></table>
+                    <p data-selection-placeholder=""><br></p>`
+                ),
+                {
+                    message: "The placeholder stopped blinking when taking the focus out.",
+                }
+            );
+            // Focus the editable.
+            editor.editable.focus();
+            await animationFrame();
+            expect(getContent(editor.editable)).toBe(focusedResult, {
+                message: "The placeholder started blinking again when taking the focus back in.",
+            });
+            // Focus the textarea, blurring the editable.
+            editor.editable.querySelector("textarea").focus();
+            await animationFrame();
+            expect(getContent(editor.editable)).toBe(
+                unformat(
+                    `<p data-selection-placeholder=""><br></p>
+                    <table><tbody><tr><td>a</td></tr></tbody></table>
+                    <p data-selection-placeholder=""><br></p>
+                    <table><tbody><tr><td>[]<textarea></textarea></td></tr></tbody></table>
+                    <p data-selection-placeholder=""><br></p>`
+                ),
+                {
+                    message:
+                        "The placeholder stopped blinking when taking the focus into the textarea.",
+                }
+            );
+            // Refocus the editable.
+            editor.editable.focus();
+            await animationFrame();
+            // Focus again, it should start blinking again.
+        },
+        contentAfterEdit: unformat(
+            `<p data-selection-placeholder="" class="o-horizontal-caret o-we-hint" o-we-hint-text='Type "/" for commands'>[]<br></p>
+            <table><tbody><tr><td>a</td></tr></tbody></table>
+            <p data-selection-placeholder=""><br></p>
+            <table><tbody><tr><td><textarea></textarea></td></tr></tbody></table>
+            <p data-selection-placeholder=""><br></p>`
+        ),
+        contentAfter: unformat(
+            `[]<table><tbody><tr><td>a</td></tr></tbody></table>
+            <table><tbody><tr><td><textarea></textarea></td></tr></tbody></table>`
+        ),
+    });
+});
+
+test.tags("focus required");
+test("typing in a selection placeholder persists it", async () => {
+    await testEditor({
+        contentBefore: unformat(
+            `<p>a</p>
+            <table><tbody><tr><td>b[]</td></tr></tbody></table>
+            <table><tbody><tr><td>d</td></tr></tbody></table>
+            <p>e</p>`
+        ),
+        contentBeforeEdit: unformat(
+            `<p>a</p>
+            <table><tbody><tr><td>b[]</td></tr></tbody></table>
+            <p data-selection-placeholder=""><br></p>
+            <table><tbody><tr><td>d</td></tr></tbody></table>
+            <p>e</p>`
+        ),
+        stepFunction: async (editor) => {
+            await pressArrowKey(editor, "ArrowDown");
+            await insertText(editor, "c");
+        },
+        contentAfterEdit: unformat(
+            `<p>a</p>
+            <table><tbody><tr><td>b</td></tr></tbody></table>
+            <p>c[]</p>
+            <table><tbody><tr><td>d</td></tr></tbody></table>
+            <p>e</p>`
+        ),
+        contentAfter: unformat(
+            `<p>a</p>
+            <table><tbody><tr><td>b</td></tr></tbody></table>
+            <p>c[]</p>
+            <table><tbody><tr><td>d</td></tr></tbody></table>
+            <p>e</p>`
+        ),
+    });
+});
+
+test.tags("focus required");
+test("moving the caret into a trailing selection placeholder in the root persists it", async () => {
+    await testEditor({
+        contentBefore: unformat(
+            `<p>a</p>
+            <table><tbody><tr><td>b[]</td></tr></tbody></table>`
+        ),
+        contentBeforeEdit: unformat(
+            `<p>a</p>
+            <table><tbody><tr><td>b[]</td></tr></tbody></table>
+            <p data-selection-placeholder=""><br></p>`
+        ),
+        stepFunction: async (editor) => {
+            await pressArrowKey(editor, "ArrowDown");
+            await animationFrame(); // wait for selectionchange
+        },
+        contentAfterEdit: unformat(
+            `<p>a</p>
+            <table><tbody><tr><td>b</td></tr></tbody></table>
+            <p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`
+        ),
+        contentAfter: unformat(
+            `<p>a</p>
+            <table><tbody><tr><td>b</td></tr></tbody></table>
+            <p>[]<br></p>`
+        ),
+    });
+});
+
+test.tags("focus required");
+test("moving the caret into a trailing selection placeholder not in the root doesn't persist it", async () => {
+    await testEditor({
+        contentBefore: unformat(
+            `<p>a</p>
+            <div contenteditable="true">
+                <table><tbody><tr><td>b[]</td></tr></tbody></table>
+            </div>
+            <p>c</p>`
+        ),
+        contentBeforeEdit: unformat(
+            `<p>a</p>
+            <div contenteditable="true">
+                <p data-selection-placeholder=""><br></p>
+                <table><tbody><tr><td>b[]</td></tr></tbody></table>
+                <p data-selection-placeholder=""><br></p>
+            </div>
+            <p>c</p>`
+        ),
+        stepFunction: async (editor) => {
+            await pressArrowKey(editor, "ArrowDown");
+            await animationFrame(); // wait for selectionchange
+        },
+        contentAfterEdit: unformat(
+            `<p>a</p>
+            <div contenteditable="true">
+                <p data-selection-placeholder=""><br></p>
+                <table><tbody><tr><td>b</td></tr></tbody></table>
+                <p data-selection-placeholder="" o-we-hint-text='Type "/" for commands' class="o-we-hint o-horizontal-caret">[]<br></p>
+            </div>
+            <p>c</p>`
+        ),
+        contentAfter: unformat(
+            `<p>a</p>
+            <div contenteditable="true">
+                <table><tbody><tr><td>b</td></tr></tbody></table>
+                []
+            </div>
+            <p>c</p>`
+        ),
+    });
+});
+
+test.tags("focus required");
+test("enter in a selection placeholder persists it", async () => {
+    await testEditor({
+        contentBefore: unformat(
+            `<p>a</p>
+            <table><tbody><tr><td>b[]</td></tr></tbody></table>
+            <table><tbody><tr><td>c</td></tr></tbody></table>
+            <p>d</p>`
+        ),
+        contentBeforeEdit: unformat(
+            `<p>a</p>
+            <table><tbody><tr><td>b[]</td></tr></tbody></table>
+            <p data-selection-placeholder=""><br></p>
+            <table><tbody><tr><td>c</td></tr></tbody></table>
+            <p>d</p>`
+        ),
+        stepFunction: async (editor) => {
+            await pressArrowKey(editor, "ArrowDown");
+            expect(getContent(editor.editable)).toBe(
+                unformat(
+                    `<p>a</p>
+                    <table><tbody><tr><td>b</td></tr></tbody></table>
+                    <p data-selection-placeholder="" o-we-hint-text='Type "/" for commands' class="o-we-hint o-horizontal-caret">[]<br></p>
+                    <table><tbody><tr><td>c</td></tr></tbody></table>
+                    <p>d</p>`
+                ),
+                { message: "The placeholder was selected." }
+            );
+            splitBlock(editor);
+            await tick();
+        },
+        contentAfterEdit: unformat(
+            `<p>a</p>
+            <table><tbody><tr><td>b</td></tr></tbody></table>
+            <p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>
+            <table><tbody><tr><td>c</td></tr></tbody></table>
+            <p>d</p>`
+        ),
+        contentAfter: unformat(
+            `<p>a</p>
+            <table><tbody><tr><td>b</td></tr></tbody></table>
+            <p>[]<br></p>
+            <table><tbody><tr><td>c</td></tr></tbody></table>
+            <p>d</p>`
+        ),
+    });
+});
+
+test.tags("focus required");
+test("can undo/redo the persiting of selection placeholders", async () => {
+    const makeContent = (inTable = "", placeholder = "") =>
+        unformat(
+            `<p>a</p>
+            <table><tbody><tr><td>${inTable}</td></tr></tbody></table>
+            ${placeholder}
+            <table><tbody><tr><td>e</td></tr></tbody></table><p>f</p>`
+        );
+    const [undo, redo] = ["Z", "Y"].map((key) => async () => {
+        await press(["Ctrl", key]);
+        await tick();
+    });
+    await testEditor({
+        contentBefore: makeContent("b[]"),
+        contentBeforeEdit: makeContent("b[]", '<p data-selection-placeholder=""><br></p>'),
+        stepFunction: async (editor) => {
+            await insertText(editor, "c");
+            expect(getContent(editor.editable)).toBe(
+                makeContent("bc[]", '<p data-selection-placeholder=""><br></p>'),
+                {
+                    message: 'The letter "c" was inserted.',
+                }
+            );
+            await pressArrowKey(editor, "ArrowDown");
+            await insertText(editor, "d");
+            expect(getContent(editor.editable)).toBe(makeContent("bc", "<p>d[]</p>"), {
+                message: "The placeholder was persisted.",
+            });
+            await undo();
+            expect(getContent(editor.editable)).toBe(
+                makeContent(
+                    "bc",
+                    `<p data-selection-placeholder="" class="o-horizontal-caret o-we-hint" o-we-hint-text='Type "/" for commands'>[]<br></p>`
+                ),
+                { message: "Undo un-persisted the placeholder." }
+            );
+            await redo();
+            expect(getContent(editor.editable)).toBe(makeContent("bc", "<p>d[]</p>"), {
+                message: "Redo re-persisted the placeholder.",
+            });
+            await undo();
+            expect(getContent(editor.editable)).toBe(
+                makeContent(
+                    "bc",
+                    `<p data-selection-placeholder="" class="o-horizontal-caret o-we-hint" o-we-hint-text='Type "/" for commands'>[]<br></p>`
+                ),
+                { message: "Undo un-persisted the placeholder again." }
+            );
+            await undo();
+            expect(getContent(editor.editable)).toBe(
+                makeContent("b[]", '<p data-selection-placeholder=""><br></p>'),
+                {
+                    message: 'Undo removed the letter "c".',
+                }
+            );
+            await undo();
+            expect(getContent(editor.editable)).toBe(
+                makeContent("b[]", '<p data-selection-placeholder=""><br></p>'),
+                {
+                    message: "Undo did nothing.",
+                }
+            );
+        },
+        contentAfter: makeContent("b[]"),
+    });
+});
+
+test("a selection placeholder is restored after deletion from within", async () => {
+    await testEditor({
+        contentBefore: `<table><tbody><tr><td>[]a</td></tr></tbody></table>`,
+        contentBeforeEdit:
+            '<p data-selection-placeholder=""><br></p>' +
+            `<table><tbody><tr><td>[]a</td></tr></tbody></table>` +
+            '<p data-selection-placeholder=""><br></p>',
+        stepFunction: async (editor) => {
+            await pressArrowKey(editor, "ArrowUp");
+            expect(getContent(editor.editable)).toBe(
+                `<p data-selection-placeholder="" o-we-hint-text='Type "/" for commands' class="o-we-hint o-horizontal-caret">[]<br></p>` +
+                    `<table><tbody><tr><td>a</td></tr></tbody></table>` +
+                    '<p data-selection-placeholder=""><br></p>',
+                { message: "The top placeholder was selected." }
+            );
+            await press("Delete");
+            await tick();
+        },
+        contentAfterEdit: `<p data-selection-placeholder=""><br></p><table><tbody><tr><td>[]a</td></tr></tbody></table><p data-selection-placeholder=""><br></p>`,
+        contentAfter: `<table><tbody><tr><td>[]a</td></tr></tbody></table>`,
+    });
+});
+
+test("a selection placeholder is restored after deletion from without", async () => {
+    await testEditor({
+        contentBefore: `<table><tbody><tr><td>[]a</td></tr></tbody></table>`,
+        contentBeforeEdit:
+            '<p data-selection-placeholder=""><br></p>' +
+            `<table><tbody><tr><td>[]a</td></tr></tbody></table>` +
+            '<p data-selection-placeholder=""><br></p>',
+        stepFunction: async () => {
+            await press("Backspace");
+            await tick();
+        },
+        contentAfterEdit: `<p data-selection-placeholder=""><br></p><table><tbody><tr><td>[]a</td></tr></tbody></table><p data-selection-placeholder=""><br></p>`,
+        contentAfter: `<table><tbody><tr><td>[]a</td></tr></tbody></table>`,
+    });
+});
+
+test("selection placeholders are vertically positioned in the middle between it and its blocker", async () => {
+    const style = document.createElement("style");
+    await testEditor({
+        contentBefore: unformat(
+            `<table style="margin: 50px"><tbody><tr><td>a</td></tr></tbody></table>
+            <table style="margin: 10px"><tbody><tr><td>[]a</td></tr></tbody></table>`
+        ),
+        contentBeforeEdit: unformat(
+            `<p data-selection-placeholder="" style="margin: 25px 0px -26px;"><br></p>
+            <table style="margin: 50px"><tbody><tr><td>a</td></tr></tbody></table>
+            <p data-selection-placeholder="" style="margin: -21px 0px 30px;"><br></p>
+            <table style="margin: 10px"><tbody><tr><td>[]a</td></tr></tbody></table>
+            <p data-selection-placeholder="" style="margin: -6px 0px 5px;"><br></p>`
+        ),
+        stepFunction: async (editor) => {
+            style.innerText = `
+                *[contenteditable=true] {
+                    border: 1px solid blue;
+                }
+                table {
+                    border: 1px solid green;
+                }
+                p[data-selection-placeholder] {
+                    border-top: 1px solid red;
+                }
+            `;
+            editor.document.head.append(style);
+        },
+    });
+    // Comment this to make it easier to debug visually.
+    style.remove();
+});
+
+test("selection placeholder margins remain correct when an element gets added", async () => {
+    const style = document.createElement("style");
+    await testEditor({
+        contentBefore: unformat(
+            `<table style="margin: 50px"><tbody><tr><td>a</td></tr></tbody></table>
+            <table style="margin: 10px"><tbody><tr><td>[]a</td></tr></tbody></table>`
+        ),
+        stepFunction: async (editor) => {
+            style.innerText = `
+                *[contenteditable=true] {
+                    border: 1px solid blue;
+                }
+                table {
+                    border: 1px solid green;
+                }
+                p[data-selection-placeholder] {
+                    border-top: 1px solid red;
+                }
+            `;
+            editor.document.head.append(style);
+            const table = parseHTML(
+                editor.document,
+                `<table style="margin: 100px"><tbody><tr><td>[]a</td></tr></tbody></table>`
+            ).firstChild;
+            editor.editable.append(table);
+            editor.shared.history.addStep();
+            await animationFrame();
+        },
+        contentAfterEdit: unformat(
+            `<p data-selection-placeholder="" style="margin: 25px 0px -26px;"><br></p>
+            <table style="margin: 50px"><tbody><tr><td>a</td></tr></tbody></table>
+            <p data-selection-placeholder="" style="margin: -21px 0px 30px;"><br></p>
+            <table style="margin: 10px"><tbody><tr><td>[]a</td></tr></tbody></table>
+            <p data-selection-placeholder="" style="margin: 55px 0px -46px;"><br></p>
+            <table style="margin: 100px"><tbody><tr><td>[]a</td></tr></tbody></table>
+            <p data-selection-placeholder="" style="margin: -51px 0px 50px;"><br></p>`
+        ),
+    });
+    // Comment this to make it easier to debug visually.
+    style.remove();
+});

--- a/addons/html_editor/static/tests/syntax_highlighting.test.js
+++ b/addons/html_editor/static/tests/syntax_highlighting.test.js
@@ -49,12 +49,12 @@ test("starting edition with a pre activates syntax highlighting", async () => {
         contentBeforeEdit:
             '<p data-selection-placeholder=""><br></p>' +
             highlightedPre({ value: "some code" }) +
-            '<p data-selection-placeholder=""><br></p>',
+            '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
         stepFunction: async () => press(["ctrl", "z"]),
         contentAfterEdit:
             '<p data-selection-placeholder=""><br></p>' +
             highlightedPre({ value: "some code" }) +
-            '<p data-selection-placeholder=""><br></p>', // Undo did nothing.
+            '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>', // Undo did nothing.
         contentAfter: `<pre data-language-id="plaintext">some code</pre>`,
         config: configWithEmbeddings,
     });
@@ -69,14 +69,14 @@ test("starting edition with a pre activates syntax highlighting (with dataset va
         contentBeforeEdit:
             '<p data-selection-placeholder=""><br></p>' +
             highlightedPre({ value: "Hello world!", language: "javascript" }) +
-            '<p data-selection-placeholder=""><br></p>',
+            '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
         stepFunction: async (editor) => {
             await press(["ctrl", "z"]);
             await compareHighlightedContent(
                 getContent(editor.editable),
                 '<p data-selection-placeholder=""><br></p>' +
                     highlightedPre({ value: "Hello world!", language: "javascript" }) +
-                    '<p data-selection-placeholder=""><br></p>',
+                    '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
                 "Undo should have done nothing.",
                 editor
             );
@@ -90,7 +90,7 @@ test("starting edition with a pre activates syntax highlighting (with dataset va
                         language: "javascript",
                         textareaRange: 13, // "Hello world!a[]"
                     }) +
-                    '<p data-selection-placeholder=""><br></p>',
+                    '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
                 "Should have written at the end of the textarea.",
                 editor
             );
@@ -104,7 +104,7 @@ test("starting edition with a pre activates syntax highlighting (with dataset va
                 language: "javascript",
                 textareaRange: 12, // "Hello world![]"
             }) +
-            '<p data-selection-placeholder=""><br></p>', // Undo did nothing.
+            '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>', // Undo did nothing.
         contentAfter: `<pre data-language-id="javascript">Hello world!</pre>[]`,
         config: configWithEmbeddings,
     });
@@ -120,7 +120,7 @@ test("inserting a code block activates syntax highlighting plugin, typing trigge
                 getContent(editor.editable),
                 '<p data-selection-placeholder=""><br></p>' +
                     highlightedPre({ value: "abc", textareaRange: 3 }) +
-                    '<p data-selection-placeholder=""><br></p>',
+                    '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
                 "The syntax highlighting wrapper was inserted, the paragraph's content is its value and the selection in at the end of the textarea.",
                 editor
             );
@@ -129,7 +129,7 @@ test("inserting a code block activates syntax highlighting plugin, typing trigge
         contentAfterEdit:
             '<p data-selection-placeholder=""><br></p>' +
             highlightedPre({ value: "abcd", textareaRange: 4 }) +
-            '<p data-selection-placeholder=""><br></p>', // The change of value in the textarea is reflected in the pre.
+            '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>', // The change of value in the textarea is reflected in the pre.
         contentAfter: `<pre data-language-id="plaintext">abcd</pre>[]`,
         config: configWithEmbeddings,
     });
@@ -143,7 +143,7 @@ test("inserting an empty code block activates syntax highlighting plugin with an
         contentAfterEdit:
             '<p data-selection-placeholder=""><br></p>' +
             highlightedPre({ value: "", textareaRange: 0 }) +
-            '<p data-selection-placeholder=""><br></p>',
+            '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
         contentAfter: `<pre data-language-id="plaintext"><br></pre>[]`,
         config: configWithEmbeddings,
     });
@@ -173,7 +173,7 @@ test("inserting a code block in an empty paragraph with a style placeholder acti
                 value: "", // There should be no content (the zws is stripped)
                 textareaRange: 0,
             })}
-            <p data-selection-placeholder=""><br></p>`
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         ),
         contentAfter: `<p><br></p><pre data-language-id="plaintext"><br></pre>[]`,
         config: configWithEmbeddings,
@@ -188,7 +188,7 @@ test("changing languages in a code block changes its highlighting", async () => 
         contentBeforeEdit:
             '<p data-selection-placeholder=""><br></p>' +
             highlightedPre({ value: "some code", language: "plaintext" }) +
-            '<p data-selection-placeholder=""><br></p>',
+            '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
         stepFunction: async () => {
             await changeLanguage(queryOne("textarea"), "Plain Text", "Javascript");
         },
@@ -199,7 +199,7 @@ test("changing languages in a code block changes its highlighting", async () => 
                 language: "javascript",
                 textareaRange: 9,
             }) +
-            '<p data-selection-placeholder=""><br></p>',
+            '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
         contentAfter: `<pre data-language-id="javascript">some code</pre>[]`,
         config: configWithEmbeddings,
     });
@@ -212,7 +212,7 @@ test("should fill an empty pre", async () => {
         contentBeforeEdit:
             '<p data-selection-placeholder=""><br></p>' +
             highlightedPre({ value: "abc" }) +
-            '<p data-selection-placeholder=""><br></p>',
+            '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
         stepFunction: async () => {
             const textarea = queryOne("textarea");
             await click(textarea);
@@ -222,7 +222,7 @@ test("should fill an empty pre", async () => {
         contentAfterEdit:
             '<p data-selection-placeholder=""><br></p>' +
             highlightedPre({ value: "", textareaRange: 0 }) +
-            '<p data-selection-placeholder=""><br></p>', // Note: the BR is outside the highlight.
+            '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>', // Note: the BR is outside the highlight.
         contentAfter: `<pre data-language-id="plaintext"><br></pre>[]`,
         config: configWithEmbeddings,
     });
@@ -235,7 +235,7 @@ test("the textarea should never contains zws", async () => {
         contentBeforeEdit:
             '<p data-selection-placeholder=""><br></p>' +
             highlightedPre({ value: "abc" }) +
-            '<p data-selection-placeholder=""><br></p>',
+            '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
         stepFunction: async () => {
             const textarea = queryOne("textarea");
             await click(textarea);
@@ -243,7 +243,7 @@ test("the textarea should never contains zws", async () => {
         contentAfterEdit:
             '<p data-selection-placeholder=""><br></p>' +
             highlightedPre({ value: "abc", textareaRange: 3 }) +
-            '<p data-selection-placeholder=""><br></p>',
+            '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
         contentAfter: `<pre data-language-id="plaintext">abc</pre>[]`,
         config: configWithEmbeddings,
     });
@@ -262,7 +262,7 @@ test("can copy content with the copy button", async () => {
         contentBeforeEdit:
             '<p data-selection-placeholder=""><br></p>' +
             highlightedPre({ value: "abc" }) +
-            '<p data-selection-placeholder=""><br></p>',
+            '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
         stepFunction: async (editor) => {
             const textarea = queryOne("textarea");
             await click(textarea);
@@ -285,7 +285,7 @@ test("can copy content with the copy button", async () => {
         contentAfterEdit:
             '<p data-selection-placeholder=""><br></p>' +
             highlightedPre({ value: "abcd", textareaRange: 4 }) +
-            '<p data-selection-placeholder=""><br></p>',
+            '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
         contentAfter: `<pre data-language-id="plaintext">abcd</pre>[]`,
         config: configWithEmbeddings,
     });
@@ -298,7 +298,7 @@ test("tab in code block inserts 4 spaces", async () => {
         contentBeforeEdit:
             '<p data-selection-placeholder=""><br></p>' +
             highlightedPre({ value: "code" }) +
-            '<p data-selection-placeholder=""><br></p>',
+            '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
         stepFunction: async () => {
             await click("textarea");
             const textarea = queryOne("textarea");
@@ -311,7 +311,7 @@ test("tab in code block inserts 4 spaces", async () => {
                 value: "co    de",
                 textareaRange: 6, // "co    []de"
             }) +
-            '<p data-selection-placeholder=""><br></p>',
+            '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
         contentAfter: `<pre data-language-id="plaintext">co    de</pre>[]`,
         config: configWithEmbeddings,
     });
@@ -325,7 +325,7 @@ test("tab in selection in code block indents each selected line", async () => {
         contentBeforeEdit:
             '<p data-selection-placeholder=""><br></p>' +
             highlightedPre({ value: "a\nb c\n d" }) +
-            '<p data-selection-placeholder=""><br></p>',
+            '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
         stepFunction: async (editor) => {
             await click("textarea");
             const textarea = queryOne("textarea");
@@ -338,7 +338,7 @@ test("tab in selection in code block indents each selected line", async () => {
                 value: valueAfter,
                 textareaRange: [5, 19], // "    a[\n    b c\n     ]d"
             }) +
-            '<p data-selection-placeholder=""><br></p>',
+            '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
         contentAfter: `<pre data-language-id="plaintext">${valueAfter.replaceAll(
             "\n",
             "<br>"
@@ -355,7 +355,7 @@ test("shift+tab in code block outdents the current line", async () => {
         contentBeforeEdit:
             '<p data-selection-placeholder=""><br></p>' +
             highlightedPre({ value: "    some\n       co    de\n    for you" }) +
-            '<p data-selection-placeholder=""><br></p>',
+            '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
         stepFunction: async (editor) => {
             await click("textarea");
             const textarea = queryOne("textarea");
@@ -368,7 +368,7 @@ test("shift+tab in code block outdents the current line", async () => {
                         value: "    some\n   co    de\n    for you",
                         textareaRange: 18, // "    some\n   co    []de\n    for you"
                     }) +
-                    '<p data-selection-placeholder=""><br></p>',
+                    '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
                 "The content was outdented a first time.",
                 editor
             );
@@ -380,7 +380,7 @@ test("shift+tab in code block outdents the current line", async () => {
                 value: valueAfter,
                 textareaRange: 15, // "    some\nco    []de\n    for you"
             }) +
-            '<p data-selection-placeholder=""><br></p>',
+            '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
         contentAfter: `<pre data-language-id="plaintext">${valueAfter.replaceAll(
             "\n",
             "<br>"
@@ -396,7 +396,7 @@ test("shift+tab in selection in code block outdents each selected line", async (
         contentBeforeEdit:
             '<p data-selection-placeholder=""><br></p>' +
             highlightedPre({ value: "    a\n    b c\n     d" }) +
-            '<p data-selection-placeholder=""><br></p>',
+            '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
         stepFunction: async (editor) => {
             await click("textarea");
             const textarea = queryOne("textarea");
@@ -409,7 +409,7 @@ test("shift+tab in selection in code block outdents each selected line", async (
                         value: "a\nb c\n d",
                         textareaRange: [1, 7], // "a[\nb c\n ]d"
                     }) +
-                    '<p data-selection-placeholder=""><br></p>',
+                    '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
                 "The content was outdented a first time.",
                 editor
             );
@@ -422,7 +422,7 @@ test("shift+tab in selection in code block outdents each selected line", async (
                 value: "a\nb c\nd",
                 textareaRange: [1, 6], // "a[\nb c\n]d"
             }) +
-            '<p data-selection-placeholder=""><br></p>',
+            '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
         config: configWithEmbeddings,
         contentAfter: `<pre data-language-id="plaintext">a<br>b c<br>d</pre>[]`,
     });
@@ -440,7 +440,7 @@ test("can switch between code blocks without issues", async () => {
             ${highlightedPre({ value: "de" })}
             <p>gh</p>
             ${highlightedPre({ value: "jk" })}
-            <p data-selection-placeholder=""><br></p>`
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         ),
         "The content was highlighted",
         editor
@@ -459,7 +459,7 @@ test("can switch between code blocks without issues", async () => {
             ${highlightedPre({ value: "de" })}
             <p>gh</p>
             ${highlightedPre({ value: "jkl", textareaRange: 3 })}
-            <p data-selection-placeholder=""><br></p>`
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         ),
         `1. Inserted "l" into the second pre and highlighted it.`,
         editor
@@ -475,7 +475,7 @@ test("can switch between code blocks without issues", async () => {
             ${highlightedPre({ value: "def", textareaRange: 3 })}
             <p>gh</p>
             ${highlightedPre({ value: "jkl" })}
-            <p data-selection-placeholder=""><br></p>`
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         ),
         `2. Inserted "f" into the first pre and highlighted it.`,
         editor
@@ -491,7 +491,7 @@ test("can switch between code blocks without issues", async () => {
             ${highlightedPre({ value: "def" })}
             <p>gh</p>
             ${highlightedPre({ value: "jkl" })}
-            <p data-selection-placeholder=""><br></p>`
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         ),
         `3. Inserted "c" into the first paragraph.`,
         editor
@@ -507,7 +507,7 @@ test("can switch between code blocks without issues", async () => {
             ${highlightedPre({ value: "def" })}
             <p>ghi[]</p>
             ${highlightedPre({ value: "jkl" })}
-            <p data-selection-placeholder=""><br></p>`
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         ),
         `4. Inserted "i" into the second paragraph.`,
         editor
@@ -521,7 +521,7 @@ test("can switch between code blocks without issues", async () => {
             ${highlightedPre({ value: "def", language: "javascript", textareaRange: 3 })}
             <p>ghi</p>
             ${highlightedPre({ value: "jkl" })}
-            <p data-selection-placeholder=""><br></p>`
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         ),
         `5. Changed the language of the first textarea to "javascript".`,
         editor
@@ -535,7 +535,7 @@ test("can switch between code blocks without issues", async () => {
             ${highlightedPre({ value: "def", language: "javascript" })}
             <p>ghi</p>
             ${highlightedPre({ value: "jkl", language: "python", textareaRange: 3 })}
-            <p data-selection-placeholder=""><br></p>`
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         ),
         `6. Changed the language of the second textarea to "python".`,
         editor
@@ -553,7 +553,7 @@ test("can switch between code blocks without issues", async () => {
             ${highlightedPre({ value: "def", language: "javascript" })}
             <p>ghi</p>
             ${highlightedPre({ value: "jkl", textareaRange: 3 })}
-            <p data-selection-placeholder=""><br></p>`
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         ),
         // TODO: is it correct to not move the focus?
         `Undo 6 changed back the language of the second textarea to "plaintext" (without losing the current focus, editor).`,
@@ -568,7 +568,7 @@ test("can switch between code blocks without issues", async () => {
             ${highlightedPre({ value: "def", textareaRange: 3 })}
             <p>ghi</p>
             ${highlightedPre({ value: "jkl" })}
-            <p data-selection-placeholder=""><br></p>`
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         ),
         // TODO: is it correct to move the focus?
         `Undo 5 changed back the language of the first textarea to "plaintext" (and move the focus to the last focused textarea, editor).`,
@@ -583,7 +583,7 @@ test("can switch between code blocks without issues", async () => {
             ${highlightedPre({ value: "def" })}
             <p>gh[]</p>
             ${highlightedPre({ value: "jkl" })}
-            <p data-selection-placeholder=""><br></p>`
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         ),
         `Undo 4 removed the "i" from the second paragraph.`,
         editor
@@ -597,7 +597,7 @@ test("can switch between code blocks without issues", async () => {
             ${highlightedPre({ value: "def" })}
             <p>gh</p>
             ${highlightedPre({ value: "jkl" })}
-            <p data-selection-placeholder=""><br></p>`
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         ),
         `Undo 3 removed the "c" from the first paragraph.`,
         editor
@@ -611,7 +611,7 @@ test("can switch between code blocks without issues", async () => {
             ${highlightedPre({ value: "de", textareaRange: 2 })}
             <p>gh</p>
             ${highlightedPre({ value: "jkl" })}
-            <p data-selection-placeholder=""><br></p>`
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         ),
         `Undo 2 removed the "f" from the first pre and un-highlighted it.`,
         editor
@@ -625,7 +625,7 @@ test("can switch between code blocks without issues", async () => {
             ${highlightedPre({ value: "de" })}
             <p>gh</p>
             ${highlightedPre({ value: "jk", textareaRange: 2 })}
-            <p data-selection-placeholder=""><br></p>`
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         ),
         `Undo 1 removed the "l" from the second pre and un-highlighted it.`,
         editor
@@ -639,7 +639,7 @@ test("can switch between code blocks without issues", async () => {
             ${highlightedPre({ value: "de" })}
             <p>gh</p>
             ${highlightedPre({ value: "jk", textareaRange: 2 })}
-            <p data-selection-placeholder=""><br></p>`
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         ),
         "Undo did nothing.",
         editor
@@ -657,7 +657,7 @@ test("can switch between code blocks without issues", async () => {
             ${highlightedPre({ value: "de" })}
             <p>gh</p>
             ${highlightedPre({ value: "jkl", textareaRange: 3 })}
-            <p data-selection-placeholder=""><br></p>`
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         ),
         `Redo 1 reinserted "l" into the second pre and re-highlighted it.`,
         editor
@@ -671,7 +671,7 @@ test("can switch between code blocks without issues", async () => {
             ${highlightedPre({ value: "def", textareaRange: 3 })}
             <p>gh</p>
             ${highlightedPre({ value: "jkl" })}
-            <p data-selection-placeholder=""><br></p>`
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         ),
         `Redo 2 reinserted "f" into the first pre and re-highlighted it.`,
         editor
@@ -685,7 +685,7 @@ test("can switch between code blocks without issues", async () => {
             ${highlightedPre({ value: "def" })}
             <p>gh</p>
             ${highlightedPre({ value: "jkl" })}
-            <p data-selection-placeholder=""><br></p>`
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         ),
         `Redo 3 reinserted "c" into the first paragraph.`,
         editor
@@ -699,7 +699,7 @@ test("can switch between code blocks without issues", async () => {
             ${highlightedPre({ value: "def" })}
             <p>ghi[]</p>
             ${highlightedPre({ value: "jkl" })}
-            <p data-selection-placeholder=""><br></p>`
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         ),
         `Redo 4 reinserted "i" into the second paragraph.`,
         editor
@@ -713,7 +713,7 @@ test("can switch between code blocks without issues", async () => {
             ${highlightedPre({ value: "def", language: "javascript", textareaRange: 3 })}
             <p>ghi</p>
             ${highlightedPre({ value: "jkl" })}
-            <p data-selection-placeholder=""><br></p>`
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         ),
         `Redo 5 changed back the language of the first textarea to "javascript".`,
         editor
@@ -727,7 +727,7 @@ test("can switch between code blocks without issues", async () => {
             ${highlightedPre({ value: "def", language: "javascript" })}
             <p>ghi</p>
             ${highlightedPre({ value: "jkl", language: "python", textareaRange: 3 })}
-            <p data-selection-placeholder=""><br></p>`
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         ),
         `Redo 6 changed back the language of the second textarea to "python".`,
         editor
@@ -741,7 +741,7 @@ test("can switch between code blocks without issues", async () => {
             ${highlightedPre({ value: "def", language: "javascript" })}
             <p>ghi</p>
             ${highlightedPre({ value: "jkl", language: "python", textareaRange: 3 })}
-            <p data-selection-placeholder=""><br></p>`
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         ),
         "Redo did nothing.",
         editor

--- a/addons/html_editor/static/tests/syntax_highlighting.test.js
+++ b/addons/html_editor/static/tests/syntax_highlighting.test.js
@@ -46,9 +46,15 @@ test("starting edition with a pre activates syntax highlighting", async () => {
     await testEditor({
         compareFunction: compareHighlightedContent,
         contentBefore: "<pre>some code</pre>",
-        contentBeforeEdit: highlightedPre({ value: "some code" }),
+        contentBeforeEdit:
+            '<p data-selection-placeholder=""><br></p>' +
+            highlightedPre({ value: "some code" }) +
+            '<p data-selection-placeholder=""><br></p>',
         stepFunction: async () => press(["ctrl", "z"]),
-        contentAfterEdit: highlightedPre({ value: "some code" }), // Undo did nothing.
+        contentAfterEdit:
+            '<p data-selection-placeholder=""><br></p>' +
+            highlightedPre({ value: "some code" }) +
+            '<p data-selection-placeholder=""><br></p>', // Undo did nothing.
         contentAfter: `<pre data-language-id="plaintext">some code</pre>`,
         config: configWithEmbeddings,
     });
@@ -60,12 +66,17 @@ test("starting edition with a pre activates syntax highlighting (with dataset va
         contentBefore: `<pre data-language-id="javascript">Hello world!</pre>`,
         // The DIV should now be filled with a highlighted pre and a textarea,
         // the respective values of which match the dataset.
-        contentBeforeEdit: highlightedPre({ value: "Hello world!", language: "javascript" }),
+        contentBeforeEdit:
+            '<p data-selection-placeholder=""><br></p>' +
+            highlightedPre({ value: "Hello world!", language: "javascript" }) +
+            '<p data-selection-placeholder=""><br></p>',
         stepFunction: async (editor) => {
             await press(["ctrl", "z"]);
             await compareHighlightedContent(
                 getContent(editor.editable),
-                highlightedPre({ value: "Hello world!", language: "javascript" }),
+                '<p data-selection-placeholder=""><br></p>' +
+                    highlightedPre({ value: "Hello world!", language: "javascript" }) +
+                    '<p data-selection-placeholder=""><br></p>',
                 "Undo should have done nothing.",
                 editor
             );
@@ -73,22 +84,27 @@ test("starting edition with a pre activates syntax highlighting (with dataset va
             await press("a");
             await compareHighlightedContent(
                 getContent(editor.editable),
-                highlightedPre({
-                    value: "Hello world!a",
-                    language: "javascript",
-                    textareaRange: 13, // "Hello world!a[]"
-                }),
+                '<p data-selection-placeholder=""><br></p>' +
+                    highlightedPre({
+                        value: "Hello world!a",
+                        language: "javascript",
+                        textareaRange: 13, // "Hello world!a[]"
+                    }) +
+                    '<p data-selection-placeholder=""><br></p>',
                 "Should have written at the end of the textarea.",
                 editor
             );
             await press(["ctrl", "z"]);
             await press(["ctrl", "z"]);
         },
-        contentAfterEdit: highlightedPre({
-            value: "Hello world!",
-            language: "javascript",
-            textareaRange: 12, // "Hello world![]"
-        }), // Undo did nothing.
+        contentAfterEdit:
+            '<p data-selection-placeholder=""><br></p>' +
+            highlightedPre({
+                value: "Hello world!",
+                language: "javascript",
+                textareaRange: 12, // "Hello world![]"
+            }) +
+            '<p data-selection-placeholder=""><br></p>', // Undo did nothing.
         contentAfter: `<pre data-language-id="javascript">Hello world!</pre>[]`,
         config: configWithEmbeddings,
     });
@@ -102,13 +118,18 @@ test("inserting a code block activates syntax highlighting plugin, typing trigge
             await insertPre(editor);
             await compareHighlightedContent(
                 getContent(editor.editable),
-                highlightedPre({ value: "abc", textareaRange: 3 }),
+                '<p data-selection-placeholder=""><br></p>' +
+                    highlightedPre({ value: "abc", textareaRange: 3 }) +
+                    '<p data-selection-placeholder=""><br></p>',
                 "The syntax highlighting wrapper was inserted, the paragraph's content is its value and the selection in at the end of the textarea.",
                 editor
             );
             await press("d");
         },
-        contentAfterEdit: highlightedPre({ value: "abcd", textareaRange: 4 }), // The change of value in the textarea is reflected in the pre.
+        contentAfterEdit:
+            '<p data-selection-placeholder=""><br></p>' +
+            highlightedPre({ value: "abcd", textareaRange: 4 }) +
+            '<p data-selection-placeholder=""><br></p>', // The change of value in the textarea is reflected in the pre.
         contentAfter: `<pre data-language-id="plaintext">abcd</pre>[]`,
         config: configWithEmbeddings,
     });
@@ -119,7 +140,10 @@ test("inserting an empty code block activates syntax highlighting plugin with an
         compareFunction: compareHighlightedContent,
         contentBefore: "<p><br>[]</p>",
         stepFunction: insertPre,
-        contentAfterEdit: highlightedPre({ value: "", textareaRange: 0 }),
+        contentAfterEdit:
+            '<p data-selection-placeholder=""><br></p>' +
+            highlightedPre({ value: "", textareaRange: 0 }) +
+            '<p data-selection-placeholder=""><br></p>',
         contentAfter: `<pre data-language-id="plaintext"><br></pre>[]`,
         config: configWithEmbeddings,
     });
@@ -148,7 +172,8 @@ test("inserting a code block in an empty paragraph with a style placeholder acti
             ${highlightedPre({
                 value: "", // There should be no content (the zws is stripped)
                 textareaRange: 0,
-            })}`
+            })}
+            <p data-selection-placeholder=""><br></p>`
         ),
         contentAfter: `<p><br></p><pre data-language-id="plaintext"><br></pre>[]`,
         config: configWithEmbeddings,
@@ -160,15 +185,21 @@ test("changing languages in a code block changes its highlighting", async () => 
     await testEditor({
         compareFunction: compareHighlightedContent,
         contentBefore: "<pre>some code</pre>",
-        contentBeforeEdit: highlightedPre({ value: "some code", language: "plaintext" }),
+        contentBeforeEdit:
+            '<p data-selection-placeholder=""><br></p>' +
+            highlightedPre({ value: "some code", language: "plaintext" }) +
+            '<p data-selection-placeholder=""><br></p>',
         stepFunction: async () => {
             await changeLanguage(queryOne("textarea"), "Plain Text", "Javascript");
         },
-        contentAfterEdit: highlightedPre({
-            value: "some code",
-            language: "javascript",
-            textareaRange: 9,
-        }),
+        contentAfterEdit:
+            '<p data-selection-placeholder=""><br></p>' +
+            highlightedPre({
+                value: "some code",
+                language: "javascript",
+                textareaRange: 9,
+            }) +
+            '<p data-selection-placeholder=""><br></p>',
         contentAfter: `<pre data-language-id="javascript">some code</pre>[]`,
         config: configWithEmbeddings,
     });
@@ -178,14 +209,20 @@ test("should fill an empty pre", async () => {
     await testEditor({
         compareFunction: compareHighlightedContent,
         contentBefore: "<pre>abc</pre>",
-        contentBeforeEdit: highlightedPre({ value: "abc" }),
+        contentBeforeEdit:
+            '<p data-selection-placeholder=""><br></p>' +
+            highlightedPre({ value: "abc" }) +
+            '<p data-selection-placeholder=""><br></p>',
         stepFunction: async () => {
             const textarea = queryOne("textarea");
             await click(textarea);
             textarea.select();
             await press("backspace");
         },
-        contentAfterEdit: highlightedPre({ value: "", textareaRange: 0 }), // Note: the BR is outside the highlight.
+        contentAfterEdit:
+            '<p data-selection-placeholder=""><br></p>' +
+            highlightedPre({ value: "", textareaRange: 0 }) +
+            '<p data-selection-placeholder=""><br></p>', // Note: the BR is outside the highlight.
         contentAfter: `<pre data-language-id="plaintext"><br></pre>[]`,
         config: configWithEmbeddings,
     });
@@ -195,12 +232,18 @@ test("the textarea should never contains zws", async () => {
     await testEditor({
         compareFunction: compareHighlightedContent,
         contentBefore: "<pre>a\u200bb\ufeffc</pre>",
-        contentBeforeEdit: highlightedPre({ value: "abc" }),
+        contentBeforeEdit:
+            '<p data-selection-placeholder=""><br></p>' +
+            highlightedPre({ value: "abc" }) +
+            '<p data-selection-placeholder=""><br></p>',
         stepFunction: async () => {
             const textarea = queryOne("textarea");
             await click(textarea);
         },
-        contentAfterEdit: highlightedPre({ value: "abc", textareaRange: 3 }),
+        contentAfterEdit:
+            '<p data-selection-placeholder=""><br></p>' +
+            highlightedPre({ value: "abc", textareaRange: 3 }) +
+            '<p data-selection-placeholder=""><br></p>',
         contentAfter: `<pre data-language-id="plaintext">abc</pre>[]`,
         config: configWithEmbeddings,
     });
@@ -216,7 +259,10 @@ test("can copy content with the copy button", async () => {
     await testEditor({
         compareFunction: compareHighlightedContent,
         contentBefore: "<pre>abc</pre>",
-        contentBeforeEdit: highlightedPre({ value: "abc" }),
+        contentBeforeEdit:
+            '<p data-selection-placeholder=""><br></p>' +
+            highlightedPre({ value: "abc" }) +
+            '<p data-selection-placeholder=""><br></p>',
         stepFunction: async (editor) => {
             const textarea = queryOne("textarea");
             await click(textarea);
@@ -236,7 +282,10 @@ test("can copy content with the copy button", async () => {
             expect.verifySteps(["abcd"]);
             textarea.focus();
         },
-        contentAfterEdit: highlightedPre({ value: "abcd", textareaRange: 4 }),
+        contentAfterEdit:
+            '<p data-selection-placeholder=""><br></p>' +
+            highlightedPre({ value: "abcd", textareaRange: 4 }) +
+            '<p data-selection-placeholder=""><br></p>',
         contentAfter: `<pre data-language-id="plaintext">abcd</pre>[]`,
         config: configWithEmbeddings,
     });
@@ -246,17 +295,23 @@ test("tab in code block inserts 4 spaces", async () => {
     await testEditor({
         compareFunction: compareHighlightedContent,
         contentBefore: "<pre>code</pre>",
-        contentBeforeEdit: highlightedPre({ value: "code" }),
+        contentBeforeEdit:
+            '<p data-selection-placeholder=""><br></p>' +
+            highlightedPre({ value: "code" }) +
+            '<p data-selection-placeholder=""><br></p>',
         stepFunction: async () => {
             await click("textarea");
             const textarea = queryOne("textarea");
             textarea.setSelectionRange(2, 2); // "co[]de"
             await press("tab");
         },
-        contentAfterEdit: highlightedPre({
-            value: "co    de",
-            textareaRange: 6, // "co    []de"
-        }),
+        contentAfterEdit:
+            '<p data-selection-placeholder=""><br></p>' +
+            highlightedPre({
+                value: "co    de",
+                textareaRange: 6, // "co    []de"
+            }) +
+            '<p data-selection-placeholder=""><br></p>',
         contentAfter: `<pre data-language-id="plaintext">co    de</pre>[]`,
         config: configWithEmbeddings,
     });
@@ -267,17 +322,23 @@ test("tab in selection in code block indents each selected line", async () => {
     await testEditor({
         compareFunction: compareHighlightedContent,
         contentBefore: "<pre>a<br>b c<br> d</pre>",
-        contentBeforeEdit: highlightedPre({ value: "a\nb c\n d" }),
+        contentBeforeEdit:
+            '<p data-selection-placeholder=""><br></p>' +
+            highlightedPre({ value: "a\nb c\n d" }) +
+            '<p data-selection-placeholder=""><br></p>',
         stepFunction: async (editor) => {
             await click("textarea");
             const textarea = queryOne("textarea");
             textarea.setSelectionRange(1, 7); // "a[\nb c\n ]d"
             await press("tab");
         },
-        contentAfterEdit: highlightedPre({
-            value: valueAfter,
-            textareaRange: [5, 19], // "    a[\n    b c\n     ]d"
-        }),
+        contentAfterEdit:
+            '<p data-selection-placeholder=""><br></p>' +
+            highlightedPre({
+                value: valueAfter,
+                textareaRange: [5, 19], // "    a[\n    b c\n     ]d"
+            }) +
+            '<p data-selection-placeholder=""><br></p>',
         contentAfter: `<pre data-language-id="plaintext">${valueAfter.replaceAll(
             "\n",
             "<br>"
@@ -291,7 +352,10 @@ test("shift+tab in code block outdents the current line", async () => {
     await testEditor({
         compareFunction: compareHighlightedContent,
         contentBefore: "<pre>    some<br>       co    de<br>    for you</pre>",
-        contentBeforeEdit: highlightedPre({ value: "    some\n       co    de\n    for you" }),
+        contentBeforeEdit:
+            '<p data-selection-placeholder=""><br></p>' +
+            highlightedPre({ value: "    some\n       co    de\n    for you" }) +
+            '<p data-selection-placeholder=""><br></p>',
         stepFunction: async (editor) => {
             await click("textarea");
             const textarea = queryOne("textarea");
@@ -299,19 +363,24 @@ test("shift+tab in code block outdents the current line", async () => {
             await press(["shift", "tab"]);
             await compareHighlightedContent(
                 getContent(editor.editable),
-                highlightedPre({
-                    value: "    some\n   co    de\n    for you",
-                    textareaRange: 18, // "    some\n   co    []de\n    for you"
-                }),
+                '<p data-selection-placeholder=""><br></p>' +
+                    highlightedPre({
+                        value: "    some\n   co    de\n    for you",
+                        textareaRange: 18, // "    some\n   co    []de\n    for you"
+                    }) +
+                    '<p data-selection-placeholder=""><br></p>',
                 "The content was outdented a first time.",
                 editor
             );
             await press(["shift", "tab"]);
         },
-        contentAfterEdit: highlightedPre({
-            value: valueAfter,
-            textareaRange: 15, // "    some\nco    []de\n    for you"
-        }),
+        contentAfterEdit:
+            '<p data-selection-placeholder=""><br></p>' +
+            highlightedPre({
+                value: valueAfter,
+                textareaRange: 15, // "    some\nco    []de\n    for you"
+            }) +
+            '<p data-selection-placeholder=""><br></p>',
         contentAfter: `<pre data-language-id="plaintext">${valueAfter.replaceAll(
             "\n",
             "<br>"
@@ -324,7 +393,10 @@ test("shift+tab in selection in code block outdents each selected line", async (
     await testEditor({
         compareFunction: compareHighlightedContent,
         contentBefore: "<pre>    a<br>    b c<br>     d</pre>",
-        contentBeforeEdit: highlightedPre({ value: "    a\n    b c\n     d" }),
+        contentBeforeEdit:
+            '<p data-selection-placeholder=""><br></p>' +
+            highlightedPre({ value: "    a\n    b c\n     d" }) +
+            '<p data-selection-placeholder=""><br></p>',
         stepFunction: async (editor) => {
             await click("textarea");
             const textarea = queryOne("textarea");
@@ -332,20 +404,25 @@ test("shift+tab in selection in code block outdents each selected line", async (
             await press(["shift", "tab"]);
             await compareHighlightedContent(
                 getContent(editor.editable),
-                highlightedPre({
-                    value: "a\nb c\n d",
-                    textareaRange: [1, 7], // "a[\nb c\n ]d"
-                }),
+                '<p data-selection-placeholder=""><br></p>' +
+                    highlightedPre({
+                        value: "a\nb c\n d",
+                        textareaRange: [1, 7], // "a[\nb c\n ]d"
+                    }) +
+                    '<p data-selection-placeholder=""><br></p>',
                 "The content was outdented a first time.",
                 editor
             );
             // Remove the last remaining leading space.
             await press(["shift", "tab"]);
         },
-        contentAfterEdit: highlightedPre({
-            value: "a\nb c\nd",
-            textareaRange: [1, 6], // "a[\nb c\n]d"
-        }),
+        contentAfterEdit:
+            '<p data-selection-placeholder=""><br></p>' +
+            highlightedPre({
+                value: "a\nb c\nd",
+                textareaRange: [1, 6], // "a[\nb c\n]d"
+            }) +
+            '<p data-selection-placeholder=""><br></p>',
         config: configWithEmbeddings,
         contentAfter: `<pre data-language-id="plaintext">a<br>b c<br>d</pre>[]`,
     });
@@ -362,7 +439,8 @@ test("can switch between code blocks without issues", async () => {
             `<p>ab</p>
             ${highlightedPre({ value: "de" })}
             <p>gh</p>
-            ${highlightedPre({ value: "jk" })}`
+            ${highlightedPre({ value: "jk" })}
+            <p data-selection-placeholder=""><br></p>`
         ),
         "The content was highlighted",
         editor
@@ -380,7 +458,8 @@ test("can switch between code blocks without issues", async () => {
             `<p>ab</p>
             ${highlightedPre({ value: "de" })}
             <p>gh</p>
-            ${highlightedPre({ value: "jkl", textareaRange: 3 })}`
+            ${highlightedPre({ value: "jkl", textareaRange: 3 })}
+            <p data-selection-placeholder=""><br></p>`
         ),
         `1. Inserted "l" into the second pre and highlighted it.`,
         editor
@@ -395,7 +474,8 @@ test("can switch between code blocks without issues", async () => {
             `<p>ab</p>
             ${highlightedPre({ value: "def", textareaRange: 3 })}
             <p>gh</p>
-            ${highlightedPre({ value: "jkl" })}`
+            ${highlightedPre({ value: "jkl" })}
+            <p data-selection-placeholder=""><br></p>`
         ),
         `2. Inserted "f" into the first pre and highlighted it.`,
         editor
@@ -410,7 +490,8 @@ test("can switch between code blocks without issues", async () => {
             `<p>abc[]</p>
             ${highlightedPre({ value: "def" })}
             <p>gh</p>
-            ${highlightedPre({ value: "jkl" })}`
+            ${highlightedPre({ value: "jkl" })}
+            <p data-selection-placeholder=""><br></p>`
         ),
         `3. Inserted "c" into the first paragraph.`,
         editor
@@ -425,7 +506,8 @@ test("can switch between code blocks without issues", async () => {
             `<p>abc</p>
             ${highlightedPre({ value: "def" })}
             <p>ghi[]</p>
-            ${highlightedPre({ value: "jkl" })}`
+            ${highlightedPre({ value: "jkl" })}
+            <p data-selection-placeholder=""><br></p>`
         ),
         `4. Inserted "i" into the second paragraph.`,
         editor
@@ -438,7 +520,8 @@ test("can switch between code blocks without issues", async () => {
             `<p>abc</p>
             ${highlightedPre({ value: "def", language: "javascript", textareaRange: 3 })}
             <p>ghi</p>
-            ${highlightedPre({ value: "jkl" })}`
+            ${highlightedPre({ value: "jkl" })}
+            <p data-selection-placeholder=""><br></p>`
         ),
         `5. Changed the language of the first textarea to "javascript".`,
         editor
@@ -451,7 +534,8 @@ test("can switch between code blocks without issues", async () => {
             `<p>abc</p>
             ${highlightedPre({ value: "def", language: "javascript" })}
             <p>ghi</p>
-            ${highlightedPre({ value: "jkl", language: "python", textareaRange: 3 })}`
+            ${highlightedPre({ value: "jkl", language: "python", textareaRange: 3 })}
+            <p data-selection-placeholder=""><br></p>`
         ),
         `6. Changed the language of the second textarea to "python".`,
         editor
@@ -468,7 +552,8 @@ test("can switch between code blocks without issues", async () => {
             `<p>abc</p>
             ${highlightedPre({ value: "def", language: "javascript" })}
             <p>ghi</p>
-            ${highlightedPre({ value: "jkl", textareaRange: 3 })}`
+            ${highlightedPre({ value: "jkl", textareaRange: 3 })}
+            <p data-selection-placeholder=""><br></p>`
         ),
         // TODO: is it correct to not move the focus?
         `Undo 6 changed back the language of the second textarea to "plaintext" (without losing the current focus, editor).`,
@@ -482,7 +567,8 @@ test("can switch between code blocks without issues", async () => {
             `<p>abc</p>
             ${highlightedPre({ value: "def", textareaRange: 3 })}
             <p>ghi</p>
-            ${highlightedPre({ value: "jkl" })}`
+            ${highlightedPre({ value: "jkl" })}
+            <p data-selection-placeholder=""><br></p>`
         ),
         // TODO: is it correct to move the focus?
         `Undo 5 changed back the language of the first textarea to "plaintext" (and move the focus to the last focused textarea, editor).`,
@@ -496,7 +582,8 @@ test("can switch between code blocks without issues", async () => {
             `<p>abc</p>
             ${highlightedPre({ value: "def" })}
             <p>gh[]</p>
-            ${highlightedPre({ value: "jkl" })}`
+            ${highlightedPre({ value: "jkl" })}
+            <p data-selection-placeholder=""><br></p>`
         ),
         `Undo 4 removed the "i" from the second paragraph.`,
         editor
@@ -509,7 +596,8 @@ test("can switch between code blocks without issues", async () => {
             `<p>ab[]</p>
             ${highlightedPre({ value: "def" })}
             <p>gh</p>
-            ${highlightedPre({ value: "jkl" })}`
+            ${highlightedPre({ value: "jkl" })}
+            <p data-selection-placeholder=""><br></p>`
         ),
         `Undo 3 removed the "c" from the first paragraph.`,
         editor
@@ -522,7 +610,8 @@ test("can switch between code blocks without issues", async () => {
             `<p>ab</p>
             ${highlightedPre({ value: "de", textareaRange: 2 })}
             <p>gh</p>
-            ${highlightedPre({ value: "jkl" })}`
+            ${highlightedPre({ value: "jkl" })}
+            <p data-selection-placeholder=""><br></p>`
         ),
         `Undo 2 removed the "f" from the first pre and un-highlighted it.`,
         editor
@@ -535,7 +624,8 @@ test("can switch between code blocks without issues", async () => {
             `<p>ab</p>
             ${highlightedPre({ value: "de" })}
             <p>gh</p>
-            ${highlightedPre({ value: "jk", textareaRange: 2 })}`
+            ${highlightedPre({ value: "jk", textareaRange: 2 })}
+            <p data-selection-placeholder=""><br></p>`
         ),
         `Undo 1 removed the "l" from the second pre and un-highlighted it.`,
         editor
@@ -548,7 +638,8 @@ test("can switch between code blocks without issues", async () => {
             `<p>ab</p>
             ${highlightedPre({ value: "de" })}
             <p>gh</p>
-            ${highlightedPre({ value: "jk", textareaRange: 2 })}`
+            ${highlightedPre({ value: "jk", textareaRange: 2 })}
+            <p data-selection-placeholder=""><br></p>`
         ),
         "Undo did nothing.",
         editor
@@ -565,7 +656,8 @@ test("can switch between code blocks without issues", async () => {
             `<p>ab</p>
             ${highlightedPre({ value: "de" })}
             <p>gh</p>
-            ${highlightedPre({ value: "jkl", textareaRange: 3 })}`
+            ${highlightedPre({ value: "jkl", textareaRange: 3 })}
+            <p data-selection-placeholder=""><br></p>`
         ),
         `Redo 1 reinserted "l" into the second pre and re-highlighted it.`,
         editor
@@ -578,7 +670,8 @@ test("can switch between code blocks without issues", async () => {
             `<p>ab</p>
             ${highlightedPre({ value: "def", textareaRange: 3 })}
             <p>gh</p>
-            ${highlightedPre({ value: "jkl" })}`
+            ${highlightedPre({ value: "jkl" })}
+            <p data-selection-placeholder=""><br></p>`
         ),
         `Redo 2 reinserted "f" into the first pre and re-highlighted it.`,
         editor
@@ -591,7 +684,8 @@ test("can switch between code blocks without issues", async () => {
             `<p>abc[]</p>
             ${highlightedPre({ value: "def" })}
             <p>gh</p>
-            ${highlightedPre({ value: "jkl" })}`
+            ${highlightedPre({ value: "jkl" })}
+            <p data-selection-placeholder=""><br></p>`
         ),
         `Redo 3 reinserted "c" into the first paragraph.`,
         editor
@@ -604,7 +698,8 @@ test("can switch between code blocks without issues", async () => {
             `<p>abc</p>
             ${highlightedPre({ value: "def" })}
             <p>ghi[]</p>
-            ${highlightedPre({ value: "jkl" })}`
+            ${highlightedPre({ value: "jkl" })}
+            <p data-selection-placeholder=""><br></p>`
         ),
         `Redo 4 reinserted "i" into the second paragraph.`,
         editor
@@ -617,7 +712,8 @@ test("can switch between code blocks without issues", async () => {
             `<p>abc</p>
             ${highlightedPre({ value: "def", language: "javascript", textareaRange: 3 })}
             <p>ghi</p>
-            ${highlightedPre({ value: "jkl" })}`
+            ${highlightedPre({ value: "jkl" })}
+            <p data-selection-placeholder=""><br></p>`
         ),
         `Redo 5 changed back the language of the first textarea to "javascript".`,
         editor
@@ -630,7 +726,8 @@ test("can switch between code blocks without issues", async () => {
             `<p>abc</p>
             ${highlightedPre({ value: "def", language: "javascript" })}
             <p>ghi</p>
-            ${highlightedPre({ value: "jkl", language: "python", textareaRange: 3 })}`
+            ${highlightedPre({ value: "jkl", language: "python", textareaRange: 3 })}
+            <p data-selection-placeholder=""><br></p>`
         ),
         `Redo 6 changed back the language of the second textarea to "python".`,
         editor
@@ -643,7 +740,8 @@ test("can switch between code blocks without issues", async () => {
             `<p>abc</p>
             ${highlightedPre({ value: "def", language: "javascript" })}
             <p>ghi</p>
-            ${highlightedPre({ value: "jkl", language: "python", textareaRange: 3 })}`
+            ${highlightedPre({ value: "jkl", language: "python", textareaRange: 3 })}
+            <p data-selection-placeholder=""><br></p>`
         ),
         "Redo did nothing.",
         editor
@@ -674,6 +772,7 @@ test("multiple ctrl+z in a highlighted code block undo changes in the block and 
     await compareHighlightedContent(
         getContent(editor.editable),
         unformat(`
+            <p data-selection-placeholder=""><br></p>
             ${highlightedPre({ value: "some code" })}
             <p>hello![]</p>
         `),
@@ -687,6 +786,7 @@ test("multiple ctrl+z in a highlighted code block undo changes in the block and 
     await compareHighlightedContent(
         getContent(editor.editable),
         unformat(`
+            <p data-selection-placeholder=""><br></p>
             ${highlightedPre({ value: "some code", language: "javascript", textareaRange: 9 })}
             <p>hello!</p>
         `),
@@ -701,6 +801,7 @@ test("multiple ctrl+z in a highlighted code block undo changes in the block and 
     await compareHighlightedContent(
         getContent(editor.editable),
         unformat(`
+            <p data-selection-placeholder=""><br></p>
             ${highlightedPre({ value: "some codeno", language: "javascript", textareaRange: 11 })}
             <p>hello!</p>
         `),
@@ -722,6 +823,7 @@ test("multiple ctrl+z in a highlighted code block undo changes in the block and 
     await compareHighlightedContent(
         getContent(editor.editable),
         unformat(`
+            <p data-selection-placeholder=""><br></p>
             ${highlightedPre({ value: "some codeyes", language: "javascript", textareaRange: 12 })}
             <p>hello!</p>
         `),
@@ -730,12 +832,14 @@ test("multiple ctrl+z in a highlighted code block undo changes in the block and 
     );
     // Write in the P again.
     actions.push("type: insert 'o' into the paragraph", "type: insert 'k' into the paragraph");
-    editor.shared.selection.setCursorEnd(queryOne("p"));
-    await pointerUp("p");
+    const p = queryOne("p:not([data-selection-placeholder])");
+    editor.shared.selection.setCursorEnd(p);
+    await pointerUp(p);
     await insertText(editor, "ok"); // <wrapper><highlight><pre>some codeyes</pre></highlight></wrapper><p>hello!ok[]</p>
     await compareHighlightedContent(
         getContent(editor.editable),
         unformat(`
+            <p data-selection-placeholder=""><br></p>
             ${highlightedPre({ value: "some codeyes", language: "javascript" })}
             <p>hello!ok[]</p>
         `),
@@ -749,6 +853,7 @@ test("multiple ctrl+z in a highlighted code block undo changes in the block and 
     await compareHighlightedContent(
         getContent(editor.editable),
         unformat(`
+            <p data-selection-placeholder=""><br></p>
             ${highlightedPre({ value: "some codeyesh", language: "javascript", textareaRange: 13 })}
             <p>hello!ok</p>
         `),
@@ -763,6 +868,7 @@ test("multiple ctrl+z in a highlighted code block undo changes in the block and 
     await compareHighlightedContent(
         getContent(editor.editable),
         unformat(`
+            <p data-selection-placeholder=""><br></p>
             ${highlightedPre({ value: "some codeyes", language: "javascript", textareaRange: 12 })}
             <p>hello!ok</p>
         `),
@@ -774,6 +880,7 @@ test("multiple ctrl+z in a highlighted code block undo changes in the block and 
     await compareHighlightedContent(
         getContent(editor.editable),
         unformat(`
+            <p data-selection-placeholder=""><br></p>
             ${highlightedPre({ value: "some codeyes", language: "javascript" })}
             <p>hello![]</p>
         `),
@@ -786,6 +893,7 @@ test("multiple ctrl+z in a highlighted code block undo changes in the block and 
     await compareHighlightedContent(
         getContent(editor.editable),
         unformat(`
+            <p data-selection-placeholder=""><br></p>
             ${highlightedPre({ value: "some code", language: "javascript", textareaRange: 9 })}
             <p>hello!</p>
         `),
@@ -797,6 +905,7 @@ test("multiple ctrl+z in a highlighted code block undo changes in the block and 
     await compareHighlightedContent(
         getContent(editor.editable),
         unformat(`
+            <p data-selection-placeholder=""><br></p>
             ${highlightedPre({ value: "some codeno", language: "javascript", textareaRange: 11 })}
             <p>hello!</p>
         `),
@@ -808,6 +917,7 @@ test("multiple ctrl+z in a highlighted code block undo changes in the block and 
     await compareHighlightedContent(
         getContent(editor.editable),
         unformat(`
+            <p data-selection-placeholder=""><br></p>
             ${highlightedPre({ value: "some code", language: "javascript", textareaRange: 9 })}
             <p>hello!</p>
         `),
@@ -818,6 +928,7 @@ test("multiple ctrl+z in a highlighted code block undo changes in the block and 
     await compareHighlightedContent(
         getContent(editor.editable),
         unformat(`
+            <p data-selection-placeholder=""><br></p>
             ${highlightedPre({ value: "some code", textareaRange: 9 })}
             <p>hello!</p>
         `),
@@ -829,6 +940,7 @@ test("multiple ctrl+z in a highlighted code block undo changes in the block and 
     await compareHighlightedContent(
         getContent(editor.editable),
         unformat(`
+            <p data-selection-placeholder=""><br></p>
             ${highlightedPre({ value: "some code" })}
             <p>hell[]</p>
         `),
@@ -839,6 +951,7 @@ test("multiple ctrl+z in a highlighted code block undo changes in the block and 
     await compareHighlightedContent(
         getContent(editor.editable),
         unformat(`
+            <p data-selection-placeholder=""><br></p>
             ${highlightedPre({ value: "some code" })}
             <p>hell[]</p>
         `),
@@ -854,7 +967,8 @@ test("multiple ctrl+z in a highlighted code block undo changes in the block and 
     await compareHighlightedContent(
         getContent(editor.editable),
         unformat(
-            `${highlightedPre({ value: "some code" })}
+            `<p data-selection-placeholder=""><br></p>
+            ${highlightedPre({ value: "some code" })}
             <p>hello![]</p>`
         ),
         `redo:\n${listActions(1, 2)}`,
@@ -864,6 +978,7 @@ test("multiple ctrl+z in a highlighted code block undo changes in the block and 
     await compareHighlightedContent(
         getContent(editor.editable),
         unformat(`
+            <p data-selection-placeholder=""><br></p>
             ${highlightedPre({ value: "some code", language: "javascript", textareaRange: 9 })}
             <p>hello!</p>
         `),
@@ -875,6 +990,7 @@ test("multiple ctrl+z in a highlighted code block undo changes in the block and 
     await compareHighlightedContent(
         getContent(editor.editable),
         unformat(`
+            <p data-selection-placeholder=""><br></p>
             ${highlightedPre({ value: "some codeno", language: "javascript", textareaRange: 11 })}
             <p>hello!</p>
         `),
@@ -886,6 +1002,7 @@ test("multiple ctrl+z in a highlighted code block undo changes in the block and 
     await compareHighlightedContent(
         getContent(editor.editable),
         unformat(`
+            <p data-selection-placeholder=""><br></p>
             ${highlightedPre({ value: "some code", language: "javascript", textareaRange: 9 })}
             <p>hello!</p>
         `),
@@ -898,6 +1015,7 @@ test("multiple ctrl+z in a highlighted code block undo changes in the block and 
     await compareHighlightedContent(
         getContent(editor.editable),
         unformat(`
+            <p data-selection-placeholder=""><br></p>
             ${highlightedPre({ value: "some codeyes", language: "javascript", textareaRange: 12 })}
             <p>hello!</p>
         `),
@@ -909,6 +1027,7 @@ test("multiple ctrl+z in a highlighted code block undo changes in the block and 
     await compareHighlightedContent(
         getContent(editor.editable),
         unformat(`
+            <p data-selection-placeholder=""><br></p>
             ${highlightedPre({ value: "some codeyes", language: "javascript" })}
             <p>hello!ok[]</p>
         `),
@@ -919,6 +1038,7 @@ test("multiple ctrl+z in a highlighted code block undo changes in the block and 
     await compareHighlightedContent(
         getContent(editor.editable),
         unformat(`
+            <p data-selection-placeholder=""><br></p>
             ${highlightedPre({ value: "some codeyesh", language: "javascript", textareaRange: 13 })}
             <p>hello!ok</p>
         `),
@@ -930,6 +1050,7 @@ test("multiple ctrl+z in a highlighted code block undo changes in the block and 
     await compareHighlightedContent(
         getContent(editor.editable),
         unformat(`
+            <p data-selection-placeholder=""><br></p>
             ${highlightedPre({ value: "some codeyesh", language: "javascript", textareaRange: 13 })}
             <p>hello!ok</p>
         `),

--- a/addons/html_editor/static/tests/table/adding_table.test.js
+++ b/addons/html_editor/static/tests/table/adding_table.test.js
@@ -58,7 +58,7 @@ test("can add a table using the powerbox and keyboard", async () => {
                 </tr>
             </tbody>
         </table>
-        <p><br></p>`
+        <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
     );
 });
 
@@ -195,7 +195,6 @@ test("add table inside empty list", async () => {
                         </tr>
                     </tbody>
                 </table>
-                <br>
             </li>
         </ul>`
     );
@@ -248,7 +247,6 @@ test("add table inside non-empty list", async () => {
                         </tr>
                     </tbody>
                 </table>
-                <br>
             </li>
         </ul>`
     );

--- a/addons/html_editor/static/tests/table/children.test.js
+++ b/addons/html_editor/static/tests/table/children.test.js
@@ -413,6 +413,17 @@ describe("row", () => {
                         </tbody>
                     </table>
                 `),
+                contentBeforeEdit: unformat(
+                    `<p data-selection-placeholder=""><br></p>
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>[]ab</td> <td>cd</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                    <p data-selection-placeholder=""><br></p>`
+                ),
                 stepFunction: removeRow(),
                 contentAfter: "<p>[]<br></p>",
             });
@@ -702,6 +713,16 @@ describe("column", () => {
                         </tbody>
                     </table>
                 `),
+                contentBeforeEdit: unformat(
+                    `<p data-selection-placeholder=""><br></p>
+                    <table>
+                        <tbody>
+                            <tr> <td>[]ab</td> </tr>
+                            <tr> <td>cd</td> </tr>
+                        </tbody>
+                    </table>
+                    <p data-selection-placeholder=""><br></p>`
+                ),
                 stepFunction: removeColumn(),
                 contentAfter: "<p>[]<br></p>",
             });
@@ -723,7 +744,8 @@ describe("tab", () => {
 
         await press("Tab");
 
-        const expectedContent = unformat(`
+        const expectedContent = unformat(
+            `<p data-selection-placeholder=""><br></p>
             <table><tbody>
                 <tr style="height: 20px;">
                     <td style="width: 20px;">ab</td>
@@ -735,13 +757,19 @@ describe("tab", () => {
                     <td><p><br></p></td>
                     <td><p><br></p></td>
                 </tr>
-            </tbody></table>`);
+            </tbody></table>
+            <p data-selection-placeholder=""><br></p>`
+        );
 
         expect(getContent(el)).toBe(expectedContent);
 
         // Check that it was registed as a history step.
         undo(editor);
-        expect(getContent(el)).toBe(contentBefore);
+        expect(getContent(el)).toBe(
+            '<p data-selection-placeholder=""><br></p>' +
+                contentBefore +
+                '<p data-selection-placeholder=""><br></p>'
+        );
     });
 
     test("should not select whole text of the next cell", async () => {

--- a/addons/html_editor/static/tests/table/selection.test.js
+++ b/addons/html_editor/static/tests/table/selection.test.js
@@ -27,7 +27,8 @@ describe("custom selection", () => {
         );
         expect(getContent(el)).toBe(
             unformat(`
-            <table class="o_selected_table">
+                <p data-selection-placeholder=""><br></p>
+                <table class="o_selected_table">
                 <tbody>
                     <tr>
                         <td>ab</td>
@@ -35,7 +36,8 @@ describe("custom selection", () => {
                         <td class="o_selected_td">e]f</td>
                     </tr>
                 </tbody>
-            </table>`)
+            </table>
+            <p data-selection-placeholder=""><br></p>`)
         );
         const overlayColorTDs = queryAll("table td").map(
             (td) => getComputedStyle(td)["box-shadow"]
@@ -60,7 +62,8 @@ describe("select a full table on cross over", () => {
                     '<td class="o_selected_td">ab</td>' +
                     '<td class="o_selected_td">cd</td>' +
                     '<td class="o_selected_td">ef]</td>' +
-                    "</tr></tbody></table>",
+                    "</tr></tbody></table>" +
+                    '<p data-selection-placeholder=""><br></p>',
             });
         });
 
@@ -69,6 +72,7 @@ describe("select a full table on cross over", () => {
                 contentBefore:
                     "<table><tbody><tr><td>ab</td><td>cd</td><td>e[f</td></tr></tbody></table><p>a]bc</p>",
                 contentAfterEdit:
+                    '<p data-selection-placeholder=""><br></p>' +
                     '<table class="o_selected_table"><tbody><tr>' +
                     '<td class="o_selected_td">ab</td>' +
                     '<td class="o_selected_td">cd</td>' +
@@ -100,7 +104,8 @@ describe("select a full table on cross over", () => {
                     '<p>abc</p><table class="o_selected_table"><tbody><tr>' +
                     '<td class="o_selected_td">ab</td>' +
                     '<td class="o_selected_td">cd</td>' +
-                    '<td class="o_selected_td">ef]</td></tr></tbody></table>',
+                    '<td class="o_selected_td">ef]</td></tr></tbody></table>' +
+                    '<p data-selection-placeholder=""><br></p>',
             });
         });
 
@@ -137,7 +142,8 @@ describe("select a full table on cross over", () => {
                     '<td class="o_selected_td"><strong>ab</strong></td>' +
                     '<td class="o_selected_td"><strong>cd</strong></td>' +
                     '<td class="o_selected_td"><strong>ef]</strong></td>' +
-                    "</tr></tbody></table>",
+                    "</tr></tbody></table>" +
+                    '<p data-selection-placeholder=""><br></p>',
             });
         });
 
@@ -151,6 +157,7 @@ describe("select a full table on cross over", () => {
                     "</tr></tbody></table><p>a]bc</p>",
                 stepFunction: bold,
                 contentAfterEdit:
+                    '<p data-selection-placeholder=""><br></p>' +
                     '<table class="o_selected_table"><tbody><tr>' +
                     '<td class="o_selected_td"><strong>[ab</strong></td>' +
                     '<td class="o_selected_td"><strong>cd</strong></td>' +
@@ -210,7 +217,8 @@ describe("select a full table on cross over", () => {
                     '<td class="o_selected_td"><strong>ab</strong></td>' +
                     '<td class="o_selected_td"><strong>cd</strong></td>' +
                     '<td class="o_selected_td"><strong>ef]</strong></td>' +
-                    "</tr></tbody></table>",
+                    "</tr></tbody></table>" +
+                    '<p data-selection-placeholder=""><br></p>',
             });
         });
 
@@ -287,7 +295,8 @@ describe("select a full table on cross over", () => {
                                 </td>
                             </tr>
                         </tbody>
-                    </table>`),
+                    </table>
+                    <p data-selection-placeholder=""><br></p>`),
             });
         });
 
@@ -301,6 +310,7 @@ describe("select a full table on cross over", () => {
                     "</tr></tbody></table><p>a]bc</p>",
                 stepFunction: setColor("aquamarine", "color"),
                 contentAfterEdit: unformat(`
+                    <p data-selection-placeholder=""><br></p>
                     <table class="o_selected_table">
                         <tbody><tr>
                             <td class="o_selected_td">
@@ -407,7 +417,8 @@ describe("select a full table on cross over", () => {
                                 <font style="color: aquamarine;">ef]</font>
                             </td>
                         </tr></tbody>
-                    </table>`),
+                    </table>
+                    <p data-selection-placeholder=""><br></p>`),
             });
         });
 
@@ -472,11 +483,13 @@ describe("select columns on cross over", () => {
                 contentBefore:
                     "<table><tbody><tr><td>a[b</td><td>c]d</td><td>ef</td></tr></tbody></table>",
                 contentAfterEdit:
+                    '<p data-selection-placeholder=""><br></p>' +
                     '<table class="o_selected_table"><tbody><tr>' +
                     '<td class="o_selected_td">a[b</td>' +
                     '<td class="o_selected_td">c]d</td>' +
                     "<td>ef</td>" +
-                    "</tr></tbody></table>",
+                    "</tr></tbody></table>" +
+                    '<p data-selection-placeholder=""><br></p>',
             });
         });
 
@@ -485,11 +498,13 @@ describe("select columns on cross over", () => {
                 contentBefore:
                     "<table><tbody><tr><td>a[b</td><td>cd</td><td>e]f</td></tr><tr><td>ab</td><td>cd</td><td>ef</td></tr></tbody></table>",
                 contentAfterEdit:
+                    '<p data-selection-placeholder=""><br></p>' +
                     '<table class="o_selected_table"><tbody><tr>' +
                     '<td class="o_selected_td">a[b</td>' +
                     '<td class="o_selected_td">cd</td>' +
                     '<td class="o_selected_td">e]f</td>' +
-                    "</tr><tr><td>ab</td><td>cd</td><td>ef</td></tr></tbody></table>",
+                    "</tr><tr><td>ab</td><td>cd</td><td>ef</td></tr></tbody></table>" +
+                    '<p data-selection-placeholder=""><br></p>',
             });
         });
 
@@ -502,6 +517,7 @@ describe("select columns on cross over", () => {
                     "<tr><td>a]b</td><td>cd</td><td>ef</td></tr>" +
                     "</tbody></table>",
                 contentAfterEdit:
+                    '<p data-selection-placeholder=""><br></p>' +
                     '<table class="o_selected_table"><tbody>' +
                     "<tr>" +
                     '<td class="o_selected_td">a[b</td>' +
@@ -518,7 +534,8 @@ describe("select columns on cross over", () => {
                     "<td>cd</td>" +
                     "<td>ef</td>" +
                     "</tr>" +
-                    "</tbody></table>",
+                    "</tbody></table>" +
+                    '<p data-selection-placeholder=""><br></p>',
             });
         });
 
@@ -531,6 +548,7 @@ describe("select columns on cross over", () => {
                     "<tr><td>ab</td><td>cd</td><td>ef</td></tr>" +
                     "</tbody></table>",
                 contentAfterEdit:
+                    '<p data-selection-placeholder=""><br></p>' +
                     '<table class="o_selected_table"><tbody>' +
                     "<tr>" +
                     '<td class="o_selected_td">a[b</td>' +
@@ -547,7 +565,8 @@ describe("select columns on cross over", () => {
                     "<td>cd</td>" +
                     "<td>ef</td>" +
                     "</tr>" +
-                    "</tbody></table>",
+                    "</tbody></table>" +
+                    '<p data-selection-placeholder=""><br></p>',
             });
         });
 
@@ -560,6 +579,7 @@ describe("select columns on cross over", () => {
                     "<tr><td>ab</td><td>cd</td><td>e]f</td></tr>" +
                     "</tbody></table>",
                 contentAfterEdit:
+                    '<p data-selection-placeholder=""><br></p>' +
                     '<table class="o_selected_table"><tbody>' +
                     "<tr>" +
                     '<td class="o_selected_td">a[b</td>' +
@@ -576,7 +596,8 @@ describe("select columns on cross over", () => {
                     '<td class="o_selected_td">cd</td>' +
                     '<td class="o_selected_td">e]f</td>' +
                     "</tr>" +
-                    "</tbody></table>",
+                    "</tbody></table>" +
+                    '<p data-selection-placeholder=""><br></p>',
             });
         });
     });
@@ -592,11 +613,13 @@ describe("select columns on cross over", () => {
                     "</tr></tbody></table>",
                 stepFunction: bold,
                 contentAfterEdit:
+                    '<p data-selection-placeholder=""><br></p>' +
                     '<table class="o_selected_table"><tbody><tr>' +
                     '<td class="o_selected_td"><strong>[ab</strong></td>' +
                     '<td class="o_selected_td"><strong>cd]</strong></td>' +
                     "<td>ef</td>" +
-                    "</tr></tbody></table>",
+                    "</tr></tbody></table>" +
+                    '<p data-selection-placeholder=""><br></p>',
             });
         });
 
@@ -610,11 +633,13 @@ describe("select columns on cross over", () => {
                     "</tr><tr><td>ab</td><td>cd</td><td>ef</td></tr></tbody></table>",
                 stepFunction: bold,
                 contentAfterEdit:
+                    '<p data-selection-placeholder=""><br></p>' +
                     '<table class="o_selected_table"><tbody><tr>' +
                     '<td class="o_selected_td"><strong>[ab</strong></td>' +
                     '<td class="o_selected_td"><strong>cd</strong></td>' +
                     '<td class="o_selected_td"><strong>ef]</strong></td>' +
-                    "</tr><tr><td>ab</td><td>cd</td><td>ef</td></tr></tbody></table>",
+                    "</tr><tr><td>ab</td><td>cd</td><td>ef</td></tr></tbody></table>" +
+                    '<p data-selection-placeholder=""><br></p>',
             });
         });
 
@@ -640,6 +665,7 @@ describe("select columns on cross over", () => {
                     "</tbody></table>",
                 stepFunction: bold,
                 contentAfterEdit:
+                    '<p data-selection-placeholder=""><br></p>' +
                     '<table class="o_selected_table"><tbody>' +
                     "<tr>" +
                     '<td class="o_selected_td"><strong>[ab</strong></td>' +
@@ -656,7 +682,8 @@ describe("select columns on cross over", () => {
                     "<td>cd</td>" +
                     "<td>ef</td>" +
                     "</tr>" +
-                    "</tbody></table>",
+                    "</tbody></table>" +
+                    '<p data-selection-placeholder=""><br></p>',
             });
         });
 
@@ -682,6 +709,7 @@ describe("select columns on cross over", () => {
                     "</tbody></table>",
                 stepFunction: bold,
                 contentAfterEdit:
+                    '<p data-selection-placeholder=""><br></p>' +
                     '<table class="o_selected_table"><tbody>' +
                     "<tr>" +
                     '<td class="o_selected_td"><strong>[ab</strong></td>' +
@@ -698,7 +726,8 @@ describe("select columns on cross over", () => {
                     "<td>cd</td>" +
                     "<td>ef</td>" +
                     "</tr>" +
-                    "</tbody></table>",
+                    "</tbody></table>" +
+                    '<p data-selection-placeholder=""><br></p>',
             });
         });
 
@@ -724,6 +753,7 @@ describe("select columns on cross over", () => {
                     "</tbody></table>",
                 stepFunction: bold,
                 contentAfterEdit:
+                    '<p data-selection-placeholder=""><br></p>' +
                     '<table class="o_selected_table"><tbody>' +
                     "<tr>" +
                     '<td class="o_selected_td"><strong>[ab</strong></td>' +
@@ -740,7 +770,8 @@ describe("select columns on cross over", () => {
                     '<td class="o_selected_td"><strong>cd</strong></td>' +
                     '<td class="o_selected_td"><strong>ef]</strong></td>' +
                     "</tr>" +
-                    "</tbody></table>",
+                    "</tbody></table>" +
+                    '<p data-selection-placeholder=""><br></p>',
             });
         });
     });
@@ -910,6 +941,7 @@ describe("select columns on cross over", () => {
                     "</tr></tbody></table>",
                 stepFunction: setColor("aquamarine", "color"),
                 contentAfterEdit: unformat(`
+                    <p data-selection-placeholder=""><br></p>
                     <table class="o_selected_table">
                         <tbody><tr>
                             <td class="o_selected_td">
@@ -920,7 +952,8 @@ describe("select columns on cross over", () => {
                             </td>
                             <td>ef</td>
                         </tr></tbody>
-                    </table>`),
+                    </table>
+                    <p data-selection-placeholder=""><br></p>`),
             });
         });
 
@@ -934,6 +967,7 @@ describe("select columns on cross over", () => {
                     "</tr><tr><td>ab</td><td>cd</td><td>ef</td></tr></tbody></table>",
                 stepFunction: setColor("aquamarine", "color"),
                 contentAfterEdit: unformat(`
+                    <p data-selection-placeholder=""><br></p>
                     <table class="o_selected_table">
                         <tbody><tr>
                             <td class="o_selected_td">
@@ -951,7 +985,8 @@ describe("select columns on cross over", () => {
                             <td>cd</td>
                             <td>ef</td>
                         </tr></tbody>
-                    </table>`),
+                    </table>
+                    <p data-selection-placeholder=""><br></p>`),
             });
         });
 
@@ -977,6 +1012,7 @@ describe("select columns on cross over", () => {
                     "</tbody></table>",
                 stepFunction: setColor("aquamarine", "color"),
                 contentAfterEdit: unformat(`
+                    <p data-selection-placeholder=""><br></p>
                     <table class="o_selected_table">
                         <tbody><tr>
                             <td class="o_selected_td">
@@ -999,7 +1035,8 @@ describe("select columns on cross over", () => {
                             <td>cd</td>
                             <td>ef</td>
                         </tr></tbody>
-                    </table>`),
+                    </table>
+                    <p data-selection-placeholder=""><br></p>`),
             });
         });
 
@@ -1025,6 +1062,7 @@ describe("select columns on cross over", () => {
                     "</tbody></table>",
                 stepFunction: setColor("aquamarine", "color"),
                 contentAfterEdit: unformat(`
+                    <p data-selection-placeholder=""><br></p>
                     <table class="o_selected_table">
                         <tbody><tr>
                             <td class="o_selected_td">
@@ -1049,7 +1087,8 @@ describe("select columns on cross over", () => {
                             <td>cd</td>
                             <td>ef</td>
                         </tr></tbody>
-                    </table>`),
+                    </table>
+                    <p data-selection-placeholder=""><br></p>`),
             });
         });
 
@@ -1075,6 +1114,7 @@ describe("select columns on cross over", () => {
                     "</tbody></table>",
                 stepFunction: setColor("aquamarine", "color"),
                 contentAfterEdit: unformat(`
+                    <p data-selection-placeholder=""><br></p>
                     <table class="o_selected_table">
                         <tbody><tr>
                             <td class="o_selected_td">
@@ -1109,7 +1149,8 @@ describe("select columns on cross over", () => {
                                 <font style="color: aquamarine;">e]f</font>
                             </td>
                         </tr></tbody>
-                    </table>`),
+                    </table>
+                    <p data-selection-placeholder=""><br></p>`),
             });
         });
     });
@@ -1255,7 +1296,7 @@ describe("move cursor with arrow keys", () => {
                 `),
             });
         });
-        test("should move cursor to the end cell of sibling table", async () => {
+        test("should move cursor between two tables", async () => {
             await testEditor({
                 contentBefore: unformat(`
                     <table>
@@ -1283,7 +1324,39 @@ describe("move cursor with arrow keys", () => {
                         </tbody>
                     </table>
                 `),
-                stepFunction: async () => press("ArrowUp"),
+                stepFunction: async () => {
+                    await press("ArrowUp");
+                    await tick();
+                },
+                contentAfterEdit: unformat(
+                    `<p data-selection-placeholder=""><br></p>
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td><br></td>
+                                <td><br></td>
+                            </tr>
+                            <tr>
+                                <td><br></td>
+                                <td><br></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                    <p data-selection-placeholder="" o-we-hint-text='Type "/" for commands' class="o-we-hint o-horizontal-caret">[]<br></p>
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td><br></td>
+                                <td><br></td>
+                            </tr>
+                            <tr>
+                                <td><br></td>
+                                <td><br></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                    <p data-selection-placeholder=""><br></p>`
+                ),
                 contentAfter: unformat(`
                     <table>
                         <tbody>
@@ -1293,10 +1366,11 @@ describe("move cursor with arrow keys", () => {
                             </tr>
                             <tr>
                                 <td><br></td>
-                                <td>[]<br></td>
+                                <td><br></td>
                             </tr>
                         </tbody>
                     </table>
+                    []
                     <table>
                         <tbody>
                             <tr>
@@ -1453,7 +1527,7 @@ describe("move cursor with arrow keys", () => {
                 `),
             });
         });
-        test("should move cursor to the first cell of sibling table", async () => {
+        test("should move cursor between two tables", async () => {
             await testEditor({
                 contentBefore: unformat(`
                     <table>
@@ -1481,7 +1555,39 @@ describe("move cursor with arrow keys", () => {
                         </tbody>
                     </table>
                 `),
-                stepFunction: async () => press("ArrowDown"),
+                stepFunction: async () => {
+                    await press("ArrowDown");
+                    await tick();
+                },
+                contentAfterEdit: unformat(
+                    `<p data-selection-placeholder=""><br></p>
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td><br></td>
+                                <td><br></td>
+                            </tr>
+                            <tr>
+                                <td><br></td>
+                                <td><br></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                    <p data-selection-placeholder="" o-we-hint-text='Type "/" for commands' class="o-we-hint o-horizontal-caret">[]<br></p>
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td><br></td>
+                                <td><br></td>
+                            </tr>
+                            <tr>
+                                <td><br></td>
+                                <td><br></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                    <p data-selection-placeholder=""><br></p>`
+                ),
                 contentAfter: unformat(`
                     <table>
                         <tbody>
@@ -1495,10 +1601,11 @@ describe("move cursor with arrow keys", () => {
                             </tr>
                         </tbody>
                     </table>
+                    []
                     <table>
                         <tbody>
                             <tr>
-                                <td>[]<br></td>
+                                <td><br></td>
                                 <td><br></td>
                             </tr>
                             <tr>
@@ -1532,12 +1639,14 @@ describe("symmetrical selection", () => {
         // Select single empty cell
         expectContentToBe(
             el,
-            `<table class="table table-bordered o_table o_selected_table">
+            `<p data-selection-placeholder=""><br></p>
+            <table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr><td class="o_selected_td">[]<br></td><td><br></td><td><br></td></tr>
                     <tr><td><br></td><td><br></td><td><br></td></tr>
                 </tbody>
-            </table>`
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         );
 
         press(["Shift", "ArrowRight"]);
@@ -1546,12 +1655,14 @@ describe("symmetrical selection", () => {
         // Select two cells consecutively
         expectContentToBe(
             el,
-            `<table class="table table-bordered o_table o_selected_table">
+            `<p data-selection-placeholder=""><br></p>
+            <table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr><td class="o_selected_td">[<br></td><td class="o_selected_td">]<br></td><td><br></td></tr>
                     <tr><td><br></td><td><br></td><td><br></td></tr>
                 </tbody>
-            </table>`
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         );
 
         press(["Shift", "ArrowDown"]);
@@ -1560,12 +1671,14 @@ describe("symmetrical selection", () => {
         // Extend selection from two cells to four cells
         expectContentToBe(
             el,
-            `<table class="table table-bordered o_table o_selected_table">
+            `<p data-selection-placeholder=""><br></p>
+            <table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr><td class="o_selected_td">[<br></td><td class="o_selected_td"><br></td><td><br></td></tr>
                     <tr><td class="o_selected_td"><br></td><td class="o_selected_td">]<br></td><td><br></td></tr>
                 </tbody>
-            </table>`
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         );
 
         press(["Shift", "ArrowLeft"]);
@@ -1574,12 +1687,14 @@ describe("symmetrical selection", () => {
         // Shrink selection from four cells to two cells
         expectContentToBe(
             el,
-            `<table class="table table-bordered o_table o_selected_table">
+            `<p data-selection-placeholder=""><br></p>
+            <table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr><td class="o_selected_td">[<br></td><td><br></td><td><br></td></tr>
                     <tr><td class="o_selected_td">]<br></td><td><br></td><td><br></td></tr>
                 </tbody>
-            </table>`
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         );
 
         press(["Shift", "ArrowUp"]);
@@ -1588,12 +1703,14 @@ describe("symmetrical selection", () => {
         // Shrink selection from two cells to single cell
         expectContentToBe(
             el,
-            `<table class="table table-bordered o_table o_selected_table">
+            `<p data-selection-placeholder=""><br></p>
+            <table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr><td class="o_selected_td">[]<br></td><td><br></td><td><br></td></tr>
                     <tr><td><br></td><td><br></td><td><br></td></tr>
                 </tbody>
-            </table>`
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         );
     });
 
@@ -1613,12 +1730,14 @@ describe("symmetrical selection", () => {
 
         expectContentToBe(
             el,
-            `<table class="table table-bordered o_table">
+            `<p data-selection-placeholder=""><br></p>
+            <table class="table table-bordered o_table">
                 <tbody>
                     <tr><td>ab[]</td><td><br></td><td><br></td></tr>
                     <tr><td><br></td><td><br></td><td><br></td></tr>
                 </tbody>
-            </table>`
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         );
         const firstTd = el.querySelector("td");
         setSelection({
@@ -1633,12 +1752,14 @@ describe("symmetrical selection", () => {
 
         expectContentToBe(
             el,
-            `<table class="table table-bordered o_table o_selected_table">
+            `<p data-selection-placeholder=""><br></p>
+            <table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr><td class="o_selected_td">[ab]</td><td><br></td><td><br></td></tr>
                     <tr><td><br></td><td><br></td><td><br></td></tr>
                 </tbody>
-            </table>`
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         );
     });
 });
@@ -1658,7 +1779,7 @@ describe("single cell selection", () => {
 
         const BORDER_SENSITIVITY = 5;
         const firstTd = el.querySelector("td");
-        const offset = BORDER_SENSITIVITY + 1;
+        const offset = BORDER_SENSITIVITY + 2;
 
         manuallyDispatchProgrammaticEvent(firstTd, "mousedown", {
             detail: 2,
@@ -1676,12 +1797,14 @@ describe("single cell selection", () => {
 
         expectContentToBe(
             el,
-            `<table class="table table-bordered o_table o_selected_table">
+            `<p data-selection-placeholder=""><br></p>
+            <table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr><td class="o_selected_td">[]<br></td><td><br></td><td><br></td></tr>
                     <tr><td><br></td><td><br></td><td><br></td></tr>
                 </tbody>
-            </table>`
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         );
     });
 
@@ -1699,7 +1822,7 @@ describe("single cell selection", () => {
 
         const BORDER_SENSITIVITY = 5;
         const firstTd = el.querySelector("td");
-        const offset = BORDER_SENSITIVITY + 1;
+        const offset = BORDER_SENSITIVITY + 2;
 
         manuallyDispatchProgrammaticEvent(firstTd, "mousedown", {
             detail: 3,
@@ -1717,12 +1840,14 @@ describe("single cell selection", () => {
 
         expectContentToBe(
             el,
-            `<table class="table table-bordered o_table o_selected_table">
+            `<p data-selection-placeholder=""><br></p>
+            <table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr><td class="o_selected_td">[abc]<br></td><td><br></td><td><br></td></tr>
                     <tr><td><br></td><td><br></td><td><br></td></tr>
                 </tbody>
-            </table>`
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         );
     });
 
@@ -1747,12 +1872,14 @@ describe("single cell selection", () => {
 
         expectContentToBe(
             el,
-            `<table class="table table-bordered o_table">
+            `<p data-selection-placeholder=""><br></p>
+            <table class="table table-bordered o_table">
                 <tbody>
                     <tr><td>ab[]c<br></td><td><br></td><td><br></td></tr>
                     <tr><td><br></td><td><br></td><td><br></td></tr>
                 </tbody>
-            </table>`
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         );
     });
 
@@ -1778,12 +1905,14 @@ describe("single cell selection", () => {
 
         expectContentToBe(
             el,
-            `<table class="table table-bordered o_table">
+            `<p data-selection-placeholder=""><br></p>
+            <table class="table table-bordered o_table">
                 <tbody>
                     <tr><td>[]<br></td><td><br></td><td><br></td></tr>
                     <tr><td><br></td><td><br></td><td><br></td></tr>
                 </tbody>
-            </table>`
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         );
     });
 
@@ -1875,7 +2004,8 @@ describe("deselecting table", () => {
                         <tr><td class="o_selected_td"><br></td><td class="o_selected_td"><br></td><td class="o_selected_td"><br></td></tr>
                         <tr><td class="o_selected_td"><br></td><td class="o_selected_td"><br></td><td class="o_selected_td">]<br></td></tr>
                     </tbody>
-                </table>`
+                </table>
+                <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         );
 
         press(["Shift", "ArrowUp"]);
@@ -1889,7 +2019,8 @@ describe("deselecting table", () => {
                     <tr><td><br></td><td><br></td><td><br></td></tr>
                     <tr><td><br></td><td><br></td><td><br></td></tr>
                 </tbody>
-            </table>`
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         );
     });
 });

--- a/addons/html_editor/static/tests/table/ui.test.js
+++ b/addons/html_editor/static/tests/table/ui.test.js
@@ -382,23 +382,27 @@ test("basic delete column operation", async () => {
     // not sure about selection...
     expect(getContent(el)).toBe(
         unformat(`
+        <p data-selection-placeholder=""><br></p>
         <table>
             <tbody>
                 <tr><td class="a">[]1</td></tr>
                 <tr><td class="c">3</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        <p data-selection-placeholder=""><br></p>`)
     );
 
     undo(editor);
     expect(getContent(el)).toBe(
         unformat(`
+        <p data-selection-placeholder=""><br></p>
         <table>
             <tbody>
                 <tr><td class="a">1[]</td><td class="b">2</td></tr>
                 <tr><td class="c">3</td><td class="d">4</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        <p data-selection-placeholder=""><br></p>`)
     );
 });
 
@@ -427,23 +431,27 @@ test("basic clear column content operation", async () => {
     // not sure about selection...
     expect(getContent(el)).toBe(
         unformat(`
+        <p data-selection-placeholder=""><br></p>
         <table>
             <tbody>
                 <tr><td class="a"><p>1[]</p></td><td class="b"><p><br></p></td></tr>
                 <tr><td class="c"><p>3</p></td><td class="d"><p><br></p></td></tr>
             </tbody>
-        </table>`)
+        </table>
+        <p data-selection-placeholder=""><br></p>`)
     );
 
     undo(editor);
     expect(getContent(el)).toBe(
         unformat(`
+        <p data-selection-placeholder=""><br></p>
         <table>
             <tbody>
                 <tr><td class="a"><p>1[]</p></td><td class="b"><p>2</p></td></tr>
                 <tr><td class="c"><p>3</p></td><td class="d"><h1>4</h1></td></tr>
             </tbody>
-        </table>`)
+        </table>
+        <p data-selection-placeholder=""><br></p>`)
     );
 });
 
@@ -472,22 +480,26 @@ test("basic delete row operation", async () => {
     // not sure about selection...
     expect(getContent(el)).toBe(
         unformat(`
+        <p data-selection-placeholder=""><br></p>
         <table>
             <tbody>
                 <tr><td class="a">[]1</td><td class="b">2</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        <p data-selection-placeholder=""><br></p>`)
     );
 
     undo(editor);
     expect(getContent(el)).toBe(
         unformat(`
+        <p data-selection-placeholder=""><br></p>
         <table>
             <tbody>
                 <tr><td class="a">1[]</td><td class="b">2</td></tr>
                 <tr><td class="c">3</td><td class="d">4</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        <p data-selection-placeholder=""><br></p>`)
     );
 });
 
@@ -516,23 +528,27 @@ test("basic clear row content operation", async () => {
     // not sure about selection...
     expect(getContent(el)).toBe(
         unformat(`
+        <p data-selection-placeholder=""><br></p>
         <table>
             <tbody>
                 <tr><td class="a"><p>1[]</p></td><td class="b"><p>2</p></td></tr>
                 <tr><td class="c"><p><br></p></td><td class="d"><p><br></p></td></tr>
             </tbody>
-        </table>`)
+        </table>
+        <p data-selection-placeholder=""><br></p>`)
     );
 
     undo(editor);
     expect(getContent(el)).toBe(
         unformat(`
+        <p data-selection-placeholder=""><br></p>
         <table>
             <tbody>
                 <tr><td class="a"><p>1[]</p></td><td class="b"><p>2</p></td></tr>
                 <tr><td class="c"><p>3</p></td><td class="d"><h2>4</h2></td></tr>
             </tbody>
-        </table>`)
+        </table>
+        <p data-selection-placeholder=""><br></p>`)
     );
 });
 
@@ -560,6 +576,7 @@ test("insert column left operation", async () => {
     await click("div[name='insert_left']");
     expect(getContent(el)).toBe(
         unformat(`
+        <p data-selection-placeholder=""><br></p>
         <table>
             <tbody>
                 <tr>
@@ -573,18 +590,21 @@ test("insert column left operation", async () => {
                     <td class="d">4</td>
                 </tr>
             </tbody>
-        </table>`)
+        </table>
+        <p data-selection-placeholder=""><br></p>`)
     );
 
     undo(editor);
     expect(getContent(el)).toBe(
         unformat(`
+        <p data-selection-placeholder=""><br></p>
         <table>
             <tbody>
                 <tr><td class="a">1[]</td><td class="b">2</td></tr>
                 <tr><td class="c">3</td><td class="d">4</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        <p data-selection-placeholder=""><br></p>`)
     );
 });
 
@@ -612,6 +632,7 @@ test("insert column right operation", async () => {
     await click("div[name='insert_right']");
     expect(getContent(el)).toBe(
         unformat(`
+        <p data-selection-placeholder=""><br></p>
         <table>
             <tbody>
                 <tr>
@@ -625,18 +646,21 @@ test("insert column right operation", async () => {
                     <td class="d">4</td>
                 </tr>
             </tbody>
-        </table>`)
+        </table>
+        <p data-selection-placeholder=""><br></p>`)
     );
 
     undo(editor);
     expect(getContent(el)).toBe(
         unformat(`
+        <p data-selection-placeholder=""><br></p>
         <table>
             <tbody>
                 <tr><td class="a">1[]</td><td class="b">2</td></tr>
                 <tr><td class="c">3</td><td class="d">4</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        <p data-selection-placeholder=""><br></p>`)
     );
 });
 
@@ -664,6 +688,7 @@ test("insert column right operation when table header exists", async () => {
     await click("div[name='insert_right']");
     expect(getContent(el)).toBe(
         unformat(`
+        <p data-selection-placeholder=""><br></p>
         <table>
             <tbody>
                 <tr>
@@ -677,7 +702,8 @@ test("insert column right operation when table header exists", async () => {
                     <td class="d">4</td>
                 </tr>
             </tbody>
-        </table>`)
+        </table>
+        <p data-selection-placeholder=""><br></p>`)
     );
 });
 
@@ -705,6 +731,7 @@ test("insert row above operation", async () => {
     await click("div[name='insert_above']");
     expect(getContent(el)).toBe(
         unformat(`
+        <p data-selection-placeholder=""><br></p>
         <table>
             <tbody>
                 <tr>
@@ -720,18 +747,21 @@ test("insert row above operation", async () => {
                     <td class="d">4</td>
                 </tr>
             </tbody>
-        </table>`)
+        </table>
+        <p data-selection-placeholder=""><br></p>`)
     );
 
     undo(editor);
     expect(getContent(el)).toBe(
         unformat(`
+        <p data-selection-placeholder=""><br></p>
         <table>
             <tbody>
                 <tr><td class="a">1[]</td><td class="b">2</td></tr>
                 <tr><td class="c">3</td><td class="d">4</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        <p data-selection-placeholder=""><br></p>`)
     );
 });
 
@@ -759,6 +789,7 @@ test("insert row above operation should not retain height and width styles", asy
     await click("div[name='insert_above']");
     expect(getContent(el)).toBe(
         unformat(`
+        <p data-selection-placeholder=""><br></p>
         <table>
             <tbody>
                 <tr>
@@ -774,7 +805,8 @@ test("insert row above operation should not retain height and width styles", asy
                     <td class="d">4</td>
                 </tr>
             </tbody>
-        </table>`)
+        </table>
+        <p data-selection-placeholder=""><br></p>`)
     );
 });
 
@@ -802,6 +834,7 @@ test("insert row below operation", async () => {
     await click("div[name='insert_below']");
     expect(getContent(el)).toBe(
         unformat(`
+        <p data-selection-placeholder=""><br></p>
         <table>
             <tbody>
                 <tr>
@@ -817,18 +850,21 @@ test("insert row below operation", async () => {
                     <td class="d">4</td>
                 </tr>
             </tbody>
-        </table>`)
+        </table>
+        <p data-selection-placeholder=""><br></p>`)
     );
 
     undo(editor);
     expect(getContent(el)).toBe(
         unformat(`
+        <p data-selection-placeholder=""><br></p>
         <table>
             <tbody>
                 <tr><td class="a">1[]</td><td class="b">2</td></tr>
                 <tr><td class="c">3</td><td class="d">4</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        <p data-selection-placeholder=""><br></p>`)
     );
 });
 
@@ -856,23 +892,27 @@ test("move column left operation", async () => {
     await click("div[name='move_left']");
     expect(getContent(el)).toBe(
         unformat(`
+        <p data-selection-placeholder=""><br></p>
         <table>
             <tbody>
             <tr><td class="b">2[]</td><td class="a">1</td></tr>
             <tr><td class="d">4</td><td class="c">3</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        <p data-selection-placeholder=""><br></p>`)
     );
 
     undo(editor);
     expect(getContent(el)).toBe(
         unformat(`
+        <p data-selection-placeholder=""><br></p>
         <table>
             <tbody>
                 <tr><td class="a">1</td><td class="b">2[]</td></tr>
                 <tr><td class="c">3</td><td class="d">4</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        <p data-selection-placeholder=""><br></p>`)
     );
 });
 
@@ -900,23 +940,27 @@ test("move column right operation", async () => {
     await click("div[name='move_right']");
     expect(getContent(el)).toBe(
         unformat(`
+        <p data-selection-placeholder=""><br></p>
         <table>
             <tbody>
             <tr><td class="b">2[]</td><td class="a">1</td></tr>
             <tr><td class="d">4</td><td class="c">3</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        <p data-selection-placeholder=""><br></p>`)
     );
 
     undo(editor);
     expect(getContent(el)).toBe(
         unformat(`
+        <p data-selection-placeholder=""><br></p>
         <table>
             <tbody>
                 <tr><td class="a">1</td><td class="b">2[]</td></tr>
                 <tr><td class="c">3</td><td class="d">4</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        <p data-selection-placeholder=""><br></p>`)
     );
 });
 
@@ -944,23 +988,27 @@ test("move row above operation", async () => {
     await click("div[name='move_up']");
     expect(getContent(el)).toBe(
         unformat(`
+        <p data-selection-placeholder=""><br></p>
         <table>
             <tbody>
             <tr><td class="c">3</td><td class="d">4</td></tr>
             <tr><td class="a">1[]</td><td class="b">2</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        <p data-selection-placeholder=""><br></p>`)
     );
 
     undo(editor);
     expect(getContent(el)).toBe(
         unformat(`
+        <p data-selection-placeholder=""><br></p>
         <table>
             <tbody>
                 <tr><td class="a">1[]</td><td class="b">2</td></tr>
                 <tr><td class="c">3</td><td class="d">4</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        <p data-selection-placeholder=""><br></p>`)
     );
 });
 
@@ -988,12 +1036,14 @@ test("move second row to top when first row is header row", async () => {
     await click("div[name='move_up']");
     expect(getContent(el)).toBe(
         unformat(`
+        <p data-selection-placeholder=""><br></p>
         <table>
             <tbody>
                 <tr><th class="o_table_header">3</th><th class="o_table_header">4</th></tr>
                 <tr><td>1[]</td><td>2</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        <p data-selection-placeholder=""><br></p>`)
     );
 });
 
@@ -1022,13 +1072,15 @@ test("preserve table rows width on move row above operation", async () => {
     await click("div[name='move_up']");
     expect(getContent(el)).toBe(
         unformat(`
+        <p data-selection-placeholder=""><br></p>
         <table>
             <tbody>
                 <tr><td style="width: 100px;" class="c">3</td><td style="width: 200px;" class="d">4</td></tr>
                 <tr><td style="width: 100px;" class="a">1[]</td><td style="width: 200px;" class="b">2</td></tr>
                 <tr><td style="width: 150px;" class="e">5</td><td style="width: 150px;" class="f">6</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        <p data-selection-placeholder=""><br></p>`)
     );
 });
 
@@ -1056,23 +1108,27 @@ test("move row below operation", async () => {
     await click("div[name='move_down']");
     expect(getContent(el)).toBe(
         unformat(`
+        <p data-selection-placeholder=""><br></p>
         <table>
             <tbody>
             <tr><td class="c">3</td><td class="d">4</td></tr>
             <tr><td class="a">1[]</td><td class="b">2</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        <p data-selection-placeholder=""><br></p>`)
     );
 
     undo(editor);
     expect(getContent(el)).toBe(
         unformat(`
+        <p data-selection-placeholder=""><br></p>
         <table>
             <tbody>
                 <tr><td class="a">1[]</td><td class="b">2</td></tr>
                 <tr><td class="c">3</td><td class="d">4</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        <p data-selection-placeholder=""><br></p>`)
     );
 });
 
@@ -1100,12 +1156,14 @@ test("move header row below operation", async () => {
     await click("div[name='move_down']");
     expect(getContent(el)).toBe(
         unformat(`
+        <p data-selection-placeholder=""><br></p>
         <table>
             <tbody>
                 <tr><th class="o_table_header">3</th><th class="o_table_header">4</th></tr>
                 <tr><td>1[]</td><td>2</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        <p data-selection-placeholder=""><br></p>`)
     );
 });
 
@@ -1134,13 +1192,15 @@ test("preserve table rows width on move row below operation", async () => {
     await click("div[name='move_down']");
     expect(getContent(el)).toBe(
         unformat(`
+        <p data-selection-placeholder=""><br></p>
         <table>
             <tbody>
                 <tr><td style="width: 100px;" class="c">3</td><td style="width: 200px;" class="d">4</td></tr>
                 <tr><td style="width: 100px;" class="a">1[]</td><td style="width: 200px;" class="b">2</td></tr>
                 <tr><td style="width: 150px;" class="e">5</td><td style="width: 150px;" class="f">6</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        <p data-selection-placeholder=""><br></p>`)
     );
 });
 
@@ -1165,23 +1225,28 @@ test("reset table size to remove custom width", async () => {
     await click(queryOne(".dropdown-menu [name='reset_table_size']"));
     expect(getContent(el)).toBe(
         unformat(`
+        <p data-selection-placeholder=""><br></p>
         <table>
             <tbody>
                 <tr><td style="" class="a">1[]</td></tr>
                 <tr><td style="" class="b">2</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        <p data-selection-placeholder=""><br></p>`)
     );
 
     undo(editor);
     expect(getContent(el)).toBe(
-        unformat(`
-        <table style="width: 150px;">
+        unformat(
+            `<p data-selection-placeholder=""><br></p>
+            <table style="width: 150px;">
             <tbody>
             <tr><td style="width: 100px;" class="a">1[]</td></tr>
             <tr><td style="width: 50px;" class="b">2</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        <p data-selection-placeholder=""><br></p>`
+        )
     );
 });
 
@@ -1206,23 +1271,27 @@ test("reset table size to remove custom height", async () => {
     await click(queryOne(".dropdown-menu [name='reset_table_size']"));
     expect(getContent(el)).toBe(
         unformat(`
+        <p data-selection-placeholder=""><br></p>
         <table>
             <tbody>
                 <tr style=""><td class="a">1[]</td></tr>
                 <tr style=""><td class="b">2</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        <p data-selection-placeholder=""><br></p>`)
     );
 
     undo(editor);
     expect(getContent(el)).toBe(
         unformat(`
+        <p data-selection-placeholder=""><br></p>
         <table>
             <tbody>
             <tr style="height: 100px;"><td class="a">1[]</td></tr>
             <tr style="height: 50px;"><td class="b">2</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        <p data-selection-placeholder=""><br></p>`)
     );
 });
 
@@ -1259,7 +1328,8 @@ test("reset row size to remove custom height", async () => {
     await waitFor(".dropdown-menu", { timeout: 1000 });
     await click(queryOne(".dropdown-menu [name='reset_row_size']"));
     expect(getContent(el)).toBe(
-        unformat(`
+        unformat(
+            `<p data-selection-placeholder=""><br></p>
             <table class="table table-bordered o_table">
                 <tbody>
                     <tr style="">
@@ -1278,7 +1348,9 @@ test("reset row size to remove custom height", async () => {
                         <td class="i">9</td>
                     </tr>
                 </tbody>
-            </table>`)
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+        )
     );
 });
 
@@ -1314,7 +1386,8 @@ test("should redistribute excess width from current column to smaller columns", 
     await waitFor(".dropdown-menu", { timeout: 1000 });
     await click(queryOne(".dropdown-menu [name='reset_column_size']"));
     expect(getContent(el)).toBe(
-        unformat(`
+        unformat(
+            `<p data-selection-placeholder=""><br></p>
             <table class="table table-bordered o_table" style="width: 500px">
                 <tbody>
                     <tr>
@@ -1332,7 +1405,9 @@ test("should redistribute excess width from current column to smaller columns", 
                         <td style="" class="j">10</td>
                     </tr>
                 </tbody>
-            </table>`)
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+        )
     );
 });
 
@@ -1372,7 +1447,8 @@ test("should redistribute excess width from larger columns to current column", a
     await waitFor(".dropdown-menu", { timeout: 1000 });
     await click(queryOne(".dropdown-menu [name='reset_column_size']"));
     expect(getContent(el)).toBe(
-        unformat(`
+        unformat(
+            `<p data-selection-placeholder=""><br></p>
             <table class="table table-bordered o_table" style="width: 700px">
                 <tbody>
                     <tr>
@@ -1394,6 +1470,8 @@ test("should redistribute excess width from larger columns to current column", a
                         <td style="width: 120px;" class="n">14</td>
                     </tr>
                 </tbody>
-            </table>`)
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+        )
     );
 });

--- a/addons/html_editor/static/tests/tags.test.js
+++ b/addons/html_editor/static/tests/tags.test.js
@@ -676,14 +676,16 @@ describe("transform", () => {
         const { el, editor } = await setupEditor("<p>[]<br></p>");
         await insertText(editor, "--- ");
         expect(getContent(el)).toBe(
-            `<hr contenteditable="false"><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`
+            `<p data-selection-placeholder="" style="margin: 8px 0px -9px;"><br></p><hr contenteditable="false"><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`
         );
     });
 
     test("should transform three dashes at the start of text to separator before the block", async () => {
         const { el, editor } = await setupEditor("<p>[]abc</p>");
         await insertText(editor, "--- ");
-        expect(getContent(el)).toBe(`<hr contenteditable="false"><p>[]abc</p>`);
+        expect(getContent(el)).toBe(
+            `<p data-selection-placeholder="" style="margin: 8px 0px -9px;"><br></p><hr contenteditable="false"><p>[]abc</p>`
+        );
     });
 
     test("should transform space preceding by greater-than symbol to blockquote", async () => {

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -573,6 +573,7 @@ test("toolbar should not open on keypress tab inside table", async () => {
         </table>
     `);
     const contentAfter = unformat(`
+        <p data-selection-placeholder=""><br></p>
         <table>
             <tbody>
                 <tr>
@@ -581,6 +582,7 @@ test("toolbar should not open on keypress tab inside table", async () => {
                 </tr>
             </tbody>
         </table>
+        <p data-selection-placeholder=""><br></p>
     `);
 
     const { el } = await setupEditor(contentBefore);
@@ -719,6 +721,7 @@ test("toolbar should close on keypress tab inside table", async () => {
         </table>
     `);
     const contentAfter = unformat(`
+        <p data-selection-placeholder=""><br></p>
         <table>
             <tbody>
                 <tr>
@@ -727,6 +730,7 @@ test("toolbar should close on keypress tab inside table", async () => {
                 </tr>
             </tbody>
         </table>
+        <p data-selection-placeholder=""><br></p>
     `);
 
     const { el } = await setupEditor(contentBefore);
@@ -764,6 +768,7 @@ test("toolbar works: show the correct vertical alignment", async () => {
     expect(".dropdown-menu button.active svg[name='vertical_align_middle']").toHaveCount(1);
     expect(getContent(el)).toBe(
         unformat(`
+            <p data-selection-placeholder=""><br></p>
             <table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr style="height: 100px;">
@@ -778,6 +783,7 @@ test("toolbar works: show the correct vertical alignment", async () => {
                     </tr>
                 </tbody>
             </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
         `)
     );
 });
@@ -808,6 +814,7 @@ test("toolbar works: show the correct vertical alignment after undo/redo", async
     expect(".dropdown-menu button.active svg[name='vertical_align_bottom']").toHaveCount(1);
     expect(getContent(el)).toBe(
         unformat(`
+            <p data-selection-placeholder=""><br></p>
             <table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr style="height: 100px;">
@@ -820,6 +827,7 @@ test("toolbar works: show the correct vertical alignment after undo/redo", async
                     </tr>
                 </tbody>
             </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
         `)
     );
     await press(["ctrl", "z"]);
@@ -827,6 +835,7 @@ test("toolbar works: show the correct vertical alignment after undo/redo", async
     expect("button[name='vertical_align'] svg[name='vertical_align_top']").toHaveCount(1);
     expect(getContent(el)).toBe(
         unformat(`
+            <p data-selection-placeholder=""><br></p>
             <table class="table table-bordered o_table">
                 <tbody>
                     <tr style="height: 100px;">
@@ -839,6 +848,7 @@ test("toolbar works: show the correct vertical alignment after undo/redo", async
                     </tr>
                 </tbody>
             </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
         `)
     );
     await press(["ctrl", "y"]);
@@ -847,6 +857,7 @@ test("toolbar works: show the correct vertical alignment after undo/redo", async
     expect(".dropdown-menu button.active svg[name='vertical_align_bottom']").toHaveCount(1);
     expect(getContent(el)).toBe(
         unformat(`
+            <p data-selection-placeholder=""><br></p>
             <table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr style="height: 100px;">
@@ -859,6 +870,7 @@ test("toolbar works: show the correct vertical alignment after undo/redo", async
                     </tr>
                 </tbody>
             </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
         `)
     );
 });

--- a/addons/html_editor/static/tests/unbreakable/split_element_block.test.js
+++ b/addons/html_editor/static/tests/unbreakable/split_element_block.test.js
@@ -26,9 +26,13 @@ test("should replace splitElementBlock with insertLineBreak (selection end)", as
 });
 test("should not split a contenteditable='false'", async () => {
     const { editor, el } = await setupEditor(`<p contenteditable="false">ab</p>`);
-    const p = el.querySelector("p");
+    const p = el.querySelector("p[contenteditable=false]");
     editor.shared.split.splitBlockNode({ targetNode: p, targetOffset: 0 });
-    expect(getContent(el)).toBe(`<p contenteditable="false">ab</p>`);
+    expect(getContent(el)).toBe(
+        '<p data-selection-placeholder=""><br></p>' +
+            '<p contenteditable="false">ab</p>' +
+            '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>'
+    );
 });
 test("should split an explicit contenteditable='true' if its ancestor isContentEditable", async () => {
     await testEditor({

--- a/addons/html_editor/static/tests/utils/dom.test.js
+++ b/addons/html_editor/static/tests/utils/dom.test.js
@@ -301,13 +301,15 @@ describe("wrapInlinesInBlocks", () => {
         // element).
         expect(getContent(el)).toBe(
             unformat(`
+                <p data-selection-placeholder=""><br></p>
                 <div>
                     <div contenteditable="false" style="display: inline;">inline</div>[]
                 </div>
-                <div class="o-paragraph"><br></div>
+                <p data-selection-placeholder=""><br></p>
                 <div>
                     <div contenteditable="false" style="display: inline;">inline</div>
                 </div>
+                <p data-selection-placeholder=""><br></p>
             `)
         );
     });
@@ -335,12 +337,13 @@ describe("wrapInlinesInBlocks", () => {
                 <div>
                     <div contenteditable="false" style="display: inline;">inline</div><span class="a">span</span>[]
                 </div>
-                <div class="o-paragraph"><br></div>
+                <p data-selection-placeholder=""><br></p>
                 <div>
                     text
                     <div contenteditable="false" style="display: inline;">inline</div>
                     <span class="a">span</span>
                 </div>
+                <p data-selection-placeholder=""><br></p>
             `)
         );
     });

--- a/addons/html_editor/static/tests/utils/dom.test.js
+++ b/addons/html_editor/static/tests/utils/dom.test.js
@@ -391,10 +391,14 @@ describe("wrapInlinesInBlocks", () => {
 describe("fillEmpty", () => {
     test("should not add fill a shrunk protected block, nor add a ZWS to it", async () => {
         const { el } = await setupEditor('<div data-oe-protected="true"></div>');
-        expect(el.innerHTML).toBe('<div data-oe-protected="true" contenteditable="false"></div>');
+        expect(el.innerHTML).toBe(
+            '<p data-selection-placeholder=""><br></p><div data-oe-protected="true" contenteditable="false"></div><p data-selection-placeholder=""><br></p>'
+        );
         const div = el.firstChild;
         fillEmpty(div);
-        expect(el.innerHTML).toBe('<div data-oe-protected="true" contenteditable="false"></div>');
+        expect(el.innerHTML).toBe(
+            '<p data-selection-placeholder=""><br></p><div data-oe-protected="true" contenteditable="false"></div><p data-selection-placeholder=""><br></p>'
+        );
     });
     test("should not fill a block containing a canvas", async () => {
         const { el } = await setupEditor("<div><canvas></canvas></div>");

--- a/addons/website/static/src/builder/plugins/options/background_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/background_option_plugin.js
@@ -38,6 +38,7 @@ class WebsiteBackgroundVideoPlugin extends Plugin {
             ToggleBgVideoAction,
             ReplaceBgVideoAction,
         },
+        system_node_selectors: ".o_bg_video_container",
     };
     loadReplaceBackgroundVideo() {
         return new Promise((resolve) => {

--- a/addons/website/static/src/builder/plugins/options/parallax_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/parallax_option_plugin.js
@@ -15,6 +15,7 @@ class WebsiteParallaxPlugin extends Plugin {
         },
         on_bg_image_hide_handlers: this.onBgImageHide.bind(this),
         content_not_editable_selectors: ".s_parallax_bg, section.s_parallax > .oe_structure",
+        system_node_selectors: ".s_parallax_bg",
         get_target_element_providers: withSequence(1, this.getTargetElement),
     };
     setup() {

--- a/addons/website/static/tests/builder/builder_overlay.test.js
+++ b/addons/website/static/tests/builder/builder_overlay.test.js
@@ -189,7 +189,7 @@ test("Mouse move on throttleForAnimation", async () => {
 
     const keyDownEvent = new KeyboardEvent("keydown", { bubbles: true });
     const mouseMoveEvent = new KeyboardEvent("mousemove", { bubbles: true });
-    const p = queryOne(":iframe p");
+    const p = queryOne(":iframe p:not([data-selection-placeholder])");
 
     p.dispatchEvent(keyDownEvent);
     expect(".oe_overlay.oe_active.o_overlay_hidden").toHaveCount(1);

--- a/addons/website/static/tests/builder/invisibility_options.test.js
+++ b/addons/website/static/tests/builder/invisibility_options.test.js
@@ -187,7 +187,7 @@ test("Show conditionally hidden elements should not be tracked in history", asyn
     expect(":iframe section").toHaveAttribute("data-invisible", "1");
     expect(".o_we_invisible_el_panel .o_we_invisible_entry i").toHaveClass("fa-eye-slash");
 
-    setSelection({ anchorNode: queryOne(":iframe p"), anchorOffset: 1 });
+    setSelection({ anchorNode: queryOne(":iframe p:not([data-selection-placeholder])"), anchorOffset: 1 });
     await insertText(getEditor(), "x"); // something to undo
     undo(getEditor());
     expect(":iframe section.o_snippet_invisible").toHaveClass("o_conditional_hidden");

--- a/addons/website/static/tests/tours/edit_link_popover.js
+++ b/addons/website/static/tests/tours/edit_link_popover.js
@@ -7,7 +7,7 @@ import {
 import { browser } from "@web/core/browser/browser";
 import { patch } from "@web/core/utils/patch";
 
-const FIRST_PARAGRAPH = ":iframe #wrap .s_text_image p:nth-child(2)";
+const FIRST_PARAGRAPH = ":iframe #wrap .s_text_image p:not([data-selection-placeholder]):nth-child(2)";
 
 const clickEditLink = {
     content: "Click on Edit Link in Popover",

--- a/addons/website/static/tests/tours/snippet_editor_panel_options.js
+++ b/addons/website/static/tests/tours/snippet_editor_panel_options.js
@@ -39,8 +39,8 @@ registerWebsitePreviewTour(
             groupName: "Content",
         }),
         // Test keeping the text selection when using the width option.
-        selectFullText("first paragraph", ".s_text_image p"),
-        checkIfParagraphSelected(":iframe .s_text_image p"),
+        selectFullText("first paragraph", ".s_text_image p:not([data-selection-placeholder])"),
+        checkIfParagraphSelected(":iframe .s_text_image p:not([data-selection-placeholder])"),
         checkIfTextToolbarVisible,
         {
             content: "Click on the width option.",
@@ -51,7 +51,7 @@ registerWebsitePreviewTour(
             content: "The snippet should have the correct class.",
             trigger: ":iframe .s_text_image > .o_container_small",
         },
-        checkIfParagraphSelected(":iframe .s_text_image p"),
+        checkIfParagraphSelected(":iframe .s_text_image p:not([data-selection-placeholder])"),
         // Test the anchor option.
         {
             content: "Click on the anchor option",
@@ -99,20 +99,20 @@ registerWebsitePreviewTour(
             name: "Text",
             groupName: "Text",
         }),
-        selectFullText("first paragraph", ".s_text_block p"),
-        checkIfParagraphSelected(":iframe .s_text_block p"),
+        selectFullText("first paragraph", ".s_text_block p:not([data-selection-placeholder])"),
+        checkIfParagraphSelected(":iframe .s_text_block p:not([data-selection-placeholder])"),
         checkIfTextToolbarVisible,
         ...changeOptionInPopover("Text", "Layout", "[data-action-value='3']"),
         {
             content: "The snippet should have the correct number of columns.",
             trigger: ":iframe .s_text_block .container > .row .col-lg-4:eq(3)",
             run() {
-                if (this.anchor.childElementCount !== 3) {
+                if ([...this.anchor.children].filter(child => !child.hasAttribute("data-selection-placeholder")).length !== 3) {
                     console.error("The snippet does not have the correct number of columns");
                 }
             },
         },
-        checkIfParagraphSelected(":iframe .s_text_block p"),
+        checkIfParagraphSelected(":iframe .s_text_block p:not([data-selection-placeholder])"),
         // Test keeping the text selection when removing all columns of a
         // snippet.
         ...changeOptionInPopover("Text", "Layout", "[data-action-value='0']"),
@@ -120,21 +120,21 @@ registerWebsitePreviewTour(
             content: "The snippet should have the correct number of columns.",
             trigger: ":iframe .s_text_block .container:not(:has(.row))",
         },
-        checkIfParagraphSelected(":iframe .s_text_block p"),
+        checkIfParagraphSelected(":iframe .s_text_block p:not([data-selection-placeholder])"),
         // Test keeping the text selection when toggling the grid mode.
         changeOption("Text", "[data-action-id='setGridLayout']"),
         {
             content: "The snippet row should have the grid mode class.",
             trigger: ":iframe .s_text_block .row.o_grid_mode",
         },
-        checkIfParagraphSelected(":iframe .s_text_block p"),
+        checkIfParagraphSelected(":iframe .s_text_block p:not([data-selection-placeholder])"),
         // Test keeping the text selection when toggling back the column mode.
         changeOption("Text", "[data-action-id='setColumnLayout']"),
         {
             content: "The snippet row should not have the grid mode class anymore.",
             trigger: ":iframe .s_text_block .row:not(.o_grid_mode)",
         },
-        checkIfParagraphSelected(":iframe .s_text_block p"),
+        checkIfParagraphSelected(":iframe .s_text_block p:not([data-selection-placeholder])"),
         ...clickOnSave(),
     ]
 );


### PR DESCRIPTION
Enterprise PR: https://github.com/odoo/enterprise/pull/96484

Currently, there is no way to put our cursor between two `contenteditable=false` blocks, between two tables, before the first block in the editable or after the last one.

This introduces placeholder blocks with no height in these places, in which the user can put their selection (which will show as a horizontal blinking line). They can then start typing and the placeholder will be persisted. At the end of the document, this is bypassed and the placeholder will be persisted as soon as the selection is in it.

task-4129699

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
