### PR TITLE
[FIX] phone_validation: add Lebanon phone numbers patch

### DIFF
--- a/addons/phone_validation/lib/phonenumbers_patch/__init__.py
+++ b/addons/phone_validation/lib/phonenumbers_patch/__init__.py
@@ -67,6 +67,10 @@ else:
         # https://github.com/daviddrysdale/python-phonenumbers/blob/v8.13.40/python/phonenumbers/data/region_KE.py
         phonenumbers.phonemetadata.PhoneMetadata.register_region_loader('KE', _local_load_region)
 
+    if parse_version(phonenumbers.__version__) < parse_version('9.0.7'):
+        # https://github.com/daviddrysdale/python-phonenumbers/blob/v9.0.7/python/phonenumbers/data/region_LB.py
+        phonenumbers.phonemetadata.PhoneMetadata.register_region_loader('LB', _local_load_region)
+
     # MONKEY PATCHING phonemetadata to fix Brazilian phonenumbers following 2016 changes
     def _hook_load_region_br(code):
         if parse_version(phonenumbers.__version__) < parse_version('8.13.39'):

--- a/addons/phone_validation/lib/phonenumbers_patch/region_LB.py
+++ b/addons/phone_validation/lib/phonenumbers_patch/region_LB.py
@@ -1,0 +1,13 @@
+"""Auto-generated file, do not edit by hand. LB metadata"""
+from ..phonemetadata import NumberFormat, PhoneNumberDesc, PhoneMetadata
+
+PHONE_METADATA_LB = PhoneMetadata(id='LB', country_code=961, international_prefix='00',
+    general_desc=PhoneNumberDesc(national_number_pattern='[27-9]\\d{7}|[13-9]\\d{6}', possible_length=(7, 8)),
+    fixed_line=PhoneNumberDesc(national_number_pattern='7(?:62|8[0-6]|9[04-9])\\d{4}|(?:[14-69]\\d|2(?:[14-69]\\d|[78][1-9])|7[2-57]|8[02-9])\\d{5}', example_number='1123456', possible_length=(7, 8)),
+    mobile=PhoneNumberDesc(national_number_pattern='(?:(?:3|81)\\d|7(?:[01]\\d|6[013-9]|8[7-9]|9[1-3]))\\d{5}', example_number='71123456', possible_length=(7, 8)),
+    premium_rate=PhoneNumberDesc(national_number_pattern='9[01]\\d{6}', example_number='90123456', possible_length=(8,)),
+    shared_cost=PhoneNumberDesc(national_number_pattern='80\\d{6}', example_number='80123456', possible_length=(8,)),
+    national_prefix='0',
+    national_prefix_for_parsing='0',
+    number_format=[NumberFormat(pattern='(\\d)(\\d{3})(\\d{3})', format='\\1 \\2 \\3', leading_digits_pattern=['[13-69]|7(?:[2-57]|62|8[0-6]|9[04-9])|8[02-9]'], national_prefix_formatting_rule='0\\1'),
+        NumberFormat(pattern='(\\d{2})(\\d{3})(\\d{3})', format='\\1 \\2 \\3', leading_digits_pattern=['[27-9]'])])

--- a/addons/phone_validation/tests/test_phonenumbers_patch.py
+++ b/addons/phone_validation/tests/test_phonenumbers_patch.py
@@ -189,3 +189,27 @@ class TestPhonenumbersPatch(BaseCase):
             self.PhoneInputOutputLine("+22176 707 0065"),
         )
         self._assert_parsing_phonenumbers(parse_test_lines_SN)
+
+    def test_region_LB_monkey_patch(self):
+        """Tests Lebanon phone number changes effective May 26, 2025
+
+        Key changes being tested:
+        1. New mobile allocations:
+           - +961 78 700 000 → 78 799 999
+           - +961 79 325 000 → 79 399 999
+        2. New fixed-line blocks with 21x-29x prefixes
+        3. All numbers now 8 digits (excluding country code)
+        """
+        parse_test_lines_LB = (
+            # NEW: Mobile numbers - May 26, 2025 allocations
+            self.PhoneInputOutputLine("+96178700000"),
+            self.PhoneInputOutputLine("+96178799999"),
+            self.PhoneInputOutputLine("+96179325000"),
+            self.PhoneInputOutputLine("+96179399999"),
+
+            # NEW: Fixed-line numbers with updated blocks
+            self.PhoneInputOutputLine("+96121012345"),
+            self.PhoneInputOutputLine("+96124012345"),
+            self.PhoneInputOutputLine("+96125012345"),
+        )
+        self._assert_parsing_phonenumbers(parse_test_lines_LB)


### PR DESCRIPTION
A new Lebanon numbering plan introduced new range codes for telecommunications services. These are currently not always supported.

### Cause

Versions of `phonenumbers` (external library) before 9.0.7 are not up-to-date with the latest Lebanese phone system changes.
Source: https://www.itu.int/oth/T0202000077/en

opw-5033655