### PR TITLE
[FIX] pos_self_order: back navigation with preserved order state

### DIFF
--- a/addons/pos_online_payment_self_order/__manifest__.py
+++ b/addons/pos_online_payment_self_order/__manifest__.py
@@ -18,6 +18,9 @@
             'pos_online_payment_self_order/static/src/**/*',
             'web/static/lib/zxing-library/zxing-library.js',
         ],
+        'pos_self_order.assets_tests': [
+            'pos_online_payment_self_order/static/tests/tours/test_self_order_kiosk.js',
+        ],
     },
     'license': 'LGPL-3',
 }

--- a/addons/pos_online_payment_self_order/static/tests/tours/test_self_order_kiosk.js
+++ b/addons/pos_online_payment_self_order/static/tests/tours/test_self_order_kiosk.js
@@ -1,0 +1,27 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import * as Utils from "@pos_self_order/../tests/helpers/utils";
+import * as CartPage from "@pos_self_order/../tests/helpers/cart_page";
+import * as ProductPage from "@pos_self_order/../tests/helpers/product_page";
+
+registry.category("web_tour.tours").add("tour_kiosk_online_payment_cart_check", {
+    test: true,
+    steps: () => [
+        Utils.clickBtn("Order Now"),
+        ProductPage.clickProduct("Coca-Cola"),
+        ProductPage.clickProduct("Fanta"),
+        Utils.clickBtn("Order"),
+        CartPage.checkProduct("Coca-Cola", "2.53", "1"),
+        CartPage.checkProduct("Fanta", "2.53", "1"),
+        Utils.clickBtn("Pay"),
+        Utils.clickBtn("Back"),
+        CartPage.checkProduct("Coca-Cola", "2.53", "1"),
+        CartPage.checkProduct("Fanta", "2.53", "1"),
+        {
+            content: "Last tour step",
+            trigger: "body",
+            isCheck: true,
+        },
+    ],
+});

--- a/addons/pos_online_payment_self_order/tests/test_self_order_frontend.py
+++ b/addons/pos_online_payment_self_order/tests/test_self_order_frontend.py
@@ -1,12 +1,48 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from unittest.mock import patch
-
 import odoo.tests
 from odoo.addons.pos_self_order.tests.self_order_common_test import SelfOrderCommonTest
-# from odoo.addons.pos_online_payment.models.pos_payment_method import PosPaymentMethod
+from odoo.addons.pos_online_payment.tests.online_payment_common import OnlinePaymentCommon
 
 
 @odoo.tests.tagged("post_install", "-at_install")
-class TestSelfOrderFrontendMobile(SelfOrderCommonTest):
-    pass
+class TestSelfOrderFrontendMobile(SelfOrderCommonTest, OnlinePaymentCommon):
+    def test_kiosk_order_with_online_payment(self):
+        """Verify that self ordering works when only an online payment method is configured."""
+
+        self.provider.write({
+            'company_id': self.company.id,
+        })
+
+        self.online_payment_method = self.env['pos.payment.method'].create({
+            'name': 'Online payment',
+            'is_online_payment': True,
+            'online_payment_provider_ids': [(6, 0, [self.provider.id])],
+        })
+
+        self.pos_config.write({
+            'self_ordering_takeaway': False,
+            'self_ordering_mode': 'kiosk',
+            'self_ordering_pay_after': 'each',
+            "payment_method_ids": [(6, 0, [self.online_payment_method.id])],
+        })
+
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self_route = self.pos_config._get_self_order_route()
+        self.start_tour(self_route, "tour_kiosk_online_payment_cart_check")
+
+        # Ensure a POS order was created after the tour
+        kiosk_order = self.env['pos.order'].search([('config_id', '=', self.pos_config.id)], order="id desc", limit=1)
+        self.assertEqual(len(kiosk_order), 1, "No POS order was created")
+
+        # Collect order lines in a dict by product name
+        order_lines = {line.product_id.display_name: line for line in kiosk_order.lines}
+        self.assertEqual(len(order_lines), 2, "There should be exactly 2 order lines")
+
+        coca_line = order_lines.get("Coca-Cola")
+        self.assertIsNotNone(coca_line, "Expected order line not found")
+        self.assertEqual(coca_line.qty, 1, "Order line quantity mismatch")
+
+        fanta_line = order_lines.get("Fanta")
+        self.assertIsNotNone(fanta_line, "Expected order line not found")
+        self.assertEqual(fanta_line.qty, 1, "Order line quantity mismatch")

