### PR TITLE
[IMP] account: improve display of trust level on Bank Accounts

### DIFF
--- a/addons/account/models/mail_tracking_value.py
+++ b/addons/account/models/mail_tracking_value.py
@@ -13,3 +13,10 @@ class MailTrackingValue(models.Model):
     def write(self, vals):
         self._except_audit_log()
         return super().write(vals)
+
+    @api.model
+    def _create_tracking_values(self, initial_value, new_value, col_name, col_info, record):
+        if self.env.context.get('display_account_trust') and isinstance(record[col_name], self.env.registry['res.partner.bank']):
+            initial_value = initial_value.with_context(display_account_trust=False)
+            new_value = new_value.with_context(display_account_trust=False)
+        return super()._create_tracking_values(initial_value, new_value, col_name, col_info, record)

--- a/addons/account/models/res_partner_bank.py
+++ b/addons/account/models/res_partner_bank.py
@@ -366,10 +366,6 @@ class ResPartnerBank(models.Model):
     def _compute_display_name(self):
         super()._compute_display_name()
         if self.env.context.get('display_account_trust'):
-            for acc in self:
-                trusted_label = _('trusted') if acc.allow_out_payment else _('untrusted')
-                if acc.bank_id:
-                    name = f'{acc.acc_number} - {acc.bank_id.name} ({trusted_label})'
-                else:
-                    name = f'{acc.acc_number} ({trusted_label})'
-                acc.display_name = name
+            for account in self:
+                if not account.allow_out_payment:
+                    account.display_name += "\u00A0\U0001F534"


### PR DESCRIPTION
Before this commit:-
- Bank Accounts in which sending money is allowed, their names were displayed with `(trusted)` and if not allowed then `(untrusted)`.
- Trust levels were displayed in Bank Account selection dropdown, after selection and in the chatter.

After this commit:-
- Bank Accounts in which sending money is not allowed, their names are displayed with red bubble(🔴) and nothing if sending money is allowed.
- Also instead of reassigning display name again, only add red bubble in display name computed by super, as apart from trust levels other logic was same here and in [base].
- Trust levels are displayed in Bank Account selection dropdown and after selection also but not in the chatter.

task-5046533

[base]: https://github.com/odoo/odoo/blob/d27a965452b1e9c3241fc4cee864bd4f43ff19d0/odoo/addons/base/models/res_bank.py#L137C1-L140C107