### PR TITLE
[FIX] website_sale: fix website redirection warning during tours dtda

### DIFF
--- a/addons/website_sale_wishlist/static/tests/tours/website_sale_wishlist.js
+++ b/addons/website_sale_wishlist/static/tests/tours/website_sale_wishlist.js
@@ -28,6 +28,7 @@ registry.category("web_tour.tours").add('shop_wishlist', {
             content: "go back to the store",
             trigger: "a[href='/shop']",
             run: "click",
+            expectUnloadPage: true,
         },
         {
             content: "hover card && click on add to wishlist",
@@ -41,6 +42,7 @@ registry.category("web_tour.tours").add('shop_wishlist', {
             content: "check value of wishlist and go to login",
             trigger: 'a[href="/web/login"]',
             run: "click",
+            expectUnloadPage: true,
         },
         {
             content: "submit login",
@@ -51,6 +53,7 @@ registry.category("web_tour.tours").add('shop_wishlist', {
                 document.querySelector('.oe_login_form input[name="redirect"]').value = "/shop?search=Customizable Desk";
                 document.querySelector(".oe_login_form").submit();
             },
+            expectUnloadPage: true,
         },
         {
             content: "check that logged in",
@@ -89,6 +92,7 @@ registry.category("web_tour.tours").add('shop_wishlist', {
             content: "check that wishlist contains 2 items and go to wishlist",
             trigger: 'a[href="/shop/wishlist"]',
             run: "click",
+            expectUnloadPage: true,
         },
         {
             content: "remove Customizable Desk (TEST)",
@@ -128,7 +132,12 @@ registry.category("web_tour.tours").add('shop_wishlist', {
             trigger: '.o_wish_add:eq(1)',
             run: "click",
         },
-        clickOnElement('Continue Shopping', 'button:contains("Continue Shopping")'),
+        {
+            content: "Clicking on the Continue Shopping button",
+            trigger: "button:contains('Continue Shopping')",
+            run: "click",
+            expectUnloadPage: true,
+        },
         {
             content: "check that user is redirect - wishlist is empty",
             trigger: "#wrap #cart_products",
@@ -268,6 +277,7 @@ registry.category("web_tour.tours").add('shop_wishlist', {
                 document.querySelector('.oe_login_form input[name="redirect"]').value = "/";
                 document.querySelector(".oe_login_form").submit();
             },
+            expectUnloadPage: true,
         },
         // Test one impossible combination while other combinations are possible
         {
@@ -343,6 +353,7 @@ registry.category("web_tour.tours").add('shop_wishlist', {
                 document.querySelector('.oe_login_form input[name="redirect"]').value = "/";
                 document.querySelector(".oe_login_form").submit();
             },
+            expectUnloadPage: true,
         },
         // test when all combinations are impossible
         {
@@ -399,6 +410,7 @@ registry.category("web_tour.tours").add('shop_wishlist', {
             content: "Click on the product",
             trigger: '.oe_product_image_link img',
             run: "click",
+            expectUnloadPage: true,
         },
         {
             content: "Add the product in the wishlist",
@@ -413,6 +425,7 @@ registry.category("web_tour.tours").add('shop_wishlist', {
             content: "Go to '/shop",
             trigger: 'header#top a[href="/shop"]',
             run: "click",
+            expectUnloadPage: true,
         },
         {
             content: "Search the product Customizable Desk'",
@@ -423,15 +436,17 @@ registry.category("web_tour.tours").add('shop_wishlist', {
                 ).value = "Customizable Desk";
                 document.querySelector("form.o_wsale_products_searchbar_form button").click();
             },
+            expectUnloadPage: true,
         },
         {
             content: "The product is in the wishlist",
-            trigger: '.oe_product_cart .o_wsale_product_information:has(.o_add_wishlist[disabled])',
+            trigger: '.oe_product_cart .o_wsale_product_btn:has(.o_add_wishlist[disabled]):not(:visible)',
         },
         {
             content: "Go to the wishlist",
             trigger: 'a[href="/shop/wishlist"]',
             run: "click",
+            expectUnloadPage: true,
         },
         {
             content: "Remove the product from the wishlist",
@@ -442,6 +457,7 @@ registry.category("web_tour.tours").add('shop_wishlist', {
             content: "Go to '/shop",
             trigger: 'header#top a[href="/shop"]',
             run: "click",
+            expectUnloadPage: true,
         },
         {
             content: "Search the product Customizable Desk'",
@@ -452,10 +468,11 @@ registry.category("web_tour.tours").add('shop_wishlist', {
                 ).value = "Customizable Desk";
                 document.querySelector("form.o_wsale_products_searchbar_form button").click();
             },
+            expectUnloadPage: true,
         },
         {
             content: "The product is not in the wishlist",
-            trigger: '.oe_product_cart .o_wsale_product_information:not(:has(.o_add_wishlist[disabled]))',
+            trigger: '.oe_product_cart .o_wsale_product_btn:not(:has(.o_add_wishlist[disabled]):not(:visible))',
         },
     ]
 });


### PR DESCRIPTION
During page redirection in tours, the browser was showing a warning 
about
unsaved/incomplete data loss. This warning is not relevant in the 
context
of tours.

To address this, the expectUnloadPage attribute is added to the tour 
test.
It prevents unnecessary pauses/timeouts caused by the browser’s warning 
and
ensures smooth redirection handling.

Additionally, few tour selectors have been corrected to improved.

runbot-231587

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
