### PR TITLE
16.0 fix website blog issue divy

### DIFF
--- a/addons/website/static/src/js/post_link.js
+++ b/addons/website/static/src/js/post_link.js
@@ -31,7 +31,7 @@ publicWidget.registry.postLink = publicWidget.Widget.extend({
 
     _onClickPost: function (ev) {
         ev.preventDefault();
-        const url = this.el.dataset.post || this.el.href;
+        const url = this.el.dataset.post || this.el.href || this.el.value;
         let data = {};
         for (let [key, value] of Object.entries(this.el.dataset)) {
             if (key.startsWith('post_')) {

--- a/addons/website_blog/__manifest__.py
+++ b/addons/website_blog/__manifest__.py
@@ -48,6 +48,7 @@
         'web.assets_frontend': [
             'website_blog/static/src/scss/website_blog.scss',
             'website_blog/static/src/js/contentshare.js',
+            'website_blog/static/src/js/post_link.js',
             'website_blog/static/src/js/website_blog.js',
         ],
     },

--- a/addons/website_blog/static/src/js/post_link.js
+++ b/addons/website_blog/static/src/js/post_link.js
@@ -1,0 +1,6 @@
+import publicWidget from "web.public.widget";
+
+// TODO: remove in master
+publicWidget.registry.BlogPostLink = publicWidget.registry.postLink.extend({
+    selector: "select[name='archive'], span:has(.fa-calendar-o) a",
+});

--- a/addons/website_blog/static/tests/tours/blog_tags_with_date.js
+++ b/addons/website_blog/static/tests/tours/blog_tags_with_date.js
@@ -1,0 +1,63 @@
+/** @odoo-module **/
+
+import wTourUtils from 'website.tour_utils';
+
+/**
+ * Makes sure that blog tags should not be removed on the additon of date filter
+ * and on the removal of date filter.
+ */
+wTourUtils.registerWebsitePreviewTour("blog_tags_with_date", {
+    test: true,
+    url: "/blog",
+    edition: true,
+}, [{
+        content: "Click on first blog",
+        trigger: "iframe article[name=blog_post] a",
+    }, {
+        content: "Click on sidebar option",
+        trigger: "we-customizeblock-options we-button[data-customize-website-views='website_blog.opt_blog_sidebar_show'] we-title",
+    },
+    ...wTourUtils.clickOnSave(),
+    {
+        content: "Check sidebar present or not",
+        trigger: "iframe #o_wblog_sidebar",
+        isCheck: true,
+    }, {
+        content: "Click on 'adventure' tag",
+        trigger: "iframe #o_wblog_sidebar a:contains('adventure')",
+    }, {
+        content: "Check 'adventure' tag has been added",
+        trigger: "#o_wblog_posts_loop span:contains('adventure')",
+        isCheck: true,
+    }, {
+        content: "Click on 'discovery' tag",
+        trigger: "#o_wblog_sidebar a:contains('discovery')",
+    }, {
+        content: "Check 'discovery' tag has been added",
+        trigger: "#o_wblog_posts_loop span:contains('discovery')",
+        isCheck: true,
+    }, {
+        content: "Select first month",
+        trigger: "select[name=archive]",
+        run: "text option 2",
+    }, {
+        content: "Check date filter has been added",
+        trigger: "#o_wblog_posts_loop span>i.fa-calendar-o",
+        isCheck: true,
+    }, {
+        content: "Check 'adventure' and 'discovery' tag is present after addition of date filter",
+        trigger: "#o_wblog_posts_loop:has(span:contains('adventure'), span:contains('discovery'))",
+        isCheck: true,
+    }, {
+        content: "Remove the date filter",
+        trigger: "#o_wblog_posts_loop span:has(i.fa-calendar-o) a",
+    }, {
+        content: "Date filter should not be present",
+        trigger: "#o_wblog_posts_loop span:not(:has(i.fa-calendar-o))",
+        isCheck: true,
+    }, {
+        content: "Check 'adventure' and 'discovery' tag is present after removal of date filter",
+        trigger: "#o_wblog_posts_loop:has(span:contains('adventure'), span:contains('discovery'))",
+        isCheck: true,
+    }]
+);

--- a/addons/website_blog/tests/test_ui.py
+++ b/addons/website_blog/tests/test_ui.py
@@ -94,3 +94,6 @@ class TestWebsiteBlogUi(odoo.tests.HttpCase, TestWebsiteBlogCommon):
 
         self.env.ref("website_blog.opt_blog_sidebar_show").active = True
         self.start_tour("/blog", "blog_sidebar_with_date_and_tag", login="admin")
+
+    def test_blog_tags_with_date(self):
+        self.start_tour(self.env["website"].get_client_action_url("/blog"), "blog_tags_with_date", login="admin")

--- a/addons/website_blog/views/website_blog_components.xml
+++ b/addons/website_blog/views/website_blog_components.xml
@@ -118,7 +118,12 @@
 ============================================================================ -->
 <template id="date_selector">
     <select name="archive" oninput="location = this.value;" class="form-select">
-        <option t-att-value="blog_url(date_begin=False, date_end=False) if blog else '/blog'"
+        <!-- TODO: remove in master -->
+        <option t-if="False" t-att-value="blog_url(date_begin=False, date_end=False) if blog else '/blog'"
+                t-att="[('selected' if (not date_begin) else 'unselected' ) , 'true' ]">
+                -- All dates
+        </option>
+        <option t-att-value="blog_url(date_begin=False, date_end=False, tag=tag)"
                 t-att="[('selected' if (not date_begin) else 'unselected' ) , 'true' ]">
                 -- All dates
         </option>

--- a/addons/website_blog/views/website_blog_posts_loop.xml
+++ b/addons/website_blog/views/website_blog_posts_loop.xml
@@ -125,7 +125,7 @@ according to the enabled options.
                             <div t-if="is_view_active('website_blog.opt_posts_loop_show_teaser')" t-att-class="opt_blog_cards_design and 'card-body pt-0'">
                                 <t t-call="website_blog.post_teaser"/>
                             </div>
-                            <div t-if="opt_blog_cards_design" t-attf-class="opt_blog_cards_design and 'card-body pt-0 pb-2'}">
+                            <div t-if="opt_blog_cards_design" t-att-class="opt_blog_cards_design and 'card-body pt-0 pb-2'">
                                 <t t-call="website_blog.post_info"></t>
                             </div>
                             <div t-else="" class="mt-3">


### PR DESCRIPTION
This PR addresses the following issues:

**Issue 1: Date Misalignment**

**Steps to Reproduce:**
1. Navigate to website → Blog Page → Edit.
2. Change the layout from Grid to List.
3. Toggle the Cards button on.
4. The date and tags will appear slightly misaligned.

**Solution:**
Adding `#{` code in the `t-attf-class` attribute will align the date with the blog post content and tags.

**Expected Behavior:**
The date should align with the blog post content and tags preview.

**Issue 2: Some Tag Filters Getting Removed**

**Steps to Reproduce:**
1. Add a date filter from the sidebar of the blog.
2. Remove this filter by clicking the X button.
3. If multiple tags are present in the filter section, only the first tag remains while the rest are removed when the date filter is added or removed.

**Solution:**
Sending a POST request whenever the date filter is selected or removed. To achieve this, we introduced the `post_link` class to the `<select>` and `<a>` elements. When a date option is chosen, the click event triggers the `_onClickPost` handler 
function, which extracts the URL from the `value` attribute of the `<option>` tag.


**Expected Behavior:**
All previously added tags should remain after adding or removing the date filter.

**Issue 3: All Tag Filters Getting Removed**

**Steps to Reproduce:**
1. Navigate to website → Blog Page → Turn On the Sidebar.
2. Select any tag from the tags section in the sidebar.
3. Ensure no blog is selected.
4. Select a date from the archives in the sidebar.
5. Change the date to '-- All Dates' in the archives dropdown.
6. All tags in the filter are removed along with the date.

**Solution:**
Removing the condition for navigation based on whether a blog is present or not will ensure tags remain in the filter section after selecting the '-- All Dates' option.

**Expected Behavior:**
Tags present in the filter section should remain after selecting the '-- All Dates' option.

task-3937884