### PR TITLE
[FIX] web: contact_image field shows broken image

### DIFF
--- a/addons/web/static/src/views/fields/contact_image/contact_image_field.js
+++ b/addons/web/static/src/views/fields/contact_image/contact_image_field.js
@@ -1,7 +1,7 @@
 import { isBinarySize } from "@web/core/utils/binary";
 import { registry } from "@web/core/registry";
 import { imageUrl } from "@web/core/utils/urls";
-import { ImageField, imageField } from "@web/views/fields/image/image_field";
+import { ImageField, imageField, fileTypeMagicWordMap } from "@web/views/fields/image/image_field";
 
 export class ContactImageField extends ImageField {
     static template = "web.ContactImageField";
@@ -19,7 +19,9 @@ export class ContactImageField extends ImageField {
                     { unique: this.rawCacheKey }
                 );
             } else {
-                this.lastURL = `data:image/png;base64,${this.props.record.data[imageFieldName]}`;
+                const magic =
+                    fileTypeMagicWordMap[this.props.record.data[imageFieldName][0]] || "png";
+                this.lastURL = `data:image/${magic};base64,${this.props.record.data[imageFieldName]}`;
             }
             return this.lastURL;
         }


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:
When creating an inline partner from voip.call, the partner image was not updating properly, forcing alt text to be displayed until voip.call record was saved.

Desired behavior after PR is merged:
When the field is dirty because of an inline creation of record which does not contains a valid image, display a placeholder image instead of an broken image or alt text.

Task-5023035





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
