### PR TITLE
[FIX] mass_mailing: exclude t nodes from style inlining

### DIFF
--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -462,7 +462,7 @@ function classToStyle($editable, cssRules) {
             }
         };
         style = correctBorderAttributes(style);
-        if (Object.keys(style || {}).length === 0) {
+        if (Object.keys(style || {}).length === 0 || node.nodeName === "T") {
             writes.push(() => { node.removeAttribute('style'); });
         } else {
             writes.push(() => {


### PR DESCRIPTION
This commit fixes an unexpected access rights error when users
try to add simple dynamic fields allowed by mail_allowed_qweb_expressions
to mass_mailing emails.

During the convert_inline process, the <t t-out=""/> placeholder element
has its style inlined, and attributed to its style attribute.
This style attribute was not filtered out during the safety
check process, resulting in the templating engine believing a disallowed
directive was used.

Steps to reproduce:
- On a fresh 18.0+ install with demo data, login as Marc Demo
- Access the Email Marketing app
- Create a new mailing campaign
- Set sending to Newsletter or Mailing Contact
- Type /field to add a dynamic value
- Set it to Name
- Save the mailing
- An access rights error is raised due to the user not having
    group_mail_template_editor permissions and the dynamic placeholder
    node having a style attribute

Fix:
T nodes are no longer granted a style attribute during style inlining.