### PR TITLE
[FIX] l10n_be,purchase_edi_ubl_bis3: use reserved domain

### DIFF
--- a/addons/l10n_be/demo/demo_company.xml
+++ b/addons/l10n_be/demo/demo_company.xml
@@ -8,8 +8,8 @@
         <field name="country_id" ref="base.be"/>
         <field name="zip">2660</field>
         <field name="phone">+32 470 12 34 56</field>
-        <field name="email">info@company.beexample.com</field>
-        <field name="website">www.beexample.com</field>
+        <field name="email">becompany@example.com</field>
+        <field name="website">www.becompany.example.com</field>
         <field name="is_company" eval="True"/>
     </record>
 

--- a/addons/purchase_edi_ubl_bis3/tests/test_files/ubl_bis3_PO.xml
+++ b/addons/purchase_edi_ubl_bis3/tests/test_files/ubl_bis3_PO.xml
@@ -37,7 +37,7 @@
       <cac:Contact>
         <cbc:Name>BE Company CoA</cbc:Name>
         <cbc:Telephone>+32 470 12 34 56</cbc:Telephone>
-        <cbc:ElectronicMail>info@company.beexample.com</cbc:ElectronicMail>
+        <cbc:ElectronicMail>becompany@example.com</cbc:ElectronicMail>
       </cac:Contact>
     </cac:Party>
   </cac:AccountingSupplierParty>

--- a/addons/purchase_edi_ubl_bis3/tests/test_files/ubl_bis3_PO_description.xml
+++ b/addons/purchase_edi_ubl_bis3/tests/test_files/ubl_bis3_PO_description.xml
@@ -34,7 +34,7 @@
       <cac:Contact>
         <cbc:Name>BE Company CoA</cbc:Name>
         <cbc:Telephone>+32 470 12 34 56</cbc:Telephone>
-        <cbc:ElectronicMail>info@company.beexample.com</cbc:ElectronicMail>
+        <cbc:ElectronicMail>becompany@example.com</cbc:ElectronicMail>
       </cac:Contact>
     </cac:Party>
   </cac:AccountingSupplierParty>


### PR DESCRIPTION
`beexample.com` is not a reserved domain, anybody could buy it. Let's switch to the more regular `example.com` domain to avoid misuses.

task-none
