### PR TITLE
[IMP] mail: skip discuss performance test

### DIFF
--- a/addons/mail/static/tests/discuss/core/discuss_performance.test.js
+++ b/addons/mail/static/tests/discuss/core/discuss_performance.test.js
@@ -18,7 +18,7 @@ import { patchWithCleanup } from "@web/../tests/web_test_helpers";
 describe.current.tags("desktop");
 defineMailModels();
 
-test("posting new message should only render relevant part", async () => {
+test.skip("posting new message should only render relevant part", async () => {
     // For example, it should not render old messages again
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "general" });


### PR DESCRIPTION
Test failed since https://github.com/odoo/odoo/pull/223004

With the introduction to `useMessageActions.more()` feature, this triggers more initial renderings on message than expected, thus the 10 messages triggers 20 renderings instead of expected 10.

Looking at fixing this issue, but in the meantime the test is skipped.