### PR TITLE
[FIX] website: show logo height changes live in editor

### DIFF
--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -1662,7 +1662,14 @@
 
             This also allows to gain some page speed scoring.
             -->
-            <span t-field="website.logo" t-options="{'widget': 'image', 'width': 95, 'height': 40}" role="img" t-att-aria-label="'Logo of %s' % website.name" t-att-title="website.name"/>
+            <t t-set="base_options" t-value="{'widget': 'image'}"/>
+            <span
+                t-field="website.logo"
+                t-options="base_options if editable else dict(base_options, width=95, height=40)"
+                role="img"
+                t-att-aria-label="'Logo of %s' % website.name"
+                t-att-title="website.name"
+            />
         </a>
     </xpath>
 </template>


### PR DESCRIPTION
Steps to reproduce:

- Website > Go to Website > Edit
- In the sidebar: Navbar logo, change Height
- Before: the logo size does not change until clicking Save (or after
  bundles reload)
- After: the logo resizes immediately while editing

Since [1], the header logo is rendered with width and height attributes
to reserve space and reduce CLS.

But since [2], the `width` and `height` attributes have been removed and
converted to inline styles, which take precedence over the CSS
stylesheet.

This commit addresses this issue.

[1]: https://github.com/odoo/odoo/commit/d80b8cbc28b6e9d16608f9ecfcf4b360d0c792c7
[2]: https://github.com/odoo/odoo/commit/cb2510f4e525192e4b3d5d673218775c2d9d174e

