### PR TITLE
[FIX] mrp: prevent traceback in MO allocation report

### DIFF
--- a/addons/mrp/report/report_stock_reception.py
+++ b/addons/mrp/report/report_stock_reception.py
@@ -39,8 +39,8 @@ class ReportStockReport_Reception(models.AbstractModel):
     def _action_assign(self, in_move, out_move):
         if in_move.production_id:
             in_move.production_id.move_dest_ids |= out_move
-            if not out_move.group_id and out_move._get_source_document() not in [False, out_move.picking_id]:
-                out_move.group_id = out_move._get_source_document()
+            if not out_move.reference_ids and out_move._get_source_document() not in [False, out_move.picking_id]:
+                out_move.reference_ids = out_move._get_source_document().reference_ids
 
     def _action_unassign(self, in_move, out_move):
         if in_move.production_id:


### PR DESCRIPTION
Issue:
----------------------------------------
When creating a manufacturing order and trying to allocate it to the desired sale order or outgoing picking, a traceback is triggered: `AttributeError: 'stock.move' object has no attribute 'group_id'. Did you mean: 'grouped'?`

Steps to Reproduce:
----------------------------------------
- Install the `mrp` module and enable `Allocation Report for Manufacturing Orders`.
- Create a product with a BoM.
- Create a Sale Order or outgoing picking for the product.
- Create a Manufacturing Order and go to the allocation report.
- Try to assign it to the picking.
- Traceback is triggered.

Cause:
----------------------------------------
In PR odoo#212679, the `group_id` field was replaced by a many2many field `reference_ids`.
However, the `_action_assign` method still tried to set the value of `group_id` instead of `reference_ids`, causing the error.

After this Commit:
----------------------------------------
In this commit, we ensure that `reference_ids` is used and set properly instead of `group_id`, allowing users to assign quantities to the desired picking smoothly without errors.

Task ID: 5076863