### PR TITLE
[FIX] base,hr_expense,account: fetch remote resources

### DIFF
--- a/addons/account/models/ir_actions_report.py
+++ b/addons/account/models/ir_actions_report.py
@@ -28,7 +28,7 @@ class IrActionsReport(models.Model):
 
         collected_streams = OrderedDict()
         for invoice in invoices:
-            attachment = invoice.message_main_attachment_id
+            attachment = self._prepare_local_attachments(invoice.message_main_attachment_id)
             if attachment:
                 stream = pdf.to_pdf_stream(attachment)
                 if stream:

--- a/addons/hr_expense/models/ir_actions_report.py
+++ b/addons/hr_expense/models/ir_actions_report.py
@@ -24,7 +24,7 @@ class IrActionsReport(models.Model):
                 expense_report = OdooPdfFileReader(stream, strict=False)
                 output_pdf = OdooPdfFileWriter()
                 output_pdf.appendPagesFromReader(expense_report)
-                for attachment in attachments:
+                for attachment in self._prepare_local_attachments(attachments):
                     if attachment.mimetype == 'application/pdf':
                         attachment_stream = pdf.to_pdf_stream(attachment)
                     else:

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -22,6 +22,7 @@ import lxml.html
 import tempfile
 import subprocess
 import re
+import requests
 import json
 
 from lxml import etree
@@ -1182,3 +1183,31 @@ class IrActionsReport(models.Model):
             if records.filtered_domain(literal_eval(action.domain)):
                 valid_action_report_ids.append(action.id)
         return valid_action_report_ids
+
+    @api.model
+    def _prepare_local_attachments(self, attachments):
+        attachments_with_data = self.env['ir.attachment']
+        for attachment in attachments:
+            if not attachment._is_remote_source():
+                attachments_with_data |= attachment
+            elif (stream := attachment._to_http_stream()) and stream.url:
+                # call `_to_http_stream()` in case the attachment is an url or cloud storage attachment
+                try:
+                    response = requests.get(stream.url, timeout=10)
+                    response.raise_for_status()
+                    attachment_data = response.content
+                    if not attachment_data:
+                        _logger.warning("Attachment %s at with URL %s retrieved successfully, but no content was found.", attachment.id, attachment.url)
+                        continue
+                    attachments_with_data |= self.env['ir.attachment'].new({
+                        'db_datas': attachment_data,
+                        'name': attachment.name,
+                        'mimetype': attachment.mimetype,
+                        'res_model': attachment.res_model,
+                        'res_id': attachment.res_id
+                    })
+                except requests.exceptions.RequestException as e:
+                    _logger.error("Request for attachment %s with URL %s failed: %s", attachment.id, attachment.url, e)
+            else:
+                _logger.error("Unexpected edge case: Is not being considered as a local or remote attachment, attachment ID:%s will be skipped.", attachment.id)
+        return attachments_with_data

--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -832,3 +832,7 @@ class IrAttachment(models.Model):
             stream.size = 0
 
         return stream
+
+    def _is_remote_source(self):
+        self.ensure_one()
+        return self.url and not self.file_size and self.url.startswith(('http://', 'https://', 'ftp://'))


### PR DESCRIPTION
### Issue
PDF reports fail when attachments are remote URLs or cloud storage resources. The `to_pdf_stream()` method expects local file data but receives boolean values from remote attachments, causing a TypeError.

### Solution
Download remote resources before processing them in PDF reports. This ensures all attachments have accessible data regardless of storage type.

### Affected Reports
- `account.report_original_vendor_bill` - Vendor bill reports
- `hr_expense.report_expense_sheet` - Expense sheet reports

### Affected Versions
- 18.0+ (17.0 theoretical; cloud_storage wasn't implemented, so doesn't make sense)

### Reproduction Steps

#### Option A: HR Expense Report
1. Create HR expense record
2. Add attachment with type=url/cloud_storage pointing to valid PDF URL
3. Link attachment to hr.expense record
4. Generate expense report → TypeError occurs

#### Option B: Vendor Bill Report
1. Create vendor bill (account.move)
2. Add attachment with type=url/cloud_storage pointing to valid PDF URL
3. Link attachment to account.move record
4. Print Original Vendor Bill → TypeError occurs

### Error Details
```python
TypeError: a bytes-like object is required, not 'bool'
  at /odoo/tools/pdf/__init__.py:220 in to_pdf_stream
  from /odoo/addons/hr_expense/models/ir_actions_report.py:29
```

#### Reference
Client demo: https://drive.google.com/file/d/1HUvZqZ21NiX34T2IQhuVNbLP41xSV7jq/view

OPW-5036638

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
