### PR TITLE
[FIX] hw_drivers: prevent duplicated actions

### DIFF
--- a/addons/event/static/src/client_action/event_registration_summary_dialog.js
+++ b/addons/event/static/src/client_action/event_registration_summary_dialog.js
@@ -165,7 +165,7 @@ export class EventRegistrationSummaryDialog extends Component {
         }
     }
 
-    async printWithLongpolling(reportId) {
+    async printWithLongpolling(reportId, uniqueId) {
         try {
             const [[ip, identifier,, printData]] = await this.orm.call("ir.actions.report", "render_and_send", [
                 reportId,
@@ -175,7 +175,7 @@ export class EventRegistrationSummaryDialog extends Component {
                 null,
                 false, // Do not use websocket
             ]);
-            const payload = { document: printData, print_id: uuid() }
+            const payload = { document: printData, print_id: uniqueId, action_unique_id: uniqueId }
             const { result } = await this.env.services.iot_longpolling.action(ip, identifier, payload, true);
             return result;
         } catch {
@@ -196,13 +196,14 @@ export class EventRegistrationSummaryDialog extends Component {
             }),
             { type: "info" }
         );
+        const uniqueId = uuid();
         if (await this.isIotBoxReachable()) {
-            const printSuccessful = await this.printWithLongpolling(reportId);
+            const printSuccessful = await this.printWithLongpolling(reportId, uniqueId);
             if (printSuccessful) {
                 return;
             }
         }
-        const printJobArguments = [reportId, [this.registration.id], null, uuid()];
+        const printJobArguments = [reportId, [this.registration.id], null, uniqueId];
         await this.env.services.iot_websocket.addJob([this.printSettings.iotPrinterId], printJobArguments);
     }
 }

--- a/addons/hw_drivers/driver.py
+++ b/addons/hw_drivers/driver.py
@@ -1,10 +1,14 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import logging
 from threading import Thread, Event
 
 from odoo.addons.hw_drivers.main import drivers, iot_devices
 from odoo.addons.hw_drivers.tools.helpers import toggleable
+from odoo.tools.lru import LRU
+
+_logger = logging.getLogger(__name__)
 
 
 class Driver(Thread):
@@ -24,6 +28,7 @@ class Driver(Thread):
         self.data = {'value': ''}
         self._actions = {}
         self._stopped = Event()
+        self._recent_action_ids = LRU(256)
 
     def __init_subclass__(cls):
         super().__init_subclass__()
@@ -44,7 +49,18 @@ class Driver(Thread):
 
         :param dict data: the `_actions` key mapped to the action method we want to call
         """
+        if self._check_if_action_is_duplicate(data.get('action_unique_id')):
+            return
         self._actions[data.get('action', '')](data)
+
+    def _check_if_action_is_duplicate(self, action_unique_id):
+        if not action_unique_id:
+            return False
+        if action_unique_id in self._recent_action_ids:
+            _logger.warning("Duplicate action %s received, ignoring", action_unique_id)
+            return True
+        self._recent_action_ids[action_unique_id] = action_unique_id
+        return False
 
     def disconnect(self):
         self._stopped.set()


### PR DESCRIPTION
Enterprise PR: odoo/enterprise#93985

In the following case an IoT box action can be duplicated:
1. Request is sent over longpolling
2. Action takes longer than 6s to execute, longpolling times out on the client side
3. Websocket request is sent as a fallback
4. Both requests cause an action to be executed (double blackbox registration, double print, etc.)

To solve this we will send an ID with every action, and if the ID has already been recently seen we will ignore the action and log a warning.

task-5067737

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
