### PR TITLE
[IMP] html_editor, *: enable theme preview over custom color or gradient

### DIFF
--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -527,22 +527,6 @@ export class ColorPlugin extends Plugin {
             removePresetGradient(element);
         }
 
-        if (color.startsWith("o_cc")) {
-            parts = backgroundImageCssToParts(element.style["background-image"]);
-            element.classList.remove(...COLOR_COMBINATION_CLASSES);
-            element.classList.add("o_cc", color);
-
-            const hasBackgroundColor = !!getComputedStyle(element).backgroundColor;
-            const hasGradient = getComputedStyle(element).backgroundImage.includes("-gradient");
-            const backgroundImage = element.style["background-image"];
-            // Override gradient background image if coming from css rather than inline style.
-            if (hasBackgroundColor && hasGradient && !backgroundImage) {
-                element.style.backgroundImage = "none";
-            }
-            this.fixColorCombination(element, color);
-            return;
-        }
-
         const hasGradientStyle = element.style.backgroundImage.includes("-gradient");
         if (mode === "backgroundColor") {
             if (!color) {
@@ -591,6 +575,25 @@ export class ColorPlugin extends Plugin {
             mode = mode.replace("backgroundColor", "background-color");
             this.delegateTo("apply_style", element, mode, color);
         }
+
+        // It was decided that applying a color combination removes any "color"
+        // value (custom color, color classes, gradients, ...). Changing any
+        // "color", including color combinations, should still not remove the
+        // other background layers though (image, video, shape, ...).
+        if (color.startsWith("o_cc")) {
+            parts = backgroundImageCssToParts(element.style["background-image"]);
+            element.classList.remove(...COLOR_COMBINATION_CLASSES);
+            element.classList.add("o_cc", color);
+
+            const hasBackgroundColor = !!getComputedStyle(element).backgroundColor;
+            const hasGradient = getComputedStyle(element).backgroundImage.includes("-gradient");
+            const backgroundImage = element.style["background-image"];
+            // Override gradient background image if coming from css rather than inline style.
+            if (hasBackgroundColor && hasGradient && !backgroundImage) {
+                element.style.backgroundImage = "none";
+            }
+        }
+
         this.fixColorCombination(element, color);
     }
     /**

--- a/addons/html_editor/static/tests/color.test.js
+++ b/addons/html_editor/static/tests/color.test.js
@@ -598,7 +598,7 @@ describe("colorElement", () => {
         });
     });
     describe("when a color was defined", () => {
-        test("should apply o_cc1 class to the element when a color #ff0000 was defined", async () => {
+        test("should apply o_cc1 class to the element and remove the background color when a color #ff0000 was defined", async () => {
             await testEditor({
                 contentBefore: `<div style="background-color: #ff0000;">a</div>`,
                 stepFunction: (editor) => {
@@ -608,7 +608,7 @@ describe("colorElement", () => {
                         "backgroundColor"
                     );
                 },
-                contentAfter: '<div style="background-color: #ff0000;" class="o_cc o_cc1">a</div>',
+                contentAfter: '<div class="o_cc o_cc1">a</div>',
             });
         });
         test("should apply o_cc1 class to the element when a color bg-900 was defined", async () => {
@@ -621,10 +621,10 @@ describe("colorElement", () => {
                         "backgroundColor"
                     );
                 },
-                contentAfter: '<div class="bg-900 o_cc o_cc1">a</div>',
+                contentAfter: '<div class="o_cc o_cc1">a</div>',
             });
         });
-        test("should apply o_cc1 class to the element when a color gradient was defined", async () => {
+        test("should apply o_cc1 class to the element and remove gradient when a color gradient was defined", async () => {
             await testEditor({
                 contentBefore: `<div style="background-image: ${greenToBlueGradient};">a</div>`,
                 stepFunction: (editor) => {
@@ -634,7 +634,7 @@ describe("colorElement", () => {
                         "backgroundColor"
                     );
                 },
-                contentAfter: `<div style="background-image: ${greenToBlueGradient};" class="o_cc o_cc1">a</div>`,
+                contentAfter: `<div class="o_cc o_cc1">a</div>`,
             });
         });
     });
@@ -685,7 +685,7 @@ describe("colorElement", () => {
             contentAfter: `<div style='background-image: url("https://example.com/image.png");' class="o_cc o_cc1">a</div>`,
         });
     });
-    test("should keep custom gradient when switching o_cc class", async () => {
+    test("should not keep custom gradient when switching o_cc class", async () => {
         await testEditor({
             contentBefore: `<div class="">a</div>`,
             stepFunction: (editor) => {
@@ -705,7 +705,7 @@ describe("colorElement", () => {
                     "backgroundColor"
                 );
             },
-            contentAfter: `<div class="o_cc o_cc2" style="background-image: ${greenToBlueGradient};">a</div>`,
+            contentAfter: `<div class="o_cc o_cc2">a</div>`,
         });
     });
 
@@ -775,7 +775,7 @@ describe("colorElement", () => {
         });
 
         describe("set o_cc1 when a color is already defined", () => {
-            test("should not write o_cc1 gradient when rgb(255, 0, 0) is already present", async () => {
+            test("should write o_cc1 gradient when rgb(255, 0, 0) is already present", async () => {
                 await testEditor({
                     contentBefore: `<div style="background-color: rgb(255, 0, 0);">a</div>`,
                     stepFunction: (editor) => {
@@ -785,10 +785,10 @@ describe("colorElement", () => {
                             "backgroundColor"
                         );
                     },
-                    contentAfter: `<div style="background-color: rgb(255, 0, 0); background-image: none;" class="o_cc o_cc1">a</div>`,
+                    contentAfter: `<div style="background-image: ${redToBlueGradient};" class="o_cc o_cc1">a</div>`,
                 });
             });
-            test("should not write o_cc1 gradient when bg-900 is already present", async () => {
+            test("should write o_cc1 gradient when bg-900 is already present", async () => {
                 await testEditor({
                     contentBefore: `<div class="bg-900">a</div>`,
                     stepFunction: (editor) => {
@@ -798,10 +798,10 @@ describe("colorElement", () => {
                             "backgroundColor"
                         );
                     },
-                    contentAfter: `<div class="bg-900 o_cc o_cc1" style="background-image: none;">a</div>`,
+                    contentAfter: `<div class="o_cc o_cc1" style="background-image: ${redToBlueGradient};">a</div>`,
                 });
             });
-            test("should not write o_cc1 gradient when a gradient is already present", async () => {
+            test("should write o_cc1 gradient when a gradient is already present", async () => {
                 await testEditor({
                     contentBefore: `<div style="background-image: ${greenToBlueGradient};">a</div>`,
                     stepFunction: (editor) => {
@@ -811,7 +811,7 @@ describe("colorElement", () => {
                             "backgroundColor"
                         );
                     },
-                    contentAfter: `<div style="background-image: ${greenToBlueGradient};" class="o_cc o_cc1">a</div>`,
+                    contentAfter: `<div style="background-image: ${redToBlueGradient};" class="o_cc o_cc1">a</div>`,
                 });
             });
         });

--- a/addons/website/static/tests/tours/snippet_background_edition.js
+++ b/addons/website/static/tests/tours/snippet_background_edition.js
@@ -174,18 +174,17 @@ changeOption("Text - Image", "button[data-action-id='toggleBgImage']"),
 // again. It should keep the bg color class.
 ...checkAndUpdateBackgroundColor({
     checkCC: "o_cc2",
-    checkBg: backgroundColors[1].code,
     checkNoBg: backgroundColors[0].code,
     changeType: 'cc',
     change: "o_cc4",
-    finalSelector: `:iframe .${snippets[0].id}.o_cc4:not(.o_cc2).bg-${backgroundColors[1].code}`,
+    finalSelector: `:iframe .${snippets[0].id}.o_cc4:not(.o_cc2):not(.bg-${backgroundColors[1].code})`,
 }),
 
 // Check the current color palette status + Replace the bg color by a gradient
 ...checkAndUpdateBackgroundColor({
     checkCC: "o_cc4",
     checkNoCC: "o_cc2",
-    checkBg: backgroundColors[1].code,
+    checkNoBg: backgroundColors[1].code,
     changeType: 'gradient',
     change: gradients[0],
     finalSelector: `:iframe .${snippets[0].id}.o_cc4:not(.bg-${backgroundColors[1].code})[style*="background-image: ${gradients[0]}"]`,
@@ -202,21 +201,24 @@ changeOption("Text - Image", "button[data-action-id='toggleBgImage']"),
 }),
 
 // Check the current color palette selection + Change the color combination
-// again. It should keep the gradient.
+// again. Gradients should switch.
 ...checkAndUpdateBackgroundColor({
     checkCC: "o_cc4",
     checkGradient: gradients[1],
     checkNoGradient: gradients[0],
     changeType: 'cc',
     change: "o_cc1",
-    finalSelector: `:iframe .${snippets[0].id}.o_cc1:not(.o_cc4)[style*="background-image: ${gradients[1]}"]`,
+    finalSelector: `:iframe .${snippets[0].id}.o_cc1:not(.o_cc4):not([style*="background-image: ${gradients[1]}"])`,
 }),
 
-// Final check of the color status in the color palette
+// Final check of the color status in the color palette + re-add a gradient
 ...checkAndUpdateBackgroundColor({
     checkCC: "o_cc1",
     checkNoCC: "o_cc4",
-    checkGradient: gradients[1],
+    checkNoGradient: gradients[1],
+    changeType: 'gradient',
+    change: gradients[1],
+    finalSelector: `:iframe .${snippets[0].id}.o_cc1:not(.o_cc4)[style*="background-image: ${gradients[1]}"]`,
 }),
 
 // Now, add an image on top of that color combination + gradient


### PR DESCRIPTION
*=website

This PR allows previewing theme colors in the colorpicker even when a custom color or gradient is applied to the selected element's background. But if a video or image background is applied, then the theme color should not be previewed.

task-5062183
