### PR TITLE
[FIX] point_of_sale: reduce minimum length of Ticket Number

### DIFF
--- a/addons/point_of_sale/controllers/main.py
+++ b/addons/point_of_sale/controllers/main.py
@@ -134,7 +134,7 @@ class PosController(PortalAccount):
 
             if errors:
                 errors['generic'] = _("Please fill all the required fields.")
-            elif len(form_values['pos_reference']) < 14:
+            elif len(form_values['pos_reference']) < 12:
                 errors['pos_reference'] = _("The Ticket Number should be at least 14 characters long.")
             else:
                 date_order = datetime(*[int(i) for i in form_values['date_order'].split('-')])


### PR DESCRIPTION
- Since this PR (https://github.com/odoo/odoo/pull/222261) the minimum length of the Ticket Number (pos_reference) has been set to 12 characters. This was causing issues when trying to download invoices with the link on the receipt.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
