### PR TITLE
[FIX] hr_holidays: Adjust alert styling for leave

### DIFF
--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -296,7 +296,7 @@
             </header>
             <sheet>
                 <field name="dashboard_warning_message" class="alert alert-danger d-flex mt-2" role="alert" style="white-space: pre-wrap;" invisible="not dashboard_warning_message"/>
-                <field name="leave_type_increases_duration" class="alert alert-info d-flex" role="alert" style="white-space: pre-wrap;" invisible="not leave_type_increases_duration"/>
+                <field name="leave_type_increases_duration" class="alert alert-info d-flex mt-2" role="alert" style="white-space: pre-wrap;" invisible="not leave_type_increases_duration"/>
 
                 <div class="alert alert-info" role="alert" invisible="not request_unit_hours or not tz_mismatch or dashboard_warning_message">
                     <span>The employee has a different timezone than yours! Here dates and times are displayed in the employee's timezone</span>

--- a/addons/l10n_in_hr_holidays/views/hr_leave_views.xml
+++ b/addons/l10n_in_hr_holidays/views/hr_leave_views.xml
@@ -6,8 +6,8 @@
         <field name="model">hr.leave</field>
         <field name="inherit_id" ref="hr_holidays.hr_leave_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='duration_display']" position="after">
-                <div name="l10n_in_contains_sandwich_leaves" invisible="not l10n_in_contains_sandwich_leaves" colspan="2" class="w-md-75 float-end ps-3 alert alert-warning" role="alert">
+            <xpath expr="//field[@name='dashboard_warning_message']" position="after">
+                <div name="l10n_in_contains_sandwich_leaves" invisible="not l10n_in_contains_sandwich_leaves" class="alert alert-warning d-flex mt-2 mb-0" role="alert" style="white-space: pre-wrap;">
                     The requested time considers the sandwich leave policy.
                 </div>
             </xpath>


### PR DESCRIPTION
Issue: The sandwich leave alert for l10n India was incorrectly shown folded when creating a new time off entry for Indian companies. Additionally, the leave_type_increases_duration alert lacked proper top margin, causing inconsistent spacing.

Steps to Reproduce:
- For the sandwich alert: When shown, it appears folded automatically when creating a new time off entry (only for Indian companies).
- For leave_type_increases_duration: When displayed, it lacks top margin.

Fixes:
- Moved the sandwich leave alert to the header alongside other alerts for consistency.
- Adapted margins for all alerts.

Task ID: 5071899

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
