### PR TITLE
[FIX] core: incorrect error handling in _receive

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1220,7 +1220,7 @@ class ChromeBrowser:
                 continue
             except websocket.WebSocketConnectionClosedException as e:
                 if not self._result.done():
-                    self.ws = None
+                    del self.ws
                     self._result.set_exception(e)
                     for f in self._responses.values():
                         f.cancel()


### PR DESCRIPTION
Followup to 16.0-closed-in-stop-xmo: the condition in `stop` is a `hasattr`, so we need to delete `self.ws` not set it to `None`.

Setting it to `None` means the condition passes then blows up as soon as we try to use it, which means we "just" converted all the old `WebSocketConnectionClosedException` to an `AttributeError`.

https://runbot.odoo.com/odoo/error/231446
