### PR TITLE
[FIX] stock: fixed get product available qty in past with location in context

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -175,16 +175,17 @@ class Product(models.Model):
         quants_res = {product.id: (quantity, reserved_quantity) for product, quantity, reserved_quantity in Quant._read_group(domain_quant, ['product_id'], ['quantity:sum', 'reserved_quantity:sum'])}
         if dates_in_the_past:
             # Calculate the moves that were done before now to calculate back in time (as most questions will be recent ones)
+            Moveline = self.env['stock.move.line']
             domain_move_in_done = [('state', '=', 'done'), ('date', '>', to_date)] + domain_move_in_done
             domain_move_out_done = [('state', '=', 'done'), ('date', '>', to_date)] + domain_move_out_done
 
-            groupby = ['product_id', 'product_uom']
+            groupby = ['product_id', 'product_uom_id']
             moves_in_res_past = defaultdict(float)
-            for product, uom, quantity in Move._read_group(domain_move_in_done, groupby, ['quantity:sum']):
+            for product, uom, quantity in Moveline._read_group(domain_move_in_done, groupby, ['quantity:sum']):
                 moves_in_res_past[product.id] += uom._compute_quantity(quantity, product.uom_id)
 
             moves_out_res_past = defaultdict(float)
-            for product, uom, quantity in Move._read_group(domain_move_out_done, groupby, ['quantity:sum']):
+            for product, uom, quantity in Moveline._read_group(domain_move_out_done, groupby, ['quantity:sum']):
                 moves_out_res_past[product.id] += uom._compute_quantity(quantity, product.uom_id)
 
         res = dict()

--- a/doc/cla/individual/jeremycormier.md
+++ b/doc/cla/individual/jeremycormier.md
@@ -1,0 +1,11 @@
+France, 2025-09-04
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Jeremy Cormier jeremy.cormier.pro@gmail.com https://github.com/Corbiezorq


### PR DESCRIPTION
Problem, Odoo check the stock.move to decrease the quantity if we want available product quantity in a past.

If i valid a stock move for new product with location_dest_id = A and stock.move.line with location_dest_id = B (B child of A) and i check the quantity in a past in B location, Odoo return the quant quantity in B location without decrease the last move line.

Before fix:
product.with_context(location=B).qty_available = 1
product.with_context(to_date="2025-09-01", location=B).qty_available = 1
After fix:
product.with_context(location=B).qty_available = 1
product.with_context(to_date="2025-09-01", location=B).qty_available = 0




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
