### PR TITLE
[FIX] website_profile: prevent re-showing of dismissed email validation banner

### DIFF
--- a/addons/website_profile/controllers/main.py
+++ b/addons/website_profile/controllers/main.py
@@ -306,4 +306,5 @@ class WebsiteProfile(http.Controller):
     @http.route('/profile/validate_email/close', type='json', auth='public', website=True)
     def validate_email_done(self, **kwargs):
         request.session['validation_email_done'] = False
+        request.session['validation_email_sent'] = False
         return True

--- a/addons/website_profile/static/src/js/website_profile.js
+++ b/addons/website_profile/static/src/js/website_profile.js
@@ -7,7 +7,7 @@ publicWidget.registry.websiteProfile = publicWidget.Widget.extend({
     selector: '.o_wprofile_email_validation_container',
     read_events: {
         'click .send_validation_email': 'async _onSendValidationEmailClick',
-        'click .validated_email_close': '_onCloseValidatedEmailClick',
+        'close.bs.alert div:has(button.validated_email_close)': '_onCloseValidatedEmailClick',
     },
 
     init() {


### PR DESCRIPTION
### Issue 1:

The validated email success banner wasn’t triggering the RPC call because
Bootstrap’s `data-bs-dismiss="alert"` removed the element from the DOM
before the handler could run.

### Issue 2

Closing the banner previously triggered `/profile/validate_email/close` RPC,
which reset `validation_email_done` to false. This mistakenly caused the
“email sent” banner to reappear, confusing users.

### Solution

- Overwrite Bootstrap’s `close.bs.alert` event to trigger the RPC when the success
banner is dismissed.

- Set `validation_email_sent = False` so the banner stays hidden after being
closed.

Task-5049533
