### PR TITLE
[IMP] web: Sort many2one properties by comodel order

### DIFF
--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -830,6 +830,7 @@ export class Record extends DataPoint {
                     },
                     propertyName: property.name,
                     relation: property.comodel,
+                    sortable: !["many2one", "many2many", "tags"].includes(property.type),
                 };
             }
             if (hasCurrentValues || !this.activeFields[propertyFieldName]) {

--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -830,7 +830,7 @@ export class Record extends DataPoint {
                     },
                     propertyName: property.name,
                     relation: property.comodel,
-                    sortable: !["many2one", "many2many", "tags"].includes(property.type),
+                    sortable: !["many2many", "tags"].includes(property.type),
                 };
             }
             if (hasCurrentValues || !this.activeFields[propertyFieldName]) {

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -414,7 +414,6 @@ export class ListRenderer extends Component {
                     type: "field",
                     hasLabel: true,
                     label: propertyField.string,
-                    sortable: false,
                     attrs: ["integer", "float"].includes(propertyField.type)
                         ? { sum: propertyField.string }
                         : {},

--- a/odoo/addons/test_orm/models/test_orm.py
+++ b/odoo/addons/test_orm/models/test_orm.py
@@ -258,6 +258,7 @@ class TestOrmPartner(models.Model):
     """
     _name = 'test_orm.partner'
     _description = 'Discussion Partner'
+    _order = 'name, id'
 
     name = fields.Char(string='Name')
 


### PR DESCRIPTION
#### [FIX] core: Ensure proper flushing of property definitions

The get_property_definition() method was not flushing the properties definition field. This oversight made it necessary to explicitly call flush_all() in every properties test.

By ensuring that get_property_definition() now correctly flushes the definition, the method becomes more robust, and many tests can be simplified.

#### [IMP] core: Sort many2one properties by comodel order

The sorting of many2one properties currently only sorts by ID, which is inconsistent with standard many2one fields and provides no value to the user.

This commit ensures that many2one properties are sorted by their comodel's order instead. It also registers these properties as sortable in the web client and fixes the groupby order when grouping by a many2one property field.
