### PR TITLE
[FIX] l10n_in_edi: resolve TypeError in _l10n_in_edi_send_invoice

### DIFF
--- a/addons/l10n_in_edi/models/account_move.py
+++ b/addons/l10n_in_edi/models/account_move.py
@@ -238,7 +238,7 @@ class AccountMove(models.Model):
                 if jwt:
                     try:
                         if data := response.get('data'):
-                            signinvoice = data.get['SignedInvoice']
+                            signinvoice = data['SignedInvoice']
                             decoded_response = jwt.decode(signinvoice, options={'verify_signature': False})
                             decoded_response = json.loads(decoded_response['data'])
                     except (json.JSONDecodeError, jwt.exceptions.DecodeError) as e:


### PR DESCRIPTION
In this commit-
---
Fixed a typeError in l10n_in_edi_send_invoice method
Replaced - incorrect syntax `data.get['SignedInvoice']` with `data['SignedInvoice']`.

opw-5071703
