### PR TITLE
[FIX] website_sale: restore live price update on quantity change

### DIFF
--- a/addons/website_sale/static/src/js/website_sale.js
+++ b/addons/website_sale/static/src/js/website_sale.js
@@ -10,7 +10,7 @@ import wSaleUtils from '@website_sale/js/website_sale_utils';
 export const WebsiteSale = publicWidget.Widget.extend(VariantMixin, {
     selector: '.oe_website_sale',
     events: {
-        'change form .js_product:first input[name="add_qty"]': '_onChangeAddQuantity',
+        'change .js_product:first form input[name="add_qty"]': '_onChangeAddQuantity',
         'click a.js_add_cart_json': '_onChangeQuantity',
         'change form.js_attributes input, form.js_attributes select': '_onChangeAttribute',
         'submit .o_wsale_products_searchbar_form': '_onSubmitSaleSearch',


### PR DESCRIPTION
Adjusting the quantity to add to the cart on a product page should trigger a server request to update the unit price dynamically. This functionality was broken in [^1] due to a major redesign of the product page, which changed the HTML structure. As a result, the JS selector for the `add_qty` button failed, preventing the change listener from functioning.

This commit resolves the issue by correcting the JS selector.

[^1]: https://github.com/odoo/odoo/pull/222320
