### PR TITLE
[FIX] sale: traceback on subsection options and combo product PDF + test cleanup

### DIFF
--- a/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.js
+++ b/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.js
@@ -17,7 +17,7 @@ const DISPLAY_TYPES = {
     SUBSECTION: "line_subsection",
 };
 
-function getParentSectionRecord(list, record) {
+export function getParentSectionRecord(list, record) {
     const { sectionIndex } = getRecordsUntilSection(list, record, false, record.data.display_type !== DISPLAY_TYPES.SUBSECTION);
     return list.records[sectionIndex];
 }

--- a/addons/sale/report/ir_actions_report_templates.xml
+++ b/addons/sale/report/ir_actions_report_templates.xml
@@ -187,9 +187,11 @@
                                     t-att-class="padding_class"
                                 >
                                     <span t-field="line.name">Combo Product</span>
+                                    x <span t-field="line.product_uom_qty" t-options="{'widget': 'integer'}"/>
                                 </td>
                                 <td name="td_combo_price" class="text-end o_price_total">
                                     <span
+                                        t-if="not collapse_prices"
                                         name="price_subtotal_combo"
                                         t-out="line._get_combo_totals(price_field)"
                                         class="text-nowrap"

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -839,7 +839,7 @@
                                             name="td_combo_taxes"
                                             t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}"
                                         />
-                                        <td t-if="not line.is_downpayment" name="td_combo_subtotal" class="text-end">
+                                        <td name="td_combo_subtotal" class="text-end">
                                             <span
                                                 t-if="not collapse_prices"
                                                 name="price_subtotal_combo"

--- a/addons/sale_management/tests/common.py
+++ b/addons/sale_management/tests/common.py
@@ -20,12 +20,5 @@ class SaleManagementCommon(SaleCommon):
     def _get_optional_product_lines(order):
         """Returns the order lines that are optional products. """
         return order.order_line.filtered(
-            lambda line: not line.display_type
-            and (
-                line.parent_id.is_optional
-                or (
-                    line.parent_id.display_type == 'line_subsection'
-                    and line.parent_id.parent_id.is_optional
-                )
-            ),
+            lambda line: not line.display_type and line._is_line_optional(),
         )


### PR DESCRIPTION
### **Description:**
- This PR addresses two functional issues in the Sale module and a minor cleanup in `sale_management` tests.

### **Fixes:**
- **Traceback on subsection options:**
   - Opening options for subsections in Sale Orders raised a traceback due to a missing export introduced during refactor 5f4db1d.
   - Fixed by restoring the missing export.
- **PDF report for combo products:**
   - Combo product prices were shown in PDF quotes despite "hide prices" being enabled.
   - Quantities of combo products were also missing in the PDF.
   - Fixed by adding the missing condition for hidden prices and showing the quantity (e.g., Office combo x 5).

**Cleanup:**
- Removed redundant logic in the optional products test method in `sale_management`.

task-4999851

See Also:
- https://github.com/odoo/enterprise/pull/94276

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
