### PR TITLE
[FIX] web: burger user menu click doesn't close it

### DIFF
--- a/addons/web/static/src/webclient/burger_menu/burger_menu.xml
+++ b/addons/web/static/src/webclient/burger_menu/burger_menu.xml
@@ -27,7 +27,7 @@
               <!-- -->
               <t t-if="isUserMenuUnfolded">
                   <MobileSwitchCompanyMenu t-if="Object.values(company.allowedCompanies).length > 1" />
-                  <BurgerUserMenu/>
+                  <BurgerUserMenu onMenuClicked.bind="_closeBurger"/>
               </t>
               <!-- Current App Sections -->
                 <ul t-if="!isUserMenuUnfolded" class="ps-0 mb-0">

--- a/addons/web/static/src/webclient/burger_menu/burger_user_menu/burger_user_menu.js
+++ b/addons/web/static/src/webclient/burger_menu/burger_user_menu/burger_user_menu.js
@@ -4,7 +4,14 @@ import { UserMenu } from "@web/webclient/user_menu/user_menu";
 
 export class BurgerUserMenu extends UserMenu {
     _onItemClicked(callback) {
-        callback();
+        return (ev) => {
+            callback(ev);
+            this.props.onMenuClicked?.(ev);
+        };
     }
 }
 BurgerUserMenu.template = "web.BurgerUserMenu";
+BurgerUserMenu.props = {
+    ...UserMenu.props,
+    onMenuClicked: { type: Function, optional: true },
+};

--- a/addons/web/static/src/webclient/burger_menu/burger_user_menu/burger_user_menu.xml
+++ b/addons/web/static/src/webclient/burger_menu/burger_user_menu/burger_user_menu.xml
@@ -5,7 +5,7 @@
     <div class="o_user_menu_mobile mt-2">
       <t t-foreach="getElements()" t-as="element" t-key="element_index">
           <t t-if="!element.hide">
-              <a t-if="element.type == 'item'" class="dropdown-item py-3 fs-4" t-att-href="element.href or ''" t-out="element.description" t-on-click.stop.prevent="() => this._onItemClicked(element.callback)"/>
+              <a t-if="element.type == 'item'" class="dropdown-item py-3 fs-4" t-att-href="element.href or ''" t-out="element.description" t-on-click.stop.prevent="_onItemClicked(element.callback)"/>
               <CheckBox
                   t-if="element.type == 'switch'"
                   value="element.isChecked"

--- a/addons/web/static/tests/mobile/webclient/burger_menu/burger_menu_tests.js
+++ b/addons/web/static/tests/mobile/webclient/burger_menu/burger_menu_tests.js
@@ -17,6 +17,7 @@ import { companyService } from "@web/webclient/company_service";
 let serverData;
 
 const serviceRegistry = registry.category("services");
+const userMenuRegistry = registry.category("user_menuitems");
 
 QUnit.module("Burger Menu", {
     beforeEach() {
@@ -139,4 +140,28 @@ QUnit.test("Burger menu closes when click on menu item", async (assert) => {
     await click(document.body, ".o_burger_menu nav.o_burger_menu_content li");
     await nextTick();
     assert.containsNone(document.body, ".o_burger_menu");
+});
+
+QUnit.test("Burger menu closes when click on user menu item", async (assert) => {
+    userMenuRegistry.add("ring_item", function () {
+        return {
+            type: "item",
+            id: "ring",
+            description: "Ring",
+            callback: () => {
+                assert.step("callback ring_item");
+            },
+            sequence: 5,
+        };
+    });
+    await createWebClient({ serverData });
+
+    assert.containsNone(document.body, ".o_burger_menu");
+
+    await click(document.body, ".o_mobile_menu_toggle");
+    assert.containsOnce(document.body, ".o_burger_menu");
+
+    await click(document.body, ".o_burger_menu .o_user_menu_mobile a");
+    assert.containsNone(document.body, ".o_burger_menu");
+    assert.verifySteps(["callback ring_item"]);
 });


### PR DESCRIPTION
This commit ensures the BurgerMenu is closed when clicking on one of its
items, and specifically on one of the BurgerUserMenu items.

Steps to reproduce (on small screen):
- on a "base" database (no app installed)
- click on the BurgerMenu (top right)
- click on "Preferences"
=> the user's preference dialog opens behind the BurgerMenu