### PR TITLE
[FIX] website_sale_comparison: bottom_bar minor CSS fixes

### DIFF
--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -522,6 +522,7 @@
 
         #o_wsale_floating_bar {
             bottom: var(--_container-gap);
+            z-index: 4; // above the comparison bottom bar and pager
             max-width: calc(100vw - calc(var(--_container-gap) * 2));
             gap: map-get($spacers, 1) 0;
         }

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1593,7 +1593,7 @@
             >
                 <nav
                     id="o_wsale_floating_bar"
-                    t-attf-class="navbar position-sticky z-3 d-flex gap-1 gap-lg-2 flex-shrink-0 bg-body rounded mb-2 px-2 px-lg-3 shadow {{floatBar_hasSearch and 'ps-1 ps-lg-1'}}"
+                    t-attf-class="navbar position-sticky d-flex gap-1 gap-lg-2 flex-shrink-0 bg-body rounded mb-2 px-2 px-lg-3 shadow {{floatBar_hasSearch and 'ps-1 ps-lg-1'}}"
                 >
                     <div t-if="floatBar_hasSearch">
                         <a

--- a/addons/website_sale_comparison/static/src/js/product_comparison_bottom_bar/product_comparison_bottom_bar.xml
+++ b/addons/website_sale_comparison/static/src/js/product_comparison_bottom_bar/product_comparison_bottom_bar.xml
@@ -4,7 +4,7 @@
         <div class="o_not_editable position-absolute top-0 start-0 bottom-0 end-0 d-flex align-items-end justify-content-end p-0 pe-none">
             <div
                 t-if="state.products.size"
-                class="o_wsale_comparison_bottom_bar sticky-bottom flex-shrink-0 w-100 bg-body shadow-lg pe-auto"
+                class="o_wsale_comparison_bottom_bar sticky-bottom z-3 flex-shrink-0 w-100 bg-body pe-auto"
                 name="comparison_bottom_bar"
             >
                 <div class="container">

--- a/addons/website_sale_comparison/static/src/scss/website_sale_comparison.scss
+++ b/addons/website_sale_comparison/static/src/scss/website_sale_comparison.scss
@@ -94,6 +94,9 @@
 }
 
 .o_wsale_comparison_bottom_bar {
+
+    box-shadow: 0px -12px 32px rgba($black, .175);
+
     .btn[data-bs-toggle="collapse"] {
         .oi-chevron-up {
             transition: transform 0.2s ease-in-out;


### PR DESCRIPTION
This PR fixes two issues related to the `website_sale_comparison` bottom bar :

1) As the `bottom_bar` is using the `sticky-bottom` utility class, which comes with the `$zindex-sticky` (1020), it was position above the `floating_bar` element, which overriddes its `z-index` with a `z-3` utility class. We could have set the `bottom_bar` `z-index` to `z-2` but unfortunately, the pager component includes a `z-index: 3` on the active entry, which would make it appear above the bottom bar. To fix this, we set the `z-index` of the `bottom_bar` to `3` and increment the one of the `floating_bar` to `4`.

2) As the `background-color` of the footer was changed in `19.0`, this highlighted an issue with the shadow of the `bottom_bar` showing above the footer. To fix this issue, we set a negative offset, ensuring it only shows on the top side and not on the bottom one.

task-5076826

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
