### PR TITLE
[FIX] website: prevent Safari from prematurely closing dropdown on focusout

### DIFF
--- a/addons/website/static/src/client_actions/configurator/configurator.js
+++ b/addons/website/static/src/client_actions/configurator/configurator.js
@@ -26,6 +26,7 @@ import {
 } from "@odoo/owl";
 import { standardActionServiceProps } from "@web/webclient/actions/action_service";
 import { addLoadingEffect as addButtonLoadingEffect } from "@web/core/utils/ui";
+import { isBrowserSafari } from "@web/core/browser/feature_detection";
 
 export const ROUTES = {
     descriptionScreen: 2,
@@ -281,9 +282,14 @@ export class DescriptionScreen extends Component {
      * @param {FocusEvent} ev
      */
     onDropdownFocusout(ev) {
-        if (ev.relatedTarget?.closest(".dropdown") !== ev.currentTarget) {
-            window.Dropdown.getOrCreateInstance(ev.currentTarget).hide();
-        }
+        const dropdown = ev.currentTarget;
+        const delay = isBrowserSafari() ? 100 : 0;
+
+        setTimeout(() => {
+            if (dropdown && !dropdown.contains(document.activeElement)) {
+                window.Dropdown.getOrCreateInstance(dropdown).hide();
+            }
+        }, delay);
     }
 
     onAutocompleteInput({ inputValue }) {


### PR DESCRIPTION
Problem
In Safari, when selecting a website type from the dropdown, the menu closes immediately before the selection registers, so the user cannot choose an option.

Steps to reproduce
1. Open Odoo in Safari.  
2. Navigate to Website > Create new website.  
3. At the step "I want [dropdown] for my ...", click the dropdown.  
4. Try to select a website type (e.g., blog, store).  
5. Notice the dropdown closes immediately and the selection is not made.

Cause
Safari’s `focusout` event fires before `document.activeElement` updates, causing premature closing.

Fix
Delay the dropdown closing with `setTimeout` and apply only for Safari using `isBrowserSafari`.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
