### PR TITLE
[FIX] web: duplicated JS bundle for assets_web{_dark}

### DIFF
--- a/addons/web/static/tests/legacy/helpers/mock_services.js
+++ b/addons/web/static/tests/legacy/helpers/mock_services.js
@@ -190,14 +190,6 @@ export const fakeTitleService = {
     },
 };
 
-export const fakeColorSchemeService = {
-    start() {
-        return {
-            switchToColorScheme() {},
-        };
-    },
-};
-
 export function makeFakeNotificationService(mock) {
     return {
         start() {
@@ -298,7 +290,6 @@ function makeFakeActionService() {
 }
 
 export const mocks = {
-    color_scheme: () => fakeColorSchemeService,
     command: () => fakeCommandService,
     effect: () => effectService, // BOI The real service ? Is this what we want ?
     localization: makeFakeLocalizationService,

--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -293,12 +293,13 @@
                     }
                 </script>
                 <t t-call-assets="web.assets_web_print" media="print" t-js="false"/>
+                <t t-call-assets="web.assets_web" t-css="false"/>
 
                 <t t-if="color_scheme == 'dark'">
-                    <t t-call-assets="web.assets_web_dark" media="screen"/>
+                    <t t-call-assets="web.assets_web_dark" media="screen" t-js="false"/>
                 </t>
                 <t t-else="">
-                    <t t-call-assets="web.assets_web" media="screen"/>
+                    <t t-call-assets="web.assets_web" media="screen" t-js="false"/>
                 </t>
                 <t t-call="web.conditional_assets_tests" media="screen"/>
             </t>


### PR DESCRIPTION
CSS bundles are different.
JS bundles are the same.
Don't download it twice.

Note: this avoids downloading a duplicated 3MB compressed (12MB
uncompressed) JS bundle with a different name (which avoids the cache
being properly used) when switching from light to dark mode.

task-5074720