### PR TITLE
[FIX] website: correct source path of snippet images

### DIFF
--- a/addons/website/views/snippets/s_cta_mobile.xml
+++ b/addons/website/views/snippets/s_cta_mobile.xml
@@ -12,7 +12,7 @@
                     <a href="https://play.google.com/store/"><img src="/web/image/website.google_play_image" class="img img-fluid" alt="Google Play"/></a>
                 </div>
                 <div class="o_grid_item o_grid_item_image o_snippet_mobile_invisible g-height-8 g-col-lg-4 col-lg-4 d-none d-lg-block" style="grid-area: 1 / 8 / 9 / 12; z-index: 2; --grid-item-padding-y: 0px; --grid-item-padding-x: 0px;">
-                    <img src="html_editor/image_shape/website.s_cta_mockups_default_image_1/html_builder/devices/galaxy_front_portrait_half.svg" class="img img-fluid" data-shape="html_builder/devices/galaxy_front_portrait_half" data-shape-colors=";;;;#111827" data-format-mimetype="image/webp" data-file-name="s_cta_mockups_1.webp" alt=""/>
+                    <img src="/html_editor/image_shape/website.s_cta_mockups_default_image_1/html_builder/devices/galaxy_front_portrait_half.svg" class="img img-fluid" data-shape="html_builder/devices/galaxy_front_portrait_half" data-shape-colors=";;;;#111827" data-format-mimetype="image/webp" data-file-name="s_cta_mockups_1.webp" alt=""/>
                 </div>
             </div>
         </div>

--- a/addons/website/views/snippets/s_cta_mockups.xml
+++ b/addons/website/views/snippets/s_cta_mockups.xml
@@ -6,7 +6,7 @@
         <div class="container">
             <div class="row o_grid_mode" data-row-count="9">
                 <div class="o_grid_item o_grid_item_image g-height-9 g-col-lg-7 col-lg-7" style="grid-area: 1 / 6 / 10 / 13; z-index: 1;">
-                    <img src="html_editor/image_shape/website.s_cta_mockups_default_image/html_builder/devices/macbook_front.svg" class="img img-fluid" data-shape="html_builder/devices/macbook_front" data-format-mimetype="image/webp" data-file-name="s_cta_mockups.webp" alt=""/>
+                    <img src="/html_editor/image_shape/website.s_cta_mockups_default_image/html_builder/devices/macbook_front.svg" class="img img-fluid" data-shape="html_builder/devices/macbook_front" data-format-mimetype="image/webp" data-file-name="s_cta_mockups.webp" alt=""/>
                 </div>
                 <div class="o_grid_item g-height-6 g-col-lg-4 col-lg-4" style="grid-area: 3 / 1 / 9 / 5; z-index: 2;">
                     <h2 class="h3-fs">50,000+ companies trust Odoo.</h2>
@@ -14,7 +14,7 @@
                     <a t-att-href="cta_btn_href" class="btn btn-primary btn-lg"><t t-out="cta_btn_text">Contact us</t></a>
                 </div>
                 <div class="o_grid_item o_grid_item_image o_snippet_mobile_invisible g-height-8 g-col-lg-2 col-lg-2 d-none d-lg-block" style="grid-area: 2 / 6 / 10 / 8; z-index: 3;">
-                    <img src="html_editor/image_shape/website.s_cta_mockups_default_image_1/html_builder/devices/iphone_front_portrait.svg" class="img img-fluid" data-shape="html_builder/devices/iphone_front_portrait" data-format-mimetype="image/webp" data-file-name="s_cta_mockups_1.webp" alt=""/>
+                    <img src="/html_editor/image_shape/website.s_cta_mockups_default_image_1/html_builder/devices/iphone_front_portrait.svg" class="img img-fluid" data-shape="html_builder/devices/iphone_front_portrait" data-format-mimetype="image/webp" data-file-name="s_cta_mockups_1.webp" alt=""/>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
The images in snippets were not displayed due to incorrect source paths.

This commit fixes the paths for `s_cta_mockups` and `s_cta_mobile` snippets.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
