### PR TITLE
[FIX] website: fix `Max # of files` option in file upload fields

### DIFF
--- a/addons/website/static/src/builder/plugins/form/form_option.xml
+++ b/addons/website/static/src/builder/plugins/form/form_option.xml
@@ -197,9 +197,11 @@
         <BuilderNumberInput id="'max_files_number_opt'" t-if="isMaxFilesVisible"
             title.translate="The maximum number of files that can be uploaded."
             dataAttributeAction="'maxFilesNumber'"
+            action="'setMultipleFiles'"
             default="1"
             applyTo="`input[type='file']`"
             step="1"
+            min="1"
         />
     </BuilderRow>
     <BuilderRow label.translate="Max File Size">

--- a/addons/website/static/src/builder/plugins/form/form_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/form/form_option_plugin.js
@@ -158,6 +158,7 @@ export class FormOptionPlugin extends Plugin {
             SetVisibilityDependencyAction,
             SetFormCustomFieldValueListAction,
             PropertyAction,
+            SetMultipleFilesAction,
         },
         force_not_editable_selector: ".s_website_form form",
         force_editable_selector: [
@@ -1282,6 +1283,12 @@ class PropertyAction extends BuilderAction {
 
     apply({ editingElement, params: { property, format } = {}, value }) {
         editingElement[property] = format ? format(value) : value;
+    }
+}
+class SetMultipleFilesAction extends BuilderAction {
+    static id = "setMultipleFiles";
+    apply({ editingElement }) {
+        editingElement.multiple = editingElement.dataset.maxFilesNumber > 1;
     }
 }
 

--- a/addons/website/static/tests/builder/website_builder/form_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/form_option.test.js
@@ -340,3 +340,33 @@ test("Correctly set field dependency name at selected field rename", async () =>
     expect(".o-main-components-container  .o-dropdown-item:contains('Option 2')").toHaveCount(1);
     expect(`.o-main-components-container  .o-dropdown-item:contains('${newName}')`).toHaveCount(1);
 });
+
+test("Changing max files number option updates file input 'multiple' attribute", async () => {
+    onRpc("get_authorized_fields", () => ({}));
+    await setupWebsiteBuilder(`
+    <section class="s_website_form" data-vcss="001" data-snippet="s_website_form" data-name="Form">
+        <form data-model_name="mail.mail">
+            <div class="s_website_form_rows">
+                <div data-name="Field" class="s_website_form_field s_website_form_custom" data-type="binary">
+                    <label class="s_website_form_label" for="o3xe8o85w0ct">
+                        <span class="s_website_form_label_content">File Upload</span>
+                    </label>
+                    <input type="file" class="form-control s_website_form_input"
+                        name="File Upload" required id="o3xe8o85w0ct"
+                        data-max-files-number="1" data-max-file-size="64">
+                </div>
+            </div>
+        </form>
+    </section>
+        `);
+    expect(":iframe input[type=file]").toHaveAttribute("data-max-files-number", "1")
+    expect(":iframe input[type=file]").not.toHaveAttribute("multiple");
+    await contains(":iframe .s_website_form_input").click();
+    await contains(".options-container div[data-action-id='setMultipleFiles'] input").edit("2");
+    expect(":iframe input[type=file]").toHaveAttribute("data-max-files-number", "2")
+    expect(":iframe input[type=file]").toHaveAttribute("multiple");
+    await contains(":iframe .s_website_form_input").click();
+    await contains(".options-container div[data-action-id='setMultipleFiles'] input").edit("1");
+    expect(":iframe input[type=file]").toHaveAttribute("data-max-files-number", "1")
+    expect(":iframe input[type=file]").not.toHaveAttribute("multiple");
+});


### PR DESCRIPTION
Steps to Reproduce:
- Open the website module.
- Drop a basic form snippet.
- Change the field type of any field to 'File Upload'.
- Set the `Max # of files` to any value greater than 1 and save the changes.
- Attempt to upload more than one file.

Observed Issue:
Users are unable to upload more than one file.

Before this commit:
The `Max # of files` option available in the snippet settings had no effect. Even when set to more than one, the file input would only allow replacing the previously uploaded file, preventing users from adding multiple files.

After this commit:
The `Max # of files` setting now functions as intended. When the limit is set to more than one, users can select multiple files, up to the configured limit and within the maximum file size. If the limit is set to one, users can only upload a single file.

task-4626847

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
