### PR TITLE
[FIX] html_editor: applying feff to icons

### DIFF
--- a/addons/html_editor/static/src/main/media/media_plugin.js
+++ b/addons/html_editor/static/src/main/media/media_plugin.js
@@ -21,6 +21,7 @@ import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 import { boundariesOut, rightPos } from "@html_editor/utils/position";
 import { withSequence } from "@html_editor/utils/resource";
 import { closestElement } from "@html_editor/utils/dom_traversal";
+import { FORMATTABLE_TAGS } from "@html_editor/utils/formatting";
 
 /**
  * @typedef { Object } MediaShared
@@ -81,7 +82,9 @@ export class MediaPlugin extends Plugin {
         functional_empty_node_predicates: isMediaElement,
 
         selectors_for_feff_providers: () =>
-            `:is(${paragraphRelatedElementsSelector}) :is(${ICON_SELECTOR})`,
+            `:is(${paragraphRelatedElementsSelector}, ${FORMATTABLE_TAGS.join(
+                ", "
+            )}, A) > :is(${ICON_SELECTOR})`,
         before_save_handlers: this.savePendingImages.bind(this),
     };
 


### PR DESCRIPTION

Description of the issue this PR addresses:

Commit [1] adds feffs around icons that were descendant of a paragraph-related elements. This caused an issue in some website snippets where icons inside a `div` (dropped within a `p`) also received FEFFs.

Though such snippets should not be allowed inside a `p` since they are block-level elements, and this will be addressed separately.

In the meantime, this commit ensures that FEFFs are only applied to icons that are direct children of paragraph-related or formatting tags.

[1]: https://github.com/odoo/odoo/pull/225994#issue-3396940401
task-5071184

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
