### PR TITLE
[FIX] project_{sale, hr}_expense: apply analytic distribution on expe…

### DIFF
--- a/addons/project_hr_expense/models/project_project.py
+++ b/addons/project_hr_expense/models/project_project.py
@@ -98,14 +98,16 @@ class Project(models.Model):
             return {}
         can_see_expense = with_action and self.user_has_groups('hr_expense.group_hr_expense_team_approver')
         query = self.env['hr.expense']._search([('state', 'in', ['approved', 'done'])])
-        query.add_where(
-            SQL(
-                "%s && %s",
-                [str(self.analytic_account_id.id)],
-                self.env['hr.expense']._query_analytic_accounts(),
-            )
+        query.add_join('JOIN', 'json_data', SQL('JSONB_EACH(hr_expense.analytic_distribution)'), SQL('true'))
+        query.add_where(SQL(
+            "%s && regexp_split_to_array(json_data.key,'\\D+')",
+            [str(self.analytic_account_id.id)],
+        ))
+        query_string, query_param = query.select(
+            'currency_id',
+            'array_agg(id) as ids',
+            SQL("SUM(untaxed_amount_currency * json_data.value::int / 100) as untaxed_amount_currency"),
         )
-        query_string, query_param = query.select('currency_id', 'array_agg(id) as ids', 'SUM(untaxed_amount_currency) as untaxed_amount')
         query_string = f"{query_string} GROUP BY currency_id"
         self._cr.execute(query_string, query_param)
         expenses_read_group = [expense for expense in self._cr.dictfetchall()]


### PR DESCRIPTION
…nse profitability

#### Issue:
While looking at project profitability, expenses analytic distribution are treated as being set to 100%.

#### Step to reproduce:
- With modules: project_{hr, sale}_expense, accountant
- enable "Analytic accounting"
- enable project > Timesheet
- Create a project "A"
- Set it as billable
- Create a Meal expense for an amount of 115$
- Set an analytic account of 50% for the project "A"
- Validate
- Approve
- Post journal entries
- Go to the project "A" > settings > Set Status

#### Current behavior:
- profitability display '-100'. It took the whole expense.

#### Expected behavior:
- profitability should display '-50'. Only 50% of the untaxed amount.

#### Cause of the issue:
- While querying `hr_expense`, the full untaxed amount of all expenses having the right `analytic_account` in their `analytic_distribution` were added together with no regard to the percent they were set to.

#### Solution:
- weight the expenses depending of their analytical distribution

opw-4949634

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
