### PR TITLE
[IMP] product: append (copy) to the name when duplicating a product category

### DIFF
--- a/addons/product/models/product_category.py
+++ b/addons/product/models/product_category.py
@@ -59,3 +59,11 @@ class ProductCategory(models.Model):
             return super()._compute_display_name()
         for record in self:
             record.display_name = record.name
+
+    def copy_data(self, default=None):
+        default = dict(default or {})
+        vals_list = super().copy_data(default=default)
+        if 'name' not in default:
+            for category, vals in zip(self, vals_list):
+                vals['name'] = _("%s (copy)", category.name)
+        return vals_list


### PR DESCRIPTION
Purpose:
================
-Currently, duplicating a `product category` record creates a new record with the same name as the original.
-This makes it difficult to distinguish duplicates from the original, leading to potential confusion when managing categories.

With this commit:
================
-Duplicating a `product category` record now appends `(copy)` to the name of the new product category record.
-This change makes duplicates clearly identifiable and reduces ambiguity in category management. Prevents mistakes in product categorization.


Task-5076170