### PR TITLE
[FIX] account: no_followup with empty lines fail

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2298,9 +2298,10 @@ class AccountMove(models.Model):
     def _compute_no_followup(self):
         for move in self:
             if move.is_invoice():
-                move.no_followup = move.line_ids.filtered(
+                lines = move.line_ids.filtered(
                     lambda line: line.account_type in ('asset_receivable', 'liability_payable'),
-                )[0].no_followup
+                )
+                move.no_followup = lines[0].no_followup if lines else True
             else:
                 move.no_followup = True
 


### PR DESCRIPTION
As soon as you try to get the no_followup status on an invoice without lines, you will get the traceback.

To reproduce:
Create an invoice without invoice lines.
Go on Documents
Select a document
Click on info & tags at the top right
On the right, No linked model, select Journal Entry

=> Traceback

no-task



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
