### PR TITLE
[FIX] hr_timesheet: prevent timeoff timesheet creation from worked time

### DIFF
--- a/addons/project_timesheet_holidays/models/account_analytic.py
+++ b/addons/project_timesheet_holidays/models/account_analytic.py
@@ -55,3 +55,9 @@ class AccountAnalyticLine(models.Model):
             super()._get_favorite_project_id_domain(employee_id),
             [('holiday_id', '=', False), ('global_leave_id', '=', False)],
         ])
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        if any('holiday_id' in val for val in vals_list):
+            vals_list = [val for val in vals_list if self.env['hr.leave'].browse(val.get('holiday_id')).holiday_status_id.time_type != 'other']
+        return super().create(vals_list)


### PR DESCRIPTION
_______________________________________
## Short functional explanation of the error
When creating a leave of type "worked time", a time off timesheet is generated.

## Reproduction Steps
1. Go to time off. Hit configuration, then time off types.
2. Create a new type of time off. Set the Kind of Time off as Worked Time. Make sure the time off doesn't require allocation.
3. Hit My Time > My Time off. Click on new, and as a time off type, select the one you just created. Save then validate.
4. Go to timesheets and click on the list view.

### Expected behavior
As the type of time off is set as Worked Time, it shouldn't appear as time off. It shouldn't appear at all in the timesheets if created from the time off app.

### Unexpected behavior
The time off shows in the timesheets as "Time Off".

## Origin of the issue
Timesheets were created for each time off request, regardless of their type.

_________________________________________
opw-5050838

---

