### PR TITLE
[FIX] account: convert Domain to list when setting json field `warning`

### DIFF
--- a/addons/account/wizard/account_secure_entries_wizard.py
+++ b/addons/account/wizard/account_secure_entries_wizard.py
@@ -196,7 +196,7 @@ class AccountSecureEntriesWizard(models.TransientModel):
                     'message': _("Securing these entries will create at least one gap in the sequence."),
                     'action_text': _("Review Entries"),
                     'action': {
-                        **self.env['account.journal']._show_sequence_holes(domain),
+                        **self.env['account.journal']._show_sequence_holes(list(domain)),
                         'views': [[self.env.ref('account.view_move_tree_multi_edit').id, 'list'], [self.env.ref('account.view_move_form').id, 'form']],
                     }
                 }
@@ -252,7 +252,7 @@ class AccountSecureEntriesWizard(models.TransientModel):
             'name': _('Draft Entries'),
             'res_model': 'account.move',
             'type': 'ir.actions.act_window',
-            'domain': self._get_draft_moves_in_hashed_period_domain(),
+            'domain': list(self._get_draft_moves_in_hashed_period_domain()),
             'search_view_id': [self.env.ref('account.view_account_move_filter').id, 'search'],
             'views': [[self.env.ref('account.view_move_tree_multi_edit').id, 'list'], [self.env.ref('account.view_move_form').id, 'form']],
         }


### PR DESCRIPTION
Steps to reproduce:
- create a draft entries in the past or/and make a sequence hole in the invoices (reset to draft an invoice which is neither the first or the last of the sequence)
- Go to the "Secure Entries" menu and set the date to today -> `TypeError: Object of type DomainAnd is not JSON serializable`

The error happen when computing the json field `warning` of `account.secure.entries.wizard`, because we try to convert to json some Domain Objects.

Fix is to convert them into lists.