### PR TITLE
[FIX] web: allow date field to re-apply same value

### DIFF
--- a/addons/web/static/src/core/datetime/datetimepicker_service.js
+++ b/addons/web/static/src/core/datetime/datetimepicker_service.js
@@ -82,28 +82,27 @@ export const datetimePickerService = {
                  * Wrapper method on the "onApply" callback to only call it when the
                  * value has changed, and set other internal variables accordingly.
                  */
-                const apply = () => {
+                const apply = async () => {
                     const valueCopy = deepCopy(pickerProps.value);
-                    if (areDatesEqual(lastAppliedValue, valueCopy)) {
+                    if (areDatesEqual(lastInitialProps.value, valueCopy)) {
                         return;
                     }
 
                     inputsChanged = ensureArray(pickerProps.value).map(() => false);
 
-                    hookParams.onApply?.(pickerProps.value);
-                    lastAppliedValue = valueCopy;
+                    await hookParams.onApply?.(pickerProps.value);
+                    lastInitialProps.value = valueCopy;
                 };
 
                 const computeBasePickerProps = () => {
                     const nextInitialProps = markValuesRaw(hookParams.pickerProps);
                     const propsCopy = deepCopy(nextInitialProps);
 
-                    if (lastInitialProps && arePropsEqual(lastInitialProps, propsCopy)) {
+                    if (arePropsEqual(lastInitialProps, propsCopy)) {
                         return;
                     }
 
                     lastInitialProps = propsCopy;
-                    lastAppliedValue = propsCopy.value;
                     inputsChanged = ensureArray(lastInitialProps.value).map(() => false);
 
                     for (const [key, value] of Object.entries(nextInitialProps)) {
@@ -452,10 +451,8 @@ export const datetimePickerService = {
                 let allowOnClose = true;
                 /** @type {boolean[]} */
                 let inputsChanged = [];
-                /** @type {DateTimePickerProps | null} */
-                let lastInitialProps = null;
-                /** @type {DateTimePickerProps["value"] | null}*/
-                let lastAppliedValue = null;
+                /** @type {Partial<DateTimePickerProps>} */
+                let lastInitialProps = {};
                 let lastIsRange = pickerProps.range;
                 /** @type {(() => void) | null} */
                 let restoreTargetMargin = null;

--- a/addons/web/static/src/views/fields/datetime/datetime_field.js
+++ b/addons/web/static/src/views/fields/datetime/datetime_field.js
@@ -132,7 +132,7 @@ export class DateTimeField extends Component {
             onChange: () => {
                 this.state.range = this.isRange(this.state.value);
             },
-            onApply: () => {
+            onApply: async () => {
                 const toUpdate = {};
                 if (Array.isArray(this.state.value)) {
                     // Value is already a range
@@ -149,7 +149,7 @@ export class DateTimeField extends Component {
                 }
 
                 if (Object.keys(toUpdate).length) {
-                    this.props.record.update(toUpdate);
+                    await this.props.record.update(toUpdate);
                 }
             },
         });


### PR DESCRIPTION
This commit allows date (i.e. date, datetime & daterange) fields to apply a value from the props (e.g. coming from an `onchange`), even if that value is the same as the initial one.

Before this commit, it was not possible due to the fact that the date service responsible for the reactivity of the field was updating the input in an incorrect order, causing the field to display the 'input' value, and not the one enforced by the props.

Task 4978896

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
