### PR TITLE
[FIX] website: do not add a new list item in tabs images on Enter

### DIFF
--- a/addons/website/static/src/builder/plugins/options/navtabs_style_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/navtabs_style_option_plugin.js
@@ -30,6 +30,7 @@ class NavTabsStyleOptionPlugin extends Plugin {
             getButtons: this.getActiveOverlayButtons.bind(this),
         }),
         is_unremovable_selector: ".nav-item",
+        unsplittable_node_predicates: this.isUnsplittable,
     };
     isNavItem(el) {
         return el.matches(".nav-item") && !!el.closest(".s_tabs, .s_tabs_images");
@@ -84,6 +85,15 @@ class NavTabsStyleOptionPlugin extends Plugin {
             nextNavItemEl.after(this.overlayTarget);
             nextTabPaneEl.after(tabPaneEl);
         }
+    }
+
+    isUnsplittable(node) {
+        return (
+            node &&
+            node.nodeType === Node.ELEMENT_NODE &&
+            node.closest(".s_tabs, .s_tabs_images") &&
+            node.closest("li")?.classList.contains("nav-item")
+        );
     }
 }
 

--- a/addons/website/static/tests/builder/s_tabs_images.test.js
+++ b/addons/website/static/tests/builder/s_tabs_images.test.js
@@ -1,0 +1,18 @@
+import { setSelection } from "@html_editor/../tests/_helpers/selection";
+import { expect, test } from "@odoo/hoot";
+import { manuallyDispatchProgrammaticEvent, queryOne } from "@odoo/hoot-dom";
+import { defineWebsiteModels, setupWebsiteBuilderWithSnippet } from "./website_helpers";
+
+defineWebsiteModels();
+
+test("pressing Enter in the .s_tabs_images_option doesn't add a new <li/>", async () => {
+    const { getEditor } = await setupWebsiteBuilderWithSnippet("s_tabs_images");
+    const editor = getEditor();
+    const numberOfSlides = queryOne(":iframe .s_tabs_images ul").children.length;
+    setSelection({ anchorNode: queryOne(":iframe .s_tabs_images ul>li:last-child small") });
+    // Simulate pressing "enter"
+    await manuallyDispatchProgrammaticEvent(editor.editable, "beforeinput", {
+        inputType: "insertParagraph",
+    });
+    expect(":iframe .s_tabs_images ul>li").toHaveCount(numberOfSlides);
+});


### PR DESCRIPTION
Following the [refactoring] of the `html_builder` we had a problem when instead of a new line
in the slide description we had a new list item.
Steps to reproduce the issue:
- Open website and start editing
- Drop the .s_tabs_images snippet
- Click on any slide description
- Press 'Enter'

-> It adds a new list item because it treats it as a regular list. Related to task-4367641

[refactoring]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2