### PR TITLE
[IMP] website: remove errors on file replace/discard

### DIFF
--- a/addons/website/static/src/snippets/s_website_form/form.js
+++ b/addons/website/static/src/snippets/s_website_form/form.js
@@ -878,6 +878,23 @@ export class Form extends Interaction {
     }
 
     /**
+     * Removes error indications from the field, file input, and add files button.
+     * Only acts if a custom error is present.
+     * @param {HTMLElement} fieldEl
+     * @param {HTMLElement} fileInputEl
+     * @param {HTMLElement} addFilesButtonEl
+     */
+    removeFileUploadErrors(fieldEl, fileInputEl, addFilesButtonEl) {
+        const customError = fieldEl.querySelector(".s_website_form_custom_error");
+        if (customError) {
+            customError.remove();
+            fileInputEl?.classList.remove("is-invalid");
+            addFilesButtonEl?.classList.remove("is-invalid");
+            this.el.querySelector("#s_website_form_result")?.replaceChildren();
+        }
+    }
+
+    /**
      * Called when files are uploaded: updates the button text content,
      * displays the file blocks (containing the files name and a cross to
      * delete them) and manages the files.
@@ -918,6 +935,9 @@ export class Form extends Interaction {
                 fileInputEl.fileList.items.add(newFile);
                 const fileDetails = { name: newFile.name, size: newFile.size, type: newFile.type };
                 this.createFileBlock(fileDetails, filesZoneEl);
+
+                // Remove visible error messages only when file is replaced.
+                this.removeFileUploadErrors(fieldEl, fileInputEl, addFilesButtonEl);
             }
         }
         // Update the input files.
@@ -931,15 +951,20 @@ export class Form extends Interaction {
      * @param {Event} ev
      */
     clickFileDelete(ev) {
-        if (!ev.target.closest(".o_file_delete")) {
-            return;
-        }
         const fileBlockEl = ev.target.closest(".o_file_block");
+        if (!fileBlockEl) {
+            return; // Prevent error if not clicking on a file block
+        }
         const fieldEl = fileBlockEl.closest(".s_website_form_field");
         const fileInputEl = fieldEl.querySelector("input[type=file]");
         const fileDetails = fileBlockEl.fileDetails;
         const addFilesButtonEl = fieldEl.querySelector(".o_add_files_button");
 
+        // Remove any visible error messages before proceeding
+        this.removeFileUploadErrors(fieldEl, fileInputEl, addFilesButtonEl);
+        if (!ev.target.closest(".o_file_delete")) {
+            return;
+        }
         // Create a new file list containing the remaining files.
         const newFileList = new DataTransfer();
         for (const file of Object.values(fileInputEl.fileList.files)) {


### PR DESCRIPTION
**Steps to reproduce:**

1. Go to the *Contact Us* page in edit mode.
2. Add a new file upload field and save.
3. Fill out the form and upload a file larger than 1 MB.
4. Submit the form → error messages appear as expected.
5. Now remove or replace the attachment with a smaller file.
6. Notice that the previous error messages remain visible even though the new file is valid.

**Cause:**
Error messages and invalid states were not being cleared when users replaced or removed files after an upload validation error.

**Fix:**
Introduced a new helper method `removeFileUploadErrors` to handle cleanup:

* Removes custom error elements from the field.
* Clears `is-invalid` classes from file inputs and “Add files” buttons.
* Resets the result container to a clean state.

Integrated this method into both the file replace and delete flows to ensure that error messages are properly cleared when attachments are changed or removed.

This results in a smoother and more intuitive form experience, preventing stale error states after file updates.
