### PR TITLE
[FIX] base: prevent deletion of default country groups

### DIFF
--- a/odoo/addons/base/models/res_country.py
+++ b/odoo/addons/base/models/res_country.py
@@ -158,6 +158,25 @@ class CountryGroup(models.Model):
     country_ids = fields.Many2many('res.country', 'res_country_res_country_group_rel',
                                    'res_country_group_id', 'res_country_id', string='Countries')
 
+    @api.ondelete(at_uninstall=False)
+    def _unlink_except_country_groups(self):
+        default_country_groups = [
+            'europe',
+            'south_america',
+            'sepa_zone',
+            'gulf_cooperation_council',
+            'eurasian_economic_union',
+            'ch_and_li'
+        ]
+
+        # fetch all default country groups
+        default_group_ids = self.env['res.country.group']
+        for xml_id in default_country_groups:
+            default_group_ids |= self.env.ref(f'base.{xml_id}')
+
+        for group in self:
+            if group.id in default_group_ids.ids:
+                raise UserError(_('You cannot delete a default country group.'))
 
 class CountryState(models.Model):
     _description = "Country state"


### PR DESCRIPTION
Currently, deleting a default country group leads to errors in modules which rely on these groups.

**Steps to reproduce:**
1. Install `contacts, account_edi_ubl_cii, l10n_be` modules.
2. Switch company to "BE Company CoA".
3. Open country group and delete "European Union".
4. Create an Invoice.

**Error:**
`ValueError - External ID not found in the system: base.europe`

**Cause:**
Default country groups are referenced in various modules. Deleting them breaks these references, causing errors when related actions are performed.

**Fix:**
Prevent deletion of default country groups by raising a user error when deletion is attempted.

**Refs:**
[1]: https://github.com/odoo/odoo/blob/ee15163fe516817da277760752892ea76a699e22/addons/account/models/partner.py#L257 [2]: https://github.com/odoo/odoo/blob/ee15163fe516817da277760752892ea76a699e22/addons/account_edi_ubl_cii/models/account_edi_common.py#L186 [3]: https://github.com/odoo/odoo/blob/ee15163fe516817da277760752892ea76a699e22/addons/account_qr_code_sepa/models/res_bank.py#L51 [4]: https://github.com/odoo/odoo/blob/ee15163fe516817da277760752892ea76a699e22/addons/l10n_gcc_invoice/models/account_move.py#L24

sentry-6857603868