### PR TITLE
[FIX] website, website_mass_mailing: fix snippet colors

### DIFF
--- a/addons/website/views/snippets/s_company_team_card.xml
+++ b/addons/website/views/snippets/s_company_team_card.xml
@@ -2,12 +2,12 @@
 <odoo>
 
 <template id="s_company_team_card" name="Card Team">
-    <section class="s_company_team_card o_colored_level o_cc o_cc5 pt48 pb48">
+    <section class="s_company_team_card o_colored_level o_cc o_cc2 pt48 pb48">
         <div class="container">
             <h2 style="text-align: center;">Our Team</h2>
             <div class="row">
                 <div data-name="Team Member" class="col-6 col-lg-3">
-                    <div class="s_card o_card_img_top card o_cc o_cc3" data-name="Card" data-snippet="s_card" data-vxml="001" style="border-width: 0px !important;">
+                    <div class="s_card o_card_img_top card o_cc o_cc1" data-name="Card" data-snippet="s_card" data-vxml="001" style="border-width: 0px !important;">
                         <figure class="o_card_img_wrapper ratio ratio-1x1 mb-0">
                             <img class="o_card_img card-img-top rounded-circle" src="/web/image/website.s_company_team_image_1" style="padding: 24px;"/>
                         </figure>
@@ -18,7 +18,7 @@
                     </div>
                 </div>
                 <div data-name="Team Member" class="col-6 col-lg-3">
-                    <div class="s_card o_card_img_top card o_cc o_cc3" data-name="Card" data-snippet="s_card" data-vxml="001" style="border-width: 0px !important;">
+                    <div class="s_card o_card_img_top card o_cc o_cc1" data-name="Card" data-snippet="s_card" data-vxml="001" style="border-width: 0px !important;">
                         <figure class="o_card_img_wrapper ratio ratio-1x1 mb-0">
                             <img class="o_card_img card-img-top rounded-circle" src="/web/image/website.s_company_team_image_2" style="padding: 24px;"/>
                         </figure>
@@ -29,7 +29,7 @@
                     </div>
                 </div>
                 <div data-name="Team Member" class="col-6 col-lg-3">
-                    <div class="s_card o_card_img_top card o_cc o_cc3" data-name="Card" data-snippet="s_card" data-vxml="001" style="border-width: 0px !important;">
+                    <div class="s_card o_card_img_top card o_cc o_cc1" data-name="Card" data-snippet="s_card" data-vxml="001" style="border-width: 0px !important;">
                         <figure class="o_card_img_wrapper ratio ratio-1x1 mb-0">
                             <img class="o_card_img card-img-top rounded-circle" src="/web/image/website.s_company_team_image_3" style="padding: 24px;"/>
                         </figure>
@@ -40,7 +40,7 @@
                     </div>
                 </div>
                 <div data-name="Team Member" class="col-6 col-lg-3">
-                    <div class="s_card o_card_img_top card o_cc o_cc3" data-name="Card" data-snippet="s_card" data-vxml="001" style="border-width: 0px !important;">
+                    <div class="s_card o_card_img_top card o_cc o_cc1" data-name="Card" data-snippet="s_card" data-vxml="001" style="border-width: 0px !important;">
                         <figure class="o_card_img_wrapper ratio ratio-1x1 mb-0">
                             <img class="o_card_img card-img-top rounded-circle" src="/web/image/website.s_company_team_image_4" style="padding: 24px;"/>
                         </figure>

--- a/addons/website/views/snippets/s_numbers_boxed.xml
+++ b/addons/website/views/snippets/s_numbers_boxed.xml
@@ -9,15 +9,15 @@
                     <h2 style="text-align: center;">Insights, stats, and metrics</h2>
                     <p style="text-align: center;">This section allows to highlight key statistics.</p>
                 </div>
