### PR TITLE
[FIX] mail: make chat bubbles visible

### DIFF
--- a/addons/mail/static/src/core/common/chat_hub.scss
+++ b/addons/mail/static/src/core/common/chat_hub.scss
@@ -1,7 +1,7 @@
 .o-mail-ChatHub-bubbles {
     width: $o-mail-ChatHub-bubblesWidth;
     z-index: $o-mail-NavigableList-zIndex - 1;
-    bottom: calc(#{var(--mail-ChatHub-bubbles-bottom, 0)} + #{var(--mail-ChatHub-bubbles-bottomLift, 0)});
+    bottom: calc(#{var(--mail-ChatHub-bubbles-bottom, 0px)} + #{var(--mail-ChatHub-bubbles-bottomLift, 0px)});
 
     &.o-liftUp {
         --mail-ChatHub-bubbles-bottomLift: 25px;


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/225757

PR above fixed issue to not use `transform: translateY()` for the lift-up feature of chat bubbles, so that it doesn't flicker position on click.

However it made a typo: the `bottom` var default value is `0` instead of `0px`. As a result, without any lift up, the `calc` does something like `bottom: 10px + 0` and confuses CSS to not understand this means this should be 10px.

This commit fixes by replacing `0` default value to `0px`.