### PR TITLE
[FIX] website_sale: fix comparison placeholder in list condensed

### DIFF
--- a/addons/website_sale/static/src/scss/product_tile.scss
+++ b/addons/website_sale/static/src/scss/product_tile.scss
@@ -900,7 +900,8 @@
             --o-wsale-card-info-text-flex: 0 1 40%;
         }
 
-        &:where(.o_wsale_products_opt_has_comparison):where(:has(.o_add_compare)) {
+        &:where(.o_wsale_products_opt_has_comparison):where(:has(.o_add_compare)),
+        &:where(:has(.o_add_to_compare)) {
             --o-wsale-comparison-btn-placeholder-display: inline-block;
         }
     }


### PR DESCRIPTION
This PR fixes an issue about the visibility of the `add_to_compare` placeholder not being defined within the CSS selector.

As the add to compare button has two different names depending on whether you are on the shop or wishlist page, we need to add both classes to the selector.

With this commit, we restore the visibility in this newly introduced layout and ensure everything is aligned.

task-5070741

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
