### PR TITLE
[FIX] website: allow space when editing login form button

### DIFF
--- a/addons/website/static/src/builder/plugins/form/form_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/form/form_option_plugin.js
@@ -65,6 +65,10 @@ export class FormOptionPlugin extends Plugin {
         "defaultMessage",
     ];
     resources = {
+        // The following line explicitly makes editable the container of the
+        // login form buttons. This trick is needed to allow the user to properly
+        // insert spaces while editing the text of the buttons.
+        o_editable_selectors: ".oe_login_form .oe_login_buttons",
         builder_header_middle_buttons: [
             {
                 Component: FormOptionAddFieldButton,


### PR DESCRIPTION
Before this commit, the text in the login form button could be edited, but pressing the spacebar did not insert any space in the text. Even if the buttons are `contenteditable`, some browsers (at least Chrome and Firefox) still interpret the space as a `submit` event.

After this commit, the button container `.oe_login_buttons` is given the attribute `contenteditable`, fixing the problem.

How to reproduce the problem:
1. While being logged in, navigate to "/web/login"
2. Enter edit mode
3. Click the "Log in" button
4. PROBLEM: text can be inserted, but pressing the spacebar has no apparent effect

task-4367641
