### PR TITLE
[FIX] run wkhtmltoimage with encoding='utf-8' to get stderr as str

### DIFF
--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -488,7 +488,7 @@ class IrActionsReport(models.Model):
                 input_file.flush()
                 wkhtmltoimage = [_wkhtml().wkhtmltoimage_bin, *command_args, input_file.name, output_file.name]
                 # start and block, no need for parallelism for now
-                completed_process = subprocess.run(wkhtmltoimage, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, check=False)
+                completed_process = subprocess.run(wkhtmltoimage, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, check=False, encoding='utf-8')
                 if completed_process.returncode:
                     message = _(
                         'Wkhtmltoimage failed (error code: %(error_code)s). Message: %(error_message_end)s',


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

  Currently wkhtmltoimage was called without encoding specified, unlike wkhtmltopdf. This result in result.stderr being returned as bytes rather than str.

Current behavior before PR:

When ther is any error during wkhtmltoimage call, the error message is not readable like this:

  2025-09-06 13:12:36,985 17760 WARNING odoo_insights odoo.addons.base.models.ir_actions_report: Wkhtmltoimage failed (error code: 1). Message: 69, 120, 105, 116, 32, 119, 105, 116, 104, 32, 99, 111, 100, 101, 32, 49, 32, 100, 117, 101, 32, 116, 111, 32, 110, 101, 116, 119, 111, 114, 107, 32, 101, 114, 114, 111, 114, 58, 32, 67, 111, 110, 116, 101, 110, 116, 65, 99, 99, 101, 115, 115, 68, 101, 110, 105, 101, 100, 13, and 10

Desired behavior after PR is merged:

  After encoding specified, the error message is readable

  2025-09-06 13:11:52,587 15780 WARNING odoo_insights odoo.addons.base.models.ir_actions_report: Wkhtmltoimage failed (error code: 1). Message: Exit with code 1 due to network error: ContentAccessDenied

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
