### PR TITLE
[IMP] web: add class for signature header

### DIFF
--- a/addons/web/static/src/core/signature/name_and_signature.xml
+++ b/addons/web/static/src/core/signature/name_and_signature.xml
@@ -50,7 +50,7 @@
                 will overflow on the corners without this rule.
             -->
             <div t-if="state.showSignatureArea" class="o_web_sign_signature_group bg-100 card mt-3" style="overflow: hidden;">
-                <div class="card-header bg-transparent">
+                <div class="card-header bg-transparent" name="signature_header">
                     <div class="row g-0">
                         <div t-if="!props.noInputName or defaultName" class="col-auto">
                             <a role="button" href="#" t-on-click.prevent="onClickSignAuto" t-attf-class="o_web_sign_auto_button me-2 btn btn-light {{ state.signMode === 'auto' ? 'active': '' }}">


### PR DESCRIPTION
Added `signature_header` name attribute to avoid relying on DOM structure in XPath. This makes extensions more stable and prevents breakages if the HTML changes.

task-4978258


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
