### PR TITLE
[FIX] website: skip broken test

### DIFF
--- a/addons/website/static/tests/builder/website_builder/animate_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/animate_option.test.js
@@ -198,7 +198,7 @@ test("animation=onScroll should not be visible when the animation is limited", a
     await contains(".options-container [data-label='Animation'] .dropdown-toggle").click();
     expect(".o-dropdown--menu [data-action-value='onScroll']").not.toHaveCount();
 });
-test("visibility of animation animation=onHover", async () => {
+test.skip("visibility of animation animation=onHover", async () => {
     function expectOnHoverOptions(options) {
         const labels = [
             "Effect",


### PR DESCRIPTION
Test seems dodgy to start with (cf odoo/odoo#224814 disabling it), and apparently #225034 made it mostly but not entirely broken: that PR did manage to pass in [140299] but broke two stagings before that ([140290], [140291]), and then broke the 4 stagings afterwards (one PR got flagged but was apparently an innocent victim).

[140299]: https://runbot.odoo.com/runbot/batch/2119196/build/88387072
[140290]: https://runbot.odoo.com/runbot/batch/2119088/build/88383126
[140291]: https://runbot.odoo.com/runbot/batch/2119112/build/88383656
