### PR TITLE
[FIX] website_sale: align `s_dynamic_snippet_products` arrows

### DIFF
--- a/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/000.scss
+++ b/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/000.scss
@@ -27,15 +27,16 @@
 
     // Adapts arrow container width
     @mixin o-adapts-col-size {
+        .carousel {
+            --o-wsale-dynamic-snippet-col-size: var(--o-carousel-item-width-percentage);
 
-        // For mobile
-        .carousel:has(:where(.s_dynamic_snippet_row > div:nth-child(2))) {
-            --o-wsale-dynamic-snippet-col-size: 50%;
-        }
+            &:where(:has(.col-6)) {
+                --o-wsale-dynamic-snippet-col-size: 50%;
+            }
 
-        // For desktop
-        .carousel:has(:where(.s_dynamic_snippet_row > div:nth-child(4))) {
-            --o-wsale-dynamic-snippet-col-size: 25%;
+            &:where(:has(.col-3)) {
+                --o-wsale-dynamic-snippet-col-size: 25%;
+            }
         }
     }
     .s_dynamic_snippet_row.row {


### PR DESCRIPTION
Arrows were misaligned when using the options

"Scrolling mode: Single".

This was due to how we detected where to apply the custom property with the 25 or 50%.

task-5076265
Follow-up of task-4997544


| Before | After fix |
|--------|--------|
| <img width="1578" height="655" alt="image" src="https://github.com/user-attachments/assets/bc745b42-83f6-4ef8-80fd-a48f6cb4a198" /> | <img width="1625" height="661" alt="image" src="https://github.com/user-attachments/assets/b31e742b-99d5-40f7-b01b-756df063e2d9" /> | 



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
