### PR TITLE
[FIX] account: warning on currency decimal change independent of entries

### DIFF
--- a/addons/account/models/res_currency.py
+++ b/addons/account/models/res_currency.py
@@ -20,9 +20,9 @@ class ResCurrency(models.Model):
     @api.depends('rounding')
     def _compute_display_rounding_warning(self):
         for record in self:
-            record.display_rounding_warning = record._origin.id \
-                                              and record._origin.rounding != record.rounding \
-                                              and record._origin._has_accounting_entries()
+            record.display_rounding_warning = (
+                record._origin.id and record._origin.rounding != record.rounding
+            )
 
     def write(self, vals):
         if 'rounding' in vals:


### PR DESCRIPTION
After this commit
 - Users will be shown a warning on the UI on changing the decimal places , regardless of currency has account entries or not.
- Please refer to [this PR](https://github.com/odoo/odoo/pull/223566) As this was missed in that PR

task-4984276
