### PR TITLE
[IMP] web: remove calendar attribute "date_delay"

### DIFF
--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -387,7 +387,7 @@
                     <i class="fa fa-video-camera text-600" title="Videocall URL"/>
                     <field name="videocall_location" nolabel="1"
                         widget="CopyClipboardChar"
-                        class="w-100 mb-0 o_field_CopyClipboardChar" 
+                        class="w-100 mb-0 o_field_CopyClipboardChar"
                     />
                     <button name="clear_videocall_location" class="btn btn-sm px-0"><i class="fa fa-remove" title="Remove"/></button>
                 </div>
@@ -396,7 +396,7 @@
                     <field name="privacy" nolabel="1" class="w-100 mb-0" placeholder="Visibility"/>
                 </div>
                 <div class="d-flex" colspan="2">
-                    <i class="fa fa-sticky-note mt-2 text-600" title="Notes"/> 
+                    <i class="fa fa-sticky-note mt-2 text-600" title="Notes"/>
                     <field name="notes" nolabel="1" class="w-100" placeholder="Notes" widget="calendar_event_notes_html"/>
                 </div>
             </form>
@@ -408,7 +408,7 @@
         <field name="model">calendar.event</field>
         <field name="priority" eval="2"/>
         <field name="arch" type="xml">
-            <calendar js_class="attendee_calendar" string="Meetings" date_start="start" date_stop="stop" date_delay="duration" all_day="allday"
+            <calendar js_class="attendee_calendar" string="Meetings" date_start="start" date_stop="stop" all_day="allday"
                 event_open_popup="true"
                 event_limit="5"
                 quick_create="true"

