### PR TITLE
[FIX] mass_mailing: update html_builder asset inclusion

### DIFF
--- a/addons/mass_mailing/__manifest__.py
+++ b/addons/mass_mailing/__manifest__.py
@@ -102,7 +102,7 @@
             'web/static/src/scss/ui.scss',
             'web/static/src/scss/fontawesome_overridden.scss',
 
-            ('include', 'html_builder.inside_builder_style'),
+            ('include', 'html_builder.assets_edit_frontend'),
             'mass_mailing/static/src/scss/mass_mailing_mail.scss',
             'mass_mailing/static/src/iframe_assets/**/*',
             'mass_mailing/static/src/theme_assets/**/*',


### PR DESCRIPTION
This commit fixes an issue with an asset that was renamed in ad6e2d3857a87a0dfec93c2bcc597328ef21ba00 but didn't include the update for mass_mailing.

This means that some styling was no longer included when creating the iframe for the mass_mailing builder. It notably included the dropzone styling which was now invisible inside mass_mailing.

task-5078825

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
