### PR TITLE
[IMP] discuss: allow push to talk from remote tab in calls

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call.js
+++ b/addons/mail/static/src/discuss/call/common/call.js
@@ -105,7 +105,7 @@ export class Call extends Component {
     }
 
     get isActiveCall() {
-        return Boolean(this.channel.eq(this.rtc.channel));
+        return this.channel.isRtcChannel;
     }
 
     get minimized() {

--- a/addons/mail/static/src/discuss/call/common/call_action_list.js
+++ b/addons/mail/static/src/discuss/call/common/call_action_list.js
@@ -76,7 +76,7 @@ export class CallActionList extends Component {
     }
 
     get isOfActiveCall() {
-        return Boolean(this.props.thread.eq(this.rtc.channel));
+        return Boolean(this.props.thread.isRtcChannel);
     }
 
     get isSmall() {

--- a/addons/mail/static/src/discuss/call/common/call_actions.js
+++ b/addons/mail/static/src/discuss/call/common/call_actions.js
@@ -27,7 +27,7 @@ export function registerCallAction(id, definition) {
 }
 
 registerCallAction("mute", {
-    condition: ({ store, thread }) => thread?.eq(store.rtc?.channel),
+    condition: ({ store, thread }) => thread?.isRtcChannel,
     name: ({ store }) => (store.rtc.selfSession.isMute ? _t("Unmute") : _t("Mute")),
     isActive: ({ store }) => store.rtc.selfSession?.isMute,
     isTracked: true,
@@ -39,7 +39,7 @@ registerCallAction("mute", {
     tags: ({ action }) => (action.isActive ? ACTION_TAGS.DANGER : undefined),
 });
 registerCallAction("deafen", {
-    condition: ({ store, thread }) => thread?.eq(store.rtc?.channel),
+    condition: ({ store, thread }) => thread?.isRtcChannel,
     name: ({ store }) => (store.rtc.selfSession.is_deaf ? _t("Undeafen") : _t("Deafen")),
     isActive: ({ store }) => store.rtc.selfSession?.is_deaf,
     isTracked: true,
@@ -51,7 +51,7 @@ registerCallAction("deafen", {
     tags: ({ action }) => (action.isActive ? ACTION_TAGS.DANGER : undefined),
 });
 registerCallAction("camera-on", {
-    condition: ({ store, thread }) => thread?.eq(store.rtc?.channel),
+    condition: ({ store, thread }) => thread?.isRtcChannel,
     disabledCondition: ({ store }) => store.rtc?.isRemote,
     name: ({ store }) =>
         store.rtc?.isRemote
@@ -69,7 +69,7 @@ registerCallAction("camera-on", {
 });
 registerCallAction("switch-camera", {
     condition: ({ store, thread }) =>
-        thread?.eq(store.rtc?.channel) && isMobileOS() && store.rtc.selfSession?.is_camera_on,
+        thread?.isRtcChannel && isMobileOS() && store.rtc.selfSession?.is_camera_on,
     name: _t("Switch Camera"),
     isActive: false,
     icon: "fa fa-refresh",
@@ -78,7 +78,7 @@ registerCallAction("switch-camera", {
     sequenceGroup: 100,
 });
 registerCallAction("raise-hand", {
-    condition: ({ store, thread }) => thread?.eq(store.rtc?.channel),
+    condition: ({ store, thread }) => thread?.isRtcChannel,
     name: ({ store }) => (store.rtc.selfSession.raisingHand ? _t("Lower Hand") : _t("Raise Hand")),
     isActive: ({ store }) => store.rtc.selfSession?.raisingHand,
     isTracked: true,
@@ -88,7 +88,7 @@ registerCallAction("raise-hand", {
     sequenceGroup: 200,
 });
 registerCallAction("share-screen", {
-    condition: ({ store, thread }) => thread?.eq(store.rtc?.channel) && !isMobileOS(),
+    condition: ({ store, thread }) => thread?.isRtcChannel && !isMobileOS(),
     disabledCondition: ({ store }) => store.rtc?.isRemote,
     name: ({ store }) =>
         store.rtc?.isRemote
@@ -105,7 +105,7 @@ registerCallAction("share-screen", {
     tags: ({ action }) => (action.isActive ? ACTION_TAGS.SUCCESS : undefined),
 });
 registerCallAction("auto-focus", {
-    condition: ({ store, thread }) => thread?.eq(store.rtc?.channel),
+    condition: ({ store, thread }) => thread?.isRtcChannel,
     name: ({ store }) =>
         store.settings.useCallAutoFocus ? _t("Disable speaker autofocus") : _t("Autofocus speaker"),
     isActive: ({ store }) => store.settings?.useCallAutoFocus,
@@ -117,7 +117,7 @@ registerCallAction("auto-focus", {
 registerCallAction("blur-background", {
     condition: ({ store, thread }) =>
         !isBrowserSafari() &&
-        thread?.eq(store.rtc?.channel) &&
+        thread?.isRtcChannel &&
         store.rtc?.selfSession?.is_camera_on &&
         store.rtc?.isHost,
     name: ({ store }) => (store.settings.useBlur ? _t("Remove Blur") : _t("Blur Background")),
@@ -128,7 +128,7 @@ registerCallAction("blur-background", {
     sequenceGroup: 200,
 });
 registerCallAction("fullscreen", {
-    condition: ({ store, thread }) => thread?.eq(store.rtc?.channel),
+    condition: ({ store, thread }) => thread?.isRtcChannel,
     name: ({ store }) => (store.rtc.state.isFullscreen ? _t("Exit Fullscreen") : _t("Fullscreen")),
     isActive: ({ store }) => store.rtc.state.isFullscreen,
     icon: ({ action }) => (action.isActive ? "fa fa-compress" : "fa fa-expand"),
@@ -145,9 +145,7 @@ registerCallAction("fullscreen", {
 });
 registerCallAction("picture-in-picture", {
     condition: ({ store, thread }) =>
-        thread?.eq(store.rtc?.channel) &&
-        store.env.services["discuss.pip_service"] &&
-        !store.env?.isSmall,
+        thread?.isRtcChannel && store.env.services["discuss.pip_service"] && !store.env?.isSmall,
     disabledCondition: ({ store }) => store.rtc?.isRemote,
     name: ({ store }) =>
         store.rtc?.state.isPipMode ? _t("Exit Picture in Picture") : _t("Picture in Picture"),
@@ -179,7 +177,7 @@ registerCallAction("accept-with-camera", {
 registerCallAction("join-back", {
     btnClass: "text-nowrap pe-2 rounded-pill",
     condition: ({ store, thread }) =>
-        !thread?.eq(store.rtc?.channel) && typeof thread?.useCameraByDefault === "boolean",
+        !thread?.isRtcChannel && typeof thread?.useCameraByDefault === "boolean",
     disabledCondition: ({ store }) => store.rtc?.state.hasPendingRequest,
     icon: ({ thread }) => (thread.useCameraByDefault ? "fa fa-video-camera" : "fa fa-phone"),
     inlineName: ({ owner }) => (owner.env.inCallInvitation ? undefined : _t("Join")),
@@ -193,7 +191,7 @@ registerCallAction("join-back", {
 registerCallAction("join-with-camera", {
     btnClass: "text-nowrap",
     condition: ({ store, thread }) =>
-        !thread?.eq(store.rtc?.channel) &&
+        !thread?.isRtcChannel &&
         !thread?.self_member_id?.rtc_inviting_session_id &&
         typeof thread?.useCameraByDefault !== "boolean",
     disabledCondition: ({ store }) => store.rtc?.state.hasPendingRequest,
@@ -206,7 +204,7 @@ registerCallAction("join-with-camera", {
 });
 registerCallAction("join", {
     condition: ({ store, thread }) =>
-        !thread?.eq(store.rtc?.channel) &&
+        !thread?.isRtcChannel &&
         !thread?.self_member_id?.rtc_inviting_session_id &&
         typeof thread?.useCameraByDefault !== "boolean",
     disabledCondition: ({ store }) => store.rtc?.state.hasPendingRequest,
@@ -240,7 +238,7 @@ registerCallAction("reject", {
 });
 registerCallAction("disconnect", {
     condition: ({ store, thread }) =>
-        thread?.eq(store.rtc?.channel) && !thread?.self_member_id?.rtc_inviting_session_id,
+        thread?.isRtcChannel && !thread?.self_member_id?.rtc_inviting_session_id,
     disabledCondition: ({ store }) => store.rtc?.state.hasPendingRequest,
     name: _t("Disconnect"),
     icon: "fa fa-phone",

--- a/addons/mail/static/src/discuss/call/common/call_menu.xml
+++ b/addons/mail/static/src/discuss/call/common/call_menu.xml
@@ -3,7 +3,7 @@
 
     <t t-name="discuss.CallMenu">
         <div class="dropdown" t-attf-class="{{ className }}" t-ref="root">
-            <button t-if="rtc.channel" class="user-select-none dropdown-toggle o-no-caret o-dropdown--narrow" t-att-title="buttonTitle" role="button" t-on-click="rtc.channel.open">
+            <button t-if="rtc.isInCall" class="user-select-none dropdown-toggle o-no-caret o-dropdown--narrow" t-att-title="buttonTitle" role="button" t-on-click="rtc.channel.open">
                 <div class="o-discuss-CallMenu-buttonContent d-flex align-items-center o-gap-0_5 rounded-3 opacity-75 opacity-100-hover px-1" t-att-class="{ 'o-is-talking': rtc.selfSession?.isActuallyTalking, 'o-isOdooCommunity': !isEnterprise }">
                     <span class="position-relative small bg-transparent">
                         <i class="me-2 fa fa-fw" t-att-class="icon" />

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.js
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.js
@@ -118,7 +118,7 @@ export class CallParticipantCard extends Component {
     }
 
     get isOfActiveCall() {
-        return Boolean(this.rtcSession && this.rtcSession.channel?.eq(this.rtc.channel));
+        return Boolean(this.rtcSession && this.rtcSession.channel?.isRtcChannel);
     }
 
     get showConnectionState() {

--- a/addons/mail/static/src/discuss/call/common/chat_window_patch.xml
+++ b/addons/mail/static/src/discuss/call/common/chat_window_patch.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-inherit="mail.ChatWindow" t-inherit-mode="extension">
         <xpath expr="//Thread" position="before">
-            <PipBanner t-if="rtc.state.isPipMode and thread.eq(rtc.channel)" compact="true"/>
+            <PipBanner t-if="rtc.state.isPipMode and thread.isRtcChannel" compact="true"/>
             <Call t-elif="thread.showCallView" thread="thread" compact="true"/>
         </xpath>
     </t>

--- a/addons/mail/static/src/discuss/call/common/pip_service.js
+++ b/addons/mail/static/src/discuss/call/common/pip_service.js
@@ -33,7 +33,7 @@ export const callPipService = {
          */
         async function openPip({ context }) {
             const rtc = env.services["discuss.rtc"];
-            if (!rtc?.channel) {
+            if (!rtc?.isInCall) {
                 return;
             }
             state.active = true;

--- a/addons/mail/static/src/discuss/call/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/call/common/thread_actions.js
@@ -5,7 +5,7 @@ import { CallSettings } from "@mail/discuss/call/common/call_settings";
 import { _t } from "@web/core/l10n/translation";
 
 registerThreadAction("call", {
-    condition: ({ store, thread }) => thread?.allowCalls && !thread?.eq(store.rtc.channel),
+    condition: ({ store, thread }) => thread?.allowCalls && !thread?.isRtcChannel,
     icon: "fa fa-fw fa-phone",
     name: ({ thread }) =>
         thread.rtc_session_ids.length > 0 ? _t("Join the Call") : _t("Start Call"),
@@ -15,7 +15,7 @@ registerThreadAction("call", {
     tags: [ACTION_TAGS.SUCCESS, ACTION_TAGS.JOIN_LEAVE_CALL],
 });
 registerThreadAction("camera-call", {
-    condition: ({ store, thread }) => thread?.allowCalls && !thread?.eq(store.rtc.channel),
+    condition: ({ store, thread }) => thread?.allowCalls && !thread?.isRtcChannel,
     icon: "fa fa-fw fa-video-camera",
     name: ({ thread }) =>
         thread.rtc_session_ids.length > 0

--- a/addons/mail/static/src/discuss/call/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/call/common/thread_model_patch.js
@@ -30,6 +30,11 @@ const ThreadPatch = {
         this.lastSessionIds = new Set();
         /** @type {number|undefined} */
         this.cancelRtcInvitationTimeout;
+        this.isRtcChannel = fields.Attr(false, {
+            compute() {
+                return this.eq(this.store.rtc?.channel);
+            },
+        });
         this.rtc_session_ids = fields.Many("discuss.channel.rtc.session", {
             /** @this {import("models").Thread} */
             onDelete(r) {
@@ -185,7 +190,7 @@ const ThreadPatch = {
      */
     updateCallFocusStack(session) {
         if (
-            this.notEq(this.store.rtc?.channel) ||
+            !this.isRtcChannel ||
             session.eq(this.store.rtc.selfSession) ||
             !this.activeRtcSession ||
             !this.store.settings.useCallAutoFocus ||

--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_indicator.xml
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_indicator.xml
@@ -2,8 +2,8 @@
 <templates xml:space="preserve">
     <t t-name="mail.DiscussSidebarCallIndicator">
         <div t-if="props.thread.rtc_session_ids.length > 0" title="Ongoing call" class="o-mail-DiscussSidebarCallIndicator fa-fw rounded-circle fa fa-volume-up" style="padding-top: 1px; padding-bottom: 1px;" t-att-class="{
-            'o-discuss-inCallIconColor': props.thread.eq(rtc.channel),
-            'opacity-50': !props.thread.eq(rtc.channel),
+            'o-discuss-inCallIconColor': props.thread.isRtcChannel,
+            'opacity-50': !props.thread.isRtcChannel,
         }"/>
     </t>
 </templates>

--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
@@ -22,7 +22,7 @@
             'ps-3 pe-2': props.compact === undefined and !compact,
             'px-2': props.compact === false,
             'rounded-3': props.compact === undefined,
-            'opacity-75': props.thread.notEq(rtc.channel) and compact,
+            'opacity-75': !props.thread.isRtcChannel and compact,
         }" style="margin: 1px;">
             <button class="o-mail-DiscussSidebarCallParticipants-expandBtn btn btn-link p-1 my-n1 ms-n1 me-0 align-self-start d-flex rounded-circle" t-if="!compact" t-on-click="() => state.expanded = !state.expanded">
                 <i class="oi o-xxsmaller text-muted text-dark" t-att-class="{'oi-chevron-right': !state.expanded, 'oi-chevron-down': state.expanded}" t-att-title="title"/>

--- a/addons/mail/static/src/discuss/core/public_web/discuss_content_patch.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_content_patch.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-inherit="mail.DiscussContent" t-inherit-mode="extension">
         <xpath expr="//Thread" position="before">
-            <PipBanner t-if="rtc.state.isPipMode and thread.eq(rtc.channel)"/>
+            <PipBanner t-if="rtc.state.isPipMode and thread.isRtcChannel"/>
             <Call t-elif="thread.showCallView" thread="thread"/>
         </xpath>
     </t>


### PR DESCRIPTION
This commit allows the push to talk feature to work from remote tabs, the remote tab system and related parts of the rtc service are also refactored to use more record fields instead of getters and raw attributes.

