### PR TITLE
[FIX] website: prevent sliding carousel on arrow key in translate mode

### DIFF
--- a/addons/website/static/src/builder/plugins/carousel_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/carousel_option_plugin.js
@@ -218,6 +218,7 @@ export class CarouselOptionPlugin extends Plugin {
             const carouselInstance = window.Carousel.getOrCreateInstance(editingElement, {
                 ride: false,
                 pause: true,
+                keyboard: false,
             });
             if (typeof direction === "number") {
                 carouselInstance.to(direction);

--- a/addons/website/static/src/interactions/carousel.edit.js
+++ b/addons/website/static/src/interactions/carousel.edit.js
@@ -9,7 +9,6 @@ export class CarouselEdit extends Interaction {
     dynamicContent = {
         ".carousel-control-prev, .carousel-control-next, .carousel-indicators": {
             "t-on-click": this.throttled(this.onControlClick),
-            "t-on-keydown": this.onControlKeyDown,
             "t-att-class": () => ({ o_we_no_overlay: true }),
         },
         ".carousel-control-prev, .carousel-control-next": {
@@ -53,20 +52,6 @@ export class CarouselEdit extends Interaction {
 
         if (this.services["website_edit"].applyAction) {
             this.services["website_edit"].applyAction("slideCarousel", applySpec);
-        }
-    }
-
-    /**
-     * Since carousel controls are disabled in edit mode because slides are
-     * handled manually, we disable the left and right keydown events to prevent
-     * sliding this way.
-     *
-     * @param {Event} ev
-     */
-    onControlKeyDown(ev) {
-        if (["ArrowLeft", "ArrowRight"].includes(ev.code)) {
-            ev.preventDefault();
-            ev.stopPropagation();
         }
     }
 

--- a/addons/website/static/src/interactions/carousel/carousel_bootstrap_upgrade_fix.edit.js
+++ b/addons/website/static/src/interactions/carousel/carousel_bootstrap_upgrade_fix.edit.js
@@ -4,7 +4,7 @@ import { withHistory } from "@website/core/website_edit_service";
 
 const CarouselBootstrapUpgradeFixEdit = I => class extends I {
     // Suspend ride in edit mode.
-    carouselOptions = { ride: false, pause: true };
+    carouselOptions = { ride: false, pause: true, keyboard: false };
 
     setup() {
         super.setup();

--- a/addons/website/static/src/interactions/carousel/carousel_slider.edit.js
+++ b/addons/website/static/src/interactions/carousel/carousel_slider.edit.js
@@ -10,7 +10,7 @@ const CarouselSliderEdit = I => class extends I {
         },
     };
     // Pause carousel in edit mode.
-    carouselOptions = { ride: false, pause: true };
+    carouselOptions = { ride: false, pause: true, keyboard: false };
 
     onContentChanged() {
         this.computeMaxHeight();


### PR DESCRIPTION
Since the initial [website builder refactor], when in translate mode
in website builder, pressing an arrow key when the cursor is inside the
text of a carousel moved to the next slide once, pressing again caused
a crash. Before the refactor, there was also the slide behavior but not
the crash.

The arrows triggers the slide because the contenteditable is inside
the slide in translate mode. It does not trigger it in normal edit mode
because the contenteditable is on an ancestor.

This commit fixes it by changing the config pass to the bootstrap
carousel in edit mode, so that the carousel does not slide on keyboard.
Changing this config makes the event handlers to stop the keydown event
on the other parts of the carousel redundant, so they are removed

Steps to reproduce:
- Open website bulider
- Drop the snippet "Quotes Minimal"
- Add a second language to the website
- Edit the translation for the second language
- Click on the text in the quote in the carousel
- Press a left or right arrow key
- Bug: the slide changed (instead of moving the cursor in side the text)
- Click on the text of the slide that is now shown
- Press again the arrow key
- Bug: Crash

[website builder refactor]: https://github.com/odoo-dev/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
task-4367641