### PR TITLE
[PERF] core: break cycle in transaction dereferencing

### DIFF
--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -618,10 +618,10 @@ class IrModuleModule(models.Model):
         registry = modules.registry.Registry.new(self.env.cr.dbname, update_module=True)
         self.env.cr.commit()
         if request and request.registry is self.env.registry:
-            request.env.cr.reset()
+            request.env.transaction.reset()
             request.registry = request.env.registry
             assert request.env.registry is registry
-        self.env.cr.reset()
+        self.env.transaction.reset()
         assert self.env.registry is registry
 
         # pylint: disable=next-method-called

--- a/odoo/addons/base/wizard/base_module_upgrade.py
+++ b/odoo/addons/base/wizard/base_module_upgrade.py
@@ -64,7 +64,7 @@ class BaseModuleUpgrade(models.TransientModel):
         # terminate transaction before re-creating cursor below
         self.env.cr.commit()
         odoo.modules.registry.Registry.new(self.env.cr.dbname, update_module=True)
-        self.env.cr.reset()
+        self.env.transaction.reset()
 
         return {'type': 'ir.actions.act_window_close'}
 

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -1546,16 +1546,14 @@ class BaseModel(metaclass=MetaModel):
     def _add_missing_default_values(self, values: ValuesType) -> ValuesType:
         # avoid overriding inherited values when parent is set
         avoid_models = set()
-
-        def collect_models_to_avoid(model):
-            for parent_mname, parent_fname in model._inherits.items():
+        avoid_models_stack = [self]
+        while avoid_models_stack:
+            for parent_mname, parent_fname in avoid_models_stack.pop()._inherits.items():
                 if parent_fname in values:
                     avoid_models.add(parent_mname)
                 else:
                     # manage the case where an ancestor parent field is set
-                    collect_models_to_avoid(self.env[parent_mname])
-
-        collect_models_to_avoid(self)
+                    avoid_models_stack.append(self.env[parent_mname])
 
         def avoid(field):
             # check whether the field is inherited from one of avoid_models
@@ -4835,21 +4833,19 @@ class BaseModel(metaclass=MetaModel):
             self = self.with_context(__copy_data_seen=defaultdict(set))
 
         # build a black list of fields that should not be copied
-        blacklist = set(MAGIC_COLUMNS + ['parent_path'])
-        whitelist = set(name for name, field in self._fields.items() if not field.inherited)
+        blacklist = {*MAGIC_COLUMNS, 'parent_path'}
+        whitelist = {name for name, field in self._fields.items() if not field.inherited}
 
-        def blacklist_given_fields(model):
-            # blacklist the fields that are given by inheritance
-            for parent_model, parent_field in model._inherits.items():
+        blacklist_stack = [self]
+        while blacklist_stack:
+            for parent_model, parent_field in blacklist_stack.pop()._inherits.items():
                 blacklist.add(parent_field)
                 if parent_field in default:
                     # all the fields of 'parent_model' are given by the record:
                     # default[parent_field], except the ones redefined in self
                     blacklist.update(set(self.env[parent_model]._fields) - whitelist)
                 else:
-                    blacklist_given_fields(self.env[parent_model])
-
-        blacklist_given_fields(self)
+                    blacklist_stack.append(self.env[parent_model])
 
         fields_to_copy = {name: field
                           for name, field in self._fields.items()

--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -186,10 +186,11 @@ class BaseCursor(_CursorProtocol):
         self.precommit.clear()
 
     def reset(self) -> None:
-        """ Reset the current transaction (this invalidates more that clear()).
+        """ Reset the current transaction (this invalidates more than `clear()`).
             This method should be called only right after commit() or rollback().
         """
         if self.transaction is not None:
+            self.transaction.default_env = None  # break the cyclic reference
             self.transaction.reset()
 
     def execute(self, query, params=None, log_exceptions: bool = True) -> None:
@@ -534,6 +535,7 @@ class Cursor(BaseCursor):
 
         # Clean the underlying connection, and run rollback hooks.
         self.rollback()
+        self.reset()
 
         self._closed = True
 

--- a/odoo/tests/test_cursor.py
+++ b/odoo/tests/test_cursor.py
@@ -82,6 +82,7 @@ class TestCursor(BaseCursor):
         if not self._closed:
             try:
                 self.rollback()
+                self.reset()
                 if self._savepoint:
                     self._savepoint.close(rollback=False)
             finally:
@@ -91,6 +92,10 @@ class TestCursor(BaseCursor):
                 if tos is not self:
                     _logger.warning("Found different un-closed cursor when trying to close %s: %s", self, tos)
                 self._lock.release()
+
+    @property
+    def closed(self) -> bool:
+        return self._closed or self._cursor.closed
 
     def commit(self) -> None:
         """ Perform an SQL `COMMIT` """


### PR DESCRIPTION
Reset the transaction when closing the cursor and remove the default
environment. The transaction has references to environments which
reference the cursor that has a reference to the transaction. Breaking
the cycle is done by removing hard references from the transaction to
the environment.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
