### PR TITLE
[IMP] im_livechat: add line break when author changes in session history

### DIFF
--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -613,24 +613,24 @@ class DiscussChannel(models.Model):
         """
         self.ensure_one()
         parts = []
-        # sudo: res.partner: accessing chat bot partner is acceptable to build channel history.
-        chatbot_op = self.sudo().chatbot_message_ids[
-            :1
-        ].script_step_id.chatbot_script_id.operator_partner_id
-        last_msg_from_chatbot = False
+        previous_message_author = None
         # sudo - mail.message: getting empty messages to exclude them is allowed.
         for message in (self.message_ids - self.message_ids.sudo()._filter_empty()).sorted("id"):
-            is_author_chatbot = message.author_id == chatbot_op
-            if is_author_chatbot and not last_msg_from_chatbot:
-                parts.append(Markup("<br/>"))
+            # sudo - res.partner: accessing livechat username or name is allowed to visitor
+            message_author = message.author_id.sudo() or message.author_guest_id
+            if previous_message_author != message_author:
+                parts.append(
+                    Markup("<br/><strong>%s:</strong><br/>")
+                    % (
+                        (message_author.user_livechat_username if message_author._name == "res.partner" else None)
+                        or message_author.name
+                    ),
+                )
             if not tools.is_html_empty(message.body):
-                if is_author_chatbot:
-                    parts.append(Markup("<strong>%s</strong><br/>") % html2plaintext(message.body))
-                else:
-                    parts.append(Markup("%s<br/>") % html2plaintext(message.body))
-                last_msg_from_chatbot = is_author_chatbot
+                parts.append(Markup("%s<br/>") % html2plaintext(message.body))
+                previous_message_author = message_author
             for attachment in message.attachment_ids:
-                last_msg_from_chatbot = is_author_chatbot
+                previous_message_author = message_author
                 # sudo - ir.attachment: public user can read attachment metadata
                 parts.append(Markup("%s<br/>") % self._attachment_to_html(attachment.sudo()))
         return Markup("").join(parts)

--- a/addons/im_livechat/tests/test_discuss_channel.py
+++ b/addons/im_livechat/tests/test_discuss_channel.py
@@ -4,7 +4,7 @@ from freezegun import freeze_time
 from markupsafe import Markup
 
 from odoo import Command, fields
-from odoo.tests import new_test_user, tagged
+from odoo.tests import new_test_user, tagged, users
 from odoo.addons.im_livechat.tests.common import TestImLivechatCommon, TestGetOperatorCommon
 from odoo.addons.mail.tests.common import MailCase
 
@@ -203,6 +203,7 @@ class TestDiscussChannel(TestImLivechatCommon, TestGetOperatorCommon, MailCase):
         self.assertFalse(has_joined)
         self.assertNotIn(jane.partner_id, chat.channel_member_ids.partner_id)
 
+    @users("michel")
     def test_livechat_conversation_history(self):
         """Test livechat conversation history formatting"""
         def _convert_attachment_to_html(attachment):
@@ -219,7 +220,6 @@ class TestDiscussChannel(TestImLivechatCommon, TestGetOperatorCommon, MailCase):
                 "<div data-embedded='file' data-oe-protected='true' contenteditable='false' data-embedded-props='%s'/>",
             ) % json.dumps({"fileData": attachment_data})
 
-        self.authenticate(self.operators[0].login, self.password)
         channel = self.env["discuss.channel"].create(
             {
                 "name": "test",
@@ -240,7 +240,8 @@ class TestDiscussChannel(TestImLivechatCommon, TestGetOperatorCommon, MailCase):
         channel_history = channel.with_user(self.visitor_user)._get_channel_history()
         self.assertEqual(
             channel_history,
-            "Operator Here<br/>%(attachment_1)s<br/>Visitor Here<br/>%(attachment_2)s<br/>"
+            "<br/><strong>Michel Operator:</strong><br/>Operator Here<br/>%(attachment_1)s<br/>"
+            "<br/><strong>Rajesh:</strong><br/>Visitor Here<br/>%(attachment_2)s<br/>"
             % {
                 "attachment_1": _convert_attachment_to_html(attachment1),
                 "attachment_2": _convert_attachment_to_html(attachment2),


### PR DESCRIPTION
When converting a livechat session history into a description (e.g., for leads), messages from different authors were shown consecutively without separation, making it difficult to follow the conversation flow.

This PR inserts a line break whenever the message author changes, making the transcript easier to read and providing clearer context shifts.

Task-5217172

**Before:**
<img width="530" height="463" alt="image" src="https://github.com/user-attachments/assets/29304bc5-d8e4-470a-adc0-bf6d1d963bcf" />

**After:**
<img width="491" height="586" alt="image" src="https://github.com/user-attachments/assets/7a019672-84fa-457d-ae2f-48bb4a3506a3" />



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
