### PR TITLE
[FIX] html_builder, html_editor: enable image options on duplicated team snippet

### DIFF
--- a/addons/html_editor/static/src/core/content_editable_plugin.js
+++ b/addons/html_editor/static/src/core/content_editable_plugin.js
@@ -16,7 +16,6 @@ export class ContentEditablePlugin extends Plugin {
     resources = {
         normalize_handlers: withSequence(5, this.normalize.bind(this)),
         clean_for_save_handlers: withSequence(Infinity, this.cleanForSave.bind(this)),
-        system_classes: ["o_editable_media"],
     };
 
     normalize(root) {


### PR DESCRIPTION
[FIX] html_builder, *: enable image options on duplicated team snippet
*: html_editor

Steps to reproduce the problem:
- Drop the "Team Basic" snippet.
- Duplicate it.

-> When you click on an image of the duplicated block, the image is not
selected and you can not change the options related to it.

The problem is that the `o_editable_media` class does not appear on the
images of the duplicated snippet as it is a system class. This commit
removes the `o_editable_media` class from the system classes. Indeed, it
was added by [1] to avoid the closest savable to be marked as dirty when
this class was added. However, this class is added during the
`normalize` and since [2], the mutations done at the `normalize` do not
trigger the adding of the `o_dirty` class anymore.

[1]: https://github.com/odoo/odoo/commit/c20dfb73528d60a079d73564504646fe7d1d4272
[2]: https://github.com/odoo/odoo/commit/7c5cdb6d70eea29dec4ba126e62eeb93c6e6eeb2

Related to task-4367641
