### PR TITLE
[FIX] website: adapt shape path for new snippets

### DIFF
--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -1680,8 +1680,8 @@
 <template id="template_footer_descriptive" inherit_id="website.layout" name="Descriptive" active="False">
     <xpath expr="//div[@id='footer']" position="replace">
         <div id="footer" class="oe_structure oe_structure_solo text-break" t-ignore="true" t-if="not no_footer">
-            <section class="s_text_block" data-snippet="s_text_block" data-name="Container" data-oe-shape-data="{'shape':'web_editor/Bold/16', 'colors':{'c5': '#0000000D'},'flip':[],'showOnMobile':false,'shapeAnimationSpeed':'0'}">
-            <div class="o_we_shape o_web_editor_Bold_16" style="background-image: url('/web_editor/shape/web_editor/Bold/16.svg?c5=%230000000D');"/>
+            <section class="s_text_block" data-snippet="s_text_block" data-name="Container" data-oe-shape-data="{'shape':'html_builder/Bold/16', 'colors':{'c5': '#0000000D'},'flip':[],'showOnMobile':false,'shapeAnimationSpeed':'0'}">
+            <div class="o_we_shape o_html_builder_Bold_16" style="background-image: url('/html_editor/shape/html_builder/Bold/16.svg?c5=%230000000D');"/>
                 <div class="container s_allow_columns">
                     <div class="row">
                         <div class="col-lg-12 pt48 pb24">
@@ -1770,8 +1770,8 @@
 <template id="template_footer_links" inherit_id="website.layout" name="Links" active="False">
     <xpath expr="//div[@id='footer']" position="replace">
         <div id="footer" class="oe_structure oe_structure_solo text-break" t-ignore="true" t-if="not no_footer">
-            <section class="s_text_block pt48 pb16" data-snippet="s_text_block" data-name="Container" data-oe-shape-data="{'shape':'web_editor/Containers/03','colors':{'c5':'o-color-4'},'flip':[],'showOnMobile':true,'shapeAnimationSpeed':'0'}">
-                <div class="o_we_shape o_web_editor_Containers_03 o_shape_show_mobile" style="background-image: url('/web_editor/shape/web_editor/Containers/03.svg?c5=o-color-4');"/>
+            <section class="s_text_block pt48 pb16" data-snippet="s_text_block" data-name="Container" data-oe-shape-data="{'shape':'html_builder/Containers/03','colors':{'c5':'o-color-4'},'flip':[],'showOnMobile':true,'shapeAnimationSpeed':'0'}">
+                <div class="o_we_shape o_html_builder_Containers_03 o_shape_show_mobile" style="background-image: url('/html_editor/shape/html_builder/Containers/03.svg?c5=o-color-4');"/>
                 <div class="container">
                     <div class="row">
                         <div class="col-lg-2 col-10 offset-1 offset-lg-0 pb16">
@@ -1934,8 +1934,8 @@
 <template id="template_footer_call_to_action" inherit_id="website.layout" name="Call-to-Action" active="False">
     <xpath expr="//div[@id='footer']" position="replace">
         <div id="footer" class="oe_structure oe_structure_solo text-break" t-ignore="true" t-if="not no_footer">
-            <section class="s_call_to_action pt56 pb32" data-snippet="s_call_to_action" data-name="Container" data-oe-shape-data="{'shape':'web_editor/Connections/14','colors':{'c5':'o-color-4'},'flip':['y'],'showOnMobile':true,'shapeAnimationSpeed':'0'}">
-                <div class="o_we_shape o_web_editor_Connections_14 o_shape_show_mobile" style="background-image: url('/web_editor/shape/web_editor/Connections/14.svg?c5=o-color-4&amp;flip=y'); background-position: 50% 0%;"/>
+            <section class="s_call_to_action pt56 pb32" data-snippet="s_call_to_action" data-name="Container" data-oe-shape-data="{'shape':'html_builder/Connections/14','colors':{'c5':'o-color-4'},'flip':['y'],'showOnMobile':true,'shapeAnimationSpeed':'0'}">
+                <div class="o_we_shape o_html_builder_Connections_14 o_shape_show_mobile" style="background-image: url('/html_editor/shape/html_builder/Connections/14.svg?c5=o-color-4&amp;flip=y'); background-position: 50% 0%;"/>
                 <div class="container s_allow_columns">
                     <div class="row o_grid_mode" data-row-count="3">
                         <div class="o_grid_item g-col-lg-6 g-height-2 offset-1 offset-lg-0 col-10 order-lg-0 col-lg-6" style="z-index: 1; --grid-item-padding-x: 10px; --grid-item-padding-y: 0px; grid-area: 1 / 1 / 3 / 7; order: 0;">
