### PR TITLE
[IMP] mail: remove useless @type comment

### DIFF
--- a/addons/mail/static/src/core/common/chat_bubble.xml
+++ b/addons/mail/static/src/core/common/chat_bubble.xml
@@ -37,7 +37,6 @@
         </div>
     </t>
 
-    <!-- @type {import("models").Message} message -->
     <t t-name="mail.message_preview_prefix">
         <t t-if="message.isSelfAuthored">
             <i class="fa fa-mail-reply me-1 opacity-75"/>You:


### PR DESCRIPTION
This @type comment inside an xml file does nothing.