### PR TITLE
[FIX] hr_attendance: allow attendance officers that are not hr office…

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -1336,7 +1336,7 @@ class HrEmployee(models.Model):
 
         date_from = fields.Date.to_date(date_from)
         for employee in self:
-            employee_versions_sudo = employee.version_ids.sudo().filtered(lambda v: v._is_in_contract(date_from))
+            employee_versions_sudo = employee.sudo().version_ids.filtered(lambda v: v._is_in_contract(date_from))
             if employee_versions_sudo:
                 res[employee.id] = employee_versions_sudo[0].resource_calendar_id.sudo(False)
         return res

--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -446,7 +446,7 @@ class HrAttendance(models.Model):
                 stop_dt = min(planned_end_dt, local_check_out)
                 work_duration += (stop_dt - start_dt).total_seconds() / 3600.0
                 # remove lunch time from work duration
-                if not employee.is_flexible:
+                if not employee.sudo().is_flexible:
                     lunch_intervals = employee._employee_attendance_intervals(start_dt, stop_dt, lunch=True)
                     work_duration -= sum((i[1] - i[0]).total_seconds() / 3600.0 for i in lunch_intervals)
 


### PR DESCRIPTION
…rs to create attendances

Because creating attendance records requires access to the `version_ids` field on the employee and subsequently `hr.version` records, which require `hr.group_hr_user` group on the user. This change runs said flow in sudo mode only if the user has `hr_attendance.group_hr_attendance_officer` or it's implying groups.

task-5071058

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
