### PR TITLE
[IMP] website_slides: fine-tune homepage card design

### DIFF
--- a/addons/website_slides/data/slide_channel_tag_demo.xml
+++ b/addons/website_slides/data/slide_channel_tag_demo.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo><data noupdate="1">
     <record id="slide_channel_tag_group_role" model="slide.channel.tag.group">
-        <field name="name">Your Role</field>
+        <field name="name">Role</field>
         <field name="is_published" eval="True"/>
     </record>
     <record id="slide_channel_tag_role_gardener" model="slide.channel.tag">

--- a/addons/website_slides/data/slide_data.xml
+++ b/addons/website_slides/data/slide_data.xml
@@ -7,7 +7,7 @@
             <field name="is_published" eval="True"/>
         </record>
         <record id="slide_channel_tag_group_level" model="slide.channel.tag.group">
-            <field name="name">Your Level</field>
+            <field name="name">Level</field>
             <field name="is_published" eval="True"/>
         </record>
         <record id="slide_channel_tag_level_basic" model="slide.channel.tag">

--- a/addons/website_slides/static/src/scss/website_slides.scss
+++ b/addons/website_slides/static/src/scss/website_slides.scss
@@ -50,26 +50,6 @@ $line-height-truncate: 1.5em;
 }
 
 .o_wslides_body {
-    > #wrapwrap > main {
-        // Change default "body" background in case of website_slides pages.
-        // Note: this only affects the "main" element as we don't want (semi-)
-        // transparent header/footer to be impacted and we also only want the
-        // "box" of boxed layouts to be impacted (not the color behind the box).
-        background-color: $o-wslides-color-bg;
-    }
-
-    .o_wslides_home_nav {
-        top: -40px;
-
-        @include media-breakpoint-up(lg) {
-            .o_wslides_nav_navbar_right {
-                padding-left: $spacer;
-                margin-left: auto;
-                border-left: 1px solid $border-color;
-            }
-        }
-    }
-
     .o_wslides_js_slide_like_up,
     .o_wslides_js_slide_like_down {
         user-select: none;
@@ -167,7 +147,7 @@ $line-height-truncate: 1.5em;
         min-height: 1px;
     }
 
