### PR TITLE
[FIX] product_expiry: prevent error when proceed except expired delivery

### DIFF
--- a/addons/product_expiry/wizard/confirm_expiry.py
+++ b/addons/product_expiry/wizard/confirm_expiry.py
@@ -45,5 +45,7 @@ class ExpiryPickingConfirmation(models.TransientModel):
     def process_no_expired(self):
         """ Remove the expired mls and confirm the picking. """
         pickings_to_validate = self.env['stock.picking'].browse(self.env.context.get('button_validate_picking_ids'))
-        self.picking_ids.move_line_ids.filtered(lambda ml: ml.use_expiration_date and ml.removal_date < datetime.now()).unlink()
+        self.picking_ids.move_line_ids.filtered(
+            lambda ml: ml.use_expiration_date and ml.removal_date and ml.removal_date < datetime.now()
+        ).unlink()
         return pickings_to_validate.button_validate()


### PR DESCRIPTION
currently an error occur when user proceed except expired delivery.

Steps to Reproduce:

 - Install the `product_expiry` module.
 - Create a product with the configuration:
   - In `Track Inventory`, select `By Lots`.
   - In the `Inventory tab`, check `Expiration Date`.
 - In the newly created product, click `Lot/Serial Numbers` button, create a new `Lot/Serial Number`, and clear the `Removal Date` of that Lot/Serial Number.
 - Go back to the newly created product and update the `Quantity On Hand` of the linked `Lot/Serial Number` by clicking `Update`.
 - Now go to `deliveries` and create a new `delivery` and add the newly created product and `validate` > `Proceed except expired`.

`TypeError: '<' not supported between instances of 'bool' and 'datetime.datetime'`

This error occurs when user proceed except expired delivery, The removal_date of the move line is computed based on the lot's removal date and the move line's expiration date. If the lot does not have a removal date and the move line also does not have an expiration date, then removal_date on the move line is set to False [1], which raises the error here [2]

This commit ensures that it only compares with the move line removal_date if it is present.

[1]- https://github.com/odoo/odoo/blob/70a7babcc830f72bd069a5bb1504748363e4e848/addons/product_expiry/models/stock_move_line.py#L56

[2]-https://github.com/odoo/odoo/blob/70a7babcc830f72bd069a5bb1504748363e4e848/addons/product_expiry/wizard/confirm_expiry.py#L48

sentry-6864176071

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
