### PR TITLE
[FIX] website: increase timeout in test with option that fetch images

### DIFF
--- a/addons/website/static/tests/builder/website_builder/background.test.js
+++ b/addons/website/static/tests/builder/website_builder/background.test.js
@@ -79,6 +79,8 @@ async function setupWebsiteAndOpenParallaxOptions({ editingElClasses = "" } = {}
         <section ${editingElClass} style="background-image: ${backgroundImageUrl}; width: 500px; height:500px">
         </section>`);
     await contains(":iframe section").click();
-    await contains("[data-label='Scroll Effect'] button.o-dropdown").click();
+    // Timeout: Images are fetched from the network for some values in the
+    // options, the normal timeout is sometimes too short
+    await contains("[data-label='Scroll Effect'] button.o-dropdown", { timeout: 1000 }).click();
     return websiteBuilder;
 }


### PR DESCRIPTION
`test parallax zoom` failed non-deterministically, because it fetches images from the network to render the values in the options. The later tests were not affected because they had the image in cache.

The non-determinism is "fixed" by allowing a longer timeout when waiting on the element that should appear.

task-4367641