### PR TITLE
[FIX] sale: partial payment confirm order test

### DIFF
--- a/addons/sale/tests/test_payment_flow.py
+++ b/addons/sale/tests/test_payment_flow.py
@@ -488,6 +488,10 @@ class TestSalePayment(AccountPaymentCommon, SaleCommon, PaymentHttpCommon):
             tx_done._reconcile_after_done()
 
             self.assertEqual(notification_mail_mock.call_count, 2)
-            notification_mail_mock.assert_called_with(
-                self.env.ref('sale.mail_template_sale_confirmation'))
+            order_confirmation_mail_template_id = int(
+                self.env["ir.config_parameter"]
+                .sudo()
+                .get_param("sale.default_confirmation_template", self.env.ref("sale.mail_template_sale_confirmation").id)
+            )
+            notification_mail_mock.assert_called_with(self.env["mail.template"].browse(order_confirmation_mail_template_id))
             self.assertEqual(self.sale_order.state, 'sale')


### PR DESCRIPTION
The email template for the sale confirmation can
be changed through the config parameters so it's
better to read it directly from there instead of
having it hard-coded.
This now correctly tests the function it's
testing.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
