### PR TITLE
[FIX] payment__razorpay_oauth: webhook creation fails if email is missing

### DIFF
--- a/addons/payment_razorpay_oauth/models/payment_provider.py
+++ b/addons/payment_razorpay_oauth/models/payment_provider.py
@@ -104,7 +104,7 @@ class PaymentProvider(models.Model):
         webhook_secret = uuid.uuid4().hex  # Generate a random webhook secret.
         payload = {
             'url': f'{self.get_base_url()}/payment/razorpay/webhook',
-            'alert_email': self.env.user.partner_id.email,
+            'alert_email': self.env.user.partner_id.email or '',
             'secret': webhook_secret,
             'events': const.HANDLED_WEBHOOK_EVENTS,
         }


### PR DESCRIPTION
**Version:**
- saas-18.1

**Steps to reproduce:**
- Install Sale app without demo data.
- Install Razorpay payment provider.
- Click on the Connect button.
- Webhook is not created.

**Issue:**
- When the database is set up without demo data, the current user’s partner has no email.
- Because of this, the system uses False instead of an email, which breaks webhook creation.

**Solution:**
- If the email is missing, pass an empty string ("") instead of False.


