### PR TITLE
[FIX] l10n_be: Fix the demo vat

### DIFF
--- a/addons/l10n_be/demo/demo_company.xml
+++ b/addons/l10n_be/demo/demo_company.xml
@@ -2,7 +2,7 @@
 <odoo>
     <record id="base.partner_demo_company_be" model="res.partner" forcecreate="1">
         <field name="name">BE Company CoA</field>
-        <field name="vat">BE246697724</field>
+        <field name="vat">BE0246697724</field>
         <field name="street">1021 Sint-Bernardsesteenweg</field>
         <field name="city">Antwerpen</field>
         <field name="country_id" ref="base.be"/>


### PR DESCRIPTION
The Belgian VAT doesn't have the right length, which is causing weird behavior when testing feature with demo data.
In particular, since the company_registry is computed based on it, Odoo doesn't pass some validation since it's not a correctly formatted data.

The VAT should be following the format `^BE[0-1][0-9]{9}$`. So "BE" followed by 10 digits, while we only had 9.

task-none
