### PR TITLE
[IMP] hr_attendance: Provision for Single Check-In System

### DIFF
--- a/addons/hr_attendance/controllers/main.py
+++ b/addons/hr_attendance/controllers/main.py
@@ -48,6 +48,7 @@ class HrAttendance(http.Controller):
                 'use_pin': employee.company_id.attendance_kiosk_use_pin,
                 'display_overtime': employee.company_id.hr_attendance_display_overtime,
                 'device_tracking_enabled': employee.company_id.attendance_device_tracking,
+                'single_checkin_enabled': employee.company_id._is_single_checkin_enabled(),
             }
         return response
 
@@ -233,7 +234,7 @@ class HrAttendance(http.Controller):
                                                   latitude=latitude,
                                                   longitude=longitude,
                                                   device_tracking_enabled=employee.company_id.attendance_device_tracking)
-        employee._attendance_action_change(geo_ip_response)
+        employee.with_context(is_from_systray_check_in_out=True)._attendance_action_change(geo_ip_response)
         return self._get_employee_info_response(employee)
 
     @http.route('/hr_attendance/attendance_user_data', type="jsonrpc", auth="user", readonly=True)

--- a/addons/hr_attendance/models/hr_employee.py
+++ b/addons/hr_attendance/models/hr_employee.py
@@ -185,6 +185,10 @@ class HrEmployee(models.Model):
             return self.env['hr.attendance'].create(vals)
         attendance = self.env['hr.attendance'].search([('employee_id', '=', self.id), ('check_out', '=', False)], limit=1)
         if attendance:
+            if self.company_id._is_single_checkin_enabled():
+                if self.env.context.get('is_from_systray_check_in_out', False):  # throw user error if user tries to checkout from systray.
+                    raise exceptions.UserError(self.env._("You’ve already checked in for the day.\nThank you."))
+                return attendance  # no need to checkout the user if single checkin enabled.
             if geo_information:
                 attendance.write({
                     'check_out': action_date,

--- a/addons/hr_attendance/models/res_company.py
+++ b/addons/hr_attendance/models/res_company.py
@@ -36,6 +36,7 @@ class ResCompany(models.Model):
         ('by_manager', 'Approved by Manager'),
     ], string='Extra Hours Validation', default='no_validation')
     auto_check_out = fields.Boolean(string="Automatic Check Out", default=False)
+    single_check_in = fields.Boolean(string="Single Check-In Attendance System", default=False)
     auto_check_out_tolerance = fields.Float(default=2, export_string_translation=False)
     absence_management = fields.Boolean(string="Absence Management", default=False)
     attendance_device_tracking = fields.Boolean(string="Device & Location Tracking", default=True)
@@ -44,6 +45,11 @@ class ResCompany(models.Model):
     def _compute_attendance_kiosk_url(self):
         for company in self:
             company.attendance_kiosk_url = url_join(self.env['res.company'].get_base_url(), '/hr_attendance/%s' % company.attendance_kiosk_key)
+
+    @api.depends("auto_check_out", "single_check_in")
+    def _is_single_checkin_enabled(self):
+        self.ensure_one()
+        return self.single_check_in and self.auto_check_out
 
     # ---------------------------------------------------------
     # ORM Overrides

--- a/addons/hr_attendance/models/res_config_settings.py
+++ b/addons/hr_attendance/models/res_config_settings.py
@@ -19,9 +19,18 @@ class ResConfigSettings(models.TransientModel):
     attendance_from_systray = fields.Boolean(related="company_id.attendance_from_systray", readonly=False)
     attendance_overtime_validation = fields.Selection(related="company_id.attendance_overtime_validation", readonly=False)
     auto_check_out = fields.Boolean(related="company_id.auto_check_out", readonly=False)
+    single_check_in = fields.Boolean(related="company_id.single_check_in", readonly=False)
     auto_check_out_tolerance = fields.Float(related="company_id.auto_check_out_tolerance", readonly=False)
     absence_management = fields.Boolean(related="company_id.absence_management", readonly=False)
     attendance_device_tracking = fields.Boolean(related="company_id.attendance_device_tracking", readonly=False)
+
+    @api.onchange("auto_check_out", "single_check_in")
+    def _onchange_auto_checkout_single_checkin(self):
+        for company in self:
+            if not company.auto_check_out:
+                company.single_check_in = False
+            elif company.single_check_in:
+                company.auto_check_out = True
 
     @api.model
     def get_values(self):

--- a/addons/hr_attendance/static/src/components/greetings/greetings.js
+++ b/addons/hr_attendance/static/src/components/greetings/greetings.js
@@ -18,6 +18,7 @@ export class KioskGreetings extends Component {
         this.attendance = this.props.employeeData.attendance;
         this.check_in_time = this.formatDateTime(this.attendance.check_in && deserializeDateTime(this.attendance.check_in));
         this.check_out_time = this.formatDateTime(this.attendance.check_out && deserializeDateTime(this.attendance.check_out));
+        this.single_checkin_enabled = this.props.employeeData.single_checkin_enabled;
         this.kiosk_delay = setTimeout(() => {
             this.props.kioskReturn(true)
         }, this.props.employeeData.kiosk_delay)

--- a/addons/hr_attendance/static/src/components/greetings/greetings.xml
+++ b/addons/hr_attendance/static/src/components/greetings/greetings.xml
@@ -40,7 +40,10 @@
                                         class="alert alert-info text-center p-3"
                                         t-if="this.hoursToday != '00:00'"
                                         role="status">
-                                        <t t-if="attendance.check_out">
+                                        <t t-if="this.single_checkin_enabled">
+                                            You’ve already checked in for the day.
+                                        </t>
+                                        <t t-elif="attendance.check_out">
                                             Hours Today: <strong><t t-esc="this.hoursToday"/></strong>
                                         </t>
                                         <t t-else="">

--- a/addons/hr_attendance/views/res_config_settings_views.xml
+++ b/addons/hr_attendance/views/res_config_settings_views.xml
@@ -24,6 +24,13 @@
                             <div invisible="not auto_check_out">
                                 <span class="me-2">Tolerance</span><field name="auto_check_out_tolerance" class="text-center" style="width: 5ch;"/><span class="ms-2">Hours</span>
                             </div>
+                            <div class="mt-3 d-flex" invisible="not auto_check_out">
+                                <field name="single_check_in" class="w-auto"/>
+                                <div>
+                                    <label string="Single Check-In Attendance System" for="single_check_in"/><br/>
+                                    <span class="text-muted">When enabled, only the first check-in of the day recorded. Further check-ins within the scheduled working hours will be ignored.</span>
+                                </div>
+                            </div>
                         </setting>
                         <setting string="Absence Management" company_dependent="1" help="If checked, days not covered by an attendance will be visible in the Report. Does not apply to employees with a flexible working schedule.">
                             <field name="absence_management"/>


### PR DESCRIPTION
After:
- This commit introduces a new single check-in attendance system.
- It works with the auto-checkout feature already available in attendance.
- If single check-in is enabled, employees will not be able to check in more than once per day; checkout will be handled automatically by the auto-checkout feature.

task-4848733

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
