### PR TITLE
[IMP] website_slides: improve responsiveness

### DIFF
--- a/addons/website_slides/static/src/interactions/search_modal.js
+++ b/addons/website_slides/static/src/interactions/search_modal.js
@@ -1,0 +1,10 @@
+import { SearchModal as WebsiteSearchModal } from "@website/interactions/search_modal";
+import { registry } from "@web/core/registry";
+
+export class SearchModal extends WebsiteSearchModal {
+    static selector = "#o_wslides_search_modal";
+}
+
+registry
+    .category("public.interactions")
+    .add("website_slides.search_modal", SearchModal);

--- a/addons/website_slides/views/website_slides_templates_homepage.xml
+++ b/addons/website_slides/views/website_slides_templates_homepage.xml
@@ -147,6 +147,52 @@
                 </div>
             </div>
             <t t-call="website_slides.courses_footer"></t>
+            <!-- Off canvas filters on mobile -->
+            <div id="o_wslides_index_offcanvas" class="o_website_offcanvas offcanvas offcanvas-end d-lg-none p-0 overflow-visible">
+                <div class="offcanvas-header">
+                    <h5 class="offcanvas-title">Filters</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"/>
+                </div>
+                <div class="offcanvas-body p-0">
+                    <div class="accordion accordion-flush">
+                        <!-- Tag Groups Filters -->
+                        <div class="accordion-item" t-foreach="tag_groups" t-as="tag_group">
+                            <t t-set="group_frontend_tags" t-value="tag_group.tag_ids.filtered('color')"/>
+                            <t t-if="group_frontend_tags">
+                                <h2 class="accordion-header">
+                                    <button class="accordion-button collapsed"
+                                        type="button"
+                                        data-bs-toggle="collapse"
+                                        t-attf-aria-controls="o_wslides_offcanvas_cat_#{tag_group.id}"
+                                        t-att-data-bs-target="'.o_wslides_offcanvas_cat_%s' % tag_group.id"
+                                        aria-expanded="false"
+                                    >
+                                        <t t-out="tag_group.name"/>
+                                    </button>
+                                </h2>
+                                <div t-attf-id="o_wslides_offcanvas_cat_#{tag_group.id}" t-attf-class="o_wslides_offcanvas_cat_#{tag_group.id} accordion-collapse collapse">
+                                    <div class="accordion-body pt-0">
+                                        <ul class="list-group list-group-flush">
+                                            <li t-foreach="group_frontend_tags" t-as="tag" class="list-group-item border-0 px-0">
+                                                <div t-att-data-post="slide_query_url(tag=slugify_tags(search_tags.ids, toggle_tag_id=tag.id), my=search_my, search=search_term, slide_category=search_slide_category, prevent_redirect=True)"
+                                                    class="post_link text-reset cursor-pointer" t-att-title="tag.name">
+                                                    <div class="form-check">
+                                                        <input class="form-check-input pe-none" type="checkbox" t-attf-name="#{tag.color}" t-att-checked="tag in search_tags"/>
+                                                        <label class="form-check-label" t-attf-for="#{tag.color}" t-out="tag.name"/>
+                                                    </div>
+                                                </div>
+                                            </li>
+                                        </ul>
+                                    </div>
+                                </div>
+                            </t>
+                        </div>
+                    </div>
+                </div>
+                <div class="offcanvas-body flex-grow-0 border-top overflow-hidden">
+                    <a href="/slides" class="btn btn-light">Clear Filters</a>
+                </div>
+            </div>
             <!-- Search Modal for Mobile -->
             <div
                 id="o_wslides_search_modal"
@@ -179,11 +225,11 @@
 
 <template id="courses_search_bar">
     <!-- Navbar dynamically composed using displayed channel tag groups. -->
-    <div class="d-flex flex-column flex-md-row flex-wrap align-items-md-center gap-2 mt-4 mb-3">
+    <div class="d-flex flex-wrap align-items-md-center gap-2 mt-4 mb-3">
         <h1 class="h4 mb-0 me-auto">Courses</h1>
         <div class="d-flex gap-2 flex-grow-1 flex-md-grow-0 align-items-start">
             <!-- Desktop tag groups -->
-            <div id="navbarTagGroups">
+            <div id="navbarTagGroups" class="d-none d-lg-block">
                 <t t-set="search_tag_groups" t-value="search_tags.mapped('group_id')"/>
                 <ul class="list-unstyled d-flex flex-wrap gap-2 mb-0">
                     <t t-foreach="tag_groups" t-as="tag_group">
@@ -230,6 +276,15 @@
                 >
                     <i class="oi oi-search" role="img"/>
                 </a>
