### PR TITLE
[IMP] hr_holidays:  Add automatic time off officer notification checkbox

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -80,6 +80,9 @@ class HrLeaveType(models.Model):
                              ('share', '=', False),
                              ('company_ids', 'in', self.env.company.id)],
         help="Choose the Time Off Officers who will be notified to approve allocation or Time Off Request. If empty, nobody will be notified")
+    notify_time_off_officers = fields.Boolean(
+        string="Notify Time Off Officer(s)?",
+        help="If checked, every time this time off type is taken, the time off officers of the same company will be notified")
     leave_validation_type = fields.Selection([
         ('no_validation', 'None needed'),
         ('hr', 'By Time Off Officer'),

--- a/addons/hr_holidays/views/hr_leave_type_views.xml
+++ b/addons/hr_holidays/views/hr_leave_type_views.xml
@@ -69,6 +69,7 @@
                                     widget="many2many_tags"
                                     placeholder="Nobody to notify"
                                     invisible="leave_validation_type in ['no_validation', 'manager'] and (not requires_allocation or allocation_validation_type not in ['hr', 'both'])"/>
+                                <field name="notify_time_off_officers" string="Notify Time Off Officer(s)?"/>
                         </group>
                         <group>
                             <field name="company_id" groups="base.group_multi_company" readonly="is_used" placeholder="Visible to all"/>


### PR DESCRIPTION
Before:
Time off types could only notify specific users selected in the 'Notify HR'
field. Each time a new time off officer was appointed , administrators
had to manually update the notification settings across all time off types.
    
After:
Added 'Notify Time Off Officer(s)?' checkbox to time off types. When enabled,
all time off officers in the same company are automatically notified when leave
requests of this type are created.
This eliminates the need for manual maintenance of notification lists.
    
task - 4797355