### PR TITLE
[FIX] html_editor: backspace not working properly

### DIFF
--- a/addons/html_editor/static/src/core/delete_plugin.js
+++ b/addons/html_editor/static/src/core/delete_plugin.js
@@ -500,8 +500,7 @@ export class DeletePlugin extends Plugin {
             // @todo: mind Icons?
             // Probably need to get deepest position's element
             // @todo: update fillEmpty
-            // @todo: check if nodes does not already have a ZWS/ZWNBSP
-            if (!isBlock(node) && !isTangible(node)) {
+            if (!isBlock(node) && !isTangible(node) && !isZWS(node) && !isZwnbsp(node)) {
                 node.appendChild(this.document.createTextNode("\u200B"));
                 node.setAttribute("data-oe-zws-empty-inline", "");
             }

--- a/addons/html_editor/static/src/core/delete_plugin.js
+++ b/addons/html_editor/static/src/core/delete_plugin.js
@@ -16,6 +16,7 @@ import {
     isZWS,
     nextLeaf,
     previousLeaf,
+    isEmptyBlock,
 } from "../utils/dom_info";
 import { getState, isFakeLineBreak, observeMutations, prepareUpdate } from "../utils/dom_state";
 import {
@@ -1073,14 +1074,18 @@ export class DeletePlugin extends Plugin {
             const nodeClosestBlock = closestBlock(node);
             let leaf = adjacentLeafFromPos(node, offset, editableRoot);
             while (leaf) {
-                blockSwitch ||= closestBlock(leaf) !== nodeClosestBlock;
+                const leafClosestBlock = closestBlock(leaf);
+                blockSwitch ||= leafClosestBlock !== nodeClosestBlock;
 
                 if (this.shouldSkip(leaf, blockSwitch)) {
                     leaf = adjacentLeaf(leaf, editableRoot);
                     continue;
                 }
 
-                if (leaf.nodeType === Node.TEXT_NODE) {
+                if (
+                    leaf.nodeType === Node.TEXT_NODE &&
+                    !(blockSwitch && isEmptyBlock(leafClosestBlock))
+                ) {
                     const [char, index] = findVisibleChar(...textEdgePos(leaf));
                     if (char) {
                         const idx = (blockSwitch ? indexBeforeChar : indexAfterChar)(index, char);

--- a/addons/html_editor/static/tests/delete/backward.test.js
+++ b/addons/html_editor/static/tests/delete/backward.test.js
@@ -509,6 +509,22 @@ describe("Selection collapsed", () => {
                 contentAfter: `<p>a[]</p>`,
             });
         });
+
+        test("should delete empty styled paragraph(s) and move cursor to previous styled inline", async () => {
+            await testEditor({
+                contentBefore: `<p><strong data-oe-zws-empty-inline="">\u200B</strong></p><p><strong data-oe-zws-empty-inline="">[]\u200B</strong></p>`,
+                stepFunction: deleteBackward,
+                contentAfterEdit: `<p o-we-hint-text='Type "/" for commands' class="o-we-hint"><strong data-oe-zws-empty-inline="">\u200B[]</strong><br></p>`,
+                contentAfter: `<p>[]<br></p>`,
+            });
+
+            await testEditor({
+                contentBefore: `<p><strong>abc</strong></p><p><strong data-oe-zws-empty-inline="">\u200B</strong></p><p><strong data-oe-zws-empty-inline="">\u200B</strong></p><p><strong data-oe-zws-empty-inline="">[]\u200B</strong></p>`,
+                stepFunction: deleteBackward,
+                contentAfterEdit: `<p><strong>abc</strong></p><p><strong data-oe-zws-empty-inline="">\u200B</strong><br></p><p o-we-hint-text='Type "/" for commands' class="o-we-hint"><strong data-oe-zws-empty-inline="">\u200B[]</strong><br></p>`,
+                contentAfter: `<p><strong>abc</strong></p><p><br></p><p>[]<br></p>`,
+            });
+        });
     });
 
     describe("Line breaks", () => {


### PR DESCRIPTION
Steps to Reproduce

Issue 1
- Apply bold on an empty paragraph using **Ctrl+B** and press Enter.
- Press Backspace
- the paragraph is not removed.

Issue 2
- Write some text. Apply bold on that text.
- Press Enter multiple times to create 2–3 new paragraphs.
- Press Backspace.
- A single backspace removes multiple paragraphs at once, and the cursor jumps back to the paragraph with the text.

Description of the issue:

After a recent commit [1], only a **zws** is inserted inside blocks containing empty inline elements. As a result, when an inline element contains only a **zws**, `adjacentLeafFromPos` returns the **zws** as a leaf node. Since **zws** is not a visible character and there are no visible characters nearby, it is not treated as a valid stop point, and the traversal continues searching for a visible character.

- In the first case, no visible character is found, so backspace does nothing and the block remains undeleted.
- In the second case, a visible character is eventually found further away, so all blocks between that character and the current selection are removed in a single operation, causing multiple paragraphs to be deleted at once.

Solution:

The fix ensures that when a block is empty and a block switch occurs, the **zws** is returned immediately instead of continuing the traversal. This prevents backspace from skipping or deleting multiple blocks unexpectedly.

task:5071252

[1]: https://github.com/odoo/odoo/pull/220568/commits/1cc0670aa4d8f1552ff6ea0cba304c8c74ffc263
