### PR TITLE
[FIX] website_sale_collect: recompte warehouse

### DIFF
--- a/addons/website_sale_collect/tests/test_sale_order.py
+++ b/addons/website_sale_collect/tests/test_sale_order.py
@@ -19,7 +19,7 @@ class TestSaleOrder(ClickAndCollectCommon):
         self.warehouse_2 = self._create_warehouse()
         self.website.warehouse_id = self.warehouse
         so = self._create_in_store_delivery_order(warehouse_id=self.warehouse_2.id)
-        so.set_delivery_line(self.free_delivery, 0)
+        so._set_delivery_method(self.free_delivery)
         self.assertEqual(so.warehouse_id, self.warehouse)
 
     def test_setting_pickup_location_assigns_warehouse(self):
@@ -61,7 +61,7 @@ class TestSaleOrder(ClickAndCollectCommon):
         })
         so = self._create_in_store_delivery_order()
         so.fiscal_position_id = fp_us
-        so.set_delivery_line(self.free_delivery, 0)
+        so._set_delivery_method(self.free_delivery)
         self.assertNotEqual(so.fiscal_position_id, fp_us)
 
     def test_free_qty_calculated_from_order_wh_if_dm_is_in_store(self):


### PR DESCRIPTION
Steps:
- Activate Click and Collect, then create a new warehouse.
- For the product, add quantities in both locations.
- Assign the second warehouse to Click and Collect.
- Go to the website, add the product to the cart, choose Click and Collect as the delivery method, then switch it to Delivery and confirm payment.

Issue:
- When checking the quotation, it still uses the warehouse linked to Click and Collect.

Cause:
- Warehouse recomputation logic is called after _remove_delivery_line which resets the delivery_type of sale order. Since delivery_type is reset the sale order filter for warehouse recomputation does not work as intended.

Fix:
- Moved warehouse recomputation logic to _set_delivery_method which will filter the sale order before _remove_delivery_line.

opw - 4965726, 5004170

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
