### PR TITLE
[FIX] website: fix `s_floating_blocks` snippet preview

### DIFF
--- a/addons/website/static/src/snippets/s_floating_blocks/floating_blocks.edit.scss
+++ b/addons/website/static/src/snippets/s_floating_blocks/floating_blocks.edit.scss
@@ -18,10 +18,10 @@
                 margin: 3% 0 -20%;
                 transform-origin: center top;
                 transform: scale(0.98);
+            }
 
-                > .s_parallax_bg {
-                    background-position: top !important;
-                }
+            .s_parallax_bg {
+                background-position: top !important;
             }
         }
     }


### PR DESCRIPTION
This PR fixes an issue with the `s_floating_blocks` snippet where some CSS rules were inactive due to the selector.

Previously, the snippet applied a `background-position: top` property to the first block. However, this rule was ineffective because the first block does not include a `s_parallax_bg`.

This PR resolves the issue by allowing all blocks to receive the `background-position` property, ensuring the behavior is fully WYSIWYG for the user.

task-5068688

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
