### PR TITLE
[FIX] html_editor: prevent error on saving modified image with no data

### DIFF
--- a/addons/html_editor/models/ir_attachment.py
+++ b/addons/html_editor/models/ir_attachment.py
@@ -51,6 +51,9 @@ class IrAttachment(models.Model):
                     attachment.image_src = '/web/image/%s-redirect/%s' % (attachment.id, name)
             else:
                 # Adding unique in URLs for cache-control
+                if not attachment.checksum:
+                    attachment.image_src = False
+                    continue
                 unique = attachment.checksum[:8]
                 if attachment.url:
                     # For attachments-by-url, unique is used as a cachebuster. They


### PR DESCRIPTION
Third-party extensions like ad blockers or image blockers might remove base64 encoded data from the frontend when an image is changed or when the page doesn’t load correctly using the `html_editor`.

In the video [1], this problem is shown by manually removing the base64 data for replication. It’s suspected that these common browser extensions could be causing the issue since this error has appeared in multiple databases.

**Error:**
`TypeError: 'bool' object is not subscriptable`

**Root cause:**
* Since data is `None` at [2], the checksum is not computed and remains `False` because [3] is not called. This leads to an error at [4] when attempting to index it.

**Solution:**
* Add an additional validation to check if the checksum exists. If it does not, set the image source to `False`.

[1]:
https://drive.google.com/file/d/1fC0HlvVKfkcAAit7UhQWDM9r4O3jMutF/view?usp=sharing
[2]:
https://github.com/odoo/odoo/blob/95ed5c75582631c7cc417b000569ff6451cc5006/addons/html_editor/controllers/main.py#L368 
[3]:
https://github.com/odoo/odoo/blob/95ed5c75582631c7cc417b000569ff6451cc5006/odoo/addons/base/models/ir_attachment.py#L280 
[4]:
https://github.com/odoo/odoo/blob/95ed5c75582631c7cc417b000569ff6451cc5006/addons/html_editor/models/ir_attachment.py#L54

sentry-6776476775