### PR TITLE
[FIX] stock: post-freeze orderpoint fixes

### DIFF
--- a/addons/mrp_subcontracting_purchase/tests/test_mrp_subcontracting_purchase.py
+++ b/addons/mrp_subcontracting_purchase/tests/test_mrp_subcontracting_purchase.py
@@ -502,12 +502,12 @@ class MrpSubcontractingPurchaseTest(TestMrpSubcontractingCommon):
         self.bom.produce_delay = 3
         self.bom.days_to_prepare_mo = 4
         delays, _ = rule._get_lead_days(self.finished, supplierinfo=seller)
-        self.assertEqual(delays['total_delay'], seller.delay + self.env.company.days_to_purchase + self.env.company.horizon_days)
+        self.assertEqual(delays['total_delay'], seller.delay + self.env.company.days_to_purchase)
         # Case 2 Vendor lead time < Manufacturing lead time + DTPMO
         self.bom.produce_delay = 5
         self.bom.days_to_prepare_mo = 6
         delays, _ = rule._get_lead_days(self.finished, supplierinfo=seller)
-        self.assertEqual(delays['total_delay'], self.bom.produce_delay + self.bom.days_to_prepare_mo + self.env.company.days_to_purchase + self.env.company.horizon_days)
+        self.assertEqual(delays['total_delay'], self.bom.produce_delay + self.bom.days_to_prepare_mo + self.env.company.days_to_purchase)
 
     def test_subcontracting_lead_days_on_overview(self):
         """Test on the BOM overview, the lead days and resupply availability are

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -426,10 +426,9 @@ class StockRule(models.Model):
                     for rule in delaying_rules
                 ]
         # Check if there's a horizon set
-        max_company_horizon_days = max(self.company_id.mapped('horizon_days')) if self.company_id else 0
-        global_horizon_days = self.env.context.get('global_horizon_days', max_company_horizon_days or self.env.company.horizon_days)
+        global_horizon_days = self.env['stock.warehouse.orderpoint'].get_horizon_days()
         if global_horizon_days:
-            delays['total_delay'] += global_horizon_days
+            delays['horizon_time'] += global_horizon_days
             if not bypass_delay_description:
                 delay_description.append((_('Time Horizon'), _('+ %d day(s)', global_horizon_days)))
         return delays, delay_description

--- a/addons/stock/static/src/widgets/json_widget.js
+++ b/addons/stock/static/src/widgets/json_widget.js
@@ -80,6 +80,9 @@ export class ReplenishmentGraphWidget extends JsonPopOver {
     get orderingPeriod() {
         return this.jsonValue["ordering_period"];
     }
+    get qtiesAreTheSame() {
+        return this.productMinQty === this.productMaxQty;
+    }
     get leadTime() {
         return this.jsonValue["lead_time"];
     }
@@ -94,7 +97,8 @@ export class ReplenishmentGraphWidget extends JsonPopOver {
 
     getScatterGraphConfig() {
         const dashLine = (ctx, value) => ctx.p1.raw.x === this.jsonValue['x_axis_vals'].slice(-1)[0] ? value : undefined;
-        const showYTick = (value) => value === this.productMinQty || value === this.productMaxQty ? value : '';
+        const pushYLabels = (ticks) => ticks.push({value: this.productMinQty}, {value: this.productMaxQty});
+        const showYLabel = (tick) => tick === this.productMinQty || tick === this.productMaxQty ? tick : '';
         const labels = this.jsonValue['x_axis_vals'];
         const maxLineColor = getColor(1, cookie.get("color_scheme"), "odoo");
         const minLineColor = getColor(2, cookie.get("color_scheme"), "odoo");
@@ -136,8 +140,10 @@ export class ReplenishmentGraphWidget extends JsonPopOver {
                 scales: {
                     y: {
                         grid: {display: false},
+                        beforeTickToLabelConversion: data => pushYLabels(data.ticks),
                         ticks: {
-                            callback: value => showYTick(value),
+                            autoSkip: false,
+                            callback: tick => showYLabel(tick),
                         },
                         suggestedMax: this.productMaxQty * 1.1,
                         suggestedMin: this.productMinQty * 0.9,

--- a/addons/stock/static/src/widgets/json_widget.xml
+++ b/addons/stock/static/src/widgets/json_widget.xml
@@ -34,7 +34,8 @@
                 <span class="pt-2">Average Stock: <span t-out="averageStock"/> <span t-out="productUomName"/></span>
             </h6>
             <h6 class="row text-muted">
-                <span>Ordering Frequency: <span t-out="orderingPeriod"/> day(s)</span>
+                <span t-if="!qtiesAreTheSame">Ordering Frequency: <span t-out="orderingPeriod"/> day(s)</span>
+                <span t-if="qtiesAreTheSame">Ordering Frequency: On demand</span>
                 <span class="pt-2">Lead Time: <span t-out="leadTime"/> day(s)</span>
             </h6>
         </div>

--- a/addons/stock/views/stock_orderpoint_views.xml
+++ b/addons/stock/views/stock_orderpoint_views.xml
@@ -42,7 +42,7 @@
                 <button name="action_product_forecast_report" type="object" icon="fa-warning text-warning" title="Due to receipts scheduled in the future, you might end up with excessive stock . Check the Forecasted Report  before reordering" invisible="not id or not unwanted_replenish"/>
                 <field name="route_id" widget="stock.forced_placeholder" options="{'no_create': True, 'no_open': True, 'placeholder_field': 'route_id_placeholder'}" optional="hidden" decoration-muted="not route_id"/>
                 <button name="action_stock_replenishment_info" type="object" icon="fa-info-circle" title="Replenishment Information" invisible="not id or show_supply_warning"/>
-                <button name="action_stock_replenishment_info" type="object" icon="fa-warning text-warning" title="Your product is missing a way to be replenished (Route, Vendor, Bill of Materials)." invisible="not (id and show_supply_warning)"/>
+                <button name="action_stock_replenishment_info" type="object" icon="fa-warning text-warning" title="Your product is missing a way to be replenished (Route, Vendor, Bill of Materials)." invisible="not id or not show_supply_warning"/>
                 <field name="trigger" optional="hide"/>
                 <field name="product_min_qty" string="Min" optional="show"/>
                 <field name="product_max_qty" string="Max" optional="show"/>

--- a/addons/stock/wizard/stock_replenishment_info.py
+++ b/addons/stock/wizard/stock_replenishment_info.py
@@ -173,7 +173,7 @@ class StockReplenishmentInfo(models.TransientModel):
             if replenishment_report.product_max_qty < replenishment_report.product_min_qty:
                 replenishment_report.product_max_qty = replenishment_report.product_min_qty
             average_stock = replenishment_report.product_min_qty + ((replenishment_report.product_max_qty - replenishment_report.product_min_qty) / 2)
-            lead_time = lead_days.get('total_delay', 0) - replenishment_report.orderpoint_id.get_horizon_days()
+            lead_time = lead_days.get('total_delay', 0)
             daily_demand = ((quantity_out - quantity_returned) / (date_to - date_from).days) * (replenishment_report.percent_factor / 100)
 
             ordering_period, graph_data = replenishment_report._prepare_graph_data(daily_demand=daily_demand)


### PR DESCRIPTION
- make the invisible condition on the warning icon lighter to process
- ensure the labels are shown on the Y axis of the graph no matter the value
- show "Ordering Frequency: On demand" if the min and max qties are the same
- separate functions for get_horizon_days & _get_horizon_days
- add a groupby location in _compute_deadline_date
- do not add horizon_days to total_delay since it's not a lead time per se

task 5072870
19.0 post-freeze bug pad

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
