### PR TITLE
[FIX] discuss: prevent fails in command palette tests

### DIFF
--- a/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
+++ b/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
@@ -46,6 +46,7 @@ test("No duplicated chat bubbles", async () => {
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-MessagingMenu button", { text: "New Message" });
     await insertText("input[placeholder='Search a conversation']", "John");
+    await contains(".o_command_name", { count: 3 });
     await click(".o_command_name", { text: "John" });
     await contains(".o-mail-ChatWindow", { text: "John" });
     await contains(".o-mail-ChatWindow", { text: "The conversation is empty." }); // wait fully loaded
@@ -55,6 +56,7 @@ test("No duplicated chat bubbles", async () => {
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-MessagingMenu button", { text: "New Message" });
     await insertText("input[placeholder='Search a conversation']", "John");
+    await contains(".o_command_name", { count: 3 });
     await click(".o_command_name", { text: "John" });
     await contains(".o-mail-ChatBubble[name='John']", { count: 0 });
     await contains(".o-mail-ChatWindow", { text: "John" });

--- a/addons/mail/static/tests/discuss/call/web/call.test.js
+++ b/addons/mail/static/tests/discuss/call/web/call.test.js
@@ -24,7 +24,8 @@ test("no auto-call on joining chat", async () => {
     await openDiscuss();
     await click("input[placeholder='Find or start a conversation']");
     await insertText("input[placeholder='Search a conversation']", "mario");
-    await click("a", { text: "mario" });
+    await contains(".o_command_name", { count: 3 });
+    await click(".o_command_name", { text: "Mario" });
     await contains(".o-mail-DiscussSidebar-item", { text: "Mario" });
     await contains(".o-mail-Message", { count: 0 });
     await contains(".o-discuss-Call", { count: 0 });

--- a/addons/mail/static/tests/discuss/core/web/discuss.test.js
+++ b/addons/mail/static/tests/discuss/core/web/discuss.test.js
@@ -110,7 +110,8 @@ test("can make a DM chat", async () => {
     await contains(".o-mail-DiscussSidebar-item", { text: "Mario", count: 0 });
     await click("input[placeholder='Find or start a conversation']");
     await insertText("input[placeholder='Search a conversation']", "mario");
-    await click("a", { text: "Mario" });
+    await contains(".o_command_name", { count: 3 });
+    await click(".o_command_name", { text: "Mario" });
     await contains(".o-mail-DiscussSidebar-item", { text: "Mario" });
     await contains(".o-mail-Message", { count: 0 });
     const channelId = pyEnv["discuss.channel"].search([["name", "=", "Mario, Mitchell Admin"]]);
@@ -159,7 +160,8 @@ test("Chat is pinned on other tabs when joined", async () => {
     await openDiscuss(undefined, { target: env2 });
     await click("input[placeholder='Find or start a conversation']", { target: env1 });
     await insertText("input[placeholder='Search a conversation']", "Jer", { target: env1 });
-    await click("a", { text: "Jerry Golay", target: env1 });
+    await contains(".o_command_name", { count: 3 });
+    await click(".o_command_name", { text: "Jerry Golay", target: env1 });
     await contains(".o-mail-DiscussSidebar-item", { target: env1, text: "Jerry Golay" });
     await contains(".o-mail-DiscussSidebar-item", { target: env2, text: "Jerry Golay" });
 });

--- a/addons/mail/static/tests/discuss/core/web/messaging_menu.test.js
+++ b/addons/mail/static/tests/discuss/core/web/messaging_menu.test.js
@@ -31,6 +31,7 @@ test("can make DM chat in mobile", async () => {
     await click("button", { text: "Chat" });
     await click("button", { text: "Start a conversation" });
     await insertText("input[placeholder='Search a conversation']", "Gandalf");
+    await contains(".o_command_name", { count: 3 });
     await click(".o_command_name", { text: "Gandalf" });
     await contains(".o-mail-ChatWindow", { text: "Gandalf" });
 });
@@ -45,7 +46,8 @@ test("can search channel in mobile", async () => {
     await click("button", { text: "Channel" });
     await click("button", { text: "Start a conversation" });
     await insertText("input[placeholder='Search a conversation']", "Gryff");
-    await click("a", { text: "Gryffindors" });
+    await contains(".o_command_name", { count: 3 });
+    await click(".o_command_name", { text: "Gryffindors" });
     await contains(".o-mail-ChatWindow div[title='Gryffindors']");
 });
 

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -2305,6 +2305,7 @@ test("Newly created chat is at the top of the DM list", async () => {
     await openDiscuss();
     await click("input[placeholder='Find or start a conversation']");
     await insertText("input[placeholder='Search a conversation']", "Jer");
+    await contains(".o_command_name", { count: 3 });
     await click(".o_command_name", { text: "Jerry Golay" });
     await contains(".o-mail-DiscussSidebar-item", {
         text: "Jerry Golay",


### PR DESCRIPTION
Before this commit, clicking on some elements of the command palette would not trigger the associated event, this was probably caused by clicking on outdated owl fragments which cannot trigger events while being destroyed. This commit fixes this issue by making sure that the interface is in a stable configuration before clicking.

https://runbot.odoo.com/odoo/runbot.build.error/112148

