### PR TITLE
[FIX] web: indexedDB version should not be stored

### DIFF
--- a/addons/web/static/tests/core/utils/indexed_db.test.js
+++ b/addons/web/static/tests/core/utils/indexed_db.test.js
@@ -53,6 +53,24 @@ test("two caches, read", async () => {
     await ensureDbIsAbsent();
 });
 
+test("two caches, read (2)", async () => {
+    onError(() => deleteCacheDB());
+    await ensureDbIsAbsent();
+
+    // having 2 caches simulates 2 tabs, each one accessing the same indexeddb
+    const indexedDB1 = new IndexedDB(CACHE_NAME, 1);
+    const indexedDB2 = new IndexedDB(CACHE_NAME, 1);
+
+    await indexedDB1.write("mytable", "test", "value for 'test'");
+    await indexedDB1.write("mytable1", "test", "value for 'test'");
+
+    expect(await indexedDB2.read("mytable", "test")).toBe("value for 'test'");
+
+    await indexedDB1.deleteDatabase();
+    await indexedDB2.deleteDatabase(); // deleting twice the same DB don't throw error !
+    await ensureDbIsAbsent();
+});
+
 test("one cache, invalidate", async () => {
     onError(() => deleteCacheDB());
     await ensureDbIsAbsent();


### PR DESCRIPTION
Open Odoo in two tabs, in a fresh browser (or delete the IndexedDB).
- Open the Contacts app in the first tab;
- Open the Contactc app in the second tab;

Before this commit, the second tab will not use the cache, and an error will be displayed in the console : `IndexedDB error: The requested version is less than the existing version`.

This issue occurs, because the IndexedDB wrapper stores the database version, which is incremented when a new table is needed in order to execute the `onupgradeneeded` function and create the table.

Now, the version is not stored anymore. When a new table is needed, the database is opened with the current version + 1. This will execute the `onupgradeneeded` function and create the table.
