### PR TITLE
[FIX] website: fix template sidebar (mobile menu position)

### DIFF
--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -1375,8 +1375,7 @@
             </div>
         </t>
         <t t-call="website.template_header_mobile"
-            _txt_elt_content.f="phone_mail"
-            _side.f="offcanvas-start"/>
+            _txt_elt_content.f="phone_mail"/>
     </xpath>
 </template>
 


### PR DESCRIPTION
Before this commit, the template sidebar would set the mobile menu position to the left and override the option of the builder.

The template sidebar no longer imposes the position of the mobile menu anymore to avoid this issue. Only the option setted in the builder will impact the side of the mobile menu.

Steps:
- Change the header template to "Sidebar"
- Switch to mobile view
- Open the mobile menu (Despite the option behind set to "right", the menu is on the left)
