### PR TITLE
[FIX] website: make confirm_password input not editable

### DIFF
--- a/addons/html_editor/static/src/core/password_input_plugin.js
+++ b/addons/html_editor/static/src/core/password_input_plugin.js
@@ -1,0 +1,10 @@
+import { Plugin } from "@html_editor/plugin";
+
+// TODO: In master adapt following code in xml
+export class PasswordInputPlugin extends Plugin {
+    static id = "password";
+    resources = {
+        force_not_editable_selector:
+            "*:has(> input[type='password']:not([contenteditable='true']))",
+    };
+}

--- a/addons/html_editor/static/src/plugin_sets.js
+++ b/addons/html_editor/static/src/plugin_sets.js
@@ -8,6 +8,7 @@ import { SeparatorPlugin } from "./main/separator_plugin";
 import { FormatPlugin } from "./core/format_plugin";
 import { HistoryPlugin } from "./core/history_plugin";
 import { InputPlugin } from "./core/input_plugin";
+import { PasswordInputPlugin } from "./core/password_input_plugin";
 import { LineBreakPlugin } from "./core/line_break_plugin";
 import { NoInlineRootPlugin } from "./core/no_inline_root_plugin";
 import { OverlayPlugin } from "./core/overlay_plugin";
@@ -134,6 +135,7 @@ export const CORE_PLUGINS = [
     FormatPlugin,
     HistoryPlugin,
     InputPlugin,
+    PasswordInputPlugin,
     LineBreakPlugin,
     NoInlineRootPlugin,
     OverlayPlugin,


### PR DESCRIPTION
Steps to produce: Go to /web/signup page in edit mode, select confirm password label and input with mouse and the press delete button, it removes confirm password input as well.

With this commit: We add o_not_editable class on confirm password to avoid deleting input element

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
