### PR TITLE
[FIX] html_editor: prevent color picker dismiss on td background

### DIFF
--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -735,10 +735,10 @@ export class TablePlugin extends Plugin {
             (node) => node.isContentEditable
         );
         if (selectedTds.length && mode === "backgroundColor") {
-            if (previewMode) {
-                // Temporarily remove backgroundColor applied by "o_selected_td" class with !important.
-                selectedTds.forEach((td) => td.classList.remove("o_selected_td"));
-            }
+            // Disable the `box-shadow` while previewing the background color.
+            selectedTds.forEach((td) =>
+                td.classList.toggle("o_selected_td_bg_color_preview", previewMode)
+            );
             for (const td of selectedTds) {
                 this.dependencies.color.colorElement(td, color, mode);
                 if (color) {

--- a/addons/html_editor/static/src/main/table/table_selection.scss
+++ b/addons/html_editor/static/src/main/table/table_selection.scss
@@ -8,4 +8,7 @@
         box-shadow: 0 0 0 100vmax rgba(117, 167, 249, 0.5) inset; /* #bad3fc equivalent when over white, overlaying on the bg color*/
         border-collapse: separate;
     }
+    .o_selected_td_bg_color_preview {
+        box-shadow: unset;
+    }
 }

--- a/addons/html_editor/static/tests/color_selector.test.js
+++ b/addons/html_editor/static/tests/color_selector.test.js
@@ -629,12 +629,12 @@ describe("color preview", () => {
             <table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr>
-                        <td class="" style="background-color: rgba(206, 0, 0, 0.6); ${defaultTextColor}">
+                        <td class="o_selected_td o_selected_td_bg_color_preview" style="background-color: rgba(206, 0, 0, 0.6); ${defaultTextColor}">
                             <p>[<br></p>
                         </td>
                     </tr>
                     <tr>
-                        <td class="" style="background-color: rgba(206, 0, 0, 0.6); ${defaultTextColor}">
+                        <td class="o_selected_td o_selected_td_bg_color_preview" style="background-color: rgba(206, 0, 0, 0.6); ${defaultTextColor}">
                             <p>]<br></p>
                         </td>
                     </tr>
@@ -697,12 +697,12 @@ describe("color preview", () => {
             <table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr>
-                        <td class="bg-black" style="${defaultTextColor}">
+                        <td class="o_selected_td o_selected_td_bg_color_preview bg-black" style="${defaultTextColor}">
                             <p>[<br></p>
                         </td>
                     </tr>
                     <tr>
-                        <td class="bg-black" style="${defaultTextColor}">
+                        <td class="o_selected_td o_selected_td_bg_color_preview bg-black" style="${defaultTextColor}">
                             <p>]<br></p>
                         </td>
                     </tr>


### PR DESCRIPTION
Problem:
When applying a background color to a `td`, the color picker dismisses
unexpectedly.

Cause:
After c810b0c17b2f882b0ab5d073ba38464bffb0617e, we rely on the class
`o_selected_td` to check if we are in a selected `td` to keep the
toolbar open. However, in another fix
(254efd86cd1ce871807fdc25479ebc5beeb4eab3), we removed that class
during the color preview operation.

Previewing a color on a `td` triggers a selection change, which runs
`shouldBeVisible`. Since `o_selected_td` is not found, the toolbar
closes along with the color picker.

Solution:
Update https://github.com/odoo-dev/odoo/commit/254efd86cd1ce871807fdc25479ebc5beeb4eab3. A better fix is to
use `o_selected_td_bg_color_preview` which will undo the `box-shadow`
when we preview a color.

Steps to reproduce:
1. Add a table.
2. Select a cell.
3. Apply a background color.
4. Select the cell again.
5. Hover a color to preview.
   → The color picker dismisses once a color is hovered.

opw-5066309

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
