### PR TITLE
[FIX] l10n_be: add translation for payment standard

### DIFF
--- a/addons/l10n_be/i18n/de.po
+++ b/addons/l10n_be/i18n/de.po
@@ -10,8 +10,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.3alpha1+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-26 17:03+0000\n"
-"PO-Revision-Date: 2023-04-14 14:22+0200\n"
+"POT-Creation-Date: 2025-09-09 08:53+0000\n"
+"PO-Revision-Date: 2025-09-09 10:59+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: de\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: \n"
-"X-Generator: Poedit 3.2.2\n"
+"X-Generator: Poedit 3.7\n"
 
 #. module: l10n_be
 #: model:ir.model,name:l10n_be.model_account_chart_template
@@ -39,10 +39,14 @@ msgid "Base"
 msgstr "Basis"
 
 #. module: l10n_be
-#: model:ir.model.fields.selection,name:l10n_be.selection__account_journal__invoice_reference_model__be
 #: model:ir.ui.menu,name:l10n_be.account_reports_be_statements_menu
 msgid "Belgium"
 msgstr "Belgien"
+
+#. module: l10n_be
+#: model:ir.model.fields.selection,name:l10n_be.selection__account_journal__invoice_reference_model__be
+msgid "Belgium (+++000/2024/00182+++)"
+msgstr "Belgien (+++000/2024/00182+++)"
 
 #. module: l10n_be
 #: model:ir.model.fields,field_description:l10n_be.field_account_journal__invoice_reference_model
@@ -59,6 +63,24 @@ msgstr "Unternehmen"
 #: model:ir.model,name:l10n_be.model_res_partner
 msgid "Contact"
 msgstr "Kontakt"
+
+#. module: l10n_be
+#: model:ir.model.fields,field_description:l10n_be.field_account_chart_template__display_name
+#: model:ir.model.fields,field_description:l10n_be.field_account_journal__display_name
+#: model:ir.model.fields,field_description:l10n_be.field_account_move__display_name
+#: model:ir.model.fields,field_description:l10n_be.field_account_tax__display_name
+#: model:ir.model.fields,field_description:l10n_be.field_res_partner__display_name
+msgid "Display Name"
+msgstr "Anzeigename"
+
+#. module: l10n_be
+#: model:ir.model.fields,field_description:l10n_be.field_account_chart_template__id
+#: model:ir.model.fields,field_description:l10n_be.field_account_journal__id
+#: model:ir.model.fields,field_description:l10n_be.field_account_move__id
+#: model:ir.model.fields,field_description:l10n_be.field_account_tax__id
+#: model:ir.model.fields,field_description:l10n_be.field_res_partner__id
+msgid "ID"
+msgstr "ID"
 
 #. module: l10n_be
 #: model:ir.model.fields.selection,name:l10n_be.selection__account_tax__tax_scope__invest
@@ -83,7 +105,7 @@ msgstr "Waren"
 #. module: l10n_be
 #: model:ir.model.fields,help:l10n_be.field_account_tax__tax_scope
 msgid "Restrict the use of taxes to a type of product."
-msgstr "Verwendung von Steuern auf eine Art von Produkt beschränken"
+msgstr "Verwendung von Steuern auf eine Art von Produkt beschränken."
 
 #. module: l10n_be
 #: model:ir.model,name:l10n_be.model_account_tax

--- a/addons/l10n_be/i18n/fr.po
+++ b/addons/l10n_be/i18n/fr.po
@@ -13,8 +13,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.3alpha1+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-26 17:03+0000\n"
-"PO-Revision-Date: 2023-04-14 14:20+0200\n"
+"POT-Creation-Date: 2025-09-09 08:53+0000\n"
+"PO-Revision-Date: 2025-09-09 10:57+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: fr\n"
@@ -22,7 +22,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
-"X-Generator: Poedit 3.2.2\n"
+"X-Generator: Poedit 3.7\n"
 
 #. module: l10n_be
 #: model:ir.model,name:l10n_be.model_account_chart_template
@@ -42,10 +42,14 @@ msgid "Base"
 msgstr "Base"
 
 #. module: l10n_be
-#: model:ir.model.fields.selection,name:l10n_be.selection__account_journal__invoice_reference_model__be
 #: model:ir.ui.menu,name:l10n_be.account_reports_be_statements_menu
 msgid "Belgium"
 msgstr "Belgique"
+
+#. module: l10n_be
+#: model:ir.model.fields.selection,name:l10n_be.selection__account_journal__invoice_reference_model__be
+msgid "Belgium (+++000/2024/00182+++)"
+msgstr "Belgique (+++000/2024/00182+++)"
 
 #. module: l10n_be
 #: model:ir.model.fields,field_description:l10n_be.field_account_journal__invoice_reference_model
@@ -62,6 +66,24 @@ msgstr "Sociétés"
 #: model:ir.model,name:l10n_be.model_res_partner
 msgid "Contact"
 msgstr "Contact"
+
+#. module: l10n_be
+#: model:ir.model.fields,field_description:l10n_be.field_account_chart_template__display_name
+#: model:ir.model.fields,field_description:l10n_be.field_account_journal__display_name
+#: model:ir.model.fields,field_description:l10n_be.field_account_move__display_name
+#: model:ir.model.fields,field_description:l10n_be.field_account_tax__display_name
+#: model:ir.model.fields,field_description:l10n_be.field_res_partner__display_name
+msgid "Display Name"
+msgstr "Nom d'affichage"
+
+#. module: l10n_be
+#: model:ir.model.fields,field_description:l10n_be.field_account_chart_template__id
+#: model:ir.model.fields,field_description:l10n_be.field_account_journal__id
+#: model:ir.model.fields,field_description:l10n_be.field_account_move__id
+#: model:ir.model.fields,field_description:l10n_be.field_account_tax__id
+#: model:ir.model.fields,field_description:l10n_be.field_res_partner__id
+msgid "ID"
+msgstr "Identifiant"
 
 #. module: l10n_be
 #: model:ir.model.fields.selection,name:l10n_be.selection__account_tax__tax_scope__invest

