### PR TITLE
[FIX] survey_crm: error when pressing the stat button after user input

### DIFF
--- a/addons/survey_crm/models/survey_user_input.py
+++ b/addons/survey_crm/models/survey_user_input.py
@@ -220,10 +220,6 @@ class SurveyUser_Input(models.Model):
         ''' Shows the lead associated, created from inputs '''
         self.ensure_one()
         action = self.env['ir.actions.act_window']._for_xml_id('crm.crm_lead_opportunities')
-        action["context"] = dict(
-            ast.literal_eval(action.get('context', '{}').strip()),  # ".strip()" prevents a crash of literal_eval which doesn't interpret the "\n" after the dictionary is closed in the string
-            create=False,
-        )
         action['views'] = [((self.env.ref('crm.crm_lead_view_form').id), 'form')]
         action['res_id'] = self.lead_id.id
         return action


### PR DESCRIPTION
**Issue**
After a user input generates a lead, this lead can be viewed from the “Lead”
stat button in the participation view in question. However, an error occurs
when clicking on it.

**Steps to reproduce**
- Create a survey that generates leads
- Complete the survey with a response that can create the lead
- From the survey form view, click on the "Participants" stat button
- Select the user input that created the lead
- Click on the "Lead" stat button

**Solution**
The problem stemmed from the interpretation of the context uid (override from
sale_crm). But the context is ultimately not useful here, because we want to
leave “New quotation” accessible after the redirection.

task-5068082