### PR TITLE
[FIX] html_builder, website: prevent toggling grid mode in mass_mailing

### DIFF
--- a/addons/html_builder/static/src/core/grid_layout/grid_layout_plugin.js
+++ b/addons/html_builder/static/src/core/grid_layout/grid_layout_plugin.js
@@ -14,7 +14,6 @@ import {
     resizeGrid,
     setElementToMaxZindex,
     toggleGridMode,
-    hasGridLayoutOption,
 } from "@html_builder/utils/grid_layout_utils";
 import { isElement } from "@html_editor/utils/dom_info";
 
@@ -26,7 +25,7 @@ function isGridItem(el) {
 
 export class GridLayoutPlugin extends Plugin {
     static id = "gridLayout";
-    static dependencies = ["history", "selection"];
+    static dependencies = ["selection", "builderOptions"];
     resources = {
         get_overlay_buttons: withSequence(0, {
             getButtons: this.getActiveOverlayButtons.bind(this),
@@ -56,6 +55,22 @@ export class GridLayoutPlugin extends Plugin {
 
     setup() {
         this.overlayTarget = null;
+    }
+
+    /**
+     * Checks if the given container element has the grid mode option.
+     *
+     * @param {HTMLElement} containerEl the container element
+     * @returns {Boolean}
+     */
+    hasGridLayoutOption(containerEl) {
+        // Check if the "LayoutOption" option is active.
+        const { targetEl } = this.dependencies.builderOptions.findOption(
+            containerEl,
+            "LayoutOption",
+            true
+        );
+        return !!targetEl && targetEl === containerEl;
     }
 
     ignoreBackgroundGrid(record) {
@@ -422,7 +437,7 @@ export class GridLayoutPlugin extends Plugin {
 
             // Allow the grid mode if the container has the option or if
             // the grid mode is already activated.
-            const hasGridOption = hasGridLayoutOption(containerEl);
+            const hasGridOption = this.hasGridLayoutOption(containerEl);
             const isRowInGridMode = rowEl.classList.contains("o_grid_mode");
             const allowGridMode = hasGridOption || isRowInGridMode;
 

--- a/addons/html_builder/static/src/utils/grid_layout_utils.js
+++ b/addons/html_builder/static/src/utils/grid_layout_utils.js
@@ -5,33 +5,6 @@ export const rowSize = 50; // 50px.
 export const additionalRowLimit = 10;
 const defaultGridPadding = 10; // 10px (see `--grid-item-padding-(x|y)` CSS variables).
 
-export const layoutOptionSelector = {
-    selector: "section, section.s_carousel_wrapper .carousel-item, .s_carousel_intro_item",
-    exclude:
-        ".s_dynamic, .s_dynamic_snippet_content, .s_dynamic_snippet_title, .s_masonry_block, .s_framed_intro, .s_features_grid, .s_media_list, .s_table_of_content, .s_process_steps, .s_image_gallery, .s_pricelist_boxed, .s_quadrant, .s_pricelist_cafe, .s_faq_horizontal, .s_image_frame, .s_card_offset, .s_contact_info, .s_tabs, .s_tabs_images, .s_floating_blocks .s_floating_blocks_block, .s_banner_categories",
-    applyTo: ":scope > *:has(> .row), :scope > .s_allow_columns",
-};
-
-/**
- * Checks if the given container has the grid mode option.
- *
- * @param {HTMLElement} containerEl the container element
- * @returns {Boolean}
- */
-export function hasGridLayoutOption(containerEl) {
-    const { selector, exclude, applyTo } = layoutOptionSelector;
-    const snippetEl = containerEl.closest(selector);
-    if (!snippetEl || snippetEl.matches(exclude)) {
-        return false;
-    }
-
-    const containerWithOptionEl = snippetEl.querySelector(applyTo);
-    if (containerWithOptionEl && containerWithOptionEl === containerEl) {
-        return true;
-    }
-    return false;
-}
-
 /**
  * Returns the grid properties: rowGap, rowSize, columnGap and columnSize.
  *

--- a/addons/website/static/src/builder/plugins/layout_option/layout_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/layout_option/layout_option_plugin.js
@@ -3,7 +3,6 @@ import {
     convertToNormalColumn,
     reloadLazyImages,
     toggleGridMode,
-    layoutOptionSelector,
 } from "@html_builder/utils/grid_layout_utils";
 import { Plugin } from "@html_editor/plugin";
 import { registry } from "@web/core/registry";
@@ -19,7 +18,11 @@ class LayoutOptionPlugin extends Plugin {
         builder_options: [
             withSequence(LAYOUT, {
                 OptionComponent: LayoutOption,
-                ...layoutOptionSelector,
+                selector:
+                    "section, section.s_carousel_wrapper .carousel-item, .s_carousel_intro_item",
+                exclude:
+                    ".s_dynamic, .s_dynamic_snippet_content, .s_dynamic_snippet_title, .s_masonry_block, .s_framed_intro, .s_features_grid, .s_media_list, .s_table_of_content, .s_process_steps, .s_image_gallery, .s_pricelist_boxed, .s_quadrant, .s_pricelist_cafe, .s_faq_horizontal, .s_image_frame, .s_card_offset, .s_contact_info, .s_tabs, .s_tabs_images, .s_floating_blocks .s_floating_blocks_block, .s_banner_categories",
+                applyTo: ":scope > *:has(> .row), :scope > .s_allow_columns",
             }),
             withSequence(LAYOUT_GRID, {
                 OptionComponent: LayoutGridOption,


### PR DESCRIPTION
Steps to reproduce:
- In mass_mailing, drop the "Text - Image" snippet.
- Drag a column. => The grid mode is toggled and does not work. It should not.

This happens because the `hasGridLayoutOption` check allowing to toggle the grid mode on drag passes in mass_mailing, where it should not, since it is supposed to be limited to website. Indeed, with the refactoring (see [1]), this check became hackish and less robust than before: it now only checks if the `LayoutOption` selector matches, while it was checking if this option was really present in the right panel before. This option being limited to website, it was automatically excluding mass_mailing.

This commit fixes this check by making it similar to how it was before, so by reimplementing the old `user_value_widget_request` event and using it to see if `LayoutOption` is active. More precisely, the `findOption` shared function was added in the `builderOptions` plugin, allowing to check if a given option is currently active, i.e. it is in the current option containers.

Doing this also allows to move the option selector back to its option plugin, instead of importing it, which was not good and confusing (it was moved there when splitting the files for the merge of [1]).

[1]: 9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2

task-4367641
task-4247642