### PR TITLE
[FIX] spreadsheet_dashboard: Fix missing path to dashboard action

### DIFF
--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.js
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.js
@@ -19,6 +19,7 @@ export const dashboardActionRegistry = new Registry();
 
 export class SpreadsheetDashboardAction extends Component {
     static template = "spreadsheet_dashboard.DashboardAction";
+    static path = "dashboards";
     static components = {
         ControlPanel,
         SpreadsheetComponent,


### PR DESCRIPTION
Steps to reproduce:
- go to dashboards
- select a dashboard with external links on scorecard charts for instance (do not select the first dashboard)
- click on the chart w/ the external link to be redirected
- Go back to the previous page through the browser

The selected dashboard is now the first dashboard instead of the one you came from.

the behaviour was broken since the introduction of the path-based routing in #157867 as we did not specify a path for the dashboard action but still worked because the action params were sent in the context but this was corrected in #216067

task-5067826

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
