### PR TITLE
[FIX] website_livechat: style consistency of livechat info panel title

### DIFF
--- a/addons/im_livechat/static/src/core/web/livechat_channel_info_list.xml
+++ b/addons/im_livechat/static/src/core/web/livechat_channel_info_list.xml
@@ -25,14 +25,14 @@
                 <textarea class="form-control" rows="3" placeholder="Add your notes here..." t-model="props.thread.livechatNoteText" t-on-blur="onBlurNote"></textarea>
             </div>
             <div class="d-flex flex-column bg-inherit gap-1" t-ref="tagsContainer">
-                <div class="align-items-center justify-content-center pt-3 d-flex">
-                    <span class="flex-grow-1 fs-3 fw-bold">Tags</span>
-                    <button t-if="!conversationTags.length" class="btn opacity-75 opacity-100-hover rounded-3 btn-light bg-transparent p-0 border-transparent" t-on-click="onClickEditTags">
+                <h6 class="align-items-baseline pt-3 d-flex">
+                    <span class="pt-3 mb-1">Tags</span>
+                    <button t-if="!conversationTags.length" class="btn opacity-75 opacity-100-hover rounded-3 btn-light bg-transparent p-0 border-transparent ms-auto" t-on-click="onClickEditTags">
                         <div class="d-flex w-100 align-items-center gap-2">
                             <i class="fa fa-plus smaller"/>
                         </div>
                     </button>
-                </div>
+                </h6>
                 <div t-if="conversationTags.length" class="d-flex flex-wrap flex-grow-1 gap-1">
                     <TagsList displayText="true" tags="conversationTags"/>
                     <button t-if="this.store.has_access_livechat" class="btn btn-sm btn-primary lh-1 position-relative d-flex align-items-center justify-content-center rounded-4 gap-1" t-on-click="onClickEditTags">

--- a/addons/website_livechat/static/src/web/livechat_channel_info_list_patch.xml
+++ b/addons/website_livechat/static/src/web/livechat_channel_info_list_patch.xml
@@ -4,7 +4,7 @@
         <xpath expr="//t[@t-name='extra_infos']" position="inside">
             <t t-set="visitor" t-value="props.thread.livechat_visitor_id"/>
             <div t-if="visitor?.history" class="d-flex flex-column bg-inherit gap-1">
-                <h3 class="pt-3">Recent page views</h3>
+                <h6 class="pt-3">Recent page views</h6>
                 <div t-if="visitor.website_id">
                     <i class="me-1 fa fa-globe" aria-label="Website"/>
                     <span t-esc="visitor.website_id.name"/>
@@ -12,7 +12,7 @@
                 <span t-esc="visitor.history"/>
             </div>
             <div t-if="!props.thread.livechat_end_dt and recentConversations.length" class="d-flex flex-column bg-inherit gap-1">
-                <h3 class="pt-3">Recent conversations</h3>
+                <h6 class="pt-3">Recent conversations</h6>
                 <div class="btn btn-group o-rounded-bubble d-flex flex-column w-100 p-0 m-0" style="gap: 1px;">
                     <a
                         t-foreach="recentConversations" t-as="thread" t-key="thread.localId"

--- a/addons/website_livechat/static/tests/livechat_channel_info_list_patch.test.js
+++ b/addons/website_livechat/static/tests/livechat_channel_info_list_patch.test.js
@@ -29,7 +29,7 @@ test("shows recent page views", async () => {
     });
     await start();
     await openDiscuss(channelId);
-    await contains("h3", { text: "Recent page views" });
+    await contains("h6", { text: "Recent page views" });
     await contains("div > span", { text: "General website" });
     await contains("span", { text: "Home → Contact" });
 });


### PR DESCRIPTION
https://github.com/odoo/odoo/pull/224553 changed titles from `h3` to `h6`, but forgot to take into account the `extra_infos` which are panel items that are specific to `website_livechat` module.

Also makes the "Tags" style consistent with others, also with `h6`.

Before
<img width="296" height="462" alt="Screenshot 2025-09-08 at 11 55 03" src="https://github.com/user-attachments/assets/772597ba-9ec0-43f7-bc1a-c72626bf51f4" />

After
<img width="304" height="474" alt="Screenshot 2025-09-08 at 11 53 00" src="https://github.com/user-attachments/assets/4ac83718-2ba5-430c-b711-a970a33d5c02" />
