### PR TITLE
[FIX] purchase_stock: fix stock moves

### DIFF
--- a/addons/purchase_mrp/models/purchase.py
+++ b/addons/purchase_mrp/models/purchase.py
@@ -75,7 +75,7 @@ class PurchaseOrderLine(models.Model):
 
     def _prepare_stock_moves(self, picking):
         res = super()._prepare_stock_moves(picking)
-        if self.order_id.reference_ids.move_ids.production_group_id:
+        if len(self.order_id.reference_ids.move_ids.production_group_id) == 1:
             for re in res:
                 re['production_group_id'] = self.order_id.reference_ids.move_ids.production_group_id.id
         return res


### PR DESCRIPTION
Steps to reproduce the bug:

With MTO enabled

Create 2 finished products sharing 1 common component

Create a sale order for those 2 products

Try to confirm the generated purchase order for the component:

ValueError: Expected singleton: mrp.production.group(x, y)

Origin:

Each generated mrp.production creates its own mrp.production.group
and a purchase.order is generated with only 1 line for the whole quantity.

Fix:
Since it is for the reception picking, skip updating the production group


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
