### PR TITLE
[IMP] *: new manifest field `iap_paid_service`

### DIFF
--- a/addons/crm_iap_enrich/__manifest__.py
+++ b/addons/crm_iap_enrich/__manifest__.py
@@ -19,6 +19,7 @@
     ],
     'post_init_hook': '_synchronize_cron',
     'auto_install': True,
+    'iap_paid_service': True,
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
 }

--- a/addons/crm_iap_mine/__manifest__.py
+++ b/addons/crm_iap_mine/__manifest__.py
@@ -24,6 +24,7 @@
         'views/crm_menus.xml',
     ],
     'auto_install': True,
+    'iap_paid_service': True,
     'assets': {
         'web.assets_backend': [
             'crm_iap_mine/static/src/js/**/*',

--- a/addons/iap/__manifest__.py
+++ b/addons/iap/__manifest__.py
@@ -21,6 +21,7 @@ to support In-App purchases inside Odoo. """,
         'views/res_config_settings.xml',
     ],
     'auto_install': True,
+    'iap_paid_service': True,
     'assets': {
         'web.assets_backend': [
             'iap/static/src/**/*.js',

--- a/addons/l10n_in/__manifest__.py
+++ b/addons/l10n_in/__manifest__.py
@@ -66,6 +66,7 @@ Sheet, now only Vertical format has been permitted Which is Supported By Odoo.
     'post_init_hook': 'post_init',
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
+    'iap_paid_service': True,
     'assets': {
         'web.assets_backend': [
             'l10n_in/static/src/components/**/*',

--- a/addons/l10n_in_ewaybill/__manifest__.py
+++ b/addons/l10n_in_ewaybill/__manifest__.py
@@ -32,6 +32,7 @@ Step 4: Repeat steps 1,2,3 for all GSTIN you have in odoo. If you have a multi-c
         'report/ewaybill_report.xml',
     ],
     'installable': True,
+    'iap_paid_service': True,
     # not auto_install because the company can be related to the service industry
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',

--- a/addons/mail_plugin/__manifest__.py
+++ b/addons/mail_plugin/__manifest__.py
@@ -19,6 +19,7 @@
         'security/ir.model.access.csv',
     ],
     'installable': True,
+    'iap_paid_service': True,
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
 }

--- a/addons/mass_mailing_sms/__manifest__.py
+++ b/addons/mass_mailing_sms/__manifest__.py
@@ -42,6 +42,7 @@
         ],
     },
     'application': True,
+    'iap_paid_service': True,
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
 }

--- a/addons/partner_autocomplete/__manifest__.py
+++ b/addons/partner_autocomplete/__manifest__.py
@@ -19,6 +19,7 @@ Auto-complete partner companies' data
         'data/iap_service_data.xml',
     ],
     'auto_install': True,
+    'iap_paid_service': True,
     'assets': {
         'web.assets_backend': [
             'partner_autocomplete/static/src/scss/*',

--- a/addons/sms/__manifest__.py
+++ b/addons/sms/__manifest__.py
@@ -43,6 +43,7 @@ The service is provided by the In App Purchase Odoo platform.
     ],
     'installable': True,
     'auto_install': True,
+    'iap_paid_service': True,
     'assets': {
         'web.assets_backend': [
             'sms/static/src/**/*',

--- a/addons/snailmail/__manifest__.py
+++ b/addons/snailmail/__manifest__.py
@@ -36,4 +36,5 @@ Allows users to send documents by post
     },
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
+    'iap_paid_service': True,
 }

--- a/addons/website_crm_iap_reveal/__manifest__.py
+++ b/addons/website_crm_iap_reveal/__manifest__.py
@@ -24,4 +24,5 @@
     ],
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
+    'iap_paid_service': True,
 }

--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -313,16 +313,12 @@ class IrModuleModule(models.Model):
     icon_image = fields.Binary(string='Icon', compute='_get_icon_image')
     icon_flag = fields.Char(string='Flag', compute='_get_icon_image')
     to_buy = fields.Boolean('Odoo Enterprise Module', default=False)
-    has_iap = fields.Boolean(compute='_compute_has_iap')
+    iap_paid_service = fields.Boolean("Contains In-App Purchases")
 
     _name_uniq = models.Constraint(
         'UNIQUE (name)',
         "The name of the module must be unique!",
     )
-
-    def _compute_has_iap(self):
-        for module in self:
-            module.has_iap = bool(module.id) and 'iap' in module.upstream_dependencies(exclude_states=('',)).mapped('name')
 
     @api.ondelete(at_uninstall=False)
     def _unlink_except_installed(self):
@@ -747,7 +743,8 @@ class IrModuleModule(models.Model):
             'icon': terp.get('icon', False),
             'summary': terp.get('summary', ''),
             'url': terp.get('url') or terp.get('live_test_url', ''),
-            'to_buy': False
+            'to_buy': False,
+            'iap_paid_service': terp.get('iap_paid_service', False),
         }
 
     @api.model_create_multi

--- a/odoo/addons/base/tests/test_module.py
+++ b/odoo/addons/base/tests/test_module.py
@@ -51,6 +51,7 @@ class TestModuleManifest(BaseCase):
             'depends': ['base'],
             'description': '',
             'external_dependencies': {},
+            'iap_paid_service': False,
             'icon': '/base/static/description/icon.png',
             'init_xml': [],
             'installable': True,

--- a/odoo/addons/base/views/ir_module_views.xml
+++ b/odoo/addons/base/views/ir_module_views.xml
@@ -72,7 +72,7 @@
                             <button invisible="state != 'to upgrade'" class="btn btn-secondary me-1" groups="base.group_system" disabled="1">Upgrading</button>
                             <button invisible="state != 'to install'" class="btn btn-secondary me-1" groups="base.group_system" disabled="1">Installing</button>
                         </div>
-                        <h6 class="text-muted mt-2" invisible="not has_iap">Contains In-App Purchases</h6>
+                        <h6 class="text-muted mt-2" invisible="not iap_paid_service">Contains In-App Purchases</h6>
                     </div>
                     <div class="clearfix"/>
                     <notebook groups="base.group_no_one">

--- a/odoo/modules/module.py
+++ b/odoo/modules/module.py
@@ -74,6 +74,7 @@ _DEFAULT_MANIFEST = {
     'depends': [],
     'description': '',  # defaults to README file
     'external_dependencies': {},
+    'iap_paid_service': False,
     'init_xml': [],
     'installable': True,
     'images': [],  # website


### PR DESCRIPTION
Currently, we have a `has_iap` field on the `IrModuleModule` model which is used to display whether the module contains In-App Purchases, i.e. a paid service provided through IAP.

However, this field is computed based on whether the module has an (indirect) dependency to the `iap` module. This is a bit too simplistic as relying on the `iap` module does not mean that the service is paid and consumes IAP credits. For instance, we have many EDIs modules now that rely on IAP, but that are totally free (e.g.: Malaysia POS, Spain POS, Switzerland Payroll, ...)

To tackle this, we introduce a new field in the manifest: `iap_paid_service`. If set to True, we explicitely mark the module as a module that uses IAP credits, and therefore contains In-App Purchases.

task-5048119

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
