### PR TITLE
[PERF] stock,mrp: optimize _search_product_quantity

### DIFF
--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -343,7 +343,8 @@ class MrpBom(models.Model):
         :rtype: defaultdict(`lambda: self.env['mrp.bom']`)
         """
         bom_by_product = defaultdict(lambda: self.env['mrp.bom'])
-        products = products.filtered(lambda p: p.type != 'service')
+        if not self.env.context.get('skip_products_filter'):
+            products = products.filtered(lambda p: p.type != 'service')
         if not products:
             return bom_by_product
         domain = self._bom_find_domain(products, picking_type=picking_type, company_id=company_id, bom_type=bom_type)


### PR DESCRIPTION
The performance when searching by `qty_available`, `virtual_available`, `free_qty`, `incoming_qty`, or `outgoing_qty` on databases with a large number of `product.product`s is currently poor.

Both `product.product.type` and `product.product.uom_id` are computed from `product_tmpl_id`. With large databases, `_compute_related()` is a large bottleneck when running `_compute_quantities()`

We fix this performance issue using two fast paths. Instead of searching all products, we specify `type != 'service'` within the search domain in `_search_product_quantity()` and skip the filter in the compute methods. And in `_compute_quantities_dict()` we directly set quantities to 0.0 if there are no quants or moves for the current product, skipping the unnecessary `uom_id` and `float_round()` computations.

Benchmark
| `product.product` count | Before this PR | After this PR | 
| ----------------------- | -------------- | ------------- |
| 5,000                   | 1.01s          | 0.41s         |
| 50,000                  | 9.97s          | 2.90s         |
| 500,000                 | 144s           | 43s           |

opw-4930856