### PR TITLE
[IMP] website: remove invalid props from BrokenLinks

### DIFF
--- a/addons/website/static/src/components/dialog/seo.js
+++ b/addons/website/static/src/components/dialog/seo.js
@@ -606,7 +606,7 @@ export class BrokenLink extends Component {
     static template = "website.BrokenLink";
 
     static props = {
-        link: String,
+        link: Object,
     };
 
     setup() {


### PR DESCRIPTION
Steps to reproduce:
 1. On home page, open editor.
 2. Create a new link on button/text with invalid url.
 3. Enable debug mode.
 4. Open seo optimiser it will start scanning for broken links.
 5. Traceback will appear:  
<img width="1154" height="585" alt="image" src="https://github.com/user-attachments/assets/ccb42fe5-932a-48b3-8aa0-68053af3a7bb" />


After this PR:
- As brokenlinks component will always have link props as object, so
  links will now have Object as type.