### PR TITLE
[IMP] html_builder, web, website: improve datetimepicker

### DIFF
--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_datetimepicker.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_datetimepicker.test.js
@@ -16,8 +16,8 @@ function isExpectedDateTime({
     expectedDateTime = DateTime.now(),
     tolerance = TIME_TOLERANCE,
 }) {
-    const actualTimestamp = DateTime.fromFormat(dateString, "MM/dd/yyyy HH:mm:ss").toUnixInteger();
-    const expectedTimestamp = expectedDateTime.toUnixInteger();
+    const actualTimestamp = DateTime.fromFormat(dateString, "MM/dd/yyyy HH:mm").toUnixInteger();
+    const expectedTimestamp = 60 * Math.floor(expectedDateTime.toUnixInteger() / 60);
     const difference = Math.abs(actualTimestamp - expectedTimestamp);
     return difference <= tolerance;
 }
@@ -71,16 +71,16 @@ test("defaults to last one when invalid date provided", async () => {
     );
     await setupHTMLBuilder(`<div class="test-options-target" data-date="1554219400">b</div>`);
     await contains(":iframe .test-options-target").click();
-    expect(".we-bg-options-container input").toHaveValue("04/02/2019 16:36:40");
+    expect(".we-bg-options-container input").toHaveValue("04/02/2019 16:36");
 
     await contains(".we-bg-options-container input").edit("INVALID DATE");
-    expect(".we-bg-options-container input").toHaveValue("04/02/2019 16:36:40");
+    expect(".we-bg-options-container input").toHaveValue("04/02/2019 16:36");
 
-    await contains(".we-bg-options-container input").edit("04/01/2019 10:00:00");
-    expect(".we-bg-options-container input").toHaveValue("04/01/2019 10:00:00");
+    await contains(".we-bg-options-container input").edit("04/01/2019 10:00");
+    expect(".we-bg-options-container input").toHaveValue("04/01/2019 10:00");
 
     await contains(".we-bg-options-container input").edit("INVALID DATE");
-    expect(".we-bg-options-container input").toHaveValue("04/01/2019 10:00:00");
+    expect(".we-bg-options-container input").toHaveValue("04/01/2019 10:00");
 });
 
 test("defaults to last one when invalid date provided (date)", async () => {
@@ -97,7 +97,7 @@ test("defaults to last one when invalid date provided (date)", async () => {
     await contains(".we-bg-options-container input").edit("INVALID DATE");
     expect(".we-bg-options-container input").toHaveValue("04/02/2019");
 
-    await contains(".we-bg-options-container input").edit("04/01/2019 10:00:00");
+    await contains(".we-bg-options-container input").edit("04/01/2019 10:00");
     expect(".we-bg-options-container input").toHaveValue("04/01/2019");
 
     await contains(".we-bg-options-container input").edit("INVALID DATE");
@@ -113,8 +113,8 @@ test("defaults to now when no date is selected", async () => {
     );
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
-    await contains(".we-bg-options-container input").edit("04/01/2019 10:00:00");
-    expect(".we-bg-options-container input").toHaveValue("04/01/2019 10:00:00");
+    await contains(".we-bg-options-container input").edit("04/01/2019 10:00");
+    expect(".we-bg-options-container input").toHaveValue("04/01/2019 10:00");
 
     await contains(".we-bg-options-container input").edit("");
     const dateString = queryOne(".we-bg-options-container input").value;
@@ -130,8 +130,8 @@ test("defaults to now when clicking on clear button", async () => {
     );
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
-    await contains(".we-bg-options-container input").edit("04/01/2019 10:00:00");
-    expect(".we-bg-options-container input").toHaveValue("04/01/2019 10:00:00");
+    await contains(".we-bg-options-container input").edit("04/01/2019 10:00");
+    expect(".we-bg-options-container input").toHaveValue("04/01/2019 10:00");
 
     for (let i = 0; i < 3; i++) {
         await contains(".we-bg-options-container input").click();
@@ -199,15 +199,15 @@ test("edit a date with the datetime picker should correctly apply the mutation",
     await contains(":iframe .test-options-target").click();
     await contains(".we-bg-options-container input").click();
     await contains(".o_date_item_cell:contains('9')").click();
-    expect(".we-bg-options-container input").toHaveValue("04/09/2019 16:36:40");
+    expect(".we-bg-options-container input").toHaveValue("04/09/2019 16:36");
 
     await contains(".o_datetime_buttons .btn:contains('apply')").click();
-    expect(".we-bg-options-container input").toHaveValue("04/09/2019 16:36:40");
-    expect(":iframe .test-options-target").toHaveAttribute("data-date", "1554824200");
+    expect(".we-bg-options-container input").toHaveValue("04/09/2019 16:36");
+    expect(":iframe .test-options-target").toHaveAttribute("data-date", "1554824160");
 
     // refresh the Edit tab
     await contains(":iframe .another-target").click();
     await contains(":iframe .test-options-target").click();
-    expect(".we-bg-options-container input").toHaveValue("04/09/2019 16:36:40");
-    expect(":iframe .test-options-target").toHaveAttribute("data-date", "1554824200");
+    expect(".we-bg-options-container input").toHaveValue("04/09/2019 16:36");
+    expect(":iframe .test-options-target").toHaveAttribute("data-date", "1554824160");
 });

--- a/addons/website/static/src/snippets/s_website_form/001.scss
+++ b/addons/website/static/src/snippets/s_website_form/001.scss
@@ -90,6 +90,11 @@
     }
 }
 
+.o_datetime_picker .o_day_of_week_cell,
+.o_datetime_picker .o_week_number_cell {
+    background-color: $o-gray-100 !important;
+}
+
 body:not(.editor_enable) .s_website_form[data-vcss="001"] {
     .s_website_form_date, .s_website_form_datetime {
         &:not(.s_website_form_datepicker_initialized) {

--- a/addons/website/static/src/snippets/s_website_form/form.js
+++ b/addons/website/static/src/snippets/s_website_form/form.js
@@ -237,6 +237,7 @@ export class Form extends Interaction {
                         onChange: () =>
                             inputEl.dispatchEvent(new Event("input", { bubbles: true })),
                         pickerProps: {
+                            showWeekNumbers: false,
                             type: fieldEl.matches(".s_website_form_date, .o_website_form_date")
                                 ? "date"
                                 : "datetime",

--- a/addons/website/views/snippets/s_countdown.xml
+++ b/addons/website/views/snippets/s_countdown.xml
@@ -4,7 +4,7 @@
 <template id="s_countdown" name="Countdown">
     <section class="s_countdown pt48 pb48"
         data-display="dhms" data-end-action="nothing" data-size="175"
-        t-att-data-end-time="datetime.datetime.now().timestamp() + 228307"
+        t-att-data-end-time="60 * round(datetime.datetime.now().timestamp() / 60) + 228300"
         data-layout="circle" data-layout-background="none"
         data-progress-bar-style="surrounded" data-progress-bar-weight="thin"
         data-text-color="o-color-1" data-layout-background-color="400" data-progress-bar-color="o-color-1">


### PR DESCRIPTION
Since there is no need to edit seconds for a countdown or a form, it was
decided to simplify the datetime picker within the website builder. The
seconds are no longer editable and are not displayed anymore to prevent
the user from editing them.

The clear button was removed for the countdown since it would set the
endtime to now, adding an history step for nothing. The clear button is
kept in form options.

The apply button was removed for two reasons:
- Since selecting a time would only preview the value, hovering options
would preview with the previous selected datetime. Changes are directly
committed to avoid this preview issue.
- There a no buttons to "apply" colors in colorpicker, the value are
committed directly. Removing the apply button will achieve a better
consistency.

task-5253214