### PR TITLE
[FIX] point_of_sale: replace `serialize` by `serializeForORM`

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.js
@@ -242,11 +242,12 @@ export class OrderSummary extends Component {
                     return line;
                 }
             }
-            const data = selectedLine.serialize();
+            const data = selectedLine.serializeForORM({ keepCommands: true });
             delete data.uuid;
             newLine = this.pos.models["pos.order.line"].create(
                 {
                     ...data,
+                    order_id: selectedLine.order_id,
                     refunded_orderline_id: selectedLine.refunded_orderline_id,
                 },
                 false,

--- a/addons/point_of_sale/static/tests/unit/components/order_summary.test.js
+++ b/addons/point_of_sale/static/tests/unit/components/order_summary.test.js
@@ -1,0 +1,19 @@
+import { test, expect, describe } from "@odoo/hoot";
+import { mountWithCleanup } from "@web/../tests/web_test_helpers";
+import { OrderSummary } from "@point_of_sale/app/screens/product_screen/order_summary/order_summary";
+import { setupPosEnv, getFilledOrder } from "../utils";
+import { definePosModels } from "../data/generate_model_definitions";
+
+definePosModels();
+
+describe("order_summary.js", () => {
+    test("getNewLine", async () => {
+        const store = await setupPosEnv();
+        const order = await getFilledOrder(store);
+        const orderSummary = await mountWithCleanup(OrderSummary, {});
+        order.getSelectedOrderline().uiState.savedQuantity = 5;
+        const newLine = orderSummary.getNewLine();
+        expect(newLine.order_id.id).toBe(order.id);
+        expect(newLine.qty).toBe(0);
+    });
+});


### PR DESCRIPTION
Replace usage of `serialize` (method that was previously removed) by `serializeForORM` in `OrderSummary`.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
