### PR TITLE
[FIX] base_import: prevent error when importing utf-16 CSV file

### DIFF
--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -567,7 +567,9 @@ class Import(models.TransientModel):
             return ()
 
         encoding = options.get('encoding')
+        encoding_guessed = False
         if not encoding:
+            encoding_guessed = True
             encoding = options['encoding'] = chardet.detect(csv_data)['encoding'].lower()
             # some versions of chardet (e.g. 2.3.0 but not 3.x) will return
             # utf-(16|32)(le|be), which for python means "ignore / don't strip
@@ -577,7 +579,14 @@ class Import(models.TransientModel):
             if bom and csv_data.startswith(bom):
                 encoding = options['encoding'] = encoding[:-2]
 
-        csv_text = csv_data.decode(encoding)
+        try:
+            csv_text = csv_data.decode(encoding)
+        except UnicodeDecodeError as exc:
+            if encoding_guessed:
+                msg = _("There was an issue decoding the file using encoding “%s”.\nThis encoding was automatically detected.", encoding)
+            else:
+                msg = _("There was an issue decoding the file using encoding “%s”.\nThis encoding was manually selected.", encoding)
+            raise ImportValidationError(msg) from exc
 
         separator = options.get('separator')
         if not separator:


### PR DESCRIPTION
Currently, an error occurs when importing CSV files encoded in utf-16.

**Steps to reproduce:**
- Install the `account_bank_statement_import_csv` module.
- Open invoicing and upload file [1] in Bank transactions.
- Change the encoding to `utf-16` and click `test`.

**Error:**
`UnicodeDecodeError: 'utf-16-le' codec can't decode byte 0x0a in position 376: truncated data`

**Root Cause:**
At [2], the CSV data is decoded strictly with the specified encoding. When 
decoding detects incomplete or unexpected byte sequences, Python raises an `error`.

**Fix:**
This commit ensures raising a `warning`, improving the `error message clarity`.

[1]:
https://drive.google.com/file/d/14thHRN210aeY8fcUBAb01PniVrd7QHer/view?usp=sharing

[2]:
https://github.com/odoo/odoo/blob/67503c0ce7ede8373800caa0a12203d271b7f1ae/addons/base_import/models/base_import.py#L544

sentry-6864546266