### PR TITLE
[FIX] website_sale_(wishlist,comparison): fix installs

### DIFF
--- a/addons/website_sale_comparison/__manifest__.py
+++ b/addons/website_sale_comparison/__manifest__.py
@@ -37,6 +37,7 @@ Finally, the module comes with an option to display an attribute summary table i
             'website_sale_comparison/static/src/website_builder/**/*',
         ],
     },
+    'auto_install': True,
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
 }

--- a/addons/website_sale_wishlist/__manifest__.py
+++ b/addons/website_sale_wishlist/__manifest__.py
@@ -29,6 +29,7 @@ Allow shoppers of your eCommerce store to create personalized collections of pro
             'website_sale_wishlist/static/src/website_builder/**/*',
         ],
     },
+    'auto_install': True,
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
 }


### PR DESCRIPTION
Enable auto-install for `website_sale_wishlist` and `website_sale_comparison`

These modules are now set to auto-install to ensure their proper availability on the frontend.
This change removes the need for explicit fields while still preventing the unintended limitations observed after [task](https://www.odoo.com/odoo/action-4043/4819667).

**Affected Version**:19.0~master
opw-5078748