### PR TITLE
[FIX] sale: ensure default sales team of so is among allowed companies

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -446,7 +446,13 @@ class SaleOrder(models.Model):
     def _compute_team_id(self):
         cached_teams = {}
         for order in self:
-            default_team_id = self.env.context.get('default_team_id', False) or order.partner_id.team_id.id or order.team_id.id
+            domain = order.team_id._check_company_domain(order.company_id or order.env.company)
+            default_team_id = (
+                self.env.context.get('default_team_id')
+                or order.partner_id.team_id.filtered_domain(domain).id
+                or order.team_id.id
+            )
+
             user_id = order.user_id.id
             company_id = order.company_id.id
             key = (default_team_id, user_id, company_id)

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -1103,3 +1103,23 @@ class TestSalesTeam(SaleCommon):
         self.assertEqual(so.amount_total, 18.22)
         self.assertEqual(so.order_line.price_tax, 2.91)
         self.assertEqual(so.order_line.price_total, 18.22)
+
+    def test_default_sales_teams_with_multi_company(self):
+        """
+        Check that the default sales team value on a sale order created for
+        a customer shared between multiple companies, is properly set according
+        to the current user company.
+        """
+        company_1 = self.env.company
+        company_2 = self.env['res.company'].create({'name': 'Company 2'})
+
+        self.sale_team_2.company_id = company_2.id
+
+        self.partner.company_id = False
+        self.partner.team_id = self.sale_team_2
+
+        user = self.user_not_in_team
+        user.company_id = company_1
+
+        sale_order = self.env['sale.order'].with_user(user).create({'partner_id': self.partner.id})
+        self.assertEqual(sale_order.team_id, self.sale_team)


### PR DESCRIPTION
**Steps to reproduce:**
- Create two companies.
- Create two sales teams, each assigned to a different company.
- Create a customer without a company (shared across both companies), and assign it a sales team from the first company.
- Create a user belonging to the second company and its sales team.
- With this user, create a new sale order for the shared customer.
- The sales team field is automatically populated with the team from the other company.
- An error is raised when saving the order.

**Issue:**
`_compute_team_id` does not validate allowed companies when determining `default_team_id`. As a result, `order.partner_id.team_id` could be used even if the user did not have access to the company of this team.

**Fix:**
Explicitly check if the proposed teams are available to the user in `self.env.companies.ids`.

opw-4920130

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
