### PR TITLE
[FIX] auth_signup, web: keep password label editable in login form

### DIFF
--- a/addons/auth_signup/views/auth_signup_login_templates.xml
+++ b/addons/auth_signup/views/auth_signup_login_templates.xml
@@ -4,7 +4,7 @@
             <xpath expr="//div[hasclass('oe_login_buttons')]/button" position="after">
                 <a t-if="signup_enabled" class="btn btn-link btn-sm mt-2" t-attf-href="/web/signup?{{ keep_query() }}">Don't have an account?</a>
             </xpath>
-            <xpath expr="//label[@for='password']" position="inside">
+            <xpath expr="//label[@for='password']" position="after">
                 <a t-if="reset_password_enabled" class="btn btn-link btn-sm" tabindex="1" t-attf-href="/web/reset_password?{{ keep_query() }}">Reset Password</a>
             </xpath>
         </template>

--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -154,7 +154,9 @@
                 </div>
 
                 <div class="o_caps_lock_warning">
-                    <label for="password" class="form-label d-flex justify-content-between">Password</label>
+                    <div class="d-flex justify-content-between align-items-start">
+                        <label for="password" class="form-label">Password</label>
+                    </div>
                     <div class="input-group mb-1">
                         <input type="password" placeholder="Enter your password" name="password" id="password" class="form-control" required="required" autocomplete="current-password" t-att-autofocus="'autofocus' if login else None" maxlength="4096"/>
                         <button type="button" class="btn btn-sm border border-start-0 o_show_password">


### PR DESCRIPTION
Before this PR, the `Reset Password` link was injected inside the password label in the login form. This prevented `inherit_branding` from applying `data-oe-*` attributes on the label, which in turn stopped the editor from making it as `contenteditable`.

With this PR, the `Reset Password` link is injected `after` the label instead `inside`. This preserves the label's branding attributes, making it editable inside the editor.

This change also improves accessibility, since placing interactive elements (links/buttons) inside a <label> is not recommended.