### PR TITLE
[FIX] stock: more fixes for pack in pack

### DIFF
--- a/addons/stock/models/stock_package.py
+++ b/addons/stock/models/stock_package.py
@@ -317,7 +317,7 @@ class StockPackage(models.Model):
     def action_add_to_picking(self):
         picking = self.env['stock.picking'].browse(self.env.context.get('picking_id'))
         if picking and self:
-            picking.action_add_entire_packs(self)
+            picking.action_add_entire_packs(self.ids)
 
     def _pre_put_in_pack_hook(self, package_id=False, package_type_id=False, package_name=False, from_package_wizard=False):
         if self.move_line_ids._should_display_put_in_pack_wizard(package_id, package_type_id, package_name, from_package_wizard):

--- a/addons/stock/models/stock_package.py
+++ b/addons/stock/models/stock_package.py
@@ -346,7 +346,11 @@ class StockPackage(models.Model):
                 'package_type_id': package_type_id,
                 'name': package_name,
             })
+        previous_dest_packages = self.env['stock.package'].browse(self._get_all_package_dest_ids())
         self.package_dest_id = package
+        if packs_to_clear := previous_dest_packages.filtered(lambda p: not p.move_line_ids):
+            # If following the put in pack, we broke the existing chain somehow, we need to free all now irrelevant packages
+            packs_to_clear.package_dest_id = False
         return package._post_put_in_pack_hook()
 
     def action_remove_package(self):

--- a/addons/stock/models/stock_package_history.py
+++ b/addons/stock/models/stock_package_history.py
@@ -12,7 +12,7 @@ class StockPackageHistory(models.Model):
     location_id = fields.Many2one('stock.location', 'Origin Location')
     location_dest_id = fields.Many2one('stock.location', 'Destination Location')
     move_line_ids = fields.One2many('stock.move.line', 'package_history_id', string='Move Lines', required=True)
-    package_id = fields.Many2one('stock.package', 'Package', required=True)
+    package_id = fields.Many2one('stock.package', 'Package', required=True, ondelete='cascade')
     package_name = fields.Char('Package Name', required=True)
     package_type_id = fields.Many2one('stock.package.type', related='package_id.package_type_id')
     parent_orig_id = fields.Many2one('stock.package', 'Origin Container')

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1864,10 +1864,10 @@ class StockPicking(models.Model):
             'target': 'new',
         }
 
-    def action_add_entire_packs(self, packages):
+    def action_add_entire_packs(self, package_ids):
         self.ensure_one()
         if self.state not in ('done', 'cancel'):
-            all_packages = self.env['stock.package'].search([('id', 'child_of', packages.ids)])
+            all_packages = self.env['stock.package'].search([('id', 'child_of', package_ids)])
             all_package_ids = set(all_packages.ids)
             # Remove existing move lines that already pulled from these packages, as using them fully now.
             self.move_line_ids.filtered(lambda ml: ml.package_id.id in all_package_ids).unlink()
