### PR TITLE
[IMP] orm: check field access when searching

### DIFF
--- a/addons/hr_expense/models/hr_employee_public.py
+++ b/addons/hr_expense/models/hr_employee_public.py
@@ -5,7 +5,7 @@ from odoo.fields import Domain
 class HrEmployee(models.Model):
     _inherit = 'hr.employee.public'
 
-    filter_for_expense = fields.Boolean(store=False, search='_search_filter_for_expense', groups="hr.group_hr_user")
+    filter_for_expense = fields.Boolean(store=False, search='_search_filter_for_expense')
 
     def _search_filter_for_expense(self, operator, value):
         if operator != 'in':

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -977,6 +977,7 @@ class DomainCondition(Domain):
 
     def _optimize_field_search_method(self, model: BaseModel) -> Domain:
         field = self._field(model)
+        model._check_field_access(field, 'read')
         operator, value = self.operator, self.value
         # use the `Field.search` function
         original_exception = None


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When seraching, we check field access for fields that are appear in the generated SQL. This commit add the check when we call searchable non-stored fields.

Current behavior before PR:
Search on non-readable searchable field works.

Desired behavior after PR is merged:
Check field permissions before calling the search method.


Linked issue: odoo/enterprise#94297

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
