### PR TITLE
[IMP] website: Introduce high-level cache for website pages

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -103,9 +103,6 @@ class Website(Home):
         Most DBs will just have a website.page with '/' as URL and keep the
         homepage_url setting empty.
         """
-        # prefetch all menus (it will prefetch website.page too)
-        top_menu = request.website.menu_id
-
         homepage_url = request.website._get_cached('homepage_url')
         if homepage_url and homepage_url != '/':
             request.reroute(homepage_url)
@@ -126,6 +123,9 @@ class Website(Home):
         # Fallback on first accessible menu
         def is_reachable(menu):
             return menu.is_visible and menu.url not in ('/', '', '#') and not menu.url.startswith(('/?', '/#', ' '))
+
+        # prefetch all menus (it will prefetch website.page too)
+        top_menu = request.website.menu_id
 
         reachable_menus = top_menu.child_id.filtered(is_reachable)
         if reachable_menus:

--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -301,7 +301,15 @@ class IrHttp(models.AbstractModel):
 
         def _search_page(comparator='='):
             page_domain = Domain('url', comparator, req_page) & request.website.website_domain()
-            return request.env['website.page'].sudo().search(page_domain, order='website_id asc', limit=1)
+
+            # Force prefetch on all fetchable fields to get all data at once (e.g., 'website_meta').
+            fields_to_fetch = [name for name, field in request.env['website.page']._fields.items() if field.store and field.column_type]
+            page = request.env['website.page'].sudo().search_fetch(page_domain, field_names=fields_to_fetch, order='website_id asc', limit=1)
+
+            # Force prefetch on all fetchable fields to get all data at once (e.g., 'website_meta').
+            fields_to_fetch = [name for name, field in page.view_id._fields.items() if field.store and field.column_type]
+            page.view_id.fetch(fields_to_fetch)
+            return page
 
         # specific page first
         page = _search_page()

--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -3,7 +3,6 @@ import contextlib
 import functools
 import logging
 from lxml import etree
-import os
 import unittest
 
 import pytz
@@ -17,7 +16,6 @@ from odoo.fields import Domain
 from odoo.http import request
 from odoo.tools.json import scriptsafe as json_scriptsafe
 from odoo.tools.safe_eval import safe_eval
-from odoo.addons.base.models.ir_http import EXTENSION_TO_WEB_MIMETYPES
 from odoo.addons.http_routing.models import ir_http
 from odoo.addons.portal.controllers.portal import _build_url_w_params
 
@@ -189,14 +187,15 @@ class IrHttp(models.AbstractModel):
             return False
         template = False
         if hasattr(response, '_cached_page'):
-            website_page, template = response._cached_page, response._cached_template
+            website_page, template = response._cached_page, response._cached_view_id
         elif hasattr(response, 'qcontext'):  # classic response
             main_object = response.qcontext.get('main_object')
             website_page = getattr(main_object, '_name', False) == 'website.page' and main_object
             template = response.qcontext.get('response_template')
+            if isinstance(template, str) and '.' not in template:
+                template = 'website.%s' % template
 
-        view = template and request.env['website'].get_template(template)
-        if not request.env.cr.readonly and view and view.track:
+        if template and not request.env.cr.readonly and request.env['ir.ui.view']._get_cached_template_info(template)['track']:
             request.env['website.visitor']._handle_webpage_dispatch(website_page)
 
         return False
@@ -298,31 +297,16 @@ class IrHttp(models.AbstractModel):
     @classmethod
     def _serve_page(cls):
         req_page = request.httprequest.path
+        WebsitePage = request.env['website.page'].sudo()
+        page_info = WebsitePage._get_page_info(request)
 
-        def _search_page(comparator='='):
-            page_domain = Domain('url', comparator, req_page) & request.website.website_domain()
-
-            # Force prefetch on all fetchable fields to get all data at once (e.g., 'website_meta').
-            fields_to_fetch = [name for name, field in request.env['website.page']._fields.items() if field.store and field.column_type]
-            page = request.env['website.page'].sudo().search_fetch(page_domain, field_names=fields_to_fetch, order='website_id asc', limit=1)
-
-            # Force prefetch on all fetchable fields to get all data at once (e.g., 'website_meta').
-            fields_to_fetch = [name for name, field in page.view_id._fields.items() if field.store and field.column_type]
-            page.view_id.fetch(fields_to_fetch)
-            return page
-
-        # specific page first
-        page = _search_page()
-
-        # case insensitive search
-        if not page:
-            page = _search_page('=ilike')
-            if page:
-                logger.info("Page %r not found, redirecting to existing page %r", req_page, page.url)
-                return request.redirect(page.url)
+        # redirect to the good url
+        if page_info and page_info['url'] != req_page:
+            logger.info("Page %r not found, redirecting to existing page %r", req_page, page_info['url'])
+            return request.redirect(page_info['url'])
 
         # redirect without trailing /
-        if not page and req_page != "/" and req_page.endswith("/"):
+        if not page_info and req_page != "/" and req_page.endswith("/"):
             # mimick `_postprocess_args()` redirect
             path = request.httprequest.path[:-1]
             if request.lang != cls._get_default_lang():
@@ -331,22 +315,9 @@ class IrHttp(models.AbstractModel):
                 path += '?' + request.httprequest.query_string.decode('utf-8')
             return request.redirect(path, code=301)
 
-        if (
-            page
-            and (request.env.user.has_group('website.group_website_designer') or page.is_visible)
-            and (
-                # If a generic page (niche case) has been COWed and that COWed
-                # page received a URL change, it should not let you access the
-                # generic page anymore, despite having a different URL.
-                page.website_id
-                or not page.view_id._get_specific_views().filtered(lambda view: view.website_id == request.website)
-            )
-        ):
-            _, ext = os.path.splitext(req_page)
-            response = request.render(page.view_id.id, {
-                'main_object': page,
-            }, mimetype=EXTENSION_TO_WEB_MIMETYPES.get(ext, 'text/html'))
-            return response
+        if page_info:
+            return WebsitePage.browse(page_info['id'])._get_response(request)
+
         return False
 
     @classmethod

--- a/addons/website/models/ir_ui_view.py
+++ b/addons/website/models/ir_ui_view.py
@@ -362,7 +362,7 @@ class IrUiView(models.Model):
 
     @api.model
     def _get_cached_template_prefetched_keys(self):
-        return super()._get_cached_template_prefetched_keys() + ['active', 'visibility']
+        return super()._get_cached_template_prefetched_keys() + ['active', 'visibility', 'track']
 
     @api.model
     def _get_template_minimal_cache_keys(self):

--- a/addons/website/models/website_visitor.py
+++ b/addons/website/models/website_visitor.py
@@ -279,7 +279,7 @@ class WebsiteVisitor(models.Model):
             visitor_id, _ = self._upsert_visitor(access_token, force_track_values)
             return self.env['website.visitor'].sudo().browse(visitor_id)
 
-        visitor = self.env['website.visitor'].sudo().search([('access_token', '=', access_token)])
+        visitor = self.env['website.visitor'].sudo().search_fetch([('access_token', '=', access_token)])
 
         if not force_create and not self.env.cr.readonly and visitor and not visitor.timezone:
             tz = self._get_visitor_timezone()

--- a/addons/website/tests/test_performance.py
+++ b/addons/website/tests/test_performance.py
@@ -28,7 +28,7 @@ class UtilPerf(HttpCaseWithUserPortal, HttpCaseWithUserDemo):
         if 'channel_id' in cls.env['website']:
             cls.env['website'].search([]).channel_id = False
 
-    def _get_url_hot_query(self, url, query_list=False):
+    def _get_url_hot_query(self, url, query_list=False, nocache=False):
         """ This method returns the number of SQL Queries used inside a request.
         The returned query number will be the same as a "real" (outside of test
         mode) case: the method takes care of removing the extra queries related
