### PR TITLE
[IMP] website, *: allow anchor on accordion item

### DIFF
--- a/addons/html_builder/static/src/core/anchor/anchor_plugin.js
+++ b/addons/html_builder/static/src/core/anchor/anchor_plugin.js
@@ -6,9 +6,18 @@ import { markup } from "@odoo/owl";
 import { AnchorDialog } from "./anchor_dialog";
 import { getElementsWithOption } from "@html_builder/utils/utils";
 
-const anchorSelector = ":not(p).oe_structure > *, :not(p)[data-oe-type=html] > *";
+const anchorSelector = ":not(p).oe_structure > *, :not(p)[data-oe-type=html] > *, .accordion-item";
 const anchorExclude =
     ".modal *, .oe_structure .oe_structure *, [data-oe-type=html] .oe_structure *, .s_popup";
+
+/**
+ * Anchor titles are usually taken from headings (h1–h6). Here, styled titles
+ * often use utility classes instead, e.g. .h*-fs, .display-*-fs, .base-fs,
+ * .o_small-fs. Including these ensures anchors reflect visible titles, even
+ * when not using semantic <h*> tags.
+ */
+const TITLE_SELECTOR =
+    "h1, h2, h3, h4, h5, h6, .h1-fs, .h2-fs, .h3-fs, .h4-fs, .h5-fs, .h6-fs, .display-1-fs, .display-2-fs, .display-3-fs, display-4-fs, .base-fs, .o_small-fs";
 
 export function canHaveAnchor(element) {
     return element.matches(anchorSelector) && !element.matches(anchorExclude);
@@ -68,7 +77,7 @@ export class AnchorPlugin extends Plugin {
     }
 
     createAnchor(element) {
-        const titleEls = element.querySelectorAll("h1, h2, h3, h4, h5, h6");
+        const titleEls = element.querySelectorAll(TITLE_SELECTOR);
         const title = titleEls.length > 0 ? titleEls[0].innerText : element.dataset.name;
         const anchorName = this.formatAnchor(title);
 

--- a/addons/website/static/src/interactions/anchor_slide.js
+++ b/addons/website/static/src/interactions/anchor_slide.js
@@ -10,6 +10,18 @@ export class AnchorSlide extends Interaction {
         },
     };
 
+    setup() {
+        /**
+         * It expands the corresponding accordion item if the target element
+         * matches the hash.
+         */
+        const hash = window.location.hash.substring(1);
+        const anchorEl = document.getElementById(hash);
+        if (anchorEl && anchorEl.classList.contains("accordion-item")) {
+            this.handleAccordionAnchor(anchorEl);
+        }
+    }
+
     /**
      * @param {HTMLElement} el the element to scroll to.
      * @param {string} [scrollValue='true'] scroll value
@@ -24,6 +36,18 @@ export class AnchorSlide extends Interaction {
 
     computeExtraOffset() {
         return 0;
+    }
+
+    /**
+     * Automatically opens the specific accordion item and closes the others.
+     *
+     * @param {HTMLElement} anchorEl - The accordion item element to handle.
+     */
+    handleAccordionAnchor(anchorEl) {
+        const accordionCollapseEl = anchorEl.querySelector(".accordion-collapse");
+        Collapse.getOrCreateInstance(accordionCollapseEl, {
+            toggle: false,
+        }).show();
     }
 
     /**
@@ -51,6 +75,9 @@ export class AnchorSlide extends Interaction {
             return;
         }
 
+        if (anchorEl.classList.contains("accordion-item")) {
+            this.handleAccordionAnchor(anchorEl);
+        }
         const offcanvasEl = this.el.closest(".offcanvas.o_navbar_mobile");
         if (offcanvasEl && offcanvasEl.classList.contains("show")) {
             // Special case for anchors in offcanvas in mobile: we can't just

--- a/addons/website/static/tests/tours/anchor_on_accordion_tour.js
+++ b/addons/website/static/tests/tours/anchor_on_accordion_tour.js
@@ -1,0 +1,82 @@
+import {
+    insertSnippet,
+    registerWebsitePreviewTour,
+    clickOnSave,
+    goBackToBlocks,
+    clickToolbarButton,
+} from "@website/js/tours/tour_utils";
+import { browser } from "@web/core/browser/browser";
+import { registry } from "@web/core/registry";
+
+registerWebsitePreviewTour(
+    "anchor_behaviour_on_accordion_same_tab",
+    {
+        edition: true,
+        url: "/",
+    },
+    () => [
+        ...insertSnippet({
+            id: "s_accordion",
+            name: "Accordion",
+        }),
+        {
+            content: "Click the first accordion item to select it",
+            trigger: ":iframe .s_accordion .accordion-item:first-child button",
+            run: "click",
+        },
+        {
+            content: "Create anchor for this accordion item",
+            trigger: "[data-container-title='Accordion Item'] .oe_snippet_anchor",
+            async run(helpers) {
+                // Patch and ignore write on clipboard in tour as we don't have permissions
+                browser.navigator.clipboard.writeText = () => {
+                    console.info("Copy in clipboard ignored!");
+                };
+                await helpers.click();
+            },
+        },
+        goBackToBlocks(),
+        ...insertSnippet({
+            id: "s_text_block",
+            name: "Text",
+            groupName: "Text",
+        }),
+        {
+            content: "Click inside the first paragraph of text block",
+            trigger: ":iframe .s_text_block .container p:first-child",
+            run: "editor Paragraph",
+        },
+        ...clickToolbarButton("Paragraph", "#wrap .s_text_block p", "Add a link", false),
+        {
+            content: "Type the link URL",
+            trigger: ".o-we-linkpopover .o_we_href_input_link",
+            run: "edit /#What-services-does-your-company-offer-%3F",
+        },
+        {
+            content: "Apply the link",
+            trigger: ".o-we-linkpopover .o_we_apply_link",
+            run: "click",
+        },
+        ...clickOnSave(),
+        {
+            content: "Click the newly created link in text block",
+            trigger:
+                ':iframe .s_text_block .container p:first-child a[href="/#What-services-does-your-company-offer-%3F"]',
+            run: "click",
+        },
+        {
+            content: "Check that the accordion item's content is visible",
+            trigger: ":iframe .s_accordion .accordion-item:first-child .accordion-collapse.show",
+        },
+    ]
+);
+
+registry.category("web_tour.tours").add("anchor_behaviour_on_accordion_new_tab", {
+    url: "/#What-services-does-your-company-offer-%3F",
+    steps: () => [
+        {
+            content: "Check that the accordion item's content is visible",
+            trigger: ".s_accordion .accordion-item:first-child .accordion-collapse.show",
+        },
+    ],
+});

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -725,3 +725,7 @@ class TestUi(HttpCaseWithWebsiteUser):
 
     def test_mega_footer(self):
         self.start_tour('/', 'mega_footer', login='admin')
+
+    def test_anchor_on_accordion_item(self):
+        self.start_tour("/", "anchor_behaviour_on_accordion_same_tab", login="admin")
+        self.start_tour("/#What-services-does-your-company-offer-%3F", "anchor_behaviour_on_accordion_new_tab", login="admin")


### PR DESCRIPTION
*=html_builder

This PR introduces the following changes:
- Add `.accordion-item` selector in the `AnchorPlugin`.
- Expands the list of titleEls selectors to include `.h1-fs, .h2-fs, .h3-fs, .h4-fs, .h5-fs, .h6-fs, .display-1-fs, .display-2-fs, .display-3-fs, .display-4-fs, .base-fs, .o_small-fs`.
-  Enhances the "AnchorSlide" interaction by adding the "handleAccordionAnchor" method, called in "animateClick" and "setup"
to automatically scroll to and expand accordion items. The method uses the `show()` function from bootstrap `Collapse` component, which efficiently manages the expansion of required accordion item and collapse the rest.

task-5065165