### PR TITLE
[IMP] website: changed warning message on /website/info page

### DIFF
--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -2733,7 +2733,7 @@
                 <div class="alert alert-warning alert-dismissable mt16" groups="website.group_website_restricted_editor" role="status">
                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
                    <p>
-                     Note: To hide this page, uncheck it from the Customize tab in edit mode.
+                     Note: To hide this page, uncheck it from the Style tab in edit mode.
                    </p>
                 </div>
                 <h2>Installed Applications</h2>


### PR DESCRIPTION
This PR changes the warning message displayed on the /website/info page from "To hide this page, uncheck it from the Customize tab in edit mode." to "To hide this page, Uncheck it from the Style tab in edit mode."
