### PR TITLE
[FIX] hr_work_entry: require Working Hours for Working Schedule source

### DIFF
--- a/addons/hr_holidays/tests/test_accrual_allocations.py
+++ b/addons/hr_holidays/tests/test_accrual_allocations.py
@@ -3982,6 +3982,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
         with freeze_time("2017-12-05"):
             employee_without_calendar = self.env['hr.employee'].create({
                 'name': 'employee without calendar',
+                'work_entry_source': 'planning',
                 'resource_calendar_id': False,
             })
             accrual_plan = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({

--- a/addons/hr_holidays/tests/test_expiring_leaves.py
+++ b/addons/hr_holidays/tests/test_expiring_leaves.py
@@ -636,6 +636,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
         })
 
         logged_in_emp = self.env.user.employee_id
+        logged_in_emp.work_entry_source = 'planning'
         logged_in_emp.resource_calendar_id = None       # Set as Fully flexible resource
 
         allocation = self.env['hr.leave.allocation'].sudo().create({

--- a/addons/hr_work_entry/models/hr_version.py
+++ b/addons/hr_work_entry/models/hr_version.py
@@ -8,7 +8,7 @@ import pytz
 from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models, _, SUPERUSER_ID
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, ValidationError
 from odoo.fields import Command, Domain
 from odoo.tools import ormcache
 from odoo.tools.intervals import Intervals
@@ -36,10 +36,16 @@ class HrVersion(models.Model):
         groups="hr.group_hr_manager",
     )
 
-    @api.depends('work_entry_source', 'resource_calendar_id')
+    @api.depends('work_entry_source', 'resource_calendar_id', 'employee_id')
     def _compute_work_entry_source_calendar_invalid(self):
         for version in self:
-            version.work_entry_source_calendar_invalid = version.work_entry_source == 'calendar' and not version.resource_calendar_id
+            version.work_entry_source_calendar_invalid = version.work_entry_source == 'calendar' and not version.resource_calendar_id and version.employee_id
+
+    @api.constrains('work_entry_source', 'resource_calendar_id', 'employee_id')
+    def _check_calendar_required(self):
+        for version in self:
+            if version.work_entry_source == 'calendar' and not version.resource_calendar_id and version.employee_id:
+                raise ValidationError(self.env._("A working schedule is required when the work entry source is set to 'Working Schedule'."))
 
     @ormcache()
     def _get_default_work_entry_type_id(self):

--- a/addons/hr_work_entry/views/hr_employee_views.xml
+++ b/addons/hr_work_entry/views/hr_employee_views.xml
@@ -20,6 +20,12 @@
             <separator name="schedule" position="after">
                 <field name="work_entry_source" invisible="1"/>
             </separator>
+            <xpath expr="//page[@name='payroll_information']//group[@name='payroll_group']//field[@name='resource_calendar_id']" position='attributes'>
+                <attribute name="required">
+                    work_entry_source_calendar_invalid == True
+                </attribute>
+                <attribute name="placeholder">e.g. Half-Time, 40h/week, Flexible 20h, ...</attribute>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
#### Steps to Reproduce
1. Go to Employees.
2. Select an employee with Work Entry Source = "Working Schedule".
3. Clear the "Working Hours" field.
4. Try to save.

#### Issue
A traceback occurs because work entries are recomputed with no working schedule set. The UI does not prevent saving without a schedule.

#### Fix
- Conditionally added the attribute `required` to `resource_calendar_id` field in the inherited `hr.employee` form view.
- Added a Python constraint to enforce the requirement in backend (API, imports) to avoid invalid data.

task-5068798
