### PR TITLE
[FIX] website_sale: hidden carousel thumbs

### DIFF
--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -1539,12 +1539,6 @@ $-product-radius-map: (
     .o_carousel_product_indicators {
         max-height: 400px;
 
-        .o_wsale_product_page_opt_image_width_100_pc & {
-            @include media-breakpoint-up(lg) {
-                @include o-position-absolute(auto, 0, .75rem, 0);
-            }
-        }
-
         // Desktop indicator styles
         @include media-breakpoint-up(lg) {
             .carousel-indicators {
@@ -1630,6 +1624,15 @@ $-product-radius-map: (
                 &:not(:first-child) {
                     margin-top: 10px;
                 }
+            }
+        }
+    }
+
+    // Indicator Positioning
+    @include media-breakpoint-up(lg) {
+        .o_wsale_product_page_opt_image_width_100_pc &:not(.o_carousel_product_left_indicators) {
+            .o_carousel_product_indicators {
+                @include o-position-absolute(auto, 0, .75rem, 0);
             }
         }
     }

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -4354,10 +4354,7 @@
             t-attf-class="o_carousel_product_indicators {{indicators_div_class}}"
         >
             <ol
-                t-att-class="'carousel-indicators '
-                    + (indicators_list_class or '')
-                    + ('justify-content-center ' if website.product_page_image_width == '100_pc' else '')
-                    + ' position-static pt-2 pt-lg-0 mx-auto my-0'"
+                t-attf-class="carousel-indicators position-static pt-2 pt-lg-0 mx-auto my-0 {{indicators_list_class}} {{website.product_page_image_width == '100_pc' and 'justify-content-center'}}"
             >
                 <li
                     t-foreach="product_images" t-as="product_image"


### PR DESCRIPTION
Before this commit, in a product page, when a user selected 100% as the image area size, sets the carousel display option for thumbnails, and positioned them on the left, they were not visible.

This commit updates the CSS rules to ensure thumbnails on the left are properly displayed when the image area is set to 100%.

task-5077519

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
