### PR TITLE
[FIX] html_builder: review darkmode colors on add snippet dialog

### DIFF
--- a/addons/html_builder/static/src/snippets/add_snippet_dialog.dark.scss
+++ b/addons/html_builder/static/src/snippets/add_snippet_dialog.dark.scss
@@ -1,0 +1,7 @@
+// = Add Snippet Dialog
+// ============================================================================
+// No CSS hacks, variables overrides only
+
+.o_add_snippet_dialog {
+    --SearchBar-bg-color: #{$o-gray-100};
+}

--- a/addons/html_builder/static/src/snippets/add_snippet_dialog.scss
+++ b/addons/html_builder/static/src/snippets/add_snippet_dialog.scss
@@ -27,15 +27,17 @@
 
         .list-group {
             --list-group-border-radius: 0;
+            --list-group-active-bg: #{$o-brand-primary};
+            --list-group-active-border-color: #{$o-brand-primary};
+            --list-group-active-color: #{color-contrast($o-brand-primary)};
 
             min-width: 200px;
             max-width: 250px;
-
-            button.active {
-                background-color: $o-brand-primary;
-                border-color: $o-brand-primary;
-            }
         }
+    }
+
+    .o_add_snippet_dialog_search {
+        background-color: var(--SearchBar-bg-color, #{$o-white});
     }
 }
 .o_add_snippet_dialog_iframe_loader {

--- a/addons/html_builder/static/src/snippets/add_snippet_dialog.xml
+++ b/addons/html_builder/static/src/snippets/add_snippet_dialog.xml
@@ -11,8 +11,8 @@
         <div class="overflow-hidden w-100">
             <div class="d-flex w-100 h-100 vertical flex-row">
                 <aside class="border-end overflow-auto">
-                    <div class="d-block position-relative p-2 bg-100 border-bottom">
-                        <input type="search" class="form-control bg-white pe-4" placeholder="Search for a block"
+                    <div class="d-block position-relative p-2 border-bottom">
+                        <input type="search" class="o_add_snippet_dialog_search form-control pe-4" placeholder="Search for a block"
                             aria-label="Search for a block" t-model="state.search"/>
                         <span class="input-group-text position-absolute top-50 end-0 translate-middle-y me-2 border-0 bg-transparent text-muted">
                             <i class="oi oi-search" aria-hidden="true"></i>
@@ -24,7 +24,7 @@
                          aria-label="Block Categories">
                         <t t-if="!state.search" t-foreach="snippetGroups" t-as="snippetGroup" t-key="snippetGroup.id">
                             <t t-set="isActive" t-value="state.groupSelected === snippetGroup.groupName"/>
-                            <button class="list-group-item list-group-item-light list-group-item-action p-3"
+                            <button class="list-group-item list-group-item-action p-3"
                                     role="tab"
                                     t-att-class="{ 'active': isActive }"
                                     t-att-id="'tab_' + snippetGroup.groupName"


### PR DESCRIPTION
The add snippet dialog is using custom colors on its `list-group` items which breaks the color-contrast when displayed in darkmode.

This commit removes `list-group-item-light` to rely on default list-group colors, and uses bootstrap CSS variables to handle the custom active background color and color.

Creates a `add_snippet_dialog.dark.scss` to handle the background of the searchbar.

task-5075140




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
