### PR TITLE
[FIX] website: fix `s_floating_blocks` snippet preview

### DIFF
--- a/addons/website/static/src/snippets/s_floating_blocks/floating_blocks.edit.scss
+++ b/addons/website/static/src/snippets/s_floating_blocks/floating_blocks.edit.scss
@@ -18,10 +18,10 @@
                 margin: 3% 0 -20%;
                 transform-origin: center top;
                 transform: scale(0.98);
+            }
 
-                > .s_parallax_bg {
-                    background-position: top !important;
-                }
+            .s_parallax_bg {
+                background-position: top !important;
             }
         }
     }


### PR DESCRIPTION
This commit fixes an issue with the `s_floating_blocks` snippet where
some CSS rules were inactive due to the selector.

Previously, the snippet applied a `background-position: top` property to
the first block. However, this rule was ineffective because the first
block does not include a `s_parallax_bg`.

This commit resolves the issue by allowing all blocks to receive the
`background-position` property, ensuring the behavior is fully WYSIWYG
for the user.

task-5068688