### PR TITLE
[FIX] l10n_fr_pos_cert: inalterability hashes should be equal if no alteration

### DIFF
--- a/addons/l10n_fr_pos_cert/tests/__init__.py
+++ b/addons/l10n_fr_pos_cert/tests/__init__.py
@@ -2,3 +2,4 @@
 
 from . import test_fr_pos
 from . import test_string_to_hash
+from . import test_hash

--- a/addons/l10n_fr_pos_cert/tests/test_hash.py
+++ b/addons/l10n_fr_pos_cert/tests/test_hash.py
@@ -1,0 +1,84 @@
+from odoo.addons.point_of_sale.tests.common import TestPointOfSaleCommon
+from odoo.addons.account_edi.tests.common import AccountTestInvoicingCommon
+from odoo.tests import tagged
+from odoo import fields
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestHash(TestPointOfSaleCommon):
+
+    @classmethod
+    @AccountTestInvoicingCommon.setup_country('fr')
+    def setUpClass(cls):
+        super().setUpClass()
+
+    def test_hashes_should_be_equal_if_no_alteration(self):
+        product1 = self.env['product.product'].create({
+            'name': 'product1',
+        })
+
+        self.pos_config.open_ui()
+        pos_session = self.pos_config.current_session_id
+        draft_order = {
+            'access_token': False,
+            'amount_paid': 0,
+            'amount_return': 0,
+            'amount_tax': 0,
+            'amount_total': 0,
+            'date_order': fields.Datetime.to_string(fields.Datetime.now()),
+            'lines': [],
+            'name': '/',
+            'partner_id': False,
+            'session_id': pos_session.id,
+            'sequence_number': 2,
+            'payment_ids': [],
+            'uuid': '12345-123-1234',
+            'last_order_preparation_change': '{}',
+            'user_id': self.env.uid,
+            'state': 'draft',
+        }
+
+        self.PosOrder.sync_from_ui([draft_order])
+        self.env.invalidate_all()
+
+        paid_order = {
+            'access_token': False,
+            'amount_paid': 20,
+            'amount_return': 5.0,
+            'amount_tax': 0,
+            'amount_total': 15.0,
+            'date_order': fields.Datetime.to_string(fields.Datetime.now()),
+            'lines': [[0,
+                0,
+                {'discount': 0,
+                'pack_lot_ids': [],
+                'price_unit': 15.0,
+                'product_id': product1.id,
+                'price_subtotal': 15.0,
+                'price_subtotal_incl': 15.0,
+                'qty': 1,
+                'tax_ids': []}]],
+            'name': 'Order 12345-123-1234',
+            'partner_id': False,
+            'session_id': pos_session.id,
+            'sequence_number': 2,
+            'payment_ids': [[0,
+                0,
+                {'amount': 20.0,
+                'name': fields.Datetime.now(),
+                'payment_method_id': self.cash_payment_method.id}]],
+            'uuid': '12345-123-1234',
+            'last_order_preparation_change': '{}',
+            'user_id': self.env.uid,
+            'state': 'paid',
+        }
+
+        self.PosOrder.sync_from_ui([paid_order])
+        self.env.invalidate_all()
+
+        posted_order = self.env['pos.order'].search([('uuid', '=', '12345-123-1234')])
+        self.assertEqual(posted_order.state, 'paid')
+
+        self.pos_config.current_session_id.action_pos_session_closing_control()
+
+        self.assertEqual(posted_order.l10n_fr_hash, posted_order._compute_hash(''))

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -113,6 +113,9 @@ class PosOrder(models.Model):
 
             del order['uuid']
             del order['access_token']
+            if order.get('state') == 'paid':
+                # The "paid" state will be assigned later by `_process_saved_order`
+                order['state'] = pos_order.state
             pos_order.write(order)
 
         pos_order._link_combo_items(combo_child_uuids_by_parent_uuid)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Starting from version 18.0, inalterability hashes in the FR localization are sometimes calculated with incomplete data, leading to incorrect `l10n_fr_hash`. Related orders are then wrongly flagged as altered when running the POS Inalterability Check.

Current behavior before PR:

When you post a POS order and a related draft order exists, Odoo updates the existing order with the new vals. Because `{'state': 'paid'}` is amongst the new vals, it triggers the generation of the `l10n_fr_hash` before the order is fully processed. For instance, the hash will be generated before a new payment line is added for change with `_process_payment_lines()`.

Desired behavior after PR is merged:

The hash should be generated at the end of the order processing, with the final write in `action_pos_order_paid()`. 
