### PR TITLE
[REM] microsoft_account: remove unused get_param variable

### DIFF
--- a/addons/microsoft_account/models/microsoft_service.py
+++ b/addons/microsoft_account/models/microsoft_service.py
@@ -121,8 +121,6 @@ class MicrosoftService(models.AbstractModel):
             'u': self.env['ir.config_parameter'].sudo().get_param('database.uuid'),
         }
 
-        get_param = self.env['ir.config_parameter'].sudo().get_param
-
         encoded_params = urls.url_encode({
             'response_type': 'code',
             'client_id': self._get_microsoft_client_id(service),


### PR DESCRIPTION
Just remove the unused variable `get_param`