### PR TITLE
[FIX] product: fix product favorite from internal links

### DIFF
--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -495,9 +495,6 @@
                     <field name="default_code"/>
                     <field name="barcode"/>
                 </xpath>
-                <xpath expr="//field[@name='is_favorite']" position="attributes">
-                    <attribute name="readonly">1</attribute>
-                </xpath>
                 <field name="list_price" position="attributes">
                    <attribute name="invisible">1</attribute>
                    <attribute name="readonly">product_variant_count &gt; 1</attribute>


### PR DESCRIPTION
Steps to reproduce:
- Access any product through an internal link that redirects to `product.product`.

Problem:
- Unable to favorite a products accessed through internal links that redirect to `product.product`.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
