### PR TITLE
[FIX] delivery: translate delivery terms on front-end

### DIFF
--- a/addons/delivery/models/__init__.py
+++ b/addons/delivery/models/__init__.py
@@ -3,6 +3,7 @@
 from . import delivery_carrier
 from . import delivery_price_rule
 from . import delivery_zip_prefix
+from . import ir_http
 from . import payment_transaction
 from . import payment_provider
 from . import product_category

--- a/addons/delivery/models/ir_http.py
+++ b/addons/delivery/models/ir_http.py
@@ -1,0 +1,12 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class IrHttp(models.AbstractModel):
+    _inherit = 'ir.http'
+
+    @classmethod
+    def _get_translation_frontend_modules_name(cls):
+        mods = super()._get_translation_frontend_modules_name()
+        return mods + ['delivery']


### PR DESCRIPTION
Versions
--------
- saas-18.3+

Steps
-----
1. Enable the Cash on Delivery payment method;
2. have a delivery method which allows cash on delivery;
3. active a second language on the website;
4. go to /shop/payment in the other language;
5. select Cash on Delivery payment.

Issue
-----
The "Place order" button isn't translated.

Cause
-----
The `delivery` module isn't listed as "front-end module" for translation purposes, making the translated term unavailable there.

Solution
--------
Add `delivery` as a front-end module via a `_get_translation_frontend_modules_name` override.

opw-4971473