### PR TITLE
[FIX] account: invoice currency rate manually changed

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1085,7 +1085,7 @@
                                             <button type="object"
                                                     name="refresh_invoice_currency_rate"
                                                     icon="fa-refresh"
-                                                    title="Refresh currency rate to the invoice date"
+                                                    title="Reset the currency rate to the default accordingly to the invoice date"
                                                     class="btn btn-link p-0"/>
                                         </div>
                                     </div>


### PR DESCRIPTION
in case the user would enter manually a different rate than the default one, but does not fill the invoice date; odoo was setting today as the invoice date, which was changing the rate and recomputing all the lines... Effectively losing everything the user just encoded.

So now, we only recompute the rate and the lines if the user didn't change it.

The title of the refresh_invoice_currency_rate button has also been improved to be more explicit on what it does.






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
