### PR TITLE
[REF] html_builder, web, website: replace WebsiteUrlPicker

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_row.scss
+++ b/addons/html_builder/static/src/core/building_blocks/builder_row.scss
@@ -67,6 +67,11 @@
         align-items: center;
         gap: var(--hb-row-content-gap);
         z-index: $_z-index; // Make sure outlines / shadows are not trimmed.
+
+        // to prevent overlapping of ul with builder options.
+        &:has(ul) {
+            z-index: auto;
+        }
     }
 
     .o_hb_collapse_toggler {

--- a/addons/web/static/src/core/autocomplete/autocomplete.js
+++ b/addons/web/static/src/core/autocomplete/autocomplete.js
@@ -24,6 +24,7 @@ export class AutoComplete extends Component {
             },
         },
         placeholder: { type: String, optional: true },
+        title: { type: String, optional: true },
         autocomplete: { type: String, optional: true },
         autoSelect: { type: Boolean, optional: true },
         resetOnSelect: { type: Boolean, optional: true },
@@ -46,6 +47,7 @@ export class AutoComplete extends Component {
     static defaultProps = {
         value: "",
         placeholder: "",
+        title: "",
         autocomplete: "new-password",
         autoSelect: false,
         dropdown: true,
@@ -358,6 +360,7 @@ export class AutoComplete extends Component {
         }
         this.props.onChange({
             inputValue: this.inputRef.el.value,
+            isOptionSelected: this.ignoreBlur,
         });
     }
     async onInput() {

--- a/addons/web/static/src/core/autocomplete/autocomplete.xml
+++ b/addons/web/static/src/core/autocomplete/autocomplete.xml
@@ -9,6 +9,7 @@
                 class="o-autocomplete--input o_input pe-3 text-truncate"
                 t-att-autocomplete="props.autocomplete"
                 t-att-placeholder="props.placeholder"
+                t-att-title="props.title"
                 role="combobox"
                 t-att-aria-activedescendant="activeSourceOptionId"
                 t-att-aria-expanded="displayOptions ? 'true' : 'false'"

--- a/addons/website/static/src/builder/builder_urlpicker.js
+++ b/addons/website/static/src/builder/builder_urlpicker.js
@@ -1,47 +1,71 @@
-import { useEffect } from "@odoo/owl";
-import wUtils from "@website/js/utils";
-import { Plugin } from "@html_editor/plugin";
-import { registry } from "@web/core/registry";
+import { textInputBasePassthroughProps } from "@html_builder/core/building_blocks/builder_text_input_base";
 import { BuilderUrlPicker } from "@html_builder/core/building_blocks/builder_urlpicker";
+import { basicContainerBuilderComponentProps, useActionInfo } from "@html_builder/core/utils";
+import { AutoComplete } from "@web/core/autocomplete/autocomplete";
+import { _t } from "@web/core/l10n/translation";
+import { useChildRef } from "@web/core/utils/hooks";
+import { patch } from "@web/core/utils/patch";
+import wUtils from "@website/js/utils";
 
-export class WebsiteUrlPicker extends BuilderUrlPicker {
+export class AutoCompleteBuilderUrlPicker extends AutoComplete {
+    static props = {
+        ...AutoComplete.props,
+        ...basicContainerBuilderComponentProps,
+        ...textInputBasePassthroughProps,
+        default: { type: String, optional: true },
+        inputClass: { type: String, optional: true },
+    };
+    static template = "website.AutoCompleteBuilderUrlPicker";
+
     setup() {
         super.setup();
+        this.info = useActionInfo();
+    }
 
-        useEffect(
-            (inputEl) => {
-                if (!inputEl) {
-                    return;
-                }
-                const unmountAutocompleteWithPages = wUtils.autocompleteWithPages(
-                    inputEl,
-                    {
-                        classes: {
-                            "ui-autocomplete": "o_website_ui_autocomplete",
-                        },
-                        body: this.env.getEditingElement().ownerDocument.body,
-                        urlChosen: () => {
-                            this.commit(this.inputRef.el.value);
-                        },
-                    },
-                    this.env
-                );
-                return () => unmountAutocompleteWithPages();
-            },
-            () => [this.inputRef.el]
-        );
+    get ulDropdownClass() {
+        return `${super.ulDropdownClass} dropdown-menu ui-autocomplete o_website_ui_autocomplete`;
     }
 }
 
-class UrlPickerPlugin extends Plugin {
-    static id = "urlPickerPlugin";
+patch(BuilderUrlPicker, {
+    components: { ...BuilderUrlPicker.components, AutoCompleteBuilderUrlPicker },
+});
 
-    /** @type {import("plugins").WebsiteResources} */
-    resources = {
-        builder_components: {
-            WebsiteUrlPicker,
-        },
-    };
-}
+patch(BuilderUrlPicker.prototype, {
+    setup() {
+        super.setup();
+        this.urlRef = useChildRef();
+    },
 
-registry.category("website-plugins").add(UrlPickerPlugin.id, UrlPickerPlugin);
+    get sources() {
+        const body = this.env.getEditingElement().ownerDocument.body;
+        return [
+            {
+                placeholder: _t("Loading..."),
+                options: (term) => wUtils.loadOptionsSource(term, body, this.onSelect.bind(this)),
+                optionSlot: "urlOption",
+            },
+        ];
+    },
+
+    onSelect(value) {
+        this.commit(value);
+        // Forces the input to update its value even if the value of the
+        // element in the DOM has not changed.
+        this.state.value = null;
+        this.state.value = value;
+    },
+
+    onChange({ inputValue, isOptionSelected }) {
+        if (isOptionSelected) {
+            return;
+        }
+        this.commit(inputValue);
+    },
+
+    openPreviewUrl() {
+        if (this.urlRef.el.value) {
+            window.open(this.urlRef.el.value, "_blank");
+        }
+    },
+});

--- a/addons/website/static/src/builder/builder_urlpicker.xml
+++ b/addons/website/static/src/builder/builder_urlpicker.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="website.AutoCompleteBuilderUrlPicker" t-inherit="web.AutoComplete">
+        <xpath expr="//div[@t-ref='root']" position="attributes">
+            <attribute name="t-att-data-action-id">info.actionId</attribute>
+            <attribute name="t-att-data-action-param">info.actionParam</attribute>
+            <attribute name="t-att-data-action-value">info.actionValue</attribute>
+            <attribute name="t-att-data-class-action">info.classAction</attribute>
+            <attribute name="t-att-data-style-action">info.styleAction</attribute>
+            <attribute name="t-att-data-style-action-value">info.styleActionValue</attribute>
+            <attribute name="t-att-data-attribute-action">info.attributeAction</attribute>
+            <attribute name="t-att-data-attribute-action-value">info.attributeActionValue</attribute>
+        </xpath>
+        <xpath expr="//input[@t-ref='input']" position="attributes">
+            <attribute name="t-attf-class" add="{{props.inputClass}}" separator=" "/>
+        </xpath>
+    </t>
+
+    <t t-inherit="html_builder.BuilderUrlPicker" t-inherit-mode="extension">
+        <xpath expr="//BuilderTextInputBase" position="replace">
+            <AutoCompleteBuilderUrlPicker
+                t-props="props"
+                sources="sources"
+                value="state.value or ''"
+                input="urlRef"
+                dropdown="true"
+                inputClass="'o-hb-input-base o_builder_url_input'"
+                onChange.bind="onChange"
+            />
+            <button class="btn" title="Preview this URL in a new tab" t-on-click="openPreviewUrl">
+                <i class="fa fa-fw fa-external-link"/>
+            </button>
+        </xpath>
+    </t>
+
+</templates>

--- a/addons/website/static/src/builder/plugins/form/form_option.xml
+++ b/addons/website/static/src/builder/plugins/form/form_option.xml
@@ -39,7 +39,7 @@
                        action="'toggleEndMessage'"/>
     </BuilderRow>
     <BuilderRow label.translate="URL">
-        <WebsiteUrlPicker dataAttributeAction="'successPage'" default="'/contactus-thank-you'" id="'url_opt'" t-if="isActiveItem('show_redirect_opt')"/>
+        <BuilderUrlPicker dataAttributeAction="'successPage'" default="'/contactus-thank-you'" id="'url_opt'" t-if="isActiveItem('show_redirect_opt')"/>
     </BuilderRow>
     <BuilderRow t-if="hasRecaptchaKey" label.translate="Show reCaptcha Policy">
         <BuilderCheckbox action="'formToggleRecaptchaLegal'" preview="false"/>

--- a/addons/website/static/src/builder/plugins/options/carousel_slides_option.xml
+++ b/addons/website/static/src/builder/plugins/options/carousel_slides_option.xml
@@ -7,7 +7,7 @@
     </BuilderRow>
 
     <BuilderRow t-if="isActiveItem('make_slide_clickable_opt')" label.translate="Your URL" level="1">
-        <WebsiteUrlPicker title.translate="Your URL"
+        <BuilderUrlPicker title.translate="Your URL"
             action="'setSlideAnchorUrl'"
             placeholder.translate="e.g. /your-website-page"/>
     </BuilderRow>

--- a/addons/website/static/src/builder/plugins/options/countdown_option.xml
+++ b/addons/website/static/src/builder/plugins/options/countdown_option.xml
@@ -21,7 +21,7 @@
     </BuilderRow>
     <BuilderRow t-if="this.isActiveItem('redirect_end_action_opt')"
                 label.translate="URL">
-            <WebsiteUrlPicker placeholder.translate="e.g. /my-awesome-page" dataAttributeAction="'redirectUrl'"/>
+            <BuilderUrlPicker placeholder.translate="e.g. /my-awesome-page" dataAttributeAction="'redirectUrl'"/>
     </BuilderRow>
     <BuilderRow label.translate="Size">
         <BuilderSelect dataAttributeAction="'size'">

--- a/addons/website/static/tests/builder/custom_tab/builder_components/website_urlpicker.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/website_urlpicker.test.js
@@ -6,6 +6,7 @@ import {
     defineWebsiteModels,
     setupWebsiteBuilder,
 } from "@website/../tests/builder/website_helpers";
+import { delay } from "@web/core/utils/concurrency";
 
 defineWebsiteModels();
 
@@ -68,7 +69,7 @@ after(() => {
 test("link button opens in new window if url not empty", async () => {
     addOption({
         selector: ".test-options-target",
-        template: xml`<WebsiteUrlPicker dataAttributeAction="'url'"/>`,
+        template: xml`<BuilderUrlPicker dataAttributeAction="'url'"/>`,
     });
     await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
@@ -89,13 +90,13 @@ test("opens dropdown when typing /", async () => {
     });
     addOption({
         selector: ".test-options-target",
-        template: xml`<WebsiteUrlPicker dataAttributeAction="'url'"/>`,
+        template: xml`<BuilderUrlPicker dataAttributeAction="'url'"/>`,
     });
     await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
 
-    await contains(".we-bg-options-container input").edit("/");
-    await contains(".we-bg-options-container input").click();
+    await contains(".we-bg-options-container input").edit("/", { confirm: false });
+    await delay(250);
     expect.verifySteps(["button_immediate_install"]);
     expect(document.querySelector(".o_website_ui_autocomplete")).toBeVisible();
 });
@@ -104,13 +105,13 @@ test("selects and commits value from dropdown", async () => {
     mockGetSuggestedLinks();
     addOption({
         selector: ".test-options-target",
-        template: xml`<WebsiteUrlPicker dataAttributeAction="'url'"/>`,
+        template: xml`<BuilderUrlPicker dataAttributeAction="'url'"/>`,
     });
     await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
 
-    await contains(".we-bg-options-container input").edit("/");
-    await contains(".we-bg-options-container input").click();
+    await contains(".we-bg-options-container input").edit("/", { confirm: false });
+    await delay(250);
     await contains(document.querySelector(".o_website_ui_autocomplete > li:first-child a")).click();
     expect(document.querySelector(".o_website_ui_autocomplete")).toBe(null);
     expect(".we-bg-options-container input").toHaveValue("/page1");
@@ -121,7 +122,7 @@ test("collects anchors in current page and suggests them", async () => {
     mockGetSuggestedLinks();
     addOption({
         selector: ".test-options-target",
-        template: xml`<WebsiteUrlPicker dataAttributeAction="'url'"/>`,
+        template: xml`<BuilderUrlPicker dataAttributeAction="'url'"/>`,
     });
     await setupWebsiteBuilder(`
         <div class="test-options-target">b</div>
@@ -129,8 +130,8 @@ test("collects anchors in current page and suggests them", async () => {
         <div id="anchor2" data-anchor="true">anchor2</div>
     `);
     await contains(":iframe .test-options-target").click();
-    await contains(".we-bg-options-container input").edit("#");
-    await contains(".we-bg-options-container input").click();
+    await contains(".we-bg-options-container input").edit("#", { confirm: false });
+    await delay(250);
 
     // Check autocomplete suggests both anchors
     const els = document.querySelectorAll(".o_website_ui_autocomplete > li a");

--- a/addons/website/static/tests/builder/website_builder/image_gallery.test.js
+++ b/addons/website/static/tests/builder/website_builder/image_gallery.test.js
@@ -157,7 +157,8 @@ test("Change gallery layout when images have a link", async () => {
     await contains("[data-label='Media'] button[data-action-id='setLink']").click();
 
     await contains("[data-label='Your URL'] [data-action-id='setUrl'] > input").fill(
-        "http://odoo.com"
+        "http://odoo.com",
+        { confirm: "blur" }
     );
     expect(":iframe section a[href='http://odoo.com'] > img[data-index='1']").toHaveCount(1);
 

--- a/addons/website/static/tests/tours/carousel.js
+++ b/addons/website/static/tests/tours/carousel.js
@@ -160,7 +160,7 @@ const setSlideUrl = (urlText, matchText) => [
     },
     {
         content: "Select the URL from autocomplete dropdown",
-        trigger: `ul.ui-autocomplete li div:contains('${matchText}')`,
+        trigger: `ul.ui-autocomplete li a:contains('${matchText}')`,
         run: "click",
     },
 ];
@@ -214,9 +214,9 @@ registerWebsitePreviewTour(
             run: "edit ",
         },
         {
-            content: "Press Enter in the URL input",
+            content: "Press Tab in the URL input",
             trigger: "div[data-action-id='setSlideAnchorUrl'] input",
-            run: "press Enter",
+            run: "press Tab",
         },
         {
             content: "Check that the anchor tag is removed",


### PR DESCRIPTION
When website is installed, all URL pickers should suggest existing
website pages and anchors.

Before this commit, the `WebsiteUrlPicker` used `autocompleteWithPages`
to suggest internal links.

This commit removes the usage of `autocompleteWithPages` and
replace `WebsiteUrlPicker` with `BuilderUrlPicker` with an Autocomplete
component completely to provide internal link and anchor
suggestions.

Key Changes:
- Introduce `AutoCompleteBuilderUrlPicker` component extending the base
  `AutoComplete` component.
- Patch BuilderUrlPicker to:
  - Replace its input with AutoCompleteBuilderUrlPicker.
  - Provide a `sources` getter delegating suggestions to
    loadOptionsSource.
  - Handle selection vs input through `isOptionSelected`.
- Extract and reuse loadOptionsSource in website utils.
- Move `loadOptionsSource` to utils.
- Add `title` prop and `isOptionSelected` flag to AutoComplete to
  properly differentiate selection vs input.


Enterprise PR: [106706](https://github.com/odoo/enterprise/pull/106706)

task-5260613