### PR TITLE
[FIX] hr_work_entry: No work entry type

### DIFF
--- a/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_calendar_controller.js
+++ b/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_calendar_controller.js
@@ -41,7 +41,7 @@ export class WorkEntryCalendarController extends CalendarController {
             );
             this.userFavoritesWorkEntries = await this.orm.read(
                 "hr.work.entry.type",
-                userFavoritesWorkEntriesIds.map((r) => r.work_entry_type_id[0]),
+                userFavoritesWorkEntriesIds.map((r) => r.work_entry_type_id?.[0]).filter(Boolean),
                 ["display_name", "display_code", "color"]
             );
             this.userFavoritesWorkEntries = this.userFavoritesWorkEntries.sort((a, b) =>


### PR DESCRIPTION
If the user creates a work entry without a work entry type, it will fetch "false" id work entry type. It raises a traceback
