### PR TITLE
[FIX] mrp_repair: traceback with kit on repair order

### DIFF
--- a/addons/mrp_repair/models/repair.py
+++ b/addons/mrp_repair/models/repair.py
@@ -81,7 +81,6 @@ class StockMove(models.Model):
         self.ensure_one()
         product = bom_line.product_id
         return {
-            'name': self.name,
             'repair_id': self.repair_id.id,
             'repair_line_type': self.repair_line_type,
             'product_id': product.id,


### PR DESCRIPTION
**PROBLEM**
There is a traceback when trying to create a repair order with a kit product.

**CAUSE**
Commit https://github.com/odoo/odoo/commit/facf4eba6cd0504aae949c23454c6ffa9eaa9c3f removed `name` field on `stock.model`, but forget one occurence in `mrp_repair`.

opw-5068120