### PR TITLE
[FIX] base: backport session existence check mechanism

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -978,6 +978,28 @@ class FilesystemSessionStore(sessions.FilesystemSessionStore):
     def is_valid_key(self, key):
         return _base64_urlsafe_re.match(key) is not None
 
+    def get_missing_session_identifiers(self, identifiers):
+        """
+            :param identifiers: session identifiers whose file existence must be checked
+                                identifiers are a part session sid (first 42 chars)
+            :type identifiers: iterable
+            :return: the identifiers which are not present on the filesystem
+            :rtype: set
+        """
+        # There are a lot of session files.
+        # Use the param ``identifiers`` to select the necessary directories.
+        # In the worst case, we have 4096 directories (64^2).
+        identifiers = set(identifiers)
+        directories = {
+            os.path.normpath(os.path.join(self.path, identifier[:2]))
+            for identifier in identifiers
+        }
+        # Remove the identifiers for which a file is present on the filesystem.
+        for directory in directories:
+            with contextlib.suppress(OSError), os.scandir(directory) as session_files:
+                identifiers.difference_update(sf.name[:42] for sf in session_files)
+        return identifiers
+
     def delete_from_identifiers(self, identifiers):
         files_to_unlink = []
         for identifier in identifiers:


### PR DESCRIPTION
The commit: https://github.com/odoo/odoo/commit/6fb676a4e3566c781ddd57480a200cddc88d99ae adds the model `res.device.log` which will hold a lot of data.

In order to use this data efficiently, we decide to process data with the boolean field `revoked` equal to `True` (via the indexes).

This boolean field indicates whether the session that generated the log is still present on the disk.

The commit: https://github.com/odoo/odoo/commit/e4c9d1794f2d4873755a8692f4861ba043fac943 adds an automatic verification mechanism to change this value if necessary.

Between the time the model was created and the time the verification mechanism was implemented, the table may have become too large. This will result in a very long write within a transaction.

The purpose of this commit is to introduce a method for performing the batch writing.