### PR TITLE
[IMP] mail: html composer handling paste

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -292,8 +292,9 @@ export class Composer extends Component {
             placeholder: this.placeholder,
             Plugins: this.ui.isSmall ? MAIL_SMALL_UI_PLUGINS : MAIL_PLUGINS,
             composerPluginDependencies: {
-                onKeydown: this.onKeydown.bind(this),
+                onBeforePaste: (selection, ev) => this.onPaste(ev),
                 onInput: this.onInput.bind(this),
+                onKeydown: this.onKeydown.bind(this),
             },
             classList: ["o-mail-Composer-html"],
             onChange: () => this.onChangeWysiwygContent(),

--- a/addons/mail/static/src/core/common/plugin/mail_composer_plugin.js
+++ b/addons/mail/static/src/core/common/plugin/mail_composer_plugin.js
@@ -6,8 +6,10 @@ import { withSequence } from "@html_editor/utils/resource";
 
 export class MailComposerPlugin extends Plugin {
     static id = "mail.composer";
-    static dependencies = ["hint", "input", "selection"];
+    static dependencies = ["clipboard", "hint", "input", "selection"];
     resources = {
+        before_paste_handlers: this.config.composerPluginDependencies.onBeforePaste.bind(this),
+        bypass_paste_image_files: () => true,
         hints: [
             withSequence(1, {
                 selector: `.odoo-editor-editable > ${baseContainerGlobalSelector}:only-child`,

--- a/addons/mail/static/tests/composer/composer.test.js
+++ b/addons/mail/static/tests/composer/composer.test.js
@@ -918,7 +918,7 @@ test("remove an attachment from composer does not need any confirmation", async 
     await contains(".o-mail-AttachmentList .o-mail-AttachmentContainer", { count: 0 });
 });
 
-test("composer: paste attachments", async () => {
+test("[text composer] composer: paste attachments", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "test" });
     const text = new File(["hello, world"], "text.txt", { type: "text/plain" });
@@ -927,6 +927,23 @@ test("composer: paste attachments", async () => {
     await contains(".o-mail-Composer-input");
     await contains(".o-mail-AttachmentList .o-mail-AttachmentContainer", { count: 0 });
     await pasteFiles(".o-mail-Composer-input", [text]);
+    await contains(
+        ".o-mail-AttachmentList .o-mail-AttachmentContainer:not(.o-isUploading):contains(text.txt)"
+    );
+});
+
+test.tags("html composer");
+test("composer: paste attachments", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "test" });
+    const text = new File(["hello, world"], "text.txt", { type: "text/plain" });
+    await start();
+    const composerService = getService("mail.composer");
+    composerService.setHtmlComposer();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Composer-html.odoo-editor-editable");
+    await contains(".o-mail-AttachmentList .o-mail-AttachmentContainer", { count: 0 });
+    await pasteFiles(".o-mail-Composer-html.odoo-editor-editable", [text]);
     await contains(
         ".o-mail-AttachmentList .o-mail-AttachmentContainer:not(.o-isUploading):contains(text.txt)"
     );

--- a/addons/mail/static/tests/mail_test_helpers_contains.js
+++ b/addons/mail/static/tests/mail_test_helpers_contains.js
@@ -324,6 +324,7 @@ function createFakeDataTransfer(files) {
         effectAllowed: "all",
         files,
         items: [],
+        getData: () => "",
         types: ["Files"],
     };
 }


### PR DESCRIPTION
This commit allows for better handling of pasted content in the HTML composer, including images and other media.
Note that images will not be pasted in the composer but as attachments.

task-5068729

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
