### PR TITLE
[FIX] l10n_account_withholding_tax: adapt tax_ids line

### DIFF
--- a/addons/l10n_account_withholding_tax/models/account_withholding_line.py
+++ b/addons/l10n_account_withholding_tax/models/account_withholding_line.py
@@ -406,6 +406,7 @@ class AccountWithholdingLine(models.AbstractModel):
             aml_create_values_list.append({
                 **grouping_key,
                 'name': self.env._('WH Base: %(names)s', names=', '.join(amounts['names'])),
+                'tax_ids': [],
                 'tax_tag_ids': [],
                 'amount_currency': amounts['amount_currency'],
                 'balance': amounts['balance'],
@@ -414,7 +415,6 @@ class AccountWithholdingLine(models.AbstractModel):
             aml_create_values_list.append({
                 **grouping_key,
                 'name': self.env._('WH Base Counterpart: %(names)s', names=', '.join(amounts['names'])),
-                'tax_ids': [],
                 'analytic_distribution': None,
                 'amount_currency': -amounts['amount_currency'],
                 'balance': -amounts['balance'],

--- a/addons/l10n_account_withholding_tax/tests/test_account_withholding_amounts.py
+++ b/addons/l10n_account_withholding_tax/tests/test_account_withholding_amounts.py
@@ -66,8 +66,8 @@ class TestL10nAccountWithholdingTaxesAmounts(TestTaxCommon):
             {'balance': 900.0,     'tax_ids': []},
             {'balance': -1000.0,   'tax_ids': []},
             {'balance': 100.0,     'tax_ids': []},
-            {'balance': 1000.0,    'tax_ids': wth_tax_affecting.ids},
-            {'balance': -1000.0,   'tax_ids': []},
+            {'balance': 1000.0,    'tax_ids': []},
+            {'balance': -1000.0,   'tax_ids': wth_tax_affecting.ids},
         ])
 
     def test_case_b(self):
@@ -102,8 +102,8 @@ class TestL10nAccountWithholdingTaxesAmounts(TestTaxCommon):
             {'balance': 913.04,    'tax_ids': []},
             {'balance': -1000.0,   'tax_ids': []},
             {'balance': 86.96,     'tax_ids': []},
-            {'balance': 869.57,    'tax_ids': wth_tax_affecting.ids},
-            {'balance': -869.57,   'tax_ids': []},
+            {'balance': 869.57,    'tax_ids': []},
+            {'balance': -869.57,   'tax_ids': wth_tax_affecting.ids},
         ])
 
     def test_case_c(self):
@@ -138,8 +138,8 @@ class TestL10nAccountWithholdingTaxesAmounts(TestTaxCommon):
             {'balance': 1035.0,    'tax_ids': []},
             {'balance': -1150.0,   'tax_ids': []},
             {'balance': 115.0,     'tax_ids': []},
-            {'balance': 1150.0,    'tax_ids': wth_tax_affecting.ids},
-            {'balance': -1150.0,   'tax_ids': []},
+            {'balance': 1150.0,    'tax_ids': []},
+            {'balance': -1150.0,   'tax_ids': wth_tax_affecting.ids},
         ])
 
     def test_case_d(self):
@@ -174,8 +174,8 @@ class TestL10nAccountWithholdingTaxesAmounts(TestTaxCommon):
             {'balance': 1050.0,    'tax_ids': []},
             {'balance': -1150.0,   'tax_ids': []},
             {'balance': 100.0,     'tax_ids': []},
-            {'balance': 1000.0,    'tax_ids': wth_tax_affecting.ids},
-            {'balance': -1000.0,   'tax_ids': []},
+            {'balance': 1000.0,    'tax_ids': []},
+            {'balance': -1000.0,   'tax_ids': wth_tax_affecting.ids},
         ])
 
     def test_case_e(self):
@@ -211,8 +211,8 @@ class TestL10nAccountWithholdingTaxesAmounts(TestTaxCommon):
             {'balance': 1035.0,    'tax_ids': []},
             {'balance': -1150.0,   'tax_ids': []},
             {'balance': 115.0,     'tax_ids': []},
