### PR TITLE
[FIX] hr_attendance: do not pass token prop to BarcodeDialog

### DIFF
--- a/addons/hr_attendance/__manifest__.py
+++ b/addons/hr_attendance/__manifest__.py
@@ -41,6 +41,9 @@ actions(Check in/Check out) performed by them.
         'web.qunit_suite_tests': [
             'hr_attendance/static/tests/hr_attendance_mock_server.js',
         ],
+        'web.assets_unit_tests': [
+            'hr_attendance/static/tests/*.test.js',
+        ],
         'web.qunit_mobile_suite_tests': [
             'hr_attendance/static/tests/hr_attendance_mock_server.js',
         ],

--- a/addons/hr_attendance/static/src/components/kiosk_barcode/kiosk_barcode.js
+++ b/addons/hr_attendance/static/src/components/kiosk_barcode/kiosk_barcode.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
 import { BarcodeScanner } from "@barcodes/components/barcode_scanner";
-import { BarcodeDialog } from '@web/core/barcode/barcode_dialog';
+import { scanBarcode } from "@web/core/barcode/barcode_dialog";
 import { isDisplayStandalone } from "@web/core/browser/feature_detection";
 
 export class KioskBarcodeScanner extends BarcodeScanner {
@@ -14,7 +14,7 @@ export class KioskBarcodeScanner extends BarcodeScanner {
     setup() {
         super.setup();
         this.isDisplayStandalone = isDisplayStandalone();
-        this.scanBarcode = () => scanBarcode(this.env, this.facingMode, this.props.token);
+        this.scanBarcode = () => scanBarcode(this.env, this.facingMode);
     }
 
     get facingMode() {
@@ -28,25 +28,4 @@ export class KioskBarcodeScanner extends BarcodeScanner {
         const url = `hr_attendance/${this.props.token}`;
         return `/scoped_app?app_id=hr_attendance&path=${encodeURIComponent(url)}`;
     }
-}
-
-/**
- * Opens the BarcodeScanning dialog and begins code detection using the device's camera.
- *
- * @returns {Promise<string>} resolves when a {qr,bar}code has been detected
- */
-export async function scanBarcode(env, facingMode = "environment", token) {
-    let res;
-    let rej;
-    const promise = new Promise((resolve, reject) => {
-        res = resolve;
-        rej = reject;
-    });
-    env.services.dialog.add(BarcodeDialog, {
-        facingMode,
-        token: token,
-        onResult: (result) => res(result),
-        onError: (error) => rej(error),
-    });
-    return promise;
 }

--- a/addons/hr_attendance/static/tests/hr_attendance_kiosk_barcode_scanner.test.js
+++ b/addons/hr_attendance/static/tests/hr_attendance_kiosk_barcode_scanner.test.js
@@ -1,0 +1,33 @@
+import { expect, test } from "@odoo/hoot";
+import { waitFor } from "@odoo/hoot-dom";
+import { Deferred } from "@odoo/hoot-mock";
+import { KioskBarcodeScanner } from "@hr_attendance/components/kiosk_barcode/kiosk_barcode";
+import { contains, mountWithCleanup, patchWithCleanup } from "@web/../tests/web_test_helpers";
+import { defineMailModels, mockGetMedia } from "@mail/../tests/mail_test_helpers";
+
+defineMailModels();
+
+test.tags("desktop");
+test("KioskBarcodeScanner can be opened and closed", async () => {
+
+    mockGetMedia();
+    const isBarcodeScannerOpened = new Deferred();
+    patchWithCleanup(KioskBarcodeScanner.prototype, {
+        setup() {
+            super.setup();
+            isBarcodeScannerOpened.resolve(true);
+        },
+    });
+
+    await mountWithCleanup(KioskBarcodeScanner, {
+        props: {
+            token: crypto.randomUUID(),
+            barcodeSource: "environment",
+            onBarcodeScanned: () => {},
+        },
+    });
+    await contains("button.o_mobile_barcode").click();
+    await waitFor(".modal-body video");
+    await contains(`.oi-arrow-left`).click();
+    expect(await isBarcodeScannerOpened).toBe(true);
+});


### PR DESCRIPTION
**Step to reproduce:**
- install Attendances app
- turn on debug mode
- go to Attendance -> kiosk mode
- open the scanner

**Observation:**
- We get a traceback

**Cause:**
-  we pass a extra prop `token` to BarcodeDialog component, which is not accepted by it
https://github.com/odoo/odoo/blob/178dff30131a93680dfd994fd22b29a766ee9354/addons/web/static/src/core/barcode/barcode_dialog.js#L12
- this raises issue from OWL when we have debug-mode on

**Fix:**
- reuse the actual `scanBarcode` method and remove the faulty one.
https://github.com/odoo/odoo/blob/178dff30131a93680dfd994fd22b29a766ee9354/addons/web/static/src/core/barcode/barcode_dialog.js#L47-L60

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
