### PR TITLE
[FIX] mrp*: do not assign component moves without operation to last WO

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1538,11 +1538,6 @@ class MrpProduction(models.Model):
                 move.write({
                     'workorder_id': workorder_per_operation[move.operation_id].id if move.operation_id in workorder_per_operation else False
                 })
-            else:
-                bom = move.bom_line_id.bom_id if (move.bom_line_id and move.bom_line_id.bom_id in workorder_boms) else self.bom_id
-                move.write({
-                    'workorder_id': last_workorder_per_bom[bom].id
-                })
 
     def action_assign(self):
         for production in self:

--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -1793,6 +1793,7 @@ class TestBoM(TestMrpCommon):
             ],
         })
         bom.bom_line_ids[0].operation_id = bom.operation_ids[0].id
+        bom.bom_line_ids[1].operation_id = bom.operation_ids[1].id
         # Creates a MO and confirms it.
         mo_form = Form(self.env['mrp.production'])
         mo_form.bom_id = bom
@@ -1800,7 +1801,7 @@ class TestBoM(TestMrpCommon):
         mo_1.action_confirm()
         self.assertRecordValues(mo_1.move_raw_ids, [
             {'operation_id': bom.operation_ids[0].id, 'workorder_id': mo_1.workorder_ids[0].id},
-            {'operation_id': False, 'workorder_id': mo_1.workorder_ids[1].id},
+            {'operation_id': bom.operation_ids[1].id, 'workorder_id': mo_1.workorder_ids[1].id},
         ])
 
         # Adds a new operation and links BoM's lines to other operations.
@@ -1834,8 +1835,8 @@ class TestBoM(TestMrpCommon):
         mo_1.action_update_bom()
         self.assertEqual(mo_1.is_outdated_bom, False)
         self.assertRecordValues(mo_1.move_raw_ids, [
-            {'operation_id': False, 'workorder_id': mo_1.workorder_ids[2].id},
-            {'operation_id': False, 'workorder_id': mo_1.workorder_ids[2].id},
+            {'operation_id': False, 'workorder_id': False},
+            {'operation_id': False, 'workorder_id': False},
         ])
 
     def test_bom_updates_mo_with_pre_prod_picking(self):

--- a/addons/mrp_account/tests/test_mrp_account.py
+++ b/addons/mrp_account/tests/test_mrp_account.py
@@ -710,6 +710,7 @@ class TestMrpAccountMove(TestAccountMoveStockCommon):
             'time_cycle': 5,
             'sequence': 1,
         })]
+        self.bom.bom_line_ids.operation_id = self.bom.operation_ids
         production = self.env['mrp.production'].create({
             'bom_id': self.bom.id,
             'product_qty': 1,
@@ -733,8 +734,8 @@ class TestMrpAccountMove(TestAccountMoveStockCommon):
             {'name': production.name + ' - Labour', 'debit': 20.0, 'credit': 0.0},
             {'name': production.name + ' - ' + self.product_A.name, 'debit': 0.0, 'credit': 10.0},
             {'name': production.name + ' - ' + self.product_A.name, 'debit': 10.0, 'credit': 0.0},
-            {'name': production.name + ' - ' + self.product_B.name, 'debit': 0.0, 'credit': 10.0},
-            {'name': production.name + ' - ' + self.product_B.name, 'debit': 10.0, 'credit': 0.0},
+            {'name': production.name + ' - ' + self.product_B.name, 'debit': 0.0, 'credit': 20.0},
+            {'name': production.name + ' - ' + self.product_B.name, 'debit': 20.0, 'credit': 0.0},
         ])
 
     def test_labor_cost_balancing_with_cost_share(self):

--- a/addons/project_mrp_account/tests/test_analytic_account.py
+++ b/addons/project_mrp_account/tests/test_analytic_account.py
@@ -476,6 +476,7 @@ class TestAnalyticAccount(TestMrpAnalyticAccount):
         mo_form.bom_id = self.bom
         mo_form.product_qty = 1
         mo_form.project_id = self.project
+        self.bom.bom_line_ids.operation_id = self.bom.operation_ids
         mo = mo_form.save()
         mo.action_confirm()
         mo.workorder_ids.button_finish()


### PR DESCRIPTION
*: mrp_account, project_mrp_account

### Steps to reproduce:

- In the setting enable: "Work Orders"
- Create a bill of material for a final prodcut (FP):
  - 2 operations: op1, op2
  - Raw moves: - 1 x COMP1 consumed in op1 - 1 x COMP2 bot consumed in any operation
- Put 10 units of COMP1 and COMP2 in stock
- Create and confirm an MO for FP

### Issue:

Opening the details of the second operation one realizes that the COMP2 component move has been associated with op2. This is somewhat inconsistent as this component is linked to that last operation in the sense that marking it as done directly will set its quantity and consume COMP2 (even without operation dependency) but yet, the move is not flagged as `manual_consumption` while moves supposed to be processed but operations are: commit 479a9eb0f16af28bf2ee2ff34da3437278ba61fa Hence, setting the qty of the MO will automatically mark these moves as `consumed` (as expected):
https://github.com/odoo/odoo/blob/35ea3dcb2eeb379c8b1127f0c7b42191853c0bd2/addons/mrp/models/mrp_production.py#L1291-L1294

### Fix:

We backport commit 22a19557eab82cf9ca276f6b75f8172673927cda even if technically the component moves are not displayed in the shopfloor.

opw-5024779
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
