### PR TITLE
[FIX] web: reloading display wrong menu navbar

### DIFF
--- a/addons/web/static/tests/webclient/actions/load_state.test.js
+++ b/addons/web/static/tests/webclient/actions/load_state.test.js
@@ -1391,6 +1391,7 @@ describe(`new urls`, () => {
 
         expect(`.o_kanban_view`).toHaveCount(1);
         expect.verifySteps([
+            "get menu_id-null",
             'set current_action-{"type":"ir.actions.act_window","res_model":"partner","res_id":1,"views":[[false,"form"]]}',
             'set current_action-{"type":"ir.actions.act_window","res_model":"partner","views":[[1,"kanban"]],"context":{"lang":"en","tz":"taht","uid":7,"allowed_company_ids":[1],"active_model":"partner","active_id":1,"active_ids":[1]}}',
         ]);
@@ -1403,11 +1404,72 @@ describe(`new urls`, () => {
         await animationFrame();
         expect(`.o_kanban_view`).toHaveCount(1);
         expect.verifySteps([
+            "get menu_id-null",
             'get current_action-{"type":"ir.actions.act_window","res_model":"partner","views":[[1,"kanban"]],"context":{"lang":"en","tz":"taht","uid":7,"allowed_company_ids":[1],"active_model":"partner","active_id":1,"active_ids":[1]}}',
             'set current_action-{"type":"ir.actions.act_window","res_model":"partner","views":[[1,"kanban"]],"context":{"lang":"en","tz":"taht","uid":7,"active_model":"partner","active_id":1,"active_ids":[1]}}',
-            "get menu_id-null",
         ]);
     });
+
+    test("menu jumping fix: multiple menus sharing same action", async () => {
+        // Test case for menu jumping issue when multiple menus share the same action
+        // Scenario: User navigates to Sale->Customers, then F5 reload should stay in Sale, not jump to Account
+        defineActions([
+            {
+                id: 9001,
+                name: "Partners",
+                res_model: "partner", 
+                type: "ir.actions.act_window",
+                views: [[false, "list"], [false, "form"]],
+            },
+        ]);
+
+        defineMenus([
+            { id: 0 }, // prevents auto-loading
+            // Sale App
+            { id: 100, name: "Sale", appID: 100, children: [101] },
+            { id: 101, name: "Customers", appID: 100, actionID: 9001, parent_id: 100 },
+            // Account App  
+            { id: 200, name: "Accounting", appID: 200, children: [201] },
+            { id: 201, name: "Customers", appID: 200, actionID: 9001, parent_id: 200 }, // Same action!
+        ]);
+
+        patchWithCleanup(browser.sessionStorage, {
+            setItem(key, value) {
+                expect.step(`set ${key}-${value}`);
+                super.setItem(key, value);
+            },
+            getItem(key) {
+                const res = super.getItem(key);
+                expect.step(`get ${key}-${res}`);
+                return res;
+            },
+        });
+
+        // Step 1: Navigate to Sale->Customers with explicit menu_id
+        redirect("/odoo/action-9001?menu_id=100");
+        logHistoryInteractions();
+
+        await mountWebClient();
+        expect(`.o_list_view`).toHaveCount(1);
+
+        // Step 2: Emulate F5 reload
+        routerBus.trigger("ROUTE_CHANGE");
+        await animationFrame();
+        await animationFrame();
+
+        expect(`.o_list_view`).toHaveCount(1);
+
+        expect.verifySteps([
+            "get menu_id-null",
+            "set menu_id-100",
+            'set current_action-{"binding_type":"action","binding_view_types":"list,form","id":9001,"type":"ir.actions.act_window","xml_id":9001,"name":"Partners","res_model":"partner","views":[[false,"list"],[false,"form"]],"context":{},"embedded_action_ids":[],"group_ids":[],"limit":80,"mobile_view_mode":"kanban","target":"current","view_ids":[],"view_mode":"list,form"}',
+            "pushState http://example.com/odoo/action-9001",
+            "get menu_id-100", // F5 reload checks stored menu
+            'set current_action-{"binding_type":"action","binding_view_types":"list,form","id":9001,"type":"ir.actions.act_window","xml_id":9001,"name":"Partners","res_model":"partner","views":[[false,"list"],[false,"form"]],"context":{},"embedded_action_ids":[],"group_ids":[],"limit":80,"mobile_view_mode":"kanban","target":"current","view_ids":[],"view_mode":"list,form"}',
+            "Update the state without updating URL, nextState: actionStack,action",
+        ]);
+    });
+
 });
 
 describe(`legacy urls`, () => {


### PR DESCRIPTION

* STEP TO REPRODUCE: install sale management module, go to sale app ->
customer menu -> Then reloading the page using F5 -> the menu is change
to invoice which is not correct

* Also Multiple modules (Sale, Account, Purchase) share same actions
(e.g. partner action)

* SOLUTION: Modified webclient.js action-to-menu mapping to handle multiple
menus sharing same action

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
