### PR TITLE
[FIX] hr_work_entry: Fix traceback on viewing work entries for multi companies

### DIFF
--- a/addons/hr_work_entry/models/hr_version.py
+++ b/addons/hr_work_entry/models/hr_version.py
@@ -89,7 +89,7 @@ class HrVersion(models.Model):
             ('resource_id', 'in', [False] + self.employee_id.resource_id.ids),
             ('date_from', '<=', end_dt.replace(tzinfo=None)),
             ('date_to', '>=', start_dt.replace(tzinfo=None)),
-            ('company_id', 'in', [False, self.company_id.id]),
+            ('company_id', 'in', [False] + self.env.companies.ids),
         ])
         return domain & self._get_sub_leave_domain()
 


### PR DESCRIPTION
**Steps to reproduce:**
- Choose multi companies from the companies on top right
- Open work entries by going into Payroll/Work Entries/Work Entries

**Issue:**
Previously, the domain contained the current company id only, when in reality there was more than a company

**Fix:**
Changed the domain to cover all companies in the env

Task: 5077545

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
