### PR TITLE
[FIX] web: Technical tooltip line-height too large, reducing

### DIFF
--- a/addons/web/static/src/core/tooltip/tooltip.scss
+++ b/addons/web/static/src/core/tooltip/tooltip.scss
@@ -40,6 +40,7 @@
 
     .o-tooltip--technical {
         padding-left: 1.3em;
+        line-height: $o-line-height-sm;
         font-family: $o-font-family-monospace;
         font-size: $o-font-size-base-smaller;
         list-style-type: disc;


### PR DESCRIPTION
The technical info on the field have a too large popup. Some fields have so many options that the popup covers the field and start flashing, appearing and disappearing.
For the moment we are reducing the `line-height` a bit, which actually looks better, then we'll see how to handle this functionally and structurally.

<img width="1833" height="870" alt="image" src="https://github.com/user-attachments/assets/8030dfad-a055-4e9f-a6f0-a4140fdb0f91" />
