### PR TITLE
[FIX] stock: Fix quants selection

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -605,7 +605,7 @@ class ProductProduct(models.Model):
         hide_lot = all(product.tracking == 'none' for product in self)
         self = self.with_context(
             hide_location=hide_location, hide_lot=hide_lot,
-            no_at_date=True, search_default_on_hand=True,
+            no_at_date=True,
         )
 
         # If user have rights to write on quant, we define the view as editable.

--- a/addons/stock/static/src/fields/stock_move_line_x2_many_field.js
+++ b/addons/stock/static/src/fields/stock_move_line_x2_many_field.js
@@ -44,14 +44,14 @@ export class SMLX2ManyField extends X2ManyField {
             ...context,
             single_product: true,
             list_view_ref: "stock.view_stock_quant_tree_simple",
-            search_default_on_hand: this.quantListViewShowOnHandOnly,
-            search_default_in_stock: true,
         };
         const productName = this.props.record.data.product_id.display_name;
         const title = _t("Add line: %s", productName);
         let domain = [
             ["product_id", "=", this.props.record.data.product_id.id],
             ["location_id", "child_of", this.props.context.default_location_id],
+            ["on_hand", "=", this.quantListViewShowOnHandOnly],
+            ["quantity", ">", 0.0],
         ];
         if (this.dirtyQuantsData.size) {
             const notFullyUsed = [];


### PR DESCRIPTION
Steps to reproduce the bug:

Create a storable product “P” tracked by serial number

Create a receipt for 100 units with serial numbers sn.001 to sn.100

Create a delivery for 10 units,
Odoo assigns serial numbers from sn.001 to sn.010, Validate

Create a delivery for 3 units,
Odoo assigns serial numbers from sn.011 to sn.013, Delete the 3 move lines,
Add a line:
you will see again the serial numbers sn.001 to sn.010 in the list

Origin:

This pr : https://github.com/odoo/odoo/pull/216035 removed the 'on_hand' & 'in_stock' without removing their uses (search_default_*).

Fix:
Ensure a correct domain when adding a line.

opw-5075144

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