--- a/addons/l10n_be/i18n/l10n_be.pot
+++ b/addons/l10n_be/i18n/l10n_be.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server saas~17.4+e\n"
+"Project-Id-Version: Odoo Server 18.5a1+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-26 17:03+0000\n"
-"PO-Revision-Date: 2024-12-26 17:03+0000\n"
+"POT-Creation-Date: 2025-09-09 08:53+0000\n"
+"PO-Revision-Date: 2025-09-09 08:53+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -33,9 +33,13 @@ msgid "Base"
 msgstr ""
 
 #. module: l10n_be
-#: model:ir.model.fields.selection,name:l10n_be.selection__account_journal__invoice_reference_model__be
 #: model:ir.ui.menu,name:l10n_be.account_reports_be_statements_menu
 msgid "Belgium"
+msgstr ""
+
+#. module: l10n_be
+#: model:ir.model.fields.selection,name:l10n_be.selection__account_journal__invoice_reference_model__be
+msgid "Belgium (+++000/2024/00182+++)"
 msgstr ""
 
 #. module: l10n_be
@@ -52,6 +56,24 @@ msgstr ""
 #. module: l10n_be
 #: model:ir.model,name:l10n_be.model_res_partner
 msgid "Contact"
+msgstr ""
+
+#. module: l10n_be
+#: model:ir.model.fields,field_description:l10n_be.field_account_chart_template__display_name
+#: model:ir.model.fields,field_description:l10n_be.field_account_journal__display_name
+#: model:ir.model.fields,field_description:l10n_be.field_account_move__display_name
+#: model:ir.model.fields,field_description:l10n_be.field_account_tax__display_name
+#: model:ir.model.fields,field_description:l10n_be.field_res_partner__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: l10n_be
+#: model:ir.model.fields,field_description:l10n_be.field_account_chart_template__id
+#: model:ir.model.fields,field_description:l10n_be.field_account_journal__id
+#: model:ir.model.fields,field_description:l10n_be.field_account_move__id
+#: model:ir.model.fields,field_description:l10n_be.field_account_tax__id
+#: model:ir.model.fields,field_description:l10n_be.field_res_partner__id
+msgid "ID"
 msgstr ""
 
 #. module: l10n_be

--- a/addons/l10n_be/i18n/nl.po
+++ b/addons/l10n_be/i18n/nl.po
@@ -11,8 +11,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.3alpha1+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-26 17:03+0000\n"
-"PO-Revision-Date: 2023-04-14 14:20+0200\n"
+"POT-Creation-Date: 2025-09-09 08:53+0000\n"
+"PO-Revision-Date: 2025-09-09 11:00+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: nl\n"
@@ -20,7 +20,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.2.2\n"
+"X-Generator: Poedit 3.7\n"
 
 #. module: l10n_be
 #: model:ir.model,name:l10n_be.model_account_chart_template
@@ -40,10 +40,14 @@ msgid "Base"
 msgstr "Basis"
 
 #. module: l10n_be
-#: model:ir.model.fields.selection,name:l10n_be.selection__account_journal__invoice_reference_model__be
 #: model:ir.ui.menu,name:l10n_be.account_reports_be_statements_menu
 msgid "Belgium"
 msgstr "België"
+
+#. module: l10n_be
+#: model:ir.model.fields.selection,name:l10n_be.selection__account_journal__invoice_reference_model__be
+msgid "Belgium (+++000/2024/00182+++)"
+msgstr "België (+++000/2024/00182+++)"
 
 #. module: l10n_be
 #: model:ir.model.fields,field_description:l10n_be.field_account_journal__invoice_reference_model
@@ -60,6 +64,24 @@ msgstr "Vennootschappen"
 #: model:ir.model,name:l10n_be.model_res_partner
 msgid "Contact"
 msgstr "Contact"
+
+#. module: l10n_be
+#: model:ir.model.fields,field_description:l10n_be.field_account_chart_template__display_name
+#: model:ir.model.fields,field_description:l10n_be.field_account_journal__display_name
+#: model:ir.model.fields,field_description:l10n_be.field_account_move__display_name
+#: model:ir.model.fields,field_description:l10n_be.field_account_tax__display_name
+#: model:ir.model.fields,field_description:l10n_be.field_res_partner__display_name
+msgid "Display Name"
+msgstr "Schermnaam"
+
+#. module: l10n_be
+#: model:ir.model.fields,field_description:l10n_be.field_account_chart_template__id
+#: model:ir.model.fields,field_description:l10n_be.field_account_journal__id
+#: model:ir.model.fields,field_description:l10n_be.field_account_move__id
+#: model:ir.model.fields,field_description:l10n_be.field_account_tax__id
+#: model:ir.model.fields,field_description:l10n_be.field_res_partner__id
+msgid "ID"
+msgstr "ID"
 
 #. module: l10n_be
 #: model:ir.model.fields.selection,name:l10n_be.selection__account_tax__tax_scope__invest


### PR DESCRIPTION
The translations were missing the reference standard example for the payments.

Bug from pad
