### PR TITLE
[FIX] hr: fixed test payroll field access error

### DIFF
--- a/addons/hr/tests/test_payroll_fields_access.py
+++ b/addons/hr/tests/test_payroll_fields_access.py
@@ -79,7 +79,8 @@ class TestPayrollFieldsAccess(TransactionCase):
             'new_bike',
             'new_bike_model_id',
             'originated_offer_id',
-            'structure_id'
+            'structure_id',
+            'l10n_hk_mpf_manulife_account',
         ]
         missing_group_field_names = [
             f_name


### PR DESCRIPTION
Issue:
test_payroll_fields_are_hidden_to_non_payroll_users_in_employee_form_view test case fails due to the missing payroll user group on the field.

Reason:
The l10n_hk_mpf_manulife_account field uses group_hr_user because it should remain visible to HR users. Using group_payroll_user instead would restrict access unnecessarily.

Fix:
Added `l10n_hk_mpf_manulife_account` field to whitelist_field_names list in the test. This ensures the test passes without enforcing payroll only restriction.

build error: 231295

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
