### PR TITLE
[FIX] mrp,purchase_stock,stock: fixes for product routes

### DIFF
--- a/addons/mrp/data/mrp_data.xml
+++ b/addons/mrp/data/mrp_data.xml
@@ -13,7 +13,6 @@
             <field name="sequence">5</field>
             <field name="product_selectable" eval="False"/>
             <field name="warehouse_selectable" eval="True"/>
-            <field name="warehouse_ids" eval="[(4, ref('stock.warehouse0'))]"/>
         </record>
 
         <!-- Enable the manufacturing in warehouse0 -->

--- a/addons/mrp/models/stock_warehouse.py
+++ b/addons/mrp/models/stock_warehouse.py
@@ -4,6 +4,7 @@
 from odoo import Command, _, api, fields, models
 from odoo.exceptions import ValidationError, UserError
 from odoo.tools import split_every
+from odoo.fields import Domain
 
 
 class StockWarehouse(models.Model):
@@ -327,3 +328,7 @@ class StockWarehouseOrderpoint(models.Model):
             non_kit_ids.extend(id_ for id_ in products.ids if id_ not in kit_ids)
             products.invalidate_recordset()
         return self.env['product.product'].browse(non_kit_ids)
+
+    def _get_route_domain(self):
+        domain = super()._get_route_domain()
+        return Domain.OR([domain, Domain([('rule_ids.action', '=', 'manufacture')])])

--- a/addons/mrp/models/stock_warehouse.py
+++ b/addons/mrp/models/stock_warehouse.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, Command, fields, models, _
+from odoo import Command, _, api, fields, models
 from odoo.exceptions import ValidationError, UserError
 from odoo.tools import split_every
 
@@ -61,7 +61,7 @@ class StockWarehouse(models.Model):
                 manufacture_route.warehouse_ids = [Command.unlink(warehouse.id)]
 
     def _create_or_update_route(self):
-        manufacture_route = self._find_or_create_global_route('mrp.route_warehouse0_manufacture', _('Manufacture'))
+        manufacture_route = self._find_or_create_global_route('mrp.route_warehouse0_manufacture', self.env._('Manufacture'))
         for warehouse in self:
             if warehouse.manufacture_to_resupply:
                 manufacture_route.warehouse_ids = [Command.link(warehouse.id)]

--- a/addons/mrp/models/stock_warehouse.py
+++ b/addons/mrp/models/stock_warehouse.py
@@ -56,7 +56,7 @@ class StockWarehouse(models.Model):
                     ('action', '=', 'manufacture'), ('warehouse_id', '=', warehouse.id)]).route_id
             if not manufacture_route:
                 continue
-            if warehouse.manufacture_to_resupply:
+            if warehouse.manufacture_to_resupply and manufacture_route.warehouse_selectable:
                 manufacture_route.warehouse_ids = [Command.link(warehouse.id)]
             else:
                 manufacture_route.warehouse_ids = [Command.unlink(warehouse.id)]
@@ -64,7 +64,7 @@ class StockWarehouse(models.Model):
     def _create_or_update_route(self):
         manufacture_route = self._find_or_create_global_route('mrp.route_warehouse0_manufacture', self.env._('Manufacture'))
         for warehouse in self:
