### PR TITLE
[FIX] loyalty: use loyalty programs from parent company

### DIFF
--- a/addons/loyalty/security/loyalty_security.xml
+++ b/addons/loyalty/security/loyalty_security.xml
@@ -16,7 +16,7 @@
         <record id="loyalty_history_company_rule" model="ir.rule">
             <field name="name">Loyalty history multi company rule</field>
             <field name="model_id" ref="model_loyalty_history"/>
-            <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
+            <field name="domain_force">['|', ('company_id', 'in', company_ids + [False]), ('company_id', 'parent_of', company_ids)]</field>
         </record>
 
         <record id="sale_loyalty_rule_company_rule" model="ir.rule">


### PR DESCRIPTION
If you have a company parent with loyaltly programs and you try to confirm a sale order from a child company, an access error will be raised.

Steps to reproduce:
-------------------
* Create a loyalty cards program
* Set company to the current company
* Create a branch company for the current one
* Switch to branch company
* Create a sale order, no need to add products, just a partner
* Try to confirm the order
> Observation: Access Error:
> Sorry, Mitchell Admin (id=2) doesn't have 'create' access to:
> -History for Loyalty cards and Ewallets (loyalty.history)

Why the fix:
------------
Here's where the access error is being triggered:
https://github.com/odoo/odoo/blob/35ea3dcb2eeb379c8b1127f0c7b42191853c0bd2/addons/sale_loyalty/models/sale_order.py#L106

Branches currently have access to the discounts & loyalty programs from the parent company, we extend the access to include loyalty history.

Another solution could be to create the loyalty history using sudo() if the coupon's program id is a parent of the current company.

opw-5055999