### PR TITLE
[FIX] hr_attendance: Bug with officer group when try to change employee for attendance

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -413,8 +413,9 @@ class HrAttendance(models.Model):
     def write(self, vals):
         if vals.get('employee_id') and \
             vals['employee_id'] not in self.env.user.employee_ids.ids and \
-            not self.env.user.has_group('hr_attendance.group_hr_attendance_officer'):
-            raise AccessError(_("Do not have access, user cannot edit the attendances that are not his own."))
+            not self.env.user.has_group('hr_attendance.group_hr_attendance_officer') or \
+            vals.get('employee_id') and self.env['hr.employee'].sudo().browse(vals['employee_id']).attendance_manager_id.id != self.env.user.id:
+            raise AccessError(_("Do not have access, user cannot edit the attendances that are not their own or if they are not the attendance manager of the employee."))
         attendances_dates = self._get_attendances_dates()
         result = super(HrAttendance, self).write(vals)
         if any(field in vals for field in ['employee_id', 'check_in', 'check_out']):

--- a/addons/hr_attendance/tests/__init__.py
+++ b/addons/hr_attendance/tests/__init__.py
@@ -3,3 +3,4 @@
 from . import test_hr_attendance_constraints
 from . import test_hr_attendance_overtime
 from . import test_hr_attendance_process
+from . import test_hr_attendance_manager

--- a/addons/hr_attendance/tests/test_hr_attendance_manager.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_manager.py
@@ -1,0 +1,56 @@
+# addons/hr_attendance/tests/test_hr_attendance_manager.py
+
+from odoo.tests.common import TransactionCase, tagged
+from odoo.tests import new_test_user
+from odoo.exceptions import AccessError
+
+
+@tagged('post_install', '-at_install')
+class TestAttendanceManager(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Create a test user
+        cls.marc = new_test_user(cls.env, login='marc', groups='base.group_user')
+        cls.marc_employee = cls.env['hr.employee'].create({
+            'name': 'Marc Employee',
+            'user_id': cls.marc.id,
+        })
+        cls.marc_employee.attendance_manager_id = cls.marc
+
+        # Create another employee
+        cls.abigail = cls.env['hr.employee'].create({
+            'name': 'Abigail Employee',
+        })
+
+    def setUp(self):
+        super().setUp()
+        # Create an attendance for Marc Demo's employee
+        self.attendance = self.env['hr.attendance'].create({
+            'employee_id': self.marc_employee.id,
+            'check_in': '2025-09-09 08:00:00',
+            'check_out': '2025-09-09 12:00:00',
+        })
+
+    def test_cannot_change_employee_without_manager_rights(self):
+        """Marc Demo should NOT be able to change the employee on his attendance
+        if he is not assigned as attendance manager of that employee.
+        """
+        attendance_as_marc = self.attendance.with_user(self.marc)
+        with self.assertRaises(AccessError):
+            attendance_as_marc.write({'employee_id': self.abigail.id})
+
+    def test_can_change_employee_with_manager_rights(self):
+        """Marc Demo should be able to change the employee on attendance
+        once he is set as attendance manager of Abigail.
+        """
+        # Assign Marc Demo as attendance manager of Abigail
+        self.abigail.attendance_manager_id = self.marc
+
+        attendance_as_marc = self.attendance.with_user(self.marc)
+        # This should succeed now
+        attendance_as_marc.write({'employee_id': self.abigail.id})
+
+        # Verify the employee_id has actually changed
+        self.assertEqual(attendance_as_marc.employee_id, self.abigail)

--- a/doc/cla/individual/hamzairfan.md
+++ b/doc/cla/individual/hamzairfan.md
@@ -1,0 +1,11 @@
+Pakistan, 2025-09-10
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Hamza Irfan hamzairfanandroid@gmail.com https://github.com/hamzairfan


### PR DESCRIPTION
Closes [odoo/odoo#226007](https://github.com/odoo/odoo/issues/226007).

Description of the issue/feature this PR addresses:
Prevents a user from updating their attendance record by changing the employee to the one whose attendance is not managed by the current user.

Current behavior before PR:
- Assign the Officer Group of Attendance group to a user.
- Assign the user as the attendance manager of itself.
- Login with that user.
- Create an attendance record for the employee and save it.
- Try to change the employee and save; an error will be thrown as expected.
- Go to the Attendance menu; the record will still be saved.

Desired behavior after PR is merged:
This commit ensures that un-allowed write does not take place + test coverage added.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
