### PR TITLE
[FIX] server.py: prevent thread error due to missing comma

### DIFF
--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -249,8 +249,8 @@ class ThreadedWSGIServerReloadable(LoggingBaseWSGIServerMixIn, werkzeug.serving.
         to be able to get the thread object which is instantiated
         and set its start time as an attribute
         """
-        t = threading.Thread(target = self.process_request_thread,
-                             args = (request, client_address))
+        t = threading.Thread(target=self.process_request_thread,
+                             args=(request, client_address,))  # noqa: COM819
         t.daemon = self.daemon_threads
         t.type = 'http'
         t.start_time = time.time()


### PR DESCRIPTION
From the references([Reference 1],[Reference 2])issue occurred because
arguments were passed without a trailing comma, which caused a string
to be interpreted as multiple positional arguments instead of a tuple.
This resulted in a error during thread initialization.

Adding the missing comma ensures arguments are correctly passed as a tuple.

Error:-
`ImDispatch.run() takes 1 positional argument but **Y** were given`

[Reference 1]: https://stackoverflow.com/questions/37116721/typeerror-in-threading-function-takes-x-positional-argument-but-y-were-given
[Reference 2]: https://stackoverflow.com/questions/69657746/a-function-takes-1-positional-argument-but-133-were-given

**sentry-3928947199**