### PR TITLE
[FIX] loyalty: make program_id field required

### DIFF
--- a/addons/loyalty/models/loyalty_card.py
+++ b/addons/loyalty/models/loyalty_card.py
@@ -28,6 +28,7 @@ class LoyaltyCard(models.Model):
     program_id = fields.Many2one(
         comodel_name='loyalty.program',
         ondelete='restrict',
+        required=True,
         index='btree_not_null',
         default=lambda self: self.env.context.get('active_id', None),
     )


### PR DESCRIPTION
Currently, an error occurs when user tries to save loyalty card.

Steps to replicate:
- Install `sale_management` and `loyalty`.
- Using Open View open `loyalty.card` form view.
- Click save and error will occur.

Error:
`KeyError: loyalty.program()`

Cause:
- The error occured because there was no loyalty program linked to the loyalty card at [1], so `create_comm_per_program` is an empty dict and then code tries to access `program_id` from empty `dict` [2] that causes the Keyerror.

Solution:
- Made the `program_id` required to prevent creation of any loyalty card with no program.

Upgrade PR: https://github.com/odoo/upgrade/pull/8821

[1]: https://github.com/odoo/odoo/blob/7747c5810eabe798a1631c3e3b26b81a5c89b4b4/addons/loyalty/models/loyalty_card.py#L139-L140
[2]: https://github.com/odoo/odoo/blob/7747c5810eabe798a1631c3e3b26b81a5c89b4b4/addons/loyalty/models/loyalty_card.py#L142

sentry-6857518052
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
