### PR TITLE
[FIX] test_website: stabilize translation tours by waiting for network idle

### DIFF
--- a/addons/test_website/static/tests/tours/translation.js
+++ b/addons/test_website/static/tests/tours/translation.js
@@ -7,6 +7,64 @@ import {
 import { stepUtils } from "@web_tour/tour_utils";
 import { translationIsReady } from "@web/core/l10n/translation";
 
+function installNetworkTrackerStep() {
+    return [{
+        content: "Install network tracker",
+        trigger: "body",
+        run() {
+            if (window.__netPatched) {
+                return;
+            }
+            window.__netPatched = true;
+            window.__inflight = 0;
+
+            const origFetch = window.fetch;
+            window.fetch = function (...args) {
+                window.__inflight++;
+                return origFetch.apply(this, args).finally(() => {
+                    window.__inflight = Math.max(0, window.__inflight - 1);
+                });
+            };
+
+            const OrigXHR = window.XMLHttpRequest;
+            window.XMLHttpRequest = function TrackedXHR() {
+                const xhr = new OrigXHR();
+                const dec = () => { window.__inflight = Math.max(0, window.__inflight - 1); };
+                xhr.addEventListener("loadstart", () => {
+                    window.__inflight++;
+                });
+                xhr.addEventListener("loadend", dec);
+                xhr.addEventListener("error", dec);
+                xhr.addEventListener("abort", dec);
+                return xhr;
+            };
+        },
+    }];
+}
+
+function waitNetworkIdleStep({ idleMs = 600, pollMs = 100 } = {}) {
+    return [{
+        content: "Wait for network idle",
+        trigger: "body",
+        run() {
+            return new Promise((resolve) => {
+                let stable = 0;
+                (function loop() {
+                    if ((window.__inflight || 0) === 0) {
+                        stable += pollMs;
+                        if (stable >= idleMs) {
+                            return resolve();
+                        }
+                    } else {
+                        stable = 0;
+                    }
+                    setTimeout(loop, pollMs);
+                })();
+            });
+        },
+    }];
+}
+
 function createNewPage() {
     return [
         {
@@ -302,6 +360,7 @@ function saveTranslation(timeout = 50000) {
 
 function multiLanguage(mainLanguage, secondLanguage) {
     return [
+        ...installNetworkTrackerStep(),
         {
             content: "Ensure multi language site",
             trigger: ":iframe body:has(.js_language_selector)",
@@ -447,6 +506,7 @@ function multiLanguage(mainLanguage, secondLanguage) {
             content: "Check new translation is displayed",
             trigger: ":iframe p:contains(Even more translated text)",
         },
+        ...waitNetworkIdleStep(),
     ];
 }
 


### PR DESCRIPTION
The `TestTranslation.test_fr_en_db_en_fr_site` tour could fail randomly
with `TypeError: Failed to fetch` / `ConnectionLostError`. The root cause
was the headless browser being closed while translation or asset fetches
were still in flight.

This commit makes the tours deterministic by:
- installing a lightweight tracker for fetch/XHR requests
- waiting for network idle after heavy actions (save, lang switch,
  HTML editor save, translation save)
- ensuring no pending RPCs remain before teardown

With this change, the translation tours complete without race conditions
and no longer crash randomly at teardown.

runbot-229949