### PR TITLE
[FIX] im_livechat: see name of ended live chat in discuss sidebar

### DIFF
--- a/addons/im_livechat/static/src/core/web/discuss_sidebar_category_patch.xml
+++ b/addons/im_livechat/static/src/core/web/discuss_sidebar_category_patch.xml
@@ -27,8 +27,8 @@
     <t t-name="im_livechat.LivechatStatusLabelOfThread">
         <t t-set="livechatThread" t-value="templateParams.livechatThread"/>
         <span t-if="livechatThread.channel_type === 'livechat' and (['waiting', 'need_help'].includes(livechatThread.livechat_status) or livechatThread.livechat_end_dt)" class="o-livechat-LivechatStatusLabel" t-att-title="livechatThread.livechatStatusLabel" t-att-class="{
-            'o-livechat-LivechatStatusLabel-Sidebar position-absolute top-0 start-0': env.inDiscussSidebar or env.inChatBubble,
-            'end-0 bottom-0 rounded-2 border': env.inDiscussSidebar,
+            'position-absolute top-0 start-0': env.inDiscussSidebar or env.inChatBubble,
+            'o-livechat-LivechatStatusLabel-Sidebar end-0 bottom-0 rounded-2 border': env.inDiscussSidebar,
             'm-n2 z-1': env.inChatBubble,
             'text-warning': livechatThread.livechat_status === 'waiting',
             'o-help': livechatThread.livechat_status === 'need_help',

--- a/addons/im_livechat/static/src/core/web/livechat_channel_info_list.scss
+++ b/addons/im_livechat/static/src/core/web/livechat_channel_info_list.scss
@@ -91,6 +91,6 @@
 }
 
 .o-livechat-LivechatStatusLabel.position-absolute {
-    background-color: $white;
+    background-color: rgba($white, var(--bg-opacity, 1));
     border-radius: 50%;
 }


### PR DESCRIPTION
Before this commit, when a live chat has ended, its name was not visible in the discuss sidebar.

This comes from live chat status whose background color and icon share same absolute positioned node. Background color was added by https://github.com/odoo/odoo/pull/224553 while removing the icons, but the icons were added back by https://github.com/odoo/odoo/pull/225145 because of accessibility concerns for colorblind users.

Last PR above added white background to properly see live chat status when floating, i.e. in chat bubble. However it forgot that bg color in discuss sidebar also uses absolute positioning so this affected ended live chats. Other live chat status were not affected because the background color uses opacity.

This commit fixes the issue with `o-livechat-LivechatStatusLabel-Sidebar` being specific to discuss sidebar, so that its style is not affecting chat bubbles, and also the style for icon bg takes `--bg-opacity` into account, such as the one in discuss sidebar. That way the name is visible in discuss sidebar while the live chat status icon is clearly visible in chat bubble.

Before / After
<img width="304" height="223" alt="Screenshot 2025-09-08 at 16 59 09" src="https://github.com/user-attachments/assets/c2643a57-553e-497b-b5d5-148b1fb2deec" /> <img width="304" height="218" alt="Screenshot 2025-09-08 at 16 58 39" src="https://github.com/user-attachments/assets/a769def1-ff44-4214-aaa4-e61896ef4d74" />
