### PR TITLE
[FIX] sale_project: fix compute_role_id for template project

### DIFF
--- a/addons/sale_project/wizard/project_template_create_wizard.py
+++ b/addons/sale_project/wizard/project_template_create_wizard.py
@@ -6,7 +6,7 @@ class ProjectTemplateCreateWizard(models.TransientModel):
 
     partner_id = fields.Many2one("res.partner")
     allow_billable = fields.Boolean(related="template_id.allow_billable")
-    role_to_users_ids = fields.One2many(compute="_compute_role_to_users_ids", readonly=False)
+    role_to_users_ids = fields.One2many(compute="_compute_role_to_users_ids", readonly=False, store=True)
 
     @api.depends("template_id")
     def _compute_role_to_users_ids(self):


### PR DESCRIPTION
Prior to this commit, when a new project is created from a project template, the project_roles are not correctly set on the tasks.

Adding a store=True to the field ensures that the data are correctly computed

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