--- a/addons/web/static/src/views/calendar/calendar_arch_parser.js
+++ b/addons/web/static/src/views/calendar/calendar_arch_parser.js
@@ -5,7 +5,6 @@ import { Field } from "@web/views/fields/field";
 
 const FIELD_ATTRIBUTE_NAMES = [
     "date_start",
-    "date_delay",
     "date_stop",
     "all_day",
     "create_name_field",
@@ -122,6 +121,10 @@ export class CalendarArchParser {
         }
         if (!Number.isInteger(eventLimit)) {
             throw new CalendarParseArchError(`Calendar view's event limit should be a number`);
+        }
+
+        if (!fieldMapping.date_stop) {
+            fieldMapping.date_stop = fieldMapping.date_start;
         }
 
         return {

--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
@@ -333,7 +333,7 @@ export class CalendarCommonRenderer extends Component {
     }
     onEventDrop(info) {
         this.fc.api.unselect();
-        this.props.model.updateRecord(this.fcEventToRecord(info.event), { moved: true });
+        this.props.model.updateRecord(this.fcEventToRecord(info.event));
     }
     onEventResize(info) {
         this.fc.api.unselect();

--- a/addons/web/static/src/views/calendar/calendar_model.js
+++ b/addons/web/static/src/views/calendar/calendar_model.js
@@ -384,11 +384,6 @@ export class CalendarModel extends Model {
                     : serializeDateTime(end);
         }
 
-        if (this.meta.fieldMapping.date_delay) {
-            if (this.meta.scale !== "month" || !options.moved) {
-                data[this.meta.fieldMapping.date_delay] = end.diff(start, "hours").hours;
-            }
-        }
         return data;
     }
     makeContextDefaults(rawRecord) {
@@ -399,7 +394,6 @@ export class CalendarModel extends Model {
             fieldMapping.create_name_field || "name",
             fieldMapping.date_start,
             fieldMapping.date_stop,
-            fieldMapping.date_delay,
             fieldMapping.all_day || "allday",
         ];
         for (const fieldName of fieldNames) {
@@ -596,14 +590,10 @@ export class CalendarModel extends Model {
         const serializeFn = this.dateStartType === "date" ? serializeDate : serializeDateTime;
         const formattedEnd = serializeFn(data.range.end);
         const formattedStart = serializeFn(data.range.start);
-
-        const domain = [[fieldMapping.date_start, "<=", formattedEnd]];
-        if (fieldMapping.date_stop) {
-            domain.push([fieldMapping.date_stop, ">=", formattedStart]);
-        } else if (!fieldMapping.date_delay) {
-            domain.push([fieldMapping.date_start, ">=", formattedStart]);
-        }
-        return domain;
+        return [
+            [fieldMapping.date_start, "<=", formattedEnd],
+            [fieldMapping.date_stop, ">=", formattedStart]
+        ];
     }
 
     //--------------------------------------------------------------------------
@@ -677,13 +667,14 @@ export class CalendarModel extends Model {
                 : deserializeDateTime(rawRecord[fieldMapping.date_stop]);
         }
 
-        const duration = rawRecord[fieldMapping.date_delay] || 1;
-
         if (isAllDay) {
             start = start.startOf("day");
             end = end.startOf("day");
         }
-        if (!fieldMapping.date_stop && duration) {
+
+        let duration = end.diff(start, "hours").hours;
+        if (!duration) {
+            duration = 1;
             end = start.plus({ hours: duration });
         }
 

--- a/addons/web/static/tests/legacy/views/calendar/helpers.js
+++ b/addons/web/static/tests/legacy/views/calendar/helpers.js
@@ -216,7 +216,6 @@ function makeFakeModelState() {
         fieldMapping: {
             date_start: "start_date",
             date_stop: "stop_date",
-            date_delay: "delay",
             all_day: "allday",
             color: "color",
         },

--- a/addons/web/static/tests/views/calendar/calendar_arch_parser.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_arch_parser.test.js
@@ -15,6 +15,7 @@ const DEFAULT_ARCH_RESULTS = {
     eventLimit: 5,
     fieldMapping: {
         date_start: "start_date",
+        date_stop: "start_date",
     },
     fieldNames: ["start_date"],
     filtersInfo: {},

--- a/addons/web/static/tests/views/calendar/calendar_test_helpers.js
+++ b/addons/web/static/tests/views/calendar/calendar_test_helpers.js
@@ -169,7 +169,6 @@ export const FAKE_MODEL = {
     fieldMapping: {
         date_start: "start_date",
         date_stop: "stop_date",
-        date_delay: "delay",
         all_day: "allday",
         color: "color",
     },

--- a/addons/web/static/tests/views/calendar/calendar_view.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_view.test.js
@@ -387,7 +387,7 @@ test(`simple calendar rendering on desktop`, async () => {
         resModel: "event",
         type: "calendar",
         arch: `
-            <calendar event_open_popup="1" date_start="start" date_stop="stop" all_day="is_all_day" mode="week" attendee="attendee_ids" color="partner_id" date_delay="delay">
+            <calendar event_open_popup="1" date_start="start" date_stop="stop" all_day="is_all_day" mode="week" attendee="attendee_ids" color="partner_id">
                 <filter name="user_id" avatar_field="image"/>
                 <field name="attendee_ids" write_model="filter.partner" write_field="partner_id"/>
                 <field name="partner_id" filters="1" invisible="1"/>
@@ -489,7 +489,7 @@ test(`simple calendar rendering on mobile`, async () => {
         resModel: "event",
         type: "calendar",
         arch: `
-            <calendar event_open_popup="1" date_start="start" date_stop="stop" all_day="is_all_day" mode="week" attendee="attendee_ids" color="partner_id" date_delay="delay">
+            <calendar event_open_popup="1" date_start="start" date_stop="stop" all_day="is_all_day" mode="week" attendee="attendee_ids" color="partner_id">
                 <filter name="user_id" avatar_field="image"/>
                 <field name="attendee_ids" write_model="filter.partner" write_field="partner_id"/>
                 <field name="partner_id" filters="1" invisible="1"/>
@@ -3412,7 +3412,7 @@ test(`events starting at midnight on desktop`, async () => {
     await mountView({
         resModel: "event",
         type: "calendar",
-        arch: `<calendar date_start="start" mode="week"/>`,
+        arch: `<calendar date_start="start" date_stop="stop" mode="week"/>`,
     });
 
     // Click on Tuesday 12am
@@ -3432,7 +3432,7 @@ test(`events starting at midnight on mobile`, async () => {
     await mountView({
         resModel: "event",
         type: "calendar",
-        arch: `<calendar date_start="start" mode="week"/>`,
+        arch: `<calendar date_start="start" date_stop="stop" mode="week"/>`,
     });
 
     // Click on Tuesday 12am
@@ -3704,7 +3704,7 @@ test(`timezone does not affect drag and drop on desktop`, async () => {
         resModel: "event",
         type: "calendar",
         arch: `
-            <calendar date_start="start" mode="month">
+            <calendar date_start="start" date_stop="stop" mode="month">
                 <field name="name"/>
                 <field name="start"/>
             </calendar>
@@ -3751,7 +3751,7 @@ test(`timezone does not affect drag and drop on mobile`, async () => {
         resModel: "event",
         type: "calendar",
         arch: `
-            <calendar date_start="start" mode="month">
+            <calendar date_start="start" date_stop="stop" mode="month">
                 <field name="name"/>
                 <field name="start"/>
             </calendar>
@@ -3928,30 +3928,6 @@ test(`drag and drop on month mode with all_day mapping`, async () => {
     await moveEventToDate(8, "2016-12-19");
     await clickEvent(8);
     expect(`.list-group-item:eq(1)`).toHaveText("07:00 - 19:00 (12 hours)");
-});
-
-test(`drag and drop on month mode with date_start and date_delay`, async () => {
-    onRpc("write", ({ args }) => {
-        expect.step("write");
-        expect(args[1].delay).toBe(undefined);
-    });
-    await mountView({
-        resModel: "event",
-        type: "calendar",
-        arch: `
-            <calendar date_start="start" date_delay="delay" mode="month">
-                <field name="name"/>
-                <field name="start"/>
-                <field name="delay"/>
-            </calendar>
-        `,
-    });
-
-    await clickDate("2016-12-20");
-    await contains(`.o-calendar-quick-create--input`).edit("An event", { confirm: false });
-    await contains(`.o-calendar-quick-create--create-btn`).click();
-    await moveEventToDate(8, "2016-11-27");
-    expect.verifySteps(["write"]);
 });
 
 test(`form_view_id attribute works (for creating events)`, async () => {

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -1613,7 +1613,7 @@ actual arch.
     # Specific node postprocessors
     #------------------------------------------------------
     def _postprocess_tag_calendar(self, node, name_manager, node_info):
-        for additional_field in ('date_start', 'date_delay', 'date_stop', 'color', 'all_day'):
+        for additional_field in ('date_start', 'date_stop', 'color', 'all_day'):
             if fname := node.get(additional_field):
                 name_manager.has_field(node, fname, node_info)
         if fname := node.get('aggregate'):
@@ -1871,7 +1871,7 @@ actual arch.
                 self._raise_view_error(msg, child)
 
     def _validate_tag_calendar(self, node, name_manager, node_info):
-        for additional_field in ('date_start', 'date_delay', 'date_stop', 'color', 'all_day'):
+        for additional_field in ('date_start', 'date_stop', 'color', 'all_day'):
             if fnames := node.get(additional_field):
                 name_manager.has_field(node, fnames.split('.', 1)[0], node_info)
         for f in node:
@@ -2864,14 +2864,8 @@ class Base(models.AbstractModel):
         set_first_of(["user_id", "partner_id", "x_user_id", "x_partner_id"],
                      self._fields, 'color')
 
-        if not set_first_of(["date_stop", "date_end", "x_date_stop", "x_date_end"],
-                            self._fields, 'date_stop'):
-            if not set_first_of(["date_delay", "planned_hours", "x_date_delay", "x_planned_hours"],
-                                self._fields, 'date_delay'):
-                raise UserError(_(
-                    "Insufficient fields to generate a Calendar View for %s, missing a date_stop or a date_delay",
-                    self._name
-                ))
+        set_first_of(["date_stop", "date_end", "x_date_stop", "x_date_end"],
+                     self._fields, 'date_stop')
 
         return view
 

--- a/odoo/addons/base/rng/calendar_view.rng
+++ b/odoo/addons/base/rng/calendar_view.rng
@@ -11,7 +11,6 @@
             <rng:optional><rng:attribute name="string" /></rng:optional>
             <rng:optional><rng:attribute name="date_start" /></rng:optional>
             <rng:optional><rng:attribute name="date_stop" /></rng:optional>
-            <rng:optional><rng:attribute name="date_delay" /></rng:optional>
             <rng:optional><rng:attribute name="all_day" /></rng:optional>
             <rng:optional><rng:attribute name="aggregate" /></rng:optional>
             <rng:optional><rng:attribute name="form_view_id" /></rng:optional>


### PR DESCRIPTION
This commit removes the attribute "date_delay" from calendar view arch. This attribute was "mandatory" if the attribute "date_stop" was not set. Now, the attribute "date_stop" is completely optional. If not given, we consider the "date_stop" to be "date_start". With these two attributes ("date_start" and "date_stop") we can calculate the duration ("date_delay").

task-4609678