### PR TITLE
[IMP] mail: cleanup leave function

### DIFF
--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -625,12 +625,6 @@ export class Thread extends Record {
         return "/mail/thread/messages";
     }
 
-    async leave() {
-        await this.store.env.services.orm.silent.call("discuss.channel", "action_unfollow", [
-            this.id,
-        ]);
-    }
-
     /**
      * Get ready to jump to a message in a thread. This method will fetch the
      * messages around the message to jump to if required, and update the thread
@@ -897,7 +891,10 @@ export class Thread extends Record {
                 )
             );
         }
-        this.leave();
+        await this.closeChatWindow();
+        await this.store.env.services.orm.silent.call("discuss.channel", "action_unfollow", [
+            this.id,
+        ]);
     }
 
     _getActualModelName() {

--- a/addons/mail/static/src/core/web/thread_model_patch.js
+++ b/addons/mail/static/src/core/web/thread_model_patch.js
@@ -34,10 +34,6 @@ const threadPatch = {
     computeIsDisplayed() {
         return this.isDisplayedInDiscussAppDesktop || super.computeIsDisplayed();
     },
-    async leave() {
-        await this.closeChatWindow();
-        super.leave(...arguments);
-    },
     async loadMoreFollowers() {
         const data = await this.store.env.services.orm.call(this.model, "message_get_followers", [
             [this.id],


### PR DESCRIPTION
This PR removes the function `leave()` from the thread and moves the code to
`leaveChannel`.
leave only job is to call the orm service and close the chat windows, but this
could be done directly by `leaveChannel`.