### PR TITLE
[FIX] website: display image gallery snippet without "missing template" error

### DIFF
--- a/addons/website/static/src/snippets/s_image_gallery/000.xml
+++ b/addons/website/static/src/snippets/s_image_gallery/000.xml
@@ -1,68 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <!--
-        ========================================================================
-        Gallery Slideshow
-
-        This template is used to display a slideshow of images inside a
-        bootstrap carousel.
-
-        ========================================================================
+    The templates (website.gallery.slideshow and
+    website.gallery.slideshow.lightbox) have been moved to ./001.xml for
+    compatibility with version 18.0.
     -->
-    <t t-name="website.gallery.slideshow">
-        <div t-attf-id="#{id}" class="carousel slide" t-att-data-bs-ride="ride" t-attf-data-bs-interval="#{interval}" style="margin: 0 12px;">
-            <div class="carousel-inner" style="padding: 0;">
-                 <t t-foreach="images" t-as="image" t-key="image_index">
-                    <div t-attf-class="carousel-item #{image_index == index and 'active' or None}">
-                        <img t-if="!hideImage" class="img img-fluid d-block" t-att-src="image.getAttribute('src')" t-att-alt="image.alt" data-name="Image"/>
-                    </div>
-                 </t>
-            </div>
-
-            <ul class="carousel-indicators">
-                <li class="o_indicators_left text-center d-none" aria-label="Previous" title="Previous">
-                    <i class="oi oi-chevron-left"/>
-                </li>
-                <t t-foreach="images" t-as="image" t-key="image_index">
-                    <li t-attf-data-bs-target="##{id}" t-att-data-bs-slide-to="image_index" t-att-class="image_index == index and 'active' or None" t-attf-style="background-image: url(#{image.getAttribute('src')})"></li>
-                </t>
-                <li class="o_indicators_right text-center d-none" aria-label="Next" title="Next">
-                    <i class="oi oi-chevron-right"/>
-                </li>
-            </ul>
-
-            <a class="carousel-control-prev o_we_no_overlay o_not_editable" t-attf-href="##{id}" data-bs-slide="prev" aria-label="Previous" title="Previous">
-                <span class="oi oi-chevron-left fa-2x text-white"></span>
-                <span class="visually-hidden">Previous</span>
-            </a>
-            <a class="carousel-control-next o_we_no_overlay o_not_editable" t-attf-href="##{id}" data-bs-slide="next" aria-label="Next" title="Next">
-                <span class="oi oi-chevron-right fa-2x text-white"></span>
-                <span class="visually-hidden">Next</span>
-            </a>
-        </div>
-    </t>
-
-    <!--
-        ========================================================================
-        Gallery Slideshow LightBox
-
-        This template is used to display a lightbox with a slideshow.
-
-        This template wraps website.gallery.slideshow in a bootstrap modal
-        dialog.
-        ========================================================================
-    -->
-    <t t-name="website.gallery.slideshow.lightbox">
-        <div role="dialog" class="modal o_technical_modal fade s_gallery_lightbox p-0" aria-label="Image Gallery Dialog" tabindex="-1">
-            <div class="modal-dialog m-0" role="Picture Gallery"
-                t-attf-style="">
-                <div class="modal-content bg-transparent modal-fullscreen">
-                    <main class="modal-body o_slideshow bg-transparent">
-                        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close" style="position: absolute; right: 10px; top: 10px;"></button>
-                        <t t-call="website.gallery.slideshow"></t>
-                    </main>
-                </div>
-            </div>
-        </div>
-    </t>
 </templates>

--- a/addons/website/static/src/snippets/s_image_gallery/001.xml
+++ b/addons/website/static/src/snippets/s_image_gallery/001.xml
@@ -40,4 +40,85 @@
             </div>
         </div>
     </t>
