### PR TITLE
[FIX] web: fix crash when viewing empty helpdesk ticket list view

### DIFF
--- a/addons/web/static/src/model/sample_server.js
+++ b/addons/web/static/src/model/sample_server.js
@@ -639,6 +639,13 @@ export class SampleServer {
                 delete group["id:array_agg"];
             }
         }
+        if (params.opening_info) {
+            params.opening_info.forEach((info, i) => {
+                if (!info.folded) {
+                    groups[i].__records ||= [];
+                }
+            });
+        }
 
         return {
             groups,

--- a/addons/web/static/tests/model/sample_server.test.js
+++ b/addons/web/static/tests/model/sample_server.test.js
@@ -411,4 +411,21 @@ describe("RPC calls", () => {
         const ids = new Array(16).fill(0).map((_, index) => index + 1);
         expect(result[0]["id:array_agg"]).toEqual(ids);
     });
+
+    test("'web_read_group': records on unfolded group", async () => {
+        const server = new DeterministicSampleServer("hobbit", fields.hobbit);
+        server.setExistingGroups([
+            { profession: "gardener", count: 0 },
+            { profession: "brewer", count: 0 },
+        ]);
+        const result = await server.mockRpc({
+            method: "web_read_group",
+            model: "hobbit",
+            groupBy: ["profession"],
+            aggregates: [],
+            opening_info: [{ folded: false }, { folded: true }],
+        });
+        expect(result.groups[0].__records).toEqual([]);
+        expect("__records" in result.groups[1]).toBe(false);
+    });
 });


### PR DESCRIPTION
When accessing the Helpdesk ticket list view with zero tickets, the view previously crashed due to improper handling of folded sample data. This commit ensures that sample data folding does not trigger errors when the view is empty, improving overall stability.

Steps to reproduce:
1. Navigate to Helpdesk > Teams > Tickets.
2. Ensure there are no tickets.
3. Switch to list view.

Task-4971510

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
