### PR TITLE
[FIX] point_of_sale: fix validate button should disabling on mobile

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.xml
@@ -67,20 +67,15 @@
     </t>
 
     <t t-name="point_of_sale.PaymentScreenValidate">
-        <t t-if="ui.isSmall">
-            <button class="btn-switchpane validation-button btn btn-primary btn-lg flex-fill py-3 lh-lg"
-                t-att-class="{ secondary: !(currentOrder.is_paid() and currentOrder._isValidEmptyOrder()) }"
-                t-on-click="() => this.validateOrder()">
-                <span>Validate</span>
-            </button>
-        </t>
-        <t t-else="">
-            <button class="button next validation btn btn-primary btn-lg w-50 py-3 lh-lg"
-                t-attf-class="{{currentOrder.is_paid() and currentOrder._isValidEmptyOrder() ? 'highlight' : 'disabled'}}"
-                t-on-click="() => this.validateOrder()">
-                <span class="next_text">Validate</span>
-            </button>
-        </t>
+        <button class="validation-button next btn btn-primary btn-lg py-3 lh-lg"
+            t-on-click="() => this.validateOrder()"
+            t-attf-class="
+                {{ ui.isSmall ? 'btn-switchpane flex-fill' : 'button next w-50' }}
+                {{ currentOrder.is_paid() and currentOrder._isValidEmptyOrder() ? 'highlight' : 'disabled' }}
+            "
+        >
+            <span>Validate</span>
+        </button>
     </t>
 
     <t t-name="point_of_sale.PaymentScreenBack">

--- a/addons/point_of_sale/static/tests/tours/utils/payment_screen_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/payment_screen_util.js
@@ -89,15 +89,8 @@ export function clickInvoiceButton() {
 export function clickValidate() {
     return [
         {
-            isActive: ["desktop"],
             content: "validate payment",
-            trigger: `.payment-screen .button.next.highlight`,
-            run: "click",
-        },
-        {
-            isActive: ["mobile"],
-            content: "validate payment",
-            trigger: `.payment-screen .btn-switchpane:contains('Validate')`,
+            trigger: `.payment-screen button.validation-button.next`,
             run: "click",
         },
     ];
@@ -259,17 +252,10 @@ export function validateButtonIsHighlighted(isHighlighted = true) {
     return [
         {
             isActive: ["desktop"],
-            content: `validate button is ${isHighlighted ? "highlighted" : "not highligted"}`,
+            content: `validate button is ${isHighlighted ? "highlighted" : "not highlighted"}`,
             trigger: isHighlighted
-                ? `.payment-screen .button.next.highlight`
-                : `.payment-screen .button.next:not(:has(.highlight))`,
-        },
-        {
-            isActive: ["mobile"],
-            content: `validate button is ${isHighlighted ? "highlighted" : "not highligted"}`,
-            trigger: isHighlighted
-                ? `.payment-screen .btn-switchpane:not(.secondary):contains('Validate')`
-                : `.payment-screen .btn-switchpane.secondary:contains('Validate')`,
+                ? `.payment-screen button.validation-button.next.highlight`
+                : `.payment-screen button.validation-button.next:not(:has(.highlight))`,
         },
     ];
 }

--- a/addons/point_of_sale/static/tests/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/product_screen_util.js
@@ -5,6 +5,7 @@ import * as PartnerList from "@point_of_sale/../tests/tours/utils/partner_list_u
 import * as TextInputPopup from "@point_of_sale/../tests/tours/utils/text_input_popup_util";
 import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
 import * as Chrome from "@point_of_sale/../tests/tours/utils/chrome_util";
+import * as PaymentScreen from "@point_of_sale/../tests/tours/utils/payment_screen_util";
 
 export function clickLine(productName, quantity = "1.0") {
     return [
@@ -684,18 +685,7 @@ export function closePos() {
 
 export function finishOrder() {
     return [
-        {
-            isActive: ["desktop"],
-            content: "validate the order",
-            trigger: ".payment-screen .button.next.highlight:visible",
-            run: "click",
-        },
-        {
-            isActive: ["mobile"],
-            content: "validate the order",
-            trigger: ".payment-screen .btn-switchpane:contains('Validate')",
-            run: "click",
-        },
+        ...PaymentScreen.clickValidate(),
         Chrome.isSyncStatusConnected(),
         {
             isActive: ["desktop"],

--- a/addons/pos_restaurant/static/src/overrides/components/payment_screen/payment_screen.xml
+++ b/addons/pos_restaurant/static/src/overrides/components/payment_screen/payment_screen.xml
@@ -2,11 +2,11 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="pos_restaurant.PaymentScreenValidate" t-inherit="point_of_sale.PaymentScreenValidate" t-inherit-mode="extension">
-        <xpath expr="//button[hasclass('button') and hasclass('next')]" position="attributes">
+        <xpath expr="//button[hasclass('validation-button') and hasclass('next')]" position="attributes">
             <attribute name="t-att-hidden">pos.config.set_tip_after_payment and !currentOrder.is_paid()</attribute>
         </xpath>
 
-        <xpath expr="//button[hasclass('button') and hasclass('next')]/span[hasclass('next_text')]" position="replace">
+        <xpath expr="//button[hasclass('validation-button') and hasclass('next')]/span" position="replace">
             <t t-if="pos.config.set_tip_after_payment and currentOrder.is_paid()">
                 <span class="back_text">Close Tab</span>
             </t>


### PR DESCRIPTION
- Fix issue where the `Validate` button (in the payment screen) was not correctly disabled on mobile devices when no payment methods was selected.

task-id: 5072759

enterprise PR: https://github.com/odoo/enterprise/pull/94100


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
