### PR TITLE
[FIX] l10n_sa_edi: prevent loggin a message when raising internal errors

### DIFF
--- a/addons/l10n_sa_edi/models/account_move.py
+++ b/addons/l10n_sa_edi/models/account_move.py
@@ -177,8 +177,6 @@ class AccountMove(models.Model):
             Save submitted invoice XML hash in case of either Rejection or Acceptance.
         """
         self.ensure_one()
-        if not response_data.get("excepted"):
-            self.journal_id.l10n_sa_latest_submission_hash = self.env['account.edi.xml.ubl_21.zatca']._l10n_sa_generate_invoice_xml_hash(xml_content)
         bootstrap_cls, title, subtitle, content = ("success", _("Invoice Successfully Submitted to ZATCA"), "", "" if (not error or not response_data) else response_data)
         status_code = response_data.get('status_code')
         attachment = False
@@ -225,6 +223,14 @@ class AccountMove(models.Model):
                     } for m in response_data['validationResults']['errorMessages']
                 ])
             }
+        if response_data.get("error") and not content:
+            # if there is an error, but no exception or rejection in the response
+            # then it is due to an internal error raised. No need to log a note
+            return
+
+        if not response_data.get("excepted"):
+            self.journal_id.l10n_sa_latest_submission_hash = self.env['account.edi.xml.ubl_21.zatca']._l10n_sa_generate_invoice_xml_hash(xml_content)
+
         self.with_context(no_new_invoice=True).message_post(body=Markup("""
                 <div role='alert' class='alert alert-%s'>
                     <h4 class='alert-heading'>%s</h4>


### PR DESCRIPTION
In a previous commit e90c35cde2a1f5de5d7bc4db7a525638ca3fab6e, we modified the logic of posting a log note when receiving a response from ZATCA to always log a note of the response.

An issue occured because sometimes, Odoo raises user errors before sending a request to ZATCA, In which case, we do not need to log a note.

Task-id: 5056724

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
