### PR TITLE
[FIX] website: stop interactions having a disconnected target element

### DIFF
--- a/addons/website/static/src/core/website_edit_service.js
+++ b/addons/website/static/src/core/website_edit_service.js
@@ -61,7 +61,7 @@ registry.category("services").add("website_edit", {
 
             // interactions are already started. we only restart them if the
             // public root is not just starting.
-
+            stopDisconnectedInteractions();
             publicInteractions.stopInteractions(target);
             if (mode === "edit") {
                 if (!editableInteractions) {
@@ -96,6 +96,14 @@ registry.category("services").add("website_edit", {
 
         const stopInteraction = (name) => {
             publicInteractions.stopInteractionByName(name);
+        };
+
+        const stopDisconnectedInteractions = () => {
+            for (const interaction of publicInteractions.interactions) {
+                if (!interaction.el.isConnected) {
+                    stop(interaction.el);
+                }
+            }
         };
 
         const isEditingTranslations = () =>
@@ -189,6 +197,9 @@ registry.category("services").add("website_edit", {
                         return NaN; // So that it is different from itself
                     },
                     shouldStop() {
+                        if (!this.el.isConnected) {
+                            return true;
+                        }
                         // Selector does not match anymore ?
                         const I = this.constructor;
                         let isMatch = this.el.matches(I.selector);

--- a/addons/website/static/src/snippets/s_countdown/countdown.js
+++ b/addons/website/static/src/snippets/s_countdown/countdown.js
@@ -62,7 +62,9 @@ export class Countdown extends Interaction {
     }
 
     destroy() {
-        this.el.querySelector(".s_countdown_canvas_wrapper").classList.remove("d-none");
+        // The optional chaining is required because the queried element may not
+        // exist anymore if the interaction target has just been deleted
+        this.el.querySelector(".s_countdown_canvas_wrapper")?.classList.remove("d-none");
         clearInterval(this.setInterval);
     }
 


### PR DESCRIPTION
Before this commit, interactions where not always destroyed when their target was removed from the DOM. An example of this problem is given by the `s_countdown` snippet. When the snippet is removed by `DeletePlugin`, the interaction is not destroyed, and a recurrent interval keeps expiring every second triggering multiple errors.

This commit introduces the following changes:
1. `EditInteractionPlugin.refreshInteractions`, which is called on normalization, now checks for every interaction and destroyes the ones linked to a disconnected DOM element.
2. `websiteEditService.refresh` now checks if the target element is disconnected, and in this case stops the interaction.
3. `Countdown` now uses the `waitForTimeout` function, which does not execute any callback if the interation has been destroyed.

How to reproduce the problem with `s_countdown`:
1. Insert the snippet `s_text_block`
2. Insert the snippet `s_countdown` in the middle of the text
3. Place the cursor after the countdown
4. Press "backspace" until the countdown is deleted
5. The error appears

(Alternatively, place the cursor before the countdown and press delete, or select a portion of text including the countdown and press backspace).

task-4367641