### PR TITLE
[FIX] l10n_ar: hidden responsibility in form


### DIFF
--- a/addons/l10n_ar/views/portal_address_templates.xml
+++ b/addons/l10n_ar/views/portal_address_templates.xml
@@ -30,6 +30,13 @@
                         been issued for your account. Please contact us directly for this
                         operation."
                 />
+                <input
+                    t-if="not (is_commercial_address and can_edit_vat)"
+                    type="hidden"
+                    readonly="1"
+                    name="l10n_ar_afip_responsibility_type_id"
+                    t-att-value="responsibility.id"
+                />
             </div>
         </div>
     </template>


### PR DESCRIPTION
Scenario:

- setup company with Argentina L10N
- do a sale order from partner to Argentinian company and confirm it (to
  make the vat not editable)
- do a checkout from ecommerce from same partner to same company, and
  at the checkout "address" step, click to edit the billing address
- click to confirm the billing address change

Result: a "Cannot read properties of undefined (reading 'classList')"
error happen in customerAddress._onSaveAddress because the field
l10n_ar_afip_responsibility_type_id is missing from the view.

Solution: similarly to c10e77ac636243025004d9ebca61af0076691f2b, add
the field as hidden if it is readonly.

opw-5019253