### PR TITLE
[FIX] mrp: add ACL to allow mrp user unlinking moves

### DIFF
--- a/addons/mrp/security/ir.model.access.csv
+++ b/addons/mrp/security/ir.model.access.csv
@@ -61,3 +61,4 @@ access_mrp_production_split,access.mrp.production.split,model_mrp_production_spl
 access_mrp_production_split_line,access.mrp.production.split.line,model_mrp_production_split_line,mrp.group_mrp_user,1,1,1,1
 access_mrp_workcenter_capacity_manager,mrp.workcenter.capacity.manager,model_mrp_workcenter_capacity,mrp.group_mrp_manager,1,1,1,1
 access_mrp_workcenter_capacity_group_user,mrp.workcenter.capacity,model_mrp_workcenter_capacity,mrp.group_mrp_user,1,0,0,0
+access_stock_move_mrp_user,stock.move mrp_user,stock.model_stock_move,mrp.group_mrp_user,1,1,1,1

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -6,7 +6,7 @@ from freezegun import freeze_time
 
 from odoo import Command, fields
 from odoo.exceptions import UserError
-from odoo.tests import Form, HttpCase, tagged
+from odoo.tests import Form, HttpCase, tagged, users
 from odoo.tools.misc import format_date
 
 from odoo.addons.mrp.tests.common import TestMrpCommon
@@ -4675,6 +4675,19 @@ class TestMrpOrder(TestMrpCommon):
         wos_to_set = mo.workorder_ids - mo.workorder_ids[1]
         wos_to_set.write({'date_start': date_start, 'date_finished': date_finished})
         self.assertTrue(mo.workorder_ids[-1].show_json_popover)
+
+    @users('hilda')
+    def test_update_mo_with_mrp_user(self):
+        """
+        Create an MO with an MRP user, in Draft status, try to update its quantity.
+        """
+        mo_form = Form(self.env['mrp.production'])
+        mo_form.product_id = self.product
+        mo_form.product_qty = 5
+        mo = mo_form.save()
+        mo_form.product_qty = 10
+        mo_form.save()
+        self.assertEqual(mo.product_qty, 10)
 
 
 @tagged('post_install', '-at_install')


### PR DESCRIPTION
#### Issue and steps to reproduce:

1- Login as demo user
2- Create a MO and save it
3- Update the schedule date and save
As you see there the stock move unlink access prevents user to update the MO

This PR is a backport of #153671

opw-5038258