### PR TITLE
[FIX]  base: fails to update existing modules

### DIFF
--- a/doc/cla/individual/tharcisse.md
+++ b/doc/cla/individual/tharcisse.md
@@ -1,0 +1,11 @@
+Kenya, 2025-09-07
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Tharcisse Mukundayi mukundayi@gmail.com https://github.com/tharcisse

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -455,9 +455,9 @@ actual arch.
 
                     # During an upgrade, we can only use the views that have been
                     # fully upgraded already.
-                    if self.pool._init and sibling_primary_views:
+                    if self.pool._init and sibling_primary_views and self.pool._init_modules:
                         query = sibling_primary_views._get_filter_xmlid_query()
-                        sql = SQL(query, res_ids=tuple(sibling_primary_views.ids), modules=tuple(self.pool._init_modules) + (self.env.context.get('install_module'),))
+                        sql = SQL(query, res_ids=tuple(sibling_primary_views.ids), modules=tuple(self.pool._init_modules))
                         loaded_view_ids = {id_ for id_, in self.env.execute_query(sql)}
                         loaded_view_ids.update({
                             id

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -457,7 +457,7 @@ actual arch.
                     # fully upgraded already.
                     if self.pool._init and sibling_primary_views:
                         query = sibling_primary_views._get_filter_xmlid_query()
-                        sql = SQL(query, res_ids=tuple(sibling_primary_views.ids), modules=tuple(self.pool._init_modules))
+                        sql = SQL(query, res_ids=tuple(sibling_primary_views.ids), modules=tuple(self.pool._init_modules) + (self.env.context.get('install_module'),))
                         loaded_view_ids = {id_ for id_, in self.env.execute_query(sql)}
                         loaded_view_ids.update({
                             id


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
--update=all fails because self.pool._init_modules is empty

Current behavior before PR:
when runnig  with --update=all  odoo fails  to load some views because the corresponding module is not found

Desired behavior after PR is merged:
--update=all should upgrade all existing views

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr