### PR TITLE
[IMP] html_editor, website: add s_icon_list snippet

### DIFF
--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -664,7 +664,7 @@ export class ListPlugin extends Plugin {
     splitList(node) {
         const cursors = this.dependencies.selection.preserveSelection();
         // Create new list
-        const currentList = closestElement(node, "ul, ol");
+        const currentList = closestElement(node.parentElement, "ul, ol");
         const newList = currentList.cloneNode(false);
         const isList = isListElement(node);
         const wrapperLi = isList ? this.document.createElement("li") : node;

--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -1264,14 +1264,18 @@ export class ListPlugin extends Plugin {
             return;
         }
 
-        const largestMarker = list.children[Symbol.iterator]()
+        const largestMarkerPadding = list.children[Symbol.iterator]()
             .map((li) => {
-                const markerWidth = parseFloat(this.window.getComputedStyle(li, "::marker").width);
-                return isNaN(markerWidth) ? 0 : markerWidth;
+                const beforeMargin = Math.abs(
+                    parseFloat(this.window.getComputedStyle(li, "::before").marginInlineStart) || 0
+                );
+                const markerWidth =
+                    parseFloat(this.window.getComputedStyle(li, "::marker").width) || 0;
+                // For `UL` with large font size the marker width is so big that more padding is needed.
+                const markerPadding = Math.round(markerWidth) * (list.nodeName === "UL" ? 2 : 1);
+                return Math.max(markerPadding, beforeMargin);
             })
             .reduce((accumulator, currentValue) => Math.max(accumulator, currentValue));
-        // For `UL` with large font size the marker width is so big that more padding is needed.
-        const largestMarkerPadding = Math.round(largestMarker) * (list.nodeName === "UL" ? 2 : 1);
 
         // bootstrap sets ul { padding-left: 2rem; }
         const defaultPadding = parseFloat(getHtmlStyle(this.document).fontSize) * 2;

--- a/addons/html_editor/static/tests/list/toggle_cl.test.js
+++ b/addons/html_editor/static/tests/list/toggle_cl.test.js
@@ -646,6 +646,33 @@ describe("Range collapsed", () => {
                 contentAfter: "<p>ab<br><b>cd</b><br><i>ef[]</i></p>",
             });
         });
+
+        test("Toggling a list item off should preserve the parent list's classes on the remaining list", async () => {
+            await testEditor({
+                contentBefore: unformat(`
+                    <ul class="o_checklist outerClass">
+                        <li><p>Test1[]</p>
+                            <ul class="o_checklist innerClass">
+                                <li>Test2</li>
+                            </ul>
+                        </li>
+                        <li>Test3</li>
+                    </ul>
+                `),
+                stepFunction: toggleCheckList,
+                contentAfter: unformat(`
+                    <p>Test1[]</p>
+                    <ul class="o_checklist outerClass">
+                        <li class="oe-nested">
+                            <ul class="o_checklist innerClass">
+                                <li>Test2</li>
+                            </ul>
+                        </li>
+                        <li>Test3</li>
+                    </ul>
+                `),
+            });
+        });
     });
 });
 

--- a/addons/html_editor/static/tests/list/toggle_ol.test.js
+++ b/addons/html_editor/static/tests/list/toggle_ol.test.js
@@ -435,6 +435,33 @@ describe("Range collapsed", () => {
                 contentAfter: "<p>ab<br><b>cd</b><br><i>ef[]</i></p>",
             });
         });
+
+        test("Toggling a list item off should preserve the parent list's classes on the remaining list", async () => {
+            await testEditor({
+                contentBefore: unformat(`
+                    <ol class="outerClass">
+                        <li><p>Test1[]</p>
+                            <ol class="innerClass">
+                                <li>Test2</li>
+                            </ol>
+                        </li>
+                        <li>Test3</li>
+                    </ol>
+                `),
+                stepFunction: toggleOrderedList,
+                contentAfter: unformat(`
+                    <p>Test1[]</p>
+                    <ol class="outerClass">
+                        <li class="oe-nested">
+                            <ol class="innerClass">
+                                <li>Test2</li>
+                            </ol>
+                        </li>
+                        <li>Test3</li>
+                    </ol>
+                `),
+            });
+        });
     });
 });
 

--- a/addons/html_editor/static/tests/list/toggle_ul.test.js
+++ b/addons/html_editor/static/tests/list/toggle_ul.test.js
@@ -476,6 +476,33 @@ describe("Range collapsed", () => {
                 contentAfter: "<p>ab<br><b>cd</b><br><i>ef[]</i></p>",
             });
         });
