### PR TITLE
[FIX] core: wrong filtered domain result for relation field

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -6608,7 +6608,11 @@ class BaseModel(metaclass=MetaModel):
                         # for relational fields, evaluate as 'any'
                         # so that negations are applied on the result of 'any' instead
                         # of on the mapped value
-                        key, comparator, value = fname, 'any', [(rest, comparator, value)]
+                        if all(record[fname] for record in self):
+                            # All records have relational value - safe to use 'any' because when have 2 records
+                            # only 1 have relational value and other is empty, when go to data.filtered_domain(value)
+                            # it will return False for empty one which is not desired behavior
+                            key, comparator, value = fname, 'any', [(rest, comparator, value)]
                 else:
                     field = self._fields[key]
                     if key == 'id':


### PR DESCRIPTION
* STEP TO REPRODUCE: 
* -Model B , have **m2o** field call **'a'** from Model A, **'a'** field is not required and is a compute store field
-Model B have company rule **[('a.company_id', 'in', company_ids + [False])]**
-After create B record but without **'a'** field or trigger compute of 'a' field that make it become false, we will get access rule error because: **[('a.company_id', 'in', company_ids + [False])]** will transform into **[('a', 'any', [('company_id', 'in', company_ids + [False])])]** , but note that **'a'** field is empty during computation which make the result become wrong because we call filtered_domain again when **'comparator' == any**, the **'self'** in it is the relation value which is 'a' field (empty record so return self)

* SOLUTION: only when all relational value of self have value then we should use any comparator

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
