### PR TITLE
[FIX] purchase: resolved anomally in print smart button

### DIFF
--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -537,6 +537,8 @@ class PurchaseOrder(models.Model):
 
     def print_quotation(self):
         self.filtered(lambda po: po.state == 'draft').write({'state': "sent"})
+        if self.state in ('purchase', 'done'):
+            return self.env.ref('purchase.action_report_purchase_order').report_action(self)
         return self.env.ref('purchase.report_purchase_quotation').report_action(self)
 
     def button_approve(self, force=False):


### PR DESCRIPTION
Why :
--------------
in saas~18.2 version the option of 'print' on purchase form view was introduced in smart button.
https://github.com/odoo/odoo/pull/197211

Before fix :
----------------
The print button in the purchase form view prints only RFQ no matter on which stage the PO is.

After fix :
----------------
in RFQ and RFQ sent stage the print button will print RFQ report in Purchase order or Done(Lock) state print button will print purchase order report

Steps to regenerate:
-------------
- Create an Request for quotation
- Confirm the  Request for quotation
- Print report when in purchase/Lock state
using  print smart button

OPW: 5060711

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
