### PR TITLE
[FIX] web: handle missing app_id in scoped_app route

### DIFF
--- a/addons/web/controllers/webmanifest.py
+++ b/addons/web/controllers/webmanifest.py
@@ -99,8 +99,10 @@ class WebManifest(http.Controller):
         })
 
     @http.route('/scoped_app', type='http', auth='public', methods=['GET'])
-    def scoped_app(self, app_id, path='', app_name=''):
+    def scoped_app(self, app_id=None, path='', app_name=''):
         """ Returns the app shortcut page to install the app given in parameters """
+        if not app_id:
+            return request.redirect('/web')
         app_name = unquote(app_name) if app_name else self._get_scoped_app_name(app_id)
         path = f"/{unquote(path)}"
         scoped_app_values = {


### PR DESCRIPTION
Currently, calling `/scoped_app` without providing an `app_id` raises an error.

**Error:**
`TypeError: WebManifest.scoped_app() missing 1 required positional argument: 'app_id'`

**Cause:**
The `scoped_app` route defined `app_id` as a required positional argument. However, in custom RPC calls, the parameter may be empty, which triggers the error.

**Fix:**
This commit handles the case when the app id is not provided and redirects to the main page instead of raising an error.

sentry-4952598215