-                <div class="o_grid_item g-height-5 g-col-lg-4 col-12 col-lg-4 border rounded o_cc o_cc3 order-lg-0" style="grid-area: 4 / 1 / 9 / 5; --grid-item-padding-y: 64px; text-align: center; border-radius: 9.6px !important; z-index: 2; order: 1;">
+                <div class="o_grid_item g-height-5 g-col-lg-4 col-12 col-lg-4 border rounded order-lg-0" style="grid-area: 4 / 1 / 9 / 5; --grid-item-padding-y: 64px; text-align: center; border-radius: 9.6px !important; z-index: 2; order: 1;">
                     <h3 class="display-3-fs"><font style="background-image: linear-gradient(135deg, var(--o-color-4) 15%, var(--o-color-5) 100%);" class="text-gradient">30+</font></h3>
                     <p><strong>Useful options</strong></p>
                 </div>
-                <div class="o_grid_item g-height-5 g-col-lg-4 col-6 col-lg-4 border rounded o_cc o_cc3" style="grid-area: 4 / 5 / 9 / 9; --grid-item-padding-y: 64px; text-align: center; border-radius: 9.6px !important; z-index: 3;">
+                <div class="o_grid_item g-height-5 g-col-lg-4 col-6 col-lg-4 border rounded" style="grid-area: 4 / 5 / 9 / 9; --grid-item-padding-y: 64px; text-align: center; border-radius: 9.6px !important; z-index: 3;">
                     <h3 class="display-3-fs"><font style="background-image: linear-gradient(45deg, var(--o-color-4) 15%, var(--o-color-5) 100%);" class="text-gradient">45%</font></h3>
                     <p><strong>More leads</strong></p>
                 </div>
-                <div class="o_grid_item g-height-5 g-col-lg-4 col-6 col-lg-4 border rounded o_cc o_cc3" style="grid-area: 4 / 9 / 9 / 13; --grid-item-padding-y: 64px; text-align: center; border-radius: 9.6px !important; z-index: 4;">
+                <div class="o_grid_item g-height-5 g-col-lg-4 col-6 col-lg-4 border rounded" style="grid-area: 4 / 9 / 9 / 13; --grid-item-padding-y: 64px; text-align: center; border-radius: 9.6px !important; z-index: 4;">
                     <h3 class="display-3-fs"><font style="background-image: linear-gradient(45deg, var(--o-color-4) 15%, var(--o-color-5) 100%);" class="text-gradient">8+</font></h3>
                     <p><strong>Amazing pages</strong></p>
                 </div>

--- a/addons/website/views/snippets/s_numbers_charts.xml
+++ b/addons/website/views/snippets/s_numbers_charts.xml
@@ -15,7 +15,7 @@
                     <div class="s_progress_bar s_progress_bar_label_hidden" data-display="inline" data-vcss="001" data-snippet="s_progress_bar">
                         <div class="s_progress_bar_wrapper d-flex gap-2">
                             <div class="progress" role="progressbar" aria-label="Progress bar" aria-valuenow="80" aria-valuemin="0" aria-valuemax="100">
-                                <div class="progress-bar overflow-visible bg-o-color-2" style="width: 80%; min-width: 3%">
+                                <div class="progress-bar overflow-visible bg-o-color-5" style="width: 80%; min-width: 3%">
                                     <span class="s_progress_bar_text small d-none">80%</span>
                                 </div>
                             </div>
@@ -28,7 +28,7 @@
                     <div class="s_progress_bar s_progress_bar_label_hidden" data-display="inline" data-vcss="001" data-snippet="s_progress_bar">
                         <div class="s_progress_bar_wrapper d-flex gap-2">
                             <div class="progress" role="progressbar" aria-label="Progress bar" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100">
-                                <div class="progress-bar overflow-visible bg-o-color-2" style="width: 25%; min-width: 3%">
+                                <div class="progress-bar overflow-visible bg-o-color-5" style="width: 25%; min-width: 3%">
                                     <span class="s_progress_bar_text small d-none">25%</span>
                                 </div>
                             </div>
@@ -36,14 +36,14 @@
                     </div>
                 </div>
                 <div class="o_grid_item o_cc o_cc2 g-col-lg-5 g-height-12 col-lg-5 rounded" style="grid-area: 1 / 8 / 13 / 13; --grid-item-padding-y: 64px; --grid-item-padding-x: 40px; z-index: 4;">
