### PR TITLE
[FIX] website_sale_wishlist: remove double border

### DIFF
--- a/addons/website_sale_wishlist/static/src/scss/website_sale_wishlist.scss
+++ b/addons/website_sale_wishlist/static/src/scss/website_sale_wishlist.scss
@@ -48,16 +48,6 @@
             grid-column: auto/span 12;
         }
 
-        &.o_wsale_products_opt_design_grid {
-            .o_wishlist_item {
-                --o-wsale-card-border-width: #{$border-width} #{$border-width} 0px #{$border-width};
-
-                &:last-of-type {
-                    --o-wsale-card-border-width: #{$border-width};
-                }
-            }
-        }
-
         &.o_wsale_products_opt_design_thumbs {
             --o-wsale-card-padding: 0 0 var(--o-wsale-wishlist-grid-gap, 16px);
         }
@@ -107,41 +97,6 @@
 
         &[data-wishlist-grid-columns] .o_wishlist_item {
             grid-column: auto/span 1 !important;
-        }
-
-        &.o_wsale_products_opt_design_grid {
-            .o_wishlist_item {
-                --o-wsale-card-border-width: #{$border-width} #{$border-width} #{$border-width} 0px;
-
-                &:first-of-type {
-                    --o-wsale-card-border-width: #{$border-width};
-                }
-            }
-
-            @mixin o-wishlist-grid-borders($cols) {
-                .o_wishlist_item:nth-of-type(n + #{$cols + 1}) {
-                    --o-wsale-card-border-width: 0 #{$border-width} #{$border-width} 0;
-                }
-                .o_wishlist_item:nth-of-type(#{$cols}n + 1):not(:nth-of-type(-n + #{$cols})) {
-                    --o-wsale-card-border-width: 0 #{$border-width} #{$border-width} #{$border-width};
-                }
-            }
-
-            @for $i from 2 through 6 {
-                &[data-wishlist-grid-columns="#{$i}"] {
-                    @include o-wishlist-grid-borders($i);
-                }
-            }
-
-            @include media-breakpoint-down(lg) {
-                &[data-wishlist-mobile-columns="1"] {
-                    @include o-wishlist-grid-borders(1);
-                }
-
-                &[data-wishlist-mobile-columns="2"] {
-                    @include o-wishlist-grid-borders(2);
-                }
-            }
         }
     }
 
@@ -210,17 +165,18 @@
 }
 
 .wishlist-section {
-    &:where(:has(.o_wsale_products_opt_design_grid.o_wsale_products_opt_layout_list)) {
+    &:where(:has(.o_wsale_products_opt_design_grid)) {
         .o_wsale_products_opt_design_grid {
             border-left: $border-width solid $border-color;
         }
-
         .o_wishlist_products_header {
             padding: 0 $container-padding-x * 0.5;
             border: $border-width solid $border-color;
             border-top: 0;
         }
+    }
 
+    &:where(:has(.o_wsale_products_opt_design_grid.o_wsale_products_opt_layout_list)) {
         &[style*="--o-wsale-products-grid-gap: 0px"] .oe_product_image_link,
         &[style*="--o-wsale-products-grid-gap:0px"] .oe_product_image_link {
             @include media-breakpoint-down(lg) {


### PR DESCRIPTION
Prior to Commit[^1], the grid wishlist grid layouts were replicating the approach in use in `/shop`, which defines a border on specific sides of the grid item.

After Commit[^1], the border is now defined on different sides of the grid items, top one included, which conflicts with the border defined on the `o_wishlist_products_header` element.

With this commit, we remove the custom mixin defining the border of the grid elements, and also fix an issue about the `o_wishlist_products_header` elements not receiving the right `padding` and `border` in the grid layouts.

task-5076598

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

[^1]: b6425c11572f3b0f8118715590868377ec25460d