### PR TITLE
[IMP] account: Intrastat Incoterms dynamic placeholder

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -705,6 +705,7 @@ class AccountMove(models.Model):
         string="PDF File",
         copy=False,
     )
+    invoice_incoterm_placeholder = fields.Char(compute='_compute_invoice_incoterm_placeholder')
 
     # === Display purpose fields === #
     # used to have a dynamic domain on journal / taxes in the form view.
@@ -2088,6 +2089,11 @@ class AccountMove(models.Model):
 
     def _compute_incoterm_location(self):
         pass
+
+    @api.depends('company_id.incoterm_id')
+    def _compute_invoice_incoterm_placeholder(self):
+        for move in self:
+            move.invoice_incoterm_placeholder = move.company_id.incoterm_id.display_name if move.company_id.incoterm_id else _('Define a default in the settings')
 
     @api.depends('partner_id', 'invoice_date', 'amount_total')
     def _compute_abnormal_warnings(self):

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1481,7 +1481,8 @@
                                            name="accounting_info_group"
                                            invisible="move_type not in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund')">
                                         <field name="company_id" groups="base.group_multi_company"/>
-                                        <field name="invoice_incoterm_id"/>
+                                        <field name="invoice_incoterm_placeholder" invisible="1"/>    <!-- Needed for placeholder_field -->
+                                        <field name="invoice_incoterm_id" options="{'placeholder_field': 'invoice_incoterm_placeholder'}"/>
                                         <field name="incoterm_location"/>
                                         <field name="fiscal_position_id" readonly="state in ['cancel', 'posted']"/>
                                         <field name="secured" groups="account.group_account_secured,base.group_no_one"/>


### PR DESCRIPTION
This commit adds a dynamic placeholder to incoterm field form view in `account.move`. The placeholder is dynamically set as the default incoterm value in setting. If no default is chosen, a default text is shown.

task-4788236

Current behavior before PR:
No placeholder is set to incoterm field in account move form view.

Desired behavior after PR is merged:
Dynamic placeholder set to incoterm field in account move form view with default incoterm value chosen in setting. If no default incoterm is chosen, a default text placeholder is shown.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
