### PR TITLE
[IMP] html_builder, website: no longer pre-apply background shape

### DIFF
--- a/addons/html_builder/static/src/plugins/background_option/background_shape_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/background_option/background_shape_option_plugin.js
@@ -352,32 +352,6 @@ class SetBackgroundShapeAction extends BaseAnimationAction {
 class ToggleBgShapeAction extends BaseAnimationAction {
     static id = "toggleBgShape";
     apply({ editingElement }) {
-        const previousSibling = editingElement.previousElementSibling;
-        let shapeToSelect;
-        const allPossiblesShapesUrl = Object.keys(this.getBackgroundShapes());
-        if (previousSibling) {
-            const previousShape = this.getShapeData(previousSibling).shape;
-            shapeToSelect = allPossiblesShapesUrl.find(
-                (shape, i) => allPossiblesShapesUrl[i - 1] === previousShape
-            );
-        }
-        // If there is no previous sibling, if the previous sibling
-        // had the last shape selected or if the previous shape
-        // could not be found in the possible shapes, default to the
-        // first shape.
-        if (!shapeToSelect) {
-            shapeToSelect = allPossiblesShapesUrl[0];
-        }
-        // Only show on mobile by default if toggled from mobile
-        // view.
-        const showOnMobile = this.config.isMobileView(editingElement);
-        this.createShapeContainer(editingElement, shapeToSelect);
-        const applyShapeParams = {
-            shape: shapeToSelect,
-            colors: this.getImplicitColors(editingElement, shapeToSelect),
-            showOnMobile,
-        };
-        this.applyShape(editingElement, () => applyShapeParams);
         this.showBackgroundShapes([editingElement]);
     }
     clean({ editingElement }) {

--- a/addons/website/static/tests/builder/website_builder/background_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/background_option.test.js
@@ -209,7 +209,7 @@ test("changing shape's background color doesn't hide the shape itself", async ()
         ".o_pager_container .o-hb-bg-shape-btn [data-action-value='html_builder/Connections/01'][data-action-id='setBackgroundShape']"
     ).click();
     const backgroundImageValue = getComputedStyle(queryOne(":iframe .o_we_shape")).backgroundImage;
-    expect(backgroundImageValue).toMatch(/Connections\/01/);
+    expect(backgroundImageValue).toMatch(/Connections%2F01/);
     await contains("[data-label='Colors'] button:nth-child(2)").click();
     await contains(".o_colorpicker_section button[data-color='o-color-1']").click();
     expect(":iframe .o_we_shape").toHaveStyle({ backgroundImage: backgroundImageValue });

--- a/addons/website/static/tests/tours/snippet_empty_parent_autoremove.js
+++ b/addons/website/static/tests/tours/snippet_empty_parent_autoremove.js
@@ -56,8 +56,8 @@ registerWebsitePreviewTour(
         // Add a shape
         changeOption("Cover", "toggleBgShape"),
         {
-            content: "Click on the back button",
-            trigger: ".o_pager_nav_angle",
+            content: "Click on the first background shape button",
+            trigger: "button[data-action-id='setBackgroundShape']",
             run: "click",
         },
         {


### PR DESCRIPTION
Before this commit, clicking on the button to apply a background shape would open the selector and apply a shape. By default it would be the first one, or based on the previous sibling, the next one in the background shape list.

To match the behavior for the image shape option, this option no longer set a shape without explicit input from the user.
