### PR TITLE
[FIX] mail, *: fix race condition with command + enter

### DIFF
--- a/addons/crm_livechat/static/tests/composer.test.js
+++ b/addons/crm_livechat/static/tests/composer.test.js
@@ -1,4 +1,5 @@
 import {
+    click,
     defineMailModels,
     insertText,
     openDiscuss,
@@ -7,7 +8,6 @@ import {
 } from "@mail/../tests/mail_test_helpers";
 import { describe, test } from "@odoo/hoot";
 import { asyncStep, onRpc, waitForSteps } from "@web/../tests/web_test_helpers";
-import { press } from "@odoo/hoot-dom";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -22,6 +22,6 @@ test("Can execute lead command", async () => {
     });
     await openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "/lead great lead");
-    await press("Enter");
+    await click(".o-mail-Composer button[title='Send']:enabled");
     await waitForSteps([[channelId]]);
 });

--- a/addons/crm_livechat/static/tests/message.test.js
+++ b/addons/crm_livechat/static/tests/message.test.js
@@ -9,7 +9,6 @@ import {
 } from "@mail/../tests/mail_test_helpers";
 import { Command, serverState } from "@web/../tests/web_test_helpers";
 import { defineCrmModels } from "@crm/../tests/crm_test_helpers";
-import { press } from "@odoo/hoot-dom";
 
 describe.current.tags("desktop");
 defineCrmModels();
@@ -29,7 +28,7 @@ test("Can open lead from internal link", async () => {
     await start();
     await openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "/lead My Lead");
-    await press("Enter");
+    await click(".o-mail-Composer button[title='Send']:enabled");
     await contains(".o-mail-ChatWindow", { count: 0 });
     await click('.o_mail_notification a[data-oe-model="crm.lead"]');
     await contains(".o-mail-ChatWindow-header", { text: "Visitor" });

--- a/addons/im_livechat/static/tests/composer_patch.test.js
+++ b/addons/im_livechat/static/tests/composer_patch.test.js
@@ -1,4 +1,5 @@
 import {
+    click,
     contains,
     insertText,
     openDiscuss,
@@ -16,7 +17,6 @@ import {
 } from "@web/../tests/web_test_helpers";
 import { defineLivechatModels } from "./livechat_test_helpers";
 
-import { press } from "@odoo/hoot-dom";
 import { rpc } from "@web/core/network/rpc";
 
 describe.current.tags("desktop");
@@ -42,7 +42,7 @@ test("Can execute help command on livechat channels", async () => {
     await start();
     await openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "/help");
-    await press("Enter");
+    await click(".o-mail-Composer button[title='Send']:enabled");
     await waitForSteps(["execute_command_help"]);
 });
 

--- a/addons/mail/static/tests/discuss/core/web/messaging_menu.test.js
+++ b/addons/mail/static/tests/discuss/core/web/messaging_menu.test.js
@@ -11,7 +11,6 @@ import {
     startServer,
 } from "@mail/../tests/mail_test_helpers";
 import { describe, expect, test } from "@odoo/hoot";
-import { press } from "@odoo/hoot-dom";
 import { disableAnimations } from "@odoo/hoot-mock";
 import { Command, getService, serverState, withUser } from "@web/../tests/web_test_helpers";
 
@@ -142,7 +141,7 @@ test("channel preview ignores transient message", async () => {
     await start();
     await openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "/who");
-    await press("Enter");
+    await click(".o-mail-Composer button[title='Send']:enabled");
     await contains(".o_mail_notification", { text: "You are alone in this channel." });
     await click(".o_menu_systray .dropdown-toggle:has(i[aria-label='Messages'])");
     await contains(".o-mail-NotificationItem-text", { text: "Demo: test" });

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -244,7 +244,7 @@ test("Can use channel command /who", async () => {
     await start();
     await openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "/who");
-    await press("Enter");
+    await click(".o-mail-Composer button[title='Send']:enabled");
     await contains(".o_mail_notification", { text: "You are alone in this channel." });
 });
 

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -834,7 +834,7 @@ test("should not be able to reply to temporary/transient messages", async () => 
     await openDiscuss(channelId);
     // these user interactions is to forge a transient message response from channel command "/who"
     await insertText(".o-mail-Composer-input", "/who");
-    await press("Enter");
+    await click(".o-mail-Composer button[title='Send']:enabled");
     await contains(".o-mail-Message [title='Reply']", { count: 0 });
 });
 
@@ -862,10 +862,10 @@ test.skip("squashed transient message should not have date in the sidebar", asyn
         text: "11:00", // FIXME: should be 10:00
     });
     await insertText(".o-mail-Composer-input", "/who");
-    await press("Enter");
+    await click(".o-mail-Composer button[title='Send']:enabled");
     await contains(".o-mail-Message", { text: "You are alone in this channel." });
     await insertText(".o-mail-Composer-input", "/who");
-    await press("Enter");
+    await click(".o-mail-Composer button[title='Send']:enabled");
     await click(":nth-child(2 of .o-mail-Message.o-squashed");
     await tick();
     await contains(":nth-child(2 of .o-mail-Message.o-squashed) .o-mail-Message-sidebar", {

--- a/addons/mail/static/tests/thread/thread.test.js
+++ b/addons/mail/static/tests/thread/thread.test.js
@@ -656,7 +656,7 @@ test("first unseen message should be directly preceded by the new message separa
     await contains(".o-mail-Message", { text: "not empty" });
     // send a command that leads to receiving a transient message
     await insertText(".o-mail-Composer-input", "/who");
-    await press("Enter");
+    await click(".o-mail-Composer button[title='Send']:enabled");
     await contains(".o-mail-Message", { count: 2 });
     // composer is focused by default, we remove that focus
     queryFirst(".o-mail-Composer-input").blur();
@@ -894,7 +894,7 @@ test("Transient messages are added at the end of the thread", async () => {
     await press("Enter");
     await contains(".o-mail-Message");
     await insertText(".o-mail-Composer-input", "/help");
-    await press("Enter");
+    await click(".o-mail-Composer button[title='Send']:enabled");
     await contains(".o-mail-Message", { count: 2 });
     await contains(":nth-child(1 of .o-mail-Message)", { text: "Mitchell Admin" });
     await contains(":nth-child(2 of .o-mail-Message)", { text: "OdooBot" });


### PR DESCRIPTION
\* = crm_livechat, im_livechat

Back-port of 3fc3e4fbbd846dc8f65938a0bfbddbebf2abc403

Enter after typing a command will either send the message when the suggestion list is not opened yet, or select the suggestion.

This can either be fixed by waiting for the suggestion list to be opened, closing it, and then pressing enter, or by simply clicking on the send button which is what is done here as the way the message is sent is irrelevant for these tests.

https://runbot.odoo.com/odoo/runbot.build.error/230977