### PR TITLE
[FIX] crm: compute lead duplicates as superuser

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -236,8 +236,10 @@ class CrmLead(models.Model):
         index=True, ondelete='restrict', tracking=71)
     # Statistics
     calendar_event_ids = fields.One2many('calendar.event', 'opportunity_id', string='Meetings')
-    duplicate_lead_ids = fields.Many2many("crm.lead", compute="_compute_potential_lead_duplicates", string="Potential Duplicate Lead", context={"active_test": False})
-    duplicate_lead_count = fields.Integer(compute="_compute_potential_lead_duplicates", string="Potential Duplicate Lead Count")
+    duplicate_lead_ids = fields.Many2many("crm.lead", compute="_compute_potential_lead_duplicates", string="Potential Duplicate Lead",
+        context={"active_test": False}, compute_sudo=True)
+    duplicate_lead_count = fields.Integer(compute="_compute_potential_lead_duplicates", string="Potential Duplicate Lead Count",
+        compute_sudo=True)
     meeting_display_date = fields.Date(compute="_compute_meeting_display")
     meeting_display_label = fields.Char(compute="_compute_meeting_display")
     # UX
@@ -641,7 +643,7 @@ class CrmLead(models.Model):
             records. Idea is that counter indicates duplicates are present and
             the lead could be escalated to managers.
             """
-            model = self.env[model_name].sudo().with_context(active_test=False)
+            model = self.env[model_name].with_context(active_test=False)
             res = model.search(domain, limit=SEARCH_RESULT_LIMIT)
             return res if len(res) < SEARCH_RESULT_LIMIT else model
 


### PR DESCRIPTION
Previously, leads belonging to a salesman with duplicates that
were inaccessible to that salesman could not be accessed,
instead return a traceback.

Steps to reproduce:
- Create a fresh database with the CRM module and demo data
- Login as Marc Demo
- Try to access the "DeltaPC: 10 Computer Desks" lead
- A traceback is returned due to lack of access on leads
  belonging to Mitchell Admin

Fix:
The "duplicate_lead_ids" and "duplicate_lead_count" CRM fields
are computed as superuser, allowing for errorless computing even if
the user does not have access to all similar leads.

task-5072901