### PR TITLE
[FIX] payment_mollie: handle 'open' payments

### DIFF
--- a/addons/payment_mollie/models/payment_transaction.py
+++ b/addons/payment_mollie/models/payment_transaction.py
@@ -114,7 +114,7 @@ class PaymentTransaction(models.Model):
         )
         payment_status = payment_data.get('status')
 
-        if payment_status == 'pending':
+        if payment_status in ('pending', 'open'):
             self._set_pending()
         elif payment_status == 'authorized':
             self._set_authorized()


### PR DESCRIPTION
Versions
--------
- 16.0+

Steps
-----
1. Enable Mollie as a payment provider;
2. set up an eCommerce order in EUR;
3. go to checkout;
4. pay via Mollie;
5. pick SEPA bank transfer as payment method;
6. leave the transaction open.

Issue
-----
When returning from the redirect, we get the following error message:
> Mollie: Received data with invalid payment status: open

Cause
-----
An 'open' payment indicates the payment has been created, but nothing else has happened yet[^1]. This is the expected status for bank transfers, but is currently not getting handled in `_process_notification_data`, leading to the error.

[^1]: https://docs.mollie.com/docs/status-change

Solution
--------
Handle 'open' payments the same as 'pending' ones.

opw-4894556