### PR TITLE
[IMP] project: remove templates menus

### DIFF
--- a/addons/project/__manifest__.py
+++ b/addons/project/__manifest__.py
@@ -88,6 +88,7 @@
             ('remove', 'project/static/src/views/project_task_analysis_pivot/**'),
             ('remove', 'project/static/src/views/burndown_chart/**'),
             ('remove', 'project/static/src/**/*.dark.scss'),
+            ('remove', 'project/static/src/views/project_project_activity/**'),
         ],
         "web.assets_web_dark": [
             'project/static/src/**/*.dark.scss',
@@ -101,6 +102,7 @@
             'project/static/src/views/project_task_analysis_graph/**',
             'project/static/src/views/project_task_analysis_pivot/**',
             'project/static/src/views/burndown_chart/**',
+            'project/static/src/views/project_project_activity/**',
         ],
         'web.assets_frontend': [
             'project/static/src/scss/portal_rating.scss',
@@ -231,6 +233,8 @@
             'project/static/src/views/project_task_control_panel/*',
             'project/static/src/views/project_task_model_mixin.js',
             'project/static/src/views/project_task_relational_model.js',
+            'project/static/src/views/project_model_mixin.js',
+            'project/static/src/views/project_relational_model.js',
 
             ('include', 'portal.assets_chatter_helpers'),
             'portal/static/src/chatter/core/**/*',

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -324,7 +324,7 @@ class ProjectTask(models.Model):
     is_template = fields.Boolean(copy=False, export_string_translation=False)
     has_project_template = fields.Boolean(related='project_id.is_template', string="Has Project Template", export_string_translation=False)
     has_template_ancestor = fields.Boolean(compute='_compute_has_template_ancestor', search='_search_has_template_ancestor',
-                                           recursive=True, export_string_translation=False)
+                                           recursive=True, export_string_translation=False, store=True)
 
     _recurring_task_has_no_parent = models.Constraint(
         'CHECK (NOT (recurring_task IS TRUE AND parent_id IS NOT NULL))',

--- a/addons/project/report/project_report.py
+++ b/addons/project/report/project_report.py
@@ -67,6 +67,7 @@ class ReportProjectTaskUser(models.Model):
     description = fields.Text(readonly=True)
     # We exclude template tasks, but we still need the field for the views
     is_template = fields.Boolean(readonly=True)
+    has_template_ancestor = fields.Boolean(readonly=True)
 
     def _select(self):
         return """
@@ -99,7 +100,8 @@ class ReportProjectTaskUser(models.Model):
                 NULLIF(t.working_hours_close, 0) as working_hours_close,
                 (extract('epoch' from (t.date_deadline-(now() at time zone 'UTC'))))/(3600*24) as delay_endings_days,
                 COUNT(td.task_id) as dependent_ids_count,
-                t.is_template
+                t.is_template,
+                t.has_template_ancestor
         """
 
     def _group_by(self):
@@ -145,8 +147,6 @@ class ReportProjectTaskUser(models.Model):
     def _where(self):
         return """
                 t.project_id IS NOT NULL
-                AND t.is_template IS NOT TRUE
-                AND p.is_template IS NOT TRUE
         """
 
     def init(self):

--- a/addons/project/report/project_report_views.xml
+++ b/addons/project/report/project_report_views.xml
@@ -75,7 +75,7 @@
             <field name="name">Tasks Analysis</field>
             <field name="res_model">report.project.task.user</field>
             <field name="path">tasks-analysis</field>
-            <field name="domain">[]</field>
+            <field name="domain">[('has_template_ancestor', '=', False)]</field>
             <field name="view_mode">graph,pivot</field>
             <field name="search_view_id" ref="view_task_project_user_search"/>
             <field name="context">{'group_by': [], 'graph_measure': '__count__'}</field>

--- a/addons/project/static/src/views/project_model_mixin.js
+++ b/addons/project/static/src/views/project_model_mixin.js
@@ -1,0 +1,13 @@
+import { Domain } from "@web/core/domain";
+
+export const ProjectModelMixin = (T) => class ProjectModelMixin extends T {
+    _processSearchDomain(domain) {
+        if (this.env.searchModel.context?.render_templates) {
+            return Domain.and([
+                Domain.removeDomainLeaves(domain, ['is_template']).toList(),
+                [['is_template', '=', true]],
+            ]).toList({});
+        }
+        return domain;
+    }
+}

--- a/addons/project/static/src/views/project_project_activity/project_project_activity_model.js
+++ b/addons/project/static/src/views/project_project_activity/project_project_activity_model.js
@@ -1,0 +1,10 @@
+import { ActivityModel } from "@mail/views/web/activity/activity_model";
+import { ProjectModelMixin } from "../project_model_mixin";
+
+export class ProjectActivityModel extends ProjectModelMixin(ActivityModel) {
+    async load(params = {}) {
+        const domain = params.domain || this.config.domain;
+        params.domain = this._processSearchDomain(domain);
+        return super.load(params);
+    }
+}

--- a/addons/project/static/src/views/project_project_activity/project_project_activity_view.js
+++ b/addons/project/static/src/views/project_project_activity/project_project_activity_view.js
@@ -1,0 +1,11 @@
+import { activityView } from "@mail/views/web/activity/activity_view";
+
+import { ProjectActivityModel } from "./project_project_activity_model";
+import { registry } from "@web/core/registry";
+
+export const projectProjectActivityView = {
+    ...activityView,
+    Model: ProjectActivityModel,
+}
+
+registry.category("views").add("project_project_activity", projectProjectActivityView);

--- a/addons/project/static/src/views/project_project_calendar/project_project_calendar_model.js
+++ b/addons/project/static/src/views/project_project_calendar/project_project_calendar_model.js
@@ -1,0 +1,11 @@
+
+import { CalendarModel } from '@web/views/calendar/calendar_model';
+import { ProjectModelMixin } from '../project_model_mixin';
+
+export class ProjectCalendarModel extends ProjectModelMixin(CalendarModel) {
+    async load(params = {}) {
+        const domain = params.domain || this.meta.domain;
+        params.domain = this._processSearchDomain(domain);
+        return super.load(params);
+    }
+}

--- a/addons/project/static/src/views/project_project_calendar/project_project_calendar_view.js
+++ b/addons/project/static/src/views/project_project_calendar/project_project_calendar_view.js
@@ -2,6 +2,7 @@ import { registry } from "@web/core/registry";
 import { calendarView } from "@web/views/calendar/calendar_view";
 import { ProjectProjectCalendarController } from "./project_project_calendar_controller";
 import { ProjectCalendarRenderer } from "./project_project_calendar_renderer";
+import { ProjectCalendarModel } from "./project_project_calendar_model";
 
 const viewRegistry = registry.category("views");
 
@@ -9,6 +10,7 @@ const projectProjectCalendarView = {
     ...calendarView,
     Controller: ProjectProjectCalendarController,
     Renderer: ProjectCalendarRenderer,
+    Model: ProjectCalendarModel,
 };
 
 viewRegistry.add("project_project_calendar", projectProjectCalendarView);

--- a/addons/project/static/src/views/project_project_kanban/project_task_kanban_view.js
+++ b/addons/project/static/src/views/project_project_kanban/project_task_kanban_view.js
@@ -2,11 +2,13 @@ import { registry } from "@web/core/registry";
 import { kanbanView } from "@web/views/kanban/kanban_view";
 import { ProjectKanbanController } from "./project_project_kanban_controller";
 import { ProjectProjectKanbanRenderer } from "./project_project_kanban_renderer";
+import { ProjectRelationalModel } from "../project_relational_model";
 
 export const projectProjectKanbanView = {
     ...kanbanView,
     Controller: ProjectKanbanController,
     Renderer: ProjectProjectKanbanRenderer,
+    Model: ProjectRelationalModel,
 };
 
 registry.category("views").add("project_project_kanban", projectProjectKanbanView);

--- a/addons/project/static/src/views/project_project_list/project_project_list_view.js
+++ b/addons/project/static/src/views/project_project_list/project_project_list_view.js
@@ -2,11 +2,13 @@ import { registry } from "@web/core/registry";
 import { listView } from '@web/views/list/list_view';
 import { ProjectProjectListRenderer } from "./project_project_list_renderer";
 import { ProjectListController } from "./project_project_list_controller";
+import { ProjectRelationalModel } from "../project_relational_model";
 
 export const projectProjectListView = {
     ...listView,
     Renderer: ProjectProjectListRenderer,
     Controller: ProjectListController,
+    Model: ProjectRelationalModel,
 };
 
 registry.category("views").add("project_project_list", projectProjectListView);

--- a/addons/project/static/src/views/project_relational_model.js
+++ b/addons/project/static/src/views/project_relational_model.js
@@ -1,0 +1,10 @@
+import { RelationalModel } from "@web/model/relational_model/relational_model";
+import { ProjectModelMixin } from "./project_model_mixin";
+
+export class ProjectRelationalModel extends ProjectModelMixin(RelationalModel) {
+    async load(params = {}) {
+        const domain = params.domain || this.config.domain;
+        params.domain = this._processSearchDomain(domain);
+        return super.load(params);
+    }
+}

--- a/addons/project/static/src/views/project_task_model_mixin.js
+++ b/addons/project/static/src/views/project_task_model_mixin.js
@@ -6,9 +6,15 @@ export const ProjectTaskModelMixin = (T) => class ProjectTaskModelMixin extends 
         const { my_tasks, subtask_action } = this.env.searchModel.globalContext;
         const showSubtasks = my_tasks || subtask_action || JSON.parse(browser.localStorage.getItem("showSubtasks"));
         if (!showSubtasks) {
-            return Domain.and([
+            domain = Domain.and([
                 domain,
                 [['display_in_project', '=', true]],
+            ]).toList({});
+        }
+        if (this.env.searchModel.context?.render_templates) {
+            domain = Domain.and([
+                Domain.removeDomainLeaves(domain, ['has_template_ancestor']).toList(),
+                [['has_template_ancestor', '=', true]],
             ]).toList({});
         }
         return domain;

--- a/addons/project/static/src/views/project_update_kanban/project_update_kanban_view.js
+++ b/addons/project/static/src/views/project_update_kanban/project_update_kanban_view.js
@@ -1,10 +1,12 @@
 import { registry } from "@web/core/registry";
 import { kanbanView } from "@web/views/kanban/kanban_view";
 import { ProjectUpdateKanbanController } from './project_update_kanban_controller';
+import { ProjectRelationalModel } from "../project_relational_model";
 
 export const projectUpdateKanbanView = {
     ...kanbanView,
     Controller: ProjectUpdateKanbanController,
+    Model: ProjectRelationalModel,
 };
 
 registry.category('views').add('project_update_kanban', projectUpdateKanbanView);

--- a/addons/project/static/src/views/project_update_list/project_update_list_view.js
+++ b/addons/project/static/src/views/project_update_list/project_update_list_view.js
@@ -1,10 +1,12 @@
 import { registry } from "@web/core/registry";
 import { listView } from "@web/views/list/list_view";
 import { ProjectUpdateListController } from './project_update_list_controller';
+import { ProjectRelationalModel } from "../project_relational_model";
 
 export const projectUpdateListView = {
     ...listView,
     Controller: ProjectUpdateListController,
+    Model: ProjectRelationalModel,
 };
 
 registry.category('views').add('project_update_list', projectUpdateListView);

--- a/addons/project/views/project_menus.xml
+++ b/addons/project/views/project_menus.xml
@@ -102,16 +102,6 @@
                 id="menu_project_tags_act"
                 action="project_tags_action"
             />
-             <menuitem
-                name="Project Templates"
-                id="project_menu_config_project_templates"
-                action="project_templates_action"
-            />
-            <menuitem
-                name="Task Templates"
-                id="project_menu_config_task_templates"
-                action="project_task_templates_action"
-            />
             <menuitem
                 name="Project Roles"
                 id="project_menu_config_project_roles"

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -4,7 +4,7 @@
             <field name="name">project.project.view.activity</field>
             <field name="model">project.project</field>
             <field name="arch" type="xml">
-                <activity string="Project">
+                <activity string="Project" js_class="project_project_activity">
                     <templates>
                         <div t-name="activity-box" class="d-flex">
                             <field name="user_id" widget="many2one_avatar_user"/>
@@ -161,6 +161,8 @@
                     <separator invisible="context.get('default_is_template')"/>
                     <filter string="Start Date" name="start_date" date="date_start" end_month="1" end_year="1"/>
                     <filter string="End Date" name="end_date" date="date" end_month="1" end_year="1"/>
+                    <separator/>
+                    <filter string="Templates" context="{'render_templates': True}" name="templates" domain="[('is_template', '=', True)]"/>
                     <separator/>
                     <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
                     <separator invisible="1"/>
@@ -708,42 +710,6 @@
                 </kanban>
                 <span name="partner_name" position="replace"/>
             </field>
-        </record>
-
-        <record id="project_templates_action" model="ir.actions.act_window">
-            <field name="name">Project Templates</field>
-            <field name="res_model">project.project</field>
-            <field name="view_mode">list,kanban,form</field>
-            <field name="domain">[('is_template', '=', True)]</field>
-            <field name="context">{'default_is_template': True}</field>
-            <field name="view_id" ref="view_project_kanban"/>
-            <field name="help" type="html">
-                <p class="o_view_nocontent_smiling_face">
-                    No project templates found. Let's create one!
-                </p>
-                <p>
-                    Save time by using project templates with pre-filled details.<br/>
-                    Standardize workflows and ensure consistency across projects.
-                </p>
-            </field>
-        </record>
-
-        <record id="project_templates_action_list" model="ir.actions.act_window.view">
-            <field name="act_window_id" ref="project_templates_action"/>
-            <field name="view_mode">list</field>
-            <field name="view_id" ref="project.project_templates_view_list"/>
-        </record>
-
-        <record id="project_templates_action_kanban" model="ir.actions.act_window.view">
-            <field name="act_window_id" ref="project_templates_action"/>
-            <field name="view_mode">kanban</field>
-            <field name="view_id" ref="project.project_templates_view_kanban"/>
-        </record>
-
-         <record id="project_templates_action_form" model="ir.actions.act_window.view">
-            <field name="act_window_id" ref="project_templates_action"/>
-            <field name="view_mode">form</field>
-            <field name="view_id" ref="project.project_templates_view_form"/>
         </record>
 
         <record id="action_server_convert_project_to_template" model="ir.actions.server">

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -27,6 +27,8 @@
                         <filter name="create_date_last_30_days" string="Last 30 Days" domain="[('date_last_stage_update', '&gt;=', 'today -30d +1d')]"/>
                         <filter name="create_date_last_365_days" string="Last 365 Days" domain="[('date_last_stage_update', '&gt;=', 'today -365d +1d')]"/>
                     </filter>
+                    <separator/>
+                    <filter string="Templates" context="{'render_templates': True}" name="templates" domain="[('has_template_ancestor', '=', True)]"/>
                     <group>
                         <filter string="Stage" name="stage" context="{'group_by': 'stage_id'}"/>
                         <filter string="Milestone" name="milestone" context="{'group_by': 'milestone_id'}" groups="project.group_project_milestone" invisible="not context.get('allow_milestones', True)"/>
@@ -1365,36 +1367,6 @@
                <field name="role_ids"/>
             </field>
         </field>
-    </record>
-
-    <record id="project_task_templates_action" model="ir.actions.act_window">
-        <field name="name">Task Templates</field>
-        <field name="res_model">project.task</field>
-        <field name="view_mode">list,kanban,form</field>
-        <field name="domain">[('is_template', '=', True)]</field>
-        <field name="context">{'default_is_template': True, 'hide_kanban_stages_nocontent': True, 'search_default_task_templates': True}</field>
-        <field name="search_view_id" ref="view_task_template_search_form"/>
-        <field name="help" type="html">
-            <p class="o_view_nocontent_smiling_face">
-                No task templates found. Let's create one!
-            </p>
-            <p>
-                Save time by using task templates with pre-filled details.<br/>
-                Standardize workflows and ensure consistency across tasks.
-            </p>
-        </field>
-    </record>
-
-    <record id="project_task_templates_action_list" model="ir.actions.act_window.view">
-        <field name="act_window_id" ref="project_task_templates_action"/>
-        <field name="view_mode">list</field>
-        <field name="view_id" ref="project.project_task_templates_list"/>
-    </record>
-
-    <record id="project_task_templates_action_kanban" model="ir.actions.act_window.view">
-        <field name="act_window_id" ref="project_task_templates_action"/>
-        <field name="view_mode">kanban</field>
-        <field name="view_id" ref="project.project_task_templates_kanban"/>
     </record>
 
 </odoo>


### PR DESCRIPTION
[IMP] project: remove templates menus
In this commit:
- task templates and project templates menus
were removed
- Templates filter added in projects and tasks
views. As by default, both views have domain
[is_template = False], the filter with domain
[is_template = True] will not work
(False & True = False), the only way to do it
was in pyhton side inside search_fetch

task-5073029