### PR TITLE
[FIX] website_sale: display quantity-based pricelist discounts

### DIFF
--- a/addons/website_sale/static/src/js/website_sale.js
+++ b/addons/website_sale/static/src/js/website_sale.js
@@ -11,7 +11,7 @@ import wSaleUtils from '@website_sale/js/website_sale_utils';
 export const WebsiteSale = publicWidget.Widget.extend(VariantMixin, {
     selector: '.oe_website_sale',
     events: Object.assign({}, VariantMixin.events || {}, {
-        'change form .js_product:first input[name="add_qty"]': '_onChangeAddQuantity',
+        'change .js_product:first form input[name="add_qty"]': '_onChangeAddQuantity',
         'click a.js_add_cart_json': '_onChangeQuantity',
         'click .a-submit': '_onClickSubmit',
         'change form.js_attributes input, form.js_attributes select': '_onChangeAttribute',

--- a/addons/website_sale/static/tests/tours/website_sale_product_pricelist_qty_change.js
+++ b/addons/website_sale/static/tests/tours/website_sale_product_pricelist_qty_change.js
@@ -1,0 +1,19 @@
+import { registry } from '@web/core/registry';
+
+registry.category('web_tour.tours').add('website_sale_product_pricelist_qty_change', {
+    steps: () => [
+        {
+            content: "Price should be $20",
+            trigger: '.product_price:contains(20.0)',
+        },
+        {
+            content: "Change quantity to 5",
+            trigger: 'input.quantity',
+            run: 'edit 5 && click body',
+        },
+        {
+            content: "Price should now be $10",
+            trigger: '.product_price:contains(10.0)',
+        },
+    ],
+});

--- a/addons/website_sale/tests/test_website_sale_product_page.py
+++ b/addons/website_sale/tests/test_website_sale_product_page.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo import Command
 from odoo.tests import HttpCase, tagged
 
 from odoo.addons.product.tests.common import ProductVariantsCommon
@@ -53,16 +54,27 @@ class TestWebsiteSaleProductPage(HttpCase, ProductVariantsCommon, WebsiteSaleCom
             subtype_xmlid="mail.mt_comment"
         )
         self.authenticate(manager.login, password)
-        self._add_reaction(message, "😊")
-
-        self.start_tour("/", "website_sale_product_reviews_reactions_public", login=None)
-
-    def _add_reaction(self, message, reaction):
         self.make_jsonrpc_request(
             "/mail/message/reaction",
             {
                 "action": "add",
-                "content": reaction,
+                "content":  "😊",
                 "message_id": message.id,
             },
         )
+
+        self.start_tour("/", 'website_sale_product_reviews_reactions_public', login=None)
+
+    def test_product_pricelist_qty_change(self):
+        """Check that pricelist discounts based on product quantity display when applicable."""
+        self.env['res.config.settings'].create({'group_product_pricelist': True}).execute()
+        self.pricelist.item_ids = [
+            Command.clear(),
+            Command.create({
+                'categ_id': self.product_category.id,
+                'compute_price': 'percentage',
+                'min_quantity': 5.0,
+                'percent_price': 50.0,
+            }),
+        ]
+        self.start_tour(self.product.website_url, 'website_sale_product_pricelist_qty_change')


### PR DESCRIPTION
Versions
--------
- saas-18.4+

Steps
-----
1. Create a pricelist with a discount based on a min quantity;
2. have the pricelist available in eCommerce;
3. open a product page where the discount can get applied;
4. change the quantity in the selector to the minimum for the discount.

Issue
-----
The product's price doesn't get updated to show the discount.

Cause
-----
The `_onChangeAddQuantity` function, which is supposed to update the price, is applied to the `form .js_product:first [name="add_qty"]` selector, but as of saas-18.4, the `form` element is located inside of the `.js_product` element, making it no longer work.

Solution
--------
Change the selector to `.js_product:first form [name="add_qty"]`.

opw-5037669