### PR TITLE
[IMP] mail: open avatar card when clicked on mentions

### DIFF
--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -404,7 +404,7 @@ export class Store extends BaseStore {
             return true;
         } else if (link.classList.contains("o_mail_redirect") && id) {
             ev.preventDefault();
-            this.openChat({ partnerId: id });
+            this.onClickPartnerMention(ev, id);
             return true;
         } else if (link.classList.contains("o_message_redirect")) {
             const message = this["mail.message"].get(id);
@@ -714,6 +714,10 @@ export class Store extends BaseStore {
         });
     }
 
+    onClickPartnerMention(ev, id) {
+        this.openChat({ partnerId: id });
+    }
+
     /**
      * @param {string} searchTerm
      * @param {Thread} thread
@@ -740,7 +744,7 @@ export class Store extends BaseStore {
 Store.register();
 
 export const storeService = {
-    dependencies: ["bus_service", "im_status", "ui"],
+    dependencies: ["bus_service", "im_status", "ui", "popover"],
     /**
      * @param {import("@web/env").OdooEnv} env
      * @param {import("services").ServiceFactories} services

--- a/addons/mail/static/src/discuss/core/web/store_service_patch.js
+++ b/addons/mail/static/src/discuss/core/web/store_service_patch.js
@@ -1,5 +1,6 @@
 import { Store } from "@mail/core/common/store_service";
 import { compareDatetime } from "@mail/utils/common/misc";
+import { AvatarCardPopover } from "@mail/discuss/web/avatar_card/avatar_card_popover";
 
 import { patch } from "@web/core/utils/patch";
 
@@ -30,6 +31,16 @@ const StorePatch = {
         if (!this.env.isSmall && fromThread?.model === "discuss.channel") {
             fromThread.open({ focus: false });
         }
+    },
+    /**
+     * @param {MouseEvent} ev - Click event triggering the popover.
+     * @param {number} id - Partner Id of mentioned partner.
+     */
+    onClickPartnerMention(ev, id) {
+        this.env.services.popover.add(ev.target, AvatarCardPopover, {
+            id,
+            model: "res.partner",
+        });
     },
 };
 patch(Store.prototype, StorePatch);

--- a/addons/mail/static/tests/activity/activity.test.js
+++ b/addons/mail/static/tests/activity/activity.test.js
@@ -604,7 +604,8 @@ test("activity with a user mention", async () => {
     await start();
     await openFormView("res.partner", partnerId1);
     await click(".o-mail-Activity-note a", { text: "@Partner 2" });
-    await contains(".o-mail-ChatWindow-header", { text: "Partner 2" });
+    await contains(".o_avatar_card");
+    await contains(".o_card_user_infos > span", { text: "Partner 2" });
 });
 
 test("activity with a channel mention", async () => {

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -1569,7 +1569,7 @@ test("data-oe-id & data-oe-model link redirection on click", async () => {
     await waitForSteps(["do-action:openFormView_some.model_250"]);
 });
 
-test("Chat with partner should be opened after clicking on their mention", async () => {
+test("Partner's avatar card should be opened after clicking on their mention", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({
         name: "Test Partner",
@@ -1584,8 +1584,8 @@ test("Chat with partner should be opened after clicking on their mention", async
     await contains(".o-mail-Composer-input", { value: "@Test Partner " });
     await click(".o-mail-Composer-send:enabled");
     await click(".o_mail_redirect");
-    await contains(".o-mail-ChatWindow .o-mail-Thread");
-    await contains(".o-mail-ChatWindow", { text: "Test Partner" });
+    await contains(".o_avatar_card");
+    await contains(".o_card_user_infos > span", { text: "Test Partner" });
 });
 
 test("Channel should be opened after clicking on its mention", async () => {

--- a/addons/mail/static/tests/scheduled_message/scheduled_message.test.js
+++ b/addons/mail/static/tests/scheduled_message/scheduled_message.test.js
@@ -351,7 +351,7 @@ test("Scheduled date is updated when time passes", async () => {
     await contains(".o-mail-Message-date", { text: "now" });
 });
 
-test("Open chat when clicking on partner mention", async () => {
+test("Open avatar card when clicking on partner mention", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv.user.partner_id;
     pyEnv["mail.scheduled.message"].create({
@@ -363,8 +363,8 @@ test("Open chat when clicking on partner mention", async () => {
     await start();
     await openFormView("res.partner", partnerId);
     await click(".o_mail_redirect");
-    await contains(".o-mail-ChatWindow .o-mail-Thread");
-    await contains(".o-mail-ChatWindow", { text: "Mitchell Admin" });
+    await contains(".o_avatar_card");
+    await contains(".o_card_user_infos > span", { text: "Mitchell Admin" });
 });
 
 test("Open chat when clicking on channel mention", async () => {


### PR DESCRIPTION
### Purpose of this commit:
Previously, clicking on an @mention would navigate the user directly to a chat session with the corresponding partner. This commit changes that behavior to open the partner's avatar card popover instead, giving the user immediate access to more detailed information without leaving the current context.

**task-3816952**