### PR TITLE
[IMP] core: Add currency conversion aggregator

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -280,21 +280,20 @@ class CrmLead(models.Model):
             else:
                 lead.company_currency = lead.company_id.currency_id
 
-    def _read_group_select(self, aggregate_spec, query) -> SQL:
-        """ Manage company_currency:array_agg_distinct to make all Monetary fields aggregable """
-        if aggregate_spec == 'company_currency:array_agg_distinct':
+    # ORM Override to manage company_currency to aggregates monetary field
+    def _field_to_sql(self, alias, field_expr, query=None) -> SQL:
+        if field_expr == 'company_currency':
             alias_company = query.make_alias(self._table, 'company_id')
             company_field_sql = self._field_to_sql(self._table, 'company_id', query)
             query.add_join('LEFT JOIN', alias_company, 'res_company', SQL(
                 "%s = %s", company_field_sql, SQL.identifier(alias_company, 'id'),
             ))
             company_currency_expr = self.env['res.company']._field_to_sql(alias_company, 'currency_id', query)
-            expr = SQL(
+            return SQL(
                 '(CASE WHEN %s IS NOT NULL THEN %s ELSE %s END)',
                 company_field_sql, company_currency_expr, self.env.company.currency_id.id
             )
-            return SQL('ARRAY_AGG(DISTINCT %s ORDER BY %s)', expr, expr)
-        return super()._read_group_select(aggregate_spec, query)
+        return super()._field_to_sql(alias, field_expr, query)
 
     @api.depends('user_id', 'type')
     def _compute_team_id(self):

--- a/odoo/addons/test_read_group/models.py
+++ b/odoo/addons/test_read_group/models.py
@@ -20,6 +20,7 @@ class Test_Read_GroupAggregateBoolean(models.Model):
     bool_or = fields.Boolean(default=False, aggregator='bool_or')
     bool_array = fields.Boolean(default=False, aggregator='array_agg')
 
+
 class TestReadGroupAggregateMonetaryRelated(models.Model):
     _name = 'test_read_group.aggregate.monetary.related'
     _description = 'To test related currency fields in Monetary aggregates'
@@ -36,6 +37,7 @@ class TestReadGroupAggregateMonetaryRelated(models.Model):
         for record in self:
             record.non_stored_currency_id = self.env.ref('base.EUR')
 
+
 class Test_Read_GroupAggregateMonetary(models.Model):
     _name = 'test_read_group.aggregate.monetary'
     _description = 'Group Test Read Monetary Aggregate'
@@ -46,16 +48,15 @@ class Test_Read_GroupAggregateMonetary(models.Model):
     currency_id = fields.Many2one('res.currency')
     related_stored_currency_id = fields.Many2one(
         related='related_model_id.stored_currency_id',
-        store=False,
     )
     related_non_stored_currency_id = fields.Many2one(
         related='related_model_id.non_stored_currency_id',
-        store=False,
     )
 
     total_in_currency_id = fields.Monetary(currency_field='currency_id')
     total_in_related_stored_currency_id = fields.Monetary(currency_field='related_stored_currency_id')
     total_in_related_non_stored_currency_id = fields.Monetary(currency_field='related_non_stored_currency_id')
+
 
 class Test_Read_GroupAggregate(models.Model):
     _name = 'test_read_group.aggregate'

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -1967,10 +1967,45 @@ class BaseModel(metaclass=MetaModel):
             raise ValueError(f"Invalid field {fname!r} on model {self._name!r} for {aggregate_spec!r}.")
         if not func:
             raise ValueError(f"Aggregate method is mandatory for {fname!r}")
+
+        field = self._fields[fname]
+        if func == 'sum_currency':
+            if field.type != 'monetary':
+                raise ValueError(f'Aggregator "sum_currency" only works on currency field for {fname!r}')
+
+            CurrencyRate = self.env['res.currency.rate']
+            rate_subquery_table = SQL(
+                """(SELECT DISTINCT ON (%(currency_field_sql)s) %(currency_field_sql)s, %(rate_field_sql)s
+                    FROM "res_currency_rate"
+                    WHERE %(company_field_sql)s IS NULL OR %(company_field_sql)s = %(company_id)s
+                    ORDER BY
+                        %(currency_field_sql)s,
+                        %(company_field_sql)s,
+                        CASE WHEN %(name_field_sql)s <= %(today)s THEN %(name_field_sql)s END DESC,
+                        CASE WHEN %(name_field_sql)s > %(today)s THEN %(name_field_sql)s END ASC)
+                """,
+                currency_field_sql=CurrencyRate._field_to_sql(CurrencyRate._table, 'currency_id'),
+                rate_field_sql=CurrencyRate._field_to_sql(CurrencyRate._table, 'rate'),
+                company_field_sql=CurrencyRate._field_to_sql(CurrencyRate._table, 'company_id'),
+                company_id=self.env.company.root_id.id,
+                name_field_sql=CurrencyRate._field_to_sql(CurrencyRate._table, 'name'),
+                today=Date.context_today(self),
+            )
+            alias_rate = query.make_alias(self._table, 'rates')
+            currency_field_name = field.get_currency_field(self)
+            currency_field_sql = self._field_to_sql(self._table, currency_field_name, query)
+            condition = SQL("%s = %s", currency_field_sql, SQL.identifier(alias_rate, "currency_id"))
+            query.add_join('LEFT JOIN', alias_rate, rate_subquery_table, condition)
+
+            return SQL(
+                "SUM(%s / COALESCE(%s, 1.0))",
+                self._field_to_sql(self._table, fname, query),
+                SQL.identifier(alias_rate, "rate"),
+            )
+
         if func not in READ_GROUP_AGGREGATE:
             raise ValueError(f"Invalid aggregate method {func!r} for {aggregate_spec!r}.")
 
-        field = self._fields[fname]
         if func == 'recordset' and not (field.relational or fname == 'id'):
             raise ValueError(f"Aggregate method {func!r} can be only used on relational field (or id) (for {aggregate_spec!r}).")
 


### PR DESCRIPTION
Since odoo/odoo#216597, the sum of monetary fields is displayed even when multiple currencies are involved in the computation. A question mark tooltip is shown and no currency symbol is displayed in this case. This information isn't very meaningful for an end-user in a multicurrency environment, but it's still better than the 18.0 behavior, where there was no tooltip and no currency symbol, even when only one currency was involved.

We want to display more relevant information when multiple currencies are implied. We'll show the sum of the monetary values converted into the current company currency, based on the closest currency rate. This is done with a new type of `_read_group` aggregator targeting monetary fields (`:sum_currency`).

The web client can request this new aggregate alongside `currency_id:array_agg_distinct`/`monetary:sum` to handle the case when one currency (other than the one of company) is used.