### PR TITLE
[FIX] hr_holidays: show correct working schedule on time off calendar view

### DIFF
--- a/addons/hr_holidays/static/src/views/calendar/calendar_model.js
+++ b/addons/hr_holidays/static/src/views/calendar/calendar_model.js
@@ -107,7 +107,7 @@ export class TimeOffCalendarModel extends CalendarModel {
     }
 
     get employeeId() {
-        return (this.meta.context.employee_id && this.meta.context.employee_id[0]) || null;
+        return (this.meta.context.employee_id && this.meta.context.employee_id[0]) || this.meta.context.active_id || null;
     }
 
     fetchRecords(data) {


### PR DESCRIPTION
Steps to reproduce:
- In the Employee app, select an employee with a different working schedule than yours
- Click on the "Time Off" smartbutton
- Switch from Kanban to Calendar view
- The displayed working schedule is yours and not the employee's (easier to see if you and the employee have different days off)

Reason:
The employee_id field in the context used by the Python method was null instead of an ID, which caused the Python method to default to not use the employee's working schedule but the working schedule of the user viewing it.

How it was fixed:
By using a different field already present in the context, the employee's ID is correctly retrieved and used to display the calendar.

Task ID: 4987732
