### PR TITLE
[IMP] account_peppol: add peppol_metadata

### DIFF
--- a/addons/account_peppol/models/res_company.py
+++ b/addons/account_peppol/models/res_company.py
@@ -93,6 +93,9 @@ class ResCompany(models.Model):
     peppol_external_provider = fields.Char(tracking=True)
     peppol_can_send = fields.Boolean(compute='_compute_peppol_can_send')
     peppol_parent_company_id = fields.Many2one(comodel_name='res.company', compute='_compute_peppol_parent_company_id')
+    # IAP-driven metadata with additive keys
+    peppol_metadata = fields.Json(string='Peppol Metadata')
+    peppol_metadata_updated_at = fields.Datetime(string='Peppol meta updated at')
 
     # -------------------------------------------------------------------------
     # HELPER METHODS


### PR DESCRIPTION
Add a JSON field on res.company to store freeform metadata returned by the Peppol server. This allows new keys to be added over time to improve UX or handle incidents without schema changes. The IAP endpoint returning this metadata should be additive-only.

Also track the last update time.

task-4498045