@@ -50,6 +50,8 @@ class UtilPerf(HttpCaseWithUserPortal, HttpCaseWithUserDemo):
         :rtype: int|tuple(int, list)
         """
         url += ('?' not in url and '?' or '')
+        if nocache:
+            url += '&nocache'
 
         # ensure worker is in hot state
         self.url_open(url)
@@ -72,8 +74,8 @@ class UtilPerf(HttpCaseWithUserPortal, HttpCaseWithUserDemo):
             return sql_count
         return sql_count, sql_queries
 
-    def _check_url_hot_query(self, url, expected_query_count, select_tables_perf=None, insert_tables_perf=None):
-        query_count, sql_queries = self._get_url_hot_query(url, query_list=True)
+    def _check_url_hot_query(self, url, expected_query_count, select_tables_perf=None, insert_tables_perf=None, nocache=False):
+        query_count, sql_queries = self._get_url_hot_query(url, query_list=True, nocache=nocache)
 
         sql_from_tables = {}
         sql_into_tables = {}
@@ -191,27 +193,14 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
                     'orm_signaling_registry': 1,
                     'ir_attachment': 1,
                     # `_get_serve_attachment` dispatcher fallback
-                    'website_page': 2,
-                    # 1. `_serve_page` search page matching URL..
-                    # 2. ..then reads it (`is_visible`)
-                    'website': 1,
-                    # menu and layout
-                    'website_menu': 1,
-                    'ir_ui_view': 1,
-                    'res_company': 1,
                 }
-                expected_query_count = 8
+                expected_query_count = 2
                 self._check_url_hot_query(self.page.url, expected_query_count, select_tables_perf)
                 self.assertEqual(self._get_url_hot_query(self.page.url), expected_query_count)
                 self.menu.unlink()  # page being or not in menu shouldn't add queries
                 self._check_url_hot_query(self.page.url, expected_query_count, select_tables_perf)
                 self.assertEqual(self._get_url_hot_query(self.page.url), expected_query_count)
 
-    def test_15_perf_sql_queries_page(self):
-        # standard tracked website.page
-        for readonly_enabled in (True, False):
-            self.set_registry_readonly_mode(readonly_enabled)
-            with self.subTest(readonly_enabled=readonly_enabled), closing(self.env.cr.savepoint()):
                 select_tables_perf = {
                     'orm_signaling_registry': 1,
                     'ir_attachment': 1,
@@ -226,6 +215,32 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
                     'res_company': 1,
                 }
                 expected_query_count = 8
+                self._check_url_hot_query(self.page.url, expected_query_count, select_tables_perf, nocache=True)
+                self.assertEqual(self._get_url_hot_query(self.page.url, nocache=True), expected_query_count)
+
+    def test_15_perf_sql_queries_page(self):
+        # standard tracked website.page
+        for readonly_enabled, cache in ((True, True), (False, True), (True, False), (False, False)):
+            self.set_registry_readonly_mode(readonly_enabled)
+            with self.subTest(readonly_enabled=readonly_enabled), closing(self.env.cr.savepoint()):
+                select_tables_perf = {
+                    'orm_signaling_registry': 1,
+                    'ir_attachment': 1,
+                    # `_get_serve_attachment` dispatcher fallback
+                } if cache else {
+                    'orm_signaling_registry': 1,
+                    'ir_attachment': 1,
+                    # `_get_serve_attachment` dispatcher fallback
+                    'website_page': 2,
+                    # 1. `_serve_page` search page matching URL..
+                    # 2. ..then reads it (`is_visible`)
+                    'website': 1,
+                    # menu and layout
+                    'website_menu': 1,
+                    'ir_ui_view': 1,
+                    'res_company': 1,
+                }
+                expected_query_count = 2 if cache else 8
                 insert_tables_perf = {}
                 if not readonly_enabled:
                     insert_tables_perf = {
@@ -236,14 +251,28 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
                 self.page.track = True
 
                 self.menu.unlink()  # page being or not in menu shouldn't add queries
-                self._check_url_hot_query(self.page.url, expected_query_count, select_tables_perf, insert_tables_perf)
-                self.assertEqual(self._get_url_hot_query(self.page.url), expected_query_count)
+                self._check_url_hot_query(self.page.url, expected_query_count, select_tables_perf, insert_tables_perf, nocache=not cache)
+                self.assertEqual(self._get_url_hot_query(self.page.url, nocache=not cache), expected_query_count)
 
     def test_20_perf_sql_queries_homepage(self):
         # homepage "/" has its own controller
         for readonly_enabled in (True, False):
             self.set_registry_readonly_mode(readonly_enabled)
             with self.subTest(readonly_enabled=readonly_enabled), closing(self.env.cr.savepoint()):
+                select_tables_perf = {
+                    'orm_signaling_registry': 1,
+                }
+                expected_query_count = 1
+                insert_tables_perf = {}
+                if not readonly_enabled:
+                    insert_tables_perf = {
+                        'website_visitor': 1,
+                        # Visitor upsert
+                    }
+                    expected_query_count += 1
+                self._check_url_hot_query('/', expected_query_count, select_tables_perf, insert_tables_perf)
+                self.assertEqual(self._get_url_hot_query('/'), expected_query_count)
+
                 select_tables_perf = {
                     'orm_signaling_registry': 1,
                     'website_menu': 1,
@@ -264,12 +293,21 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
                         # Visitor upsert
                     }
                     expected_query_count += 1
-                self._check_url_hot_query('/', expected_query_count, select_tables_perf, insert_tables_perf)
-                self.assertEqual(self._get_url_hot_query('/'), expected_query_count)
+                self._check_url_hot_query('/', expected_query_count, select_tables_perf, insert_tables_perf, nocache=True)
+                self.assertEqual(self._get_url_hot_query('/', nocache=True), expected_query_count)
 
     def test_30_perf_sql_queries_page_no_layout(self):
         # untrack website.page with no call to layout templates
         self.page.arch = '<div>I am a blank page</div>'
+
+        select_tables_perf = {
+            'orm_signaling_registry': 1,
+            'ir_attachment': 1,
+            # `_get_serve_attachment` dispatcher fallback
+        }
+        self._check_url_hot_query(self.page.url, 2, select_tables_perf)
+        self.assertEqual(self._get_url_hot_query(self.page.url), 2)
+
         select_tables_perf = {
             'orm_signaling_registry': 1,
             'ir_attachment': 1,
@@ -282,8 +320,8 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
             'ir_ui_view': 1,
             # Check if `view.track` to track visitor or not
         }
-        self._check_url_hot_query(self.page.url, 5, select_tables_perf)
-        self.assertEqual(self._get_url_hot_query(self.page.url), 5)
+        self._check_url_hot_query(self.page.url, 5, select_tables_perf, nocache=True)
+        self.assertEqual(self._get_url_hot_query(self.page.url, nocache=True), 5)
 
     def test_40_perf_sql_queries_page_multi_level_menu(self):
         # menu structure should not impact SQL requests
@@ -299,6 +337,14 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
             'orm_signaling_registry': 1,
             'ir_attachment': 1,
             # `_get_serve_attachment` dispatcher fallback
+        }
+        self._check_url_hot_query(self.page.url, 2, select_tables_perf)
+        self.assertEqual(self._get_url_hot_query(self.page.url), 2)
+
+        select_tables_perf = {
+            'orm_signaling_registry': 1,
+            'ir_attachment': 1,
+            # `_get_serve_attachment` dispatcher fallback
             'website_page': 2,
             # 1. `_serve_page` search page matching URL..
             # 2. ..then reads it (`is_visible`)
@@ -309,8 +355,8 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
             # layout content (company name, logo)
             'res_company': 1,
         }
-        self._check_url_hot_query(self.page.url, 8, select_tables_perf)
-        self.assertEqual(self._get_url_hot_query(self.page.url), 8)
+        self._check_url_hot_query(self.page.url, 8, select_tables_perf, nocache=True)
+        self.assertEqual(self._get_url_hot_query(self.page.url, nocache=True), 8)
 
 @tagged('-at_install', 'post_install')
 class TestWebsitePerformancePost(UtilPerf):

--- a/addons/website/tests/test_performance.py
+++ b/addons/website/tests/test_performance.py
@@ -191,16 +191,16 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
                     'orm_signaling_registry': 1,
                     'ir_attachment': 1,
                     # `_get_serve_attachment` dispatcher fallback
-                    'website_page': 3,
+                    'website_page': 2,
                     # 1. `_serve_page` search page matching URL..
                     # 2. ..then reads it (`is_visible`)
                     'website': 1,
                     # menu and layout
                     'website_menu': 1,
-                    'ir_ui_view': 2,
+                    'ir_ui_view': 1,
                     'res_company': 1,
                 }
-                expected_query_count = 10
+                expected_query_count = 8
                 self._check_url_hot_query(self.page.url, expected_query_count, select_tables_perf)
                 self.assertEqual(self._get_url_hot_query(self.page.url), expected_query_count)
                 self.menu.unlink()  # page being or not in menu shouldn't add queries
@@ -216,16 +216,16 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
                     'orm_signaling_registry': 1,
                     'ir_attachment': 1,
                     # `_get_serve_attachment` dispatcher fallback
-                    'website_page': 3,
+                    'website_page': 2,
                     # 1. `_serve_page` search page matching URL..
                     # 2. ..then reads it (`is_visible`)
                     'website': 1,
                     # menu and layout
                     'website_menu': 1,
-                    'ir_ui_view': 2,
+                    'ir_ui_view': 1,
                     'res_company': 1,
                 }
-                expected_query_count = 10
+                expected_query_count = 8
                 insert_tables_perf = {}
                 if not readonly_enabled:
                     insert_tables_perf = {
@@ -253,10 +253,10 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
                     # 2. find page matching the `/` url
                     'website': 1,
                     # layout
-                    'ir_ui_view': 2,
+                    'ir_ui_view': 1,
                     'res_company': 1,
                 }
-                expected_query_count = 8
+                expected_query_count = 7
                 insert_tables_perf = {}
                 if not readonly_enabled:
                     insert_tables_perf = {
@@ -274,7 +274,7 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
             'orm_signaling_registry': 1,
             'ir_attachment': 1,
             # `_get_serve_attachment` dispatcher fallback
-            'website_page': 2,
+            'website_page': 1,
             # 1. `_serve_page` search page matching URL..
             # 2. ..then reads it (`is_visible`)
             'website': 1,
@@ -282,8 +282,8 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
             'ir_ui_view': 1,
             # Check if `view.track` to track visitor or not
         }
-        self._check_url_hot_query(self.page.url, 6, select_tables_perf)
-        self.assertEqual(self._get_url_hot_query(self.page.url), 6)
+        self._check_url_hot_query(self.page.url, 5, select_tables_perf)
+        self.assertEqual(self._get_url_hot_query(self.page.url), 5)
 
     def test_40_perf_sql_queries_page_multi_level_menu(self):
         # menu structure should not impact SQL requests
@@ -299,18 +299,18 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
             'orm_signaling_registry': 1,
             'ir_attachment': 1,
             # `_get_serve_attachment` dispatcher fallback
-            'website_page': 3,
+            'website_page': 2,
             # 1. `_serve_page` search page matching URL..
             # 2. ..then reads it (`is_visible`)
             'website': 1,
             'website_menu': 1,
-            'ir_ui_view': 2,
+            'ir_ui_view': 1,
             # Check if `view.track` to track visitor or not
             # layout content (company name, logo)
             'res_company': 1,
         }
-        self._check_url_hot_query(self.page.url, 10, select_tables_perf)
-        self.assertEqual(self._get_url_hot_query(self.page.url), 10)
+        self._check_url_hot_query(self.page.url, 8, select_tables_perf)
+        self.assertEqual(self._get_url_hot_query(self.page.url), 8)
 
 @tagged('-at_install', 'post_install')
 class TestWebsitePerformancePost(UtilPerf):

--- a/addons/website/tests/test_website_visitor.py
+++ b/addons/website/tests/test_website_visitor.py
@@ -38,34 +38,34 @@ class WebsiteVisitorTestsCommon(MockVisitor, HttpCaseWithUserDemo):
         untracked_view = self.env['ir.ui.view'].create({
             'name': 'UntackedView',
             'type': 'qweb',
-            'arch': '''<t name="Homepage" t-name="website.base_view">
+            'arch': '''<t name="Homepage" t-name="test.untracked_page">
                         <t t-call="website.layout">
                             I am a generic page²
                         </t>
                     </t>''',
-            'key': 'test.base_view',
+            'key': 'test.untracked_page',
             'track': False,
         })
         tracked_view = self.env['ir.ui.view'].create({
             'name': 'TrackedView',
             'type': 'qweb',
-            'arch': '''<t name="Homepage" t-name="website.base_view">
+            'arch': '''<t name="Homepage" t-name="test.tracked_page">
                         <t t-call="website.layout">
                             I am a generic page
                         </t>
                     </t>''',
-            'key': 'test.base_view',
+            'key': 'test.tracked_page',
             'track': True,
         })
         tracked_view_2 = self.env['ir.ui.view'].create({
             'name': 'TrackedView2',
             'type': 'qweb',
-            'arch': '''<t name="OtherPage" t-name="website.base_view">
+            'arch': '''<t name="OtherPage" t-name="test.tracked_page_2">
                         <t t-call="website.layout">
                             I am a generic second page
                         </t>
                     </t>''',
-            'key': 'test.base_view',
+            'key': 'test.tracked_page_2',
             'track': True,
         })
         [self.untracked_page, self.tracked_page, self.tracked_page_2] = self.env['website.page'].create([

--- a/addons/website/views/website_pages_views.xml
+++ b/addons/website/views/website_pages_views.xml
@@ -19,6 +19,8 @@
                         <field name="website_indexed"/>
                         <field name="is_published"/>
                         <field name="date_publish"/>
+                        <field name="cache_time" groups="base.group_no_one"/>
+                        <field name="cache_key_expr" groups="base.group_no_one"/>
                     </group>
                 </group>
                 <label for="menu_ids" string="Related Menu Items"/>

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -87,12 +87,14 @@
             'data-main-object': repr(main_object) if main_object else None,
             'data-seo-object': repr(seo_object) if seo_object else None,
         }"/>
-        <t t-if="not request.env.user._is_public()" t-set="nothing" t-value="html_data.update({
-            'data-is-published': 'website_published' in main_object.fields_get() and main_object.sudo().website_published,
-            'data-can-optimize-seo': 'website_meta_description' in main_object.fields_get(),
-            'data-can-publish': 'can_publish' in main_object.fields_get() and main_object.sudo(False).can_publish,
-            'data-editable-in-backend': edit_in_backend or ('website_published' in main_object.fields_get() and main_object._name != 'website.page'),
-        })"/>
+        <t t-if="not request.env.user._is_public()">
+            <t t-set="nothing" t-value="html_data.update({
+                'data-is-published': 'website_published' in main_object._fields and main_object.sudo().website_published,
+                'data-can-optimize-seo': 'website_meta_description' in main_object._fields,
+                'data-can-publish': 'can_publish' in main_object._fields and main_object.sudo(False).can_publish,
+                'data-editable-in-backend': edit_in_backend or ('website_published' in main_object._fields and main_object._name != 'website.page'),
+            })"/>
+        </t>
         <t t-if="editable or translatable" t-set="nothing" t-value="html_data.update({
             'data-editable': '1' if editable else None,
             'data-translatable': '1' if translatable else None,

--- a/addons/website_livechat/models/__init__.py
+++ b/addons/website_livechat/models/__init__.py
@@ -8,3 +8,4 @@ from . import discuss_channel
 from . import res_config_settings
 from . import website
 from . import website_visitor
+from . import website_page

--- a/addons/website_livechat/models/website_page.py
+++ b/addons/website_livechat/models/website_page.py
@@ -1,0 +1,12 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models
+
+
+class WebsitePage(models.Model):
+    _inherit = 'website.page'
+
+    @api.model
+    def _post_process_response_from_cache(self, request, response):
+        super()._post_process_response_from_cache(request, response)
+        request.website._get_livechat_channel_info()

--- a/addons/website_sale/models/__init__.py
+++ b/addons/website_sale/models/__init__.py
@@ -26,6 +26,7 @@ from . import sale_order
 from . import sale_order_line
 from . import theme_utils
 from . import website
+from . import website_page
 from . import website_base_unit
 from . import website_checkout_step
 from . import website_menu

--- a/addons/website_sale/models/website_page.py
+++ b/addons/website_sale/models/website_page.py
@@ -1,0 +1,17 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models
+
+
+class WebsitePage(models.Model):
+    _inherit = 'website.page'
+
+    @api.model
+    def _allow_to_use_cache(self, request):
+        if not super()._allow_to_use_cache(request):
+            return False
+        return not request.session.get('sale_order_id') or not request.session.get('website_sale_cart_quantity')
+
+    @api.model
+    def _allow_cache_insertion(self, layout):
+        return ' data-order-id=' not in layout and super()._allow_cache_insertion(layout)

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -8,7 +8,7 @@
             <a href="/shop/cart" t-attf-class="#{_link_class}" aria-label="eCommerce cart">
                 <div t-attf-class="#{_icon_wrap_class}">
                     <i t-if="_icon" class="fa fa-shopping-cart fa-stack"/>
-                    <sup t-attf-class="my_cart_quantity badge bg-primary #{_badge_class} #{'d-none' if (website_sale_cart_quantity == 0) else ''}" t-out="website_sale_cart_quantity" t-att-data-order-id="request.session.get('sale_order_id', '')"/>
+                    <sup t-attf-class="my_cart_quantity badge bg-primary #{_badge_class} #{'d-none' if (website_sale_cart_quantity == 0) else ''}" t-out="website_sale_cart_quantity" t-att-data-order-id="request.session.get('sale_order_id', None) if website_sale_cart_quantity else None"/>
                 </div>
                 <span t-if="_text" t-attf-class="#{_text_class}">My Cart</span>
             </a>


### PR DESCRIPTION
Performance commits are in another pr: https://github.com/odoo/odoo/pull/226019.

This commit introduces a high-level cache on the `website.page` model,
similar to the one that existed before the `t-cache` directive was
implemented in `ir.qweb`. This cache is designed to significantly improve
performance by storing the HTML response of published pages, thereby
reducing rendering time and database queries.

The management and logic for this cache are placed directly on the
`website.page` model, as it is the source of the HTML response for these
records. This approach makes it easy to control caching behavior through
a few new, overridable methods:

-  `_allow_to_use_cache`: Determines whether a page is allowed to be
served from the cache based on the current request, URL, or session. For
example, a page with a `sale.order` in the session would not use the cache.

-  `_allow_cache_insertion`: Checks if the generated HTML content is
eligible for caching. This is useful for preventing sensitive or dynamic
content from being stored. For instance, a page with a reference to a
`sale.order` would not be inserted into the cache.

-  `_post_process_response_from_cache`: A hook called after a response is
retrieved from the cache. This method allows for post-processing, such as
incrementing counters or modifying HTTP headers, without regenerating the
entire page.

see https://github.com/odoo/odoo/pull/224487
see https://github.com/odoo/odoo/pull/88276