### PR TITLE
[FIX] account: Move 'Self Billing' field from invoice to journal

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -110,6 +110,11 @@ class AccountJournal(models.Model):
         Select 'Cash', 'Bank' or 'Credit Card' for journals that are used in customer or vendor payments.
         Select 'General' for miscellaneous operations journals.
         """)
+    is_self_billing = fields.Boolean(
+        string='Self Billing',
+        help="This journal is for self-billing invoices. "
+             "Invoices will be created using a different sequence per partner.",
+    )
     default_account_type = fields.Char(string='Default Account Type', compute="_compute_default_account_type")
     default_account_id = fields.Many2one(
         comodel_name='account.account', check_company=True, copy=False, ondelete='restrict',

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -631,10 +631,6 @@ class AccountMove(models.Model):
     invoice_source_email = fields.Char(string='Source Email', tracking=True)
     invoice_partner_display_name = fields.Char(compute='_compute_invoice_partner_display_info', store=True)
     is_manually_modified = fields.Boolean()
-    is_self_billing = fields.Boolean(
-        string='Self Billing',
-        help="This bill is a self-billing invoice (that you create on behalf of your vendor).",
-    )
 
     # === Fiduciary mode fields === #
     quick_edit_mode = fields.Boolean(compute='_compute_quick_edit_mode')
@@ -5907,9 +5903,9 @@ class AccountMove(models.Model):
         template_xmlid = 'account.email_template_edi_invoice'
         if all(move.move_type == 'out_refund' for move in self):
             template_xmlid = 'account.email_template_edi_credit_note'
-        elif all(move.move_type == 'in_invoice' and move.is_self_billing for move in self):
+        elif all(move.move_type == 'in_invoice' and move.journal_id.is_self_billing for move in self):
             template_xmlid = 'account.email_template_edi_self_billing_invoice'
-        elif all(move.move_type == 'in_refund' and move.is_self_billing for move in self):
+        elif all(move.move_type == 'in_refund' and move.journal_id.is_self_billing for move in self):
             template_xmlid = 'account.email_template_edi_self_billing_credit_note'
         return self.env.ref(template_xmlid)
 

--- a/addons/account/views/account_journal_views.xml
+++ b/addons/account/views/account_journal_views.xml
@@ -158,6 +158,7 @@
                                     <group string="Automation" groups="account.group_account_manager">
                                         <field name="restrict_mode_hash_table" groups="account.group_account_readonly" invisible="type not in ['sale', 'purchase', 'general']"
                                         />
+                                        <field name="is_self_billing" invisible="type != 'purchase'"/>
                                     </group>
                                     <group string="Emails" name="group_email_alias"
                                            invisible="type not in ('general', 'sale', 'purchase')">

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1506,8 +1506,6 @@
                                         <field name="auto_post_until"
                                                invisible="auto_post in ('no', 'at_date')"
                                                readonly="state != 'draft'"/>
-                                        <field name="is_self_billing"
-                                               invisible="move_type not in ('in_invoice', 'in_refund')"/>
                                     </group>
                                 </group>
                             </page>

--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -70,16 +70,16 @@
                                 <span t-elif="o.move_type == 'out_refund' and o.state == 'cancel'">
                                     <t name="cancelled_credit_note_title">Cancelled Credit Note</t>
                                 </span>
-                                <span t-elif="o.move_type == 'in_refund' and not o.is_self_billing">
+                                <span t-elif="o.move_type == 'in_refund' and not o.journal_id.is_self_billing">
                                     <t name="vendor_credit_note_title">Vendor Credit Note</t>
                                 </span>
-                                <span t-elif="o.move_type == 'in_refund' and o.is_self_billing">
+                                <span t-elif="o.move_type == 'in_refund' and o.journal_id.is_self_billing">
                                     <t name="self_billing_credit_note_title">Self Billing Credit Note</t>
                                 </span>
-                                <span t-elif="o.move_type == 'in_invoice' and not o.is_self_billing">
+                                <span t-elif="o.move_type == 'in_invoice' and not o.journal_id.is_self_billing">
                                     <t name="vendor_bill_title">Vendor Bill</t>
                                 </span>
-                                <span t-elif="o.move_type == 'in_invoice' and o.is_self_billing">
+                                <span t-elif="o.move_type == 'in_invoice' and o.journal_id.is_self_billing">
                                     <t name="self_billing_invoice_title">Self Billing</t>
                                 </span>
                             </t>

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -49,7 +49,7 @@ class AccountEdiXmlUbl_Bis3(models.AbstractModel):
     def _add_invoice_config_vals(self, vals):
         super()._add_invoice_config_vals(vals)
         invoice = vals['invoice']
-        vals['process_type'] = 'selfbilling' if invoice.is_purchase_document() and invoice.is_self_billing else 'billing'
+        vals['process_type'] = 'selfbilling' if invoice.is_purchase_document() and invoice.journal_id.is_self_billing else 'billing'
 
     def _can_export_selfbilling(self):
         return bool(self._get_customization_id(process_type='selfbilling'))

--- a/addons/account_edi_ubl_cii/models/account_move.py
+++ b/addons/account_edi_ubl_cii/models/account_move.py
@@ -220,7 +220,7 @@ class AccountMove(models.Model):
         return (
             self.state == 'posted'
             and self.is_purchase_document()
-            and self.is_self_billing
+            and self.journal_id.is_self_billing
             and (invoice_edi_format := self.commercial_partner_id._get_peppol_edi_format())
             and (edi_builder := self.partner_id._get_edi_builder(invoice_edi_format)) is not None
             and edi_builder._can_export_selfbilling()

--- a/addons/account_edi_ubl_cii/tests/test_files/bis3/test_vendor_bill.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/bis3/test_vendor_bill.xml
@@ -2,13 +2,13 @@
 <Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2">
   <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:selfbilling:3.0</cbc:CustomizationID>
   <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:selfbilling:01:1.0</cbc:ProfileID>
-  <cbc:ID>BILL/2017/01/0001</cbc:ID>
+  <cbc:ID>SB/2017/01/0001</cbc:ID>
   <cbc:IssueDate>2017-01-01</cbc:IssueDate>
   <cbc:DueDate>2017-01-01</cbc:DueDate>
   <cbc:InvoiceTypeCode>389</cbc:InvoiceTypeCode>
   <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
   <cac:OrderReference>
-    <cbc:ID>BILL/2017/01/0001</cbc:ID>
+    <cbc:ID>SB/2017/01/0001</cbc:ID>
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>___ignore___</cbc:ID>
@@ -88,7 +88,7 @@
   </cac:Delivery>
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode name="standing agreement">57</cbc:PaymentMeansCode>
-    <cbc:PaymentID>BILL/2017/01/0001</cbc:PaymentID>
+    <cbc:PaymentID>SB/2017/01/0001</cbc:PaymentID>
     <cac:PayeeFinancialAccount>
       <cbc:ID>BE90735788866632</cbc:ID>
     </cac:PayeeFinancialAccount>

--- a/addons/account_edi_ubl_cii/tests/test_files/bis3/test_vendor_bill_reverse_charge.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/bis3/test_vendor_bill_reverse_charge.xml
@@ -2,13 +2,13 @@
 <Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2">
   <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:selfbilling:3.0</cbc:CustomizationID>
   <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:selfbilling:01:1.0</cbc:ProfileID>
-  <cbc:ID>BILL/2017/01/0001</cbc:ID>
+  <cbc:ID>SB/2017/01/0001</cbc:ID>
   <cbc:IssueDate>2017-01-01</cbc:IssueDate>
   <cbc:DueDate>2017-01-01</cbc:DueDate>
   <cbc:InvoiceTypeCode>389</cbc:InvoiceTypeCode>
   <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
   <cac:OrderReference>
-    <cbc:ID>BILL/2017/01/0001</cbc:ID>
+    <cbc:ID>SB/2017/01/0001</cbc:ID>
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>___ignore___</cbc:ID>
@@ -89,7 +89,7 @@
   </cac:Delivery>
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode name="standing agreement">57</cbc:PaymentMeansCode>
-    <cbc:PaymentID>BILL/2017/01/0001</cbc:PaymentID>
+    <cbc:PaymentID>SB/2017/01/0001</cbc:PaymentID>
     <cac:PayeeFinancialAccount>
       <cbc:ID>BE90735788866632</cbc:ID>
     </cac:PayeeFinancialAccount>

--- a/addons/account_edi_ubl_cii/tests/test_files/bis3/test_vendor_credit_note.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/bis3/test_vendor_credit_note.xml
@@ -2,13 +2,13 @@
 <Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2">
   <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:selfbilling:3.0</cbc:CustomizationID>
   <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:selfbilling:01:1.0</cbc:ProfileID>
-  <cbc:ID>RBILL/2017/01/0001</cbc:ID>
+  <cbc:ID>RSB/2017/01/0001</cbc:ID>
   <cbc:IssueDate>2017-01-01</cbc:IssueDate>
   <cbc:DueDate>2017-01-01</cbc:DueDate>
   <cbc:InvoiceTypeCode>389</cbc:InvoiceTypeCode>
   <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
   <cac:OrderReference>
-    <cbc:ID>RBILL/2017/01/0001</cbc:ID>
+    <cbc:ID>RSB/2017/01/0001</cbc:ID>
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>___ignore___</cbc:ID>
@@ -88,7 +88,7 @@
   </cac:Delivery>
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode name="standing agreement">57</cbc:PaymentMeansCode>
-    <cbc:PaymentID>RBILL/2017/01/0001</cbc:PaymentID>
+    <cbc:PaymentID>RSB/2017/01/0001</cbc:PaymentID>
     <cac:PayeeFinancialAccount>
       <cbc:ID>BE15001559627230</cbc:ID>
     </cac:PayeeFinancialAccount>

--- a/addons/account_edi_ubl_cii/tests/test_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_bis3.py
@@ -635,9 +635,16 @@ class TestUblBis3(AccountTestInvoicingCommon):
         self.setup_partner_as_be2(self.partner_a)
         tax_21 = self.percent_tax(21.0)
 
+        self_billing_journal = self.env['account.journal'].create({
+            'name': 'Self Billing',
+            'code': 'SB',
+            'type': 'purchase',
+            'is_self_billing': True,
+        })
+
         invoice = self.env['account.move'].create({
             'move_type': 'in_invoice',
-            'is_self_billing': True,
+            'journal_id': self_billing_journal.id,
             'partner_id': self.partner_a.id,
             'invoice_date': '2017-01-01',
             'invoice_line_ids': [
@@ -672,9 +679,16 @@ class TestUblBis3(AccountTestInvoicingCommon):
             ],
         )
 
+        self_billing_journal = self.env['account.journal'].create({
+            'name': 'Self Billing',
+            'code': 'SB',
+            'type': 'purchase',
+            'is_self_billing': True,
+        })
+
         invoice = self.env['account.move'].create({
             'move_type': 'in_invoice',
-            'is_self_billing': True,
+            'journal_id': self_billing_journal.id,
             'partner_id': self.partner_a.id,
             'invoice_date': '2017-01-01',
             'invoice_line_ids': [
@@ -696,9 +710,16 @@ class TestUblBis3(AccountTestInvoicingCommon):
         self.setup_partner_as_be2(self.partner_a)
         tax_21 = self.percent_tax(21.0)
 
+        self_billing_journal = self.env['account.journal'].create({
+            'name': 'Self Billing',
+            'code': 'SB',
+            'type': 'purchase',
+            'is_self_billing': True,
+        })
+
         invoice = self.env['account.move'].create({
             'move_type': 'in_refund',
-            'is_self_billing': True,
+            'journal_id': self_billing_journal.id,
             'partner_id': self.partner_a.id,
             'invoice_date': '2017-01-01',
             'invoice_line_ids': [

--- a/addons/account_peppol/tests/test_peppol_messages.py
+++ b/addons/account_peppol/tests/test_peppol_messages.py
@@ -576,10 +576,17 @@ class TestPeppolMessage(TestAccountMoveSendCommon, MailCommon):
         self.env.company.peppol_activate_self_billing_sending = True
         self.valid_partner.invoice_edi_format = 'ubl_bis3'
 
+        self_billing_journal = self.env['account.journal'].create({
+            'name': 'Self Billing',
+            'code': 'SB',
+            'type': 'purchase',
+            'is_self_billing': True,
+        })
+
         # Create a vendor bill (in_invoice) that can be sent as self-billed
         vendor_bill = self.env['account.move'].create({
             'move_type': 'in_invoice',
-            'is_self_billing': True,
+            'journal_id': self_billing_journal.id,
             'company_id': self.env.company.id,
             'partner_id': self.valid_partner.id,
             'date': '2023-01-01',
@@ -623,9 +630,16 @@ class TestPeppolMessage(TestAccountMoveSendCommon, MailCommon):
         self.env.company.peppol_activate_self_billing_sending = True
         self.valid_partner.invoice_edi_format = 'ubl_bis3'
 
+        self_billing_journal = self.env['account.journal'].create({
+            'name': 'Self Billing',
+            'code': 'SB',
+            'type': 'purchase',
+            'is_self_billing': True,
+        })
+
         vendor_bill = self.env['account.move'].create({
             'move_type': 'in_invoice',
-            'is_self_billing': True,
+            'journal_id': self_billing_journal.id,
             'company_id': self.env.company.id,
             'partner_id': self.valid_partner.id,
             'date': '2023-01-01',


### PR DESCRIPTION
In 839859df82 we introduced a new `is_self_billing` field to `account.move`, to indicate that a vendor bill is a self-billed invoice created on behalf of the supplier.

Since then, we realised that self-billed invoices always need to be created in a specific journal, for sequencing reasons.

As a result, it makes more sense for this to be a field on the journal rather than on the invoice.

task-none