### PR TITLE
[FIX] orm: copy only readable m2m records

### DIFF
--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -5446,7 +5446,8 @@ class BaseModel(metaclass=MetaModel):
                     # reassigned to the correct one thanks to the (Command.CREATE, 0, ...)
                     vals[name] = [Command.create(line) for line in lines if line]
                 elif field.type == 'many2many':
-                    vals[name] = [Command.set(record[name].ids)]
+                    # copy only links that we can read, otherwise the write will fail
+                    vals[name] = [Command.set(record[name]._filtered_access('read').ids)]
                 else:
                     vals[name] = field.convert_to_write(record[name], record)
             vals_list.append(vals)


### PR DESCRIPTION
When copying data, just cpoy the records that we are able to read. We recently added a check that assigned records to m2m fields must be readable which may not be the case for all returned ids.

runbot-error-231611


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
