### PR TITLE
[FIX] mail: use inlineBody instead of richBody in message reply

### DIFF
--- a/addons/mail/static/src/core/common/message_in_reply.scss
+++ b/addons/mail/static/src/core/common/message_in_reply.scss
@@ -23,13 +23,7 @@
 
 .o-mail-MessageInReply-message {
     // Make the body single line when possible
-    p, div {
-        display: inline;
+    p {
         margin: 0;
     }
-
-    br {
-        display: none;
-    }
 }
-

--- a/addons/mail/static/src/core/common/message_in_reply.xml
+++ b/addons/mail/static/src/core/common/message_in_reply.xml
@@ -14,7 +14,7 @@
                             <b class="o-mail-MessageInReply-author"><t t-out="props.message.parent_id.authorName"/></b>:
                             <span class="o-mail-MessageInReply-message ms-1 text-break">
                                 <t t-if="!props.message.parent_id.isBodyEmpty">
-                                    <t t-out="props.message.parent_id.richBody"/>
+                                    <t t-out="props.message.parent_id.inlineBody"/>
                                     <em t-if="props.message.parent_id.edited" class="smaller fw-bold text-500"> (edited)</em>
                                 </t>
                                 <t t-elif="props.message.parent_id.attachment_ids.length > 0">


### PR DESCRIPTION
Before this PR, message that contains <br> would not be properly inlined. The second line would be directly append to the first without space. This PR use the existing inlineBody to fix the issue and cleanup the css that inlined the message before.

task-5072071
