### PR TITLE
[18.0][FIX] analytic: Add company filter to analytic distribution

### DIFF
--- a/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.js
+++ b/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.js
@@ -287,6 +287,16 @@ export class AnalyticDistribution extends Component {
         // Analytic Account fields
         line.analyticAccounts.map((account) => {
             const fieldName = this.planIdToColumn[account.planId];
+            const companyId = this.props.record.data.company_id && this.props.record.data.company_id[0];
+            const domain = companyId
+                ? [
+                    "&",
+                    ["root_plan_id", "=", account.planId],
+                    "|",
+                    ["company_id", "parent_of", companyId],
+                    ["company_id", "=", false],
+                  ]
+                : [["root_plan_id", "=", account.planId]];
             recordFields[fieldName] = {
                 string: account.planName,
                 relation: "account.analytic.account",
@@ -295,8 +305,7 @@ export class AnalyticDistribution extends Component {
                     fields: analyticAccountFields,
                     activeFields: analyticAccountFields,
                 },
-                // company domain might be required here
-                domain: [["root_plan_id", "=", account.planId]],
+                domain,
             };
             values[fieldName] =  account?.accountId || false;
         });
@@ -675,7 +684,10 @@ export class AnalyticDistribution extends Component {
 export const analyticDistribution = {
     component: AnalyticDistribution,
     supportedTypes: ["char", "text"],
-    fieldDependencies: [{ name:"analytic_precision", type: "integer" }],
+    fieldDependencies: [
+        { name: "analytic_precision", type: "integer" },
+        { name: "company_id", type: "many2one" },
+    ],
     supportedOptions: [
         {
             label: _t("Disable save"),

--- a/addons/analytic/static/tests/analytic_distribution_tests.js
+++ b/addons/analytic/static/tests/analytic_distribution_tests.js
@@ -23,6 +23,14 @@ QUnit.module("Analytic", (hooks) => {
         target = getFixture();
         serverData = {
             models: {
+                company: {
+                    fields: {
+                        name: { string: "Company", type: "char" },
+                    },
+                    records: [
+                        { id: 1, name: "Company A" },
+                    ]
+                },
                 "account.analytic.account": {
                     fields: {
                         plan_id: { string: "Plan", type: "many2one", relation: "plan" },
@@ -30,24 +38,25 @@ QUnit.module("Analytic", (hooks) => {
                         color: { string: "Color", type: "integer" },
                         code: { string: "Ref", type: "string"},
                         partner_id: { string: "Partner", type: "many2one", relation: "partner" },
+                        company_id: { string: "Company", type: "many2one", relation: "company" },
                     },
                     records: [
-                        {id:  1, color: 1, root_plan_id: 2, plan_id: 2, name: "RD" },
-                        {id:  2, color: 1, root_plan_id: 2, plan_id: 2, name: "HR" },
-                        {id:  3, color: 1, root_plan_id: 2, plan_id: 2, name: "FI" },
-                        {id:  4, color: 2, root_plan_id: 1, plan_id: 1, name: "Time Off" },
-                        {id:  5, color: 2, root_plan_id: 1, plan_id: 1, name: "Operating Costs" },
-                        {id:  6, color: 6, root_plan_id: 4, plan_id: 4, name: "Incognito" },
-                        {id:  7, color: 5, root_plan_id: 5, plan_id: 5, name: "Belgium" },
-                        {id:  8, color: 6, root_plan_id: 5, plan_id: 6, name: "Brussels" },
-                        {id:  9, color: 6, root_plan_id: 5, plan_id: 6, name: "Beirut" },
-                        {id: 10, color: 6, root_plan_id: 5, plan_id: 6, name: "Berlin" },
-                        {id: 11, color: 6, root_plan_id: 5, plan_id: 6, name: "Bruges" },
-                        {id: 12, color: 6, root_plan_id: 5, plan_id: 6, name: "Birmingham" },
-                        {id: 13, color: 6, root_plan_id: 5, plan_id: 6, name: "Bologna" },
-                        {id: 14, color: 6, root_plan_id: 5, plan_id: 6, name: "Bratislava" },
-                        {id: 15, color: 6, root_plan_id: 5, plan_id: 6, name: "Budapest" },
-                        {id: 16, color: 6, root_plan_id: 5, plan_id: 6, name: "Namur" },
+                        {id:  1, color: 1, root_plan_id: 2, plan_id: 2, name: "RD", company_id: 1 },
+                        {id:  2, color: 1, root_plan_id: 2, plan_id: 2, name: "HR", company_id: 1 },
+                        {id:  3, color: 1, root_plan_id: 2, plan_id: 2, name: "FI", company_id: 1 },
+                        {id:  4, color: 2, root_plan_id: 1, plan_id: 1, name: "Time Off", company_id: 1 },
+                        {id:  5, color: 2, root_plan_id: 1, plan_id: 1, name: "Operating Costs", company_id: 1 },
+                        {id:  6, color: 6, root_plan_id: 4, plan_id: 4, name: "Incognito", company_id: 1 },
+                        {id:  7, color: 5, root_plan_id: 5, plan_id: 5, name: "Belgium", company_id: 1 },
+                        {id:  8, color: 6, root_plan_id: 5, plan_id: 6, name: "Brussels", company_id: 1 },
+                        {id:  9, color: 6, root_plan_id: 5, plan_id: 6, name: "Beirut", company_id: 1 },
+                        {id: 10, color: 6, root_plan_id: 5, plan_id: 6, name: "Berlin", company_id: 1 },
+                        {id: 11, color: 6, root_plan_id: 5, plan_id: 6, name: "Bruges", company_id: 1 },
+                        {id: 12, color: 6, root_plan_id: 5, plan_id: 6, name: "Birmingham", company_id: 1 },
+                        {id: 13, color: 6, root_plan_id: 5, plan_id: 6, name: "Bologna", company_id: 1 },
+                        {id: 14, color: 6, root_plan_id: 5, plan_id: 6, name: "Bratislava", company_id: 1 },
+                        {id: 15, color: 6, root_plan_id: 5, plan_id: 6, name: "Budapest", company_id: 1 },
+                        {id: 16, color: 6, root_plan_id: 5, plan_id: 6, name: "Namur", company_id: 1 },
                     ],
                 },
                 plan: {
@@ -82,12 +91,13 @@ QUnit.module("Analytic", (hooks) => {
                         analytic_distribution: { string: "Analytic", type: "json" },
                         move_id: { string: "Account Move", type: "many2one", relation: "move" },
                         analytic_precision: { string: "Analytic Precision", type: "integer" },
+                        company_id: { string: "Company", type: "many2one", relation: "company" },
                     },
                     records: [
-                        { id: 1, label: "Developer Time", amount: 100.00, analytic_distribution: {"1, 7": 30.3, "3": 69.704}, analytic_precision: 3},
-                        { id: 2, label: "Coke", amount: 100.00, analytic_distribution: {}},
-                        { id: 3, label: "Sprite", amount: 100.00, analytic_distribution: {}, analytic_precision: 3},
-                        { id: 4, label: "", amount: 100.00, analytic_distribution: {}},
+                        { id: 1, label: "Developer Time", amount: 100.00, analytic_distribution: {"1, 7": 30.3, "3": 69.704}, analytic_precision: 3, company_id: 1},
+                        { id: 2, label: "Coke", amount: 100.00, analytic_distribution: {}, company_id: 1},
+                        { id: 3, label: "Sprite", amount: 100.00, analytic_distribution: {}, analytic_precision: 3, company_id: 1},
+                        { id: 4, label: "", amount: 100.00, analytic_distribution: {}, company_id: 1},
                     ],
                 },
                 partner: {

--- a/addons/web/static/src/core/domain.js
+++ b/addons/web/static/src/core/domain.js
@@ -393,6 +393,9 @@ function matchCondition(record, condition) {
         case "any":
         case "not_any":
             return true;
+        case "child_of":
+        case "parent_of":
+            return true;
     }
     throw new InvalidDomainError("could not match domain");
 }

--- a/doc/cla/corporate/forgeflow.md
+++ b/doc/cla/corporate/forgeflow.md
@@ -24,3 +24,4 @@ Guillem Casassas guillem.casassas@forgeflow.com https://github.com/GuillemCForge
 Arnau Cruz arnau.cruz@forgeflow.com https://github.com/ArnauCForgeFlow
 Ricard Calvo ricard.calvo@forgeflow.com https://github.com/RicardCForgeFlow
 Marina Alapont marina.alapont@forgeflow.com https://github.com/MarinaAForgeFlow
+Thiago Mulero thiago.mulero@forgeflow.com https://github.com/ThiagoMForgeFlow


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
When creating or editing an analytic distribution, the analytic account selection does not respect the company context.
This allows users to see and select analytic accounts from other companies, which violates the multi-company record rules.

<img width="669" height="333" alt="2025-09-08_09-28" src="https://github.com/user-attachments/assets/488eb4b1-fdfa-49ca-a57e-8f46a264107d" />


**Current behavior before PR:**
The analytic account dropdown in the analytic distribution widget shows analytic accounts from all companies, instead of being restricted to the current company.

**Desired behavior after PR is merged:**
The analytic account selection in the analytic distribution widget is filtered by company.
Only analytic accounts belonging to the document company will be displayed, ensuring compliance with multi-company record rules.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
