### PR TITLE
[FIX] website_sale: ensure cart column width updates correctly

### DIFF
--- a/addons/website_sale/static/src/interactions/quick_reorder.js
+++ b/addons/website_sale/static/src/interactions/quick_reorder.js
@@ -133,22 +133,21 @@ export class QuickReorder extends Interaction {
                 }));
         }
 
+        const data = await this.waitFor(rpc('/shop/cart/quick_add', {
+            product_template_id: productTemplateId,
+            product_id: productId,
+            quantity: quantity,
+            ...(isCombo && { linked_products: linkedProducts }),
+        }));
+
         // Add the product to the cart and update the DOM.
         const cart = document.getElementById('shop_cart');
         // `updateCartNavBar` regenerates the cart lines and `updateQuickReorderSidebar`
         // regenerates the quick reorder products, so we need to stop and start interactions to
         // make sure the regenerated reorder products and cart lines are properly handled.
-        this.services['public.interactions'].stopInteractions();
         this.services['public.interactions'].stopInteractions(cart);
-        const data = await rpc('/shop/cart/quick_add', {
-            product_template_id: productTemplateId,
-            product_id: productId,
-            quantity: quantity,
-            ...(isCombo && { linked_products: linkedProducts }),
-        })
-        wSaleUtils.updateQuickReorderSidebar(data);
         wSaleUtils.updateCartNavBar(data);
-        this.services['public.interactions'].startInteractions();
+        wSaleUtils.updateQuickReorderSidebar(data);
         this.services['public.interactions'].startInteractions(cart);
 
         // Move the focus to the next quantity input.

--- a/addons/website_sale/static/src/js/website_sale_utils.js
+++ b/addons/website_sale/static/src/js/website_sale_utils.js
@@ -88,6 +88,11 @@ function updateCartNavBar(data) {
 
     updateCartSummary(data);
 
+    // Adjust the cart's left column width to accommodate the cart summary (right column). The left
+    // column of an empty cart initially takes the full width, but adding products (e.g. via quick 
+    // reorder) enables the cart summary on the right.
+    document.querySelector('.oe_cart').classList.toggle('col-lg-7', !!data.cart_quantity);
+
     if (data.cart_ready) {
         document.querySelector("a[name='website_sale_main_button']")?.classList.remove('disabled');
     } else {


### PR DESCRIPTION
When the cart was previously empty, adding products (e.g., via the quick reorder feature) caused the cart summary to display incorrectly at the bottom of the page. This happened because the left column's default width spans the entire screen when the cart is empty, and adding products did not update the column widths. As a result, the left column retained a full width which left no space for the cart summary on the right.

This commit resolves the issue by ensuring the cart columns are updated dynamically when the cart content changes.

