### PR TITLE
[FIX] payment_mercado_pago: show access token 

### DIFF
--- a/addons/payment_mercado_pago/controllers/onboarding.py
+++ b/addons/payment_mercado_pago/controllers/onboarding.py
@@ -50,7 +50,10 @@ class MercadoPagoOnboardingController(Controller):
 
         # Fetch an access token using the authorization token.
         proxy_payload = self.env['payment.provider']._prepare_json_rpc_payload(
-            {'authorization_code': authorization_code}
+            {
+                'authorization_code': authorization_code,
+                'account_country_code': provider_sudo.mercado_pago_account_country_id.code.lower(),
+            }
         )
         try:
             response_content = provider_sudo._send_api_request(

--- a/addons/payment_mercado_pago/models/payment_provider.py
+++ b/addons/payment_mercado_pago/models/payment_provider.py
@@ -151,6 +151,7 @@ class PaymentProvider(models.Model):
         return_url = urljoin(self.get_base_url(), const.OAUTH_RETURN_ROUTE)
         proxy_url_params = {
             'return_url': f'{return_url}?{urlencode(return_url_params)}',
+            'account_country_code': self.mercado_pago_account_country_id.code.lower(),
         }
         proxy_url = self._build_request_url('/authorize', is_proxy_request=True)
         return {
@@ -274,7 +275,10 @@ class PaymentProvider(models.Model):
             return self.mercado_pago_access_token
         else:
             proxy_payload = self._prepare_json_rpc_payload(
-                {'refresh_token': self.mercado_pago_refresh_token}
+                {
+                    'refresh_token': self.mercado_pago_refresh_token,
+                    'account_country_code': self.mercado_pago_account_country_id.code.lower(),
+                }
             )
             response_content = self._send_api_request(
                 'POST',

--- a/addons/payment_mercado_pago/models/payment_provider.py
+++ b/addons/payment_mercado_pago/models/payment_provider.py
@@ -34,6 +34,8 @@ class PaymentProvider(models.Model):
         domain=[('code', 'in', list(const.SUPPORTED_COUNTRIES))],
         required_if_provider='mercado_pago',
     )
+    # TODO anko remove in 19.1
+    mercado_pago_is_oauth_supported = fields.Boolean(compute='_compute_mercado_pago_is_oauth_supported')
 
     # OAuth fields
     mercado_pago_access_token = fields.Char(
@@ -67,6 +69,10 @@ class PaymentProvider(models.Model):
                 active_test=False,
             ).search([('name', '=', currency_code)], limit=1)
             provider.available_currency_ids = [Command.set(currency.ids)]
+
+    def _compute_mercado_pago_is_oauth_supported(self):
+        """Return current state of OAuth support by Odoo. To be removed in future versions."""
+        self.mercado_pago_is_oauth_supported = False
 
     # === CONSTRAINT METHODS === #
 

--- a/addons/payment_mercado_pago/views/payment_provider_views.xml
+++ b/addons/payment_mercado_pago/views/payment_provider_views.xml
@@ -12,17 +12,21 @@
                         string="Account Country"
                         name="mercado_pago_account_country_id"
                         required="code == 'mercado_pago' and state != 'disabled'"
-                        readonly="mercado_pago_access_token"
+                        readonly="mercado_pago_access_token and mercado_pago_is_oauth_supported"
                         options="{'no_create': True}"
                     />
                     <label
-                        for="mercado_pago_access_token" invisible="not mercado_pago_access_token"
+                        for="mercado_pago_access_token"
+                        invisible="not mercado_pago_access_token and mercado_pago_is_oauth_supported"
                     />
-                    <div class="o_row" invisible="not mercado_pago_access_token">
+                    <div
+                        class="o_row"
+                        invisible="not mercado_pago_access_token and mercado_pago_is_oauth_supported"
+                    >
                         <field
                             string="Access Token"
                             name="mercado_pago_access_token"
-                            readonly="True"
+                            readonly="mercado_pago_is_oauth_supported"
                             password="True"
                         />
                         <button
@@ -30,6 +34,7 @@
                             type="object"
                             name="action_reset_credentials"
                             confirm="Are you sure you want to disconnect?"
+                            invisible="not mercado_pago_is_oauth_supported"
                             class="btn-secondary ms-2"
                         />
                     </div>
@@ -37,7 +42,7 @@
             </group>
             <group name="provider_credentials" position="after">
                 <div
-                    invisible="code != 'mercado_pago' or (mercado_pago_access_token and mercado_pago_public_key)"
+                    invisible="code != 'mercado_pago' or (mercado_pago_access_token and mercado_pago_public_key) or not mercado_pago_is_oauth_supported"
                 >
                     <div
                         class="alert alert-warning mt-2"


### PR DESCRIPTION
Enable old account configuration for new users. Country code is passed to Mercado Pago proxy so correct account can be
retrieved.

OAuth was not configured yet on Odoo side, which means that new users
couldn't connect their account. Access token is now visible and editable
for all users.