### PR TITLE
[IMP] crm, project: hide measure `Stage Color`

### DIFF
--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -880,6 +880,7 @@
                     <field name="recurring_revenue_monthly_prorated" groups="!crm.group_use_recurring_revenues" invisible="1"/>
                     <field name="recurring_revenue" groups="!crm.group_use_recurring_revenues" invisible="1"/>
                     <field name="recurring_revenue_prorated" groups="!crm.group_use_recurring_revenues" invisible="1"/>
+                    <field name="stage_id_color" invisible="1"/>
                 </graph>
             </field>
         </record>
@@ -902,6 +903,7 @@
                     <field name="recurring_revenue_monthly_prorated" groups="!crm.group_use_recurring_revenues" invisible="1"/>
                     <field name="recurring_revenue" groups="!crm.group_use_recurring_revenues" invisible="1"/>
                     <field name="recurring_revenue_prorated" groups="!crm.group_use_recurring_revenues" invisible="1"/>
+                    <field name="stage_id_color" invisible="1"/>
                 </graph>
             </field>
         </record>
@@ -915,6 +917,7 @@
                     <field name="stage_id" type="col"/>
                     <field name="expected_revenue" type="measure"/>
                     <field name="color" invisible="1"/>
+                    <field name="stage_id_color" invisible="1"/>
                     <field name="automated_probability" invisible="1"/>
                     <field name="message_bounce" invisible="1"/>
                     <field name="probability" invisible="1"/>
@@ -945,6 +948,7 @@
                     <field name="recurring_revenue_monthly_prorated" groups="!crm.group_use_recurring_revenues" invisible="1"/>
                     <field name="recurring_revenue" groups="!crm.group_use_recurring_revenues" invisible="1"/>
                     <field name="recurring_revenue_prorated" groups="!crm.group_use_recurring_revenues" invisible="1"/>
+                    <field name="stage_id_color" invisible="1"/>
                 </pivot>
             </field>
         </record>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -146,6 +146,7 @@
                     <field name="working_hours_close" widget="float_time"/>
                     <field name="color" invisible="1"/>
                     <field name="sequence" invisible="1"/>
+                    <field name="stage_id_color" invisible="1"/>
                     <field name="rating_last_value" string="Rating (/5)"/>
                 </graph>
             </field>
@@ -176,6 +177,7 @@
                     <field name="project_id" type="row"/>
                     <field name="color" invisible="1"/>
                     <field name="sequence" invisible="1"/>
+                    <field name="stage_id_color" invisible="1"/>
                     <field name="allocated_hours" widget="float_time"/>
                     <field name="working_hours_close" widget="float_time"/>
                     <field name="working_hours_open" widget="float_time"/>


### PR DESCRIPTION
This commit hides the measure `Stage Color` from graph, cohort and pivot views of the `crm.lead, project.task` model, as it doesn't really make sense to measure on a stage color.

The measures are made from the model's fields and all possible measures are shown unless it is made invisible. Therefore make it explicitly invisible.

Task-5065924
