### PR TITLE
[FIX] stock: set quant to 0 via action

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -549,7 +549,9 @@ class StockQuant(models.Model):
         self.user_id = False
 
     def action_set_inventory_quantity_zero(self):
-        self.filtered(lambda l: not l.inventory_quantity).inventory_quantity = 0
+        self.inventory_quantity = 0
+        if self.env.context.get('inventory_report_mode'):
+            self._apply_inventory()
         self.user_id = self.env.user.id
 
     @api.depends('location_id', 'lot_id', 'package_id', 'owner_id')


### PR DESCRIPTION
The action "Set to 0" was working only via the "Physical inventory" menu and not via the list quants from the forecasted report. This commit makes sure the quant is set to 0 and autoapply the new quantity based on the context (either the "apply" button is present or not

Task : 5064269

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
