### PR TITLE
[FIX] website: skip test options of animation onHover

### DIFF
--- a/addons/website/static/tests/builder/website_builder/animate_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/animate_option.test.js
@@ -198,7 +198,7 @@ test("animation=onScroll should not be visible when the animation is limited", a
     await contains(".options-container [data-label='Animation'] .dropdown-toggle").click();
     expect(".o-dropdown--menu [data-action-value='onScroll']").not.toHaveCount();
 });
-test("visibility of animation animation=onHover", async () => {
+test.skip("visibility of animation animation=onHover", async () => {
     function expectOnHoverOptions(options) {
         const labels = [
             "Effect",


### PR DESCRIPTION
The test fails non-deterministically. We sip it while looking for a long term fix

task-4367641
