### PR TITLE
[FIX] spreadsheet_dashboard: prevent unnecessary treemap animations

### DIFF
--- a/addons/spreadsheet_dashboard/static/src/bundle/chart/chart_js_component_dashboard.js
+++ b/addons/spreadsheet_dashboard/static/src/bundle/chart/chart_js_component_dashboard.js
@@ -41,9 +41,20 @@ patch(components.ChartJsComponent.prototype, {
     },
     hasChartDataChanged() {
         return !deepEquals(
-            this.currentRuntime.chartJsConfig.data,
-            this.chartRuntime.chartJsConfig.data
+            this.getChartDataInRuntime(this.currentRuntime),
+            this.getChartDataInRuntime(this.chartRuntime)
         );
+    },
+    getChartDataInRuntime(runtime) {
+        const data = runtime.chartJsConfig.data;
+        return {
+            labels: data.labels,
+            dataset: data.datasets.map((dataset) => ({
+                data: dataset.data,
+                label: dataset.label,
+                tree: dataset.tree,
+            })),
+        };
     },
     enableAnimationInChartData(chartData) {
         return {


### PR DESCRIPTION
Charts animations are played every time the chart data changes in dashboards. But the treemap data contains callbacks, which mess up the deepEqual we use to check if the data changed, since new callbacks are created each time.

This adds an argument to deepEqual to ignore functions.

Task: [5003595](https://www.odoo.com/odoo/2328/tasks/5003595)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
