### PR TITLE
[FIX] website: fix auto_hide_menu failing tour

### DIFF
--- a/addons/website/static/tests/tours/auto_hide_menu.js
+++ b/addons/website/static/tests/tours/auto_hide_menu.js
@@ -1,13 +1,32 @@
-import { animationFrame } from "@odoo/hoot-dom";
-import { registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
+import {
+    clickOnEditAndWaitEditMode,
+    registerWebsitePreviewTour,
+} from "@website/js/tours/tour_utils";
 
 let numNavChildren;
+
+const addNavItem = [
+    {
+        content: "Add a menu item",
+        trigger: ".modal-dialog .fa-plus-circle:first-child",
+        run: "click",
+    },
+    {
+        content: "Input name",
+        trigger: ".o_menu_dialog_form input",
+        run: "edit name",
+    },
+    {
+        content: "Click OK",
+        trigger: ".modal-dialog .modal-footer .btn:contains(OK)",
+        run: "click",
+    },
+];
 
 const getTheLayoutChildren = {
     content: "Get the number of elements in the navbar",
     trigger: ":iframe #o_main_nav ul[role='menu']",
     async run() {
-        await animationFrame();
         numNavChildren = this.anchor.children.length;
     },
 };
@@ -16,7 +35,6 @@ const checkThatLayoutChanged = {
     content: "Ensure that the navbar layout has changed",
     trigger: ":iframe #o_main_nav ul[role='menu']",
     async run() {
-        await animationFrame();
         if (this.anchor.children.length === numNavChildren) {
             throw new Error("Navbar layout should change");
         }
@@ -26,10 +44,30 @@ const checkThatLayoutChanged = {
 registerWebsitePreviewTour(
     "website_auto_hide_menu",
     {
-        edition: true,
         url: "/",
     },
     () => [
+        {
+            content: "Click on Site",
+            trigger: ".o_main_navbar .o_menu_sections :contains('Site')",
+            run: "click",
+        },
+        {
+            content: "Click on Menu Editor",
+            trigger: ".o_popover .o-dropdown-item:contains('Menu Editor')",
+            run: "click",
+        },
+        ...Array(5).fill(addNavItem).flat(),
+        {
+            content: "Save",
+            trigger: ".modal-footer .btn:contains('Save')",
+            run: "click",
+        },
+        {
+            content: "Check that modal has disappeared",
+            trigger: "body:not(:has(.modal))",
+        },
+        ...clickOnEditAndWaitEditMode(),
         getTheLayoutChildren,
         {
             content: "Click on the navbar",


### PR DESCRIPTION
Following this [commit], this tour would fail whenever it is run in single-app test builds.
This happened because there were not enough items in the nav 
for the tour to function properly. Also, removed the "@odoo/hoot-dom" dependency.

Build error-231699

[commit]: https://github.com/odoo/odoo/commit/7279c92fcb999f621fd9725c2339247c620ed378