### PR TITLE
[FIX] purchase_stock: apply vendor validity date on fallback

### DIFF
--- a/addons/purchase_stock/models/stock_replenish_mixin.py
+++ b/addons/purchase_stock/models/stock_replenish_mixin.py
@@ -16,3 +16,9 @@ class ProductReplenishMixin(models.AbstractModel):
 
     def _get_show_vendor(self, route):
         return any(r.action == 'buy' for r in route.rule_ids)
+
+    def _additional_replenishment_context(self):
+        res = super()._additional_replenishment_context()
+        if self.supplier_id:
+            res['preferred_supplier_name'] = self.supplier_id.partner_id
+        return res

--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -348,4 +348,4 @@ class StockRule(models.Model):
         return res
 
     def _get_partner_id(self, values, rule):
-        return values.get("supplierinfo_name") or (values.get("group_id") and values.get("group_id").partner_id)
+        return values.get("supplierinfo_name") or self.env.context.get('preferred_supplier_name')

--- a/addons/purchase_stock/wizard/product_replenish.py
+++ b/addons/purchase_stock/wizard/product_replenish.py
@@ -44,7 +44,6 @@ class ProductReplenish(models.TransientModel):
         res = super()._prepare_run_values()
         if self.supplier_id:
             res['supplierinfo_id'] = self.supplier_id
-            res['group_id'].partner_id = self.supplier_id.partner_id
         return res
 
     def action_stock_replenishment_info(self):

--- a/addons/stock/models/stock_replenish_mixin.py
+++ b/addons/stock/models/stock_replenish_mixin.py
@@ -29,3 +29,6 @@ class ProductReplenishMixin(models.AbstractModel):
             ('rule_ids.location_src_id', '!=', stock_location_inter_company_id),
             ('rule_ids.location_dest_id', '!=', stock_location_inter_company_id)
         ]
+
+    def _additional_replenishment_context(self):
+        return {}

--- a/addons/stock/wizard/product_replenish.py
+++ b/addons/stock/wizard/product_replenish.py
@@ -92,7 +92,7 @@ class ProductReplenish(models.TransientModel):
         self.quantity = self.product_uom_id._compute_quantity(self.quantity, uom_reference, rounding_method='HALF-UP')
         try:
             now = self.env.cr.now()
-            self.env['procurement.group'].with_context(clean_context(self.env.context)).run([
+            self.env['procurement.group'].with_context(clean_context(self.env.context | self._additional_replenishment_context())).run([
                 self.env['procurement.group'].Procurement(
                     self.product_id,
                     self.quantity,

--- a/addons/stock_dropshipping/models/stock.py
+++ b/addons/stock_dropshipping/models/stock.py
@@ -15,13 +15,6 @@ class StockRule(models.Model):
         """
         return procurement.values.get('sale_line_id'), super(StockRule, self)._get_procurements_to_merge_groupby(procurement)
 
-    def _get_partner_id(self, values, rule):
-        route = self.env.ref('stock_dropshipping.route_drop_shipping', raise_if_not_found=False)
-        if route and rule.route_id == route:
-            return False
-        return super()._get_partner_id(values, rule)
-
-
 class ProcurementGroup(models.Model):
     _inherit = "procurement.group"
 


### PR DESCRIPTION
_______________________________________
## Short functional explanation of the error
Let's say we have a products that has 2 suppliers. In the list of suppliers, the first one set has an expired date. If we generate a PO from an SO with the MTO route, the assigned supplier for this product will be the first one set in the list, therefore having an expired date.

## Reproduction Steps
1. Go to Inventory > Configuration > settings. Check the option Multi-Step routes.
2. Click on Configuration > routes and unarchive the Replenish On Order (MTO) route.
3. Create or use an already existing product. Go to the Inventory tab, and under Operations, check the routes Replenish on Order (MTO) and Buy.
4. Click on the Purchase tab. There, set a first vendor for which the end date is earlier than today. For the second one, set an end date for which the date is later than today.
5. Go to Sales and create a new quotation. Set a customer and add a line with the product you just set. Click confirm. A smart button 'Purchase' should appear. Click on it.

### Expected behavior
The assigned vendor of the PO should be the second vendor as it isn't expired yet.

### Unexpected behavior
The assigned vendor is the first vendor, expired.

## Origin of the issue
When generating a PO from an SO, the partner is the person ordering the product, not the vendor. Therefore, when this code is executed:

https://github.com/odoo/odoo/blob/6b677319c47baacb5bee829b7e41448dec4136eb/addons/purchase_stock/models/stock_rule.py#L62-L66

no corresponding supplier is found, as
```self._get_partner_id(procurement.values, rule)``` returns the customer
and not the vendor. This leads us to the fallback:
https://github.com/odoo/odoo/blob/6b677319c47baacb5bee829b7e41448dec4136eb/addons/purchase_stock/models/stock_rule.py#L68-L72
which doesn't take into account the end date of vendors.

__
opw-5030849

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