-            {'balance': 1150.0,    'tax_ids': wth_tax_affecting.ids},
-            {'balance': -1150.0,   'tax_ids': []},
+            {'balance': 1150.0,    'tax_ids': []},
+            {'balance': -1150.0,   'tax_ids': wth_tax_affecting.ids},
         ])
 
     def test_case_f(self):
@@ -248,8 +248,8 @@ class TestL10nAccountWithholdingTaxesAmounts(TestTaxCommon):
             {'balance': 1050.0,    'tax_ids': []},
             {'balance': -1150.0,   'tax_ids': []},
             {'balance': 100.0,     'tax_ids': []},
-            {'balance': 1000.0,    'tax_ids': wth_tax_affecting.ids},
-            {'balance': -1000.0,   'tax_ids': []},
+            {'balance': 1000.0,    'tax_ids': []},
+            {'balance': -1000.0,   'tax_ids': wth_tax_affecting.ids},
         ])
 
     def test_case_g(self):
@@ -285,8 +285,8 @@ class TestL10nAccountWithholdingTaxesAmounts(TestTaxCommon):
             {'balance': 1017.4,    'tax_ids': []},
             {'balance': -1130.44,   'tax_ids': []},
             {'balance': 113.04,     'tax_ids': []},
-            {'balance': 1130.44,    'tax_ids': wth_tax_affecting.ids},
-            {'balance': -1130.44,   'tax_ids': []},
+            {'balance': 1130.44,    'tax_ids': []},
+            {'balance': -1130.44,   'tax_ids': wth_tax_affecting.ids},
         ])
 
     def test_case_h(self):
@@ -322,8 +322,8 @@ class TestL10nAccountWithholdingTaxesAmounts(TestTaxCommon):
             {'balance': 1030.44,    'tax_ids': []},
             {'balance': -1130.44,   'tax_ids': []},
             {'balance': 100.00,     'tax_ids': []},
-            {'balance': 1000.00,    'tax_ids': wth_tax_affecting.ids},
-            {'balance': -1000.00,   'tax_ids': []},
+            {'balance': 1000.00,    'tax_ids': []},
+            {'balance': -1000.00,   'tax_ids': wth_tax_affecting.ids},
         ])
 
     def test_case_i(self):
@@ -359,8 +359,8 @@ class TestL10nAccountWithholdingTaxesAmounts(TestTaxCommon):
             {'balance': 1030.44,    'tax_ids': []},
             {'balance': -1130.44,   'tax_ids': []},
             {'balance': 100.00,     'tax_ids': []},
-            {'balance': 1000.01,    'tax_ids': wth_tax_affecting.ids},
-            {'balance': -1000.01,   'tax_ids': []},
+            {'balance': 1000.01,    'tax_ids': []},
+            {'balance': -1000.01,   'tax_ids': wth_tax_affecting.ids},
         ])
 
     def test_case_j(self):
@@ -396,8 +396,8 @@ class TestL10nAccountWithholdingTaxesAmounts(TestTaxCommon):
             {'balance': 1043.48,    'tax_ids': []},
             {'balance': -1130.44,   'tax_ids': []},
             {'balance': 86.96,      'tax_ids': []},
-            {'balance': 869.57,     'tax_ids': wth_tax_affecting.ids},
-            {'balance': -869.57,    'tax_ids': []},
+            {'balance': 869.57,     'tax_ids': []},
+            {'balance': -869.57,    'tax_ids': wth_tax_affecting.ids},
         ])
 
     # Note, tests were written based on a spreadsheet that was worked on collaboratively, which is why test case K was skipped.
@@ -435,8 +435,8 @@ class TestL10nAccountWithholdingTaxesAmounts(TestTaxCommon):
             {'balance': 1050.00,    'tax_ids': []},
             {'balance': -1150.00,   'tax_ids': []},
             {'balance': 100.00,      'tax_ids': []},
