### PR TITLE
[FIX] web: refine ribbon position in modal forms with statusbar

### DIFF
--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -315,10 +315,12 @@
             position: sticky;
             top: 0;
             z-index: $zindex-sticky;
+            background-color: $body-bg;
+            box-shadow: 0 0.3rem 0.25rem -0.25rem rgba(0, 0, 0, 0.075);
 
-            &:not(.modal .o_form_statusbar) {
-                background-color: $body-bg;
-                box-shadow: 0 0.3rem 0.25rem -0.25rem rgba(0, 0, 0, 0.075);
+            .modal & {
+                background-color: $o-view-background-color;
+                box-shadow: none;
             }
         }
 

--- a/addons/web/static/src/views/widgets/ribbon/ribbon.scss
+++ b/addons/web/static/src/views/widgets/ribbon/ribbon.scss
@@ -64,6 +64,7 @@
     }
 }
 
-.modal .modal-dialog .o_form_sheet:has(> .o_widget_web_ribbon) {
+.modal .modal-dialog .o_form_sheet_bg:not(:has(> .o_form_statusbar))
+    > .o_form_sheet:has(> .o_widget_web_ribbon) {
     position: static !important;
 }


### PR DESCRIPTION
Previously, `position: static` was added on `.o_form_sheet` in modal 
forms to fix an issue where the ribbon looked ugly (not pinned to the 
top right) due to the absence of borders in modals. See commit: https://github.com/odoo/odoo/commit/1ac2ff5b7dd64ccfe1bfb9c3fb7bb8a758e887d7

However, when a statusbar is present, this rule caused the ribbon to 
merge into the statusbar, making its display worse.

In addition, on scrolling in a modal, the statusbar and
the form contents were getting merged.

This commit refines :
- the selector so that `position: static` is only
applied when a modal form has a ribbon but no statusbar. When a
statusbar exists, the ribbon remains visually separated from the
statusbar.
- the statusbar background-color logic so that inside modals
it uses the proper `$o-view-background-color`, ensuring a
clean separation even on scrolling.

task-4873636

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
