### PR TITLE
[FIX] web: Hoot - fix URL simplification

### DIFF
--- a/addons/web/static/lib/hoot/core/runner.js
+++ b/addons/web/static/lib/hoot/core/runner.js
@@ -1956,9 +1956,7 @@ export class Runner {
                 continue;
             }
             const siblingIds = item.parent.jobs.map((job) => job.id);
-            if (
-                siblingIds.every((siblingId) => siblingId === id || remaining.includes(siblingId))
-            ) {
+            if (siblingIds.every((siblingId) => idSpecs[siblingId] === INCLUDE_LEVEL.url)) {
                 remaining = remaining.filter((id) => !siblingIds.includes(id));
                 this._include(idSpecs, [item.parent.id], INCLUDE_LEVEL.url, true);
                 this._include(idSpecs, siblingIds, 0, true);


### PR DESCRIPTION
Before this commit, when the test runner simplified the URL (e.g. if the runner is given the ID of every test in a suite, it will remove them and only include the suite ID), it always considered IDs as being "included", and ignored the "-" specifying that some IDs should be "excluded".

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
