### PR TITLE
[FIX] website_sale: cart notification with price incl/excl tax

### DIFF
--- a/addons/website_sale/controllers/cart.py
+++ b/addons/website_sale/controllers/cart.py
@@ -206,11 +206,15 @@ class Cart(PaymentPortal):
         if main_product_line.product_type == 'combo':
             main_product_line._check_validity()
 
+        positive_added_qty_per_line = {
+            line_id: qty for line_id, qty in added_qty_per_line.items() if qty > 0
+        }
+
         return {
             'cart_quantity': order_sudo.cart_quantity,
             'notification_info': {
                 **self._get_cart_notification_information(
-                    order_sudo, added_qty_per_line
+                    order_sudo, positive_added_qty_per_line
                 ),
                 'warning': warning,
             },

--- a/addons/website_sale/static/src/js/notification/cart_notification/cart_notification.js
+++ b/addons/website_sale/static/src/js/notification/cart_notification/cart_notification.js
@@ -31,8 +31,6 @@ export class CartNotification extends Component {
         currency_id: {type: Number, optional: true},
         className: String,
         close: Function,
-        refresh: Function,
-        freeze: Function,
     }
 
     setup() {

--- a/addons/website_sale/static/tests/tours/website_sale_cart_notification.js
+++ b/addons/website_sale/static/tests/tours/website_sale_cart_notification.js
@@ -1,7 +1,74 @@
 import { registry } from "@web/core/registry";
 import * as tourUtils from "@website_sale/js/tours/tour_utils";
 
-registry.category("web_tour.tours").add("website_sale_cart_notification", {
+registry.category("web_tour.tours").add("website_sale_cart_notification_tax_included", {
+    url: "/shop",
+    steps: () => [
+        ...tourUtils.addToCart({
+            productName: "website_sale_cart_notification_product_1",
+            expectUnloadPage: true,
+        }),
+        {
+            content: "check that 1 website_sale_cart_notification_product_1 was added",
+            trigger: '.toast-body span:contains("website_sale_cart_notification_product_1")',
+        },
+        {
+            content: "check that 1 website_sale_cart_notification_product_1 was added",
+            trigger: '.toast-body span:contains("1")',
+        },
+        {
+            content: "check the price of 1 website_sale_cart_notification_product_1",
+            trigger: '.toast-body div:contains("$ 1,150.00")',
+        },
+        ...tourUtils.searchProduct("website_sale_cart_notification_product_2", { select: true }),
+        {
+            trigger: "#product_detail",
+        },
+        {
+            content: "change quantity",
+            trigger: '#product_detail form input[name=add_qty]',
+            run: "edit 3",
+        },
+        {
+            content: "click on add to cart",
+            trigger: '#product_detail form #add_to_cart',
+            run: "click",
+        },
+        {
+            content: "check that 3 website_sale_cart_notification_product_2 was added",
+            trigger: '.toast-body span:contains("website_sale_cart_notification_product_2")',
+        },
+        {
+            content: "check that 3 website_sale_cart_notification_product_2 was added",
+            trigger: '.toast-body span:contains("3")',
+        },
+        {
+            content: "check that the novariants/custom attributes are displayed.",
+            trigger: '.toast-body span.text-muted.small:contains("Size: S")',
+        },
+        {
+            content: "check the price of 3 website_sale_cart_notification_product_2",
+            trigger: '.toast-body div:contains("$ 17,250.00")',
+        },
+        {
+            content: "Go To Cart",
+            trigger: '.toast-body a:contains("View cart")',
+            run: "click",
+            expectUnloadPage: true,
+        },
+        ...tourUtils.assertCartContains({
+            productName: "website_sale_cart_notification_product_1",
+            backend: false,
+        }),
+        ...tourUtils.assertCartContains({
+            productName: "website_sale_cart_notification_product_2",
+            backend: false,
+        }),
+    ],
+});
+
+
+registry.category("web_tour.tours").add("website_sale_cart_notification_tax_excluded", {
     url: "/shop",
     steps: () => [
         ...tourUtils.addToCart({

--- a/addons/website_sale/tests/test_website_sale_cart_notification.py
+++ b/addons/website_sale/tests/test_website_sale_cart_notification.py
@@ -4,7 +4,6 @@ from odoo.fields import Command
 from odoo.tests import HttpCase, tagged
 
 from odoo.addons.product.tests.common import ProductVariantsCommon
-from odoo.addons.website_sale.controllers.cart import Cart
 
 
 @tagged('post_install', '-at_install')
@@ -13,15 +12,15 @@ class TestWebsiteSaleCartNotification(HttpCase, ProductVariantsCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.WebsiteSaleCartController = Cart()
+        cls.website = cls.env.company.website_id
         cls.size_attribute.create_variant = 'no_variant'
-        cls.env['product.template'].create({
+        cls.product_tmpl_1 = cls.env['product.template'].create({
             'name': 'website_sale_cart_notification_product_1',
             'type': 'consu',
             'website_published': True,
             'list_price': 1000,
         })
-        cls.env['product.template'].create({
+        cls.product_tmpl_2 = cls.env['product.template'].create({
             'name': 'website_sale_cart_notification_product_2',
             'type': 'consu',
             'website_published': True,
@@ -36,9 +35,15 @@ class TestWebsiteSaleCartNotification(HttpCase, ProductVariantsCommon):
             })],
         })
 
-    def test_website_sale_cart_notification(self):
+    def test_website_sale_cart_notification_tax_included(self):
         self.env.ref('website_sale.product_search').active = True
-        self.start_tour("/", 'website_sale_cart_notification')
+        self.website.show_line_subtotals_tax_selection = 'tax_included'
+        self.start_tour("/", 'website_sale_cart_notification_tax_included')
+
+    def test_website_sale_cart_notification_tax_excluded(self):
+        self.env.ref('website_sale.product_search').active = True
+        self.website.show_line_subtotals_tax_selection = 'tax_excluded'
+        self.start_tour("/", 'website_sale_cart_notification_tax_excluded')
 
     def test_website_sale_cart_notification_qty_and_total(self):
         """ Check that adding product into cart which is already in the cart only display newly
@@ -46,29 +51,3 @@ class TestWebsiteSaleCartNotification(HttpCase, ProductVariantsCommon):
 
         self.env.ref('website_sale.product_search').active = True
         self.start_tour("/", 'website_sale_cart_notification_qty_and_total')
-
-    def test_website_sale_cart_notification_product_price(self):
-        """Check that the cart notification displays the correct total price included/excluded taxes
-        depending on the website settings.
-        """
-        website = self.env['website'].get_current_website()
-        sale_order = self.env['sale.order'].create({
-            'partner_id': self.env.user.partner_id.id,
-            'website_id': website.id,
-            'order_line': [
-                Command.create({
-                    'product_id': self.product.id,
-                }),
-            ]
-        })
-        added_qty_per_line = {sale_order.order_line.id: 1.0}
-        website.show_line_subtotals_tax_selection = 'tax_included'
-        price_tax_included = self.WebsiteSaleCartController._get_cart_notification_information(
-            sale_order, added_qty_per_line
-        )['lines'][0]['price_total']
-        self.assertEqual(price_tax_included, 23)
-        website.show_line_subtotals_tax_selection = 'tax_excluded'
-        price_tax_excluded = self.WebsiteSaleCartController._get_cart_notification_information(
-            sale_order, added_qty_per_line
-        )['lines'][0]['price_total']
-        self.assertEqual(price_tax_excluded, 20)


### PR DESCRIPTION
The displayed price in the notification pop-up has to follow the website settings (tax included/excluded) and not the backend invoicing settings.

**How to reproduce the issue:**
Invoicing Taxes settings: Tax Prices = Tax Excluded
Website settings: Display Product Prices = Tax Included

**Description of the issue/feature this PR addresses:**
The price on the cart notification doesn't include the tax while the website settings says it should. 
<img width="1107" height="569" alt="image" src="https://github.com/user-attachments/assets/629e89c9-a9c9-4932-b36b-97416e747d83" />

