### PR TITLE
[FIX/IMP] sale: Fix SO to invoice flow for (sub)sections and display totals for combo products

### DIFF
--- a/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_backend.scss
+++ b/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_backend.scss
@@ -27,6 +27,11 @@ table.o_section_and_note_list_view tr.o_data_row {
                 cursor: pointer;
             }
         }
+        &.o_selected_row {
+            th:focus-within, td:focus-within {
+                background-color: var(--table-bg);
+            }
+        }
     }
     &.o_is_line_note,
     &.o_is_line_section,

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1449,11 +1449,16 @@ class SaleOrder(models.Model):
         down_payment_line_ids = []
         invoiceable_line_ids = []
         section_line_ids = []
+        subsection_line_ids = []
         precision = self.env['decimal.precision'].precision_get('Product Unit')
 
         for line in self.order_line:
-            if line.display_type in ('line_section', 'line_subsection'):
+            if line.display_type == 'line_section':
                 section_line_ids = [line.id]  # Start a new section.
+                subsection_line_ids = []
+                continue
+            if line.display_type == 'line_subsection':
+                subsection_line_ids = [line.id]  # Start a new subsection.
                 continue
             if line.display_type != 'line_note' and float_is_zero(line.qty_to_invoice, precision_digits=precision):
                 continue
@@ -1463,12 +1468,23 @@ class SaleOrder(models.Model):
                     # at the end of the invoice, in a specific dedicated section.
                     down_payment_line_ids.append(line.id)
                     continue
-                if section_line_ids:
+                # If the invoicable line is under subsection
+                if subsection_line_ids:
+                    if line.display_type:
+                        subsection_line_ids.append(line.id)
+                        continue
+                    # Extend the subsection lines too if altleast one invoicable line is under subsection
+                    invoiceable_line_ids.extend(section_line_ids + subsection_line_ids)
+                    subsection_line_ids = []
+                    section_line_ids = []
+                # If the invoicable line is under section
+                elif section_line_ids:
                     if line.display_type:
                         section_line_ids.append(line.id)
                         continue
                     invoiceable_line_ids.extend(section_line_ids)
                     section_line_ids = []
+                    subsection_line_ids = []
                 invoiceable_line_ids.append(line.id)
 
         return self.env['sale.order.line'].browse(invoiceable_line_ids + down_payment_line_ids)

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -1505,6 +1505,14 @@ class SaleOrderLine(models.Model):
         section_lines = self._get_section_lines()
         return sum(section_lines.mapped(totals_field))
 
+    def _get_combo_totals(self, totals_field):
+        """Return the total/subtotal amount sale order lines linked to combo."""
+        self.ensure_one()
+        combo_item_lines = self.order_id.order_line.filtered(
+            lambda line: line.linked_line_id == self and line.combo_item_id,
+        )
+        return sum(combo_item_lines.mapped(totals_field))
+
     def _has_taxes(self):
         """Check if a line has taxes or not. For (sub)sections, check if any child line has taxes."""
         self.ensure_one()

--- a/addons/sale/report/ir_actions_report_templates.xml
+++ b/addons/sale/report/ir_actions_report_templates.xml
@@ -183,10 +183,20 @@
                             <tr t-elif="is_combo" name="tr_combo" class="fw-bold o_line_subsection">
                                 <td
                                     name="td_combo_name"
-                                    colspan="99"
+                                    t-att-colspan="3 + (1 if display_discount else 0) + (1 if display_taxes else 0)"
                                     t-att-class="padding_class"
                                 >
                                     <span t-field="line.name">Combo Product</span>
+                                </td>
+                                <td name="td_combo_price" class="text-end o_price_total">
+                                    <span
+                                        name="price_subtotal_combo"
+                                        t-out="line._get_combo_totals(price_field)"
+                                        class="text-nowrap"
+                                        t-options="{'widget': 'monetary', 'display_currency': doc.currency_id}"
+                                    >
+                                        27.00
+                                    </span>
                                 </td>
                             </tr>
                             <tr t-else="" name="tr_product">

--- a/addons/sale/static/src/js/sale_order_line_field/sale_order_line_field.xml
+++ b/addons/sale/static/src/js/sale_order_line_field/sale_order_line_field.xml
@@ -20,7 +20,7 @@
         <xpath expr="//td[hasclass('o_list_section_options')]" position="before">
             <td t-elif="isCombo(record)" class="o_list_section_options w-print-0 p-print-0 text-center">
                 <Dropdown position="'bottom-end'" t-if="!props.readonly">
-                    <button class="btn px-1cursor-pointer">
+                    <button class="btn px-1 cursor-pointer">
                         <i class="fa fa-ellipsis-v"/>
                     </button>
                     <t t-set-slot="content">

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -622,7 +622,7 @@
                                 <field name="currency_id" column_invisible="True"/>
 
                                 <!-- Standard fields -->
-                                <field name="sequence" widget="handle"/>
+                                <field name="sequence" invisible="combo_item_id" widget="handle"/>
                                 <field
                                     name="product_id"
                                     string="Product Variant"

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -812,10 +812,20 @@
                                     <tr t-elif="is_combo" name="tr_combo" class="fw-bold o_line_subsection">
                                         <td
                                             name="td_combo_name"
-                                            colspan="99"
+                                            t-att-colspan="3 + (1 if display_discount else 0) + (1 if display_taxes else 0)"
                                             t-att-class="padding_class"
                                         >
                                             <span t-field="line.name">Combo Product</span>
+                                        </td>
+                                        <td name="td_combo_price" class="text-end o_price_total">
+                                            <span
+                                                name="price_subtotal_combo"
+                                                t-out="line._get_combo_totals(price_field)"
+                                                class="text-nowrap"
+                                                t-options="{'widget': 'monetary', 'display_currency': sale_order.currency_id}"
+                                            >
+                                                27.00
+                                            </span>
                                         </td>
                                     </tr>
                                     <tr t-else="" name="tr_product">


### PR DESCRIPTION
### 1. Fix SO → Invoice (sub)sections flow

Problem:
- When confirming a Sale Order with nested (sub)sections and generating an invoice, parent sections and notes were missing if only their subsections contained invoicable lines.
Root cause:
- `_get_invoiceable_lines` did not treat subsections as children of their parent sections.

Solution:
- Track both section_line_ids and subsection_line_ids.
- Ensure subsection lines are appended alongside their parent section when an invoicable line is encountered.

### 2. Display totals for combo product lines

Before this commit:
- Combo products had no totals/subtotals in the backend (set to 0 by design).
- While prices were visible in eCommerce, they were missing in backend views, reports, and the portal.

After this commit:
- Compute totals and subtotals for combo products in JS, without altering the backend design.
- Display combo totals consistently across backend, portal, and reports.

Affected version: 19.0
task-5009037

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