-                    <div class="s_chart" data-type="doughnut" data-legend-position="none" data-tooltip-display="false" data-stacked="false" data-border-width="2" data-data='{"labels":["First","Second"],"datasets":[{"label":"One","data":["25","75"],"backgroundColor":["o-color-3","o-color-2"],"borderColor":["",""]}]}' data-snippet="s_chart" data-name="Chart">
+                    <div class="s_chart" data-type="doughnut" data-legend-position="none" data-tooltip-display="false" data-stacked="false" data-border-width="2" data-data='{"labels":["First","Second"],"datasets":[{"label":"One","data":["25","75"],"backgroundColor":["o-color-3","o-color-5"],"borderColor":["",""]}]}' data-snippet="s_chart" data-name="Chart">
                         <p><br/></p>
                         <canvas style="box-sizing: border-box;" width="456" height="228"/>
                     </div>
                     <!-- Placeholder chart, to be displayed in the preview modal -->
                     <svg class="s_dialog_preview d-block mt-3 mx-auto" width="450" height="230" viewBox="0 0 100 110" xmlns="http://www.w3.org/2000/svg">
                         <circle cx="50" cy="50" r="40" fill="transparent" stroke="transparent" stroke-width="25"/>
-                        <circle cx="50" cy="55" r="40" fill="transparent" stroke="var(--o-color-2)" stroke-width="25"  stroke-dasharray="251.2" stroke-dashoffset="62.8"/>
+                        <circle cx="50" cy="55" r="40" fill="transparent" stroke="var(--o-color-5)" stroke-width="25"  stroke-dasharray="251.2" stroke-dashoffset="62.8"/>
                     </svg>
                     <!-- End of placeholder -->
                     <p><br/></p>

--- a/addons/website/views/snippets/s_text_cover.xml
+++ b/addons/website/views/snippets/s_text_cover.xml
@@ -2,7 +2,7 @@
 <odoo>
 
 <template id="s_text_cover" name="Text Cover">
-    <section class="s_text_cover o_colored_level o_cc o_cc3">
+    <section class="s_text_cover o_colored_level o_cc o_cc5">
         <div class="container-fluid">
             <div class="row o_grid_mode" data-row-count="11">
                 <div class="o_grid_item g-height-9 g-col-lg-5 col-lg-5 o_cc o_cc1" style="z-index: 1; grid-area: 2 / 3 / 11 / 8; --grid-item-padding-x: 24px; --grid-item-padding-y: 24px;">

--- a/addons/website_mass_mailing/views/snippets_templates.xml
+++ b/addons/website_mass_mailing/views/snippets_templates.xml
@@ -80,8 +80,8 @@ database, without the s_newsletter_list class. See fixNewsletterListClass.
 </template>
 
 <template id="s_newsletter_box" name="Newsletter Box">
-    <section class="s_newsletter_box s_newsletter_list o_colored_level pt64 pb64 o_cc o_cc2" data-name="Newsletter Box" data-list-id="0" data-oe-shape-data="{'shape':'html_builder/Blobs/04_001','colors':{'c5':'o-color-2'},'flip':[],'showOnMobile':false,'shapeAnimationSpeed':'0'}">
-        <div class="o_we_shape o_html_builder_Blobs_04_001" style="background-image: url('/html_editor/shape/html_builder/Blobs/04_001.svg?c5=o-color-2');"/>
+    <section class="s_newsletter_box s_newsletter_list o_colored_level pt64 pb64 o_cc o_cc2" data-name="Newsletter Box" data-list-id="0" data-oe-shape-data="{'shape':'html_builder/Blobs/04_001','colors':{'c5':'o-color-5'},'flip':[],'showOnMobile':false,'shapeAnimationSpeed':'0'}">
+        <div class="o_we_shape o_html_builder_Blobs_04_001" style="background-image: url('/html_editor/shape/html_builder/Blobs/04_001.svg?c5=o-color-5');"/>
         <div class="container">
             <div class="row s_nb_column_fixed s_col_no_bgcolor">
                 <div class="s_media_list_item col-lg-7 offset-lg-4 pt16 pb16" data-name="Box">


### PR DESCRIPTION
This commit adapts multiple snippets after the change of the default palette.

Several snippets assumed the secondary color was dark. Since this is not always true (e.g., the default palette now defines it as light), those snippets were updated to work in both cases.

Design-themes: https://github.com/odoo/design-themes/pull/1143
task-5072830

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
