### PR TITLE
[FIX] website, *: fix failing tours due to reload/redirect

### DIFF
--- a/addons/website/static/tests/tours/website_backend_menus_redirect.js
+++ b/addons/website/static/tests/tours/website_backend_menus_redirect.js
@@ -20,6 +20,7 @@ registry.category("web_tour.tours").add('website_backend_menus_redirect', {
     content: 'Click on Test Root backend menu',
     trigger: '.o_frontend_to_backend_apps_menu a:contains("Test Root")',
     run: "click",
+    expectUnloadPage: true,
 }, {
     isActive: ["community"],
     content: 'Check that we landed on the apps page (Apps), and not the Home Action page (Settings)',

--- a/addons/website_event_booth_exhibitor/static/tests/tours/website_event_booth_exhibitor.js
+++ b/addons/website_event_booth_exhibitor/static/tests/tours/website_event_booth_exhibitor.js
@@ -43,9 +43,4 @@
     },
     {
         trigger: "input[name='sponsor_name'], input[name='sponsor_email'], input[name='sponsor_phone']",
-    },
-    {
-        content: "Validate booth details",
-        trigger: 'button.o_wbooth_registration_confirm',
-        run: 'click',
     }, ...new FinalSteps()._getSteps()].filter(Boolean)});

--- a/addons/website_event_booth_exhibitor/static/tests/tours/website_event_booth_exhibitor_steps.js
+++ b/addons/website_event_booth_exhibitor/static/tests/tours/website_event_booth_exhibitor_steps.js
@@ -2,6 +2,10 @@ class FinalSteps {
 
     _getSteps() {
         return [{
+            content: "Click on confirm button",
+            trigger: "button.o_wbooth_registration_confirm",
+            run: "click",
+        }, {
             trigger: 'h4:contains("Booth Registration completed!")',
         }];
     }

--- a/addons/website_event_booth_sale_exhibitor/static/tests/tours/website_event_booth_sale_exhibitor.js
+++ b/addons/website_event_booth_sale_exhibitor/static/tests/tours/website_event_booth_sale_exhibitor.js
@@ -6,8 +6,14 @@ patch(FinalSteps.prototype, {
 
     _getSteps: function () {
         return [
+            {
+                content: "Click on confirm button",
+                trigger: "button.o_wbooth_registration_confirm",
+                run: "click",
+                expectUnloadPage: true,
+            },
             wsTourUtils.goToCheckout(),
-            ...wsTourUtils.payWithTransfer(),
+            ...wsTourUtils.payWithTransfer({ expectUnloadPage: true }),
         ];
     }
 

--- a/addons/website_sale_collect/static/src/tests/tours/buy_with_click_and_collect.js
+++ b/addons/website_sale_collect/static/src/tests/tours/buy_with_click_and_collect.js
@@ -44,6 +44,7 @@ registry.category('web_tour.tours').add('website_sale_collect_buy_product', {
             content: "Click on confirm button",
             trigger: '[name="website_sale_main_button"]',
             run: 'click',
+            expectUnloadPage: true,
         },
         {
             content: "Ensure in store delivery method is selected.",


### PR DESCRIPTION
\* = website_event_booth_exhibitor, website_event_booth_sale_exhibitor, website_sale_collect

**Issue:**
1. Several tours across multiple modules were failing on runbot because
some steps triggered a page reload or redirect without using
`expectUnloadPage: true`, which caused those steps to fail.
2. In the `webooth_exhibitor_register` tour, the behavior of the last
step before calling the `_getSteps` function differs depending on the
installed modules:
- With only `website_event_booth_exhibitor` installed, the last step
does not trigger a page reload.
- With `website_event_booth_sale_exhibitor` also installed, the same
step triggers a redirect to the checkout page, which caused the tour to
fail.

**Fix:**
1. Added `expectUnloadPage: true` to steps that trigger a
reload/redirect, so the tour now waits for the new page to load before
continuing.
2. Updated `_getSteps` in both modules:
- Moved the problematic step of the `webooth_exhibitor_register` tour
inside `_getSteps`.
- In `website_event_booth_sale_exhibitor`, the same step was updated
with `expectUnloadPage: true` to correctly handle the checkout
redirection during the payment flow.

runbot-[231586](https://runbot.odoo.com/odoo/error/231586)





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
