### PR TITLE
[FIX] website: highlight not misplaced above RTL content

### DIFF
--- a/addons/website/static/src/interactions/text_highlights.js
+++ b/addons/website/static/src/interactions/text_highlights.js
@@ -2,6 +2,7 @@ import { Interaction } from "@web/public/interaction";
 import { registry } from "@web/core/registry";
 import {
     getCurrentTextHighlight,
+    adaptHighlightPosition,
     makeHighlightSvgs,
     closestToObserve,
     getObservedEls,
@@ -54,13 +55,14 @@ export class TextHighlight extends Interaction {
         for (const closestToObserve of closestToObserves) {
             for (const el of closestToObserve.querySelectorAll(".o_text_highlight")) {
                 const highlightID = getCurrentTextHighlight(el);
-                const svgs = makeHighlightSvgs(el, highlightID);
                 const currentSVGs = el.querySelectorAll(".o_text_highlight_svg");
                 for (const svg of currentSVGs) {
                     svg.remove();
                 }
+                const svgs = makeHighlightSvgs(el, highlightID);
                 for (const svg of svgs) {
                     this.insert(svg, el);
+                    adaptHighlightPosition(el, svg);
                 }
             }
         }

--- a/addons/website/static/tests/interactions/text_highlight.test.js
+++ b/addons/website/static/tests/interactions/text_highlight.test.js
@@ -46,3 +46,45 @@ test("[resize] update the number of highlight items when necessary", async () =>
 
     expect(numberOfItems1).toBeLessThan(numberOfItems2);
 });
+
+test("[rtl] SVG positionned inside highlighted text", async () => {
+    const relativePosition = (element, relativeElement) => {
+        const e = element.getBoundingClientRect();
+        const r = relativeElement.getBoundingClientRect();
+        const position = [];
+        if (Math.round(e.left) < Math.round(r.left)) {
+            position.push("beforeLeft");
+        }
+        if (Math.round(e.top) < Math.round(r.top)) {
+            position.push("beforeTop");
+        }
+        if (Math.round(e.right) > Math.round(r.right)) {
+            position.push("afterRight");
+        }
+        if (Math.round(e.bottom) > Math.round(r.bottom)) {
+            position.push("afterBottom");
+        }
+        return position.join() || "inside";
+    }
+    await startInteractions(`
+      <p style="direction: rtl">
+        اَلْعَرَﺐِﻳَّ<span class="o_text_highlight o_text_highlight_circle_1" style="--text-highlight-width: 2px;">ةُ<br>اَ</span>لْعَرَبِيَّةُ
+        <br>
+        hello worl<span class="o_text_highlight o_text_highlight_circle_1" style="--text-highlight-width: 2px;">d<br>h</span>ello world
+      </p>
+    `);
+    // Ensure the update is finished
+    await animationFrame();
+    expect(".o_text_highlight svg").toHaveCount(4);
+    const containers = queryAll(".o_text_highlight");
+    const items = queryAll(".o_text_highlight svg");
+    // all SVG are positionned inside the container
+    expect(relativePosition(items[0], containers[0])).toBe("inside");
+    expect(relativePosition(items[1], containers[0])).toBe("inside");
+    expect(relativePosition(items[2], containers[1])).toBe("inside");
+    expect(relativePosition(items[3], containers[1])).toBe("inside");
+    // in RTL with RTL content, hightlight of previous line is top left
+    expect(relativePosition(items[1], items[0])).toBe("afterRight,afterBottom");
+    // in RTL with LTR content, highlight of previous line is top right
+    expect(relativePosition(items[3], items[2])).toBe("beforeLeft,afterBottom");
+});


### PR DESCRIPTION
Scenario:

- add a RTL language to website (eg. arabic)
- go to the website and add a highlight to part of a line
- switch to RTL language

Result: the highlight is not at the correct X position.

This commit fixes the issue for most browser by changing in RTL that:

- the SVG is positionned from the right so the SVG right matches
  the boundary rect right

- mirroring the SVG so when the 1x1 pixel is scaled, it is scaled toward
  the left and it matches the left boundary rect

This is not always working (mostly for safari) because the positionning
of position:absolute SVG inside highlighted position:relative SPAN is
behavior differently in RTL (an even behave differently in case of mixed
RTL / LTR strings in dir:rtl blocks).

This is reproduced in this code:
https://gist.github.com/nle-odoo/21fea59d338b55b3e2a337cf360ef878

So to fix that issue, after inserting a SVG element in RTL in DOM, we
correct the X position by the current error from what we intended.

opw-5049432
opw-5344412
opw-5867908

## PR NOTE:

### 1) For the part:

```diff
-    const firstRect = highlightEl.getClientRects()[0];
+    const rtl = window.getComputedStyle(highlightEl).direction === "rtl";
+    let firstRect;
+    if (rtl) { // Take the first top right element instead of top left
+        firstRect = [...highlightEl.getClientRects()].sort((a, b) => a.top - b.top || (b.left + b.width) - (a.left + a.width))[0];
+    } else {
+        firstRect = highlightEl.getClientRects()[0];
+    }
+
  ...
-        const spanOffsetX = firstRect.x - containerRect.x;
         const spanOffsetY = firstRect.y - containerRect.y;
-        svg.style.left = `${(rects.x - containerRect.x - spanOffsetX) * scale}px`;
         svg.style.top = `${(rects.y - containerRect.y - spanOffsetY) * scale}px`;
         svg.style.bottom = `0px`;
-        svg.style.right = `0px`;
+        if (rtl) { // Position from the right instead of left and mirror the SVG
+            const spanOffsetX = containerRect.x + containerRect.width - firstRect.x - firstRect.width;
+            svg.style.left = `0px`;
+            svg.style.right = `${(containerRect.x + containerRect.width - rects.x - rects.width - spanOffsetX) * scale}px`;
+            svg.style.transform = 'scale(-1, 1)';
+        } else {
+            const spanOffsetX = firstRect.x - containerRect.x;
+            svg.style.left = `${(rects.x - containerRect.x - spanOffsetX) * scale}px`;
+            svg.style.right = `0px`;
+        }
```

I don't understand why the other SVG are positioned relative to the first one(but the original code did that and making it but with the logic of RTL instead of LTR seems to be the only way to make it work).

Note that in saas-18.3 the logic seemed to be a lot more simple, but there was a "display: inline-block;" on the highlight item which simplified the logic a lot (you can just have 100% width to match the item highlighted), but would make (LTR in RTL content, or RTL in LTR content) "`<highlight>hello</highlight> world`" appear in RTL as "`world <highlight>hello</highlight>`".