### PR TITLE
[IMP] account: remove `__get_bank_statements_available_sources`

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -55,11 +55,8 @@ class AccountJournal(models.Model):
     def _default_outbound_payment_methods(self):
         return self.env.ref('account.account_payment_method_manual_out')
 
-    def __get_bank_statements_available_sources(self):
-        return [('undefined', _('Undefined Yet'))]
-
     def _get_bank_statements_available_sources(self):
-        return self.__get_bank_statements_available_sources()
+        return [('undefined', _('Undefined Yet'))]
 
     def _default_invoice_reference_model(self):
         """Get the invoice reference model according to the company's country."""


### PR DESCRIPTION
The function `__get_bank_statements_available_sources` is pointless and can just be replaced with `_get_bank_statements_available_sources` (single underscore version).

See related community PR.

task-None
