### PR TITLE
[FIX] website_sale: products snippets background repeat

### DIFF
--- a/addons/website_sale/static/src/scss/product_tile.scss
+++ b/addons/website_sale/static/src/scss/product_tile.scss
@@ -117,6 +117,7 @@
             object-position: var(--o-wsale-card-thumb-position, center);
             background-size: var(--o-wsale-card-thumb-fill-mode, contain);
             background-position: var(--o-wsale-card-thumb-position, center);
+            background-repeat: var(--o-wsale-card-thumb-repeat, no-repeat);
         }
         @include media-breakpoint-up(lg) {
             .oe_product_image_img_wrapper {


### PR DESCRIPTION
This PR fixes a issue where the thumbnail image on the 'products' snippets would repeat itself.

task-5076717

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
