### PR TITLE
[FIX] website_event_track: elements not rendered in mails

### DIFF
--- a/addons/website_event_track/data/mail_template_data.xml
+++ b/addons/website_event_track/data/mail_template_data.xml
@@ -228,7 +228,7 @@
                                 <!-- GOOGLE MAPS LINK -->
                                 <table t-if="event_address and location" style="width:100%;"><tr><td>
                                     <div>
-                                        <i class="fa fa-map-marker"/>
+                                        <img src="/web_editor/font_to_img/61505/rgb(81,81,102)/20" height="20" style="vertical-align: bottom;"/>
                                         <a t-attf-href="https://maps.google.com/maps?q={{ location }}" target="new">
                                             <img t-if="event_address.static_map_url and event_address.static_map_url_is_valid"
                                                  t-attf-src="{{ event_address.static_map_url }}"


### PR DESCRIPTION
Font awesome classes must no be inserted into email as external servers do not use them so icons are not displayed. This commit replaces i tags with font awesome classes in mail by images.

Task-5082165
