### PR TITLE
[FIX] web: protect menu localStorage setItem

### DIFF
--- a/addons/web/static/src/webclient/menus/menu_service.js
+++ b/addons/web/static/src/webclient/menus/menu_service.js
@@ -29,7 +29,11 @@ export const menuService = {
                 if (res) {
                     const fetchedMenus = JSON.stringify(res);
                     if (fetchedMenus !== storedMenus) {
-                        browser.localStorage.setItem("webclient_menus", fetchedMenus);
+                        try {
+                            browser.localStorage.setItem("webclient_menus", fetchedMenus);
+                        } catch (error) {
+                            console.error("Error while storing menus in localStorage", error);
+                        }
                         menusData = res;
                         env.bus.trigger("MENUS:APP-CHANGED");
                     }
@@ -39,8 +43,12 @@ export const menuService = {
         } else {
             menusData = await fetchMenus();
             if (menusData) {
-                browser.localStorage.setItem("webclient_menus_version", session.registry_hash);
-                browser.localStorage.setItem("webclient_menus", JSON.stringify(menusData));
+                try {
+                    browser.localStorage.setItem("webclient_menus_version", session.registry_hash);
+                    browser.localStorage.setItem("webclient_menus", JSON.stringify(menusData));
+                } catch (error) {
+                    console.error("Error while storing menus in localStorage", error);
+                }
             }
         }
 


### PR DESCRIPTION
Before this commit, if a user uses a large image as an icon for a custom application, an error could be triggered due to the size limit in localStorage.