### PR TITLE
[FIX] point_of_sale: ensure logo is displayed on receipt

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_config.js
+++ b/addons/point_of_sale/static/src/app/models/pos_config.js
@@ -1,5 +1,9 @@
 import { registry } from "@web/core/registry";
+import { imageUrl } from "@web/core/utils/urls";
 import { Base } from "./related_models";
+import { getImageDataUrl } from "@point_of_sale/utils";
+import { logPosMessage } from "../utils/pretty_console_log";
+const CONSOLE_COLOR = "#F5B427";
 
 export class PosConfig extends Base {
     static pythonModel = "pos.config";
@@ -51,6 +55,31 @@ export class PosConfig extends Base {
 
     get displayTrackingNumber() {
         return this.module_pos_restaurant;
+    }
+
+    async cacheReceiptLogo() {
+        try {
+            this.uiState.receiptLogoDataUrl = await getImageDataUrl(this.receiptCompanyLogoUrl);
+        } catch (error) {
+            logPosMessage(
+                "PosConfig",
+                "cacheReceiptLogo",
+                "Error while caching receipt logo",
+                CONSOLE_COLOR,
+                [error]
+            );
+        }
+    }
+
+    get receiptLogoUrl() {
+        return this.uiState.receiptLogoDataUrl || this.receiptCompanyLogoUrl;
+    }
+
+    get receiptCompanyLogoUrl() {
+        return imageUrl("res.company", this.company_id.id, "logo", {
+            width: 256,
+            height: 256,
+        });
     }
 }
 

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.js
@@ -10,6 +10,10 @@ export class ReceiptHeader extends Component {
         return this.props.order;
     }
 
+    get logoUrl() {
+        return this.order.config.receiptLogoUrl;
+    }
+
     get partnerAddress() {
         return this.order.partner_id.pos_contact_address
             .split("\n")

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="point_of_sale.ReceiptHeader">
-        <img t-attf-src="/web/image?model=res.company&amp;id={{order.company.id}}&amp;field=logo" alt="Logo" class="pos-receipt-logo"/>
+        <img t-att-src="logoUrl" alt="Logo" class="pos-receipt-logo"/>
         <div class="text-center pt-3" style="font-size: 75%;">
             <span class="pos-receipt-vat">
                 <t t-if="order.config._IS_VAT"> VAT </t>

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
@@ -80,11 +80,12 @@ export class ReceiptScreen extends Component {
         this.pos.showScreen(this.nextScreen);
     }
 
-    generateTicketImage = async () =>
+    generateTicketImage = async (basicReceipt = false) =>
         await this.renderer.toJpeg(
             OrderReceipt,
             {
                 order: this.pos.getOrder(),
+                basic_receipt: basicReceipt,
             },
             { addClass: "pos-receipt-print p-3" }
         );
@@ -100,12 +101,14 @@ export class ReceiptScreen extends Component {
             return Promise.reject();
         }
         const fullTicketImage = await this.generateTicketImage();
-        const basicTicketImage = await this.generateTicketImage(true);
+        const basicTicketImage = this.pos.config.basic_receipt
+            ? await this.generateTicketImage(true)
+            : null;
         await this.pos.data.call("pos.order", action, [
             [order.id],
             destination,
             fullTicketImage,
-            this.pos.config.basic_receipt ? basicTicketImage : null,
+            basicTicketImage,
         ]);
     }
 }

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -379,6 +379,7 @@ export class PosStore extends WithLazyGetterTrap {
         });
 
         await this.processProductAttributes();
