### PR TITLE
[FIX] base: invalid user-defined defaults value

### DIFF
--- a/odoo/addons/base/i18n/base.pot
+++ b/odoo/addons/base/i18n/base.pot
@@ -19770,6 +19770,13 @@ msgstr ""
 
 #. module: base
 #. odoo-python
+#: code:addons/base/models/ir_default.py:0
+#, python-format
+msgid "Invalid value in Default Value field. Expected type '%s' for '%s.%s'."
+msgstr ""
+
+#. module: base
+#. odoo-python
 #: code:addons/base/models/ir_ui_view.py:0
 #, python-format
 msgid "Invalid composed field %(definition)s in %(use)s"

--- a/odoo/addons/base/models/ir_default.py
+++ b/odoo/addons/base/models/ir_default.py
@@ -23,13 +23,19 @@ class IrDefault(models.Model):
     condition = fields.Char('Condition', help="If set, applies the default upon condition.")
     json_value = fields.Char('Default Value (JSON format)', required=True)
 
-    @api.constrains('json_value')
+    @api.constrains('json_value', 'field_id')
     def _check_json_format(self):
         for record in self:
+            model_name = record.sudo().field_id.model_id.model
+            model = self.env[model_name]
+            field = model._fields[record.field_id.name]
             try:
-                json.loads(record.json_value)
+                value = json.loads(record.json_value)
+                field.convert_to_cache(value, model)
             except json.JSONDecodeError:
                 raise ValidationError(_('Invalid JSON format in Default Value field.'))
+            except Exception:  # noqa: BLE001
+                raise ValidationError(_("Invalid value in Default Value field. Expected type '%s' for '%s.%s'.", record.field_id.ttype, model_name, record.field_id.name))
 
     @api.model_create_multi
     def create(self, vals_list):


### PR DESCRIPTION
Steps:
- Create a user defined defaults value
    - Model: res.partner
    - Field: date
    - Value: 1
- Create a new contact

Actual result:
- invalid field type
- 'int' object is not subscriptable (depends of field type)

Expected result:
- No error
- User is not able to put an invalid value as a default

task-3729963