### PR TITLE
[REM] mail: removed displayName from mail.guest

### DIFF
--- a/addons/mail/static/src/core/common/mail_guest_model.js
+++ b/addons/mail/static/src/core/common/mail_guest_model.js
@@ -34,11 +34,6 @@ export class MailGuest extends Record {
     /** @type {number} */
     id;
     debouncedSetImStatus;
-    displayName = fields.Attr(undefined, {
-        compute() {
-            return this._computeDisplayName();
-        },
-    });
     monitorPresence = fields.Attr(false, {
         compute() {
             return this.store.env.services.bus_service.isActive && this.id > 0;
@@ -89,10 +84,6 @@ export class MailGuest extends Record {
         },
     });
     write_date = fields.Datetime();
-
-    _computeDisplayName() {
-        return this.name;
-    }
 
     get avatarUrl() {
         const accessTokenParam = {};

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -604,7 +604,7 @@ export class Message extends Record {
      * @returns {string}
      */
     getPersonaName(persona) {
-        return this.thread?.getPersonaName(persona) || persona.displayName;
+        return this.thread?.getPersonaName(persona) || persona.displayName || persona.name;
     }
 
     async react(content) {

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -321,7 +321,7 @@ export class Thread extends Record {
      * @returns {string}
      */
     getPersonaName(persona) {
-        return persona.displayName;
+        return persona.displayName || persona.name;
     }
 
     get hasAttachmentPanel() {

--- a/addons/mail/static/src/discuss/core/common/avatar_stack.xml
+++ b/addons/mail/static/src/discuss/core/common/avatar_stack.xml
@@ -4,7 +4,7 @@
         <div t-if="props.personas.length > 0" class="bg-inherit" t-att-class="props.containerClass" t-on-click="props.onClick">
             <div class="d-flex bg-inherit" t-att-class="{'flex-column': props.direction === 'v'}">
                 <span t-foreach="props.personas.slice(0, props.max)" t-as="persona" t-key="persona.localId" class="bg-inherit rounded-circle position-relative" t-attf-style="{{getStyle(persona_index)}}">
-                    <img t-att-src="persona.avatarUrl" t-att-title="persona.displayName" class="w-100 h-100 rounded-circle object-fit-cover" t-attf-class="{{props.avatarClass(persona)}}"/>
+                    <img t-att-src="persona.avatarUrl" t-att-title="persona.displayName or persona.name" class="w-100 h-100 rounded-circle object-fit-cover" t-attf-class="{{props.avatarClass(persona)}}"/>
                     <t t-slot="avatarExtraInfo" persona="persona"/>
                 </span>
                 <span t-if="props.personas.length > props.max" class="rounded-circle bg-secondary smaller d-flex justify-content-center align-items-center user-select-none" t-attf-style="{{getStyle(props.personas.length)}}; font-weight: 450;">+<t t-esc="props.personas.length - props.max"/></span>


### PR DESCRIPTION
This commit removes the `displayName` field from the JS model of `mail.guest`.
It's not needed as we always display the guest `name` field.

task-4965928