### PR TITLE
[FIX] point_of_sale: make receipt web printing fallback non blocking

### DIFF
--- a/addons/pos_online_payment_self_order/static/src/overrides/services/pos_store.js
+++ b/addons/pos_online_payment_self_order/static/src/overrides/services/pos_store.js
@@ -37,8 +37,8 @@ patch(PosStore.prototype, {
                 orderId,
             ]);
             const order = result["pos.order"][0];
-            await this.printReceipt({ order });
             await this.sendOrderInPreparation(order, { bypassPdis: true });
+            await this.printReceipt({ order });
         } catch {
             logPosMessage(
                 "Store",


### PR DESCRIPTION
Steps to reproduce:
-------------------
1. Enable self orderdering, and set an online payment method
2. Open 3 tabs: the main PoS one, the self order one, and the preparation display one (we have to setup the prep display too)
3. In the self order tab, make an order and pay for it

Observe that in the main tab, a receipt modal (window.print) appears, and the order is not sent to the payment display (on the third tab) until we either dismiss or accept the printing popup on the main tab.

Reason:
-------
If there is no printing device connected, we fallback to printing the receipt with `window.print`; this operation blocks the execution of the code that follows it, in our case sending the order to the preparation display, until we either dismiss or confirm the printing popup.

Now if the user is not paying attention to the main tab (only looking at the preparation display for instance), the order will not appear in the prep display.

Fix:
----
In the case of fallbacking to web printing, we execute the print in a `setTimeout`, so to not block the code that comes after it.

opw-5039685