### PR TITLE
[FIX] pos_online_payment: allow invoice with online payments

### DIFF
--- a/addons/pos_online_payment/static/tests/tours/online_payment_tour.js
+++ b/addons/pos_online_payment/static/tests/tours/online_payment_tour.js
@@ -1,6 +1,8 @@
 import * as ProductScreen from "@point_of_sale/../tests/tours/utils/product_screen_util";
 import * as Chrome from "@point_of_sale/../tests/tours/utils/chrome_util";
 import * as PaymentScreen from "@point_of_sale/../tests/tours/utils/payment_screen_util";
+import * as ReceiptScreen from "@point_of_sale/../tests/tours/utils/receipt_screen_util";
+import * as OnlinePayment from "@pos_online_payment/../tests/tours/utils/online_payment_util";
 import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
 import { registry } from "@web/core/registry";
 
@@ -76,5 +78,23 @@ registry.category("web_tour.tours").add("test_selected_customer_after_adding_pay
             PaymentScreen.validateButtonIsHighlighted(true),
             PaymentScreen.clickValidate(),
             Dialog.is("Scan to Pay"),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_online_payment_with_invoice", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Letter Tray"),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("A powerful PoS man!"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickInvoiceButton(),
+            PaymentScreen.clickPaymentMethod("Online payment"),
+            PaymentScreen.selectedPaymentlineHas("Online payment", "4.80"),
+            OnlinePayment.patchAndMockOnlinePayment(),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
         ].flat(),
 });

--- a/addons/pos_online_payment/static/tests/tours/utils/online_payment_util.js
+++ b/addons/pos_online_payment/static/tests/tours/utils/online_payment_util.js
@@ -1,0 +1,28 @@
+/* global posmodel */
+export function patchAndMockOnlinePayment() {
+    return [
+        {
+            content: "Mock online payment by patching the method used to confirm it",
+            trigger: "body",
+            run: function () {
+                posmodel.update_online_payments_data_with_server = async function (order, amount) {
+                    const opData = {
+                        id: order.id,
+                        is_paid: true,
+                        paid_order: [
+                            {
+                                id: order.id,
+                                name: order.name,
+                                account_move: {
+                                    id: 500,
+                                    name: "INV/2025/001",
+                                },
+                            },
+                        ],
+                    };
+                    return posmodel.process_online_payments_data_from_server(order, opData);
+                };
+            },
+        },
+    ];
+}

--- a/addons/pos_online_payment/tests/test_frontend.py
+++ b/addons/pos_online_payment/tests/test_frontend.py
@@ -339,6 +339,10 @@ class TestUi(TestPointOfSaleHttpCommon, OnlinePaymentCommon):
         self.assertEqual(order.state, "draft", "The order should still be in draft state.")
         self.assertEqual(len(order.payment_ids), 0, "There should be no payment line in the order.")
 
+    def test_online_payment_with_invoice(self):
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_online_payment_with_invoice', login="pos_user")
+
     @classmethod
     def tearDownClass(cls):
         # Restore company values after the tests


### PR DESCRIPTION
**Steps to reproduce:**
- Setup an online payment method
- Make a purchase 
*On the payment screen, reproduce those steps in order*
- Click on the invoice checkbox
- Chose a customer
- Click on the online payment method
- Pay for the order, a traceback appears

**Why the fix:**
When using those steps in order, we were not allowed to pay through an online payment method, as we would try to access *orderJSON[0].raw.account_method*, but the raw was undefined. When doing the steps in this order, orderJson[0] contained all the needed values, and there was no raw values.

This change allows us to call the downloadPdf method to get our invoice.

opw-5022557