### PR TITLE
[FIX] mrp_subcontracting: prevent unwanted quants subcontracted track…

### DIFF
--- a/addons/mrp_subcontracting/models/stock_location.py
+++ b/addons/mrp_subcontracting/models/stock_location.py
@@ -101,3 +101,6 @@ class StockLocation(models.Model):
         reference_routes = reference_rules.route_id
         rules_to_archive = self.env['stock.rule'].search(['&', ('route_id', 'in', reference_routes.ids), '|', ('location_src_id', 'in', self.ids), ('location_dest_id', 'in', self.ids)])
         rules_to_archive.action_archive()
+
+    def is_subcontracted_location(self):
+        return super().is_subcontracted_location() or self.is_subcontracting_location

--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -495,6 +495,10 @@ class Location(models.Model):
 
         return result
 
+    def is_subcontracted_location(self):
+        self.ensure_one()
+        return False
+
 
 class StockRoute(models.Model):
     _name = 'stock.route'

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -1053,7 +1053,7 @@ class StockQuant(models.Model):
             raise ValidationError(_('Quantity or Reserved Quantity should be set.'))
         self = self.sudo()
         quants = self._gather(product_id, location_id, lot_id=lot_id, package_id=package_id, owner_id=owner_id, strict=True)
-        if lot_id and quantity > 0:
+        if lot_id and (quantity > 0 or location_id.is_subcontracted_location()):
             quants = quants.filtered(lambda q: q.lot_id)
 
         if location_id.should_bypass_reservation():


### PR DESCRIPTION
…ed PO

**Steps to reproduce:**
- Create a new product and track by lots
- Add a BOM for this product, setting type to Subcontracting
- Create a PO for the product and confirm it (with the vendor as the subcontractor specified on the BOM)
- With debug enabled: go to Inventory/Operations/Procurement: run scheduler
- Go to Inventory > Reporting > Locations and search for the product note the quant line at the subcontractor location with no lot number
- Return to the PO and recieve, specifying lot number
- Go to Inventory > Reporting > Locations
- Search for the product again

**Current behavior:**
there are now 2 quant lines at the subcontractor location: one with lot and one without lot

**Expected behavior:**
There shouldn't be any visible quant line at the subcontractor location because the quantity and reserved quantity of the product at subcontractor location should both be 0

**Cause of the issue:**
Step 1:
When we confirm the PO, this creates a picking and a stock move (move A) from the sbc location to the stock location.
When _action_assign is run on this move, self._should_bypass_reservation() will return true because the move is subcontract
https://github.com/odoo/odoo/blob/95ed5c75582631c7cc417b000569ff6451cc5006/addons/mrp_subcontracting/models/stock_move.py#L302-L307 so we will not create a quant.
(another move (move B) is also created from Production location to sbc location). However when we open Locations this triggers _clean_reserations() and because should_bypass_reservation() returns false for the sbc location, we will run update_reservation_quantity and create a new quant with a reserve quantity of 1 and no lot_id
https://github.com/odoo/odoo/blob/35ea3dcb2eeb379c8b1127f0c7b42191853c0bd2/addons/stock/models/stock_quant.py#L1167-L1172

Step 2:
Then, when we recieve the products and validate the picking, this will call _action_done() on move A.
which will call synchronize_quant()
https://github.com/odoo/odoo/blob/35ea3dcb2eeb379c8b1127f0c7b42191853c0bd2/addons/stock/models/stock_move_line.py#L690 which will call _update_available_quantity() for a quantity of -1, the location sbc and the lot that we just created in the steps. https://github.com/odoo/odoo/blob/35ea3dcb2eeb379c8b1127f0c7b42191853c0bd2/addons/stock/models/stock_move_line.py#L712 Inside _update_available_quantity(), the call to _gather() will return the quant that we created in step 1 (even though the existing quant has no lot and we give the lot we created as parameter). https://github.com/odoo/odoo/blob/35ea3dcb2eeb379c8b1127f0c7b42191853c0bd2/addons/stock/models/stock_quant.py#L1055 So we don't create a new quant but we update the existing one that has no lot.

Step 3:
_action_done() is then called on move B which calls _synchronize_quant() https://github.com/odoo/odoo/blob/35ea3dcb2eeb379c8b1127f0c7b42191853c0bd2/addons/stock/models/stock_move_line.py#L691 which calls _udpate_available_quantity() for a quantity of 1, the location sbc and the lot created in the steps.
Inside _update_available_quantity(), the call to _gather() will return the quant that we created in step 1.
BUT this time, because the quantity is positive,
the quant will be filtered out
https://github.com/odoo/odoo/blob/35ea3dcb2eeb379c8b1127f0c7b42191853c0bd2/addons/stock/models/stock_quant.py#L1056-L1057 so we will create a new quant with a lot_id this time and a quantity of 1.

As a consequence instead of having the quantities zeroed out, we end up with two quants one with a lot and a quantity of 1 and one with no lot and a quantity of -1.

opw-4935822