### PR TITLE
[FIX] hr_timesheet, hr_timesheet_attendance: "Today" filters' TZ issues

### DIFF
--- a/addons/hr_timesheet/views/hr_timesheet_views.xml
+++ b/addons/hr_timesheet/views/hr_timesheet_views.xml
@@ -214,16 +214,16 @@
                 </xpath>
                 <filter name="month" position="inside">
                     <filter name="date_this_week" string="This Week" domain="[
-                        ('date', '&gt;=', (datetime.datetime.combine(context_today() + relativedelta(weeks=-1,days=1,weekday=0), datetime.time(0,0,0)).to_utc())),
-                        ('date', '&lt;', (datetime.datetime.combine(context_today() + relativedelta(days=1,weekday=0), datetime.time(0,0,0)).to_utc())),
+                        ('date', '&gt;=', context_today() + relativedelta(weeks=-1,days=1,weekday=0)),
+                        ('date', '&lt;', context_today() + relativedelta(days=1,weekday=0)),
                     ]"/>
                     <filter name="date_today" string="Today" domain="[
-                        ('date', '&gt;=', datetime.datetime.combine(context_today(), datetime.time(0, 0, 0)).to_utc()),
-                        ('date', '&lt;', datetime.datetime.combine(context_today() + relativedelta(days=1), datetime.time(0, 0, 0)).to_utc())
+                        ('date', '&gt;=', context_today()),
+                        ('date', '&lt;', context_today() + relativedelta(days=1)),
                     ]"/>
                     <filter name="date_last_week" string="Last Week" domain="[
-                        ('date', '&gt;=', (datetime.datetime.combine(context_today() + relativedelta(weeks=-2,days=1,weekday=0), datetime.time(0,0,0)).to_utc())),
-                        ('date', '&lt;', (datetime.datetime.combine(context_today() + relativedelta(weeks=-1,days=1,weekday=0), datetime.time(0,0,0)).to_utc())),
+                        ('date', '&gt;=', context_today() + relativedelta(weeks=-2,days=1,weekday=0)),
+                        ('date', '&lt;', context_today() + relativedelta(weeks=-1,days=1,weekday=0)),
                     ]"/>
                 </filter>
                 <xpath expr="//group[@name='groupby']" position="before">

--- a/addons/hr_timesheet_attendance/report/hr_timesheet_attendance_report_view.xml
+++ b/addons/hr_timesheet_attendance/report/hr_timesheet_attendance_report_view.xml
@@ -12,16 +12,16 @@
                     <separator/>
                     <filter name="month" string="Date" date="date">
                         <filter name="date_this_week" string="This Week" domain="[
-                            ('date', '&gt;=', (datetime.datetime.combine(context_today() + relativedelta(weeks=-1,days=1,weekday=0), datetime.time(0,0,0)).to_utc())),
-                            ('date', '&lt;', (datetime.datetime.combine(context_today() + relativedelta(days=1,weekday=0), datetime.time(0,0,0)).to_utc())),
+                            ('date', '&gt;=', context_today() + relativedelta(weeks=-1,days=1,weekday=0)),
+                            ('date', '&lt;', context_today() + relativedelta(days=1,weekday=0)),
                         ]"/>
                         <filter name="date_today" string="Today" domain="[
-                            ('date', '&gt;=', datetime.datetime.combine(context_today(), datetime.time(0, 0, 0)).to_utc()),
-                            ('date', '&lt;', datetime.datetime.combine(context_today() + relativedelta(days=1), datetime.time(0, 0, 0)).to_utc())
+                            ('date', '&gt;=', context_today()),
+                            ('date', '&lt;', context_today() + relativedelta(days=1)),
                         ]"/>
                         <filter name="date_last_week" string="Last Week" domain="[
-                            ('date', '&gt;=', (datetime.datetime.combine(context_today() + relativedelta(weeks=-2,days=1,weekday=0), datetime.time(0,0,0)).to_utc())),
-                            ('date', '&lt;', (datetime.datetime.combine(context_today() + relativedelta(weeks=-1,days=1,weekday=0), datetime.time(0,0,0)).to_utc())),
+                            ('date', '&gt;=', context_today() + relativedelta(weeks=-2,days=1,weekday=0)),
+                            ('date', '&lt;', context_today() + relativedelta(weeks=-1,days=1,weekday=0)),
                         ]"/>
                     </filter>
                     <filter name="group_by_user" string="Employee" context="{'group_by': 'employee_id'}"/>


### PR DESCRIPTION
This commit fixes issues with the timesheet Date filters, in which the `date` field of account.analytic.line records, which is stored as the local timezone's date, is being compared to a UTC DateTime value. This leads to off-by-one errors. For example, if you are in Berlin and try to filter for all timesheet entries from "Today", you will only find entries from the previous day. Similarly, for the "This Week" and "Last Week" filters, which would be shifted by one day.

The filter domains have been changed to compare the `date` to the local timezone's "today".

opw-5003310