### PR TITLE
[FIX] l10n_in: add TAN number in comapny demo data

### DIFF
--- a/addons/l10n_in/demo/demo_company.xml
+++ b/addons/l10n_in/demo/demo_company.xml
@@ -3,6 +3,7 @@
     <record id="base.partner_demo_company_in" model="res.partner" forcecreate="1">
         <field name="name">IN Company</field>
         <field name="vat">24FANCY1234AAZA</field>
+        <field name="l10n_in_tan">GANI12345A</field>
         <field name="street">Block no. 401</field>
         <field name="street2">Street 2</field>
         <field name="city">Gandhinagar</field>


### PR DESCRIPTION
TAN number is a mandatory field when TDS is enabled on a company.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