+        await this.config.cacheReceiptLogo();
     }
     cashMove() {
         this.hardwareProxy.openCashbox(_t("Cash in / out"));

--- a/addons/point_of_sale/static/src/utils.js
+++ b/addons/point_of_sale/static/src/utils.js
@@ -1,5 +1,5 @@
 import { session } from "@web/session";
-
+import { getDataURLFromFile } from "@web/core/utils/urls";
 /*
  * comes from o_spreadsheet.js
  * https://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript
@@ -174,3 +174,9 @@ export function isValidEmail(email) {
 }
 
 export const LONG_PRESS_DURATION = session.test_mode ? 100 : 1000;
+
+export async function getImageDataUrl(imageUrl) {
+    const res = await fetch(imageUrl);
+    const blob = await res.blob();
+    return await getDataURLFromFile(blob);
+}

--- a/addons/point_of_sale/static/tests/unit/services/pos_service.test.js
+++ b/addons/point_of_sale/static/tests/unit/services/pos_service.test.js
@@ -2,6 +2,8 @@ import { test, expect, describe } from "@odoo/hoot";
 import { getFilledOrder, setupPosEnv } from "../utils";
 import { definePosModels } from "../data/generate_model_definitions";
 import { ConnectionLostError } from "@web/core/network/rpc";
+import { onRpc } from "@web/../tests/web_test_helpers";
+import { imageUrl } from "@web/core/utils/urls";
 
 definePosModels();
 
@@ -321,5 +323,52 @@ describe("pos_store.js", () => {
         screen = store.mainScreen.component.name;
         expect(screen).toBe("ProductScreen");
         expect(store.previousScreen).toBe("LoginScreen");
+    });
+
+    describe("cacheReceiptLogo", () => {
+        function getCompanyLogo256Url(companyId) {
+            const fullUrl = imageUrl("res.company", companyId, "logo", {
+                width: 256,
+                height: 256,
+            });
+            const index = fullUrl.indexOf("/web");
+            return fullUrl.substring(index);
+        }
+
+        test("correctly cached", async () => {
+            onRpc(
+                getCompanyLogo256Url("<int:id>"),
+                async (request, { id }) => {
+                    expect.step(`Company logo ${id} fetched`);
+                    return `Company logo ${id}`;
+                },
+                {
+                    pure: true,
+                }
+            );
+            const store = await setupPosEnv();
+            const companyId = store.company.id;
+            expect.verifySteps([`Company logo ${companyId} fetched`]);
+            const { receiptLogoUrl } = store.config;
+            expect(receiptLogoUrl).toInclude("data:");
+            expect(atob(receiptLogoUrl.split(",")[1])).toInclude(`Company logo ${companyId}`);
+        });
+
+        test("fetch failed", async () => {
+            onRpc(
+                getCompanyLogo256Url("<int:id>"),
+                async (request, { id }) => {
+                    expect.step(`Company logo ${id} fetched`);
+                    throw new Error("Fetch failed");
+                },
+                {
+                    pure: true,
+                }
+            );
+            const store = await setupPosEnv();
+            const companyId = store.company.id;
+            expect.verifySteps([`Company logo ${companyId} fetched`]);
+            expect(store.config.receiptLogoUrl).toInclude(getCompanyLogo256Url(companyId));
+        });
     });
 });

--- a/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
+++ b/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
@@ -138,11 +138,12 @@ export class CartPage extends Component {
         }
     }
 
-    generateTicketImage = async () =>
+    generateTicketImage = async (basicReceipt = false) =>
         await this.renderer.toJpeg(
             OrderReceipt,
             {
                 order: this.selfOrder.currentOrder,
+                basic_receipt: basicReceipt,
             },
             { addClass: "pos-receipt-print p-3" }
         );
@@ -150,13 +151,15 @@ export class CartPage extends Component {
     async _sendReceiptToCustomer({ action, destination, mail_template_id }) {
         const order = this.selfOrder.currentOrder;
         const fullTicketImage = await this.generateTicketImage();
-        const basicTicketImage = await this.generateTicketImage(true);
+        const basicTicketImage = this.selfOrder.config.basic_receipt
+            ? await this.generateTicketImage(true)
+            : null;
         await this.selfOrder.data.call("pos.order", action, [
             [order.id],
             destination,
             mail_template_id,
             fullTicketImage,
-            this.selfOrder.config.basic_receipt ? basicTicketImage : null,
+            basicTicketImage,
         ]);
     }
 

--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -68,7 +68,7 @@ export class SelfOrder extends Reactive {
 
         this.initData();
         if (this.config.self_ordering_mode === "kiosk") {
-            this.initKioskData();
+            await this.initKioskData();
         } else {
             await this.initMobileData();
         }
@@ -505,10 +505,12 @@ export class SelfOrder extends Reactive {
             }
         }
     }
-    initKioskData() {
+    async initKioskData() {
         if (this.session && this.access_token) {
             this.ordering = true;
         }
+
+        await this.config.cacheReceiptLogo();
 
         window.addEventListener("click", (event) => {
             clearTimeout(this.idleTimout);


### PR DESCRIPTION
Some clients reported that the company logo was not displayed on receipts. This issue was reproducible when using iOS with a large logo file, and in some cases when the browser cache was disabled. This commit addresses the issue by:
- Using the image_256 version of the company logo to fix rendering on iOS.
- Storing the logo as data url to avoid repeated URL requests and cache-related issues.

Task-5055910

Sample company logo causing issue 

[logo.zip](https://github.com/user-attachments/files/22251877/logo.zip)

