### PR TITLE
[IMP] mail: use AI plugin in small composer

### DIFF
--- a/addons/mail/static/src/core/common/plugin/plugin_sets.js
+++ b/addons/mail/static/src/core/common/plugin/plugin_sets.js
@@ -5,9 +5,11 @@ import { InlineCodePlugin } from "@html_editor/main/inline_code";
 import { TabulationPlugin } from "@html_editor/main/tabulation_plugin";
 import { HintPlugin } from "@html_editor/main/hint_plugin";
 import { MailComposerPlugin } from "@mail/core/common/plugin/mail_composer_plugin";
+import { ChatGPTTranslatePlugin } from "@html_editor/main/chatgpt/chatgpt_translate_plugin";
 
 export const MAIL_PLUGINS = [
     ...CORE_PLUGINS,
+    ChatGPTTranslatePlugin,
     HintPlugin,
     InlineCodePlugin,
     MailComposerPlugin,
@@ -18,6 +20,7 @@ export const MAIL_PLUGINS = [
 
 export const MAIL_SMALL_UI_PLUGINS = [
     ...CORE_PLUGINS,
+    ChatGPTTranslatePlugin,
     HintPlugin,
     InlineCodePlugin,
     MailComposerPlugin,


### PR DESCRIPTION
This commit allows the use of the AI plugin in the HTML composer, enhancing its functionality and user experience and hence, the user does not have to switch between different tools to access AI features.

task-4772129

https://github.com/odoo/enterprise/pull/94285

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
