### PR TITLE
[FIX] website_sale_wishlist: prevent crash on shop if no header

### DIFF
--- a/addons/website_sale_wishlist/static/src/js/website_sale_wishlist.js
+++ b/addons/website_sale_wishlist/static/src/js/website_sale_wishlist.js
@@ -136,13 +136,10 @@ publicWidget.registry.ProductWishlist = publicWidget.Widget.extend(VariantMixin,
             $wishButton.toggleClass('d-none', !this.wishlistProductIDs.length);
         }
         $wishButton.find('.my_wish_quantity').text(this.wishlistProductIDs.length);
-        const wishlistQuantity = document.querySelector('.my_wish_quantity');
-        if (this.wishlistProductIDs.length != 0) {
-            wishlistQuantity.classList.remove('d-none');
-        }
-        else {
-            wishlistQuantity.classList.add('d-none');
-        }
+        const wishlistQuantities = document.querySelectorAll(".my_wish_quantity");
+        wishlistQuantities.forEach((quantity) => {
+            quantity.classList.toggle("d-none", !this.wishlistProductIDs.length);
+        });
     },
     /**
      * @private


### PR DESCRIPTION
__Current behavior before commit:__
It is possible to hide the header on the website. If it is hidden, the `_updateWishlistView` method will not find `.my_wish_quantity` in the page; leading to a crash.
Furthermore, the current implementation only updates the first wishlist button. However there is a second one in the DOM for the mobile view.

__Description of the fix:__
Looping through all the wishlist buttons on the page just like it is done in [master].

__Steps to reproduce the issue on runbot:__
1. Open the mobile preview on the website
2. Go to `/shop` and add an item to the wishlist => The wishlist button is not updated
1. Open the website builder
2. In the Theme tab, disable *Advanced > Show Header*
3. Go to `/shop` => Crash

[master]: https://github.com/odoo/odoo/blob/d65163ea740d8d65/addons/website_sale_wishlist/static/src/js/website_sale_wishlist_utils.js#L57-L60

Bug introduced in: https://github.com/odoo/odoo/pull/212584

opw-4959473
