### PR TITLE
[FIX] website_sale: fix race condition between tour step

### DIFF
--- a/addons/website_sale/static/tests/tours/website_sale_add_to_cart_snippet_tour.js
+++ b/addons/website_sale/static/tests/tours/website_sale_add_to_cart_snippet_tour.js
@@ -49,6 +49,10 @@ registerWebsitePreviewTour('add_to_cart_snippet_tour', {
         // Product with 2 variants with a variant selected
         ...editAddToCartSnippet(),
         ...changeOptionInPopover("Add to Cart Button", "Product", "Product Yes Variant 2", true),
+        {
+            content: "Check if variant option is visible",
+            trigger: "[data-container-title='Add to Cart Button'] [data-label='Variant']"
+        },
         ...changeOptionInPopover("Add to Cart Button", "Variant", "Product Yes Variant 2 (Pink)"),
         ...clickOnSave(),
         clickOnElement("add to cart button", ":iframe .s_add_to_cart_btn"),


### PR DESCRIPTION
Some tour steps executed too quickly and did not wait for the target element to appear, causing race conditions where the next step failed due to missing elements.

This commit adds an explicit check step between the failing steps to ensure the element is present before continuing, guaranteeing stable tour execution without premature step execution.

runbot-229723

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
