### PR TITLE
[IMP] mail: html composer triggers typing status

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -293,6 +293,7 @@ export class Composer extends Component {
             Plugins: this.ui.isSmall ? MAIL_SMALL_UI_PLUGINS : MAIL_PLUGINS,
             composerPluginDependencies: {
                 onKeydown: this.onKeydown.bind(this),
+                onInput: this.onInput.bind(this),
             },
             classList: ["o-mail-Composer-html"],
             onChange: () => this.onChangeWysiwygContent(),

--- a/addons/mail/static/src/core/common/plugin/mail_composer_plugin.js
+++ b/addons/mail/static/src/core/common/plugin/mail_composer_plugin.js
@@ -6,7 +6,7 @@ import { withSequence } from "@html_editor/utils/resource";
 
 export class MailComposerPlugin extends Plugin {
     static id = "mail.composer";
-    static dependencies = ["hint", "selection"];
+    static dependencies = ["hint", "input", "selection"];
     resources = {
         hints: [
             withSequence(1, {
@@ -27,6 +27,7 @@ export class MailComposerPlugin extends Plugin {
                 return [];
             }
         },
+        input_handlers: this.config.composerPluginDependencies.onInput.bind(this),
     };
 
     setup() {


### PR DESCRIPTION
This commit ensures that the HTML composer correctly triggers the typing status for users when they are typing in the composer by correctly binding the input handler to the composer.

task-5068561



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
