### PR TITLE
[IMP] account{,_peppol}: Display Self-Billing if Peppol SB is activated

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -765,6 +765,8 @@ class AccountMove(models.Model):
     display_send_button = fields.Boolean(compute='_compute_display_send_button')
     highlight_send_button = fields.Boolean(compute='_compute_highlight_send_button')
 
+    display_is_self_billing_field = fields.Boolean(compute='_compute_display_is_self_billing_field')
+
     _checked_idx = models.Index("(journal_id) WHERE (checked IS NOT TRUE)")
     _payment_idx = models.Index("(journal_id, state, payment_state, move_type, date)")
     _unique_name = models.UniqueIndex(
@@ -2283,6 +2285,10 @@ class AccountMove(models.Model):
     def _compute_highlight_send_button(self):
         for move in self:
             move.highlight_send_button = not move.is_being_sent and not move.invoice_pdf_report_id
+
+    def _compute_display_is_self_billing_field(self):
+        """ Default behaviour is to not display the 'Self-Billing' field. """
+        self.display_is_self_billing_field = False
 
     def _search_next_payment_date(self, operator, value):
         if operator not in ('in', '<', '<='):

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1507,7 +1507,7 @@
                                                invisible="auto_post in ('no', 'at_date')"
                                                readonly="state != 'draft'"/>
                                         <field name="is_self_billing"
-                                               invisible="move_type not in ('in_invoice', 'in_refund')"/>
+                                               invisible="not display_is_self_billing_field"/>
                                     </group>
                                 </group>
                             </page>

--- a/addons/account_peppol/models/account_move.py
+++ b/addons/account_peppol/models/account_move.py
@@ -43,6 +43,16 @@ class AccountMove(models.Model):
             if move.company_id.peppol_activate_self_billing_sending and move._is_exportable_as_self_invoice():
                 move.display_send_button = True
 
+    def _compute_display_is_self_billing_field(self):
+        # EXTENDS 'account'
+        super()._compute_display_is_self_billing_field()
+        for move in self:
+            if (
+                move.move_type in ('in_invoice', 'in_refund')
+                and move.company_id.peppol_activate_self_billing_sending
+            ):
+                move.display_is_self_billing_field = True
+
     @api.depends('state')
     def _compute_peppol_move_state(self):
         for move in self:


### PR DESCRIPTION
We only want to display the `Self-Billing` field on invoices if Peppol is active on the current company and self-billing has been activated.

Otherwise, the field would be useless which would be confusing to the user.

task-none