### PR TITLE
[FIX] web: group folded on cache

### DIFF
--- a/addons/web/static/src/model/relational_model/relational_model.js
+++ b/addons/web/static/src/model/relational_model/relational_model.js
@@ -328,6 +328,9 @@ export class RelationalModel extends Model {
                         // in case there're less groups, we don't want to keep displaying groups
                         // that are no longer there => forget previous groups
                         delete this.root.config.currentGroups;
+                        // in case that the config of the groups changed (e.g. group is now folded)
+                        // we want to update the groups.
+                        this.root.config.groups = [];
                         result = await this._postprocessReadGroup(root.config, result);
                     }
                     root._setData(result);


### PR DESCRIPTION
- Open a grouped kanban;
- Fold a group;
- Reload the page;

Before this commit, an error occurred because the configuration says that the group is unfolded, but the returning RPC didn't have any records.

This commit clears the current configuration, which will then be reloaded based on the returning RPC.