### PR TITLE
[FIX] web, _* : allow specifying fields when duplicating a record in StaticList

### DIFF
--- a/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.js
+++ b/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.js
@@ -93,6 +93,8 @@ export class SectionAndNoteListRenderer extends ListRenderer {
         super.setup();
         this.titleField = "name";
         this.priceColumns = [...this.props.aggregatedFields, "price_unit"];
+        // invisible fields to force copy when duplicating a section
+        this.copyFields = ["display_type"];
         useEffect(
             (editedRecord) => this.focusToName(editedRecord),
             () => [this.editedRecord]
@@ -227,6 +229,7 @@ export class SectionAndNoteListRenderer extends ListRenderer {
         });
         await this.props.list.duplicateRecords(recordsToDuplicate, {
             targetIndex: sectionIndex,
+            copyFields: this.copyFields,
         });
     }
 
@@ -345,7 +348,7 @@ export class SectionAndNoteListRenderer extends ListRenderer {
 
     getCellClass(column, record) {
         let classNames = super.getCellClass(column, record);
-        // For hiding columnns of section and note 
+        // For hiding columnns of section and note
         if (
             this.isSectionOrNote(record)
             && column.widget !== "handle"

--- a/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.js
+++ b/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.js
@@ -94,7 +94,7 @@ export class SectionAndNoteListRenderer extends ListRenderer {
         this.titleField = "name";
         this.priceColumns = [...this.props.aggregatedFields, "price_unit"];
         // invisible fields to force copy when duplicating a section
-        this.copyFields = ["display_type"];
+        this.copyFields = ["display_type", "collapse_composition", "collapse_prices"];
         useEffect(
             (editedRecord) => this.focusToName(editedRecord),
             () => [this.editedRecord]

--- a/addons/sale_management/static/src/fields/sale_order_line_field/sale_order_line_field.js
+++ b/addons/sale_management/static/src/fields/sale_order_line_field/sale_order_line_field.js
@@ -5,6 +5,11 @@ import { getSectionRecords, getParentSectionRecord } from '@account/components/s
 
 patch(SaleOrderLineListRenderer.prototype, {
 
+    setup() {
+        super.setup();
+        this.copyFields.push('is_optional');
+    },
+
     get showOptionalButton() {
         if (this.isSubSection(this.record)) {
             const parentRecord = getParentSectionRecord(this.props.list, this.record);

--- a/addons/sale_management/static/src/fields/sale_order_template_line_field/sale_order_template_line_field.js
+++ b/addons/sale_management/static/src/fields/sale_order_template_line_field/sale_order_template_line_field.js
@@ -11,6 +11,11 @@ import { registry } from '@web/core/registry';
 export class SaleOrderTemplateLineListRenderer extends SectionAndNoteListRenderer {
     static recordRowTemplate = 'sale_management.ListRenderer.RecordRow';
 
+    setup() {
+        super.setup();
+        this.copyFields.push('is_optional');
+    }
+
     get showOptionalButton() {
         if (this.isSubSection(this.record)) {
             const parentRecord = getParentSectionRecord(this.props.list, this.record);

--- a/addons/web/static/src/model/relational_model/static_list.js
+++ b/addons/web/static/src/model/relational_model/static_list.js
@@ -38,11 +38,11 @@ function compareRecords(r1, r2, orderBy, fields) {
     return 0;
 }
 
-function copyRecordData(record) {
+function copyRecordData(record, copyFields = []) {
     const data = {};
     for (const [name, value] of Object.entries(record.data)) {
         if (
-            !["display_type", "display_name"].includes(name) &&
+            ![...copyFields, "display_name"].includes(name) &&
             (record._isReadonly(name) || record._isInvisible(name)) &&
             !record._isRequired(name)
         ) {
@@ -924,6 +924,7 @@ export class StaticList extends DataPoint {
      */
     async _duplicateRecords(records, options) {
         const targetIndex = options.targetIndex ?? this.records.indexOf(records.at(-1)) + 1;
+        const copyFields = options.copyFields || [];
         let sequence = this.records[targetIndex - 1].data[this.handleField] + 1;
         const newRecords = await Promise.all(
             records.map(async () =>
@@ -935,7 +936,7 @@ export class StaticList extends DataPoint {
         await Promise.all(
             records.map((record, index) =>
                 newRecords[index]._update({
-                    ...copyRecordData(record),
+                    ...copyRecordData(record, copyFields),
                     [this.handleField]: sequence++,
                 })
             )


### PR DESCRIPTION
Steps to reproduce:
- Create a quotation/invoice with a section and a product line
- Mark the section as optional section or hide composition
- Duplicate the section

Issue:
- The duplicated section does not retain its "optional/hidden composition"
  status.
- This happens because readonly/invisible fields (like `is_optional`,
  `collapse_*`) are not copied when duplicating records in a StaticList.

Cause:
- By default, StaticList skips readonly/invisible fields during duplication
  to avoid issues with some technical fields (e.g., in accounting).

Solution:
- Introduce a `copyFields` option to `duplicateRecords` in StaticList to
  explicitly allow copying certain fields, even if they are readonly or
  invisible.

Affected version: 19.0  
opw-4669991

Co-Authored by: Julien Carion <juca@odoo.com>

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