-            if warehouse.manufacture_to_resupply:
+            if warehouse.manufacture_to_resupply and manufacture_route.warehouse_selectable:
                 manufacture_route.warehouse_ids = [Command.link(warehouse.id)]
         return super()._create_or_update_route()
 

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -18,9 +18,7 @@ class TestMrpOrder(TestMrpCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.env.ref('mrp.route_warehouse0_manufacture').write({
-            'product_selectable': True,
-        })
+        cls.env.ref('mrp.route_warehouse0_manufacture').product_selectable = True
         cls.env.ref('base.group_user').write({'implied_ids': [(4, cls.env.ref('stock.group_production_lot').id)]})
 
     def test_access_rights_manager(self):

--- a/addons/mrp_subcontracting/data/mrp_subcontracting_data.xml
+++ b/addons/mrp_subcontracting/data/mrp_subcontracting_data.xml
@@ -7,7 +7,6 @@
             <field name="sequence">15</field>
             <field name="product_selectable" eval="False"/>
             <field name="warehouse_selectable" eval="True"/>
-            <field name="warehouse_ids" eval="[(4, ref('stock.warehouse0'))]"/>
         </record>
 
         <function model="res.company" name="_create_missing_subcontracting_location" />

--- a/addons/mrp_subcontracting/models/stock_rule.py
+++ b/addons/mrp_subcontracting/models/stock_rule.py
@@ -18,3 +18,10 @@ class StockRule(models.Model):
             if values.get('move_dest_ids') and values['move_dest_ids'].raw_material_production_id.subcontractor_id:
                 move_values['partner_id'] = values['move_dest_ids'].raw_material_production_id.subcontractor_id.id
         return move_values
+
+    def _filter_warehouse_routes(self, product, warehouses, route):
+        if any(rule.action == 'pull' and rule.picking_type_id.code == 'internal' and rule.location_src_id.is_subcontract() for rule in route.rule_ids):
+            if any(bom_line.bom_id.type == 'subcontract' for bom_line in product.bom_line_ids):
+                return super()._filter_warehouse_routes(product, warehouses, route)
+            return False
+        return super()._filter_warehouse_routes(product, warehouses, route)

--- a/addons/mrp_subcontracting/models/stock_warehouse.py
+++ b/addons/mrp_subcontracting/models/stock_warehouse.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models, _
+from odoo import Command, _, api, fields, models
 
 
 class StockWarehouse(models.Model):

--- a/addons/mrp_subcontracting/models/stock_warehouse.py
+++ b/addons/mrp_subcontracting/models/stock_warehouse.py
@@ -8,7 +8,8 @@ class StockWarehouse(models.Model):
     _inherit = 'stock.warehouse'
 
     subcontracting_to_resupply = fields.Boolean(
-        'Resupply Subcontractors', default=True)
+        'Resupply Subcontractors', compute='_compute_subcontracting_to_resupply',
+        inverse='_inverse_subcontracting_to_resupply', default=True)
     subcontracting_mto_pull_id = fields.Many2one(
         'stock.rule', 'Subcontracting MTO Rule', copy=False)
     subcontracting_pull_id = fields.Many2one(
@@ -52,6 +53,36 @@ class StockWarehouse(models.Model):
                 ]
             })
         return result
