### PR TITLE
[FIX] website: make svgs be able to receive var colors

### DIFF
--- a/addons/website/static/src/builder/plugins/dynamic_svg_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/dynamic_svg_option_plugin.js
@@ -6,6 +6,7 @@ import { loadImage } from "@html_editor/utils/image_processing";
 import { withSequence } from "@html_editor/utils/resource";
 import { DYNAMIC_SVG } from "@html_builder/utils/option_sequence";
 import { BuilderAction } from "@html_builder/core/builder_action";
+import { getCSSVariableValue, getHtmlStyle } from "@html_editor/utils/formatting";
 
 class DynamicSvgOptionPlugin extends Plugin {
     static id = "DynamicSvgOption";
@@ -30,6 +31,10 @@ export class SvgColorAction extends BuilderAction {
         return searchParams.get(colorName);
     }
     async load({ editingElement: imgEl, params: { mainParam: colorName }, value: color }) {
+        const match = color.match(/^var\(--(.+)\)$/);
+        if (match) {
+            color = getCSSVariableValue(match[1], getHtmlStyle(this.document));
+        }
         const newURL = new URL(imgEl.src, window.location.origin);
         newURL.searchParams.set(colorName, normalizeCSSColor(color));
         const src = newURL.pathname + newURL.search;

--- a/addons/website/static/tests/builder/options/dynamic_svg_option.test.js
+++ b/addons/website/static/tests/builder/options/dynamic_svg_option.test.js
@@ -1,0 +1,40 @@
+import { expect, test } from "@odoo/hoot";
+import { animationFrame, queryOne } from "@odoo/hoot-dom";
+import { contains } from "@web/../tests/web_test_helpers";
+import { defineWebsiteModels, setupWebsiteBuilder } from "../website_helpers";
+import { getCSSVariableValue, getHtmlStyle } from "@html_editor/utils/formatting";
+
+defineWebsiteModels();
+
+test("can change the dynamic color", async () => {
+    await setupWebsiteBuilder(
+        "<img src='/html_editor/shape/test.svg?c1=rgba(0,0,0,.25)&c2=rgba(0,0,0,.5)' class='testSvg'/>"
+    );
+    await contains(":iframe img.testSvg").click();
+    await contains(
+        ".hb-row[data-label='Dynamic Colors'] button.o_we_color_preview:first-child"
+    ).click();
+    await contains(".o_popover .o_color_button[data-color='#FF0000']").click();
+    await animationFrame();
+    const searchParams = new URL(queryOne(":iframe img.testSvg").src, window.location.origin)
+        .searchParams;
+    expect(searchParams.get("c1")).toBe("#FF0000");
+    expect(searchParams.get("c2")).toBe("rgba(0,0,0,.5)");
+});
+
+test("can change the dynamic color to a var color", async () => {
+    await setupWebsiteBuilder(
+        `<img src='/html_editor/shape/test.svg?c1=rgba(0,0,0,.25)&c2=rgba(0,0,0,.5)' class='testSvg'/>`,
+        { loadIframeBundles: true }
+    );
+    const color = getCSSVariableValue("o-color-1", getHtmlStyle(document));
+    await contains(":iframe img.testSvg").click();
+    await contains(
+        ".hb-row[data-label='Dynamic Colors'] button.o_we_color_preview:nth-child(2)"
+    ).click();
+    await contains(".o_popover .o_color_button[data-color='o-color-1']").click();
+    await animationFrame();
+    const searchParams = new URL(queryOne(":iframe img.testSvg").src, window.location.origin)
+        .searchParams;
+    expect(searchParams.get("c2")).toBe(color);
+});


### PR DESCRIPTION
Following the [refactor] of the html_builder we had an issue whenever we tried to apply a dynamic color.
To reproduce the problem:
- Open website and start editing
- Drop a s_attributes_horizontal snippet
- Click on any of its images
- Click on the "Dynamic Colors" option
- Apply a theme color (in the first line)

-> Image dissapears because instead of the actual color it applies a variable i.e. o-color-1

[refactor]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2