### PR TITLE
[FIX] survey: comment as answer not working on roaming multiple choice

### DIFF
--- a/addons/survey/models/survey_question.py
+++ b/addons/survey/models/survey_question.py
@@ -472,12 +472,22 @@ class SurveyQuestion(models.Model):
         return {}
 
     def _validate_choice(self, answer, comment):
-        # Empty comment
-        if not self.survey_id.users_can_go_back \
-                and self.constr_mandatory \
-                and not answer \
-                and not (self.comments_allowed and self.comment_count_as_answer and comment):
+        """ Validates choice-based questions.
+        - Checks that mandatory questions have at least one answer.
+        - For 'simple_choice', ensures that exactly one answer is provided.
+        """
+        answers = answer if isinstance(answer, list) else ([answer] if answer else [])
+
+        valid_answers_count = len(answers)
+        if comment and self.comment_count_as_answer:
+            valid_answers_count += 1
+
+        if valid_answers_count == 0 and self.constr_mandatory and not self.survey_id.users_can_go_back:
             return {self.id: self.constr_error_msg or _('This question requires an answer.')}
+
+        if valid_answers_count > 1 and self.question_type == 'simple_choice':
+            return {self.id: _('For this question, you can only select one answer.')}
+
         return {}
 
     def _validate_matrix(self, answers):

--- a/addons/survey/models/survey_user_input.py
+++ b/addons/survey/models/survey_user_input.py
@@ -312,18 +312,12 @@ class SurveyUserInput(models.Model):
         if not (isinstance(answers, list)):
             answers = [answers]
 
-        if not answers:
+        if not answers and not (comment and question.comment_count_as_answer):
             # add a False answer to force saving a skipped line
             # this will make this question correctly considered as skipped in statistics
             answers = [False]
 
-        vals_list = []
-
-        if question.question_type == 'simple_choice':
-            if not question.comment_count_as_answer or not question.comments_allowed or not comment:
-                vals_list = [self._get_line_answer_values(question, answer, 'suggestion') for answer in answers]
-        elif question.question_type == 'multiple_choice':
-            vals_list = [self._get_line_answer_values(question, answer, 'suggestion') for answer in answers]
+        vals_list = [self._get_line_answer_values(question, answer, 'suggestion') for answer in answers]
 
         if comment:
             vals_list.append(self._get_line_comment_values(question, comment))

--- a/addons/survey/tests/test_survey.py
+++ b/addons/survey/tests/test_survey.py
@@ -222,6 +222,35 @@ class TestSurveyInternals(common.TestSurveyCommon, MailCase):
             {}
         )
 
+    @users('survey_manager')
+    def test_answer_validation_comment(self):
+        """ Check that a comment validates a mandatory question based on 'comment_count_as_answer'. """
+        # Scenario 1: A comment counts as a valid answer.
+        question_ok = self._add_question(
+            self.page_0, 'Q_OK', 'multiple_choice',
+            constr_mandatory=True, validation_error_msg='ValidationError',
+            comments_allowed=True,
+            comment_count_as_answer=True,
+            labels=[{'value': 'Choice A'}, {'value': 'Choice B'}])
+
+        self.assertEqual(
+            question_ok.validate_question(answer='', comment='This comment is a valid answer.'),
+            {}
+        )
+
+        # Scenario 2: A comment does NOT count as a valid answer.
+        question_fail = self._add_question(
+            self.page_0, 'Q_FAIL', 'multiple_choice',
+            constr_mandatory=True, validation_error_msg='ValidationError',
+            comments_allowed=True,
+            comment_count_as_answer=False,
+            labels=[{'value': 'Choice A'}, {'value': 'Choice B'}])
+
+        self.assertEqual(
+            question_fail.validate_question(answer='', comment='This comment is not enough.'),
+            {question_fail.id: 'TestError'}
+        )
+
     def test_partial_scores_simple_choice(self):
         """" Check that if partial scores are given for partially correct answers, in the case of a multiple
         choice question with single choice, choosing the answer with max score gives 100% of points. """
@@ -335,6 +364,30 @@ class TestSurveyInternals(common.TestSurveyCommon, MailCase):
 
         for question in questions:
             self._assert_skipped_question(question, survey_user)
+
+    @users('survey_manager')
+    def test_multiple_choice_comment_not_skipped(self):
+        """ Test that a multiple choice question with only a comment is not marked as skipped. """
+        survey_user = self.survey._create_answer(user=self.survey_user)
+        question = self._add_question(
+            self.page_0, 'MCQ with Comment', 'multiple_choice',
+            comments_allowed=True,
+            comment_count_as_answer=True,
+            labels=[{'value': 'Choice A'}, {'value': 'Choice B'}]
+        )
+
+        # Save an answer with no selected choice but with a comment.
+        survey_user._save_lines(question, answer=[], comment='This is only a comment')
+
+        answer_line = self.env['survey.user_input.line'].search([
+            ('user_input_id', '=', survey_user.id),
+            ('question_id', '=', question.id)
+        ])
+
+        self.assertEqual(len(answer_line), 1)
+        self.assertFalse(answer_line.skipped)
+        self.assertEqual(answer_line.answer_type, 'char_box')
+        self.assertEqual(answer_line.value_char_box, 'This is only a comment')
 
     @users('survey_manager')
     def test_copy_conditional_question_settings(self):

--- a/addons/survey/tests/test_survey.py
+++ b/addons/survey/tests/test_survey.py
@@ -223,6 +223,57 @@ class TestSurveyInternals(common.TestSurveyCommon, MailCase):
         )
 
     @users('survey_manager')
+    def test_simple_choice_validation_multiple_answers(self):
+        """
+        Check that a 'simple_choice' question fails validation if more than one
+        valid answer is provided.
+        """
+        question = self._add_question(
+            self.page_0, 'Simple Choice Constraint Test', 'simple_choice',
+            constr_mandatory=True,
+            comments_allowed=True,
+            comment_count_as_answer=True,
+            labels=[{'value': 'Choice X'}, {'value': 'Choice Y'}]
+        )
+        answer_choice_x_id = question.suggested_answer_ids[0].id
+        answer_choice_y_id = question.suggested_answer_ids[1].id
+
+        scenarios = [
+            (
+                'Two selected choices should not be allowed',
+                [answer_choice_x_id, answer_choice_y_id],
+                None,
+                True,
+            ),
+            (
+                'One choice and one comment that counts as an answer',
+                answer_choice_x_id,
+                'This is my comment, which is also an answer.',
+                True,
+            ),
+            (
+                'A single valid answer should pass validation',
+                answer_choice_x_id,
+                None,
+                False,
+            ),
+            (
+                'A single valid comment should pass validation',
+                '',
+                'This is my comment, which is also an answer.',
+                False,
+            ),
+        ]
+
+        for case_description, answers, comment, is_multiple_answers in scenarios:
+            with self.subTest(answers=answers, comment=comment):
+                self.assertEqual(
+                    question.validate_question(answers, comment),
+                    {question.id: 'For this question, you can only select one answer.'} if is_multiple_answers else {},
+                    case_description,
+                )
+
+    @users('survey_manager')
     def test_answer_validation_comment(self):
         """ Check that a comment validates a mandatory question based on 'comment_count_as_answer'. """
         # Scenario 1: A comment counts as a valid answer.


### PR DESCRIPTION
Issue:
When answering a question with a comment in multiple choice with roaming activated for the survey, the UI will display a warning message that says the question requires an answer.

Cause:
The backend creates a skipped record if none of the pre-created answers is chosen.

Solution:
Don't create a skipped record if a comment counts as an answer and a comment is provided.

Added validation of input and unittests

Task-5062984