### PR TITLE
[IMP] point_of_sale: block unintended orderline editing when popup is open

### DIFF
--- a/addons/point_of_sale/static/src/app/utils/number_buffer_service.js
+++ b/addons/point_of_sale/static/src/app/utils/number_buffer_service.js
@@ -55,7 +55,7 @@ const getDefaultConfig = () => ({
  * - Write more integration tests. NumberPopup can be used as test component.
  */
 class NumberBuffer extends EventBus {
-    static serviceDependencies = ["mail.sound_effects", "localization"];
+    static serviceDependencies = ["mail.sound_effects", "localization", "overlay"];
     constructor() {
         super();
         this.setup(...arguments);
@@ -65,6 +65,7 @@ class NumberBuffer extends EventBus {
         this.bufferHolderStack = [];
         this.sound = services["mail.sound_effects"];
         this.defaultDecimalPoint = services.localization.decimalPoint;
+        this.overlay = services.overlay;
         window.addEventListener("keyup", this._onKeyboardInput.bind(this));
     }
     /**
@@ -160,6 +161,9 @@ class NumberBuffer extends EventBus {
             : 0;
     }
     _onKeyboardInput(event) {
+        if (Object.keys(this.overlay.overlays).length) {
+            return;
+        }
         return (
             this._currentBufferHolder &&
             this._bufferEvents(this._onInput((event) => event.key))(event)

--- a/addons/point_of_sale/static/tests/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_screen_tour.js
@@ -1,3 +1,4 @@
+/* global posmodel */
 import * as PaymentScreen from "@point_of_sale/../tests/tours/utils/payment_screen_util";
 import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
 import * as PartnerList from "@point_of_sale/../tests/tours/utils/partner_list_util";
@@ -178,6 +179,34 @@ registry.category("web_tour.tours").add("FloatingOrderTour", {
             ProductScreen.isShown(),
             ProductScreen.selectFloatingOrder(1),
             ProductScreen.productCardQtyIs("Letter Tray", "2.0"),
+            inLeftSide([
+                ...ProductScreen.clickLine("Letter Tray", "2.0"),
+                ...ProductScreen.clickControlButtonMore(),
+                {
+                    trigger: "body",
+                    run: () => {
+                        window.dispatchEvent(new KeyboardEvent("keyup", { key: "9" }));
+                    },
+                },
+                Dialog.cancel(),
+            ]),
+            ProductScreen.isShown(),
+            ProductScreen.productCardQtyIs("Letter Tray", "2.0"),
+            inLeftSide([
+                ...Order.hasLine({
+                    productName: "Letter Tray",
+                    quantity: "2.0",
+                }),
+            ]),
+            {
+                trigger: "body",
+                run: () => {
+                    const bufferValue = posmodel.numberBuffer.get();
+                    if (bufferValue != "") {
+                        throw new Error(`Number buffer should be empty, but got ${bufferValue}`);
+                    }
+                },
+            },
         ].flat(),
 });
 


### PR DESCRIPTION
Before this commit:
- Even when a popup (e.g., customer selection, note, coupon) was open, unfocused keyboard inputs could still update orderline values.

After this commit:
- Orderline editing via keyboard is disabled whenever a popup is active.
- Prevents unintended changes and ensures a safer user flow in POS.

Task-5033716
