### PR TITLE
[FIX] website_sale, *: relocate `_is_sellable` to `website_sale`

### DIFF
--- a/addons/delivery/models/sale_order_line.py
+++ b/addons/delivery/models/sale_order_line.py
@@ -12,14 +12,6 @@ class SaleOrderLine(models.Model):
     )
     recompute_delivery_price = fields.Boolean(related='order_id.recompute_delivery_price')
 
-    def _is_sellable(self):
-        """ Override of `sale` to flag delivery lines as not sellable.
-
-        :return: Whether the line is sellable or not.
-        :rtype: bool
-        """
-        return super()._is_sellable() and not self.is_delivery
-
     def _can_be_invoiced_alone(self):
         return super()._can_be_invoiced_alone() and not self.is_delivery
 

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -1556,16 +1556,6 @@ class SaleOrderLine(models.Model):
         self.ensure_one()
         return False
 
-    def _is_sellable(self):
-        """ Check if a line is sellable or not.
-
-        A line is not sellable if the product is unpublished.
-
-        :return: Whether the line is sellable or not.
-        :rtype: bool
-        """
-        return self.product_id.is_published
-
     def _get_product_catalog_lines_data(self, **kwargs):
         """ Return information about sale order lines in `self`.
 

--- a/addons/sale_loyalty/models/sale_order_line.py
+++ b/addons/sale_loyalty/models/sale_order_line.py
@@ -51,18 +51,6 @@ class SaleOrderLine(models.Model):
     def _can_be_invoiced_alone(self):
         return super()._can_be_invoiced_alone() and not self.is_reward_line
 
-    def _is_sellable(self):
-        """ Override of `sale` to flag reward lines as not sellable.
-
-        :return: Whether the line is sellable or not.
-        :rtype: bool
-        """
-        return super()._is_sellable() and (
-            not self.is_reward_line
-            # Sellable so the link is clickable in the cart.
-            or self.reward_id.reward_type == 'product'
-        )
-
     def _reset_loyalty(self, complete=False):
         """
         Reset the line(s) to a state which does not impact reward computation.

--- a/addons/website_sale/models/sale_order_line.py
+++ b/addons/website_sale/models/sale_order_line.py
@@ -120,3 +120,13 @@ class SaleOrderLine(models.Model):
         :rtype: bool
         """
         return self.discount and self._is_sellable() and self._get_displayed_unit_price()
+
+    def _is_sellable(self):
+        """Check if a line is sellable or not, i.e the link is clickable in the cart or not.
+
+        A line is sellable if the product is published and not a delivery line.
+
+        :return: Whether the line is sellable or not.
+        :rtype: bool
+        """
+        return self.product_id.is_published and not self.is_delivery

--- a/addons/website_sale_loyalty/models/sale_order_line.py
+++ b/addons/website_sale_loyalty/models/sale_order_line.py
@@ -34,3 +34,13 @@ class SaleOrderLine(models.Model):
     def _should_show_strikethrough_price(self):
         """ Override of `website_sale` to hide the strikethrough price for rewards. """
         return super()._should_show_strikethrough_price() and not self.is_reward_line
+
+    def _is_sellable(self):
+        """Override of `website_sale` to flag reward lines as not sellable.
+
+        :return: Whether the line is sellable or not.
+        :rtype: bool
+        """
+        return super()._is_sellable() and (
+            not self.is_reward_line or self.reward_id.reward_type == 'product'
+        )


### PR DESCRIPTION
*: sale, delivery, sale_loyalty, website_sale_loyalty

In [^1], the eCommerce cart page was refactored to enhance its responsiveness and design. During development, a method closely tied to the `website_sale` module was mistakenly placed in the `sale` module. This method relies on the `is_published` field, which is only available in `website_sale`.

This commit corrects the placement by moving the method to its appropriate module, `website_sale`.

[^1]: https://github.com/odoo/odoo/pull/190720