### PR TITLE
[FIX] mrp_account: fix traceback when trying to post WIP entry

### DIFF
--- a/addons/mrp_account/wizard/mrp_wip_accounting.py
+++ b/addons/mrp_account/wizard/mrp_wip_accounting.py
@@ -71,10 +71,7 @@ class MrpAccountWipAccounting(models.TransientModel):
         if overhead_account:
             return overhead_account.id
         ProductCategory = self.env['product.category']
-        cop_acc = ProductCategory._fields['property_stock_account_production_cost_id'].get_company_dependent_fallback(ProductCategory)
-        if cop_acc:
-            return cop_acc.id
-        return ProductCategory._fields['property_stock_account_input_categ_id'].get_company_dependent_fallback(ProductCategory).id
+        return ProductCategory._fields['property_stock_account_production_cost_id'].get_company_dependent_fallback(ProductCategory).id
 
     def _get_line_vals(self, productions=False, date=False):
         if not productions:


### PR DESCRIPTION
Steps to reproduce:
* install MRP and Accounting
* open an MO
* go to actions -> "Post WIP Accounting Entry"

Odoo shows an error message, ending with:

```
KeyError: 'property_stock_account_input_categ_id'
```
This looks like a missing part of the "New Inventory valuation"
(commit https://github.com/odoo/odoo/commit/08b62a4bbcc6f9a391b2cc00a621ef4c76100229).

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
