### PR TITLE
[FIX] website: categories showcase scroll clone bug

### DIFF
--- a/addons/website/static/src/builder/plugins/options/ecomm_categories_showcase_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/ecomm_categories_showcase_option_plugin.js
@@ -2,8 +2,6 @@ import { Plugin } from "@html_editor/plugin";
 import { registry } from "@web/core/registry";
 import { withSequence } from "@html_editor/utils/resource";
 import { SNIPPET_SPECIFIC_BEFORE, END, VERTICAL_ALIGNMENT } from "@html_builder/utils/option_sequence";
-import { WEBSITE_BACKGROUND_OPTIONS } from "@website/builder/option_sequence";
-import { WebsiteBackgroundOption } from "@website/builder/plugins/options/background_option";
 import { BuilderAction } from "@html_builder/core/builder_action";
 
 class EcommCategoriesShowcaseOptionPlugin extends Plugin {
@@ -22,17 +20,6 @@ class EcommCategoriesShowcaseOptionPlugin extends Plugin {
             withSequence(SNIPPET_SPECIFIC_BEFORE, {
                 template: "website.EcommCategoriesShowcaseOption",
                 selector: ".s_ecomm_categories_showcase",
-            }),
-            withSequence(WEBSITE_BACKGROUND_OPTIONS + 1, {
-                OptionComponent: WebsiteBackgroundOption,
-                selector: ".s_ecomm_categories_showcase_block",
-                props: {
-                    withColors: true,
-                    withImages: true,
-                    withVideos: true,
-                    withShapes: true,
-                    withColorCombinations: true,
-                },
             }),
             withSequence(VERTICAL_ALIGNMENT, {
                 template: "website.EcommCategoriesShowcaseBlockDesign",

--- a/addons/website/static/src/builder/plugins/options/utils.js
+++ b/addons/website/static/src/builder/plugins/options/utils.js
@@ -10,5 +10,5 @@ export const ONLY_BG_IMAGE_SELECTOR = BASE_ONLY_BG_IMAGE_SELECTOR;
 export const ONLY_BG_IMAGE_EXLUDE = "";
 
 export const BOTH_BG_COLOR_IMAGE_SELECTOR =
-    "section, .carousel-item, .s_masonry_block .row > div, .s_color_blocks_2 .row > div, .parallax, .s_text_cover .row > .o_not_editable, .s_website_form_cover .row > .o_not_editable, .s_split_intro .row > .o_not_editable, .s_bento_grid .row > div, .s_banner_categories .row > div";
+    "section, .carousel-item, .s_masonry_block .row > div, .s_color_blocks_2 .row > div, .parallax, .s_text_cover .row > .o_not_editable, .s_website_form_cover .row > .o_not_editable, .s_split_intro .row > .o_not_editable, .s_bento_grid .row > div, .s_banner_categories .row > div, .s_ecomm_categories_showcase_block";
 export const BOTH_BG_COLOR_IMAGE_EXCLUDE = `${BASE_ONLY_BG_IMAGE_SELECTOR}, .s_carousel_wrapper, .s_image_gallery .carousel-item, .s_google_map, .s_map, [data-snippet] :not(.oe_structure) > [data-snippet], .s_masonry_block .s_col_no_resize, .s_quotes_carousel_wrapper, .s_carousel_intro_wrapper, .s_carousel_cards_item, .s_dynamic_snippet_category .s_dynamic_snippet_title`;


### PR DESCRIPTION
Applying a scroll effect on a block from the categories showcase snippets triggers the parallax plugin, which converts the block into .parallax and adds a .s_parallax_bg child. But both global and snippet-local background option registrations then target the same block, resulting in duplicated controls in the builder.

This commit fixes this by removing the snippet's custom WebsiteBackgroundOption registration entirely and adding 
.s_ecomm_categories_showcase_block to the global background selector.

task-5076305

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
