### PR TITLE
[FIX] point_of_sale: process IndexedDB batches sequentially

### DIFF
--- a/addons/point_of_sale/static/src/app/models/utils/indexed_db.js
+++ b/addons/point_of_sale/static/src/app/models/utils/indexed_db.js
@@ -152,10 +152,13 @@ export default class IndexedDB {
                 }
             });
 
-            results.push(batchPromise);
+            const result = await batchPromise
+                .then(() => ({ status: "fulfilled" }))
+                .catch((err) => ({ status: "rejected", reason: err }));
+            results.push(result);
         }
 
-        return Promise.allSettled(results);
+        return results;
     }
 
     getNewTransaction(dbStore) {


### PR DESCRIPTION
When saving large datasets to IndexedDB, all batches were started in parallel. This could cause excessive open transactions, long execution times, and premature transaction aborts due to the timeout.

With this commit, batches are now processed one at a time, ensuring that each batch completes before starting the next. This improves stability and prevents transaction overload when handling high volumes
of data.

opw-5052956

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
