### PR TITLE
[FIX] website_sale(,_collect): exclude in-store DM from express checkout

### DIFF
--- a/addons/website_sale/controllers/delivery.py
+++ b/addons/website_sale/controllers/delivery.py
@@ -212,7 +212,7 @@ class Delivery(WebsiteSale):
             'name': dm.name,
             'description': dm.website_description,
             'minorAmount': payment_utils.to_minor_currency_units(price, order_sudo.currency_id),
-        } for dm, price in Delivery._get_delivery_methods_express_checkout(order_sudo).items()
+        } for dm, price in self._get_delivery_methods_express_checkout(order_sudo).items()
         ], key=lambda dm: dm['minorAmount'])
 
         # Preselect the cheapest method imitating the behavior of the express checkout form.
@@ -229,8 +229,8 @@ class Delivery(WebsiteSale):
         # Return the list of delivery methods available for the sales order.
         return {'delivery_methods': sorted_delivery_methods}
 
-    @staticmethod
-    def _get_delivery_methods_express_checkout(order_sudo):
+    @classmethod
+    def _get_delivery_methods_express_checkout(cls, order_sudo):
         """ Return available delivery methods and their prices for the given order.
 
         :param sale.order order_sudo: The sudoed sales order.

--- a/addons/website_sale_collect/controllers/delivery.py
+++ b/addons/website_sale_collect/controllers/delivery.py
@@ -34,3 +34,12 @@ class InStoreDelivery(Delivery):
             in_store_dm = request.website.sudo().in_store_dm_id
             order_sudo.set_delivery_line(in_store_dm, in_store_dm.product_id.list_price)
         order_sudo._set_pickup_location(pickup_location_data)
+
+    @classmethod
+    def _get_delivery_methods_express_checkout(cls, order_sudo):
+        """Override to exclude `in_store` delivery methods from exress checkout delivery options."""
+        dm_rate_mapping = super()._get_delivery_methods_express_checkout(order_sudo)
+        for dm in list(dm_rate_mapping):
+            if dm.delivery_type == 'in_store':
+                del dm_rate_mapping[dm]
+        return dm_rate_mapping

--- a/addons/website_sale_collect/tests/__init__.py
+++ b/addons/website_sale_collect/tests/__init__.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_delivery_carrier
+from . import test_click_and_collect_express_checkout
 from . import test_click_and_collect_flow
 from . import test_payment_provider
 from . import test_payment_transaction

--- a/addons/website_sale_collect/tests/test_click_and_collect_express_checkout.py
+++ b/addons/website_sale_collect/tests/test_click_and_collect_express_checkout.py
@@ -1,0 +1,15 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import tagged
+
+from odoo.addons.website_sale_collect.controllers.delivery import InStoreDelivery
+from odoo.addons.website_sale_collect.tests.common import ClickAndCollectCommon
+
+
+@tagged('post_install', '-at_install')
+class TestClickAndCollectExpressCheckout(ClickAndCollectCommon):
+
+    def test_exclude_in_store_delivery_methods(self):
+        express_delivery_methods = InStoreDelivery._get_delivery_methods_express_checkout(self.cart)
+
+        self.assertNotIn(self.in_store_dm, express_delivery_methods)


### PR DESCRIPTION
Before this commit, when entering the express checkout flow, Click & Collect (C&C) delivery methods (DM) were included in the list of possible delivery methods available for express checkout. However, the express checkout flow does not allow customers to select which store they want to pick up their order from.

After this commit, C&C DMs are excluded from the list if they have more than one store configured. If only one store is configured, the customer implicitly knows where they will need to pick up their order.
