### PR TITLE
[IMP] account: move extract single line to account

### DIFF
--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -304,6 +304,9 @@ class ResCompany(models.Model):
         help="During perpetual valuation, this account will hold the price difference between the standard price and the bill price.",
     )
 
+    # Group invoice lines per tax
+    extract_single_line_per_tax = fields.Boolean(string="Single Invoice Line Per Tax", default=True)
+
     def get_next_batch_payment_communication(self):
         '''
         When in need of a batch payment communication reference (several invoices paid at the same time)

--- a/addons/account/models/res_config_settings.py
+++ b/addons/account/models/res_config_settings.py
@@ -207,6 +207,9 @@ class ResConfigSettings(models.TransientModel):
     income_account_id = fields.Many2one(related='company_id.income_account_id', readonly=False)
     expense_account_id = fields.Many2one(related='company_id.expense_account_id', readonly=False)
 
+    # Group invoice lines per tax
+    extract_single_line_per_tax = fields.Boolean(related='company_id.extract_single_line_per_tax', readonly=False)
+
     @api.depends('country_code')
     def _compute_is_account_peppol_eligible(self):
         # we want to show Peppol settings only to customers that are eligible for Peppol,

--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -250,6 +250,9 @@
                                     </div>
                                 </div>
                             </setting>
+                            <setting company_dependent="1" help="Enable to get only one invoice line per tax">
+                                <field name="extract_single_line_per_tax"/>
+                            </setting>
                         </block>
 
                         <t groups="account.group_account_user">


### PR DESCRIPTION
[IMP] account: move extract single line to account

This commit move the field extract_single_line_per_tax from the module account_invoice_extract to the module account
This is done before the freeze to complete the task after

task-5047859
