### PR TITLE
[FIX] pos_sale: change sale_order state when settling with PoS

### DIFF
--- a/addons/pos_sale/models/pos_order.py
+++ b/addons/pos_sale/models/pos_order.py
@@ -78,6 +78,8 @@ class PosOrder(models.Model):
                 sale_order_sudo._create_down_payment_lines_from_base_lines(down_payment_base_lines)
 
             # Confirm the unconfirmed sale orders that are linked to the sale order lines.
+            so_lines = pos_order.lines.mapped('sale_order_line_id')
+            sale_orders |= so_lines.mapped('order_id')
             if pos_order.state != 'draft':
                 for sale_order in sale_orders.filtered(lambda so: so.state in ['draft', 'sent']):
                     sale_order.action_confirm()
@@ -85,7 +87,6 @@ class PosOrder(models.Model):
             # update the demand qty in the stock moves related to the sale order line
             # flush the qty_delivered to make sure the updated qty_delivered is used when
             # updating the demand value
-            so_lines = pos_order.lines.mapped('sale_order_line_id')
             so_lines.flush_recordset(['qty_delivered'])
             # track the waiting pickings
             waiting_picking_ids = set()

--- a/addons/pos_sale/static/tests/tours/pos_sale_tour.js
+++ b/addons/pos_sale/static/tests/tours/pos_sale_tour.js
@@ -187,6 +187,10 @@ registry.category("web_tour.tours").add("PosSettleDraftOrder", {
             Dialog.confirm("Open Register"),
             PosSale.settleNthOrder(1),
             ProductScreen.selectedOrderlineHas("Test service product", "1", "50.00"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
         ].flat(),
 });
 

--- a/addons/pos_sale_loyalty/tests/test_pos_sale_loyalty.py
+++ b/addons/pos_sale_loyalty/tests/test_pos_sale_loyalty.py
@@ -6,6 +6,11 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestPoSSaleLoyalty(TestPointOfSaleHttpCommon):
+    @classmethod
+    def get_default_groups(cls):
+        groups = super().get_default_groups()
+        return groups | cls.quick_ref('sales_team.group_sale_manager')
+
     def test_pos_sale_loyalty_1(self):
         """Test that only one loyalty card is created when settling an unconfirmed order."""
         self.env['loyalty.program'].search([]).write({'active': False})


### PR DESCRIPTION
**Steps to reproduce:**
- Make a quotation in the Sales module
- Go to PoS, click Quotation/Order and select your quotation
- Select Settle the order
- Go through with the payment
- Go back to the Quotation in the Sales module
The Status widget still shows Quotation instead of Sales Order

**Why the fix:**
Since 18.3, the sale_order.state was not updated anymore when the state changed through the PoS.

This happened because we would only change the sale_order state if there was a downpayment involved. In 18.2, we
always recomputed the sale_order that was linked to the order we are currently settling.

The way it is done now is part of the same way it was done in 18.2 and before, meaning we add the linked sale_order
regardless of downpayments.

In 18.2, we did an action_confirm on the selected  sale_orders, but doing that in 18.3 will create another picking for this sale_order. This is not what we want as the picking is now handled and created by the PoS. 

This fix will just put the related sale orders in the "sale" state, so that users can no longer confirm it in the sales modules, which would create a second picking and create duplicates.

opw-5033979