### PR TITLE
[FIX] pos_restaurant_preparation_display: merge orders sent to kitchen

### DIFF
--- a/addons/point_of_sale/static/src/app/models/utils/order_change.js
+++ b/addons/point_of_sale/static/src/app/models/utils/order_change.js
@@ -96,18 +96,14 @@ export const getOrderChanges = (order, orderPreparationCategories) => {
 
                 orderline.setHasChange(true);
             } else {
-                if (quantityDiff) {
-                    orderline.setHasChange(false);
+                // If only note updated
+                if (noteChange) {
+                    lineDetails.quantity = orderline.qty;
+                    noteUpdate[lineKey] = lineDetails;
+                    orderline.setHasChange(true);
+                    changesCount += 1;
                 } else {
-                    // If only note updated
-                    if (noteChange) {
-                        lineDetails.quantity = orderline.qty;
-                        noteUpdate[lineKey] = lineDetails;
-                        orderline.setHasChange(true);
-                        changesCount += 1;
-                    } else {
-                        orderline.setHasChange(false);
-                    }
+                    orderline.setHasChange(false);
                 }
             }
         } else {

--- a/addons/pos_restaurant/models/pos_restaurant.py
+++ b/addons/pos_restaurant/models/pos_restaurant.py
@@ -138,3 +138,20 @@ class RestaurantTable(models.Model):
             error_msg = _("You cannot remove a table that is used in a PoS session, close the session(s) first.")
             if confs:
                 raise UserError(error_msg)
+
+    def get_recursive_parent(self):
+        self.ensure_one()
+        if not self.parent_id:
+            return self
+        return self.parent_id.get_recursive_parent()
+
+    def get_children(self):
+        self.ensure_one()
+        return self.env['restaurant.table'].search([('parent_id', '=', self.id)])
+
+    def get_recursive_children(self):
+        self.ensure_one()
+        all_children = self.get_children()
+        for child in all_children:
+            all_children |= child.get_recursive_children()
+        return all_children

--- a/addons/pos_restaurant/static/src/app/models/pos_order.js
+++ b/addons/pos_restaurant/static/src/app/models/pos_order.js
@@ -40,18 +40,13 @@ patch(PosOrder.prototype, {
             if (this.isDirectSale) {
                 return _t("Direct Sale");
             }
-            if (this.getTable()) {
-                const table = this.getTable();
-                const child_tables = this.models["restaurant.table"].filter((t) => {
-                    if (t.floor_id && t.floor_id.id === table.floor_id.id) {
-                        return table.isParent(t);
-                    }
-                });
-                let name = "T " + table.table_number.toString();
-                for (const child_table of child_tables) {
-                    name += ` & ${child_table.table_number}`;
-                }
-                return name;
+            const table = this.getTable();
+            if (table) {
+                const children = table.recursiveChildren;
+                const tables = [table, ...children];
+
+                const tableNumbers = tables.map((t) => t.table_number).sort((a, b) => a - b);
+                return "T" + tableNumbers.join(" & ");
             }
         }
         return super.getName(...arguments);

--- a/addons/pos_restaurant/static/src/app/models/restaurant_table.js
+++ b/addons/pos_restaurant/static/src/app/models/restaurant_table.js
@@ -90,6 +90,13 @@ export class RestaurantTable extends Base {
     get children() {
         return this["<-restaurant.table.parent_id"];
     }
+    get recursiveChildren() {
+        let children = [...this.children];
+        this.children.forEach((child) => {
+            children = children.concat(child.recursiveChildren);
+        });
+        return children;
+    }
     get rootTable() {
         let table = this;
         while (table.parent_id) {

--- a/addons/pos_restaurant/static/tests/tours/ticket_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/ticket_screen_tour.js
@@ -43,9 +43,9 @@ registry.category("web_tour.tours").add("OrderNumberConflictTour", {
             Chrome.clickPlanButton(),
             Chrome.clickOrders(),
             TicketScreen.nthRowContains(1, "Self-Order"),
-            TicketScreen.nthRowContains(1, "T 101"),
+            TicketScreen.nthRowContains(1, "T101"),
             TicketScreen.nthRowNotContains(2, "Self-Order"),
-            TicketScreen.nthRowContains(2, "T 103"),
+            TicketScreen.nthRowContains(2, "T103"),
         ].flat(),
 });
 


### PR DESCRIPTION
- **Task:** [#5005179](https://www.odoo.com/odoo/my-tasks/5005179)
- **Community:** [#225700](https://github.com/odoo/odoo/pull/225700)
- **Enterprise:** [#93997](https://github.com/odoo/enterprise/pull/93997)
- **Runbot:** [saas-18.2-fix_merging_tables_kitchen_display-ltra-397311](https://runbot.odoo.com/runbot/bundle/saas-18.2-fix_merging_tables_kitchen_display-ltra-397311)

---
**Before**
- The kitchen display was not updated when transferring, merging, or linking orders between tables.
- When merging orders with the same product, quantities were not summed correctly, requiring the product to be ordered again.
- When linking 3 or more tables, the linked table name only showed the first two tables.

**After**
- The kitchen display is now notified when transferring, merging, unmerging, or linking orders between tables.
- Product quantities are correctly aggregated when merging orders.
- The names of linked tables now include all related tables, sorted by table number.