### PR TITLE
[IMP] *: check identity before changing users' password

### DIFF
--- a/addons/hr/tests/test_self_user_access.py
+++ b/addons/hr/tests/test_self_user_access.py
@@ -65,7 +65,7 @@ class TestSelfAccessPreferences(TestHrCommon):
         })
         view = self.env.ref('hr.res_users_view_form_preferences')
         available_actions = james.get_views([(view.id, 'form')], {'toolbar': True})['views']['form']['toolbar'].get('action', {})
-        change_password_action = self.env.ref("base.change_password_wizard_action")
+        change_password_action = self.env.ref("base.ir_actions_server_change_password_wizard")
 
         self.assertFalse(any(x['id'] == change_password_action.id for x in available_actions))
 

--- a/addons/web/tests/test_res_users.py
+++ b/addons/web/tests/test_res_users.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.tests import Form, TransactionCase
+from odoo.tests import TransactionCase
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 from odoo.tests.common import tagged
 
@@ -46,22 +46,6 @@ class TestResUsers(TransactionCase):
         self.assertNotEqual(claude.id, user_ids[1], "The current user, Claude, should not appear twice in the result")
         user_ids = [id_ for id_, __ in ResUsers.with_user(claude).name_search('', limit=5)]
         self.assertEqual(len(user_ids), len(set(user_ids)), "Some user(s), appear multiple times in the result")
-
-    def test_change_password(self):
-        '''
-        We should be able to change user password without any issue
-        '''
-        user_internal = self.env['res.users'].create({
-            'name': 'Internal',
-            'login': 'user_internal',
-            'password': 'password',
-            'group_ids': [self.env.ref('base.group_user').id],
-        })
-        with Form(self.env['change.password.wizard'].with_context(active_model='res.users', active_ids=user_internal.ids), view='base.change_password_wizard_view') as form:
-            with form.user_ids.edit(0) as line:
-                line.new_passwd = 'blablabla'
-        rec = form.save()
-        rec.change_password_button()
 
 
 @tagged('post_install', '-at_install')

--- a/odoo/addons/base/__manifest__.py
+++ b/odoo/addons/base/__manifest__.py
@@ -75,6 +75,7 @@ The kernel of Odoo, needed for all installation.
         'views/res_config_settings_views.xml',
         'views/report_paperformat_views.xml',
         'security/ir.model.access.csv',
+        'data/ir_action_data.xml',
     ],
     'demo': [
         'data/res_users_demo.xml',

--- a/odoo/addons/base/data/ir_action_data.xml
+++ b/odoo/addons/base/data/ir_action_data.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="ir_actions_server_change_password_wizard" model="ir.actions.server">
+        <field name="name">Change Password</field>
+        <field name="model_id" ref="base.model_res_users"/>
+        <field name="binding_model_id" ref="base.model_res_users"/>
+        <field name="state">code</field>
+        <field name="code">
+            action = records.action_change_password_wizard()
+        </field>
+        <field name="group_ids" eval="[(4, ref('base.group_erp_manager'))]"/>
+    </record>
+</odoo>

--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -49,7 +49,6 @@
             <field name="res_model">change.password.wizard</field>
             <field name="view_mode">form</field>
             <field name="target">new</field>
-            <field name="binding_model_id" ref="base.model_res_users"/>
         </record>
 
         <!-- res.users -->


### PR DESCRIPTION
* = base, hr, web

This PR checks the identity of the ERP manager before authorizing it to change other users' passwords from the list and the form of the res.users model.

For now on, the window action triggering the change password form has been replaced by a server action calling ResUsers.action_change_password_wizard, which is a method decorated with a check_identity, in order to display the identity check before form. The ChangePasswordUser.change_password_button has also been decorated with a check_identity as an identity check must be performed wherever this method is executed as it permits to change the users' password.

TestResUsers.test_change_password in the web module has been corrected as an identity check is required now and it makes sure that a request exists while the decorated method is called. For this reason, the forms are submitted with HttpCase.url_open and not longer with odoo.test.Form. As the change_password_button method used to change user's password is in base, the test has been moved in that module.

Task-5071825