### PR TITLE
[IMP] purchase_stock, *: Add filter on suggest activation

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2866,19 +2866,6 @@ class AccountMove(models.Model):
     def _get_parent_field_on_child_model(self):
         return 'move_id'
 
-    def _is_line_valid_for_section_line_count(self, line):
-        """Check if a line is valid for inclusion in the section's line count.
-
-        :param recordset line: A record of a move line.
-        :return: True if this line is a valid, else False.
-        :rtype: bool
-        """
-        return (
-            line.product_id
-            and line.product_id.product_tmpl_id.type != 'combo'
-            and line.quantity > 0
-        )
-
     # -------------------------------------------------------------------------
     # EARLY PAYMENT DISCOUNT
     # -------------------------------------------------------------------------
@@ -5236,7 +5223,6 @@ class AccountMove(models.Model):
                 ):
                     lines.with_context(move_reverse_cancel=move_reverse_cancel).reconcile()
         return reverse_moves
-
 
     def _reverse_moves(self, default_values_list=None, cancel=False):
         ''' Reverse a recordset of account.move.

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2748,6 +2748,7 @@ class AccountMove(models.Model):
         if self.is_purchase_document() and self.partner_id:
             res['search_default_seller_ids'] = self.partner_id.name
 
+        res['product_catalog_move_type'] = self.move_type
         res['product_catalog_currency_id'] = self.currency_id.id
         res['product_catalog_digits'] = self.line_ids._fields['price_unit'].get_digits(self.env)
         res['show_sections'] = bool(self.id)

--- a/addons/account/static/src/components/product_catalog/kanban_controller.js
+++ b/addons/account/static/src/components/product_catalog/kanban_controller.js
@@ -3,17 +3,13 @@ import { patch } from "@web/core/utils/patch";
 import { _t } from "@web/core/l10n/translation";
 
 patch(ProductCatalogKanbanController.prototype, {
-    get stateFiels() {
-        return this.orderResModel === "account.move" ? ["state", "move_type"] : super.stateFiels;
-    },
-
     _defineButtonContent() {
-        if (this.orderStateInfo.move_type === "out_invoice") {
-            this.buttonString = _t("Back to Invoice");
-        } else if (this.orderStateInfo.move_type === "in_invoice") {
-            this.buttonString = _t("Back to Bill");
-        } else {
+        if (this.orderResModel !== "account.move") {
             super._defineButtonContent();
+        } else if (this.props.context.product_catalog_move_type === "out_invoice") {
+            this.buttonString = _t("Back to Invoice");
+        } else if (this.props.context.product_catalog_move_type === "in_invoice") {
+            this.buttonString = _t("Back to Bill");
         }
     },
 });

--- a/addons/account/static/src/components/product_catalog/kanban_record.js
+++ b/addons/account/static/src/components/product_catalog/kanban_record.js
@@ -40,7 +40,7 @@ patch(ProductCatalogKanbanRecord.prototype, {
             this.notifyLineCountChange(lineCountChange);
         }
 
-        super.updateQuantity(quantity);
+        return super.updateQuantity(quantity);
     },
 
     notifyLineCountChange(lineCountChange) {

--- a/addons/mrp/static/src/components/product_catalog/kanban_controller.js
+++ b/addons/mrp/static/src/components/product_catalog/kanban_controller.js
@@ -3,13 +3,6 @@ import { patch } from "@web/core/utils/patch";
 import { _t } from "@web/core/l10n/translation";
 
 patch(ProductCatalogKanbanController.prototype, {
-    setOrderStateInfo() {
-        if (["mrp.bom", "mrp.production"].includes(this.orderResModel)) {
-            return {};
-        }
-        return super.setOrderStateInfo();
-    },
-
     _defineButtonContent() {
         if (this.orderResModel === "mrp.bom") {
             this.buttonString = _t("Back to BoM");

--- a/addons/product/models/product_catalog_mixin.py
+++ b/addons/product/models/product_catalog_mixin.py
@@ -128,6 +128,7 @@ class ProductCatalogMixin(models.AbstractModel):
         return {
             'display_uom': self.env.user.has_group('uom.group_uom'),
             'product_catalog_order_id': self.id,
+            'product_catalog_order_state': self.state if "state" in self._fields else None,
             'product_catalog_order_model': self._name,
         }
 

--- a/addons/product/static/src/product_catalog/kanban_controller.js
+++ b/addons/product/static/src/product_catalog/kanban_controller.js
@@ -10,15 +10,14 @@ export class ProductCatalogKanbanController extends KanbanController {
     setup() {
         super.setup();
         this.orm = useService("orm");
-        this.orderId = this.props.context.order_id;
+        this.orderId = this.props.context.product_catalog_order_id;
         this.orderResModel = this.props.context.product_catalog_order_model;
-        this.backToQuotationDebounced = useDebounced(this.backToQuotation, 500)
+        this.backToQuotationDebounced = useDebounced(this.backToQuotation, 500);
 
         onWillStart(() => this.onWillStart());
     }
 
     async onWillStart() {
-        await this.setOrderStateInfo();
         this._defineButtonContent();
     }
 
@@ -27,20 +26,10 @@ export class ProductCatalogKanbanController extends KanbanController {
         return true;
     }
 
-    get stateFiels() {
-        return ["state"];
-    }
-
-    async setOrderStateInfo() {
-        const orderData = await this.orm.searchRead(
-            this.orderResModel, [["id", "=", this.orderId]], this.stateFiels
-        );
-        this.orderStateInfo = orderData[0] || {};
-    }
-
     _defineButtonContent() {
         // Define the button's label depending of the order's state.
-        const orderIsQuotation = ["draft", "sent"].includes(this.orderStateInfo.state);
+        const order_state = this.props.context.product_catalog_order_state;
+        const orderIsQuotation = ["draft", "sent"].includes(order_state);
         if (orderIsQuotation) {
             this.buttonString = _t("Back to Quotation");
         } else {

--- a/addons/product/static/src/product_catalog/kanban_record.js
+++ b/addons/product/static/src/product_catalog/kanban_record.js
@@ -86,7 +86,7 @@ export class ProductCatalogKanbanRecord extends KanbanRecord {
             return;
         }
         this.productCatalogData.quantity = quantity || 0;
-        this.debouncedUpdateQuantity();
+        return this.debouncedUpdateQuantity();
     }
 
     /**

--- a/addons/product/static/src/product_catalog/order_line/order_line.scss
+++ b/addons/product/static/src/product_catalog/order_line/order_line.scss
@@ -13,5 +13,5 @@ div.o_product_catalog_quantity {
 .o_kanban_view .o_kanban_renderer .o_kanban_record.o_product_added {
     background-color: $o-component-active-bg;
     border-color: $o-component-active-border;
-    z-index: 3;  // Makes sure bottom border in groupby view is above 
+    z-index: 3;  // Makes sure bottom border in groupby view is above
 }

--- a/addons/purchase/static/tests/tours/tour_helper.js
+++ b/addons/purchase/static/tests/tours/tour_helper.js
@@ -30,7 +30,7 @@ export function selectPOWarehouse(warehouseName) {
             run: `edit ${warehouseName}`,
         },
         {
-            content: "Select BaseWarehouse as PO WH",
+            content: `Select ${warehouseName} as PO Warehouse`,
             isActive: ["auto"],
             trigger: `.ui-menu-item > a:contains(${warehouseName})`,
             run: "click",

--- a/addons/purchase_stock/models/product.py
+++ b/addons/purchase_stock/models/product.py
@@ -103,11 +103,11 @@ class ProductProduct(models.Model):
             to_date=to_date,
         )
 
-    @api.depends_context('suggest_based_on', 'warehouse_id')
+    @api.depends_context('monthly_demand_start', 'monthly_demand_limit', 'warehouse_id')
     def _compute_monthly_demand(self):
-        based_on = self.env.context.get("suggest_based_on", "30_days")
         warehouse_id = self.env.context.get('warehouse_id')
-        start_date, limit_date = self._get_monthly_demand_range(based_on)
+        start_date = fields.Datetime.to_datetime(self.env.context.get('monthly_demand_start')) or datetime.now() - relativedelta(days=30)
+        limit_date = fields.Datetime.to_datetime(self.env.context.get('monthly_demand_limit')) or datetime.now()
 
         move_domain = Domain([
             ('product_id', 'in', self.ids),
@@ -124,13 +124,7 @@ class ProductProduct(models.Model):
         move_qty_by_products = self.env['stock.move']._read_group(move_domain, ['product_id'], ['product_qty:sum'])
         qty_by_product = {product.id: qty for product, qty in move_qty_by_products}
 
-        factor = 1
-        if based_on == "one_year":
-            factor = 12
-        elif based_on == "three_months" or based_on == "last_year_quarter":
-            factor = 3
-        elif based_on == "one_week":
-            factor = 7 / (365.25 / 12)  # 7 days / (365.25 days/yr / 12 mth/yr) = 0.23 months
+        factor = (limit_date - start_date).days / (365.25 / 12) or 1  # Convert demand to monthly demand (365.2 / 12 = 30.4... days)
         for product in self:
             product.monthly_demand = qty_by_product.get(product.id, 0) / factor
 
@@ -190,33 +184,6 @@ class ProductProduct(models.Model):
                         ('orderpoint_id.warehouse_id', 'in', warehouse_ids)
             ]))
         return rfq_domain & Domain.OR(domains or [Domain.TRUE])
-
-    def _get_monthly_demand_range(self, based_on):
-        start_date = limit_date = datetime.now()
-
-        if not based_on or based_on == 'actual_demand' or based_on == '30_days':
-            start_date = start_date - relativedelta(days=30)  # Default monthly demand
-        elif based_on == 'one_week':
-            start_date = start_date - relativedelta(weeks=1)
-        elif based_on == 'three_months':
-            start_date = start_date - relativedelta(months=3)
-        elif based_on == 'one_year':
-            start_date = start_date - relativedelta(years=1)
-        else:  # Relative period of time.
-            today = datetime.now()
-            start_date = datetime(year=today.year - 1, month=today.month, day=1)
-
-            if based_on == 'last_year_m_plus_1':
-                start_date += relativedelta(months=1)
-            elif based_on == 'last_year_m_plus_2':
-                start_date += relativedelta(months=2)
-
-            if based_on == 'last_year_quarter':
-                limit_date = start_date + relativedelta(months=3)
-            else:
-                limit_date = start_date + relativedelta(months=1)
-
-        return start_date, limit_date
 
 
 class ProductSupplierinfo(models.Model):

--- a/addons/purchase_stock/models/purchase_order.py
+++ b/addons/purchase_stock/models/purchase_order.py
@@ -127,16 +127,15 @@ class PurchaseOrder(models.Model):
             'po_state': self.state,
         }
 
-    def action_purchase_order_suggest(self):
+    def action_purchase_order_suggest(self, search_domain):
         """ Adds suggested products to PO, removing products with no suggested_qty, and
         collapsing existing po_lines into at most 1 orderline. Saves suggestion params
         (eg. number_of_days) to partner table. """
         self.ensure_one()
         ctx = self.env.context
         domain = [('type', '=', 'consu')]
-        if ctx.get("domain"):
-            domain = fields.Domain.AND([domain, ctx.get("domain")])
-
+        if search_domain:
+            domain = fields.Domain.AND([domain, search_domain])
         products = self.env['product.product'].search(domain)
 
         self.partner_id.write({

--- a/addons/purchase_stock/models/purchase_order.py
+++ b/addons/purchase_stock/models/purchase_order.py
@@ -124,7 +124,6 @@ class PurchaseOrder(models.Model):
             'vendor_suggest_days': self.partner_id.suggest_days,
             'vendor_suggest_based_on': self.partner_id.suggest_based_on,
             'vendor_suggest_percent': self.partner_id.suggest_percent,
-            'po_state': self.state,
         }
 
     def action_purchase_order_suggest(self, search_domain):

--- a/addons/purchase_stock/models/purchase_order.py
+++ b/addons/purchase_stock/models/purchase_order.py
@@ -126,7 +126,7 @@ class PurchaseOrder(models.Model):
             'vendor_suggest_percent': self.partner_id.suggest_percent,
         }
 
-    def action_purchase_order_suggest(self, search_domain):
+    def action_purchase_order_suggest(self, search_domain, section_id):
         """ Adds suggested products to PO, removing products with no suggested_qty, and
         collapsing existing po_lines into at most 1 orderline. Saves suggestion params
         (eg. number_of_days) to partner table. """
@@ -153,17 +153,23 @@ class PurchaseOrder(models.Model):
                 self.partner_id,
                 self
             )
-            existing_po_lines = self.order_line.filtered(lambda pol: pol.product_id == product)
-            if existing_po_lines:
+            existing_lines = self.order_line.filtered(lambda pol: pol.product_id == product)
+            if section_id:
+                existing_lines = existing_lines.filtered(lambda pol: pol.get_parent_section_line().id == section_id)
+                suggest_line["sequence"] = self._get_new_line_sequence("order_line", section_id)
+            else:
+                existing_lines = existing_lines.filtered(lambda pol: not pol.parent_id)  # lines with no sections
+            if existing_lines:
                 # Collapse into 1 or 0 po line, discarding previous data in favor of suggested qtys
-                to_unlink = existing_po_lines if product.suggested_qty == 0 else existing_po_lines[:-1]
+                to_unlink = existing_lines if product.suggested_qty == 0 else existing_lines[:-1]
                 po_lines_commands += [Command.unlink(line.id) for line in to_unlink]
                 if product.suggested_qty > 0:
-                    po_lines_commands.append(Command.update(existing_po_lines[-1].id, suggest_line))
+                    po_lines_commands.append(Command.update(existing_lines[-1].id, suggest_line))
             elif product.suggested_qty > 0:
                 po_lines_commands.append(Command.create(suggest_line))
 
         self.order_line = po_lines_commands
+        return sum({"CREATE": 1, "UNLINK": -1}.get(c[0].name, 0) for c in po_lines_commands)
 
     def button_approve(self, force=False):
         result = super(PurchaseOrder, self).button_approve(force=force)

--- a/addons/purchase_stock/models/purchase_order.py
+++ b/addons/purchase_stock/models/purchase_order.py
@@ -426,7 +426,8 @@ class PurchaseOrder(models.Model):
     def _get_product_catalog_order_line_info(self, product_ids, child_field=False, **kwargs):
         """ Add suggest_ctx to env in order to trigger product.product suggest compute fields"""
         if kwargs.get('suggest_based_on'):
-            suggest_keys = ('suggest_days', 'suggest_based_on', 'suggest_percent', 'warehouse_id')
+            suggest_keys = ('suggest_days', 'suggest_based_on', 'suggest_percent', 'warehouse_id',
+                            'monthly_demand_start', 'monthly_demand_end')
             suggest_ctx = {k: v for k, v in kwargs.items() if k in suggest_keys}
             return super(PurchaseOrder, self.with_context(suggest_ctx))._get_product_catalog_order_line_info(
                 product_ids, child_field=child_field, **kwargs

--- a/addons/purchase_stock/static/src/product_catalog/kanban_controller.js
+++ b/addons/purchase_stock/static/src/product_catalog/kanban_controller.js
@@ -15,7 +15,7 @@ export class PurchaseSuggestCatalogKanbanController extends ProductCatalogKanban
         this.suggestParams = {
             currencyId: this.props.context.product_catalog_currency_id,
             digits: this.props.context.product_catalog_digits,
-            poState: this.props.context.po_state,
+            poState: this.props.context.product_catalog_order_state,
             vendorName: this.props.context.vendor_name,
             warehouse_id: this.props.context.warehouse_id,
         };
@@ -64,7 +64,7 @@ export class PurchaseSuggestCatalogKanbanController extends ProductCatalogKanban
             await this.model.orm.call(
                 "purchase.order",
                 "action_purchase_order_suggest",
-                [this._baseContext["order_id"], sm.domain],
+                [this._baseContext["product_catalog_order_id"], sm.domain], // Change
                 { context: this._getSuggestContext() }
             );
             this._toggleSuggestFilters(true);

--- a/addons/purchase_stock/static/src/product_catalog/kanban_controller.js
+++ b/addons/purchase_stock/static/src/product_catalog/kanban_controller.js
@@ -54,13 +54,18 @@ export class PurchaseSuggestCatalogKanbanController extends ProductCatalogKanban
         /** Method to add all suggestions to purchase order */
         const onAddAll = async () => {
             const sm = this.env.searchModel;
-            await this.model.orm.call(
+            const section_id = sm.selectedSection.sectionId;
+            const lineCountChange = await this.model.orm.call(
                 "purchase.order",
                 "action_purchase_order_suggest",
-                [this._baseContext["product_catalog_order_id"], sm.domain], // Change
+                [this._baseContext["product_catalog_order_id"], sm.domain, section_id],
                 { context: this._getSuggestContext() }
             );
             this._toggleSuggestFilters(true);
+            this.env.searchModel.trigger("section-line-count-change", {
+                sectionId: section_id,
+                lineCountChange: lineCountChange,
+            });
         };
 
         /** When user toggles suggestion switch, we reload && toggle filters */

--- a/addons/purchase_stock/static/src/product_catalog/kanban_controller.js
+++ b/addons/purchase_stock/static/src/product_catalog/kanban_controller.js
@@ -1,7 +1,8 @@
 import { ProductCatalogKanbanController } from "@product/product_catalog/kanban_controller";
-import { onWillStart, useState, useSubEnv, useEffect } from "@odoo/owl";
+import { onWillStart, useState, useSubEnv } from "@odoo/owl";
 import { useDebounced } from "@web/core/utils/timing";
 import { useBus } from "@web/core/utils/hooks";
+import { loadSuggestToggleState, editSuggestContext, filterInTheOrder } from "./utils";
 
 /* Controller reacts to most UI events on product catalog view (eg. next page, filters, suggestion changes),
  * pass suggestion inputs to backend through context, and reorders kanban records based on backend computations.
@@ -11,16 +12,19 @@ import { useBus } from "@web/core/utils/hooks";
 export class PurchaseSuggestCatalogKanbanController extends ProductCatalogKanbanController {
     setup() {
         super.setup();
+        this.suggestParams = {
+            currencyId: this.props.context.product_catalog_currency_id,
+            digits: this.props.context.product_catalog_digits,
+            poState: this.props.context.po_state,
+            vendorName: this.props.context.vendor_name,
+            warehouse_id: this.props.context.warehouse_id,
+        };
         this.state = useState({
             numberOfDays: this.props.context.vendor_suggest_days,
             basedOn: this.props.context.vendor_suggest_based_on,
             percentFactor: this.props.context.vendor_suggest_percent,
-            poState: this.props.context.po_state,
             totalEstimatedPrice: 0.0,
-            currencyId: this.props.context.product_catalog_currency_id,
-            digits: this.props.context.product_catalog_digits,
-            vendorName: this.props.context.vendor_name,
-            suggestToggle: this._loadSuggestToggleState(),
+            suggestToggle: loadSuggestToggleState(this.suggestParams.poState),
         });
 
         onWillStart(async () => {
@@ -29,59 +33,49 @@ export class PurchaseSuggestCatalogKanbanController extends ProductCatalogKanban
 
         /* Pass context to backend and reload front-end with computed values
          * using a 300ms delay to avoid rendering entire kanban on each digit change */
-        this._debouncedKanbanRecompute = useDebounced(async () => {
-            this.model.config.context = this._getCatalogContext();
+        const debouncedKanbanRecompute = useDebounced(async () => {
+            this.model.config.context = this._getSuggestContext();
             await this.model.root.load({}); // Reload the Kanban with ctx
 
             if (this.state.suggestToggle.isOn) {
-                const product_prices = await this.orm.searchRead(
-                    "product.product",
-                    this.model.config.domain,
-                    ["suggest_estimated_price"],
-                    { context: this._getCatalogContext() }
-                );
-                this.state.totalEstimatedPrice = product_prices.reduce(
-                    (sum, p) => sum + Number(p.suggest_estimated_price || 0),
-                    0
-                );
+                this._computeTotalEstimatedPrice();
                 await this._reorderKanbanGrid();
             }
-        }, 300); // Enough to type eg. 110 in percent input without rendering 3 times
+        });
 
-        useEffect(
-            () => {
-                this._debouncedKanbanRecompute();
-            },
-            () => [
-                this.state.basedOn,
-                this.state.numberOfDays,
-                this.state.percentFactor,
-                this.state.suggestToggle.isOn,
-            ]
-        );
-
-        /* Recompute Kanban on filter changes (incl. sidebar category filters)
-         * The "update" triggers a refresh, which can happen before debounce on slow
-         * internet --> pass suggest context to searchModel in case it refreshes first */
+        // Recompute Kanban on filter changes (incl. sidebar category filters)
         useBus(this.env.searchModel, "update", () => {
-            this.env.searchModel.globalContext = this._getCatalogContext(); // Check with slow internet before removing
-            this._debouncedKanbanRecompute();
+            this.env.searchModel.globalContext = this._getSuggestContext(); // Check with slow internet before removing
+            debouncedKanbanRecompute();
         });
 
         const onAddAll = async () => {
-            const ctx = this._filter_add_all_ctx(this._getCatalogContext()); // IMPROVE: Quickfix
+            const ctx = this._filter_add_all_ctx(this._getSuggestContext()); // IMPROVE: Quickfix
             await this.model.orm.call(
                 "purchase.order",
                 "action_purchase_order_suggest",
                 [ctx["order_id"]],
                 { context: ctx }
             );
-            this._filterInTheOrder(); // Apply filter to show what was added
+            filterInTheOrder(); // Apply filter to show what was added
+        };
+
+        /** When user toggles suggestion switch, we reload && toggle filters */
+        const toggleSuggest = () => {
+            this.state.suggestToggle.isOn = !this.state.suggestToggle.isOn;
+            localStorage.setItem(
+                "purchase_stock.suggest_toggle_state",
+                JSON.stringify({ isOn: this.state.suggestToggle.isOn })
+            );
+            debouncedKanbanRecompute();
         };
 
         useSubEnv({
-            suggest: this.state,
+            suggestState: this.state,
+            suggestParams: this.suggestParams,
             addAllProducts: onAddAll,
+            toggleSuggest: toggleSuggest,
+            reloadKanban: debouncedKanbanRecompute,
         });
     }
 
@@ -97,6 +91,19 @@ export class PurchaseSuggestCatalogKanbanController extends ProductCatalogKanban
             el[0] === "is_in_purchase_order" && el[1] === "=" && el[2] === true ? domain_all : el
         );
         return ctx;
+    }
+
+    async _computeTotalEstimatedPrice() {
+        const product_prices = await this.orm.searchRead(
+            "product.product",
+            this.env.searchModel.domain,
+            ["suggest_estimated_price"],
+            { context: this._getSuggestContext() }
+        );
+        this.state.totalEstimatedPrice = product_prices.reduce(
+            (sum, p) => sum + Number(p.suggest_estimated_price || 0),
+            0
+        );
     }
 
     /**
@@ -127,47 +134,17 @@ export class PurchaseSuggestCatalogKanbanController extends ProductCatalogKanban
         this._debouncedKanbanRecompute();
     }
 
-    /** Add "In the Order" filter, returning products in PO, if it wasn't already there. */
-    _filterInTheOrder() {
-        const sm = this.env.searchModel;
-        const inTheOrderFilter = Object.values(sm.searchItems).find(
-            (searchItem) => searchItem.name === "products_in_purchase_order"
-        );
-        const isActive = sm.query.some((f) => f.searchItemId === inTheOrderFilter.id);
-        sm.toggleSearchItem(inTheOrderFilter.id);
-        if (isActive) {
-            sm.toggleSearchItem(inTheOrderFilter.id); // Reapply with new updated values
-        }
-    }
-
     /**
-     * Packs the suggest parameters in a object to pass to backend
-     * (product & purchase_order models). Returns base context if suggest is OFF.
-     * @returns {Object} base context or base + suggest context
+     * Adds the suggest parameters to context if suggest feature is activated
+     * @returns {Object} base context if suggest is OFF or base + suggest context
      */
-    _getCatalogContext() {
-        if (this.state.suggestToggle.isOn === false) {
-            return this._baseContext; // removes suggest context
-        }
-        return {
-            ...this._baseContext,
-            domain: this.model.config.domain,
-            warehouse_id: this.props.context.warehouse_id,
+    _getSuggestContext() {
+        const suggestCtx = {
             suggest_based_on: this.state.basedOn,
             suggest_days: this.state.numberOfDays,
             suggest_percent: this.state.percentFactor,
+            warehouse_id: this.suggestParams.warehouse_id,
         };
-    }
-
-    /** Loads last suggest toggle state from local storage (defaults to false) */
-    _loadSuggestToggleState() {
-        if (this.props.context.po_state !== "draft") {
-            return { isOn: false };
-        }
-        const local_state = JSON.parse(localStorage.getItem("purchase_stock.suggest_toggle_state"));
-        if (local_state?.isOn !== undefined) {
-            return local_state;
-        }
-        return { isOn: false };
+        return editSuggestContext(this._baseContext, this.state.suggestToggle.isOn, suggestCtx);
     }
 }

--- a/addons/purchase_stock/static/src/product_catalog/kanban_model.js
+++ b/addons/purchase_stock/static/src/product_catalog/kanban_model.js
@@ -1,11 +1,70 @@
 import { ProductCatalogKanbanModel } from "@product/product_catalog/kanban_model";
+import { loadSuggestToggleState, toggleFilters, editSuggestContext } from "./utils";
 
 export class PurchaseSuggestCatalogKanbanModel extends ProductCatalogKanbanModel {
-    /* Pass suggest context to /product/catalog/order_lines_info RPC
+    setup() {
+        super.setup(...arguments);
+        this.firstLoad = true;
+    }
+
+    /**
+     * Override to move records with suggested_qty > 0 to the front, keeping original order.
+     */
+    async _loadData(params) {
+        const sortBySuggested = (list) => {
+            const suggestProducts = list.filter((record) => record.suggested_qty > 0);
+            const notSuggestedProducts = list.filter((record) => record.suggested_qty == 0);
+            return [...suggestProducts, ...notSuggestedProducts];
+        };
+        const suggest = loadSuggestToggleState(this.config.context.product_catalog_order_state);
+        this._suggestOnFirstLoad(suggest, params);
+        const result = await super._loadData(params);
+        if (!suggest.isOn || !result.records.some((r) => r.suggested_qty > 0)) {
+            return result;
+        }
+        if (!params.isMonoRecord) {
+            if (params.groupBy?.length) {
+                for (const group of result.groups) {
+                    group.list.records = sortBySuggested(group.list.records);
+                }
+            } else {
+                result.records = sortBySuggested(result.records);
+            }
+        }
+        return result;
+    }
+
+    /** Pass suggest context to /product/catalog/order_lines_info RPC
      * to add computed ["suggested_qty"] key to productCatalogData */
     _getOrderLinesInfoParams(loadParams, productIds) {
         const base = super._getOrderLinesInfoParams(loadParams, productIds);
-        const suggestCtx = this.config.context || {}; // Controller sets context in config
-        return { ...base, ...suggestCtx };
+        return { ...base, ...loadParams.context };
+    }
+
+    /**
+     *  Adds suggest_context and toggles filters if first load with suggest on.
+     *  IMPROVE: action_add_from_catalog should pass context and activate filters
+     *  using default_search filters (not easy bc toggle state in local storage)
+     */
+    _suggestOnFirstLoad(suggestToggle, params) {
+        if (!this.firstLoad) {
+            return;
+        }
+        const ctx = this.config.context;
+        const sm = this.env.searchModel;
+        if (suggestToggle.isOn && this.firstLoad) {
+            const suggestCtx = {
+                suggest_domain: this.env.searchModel.domain,
+                suggest_days: ctx.vendor_suggest_days,
+                suggest_based_on: ctx.vendor_suggest_based_on,
+                suggest_percent: ctx.vendor_suggest_percent,
+                warehouse_id: ctx.warehouse_id,
+            };
+            this.config.context = editSuggestContext(this.config.context, true, suggestCtx);
+            sm.globalContext = editSuggestContext(this.config.context, true, suggestCtx);
+            toggleFilters(sm, ["suggested", "products_in_purchase_order"], true);
+            params.domain = sm.domain; // TODO safer
+            this.firstLoad = false;
+        }
     }
 }

--- a/addons/purchase_stock/static/src/product_catalog/record/kanban_record.js
+++ b/addons/purchase_stock/static/src/product_catalog/record/kanban_record.js
@@ -6,13 +6,9 @@ export class ProductCatalogPurchaseSuggestKanbanRecord extends ProductCatalogKan
      * hiding suggest line if suggest_qty == qty in PO */
     getRecordClasses(...args) {
         const classes = super.getRecordClasses(args) || "";
-
         const catalogData = this.productCatalogData || {};
-        if (catalogData.suggested_qty) {
-            if (catalogData.suggested_qty == catalogData.quantity) {
-                return classes + " o_suggest_highlight" + " o_hide_suggest_qty";
-            }
-            return classes + " o_suggest_highlight";
+        if (catalogData.suggested_qty && catalogData.suggested_qty == catalogData.quantity) {
+            return classes + " o_hide_suggest_qty";
         }
         return classes;
     }
@@ -25,5 +21,9 @@ export class ProductCatalogPurchaseSuggestKanbanRecord extends ProductCatalogKan
     addProduct() {
         const { min_qty = 1, suggested_qty = 0 } = this.productCatalogData;
         super.addProduct(Math.max(min_qty, suggested_qty, 1));
+    }
+
+    async updateQuantity(quantity) {
+        await super.updateQuantity(quantity);
     }
 }

--- a/addons/purchase_stock/static/src/product_catalog/record/kanban_record.js
+++ b/addons/purchase_stock/static/src/product_catalog/record/kanban_record.js
@@ -2,8 +2,7 @@ import { ProductCatalogKanbanRecord } from "@product/product_catalog/kanban_reco
 import { ProductCatalogPurchaseSuggestOrderLine } from "./purchase_order_line";
 
 export class ProductCatalogPurchaseSuggestKanbanRecord extends ProductCatalogKanbanRecord {
-    /* Highlights product card if suggest_qty > 0,
-     * hiding suggest line if suggest_qty == qty in PO */
+    /** Highlights product card if suggest_qty > 0 hiding suggest line if suggest_qty == qty in PO */
     getRecordClasses(...args) {
         const classes = super.getRecordClasses(args) || "";
         const catalogData = this.productCatalogData || {};

--- a/addons/purchase_stock/static/src/product_catalog/record/kanban_record.scss
+++ b/addons/purchase_stock/static/src/product_catalog/record/kanban_record.scss
@@ -1,9 +1,3 @@
-.o_purchase_product_kanban_catalog_view .o_kanban_record.o_suggest_highlight {
-    background-color: $o-component-active-bg;
-    z-index: 3;  // Makes sure bottom border in groupby view is above
-    border-color: $o-component-active-border;
-}
-
 .o_purchase_product_kanban_catalog_view .o_kanban_record.o_hide_suggest_qty [name="kanban_purchase_suggest"] {
   display: none !important;
 }

--- a/addons/purchase_stock/static/src/product_catalog/search/search_panel.xml
+++ b/addons/purchase_stock/static/src/product_catalog/search/search_panel.xml
@@ -7,10 +7,15 @@
         </xpath>
     </t>
     <t t-name="purchase_stock.ProductCatalogSearchPanelContent" t-inherit="account.ProductCatalogSearchPanelContent" t-inherit-mode="primary">
+        <xpath expr="//section[hasclass('o_search_panel_sections')]" position="attributes">
+            <t t-if="suggestState.suggestToggle.isOn">
+                <attribute name="class">o_search_panel_sections mt-4</attribute>
+            </t>
+        </xpath>
         <xpath expr="//section[hasclass('o_search_panel_sections')]" position="before">
             <t t-if="displaySuggest">
                 <t t-call="PurchaseSuggest.SearchPanel.Header"/>
-                <t t-if="suggest.suggestToggle.isOn">
+                <t t-if="suggestState.suggestToggle.isOn">
                     <div class="o_suggest_feature">
                         <t t-call="PurchaseSuggest.SearchPanel.DaysInput"/>
                         <t t-call="PurchaseSuggest.SearchPanel.BasedOn"/>
@@ -33,8 +38,8 @@
                         class="form-check-input"
                         type="checkbox"
                         role="switch"
-                        t-att-checked="suggest.suggestToggle.isOn? true : false"
-                        t-on-click="onSuggestToggle"
+                        t-att-checked="suggestState.suggestToggle.isOn? true : false"
+                        t-on-click="toggleSuggest"
                     />
                 </div>
             </div>
@@ -45,7 +50,7 @@
         <div class="d-flex align-items-center ms-2 pt-2">
             <span class="me-2 fw-bold">Replenish for</span>
             <input type="text" inputmode="numeric" class="o_PurchaseSuggestInput"
-                t-att-value="suggest.numberOfDays"
+                t-att-value="suggestState.numberOfDays"
                 t-on-input="onDaysInput"/>
             <span class="ms-2">day(s)</span>
         </div>
@@ -59,7 +64,7 @@
             </div>
             <span class="m-1">x</span>
             <input type="text" inputmode="numeric" class="o_PurchaseSuggestInput"
-                t-att-value="suggest.percentFactor"
+                t-att-value="suggestState.percentFactor"
                 t-on-input="onPercentFactorInput"/>
             <span>%</span>
         </div>

--- a/addons/purchase_stock/static/src/product_catalog/utils.js
+++ b/addons/purchase_stock/static/src/product_catalog/utils.js
@@ -1,0 +1,50 @@
+/**
+ * Adds / Removes the suggest parameters if suggest feature is ON / OFF
+ * @param {Object} baseContext Object to modify in place
+ * @param {boolean} suggestOn
+ * @param {Object} suggestContext must contain at least based_on key / val pair
+ * @returns {Object} base context if suggest is OFF or base + suggest context
+ */
+export function editSuggestContext(baseContext, suggestOn, suggestContext) {
+    if (!suggestOn) {
+        return removeSuggestContext(baseContext, suggestContext);
+    }
+    return {
+        ...baseContext,
+        ...suggestContext,
+    };
+}
+
+function removeSuggestContext(baseContext, suggestContext) {
+    const suggestKeys = new Set([
+        ...Object.keys(suggestContext || {}).filter((k) => k != "warehouse_id"),
+        "monthly_demand_start",
+        "monthly_demand_limit",
+    ]);
+    for (const k of suggestKeys) {
+        delete baseContext[k];
+    }
+    return baseContext;
+}
+
+/** False if PO is not draft, otherwise loads last toggle state from local storage (defaults to false)  */
+export function loadSuggestToggleState(poState) {
+    if (poState == "draft") {
+        const toggle = JSON.parse(localStorage.getItem("purchase_stock.suggest_toggle_state"));
+        return toggle ?? { isOn: false };
+    }
+    return { isOn: false };
+}
+
+/** Add "In the Order" filter, returning products in PO, if it wasn't already there. */
+export function filterInTheOrder() {
+    const sm = this.env.searchModel;
+    const inTheOrderFilter = Object.values(sm.searchItems).find(
+        (searchItem) => searchItem.name === "products_in_purchase_order"
+    );
+    const isActive = sm.query.some((f) => f.searchItemId === inTheOrderFilter.id);
+    sm.toggleSearchItem(inTheOrderFilter.id);
+    if (isActive) {
+        sm.toggleSearchItem(inTheOrderFilter.id); // Reapply with new updated values
+    }
+}

--- a/addons/purchase_stock/static/src/product_catalog/utils.js
+++ b/addons/purchase_stock/static/src/product_catalog/utils.js
@@ -1,3 +1,5 @@
+const { DateTime } = luxon;
+
 /**
  * Adds / Removes the suggest parameters if suggest feature is ON / OFF
  * @param {Object} baseContext Object to modify in place
@@ -9,9 +11,12 @@ export function editSuggestContext(baseContext, suggestOn, suggestContext) {
     if (!suggestOn) {
         return removeSuggestContext(baseContext, suggestContext);
     }
+    const [start, limit] = getMonthlyDemandRange(suggestContext.suggest_based_on);
     return {
         ...baseContext,
         ...suggestContext,
+        monthly_demand_start: toServerDatetime(start),
+        monthly_demand_limit: toServerDatetime(limit),
     };
 }
 
@@ -60,4 +65,41 @@ export function toggleFilters(sm, filterNames, turnOn) {
         sm.blockNotification = !isLast;
         sm.toggleSearchItem(toToggle[i]);
     }
+}
+
+function toServerDatetime(datetime) {
+    return new Date(datetime).toISOString().slice(0, 19).replace("T", " ");
+}
+
+/** Transform a string to its equivalent date range using hardcoded rules */
+export function getMonthlyDemandRange(basedOn) {
+    const now = DateTime.now();
+    let startDate = now;
+    let limitDate = now;
+
+    if (!basedOn || basedOn === "actual_demand" || basedOn === "30_days") {
+        startDate = now.minus({ days: 30 });
+    } else if (basedOn === "one_week") {
+        startDate = now.minus({ weeks: 1 });
+    } else if (basedOn === "three_months") {
+        startDate = now.minus({ months: 3 });
+    } else if (basedOn === "one_year") {
+        startDate = now.minus({ years: 1 });
+    } else {
+        startDate = DateTime.local(now.year - 1, now.month, now.day);
+
+        if (basedOn === "last_year_m_plus_1") {
+            startDate = startDate.plus({ months: 1 });
+        } else if (basedOn === "last_year_m_plus_2") {
+            startDate = startDate.plus({ months: 2 });
+        }
+
+        if (basedOn === "last_year_quarter") {
+            limitDate = startDate.plus({ months: 3 });
+        } else {
+            limitDate = startDate.plus({ months: 1 });
+        }
+    }
+
+    return [startDate, limitDate];
 }

--- a/addons/purchase_stock/static/tests/tours/purchase_catalog_suggest.js
+++ b/addons/purchase_stock/static/tests/tours/purchase_catalog_suggest.js
@@ -131,8 +131,9 @@ registry.category("web_tour.tours").add("test_purchase_order_suggest_search_pane
         { trigger: "span[name='kanban_monthly_demand_qty']:visible:contains('52')" }, // ceil(12 * 30/ 7)
         { trigger: "div[name='kanban_purchase_suggest'] span:visible:contains('24')" }, // 12 * 4 * 50%
         checkKanbanRecordPosition("test_product", 0),
+
         ...toggleSuggest(false),
-        { trigger: "span[name='kanban_monthly_demand_qty']:visible:contains('24')" }, // Should come back to normal monthly demand
+        { trigger: "span[name='kanban_monthly_demand_qty']:visible:contains('24')" }, // 24 for One warehouse, 1 for another warehouse
         { trigger: "div.o_product_catalog_buttons i.fa-shopping-cart:visible" }, // == wait for front end to sync (shopping carts only when not suggested)
         checkKanbanRecordPosition("Courage", 0), // Product with lowest ref number should be first, test product should be first anymore
         ...toggleSuggest(true),
@@ -196,7 +197,7 @@ registry.category("web_tour.tours").add("test_purchase_order_suggest_search_pane
         },
         { trigger: ".fa-trash" }, // Wait till its added
         {
-            content: "Check added qty matches expecations",
+            content: "Check added qty matches expectations",
             trigger: ".o_product_catalog_quantity input",
             run() {
                 assert(parseInt(this.anchor.value), 24); // 12 * 4 * 50%
@@ -228,7 +229,6 @@ registry.category("web_tour.tours").add("test_purchase_order_suggest_search_pane
          * (Add / Remove with filters), TODO category filters
          * ------------------------------------------------------------------
          */
-        // Remove suggest filter
         {
             content: "Remove the Suggested Or In Order filter",
             trigger: '.o_facet_value:contains("Suggested")',
@@ -248,6 +248,13 @@ registry.category("web_tour.tours").add("test_purchase_order_suggest_search_pane
             trigger: "div.o_product_catalog_buttons i.fa-shopping-cart",
             run: "click",
         },
+        {
+            content: "Add a delay to make sure its added to PO",
+            trigger: ".fa-trash",
+            async run() {
+                await new Promise((r) => setTimeout(r, 1000));
+            },
+        }, // Wait till its added
         ...toggleSuggest(true),
         { trigger: '.o_facet_value:contains("Suggested")' }, // 12 * 4 * 50%
         {
@@ -277,6 +284,7 @@ registry.category("web_tour.tours").add("test_purchase_order_suggest_search_pane
             trigger: ".o_kanban_record",
             run: "click",
         },
+        // TODO non deterministic
         { trigger: ".fa-trash" }, // Wait till its added
         ...goToPOFromCatalog(),
         {

--- a/addons/purchase_stock/static/tests/tours/tour_helper.js
+++ b/addons/purchase_stock/static/tests/tours/tour_helper.js
@@ -84,28 +84,17 @@ export function toggleSuggest(turnOn) {
 }
 
 /**
- * Checks a product Kanban is highlighted and in a specified place
+ * Checks a product's record order in Kanban
  * @param {string} product product display name
- * @param {number} expected_order  1 == [0], 2 == [1] ...
- * @param {boolean} highlightOn default to true
+ * @param {number | false } expectedOrder 0 is the first card
  */
-export function checkKanbanRecordHighlight(product, expected_order, highlightOn = true) {
+export function checkKanbanRecordPosition(product, expectedOrder) {
     return {
         trigger: ".o_kanban_view.o_purchase_product_kanban_catalog_view .o_kanban_record",
         run() {
             const cards = [...document.querySelectorAll(".o_kanban_record")];
-            const product_card = cards.find((card) => card.textContent.includes(product));
-            const highlighted = product_card.className.includes("o_suggest_highlight");
-            if (highlightOn === true) {
-                assert(highlighted, true, `${product} record should be highlighted.`);
-                assert(
-                    product_card == cards[expected_order - 1],
-                    true,
-                    `Card in position ${cards.indexOf(product_card)} not ${expected_order}.`
-                );
-            } else if (highlightOn === false) {
-                assert(highlighted, false, `${product} record should not be highlighted.`);
-            }
+            assert(expectedOrder + 1 <= cards.length, true, "expectedOrder out of range.");
+            assert(cards[expectedOrder].textContent.includes(product), true, "Wrong order");
         },
     };
 }

--- a/addons/purchase_stock/tests/test_purchase_order_suggest.py
+++ b/addons/purchase_stock/tests/test_purchase_order_suggest.py
@@ -4,6 +4,7 @@ from dateutil.relativedelta import relativedelta
 
 from odoo import Command, fields
 from odoo.addons.purchase_stock.tests.common import PurchaseTestCommon
+from odoo.addons.stock.utils import get_based_on_date_range
 from odoo.tests import tagged, freeze_time
 from odoo.tests.common import HttpCase
 
@@ -33,11 +34,12 @@ class TestPurchaseOrderSuggest(PurchaseTestCommon, HttpCase):
         Note that the wizard fields are updated each time this method is called."""
         base_warehouse = self.picking_type_out.default_location_src_id.warehouse_id
         warehouse_id = (warehouse or base_warehouse).id
+        monthly_date_range = get_based_on_date_range(based_on)
         suggest_context = {
+            **monthly_date_range,
             "order_id": po.id,
             "partner_id": po.partner_id.id,
             "warehouse_id": warehouse_id,
-            "suggest_based_on": based_on,
             "suggest_days": days,
             "suggest_percent": factor,
         }
@@ -49,9 +51,10 @@ class TestPurchaseOrderSuggest(PurchaseTestCommon, HttpCase):
     def actionAddAll(self, po, based_on='30_days', days=30, factor=100, warehouse=False):
         base_warehouse = self.picking_type_out.default_location_src_id.warehouse_id
         warehouse_id = (warehouse or base_warehouse).id
+        monthly_date_range = get_based_on_date_range(based_on)
         suggest_context = {
+            **monthly_date_range,
             "warehouse_id": warehouse_id,
-            "suggest_based_on": based_on,
             "suggest_percent": factor,
             "suggest_days": days,
         }
@@ -126,39 +129,39 @@ class TestPurchaseOrderSuggest(PurchaseTestCommon, HttpCase):
         )
 
         # Check product demand quantity.
-        # With no dates given in the context, the monthly demand should take only last month.
-        self.assertEqual(self.product_1.monthly_demand, 20)
-        self.assertEqual(product_2.monthly_demand, 10)
-        self.assertEqual(product_3.monthly_demand, 10)
+        # With no dates given in the context, the monthly demand should take only last month. ()
+        self.assertAlmostEqual(self.product_1.monthly_demand, 20, places=0)
+        self.assertAlmostEqual(product_2.monthly_demand, 10, places=0)
+        self.assertAlmostEqual(product_3.monthly_demand, 10, places=0)
         # Check for last week.
-        context = {'suggest_based_on': "one_week"}
+        context = get_based_on_date_range("one_week")
         self.assertEqual(self.product_1.with_context(context).monthly_demand, 0)
         self.assertAlmostEqual(product_2.with_context(context).monthly_demand, 5 * (365.25 / 12) / 7, places=6)
         self.assertEqual(product_3.with_context(context).monthly_demand, 0)
         # Check for last three months.
-        context = {'suggest_based_on': "three_months"}
-        self.assertAlmostEqual(self.product_1.with_context(context).monthly_demand, 25 / 3, places=6)
-        self.assertAlmostEqual(product_2.with_context(context).monthly_demand, 10 / 3, places=6)
-        self.assertAlmostEqual(product_3.with_context(context).monthly_demand, 20 / 3, places=6)
+        context = get_based_on_date_range("three_months")
+        self.assertAlmostEqual(self.product_1.with_context(context).monthly_demand, 25 / 3, places=0)
+        self.assertAlmostEqual(product_2.with_context(context).monthly_demand, 10 / 3, places=0)
+        self.assertAlmostEqual(product_3.with_context(context).monthly_demand, 20 / 3, places=0)
         # Check for last year months.
-        context = {'suggest_based_on': "one_year"}
-        self.assertAlmostEqual(self.product_1.with_context(context).monthly_demand, 42 / 12, places=6)
-        self.assertAlmostEqual(product_2.with_context(context).monthly_demand, 15 / 12, places=6)
-        self.assertAlmostEqual(product_3.with_context(context).monthly_demand, 20 / 12, places=6)
+        context = get_based_on_date_range("one_year")
+        self.assertAlmostEqual(self.product_1.with_context(context).monthly_demand, 42 / 12, places=1)
+        self.assertAlmostEqual(product_2.with_context(context).monthly_demand, 15 / 12, places=1)
+        self.assertAlmostEqual(product_3.with_context(context).monthly_demand, 20 / 12, places=1)
         # Check for January 2020.
-        context = {'suggest_based_on': "last_year"}
-        self.assertEqual(self.product_1.with_context(context).monthly_demand, 12)
+        context = get_based_on_date_range("last_year")
+        self.assertAlmostEqual(self.product_1.with_context(context).monthly_demand, 12, places=0)
         self.assertEqual(product_2.with_context(context).monthly_demand, 0)
         self.assertEqual(product_3.with_context(context).monthly_demand, 0)
         # Check for February 2020.
-        context = {'suggest_based_on': "last_year_m_plus_1"}
+        context = get_based_on_date_range("last_year_m_plus_1")
         self.assertEqual(self.product_1.with_context(context).monthly_demand, 0)
         self.assertEqual(product_2.with_context(context).monthly_demand, 0)
         self.assertEqual(product_3.with_context(context).monthly_demand, 0)
         # Check for March 2020.
-        context = {'suggest_based_on': "last_year_m_plus_2"}
-        self.assertEqual(self.product_1.with_context(context).monthly_demand, 5)
-        self.assertEqual(product_2.with_context(context).monthly_demand, 5)
+        context = get_based_on_date_range("last_year_m_plus_2")
+        self.assertAlmostEqual(self.product_1.with_context(context).monthly_demand, 5, places=0)
+        self.assertAlmostEqual(product_2.with_context(context).monthly_demand, 5, places=0)
         self.assertEqual(product_3.with_context(context).monthly_demand, 0)
 
         # Create a new PO for the vendor then check suggest wizard estimed price.
@@ -308,25 +311,25 @@ class TestPurchaseOrderSuggest(PurchaseTestCommon, HttpCase):
 
         # Check product demand quantity.
         # With no dates given in the context, the monthly demand should take only last month.
-        self.assertEqual(consu.monthly_demand, 20)
+        self.assertAlmostEqual(consu.monthly_demand, 20, places=0)
         # Check for last week.
-        context = {'suggest_based_on': "one_week"}
+        context = get_based_on_date_range("one_week")
         self.assertEqual(consu.with_context(context).monthly_demand, 0)
         # Check for last three months.
-        context = {'suggest_based_on': "three_months"}
-        self.assertAlmostEqual(consu.with_context(context).monthly_demand, 25 / 3, places=6)
+        context = get_based_on_date_range("three_months")
+        self.assertAlmostEqual(consu.with_context(context).monthly_demand, 25 / 3, places=0)
         # Check for last year months.
-        context = {'suggest_based_on': "one_year"}
-        self.assertAlmostEqual(consu.with_context(context).monthly_demand, 42 / 12, places=6)
+        context = get_based_on_date_range("one_year")
+        self.assertAlmostEqual(consu.with_context(context).monthly_demand, 42 / 12, places=1)
         # Check for January 2020.
-        context = {'suggest_based_on': "last_year"}
-        self.assertEqual(consu.with_context(context).monthly_demand, 12)
+        context = get_based_on_date_range("last_year")
+        self.assertAlmostEqual(consu.with_context(context).monthly_demand, 12, places=0)
         # Check for February 2020.
-        context = {'suggest_based_on': "last_year_m_plus_1"}
+        context = get_based_on_date_range("last_year_m_plus_1")
         self.assertEqual(consu.with_context(context).monthly_demand, 0)
         # Check for March 2020.
-        context = {'suggest_based_on': "last_year_m_plus_2"}
-        self.assertEqual(consu.with_context(context).monthly_demand, 5)
+        context = get_based_on_date_range("last_year_m_plus_2")
+        self.assertAlmostEqual(consu.with_context(context).monthly_demand, 5, places=0)
 
         # Create a new PO for the vendor then check suggest wizard estimed price.
         po = self.env['purchase.order'].create({'partner_id': self.partner_1.id})
@@ -454,9 +457,11 @@ class TestPurchaseOrderSuggest(PurchaseTestCommon, HttpCase):
         # Make a delivery in each warehouse.
         self._create_and_process_delivery_at_date([(self.product_1, 5)], date, warehouse=main_warehouse)
         self._create_and_process_delivery_at_date([(self.product_1, 10)], date, warehouse=self.warehouse_1)
-        self.assertEqual(self.product_1.monthly_demand, 15)
-        self.assertEqual(self.product_1.with_context(warehouse_id=main_warehouse.id).monthly_demand, 5)
-        self.assertEqual(self.product_1.with_context(warehouse_id=self.warehouse_1.id).monthly_demand, 10)
+        self.assertAlmostEqual(self.product_1.monthly_demand, 15 * (365.25 / 12) / 30, places=6)
+        self.assertAlmostEqual(self.product_1.with_context(warehouse_id=main_warehouse.id).
+                               monthly_demand, 5 * (365.25 / 12) / 30, places=6)
+        self.assertAlmostEqual(self.product_1.with_context(warehouse_id=self.warehouse_1.id).
+                               monthly_demand, 10 * (365.25 / 12) / 30, places=6)
 
         # Create a PO for each warehouse and check the right quantity is added to the PO line.
         po_1 = self.env['purchase.order'].create({
@@ -619,7 +624,7 @@ class TestPurchaseOrderSuggest(PurchaseTestCommon, HttpCase):
         self._create_and_process_delivery_at_date(
             [(test_product, 12)], date=fields.Datetime.now() - relativedelta(days=10)
         )
-        self.assertEqual(test_product.monthly_demand, 24)
+        self.assertAlmostEqual(test_product.monthly_demand, 24, places=0)
 
         # Create a and mark as todo a move in 20 days (for checking suggest/forecasted)
         self._create_and_process_delivery_at_date(
@@ -631,5 +636,4 @@ class TestPurchaseOrderSuggest(PurchaseTestCommon, HttpCase):
         self._create_and_process_delivery_at_date(
             [(test_product, 1)], date=today - relativedelta(days=1), warehouse=other_warehouse
         )
-        # TODO fix not working on local with Debug & without step_delay (maybe due to xml Math.round)
         self.start_tour('/odoo/purchase', "test_purchase_order_suggest_search_panel_ux", login='admin')

--- a/addons/purchase_stock/tests/test_purchase_order_suggest.py
+++ b/addons/purchase_stock/tests/test_purchase_order_suggest.py
@@ -58,7 +58,7 @@ class TestPurchaseOrderSuggest(PurchaseTestCommon, HttpCase):
             "suggest_percent": factor,
             "suggest_days": days,
         }
-        po.with_context(suggest_context).action_purchase_order_suggest([])  # Simplify by passing empty domain
+        po.with_context(suggest_context).action_purchase_order_suggest([], False)  # Simplify by passing empty domain & no setcion
 
     def _create_and_process_delivery_at_date(self, products_and_quantities, date=False, warehouse=False, to_validate=True):
         date = date or datetime.now()

--- a/addons/purchase_stock/tests/test_purchase_order_suggest.py
+++ b/addons/purchase_stock/tests/test_purchase_order_suggest.py
@@ -36,7 +36,6 @@ class TestPurchaseOrderSuggest(PurchaseTestCommon, HttpCase):
         suggest_context = {
             "order_id": po.id,
             "partner_id": po.partner_id.id,
-            "domain": domain,
             "warehouse_id": warehouse_id,
             "suggest_based_on": based_on,
             "suggest_days": days,
@@ -56,7 +55,7 @@ class TestPurchaseOrderSuggest(PurchaseTestCommon, HttpCase):
             "suggest_percent": factor,
             "suggest_days": days,
         }
-        po.with_context(suggest_context).action_purchase_order_suggest()
+        po.with_context(suggest_context).action_purchase_order_suggest([])  # Simplify by passing empty domain
 
     def _create_and_process_delivery_at_date(self, products_and_quantities, date=False, warehouse=False, to_validate=True):
         date = date or datetime.now()

--- a/addons/purchase_stock/views/product_views.xml
+++ b/addons/purchase_stock/views/product_views.xml
@@ -20,19 +20,19 @@
                 <t name="qty_forecasted" t-if="record.qty_available.raw_value != record.virtual_available.raw_value">
                     <span> / </span>
                     <span class="fw-bold" t-att-class="record.virtual_available.raw_value &lt; 0 ? 'text-danger' : ''" t-out="record.virtual_available.raw_value"  name="o_kanban_forecasted_qty"/>
-                    <span class="text-muted small"> Forecasted</span>
+                    <span class="text-muted small ms-1">Forecasted</span>
                 </t>
             </t>
             <div name="o_kanban_qty_available_and_on_hand" position="after">
                 <div t-if="record.type.raw_value === 'consu' and record.monthly_demand.raw_value != 0" name="kanban_monthly_demand">
-                    <span class="text-muted small">Monthly Demand: </span>
+                    <span class="text-muted small me-1">Monthly Demand:</span>
                     <span class="fw-bold ms-1" t-esc="Math.round(record.monthly_demand.raw_value *100)/100"  name="kanban_monthly_demand_qty"/>
                     <field name="uom_id" class="text-muted small ms-1" groups="uom.group_uom"/>
                 </div>
                 <div name="kanban_purchase_suggest" t-if="record.suggested_qty.raw_value != 0">
-                    <span class="text-info fw-bold fs-5"> Suggest </span>
-                    <span class="text-info fw-bold fs-5" t-out="record.suggested_qty.raw_value or 0" name="kanban_purchase_suggest_qty" />
-                    <span class="text-info fw-bold fs-5"> units </span>
+                    <span class="text-info fw-bold fs-5 me-1">Suggest</span>
+                    <span class="text-info fw-bold fs-5 me-1" t-out="record.suggested_qty.raw_value or 0" name="kanban_purchase_suggest_qty" />
+                    <span class="text-info fw-bold fs-5 me-1">units</span>
                 </div>
             </div>
         </field>
@@ -45,10 +45,11 @@
         <field name="inherit_id" ref="purchase.product_view_search_catalog"/>
         <field name="arch" type="xml">
             <xpath expr="//filter[@name='products_in_purchase_order']" position="after">
+                <filter string="Suggested" name="suggested" domain="[('suggested_qty', '!=', 0)]"/>
                 <separator/>
                 <filter string="To Order" name="products_with_negative_forecast" domain="[('virtual_available', '&lt;', 0)]"/>
+                <separator/>
             </xpath>
         </field>
     </record>
-
 </odoo>

--- a/addons/sale_stock/static/src/product_catalog/kanban_record.js
+++ b/addons/sale_stock/static/src/product_catalog/kanban_record.js
@@ -5,7 +5,7 @@ import { patch } from "@web/core/utils/patch";
 patch(ProductCatalogKanbanRecord.prototype, {
     updateQuantity(quantity) {
         if (this.env.orderResModel !== "sale.order" || this.productCatalogData.productType == "service") {
-            super.updateQuantity(...arguments);
+            return super.updateQuantity(...arguments);
         } else if (
             this.productCatalogData.quantity === this.productCatalogData.deliveredQty &&
             quantity < this.productCatalogData.quantity
@@ -16,7 +16,7 @@ patch(ProductCatalogKanbanRecord.prototype, {
             this.props.record.load();
             this.props.record.model.notify();
         } else {
-            super.updateQuantity(Math.max(quantity, this.productCatalogData.deliveredQty));
+            return super.updateQuantity(Math.max(quantity, this.productCatalogData.deliveredQty));
         }
     },
 

--- a/addons/stock/static/tests/tours/tour_helper.js
+++ b/addons/stock/static/tests/tours/tour_helper.js
@@ -7,3 +7,14 @@ export function assert(current, expected, info) {
         fail(`${info}: "${current}" instead of "${expected}".`);
     }
 }
+
+export function freezeDateTime(date, format = "yyyy-MM-dd HH:mm:ss") {
+    return [
+        {
+            trigger: "body",
+            run: () => {
+                luxon.DateTime.now = () => luxon.DateTime.fromFormat(date, format);
+            },
+        },
+    ];
+}

--- a/addons/stock/utils.py
+++ b/addons/stock/utils.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+from dateutil.relativedelta import relativedelta
+
+
+def get_based_on_date_range(based_on):
+    start_date = limit_date = datetime.now()
+    if not based_on or based_on == 'actual_demand' or based_on == '30_days':
+        start_date = start_date - relativedelta(days=30)  # Default monthly demand
+    elif based_on == 'one_week':
+        start_date = start_date - relativedelta(weeks=1)
+    elif based_on == 'three_months':
+        start_date = start_date - relativedelta(months=3)
+    elif based_on == 'one_year':
+        start_date = start_date - relativedelta(years=1)
+    else:  # Relative period of time.
+        today = datetime.now()
+        start_date = datetime(year=today.year - 1, month=today.month, day=1)
+
+        if based_on == 'last_year_m_plus_1':
+            start_date += relativedelta(months=1)
+        elif based_on == 'last_year_m_plus_2':
+            start_date += relativedelta(months=2)
+
+        if based_on == 'last_year_quarter':
+            limit_date = start_date + relativedelta(months=3)
+        else:
+            limit_date = start_date + relativedelta(months=1)
+
+    return {
+        "suggest_based_on": based_on,
+        "monthly_demand_start": start_date,
+        "monthly_demand_limit": limit_date,
+    }


### PR DESCRIPTION
Modules modified: product, account, purchase_stock, sale_stock, stock, 

Filters the purchase product catalog, on suggestion activation (via the toggle), with products which have suggested qty > 0 or are in the purchase order (2 separate filters in the same section acting as OR). Also improve performance and code (listed below). 

WHY: Filtering ensures all suggested product are in the front of catalog when nb of products > Pager limit.
BEFORE: Suggested products moved to the top of Kanban on client only (didn't work if nb products > Pager limit).
NOW: Only suggested products showed on filter activation (removing filter manually will behave as BEFORE).  

IMPROVEMENTS: 
- Reordering Kanban done in an OnRendered hook, abstracting it from the model reload logic. 
- Add a non-debounced version of the KanbanReload for programmatic reload saving 300ms (debounced time). 
- Removed the duplication of server calls on filter updates + fix the search panel categories fetching (by passing the context to the search model and making sure filter toggles apply all at once)

REFACTORS: 
- Changes compute_monthly_demand from string based context to data based context.

FEATURE / UI Changes: 
- Adds new suggest filter that is a OR in the order or suggested on suggest toggle

task [#4783508](https://www.odoo.com/odoo/project/966/tasks/4783508)
previous PR: https://github.com/odoo/odoo/pull/226620

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
