### PR TITLE
[REM] mrp{,_subcontracting}: remove `{order_,}finished_lot_ids` fields

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -111,10 +111,6 @@ class MrpWorkorder(models.Model):
     move_line_ids = fields.One2many(
         'stock.move.line', 'workorder_id', 'Moves to Track',
         help="Inventory moves for which you must scan a lot number at this work order")
-    finished_lot_ids = fields.Many2many(
-        'stock.lot', string='Lot/Serial Numbers', related='production_id.lot_producing_ids',
-        domain="[('product_id', '=', product_id), ('company_id', '=', company_id)]",
-        readonly=False, check_company=True)
     time_ids = fields.One2many(
         'mrp.workcenter.productivity', 'workorder_id', copy=False)
     is_user_working = fields.Boolean(
@@ -463,13 +459,6 @@ class MrpWorkorder(models.Model):
             domain=[('time_type', 'in', ['leave', 'other'])]
         )
         return interval['hours'] * 60
-
-    @api.onchange('finished_lot_ids')
-    def _onchange_finished_lot_ids(self):
-        if self.production_id:
-            res = self.production_id._can_produce_serial_numbers(sns=self.finished_lot_ids)
-            if res is not True:
-                return res
 
     def write(self, vals):
         values = vals

--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -51,7 +51,6 @@ class StockMove(models.Model):
         'mrp.bom.byproduct', 'By-products', check_company=True,
         help="By-product line that generated the move in a manufacturing order")
     unit_factor = fields.Float('Unit Factor', compute='_compute_unit_factor', store=True)
-    order_finished_lot_ids = fields.Many2many('stock.lot', string="Finished Lot/Serial Number", related="raw_material_production_id.lot_producing_ids")
     should_consume_qty = fields.Float('Quantity To Consume', compute='_compute_should_consume_qty', digits='Product Unit')
     cost_share = fields.Float(
         "Cost Share (%)", digits=(5, 2),  # decimal = 2 is important for rounding calculations!!

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -8,7 +8,6 @@
                 <field name="production_id"/>
                 <field name="workcenter_id"/>
                 <field name="product_id"/>
-                <field name="finished_lot_ids"/>
                 <filter string="To Do" name="ready" domain="[('state','=','ready')]"/>
                 <filter string="Blocked" name="blocked" domain="[('state','=','blocked')]"/>
                 <filter string="In Progress" name="progress" domain="[('state','=','progress')]"/>
@@ -77,7 +76,6 @@
                 <field name="product_id" optional="show"/>
                 <field name="qty_remaining" optional="show" string="Quantity"/>
                 <field name="qty_ready" optional="hide" groups="base.group_no_one"/>
-                <field name="finished_lot_ids" optional="hide" string="Lot/Serial"/>
                 <field name="date_start" optional="hide" readonly="state in ['progress', 'done', 'cancel']"/>
                 <field name="date_finished" optional="hide" readonly="state in ['progress', 'done', 'cancel']"/>
                 <field name="duration_expected" widget="float_time" sum="expected duration" readonly="state in ['cancel', 'done']"/>
@@ -155,7 +153,6 @@
                 <field name="company_id" invisible="1"/>
                 <field name="product_tracking" invisible="1"/>
                 <field name="product_id" invisible="1"/>
-                <field name="finished_lot_ids" invisible="1"/>
                 <group>
                     <group>
                         <field name="name" readonly="state in ['cancel', 'done']" force_save="1"/>
@@ -165,7 +162,6 @@
                         <field name="product_id" readonly="1"/>
                         <field name="qty_remaining" string="Quantity" readonly="1" invisible="state == 'done'"/>
                         <field name="qty_produced" string="Produced Quantity" groups="base.group_no_one" readonly="state == 'done' or product_tracking == 'serial'"/>
-                        <field name="finished_lot_ids" readonly="1" widget="many2many_tags" options="{'on_tag_click': 'open_form'}"/>
                     </group>
                 </group>
                 <group>
@@ -271,7 +267,6 @@
                 <field name="workcenter_id"/>
                 <field name="production_id"/>
                 <field name="product_id"/>
-                <field name="finished_lot_ids"/>
                 <field name="product_variant_attributes"/>
                 <field name="move_raw_ids" string="Component" filter_domain="[('move_raw_ids.product_id', 'ilike', self)]"/>
                 <filter string="In Progress" name="progress" domain="[('state', '=', 'progress')]"/>
@@ -361,7 +356,7 @@
                         </div>
                         <footer>
                             <h5>
-                                <field name="product_id"/>, <field name="qty_production" class="ms-1"/> <field name="uom_id" groups="uom.group_uom"/><t t-if="record.finished_lot_ids.value">, </t> <field t-if="record.finished_lot_ids.value" name="finished_lot_ids" class="ms-1"/>
+                                <field name="product_id"/>, <field name="qty_production" class="ms-1"/> <field name="uom_id" groups="uom.group_uom"/>
                             </h5>
                             <div class="o_kanban_workorder_status d-flex ms-auto" t-if="record.state.raw_value == 'progress'">
                                 <span t-if="record.working_state.raw_value != 'blocked' and record.working_user_ids.raw_value.length > 0" class="fa fa-play fs-6" role="img" aria-label="Is running" title="Is running"/>

--- a/addons/mrp_subcontracting/views/stock_move_views.xml
+++ b/addons/mrp_subcontracting/views/stock_move_views.xml
@@ -87,7 +87,6 @@
                     <field name="uom_id" invisible="1"/>
                     <field name="product_uom_qty" invisible="1" readonly="state == 'done'"/>
                     <group>
-                        <field name="order_finished_lot_ids"/>
                         <field name="uom_id" groups="uom.group_uom" widget="many2one_uom"/>
                         <field name="quantity" string="Total Consumed" readonly="1"/>
                     </group>
@@ -119,9 +118,6 @@
         <field name="priority">1000</field>
         <field name="inherit_id" ref="mrp_subcontracting_move_form_view" />
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='order_finished_lot_ids']" position="attributes">
-                <attribute name="options">{'no_open': True}</attribute>
-            </xpath>
             <xpath expr="//list" position="attributes">
                 <attribute name="no_open">1</attribute>
             </xpath>
@@ -151,21 +147,9 @@
                 <field name="state" column_invisible="True" force_save="1"/>
                 <field name="raw_material_production_id" column_invisible="True"/>
                 <field name="product_id" required="1" readonly="state == 'done'"/>
-                <field name="order_finished_lot_ids"/>
                 <field name="quantity" string="Consumed" readonly="1"/>
                 <field name="uom_id" groups="uom.group_uom" widget="many2one_uom"/>
             </list>
         </field>
     </record>
-    <record id="view_move_search" model="ir.ui.view">
-        <field name="name">stock.move.search</field>
-        <field name="model">stock.move</field>
-        <field name="inherit_id" ref="stock.view_move_search" />
-        <field name="arch" type="xml">
-            <xpath expr="//field[@name='partner_id']" position="after">
-                <field name="order_finished_lot_ids"/>
-            </xpath>
-        </field>
-    </record>
-
 </odoo>


### PR DESCRIPTION
The fields `stock_move.order_finished_lot_ids` and `mrp_workorder.finished_lot_ids` are being removed for being superfluous after the views they were used in were scrapped. `quality_check.lot_ids` fills the same task in quality checks, the last place it was useful in.

* `lot_ids` needs to be added to the views `{order_,}finished_lot_ids` was excised from wherever it makes sense.
* Do we need to do the same with `_onchange_finished_lot_ids()`? Let's find out. (Apparently not.)

Task ID: [5025510](https://www.odoo.com/odoo/my-tasks/5025510)