### PR TITLE
[FIX] account: Qualify column names in SQL selects for vendor bill da…

### DIFF
--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -744,12 +744,12 @@ class AccountJournal(models.Model):
             ('state', '=', 'posted'),
         ])
         selects = [
-            SQL("journal_id"),
-            SQL("company_id"),
-            SQL("currency_id AS currency"),
-            SQL("invoice_date_due < %s AS late", fields.Date.context_today(self)),
-            SQL("SUM(amount_residual_signed) AS amount_total_company"),
-            SQL("SUM((CASE WHEN move_type = 'in_invoice' THEN -1 ELSE 1 END) * amount_residual) AS amount_total"),
+            SQL("account_move.journal_id"),
+            SQL("account_move.company_id"),
+            SQL("account_move.currency_id AS currency"),
+            SQL("account_move.invoice_date_due < %s AS late", fields.Date.context_today(self)),
+            SQL("SUM(account_move.amount_residual_signed) AS amount_total_company"),
+            SQL("SUM((CASE WHEN account_move.move_type = 'in_invoice' THEN -1 ELSE 1 END) * account_move.amount_residual) AS amount_total"),
             SQL("COUNT(*)"),
             SQL("TRUE AS to_pay")
         ]
@@ -1171,3 +1171,4 @@ class AccountJournal(models.Model):
     def create_supplier_payment(self):
         """return action to create a supplier payment"""
         return self.open_payments_action('outbound', mode='form')
+


### PR DESCRIPTION

Description of the issue/feature this PR addresses:
---------------------------------------------------
Opening the Accounting dashboard can raise an `AmbiguousColumn` SQL error 
when custom record rules are defined on the `account.move` model.  
Example: adding a record rule with a domain like 
`[('partner_id.name','=','x')]` leads to an error on `company_id`.

Current behavior before PR:
---------------------------
The SQL query in the vendor bill dashboard does not qualify some column 
names (e.g., `journal_id`, `company_id`, `currency_id`, `invoice_date_due`, 
`amount_residual_signed`, `move_type`, `amount_residual`).  
As a result, PostgreSQL raises an `AmbiguousColumn` error when such 
columns appear in joins triggered by record rules.

Desired behavior after PR is merged:
------------------------------------
The dashboard query prefixes all ambiguous column names with the 
`account_move.` table name, ensuring the dashboard loads correctly 
even with custom record rules.