### PR TITLE
[FIX] hr_org_chart: solved test case test_employee_ui

### DIFF
--- a/addons/hr_org_chart/tests/test_employee_ui.py
+++ b/addons/hr_org_chart/tests/test_employee_ui.py
@@ -1,3 +1,4 @@
+from odoo import Command
 from odoo.tests import HttpCase, tagged
 
 from odoo.addons.hr.tests.common import TestHrCommon
@@ -8,6 +9,7 @@ class TestEmployeeUi(TestHrCommon, HttpCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.res_users_hr_officer.write({'group_ids': [Command.link(cls.env.ref('hr_payroll.group_hr_payroll_user').id)]})
         cls.employee_georges, cls.employee_paul, cls.employee_pierre = cls.env['hr.employee'].with_user(cls.res_users_hr_officer).create([
             {'name': 'Georges'},
             {'name': 'Paul'},


### PR DESCRIPTION
Issue:
test case failing test_employee_ui.

Reason:
In TestEmployeeUi setup class, an employee is created with res_users_hr_officer as this class inherits TestHrCommon, where res_users_hr_officer doesn't have hr_payroll.group_hr_payroll_user group, so it fails when accessing structure_type_id in the module l10n_ch_hr_payroll.

Fix:
Add group (hr_payroll.group_hr_payroll_user) to res_users_hr_officer.

Runbot Error: https://runbot.odoo.com/odoo/runbot.build.error/231300