### PR TITLE
[FIX] mail: discuss sidebar compact items aligned

### DIFF
--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -154,7 +154,7 @@
             t-on-click="(ev) => this.openThread(ev, thread)"
             t-ref="root"
         >
-            <div class="o-mail-DiscussSidebarChannel-itemMain border-0 rounded-start-2 text-reset d-flex align-items-center p-0 flex-grow-1" t-att-class="{ 'overflow-hidden': !store.discuss.isSidebarCompact }" t-att-title="store.discuss.isSidebarCompact ? undefined : thread.displayName">
+            <div class="o-mail-DiscussSidebarChannel-itemMain border-0 rounded-start-2 text-reset d-flex align-items-center p-0 flex-grow-1" t-att-class="{ 'justify-content-center': store.discuss.isSidebarCompact, 'overflow-hidden': !store.discuss.isSidebarCompact }" t-att-title="store.discuss.isSidebarCompact ? undefined : thread.displayName">
                 <div class="bg-inherit position-relative d-flex flex-shrink-0 o-my-0_5 rounded-2" style="width:26px;height:26px;" name="threadAvatar" t-att-class="{ 'ms-2': !store.discuss.isSidebarCompact }">
                     <img class="w-100 h-100 rounded-2 object-fit-cover" t-att-class="threadAvatarAttClass" t-att-src="thread.avatarUrl" alt="Thread Image"/>
                     <ThreadIcon t-if="thread.channel_type?.includes('chat') or (thread.channel_type === 'channel' and !thread.group_public_id)" thread="thread" size="'small'" className="'o-mail-DiscussSidebarChannel-threadIcon position-absolute top-100 start-100 translate-middle mt-n1 ms-n1 d-flex align-items-center justify-content-center rounded-circle bg-inherit'"/>


### PR DESCRIPTION
Items were not centered, so the avatar and click zone was off-centered. This commit centers the avatar to fix the issue.

Before / After
<img width="56" height="578" alt="Screenshot 2025-09-10 at 14 34 09" src="https://github.com/user-attachments/assets/400de8c1-6a87-49d3-823e-157048962bca" /> <img width="59" height="578" alt="Screenshot 2025-09-10 at 14 34 21" src="https://github.com/user-attachments/assets/c4dd72cb-04e9-40df-8e13-f0fe39643c3a" />
