### PR TITLE
[FIX] purchase: prevent singleton error when matching PO and Bill with individual

### DIFF
--- a/addons/purchase/models/purchase_bill_line_match.py
+++ b/addons/purchase/models/purchase_bill_line_match.py
@@ -180,8 +180,11 @@ class PurchaseBillMatch(models.Model):
     def action_add_to_po(self):
         if not self or not self.aml_id:
             raise UserError(_("Select Vendor Bill lines to add to a Purchase Order"))
+        partner = self.mapped("partner_id.commercial_partner_id")
+        if len(partner) > 1:
+            raise UserError(_("Please select bill lines with the same vendor."))
         context = {
-            'default_partner_id': self.partner_id.id,
+            'default_partner_id': partner.id,
             'dialog_size': 'medium',
             'has_products': bool(self.aml_id.product_id),
         }

--- a/addons/purchase/tests/test_purchase.py
+++ b/addons/purchase/tests/test_purchase.py
@@ -984,6 +984,12 @@ class TestPurchase(AccountTestInvoicingCommon):
         self.env['purchase.order.line'].flush_model()
         result = vendor_bill.action_purchase_matching()
         matching_records = self.env['purchase.bill.line.match'].search(result['domain'])
+
+        # Ensure that calling `action_add_to_po()` on multiple records
+        # does not raise a singleton ValueError when the vendor is an individual
+        # linked to a company.
+        matching_records.action_add_to_po()
+
         self.assertEqual(len(matching_records), 2)
         self.assertEqual(matching_records.account_move_id, vendor_bill)
         self.assertEqual(matching_records.purchase_order_id, purchase_order)


### PR DESCRIPTION
**Issue**
When both a Purchase Order and a Vendor Bill are created using the same individual contact linked to a company, Bill Matching fails with a traceback.

**Steps to Reproduce**
1. Create an individual contact and link it to a company.
2. Create a Purchase Order with the individual as a vendor.
3. Create a Vendor Bill with the same individual as the vendor.
4. Try to perform Bill Matching.
5. A `ValueError: Expected singleton: res.partner(...)` is raised.

Video for reference:
https://drive.google.com/file/d/1qVnPLpk8jyMTKz-6AVLSaN2nVVeWiF4y/view

**Root Cause**
Purchase Orders store the partner exactly as selected (the individual contact), while Vendor Bills are normalized internally to the parent company (`commercial_partner_id`). This creates a mismatch in the Bill Matching logic, where records reference both the individual and the company, leading to an invalid recordset and the singleton error.

**Fix**
Always normalize vendors to their `commercial_partner_id` during Bill Matching. This ensures that both Purchase Orders and Vendor Bills consistently reference the same partner, avoiding mismatches between individual contacts and their parent company.

Opw-5050339
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
