### PR TITLE
[FIX] account: allow forcing a move on payment creation

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -849,7 +849,7 @@ class AccountPayment(models.Model):
         accounting_installed = self.env['account.move']._get_invoice_in_payment_state() == 'in_payment'
 
         for i, (pay, vals) in enumerate(zip(payments, vals_list)):
-            if not accounting_installed and not pay.outstanding_account_id:
+            if (not accounting_installed and not pay.outstanding_account_id) or self.env.context.get('force_payment_move'):
                 outstanding_account = pay._get_outstanding_account(pay.payment_type)
                 pay.outstanding_account_id = outstanding_account.id
 

--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -248,6 +248,12 @@ class AccountPayment(models.Model):
             self.outstanding_account_id
         )
 
+    def _valid_payment_states(self):
+        """ This method is used to know in which edition we are: Community or Enterprise
+            and fetch the payment states accordingly.
+        """
+        return ['in_process', 'paid'] if self.env['account.move']._get_invoice_in_payment_state() == 'paid' else ['in_process']
+
     def _get_aml_default_display_name_list(self):
         """ Hook allowing custom values when constructing the default label to set on the journal items.
 


### PR DESCRIPTION
For now, it is not really possible to force a move on a new payment
if the journal does not have an outstanding account set up.
This fix allows it, which can be usefull when processing complex cases
of reconciliation with early payment discount in multi-currencies and
exchange difference, for example.

Also moved _valid_payment_states to account, as multiple modules were using it while having a error-prone dependency tree

task-4681366