### PR TITLE
[FIX] im_livechat,mail: prevent error when enabling can create in studio

### DIFF
--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -165,7 +165,8 @@ class DiscussChannel(models.Model):
         }
         for record in self:
             end = last.date if (last := last_msg_by_channel_id.get(record.id)) else fields.Datetime.now()
-            record.duration = (end - record.create_date).total_seconds() / 3600
+            start = record.create_date or fields.Datetime.now()
+            record.duration = (end - start).total_seconds() / 3600
 
     @api.depends("livechat_end_dt")
     def _compute_livechat_status(self):

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -1398,7 +1398,7 @@ class DiscussChannel(models.Model):
 
     def _get_last_messages(self):
         """ Return the last message for each of the given channels."""
-        if not self:
+        if not self.ids:
             return self.env["mail.message"]
         self.env['mail.message'].flush_model()
         self.env.cr.execute(


### PR DESCRIPTION
Currently, an error occurs when enabling `Can Create` in Studio for a Website
Live Chat channels.

**Steps to reproduce:**

- Install the `im_livechat` and `web_studio` modules.
- Go to `Live Chat`, create a new channel, then return to the Live Chat channels
  view and open the newly created channel in kanban view.
- Open `Studio` and enable `Can Create`.

**Error:**
```
SyntaxError: syntax error at or near ')'
LINE 12: WHERE discuss_channel.id IN ()
```

**Root Cause:**
At [1], an `SQL query` is executed with `self.ids`, when `self.ids` is `empty`, this
leads to an `error`.

**Fix:**
This commit prevents the error by updating `_get_last_messages` to check for `empty self.ids` 
and return an empty recordset early and also updates `_compute_duration` to safely handle 
cases where `record.create_date` is `False`.

[1]:
https://github.com/odoo/odoo/blob/70a7babcc830f72bd069a5bb1504748363e4e848/addons/mail/models/discuss/discuss_channel.py#L1404-L1421

sentry-6861438710