### PR TITLE
[FIX] l10n_hu_edi: missing 'SZJ' product code

### DIFF
--- a/addons/l10n_hu_edi/i18n/hu.po
+++ b/addons/l10n_hu_edi/i18n/hu.po
@@ -1242,6 +1242,11 @@ msgid "Small Business"
 msgstr "Kisadózó"
 
 #. module: l10n_hu_edi
+#: model:ir.model.fields.selection,name:l10n_hu_edi.selection__product_template__l10n_hu_product_code_type__szj
+msgid "SZJ - Service Registry Code"
+msgstr "SZJ - Szolgáltatás jegyzék"
+
+#. module: l10n_hu_edi
 #: model:ir.model.fields.selection,name:l10n_hu_edi.selection__account_tax__l10n_hu_tax_type__tam
 msgid ""
 "TAM - tax-exempt activity or tax-exempt due to being in public interest or "

--- a/addons/l10n_hu_edi/i18n/l10n_hu_edi.pot
+++ b/addons/l10n_hu_edi/i18n/l10n_hu_edi.pot
@@ -1176,6 +1176,11 @@ msgid "Small Business"
 msgstr ""
 
 #. module: l10n_hu_edi
+#: model:ir.model.fields.selection,name:l10n_hu_edi.selection__product_template__l10n_hu_product_code_type__szj
+msgid "SZJ - Service Registry Code"
+msgstr ""
+
+#. module: l10n_hu_edi
 #: model:ir.model.fields.selection,name:l10n_hu_edi.selection__account_tax__l10n_hu_tax_type__tam
 msgid ""
 "TAM - tax-exempt activity or tax-exempt due to being in public interest or "

--- a/addons/l10n_hu_edi/models/product.py
+++ b/addons/l10n_hu_edi/models/product.py
@@ -9,6 +9,7 @@ class ProductTemplate(models.Model):
     l10n_hu_product_code_type = fields.Selection(
         selection=[
             ('VTSZ', 'VTSZ - Customs Code'),
+            ('SZJ', 'SZJ - Service Registry Code'),
             ('TESZOR', 'TESZOR - CPA 2.1 Code'),
             ('KN', 'KN - Combined Nomenclature Code'),
             ('AHK', 'AHK - e-TKO Excise Duty Code'),


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

In the official NAV XML 3.0 documentation (available at: https://onlineszamla.nav.gov.hu/dokumentaciok page 123), according to the list of possible product codes, there is an 'SZJ' code that is missing.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
