### PR TITLE
[FIX] mail: message container not reversed

### DIFF
--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -61,7 +61,7 @@
                             <t t-if="isAlignedRight" t-call="mail.Message.notification"/>
                             <t t-if="!isAlignedRight and !message.bubbleColor and !(props.asCard and isMobileOS)" t-call="mail.Message.actions"/>
                         </div>
-                        <div class="o-mail-Message-contentContainer position-relative d-flex">
+                        <div class="o-mail-Message-contentContainer position-relative d-flex" t-att-class="{ 'flex-row-reverse': isAlignedRight }">
                             <div class="o-mail-Message-content o-min-width-0" t-att-class="{ 'w-100': isEditing, 'opacity-50': message.isPending, 'pt-1': message.isNote }">
                                 <div class="o-mail-Message-textContent position-relative d-flex" t-att-class="{ 'w-100': isEditing }">
                                     <t t-if="message.message_type === 'notification' and message.richBody" t-call="mail.Message.bodyAsNotification" name="bodyAsNotification"/>


### PR DESCRIPTION
Purpose of this PR,
The message container is not reversed when required, this commit handles that issue by adding the class when required.

Before:
<img width="504" height="137" alt="image" src="https://github.com/user-attachments/assets/838c14e3-8961-4972-9959-702ade483389" />

After:
<img width="570" height="79" alt="image" src="https://github.com/user-attachments/assets/bb2d8ede-0599-4ef4-b782-04b4d668c4f0" />