-    .o_wslides_home_aside {
+    .o_wslides_home_aside, .o_avatar {
         --Avatar-size: 35px;
     }
 

--- a/addons/website_slides/views/website_slides_templates_homepage.xml
+++ b/addons/website_slides/views/website_slides_templates_homepage.xml
@@ -247,9 +247,9 @@
             <div t-if="original_search" class="alert alert-warning mb-5">
                 No results found for '<span t-out="original_search"/>'. Showing results for '<span t-out="search_term"/>'.
             </div>
-            <div class="row mx-n2">
+            <div t-attf-class="row g-4 g-lg-3 g-xxl-4 #{'row-cols-1 row-cols-sm-2 row-cols-xl-4' if (is_public_user and not has_side_column) else 'row-cols-1 row-cols-sm-2 row-cols-xl-3'}">
                 <t t-foreach="channels" t-as="channel">
-                    <div class="col-12 col-sm-6 col-md-4 col-lg-3 px-2 d-flex">
+                    <div class="d-flex">
                         <t t-call="website_slides.course_card"/>
                     </div>
                 </t>
@@ -268,18 +268,18 @@
 </template>
 
 <template id='course_card' name="Course Card">
-    <div t-attf-class="card w-100 o_wslides_course_card mb-4 #{'o_wslides_course_unpublished' if not channel.is_published else ''}">
+    <a t-attf-href="/slides/#{slug(channel)}" t-title="channel.name" t-attf-class="card o_wslides_course_card w-100 h-100 text-decoration-none #{'o_wslides_course_unpublished' if not channel.is_published else ''}">
         <t t-set="channel_frontend_tags" t-value="channel.tag_ids.filtered(lambda tag: tag.color)"/>
-        <a t-attf-href="/slides/#{slug(channel)}" t-title="channel.name" style="height:120px">
-            <div t-field="channel.image_1920" t-options="{'widget': 'image', 'preview_image': 'image_512'}" class="o_wslides_background_image h-100"/>
+        <div>
+            <div t-field="channel.image_1920" t-options="{'widget': 'image', 'preview_image': 'image_512'}" class="o_wslides_background_image ratio ratio-16x9"/>
             <t t-if="channel.partner_has_new_content" t-call="website_slides.course_card_information"/>
-        </a>
-        <div class="card-body p-3">
-            <a class="card-title h5 mb-2 o_wslides_desc_truncate_2" t-attf-href="/slides/#{slug(channel)}" t-field="channel.name"/>
+        </div>
+        <div class="card-body">
+            <h3 class="o_line_clamp card-title h6" t-field="channel.name"/>
             <span t-if="not channel.is_published" class="badge text-bg-danger">Unpublished</span>
             <div class="card-text d-flex flex-column flex-grow-1 mt-1">
-                <div class="fw-light o_wslides_desc_truncate_3" t-field="channel.description_short"/>
-                <div t-if="channel_frontend_tags" class="mt-auto pt-1 o_wslides_desc_truncate_2_badges">
+                <small class="o_line_clamp" t-field="channel.description_short"/>
+                <div t-if="channel_frontend_tags" class="small o_wslides_desc_truncate_2_badges">
                     <t t-foreach="channel_frontend_tags" t-as="tag">
                         <t t-if="search_tags">
                             <span t-att-data-post="slide_query_url(tag=slugify_tags(search_tags.ids, toggle_tag_id=tag.id), my=search_my, search=search_term, slide_category=search_slide_category, prevent_redirect=True)"
@@ -293,21 +293,27 @@
                 </div>
             </div>
         </div>
-        <div class="card-footer bg-white text-600 px-3">
-            <div class="d-flex justify-content-between align-items-center">
-                <small t-if="channel.total_time" class="fw-bold" t-out="channel.total_time" t-options="{'widget': 'duration', 'unit': 'hour', 'round': 'minute'}"/>
-                <div class="d-flex flex-grow-1 justify-content-end">
-                    <t t-if="channel.is_member and channel.completed">
-                        <span class="badge text-bg-success pull-right"><i class="fa fa-check"/> Completed</span>
-                    </t>
-                    <div t-elif="channel.is_member and channel.channel_type != 'documentation'" class="progress w-50" style="height: 6px">
+        <div t-attf-class="card-footer d-flex align-items-center #{'justify-content-between' if channel.total_time else 'justify-content-end'}">
+            <t t-if="channel.completion and not channel.completed">
+                <div class="d-flex align-items-center gap-2 flex-basis-50">
+                    <div class="progress flex-grow-1" style="height: 6px">
                         <div class="progress-bar" role="progressbar" t-att-aria-valuenow="channel.completion" aria-valuemin="0" aria-valuemax="100" t-attf-style="width:#{channel.completion}%;" aria-label="Progress bar"/>
                     </div>
-                    <small t-else="" class="fw-bold"><t t-out="channel.total_slides"/> steps</small>
+                    <small><t t-out="channel.completion"/>%</small>
                 </div>
-            </div>
+                <button class="btn btn-sm btn-primary">Continue</button>
+            </t>
+            <t t-elif="channel.is_member and not channel.completion">
+                <small t-if="channel.total_time" t-out="channel.total_time" t-options="{'widget': 'duration', 'unit': 'hour', 'round': 'minute', 'format': 'narrow'}"/>
+                <button class="btn btn-sm btn-primary">Start now</button>
+            </t>
+            <span t-elif="channel.is_member and channel.completed" class="badge text-bg-success"><i class="fa fa-check" aria-hidden="true"/> Completed</span>
+            <t t-else="">
+                <small t-if="channel.total_time" t-out="channel.total_time" t-options="{'widget': 'duration', 'unit': 'hour', 'round': 'minute', 'format': 'narrow'}"/>
+                <small><t t-out="channel.total_slides"/> steps</small>
+            </t>
         </div>
-    </div>
+    </a>
 </template>
 
 <template id="course_card_information" name='Course Information'>

--- a/addons/website_slides/views/website_slides_templates_homepage.xml
+++ b/addons/website_slides/views/website_slides_templates_homepage.xml
@@ -43,7 +43,11 @@
 
 <template id="courses_my">
     <div t-if="channels_my" class="container">
-        <div class="o_wslides_home_content_section mb-4">
+        <div class="o_wslides_home_content_section mb-5">
+            <div class="d-flex justify-content-between">
+                <h2 class="h5 mb-3">My courses</h2>
+                <a t-if="channels_my[5:]" href="/slides?my=1">View all</a>
+            </div>
             <div t-foreach="channels_my[:5]" t-as="channel">
                 <div class="row">
                     <div class="col-5 d-flex align-items-center my-2">
@@ -55,7 +59,7 @@
                             <i class="fa fa-check"/> Completed
                         </div>
                         <t t-elif="not channel.completion">
-                            <div class="text-success d-none d-md-block">0 % (not started yet)</div>
+                            <small class="text-muted d-none d-md-inline"><i class="fa fa-check me-1" role="img"/>You are enrolled</small>
                             <div class="d-md-none">0 %</div>
                         </t>
                         <t t-else="">
@@ -72,14 +76,11 @@
                         </div>
                     </div>
                     <div t-if="not channel.completed" class="col-2 d-flex flex-row-reverse align-items-center">
-                        <a t-if="not channel.completion" role="button" class="btn btn-primary d-none d-md-block" t-attf-href="/slides/#{slug(channel)}">
-                            <span>Start now !</span>
+                        <a t-if="not channel.completion" role="button" class="btn btn-sm btn-primary" t-attf-href="/slides/#{slug(channel)}">
+                            <span class="d-none d-md-inline me-2 me-md-0">Start now</span><i class="oi oi-arrow-right d-md-none" aria-hidden="true"/>
                         </a>
-                        <a t-else="" role="button" class="align-items-center d-none d-md-flex" t-attf-href="/slides/#{slug(channel)}">
-                            <div class="me-2">Continue</div><i class="oi oi-arrow-right me-1"/>
-                        </a>
-                        <a t-attf-href="/slides/#{slug(channel)}" class="d-md-none">
-                            <i class="oi oi-arrow-right me-1"/>
+                        <a t-else="" role="button" class="align-items-center" t-attf-href="/slides/#{slug(channel)}">
+                            <span class="me-2 d-none d-md-inline">Continue</span><i class="oi oi-arrow-right" aria-hidden="true"/>
                         </a>
                     </div>
                     <div t-else="" class="col-2">&amp;nbsp;</div>
@@ -87,9 +88,6 @@
                 <div t-if="not channel_last" class="row mx-1 my-1">
                     <hr class="m-0"/>
                 </div>
-            </div>
-            <div t-if="channels_my[5:]" class="text-end mt-2">
-                <a href="/slides?my=1">See all my courses (<t t-out="len(channels_my)"/>)</a>
             </div>
         </div>
     </div>
@@ -102,11 +100,12 @@
     <t t-call="website.layout">
         <div id="wrap" class="wrap o_wslides_wrap">
             <div class="oe_structure oe_empty"/>
-            <div class="container-fluid mt-2">
+            <div class="container">
+                <t t-call="website_slides.courses_search_bar"/>
                 <div class="row">
-                    <div t-attf-class="#{'col-12 col-lg-8 col-xl-9' if has_side_column else 'col-12'}">
+                    <div t-attf-class="#{'col-12 col-lg-8 col-xl-9 pe-lg-5' if has_side_column else 'col-12'}">
                         <div t-if="invite_error_msg" role="alert" class="o_not_editable alert alert-danger text-center" t-out="invite_error_msg"/>
-                        <div class="container o_wslides_home_nav">
+                        <div class="o_wslides_home_nav">
                             <div class="o_wprofile_email_validation_container">
                                 <t t-call="website_profile.email_validation_banner">
                                     <t t-set="redirect_url" t-value="'/slides'"/>
@@ -117,7 +116,6 @@
                                 </t>
                             </div>
                         </div>
-                        <t t-call="website_slides.courses_search_bar"/>
                         <div class="container o_wslides_home_content_section mb-3"
                             t-if="not len(channels)">
                             <p class="h2">No Course created yet.</p>
@@ -154,46 +152,18 @@
 </template>
 
 <template id="courses_search_bar">
-    <div class="container o_wslides_home_nav">
-        <!-- Navbar dynamically composed using displayed channel tag groups. -->
-        <nav class="navbar navbar-expand-md navbar-light shadow-sm px-2 mb-4">
-            <a class="fw-bold" href="/slides">Online Courses</a>
-            <a class="btn d-block d-lg-none ms-auto p-0" data-bs-toggle="offcanvas" href="#o_wslides_overview_offcanvas" role="button" aria-controls="o_wslides_overview_offcanvas">
-                <t t-call="website_slides.slides_misc_user_image">
-                    <t t-set="img_class" t-value="'o_wslides_user_avatar rounded-circle'"/>
-                </t>
-            </a>
-            <!-- Clear filtering (mobile)-->
-            <div class="text-nowrap ms-auto d-md-none" t-if="search_slide_category or search_tags">
-                <a href="/slides" class="btn btn-info me-2" role="button" title="Clear filters">
-                    <i class="fa fa-eraser"/> Clear filters
-                </a>
-            </div>
-            <t t-else="" t-call="website.website_search_box_input">
-                <!-- Search box (mobile)-->
-                <t t-set="_form_classes" t-valuef="o_wslides_nav_navbar_right d-md-none"/>
-                <t t-set="search_type" t-valuef="slides"/>
-                <!-- No action: remain on same URL -->
-                <t t-set="display_description" t-valuef="true"/>
-                <t t-set="display_detail" t-valuef="false"/>
-                <t t-set="placeholder">Search courses</t>
-                <t t-set="search" t-value="original_search or search_term"/>
-                <input type="hidden" name="my" t-attf-value="#{1 if search_my else 0}"/>
-                <input t-if="search_slide_category" type="hidden" name="slide_category" t-att-value="search_slide_category" />
-                <input type="hidden" name="prevent_redirect" value="True"/>
-            </t>
-            <button class="navbar-toggler px-1" type="button"
-                data-bs-toggle="collapse" data-bs-target="#navbarTagGroups"
-                aria-controls="navbarTagGroups" aria-expanded="false" aria-label="Toggle navigation">
-                <span class="navbar-toggler-icon small"/>
-            </button>
-            <div class="collapse navbar-collapse" id="navbarTagGroups">
+    <!-- Navbar dynamically composed using displayed channel tag groups. -->
+    <div class="d-flex flex-column flex-md-row flex-wrap align-items-md-center gap-2 mt-4 mb-3">
+        <h1 class="h4 mb-0 me-auto">Courses</h1>
+        <div class="d-flex gap-2 flex-column flex-md-row flex-grow-1 flex-md-grow-0 align-items-start">
+            <!-- Desktop tag groups -->
+            <div id="navbarTagGroups">
                 <t t-set="search_tag_groups" t-value="search_tags.mapped('group_id')"/>
-                <ul class="navbar-nav flex-grow-1">
+                <ul class="list-unstyled d-flex flex-wrap gap-2 mb-0">
                     <t t-foreach="tag_groups" t-as="tag_group">
                         <t t-set="group_frontend_tags" t-value="tag_group.tag_ids.filtered(lambda tag: tag.color)"/>
-                        <li class="nav-item dropdown ml16" t-if="group_frontend_tags">
-                            <a t-att-class="'nav-link dropdown-toggle %s' % ('active' if tag_group in search_tag_groups else '')"
+                        <li class="dropdown" t-if="group_frontend_tags">
+                            <a t-att-class="'btn btn-light dropdown-toggle %s' % ('active' if tag_group in search_tag_groups else '')"
                                 href="/slides"
                                 t-att-data-bs-target="'#navToogleTagGroup%s' % tag_group.id"
                                 role="button" data-bs-toggle="dropdown"
@@ -202,22 +172,16 @@
                             <div class="dropdown-menu" t-att-id="'navToogleTagGroup%s' % tag_group.id">
                                 <t t-foreach="group_frontend_tags" t-as="tag">
                                     <span t-att-class="'post_link cursor-pointer dropdown-item %s' % ('active' if tag in search_tags else '')"
-                                          t-att-data-post="slide_query_url(tag=slugify_tags(search_tags.ids, toggle_tag_id=tag.id), my=search_my, search=search_term, slide_category=search_slide_category, prevent_redirect=True)"
-                                          t-out="tag.name"/>
+                                        t-att-data-post="slide_query_url(tag=slugify_tags(search_tags.ids, toggle_tag_id=tag.id), my=search_my, search=search_term, slide_category=search_slide_category, prevent_redirect=True)"
+                                        t-out="tag.name"/>
                                 </t>
                             </div>
                         </li>
                     </t>
                 </ul>
-                <!-- Clear filtering (desktop)-->
-                <div class="ms-auto d-none d-md-flex" t-if="search_slide_category or search_tags">
-                    <a href="/slides" class="btn btn-info text-nowrap me-2" role="button" title="Clear filters">
-                        <i class="fa fa-eraser"/> Clear filters
-                    </a>
-                </div>
-                <!-- Search box (desktop) -->
+            </div>
+            <div class="d-flex gap-2 align-items-center ms-md-auto">
                 <t t-call="website.website_search_box_input">
-                    <t t-set="_form_classes" t-valuef="o_wslides_nav_navbar_right d-none d-md-flex"/>
                     <t t-set="search_type" t-valuef="slides"/>
                     <!-- No action: remain on same URL -->
                     <t t-set="display_description" t-valuef="true"/>
@@ -228,8 +192,13 @@
                     <input t-if="search_slide_category" type="hidden" name="slide_category" t-att-value="search_slide_category" />
                     <input type="hidden" name="prevent_redirect" value="True"/>
                 </t>
+                <a class="btn d-block d-lg-none p-0" data-bs-toggle="offcanvas" href="#o_wslides_overview_offcanvas" role="button" aria-controls="o_wslides_overview_offcanvas">
+                    <t t-call="website_slides.slides_misc_user_image">
+                        <t t-set="img_class" t-value="'o_wslides_user_avatar rounded-circle'"/>
+                    </t>
+                </a>
             </div>
-        </nav>
+        </div>
     </div>
 </template>
 
@@ -261,7 +230,8 @@
 </template>
 
 <template id="courses_search_results">
-    <div class="container o_wslides_home_main pb-5">
+    <div class="o_wslides_home_main pb-5">
+        <h2 t-if="not search_term and not search_slide_category and not search_my and not search_tags" class="h5 mb-3">All Courses</h2>
         <t t-call="website_slides.courses_search_tags"/>
         <div t-if="not channels and not search_term and not search_slide_category and not search_my and not search_tags">
             <p class="h2">No Course created yet.</p>

--- a/addons/website_slides_survey/views/website_slides_templates_homepage.xml
+++ b/addons/website_slides_survey/views/website_slides_templates_homepage.xml
@@ -2,12 +2,14 @@
 <odoo>
     <data>
         <template id="courses_search_bar_inherit_survey" inherit_id="website_slides.courses_search_bar">
-            <xpath expr="//div[@id='navbarTagGroups']" position="before">
-                <a t-if="search_slide_category != 'certification'" class="nav-link nav-link d-flex mx-3"
-                   t-att-href="slide_query_url(tag=slugify_tags(search_tags.ids), my=search_my, search=search_term, slide_category='certification')">
-                    <t t-call="website_slides_survey.o_wss_certification_icon"/>
-                    <span class="ms-1">Certifications</span>
-                </a>
+            <xpath expr="//div[@id='navbarTagGroups']//ul" position="inside">
+                <li class="order-first">
+                    <a t-if="search_slide_category != 'certification'" class="btn btn-light"
+                    t-att-href="slide_query_url(tag=slugify_tags(search_tags.ids), my=search_my, search=search_term, slide_category='certification')">
+                        <t t-call="website_slides_survey.o_wss_certification_icon"/>
+                        <span class="ms-1">Certifications</span>
+                    </a>
+                </li>
             </xpath>
         </template>
 


### PR DESCRIPTION
This PR improves the look of the course cards on the `website_slides` homepage, as part of the `website_slides` redesign.

| Master | This PR |
|--------|--------|
| <img width="1287" height="854" alt="image" src="https://github.com/user-attachments/assets/b86cfb96-5565-41e7-8fc4-5ce7592a7b0d" /> | <img width="1015" height="854" alt="image" src="https://github.com/user-attachments/assets/82ef02d7-517a-4e54-8d08-b9f2d210796c" /> | 


----------

### Changes applied

- Setting the main container from `container-fluid` to `container` as a
standard value

- Display either a continue or start now button in the footer of the
course card, as well as a progressbar, allowing user to scan what course
they are enrolled in and track their progression.

- Fine-tuning the hierarchy of the text inside the card (heading tag,
typescale, ...)

- Remove the gray background enforced on `website_slides` to match the
look and feel of the front-end

- Fine-tune the grid layout (changed the number of cards rendered,
fine-tuned the gap, ...)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