@@ -1898,6 +1898,7 @@ class StockPicking(models.Model):
             'domain': [('picking_ids', 'in', self.ids)],
             'context': {
                 'picking_id': self.id,
+                'location_id': self.location_id.id,
                 'can_add_entire_packs': self.picking_type_code != 'incoming',
                 'search_default_main_packages': True,
             },

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -1511,11 +1511,14 @@ class StockQuant(models.Model):
         :param unpack: set to True when needing to unpack the quant
         :param up_to_parent_packages: `stock.package` that are the upper limit to keep the parents
         """
-        def set_parent_package(package, limit_ids):
-            if not package.parent_package_id or not limit_ids or package.id in limit_ids:
+        def set_parent_package(all_quants, package, limit_ids):
+            if not package.parent_package_id or (limit_ids and package.id in limit_ids):
+                return
+            if any(quant not in all_quants for quant in package.parent_package_id.contained_quant_ids):
+                # Only move the container package as well if its whole content is moved as well
                 return
             package.package_dest_id = package.parent_package_id
-            return set_parent_package(package.parent_package_id, limit_ids)
+            return set_parent_package(all_quants, package.parent_package_id, limit_ids)
 
         message = message or _('Quantity Relocated')
         move_vals = []
@@ -1524,7 +1527,7 @@ class StockQuant(models.Model):
             result_package_id = package_dest_id  # temp variable to keep package_dest_id unchanged
             if not unpack and not package_dest_id:
                 result_package_id = quant.package_id
-                set_parent_package(result_package_id, limit_ids)
+                set_parent_package(self, result_package_id, limit_ids)
             move_vals.append(quant.with_context(inventory_name=message)._get_inventory_move_values(
                 quant.quantity,
                 quant.location_id,

--- a/addons/stock/static/src/views/list/stock_add_package_list_view.js
+++ b/addons/stock/static/src/views/list/stock_add_package_list_view.js
@@ -9,11 +9,11 @@ export class AddPackageListRenderer extends ListRenderer {
         this.orm = useService("orm");
         this.actionService = useService("action");
         this.pickingId = this.props.list.context.picking_id || 0;
+        this.canAddEntirePacks = this.props.list.context?.can_add_entire_packs;
     }
 
     get displayRowCreates() {
-        // As this view is not a Many2Many, this would be false otherwise.
-        return true;
+        return this.canAddEntirePacks;
     }
 
     async add(params) {

--- a/addons/stock/static/src/views/picking_form/stock_move_product_label.xml
+++ b/addons/stock/static/src/views/picking_form/stock_move_product_label.xml
@@ -24,4 +24,10 @@
             t-ref="labelNodeRef"
         />
     </t>
+
+    <t t-name="stock.AddPackageListRendererRows" t-inherit="web.ListRenderer.Rows" t-inherit-mode="primary">
+        <td class="o_field_x2many_list_row_add" position="inside">
+            <a t-if="canAddPackage" href="#" class="px-3" tabindex="0" t-on-click.stop.prevent="() => this.onClickMovePackage()">Move a Pack</a>
+        </td>
+    </t>
 </templates>

--- a/addons/stock/static/src/widgets/stock_package_m2o.xml
+++ b/addons/stock/static/src/widgets/stock_package_m2o.xml
@@ -1,16 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates>
 
-    <t t-name="stock.PackageMany2One" t-inherit="web.Many2One">
-        <t t-if="props.value" position="replace">
-            <t t-if="props.value">
-                <span t-esc="displayName"/>
-            </t>
-        </t>
-    </t>
-
     <t t-name="stock.StockPackageMany2One">
-        <Many2One t-props="m2oProps"/>
+        <t t-if="!isEditing" t-out="displayValue.display_name"/>
+        <Many2One t-else="" t-props="m2oProps"/>
     </t>
 
 </templates>

--- a/addons/stock/static/src/widgets/stock_pick_from.js
+++ b/addons/stock/static/src/widgets/stock_pick_from.js
@@ -25,7 +25,11 @@ export class StockPickFrom extends Component {
             name_parts.push(data.lot_id?.display_name || data.lot_name)
         }
         if (data.package_id) {
-            name_parts.push(data.package_id?.display_name)
+            let packageName = data.package_id?.display_name;
+            if (packageName && ["done", "cancel"].includes(data.state)) {
+                packageName = packageName.split(" > ").pop();
+            }
+            name_parts.push(packageName);
         }
         if (data.owner) {
             name_parts.push(data.owner?.display_name)
@@ -44,5 +48,6 @@ registry.category("fields").add("pick_from", {
         { name: "location_dest_id", type: "relation" },
         { name: "package_id", type: "relation" },
         { name: "owner_id", type: "relation" },
+        { name: "state", type: "char" },
     ],
 });

--- a/addons/stock/tests/test_packing.py
+++ b/addons/stock/tests/test_packing.py
@@ -107,7 +107,7 @@ class TestPacking(TestPackingCommon):
             'location_dest_id': self.stock_location.id,
             'state': 'draft',
         })
-        picking.action_add_entire_packs(pack)
+        picking.action_add_entire_packs(pack.id)
         picking.action_confirm()
         self.assertEqual(len(picking.move_ids), 1,
                          'One move should be created when the package has been added')
@@ -154,12 +154,12 @@ class TestPacking(TestPackingCommon):
             'location_dest_id': self.stock_location.id,
             'state': 'draft',
         })
-        picking.action_add_entire_packs(pack)
+        picking.action_add_entire_packs(pack.id)
         self.assertEqual(len(picking.move_line_ids), 1)
         self.assertEqual(picking.move_line_ids.location_id, shelf1_location)
         self.assertEqual(pack.location_id, shelf1_location)
 
-        picking.action_add_entire_packs(pack)
+        picking.action_add_entire_packs(pack.id)
         self.assertEqual(len(picking.move_line_ids), 1)
         self.assertEqual(picking.move_line_ids.location_id, shelf1_location)
         self.assertEqual(pack.location_id, shelf1_location)
@@ -441,7 +441,7 @@ class TestPacking(TestPackingCommon):
             'state': 'draft',
             'picking_type_id':  self.warehouse.store_type_id.id,
             })
-        picking.action_add_entire_packs(receipt_package)
+        picking.action_add_entire_packs(receipt_package.id)
         internal_transfer = picking
 
         # Checks the package fields have been correctly set.
@@ -563,7 +563,7 @@ class TestPacking(TestPackingCommon):
             'state': 'draft',
             'picking_type_id':  self.warehouse.store_type_id.id,
             })
-        picking.action_add_entire_packs(package)
+        picking.action_add_entire_packs(package.id)
         internal_transfer = picking
 
         # Checks the package fields have been correctly set.
@@ -738,7 +738,7 @@ class TestPacking(TestPackingCommon):
                 move.product_uom_qty = 75
         picking.action_confirm()
         picking.action_assign()
-        picking.action_add_entire_packs(package)
+        picking.action_add_entire_packs(package.id)
         self.assertEqual(len(picking.move_ids), 1, 'Should have only 1 stock move')
         self.assertEqual(len(picking.move_line_ids), 1, 'Should have only 1 stock move line')
         action = picking.button_validate()
@@ -868,7 +868,7 @@ class TestPacking(TestPackingCommon):
             'location_dest_id': shelf2_location.id,
             'state': 'draft',
         })
-        picking.action_add_entire_packs(pack)
+        picking.action_add_entire_packs(pack.id)
         self.assertEqual(picking.move_line_ids.location_id, shelf1_location)
 
         picking.button_validate()
@@ -1640,7 +1640,7 @@ class TestPacking(TestPackingCommon):
         delivery.action_confirm()
         self.assertEqual(delivery.move_line_ids.package_id, pack1 | pack2, 'The two first packages should be picked')
         delivery.move_line_ids[-1].unlink()
-        delivery.action_add_entire_packs(pack3)
+        delivery.action_add_entire_packs(pack3.id)
 
         self.assertRecordValues(delivery.move_line_ids.sorted('id'), [
             {'package_id': pack1.id, 'state': 'assigned'},
@@ -1889,7 +1889,7 @@ class TestPackagePropagation(TestPackingCommon):
             'location_dest_id': self.customer_location.id,
         })
 
-        delivery.action_add_entire_packs(pack)
+        delivery.action_add_entire_packs(pack.id)
         self.assertEqual(delivery.move_line_ids.result_package_id, pack)
         self.assertTrue(delivery.move_line_ids.is_entire_pack)
         self.assertFalse(pack.package_dest_id)
@@ -1897,7 +1897,7 @@ class TestPackagePropagation(TestPackingCommon):
         pack.with_context(picking_id=delivery.id).action_remove_package()
         self.assertFalse(pack.move_line_ids)
 
-        delivery.action_add_entire_packs(container)
+        delivery.action_add_entire_packs(container.id)
         self.assertEqual(delivery.move_line_ids.result_package_id, pack)
         self.assertTrue(delivery.move_line_ids.is_entire_pack)
         self.assertEqual(pack.package_dest_id, container)
@@ -1919,7 +1919,7 @@ class TestPackagePropagation(TestPackingCommon):
             'location_dest_id': self.customer_location.id,
         })
 
-        delivery.action_add_entire_packs(pack1 | pack2)
+        delivery.action_add_entire_packs((pack1 | pack2).ids)
         self.assertEqual(delivery.move_line_ids.mapped('is_entire_pack'), [True, True, True])
 
         # Remove some quantity from one move line. The package should not be considered as 'entire' for both move lines.

--- a/addons/stock/tests/test_quant.py
+++ b/addons/stock/tests/test_quant.py
@@ -1637,7 +1637,7 @@ class TestStockQuantRemovalStrategy(TestStockCommon):
         delivery.action_confirm()
         # Make an internal transfer to move Pack 001 in a sublocation
         self.picking_type_int.show_entire_packs = True
-        internal_transfer.action_add_entire_packs(packages[0])
+        internal_transfer.action_add_entire_packs(packages[0].id)
         internal_transfer.action_confirm()
         internal_transfer.button_validate()
         quants = self.env['stock.quant'].search([('product_id', 'in', products.ids)])

--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -174,7 +174,7 @@
                     <field name="product_id" column_invisible="True"/>
                     <field name="location_id" column_invisible="True"/>
                     <field name="location_dest_id" column_invisible="True"/>
-                    <field name="package_id" column_invisible="True"/>
+                    <field name="package_id" column_invisible="True" context="{'show_src_package': 1}"/>
                     <field name="result_package_id" column_invisible="True"/>
                     <field name="tracking" column_invisible="True"/>
                     <field name="picking_type_id" column_invisible="True"/>
@@ -230,6 +230,7 @@
                     <field name="picking_location_dest_id" column_invisible="True"/>
                     <field name="location_id" column_invisible="True"/>
                     <field name="location_dest_id" column_invisible="True"/>
+                    <field name="package_id" column_invisible="True" context="{'show_src_package': 1}"/>
                     <field name="quant_id" column_invisible="context.get('picking_code') == 'incoming'"
                         domain="[('product_id', '=', product_id), ('location_id', 'child_of', picking_location_id)]"
                         context="{'default_location_id': location_id, 'default_product_id': product_id, 'search_view_ref': 'stock.quant_search_view', 'list_view_ref': 'stock.view_stock_quant_tree_simple', 'form_view_ref': 'stock.view_stock_quant_form', 'readonly_form': False}"
@@ -239,7 +240,6 @@
                     <field name="lot_id" column_invisible="context.get('picking_code') != 'incoming' or context.get('show_lots_text')" groups="stock.group_production_lot" invisible="not lots_visible" readonly="state in ('done', 'cancel') and is_locked" context="{'default_product_id': product_id, 'active_picking_id': picking_id}" optional="show"/>
                     <field name="lot_name" column_invisible="context.get('picking_code') != 'incoming' or not context.get('show_lots_text')"  groups="stock.group_production_lot" invisible="not lots_visible" readonly="state in ('done', 'cancel') and is_locked" context="{'default_product_id': product_id}"/>
                     <field name="location_dest_id" options="{'no_create': True}" column_invisible="context.get('picking_code') == 'outgoing'" readonly="state in ('done', 'cancel') and is_locked" groups="stock.group_stock_multi_locations" domain="[('id', 'child_of', picking_location_dest_id), '|', ('company_id', '=', False), ('company_id', '=', company_id), ('usage', '!=', 'view')]"/>
-                    <field name="package_id" readonly="state in ('done', 'cancel') and is_locked" column_invisible="True"/>
                     <field name="result_package_id" readonly="state in ('done', 'cancel') and is_locked" widget="package_m2o" context="{'show_dest_package': 1}" groups="stock.group_tracking_lot"/>
                     <field name="lots_visible" column_invisible="True"/>
                     <field name="owner_id" groups="stock.group_tracking_owner" column_invisible="context.get('picking_code') == 'incoming'" readonly="state in ('done', 'cancel') and is_locked" />

--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -175,7 +175,7 @@
                     <field name="location_id" column_invisible="True"/>
                     <field name="location_dest_id" column_invisible="True"/>
                     <field name="package_id" column_invisible="True" context="{'show_src_package': 1}"/>
-                    <field name="result_package_id" column_invisible="True"/>
+                    <field name="result_package_id" column_invisible="True" context="{'show_dest_package': 1}"/>
                     <field name="tracking" column_invisible="True"/>
                     <field name="picking_type_id" column_invisible="True"/>
                     <field name="quant_id"

--- a/addons/stock/views/stock_package_views.xml
+++ b/addons/stock/views/stock_package_views.xml
@@ -96,7 +96,7 @@
         <field name="name">stock.package.list.editable</field>
         <field name="model">stock.package</field>
         <field name="arch" type="xml">
-            <list editable="bottom" js_class="stock_add_package_list_view" open_form_view="1">
+            <list create="0" editable="bottom" js_class="stock_add_package_list_view" open_form_view="1">
                 <header>
                     <button class="btn-primary" name="action_put_in_pack" type="object" string="Put in Pack"/>
                     <button class="btn-secondary" name="action_remove_package" type="object" string="Remove"/>
@@ -117,11 +117,8 @@
         <field name="model">stock.package</field>
         <field name="arch" type="xml">
             <list create="0">
-                <header>
-                    <button name="action_add_to_picking" type="object" class="btn-primary" string="Select"/>
-                </header>
                 <field name="name" string="Package"/>
-                <field name="parent_package_id" string="Container"/>
+                <field name="parent_package_id" string="Container" context="{'show_src_package': 1}" widget="package_m2o"/>
                 <field name="package_type_id" string="Type" optional="hide"/>
                 <field name="location_id" groups="stock.group_stock_multi_locations"/>
                 <field name="content_description" width="500px"/>

--- a/addons/stock/views/stock_package_views.xml
+++ b/addons/stock/views/stock_package_views.xml
@@ -120,7 +120,8 @@
                 <header>
                     <button name="action_add_to_picking" type="object" class="btn-primary" string="Select"/>
                 </header>
-                <field name="display_name" string="Package"/>
+                <field name="name" string="Package"/>
+                <field name="parent_package_id" string="Container"/>
                 <field name="package_type_id" string="Type" optional="hide"/>
                 <field name="location_id" groups="stock.group_stock_multi_locations"/>
                 <field name="content_description" width="500px"/>

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -269,7 +269,7 @@
                                 <list decoration-muted="scrap_id or state == 'cancel' or (state == 'done' and is_locked == True)" string="Stock Moves" editable="bottom">
                                     <control>
                                         <create string="Add a Product"/>
-                                        <button name="action_add_packages" context="{'picking_id': parent.id, 'show_src_package': 1}" string="Move a Pack" type="object" class="px-4 btn-link" groups="stock.group_tracking_lot"/>
+                                        <button name="action_add_packages" context="{'picking_id': parent.id, 'show_src_package': 1}" string="Move a Pack" type="object" invisible="parent.picking_type_code == 'incoming'" class="px-4 btn-link" groups="stock.group_tracking_lot"/>
                                     </control>
                                     <field name="company_id" column_invisible="True"/>
                                     <field name="state" readonly="0" column_invisible="True"/>

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -265,11 +265,10 @@
                             <field name="move_ids" mode="list,kanban"
                                 widget="stock_move_one2many"
                                 readonly="state == 'done' and is_locked"
-                                context="{'default_company_id': company_id, 'default_date': scheduled_date, 'default_date_deadline': date_deadline, 'picking_type_code': picking_type_code, 'default_picking_id': id, 'form_view_ref': 'stock.view_stock_move_operations', 'address_in_id': partner_id, 'default_picking_type_id': picking_type_id, 'default_location_id': location_id, 'default_location_dest_id': location_dest_id, 'default_partner_id': partner_id}">
+                                context="{'default_company_id': company_id, 'default_date': scheduled_date, 'default_date_deadline': date_deadline, 'picking_type_code': picking_type_code, 'default_picking_id': id, 'form_view_ref': 'stock.view_stock_move_operations', 'address_in_id': partner_id, 'default_picking_type_id': picking_type_id, 'default_location_id': location_id, 'default_location_dest_id': location_dest_id, 'default_partner_id': partner_id, 'picking_state': state}">
                                 <list decoration-muted="scrap_id or state == 'cancel' or (state == 'done' and is_locked == True)" string="Stock Moves" editable="bottom">
                                     <control>
                                         <create string="Add a Product"/>
-                                        <button name="action_add_packages" context="{'picking_id': parent.id, 'show_src_package': 1}" string="Move a Pack" type="object" invisible="parent.picking_type_code == 'incoming'" class="px-4 btn-link" groups="stock.group_tracking_lot"/>
                                     </control>
                                     <field name="company_id" column_invisible="True"/>
                                     <field name="state" readonly="0" column_invisible="True"/>

--- a/addons/stock_picking_batch/models/stock_picking_batch.py
+++ b/addons/stock_picking_batch/models/stock_picking_batch.py
@@ -388,6 +388,7 @@ class StockPickingBatch(models.Model):
             'domain': [('picking_ids', 'in', self.picking_ids.ids)],
             'context': {
                 'picking_id': self.picking_ids[:1].id,
+                'location_id': self.picking_ids[:1].location_id.id,
                 'can_add_entire_packs': self.picking_type_code != 'incoming',
                 'search_default_main_packages': True,
             },

--- a/addons/stock_picking_batch/models/stock_picking_batch.py
+++ b/addons/stock_picking_batch/models/stock_picking_batch.py
@@ -388,6 +388,7 @@ class StockPickingBatch(models.Model):
             'domain': [('picking_ids', 'in', self.picking_ids.ids)],
             'context': {
                 'picking_id': self.picking_ids[:1].id,
+                'can_add_entire_packs': self.picking_type_code != 'incoming',
                 'search_default_main_packages': True,
             },
         }


### PR DESCRIPTION
Various fixes following the pack in pack introduced in #203987

Summary of the changes:
- Allow the deletion of a container package even if it was used in a picking, as long as it was only ever used as a container (so it has no `stock.move.line` related to it).
- A bunch of visual changes.
- Display the full current package name for ongoing pickings in the `Pick From` column.
- When relocating packages, if their container are completely moved as well, move the container as well instead of removing them from it.
- Adjust the `package_m2o` widget so it is less costly
- Use `SelectCreateDialog` for the 'Move a Pack' button.
- Fixes an issue where adding a new package on top of packages and their destination container at the same time would leave some unnecessary data behind.
For more information, check the commit descriptions.

Task-5065793

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
