### PR TITLE
[FIX] mail: race condition in HTML composer tour

### DIFF
--- a/addons/mail/static/tests/tours/mail_html_composer_test_tour.js
+++ b/addons/mail/static/tests/tours/mail_html_composer_test_tour.js
@@ -88,7 +88,7 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/mail_html_compo
         },
         {
             content: "Click on Send Message",
-            trigger: "button:contains(Send message)",
+            trigger: "button:not(.active):contains(Send message)",
             run: "click",
         },
         {


### PR DESCRIPTION
Guard against race conditions in the HTML composer tour by ensuring the small composer is hidden before reopening.

runbot-231733


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
