### PR TITLE
[FIX] hr_recruitement, mail: propagate applicant name to mail activity

### DIFF
--- a/addons/hr_recruitment/models/hr_candidate.py
+++ b/addons/hr_recruitment/models/hr_candidate.py
@@ -245,6 +245,18 @@ class HrCandidate(models.Model):
 
         if vals.get("company_id") and not self.env.context.get('do_not_propagate_company', False):
             self.applicant_ids.with_context(do_not_propagate_company=True).write({"company_id": vals["company_id"]})
+
+        if 'partner_name' in vals:
+
+            activities_to_update_sudo = self.env['mail.activity'].sudo().search([
+                '|',
+                '&', ('res_model', '=', 'hr.candidate'), ('res_id', 'in', self.ids),
+                '&', ('res_model', '=', 'hr.applicant'), ('res_id', 'in', self.applicant_ids.ids)
+            ])
+
+            if activities_to_update_sudo:
+                activities_to_update_sudo._compute_res_name()
+
         return res
 
     def action_open_similar_candidates(self):

--- a/addons/hr_recruitment/tests/test_recruitment.py
+++ b/addons/hr_recruitment/tests/test_recruitment.py
@@ -21,6 +21,26 @@ class TestRecruitment(TransactionCase):
         })
         self.assertEqual(applicant.partner_id.lang, 'pl_PL', 'Context langague not used for partner creation')
 
+    def test_update_candidate_name_propagates_to_activities(self):
+        """
+            Test that updating the name of an candidate propagates to planned activities.
+        """
+
+        candidate = self.env['hr.candidate'].create({
+            'partner_name': 'Test Candidate',
+            'email_from': "test_aplicant@example.com"
+        })
+        activity = self.env['mail.activity'].create({
+            'activity_type_id': self.env.ref('mail.mail_activity_data_todo').id,
+            'res_id': candidate.id,
+            'res_model_id': self.env['ir.model']._get_id('hr.candidate'),
+            'summary': 'Test',
+        })
+        self.assertEqual(activity.res_name, 'Test Candidate')
+
+        candidate.write({'partner_name': 'A New Candidate Name'})
+        self.assertEqual(activity.res_name, 'A New Candidate Name')
+
     def test_duplicate_email(self):
         # Tests that duplicate email match ignores case
         # And that no match is found when there is none


### PR DESCRIPTION
Issue:
When updating an hr recruitement candidate name (stored in hr_applicant after 18.2) the name change is not updated in the name of previously created activities.

Cause:
The field res_name in mail.activity is computed and stored only at creation of an activity.

Solution:
Retrigger the compute of an activity when updating a candidates name.

Task-4988342
