### PR TITLE
[IMP] purchase_requisition: keep UoM and price from Blanket Order to RFQ

### DIFF
--- a/addons/purchase_requisition/models/purchase.py
+++ b/addons/purchase_requisition/models/purchase.py
@@ -84,20 +84,10 @@ class PurchaseOrder(models.Model):
             # Compute taxes
             taxes_ids = fpos.map_tax(line.product_id.supplier_taxes_id.filtered(lambda tax: tax.company_id == requisition.company_id)).ids
 
-            # Compute quantity and price_unit
-            if line.product_uom_id != line.product_id.uom_id:
-                product_qty = line.product_uom_id._compute_quantity(line.product_qty, line.product_id.uom_id)
-                price_unit = line.product_uom_id._compute_price(line.price_unit, line.product_id.uom_id)
-            else:
-                product_qty = line.product_qty
-                price_unit = line.price_unit
-
-            if requisition.requisition_type != 'purchase_template':
-                product_qty = 0
-
+            product_qty = line.product_qty if requisition.requisition_type == 'purchase_template' else 0
             # Create PO line
             order_line_values = line._prepare_purchase_order_line(
-                name=name, product_qty=product_qty, price_unit=price_unit,
+                name=name, product_qty=product_qty, price_unit=line.price_unit,
                 taxes_ids=taxes_ids)
             order_lines.append((0, 0, order_line_values))
         self.order_line = order_lines
@@ -270,27 +260,31 @@ class PurchaseOrderLine(models.Model):
             if pol.product_id.id not in pol.order_id.requisition_id.line_ids.product_id.ids:
                 po_lines_without_requisition |= pol
                 continue
-            for line in pol.order_id.requisition_id.line_ids:
-                if line.product_id == pol.product_id:
-                    pol.price_unit = line.product_uom_id._compute_price(line.price_unit, pol.product_uom_id)
-                    partner = pol.order_id.partner_id or pol.order_id.requisition_id.vendor_id
-                    params = {'order_id': pol.order_id}
-                    seller = pol.product_id._select_seller(
-                        partner_id=partner,
-                        quantity=pol.product_qty,
-                        date=pol.order_id.date_order and pol.order_id.date_order.date(),
-                        uom_id=line.product_uom_id,
-                        params=params)
 
-                    if not pol.date_planned:
-                        pol.date_planned = pol._get_date_planned(seller).strftime(DEFAULT_SERVER_DATETIME_FORMAT)
+            line = None
+            # Match the requisition line with exact UoM first, then product-only as fallback.
+            for req_line in pol.order_id.requisition_id.line_ids:
+                if req_line.product_id == pol.product_id:
+                    line = req_line
+                    if req_line.product_uom_id == pol.product_uom_id:
+                        break
 
-                    product_ctx = {'seller_id': seller.id, 'lang': get_lang(pol.env, partner.lang).code}
-                    name = pol._get_product_purchase_description(pol.product_id.with_context(product_ctx))
-                    if line.product_description_variants:
-                        name += '\n' + line.product_description_variants
-                    pol.name = name
-                    break
+            pol.price_unit = line.product_uom_id._compute_price(line.price_unit, pol.product_uom_id)
+            partner = pol.order_id.partner_id or pol.order_id.requisition_id.vendor_id
+            params = {'order_id': pol.order_id}
+            seller = pol.product_id._select_seller(
+                partner_id=partner,
+                quantity=pol.product_qty,
+                date=pol.order_id.date_order and pol.order_id.date_order.date(),
+                uom_id=line.product_uom_id,
+                params=params)
+            if not pol.date_planned:
+                pol.date_planned = pol._get_date_planned(seller).strftime(DEFAULT_SERVER_DATETIME_FORMAT)
+            product_ctx = {'seller_id': seller.id, 'lang': get_lang(pol.env, partner.lang).code}
+            name = pol._get_product_purchase_description(pol.product_id.with_context(product_ctx))
+            if line.product_description_variants:
+                name += '\n' + line.product_description_variants
+            pol.name = name
         super(PurchaseOrderLine, po_lines_without_requisition)._compute_price_unit_and_date_planned_and_name()
 
     def action_clear_quantities(self):

--- a/addons/purchase_requisition/models/purchase_requisition.py
+++ b/addons/purchase_requisition/models/purchase_requisition.py
@@ -269,7 +269,7 @@ class PurchaseRequisitionLine(models.Model):
         return {
             'name': name,
             'product_id': self.product_id.id,
-            'product_uom_id': self.product_id.uom_id.id,
+            'product_uom_id': self.product_uom_id.id,
             'product_qty': product_qty,
             'price_unit': price_unit,
             'tax_ids': [(6, 0, taxes_ids)],


### PR DESCRIPTION
## **Purpose:**
When creating an RFQ from a Blanket Order,
the product lines did not retain the UoM and price from the Blanket Order.
This caused RFQs to display incorrect values, which could confuse users,
especially when same product had multiple lines with different UoMs and prices.

## **With This Commit:**
RFQs generated from Blanket Orders now correctly preserve the UoM and price
from the original Blanket Order.
This ensures consistency and accuracy,
giving users the expected values in the RFQ lines.

task - 5075869