+
+    def _compute_subcontracting_to_resupply(self):
+        for warehouse in self:
+            subcontracting_route = warehouse.subcontracting_pull_id.route_id
+            warehouse.subcontracting_to_resupply = bool(subcontracting_route.product_selectable or subcontracting_route.warehouse_ids.filtered(lambda w: w.id == warehouse.id))
+
+    def _inverse_subcontracting_to_resupply(self):
+        for warehouse in self:
+            subcontracting_route = warehouse.subcontracting_pull_id.route_id
+            if not subcontracting_route:
+                rules = self.env['stock.rule'].search([
+                    ('action', '=', 'pull'),
+                    ('picking_type_id.code', '=', 'internal'),
+                    ('warehouse_id', '=', warehouse.id),
+                    ('active', '=', True),
+                ])
+                subcontracting_route = rules.filtered(lambda r: r.location_src_id.is_subcontract()).mapped('route_id')
+            if not subcontracting_route:
+                continue
+            if warehouse.subcontracting_to_resupply and subcontracting_route.warehouse_selectable:
+                subcontracting_route.warehouse_ids = [Command.link(warehouse.id)]
+            else:
+                subcontracting_route.warehouse_ids = [Command.unlink(warehouse.id)]
+
+    def _create_or_update_route(self):
+        subcontracting_route = self._find_or_create_global_route('mrp_subcontracting.route_resupply_subcontractor_mto', self.env._('Resupply Subcontractor on Order'))
+        for warehouse in self:
+            if warehouse.subcontracting_to_resupply and subcontracting_route.warehouse_selectable:
+                subcontracting_route.warehouse_ids = [Command.link(warehouse.id)]
+        return super()._create_or_update_route()
 
     def _update_global_route_resupply_subcontractor(self):
         route_id = self._find_or_create_global_route('mrp_subcontracting.route_resupply_subcontractor_mto',

--- a/addons/mrp_subcontracting/tests/test_subcontracting.py
+++ b/addons/mrp_subcontracting/tests/test_subcontracting.py
@@ -30,6 +30,7 @@ class TestSubcontractingBasic(TransactionCase):
         wh_copy = wh_original.copy(default={'name': 'Dummy Warehouse (copy)', 'code': 'Dummy'})
         wh_original.buy_to_resupply = False
         wh_original.manufacture_to_resupply = False
+        wh_original.subcontracting_to_resupply = False
         # Check if warehouse routes got RECREATED (instead of reused)
         route_types = [
             "route_ids",

--- a/addons/mrp_subcontracting_dropshipping/tests/test_purchase_subcontracting.py
+++ b/addons/mrp_subcontracting_dropshipping/tests/test_purchase_subcontracting.py
@@ -20,7 +20,6 @@ class TestSubcontractingDropshippingFlows(TestMrpSubcontractingCommon):
         - Delivery for the component to the subcontractor for the specified wh.
         - Po created for the component.
         """
-        self.warehouse.manufacture_pull_id.route_id.write({'sequence': 20})
         self.env.ref('stock.route_warehouse0_mto').active = True
         mto_route = self.env['stock.route'].search([('name', '=', 'Replenish on Order (MTO)')])
         resupply_route = self.env['stock.route'].search([('name', '=', 'Resupply Subcontractor on Order')])
@@ -360,7 +359,6 @@ class TestSubcontractingDropshippingFlows(TestMrpSubcontractingCommon):
         supplier to each subcontractor.
         """
         dropship_route = self.env.ref('stock_dropshipping.route_drop_shipping')
-        dropship_route.rule_ids.filtered(lambda r: r.action == 'buy').group_propagation_option = 'none'
 
         subcontractor01, subcontractor02, component_supplier = self.env['res.partner'].create([{
             'name': 'Super Partner %d' % i
@@ -412,7 +410,6 @@ class TestSubcontractingDropshippingFlows(TestMrpSubcontractingCommon):
         route_buy = self.env.ref('purchase_stock.route_warehouse0_buy')
         dropship_route = self.env['stock.route'].search([('name', '=', 'Dropship')], limit=1)
         warehouse = self.env['stock.warehouse'].search([], limit=1)
-        warehouse.manufacture_pull_id.route_id.write({'sequence': 20})
 
         compo_drop, compo_rr = self.env['product.product'].create([{
             'name': name,

--- a/addons/mrp_subcontracting_purchase/tests/test_mrp_subcontracting_purchase.py
+++ b/addons/mrp_subcontracting_purchase/tests/test_mrp_subcontracting_purchase.py
@@ -49,7 +49,6 @@ class MrpSubcontractingPurchaseTest(TestMrpSubcontractingCommon):
 
     def test_bom_overview_availability(self):
         # Create routes for components and the main product
-        self.comp2.bom_ids.unlink()
         self.env['product.supplierinfo'].create({
             'product_tmpl_id': self.finished.product_tmpl_id.id,
             'partner_id': self.subcontractor_partner1.id,
@@ -244,6 +243,61 @@ class MrpSubcontractingPurchaseTest(TestMrpSubcontractingCommon):
 
         self.assertEqual(self.finished2.qty_available, 7.0)
         self.assertEqual(po.order_line.qty_received, 10.0)
+
+    def test_orderpoint_warehouse_not_required(self):
+        """
+        The user creates a subcontracted bom for the product,
+        then we create a po for the subcontracted bom we are gonna get
+        orderpoints for the components without warehouse.Notice this is
+        when our subcontracting location is also a replenish location.
+        The test ensure that we can get those orderpoints without warehouse.
+        """
+        # Create a second warehouse to check which one will be used
+        self.env['stock.warehouse'].create({'name': 'Second WH', 'code': 'WH02'})
+
+        product = self.env['product.product'].create({
+            'name': 'Product',
+            'is_storable': True,
+        })
+        component = self.env['product.product'].create({
+            'name': 'Component',
+            'is_storable': True,
+        })
+        subcontractor = self.env['res.partner'].create({
+            'name': 'Subcontractor',
+            'property_stock_subcontractor': self.env.company.subcontracting_location_id.id,
+        })
+        self.env.company.subcontracting_location_id.replenish_location = True
+
+        self.env['mrp.bom'].create({
+            'product_tmpl_id': product.product_tmpl_id.id,
+            'product_qty': 1,
+            'product_uom_id': product.uom_id.id,
+            'type': 'subcontract',
+            'subcontractor_ids': [(subcontractor.id)],
+            'bom_line_ids': [(0, 0, {
+                    'product_id': component.id,
+                    'product_qty': 1,
+                    'product_uom_id': component.uom_id.id,
+            })],
+        })
+
+        po = self.env['purchase.order'].create({
+            'partner_id': subcontractor.id,
+            'order_line': [(0, 0, {
+                'product_id': product.id,
+                'product_qty': 1,
+                'product_uom_id': product.uom_id.id,
+                'name': product.name,
+                'price_unit': 1,
+            })],
+        })
+        po.button_confirm()
+
+        self.env['stock.warehouse.orderpoint']._get_orderpoint_action()
+        orderpoint = self.env['stock.warehouse.orderpoint'].search([('product_id', '=', component.id)])
+        self.assertTrue(orderpoint)
+        self.assertEqual(orderpoint.warehouse_id, self.warehouse)
 
     def test_purchase_and_return03(self):
         """
@@ -758,7 +812,6 @@ class MrpSubcontractingPurchaseTest(TestMrpSubcontractingCommon):
     # TODO: po_lead doesn't exist anymore, remove?
     def test_bom_overview_availability_po_lead(self):
         # Create routes for components and the main product
-        self.comp2.bom_ids.unlink()
         self.env['product.supplierinfo'].create({
             'product_tmpl_id': self.finished.product_tmpl_id.id,
             'partner_id': self.subcontractor_partner1.id,

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -1125,7 +1125,6 @@ class TestPointOfSaleFlow(CommonPosTest):
         if self.env['ir.module.module']._get('purchase').state != 'installed':
             self.skipTest("Purchase module is required for this test to run")
 
-        self.env['stock.route'].search([('name', '=', 'Buy')]).warehouse_ids = self.env['stock.warehouse'].search([])
         self.ten_dollars_with_15_incl.write({
             'seller_ids': [Command.create({
                 'partner_id': self.partner_stva.id,

--- a/addons/pos_mrp/tests/test_frontend.py
+++ b/addons/pos_mrp/tests/test_frontend.py
@@ -60,7 +60,6 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         mto_route = self.env.ref('stock.route_warehouse0_mto')
         manu_route = self.env.ref('mrp.route_warehouse0_manufacture')
-        manu_route.product_selectable = True
         mto_route.active = True
         self.finished.route_ids = [Command.set((mto_route | manu_route).ids)]
 

--- a/addons/purchase_mrp/tests/test_purchase_mrp_flow.py
+++ b/addons/purchase_mrp/tests/test_purchase_mrp_flow.py
@@ -647,7 +647,7 @@ class TestPurchaseMrpFlow(AccountTestInvoicingCommon):
         self.env['stock.warehouse.orderpoint']._get_orderpoint_action()
         orderpoint_product = self.env['stock.warehouse.orderpoint'].search(
             [('product_id', '=', product.id)])
-        self.assertEqual(orderpoint_product.route_id, manu_route, "The route manufacture should be set on the orderpoint")
+        self.assertEqual(orderpoint_product.route_id, buy_route, "The route buy should be set on the orderpoint")
         # Delete the orderpoint to generate a new one with the manufacture route
         orderpoint_product.unlink()
         # switch the product route to manufacture
@@ -655,7 +655,7 @@ class TestPurchaseMrpFlow(AccountTestInvoicingCommon):
         self.env['stock.warehouse.orderpoint']._get_orderpoint_action()
         orderpoint_product = self.env['stock.warehouse.orderpoint'].search(
             [('product_id', '=', product.id)])
-        self.assertEqual(orderpoint_product.route_id, manu_route, "The route manufacture should be set on the orderpoint")
+        self.assertEqual(orderpoint_product.route_id, buy_route, "The route buy should be set on the orderpoint")
 
     def test_compute_bom_days_00(self):
         """ Check Days to prepare Manufacturing Order are correctly computed when Days to Purchase is set. """

--- a/addons/purchase_stock/data/purchase_stock_data.xml
+++ b/addons/purchase_stock/data/purchase_stock_data.xml
@@ -13,7 +13,6 @@
             <field name="sequence">10</field>
             <field name="product_selectable" eval="False"/>
             <field name="warehouse_selectable" eval="True"/>
-            <field name="warehouse_ids" eval="[(4, ref('stock.warehouse0'))]"/>
         </record>
 
         <!-- enable purchase on main warehouse -->

--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -245,13 +245,6 @@ class StockWarehouseOrderpoint(models.Model):
 
         return result
 
-    def _filter_warehouse_routes(self, product, warehouses, route):
-        if any(rule.action == 'buy' for rule in route.rule_ids):
-            if product.seller_ids:
-                return super()._filter_warehouse_routes(product, warehouses, route)
-            return False
-        return super()._filter_warehouse_routes(product, warehouses, route)
-
     def _get_default_route(self):
         route_ids = self.env['stock.rule'].search([
             ('action', '=', 'buy')

--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -58,16 +58,16 @@ class StockWarehouse(models.Model):
             if not buy_route:
                 buy_route = self.env['stock.rule'].search([
                     ('action', '=', 'buy'), ('warehouse_id', '=', warehouse.id)]).route_id
-            if warehouse.buy_to_resupply:
+            if warehouse.buy_to_resupply and buy_route.warehouse_selectable:
                 buy_route.warehouse_ids = [Command.link(warehouse.id)]
             else:
                 buy_route.warehouse_ids = [Command.unlink(warehouse.id)]
 
     def _create_or_update_route(self):
-        purchase_route = self._find_or_create_global_route('purchase_stock.route_warehouse0_buy', self.env._('Buy'))
+        buy_route = self._find_or_create_global_route('purchase_stock.route_warehouse0_buy', self.env._('Buy'))
         for warehouse in self:
-            if warehouse.buy_to_resupply:
-                purchase_route.warehouse_ids = [Command.link(warehouse.id)]
+            if warehouse.buy_to_resupply and buy_route.warehouse_selectable:
+                buy_route.warehouse_ids = [Command.link(warehouse.id)]
         return super()._create_or_update_route()
 
     def _generate_global_route_rules_values(self):

--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -157,6 +157,10 @@ class StockWarehouseOrderpoint(models.Model):
                 orderpoint.supplier_id = False
         super()._inverse_route_id()
 
+    def _get_route_domain(self):
+        domain = super()._get_route_domain()
+        return Domain.OR([domain, [('rule_ids.action', '=', 'buy')]])
+
     @api.depends('supplier_id')
     def _compute_deadline_date(self):
         """ Extend to add more depends values """

--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -64,7 +64,7 @@ class StockWarehouse(models.Model):
                 buy_route.warehouse_ids = [Command.unlink(warehouse.id)]
 
     def _create_or_update_route(self):
-        purchase_route = self._find_or_create_global_route('purchase_stock.route_warehouse0_buy', _('Buy'))
+        purchase_route = self._find_or_create_global_route('purchase_stock.route_warehouse0_buy', self.env._('Buy'))
         for warehouse in self:
             if warehouse.buy_to_resupply:
                 purchase_route.warehouse_ids = [Command.link(warehouse.id)]

--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -162,6 +162,13 @@ class StockRule(models.Model):
                         po.date_order = order_date_planned
             self.env['purchase.order.line'].sudo().create(po_line_values)
 
+    def _filter_warehouse_routes(self, product, warehouses, route):
+        if any(rule.action == 'buy' for rule in route.rule_ids):
+            if product.seller_ids:
+                return super()._filter_warehouse_routes(product, warehouses, route)
+            return False
+        return super()._filter_warehouse_routes(product, warehouses, route)
+
     def _get_matching_supplier(self, product_id, product_qty, product_uom, company_id, values):
         supplier = False
         # Get the schedule date in order to find a valid seller

--- a/addons/purchase_stock/tests/test_purchase_order.py
+++ b/addons/purchase_stock/tests/test_purchase_order.py
@@ -480,7 +480,6 @@ class TestPurchaseOrder(ValuationReconciliationTestCommon):
         description should be based on the correct seller
         """
         self.env.user.write({'company_id': self.company_data['company'].id})
-        self.env['stock.route'].search([('name', '=', 'Buy')]).warehouse_ids = self.env['stock.warehouse'].search([])
 
         product = self.env['product.product'].create({
             'name': 'Super Product',
@@ -669,7 +668,6 @@ class TestPurchaseOrder(ValuationReconciliationTestCommon):
         influence the destination of the delivery, if the stock picking type
         is more precise than the orderpoint.
         """
-        self.env['stock.route'].search([('name', '=', 'Buy')]).warehouse_ids = self.env['stock.warehouse'].search([])
         product = self.env['product.product'].create({
             'name': 'Super product',
             'is_storable': True,

--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -75,8 +75,9 @@ class StockWarehouseOrderpoint(models.Model):
     lead_days = fields.Float(compute='_compute_lead_days')
     route_id = fields.Many2one(
         'stock.route', string='Route',
-        domain="['|', ('product_selectable', '=', True), ('rule_ids.action', 'in', ['buy', 'manufacture'])]",
-        inverse='_inverse_route_id')
+        domain=lambda self: self._get_route_domain(),
+        inverse='_inverse_route_id'
+    )
     route_id_placeholder = fields.Char(compute='_compute_route_id_placeholder')
     effective_route_id = fields.Many2one(
         'stock.route', search='_search_effective_route_id', compute='_compute_effective_route_id',
@@ -222,6 +223,9 @@ class StockWarehouseOrderpoint(models.Model):
     def _inverse_route_id(self):
         # Override this method to add custom behavior when route is set
         pass
+
+    def _get_route_domain(self):
+        return Domain([('product_selectable', '=', True)])
 
     @api.depends('product_id', 'product_id.categ_id', 'product_id.route_ids', 'product_id.categ_id.route_ids', 'location_id')
     def _compute_route_id_placeholder(self):

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -549,9 +549,10 @@ class StockRule(models.Model):
             if product_routes:
                 res = Rule.search(Domain('route_id', 'in', product_routes.ids) & domain, order='route_sequence, sequence', limit=1)
         if not res and warehouse_id:
-            warehouse_routes = warehouse_id.route_ids
+            filter_function = partial(self._filter_warehouse_routes, product_id, warehouse_id)
+            warehouse_routes = warehouse_id.route_ids.filtered(filter_function).ids
             if warehouse_routes:
-                res = Rule.search(Domain('route_id', 'in', warehouse_routes.ids) & domain, order='route_sequence, sequence', limit=1)
+                res = Rule.search(Domain('route_id', 'in', warehouse_routes) & domain, order='route_sequence, sequence', limit=1)
         return res
 
     @api.model

--- a/addons/stock/models/stock_warehouse.py
+++ b/addons/stock/models/stock_warehouse.py
@@ -549,7 +549,7 @@ class StockWarehouse(models.Model):
                     'warehouse_selectable': True,
                     'product_selectable': False,
                     'company_id': self.company_id.id,
-                    'sequence': 50,
+                    'sequence': 9,
                 },
                 'rules_values': {
                     'active': True,
@@ -568,7 +568,7 @@ class StockWarehouse(models.Model):
                     'warehouse_selectable': True,
                     'product_selectable': False,
                     'company_id': self.company_id.id,
-                    'sequence': 60,
+                    'sequence': 10,
                 },
                 'rules_values': {
                     'active': True,

--- a/addons/stock_delivery/tests/test_carrier_propagation.py
+++ b/addons/stock_delivery/tests/test_carrier_propagation.py
@@ -135,6 +135,7 @@ class TestCarrierPropagation(TransactionCase):
             'name': 'Route1',
             'sale_selectable' : True,
             'shipping_selectable': True,
+            'warehouse_ids': [Command.link(self.env.ref("stock.warehouse0").id)],
             'rule_ids': [Command.create({
                 'name': 'rule1',
                 'location_src_id': self.warehouse.lot_stock_id.id,
@@ -153,7 +154,8 @@ class TestCarrierPropagation(TransactionCase):
         route2 = self.env['stock.route'].create({
             'name': 'Route2',
             'sale_selectable' : True,
-            'shipping_selectable':True,
+            'shipping_selectable': True,
+            'warehouse_ids': [Command.link(self.env.ref("stock.warehouse0").id)],
             'rule_ids': [Command.create({
                 'name': 'rule2',
                 'location_src_id': shelf1_location.id,


### PR DESCRIPTION
- Various fixes following the product route improvement
  introduced in this [PR](https://github.com/odoo/odoo/pull/223685).

Summary of the changes:
 - Removed redundant demo warehouse addition (already added).
 - Follow coding guidelines and restore sequence.
 - Move the method to its appropriate model.
 - Adapted test cases to the new approach and removed unnecessary changes.
 - Adapted a similar approach as the `Buy and Manufacturing routes` for the
  `Resupply Subcontractor on Order` route.
 - Made the `route_id` domain in `StockWarehouseOrderpoint` extendable.
 - Avoid unnecessary addition of a warehouse;

- See each commit for details.

Task - [4385221](https://www.odoo.com/odoo/my-tasks/4385221)