+
+        test("Toggling a list item off should preserve the parent list's classes on the remaining list", async () => {
+            await testEditor({
+                contentBefore: unformat(`
+                    <ul class="outerClass">
+                        <li><p>Test1[]</p>
+                            <ul class="innerClass">
+                                <li>Test2</li>
+                            </ul>
+                        </li>
+                        <li>Test3</li>
+                    </ul>
+                `),
+                stepFunction: toggleUnorderedList,
+                contentAfter: unformat(`
+                    <p>Test1[]</p>
+                    <ul class="outerClass">
+                        <li class="oe-nested">
+                            <ul class="innerClass">
+                                <li>Test2</li>
+                            </ul>
+                        </li>
+                        <li>Test3</li>
+                    </ul>
+                `),
+            });
+        });
     });
     describe("Transform", () => {
         test("should turn an empty ordered list into an unordered list", async () => {

--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -67,6 +67,7 @@
         'views/snippets/s_carousel_intro.xml',
         'views/snippets/s_carousel_cards.xml',
         'views/snippets/s_alert.xml',
+        'views/snippets/s_icon_list.xml',
         'views/snippets/s_motto.xml',
         'views/snippets/s_card.xml',
         'views/snippets/s_cards_grid.xml',

--- a/addons/website/static/src/builder/plugins/options/icon_list_option.xml
+++ b/addons/website/static/src/builder/plugins/options/icon_list_option.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+<t t-name="website.IconListOption">
+    <BuilderRow label.translate="Icons" tooltip.translate="Applies to all icons at once">
+        <BuilderButton action="'replaceListIcon'" preview="false">
+            <i class="fa fa-fw fa-refresh me-1"/> Replace Icons
+        </BuilderButton>
+    </BuilderRow>
+
+    <BuilderRow label.translate="Color" level="1">
+        <BuilderColorPicker enabledTabs="['solid', 'custom']" styleAction="'--icon-list-icon-color'"/>
+    </BuilderRow>
+
+    <BuilderRow label.translate="Background Color" level="1">
+        <BuilderColorPicker enabledTabs="['solid', 'custom', 'gradient']" styleAction="'--icon-list-icon-bg-color'"/>
+    </BuilderRow>
+</t>
+
+<t t-inherit="website.BuilderOptions" t-inherit-mode="extension">
+    <xpath expr="//t[@id='snippet_specific_options']" position="after">
+        <icon_list_option template="website.IconListOption" selector=".s_icon_list"/>
+    </xpath>
+</t>
+
+</templates>

--- a/addons/website/static/src/builder/plugins/options/icon_list_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/icon_list_option_plugin.js
@@ -1,0 +1,45 @@
+import { BuilderAction } from "@html_builder/core/builder_action";
+import { Plugin } from "@html_editor/plugin";
+import { registry } from "@web/core/registry";
+
+class IconListOptionPlugin extends Plugin {
+    static id = "iconListOption";
+    resources = {
+        so_content_addition_selectors: [".s_icon_list"],
+        builder_actions: {
+            ReplaceListIconAction,
+        },
+    };
+}
+
+export class ReplaceListIconAction extends BuilderAction {
+    static id = "replaceListIcon";
+    static dependencies = ["media"];
+
+    load() {
+        return new Promise((resolve) => {
+            const onClose = this.dependencies.media.openMediaDialog({
+                visibleTabs: ["ICONS"],
+                save: resolve,
+            });
+            onClose.then(() => resolve());
+        });
+    }
+
+    apply({ editingElement, loadResult: savedIconEl }) {
+        if (!savedIconEl) {
+            return;
+        }
+        // Temporarily add the icon to the DOM to read its unicode.
+        savedIconEl.style.display = "none";
+        editingElement.appendChild(savedIconEl);
+        const iconContent = getComputedStyle(savedIconEl, "::before").content;
+        editingElement.removeChild(savedIconEl);
+        // Convert the raw character to a readable "\fXXX" CSS escape.
+        const char = iconContent.slice(1, -1);
+        const iconUnicode = `"\\${char.charCodeAt(0).toString(16)}"`;
+        editingElement.style.setProperty("--icon-list-icon-content", iconUnicode);
+    }
+}
+
+registry.category("website-plugins").add(IconListOptionPlugin.id, IconListOptionPlugin);

--- a/addons/website/static/src/img/snippets_thumbs/s_icon_list.svg
+++ b/addons/website/static/src/img/snippets_thumbs/s_icon_list.svg
@@ -1,0 +1,38 @@
+<svg width="82" height="60" viewBox="0 0 82 60" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <circle cx="18" cy="21" r="3" fill="#D9D9D9"/>
+    <circle cx="18" cy="21" r="3" fill="url(#paint0_linear_2_164)"/>
+    <circle cx="18" cy="30" r="3" fill="url(#paint1_linear_2_164)"/>
+    <circle cx="18" cy="39" r="3" fill="url(#paint2_linear_2_164)"/>
+    <g filter="url(#filter0_i_2_164)">
+        <path d="M24 20H59V22H24V20Z" fill="black"/>
+        <path d="M24 29H67V31H24V29Z" fill="black"/>
+        <path d="M24 38H52V40H24V38Z" fill="black"/>
+    </g>
+    <path d="M24 20H59V22H24V20Z" fill="white" fill-opacity="0.66"/>
+    <path d="M24 29H67V31H24V29Z" fill="white" fill-opacity="0.66"/>
+    <path d="M24 38H52V40H24V38Z" fill="white" fill-opacity="0.66"/>
+    <defs>
+        <filter id="filter0_i_2_164" x="24" y="20" width="43" height="21" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+            <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+            <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+            <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+            <feOffset dy="1"/>
+            <feGaussianBlur stdDeviation="2"/>
+            <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+            <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.0995138 0"/>
+            <feBlend mode="normal" in2="shape" result="effect1_innerShadow_2_164"/>
+        </filter>
+        <linearGradient id="paint0_linear_2_164" x1="9" y1="12" x2="26.5" y2="47.5" gradientUnits="userSpaceOnUse">
+            <stop stop-color="#00A09D"/>
+            <stop offset="1" stop-color="#00E2FF"/>
+        </linearGradient>
+        <linearGradient id="paint1_linear_2_164" x1="9" y1="21" x2="26.5" y2="56.5" gradientUnits="userSpaceOnUse">
+            <stop stop-color="#00A09D"/>
+            <stop offset="1" stop-color="#00E2FF"/>
+        </linearGradient>
+        <linearGradient id="paint2_linear_2_164" x1="9" y1="30" x2="26.5" y2="65.5" gradientUnits="userSpaceOnUse">
+            <stop stop-color="#00A09D"/>
+            <stop offset="1" stop-color="#00E2FF"/>
+        </linearGradient>
+    </defs>
+</svg>

--- a/addons/website/static/src/snippets/s_icon_list/000.scss
+++ b/addons/website/static/src/snippets/s_icon_list/000.scss
@@ -1,0 +1,42 @@
+.s_icon_list {
+    --icon-list-icon-content: "\f00c";
+    --icon-list-icon-width: 1.5em;
+    --icon-list-icon-color: var(--o-cc1-btn-primary);
+    --icon-list-icon-bg-color: #{fade-currentColor(10%)};
+    --icon-list-items-spacing: #{map-get($spacers, 3)};
+
+    &:not(.o_checklist):not(ol), ul:not(.o_checklist) {
+        display: flex;
+        flex-direction: column;
+        gap: var(--icon-list-items-spacing);
+        list-style: none;
+
+        > li {
+            position: relative;
+
+            &:not(.oe-nested)::before {
+                content: var(--icon-list-icon-content);
+                position: absolute;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                width: var(--icon-list-icon-width);
+                margin-inline-start: calc((var(--icon-list-icon-width) + #{map-get($spacers, 2)}) * -1);
+                border-radius: 100%;
+                background: var(--icon-list-icon-bg-color);
+                color: var(--icon-list-icon-color);
+                font-family: FontAwesome, odoo_ui_icons;
+            }
+
+            &:not(.oe-nested) > :is(ul, ol) {
+                margin-top: var(--icon-list-items-spacing);
+            }
+        }
+    }
+}
+
+@for $index from 1 through 5 {
+    .o_cc#{$index} .s_icon_list {
+        --icon-list-icon-color: var(--o-cc#{$index}-btn-primary);
+    }
+}

--- a/addons/website/static/tests/builder/website_builder/s_icon_list.test.js
+++ b/addons/website/static/tests/builder/website_builder/s_icon_list.test.js
@@ -1,0 +1,28 @@
+import { expect, test } from "@odoo/hoot";
+import { contains } from "@web/../tests/web_test_helpers";
+import {
+    defineWebsiteModels,
+    setupWebsiteBuilderWithSnippet,
+} from "@website/../tests/builder/website_helpers";
+
+defineWebsiteModels();
+
+test("Icon List Snippet", async () => {
+    await setupWebsiteBuilderWithSnippet("s_icon_list", { loadIframeBundles: true });
+    await contains(":iframe .s_icon_list").click();
+
+    await contains(".options-container div[data-label='Color'] button").click();
+    await contains(".o_popover button[data-color='#FF0000']").click();
+    expect(":iframe .s_icon_list").toHaveStyle("--icon-list-icon-color: #FF0000");
+
+    await contains(".options-container div[data-label='Background Color'] button").click();
+    await contains(".popover button.gradient-tab").click();
+    await contains(".o_colorpicker_sections button").click();
+    expect(":iframe .s_icon_list").toHaveStyle(
+        "--icon-list-icon-bg-color: linear-gradient(135deg,rgb(255,204,51) 0%,rgb(226,51,255) 100%)"
+    );
+
+    await contains(".options-container button[data-action-id='replaceListIcon']").click();
+    await contains(".modal-dialog .fa-remove").click();
+    expect(":iframe .s_icon_list").toHaveStyle('--icon-list-icon-content: "\\f00d"');
+});

--- a/addons/website/views/snippets/s_cta_card.xml
+++ b/addons/website/views/snippets/s_cta_card.xml
@@ -15,9 +15,7 @@
                         <div class="card-body p-4">
                             <h3 class="card-title h5-fs">What you will get</h3>
                             <br/>
-                            <p><i class="fa fa-check text-o-color-1" role="img"/>&#160;&#160;Wonderful experience</p>
-                            <p><i class="fa fa-check text-o-color-1" role="img"/>&#160;&#160;Quick support</p>
-                            <p><i class="fa fa-check text-o-color-1" role="img"/>&#160;&#160;Complete access</p>
+                            <t t-snippet-call="website.s_icon_list" string="Icon List"/>
                             <a t-att-href="cta_btn_href" class="btn btn-primary w-100"><t t-out="cta_btn_text">Contact us</t></a>
                         </div>
                     </div>

--- a/addons/website/views/snippets/s_icon_list.xml
+++ b/addons/website/views/snippets/s_icon_list.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_icon_list" name="Icon List">
+    <ul class="s_icon_list">
+        <li>Wonderful experience</li>
+        <li>Quick support</li>
+        <li>Complete access</li>
+    </ul>
+</template>
+
+<asset id="website.s_icon_list_000_scss" name="Icon List 000 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_icon_list/000.scss</path>
+</asset>
+
+</odoo>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -490,6 +490,7 @@
             <t t-snippet="website.s_icon" string="Icon" t-thumbnail="/website/static/src/img/snippets_thumbs/s_icon.svg"/>
             <t t-snippet="website.s_accordion" string="Accordion" t-thumbnail="/website/static/src/img/snippets_thumbs/s_accordion.svg"/>
             <t t-snippet="website.s_alert" string="Alert" t-thumbnail="/website/static/src/img/snippets_thumbs/s_alert.svg"/>
+            <t t-snippet="website.s_icon_list" string="Icon List" t-thumbnail="/website/static/src/img/snippets_thumbs/s_icon_list.svg" t-grid-column-span="4"/>
             <t t-snippet="website.s_rating" string="Rating" t-thumbnail="/website/static/src/img/snippets_thumbs/s_rating.svg" t-grid-column-span="3"/>
             <t t-snippet="website.s_card" string="Card" t-thumbnail="/website/static/src/img/snippets_thumbs/s_card.svg"/>
             <t t-snippet="website.s_share" string="Share" t-thumbnail="/website/static/src/img/snippets_thumbs/s_share.svg"/>


### PR DESCRIPTION
### [FIX] html_editor: preserve list classes when toggling off a list item

Before this commit:
When toggling off a list item, the nested list was cloned instead of the
parent, losing any classes or attributes applied on the parent list. As
a result, any styles scoped to the parent list's classes would no longer
apply to the remaining list items.

Steps to reproduce:
- Create a list (ul).
- Add 3 items in the list.
- Indent the 2nd item.
- Add a class on the outer ul and a different class on the indented ul.
- Toggle off the 1st item and check the DOM, the inner ul is cloned
  instead of the outer one, we loose the class of outer list.

After this commit:
The parent list is now cloned, preserving its classes and attributes on
the resulting list.

### [IMP] html_editor, website: add s_icon_list snippet
Introduce a new Icon List snippet for the website builder. The snippet
displays a styled list where each item is prefixed by an icon.

Users can:
- Interact with the snippet the same way as with a normal list.
- Replace all icons in the list at once.
- Customize color and background color for all icons.

Also now the `s_cta_card` uses this snippet to replace its fake icon
list.

[design-theme PR](https://github.com/odoo/design-themes/pull/1237)

task-[3856845](https://www.odoo.com/odoo/project/974/tasks/3856845)

<img width="920" height="191" alt="image" src="https://github.com/user-attachments/assets/0771132c-89fe-4a7b-aeb0-ab0dd2f2f953" />