### PR TITLE
[FIX] website_sale: limit GMC warning frequency and clean up TODOs

### DIFF
--- a/addons/website_sale/controllers/product_feed.py
+++ b/addons/website_sale/controllers/product_feed.py
@@ -41,19 +41,7 @@ class ProductFeed(Controller):
         feed_sudo = self._find_and_check_feed_access(feed_id, access_token)
 
         if feed_sudo.website_id != request.website:
-            feed_sudo._notify_website_manager(
-                subject=request.env._("GMC: Domain Mismatch"),
-                body=request.env._(
-                    "The feed '%(feed_name)s' is configured for '%(feed_website)s', but was"
-                    " accessed from '%(request_website)s'. This may be due to a recent"
-                    " configuration change. Please ensure the URL is updated in Google Merchant"
-                    " Center as well.",
-                    feed_name=feed_sudo.display_name,
-                    request_website=request.website.display_name,
-                    feed_website=feed_sudo.website_id.display_name,
-                ),
-            )
-            raise BadRequest()
+            raise BadRequest("Website does not match.")
 
         compressed_gmc_xml = feed_sudo._render_and_cache_compressed_gmc_feed()
 

--- a/addons/website_sale/models/res_config_settings.py
+++ b/addons/website_sale/models/res_config_settings.py
@@ -168,7 +168,6 @@ class ResConfigSettings(models.TransientModel):
             'target': 'new',
             'context': {
                 'default_website_id': self.website_id.id,
-                'default_lang_id': self.website_id.default_lang_id.id,
                 'hide_website_column': True,
             },
             'domain': [('website_id', '=', self.website_id.id)],

--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -1055,5 +1055,4 @@ class Website(models.Model):
             website.env['product.feed'].create({
                 'name': website.env._("GMC 1"),
                 'website_id': website.id,
-                'lang_id': website.default_lang_id.id,
             })

--- a/addons/website_sale/tests/common_gmc.py
+++ b/addons/website_sale/tests/common_gmc.py
@@ -20,7 +20,6 @@ class WebsiteSaleGMCCommon(ProductVariantsCommon, WebsiteSaleCommon):
         cls.gmc_feed = cls.env['product.feed'].create({
             'name': "GMC",
             'website_id': cls.website.id,
-            'lang_id': cls.website.default_lang_id.id,
         })
 
         # Prepare products


### PR DESCRIPTION
This commit addresses an issue where the website manager could be overwhelmed by excessive GMC feed warnings when too many products are included in the feed.

Previously, a warning message was sent to the product manager every time the feed was rendered (at most once a day) if the number of products exceeded a certain limit, potentially leading to spam.

With this fix, the warning message will now be sent at most once a week.

Additionally, leftover TODO comments from a rushed merge have been removed.
