### PR TITLE
[IMP] website: fix background overlay for parallax

### DIFF
--- a/addons/html_builder/static/src/plugins/background_option/background_position_overlay.js
+++ b/addons/html_builder/static/src/plugins/background_option/background_position_overlay.js
@@ -63,7 +63,7 @@ export class BackgroundPositionOverlay extends Component {
                 top: (position[1] / 100) * delta.y || 0,
             };
             // Make sure the editing element is visible
-            const rect = this.targetContainerEl.getBoundingClientRect();
+            const rect = this.getRect();
             const isEditingElEntirelyVisible =
                 rect.top >= 0 &&
                 rect.bottom <= this.targetContainerEl.ownerDocument.defaultView.innerHeight;
@@ -163,7 +163,7 @@ export class BackgroundPositionOverlay extends Component {
 
     dimensionOverlay() {
         const iframeRect = this.iframe.getBoundingClientRect();
-        const targetContainerRect = this.targetContainerEl.getBoundingClientRect();
+        const targetContainerRect = this.getRect();
         const scale = this.getIframeContainerScale();
         const scaledRect = new DOMRect(
             scale * targetContainerRect.x,
@@ -271,5 +271,24 @@ export class BackgroundPositionOverlay extends Component {
             x: bgRect.width - (width || (height * naturalWidth) / naturalHeight),
             y: bgRect.height - (height || (width * naturalHeight) / naturalWidth),
         };
+    }
+
+    /**
+     * Returns the editing element's bounding client rect. If the element is
+     * transformed, temporarily disables the transform to get the real position.
+     * (The transform is put back right after.)
+     *
+     * @returns {DOMRect}
+     */
+    getRect() {
+        const editingEl = this.targetContainerEl;
+        if (editingEl.style.transform) {
+            const prevTransform = editingEl.style.transform;
+            editingEl.style.transform = "";
+            const rect = editingEl.getBoundingClientRect();
+            editingEl.style.transform = prevTransform;
+            return rect;
+        }
+        return editingEl.getBoundingClientRect();
     }
 }

--- a/addons/html_builder/static/src/utils/scrolling.js
+++ b/addons/html_builder/static/src/utils/scrolling.js
@@ -114,6 +114,15 @@ export function scrollTo(el, options = {}) {
         el.classList.add("o_check_scroll_position");
         let offsetTop = el.getBoundingClientRect().top + window.scrollY;
         el.classList.remove("o_check_scroll_position");
+        if (el.style.transform) {
+            // If the element is transformed, we can't get its real position
+            // using getBoundingClientRect. We thus temporarily disable the
+            // transform to get the position, and put it back right after.
+            const prevTransform = el.style.transform;
+            el.style.transform = "";
+            offsetTop = el.getBoundingClientRect().top + window.scrollY;
+            el.style.transform = prevTransform;
+        }
         if (el.classList.contains("d-none")) {
             el.classList.remove("d-none");
             offsetTop = el.getBoundingClientRect().top + window.scrollY;


### PR DESCRIPTION
Steps to reproduce:
1. Open website in edit mode.
2. Drop a large snippet (e.g., s_company_team_detail).
3. Add a parallax snippet below it.
4. Set the parallax scroll effect to `Zoom in` or `Zoom out`.
5. Scroll to the top of the page while keeping the parallax snippet
   selected.

Current behavior:
- The page scrolls slightly and a loading spinner appears.
- Nothing happens until the user interacts.
- Clicking cancels the repositioning.
- Scrolling resumes the repositioning (sometimes with a delay).

Root cause:
The transform applied by the zoom scroll effects conflicts with the
editor’s overlay repositioning, leaving the editor stuck in a loading
state.

Fix:
Temporarily disable the transform applied by the Zoom in and Zoom out
scroll effects when in edit mode.

task-4925787