### PR TITLE
[FIX] website_sale: avoid rendering conditions on header el

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -531,9 +531,9 @@
             <t t-set="opt_wsale_show_shop_title" t-value="is_view_active('website_sale.products_shop_title')"/>
             <t t-set="opt_wsale_shop_title_align" t-value="is_view_active('website_sale.products_shop_title_align')"/>
 
-            <t t-set="opt_wsale_show_category_title" t-value="category and category.show_category_title"/>
-            <t t-set="opt_wsale_show_category_description" t-value="category and category.show_category_description"/>
-            <t t-set="opt_wsale_category_align" t-value="category and category.align_category_content"/>
+            <t t-set="opt_wsale_show_category_title" t-value="bool(category) and category.show_category_title"/>
+            <t t-set="opt_wsale_show_category_description" t-value="bool(category) and category.show_category_description"/>
+            <t t-set="opt_wsale_category_align" t-value="bool(category) and category.align_category_content"/>
 
             <t t-set="website_sale_pricelists" t-value="website.get_pricelist_available(show_visible=True)" />
             <t t-set="website_sale_sortable" t-value="website._get_product_sort_mapping()"/>


### PR DESCRIPTION
In odoo/odoo@f207c7644400228a2ee10dcb3f2731250fcbea08 we introduced conditions on the `o_wsale_products_header` to tweak its styling. However some of the conditions were returning the value of `category` instead of a False boolean.

This commit replaces it with `bool(category)` to ensure the condition is False and not rendered in the DOM.

task-5059179

What was rendered before this fix:
<img width="365" height="157" alt="image" src="https://github.com/user-attachments/assets/ae60629b-7b3d-46bd-bfb4-d935419402a9" />


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
