### PR TITLE
[FIX] sale: pass context to handle invoice creation from payment transaction

### DIFF
--- a/addons/sale/models/payment_transaction.py
+++ b/addons/sale/models/payment_transaction.py
@@ -205,7 +205,8 @@ class PaymentTransaction(models.Model):
                 # For fully paid orders create a final invoice.
                 fully_paid_orders._force_lines_to_invoice_policy_order()
                 final_invoices = fully_paid_orders.with_context(
-                    raise_if_nothing_to_invoice=False
+                    raise_if_nothing_to_invoice=False,
+                    is_payment_transaction_invoice=True,
                 )._create_invoices(final=True)
                 invoices = downpayment_invoices + final_invoices
 


### PR DESCRIPTION
Version:
- 18.0

On order confirmation, portal payments only invoice order-based products.
Passing context `is_payment_transaction_invoice` allows 
sale_subscription to also handle delivered products correctly and avoid
duplicate payments.

related-PR: https://github.com/odoo/enterprise/pull/94009
Taskid-4250892

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
