### PR TITLE
[FIX] hr_holidays: leaves date picker without range

### DIFF
--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -374,7 +374,7 @@
                                     widget="daterange"
                                     readonly="state != 'confirm'"
                                     required="not date_from or not date_to"
-                                    options="{'end_date_field': 'request_date_to'}"/>
+                                    options="{'always_range': True, 'end_date_field': 'request_date_to'}"/>
                                 <field name="request_date_to" invisible="1"/> <!-- For Form view test-->
                                 <div>
                                     ( <field name="duration_display" readonly="1" class="w-auto"/> )


### PR DESCRIPTION
- removed the toggle button so leaves can be only created with date range

task-id: 5065209
