### PR TITLE
[FIX] website_sale_*: minor CSS fixes

### DIFF
--- a/addons/website_sale_stock_wishlist/views/website_sale_stock_wishlist_templates.xml
+++ b/addons/website_sale_stock_wishlist/views/website_sale_stock_wishlist_templates.xml
@@ -5,7 +5,7 @@
             <t t-set="product_extra_information">
                 <span
                     t-if="wish.product_id._is_sold_out() and not wish.product_id.allow_out_of_stock_order"
-                    class="o_wsale_stock_badge badge text-bg-danger align-top" 
+                    class="o_wsale_stock_badge badge text-bg-danger align-self-start align-top"
                 >
                     <i class="fa fa-circle text-danger me-1" aria-hidden="true"/>
                     Out of stock

--- a/addons/website_sale_wishlist/static/src/scss/website_sale_wishlist.scss
+++ b/addons/website_sale_wishlist/static/src/scss/website_sale_wishlist.scss
@@ -125,9 +125,9 @@
 }
 
 .wishlist-section {
-    &:where(:has(.o_wsale_products_opt_design_grid)) {
+    &:where(:has(.o_wsale_products_opt_design_grid.o_wsale_products_opt_layout_list)) {
         .o_wsale_products_opt_design_grid {
-            border-left: 1px solid $border-color;
+            border-left: $border-width solid $border-color;
         }
 
         .o_wishlist_products_header {
@@ -203,7 +203,7 @@
     }
 
     // Grid view only
-    :where(.o_wsale_products_opt_design_grid) .o_wsale_product_btn{
+    :where(.o_wsale_products_opt_design_grid.o_wsale_products_opt_layout_list) .o_wsale_product_btn {
         @include media-breakpoint-between(md, lg) {
             @include hide-submit-button-label;
 


### PR DESCRIPTION
*: wishlist, stock_wishlist

This commit fine-tunes minor CSS issues related to the `website_sale_wishlist` redesign.

1) Prevented the out of stock badge from growing inside flex layouts

2) Scoped grid mode CSS rules to list view

3) Fixed minor guidelines issues (missing empty space, `px` units, ...)

task-5070263

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
