### PR TITLE
[IMP] hr_holidays: tighten accrual plans grid layout

### DIFF
--- a/addons/hr_holidays/static/src/components/accrual_level/accrual_levels.scss
+++ b/addons/hr_holidays/static/src/components/accrual_level/accrual_levels.scss
@@ -1,6 +1,7 @@
 @media (min-width: 576px) {
   .o_accrual_plan_settings .o_accrual {
-    grid-template-columns: 1fr 1fr !important;
+    grid-template-columns: max-content auto !important;
+    column-gap: 4rem;
   }
 
   .o_accrual_level_form .o_accrual {


### PR DESCRIPTION
#### Issue
Before this commit, the label and field columns in the accrual plan configuration were defined as `1fr 1fr`, which left excessive spacing between them.

#### Fix
The grid now uses `max-content auto` with a small column gap so that labels only take the space they need and fields are aligned closer.

task-5076710