### PR TITLE
[IMP] point_of_sale: show total product stock quantities on product info popup

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/product_info_popup/product_info_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/product_info_popup/product_info_popup.xml
@@ -38,6 +38,10 @@
                                 forecasted
                             </div>
                         </div>
+                        <div>
+                            On hand: <span class="me-1 fw-bolder"><t t-out="warehouse.available_quantity"/></span>
+                            <t t-out="warehouse.uom"/>
+                        </div>
                     </t>
                 </div>
             </div>

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -824,6 +824,10 @@ registry.category("web_tour.tours").add("test_product_long_press", {
             Dialog.confirm("Open Register"),
             ProductScreen.longPressProduct("Test Product"),
             Dialog.is(),
+            {
+                content: "Check On hand quantity is display on product info popup",
+                trigger: ".section-inventory-body div:contains('On hand: 0')",
+            },
             Chrome.endTour(),
         ].flat(),
 });


### PR DESCRIPTION
PURPOSE:
------------------------------
- Make it easier for POS users to see total stock levels for a product.

Before this commit:
------------------------------
- The Product Info Popup did not show On Hand Qty.
- It showed variant-level Available & Forecasted quantities, even though only
  the product name (not variants) was displayed.

After this commit:
---------------------------------
- The popup now displays On Hand Qty for the full product.
- All quantities (On Hand, Available, Forecasted) now represent total product
  stock rather than per-variant values.

Task: 5056153
