### PR TITLE
[FIX] base: fix _run_wkhtmltoimage on Windows

### DIFF
--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -500,7 +500,7 @@ class IrActionsReport(models.Model):
                     _logger.warning(message)
                     output_images.append(None)
                 else:
-                    with closing(open(output_path, 'rb')) as output_file:
+                    with open(output_path, 'rb') as output_file:
                         output_images.append(output_file.read())
         return output_images
 


### PR DESCRIPTION
On Windows tempfile.NamedTemporaryFile won't allow access from external process. This result in "ContentAccessDenied" error when wkhtmltoimage process is executed. Below is the example error message on Windows:

    2025-09-06 13:11:52,587 15780 WARNING odoo_insights odoo.addons.base.models.ir_actions_report: Wkhtmltoimage failed (error code: 1). Message: Exit with code 1 due to network error: ContentAccessDenied

Follow `_run_wkhtmltopdf` and manage the temp file by hand via mkstemp.

An alternate solution is to use `delete=False` and delete the temp file manually later e.g.

- https://github.com/appveyor/ci/issues/2547
- https://github.com/allenai/olmocr/issues/74

Could be used to modernise the code later.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
