### PR TITLE
[FIX] website: restore background colors for translator indicators

### DIFF
--- a/addons/website/static/src/builder/translation_components/translator.scss
+++ b/addons/website/static/src/builder/translation_components/translator.scss
@@ -1,0 +1,13 @@
+.oe_translate_examples {
+    li {
+        margin: 10px;
+        padding: 4px;
+
+        &[data-oe-translation-state] {
+            background: $o-we-translated-content-color;
+        }
+        &[data-oe-translation-state="to_translate"] {
+            background: $o-we-content-to-translate-color;
+        }
+    }
+}


### PR DESCRIPTION
When going in translate mode, in the dialog explaining how this mode
works, the green and yellow background colors showing the different
translation states are not there anymore.

They disappeared since commit [1], which removed the unused snippets
options as a follow-up of the refactoring. The SCSS file with the
translation highlight rules was wrongly removed with them.

This PR restores it.

[1]: https://github.com/odoo/odoo/commit/55d5144

| Before (missing highlights) | After (reintroduced highlights) |
|-----------------------------|---------------------------------|
| <img width="663" height="377" alt="Before" src="https://github.com/user-attachments/assets/3e2b9d6c-aacc-4cdb-955b-312e174f019d" /> | <img width="647" height="399" alt="image" src="https://github.com/user-attachments/assets/8578b1aa-9c06-461b-aab0-169c70e3e1c7" /> |
