### PR TITLE
[FIX] mail: no double rendering with useAction.more()

### DIFF
--- a/addons/mail/static/src/core/common/action.js
+++ b/addons/mail/static/src/core/common/action.js
@@ -1,5 +1,6 @@
 import { isRecord, STORE_SYM } from "@mail/model/misc";
 import { toRaw } from "@odoo/owl";
+import { DropdownState } from "@web/core/dropdown/dropdown_hooks";
 import { useService } from "@web/core/utils/hooks";
 import { Reactive } from "@web/core/utils/reactive";
 
@@ -25,6 +26,7 @@ export const ACTION_TAGS = Object.freeze({
  * @property {boolean} [dropdown]
  * @property {string|(action: Action) => string} [dropdownMenuClass]
  * @property {string|(action: Action) => string} [dropdownPosition]
+ * @property {DropdownState|(action: Action) => DropdownState} [dropdownState]
  * @property {string|(action: Action) => string} [dropdownTemplate]
  * @property {Object|(action: Action) => Object} [dropdownTemplateParams]
  * @property {string|(action: Action) => string} [hotkey]
@@ -169,6 +171,18 @@ export class Action {
             (typeof this.definition.dropdownPosition === "function"
                 ? this.definition.dropdownPosition.call(this, this.params)
                 : this.definition.dropdownPosition)
+        );
+    }
+
+    /** @param {Action} action @returns {DropdownState|undefined} */
+    _dropdownState(action) {}
+    /** When action is a dropdown @see dropdown, this determines the preferred position of the dropdown */
+    get dropdownState() {
+        return (
+            this._dropdownState(this.params) ??
+            (typeof this.definition.dropdownState === "function"
+                ? this.definition.dropdownState.call(this, this.params)
+                : this.definition.dropdownState)
         );
     }
 
@@ -370,7 +384,9 @@ export class UseActions extends Reactive {
                 definition: {
                     ...data,
                     dropdown: true,
+                    dropdownState: new DropdownState(),
                     icon: data?.icon ?? "oi oi-ellipsis-v",
+                    isActive: ({ action }) => action.dropdownState.isOpen,
                     isMoreAction: true,
                     sequence: data.sequence ?? 1000,
                 },

--- a/addons/mail/static/src/core/common/action_list.js
+++ b/addons/mail/static/src/core/common/action_list.js
@@ -1,8 +1,7 @@
 import { CallDropdown } from "@mail/discuss/call/common/call_dropdown";
 import { attClassObjectToString } from "@mail/utils/common/format";
-import { Component, onWillUnmount, useEffect } from "@odoo/owl";
+import { Component, onWillUnmount } from "@odoo/owl";
 import { Dropdown } from "@web/core/dropdown/dropdown";
-import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 
 import { useService } from "@web/core/utils/hooks";
@@ -39,15 +38,8 @@ class Action extends Component {
         this.ui = useService("ui");
         this.attClassObjectToString = attClassObjectToString;
         if (this.props.action.definition?.isMoreAction) {
-            this.dropdownState = useDropdownState();
-            useEffect(
-                () => {
-                    this.props.action.definition.isActive = this.dropdownState.isOpen;
-                },
-                () => [this.dropdownState?.isOpen]
-            );
             onWillUnmount(() => {
-                this.props.action.definition.isActive = false;
+                this.props.action.dropdownState.close();
             });
         }
     }

--- a/addons/mail/static/src/core/common/action_list.xml
+++ b/addons/mail/static/src/core/common/action_list.xml
@@ -25,7 +25,7 @@
 
 <t t-name="mail.Action">
     <t t-if="action.dropdown">
-        <t t-component="Dropdown" menuClass="(action.dropdownMenuClass ?? '') + ' ' + store.discussDropdownMenuClass(this)" position="action.dropdownPosition" state="dropdownState">
+        <t t-component="Dropdown" menuClass="(action.dropdownMenuClass ?? '') + ' ' + store.discussDropdownMenuClass(this)" position="action.dropdownPosition" state="action.dropdownState">
             <t t-call="mail.Action.main"/>
             <t t-set-slot="content">
                 <t t-if="action.dropdownTemplate" t-call="{{ action.dropdownTemplate }}">

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -348,7 +348,7 @@ export class Message extends Component {
             this.state.isHovered ||
             this.state.isClicked ||
             this.emojiPicker?.isOpen ||
-            this.state.moreAction?.definition.isActive
+            Boolean(this.state.moreAction?.isActive)
         );
     }
 

--- a/addons/mail/static/tests/discuss/core/discuss_performance.test.js
+++ b/addons/mail/static/tests/discuss/core/discuss_performance.test.js
@@ -18,7 +18,7 @@ import { patchWithCleanup } from "@web/../tests/web_test_helpers";
 describe.current.tags("desktop");
 defineMailModels();
 
-test.skip("posting new message should only render relevant part", async () => {
+test("posting new message should only render relevant part", async () => {
     // For example, it should not render old messages again
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "general" });


### PR DESCRIPTION
Before this commit, when using the `useAction.more()` feature, this triggers double rendering of the component.

This happens because the initial value of `isActive` of the more action is `undefined`, while the component instance `Action` of the more action has a useEffect that forces the value being a boolean in a useEffect. This useEffect is meant to synchronise the definition state with the dropdown, so that the code in parent can rely on pure action definition and dropdown state is technical detail of the child component.

Because of `isActive` being `undefined` initially and then immediately set to `false` by component, if the parent component was observing the `moreAction.isActive` state, then this would trigger double rendering.

The `Message` component had this problem: it has `Message.isActive` in the template, whose value depends on `moreAction.isActive`. As the test `discuss_performance.test.js` is made with several `Message` components, this explains why the messages were rendering twice as much as expected.

One solution is to enforce `false` to `isActive`, but a even cleaner solution is to not have useEffect in Action to sync the dropdown state with isActive. This commit replaces the local useDropdownState to Action.dropdownState in action definition. That way the value does not need syncing by writing on it thus preventing the bug. Also writing on definition.isActive was a hack and not is changed to have its value synced with `dropdownState.isOpen`, so this is the other way around.

Fixes runbot-error-231757