### PR TITLE
[REF] pos_restaurant, web_tour: unpatch tour_helpers

### DIFF
--- a/addons/web_tour/static/src/js/tour_automatic/tour_helpers.js
+++ b/addons/web_tour/static/src/js/tour_automatic/tour_helpers.js
@@ -315,6 +315,17 @@ export class TourHelpers {
         });
     }
 
+    async scan(barcode) {
+        odoo.__WOWL_DEBUG__.root.env.services.barcode.bus.trigger("barcode_scanned", { barcode });
+        await new Promise(requestAnimationFrame);
+    }
+
+    async scanRFID(rfid) {
+        const params = { data: rfid.split(",") };
+        odoo.__WOWL_DEBUG__.root.env.services.mobile.bus.trigger("mobile_reader_scanned", params);
+        await new Promise(requestAnimationFrame);
+    }
+
     /**
      * Get Node for **{@link Selector}**
      * @param {Selector} selector


### PR DESCRIPTION
In this commit, we unpatch tour_helpers. Custom helper drag_multiple_and_then_drop is only used once. We prefer to call this function only where it's used rather than put it in tour_helpers. This commit is made in order to lazy load hoot-dom in web_tour.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
