### PR TITLE
[FIX] html_editor: include transparent grays in editor color variables

### DIFF
--- a/addons/html_editor/static/src/utils/color.js
+++ b/addons/html_editor/static/src/utils/color.js
@@ -13,8 +13,6 @@ export const COLOR_PALETTE_COMPATIBILITY_COLOR_NAMES = [
     "info",
     "warning",
     "danger",
-    "black",
-    "white",
 ];
 
 /**
@@ -60,6 +58,22 @@ for (let i = 1; i <= 5; i++) {
 for (let i = 100; i <= 900; i += 100) {
     EDITOR_COLOR_CSS_VARIABLES.push(`${i}`);
 }
+
+// Black, white and their opacity variants.
+// These variables are necessary to prevent the colorpicker from being affected
+// by the backend "Dark Mode".
+EDITOR_COLOR_CSS_VARIABLES.push(
+    "black",
+    "black-15",
+    "black-25",
+    "black-50",
+    "black-75",
+    "white",
+    "white-25",
+    "white-50",
+    "white-75",
+    "white-85"
+);
 
 /**
  * @param {string|number} name


### PR DESCRIPTION
Following the [refactor] of the html_builder, [addition] of the transparent grayscale,
and this [commit], we had an issue when the transparent grayscale wasn't displayed as
needed because it wasn't added to 'EDITOR_COLOR_CSS_VARIABLES', which later were
used to save colors together with the theme color prefix, i.e., --hb-cp-'color'.
Steps to see the issue:
- Open website and start editing
- Drop a s_cover snipper and click on it
- Click on the "Filter" option and select "Custom"
- Click on "Color Filter" and go to the "Custom" tab

-> Transparent Grayscale isn't displayed correctly. 
This commit copies [1], which was lost in the refactor.

[refactor]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
[addition]: https://github.com/odoo/odoo/commit/55c58bf45165e3a3eafcbaecc516e7c1d19809a6
[commit]: https://github.com/odoo/odoo/commit/eb12451a169c752034abb5d4aab9926c19067ebf
[1]: https://github.com/odoo/odoo/commit/5490c126f42bd1729ba0d4b4103d7284ba7ab8c0