### PR TITLE
[FIX] web: kanban: update currency aggregates on quick create

### DIFF
--- a/addons/web/static/src/views/kanban/progress_bar_hook.js
+++ b/addons/web/static/src/views/kanban/progress_bar_hook.js
@@ -138,26 +138,28 @@ class ProgressBarState {
     }
 
     getAggregateValue(group, aggregateField) {
+        const { groupByField, serverValue } = group;
         const title = aggregateField ? aggregateField.string : _t("Count");
         let value = 0;
-        if (!this.activeBars[group.serverValue]) {
+        if (!this.activeBars[serverValue]) {
             value = group.count;
             if (value && aggregateField) {
-                value = _findGroup(this._aggregateValues, group.groupByField, group.serverValue)[
+                value = _findGroup(this._aggregateValues, groupByField, serverValue)[
                     aggregateField.name
                 ];
             }
         } else {
-            value = this.activeBars[group.serverValue].count;
+            value = this.activeBars[serverValue].count;
             if (value && aggregateField) {
                 value =
-                    this.activeBars[group.serverValue]?.aggregates &&
-                    this.activeBars[group.serverValue]?.aggregates[aggregateField.name];
+                    this.activeBars[serverValue]?.aggregates &&
+                    this.activeBars[serverValue]?.aggregates[aggregateField.name];
             }
         }
         value ||= 0;
         if (aggregateField.type === "monetary" && aggregateField.currency_field) {
-            const currencies = group.aggregates?.[aggregateField.currency_field];
+            const aggValues = _findGroup(this._aggregateValues, groupByField, serverValue);
+            const currencies = aggValues?.[aggregateField.currency_field];
             if (currencies?.length > 1) {
                 return {
                     value,


### PR DESCRIPTION
Have 2 companies with different currencies. Go to a grouped kanban view with a progressbar and aggregates on a monetary field (e.g. crm pipeline). In a column where all records use the same currency (not the one of the current company), quick create a record for the other currency (in CRM, the currency used is the one of the current company).

Before this commit, the total displayed next to the progressbar was still displaying the former currency symbol, even though this total has been computed on values converted in the default company currency. The issue occured because we used the data from the `group` datapoint, which isn't updated. Instead, we now use the progressbar aggregates, that are reloaded after the record creation. As a consequence, the total is now displayed with the correct currency symbol, and a `?` is displayed next to it, indicating the rates that have been used to compute that value.

Followup of task~4900037

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
