### PR TITLE
[IMP] hr_recruitment: obsolete applicants (not unique)

### DIFF
--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -138,6 +138,7 @@ class HrApplicant(models.Model):
     refuse_date = fields.Datetime('Refuse Date')
     talent_pool_ids = fields.Many2many(comodel_name="hr.talent.pool", string="Talent Pools")
     pool_applicant_id = fields.Many2one("hr.applicant", index='btree_not_null')
+    is_obsolete = fields.Boolean()
     is_pool_applicant = fields.Boolean(compute="_compute_is_pool")
     is_applicant_in_pool = fields.Boolean(
         compute="_compute_is_applicant_in_pool", search="_search_is_applicant_in_pool"
@@ -621,6 +622,19 @@ class HrApplicant(models.Model):
             if not applicant.stage_id.hired_stage:
                 applicant.date_closed = False
 
+    def _flag_obsolete_applicants(self):
+        """
+        Flag previous applicants as obsolete when one of their identifiers
+        match with new candidates's email, phone number or LinkedIn profile.
+        """
+        self.ensure_one()
+        duplicates_domain = self._get_similar_applicants_domain(ignore_talent=True)
+        duplicated_applicants = self.search(duplicates_domain)
+
+        if len(duplicated_applicants) > 1:
+            unflagged_duplicates = duplicated_applicants.filtered(lambda a: not a.is_obsolete)
+            (unflagged_duplicates - self).is_obsolete = True
+
     def copy_data(self, default=None):
         vals_list = super().copy_data(default=default)
 
@@ -641,6 +655,9 @@ class HrApplicant(models.Model):
                 vals['email_from'] = vals['email_from'].strip()
         applicants = super().create(vals_list)
         applicants.sudo().interviewer_ids._create_recruitment_interviewers()
+
+        for applicant in applicants:
+            applicant._flag_obsolete_applicants()
 
         if (applicants.interviewer_ids.partner_id - self.env.user.partner_id):
             for applicant in applicants:
@@ -684,6 +701,8 @@ class HrApplicant(models.Model):
         res = super().write(vals)
 
         for applicant in self:
+            if not applicant.is_obsolete:
+                applicant._flag_obsolete_applicants()
             if applicant.pool_applicant_id and applicant != applicant.pool_applicant_id and (not applicant.is_pool_applicant):
                 if 'email_from' in vals:
                     applicant.pool_applicant_id.email_from = vals['email_from']


### PR DESCRIPTION
This commit adds the boolean `is_obsolete` for flagging applicants with duplicated email, phone number or LinkedIn URL. Past applicants records are also flagged with `is_obsolete` equals True when they have any of those fields duplicated by the new applicant.

[Enterprise PR](https://github.com/odoo/enterprise/pull/93938)
task-4535862