### PR TITLE
[FIX] mrp_subcontracting_dropshipping: fix failing test

### DIFF
--- a/addons/mrp_subcontracting_dropshipping/tests/test_sale_dropshipping.py
+++ b/addons/mrp_subcontracting_dropshipping/tests/test_sale_dropshipping.py
@@ -348,10 +348,10 @@ class TestSaleDropshippingFlows(TestMrpSubcontractingCommon):
             'seller_ids': [(0, 0, {'partner_id': self.supplier.id})],
         })
         product.product_tmpl_id.categ_id = self.env.ref('product.product_category_all')
+        self._setup_category_stock_journals()
         product.product_tmpl_id.categ_id.property_cost_method = 'standard'
         product.product_tmpl_id.categ_id.property_valuation = 'real_time'
         product.product_tmpl_id.invoice_policy = 'order'
-        self._setup_category_stock_journals()
         sale_order = self.env['sale.order'].create({
             'partner_id': self.customer.id,
             'picking_policy': 'direct',


### PR DESCRIPTION
this PR fixes the runbot error 230451
introduced by the test of PR
https://github.com/odoo/odoo/pull/221009
(a first corrective PR was made here
https://github.com/odoo/odoo/pull/224431)

fix :
populate the accounts of the category before using them