### PR TITLE
[FIX] website: fix footer visibility tooltip message

### DIFF
--- a/addons/website/static/src/builder/plugins/options/website_page_config_option.xml
+++ b/addons/website/static/src/builder/plugins/options/website_page_config_option.xml
@@ -20,7 +20,7 @@
 </t>
 
 <t t-name="website.HideFooterOption">
-    <BuilderRow label.translate="Page Visibility" tooltip.translate="Enable to hide the footer on this page">
+    <BuilderRow label.translate="Page Visibility" tooltip.translate="Disable to hide the footer on this page">
         <BuilderCheckbox action="'setWebsiteFooterVisible'"/>
     </BuilderRow>
 </t>


### PR DESCRIPTION
A tooltip message was added to the option for the visibility of the footer in e0474c19d212d9c19fd1c3bbc9546b4258770018. The message indicates the opposite of the effect. This commit changes the message to match the behavior of the checkbox.

Steps to reproduce:
- Open website builder
- Click on footer
- Hover "Page Visibility"
- Bug: the message "Enable to hide...", but enabling actually shows

task-4991435