### PR TITLE
[IMP] point_of_sale: align QR code with text on receipt

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
@@ -76,7 +76,7 @@
                 </t>
 
                 <div t-if="qrCode" class="gap-2 d-flex flex-row pt-3" style="font-size: 75%;">
-                    <div t-if="['qr_code', 'qr_code_and_url'].includes(header.company.point_of_sale_ticket_portal_url_display_mode)" class="pt-1">
+                    <div t-if="['qr_code', 'qr_code_and_url'].includes(header.company.point_of_sale_ticket_portal_url_display_mode)" class="pt-1 me-1">
                         <img id="posqrcode" t-att-src="qrCode" class="pos-receipt-logo m-0 w-100"/>
                     </div>
                     <div class="w-100">

--- a/addons/point_of_sale/static/src/utils.js
+++ b/addons/point_of_sale/static/src/utils.js
@@ -73,7 +73,7 @@ export function random5Chars() {
 }
 
 export function qrCodeSrc(url, { size = 200 } = {}) {
-    return `/report/barcode/QR/${encodeURIComponent(url)}?width=${size}&height=${size}`;
+    return `/report/barcode/QR/${encodeURIComponent(url)}?width=${size}&height=${size}&quiet=0`;
 }
 
 /**


### PR DESCRIPTION
This commit ensures that the QR code on the receipt is properly aligned with the text on the right.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
