### PR TITLE
[FIX] mail: no crash on Welcome Bot select pricing question

### DIFF
--- a/addons/mail/static/src/model/record_list.js
+++ b/addons/mail/static/src/model/record_list.js
@@ -351,7 +351,7 @@ export class RecordList extends Array {
                                         newRecord
                                     );
                                     if (inverse) {
-                                        newRecord[inverse].add(recordList._.owner);
+                                        newRecord[inverse].add?.(recordList._.owner);
                                     }
                                 }
                             }


### PR DESCRIPTION
Before this commit, picking "pricing question" on the Welcome bot would lead to the following crash:

```
TypeError: newRecord[inverse].add is not a function
```

The LOC in question should retrieve a recordList object that has necessarily the `.add()` function.

In the internal code of JS models, when inserting relational data with inverse, the insertion of data must make sure to not have infinite loop. To do so, it uses a special command `ADD.noinv` so that it knows the data is inserted in one way and should have special handling when doing the inverse as to not add the inverse, to not do the same again, and again, and again... and have maximum call stack reached!

This commit quick-fix by ignoring `.add()` when this is not a record list shape, i.e. when this is this special command `ADD.noinv`. The record is already flagged for insert so this is not a big deal to abort attempt to add it.

It's a bit dirty to have this special command `ADD.noinv` in the 1st place, but this was implemented that way as a shortcut to do partial handling of relational data without having to find some other official means to flag it in some contextual object outside of data of model to insert...

We should ideally convert "ADD.noinv" to genuine data, so just insert the actual data part, and save the "ADD.noinv" partial processing in something else other than the data itself.