### PR TITLE
[FIX] product: prevent mutually recursive pricelist rules

### DIFF
--- a/addons/product/tests/test_pricelist.py
+++ b/addons/product/tests/test_pricelist.py
@@ -1,6 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.exceptions import UserError
+from itertools import pairwise
+
+from odoo.exceptions import UserError, ValidationError
 from odoo.fields import Command
 from odoo.tests import tagged, Form
 
@@ -262,3 +264,48 @@ class TestPricelist(ProductCommon):
             company_2_b2b_pl,
             "Assigning pricelists in one company shouldn't impact pricelists in other companies",
         )
+
+    def test_prevent_pricelist_recursion(self):
+        """Ensure recursive pricelist rules raise an error on creation."""
+        def create_item_vals(pl_from, pl_to):
+            return {
+                'pricelist_id': pl_from.id,
+                'compute_price': 'formula',
+                'base': 'pricelist',
+                'base_pricelist_id': pl_to.id,
+                'applied_on': '3_global',
+            }
+        Pricelist = self.env['product.pricelist']
+        pl_a, pl_b, pl_c, pl_d = pricelists = Pricelist.create([{
+            'name': f"Pricelist {c}",
+        } for c in 'ABCD'])
+
+        # A -> B -> C -> D
+        Pricelist.item_ids.create([
+            create_item_vals(pl_from, pl_to)
+            for (pl_from, pl_to) in pairwise(pricelists)
+        ])
+
+        with self.assertRaises(ValidationError):
+            # A -> B -> C -> D -> D -> _ (recurs)
+            Pricelist.item_ids.create(create_item_vals(pl_d, pl_d))
+        with self.assertRaises(ValidationError):
+            # A -> B -> C -> D -> A -> _ (recurs)
+            Pricelist.item_ids.create(create_item_vals(pl_d, pl_a))
+        with self.assertRaises(ValidationError):
+            # A -> B -> C -> [B -> _, D] (recurs)
+            Pricelist.item_ids.create(create_item_vals(pl_c, pl_b))
+
+        # A -> B, C -> D
+        pl_b.item_ids.unlink()
+        # C -> D -> A -> B
+        Pricelist.item_ids.create(create_item_vals(pl_d, pl_a))
+        # C -> [B, D -> A -> B]
+        Pricelist.item_ids.create(create_item_vals(pl_c, pl_b))
+
+        with self.assertRaises(ValidationError):
+            # C -> [B, D -> A -> [B, C -> _]] (recurs)
+            Pricelist.item_ids.create(create_item_vals(pl_a, pl_c))
+        with self.assertRaises(ValidationError):
+            # C -> [B -> D -> A -> B -> _, D -> _] (recurs)
+            Pricelist.item_ids.create(create_item_vals(pl_b, pl_d))


### PR DESCRIPTION
Steps
-----
1. Create a selectable pricelist A;
2. create a selectable pricelist B;
3. add a rule to pricelist B which uses pricelist A;
4. add a rule to pricelist A which uses pricelist B;
5. go to /shop & select one of the pricelists.

Issue
-----
> 500: Internal Server Error
> Error while render the template
> RecursionError: maximum recursion depth exceeded in comparison

Cause
-----
The `_check_pricelist_recursion` constraint only checks if a pricelist item's `base_pricelist_id` is the same as the item's `pricelist_id`. It can therefore not detect if two or more pricelists have a mutually recursive dependence relationship.

Solution
--------
Use a depth-first search to ensure any dependent pricelist doesn't depend on a parent pricelist.

opw-5070604