### PR TITLE
[FIX] website*: Add "Popup" label to Newsletter Benefits

### DIFF
--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -532,7 +532,7 @@
             t-image-preview="/website/static/src/img/snippets_previews/s_newsletter_box_preview.jpg"/>
         <t t-install="mass_mailing_sms" string="Newsletter SMS Notifications" group="contact_and_forms"
             t-image-preview="/website/static/src/img/snippets_previews/s_newsletter_sms_notifications_preview.png"/>
-        <t t-install="mass_mailing" string="Newsletter Benefits" group="contact_and_forms"
+        <t t-install="mass_mailing" string="Newsletter Benefits" group="contact_and_forms" label="Popup"
             t-image-preview="/website/static/src/img/snippets_previews/s_newsletter_benefits_popup_preview.webp"/>
         <t t-install="website_payment" string="Donation" group="contact_and_forms"
             t-image-preview="/website/static/src/img/snippets_previews/s_donation_preview.png"/>

--- a/addons/website_mass_mailing/views/snippets_templates.xml
+++ b/addons/website_mass_mailing/views/snippets_templates.xml
@@ -29,7 +29,7 @@
         <t t-snippet="website_mass_mailing.s_newsletter_subscribe_popup" string="Newsletter Popup" t-forbid-sanitize="form" group="contact_and_forms" label="Popup"/>
     </xpath>
     <xpath expr="//t[@id='mass_mailing_newsletter_benefits_popup_hook']" position="replace">
-        <t t-snippet="website_mass_mailing.s_newsletter_benefits_popup" string="Newsletter Benefits" t-forbid-sanitize="form" group="contact_and_forms"/>
+        <t t-snippet="website_mass_mailing.s_newsletter_benefits_popup" string="Newsletter Benefits" t-forbid-sanitize="form" group="contact_and_forms" label="Popup"/>
     </xpath>
     <xpath expr="//t[@id='mass_mailing_newsletter_hook']" position="replace">
         <t t-snippet="website_mass_mailing.s_newsletter_subscribe_form" string="Newsletter" t-thumbnail="/website/static/src/img/snippets_thumbs/s_newsletter_subscribe_form.svg" t-forbid-sanitize="form" t-grid-column-span="5"/>


### PR DESCRIPTION
This PR adds the "Popup" label to the "Newsletter Benefits" snippet in the preview in `AddSnippetDialog`.

[*]: website_mass_mailing

| Before (missing label) | After (introduced label) |
|-----------------------------|---------------------------------|
| <img width="433" height="214" alt="image" src="https://github.com/user-attachments/assets/22bd30c6-0085-4739-bcf5-d4c84b1353a0" />| <img width="435" height="226" alt="image" src="https://github.com/user-attachments/assets/e29c2707-fb85-4252-931a-8044ffb183f0" /> |
