### PR TITLE
[FIX] survey: fix traceback when viewing question's options

### DIFF
--- a/addons/survey/models/survey_question.py
+++ b/addons/survey/models/survey_question.py
@@ -70,6 +70,9 @@ class SurveyQuestion(models.Model):
     scoring_type = fields.Selection(related='survey_id.scoring_type', string='Scoring Type', readonly=True)
     sequence = fields.Integer('Sequence', default=10)
     session_available = fields.Boolean(related='survey_id.session_available', string='Live Session available', readonly=True)
+    survey_session_speed_rating = fields.Boolean(related="survey_id.session_speed_rating")
+    survey_session_speed_rating_time_limit = fields.Integer(related="survey_id.session_speed_rating_time_limit", string="General Time limit (seconds)")
+
     # page specific
     is_page = fields.Boolean('Is a page?')
     question_ids = fields.One2many('survey.question', string='Questions', compute="_compute_question_ids")

--- a/addons/survey/views/survey_question_views.xml
+++ b/addons/survey/views/survey_question_views.xml
@@ -272,11 +272,11 @@
                                         <field name="is_time_limited" nolabel="1" class="oe_inline"
                                             widget="boolean_update_flag"
                                             options="{'flagFieldName': 'is_time_customized'}"
-                                            context="{'referenceValue': parent.session_speed_rating}"/>
+                                            context="{'referenceValue': survey_session_speed_rating}"/>
                                         <field name="time_limit" nolabel="1" class="oe_inline"
                                             widget="integer_update_flag"
                                             options="{'flagFieldName': 'is_time_customized'}"
-                                            context="{'referenceValue': parent.session_speed_rating_time_limit}"
+                                            context="{'referenceValue': survey_session_speed_rating_time_limit}"
                                             invisible="not is_time_limited" />
                                     </div>
                                 </group>


### PR DESCRIPTION
Currently, you cannot view a survey question's option through the 'Questions and Answers' menu.

### Steps to reproduce

* install and open 'survey'
* access all survey questions from the menu 'Questions and Answers' > 'Questions'
* open any question and try to view the 'Options' tab

You will be met with the following traceback:
```
EvalError: Can not evaluate python expression: ({'referenceValue': parent.session\_speed\_rating})
Error: Name 'parent' is not defined
```

### Cause

'parent' here refers to a survey container record and works only inside sub-views of relational fields.

opw-5026204

---
Backport of 89b502614e4b185cf722c733f42f9a646aaed564