### PR TITLE
[IMP] l10n_in_edi: store JSON data for all edi, eway-bill requests.

### DIFF
--- a/addons/l10n_in/models/__init__.py
+++ b/addons/l10n_in/models/__init__.py
@@ -6,6 +6,7 @@ from . import account_payment
 from . import account_tax
 from . import company
 from . import iap_account
+from . import ir_logging
 from . import product_template
 from . import port_code
 from . import res_config_settings

--- a/addons/l10n_in/models/ir_logging.py
+++ b/addons/l10n_in/models/ir_logging.py
@@ -1,0 +1,16 @@
+from odoo import models
+
+
+class IrLogging(models.Model):
+    _inherit = 'ir.logging'
+
+    def _l10n_in_log_message(self, func: str, message: str, name: str, path: str):
+        self.env['ir.logging'].create({
+            'func': func,
+            'message': message,
+            'name': name,
+            'path': path,
+            'level': 'INFO',
+            'type': 'server',
+            'line': ' ',
+        })

--- a/addons/l10n_in/models/res_partner.py
+++ b/addons/l10n_in/models/res_partner.py
@@ -127,6 +127,12 @@ class ResPartner(models.Model):
             "gstin_to_search": self.vat,
             "gstin": self.env.company.vat,
         }
+        self.env['ir.logging']._l10n_in_log_message(
+            name=f'{self._name}({self.id})',
+            path='/l10n_in_reports/1/public/search',
+            message='GST verification service triggered',
+            func='action_l10n_in_verify_gstin_status',
+        )
         try:
             response = self.env['iap.account']._l10n_in_connect_to_server(
                 is_production,

--- a/addons/l10n_in_edi/models/account_move.py
+++ b/addons/l10n_in_edi/models/account_move.py
@@ -206,6 +206,13 @@ class AccountMove(models.Model):
                 return partner_validation
         self._l10n_in_lock_invoice()
         generate_json = self._l10n_in_edi_generate_invoice_json()
+        request_json_name = "%s_request_einvoice_.json" % (self.name.replace("/", "_"))
+        self.env['ir.logging']._l10n_in_log_message(
+            name=f'{self._name}({self.id})',
+            path='/l10n_in_edi/1/generate',
+            message='E-invoice request sent to Government',
+            func='_l10n_in_edi_send_invoice',
+        )
         response = self._l10n_in_edi_connect_to_server(
             url_end_point='generate',
             json_payload=generate_json
@@ -216,6 +223,12 @@ class AccountMove(models.Model):
             if '2150' in error_codes:
                 # Get IRN by details in case of IRN is already generated
                 # this happens when timeout from the Government portal but IRN is generated
+                self.env['ir.logging']._l10n_in_log_message(
+                    name=f'{self._name}({self.id})',
+                    path='/l10n_in_edi/1/getirnbydocdetails',
+                    message='Get E-invoice when duplicate IRN is generated',
+                    func='_l10n_in_edi_send_invoice',
+                )
                 response = self._l10n_in_edi_connect_to_server(
                     url_end_point='getirnbydocdetails',
                     params={
@@ -286,17 +299,11 @@ class AccountMove(models.Model):
                 # values are sanitized with `<p>` tag
                 return msg
         data = response.get("data", {})
-        json_dump = json.dumps(data)
-        json_name = "%s_einvoice.json" % (self.name.replace("/", "_"))
-        attachment = self.env["ir.attachment"].create({
-            'name': json_name,
-            'raw': json_dump.encode(),
-            'res_model': self._name,
-            'res_field': 'l10n_in_edi_attachment_file',
-            'res_id': self.id,
-            'mimetype': 'application/json',
-            'company_id': self.company_id.id,
-        })
+        response_json_name = "%s_einvoice.json" % (self.name.replace("/", "_"))
+        # Response attachment
+        self._create_and_post_attachment(data=data, name=response_json_name)
+        # Request attachment
+        self._create_and_post_attachment(data=generate_json, name=request_json_name)
         self.l10n_in_edi_status = 'sent'
         message = []
         for partner in partners:
@@ -323,6 +330,14 @@ class AccountMove(models.Model):
             "CnlRsn": self.l10n_in_edi_cancel_reason,
             "CnlRem": self.l10n_in_edi_cancel_remarks,
         }
+        cancel_request_json_name = "%s_request_cancel_einvoice.json" % (self.name.replace("/", "_"))
+        self._create_and_post_attachment(data=cancel_json, name=cancel_request_json_name)
+        self.env['ir.logging']._l10n_in_log_message(
+            name=f'{self._name}({self.id})',
+            path='/l10n_in_edi/1/cancel',
+            message='E-invoice cancellation request sent to Government',
+            func='l10n_in_edi_cancel_invoice',
+        )
         response = self._l10n_in_edi_connect_to_server(url_end_point='cancel', json_payload=cancel_json)
         # Creating a lambda function so it fetches the odoobot id only when needed
         _get_odoobot_id = (
@@ -356,17 +371,10 @@ class AccountMove(models.Model):
                     )
                 )
         if "error" not in response:
-            json_dump = json.dumps(response.get('data', {}))
             json_name = "%s_cancel_einvoice.json" % (self.name.replace("/", "_"))
-            if json_dump:
-                attachment = self.env['ir.attachment'].create({
-                    'name': json_name,
-                    'raw': json_dump.encode(),
-                    'res_model': self._name,
-                    'res_field': 'l10n_in_edi_attachment_file',
-                    'res_id': self.id,
-                    'mimetype': 'application/json',
-                })
+            data = response.get('data', {})
+            if data:
+                self._create_and_post_attachment(data=data, name=json_name)
             self.message_post(author_id=_get_odoobot_id(self), body=_(
                 "E-Invoice has been cancelled successfully. "
                 "Cancellation Reason: %(reason)s and Cancellation Remark: %(remark)s",
@@ -752,3 +760,18 @@ class AccountMove(models.Model):
             else:
                 return authenticate_response
         return response
+
+    def _create_and_post_attachment(self, data, name):
+        attachment = self.env['ir.attachment'].create({
+            'name': name,
+            'mimetype': 'application/json',
+            'raw': json.dumps(data),
+            'res_model': self._name,
+            'res_id': self.id,
+            'res_field': 'l10n_in_edi_attachment_file',
+            'company_id': self.company_id.id
+        })
+        self.message_post(
+            author_id=self.env.ref('base.partner_root').id,
+            attachment_ids=attachment.ids
+        )

--- a/addons/l10n_in_edi/models/res_company.py
+++ b/addons/l10n_in_edi/models/res_company.py
@@ -51,6 +51,12 @@ class ResCompany(models.Model):
             "password": self_sudo.l10n_in_edi_password,
             "gstin": self_sudo.vat,
         }
+        self.env['ir.logging']._l10n_in_log_message(
+            name=f'{self._name}({self.id})',
+            path='/l10n_in_edi/1/authenticate',
+            message='E-invoice authentication request sent',
+            func='_l10n_in_edi_authenticate',
+        )
         try:
             response = self.env['iap.account']._l10n_in_connect_to_server(
                 self_sudo.l10n_in_edi_production_env,

--- a/addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py
@@ -460,15 +460,11 @@ class L10nInEwaybill(models.Model):
             blocking_level = 'warning'
         self._write_error(error_message, blocking_level)
 
-    def _create_and_post_response_attachment(self, ewb_name, response, is_cancel=False):
-        if not is_cancel:
-            name = f'ewaybill_{ewb_name}.json'
-        else:
-            name = f'ewaybill_{ewb_name}_cancel.json'
+    def _create_and_post_attachment(self, data, name):
         attachment = self.env['ir.attachment'].create({
             'name': name,
             'mimetype': 'application/json',
-            'raw': json.dumps(response),
+            'raw': json.dumps(data),
             'res_model': self._name,
             'res_id': self.id,
             'res_field': 'attachment_file',
@@ -485,6 +481,14 @@ class L10nInEwaybill(models.Model):
             'cancelRsnCode': int(self.cancel_reason),
             'cancelRmrk': self.cancel_remarks,
         }
+        cancel_request_json_name = f'ewaybill_{self.name}_cancel_request.json'
+        self._create_and_post_attachment(data=cancel_json, name=cancel_request_json_name)
+        self.env['ir.logging']._l10n_in_log_message(
+            name=f'{self._name}({self.id})',
+            path='/l10n_in_edi_ewaybill/1/cancel',
+            message='E-invoice cancellation request sent to Government',
+            func='_ewaybill_cancel',
+        )
         ewb_api = EWayBillApi(self.company_id)
         if self.error_message and self.blocking_level == 'error':
             self.message_post(body=_(
@@ -497,11 +501,9 @@ class L10nInEwaybill(models.Model):
             self._handle_error(error)
             return False
         self._handle_internal_warning_if_present(response)  # In case of error 312
-        self._create_and_post_response_attachment(
-            ewb_name=self.name,
-            response=response,
-            is_cancel=True
-        )
+        cancel_response_json_name = f'ewaybill_{self.name}_cancel.json'
+        response_data = response.get('data', {})
+        self._create_and_post_attachment(data=response_data, name=cancel_response_json_name)
         self._write_successfully_response({'state': 'cancel'})
         self.env.cr.commit()
 
@@ -515,16 +517,25 @@ class L10nInEwaybill(models.Model):
         self.ensure_one()
         self._log_retry_message_on_generate()
         ewb_api = EWayBillApi(self.company_id)
+        generate_json = self._ewaybill_generate_direct_json()
+        request_json_name = 'ewaybill_request.json'
+        self._create_and_post_attachment(data=generate_json, name=request_json_name)
+        self.env['ir.logging']._l10n_in_log_message(
+            name=f'{self._name}({self.id})',
+            path='/l10n_in_edi_ewaybill/1/generate',
+            message='E-invoice request sent to Government',
+            func='_generate_ewaybill',
+        )
         self._lock_ewaybill()
         try:
-            response = ewb_api._ewaybill_generate(self._ewaybill_generate_direct_json())
+            response = ewb_api._ewaybill_generate(generate_json)
         except EWayBillError as error:
             self._handle_error(error)
             return False
         self._handle_internal_warning_if_present(response)  # In case of error 604
         response_data = response.get('data', {})
         name = response_data.get('ewayBillNo')
-        self._create_and_post_response_attachment(name, response)
+        self._create_and_post_attachment(data=response_data, name=f'ewaybill_{name}.json')
         self._write_successfully_response({
             'name': name,
             'state': 'generated',

--- a/addons/l10n_in_ewaybill/models/res_config_settings.py
+++ b/addons/l10n_in_ewaybill/models/res_config_settings.py
@@ -24,6 +24,12 @@ class ResConfigSettings(models.TransientModel):
     def l10n_in_ewaybill_test(self):
         self._l10n_in_check_gst_number()
         ewaybill_api = EWayBillApi(self.company_id)
+        self.env['ir.logging']._l10n_in_log_message(
+            name=f'{self._name}({self.id})',
+            path='/l10n_in_edi_ewaybill/1/authenticate',
+            message='Verify E-waybill credentials',
+            func='_ewaybill_authenticate',
+        )
         try:
             ewaybill_api._ewaybill_authenticate()
         except EWayBillError as e:


### PR DESCRIPTION
Before PR:
- JSON payloads sent to the EDI and e-Waybill API (including cancellation requests) were not stored.

After PR: 
- Outgoing JSON requests and incoming JSON responses are now stored as attachments. 
- Also logs are stored in client DB to  ensure traceability and better debugging.

Task: 4896516

Related PR (Enterprise):  https://github.com/odoo/enterprise/pull/94135