### PR TITLE
[FIX] product: duplicated packaging on one-variant product

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -502,7 +502,7 @@ class ProductTemplate(models.Model):
 
     def _get_related_fields_variant_template(self):
         """ Return a list of fields present on template and variants models and that are related"""
-        return ['barcode', 'default_code', 'standard_price', 'volume', 'weight', 'packaging_ids', 'product_properties']
+        return ['barcode', 'default_code', 'standard_price', 'volume', 'weight', 'product_properties']
 
     @api.model_create_multi
     def create(self, vals_list):
@@ -511,6 +511,7 @@ class ProductTemplate(models.Model):
         if self._context.get("create_product_product", True):
             templates._create_variant_ids()
 
+        # TODO remove in master: this is not needed anymore
         # This is needed to set given values to first variant after creation
         for template, vals in zip(templates, vals_list):
             related_vals = {}

--- a/addons/product/tests/test_variants.py
+++ b/addons/product/tests/test_variants.py
@@ -401,6 +401,31 @@ class TestVariants(ProductVariantsCommon):
         product = product_form.save()
         self.assertEqual(uom_unit, product.uom_id)
 
+    def test_single_variant_template_computed_values_after_creation(self):
+        """Check that only one packaging gets created along with a single-attribute product."""
+        product_template = self.env['product.template'].create({
+            'name': "one variant template",
+            'attribute_line_ids': [Command.create({
+                'attribute_id': self.size_attribute.id,
+                'value_ids': [Command.set(self.size_attribute_s.ids)],
+            })],
+            'packaging_ids': [Command.create({'name': "packaging"})],
+            'barcode': 'THIS IS A TEST',
+        })
+        self.assertEqual(
+            product_template.packaging_ids.ids,
+            product_template.product_variant_id.packaging_ids.ids,
+        )
+        self.assertEqual(len(product_template.packaging_ids), 1)
+        self.assertEqual(
+            product_template.barcode,
+            product_template.product_variant_id.barcode,
+        )
+        self.assertEqual(
+            product_template.barcode,
+            'THIS IS A TEST',
+        )
+
 @tagged('post_install', '-at_install')
 class TestVariantsNoCreate(ProductAttributesCommon):
 


### PR DESCRIPTION
**PROBLEM**
When creating a new product, with attributes
but only one variant the packaging is duplicated on save.

**STEP TO REPRODUCE**
1. Install inventory, go to the settings and enable the product packagings option.
2. Create a new product, with one attribute with one possible value, and with a packaging.
3. save the product and notice the packaging was duplicated.

**CAUSE**
`packaging_ids` is stored on the product.product model (product variant). `packaging_ids` in the product.template model is a compute field with an inverse. When creating the product, the inverse function is called a first time, creating a first packaging. Later in the product creation, it is called a second time because of a write call on the product.template model, creating a second packaging.

**FIX**
In the create() and write() of product template, set some value in the context to know if we should create the packaging or not when calling the inverse function.

opw-5050592