@@ -2110,7 +2110,7 @@
                         <div class="col-lg-4">
                             <div class="s_text_highlight o_cc o_cc3 w-100 my-3 text-center" data-snippet="s_text_highlight" data-name="Text Highlight">
                                 <img
-                                    src="/web_editor/shape/website/s_attributes_1.svg?c1=rgba(0,0,0,.25)&amp;c4=o-color-4&amp;c5=o-color-5"
+                                    src="/html_editor/shape/website/s_attributes_1.svg?c1=rgba(0,0,0,.25)&amp;c4=o-color-4&amp;c5=o-color-5"
                                     class="img img-fluid d-block mx-auto"
                                     alt=""
                                     style="width: 25% !important;"
@@ -2148,7 +2148,7 @@
                         <div class="col-lg-4">
                             <div class="s_text_highlight o_cc o_cc3 w-100 my-3 text-center" data-snippet="s_text_highlight" data-name="Text Highlight">
                                 <img
-                                    src="/web_editor/shape/website/s_attributes_2.svg?c1=rgba(0,0,0,.25)&amp;c2=rgba(0,0,0,.5)&amp;c4=o-color-4&amp;c5=o-color-5"
+                                    src="/html_editor/shape/website/s_attributes_2.svg?c1=rgba(0,0,0,.25)&amp;c2=rgba(0,0,0,.5)&amp;c4=o-color-4&amp;c5=o-color-5"
                                     class="img img-fluid d-block mx-auto"
                                     alt=""
                                     style="width: 25% !important;"
@@ -2167,7 +2167,7 @@
                         <div class="col-lg-4">
                             <div class="s_text_highlight o_cc o_cc3 w-100 my-3 text-center" data-snippet="s_text_highlight" data-name="Text Highlight">
                                 <img
-                                    src="/web_editor/shape/website/s_attributes_3.svg?c1=rgba(0,0,0,.25)&amp;c4=o-color-4&amp;c5=o-color-5"
+                                    src="/html_editor/shape/website/s_attributes_3.svg?c1=rgba(0,0,0,.25)&amp;c4=o-color-4&amp;c5=o-color-5"
                                     class="img img-fluid d-block mx-auto"
                                     alt=""
                                     style="width: 25% !important;"
@@ -2368,7 +2368,7 @@
                         </div>
                         <div class="o_grid_item g-col-lg-4 col-lg-4 g-height-4 d-lg-block d-none o_snippet_mobile_invisible" style="z-index: 3; grid-area: 1 / 9 / 5 / 13; --grid-item-padding-y: 0px; --grid-item-padding-x: 27px;">
                             <img
-                                src="/web_editor/shape/website/footer_mega_cards_image.svg?c1=o-color-1"
+                                src="/html_editor/shape/website/footer_mega_cards_image.svg?c1=o-color-1"
                                 class="img img-fluid d-block mx-auto"
                                 alt=""
                                 />


### PR DESCRIPTION
In [1], shape controller was moved from web_editor to html_editor. In [2], shapes were moved from web_editor to html_builder. This commit adapts the path for new snippets.
The former path is still supported but ideally should not be used for newer snippets.

[1]: https://github.com/odoo/odoo/commit/44129d85bdc993e37384536519a03d7c29ac7e83
[2]: https://github.com/odoo/odoo/commit/d2cbe9a3535d3563c4252743c7849a6d669ee177
