### PR TITLE
[FIX] l10n_it_stock_ddt: fix rounding error in ddt report

### DIFF
--- a/addons/l10n_it_stock_ddt/report/l10n_it_ddt_report.xml
+++ b/addons/l10n_it_stock_ddt/report/l10n_it_ddt_report.xml
@@ -128,7 +128,7 @@
                                     </td>
                                     <td>
                                         <t t-if="move.sale_line_id">
-                                            <t t-set="lst_price" t-value="move.sale_line_id.price_reduce_taxinc * move.product_id.uom_id._compute_quantity(move.quantity, move.sale_line_id.product_uom_id)"/>
+                                            <t t-set="lst_price" t-value="move.sale_line_id.price_total"/>
                                         </t>
                                         <t t-else="">
                                             <t t-set="lst_price" t-value="move.product_id.lst_price * move.product_uom._compute_quantity(move.quantity, move.product_id.uom_id)"/>


### PR DESCRIPTION
#### Issue:
In the DDT Report, the value displayed on each line is the rounded value of one unit multiplied by the number of unit. Therefore, the amount on a line differ from the real value.

#### Step to reproduce:
- in an Italian company
- create a sale order with a product
- confirm it
- go to delivery
- validate the delivery
- print

#### Current behavior:
On the DDT report, the value of each line is the rounded value of one unit multiplied by the number of unit.

#### Expected behavior:
On the DDT report, the value of each line should be the same as in the sale order.

#### Cause of the issue:
The value of a line was miscalculated based on the rounded price of a unit.

#### Solution:
This error occurs when a calculation is applied to the sale price, such as a tax or a discount. This applies for deliveries coming from sale orders. These calculations are included in the `price_total` field of the corresponding line in the SO.

opw-5012921

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
