### PR TITLE
[FIX] project: hide 'Recurrent' field for archived tasks in project sharing view

### DIFF
--- a/addons/project/views/project_sharing_project_task_views.xml
+++ b/addons/project/views/project_sharing_project_task_views.xml
@@ -179,7 +179,7 @@
                             <field name="partner_id" readonly="not current_user_same_company_partner" options="{'no_open': True, 'no_create': True, 'no_edit': True}" invisible="not project_id"/>
                             <field name="priority" widget="priority"/>
                             <field name="date_deadline" decoration-danger="date_deadline &lt; current_date and state not in ['1_done', '1_canceled']"/>
-                            <field name="recurring_task" groups="project.group_project_recurring_tasks"/>
+                            <field name="recurring_task" groups="project.group_project_recurring_tasks" invisible="not active or parent_id"/>
                             <label for="repeat_interval" invisible="not recurring_task" groups="project.group_project_recurring_tasks"/>
                             <div invisible="not recurring_task" class="d-flex" groups="project.group_project_recurring_tasks" name="repeat_intervals">
                                 <field name="repeat_interval" required="recurring_task"


### PR DESCRIPTION
**Steps to Reproduce:**
  - Share a project.
  - From the shared project, archive a task.
  - Open the archived task in the standard project form view → the Recurrent field becomes invisible (as expected).
  - Open the same archived task from the Project Sharing view by applying the Inactive/Archived filter → the Recurrent field is 
     still visible.

**Issue:**
The Recurrent field should not be visible for archived tasks. However, in the Project Sharing view, it still appears for inactive tasks.

**Current behaviour:**
The Recurrent field is hidden in the standard form view for archived tasks, but remains visible in the project sharing view.

**Expected behaviour:**
The Recurrent field should remain invisible in both the standard form view and the project sharing view when the task is archived.

**Fix:**
Adjusted the project sharing form view XML to apply the same invisible logic, ensuring the Recurrent field is hidden when the task is archived.

**Task-5040281**