### PR TITLE
[FIX] html_builder, mass_mailing: add defaultImageMimetype config

### DIFF
--- a/addons/html_builder/static/src/plugins/image/image_format_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/image_format_option_plugin.js
@@ -40,20 +40,29 @@ class ImageFormatOptionPlugin extends Plugin {
         const maxWidth = await this.getImageWidth(data.originalSrc, data.width);
         const optimizedWidth = Math.min(maxWidth, computeMaxDisplayWidth?.(img) || 0);
         const widths = {
-            128: ["128px", "image/webp"],
-            256: ["256px", "image/webp"],
-            512: ["512px", "image/webp"],
-            1024: ["1024px", "image/webp"],
-            1920: ["1920px", "image/webp"],
+            128: ["128px", this.config.defaultImageMimetype ?? "image/webp"],
+            256: ["256px", this.config.defaultImageMimetype ?? "image/webp"],
+            512: ["512px", this.config.defaultImageMimetype ?? "image/webp"],
+            1024: ["1024px", this.config.defaultImageMimetype ?? "image/webp"],
+            1920: ["1920px", this.config.defaultImageMimetype ?? "image/webp"],
         };
-        widths[img.naturalWidth] = [_t("%spx", img.naturalWidth), "image/webp"];
-        widths[optimizedWidth] = [_t("%spx (Suggested)", optimizedWidth), "image/webp"];
+        widths[img.naturalWidth] = [
+            _t("%spx", img.naturalWidth),
+            this.config.defaultImageMimetype ?? "image/webp",
+        ];
+        widths[optimizedWidth] = [
+            _t("%spx (Suggested)", optimizedWidth),
+            this.config.defaultImageMimetype ?? "image/webp",
+        ];
         const mimetypeBeforeConversion = data.mimetypeBeforeConversion;
         widths[maxWidth] = [_t("%spx (Original)", maxWidth), mimetypeBeforeConversion, true];
-        if (mimetypeBeforeConversion !== "image/webp") {
-            // Avoid a key collision by subtracting 0.1 - putting the webp
+        if (mimetypeBeforeConversion !== this.config.defaultImageMimetype ?? "image/webp") {
+            // Avoid a key collision by subtracting 0.1 - putting the default image mimetype
             // above the original format one of the same size.
-            widths[maxWidth - 0.1] = [_t("%spx", maxWidth), "image/webp"];
+            widths[maxWidth - 0.1] = [
+                _t("%spx", maxWidth),
+                this.config.defaultImageMimetype ?? "image/webp",
+            ];
         }
         return Object.entries(widths)
             .filter(([width]) => width <= maxWidth)

--- a/addons/html_builder/static/src/plugins/image/image_tool_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/image_tool_option_plugin.js
@@ -73,7 +73,7 @@ class ImageToolOptionPlugin extends Plugin {
                         await this.dependencies.imagePostProcess.processImage({
                             img: image,
                             newDataset: {
-                                formatMimetype: "image/webp",
+                                formatMimetype: this.config.defaultImageMimetype ?? "image/webp",
                             },
                             // TODO Using a callback is currently needed to avoid
                             // the extra RPC that would occur if loadImageInfo was

--- a/addons/mass_mailing/static/src/fields/html_field/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/fields/html_field/mass_mailing_html_field.js
@@ -212,6 +212,7 @@ export class MassMailingHtmlField extends HtmlField {
         return {
             ...config,
             mobileBreakpoint: "md",
+            defaultImageMimetype: "image/jpeg",
             onEditorReady: () => this.commitChanges(),
         };
     }


### PR DESCRIPTION
This commit fixes an issue with the html_builder's ImageFormatOption that forces
images to have the `image/webp` mimetype. The issue is that this format isn't
well supported in mail clients thus we needed to add the possibility to
configure the default image mimetype.

Thus the defaultImageMimetype is added to the mass_mailing config so that now
images are by default using `image/jpeg` when replacing their format inside
the option.

task-5076505

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
