### PR TITLE
[FIX] base_import: import action not opening

### DIFF
--- a/addons/base_import/static/src/import_action/import_action.js
+++ b/addons/base_import/static/src/import_action/import_action.js
@@ -93,11 +93,11 @@ export class ImportAction extends Component {
             if (!this.action) {
                 return this.env.config.historyBack();
             }
-            if (this.action.type !== "ir.actions.act_window") {
+            if (this.action.type !== "ir.actions.client") {
                 return this.actionService.restore(this.actionService.currentController.jsId);
             }
 
-            this.resModel = this.action.res_model;
+            this.resModel = this.props.action.params.model;
             this.model.setResModel(this.resModel);
             return this.model.init();
         });


### PR DESCRIPTION
After 033d6af a bug was introduced where trying to open an import guide didn't work.

To reproduce:
1- Go to accounting settings.
2- Click on "Import (for full history)".
3- Nothing happens.

This commit fixes two things:
- The check for the action type was incorrect leading to an early return.
- The res_model was not computed correctly.

No task-id.