### PR TITLE
[FIX] *: tests - avoid imports to _framework

### DIFF
--- a/addons/google_address_autocomplete/static/tests/google_address_autocomplete.test.js
+++ b/addons/google_address_autocomplete/static/tests/google_address_autocomplete.test.js
@@ -1,16 +1,16 @@
 import { expect, test } from "@odoo/hoot";
 import { runAllTimers } from "@odoo/hoot-mock";
-import * as fields from "@web/../tests/_framework/mock_server/mock_fields";
-import { Model, ServerModel } from "@web/../tests/_framework/mock_server/mock_model";
 import {
     contains,
     defineModels,
+    fields,
+    models,
     mountView,
     onRpc,
     webModels,
 } from "@web/../tests/web_test_helpers";
 
-class ResCountryState extends ServerModel {
+class ResCountryState extends models.ServerModel {
     _name = "res.country.state";
 
     _records = [
@@ -39,7 +39,7 @@ class ResPartner extends webModels.ResPartner {
     state_id = fields.Many2one({ relation: "res.country.state" });
 }
 
-class OtherModel extends Model {
+class OtherModel extends models.Model {
     _name = "other.model";
     city = fields.Char();
     some_char = fields.Char();

--- a/addons/html_editor/static/tests/embedded_components.test.js
+++ b/addons/html_editor/static/tests/embedded_components.test.js
@@ -36,8 +36,7 @@ import { setupEditor } from "./_helpers/editor";
 import { unformat } from "./_helpers/format";
 import { getContent, setSelection } from "./_helpers/selection";
 import { addStep, deleteBackward, deleteForward, redo, undo } from "./_helpers/user_actions";
-import { makeMockEnv } from "@web/../tests/_framework/env_test_helpers";
-import { patchWithCleanup } from "@web/../tests/web_test_helpers";
+import { makeMockEnv, patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { Deferred } from "@web/core/utils/concurrency";
 import { Plugin } from "@html_editor/plugin";
 import { cleanHints, dispatchCleanForSave } from "./_helpers/dispatch";
@@ -448,9 +447,9 @@ describe("Mount and Destroy embedded components", () => {
         // the editable element, before being removed again.
         const fixture = getFixture();
         expect(
-            [...fixture.querySelectorAll("[data-embedded]")].filter((elem) => {
-                return !elem.closest(".odoo-editor-editable");
-            })
+            [...fixture.querySelectorAll("[data-embedded]")].filter(
+                (elem) => !elem.closest(".odoo-editor-editable")
+            )
         ).toEqual([]);
     });
 
@@ -477,9 +476,9 @@ describe("Mount and Destroy embedded components", () => {
         // the editable element, before being removed again.
         const fixture = getFixture();
         expect(
-            [...fixture.querySelectorAll("[data-embedded]")].filter((elem) => {
-                return !elem.closest(".odoo-editor-editable");
-            })
+            [...fixture.querySelectorAll("[data-embedded]")].filter(
+                (elem) => !elem.closest(".odoo-editor-editable")
+            )
         ).toEqual([]);
     });
 
@@ -508,9 +507,9 @@ describe("Mount and Destroy embedded components", () => {
         // the editable element, before being removed again.
         const fixture = getFixture();
         expect(
-            [...fixture.querySelectorAll("[data-embedded]")].filter((elem) => {
-                return !elem.closest(".odoo-editor-editable");
-            })
+            [...fixture.querySelectorAll("[data-embedded]")].filter(
+                (elem) => !elem.closest(".odoo-editor-editable")
+            )
         ).toEqual([]);
         expect(editor.editable.contains(parent)).toBe(false);
         expect(parent.contains(hostElement)).toBe(true);

--- a/addons/html_editor/static/tests/link/existing.test.js
+++ b/addons/html_editor/static/tests/link/existing.test.js
@@ -1,10 +1,10 @@
 import { expect, test } from "@odoo/hoot";
-import { setupEditor, testEditor } from "../_helpers/editor";
-import { deleteBackward, insertText } from "../_helpers/user_actions";
 import { click, waitFor } from "@odoo/hoot-dom";
-import { getContent } from "../_helpers/selection";
+import { contains } from "@web/../tests/web_test_helpers";
+import { setupEditor, testEditor } from "../_helpers/editor";
 import { cleanLinkArtifacts } from "../_helpers/format";
-import { contains } from "@web/../tests/_framework/dom_test_helpers";
+import { getContent } from "../_helpers/selection";
+import { deleteBackward, insertText } from "../_helpers/user_actions";
 
 test("should parse correctly a span inside a Link", async () => {
     await testEditor({

--- a/addons/im_livechat/static/tests/mock_server/mock_models/livechat_channel_rule.js
+++ b/addons/im_livechat/static/tests/mock_server/mock_models/livechat_channel_rule.js
@@ -1,5 +1,5 @@
-import { ServerModel } from "@web/../tests/_framework/mock_server/mock_model";
+import { models } from "@web/../tests/web_test_helpers";
 
-export class LivechatChannelRule extends ServerModel {
+export class LivechatChannelRule extends models.ServerModel {
     _name = "im_livechat.channel.rule";
 }

--- a/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
+++ b/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
@@ -50,7 +50,9 @@ test("No duplicated chat bubbles", async () => {
     await insertText("input[placeholder='Search a conversation']", "John");
     await click(".o_command_name", { text: "John" });
     await contains(".o-mail-ChatWindow", { text: "John" });
-    await contains(".o-mail-ChatWindow", { text: "This is the start of your direct chat with John" }); // wait fully loaded
+    await contains(".o-mail-ChatWindow", {
+        text: "This is the start of your direct chat with John",
+    }); // wait fully loaded
     await click("button[title='Fold']");
     await contains(".o-mail-ChatBubble[name='John']");
     // Make bubble of "John" chat again

--- a/addons/mail/static/tests/web/fields/avatar.test.js
+++ b/addons/mail/static/tests/web/fields/avatar.test.js
@@ -1,7 +1,6 @@
 import { click, contains, defineMailModels, start } from "@mail/../tests/mail_test_helpers";
 import { describe, test } from "@odoo/hoot";
-import { mountWithCleanup } from "@web/../tests/web_test_helpers";
-import { serverState } from "@web/../tests/_framework/mock_server_state.hoot";
+import { mountWithCleanup, serverState } from "@web/../tests/web_test_helpers";
 
 import { Avatar } from "@mail/views/web/fields/avatar/avatar";
 

--- a/addons/point_of_sale/static/tests/unit/data/res_company.data.js
+++ b/addons/point_of_sale/static/tests/unit/data/res_company.data.js
@@ -1,6 +1,6 @@
-import { ResCompany as WebResCompany } from "@web/../tests/_framework/mock_server/mock_models/res_company";
+import { webModels } from "@web/../tests/web_test_helpers";
 
-export class ResCompany extends WebResCompany {
+export class ResCompany extends webModels.ResCompany {
     _name = "res.company";
 
     _load_pos_data_fields() {
@@ -29,7 +29,7 @@ export class ResCompany extends WebResCompany {
     }
 
     _records = [
-        ...WebResCompany.prototype.constructor._records,
+        ...webModels.ResCompany._records,
         {
             id: 250,
             currency_id: 1,

--- a/addons/point_of_sale/static/tests/unit/data/res_country.data.js
+++ b/addons/point_of_sale/static/tests/unit/data/res_country.data.js
@@ -1,6 +1,6 @@
-import { ResCountry as WebResCountry } from "@web/../tests/_framework/mock_server/mock_models/res_country";
+import { webModels } from "@web/../tests/web_test_helpers";
 
-export class ResCountry extends WebResCountry {
+export class ResCountry extends webModels.ResCountry {
     _name = "res.country";
 
     _load_pos_data_fields() {
@@ -8,7 +8,7 @@ export class ResCountry extends WebResCountry {
     }
 
     _records = [
-        ...WebResCountry.prototype.constructor._records,
+        ...webModels.ResCountry._records,
         {
             id: 233,
             name: "United States",

--- a/addons/point_of_sale/static/tests/unit/data/res_currency.data.js
+++ b/addons/point_of_sale/static/tests/unit/data/res_currency.data.js
@@ -1,6 +1,6 @@
-import { ResCurrency as WebResCurrency } from "@web/../tests/_framework/mock_server/mock_models/res_currency";
+import { webModels } from "@web/../tests/web_test_helpers";
 
-export class ResCurrency extends WebResCurrency {
+export class ResCurrency extends webModels.ResCurrency {
     _name = "res.currency";
 
     _load_pos_data_fields() {
@@ -17,12 +17,6 @@ export class ResCurrency extends WebResCurrency {
     }
 
     _records = [
-        ...WebResCurrency.prototype.constructor._records.reduce((acc, record) => {
-            if (record.id !== 1) {
-                acc.push(record);
-            }
-            return acc;
-        }, []),
         {
             id: 1,
             name: "USD",
@@ -33,5 +27,6 @@ export class ResCurrency extends WebResCurrency {
             decimal_places: 2,
             iso_numeric: 840,
         },
+        ...webModels.ResCurrency._records.filter((record) => record.id !== 1),
     ];
 }

--- a/addons/pos_restaurant/static/tests/unit/services/pos_service.test.js
+++ b/addons/pos_restaurant/static/tests/unit/services/pos_service.test.js
@@ -1,11 +1,11 @@
-import { describe, test, expect } from "@odoo/hoot";
+import { describe, expect, test } from "@odoo/hoot";
 import { definePosModels } from "@point_of_sale/../tests/unit/data/generate_model_definitions";
 import {
     getFilledOrder,
     setupPosEnv,
     waitUntilOrdersSynced,
 } from "@point_of_sale/../tests/unit/utils";
-import { MockServer } from "@web/../tests/_framework/mock_server/mock_server";
+import { MockServer } from "@web/../tests/web_test_helpers";
 
 const { DateTime } = luxon;
 

--- a/addons/spreadsheet/static/tests/helpers/model.js
+++ b/addons/spreadsheet/static/tests/helpers/model.js
@@ -1,15 +1,20 @@
 import { animationFrame } from "@odoo/hoot-mock";
 import { Model } from "@odoo/o-spreadsheet";
 import { OdooDataProvider } from "@spreadsheet/data_sources/odoo_data_provider";
-import { getMockEnv } from "@web/../tests/_framework/env_test_helpers";
-import { defineActions, defineMenus, makeMockEnv, onRpc } from "@web/../tests/web_test_helpers";
+import {
+    defineActions,
+    defineMenus,
+    getMockEnv,
+    makeMockEnv,
+    onRpc,
+} from "@web/../tests/web_test_helpers";
 import { setCellContent } from "./commands";
 import { addRecordsFromServerData, addViewsFromServerData } from "./data";
 
 /**
  * @typedef {import("@spreadsheet/../tests/helpers/data").ServerData} ServerData
  * @typedef {import("@spreadsheet/helpers/model").OdooSpreadsheetModel} OdooSpreadsheetModel
- * @typedef {import("@web/../tests/_framework/mock_server/mock_server").MockServerEnvironment} MockServerEnvironment
+ * @typedef {import("@web/../tests/web_test_helpers").MockServerEnvironment} MockServerEnvironment
  */
 
 export function setupDataSourceEvaluation(model) {

--- a/addons/web/static/tests/_framework/mock_server/mock_models/@types/mock_models.d.ts
+++ b/addons/web/static/tests/_framework/mock_server/mock_models/@types/mock_models.d.ts
@@ -1,14 +1,15 @@
 declare module "mock_models" {
-    import { IrModelFields as IrModelFields2 } from "@web/../tests/_framework/mock_server/mock_models/ir_model_fields";
-    import { resGroupsPrivilege } from "@web/../tests/_framework/mock_server/mock_models/res_groups_privilege";
-    import { ResGroups as ResGroups2 } from "@web/../tests/_framework/mock_server/mock_models/res_groups";
+    import { webModels } from "@web/../tests/web_test_helpers";
 
-    export interface IrModelFields extends IrModelFields2 {}
-    export interface ResGroups extends ResGroups2 {}
+    export interface IrModelFields extends webModels.IrModelFields {}
+    export interface IrModuleCategory extends webModels.IrModuleCategory {}
+    export interface ResGroups extends webModels.ResGroups {}
+    export interface ResGroupsPrivilege extends webModels.ResGroupsPrivilege {}
 
     export interface Models {
-        "ir.model.fields": IrModelFields,
-        "res.groups": ResGroups,
-        "res.groups.privilege": resGroupsPrivilege,
+        "ir.model.fields": IrModelFields;
+        "ir.module.category": IrModuleCategory;
+        "res.groups": ResGroups;
+        "res.groups.privilege": ResGroupsPrivilege;
     }
 }

--- a/addons/web/static/tests/core/action_swiper.test.js
+++ b/addons/web/static/tests/core/action_swiper.test.js
@@ -6,6 +6,7 @@ import { advanceTime, animationFrame, mockTouch } from "@odoo/hoot-mock";
 import { Component, onPatched, xml } from "@odoo/owl";
 import {
     contains,
+    defineParams,
     mountWithCleanup,
     patchWithCleanup,
     swipeLeft,
@@ -13,7 +14,6 @@ import {
 } from "@web/../tests/web_test_helpers";
 import { ActionSwiper } from "@web/core/action_swiper/action_swiper";
 import { Deferred } from "@web/core/utils/concurrency";
-import { defineParams } from "../_framework/mock_server/mock_server";
 
 beforeEach(() => mockTouch(true));
 

--- a/addons/web/static/tests/core/dropdown/dropdown.test.js
+++ b/addons/web/static/tests/core/dropdown/dropdown.test.js
@@ -14,11 +14,12 @@ import {
 import { Deferred, animationFrame, runAllTimers, tick } from "@odoo/hoot-mock";
 import { Component, onMounted, onPatched, useRef, useState, xml } from "@odoo/owl";
 
-import { makeMockEnv, mockService } from "@web/../tests/_framework/env_test_helpers";
 import { getPickerCell } from "@web/../tests/core/datetime/datetime_test_helpers";
 import {
     contains,
     defineParams,
+    makeMockEnv,
+    mockService,
     mountWithCleanup,
     patchWithCleanup,
 } from "@web/../tests/web_test_helpers";

--- a/addons/web/static/tests/web_test_helpers.js
+++ b/addons/web/static/tests/web_test_helpers.js
@@ -22,7 +22,9 @@ import { defineModels } from "./_framework/mock_server/mock_server";
 import { globalCachedFetch } from "./_framework/module_set.hoot";
 
 /**
+ * @typedef {import("./_framework/dom_test_helpers").DragAndDropOptions} DragAndDropOptions
  * @typedef {import("./_framework/mock_server/mock_fields").FieldType} FieldType
+ * @typedef {import("./_framework/mock_server/mock_server").MockServerEnvironment} MockServerEnvironment
  * @typedef {import("./_framework/mock_server/mock_model").ModelRecord} ModelRecord
  */
 
@@ -74,7 +76,7 @@ export {
     validateKanbanColumn,
     validateKanbanRecord,
 } from "./_framework/kanban_test_helpers";
-export { Command } from "./_framework/mock_server/mock_model";
+export { Command, registerInlineViewArchs } from "./_framework/mock_server/mock_model";
 export {
     authenticate,
     defineActions,

--- a/addons/web/static/tests/webclient/res_user_group_ids_field.test.js
+++ b/addons/web/static/tests/webclient/res_user_group_ids_field.test.js
@@ -6,11 +6,10 @@ import {
     mountView,
     onRpc,
     serverState,
+    webModels,
 } from "@web/../tests/web_test_helpers";
-import { ResGroups } from "../_framework/mock_server/mock_models/res_groups";
-import { ResUsers } from "../_framework/mock_server/mock_models/res_users";
-import { ResCompany } from "../_framework/mock_server/mock_models/res_company";
-import { ResPartner } from "../_framework/mock_server/mock_models/res_partner";
+
+const { ResCompany, ResGroups, ResPartner, ResUsers } = webModels;
 
 defineModels([ResCompany, ResGroups, ResPartner, ResUsers]);
 


### PR DESCRIPTION
This commit reduces imports to the 'tests/_framework/' subfolder, which is meant to be accessed through the 'web_test_helpers' module as to reduce the amount of imports, as well as centralizing all web helpers to have a quick overview of the available helpers.

Enterprise: https://github.com/odoo/enterprise/pull/94074

Originally contained within the following pull request: https://github.com/odoo/odoo/pull/225744
But has been separated for convenience sake since the original PR was involving security overrides, and would be consistently interrupted by conflicts ensuing from this specific commit.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