+                <!-- Mobile Filter button -->
+                <button class="o_not_editable btn btn-light position-relative d-lg-none"
+                    data-bs-toggle="offcanvas"
+                    data-bs-target="#o_wslides_index_offcanvas">
+                    <i class="fa fa-sliders"/>
+                    <span t-if="search_tags or search_my"
+                        class="position-absolute top-0 start-100 translate-middle border border-light rounded-circle bg-danger p-1"
+                    />
+                </button>
                 <a class="btn d-block d-lg-none p-0" data-bs-toggle="offcanvas" href="#o_wslides_overview_offcanvas" role="button" aria-controls="o_wslides_overview_offcanvas">
                     <t t-call="website_slides.slides_misc_user_image">
                         <t t-set="img_class" t-value="'o_wslides_user_avatar rounded-circle'"/>

--- a/addons/website_slides/views/website_slides_templates_homepage.xml
+++ b/addons/website_slides/views/website_slides_templates_homepage.xml
@@ -147,6 +147,32 @@
                 </div>
             </div>
             <t t-call="website_slides.courses_footer"></t>
+            <!-- Search Modal for Mobile -->
+            <div
+                id="o_wslides_search_modal"
+                class="modal fade css_editable_mode_hidden"
+                aria-hidden="true"
+                tabindex="-1"
+            >
+                <div class="modal-dialog modal-lg pt-5">
+                    <div class="modal-content mt-5 bg-transparent border-0">
+                        <div class="o_container_small">
+                            <t t-call="website.website_search_box_input">
+                                <t t-set="default_style" t-valuef="true"/>
+                                <t t-set="search_type" t-valuef="slides"/>
+                                <t t-set="_classes" t-valuef="input-group rounded o_cc o_cc1 mb-1"/>
+                                <t t-set="_input_classes" t-valuef="border-0 p-3"/>
+                                <t t-set="_submit_classes" t-valuef="px-4"/>
+                                <t t-set="placeholder">Search courses</t>
+                                <t t-set="search" t-value="original_search or search_term"/>
+                                <input type="hidden" name="my" t-attf-value="#{1 if search_my else 0}"/>
+                                <input t-if="search_slide_category" type="hidden" name="slide_category" t-att-value="search_slide_category" />
+                                <input type="hidden" name="prevent_redirect" value="True"/>
+                            </t>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
     </t>
 </template>
@@ -155,7 +181,7 @@
     <!-- Navbar dynamically composed using displayed channel tag groups. -->
     <div class="d-flex flex-column flex-md-row flex-wrap align-items-md-center gap-2 mt-4 mb-3">
         <h1 class="h4 mb-0 me-auto">Courses</h1>
-        <div class="d-flex gap-2 flex-column flex-md-row flex-grow-1 flex-md-grow-0 align-items-start">
+        <div class="d-flex gap-2 flex-grow-1 flex-md-grow-0 align-items-start">
             <!-- Desktop tag groups -->
             <div id="navbarTagGroups">
                 <t t-set="search_tag_groups" t-value="search_tags.mapped('group_id')"/>
@@ -180,8 +206,9 @@
                     </t>
                 </ul>
             </div>
-            <div class="d-flex gap-2 align-items-center ms-md-auto">
+            <div class="d-flex gap-2 align-items-center ms-auto">
                 <t t-call="website.website_search_box_input">
+                    <t t-set="_classes" t-valuef="d-none d-md-flex"/>
                     <t t-set="search_type" t-valuef="slides"/>
                     <!-- No action: remain on same URL -->
                     <t t-set="display_description" t-valuef="true"/>
@@ -192,6 +219,17 @@
                     <input t-if="search_slide_category" type="hidden" name="slide_category" t-att-value="search_slide_category" />
                     <input type="hidden" name="prevent_redirect" value="True"/>
                 </t>
+                <!-- Mobile Search button -->
+                <a
+                    class="btn o_not_editable d-md-none btn-light"
+                    data-bs-target="#o_wslides_search_modal"
+                    data-bs-toggle="modal"
+                    role="button"
+                    title="Search Courses"
+                    href="#"
+                >
+                    <i class="oi oi-search" role="img"/>
+                </a>
                 <a class="btn d-block d-lg-none p-0" data-bs-toggle="offcanvas" href="#o_wslides_overview_offcanvas" role="button" aria-controls="o_wslides_overview_offcanvas">
                     <t t-call="website_slides.slides_misc_user_image">
                         <t t-set="img_class" t-value="'o_wslides_user_avatar rounded-circle'"/>


### PR DESCRIPTION
This PR improves the overall responsiveness of the 
`website_slides` module by introducing two new 
component on Mobile: 

### Filters offcanvas
Under the `lg` breakpoint, all the filters are now wrapped
within an offcanvas, enhancing the filtering behaviour
while keeping everything accessible.

### Search modal
Similarly to what we do in others modules such as 
`website_sale`, this component contains all the logic of
the regular search, while providing a good alternative
to save up some space, which is really welcome in such
condensed layout where we don't know how many 
filters will be displayed in the view.

Task-4176342
part of task-3638127
