### PR TITLE
[FIX] account: fix a random test and check fiscal position data

### DIFF
--- a/addons/account/tests/test_fiscal_position.py
+++ b/addons/account/tests/test_fiscal_position.py
@@ -346,7 +346,9 @@ class TestFiscalPosition(common.TransactionCase):
         fp_3.write({'country_group_id': a_country_group.id})
         self.assertEqual(self.env.company.domestic_fiscal_position_id, fp_2)
 
+        # Check that sequence is applied after the country
         fp_2.write({'sequence': 20})
+        fp_3.write({'sequence': 15})
         self.assertEqual(self.env.company.domestic_fiscal_position_id, fp_1)
 
         # CH/LI case - one fp with country_group_id only, nothing for others


### PR DESCRIPTION
#### Issue:
`test_domestic_fp` randomly fail

#### Cause:
While computing domestic fiscal position, there are 2 fiscal position candidates for being domestic as they got the same  `sequence` and no `country_id`. It happens randomly that the second one is fetch instead of the first one.

#### Solution:
The failing assert checks a case that doesn't exist in any fiscal position data. Therefore, this commits remove this part of the test, but add a warning in `test_all_l10n` to ensure this case won't happen in new data.

runbot-231686
This PR is linked to [this PR](https://github.com/odoo/odoo/pull/224599)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
