### PR TITLE
[FIX] stock: orderpoint graph test

### DIFF
--- a/addons/stock/tests/test_proc_rule.py
+++ b/addons/stock/tests/test_proc_rule.py
@@ -836,6 +836,7 @@ class TestProcRule(TransactionCase):
         self.assertEqual(orderpoint_1.deadline_date, False)
         self.assertEqual(orderpoint_2.deadline_date, delivery_date_1.date())
 
+    @freeze_time('2025-08-14 10:00:00')
     def test_orderpoint_wizard_graph(self):
         """ Test that the graph data is correctly computed. """
         self.product.is_storable = True


### PR DESCRIPTION
The code divides the demand by the number of days per month, so the test absolutely needs to be done 'during' a period of 31 days.

runbot error 231696

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
