### PR TITLE
[FIX] resource, project_timesheet_holidays: respect hours per day when creating holidays

### DIFF
--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -379,7 +379,7 @@ class ResourceCalendar(models.Model):
                         'duration_days': days,
                     })
                     result_per_resource_id[resource.id] = WorkIntervals([(start_dt, end_dt, dummy_attendance)])
-                elif resource and resource.calendar_id.flexible_hours:
+                elif (resource and resource.calendar_id.flexible_hours) or self.flexible_hours:
                     # For flexible Calendars, we create intervals to fill in the weekly intervals with the average daily hours
                     # until the full time required hours are met. This gives us the most correct approximation when looking at a daily
                     # and weekly range for time offs and overtime calculations and work entry generation
@@ -387,8 +387,10 @@ class ResourceCalendar(models.Model):
                     end_datetime_adjusted = end_datetime - relativedelta(seconds=1)
                     end_date = end_datetime_adjusted.date()
 
-                    full_time_required_hours = resource.calendar_id.full_time_required_hours
-                    max_hours_per_day = resource.calendar_id.hours_per_day
+                    calendar_id = resource.calendar_id or self
+
+                    full_time_required_hours = calendar_id.full_time_required_hours
+                    max_hours_per_day = calendar_id.hours_per_day
 
                     intervals = []
                     current_start_day = start_date

--- a/addons/resource/tests/test_resource_calendar.py
+++ b/addons/resource/tests/test_resource_calendar.py
@@ -43,3 +43,25 @@ class TestResourceCalendar(TransactionCase):
         self.assertEqual(end, end_dt, "Output end time should match the input end time")
         self.assertEqual(attendance.duration_hours, 3.0, "Attendance duration should be 3 hours")
         self.assertEqual(attendance.duration_days, 0.125, "Attendance duration should be 0.125 days (3 hours)")
+
+    def test_flexible_calendar_attendance_interval_duration(self):
+        """
+        Test that the duration of an attendance interval for flexible calendar is correctly computed.
+        """
+        calendar = self.env['resource.calendar'].create({
+            'name': 'Flexible Calendar',
+            'hours_per_day': 7.0,
+            'full_time_required_hours': 7.0,
+            'flexible_hours': True,
+        })
+        UTC = pytz.timezone('UTC')
+        start_dt = datetime(2025, 6, 4, 0, 0, 0).astimezone(UTC)
+        end_dt = datetime(2025, 6, 4, 12, 0, 0).astimezone(UTC)
+        result_per_resource_id = calendar._attendance_intervals_batch(
+            start_dt, end_dt
+        )
+        start, end, _ = result_per_resource_id[0]._items[0]
+
+        actual_duration = end - start
+
+        self.assertEqual(actual_duration.seconds / 3600, calendar.full_time_required_hours, "For a full day, the interval must match full time required hours")


### PR DESCRIPTION
## Issue:
For employees with flexible working hours, when a Public Holiday is added, the timesheet was filled with 8h based on the company’s default calendar instead of the employee’s flexible schedule

## Cause:
When creating `resource.calendar.leaves`, timesheets call `_work_time_per_day()`
This method uses `work_hours_data` containing half-day intervals (tmp_start/tmp_end)
These data come from `_attendance_intervals_batch()`, but we were passing an empty resource, so the check for `flexible_hours` failed:
https://github.com/odoo/odoo/blob/bd7d5fdf8df3a4d544de3e2493cd4b3966fa7d0b/addons/resource/models/resource_calendar.py#L382-L393
We want to use the calendar itself as the calendar resource to get the `work_hours_data`

## Steps to reproduce:
- On an employee, in Work Information, set the Working Hours to Flexible 40 hours/week
- Modify Flexible 40 hours/week (Hours per Week: 30, Average Hour per Day: 6)
- In Time Off > Configuration > Public Holidays, add a New holiday (You can leave default values)
- Go in Timesheets > All Timesheets, before the fix, the flexible employee have 8h in internal for Time Off

opw-4881758