### PR TITLE
[IMP] project: add pencil/trash icons to edit/delete tmpl from dropdown

### DIFF
--- a/addons/project/static/src/views/components/project_task_template_dropdown.js
+++ b/addons/project/static/src/views/components/project_task_template_dropdown.js
@@ -3,11 +3,14 @@ import { useService } from "@web/core/utils/hooks";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 
+import { ProjectTemplateButtons } from "./project_template_buttons";
+
 export class ProjectTaskTemplateDropdown extends Component {
     static template = "project.TemplateDropdown";
     static components = {
         Dropdown,
         DropdownItem,
+        ProjectTemplateButtons,
     };
 
     static props = {

--- a/addons/project/static/src/views/components/project_task_template_dropdown.xml
+++ b/addons/project/static/src/views/components/project_task_template_dropdown.xml
@@ -13,8 +13,10 @@
                 <div role="separator" class="dropdown-divider"/>
                 <div class="dropdown-header">Task Templates</div>
                 <t t-foreach="state.taskTemplates" t-as="template" t-key="template.id">
-                    <DropdownItem tag="'button'" class="'btn btn-link o-dropdopwn-item-indent'" onSelected="() => this.createTaskFromTemplate(template.id)">
-                        <t t-out="template.name"/>
+                    <DropdownItem tag="'button'" class="'btn btn-link o-dropdopwn-item-indent o-task-template d-flex align-items-center pe-0'"
+                        onSelected="() => this.createTaskFromTemplate(template.id)">
+                        <span class="text-truncate" t-out="template.name"/>
+                        <ProjectTemplateButtons resModel="'project.task'" resId="template.id"/>
                     </DropdownItem>
                 </t>
             </t>

--- a/addons/project/static/src/views/components/project_template_buttons.js
+++ b/addons/project/static/src/views/components/project_template_buttons.js
@@ -1,0 +1,41 @@
+import { Component, onWillStart } from "@odoo/owl";
+import { useService } from "@web/core/utils/hooks";
+import { user } from "@web/core/user";
+import { ConfirmationDialog, deleteConfirmationMessage } from "@web/core/confirmation_dialog/confirmation_dialog";
+
+export class ProjectTemplateButtons extends Component {
+    static template = "project.ProjectTemplateButtons";
+    static props = {
+        resModel: String,
+        resId: Number,
+    };
+
+    setup() {
+        this.orm = useService("orm");
+        this.dialogService = useService("dialog");
+        this.action = useService("action");
+        onWillStart(async () => {
+            this.isProjectManager = await user.hasGroup('project.group_project_manager');
+        });
+    }
+
+    onEditClick() {
+        this.action.doAction({
+            type: "ir.actions.act_window",
+            res_model: this.props.resModel,
+            res_id: this.props.resId,
+            views: [[false, "form"]],
+        });
+    }
+
+    async onDeleteClick() {
+        this.dialogService.add(ConfirmationDialog, {
+            body: deleteConfirmationMessage,
+            confirm: async () => {
+                await this.orm.unlink(this.props.resModel, [this.props.resId]);
+                this.action.doAction("soft_reload");
+            },
+            cancel: () => {},
+        });
+    }
+}

--- a/addons/project/static/src/views/components/project_template_buttons.scss
+++ b/addons/project/static/src/views/components/project_template_buttons.scss
@@ -1,0 +1,25 @@
+.o-project-template, .o-task-template {
+    @include media-breakpoint-up(sm) {
+        .o_template_icon_group {
+            visibility: hidden;
+        }
+
+        &:hover, &.focus {
+            .o_template_icon_group {
+                visibility: visible;
+
+                .btn {
+                    color: $text-muted !important;
+
+                    &.btn-link:hover {
+                        color: $btn-link-hover-color !important;
+                    }
+
+                    &.fa-trash:hover {
+                        color: $o-danger !important;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/addons/project/static/src/views/components/project_template_buttons.xml
+++ b/addons/project/static/src/views/components/project_template_buttons.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<templates>
+    <t t-name="project.ProjectTemplateButtons">
+        <div class="btn-group o_template_icon_group ms-auto d-flex ps-1" t-if="isProjectManager">
+            <i role="button" t-on-click.stop="onEditClick" class="btn btn-link fa fa-pencil fs-3"></i>
+            <i role="button" t-on-click.stop="onDeleteClick" class="btn text-danger fa fa-trash fs-3"></i>
+        </div>
+    </t>
+</templates>

--- a/addons/project/static/src/views/components/project_template_dropdown.js
+++ b/addons/project/static/src/views/components/project_template_dropdown.js
@@ -3,11 +3,14 @@ import { useService } from "@web/core/utils/hooks";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 
+import { ProjectTemplateButtons } from "./project_template_buttons";
+
 export class ProjectTemplateDropdown extends Component {
     static template = "project.ProjectTemplateDropdown";
     static components = {
         Dropdown,
         DropdownItem,
+        ProjectTemplateButtons,
     };
 
     static props = {

--- a/addons/project/static/src/views/components/project_template_dropdown.xml
+++ b/addons/project/static/src/views/components/project_template_dropdown.xml
@@ -13,8 +13,10 @@
                 <div role="separator" class="dropdown-divider"/>
                 <div class="dropdown-header">Project Templates</div>
                 <t t-foreach="state.projectTemplates" t-as="template" t-key="template.id">
-                    <DropdownItem tag="'button'" class="'btn btn-link o-dropdopwn-item-indent'" onSelected="() => this.createProjectFromTemplate(template)">
-                        <t t-out="template.name"/>
+                    <DropdownItem tag="'button'" class="'btn btn-link o-dropdopwn-item-indent o-project-template d-flex align-items-center pe-0'"
+                        onSelected="() => this.createProjectFromTemplate(template)">
+                        <span class="text-truncate" t-out="template.name"/>
+                        <ProjectTemplateButtons resModel="'project.project'" resId="template.id"/>
                     </DropdownItem>
                 </t>
             </t>


### PR DESCRIPTION
**Current behavior:**

  The user can not directly edit or delete task or project templates from the dropdown list; they must open the template  first to  perform these actions.

**New behavior:**
  - Added pencil (edit) and trash (delete) icons to the dropdown actions for both task and project templates.
  - These icons allow users to edit or delete templates directly from the dropdown.
  - Icons are visible only to Project Managers.
  - By default, icons are hidden and appear on mouse-over.
  - In a small device, icons are always visible.

task-5073053
