### PR TITLE
[FIX] website_sale: use correct template key

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2505,7 +2505,7 @@
                 <section data-snippet="s_dynamic_snippet_products"
                     class="oe_unmovable oe_unremovable s_dynamic_snippet_products o_wsale_alternative_products s_dynamic pt32 pb32 o_colored_level s_product_product_borderless_1"
                     data-name="Alternative Products" style="background-image: none;" t-att-data-filter-id="product._get_alternative_product_filter()"
-                    data-template-key="website_sale.dynamic_filter_template_product_product_borderless_1" data-product-category-id="all" data-number-of-elements="4"
+                    data-template-key="website_sale.dynamic_filter_template_product_product_products_item" data-product-category-id="all" data-number-of-elements="4"
                     data-number-of-elements-small-devices="1" data-number-of-records="16" data-carousel-interval="5000" data-bs-original-title="" title="">
                     <div class="container">
                         <div class="row s_nb_column_fixed">


### PR DESCRIPTION
This commit use correct template key in alternative snippet.

Issued PR: https://github.com/odoo/odoo/pull/214744
