### PR TITLE
[FIX] website_sale: compute pricelist with geoip country

### DIFF
--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -112,6 +112,16 @@ class SaleOrder(models.Model):
             if order.website_id:
                 order.payment_term_id = order.website_id.with_company(order.company_id).sale_get_payment_term(order.partner_id)
 
+    def _compute_pricelist_id(self):
+        # Override to compute pricelists for carts using the partner's GeoIP,
+        # providing a fallback in case they don't have an address set.
+        if not (country_code := self.env['website']._get_geoip_country_code()):
+            return super()._compute_pricelist_id()
+        if website_orders := self.filtered('website_id'):
+            website_orders = website_orders.with_context(country_code=country_code)
+            super(SaleOrder, website_orders)._compute_pricelist_id()
+        return super(SaleOrder, self - website_orders)._compute_pricelist_id()
+
     def _search_abandoned_cart(self, operator, value):
         website_ids = self.env['website'].search_read(fields=['id', 'cart_abandoned_delay', 'partner_id'])
         deadlines = [[

--- a/addons/website_sale/tests/test_website_sale_cart.py
+++ b/addons/website_sale/tests/test_website_sale_cart.py
@@ -183,6 +183,43 @@ class WebsiteSaleCart(TransactionCaseWithUserPortal):
             sale_order = website.sale_get_order()
             self.assertEqual(len(sale_order._cart_accessories()), 0)
 
+    def test_cart_new_pricelist_from_geoip(self):
+        """Check that, when adding a new partner to a website order, the partner's GeoIP
+        is factored into the pricelist recomputation.
+        """
+        eu_group = self.env.ref('base.europe')
+        not_eu_group = self.env['res.country.group'].create({
+            'name': "Not EU",
+            'country_ids': self.env['res.country'].search([
+                ('id', 'not in', eu_group.country_ids.ids),
+            ]).ids,
+        })
+
+        _pricelist_eu, pricelist_not_eu = self.env['product.pricelist'].create([{
+            'name': "EU",
+            'country_group_ids': eu_group.ids,
+            'website_id': self.website.id,
+            'sequence': 1,
+        }, {
+            'name': "Not EU",
+            'country_group_ids': not_eu_group.ids,
+            'website_id': self.website.id,
+            'sequence': 2,
+        }])
+
+        website = self.website.with_user(self.public_user)
+        with (
+            MockRequest(website.env, website=website, country_code='US'),
+            patch.object(website.__class__, '_get_geoip_country_code', return_value='US'),
+        ):
+            self.WebsiteSaleController.cart_update_json(product_id=self.product.id, add_qty=1)
+            cart = website.sale_get_order()
+            self.assertEqual(cart.pricelist_id, pricelist_not_eu)
+            cart.partner_id = self.env['res.partner'].create({
+                'name': "New Partner",
+            })
+            self.assertEqual(cart.pricelist_id, pricelist_not_eu)
+
     def test_remove_archived_product_line(self):
         """If an order has a line containing an archived product,
         it is removed when opening the order in the cart."""


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Have GeoIP enabled/mocked;
2. have at least 2 pricelists available in eCommerce;
3. have all pricelists restricted to a certain country group;
4. have the 1st pricelist be incompatible w/ the current GeoIP location;
5. open a cart as a public user;
6. check pricelist in back-end (should be correct);
7. go to "Sign In" & create a new portal account without address;
8. check pricelist in back-end (should still be correct);
9. go back to cart with portal account;
10. check pricelist in back-end.

Issue
-----
The first pricelist is assigned to the order, which shouldn't be compatibly with the partner's current GeoIP location.

Cause
-----
The pricelist is recomputed on changing the `partner_id` on a sale order. Commit 6504c0624b990 added a check on the `country_code` context value when retrieving the `property_product_pricelist` for a partner. This context value is currently not getting added during `_compute_pricelist_id`.

Because all pricelists are restricted to a country group, when the pricelist gets recomputed on `partner_id` change, there's no location-independent pricelist to fall back on, which is why the first pricelist is used regardless of country restrictions.

Solution
--------
Add a `_compute_pricelist_id` override which adds the current GeoIP country code to the context when computing the field for website orders.

opw-5000198