### PR TITLE
[FIX] website_sale_comparison: avoid unwanted scrollbars

### DIFF
--- a/addons/website_sale_comparison/static/src/scss/website_sale_comparison.scss
+++ b/addons/website_sale_comparison/static/src/scss/website_sale_comparison.scss
@@ -21,7 +21,9 @@
     --o-website-sale-comparison-table-column-padding-x: #{map-get($spacers, 2)};
 
     > .overflow-x-auto {
-        @include media-breakpoint-down(sm) {
+        margin: 0 calc(var(--o-website-sale-comparison-table-column-padding-x) * -1);
+
+        @include media-breakpoint-down(lg) {
             margin: 0 calc(var(--gutter-x, 30px) / -2);
         }
     }
@@ -38,13 +40,12 @@
     }
 
     #o_comparelist_table {
-        margin: 0 calc(var(--o-website-sale-comparison-table-column-padding-x) * -1);
-
         @include media-breakpoint-down(xl) {
             min-width: max-content;
         }
-        @include media-breakpoint-down(sm) {
-            padding: 0 calc(var(--gutter-x, 30px) / 2);
+
+        @include media-breakpoint-down(lg) {
+            padding: 0 calc(var(--o-website-sale-comparison-table-column-padding-x));
         }
     }
 

--- a/addons/website_sale_comparison/views/website_sale_comparison_template.xml
+++ b/addons/website_sale_comparison/views/website_sale_comparison_template.xml
@@ -443,7 +443,7 @@
                 </div>
                 <div class="oe_structure" id="oe_structure_website_sale_comparison_product_compare_2"/>
                 <div class="align-items-end bottom-0 d-flex end-0 justify-content-end o_not_editable p-0 position-absolute top-0 start-0 pe-none">
-                    <div class="o_wsale_comparison_bottom_bar sticky-bottom flex-shrink-0 w-100 bg-body shadow-lg pe-auto">
+                    <div class="o_wsale_comparison_bottom_bar sticky-bottom flex-shrink-0 w-100 bg-body pe-auto">
                         <div t-attf-class="d-flex align-items-center py-3 #{website.shop_page_container == 'fluid' and 'container-fluid' or 'container'}">
                             <button
                                 class="btn btn-link ps-0 text-decoration-none"


### PR DESCRIPTION
This PR fixes an issue about the `website_sale_comparison` page showing an unwanted scrollbar on desktop.

Since each `.o_wsale_compare_table_column` element comes with a padding on the left and right side, it was creating a misalignment between the page content and the page header and footer.

With this commit, we fix the issue by assigning a new `width` to the container, based on those padding values.

task-5076730

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
