### PR TITLE
[FIX] mail: join button should be shown on receiving call invitation

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_actions.js
+++ b/addons/mail/static/src/discuss/call/common/call_actions.js
@@ -206,9 +206,7 @@ registerCallAction("join-with-camera", {
 });
 registerCallAction("join", {
     condition: ({ store, thread }) =>
-        !thread?.eq(store.rtc?.channel) &&
-        !thread?.self_member_id?.rtc_inviting_session_id &&
-        typeof thread?.useCameraByDefault !== "boolean",
+        !thread?.eq(store.rtc?.channel) && typeof thread?.useCameraByDefault !== "boolean",
     disabledCondition: ({ store }) => store.rtc?.state.hasPendingRequest,
     name: _t("Join Call"),
     icon: "fa fa-phone",

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -187,6 +187,7 @@ test("should display invitations", async () => {
             .get_result()
     );
     await contains(".o-discuss-CallInvitation");
+    await contains(".o-discuss-CallInvitation button[title='Join Call']");
     await waitForSteps(["play - call-invitation"]);
     // Simulate stop receiving call invitation
 


### PR DESCRIPTION
Before this commit, when receiving a discuss call invitation, the user could only refuse the call.

This happens due to wrong condition for the showing the "join" call button: this button condition had "no call invitation", which is the exact opposite of the flow that should work!

This happens from https://github.com/odoo/odoo/pull/223004 that convert the call invitation buttons into call actions. When doing this improvements, it also reconciled the actions as there was a lot of code duplication, one of which was "join" button in call invitation but also "join" on the call view when not in call. PR made the mistake to have the condition of "join" in call view when not in call (and no invitation), but completely forgot the "join" from call invitation whose condition was excluded from the condition.

This commit relax the condition so that it takes into account both cases for the showing of the "join" call button.