### PR TITLE
[FIX] web: Hoot - log errors in dry run

### DIFF
--- a/addons/web/static/lib/hoot/core/runner.js
+++ b/addons/web/static/lib/hoot/core/runner.js
@@ -526,7 +526,11 @@ export class Runner {
             try {
                 result = fn();
             } catch (err) {
-                error = String(err);
+                if (err instanceof HootError) {
+                    throw err;
+                } else {
+                    error = String(err);
+                }
             }
         }
         this.suiteStack.pop();
@@ -1798,7 +1802,12 @@ export class Runner {
         safePrevent(ev);
 
         // Log error
-        logger.error(error);
+        if (this.dry || error.global) {
+            // Stringify the error to avoid logging whole traceback on CI
+            logger.logGlobalError(String(error));
+        } else {
+            logger.error(error);
+        }
     }
 
     /**

--- a/addons/web/static/lib/hoot/core/test.js
+++ b/addons/web/static/lib/hoot/core/test.js
@@ -15,7 +15,7 @@ import { Tag } from "./tag";
 //-----------------------------------------------------------------------------
 
 const {
-    Object: { freeze: $freeze },
+    Object: { assign: $assign, freeze: $freeze },
 } = globalThis;
 
 //-----------------------------------------------------------------------------
@@ -35,8 +35,11 @@ const SHARED_RESULTS = $freeze([]);
  */
 export function testError({ name, parent }, ...message) {
     const parentString = parent ? ` (in suite ${stringify(parent.name)})` : "";
-    return new HootError(
-        `error while registering test ${stringify(name)}${parentString}: ${message.join("\n")}`
+    return $assign(
+        new HootError(
+            `error while registering test ${stringify(name)}${parentString}: ${message.join("\n")}`
+        ),
+        { global: true }
     );
 }
 


### PR DESCRIPTION
The test runner replaces most occurences of `console.log` with a formatted `console.trace`, as to avoid duplicate runbot error messages in general. The issue is that during the dry run, errors that are caught should be logged on the runbot since these errors are more critical (i.e. duplicate test name, which will prevent the runner to run at all).

This commit ensures that errors caught during dry run are logged as actual errors to prevent this issue.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