-            {'balance': 1000.00,     'tax_ids': wth_tax_affecting.ids},
-            {'balance': -1000.00,    'tax_ids': []},
+            {'balance': 1000.00,     'tax_ids': []},
+            {'balance': -1000.00,    'tax_ids': wth_tax_affecting.ids},
         ])
 
     def test_case_m(self):
@@ -477,10 +477,10 @@ class TestL10nAccountWithholdingTaxesAmounts(TestTaxCommon):
             {'balance': -1150.00,   'tax_ids': []},
             {'balance': 115.00,     'tax_ids': []},
             {'balance': 103.50,     'tax_ids': []},
-            {'balance': 1150.00,    'tax_ids': wth_tax_affecting.ids},
-            {'balance': -1150.00,   'tax_ids': []},
-            {'balance': 1035.00,    'tax_ids': wth_tax.ids},
-            {'balance': -1035.00,   'tax_ids': []},
+            {'balance': 1150.00,    'tax_ids': []},
+            {'balance': -1150.00,   'tax_ids': wth_tax_affecting.ids},
+            {'balance': 1035.00,    'tax_ids': []},
+            {'balance': -1035.00,   'tax_ids': wth_tax.ids},
         ])
 
     def test_case_n(self):
@@ -521,10 +521,10 @@ class TestL10nAccountWithholdingTaxesAmounts(TestTaxCommon):
             {'balance': -1150.00,    'tax_ids': []},
             {'balance': 115.00,      'tax_ids': []},
             {'balance': 100.00,      'tax_ids': []},
-            {'balance': 1150.00,     'tax_ids': wth_tax_affecting.ids},
-            {'balance': -1150.00,    'tax_ids': []},
-            {'balance': 1000.00,     'tax_ids': wth_tax_affected.ids},
-            {'balance': -1000.00,    'tax_ids': []},
+            {'balance': 1150.00,     'tax_ids': []},
+            {'balance': -1150.00,    'tax_ids': wth_tax_affecting.ids},
+            {'balance': 1000.00,     'tax_ids': []},
+            {'balance': -1000.00,    'tax_ids': wth_tax_affected.ids},
         ])
 
     def test_invoice_total_unaffected(self):

--- a/addons/l10n_account_withholding_tax/tests/test_account_withholding_flows.py
+++ b/addons/l10n_account_withholding_tax/tests/test_account_withholding_flows.py
@@ -76,8 +76,8 @@ class TestL10nAccountWithholdingTaxesFlows(TestTaxCommon, AnalyticCommon):
             {'balance': 1140.0,     'tax_ids': []},
             {'balance': -1150.0,    'tax_ids': []},
             {'balance': 10.0,       'tax_ids': []},
-            {'balance': 1000.0,     'tax_ids': withholding_tax.ids},
-            {'balance': -1000.0,    'tax_ids': []},
+            {'balance': 1000.0,     'tax_ids': []},
+            {'balance': -1000.0,    'tax_ids': withholding_tax.ids},
         ])
 
     def test_withholding_tax_before_payment(self):
@@ -1065,8 +1065,8 @@ class TestL10nAccountWithholdingTaxesFlows(TestTaxCommon, AnalyticCommon):
             {'balance': 900.0,     'tax_ids': [],                    'partner_id': self.partner_a.id},
             {'balance': -1000.0,   'tax_ids': [],                    'partner_id': self.partner_a.id},
             {'balance': 100.0,     'tax_ids': [],                    'partner_id': self.partner_a.id},
-            {'balance': 1000.0,    'tax_ids': withholding_tax.ids,   'partner_id': self.partner_a.id},
-            {'balance': -1000.0,   'tax_ids': [],                    'partner_id': self.partner_a.id},
+            {'balance': 1000.0,    'tax_ids': [],                    'partner_id': self.partner_a.id},
+            {'balance': -1000.0,   'tax_ids': withholding_tax.ids,   'partner_id': self.partner_a.id},
         ])
 
     def test_tax_repartition_on_refund(self):


### PR DESCRIPTION
The commit removing the tax tag signs changed on which line the tags are applied but it should have also changed on which line the tax is applied for consistency.

See b6bbc31f7464b0fdae6a83122b42b99cd7fca1cf
