### PR TITLE
[FIX] l10n_ro_edi: Fix wrong endpoint during ANAF bill import

### DIFF
--- a/addons/l10n_ro_edi/models/account_edi_xml_ubl_ciusro.py
+++ b/addons/l10n_ro_edi/models/account_edi_xml_ubl_ciusro.py
@@ -124,3 +124,19 @@ class AccountEdiXmlUbl_Ro(models.AbstractModel):
                     partner.display_name)
 
         return constraints
+
+    # -------------------------------------------------------------------------
+    # IMPORT
+    # -------------------------------------------------------------------------
+
+    def _import_retrieve_partner_vals(self, tree, role):
+        # EXTENDS account.edi.xml.ubl_bis3
+        partner_vals = super()._import_retrieve_partner_vals(tree, role)
+        if 'peppol_endpoint' in partner_vals:
+            # ANAF allows for endpoints to be an address mail, since we don't want to create a new
+            # user with an address mail as a PEPPOL endpoint, we simply remove it in that case.
+            error = self.env['res.partner']._build_error_peppol_endpoint(False, partner_vals['peppol_endpoint'])
+            if error:
+                partner_vals['peppol_endpoint'] = False
+                partner_vals['peppol_eas'] = False
+        return partner_vals


### PR DESCRIPTION
Problem
---------
When importing the bill, the XML contains a faulty PEPPOL Endpoint (an address mail). Since the partner in the XML does not yet exist in the client database, we attempt to create it with the name, VAT, address and the faulty endpoint; which, triggers an error that is logged in the chatter.

For unknown reasons, the RO government allows for such error to be introduced but since we can't change ANAF itself, we have to make a fix to manage the case.

Solution
---------
When importing the partner data from the XML, we check if the endpoint is valid before creating the partner. If it is not the case, we simply remove and ignore the endpoint data.

opw-5046567

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
