### PR TITLE
[FIX] purchase_requisition: fix uom of pricelist created from BO

### DIFF
--- a/addons/purchase_requisition/models/purchase_requisition.py
+++ b/addons/purchase_requisition/models/purchase_requisition.py
@@ -252,6 +252,7 @@ class PurchaseRequisitionLine(models.Model):
             self.env['product.supplierinfo'].sudo().create({
                 'partner_id': purchase_requisition.vendor_id.id,
                 'product_id': self.product_id.id,
+                'product_uom_id': self.product_uom_id.id,
                 'product_tmpl_id': self.product_id.product_tmpl_id.id,
                 'price': self.price_unit,
                 'currency_id': self.requisition_id.currency_id.id,


### PR DESCRIPTION
This commit fixes setting the UoM of the vendor pricelist generated by a blanket order. Previously, the created pricelist had the base unit of the product. Now, it has the unit of the blanket order line.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
