### PR TITLE
[FIX] website_sale,sale: align product configurator buttons & total on mobile

### DIFF
--- a/addons/sale/static/src/js/product_configurator_dialog/product_configurator_dialog.xml
+++ b/addons/sale/static/src/js/product_configurator_dialog/product_configurator_dialog.xml
@@ -10,20 +10,20 @@
             <t t-set-slot="footer">
                 <button
                     name="sale_product_configurator_confirm_button"
-                    class="btn btn-primary"
+                    class="btn btn-primary order-2 order-md-1"
                     t-on-click="onConfirm"
                     t-att-disabled="!isPossibleConfiguration()">
                     Confirm
                 </button>
                 <button
                     name="sale_product_configurator_cancel_button"
-                    class="btn btn-secondary"
+                    class="btn btn-secondary order-2 order-md-1"
                     t-on-click="onDiscard"
                 >
                     Cancel
                 </button>
                 <h6
-                    class="o_configurator_price_total d-none d-sm-inline-block ms-3 mb-0 mt-0"
+                    class="o_configurator_price_total order-1 order-md-2 d-block d-sm-inline-block w-100 w-md-auto text-end ms-md-3 mb-0"
                     name="sale_product_configurator_list_total"
                 >
                     <t t-out="totalMessage"/>

--- a/addons/website_sale/static/src/js/product_configurator_dialog/product_configurator_dialog.xml
+++ b/addons/website_sale/static/src/js/product_configurator_dialog/product_configurator_dialog.xml
@@ -8,15 +8,22 @@
             <attribute name="class" remove="btn-secondary" add="btn-light" separator=" "/>
             <attribute name="t-if">!showShopButtons()</attribute>
         </button>
+        <h6 name="sale_product_configurator_list_total" position="attributes">
+            <attribute
+                name="class"
+                add="order-1 order-md-2 w-100 text-end d-sm-inline-block ms-md-3 mb-0"
+                remove="d-none mt-0"
+            />
+        </h6>
         <button name="sale_product_configurator_cancel_button" position="after">
             <div
                 t-if="showShopButtons()"
-                class="d-flex flex-column flex-sm-row align-items-center gap-2"
+                class="d-flex flex-column flex-md-row align-items-center gap-2 order-2 order-md-1 w-100 w-md-auto"
             >
                 <button
                     t-if="!this.props.options.isBuyNow"
                     name="website_sale_product_configurator_continue_button"
-                    class="btn btn-primary w-100 w-sm-auto flex-shrink-0 flex-grow-0"
+                    class="btn btn-primary w-100"
                     t-on-click="() => this.onConfirm({goToCart: false})"
                     t-att-disabled="!isPossibleConfiguration() || !canBeSold()"
                 >
@@ -25,14 +32,13 @@
                 </button>
                 <button
                     name="website_sale_product_configurator_checkout_button"
-                    class="btn btn-outline-primary w-100 w-sm-auto flex-shrink-0 flex-grow-0"
+                    class="btn btn-outline-primary text-nowrap w-100"
                     t-on-click="() => this.onConfirm({goToCart: true})"
                     t-att-disabled="!isPossibleConfiguration() || !canBeSold()"
                 >
                     Go to Checkout
                     <i class="fa fa-angle-right ms-2"/>
                 </button>
-
             </div>
         </button>
     </t>


### PR DESCRIPTION
Description : 
This fixes the mobile misalignment without affecting the desktop view.
Before this commit:
- On mobile, the `Total`was hidden due to `d-none d-sm-inline-block`.
- The `Add to cart` and `Go to Checkout`  buttons are stacked unevenly.
- Desktop looked correct, but the mobile footer was broken.

After this commit:
- Desktop layout remains unchanged.
- On mobile:
  • `Total` is visible on its own line, right-aligned.
  • `Add to cart` and `Go to Checkout` buttons appear with equal width.

opw-5068627

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
