### PR TITLE
[FIX] website_sale: avoid duplicate product names in sample preview

### DIFF
--- a/addons/website_sale/data/product_snippet_template_data.xml
+++ b/addons/website_sale/data/product_snippet_template_data.xml
@@ -69,7 +69,6 @@
                                         t-att-title="product.display_name"
                                         t-field="product.display_name"
                                     />
-                                    <span t-if="is_sample">Product name</span>
                                 </h2>
                                 <!-- Description -->
                                 <div class="oe_subdescription_wrapper">


### PR DESCRIPTION
When editing the dynamic product catalog snippet with no real products available, a default sample is generated. Each sample product is assigned a fictitious name. However, the card template for each product also renders a default product name when sampling is enabled, leading to an issue where two names were displayed.

This fix ensures only one name is shown by removing the default product name if one is already available.
