### PR TITLE
[FIX] html_editor: duplicate button when open color picker in popover

### DIFF
--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -179,11 +179,11 @@ export class LinkPopover extends Component {
                         },
                         applyColorResetPreview: () => {
                             this[colorStateRef].selectedColor = this[resetValueRef];
+                            this.onChange();
                         },
                     },
                     {
                         env: this.__owl__.childEnv,
-                        onClose: this.onChange.bind(this),
                     }
                 );
             this.customTextColorPicker = createCustomColorPicker(

--- a/addons/html_editor/static/tests/link/button.test.js
+++ b/addons/html_editor/static/tests/link/button.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "@odoo/hoot";
 import {
     click,
+    hover,
     queryOne,
     queryAll,
     select,
@@ -122,6 +123,28 @@ describe("Custom button style", () => {
         expect(queryOne(".custom-border-picker").style.backgroundColor).toBe("rgb(255, 0, 0)");
         expect(queryOne(".custom-border-size").value).toBe("4");
         expect(queryOne(".custom-border-style").value).toBe("dotted");
+    });
+
+    test.tags("desktop");
+    test("The color preview should be reset after cursor is out of the colorpicker", async () => {
+        await setupEditor(
+            '<p><a href="https://test.com/" class="btn btn-custom" style="color: rgb(0, 255, 0); background-color: rgb(0, 0, 255); border-width: 4px; border-color: rgb(255, 0, 0); border-style: dotted;">link[]Label</a></p>',
+            allowCustomOpt
+        );
+        await waitFor(".o-we-linkpopover");
+        await click(".o_we_edit_link");
+        await animationFrame();
+        await click(".custom-fill-picker");
+        await animationFrame();
+        await hover(".o_color_button[data-color='#00FF00']");
+        await animationFrame();
+
+        expect(queryOne(".custom-fill-picker").style.backgroundColor).toBe("rgb(0, 255, 0)");
+
+        await hover(".custom-fill-picker"); // cursor out of the colorpicker
+        await animationFrame();
+
+        expect(queryOne(".custom-fill-picker").style.backgroundColor).toBe("rgb(0, 0, 255)");
     });
 
     test("should convert all selected text to a custom button", async () => {


### PR DESCRIPTION
Before this commit: the onchange is applied when the color picker closes, it has a few issues,
1. adding duplicate button cause the reference of the link element is not passed correctly
2. the preview color isn't reset when mouse no longer hovering on the colors

After this commit:
The onchange is applied when on color reset. No more additional button inserted and color of the button is properly restored after the cursor is out of color picker

task-4966317


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
