### PR TITLE
[FIX] calendar: fix status help typo

### DIFF
--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -184,7 +184,7 @@
                             <div class="d-flex">
                                 <field name="show_as" class="oe_inline me-2" readonly="not user_can_edit" nolabel="1"/>
                                 <field name="privacy" class="oe_inline me-2" readonly="not user_can_edit" nolabel="1" placeholder="User default"
-                                    help="Set whether you're available for other simultaneous avents and the privacy of this event to others. Manage your default privacy in your user preferences."/>
+                                    help="Set whether you're available for other simultaneous events and the privacy of this event to others. Manage your default privacy in your user preferences."/>
                             </div>
                             <field name="should_show_status" invisible="1"/>
                             <div class="d-flex mb-2" colspan="2">


### PR DESCRIPTION
A typo slipped itself in the rework of the calendar form view in [1]

[1] odoo/odoo@95a7c10625bcbc75d602ed08ce8062b00df48d7f

Task-5057504
