### PR TITLE
[FIX] website: restore document access in portal.

### DIFF
--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -255,6 +255,8 @@ class Http(models.AbstractModel):
         if user.id == website._get_cached('user_id'):
             # avoid a read on res_company_user_rel in case of public user
             allowed_company_ids = [website_company_id]
+        elif request.httprequest.path.startswith('/my'):
+            allowed_company_ids = user.company_ids.ids
         elif website_company_id in user._get_company_ids():
             allowed_company_ids = [website_company_id]
         else:


### PR DESCRIPTION
The behavior of the portal is different when website is installed, When it's not installed, users can acces documents from all the companies they have the right to. When website is installed, users only have access to the company of the website. 

Steps to reproduce:
-------------------
* Create a second company
* Give acces to both company for user A
* Create documents from both company for user A (portal or internal)
* Acces portal with user A => has acces to all documents
* Install website
* Acces portal with user A => only has acces to documents from website company. Observation:

Why the fix:
------------
To align the behavior when website is not installed. 

opw-4942085
