### PR TITLE
[FIX] website: selection on social media snippet

### DIFF
--- a/addons/html_builder/static/src/plugins/rating_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/rating_option_plugin.js
@@ -18,6 +18,8 @@ class RatingOptionPlugin extends Plugin {
             ActiveIconsNumberAction,
             TotalIconsNumberAction,
         },
+        force_not_editable_selector: [".s_rating"],
+        force_editable_selector: [".s_rating_title"],
     };
 }
 

--- a/addons/website/static/src/builder/plugins/options/social_media_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/social_media_option_plugin.js
@@ -144,6 +144,8 @@ class SocialMediaOptionPlugin extends Plugin {
         normalize_handlers: this.normalize.bind(this),
         save_handlers: this.saveRecordedSocialMedia.bind(this),
         extra_contenteditable_handlers: this.extraContentEditableHandlers.bind(this),
+        force_not_editable_selector: [".s_share"],
+        force_editable_selector: [".s_share .s_share_title", ".s_share a > i"],
     };
 
     extraContentEditableHandlers(filteredContentEditableEls) {

--- a/addons/website/static/src/snippets/s_rating/001.scss
+++ b/addons/website/static/src/snippets/s_rating/001.scss
@@ -18,3 +18,7 @@
         }
     }
 }
+
+.s_rating[contenteditable="false"] {
+    user-select: none;
+}

--- a/addons/website/static/src/snippets/s_share/000.scss
+++ b/addons/website/static/src/snippets/s_share/000.scss
@@ -1,5 +1,8 @@
 
 .s_share {
+    &[contenteditable="false"] {
+        user-select: none;
+    }
     > * {
         display: inline-block;
         vertical-align: middle;

--- a/addons/website/static/src/snippets/s_social_media/000.scss
+++ b/addons/website/static/src/snippets/s_social_media/000.scss
@@ -1,6 +1,9 @@
 
 .s_social_media {
     $-size: map-get($spacers, 5);
+    &[contenteditable="false"] {
+        user-select: none;
+    }
     > * {
         display: inline-block;
         vertical-align: middle;

--- a/addons/website/static/tests/builder/options/rating_option.test.js
+++ b/addons/website/static/tests/builder/options/rating_option.test.js
@@ -1,6 +1,6 @@
 import { defineWebsiteModels, setupWebsiteBuilder } from "../website_helpers";
 import { expect, test } from "@odoo/hoot";
-import { animationFrame, clear, click, fill, waitFor } from "@odoo/hoot-dom";
+import { animationFrame, clear, click, fill, queryOne, waitFor } from "@odoo/hoot-dom";
 import { contains } from "@web/../tests/web_test_helpers";
 
 defineWebsiteModels();
@@ -37,7 +37,7 @@ test("change rating score", async () => {
     await animationFrame();
     expect(":iframe .s_rating .s_rating_inactive_icons i").toHaveCount(3);
     expect(":iframe .s_rating").toHaveInnerHTML(
-        `<h4 class="s_rating_title">Quality</h4>
+        `<h4 class="s_rating_title" contenteditable="true">Quality</h4>
         <div class="s_rating_icons o_not_editable" contenteditable="false">
             <span class="s_rating_active_icons">
                 <i class="fa fa-star" contenteditable="false">
@@ -80,4 +80,11 @@ test("Ensure order of operations when clicking very fast on two options", async 
     expect("[data-label='Icon'] .dropdown-toggle").toHaveText("Stars");
     expect(":iframe .s_rating").not.toHaveAttribute("data-active-custom-icon");
     expect(":iframe .s_rating_icons").not.toHaveClass("fa-2x");
+});
+
+test("rating snippet should not be editable (except title) nor user-selectable", async () => {
+    await setupWebsiteBuilder(websiteContent, { loadIframeBundles: true });
+    expect(queryOne(":iframe .s_rating").isContentEditable).toBe(false);
+    expect(queryOne(":iframe .s_rating_title").isContentEditable).toBe(true);
+    expect(":iframe .s_rating").toHaveStyle({ "user-select": "none" });
 });

--- a/addons/website/static/tests/builder/website_builder/social_media.test.js
+++ b/addons/website/static/tests/builder/website_builder/social_media.test.js
@@ -171,3 +171,11 @@ test("save social medias", async () => {
     await contains(".o-snippets-top-actions button[data-action='save']").click();
     expect(writeCalled).toBe(true, { message: "did not write social links" });
 });
+
+test("social media snippet should not be user-selectable", async () => {
+    await setupWebsiteBuilder(
+        `<div class="s_social_media o_not_editable"><h4>Social Media</h4></div>`,
+        { loadIframeBundles: true }
+    );
+    expect(":iframe .s_social_media").toHaveStyle({ "user-select": "none" });
+});

--- a/addons/website/static/tests/builder/website_builder/social_media.test.js
+++ b/addons/website/static/tests/builder/website_builder/social_media.test.js
@@ -1,7 +1,7 @@
 import { expect, test } from "@odoo/hoot";
 import { defineWebsiteModels, setupWebsiteBuilder } from "../website_helpers";
 import { contains, onRpc } from "@web/../tests/web_test_helpers";
-import { click } from "@odoo/hoot-dom";
+import { click, queryOne } from "@odoo/hoot-dom";
 
 defineWebsiteModels();
 
@@ -178,4 +178,17 @@ test("social media snippet should not be user-selectable", async () => {
         { loadIframeBundles: true }
     );
     expect(":iframe .s_social_media").toHaveStyle({ "user-select": "none" });
+});
+
+test("share snippet should not be editable (except title) nor user-selectable", async () => {
+    await setupWebsiteBuilder(
+        `<div class="s_share">
+            <h4 class="s_share_title">Share</h4>
+            <a href="#"><i class="fa fa-facebook"/></a>
+        </div>`,
+        { loadIframeBundles: true }
+    );
+    expect(queryOne(":iframe .s_share").isContentEditable).toBe(false);
+    expect(queryOne(":iframe .s_share_title").isContentEditable).toBe(true);
+    expect(":iframe .s_share").toHaveStyle({ "user-select": "none" });
 });


### PR DESCRIPTION
This PR fixes undesired selections that might happen when clicking on empty spaces on the following snippets:
- s_social_media
- s_share
- s_rating

Such selections are undesired as:
- these snippets are not meant to be editable via the Editor (except for their title, when present).
- the uncollapsed selection results in the floating toolbar being displayed.

This PR's strategy was:
- to make sure these snippets are contenteditable=false at their root, in case that was not already the case in the snippet template.
- to make the snippets' content non user-selectable. While this does not affect the contenteditable=true areas (.i.e. the title), it effectively prevents selecting the non editable areas.

task-5066301

