### PR TITLE
[FIX] spreadsheet: display value for id fields in pivots

### DIFF
--- a/addons/spreadsheet/static/src/pivot/pivot_model.js
+++ b/addons/spreadsheet/static/src/pivot/pivot_model.js
@@ -515,6 +515,21 @@ export class OdooPivotModel extends PivotModel {
     }
 
     /**
+     * @override
+     */
+    _sanitizeLabel(value, groupBy, config) {
+        const { metaData } = config;
+        const fieldName = groupBy.split(":")[0];
+        if (fieldName && metaData.fields[fieldName]) {
+            const fields = fieldName.split(".");
+            if (fields.length > 1 && fields.at(-1) === "id" && Array.isArray(value)) {
+                return value[0];
+            }
+        }
+        return super._sanitizeLabel(value, groupBy, config);
+    }
+
+    /**
      * Check if the given field is used as col group by
      */
     _isCol(nameWithGranularity) {

--- a/addons/spreadsheet/static/tests/pivots/model/pivot_plugin.test.js
+++ b/addons/spreadsheet/static/tests/pivots/model/pivot_plugin.test.js
@@ -1015,6 +1015,34 @@ test("pivot grouped by ID displays values correctly", async () => {
     expect(getCellValue(model, "A1")).toBe("Raoul");
 });
 
+test("pivot grouped by ID in a chain displays values correctly", async () => {
+    const spreadsheetData = {
+        pivots: {
+            1: {
+                type: "ODOO",
+                rows: [{ fieldName: "product_id.id" }],
+                columns: [],
+                domain: [],
+                measures: [
+                    {
+                        id: "probability:sum",
+                        fieldName: "probability",
+                        aggregator: "sum",
+                    },
+                ],
+                model: "partner",
+            },
+        },
+    };
+
+    const { model } = await createModelWithDataSource({ spreadsheetData });
+
+    setCellContent(model, "A1", `=PIVOT.HEADER(1,"#product_id.id",1)`);
+    await waitForDataLoaded(model);
+
+    expect(getCellValue(model, "A1")).toBe(37);
+});
+
 test("PIVOT.HEADER grouped by date field without value", async function () {
     const { model, pivotId } = await createSpreadsheetWithPivot({
         arch: /* xml */ `


### PR DESCRIPTION
Steps to reproduce:
- Insert a pivot in spreadsheet
- Change a groupby to an id of a relation ("country_id.id") => The value is blank

Task: 5067425

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
