### PR TITLE
[FIX] account_peppol: enforce Peppol registration with 0208 in Belgium

### DIFF
--- a/addons/account_peppol/models/res_partner.py
+++ b/addons/account_peppol/models/res_partner.py
@@ -194,4 +194,15 @@ class ResPartner(models.Model):
             edi_identification = f'{self.peppol_eas}:{self.peppol_endpoint}'.lower()
             self.account_peppol_validity_last_check = fields.Date.context_today(self)
             self.account_peppol_is_endpoint_valid = bool(self._check_peppol_participant_exists(edi_identification, ubl_cii_format=self.ubl_cii_format))
+
+            if (
+                not self.account_peppol_is_endpoint_valid
+                and self.peppol_eas in ('0208', '9925')
+            ):
+                inverse_eas = '9925' if self.peppol_eas == '0208' else '0208'
+                inverse_endpoint = f'BE{self.peppol_endpoint}' if self.peppol_eas == '0208' else self.peppol_endpoint[2:]
+                if self._check_peppol_participant_exists(f'{inverse_eas}:{inverse_endpoint}', ubl_cii_format=self.ubl_cii_format):
+                    self.peppol_eas = inverse_eas
+                    self.peppol_endpoint = inverse_endpoint
+                    self.account_peppol_is_endpoint_valid = True
         return False

--- a/addons/account_peppol/views/res_config_settings_views.xml
+++ b/addons/account_peppol/views/res_config_settings_views.xml
@@ -25,12 +25,6 @@
                                      invisible="not account_peppol_endpoint_warning">
                                     <field name="account_peppol_endpoint_warning"/>
                                 </div>
-                                <div class="alert alert-warning mt-3"
-                                     colspan="2"
-                                     role="alert"
-                                     invisible="country_code != 'BE' or account_peppol_eas in (False, '0208')">
-                                    The recommended EAS code for Belgium is 0208. The Endpoint should be the Company Registry number.
-                                </div>
                                 <div class="pt-3">
                                     <div class="row">
                                         <label string="Peppol EAS"

--- a/addons/account_peppol/views/res_partner_views.xml
+++ b/addons/account_peppol/views/res_partner_views.xml
@@ -9,12 +9,6 @@
             <data>
                 <xpath expr="//field[@name='ubl_cii_format']" position="before">
                     <field name="bank_account_count" invisible="1"/>
-                    <div class="alert alert-warning mb-0"
-                         colspan="2"
-                         role="alert"
-                         invisible="country_code != 'BE' or ubl_cii_format in (False, 'facturx') or peppol_eas in (False, '0208')">
-                         The recommended EAS code for Belgium is 0208. The Endpoint should be the Company Registry number.
-                    </div>
                     <div class="alert alert-warning"
                          colspan="2"
                          role="alert"


### PR DESCRIPTION
Belgium Peppol autorities enforces us to register our Belgian Peppol user with EAS 0208, the Enterprise Number (company_registry).

Also allows for Belgium to check for 9925 existence on Peppol when 0208 check failed. And vice-versa.

task-4852903
