### PR TITLE
[IMP] mail,*: composer inactive when chatbot expects inputs

### DIFF
--- a/addons/im_livechat/static/src/core/common/@types/models.d.ts
+++ b/addons/im_livechat/static/src/core/common/@types/models.d.ts
@@ -44,8 +44,7 @@ declare module "models" {
         "im_livechat.expertise": StaticMailRecord<LivechatExpertise, typeof LivechatExpertiseClass>;
     }
     export interface Thread {
-        composerDisabled: Readonly<boolean>;
-        composerDisabledText: Readonly<string>;
+        composerHidden: Readonly<boolean>;
         livechat_conversation_tag_ids: LivechatConversationTag[];
         livechat_end_dt: luxon.DateTime;
         livechat_operator_id: ResPartner;

--- a/addons/im_livechat/static/src/core/common/chat_window_patch.xml
+++ b/addons/im_livechat/static/src/core/common/chat_window_patch.xml
@@ -8,9 +8,9 @@
             </t>
         </xpath>
         <xpath expr="//Composer" position="replace">
-            <div t-if="thread?.composerDisabled" class="bg-200 py-1 text-center d-flex fst-italic fw-bold text-muted" t-ref="composerDisabledContainer">
+            <div t-if="thread?.composerHidden" class="bg-200 py-1 text-center d-flex fst-italic fw-bold text-muted" t-ref="composerHiddenContainer">
                 <span t-if="!showGiveFeedbackBtn" class="flex-grow-1"/>
-                <span t-esc="thread.composerDisabledText"/>
+                <span>This livechat conversation has ended</span>
                 <span class="flex-grow-1"/>
             </div>
             <t t-else="">$0</t>

--- a/addons/im_livechat/static/src/core/common/message_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/message_model_patch.js
@@ -10,10 +10,10 @@ const messagePatch = {
         this.chatbotStep = fields.One("ChatbotStep", { inverse: "message" });
     },
     canReplyTo(thread) {
-        return (
-            super.canReplyTo(thread) &&
-            (thread?.channel_type !== "livechat" || !thread.composerDisabled)
-        );
+        if (thread?.channel_type === "livechat") {
+            return !thread.composerDisabled && !thread.composerHidden;
+        }
+        return super.canReplyTo(thread);
     },
     isTranslatable(thread) {
         return (

--- a/addons/im_livechat/static/src/core/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/thread_model_patch.js
@@ -1,7 +1,6 @@
 import { fields } from "@mail/core/common/record";
 import { Thread } from "@mail/core/common/thread_model";
 
-import { _t } from "@web/core/l10n/translation";
 import { patch } from "@web/core/utils/patch";
 
 patch(Thread.prototype, {
@@ -66,14 +65,8 @@ patch(Thread.prototype, {
         return this.channel_type === "livechat" || super.allowDescription;
     },
 
-    get composerDisabled() {
+    get composerHidden() {
         return this.channel_type === "livechat" && this.livechat_end_dt;
-    },
-
-    get composerDisabledText() {
-        return this.channel_type === "livechat" && this.livechat_end_dt
-            ? _t("This livechat conversation has ended")
-            : "";
     },
     /**
      * @override

--- a/addons/im_livechat/static/src/core/public_web/discuss_content_patch.xml
+++ b/addons/im_livechat/static/src/core/public_web/discuss_content_patch.xml
@@ -2,7 +2,9 @@
 <templates xml:space="preserve">
     <t t-inherit="mail.DiscussContent" t-inherit-mode="extension">
         <xpath expr="//Composer" position="replace">
-            <span t-if="thread?.composerDisabled" class="bg-200 py-1 text-center fst-italic fw-bold text-muted" t-esc="thread.composerDisabledText"/>
+            <span t-if="thread?.composerHidden" class="bg-200 py-1 text-center fst-italic fw-bold text-muted">
+                This livechat conversation has ended
+            </span>
             <t t-else="">$0</t>
         </xpath>
     </t>

--- a/addons/im_livechat/static/src/embed/common/chat_window_patch.xml
+++ b/addons/im_livechat/static/src/embed/common/chat_window_patch.xml
@@ -13,10 +13,10 @@
         <xpath expr="//*[hasclass('o-mail-ChatWindow-header')]" position="attributes">
             <attribute name="t-attf-style" add="color: {{ livechatService.options.title_color }}; --o-mail-livechat-btn-color: {{ livechatService.options.title_color }}; background-color: {{ livechatService.options.header_background_color }} !important;" separator=" "/>
         </xpath>
-        <xpath expr="//*[@t-ref='composerDisabledContainer']" position="inside">
+        <xpath expr="//*[@t-ref='composerHiddenContainer']" position="inside">
             <button t-if="showGiveFeedbackBtn" class="btn btn-link p-0" title="Give your feedback" t-on-click="() => this.onClickFeedback()">Continue</button>
         </xpath>
-        <xpath expr="//*[@t-ref='composerDisabledContainer']" position="attributes">
+        <xpath expr="//*[@t-ref='composerHiddenContainer']" position="attributes">
             <attribute name="t-attf-class" add="{{ showGiveFeedbackBtn ? 'px-2' : '' }}" separator=" "/>
         </xpath>
     </t>

--- a/addons/im_livechat/static/src/embed/common/composer_patch.scss
+++ b/addons/im_livechat/static/src/embed/common/composer_patch.scss
@@ -1,0 +1,3 @@
+.o-mail-Composer.o-disabled .o-mail-Composer-bg {
+    background-color: $gray-200 !important;
+}

--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -70,7 +70,7 @@
                 <t t-elif="thread">
                     <Thread autofocus="isMobileOS ? props.chatWindow.autofocus : undefined" isInChatWindow="true" thread="thread" t-key="thread.localId" jumpPresent="state.jumpThreadPresent" jumpToNewMessage="props.chatWindow.jumpToNewMessage"/>
                     <t t-call="mail.ChatWindow.memberTyping"/>
-                    <Composer composer="thread.composer" autofocus="isMobileOS ? undefined : props.chatWindow.autofocus" mode="'compact'" onPostCallback.bind="() => this.state.jumpThreadPresent++" dropzoneRef="contentRef" type="composerType"/>
+                    <Composer composer="thread.composer" autofocus="isMobileOS ? undefined : props.chatWindow.autofocus" mode="'compact'" onPostCallback.bind="() => this.state.jumpThreadPresent++" dropzoneRef="contentRef" type="composerType" disabled="thread?.composerDisabled"/>
                 </t>
             </t>
         </div>

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -98,6 +98,7 @@ export class Composer extends Component {
         "type?",
         "showFullComposer?",
         "allowUpload?",
+        "disabled?",
     ];
     static template = "mail.Composer";
 
@@ -260,7 +261,7 @@ export class Composer extends Component {
     }
 
     get areAllActionsDisabled() {
-        return false;
+        return this.props.disabled;
     }
 
     get isMultiUpload() {

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -23,6 +23,7 @@
                     'mb-2': env.inChatWindow and !props.composer.message,
                     'o-discussApp pt-1 ps-2 pe-4 pb-2': env.inDiscussApp,
                     'ps-xl-3': env.inDiscussApp and !ui.isSmall,
+                    'o-disabled': props.disabled,
                 }" t-attf-class="{{ props.className }}">
             <FileUploader t-if="allowUpload" multiUpload="isMultiUpload" onUploaded.bind="(data) => { attachmentUploader.uploadData(data) }">
                 <t t-set-slot="toggler">
@@ -77,6 +78,7 @@
                                 t-on-input="(ev) => this.onInput(ev)"
                                 t-att-placeholder="placeholder"
                                 t-att-readOnly="!state.active"
+                                t-att-disabled="props.disabled"
                                 tabindex="0"
                             />
                             <!--
@@ -153,7 +155,7 @@
 </t>
 
 <t t-name="mail.Composer.moreActions">
-    <div class="o-mail-Composer-bg" t-attf-class="{{ actionsContainerClass }}" t-ref="more-actions">
+    <button class="btn btn-link p-0" t-att-disabled="areAllActionsDisabled" t-ref="more-actions">
         <div class="o-mail-Composer-mainActions d-flex flex-grow-1 align-items-baseline">
             <t t-set="moreName">More Actions</t>
             <ActionList inline="true" actions="[{
@@ -164,7 +166,7 @@
                 'tags': [],
             }]"/> 
         </div>
-    </div>
+    </button>
 </t>
 
 <t t-name="mail.Composer.extraActions">

--- a/addons/mail/static/src/core/common/composer_actions.js
+++ b/addons/mail/static/src/core/common/composer_actions.js
@@ -88,6 +88,7 @@ registerComposerAction("send-message", {
     sequenceQuick: 30,
 });
 registerComposerAction("add-emoji", {
+    disabledCondition: ({ owner }) => owner.areAllActionsDisabled,
     icon: "fa fa-smile-o",
     isPicker: true,
     pickerName: _t("Emoji"),
@@ -111,6 +112,7 @@ registerComposerAction("add-emoji", {
     sequenceQuick: 20,
 });
 registerComposerAction("upload-files", {
+    disabledCondition: ({ owner }) => owner.areAllActionsDisabled,
     condition: ({ owner }) => owner.allowUpload,
     icon: "fa fa-paperclip",
     name: _t("Attach Files"),

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -249,6 +249,14 @@ export class Thread extends Record {
      *  @type {integer|undefined}
      */
     pid;
+    composerDisabled = fields.Attr(false, {
+        compute() {
+            return this.computeComposerDisabled();
+        },
+        onUpdate() {
+            this.composerDisabledonUpdate();
+        },
+    });
 
     get accessRestrictedToGroupText() {
         if (!this.group_public_id?.full_name) {
@@ -363,6 +371,10 @@ export class Thread extends Record {
     }
 
     onPinStateUpdated() {}
+
+    computeComposerDisabled() {}
+
+    composerDisabledonUpdate() {}
 
     get isEmpty() {
         return this.messages.length === 0;


### PR DESCRIPTION
*=im_livechat

Before this commit:
When the chatbot required processing, the composer became inactive. Upon re-enabling for user input, the composer lost focus, forcing users to click on it each time to provide input.

This commit ensures that the composer retains focus, allowing users to immediately start typing without needing to click.

task-4509416




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
