### PR TITLE
[IMP] hr: improve user preferences form

### DIFF
--- a/addons/hr/models/res_users.py
+++ b/addons/hr/models/res_users.py
@@ -84,6 +84,7 @@ class ResUsers(models.Model):
     private_email = fields.Char(related='employee_id.private_email', string="Private Email", readonly=False)
     km_home_work = fields.Integer(related='employee_id.km_home_work', readonly=False, related_sudo=False)
     # res.users already have a field bank_account_id and country_id from the res.partner inheritance: don't redefine them
+    # This field no longer appears to be in use. To avoid breaking anything it must only be removed after the freeze of v19.
     employee_bank_account_ids = fields.Many2many('res.partner.bank', related='employee_id.bank_account_ids', string="Employee's Bank Accounts", related_sudo=False, readonly=False)
     emergency_contact = fields.Char(related='employee_id.emergency_contact', readonly=False, related_sudo=False)
     emergency_phone = fields.Char(related='employee_id.emergency_phone', readonly=False, related_sudo=False)

--- a/addons/hr/models/res_users.py
+++ b/addons/hr/models/res_users.py
@@ -69,7 +69,7 @@ class ResUsers(models.Model):
     work_email = fields.Char(related='employee_id.work_email', readonly=False, related_sudo=False)
     category_ids = fields.Many2many(related='employee_id.category_ids', string="Employee Tags", readonly=False, related_sudo=False)
     work_contact_id = fields.Many2one(related='employee_id.work_contact_id', readonly=False, related_sudo=False)
-    work_location_id = fields.Many2one(related='employee_id.work_location_id')
+    work_location_id = fields.Many2one(related='employee_id.work_location_id', readonly=False, related_sudo=False)
     work_location_name = fields.Char(related="employee_id.work_location_name")
     work_location_type = fields.Selection(related="employee_id.work_location_type")
     private_street = fields.Char(related='employee_id.private_street', string="Private Street", readonly=False, related_sudo=False)

--- a/addons/hr/views/res_users.xml
+++ b/addons/hr/views/res_users.xml
@@ -94,7 +94,6 @@
                                 </div>
                                 <field name="private_email" string="Private Email"/>
                                 <field name="private_phone" string="Private Phone" class="o_force_ltr"/>
-                                <field name="employee_bank_account_ids" widget="many2many_tags" context="{'display_partner': True}" readonly="not is_hr_user"/>
                             </group>
                             <group string="Emergency Contact">
                                 <field name="emergency_contact" string="Contact Name" placeholder="e.g. John Doe"/>

--- a/addons/hr/views/res_users.xml
+++ b/addons/hr/views/res_users.xml
@@ -72,11 +72,10 @@
                     </h5>
                 </xpath>
                 <xpath expr="//group[@name='other_preferences']" position="inside">
-                    <field name="is_hr_user" invisible="1"/>
-                    <field name="pin" string="Attendance PIN" readonly="not is_hr_user"/>
+                    <field name="pin" string="Attendance PIN"/>
                 </xpath>
                 <xpath expr="//group[@name='other_calendar_preferences']" position="inside">
-                    <field name="work_location_id" string="Main Work Location"/>
+                    <field name="work_location_id" string="Main Work Location" options="{'no_create': True}"/>
                 </xpath>
                 <xpath expr="//page[@name='calendar']" position="after">
                     <page name="private_information" string="Private">

--- a/addons/mail/views/res_users_views.xml
+++ b/addons/mail/views/res_users_views.xml
@@ -35,12 +35,14 @@
                     <field name="signature" position="attributes">
                         <attribute name="widget">html_mail</attribute>
                     </field>
-                    <field name="signature" position="after">
-                        <field name="out_of_office_from" widget="daterange"
-                               options="{'end_date_field': 'out_of_office_to'}"/>
-                        <field name="out_of_office_to" invisible="1"/>  <!-- otherwise it is visible, smort -->
-                        <field name="out_of_office_message"/>
-                    </field>
+                    <group name="calendar_preferences" position="inside">
+                        <label for="out_of_office_from" string="Out-of-office" />
+                        <div class="o_row">
+                            <field name="out_of_office_from" widget="daterange" options="{'end_date_field': 'out_of_office_to', 'show_time': False}" placeholder="None planned"/>
+                            <field name="out_of_office_to" invisible="1"/> <!-- otherwise it is visible, smort -->
+                        </div>
+                        <field name="out_of_office_message" string="" options="{'height': 112}" class="border border-secondary w-100" placeholder="Your out-of-office message..."/>
+                    </group>
                 </data>
             </field>
         </record>
@@ -65,12 +67,14 @@
                     <field name="signature" position="attributes">
                         <attribute name="widget">html_mail</attribute>
                     </field>
-                    <field name="signature" position="after">
-                        <field name="out_of_office_from" widget="daterange"
-                               options="{'end_date_field': 'out_of_office_to'}"/>
-                        <field name="out_of_office_to" invisible="1"/>  <!-- otherwise it is visible, smort -->
-                        <field name="out_of_office_message"/>
-                    </field>
+                    <group name="calendar_preferences" position="inside">
+                        <label for="out_of_office_from" string="Out-of-office" />
+                        <div class="o_row">
+                            <field name="out_of_office_from" widget="daterange" options="{'end_date_field': 'out_of_office_to', 'show_time': False}" placeholder="None planned"/>
+                            <field name="out_of_office_to" invisible="1"/> <!-- otherwise it is visible, smort -->
+                        </div>
+                        <field name="out_of_office_message" string="" options="{'height': 112}" class="border border-secondary w-100" placeholder="Your out-of-office message..."/>
+                    </group>
                 </data>
             </field>
         </record>


### PR DESCRIPTION
This PR improves the users preferences form and the user form for the admin. It contains 3 commits.

- Commit 1: remove the employee_bank_account_id of the preferences form as it must be changed from the hr.employee form by members of group_hr_user.
- Commit 2: allows the edition of the pin and work_location_id fields on the preferences form as all the fields of the form must be editable.
- Commit 3: move the out_of_office fields to the calendar tab and improve their display.  

Task-5071765
