### PR TITLE
[FIX] account: handle non-alphanumeric journal codes in European payment references

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3906,7 +3906,7 @@ class AccountMove(models.Model):
             reference will be 'RF67 INV0 0003 7'.
         """
         self.ensure_one()
-        journal_identifier = self.journal_id.code if self.journal_id.code.isascii() else self.journal_id.id
+        journal_identifier = self.journal_id.code if self.journal_id.code.isascii() and self.journal_id.code.isalnum() else self.journal_id.id
         return format_structured_reference_iso(f'{journal_identifier}{str(self.id).zfill(6)}')
 
     def _get_invoice_reference_euro_partner(self):
@@ -3921,7 +3921,7 @@ class AccountMove(models.Model):
             be used.
         """
         self.ensure_one()
-        journal_identifier = self.journal_id.code if self.journal_id.code.isascii() else self.journal_id.id
+        journal_identifier = self.journal_id.code if self.journal_id.code.isascii() and self.journal_id.code.isalnum() else self.journal_id.id
         partner_ref = self.partner_id.ref
         partner_ref_nr = re.sub(r'\D', '', partner_ref or '')[-21:] or str(self.partner_id.id)[-21:]
         partner_ref_nr = f'{journal_identifier}{partner_ref_nr}'[-21:]

--- a/addons/account/tests/test_account_journal.py
+++ b/addons/account/tests/test_account_journal.py
@@ -33,6 +33,38 @@ class TestAccountJournal(AccountTestInvoicingCommon):
         with self.assertRaises(ValidationError), self.cr.savepoint():
             journal_bank.default_account_id.currency_id = self.company_data['currency']
 
+    def test_euro_payment_reference_generation(self):
+        """
+        Test the generation of European (ISO 11649) payment references to ensure
+        it correctly handles various journal short codes.
+        """
+        journal = self.company_data['default_journal_sale']
+        journal.invoice_reference_model = 'euro'
+
+        # Case 1: Code contains alphanumeric value.
+        journal.code = 'INV'
+        invoice_valid = self.init_invoice("out_invoice", products=self.product_a)
+        invoice_valid.journal_id = journal
+        invoice_valid.action_post()
+        self.assertTrue(invoice_valid.payment_reference, "A payment reference should be generated.")
+        self.assertIn('INV', invoice_valid.payment_reference, "The reference should be based on the journal code.")
+
+        # Case 2: Code contains a hyphen.
+        journal.code = 'INV-'
+        invoice_invalid = self.init_invoice("out_invoice", products=self.product_a)
+        invoice_invalid.journal_id = journal
+        invoice_invalid.action_post()
+        self.assertTrue(invoice_invalid.payment_reference, "A payment reference should be generated.")
+        self.assertIn(str(journal.id), invoice_invalid.payment_reference, "The reference should fall back to using the journal ID.")
+
+        # Case 3: Code is non-ASCII but alphanumeric (e.g., Greek letter 'INVα'). # noqa: RUF003
+        journal.code = 'INVα'
+        invoice_unicode = self.init_invoice("out_invoice", products=self.product_a)
+        invoice_unicode.journal_id = journal
+        invoice_unicode.action_post()
+        self.assertTrue(invoice_unicode.payment_reference, "A payment reference should be generated.")
+        self.assertIn(str(journal.id), invoice_unicode.payment_reference, "The reference should fall back to using the journal ID for non-ASCII codes.")
+
     def test_changing_journal_company(self):
         ''' Ensure you can't change the company of an account.journal if there are some journal entries '''
 
@@ -347,8 +379,9 @@ class TestAccountJournalAlias(AccountTestInvoicingCommon, MailCommon):
             journal=journal_latin,
         )
 
+        expected_id = str(invoice_non_latin.journal_id.id)
         ref_parts_non_latin = invoice_non_latin.payment_reference.split()
-        self.assertEqual(ref_parts_non_latin[1][:3], str(invoice_non_latin.journal_id.id), "The reference should start with " + str(invoice_non_latin.journal_id.id))
+        self.assertEqual(ref_parts_non_latin[1][:len(expected_id)], expected_id, "The reference should start with " + expected_id)
 
         ref_parts_latin = invoice_latin.payment_reference.split()
         self.assertIn(ref_parts_latin[1][:3], latin_code, f"Expected journal code '{latin_code}' in second part of reference")


### PR DESCRIPTION
Currently, an error occurs when confirming a customer invoice that uses a journal with an invalid configuration.

**Steps to Reproduce:**
1) Install Accounting app.(with Demo)
2) Navigate to Accounting>Configuration>Journals
3) Open existing 'Sales' journal and make following changes:
- set Sequence Prefix: INV-
- In the Advanced Settings Page, set 'Communication Standard' as 'European' and
   save the journal.
4) Create a Customer Invoice with this Sales Journal and click on `Confirm`.

**Error :**
`ValueError: invalid literal for int() with base 36: '-'`

**Root Cause:**
Since [this commit](https://github.com/odoo/odoo/pull/212169/commits/e4a09467a20f282d28baa09091c10a6aea6d0094#diff-cc13d9842e166c12738b659e0478ceb8b1b15734442c1e090252919e7efb6ed7), On following above steps, The value of 'number' received at [1]  looks like 'INV-000003' due to which on further computation of this value at [1] causing an error.

**Fix:**
prevent crash by adding a additional check on methods
`_get_invoice_reference_euro_invoice` and `_get_invoice_reference_euro_partner`
to validate the journal's short code.

[1]- https://github.com/odoo/odoo/blob/2646790e7e31b4c600e39f2d5c87f0744b1578b0/addons/account/tools/structured_reference.py#L20-L26

**sentry-6860586611**