### PR TITLE
[FIX] website_slides: change default `o_cc` for `record_cover`

### DIFF
--- a/addons/website_slides/models/slide_channel.py
+++ b/addons/website_slides/models/slide_channel.py
@@ -41,7 +41,7 @@ class SlideChannel(models.Model):
         its height is set to fit to content (snippet option to change this also disabled on the view)."""
         res = super()._default_cover_properties()
         res.update({
-            "background_color_class": "o_cc3",
+            "background_color_class": "o_cc4",
             'background_color_style': (
                 'background-color: rgba(0, 0, 0, 0); '
                 'background-image: linear-gradient(120deg, #875A7B, #78516F);'


### PR DESCRIPTION
This PR replaces the previous `o_cc` preset as the default palette for website changed for `.version 19`

With this PR, we change the default preset from `o_cc4` to `o_cc3`, ensuring the text remains readable no matter the color preset.

task-5078900
part of task-3638127

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
