### PR TITLE
[FIX] mass_mailing, html_editor: mass_mailing refactoring follow up

### DIFF
--- a/addons/html_editor/static/src/core/shortcut_plugin.js
+++ b/addons/html_editor/static/src/core/shortcut_plugin.js
@@ -46,13 +46,16 @@ export class ShortCutPlugin extends Plugin {
     }
 
     addShortcut(hotkey, action, { isAvailable, global }) {
-        this.services.hotkey.add(hotkey, action, {
-            area: () => this.editable,
-            bypassEditableProtection: true,
-            allowRepeat: true,
-            isAvailable: (target) =>
-                (!isAvailable || isAvailable(this.dependencies.selection.getEditableSelection())) &&
-                (global || isValidTargetForDomListener(target)),
-        });
+        this._cleanups.push(
+            this.services.hotkey.add(hotkey, action, {
+                area: () => this.editable,
+                bypassEditableProtection: true,
+                allowRepeat: true,
+                isAvailable: (target) =>
+                    (!isAvailable ||
+                        isAvailable(this.dependencies.selection.getEditableSelection())) &&
+                    (global || isValidTargetForDomListener(target)),
+            })
+        );
     }
 }

--- a/addons/mass_mailing/__manifest__.py
+++ b/addons/mass_mailing/__manifest__.py
@@ -105,7 +105,6 @@
             ('include', 'html_builder.assets_edit_frontend'),
             'mass_mailing/static/src/scss/mass_mailing_mail.scss',
             'mass_mailing/static/src/iframe_assets/**/*',
-            'mass_mailing/static/src/theme_assets/**/*',
         ],
         'html_builder.iframe_add_dialog': [
             'mass_mailing/static/src/builder/snippet_viewer/*.scss',

--- a/addons/mass_mailing/static/src/builder/options/image_tool_option.js
+++ b/addons/mass_mailing/static/src/builder/options/image_tool_option.js
@@ -1,0 +1,12 @@
+import { useDomState } from "@html_builder/core/utils";
+import { ImageToolOption } from "@html_builder/plugins/image/image_tool_option";
+
+export class MassMailingImageToolOption extends ImageToolOption {
+    static template = "mass_mailing.ImageToolOption";
+    setup() {
+        super.setup();
+        this.massMailingState = useDomState((editingElement) => ({
+            isImgFluid: editingElement.classList.contains("img-fluid"),
+        }));
+    }
+}

--- a/addons/mass_mailing/static/src/builder/options/image_tool_option.xml
+++ b/addons/mass_mailing/static/src/builder/options/image_tool_option.xml
@@ -16,6 +16,9 @@
             <attribute name="withAnimatedShapes">false</attribute>
         </xpath>
         <xpath expr="//ImageTransformOption" position="replace"/>
+        <xpath expr="//BuilderRow[@label.translate=&quot;Size&quot;]" position="attributes">
+            <attribute name="t-if">massMailingState.isImgFluid</attribute>
+        </xpath>
     </t>
     <t t-name="mass_mailing.FontAwesomeOption">
         <BuilderRow label.translate="Color">

--- a/addons/mass_mailing/static/src/builder/plugins/image_tool_options_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/image_tool_options_plugin.js
@@ -1,9 +1,9 @@
-import { ImageToolOption } from "@html_builder/plugins/image/image_tool_option";
 import { CropImageAction } from "@html_builder/plugins/image/image_tool_option_plugin";
 import { IMAGE_TOOL } from "@html_builder/utils/option_sequence";
 import { Plugin } from "@html_editor/plugin";
 import { closestElement } from "@html_editor/utils/dom_traversal";
 import { withSequence } from "@html_editor/utils/resource";
+import { MassMailingImageToolOption } from "@mass_mailing/builder/options/image_tool_option";
 import { registry } from "@web/core/registry";
 import { patch } from "@web/core/utils/patch";
 
@@ -36,10 +36,6 @@ class ImageToolOptionPlugin extends Plugin {
             }),
         ],
     };
-}
-
-export class MassMailingImageToolOption extends ImageToolOption {
-    static template = "mass_mailing.ImageToolOption";
 }
 
 patch(CropImageAction.prototype, {

--- a/addons/mass_mailing/static/src/iframe_assets/iframe_style.scss
+++ b/addons/mass_mailing/static/src/iframe_assets/iframe_style.scss
@@ -14,6 +14,12 @@ body:not(.o_mass_mailing_iframe_fullscreen, .o_mass_mailing_iframe_mobile) {
 }
 
 body {
+    &.o_mass_mailing_iframe_fullscreen, &.o_mass_mailing_iframe_mobile {
+        .note-editable {
+            overflow: auto;
+            height: 100%;
+        }
+    }
     &.o_mass_mailing_iframe_fullscreen {
         .o_layout {
             display: grid;

--- a/addons/mass_mailing/static/src/iframe_assets/iframe_style.scss
+++ b/addons/mass_mailing/static/src/iframe_assets/iframe_style.scss
@@ -34,9 +34,3 @@ body {
         display: none !important;
     }
 }
-// Smaller container
-.o_container_small {
-    @include media-breakpoint-up(lg) {
-        max-width: map-get($container-max-widths, md);
-    }
-}

--- a/addons/mass_mailing/static/src/iframe_assets/snippets_style.scss
+++ b/addons/mass_mailing/static/src/iframe_assets/snippets_style.scss
@@ -1,0 +1,14 @@
+.o_layout .o_mail_wrapper {
+    // Smaller container
+    .o_container_small {
+        @include media-breakpoint-up(lg) {
+            max-width: map-get($container-max-widths, md);
+        }
+    }
+    hr {
+        // override necessary because bootstrap opacity is 0.25 by default
+        // depending on the modules installed.
+        opacity: 1;
+    }
+}
+

--- a/addons/mass_mailing/static/src/theme_assets/theme_default.scss
+++ b/addons/mass_mailing/static/src/theme_assets/theme_default.scss
@@ -1,6 +1,0 @@
-.o_mass_mailing_value .o_layout {
-    .o_mail_wrapper hr {
-        // override necessary because bootstrap opacity is 0.25 by default
-        opacity: 1;
-    }
-}


### PR DESCRIPTION
Follow up of the `mass_mailing` [refactoring] and `web_editor` [removal]:

- Fix scrolling in the mobile preview and fullscreen view
- Hide options for resizing images on non-resizable images
- Reorganize style files in `mass_mailing`
- Fix cleanup hotkeys created by the `shortcut_plugin`

[refactoring]: https://github.com/odoo/odoo/commit/82969dc5c6c36a7a91194cf15b33c9abb560a8e7
[removal]: https://github.com/odoo/odoo/commit/2659ab4f39f9a6bbca830d2d9b16e9421e4aac31

task-5078825