--- a/addons/pos_self_order/static/src/app/pages/payment_page/payment_page.js
+++ b/addons/pos_self_order/static/src/app/pages/payment_page/payment_page.js
@@ -35,6 +35,11 @@ export class PaymentPage extends Component {
         return this.selfOrder.paymentError || this.state.selection;
     }
 
+    back() {
+        this.selfOrder.restoreChangesFromBackNavigation();
+        this.router.back();
+    }
+
     selectMethod(methodId) {
         this.state.selection = false;
         this.state.paymentMethodId = methodId;

--- a/addons/pos_self_order/static/src/app/pages/payment_page/payment_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/payment_page/payment_page.xml
@@ -23,7 +23,7 @@
             </div>
         </div>
         <div class="px-3 py-4 d-flex gap-1 justify-content-center">
-            <button class="btn btn-primary btn-lg" t-if="state.selection || selectedPaymentMethod.is_online_payment || this.selfOrder.paymentError" t-on-click="() => this.router.back()">Back</button>
+            <button class="btn btn-primary btn-lg" t-if="state.selection || selectedPaymentMethod.is_online_payment || this.selfOrder.paymentError" t-on-click="back">Back</button>
             <button class="btn btn-info btn-lg" t-if="!state.selection and selfOrder.paymentError" t-on-click="startPayment">Retry</button>
         </div>
     </t>

--- a/addons/pos_self_order/static/src/app/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/self_order_service.js
@@ -55,6 +55,7 @@ export class SelfOrder extends Reactive {
         this.ordering = false;
         this.orders = [];
         this.kitchenPrinters = [];
+        this.preservedOrderState = null;
 
         this.initData();
         if (this.config.self_ordering_mode === "kiosk") {
@@ -160,6 +161,13 @@ export class SelfOrder extends Reactive {
             return;
         }
 
+        // Preserve the current order state for restoring later
+        this.preservedOrderState = {
+            orderUuid: order.uuid,
+            lines: order.lines,
+            lastChangesSent: order.lastChangesSent,
+        };
+
         // if the amount is 0, we don't need to go to the payment page
         // this directive works for both mode each and meal
         if (order.amount_total === 0 && order.lines.length > 0) {
@@ -190,6 +198,22 @@ export class SelfOrder extends Reactive {
                 this.router.navigate("payment");
             }
         }
+    }
+
+    restoreChangesFromBackNavigation() {
+        if (this.preservedOrderState) {
+            const { orderUuid, lines, lastChangesSent } = this.preservedOrderState;
+            const currentOrder = this.currentOrder;
+
+            if (currentOrder?.uuid === orderUuid) {
+                currentOrder.lines = lines;
+                currentOrder.lastChangesSent = lastChangesSent;
+            }
+
+            this.preservedOrderState = null;
+            return true;
+        }
+        return false;
     }
 
     get currentOrder() {


### PR DESCRIPTION
Steps to reproduce:
===================
- Start a self-order session.
- Add some products to the cart.
- Navigate to the payment page.
- Click the back button.

Issue:
======
- The previous order state is lost when going back from the payment page.
- Not able to update the cart after click on the pay button.

Cause:
======
- No code existed to preserve the current order state before navigation.
- The server kept old lines even if the client removed them from the payload, preventing proper synchronization.

Fix:
====
- Added preservation of order details (`lines`, `lastChangesSent`) so that the state can be restored when navigating back.
- Implemented removal of order lines that are no longer present in the incoming payload.

Task: 5055279