### PR TITLE
[FIX] base_automation: Adapt trigger selection to dark mode

### DIFF
--- a/addons/base_automation/static/src/base_automation.scss
+++ b/addons/base_automation/static/src/base_automation.scss
@@ -54,3 +54,9 @@
         }
     }
 }
+
+.o_field_base_automation_trigger_selection select {
+    option, optgroup {
+        background-color: $dropdown-bg;
+    }
+}


### PR DESCRIPTION
Steps:
- Install `base_automation`
- Enable dark mode
- Open Automation rules
- Create a new rule
- open trigger dropdown
- the dropdown background is still in light mode

This commit apply $dropdown-bg on `o_field_base_automation_trigger_selection`

opw-5064357