### PR TITLE
[FIX] payment_stripe: pass the website language to Stripe's API

### DIFF
--- a/addons/payment_stripe/static/src/js/stripe_options.js
+++ b/addons/payment_stripe/static/src/js/stripe_options.js
@@ -10,8 +10,10 @@ export class StripeOptions {
      * @return {object}
      */
     _prepareStripeOptions(processingValues) {
+        const locale = document.documentElement.lang;
         return {
             'apiVersion': '2019-05-16',  // The API version of Stripe implemented in this module.
+            ...(locale ? { locale } : {}),  // Default to browser locale if not set.
         };
     };
 }


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Enable Stripe;
2. enable a second language on the website;
3. use second language on website;
3. go to checkout;
4. open card payment method.

Issue
-----
The card field values are displayed using the current browser's locale instead of the website's language.

Cause
-----
The `locale` parameter isn't included when connecting to the Stripe API.

Solution
--------
Include the lang from the `html` element via `_prepareStripeOptions`. If not present, let it fall back on the browser's locale.

opw-5024805