### PR TITLE
[FIX] website: press escape should hide the navbar

### DIFF
--- a/addons/website/static/src/client_actions/website_preview/new_content_systray_item.js
+++ b/addons/website/static/src/client_actions/website_preview/new_content_systray_item.js
@@ -103,10 +103,8 @@ export class NewContentSystrayItem extends Component {
             ],
         });
 
-        useHotkey("escape", () => {
-            if (this.dropdown.isOpen) {
-                this.dropdown.close();
-            }
+        useHotkey("escape", () => this.dropdown.close(), {
+            isAvailable: () => this.dropdown.isOpen,
         });
     }
 


### PR DESCRIPTION
The goal of this commit is to reactivate the hide of the navbar in the website when the “escape” key is pressed.

Problem:
========
NewContentSystrayItem adds a listener to the "escape" hotkey. It is therefore used instead of the one used to hide the navbar. The hotkey service executes a single callback (always the most specific one).

Solution:
========
Enable the NewContentSystrayItem "escape" hotkey only when the dropdown is open.

How to reproduce:
====================
- Go to the website.
- Press “escape.”

Before this commit:
    Nothing happens.

After this commit:
    The navbar hides.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
