### PR TITLE
[FIX] website_sale_{,loyalty_}delivery: avoid creating multiple carts

### DIFF
--- a/addons/website_sale_delivery/controllers/main.py
+++ b/addons/website_sale_delivery/controllers/main.py
@@ -41,7 +41,9 @@ class WebsiteSaleDelivery(WebsiteSale):
 
     @http.route(['/shop/carrier_rate_shipment'], type='json', auth='public', methods=['POST'], website=True)
     def cart_carrier_rate_shipment(self, carrier_id, **kw):
-        order = request.website.sale_get_order(force_create=True)
+        order = request.website.sale_get_order()
+        if not order:
+            raise ValidationError(_("Your cart is empty."))
 
         if not int(carrier_id) in order._get_delivery_methods().ids:
             raise UserError(_('It seems that a delivery method is not compatible with your address. Please refresh the page and try again.'))

--- a/addons/website_sale_loyalty_delivery/controllers/main.py
+++ b/addons/website_sale_loyalty_delivery/controllers/main.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-from odoo import http
+from odoo import _, http
+from odoo.exceptions import ValidationError
+
 from odoo.addons.payment import utils as payment_utils
 from odoo.addons.website_sale_delivery.controllers.main import WebsiteSaleDelivery
 from odoo.http import request
@@ -42,7 +44,9 @@ class WebsiteSaleLoyaltyDelivery(WebsiteSaleDelivery):
     @http.route()
     def cart_carrier_rate_shipment(self, carrier_id, **kw):
         Monetary = request.env['ir.qweb.field.monetary']
-        order = request.website.sale_get_order(force_create=True)
+        order = request.website.sale_get_order()
+        if not order:
+            raise ValidationError(_("Your cart is empty."))
         free_shipping_lines = order._get_free_shipping_lines()
         # Avoid computing carrier price delivery is free (coupon). It means if
         # the carrier has error (eg 'delivery only for Belgium') it will show


### PR DESCRIPTION
Versions
--------
- 16.0
- 17.0

Steps
-----
1. Have multiple delivery methods published;
2. open a cart;
3. pay for cart;
4. after landing on /shop/confirmation, go back to /shop/payment.

Issue
-----
A new cart is opened for each published delivery method.

Cause
-----
Website sale orders are retrieved using `force_create=True` for each carrier.

Solution
--------
Don't force create sale orders, and as in 18.0, throw a `ValidationError` if the cart is empty.

opw-4924889
