### PR TITLE
[FIX] website_sale: prevent error when category comes as str instead of int

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1825,6 +1825,8 @@ class WebsiteSale(payment_portal.PaymentPortal):
         :rtype: product.public.category
         """
         ProductCategory = request.env['product.public.category']
+        if not isinstance(category, ProductCategory.__class__) and category and not str(category).isdigit():
+            raise ValidationError(_("Invalid category."))
         if (
             (category := ProductCategory.browse(category and int(category)).exists())
             and category.can_access_from_current_website()


### PR DESCRIPTION
Currently, an error occurs when the `category` is received as a `string` and the 
code tries to evaluate `int(category)`.

**Steps to reproduce:**

- Install the `website_sale` module.
- Open a product page in the website with an `invalid category` parameter, 
  for example: `http://localhost:8069/shop/warranty-39?category=1;`

**Error:**
`ValueError: invalid literal for int() with base 10: '1;'`

**Root Cause:**
At [1], the code directly calls `int(category)` without validating the input. 
When the parameter contains `non-numeric` characters, Python raises an `error`.

**Fix:**
This commit ensures raising a `ValidationError`, improving the `error message` clarity,
when users manually input `invalid or tampered` category values in the `URL`.

[1]:
https://github.com/odoo/odoo/blob/d32f98dd199f80d2b0031bd52a6ff74411c3e7e0/addons/website_sale/controllers/main.py#L1827

sentry-6658317828