### PR TITLE
[FIX] payment_razorpay_oauth: use url_join for URLs

### DIFF
--- a/addons/payment_razorpay_oauth/models/payment_provider.py
+++ b/addons/payment_razorpay_oauth/models/payment_provider.py
@@ -7,6 +7,7 @@ from datetime import timedelta
 from urllib.parse import urlencode
 
 import requests
+from werkzeug import urls
 
 from odoo import _, api, fields, models
 from odoo.exceptions import RedirectWarning, ValidationError
@@ -61,7 +62,7 @@ class PaymentProvider(models.Model):
             )
 
         params = {
-            'return_url': f'{self.get_base_url()}{RazorpayController.OAUTH_RETURN_URL}',
+            'return_url': urls.url_join(self.get_base_url(), RazorpayController.OAUTH_RETURN_URL),
             'provider_id': self.id,
             'csrf_token': request.csrf_token(),
         }
@@ -103,7 +104,7 @@ class PaymentProvider(models.Model):
 
         webhook_secret = uuid.uuid4().hex  # Generate a random webhook secret.
         payload = {
-            'url': f'{self.get_base_url()}/payment/razorpay/webhook',
+            'url': urls.url_join(self.get_base_url(), 'payment/razorpay/webhook'),
             'alert_email': self.env.user.partner_id.email,
             'secret': webhook_secret,
             'events': const.HANDLED_WEBHOOK_EVENTS,


### PR DESCRIPTION
A bad URL could be generated when the `website_payment` module is installed, as it overrides `get_base_url` and may return a URL ending with `/`. Using f-strings to create URLs could result in a double slash `//`, causing errors.

Steps to reproduce:
- Install `website_payment` and `payment_razorpay_oauth`
- Go to Payment Acquirers and connect via OAuth
- Click "Generate your webhook"
- "Authentication failed" error appears

This fix uses `url_join`, like other payment providers, to build URLs correctly and avoid the double slash issue.

opw-5079295