### PR TITLE
[FIX] stock : show warning when warehouse doesn't exists

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -1052,6 +1052,8 @@ class ProductTemplate(models.Model):
 
     def action_product_tmpl_forecast_report(self):
         self.ensure_one()
+        if not self.env.user._get_default_warehouse_id():
+            self.env['stock.warehouse']._warehouse_redirect_warning()
         action = self.env["ir.actions.actions"]._for_xml_id('stock.stock_forecasted_product_template_action')
         return action
 


### PR DESCRIPTION
Step to reproduce:
- install stock
- create a new company and switch to that company
- open a storable product
- click on forecasted smart button

Cause:
- StockForecasted component needs at least 1 warehouse, but when we create a new company, it does not have any warehouse

https://github.com/odoo/odoo/blob/7747c5810eabe798a1631c3e3b26b81a5c89b4b4/addons/stock/static/src/stock_forecasted/stock_forecasted.js#L49-L52
- clicking on the smart button, raises traceback

Fix:
- we show a warning when the smart button is clicked and no warehouse is found


**Note**: not adding a test case, as issue is not reproducible in test mode due to this
https://github.com/odoo/odoo/blob/de264d99c22283390d18beb7c7c62c29824f72b3/addons/stock/models/res_company.py#L197-L198

opw-5059799

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
