### PR TITLE
[FIX] portal: hide filters offcanvas on mobile if no data

### DIFF
--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -314,7 +314,7 @@
             <span t-else="" class="navbar-brand mb-0 h1 me-auto" t-esc="title or 'No title'"/>
 
             <!--  Collapse button -->
-            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#o_portal_navbar_content" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle filters">
+            <button t-if="searchbar_sortings or searchbar_filters or searchbar_groupby or searchbar_inputs" class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#o_portal_navbar_content" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle filters">
                 <span class="fa fa-fw fa-bars"/>
             </button>
 


### PR DESCRIPTION
This PR prevents the offcanvas containing filters/sort buttons to be displayed in there is no data in the view, preventing to show an empty menu on screen.

task-5072304

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
