### PR TITLE
[FIX] web_editor, mass_mailing: fix separator visiblity in s_showcase

### DIFF
--- a/addons/mass_mailing/static/src/scss/mass_mailing_mail.scss
+++ b/addons/mass_mailing/static/src/scss/mass_mailing_mail.scss
@@ -62,4 +62,7 @@
     .o_desktop_h100 {
         height: unset !important;
     }
+    .s_showcase div:not(:has(*)) {
+        display: none;
+    }
 }

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -45,6 +45,7 @@ const GROUPED_STYLES = {
     border: [
         "border-top-width", "border-right-width", "border-bottom-width", "border-left-width",
         "border-top-style", "border-right-style", "border-bottom-style", "border-left-style",
+        "border-top-color", "border-right-color", "border-bottom-color", "border-left-color",
     ],
     padding: ["padding-top", "padding-bottom", "padding-left", "padding-right"],
     margin: ["margin-top", "margin-bottom", "margin-left", "margin-right"],
@@ -730,6 +731,12 @@ export async function toInline($editable, options) {
     // Fix card-img-top heights (must happen before we transform everything).
     for (const imgTop of editable.querySelectorAll('.card-img-top')) {
         imgTop.style.setProperty('height', _getHeight(imgTop) + 'px');
+    }
+    // Fix empty element heights to be always visible as they might have borders
+    // (used as separation) and can be rendered with height 0px.
+    // like having empty div with % height and display inline-block.
+    for (const el of editable.querySelectorAll(".o_not_editable[class*='border-']:empty")) {
+        el.style.height = getComputedStyle(el).height;
     }
 
     attachmentThumbnailToLinkImg($editable);

--- a/addons/web_editor/static/tests/convert_inline_tests.js
+++ b/addons/web_editor/static/tests/convert_inline_tests.js
@@ -636,9 +636,9 @@ QUnit.module('convert_inline', {}, function () {
         // Some positional properties (eg., padding-right, margin-left) are not
         // concatenated (eg., as padding, margin) because they were defined with
         // variables (var) or calculated (calc).
-        const containerStyle = `border-radius: 0px; border-style: none; margin: 0px auto; box-sizing: border-box; border-width: 0px; max-width: 1320px; padding-left: 16px; padding-right: 16px; width: 100%;`;
-        const rowStyle = `border-radius: 0px; border-style: none; padding: 0px; box-sizing: border-box; border-width: 0px; margin-left: -16px; margin-right: -16px; margin-top: 0px;`;
-        const colStyle = `border-radius: 0px; border-style: none; box-sizing: border-box; border-width: 0px; margin-top: 0px; padding-left: 16px; padding-right: 16px; max-width: 100%; width: 100%;`;
+        const containerStyle = `border-radius: 0px; border-style: none; margin: 0px auto; box-sizing: border-box; border-color: rgb(55, 65, 81); border-width: 0px; max-width: 1320px; padding-left: 16px; padding-right: 16px; width: 100%;`;
+        const rowStyle = `border-radius: 0px; border-style: none; padding: 0px; box-sizing: border-box; border-color: rgb(55, 65, 81); border-width: 0px; margin-left: -16px; margin-right: -16px; margin-top: 0px;`;
+        const colStyle = `border-radius: 0px; border-style: none; box-sizing: border-box; border-color: rgb(55, 65, 81); border-width: 0px; margin-top: 0px; padding-left: 16px; padding-right: 16px; max-width: 100%; width: 100%;`;
         assert.strictEqual($editable.html(),
             `<div class="container" style="${containerStyle}" width="100%">` +
             `<div class="row" style="${rowStyle}">` +
@@ -1002,7 +1002,7 @@ QUnit.module('convert_inline', {}, function () {
         $iframeEditable.append(`<div class="o_layout" style="padding: 50px;"></div>`);
         convertInline.classToStyle($iframeEditable, convertInline.getCSSRules($iframeEditable[0].ownerDocument));
         assert.strictEqual($iframeEditable.html(),
-            `<div class="o_layout" style="border-radius:0px;border-style:none;margin:0px;box-sizing:border-box;border-left-width:0px;border-bottom-width:0px;border-right-width:0px;border-top-width:0px;font-size:50px;color:white;background-color:red;padding: 50px;"></div>`,
+            `<div class="o_layout" style="border-radius:0px;border-style:none;margin:0px;box-sizing:border-box;border-left-color:rgb(255, 255, 255);border-bottom-color:rgb(255, 255, 255);border-right-color:rgb(255, 255, 255);border-top-color:rgb(255, 255, 255);border-left-width:0px;border-bottom-width:0px;border-right-width:0px;border-top-width:0px;font-size:50px;color:white;background-color:red;padding: 50px;"></div>`,
             "should have given all styles of body to .o_layout");
         styleSheet.deleteRule(0);
 


### PR DESCRIPTION
Problem:
When adding the `s_showcase` template in email marketing and saving, the separator is not properly rendered in the received email.

Cause:
The separator is implemented as an empty `<div>` with `display: inline-block` and `height: 100%`. In emails, this can collapse to 0px, making the separator invisible. Additionally, `border-<position>-color` was not applied correctly in some cases.

Solution:
- Lock the computed height of empty separator elements so they remain visible.
- Restrict visibility of separators to desktop screen sizes where columns are stacked horizontally.
- Fix rendering of `border-<position>-color`.

Steps to reproduce:
1. Open a new email marketing.
2. Add the `s_showcase` template.
3. Test-send the email.
4. Observe that the separator is not visible.

opw-5077992

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
