### PR TITLE
[FIX] truncate m2o text

### DIFF
--- a/addons/web/static/src/core/autocomplete/autocomplete.xml
+++ b/addons/web/static/src/core/autocomplete/autocomplete.xml
@@ -6,7 +6,7 @@
             <input
                 type="text"
                 t-att-id="props.id"
-                class="o-autocomplete--input o_input pe-3"
+                class="o-autocomplete--input o_input pe-3 text-truncate"
                 t-att-autocomplete="props.autocomplete"
                 t-att-placeholder="props.placeholder"
                 role="combobox"

--- a/addons/web/static/src/views/fields/many2one/many2one.xml
+++ b/addons/web/static/src/views/fields/many2one/many2one.xml
@@ -17,14 +17,14 @@
     </t>
 
     <t t-name="web.Many2One">
-        <div class="o_many2one text-truncate" t-att-class="props.cssClass">
+        <div class="o_many2one" t-att-class="props.cssClass">
             <t t-if="props.readonly">
                 <t t-if="value">
                     <t t-if="props.canOpen">
-                        <a class="o_form_uri" t-att-class="props.linkCssClass" t-att-href="linkHref" t-on-click.prevent.stop="() => this.openRecord('action')" t-esc="displayName"/>
+                        <a class="o_form_uri text-truncate d-inline-block w-100 align-bottom" t-att-class="props.linkCssClass" t-att-href="linkHref" t-on-click.prevent.stop="() => this.openRecord('action')" t-esc="displayName" t-att-title="displayName"/>
                     </t>
                     <t t-else="">
-                        <span t-esc="displayName"/>
+                        <span t-esc="displayName" t-att-title="displayName" class="text-truncate d-inline-block w-100 align-bottom"/>
                     </t>
                 </t>
             </t>
@@ -45,7 +45,7 @@
             <t t-if="lines.length">
                 <div class="o_field_many2one_extra">
                     <t t-foreach="lines" t-as="line" t-key="line_index">
-                        <div t-esc="line"/>
+                        <div t-esc="line" t-att-title="line"  class="text-truncate"/>
                     </t>
                 </div>
             </t>

--- a/addons/web/static/tests/views/fields/many2one_field.test.js
+++ b/addons/web/static/tests/views/fields/many2one_field.test.js
@@ -411,9 +411,10 @@ test("many2ones in form views with show_address", async () => {
     });
 
     expect("input.o_input").toHaveValue("aaa");
-    expect(".o_field_many2one_extra").toHaveInnerHTML("<div>Street</div><div>City ZIP</div>", {
-        type: "html",
-    });
+    expect(".o_field_many2one_extra").toHaveInnerHTML(
+        `<div class="text-truncate" title="Street">Street</div> <div class="text-truncate" title="City ZIP">City ZIP</div>`,
+        { type: "html" }
+     );
     expect("button.o_external_button").toHaveCount(1);
 });
 
@@ -457,27 +458,30 @@ test("many2one show_address in edit", async () => {
     });
 
     expect(".o_field_widget input").toHaveValue("aaa");
-    expect(".o_field_many2one_extra").toHaveInnerHTML("<div>AAA</div><div>Record</div>", {
-        type: "html",
-    });
+    expect(".o_field_many2one_extra").toHaveInnerHTML(
+        `<div class="text-truncate" title="AAA">AAA</div><div class="text-truncate" title="Record">Record</div>`,
+        { type: "html" }
+    );
 
     await contains(".o_field_widget input").edit("first record", { confirm: false });
     await runAllTimers();
     await contains(".dropdown-menu li").click();
 
     expect(".o_field_widget input").toHaveValue("first record");
-    expect(".o_field_many2one_extra").toHaveInnerHTML("<div>First</div><div>Record</div>", {
-        type: "html",
-    });
+    expect(".o_field_many2one_extra").toHaveInnerHTML(
+        `<div class="text-truncate" title="First">First</div><div class="text-truncate" title="Record">Record</div>`,
+        { type: "html" }
+    );
 
     await contains(".o_field_widget input").edit("second record", { confirm: false });
     await runAllTimers();
     await contains(".dropdown-menu li").click();
 
     expect(".o_field_widget input").toHaveValue("second record");
-    expect(".o_field_many2one_extra").toHaveInnerHTML("<div>Second</div><div>Record</div>", {
-        type: "html",
-    });
+    expect(".o_field_many2one_extra").toHaveInnerHTML(
+        `<div class="text-truncate" title="Second">Second</div><div class="text-truncate" title="Record">Record</div>`,
+        { type: "html" }
+    );
 });
 
 test("show_address works in a view embedded in a view of another type", async () => {


### PR DESCRIPTION
The text-truncate bootstrap class of the m2o field does not work properly as the ellipsis is not visible and create an alignment issue with the private_state_id field. This PR solves this issue which can be seen in the "Private information" tab of the employee form. 

Task-5078736
