### PR TITLE
[FIX] discuss: prevent fails in command palette tests

### DIFF
--- a/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
+++ b/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
@@ -45,7 +45,9 @@ test("No duplicated chat bubbles", async () => {
     // Make bubble of "John" chat
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-MessagingMenu button", { text: "New Message" });
+    await contains(".o_command_name", { count: 5 });
     await insertText("input[placeholder='Search a conversation']", "John");
+    await contains(".o_command_name", { count: 3 });
     await click(".o_command_name", { text: "John" });
     await contains(".o-mail-ChatWindow", { text: "John" });
     await contains(".o-mail-ChatWindow", { text: "The conversation is empty." }); // wait fully loaded
@@ -54,7 +56,9 @@ test("No duplicated chat bubbles", async () => {
     // Make bubble of "John" chat again
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-MessagingMenu button", { text: "New Message" });
+    await contains(".o_command_name", { count: 5 });
     await insertText("input[placeholder='Search a conversation']", "John");
+    await contains(".o_command_name", { count: 3 });
     await click(".o_command_name", { text: "John" });
     await contains(".o-mail-ChatBubble[name='John']", { count: 0 });
     await contains(".o-mail-ChatWindow", { text: "John" });

--- a/addons/mail/static/tests/discuss/call/web/call.test.js
+++ b/addons/mail/static/tests/discuss/call/web/call.test.js
@@ -23,8 +23,10 @@ test("no auto-call on joining chat", async () => {
     await start();
     await openDiscuss();
     await click("input[placeholder='Find or start a conversation']");
+    await contains(".o_command_name", { count: 5 });
     await insertText("input[placeholder='Search a conversation']", "mario");
-    await click("a", { text: "mario" });
+    await contains(".o_command_name", { count: 3 });
+    await click(".o_command_name", { text: "Mario" });
     await contains(".o-mail-DiscussSidebar-item", { text: "Mario" });
     await contains(".o-mail-Message", { count: 0 });
     await contains(".o-discuss-Call", { count: 0 });

--- a/addons/mail/static/tests/discuss/core/web/crosstab.test.js
+++ b/addons/mail/static/tests/discuss/core/web/crosstab.test.js
@@ -1,8 +1,6 @@
 import {
     click,
-    contains,
     defineMailModels,
-    insertText,
     openDiscuss,
     start,
     startServer,
@@ -15,17 +13,16 @@ defineMailModels();
 
 test("Channel subscription is renewed when channel is manually added", async () => {
     const pyEnv = await startServer();
-    pyEnv["discuss.channel"].create({ name: "General", channel_member_ids: [] });
+    const channelId = pyEnv["discuss.channel"].create({ name: "General", channel_member_ids: [] });
     await start();
     mockService("bus_service", {
         forceUpdateChannels() {
             asyncStep("update-channels");
         },
     });
-    await openDiscuss();
-    await click("input[placeholder='Find or start a conversation']");
-    await insertText("input[placeholder='Search a conversation']", "General");
-    await click("a", { text: "General" });
-    await contains(".o-mail-DiscussSidebar-item", { text: "General" });
+    await openDiscuss(channelId);
+    await click("[title='Invite People']");
+    await click(".o-discuss-ChannelInvitation-selectable", { text: "Mitchell Admin" });
+    await click("[title='Invite to Channel']:enabled");
     await waitForSteps(["update-channels"]);
 });

--- a/addons/mail/static/tests/discuss/core/web/discuss.test.js
+++ b/addons/mail/static/tests/discuss/core/web/discuss.test.js
@@ -109,8 +109,10 @@ test("can make a DM chat", async () => {
     await contains(".o-mail-Discuss");
     await contains(".o-mail-DiscussSidebar-item", { text: "Mario", count: 0 });
     await click("input[placeholder='Find or start a conversation']");
+    await contains(".o_command_name", { count: 5 });
     await insertText("input[placeholder='Search a conversation']", "mario");
-    await click("a", { text: "Mario" });
+    await contains(".o_command_name", { count: 3 });
+    await click(".o_command_name", { text: "Mario" });
     await contains(".o-mail-DiscussSidebar-item", { text: "Mario" });
     await contains(".o-mail-Message", { count: 0 });
     const channelId = pyEnv["discuss.channel"].search([["name", "=", "Mario, Mitchell Admin"]]);
@@ -158,8 +160,10 @@ test("Chat is pinned on other tabs when joined", async () => {
     await openDiscuss(undefined, { target: env1 });
     await openDiscuss(undefined, { target: env2 });
     await click(`${env1.selector} input[placeholder='Find or start a conversation']`);
+    await contains(`${env1.selector} .o_command_name`, { count: 5 });
     await insertText(`${env1.selector} input[placeholder='Search a conversation']`, "Jer");
-    await click(`${env1.selector} a`, { text: "Jerry Golay" });
+    await contains(`${env1.selector} .o_command_name`, { count: 3 });
+    await click(`${env1.selector} .o_command_name`, { text: "Jerry Golay" });
     await contains(`${env1.selector} .o-mail-DiscussSidebar-item`, { text: "Jerry Golay" });
     await contains(`${env2.selector} .o-mail-DiscussSidebar-item`, { text: "Jerry Golay" });
 });

--- a/addons/mail/static/tests/discuss/core/web/messaging_menu.test.js
+++ b/addons/mail/static/tests/discuss/core/web/messaging_menu.test.js
@@ -30,7 +30,9 @@ test("can make DM chat in mobile", async () => {
     await contains("button.active", { text: "Inbox" });
     await click("button", { text: "Chat" });
     await click("button", { text: "Start a conversation" });
+    await contains(".o_command_name", { count: 5 });
     await insertText("input[placeholder='Search a conversation']", "Gandalf");
+    await contains(".o_command_name", { count: 3 });
     await click(".o_command_name", { text: "Gandalf" });
     await contains(".o-mail-ChatWindow", { text: "Gandalf" });
 });
@@ -44,8 +46,10 @@ test("can search channel in mobile", async () => {
     await contains("button.active", { text: "Inbox" });
     await click("button", { text: "Channel" });
     await click("button", { text: "Start a conversation" });
+    await contains(".o_command_name", { count: 5 });
     await insertText("input[placeholder='Search a conversation']", "Gryff");
-    await click("a", { text: "Gryffindors" });
+    await contains(".o_command_name", { count: 3 });
+    await click(".o_command_name", { text: "Gryffindors" });
     await contains(".o-mail-ChatWindow div[title='Gryffindors']");
 });
 

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -2325,7 +2325,9 @@ test("Newly created chat is at the top of the DM list", async () => {
     await start();
     await openDiscuss();
     await click("input[placeholder='Find or start a conversation']");
+    await contains(".o_command_name", { count: 6 });
     await insertText("input[placeholder='Search a conversation']", "Jer");
+    await contains(".o_command_name", { count: 3 });
     await click(".o_command_name", { text: "Jerry Golay" });
     await contains(".o-mail-DiscussSidebar-item", {
         text: "Jerry Golay",

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -918,23 +918,23 @@ async function search(request) {
         ["channel_type", "!=", "chat"],
     ];
     const priority_conditions = [[["is_member", "=", true], ...base_domain], base_domain];
-    const channels = new Set();
+    const channelIds = new Set();
     let remaining_limit;
     for (const domain of priority_conditions) {
-        remaining_limit = limit - channels.size;
+        remaining_limit = limit - channelIds.size;
         if (remaining_limit <= 0) {
             break;
         }
-        const channelIds = DiscussChannel.search(
-            Domain.and([[["id", "not in", [...channels]]], domain]).toList(),
+        const partialChannelIds = DiscussChannel.search(
+            Domain.and([[["id", "not in", [...channelIds]]], domain]).toList(),
             undefined,
             remaining_limit
         );
-        for (const channelId of channelIds) {
-            channels.add(channelId);
+        for (const channelId of partialChannelIds) {
+            channelIds.add(channelId);
         }
     }
-    store.add(channels);
+    store.add(DiscussChannel.browse(channelIds));
     ResPartner._search_for_channel_invite(store, term, undefined, limit);
     return store.get_result();
 }


### PR DESCRIPTION
Before this commit, clicking on some elements of the command palette
would not trigger the associated event, this was probably caused
by clicking on outdated owl fragments which cannot trigger events while
being destroyed. This commit fixes this issue by making sure that
the interface is in a stable configuration before clicking.

The commit also fixes the mock of `discuss/search` ( for
https://github.com/odoo/enterprise/pull/94075 ) and a test
that was incomplete and relied on the incorrect implementation

https://runbot.odoo.com/odoo/runbot.build.error/112148