+
+    <!--
+    The templates (website.gallery.slideshow and
+    website.gallery.slideshow.lightbox) have been moved from "./000.xml" to
+    here for compatibility with version 18.0.
+
+    Deprecation notice:
+    - These templates will be removed in version 19.1 as we always want to
+    use website.s_image_gallery_mirror and
+    website.gallery.s_image_gallery_mirror.lightbox instead.
+
+    Additionally:
+    - The content of this file will be moved to "000.xml" and file "001.xml"
+    will no longer exist.
+    -->
+
+    <!--
+        ========================================================================
+        Gallery Slideshow
+
+        This template is used to display a slideshow of images inside a
+        bootstrap carousel.
+
+        ========================================================================
+    -->
+    <t t-name="website.gallery.slideshow">
+        <div t-attf-id="#{id}" class="carousel slide" t-att-data-bs-ride="ride" t-attf-data-bs-interval="#{interval}" style="margin: 0 12px;">
+            <div class="carousel-inner" style="padding: 0;">
+                 <t t-foreach="images" t-as="image" t-key="image_index">
+                    <div t-attf-class="carousel-item #{image_index == index and 'active' or None}">
+                        <img t-if="!hideImage" class="img img-fluid d-block" t-att-src="image.getAttribute('src')" t-att-alt="image.alt" data-name="Image"/>
+                    </div>
+                 </t>
+            </div>
+
+            <ul class="carousel-indicators">
+                <li class="o_indicators_left text-center d-none" aria-label="Previous" title="Previous">
+                    <i class="oi oi-chevron-left"/>
+                </li>
+                <t t-foreach="images" t-as="image" t-key="image_index">
+                    <li t-attf-data-bs-target="##{id}" t-att-data-bs-slide-to="image_index" t-att-class="image_index == index and 'active' or None" t-attf-style="background-image: url(#{image.getAttribute('src')})"></li>
+                </t>
+                <li class="o_indicators_right text-center d-none" aria-label="Next" title="Next">
+                    <i class="oi oi-chevron-right"/>
+                </li>
+            </ul>
+
+            <a class="carousel-control-prev o_we_no_overlay o_not_editable" t-attf-href="##{id}" data-bs-slide="prev" aria-label="Previous" title="Previous">
+                <span class="oi oi-chevron-left fa-2x text-white"></span>
+                <span class="visually-hidden">Previous</span>
+            </a>
+            <a class="carousel-control-next o_we_no_overlay o_not_editable" t-attf-href="##{id}" data-bs-slide="next" aria-label="Next" title="Next">
+                <span class="oi oi-chevron-right fa-2x text-white"></span>
+                <span class="visually-hidden">Next</span>
+            </a>
+        </div>
+    </t>
+
+    <!--
+        ========================================================================
+        Gallery Slideshow LightBox
+
+        This template is used to display a lightbox with a slideshow.
+
+        This template wraps website.gallery.slideshow in a bootstrap modal
+        dialog.
+        ========================================================================
+    -->
+    <t t-name="website.gallery.slideshow.lightbox">
+        <div role="dialog" class="modal o_technical_modal fade s_gallery_lightbox p-0" aria-label="Image Gallery Dialog" tabindex="-1">
+            <div class="modal-dialog m-0" role="Picture Gallery"
+                t-attf-style="">
+                <div class="modal-content bg-transparent modal-fullscreen">
+                    <main class="modal-body o_slideshow bg-transparent">
+                        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close" style="position: absolute; right: 10px; top: 10px;"></button>
+                        <t t-call="website.gallery.slideshow"></t>
+                    </main>
+                </div>
+            </div>
+        </div>
+    </t>
 </templates>


### PR DESCRIPTION
Clicking on an image gallery snippet currently triggers a "missing template" error. This happens because the gallery template is only defined in the 000 version file, while the corresponding view record for that version has been disabled.

This commit resolves the issue by moving the gallery templates to the 001 version file, ensuring they are properly loaded.

Steps to reproduce:
1. In Website, navigate to /jobs.
2. Create a new job and save it.
3. Click on any image at the end of the job page.
4. Observe the "missing template" error.