### PR TITLE
[FIX] account: make get_account_kpi_summary include moves to check

### DIFF
--- a/addons/account/models/kpi_provider.py
+++ b/addons/account/models/kpi_provider.py
@@ -6,21 +6,31 @@ class KpiProvider(models.AbstractModel):
 
     @api.model
     def get_account_kpi_summary(self):
-        AccountMove = self.env['account.move']
-        grouped_draft_moves = AccountMove._read_group([('state', '=', 'draft')], ['move_type'], ['move_type'])
+        grouped_moves_to_report = self.env['account.move']._read_group([
+            '|', ('state', '=', 'draft'),
+            '&', ('state', '=', 'posted'), ('to_check', '=', True),
+        ], ['journal_id'], ['journal_id'])
 
         FieldsSelection = self.env['ir.model.fields.selection'].with_context(lang=self.env.user.lang)
-        move_type_names = {x.value: x.name for x in FieldsSelection.search([
-            ('field_id.model', '=', 'account.move'),
-            ('field_id.name', '=', 'move_type'),
+        journal_type_names = {x.value: x.name for x in FieldsSelection.search([
+            ('field_id.model', '=', 'account.journal'),
+            ('field_id.name', '=', 'type'),
         ])}
 
+        journals = self.env['account.journal'].browse(x['journal_id'][0] for x in grouped_moves_to_report)
+        journal_type_by_journal_id = dict(journals.mapped(lambda j: (j.id, j.type)))
+        count_by_type = {}
+        for group in grouped_moves_to_report:
+            journal_id = group['journal_id'][0]
+            journal_type = journal_type_by_journal_id[journal_id]
+            count_by_type[journal_type] = count_by_type.get(journal_type, 0) + group['journal_id_count']
+
         return [{
-            'id': f'account_move_type.{group["move_type"]}',
-            'name': move_type_names[group['move_type']],
+            'id': f'account_journal_type.{journal_type}',
+            'name': journal_type_names[journal_type],
             'type': 'integer',
-            'value': group['move_type_count'],
-        } for group in grouped_draft_moves]
+            'value': count,
+        } for journal_type, count in count_by_type.items()]
 
     @api.model
     def get_kpi_summary(self):

--- a/addons/account/tests/test_kpi_provider.py
+++ b/addons/account/tests/test_kpi_provider.py
@@ -1,5 +1,5 @@
 from odoo import Command
-from odoo.tests import TransactionCase, tagged
+from odoo.tests import tagged, TransactionCase
 
 
 @tagged('post_install', '-at_install')
@@ -8,9 +8,9 @@ class TestKpiProvider(TransactionCase):
     def test_kpi_summary(self):
         """
         - Ensure that nothing is reported when there is nothing to report
-        - All <account.move> in draft should be reported
+        - All <account.move> in draft or to_check should be reported
         - Posting one <account.move> should reduce the number reported
-        - Posting all <account.move> of a move_type should remove that move_type from the reporting
+        - Posting all <account.move> of a journal_type should remove that journal_type from the reporting
         """
         # Clean things for the test
         self.env['account.move'].search([('state', '=', 'draft')]).unlink()
@@ -21,6 +21,7 @@ class TestKpiProvider(TransactionCase):
         base_move = {
             'company_id': company_id,
             'line_ids': [Command.create({'account_id': account_id.id, 'quantity': 15, 'price_unit': 10})],
+            'partner_id': self.env.user.partner_id.id,
         }
         all_moves = self.env['account.move'].create(
             [{**base_move, 'move_type': 'entry'}] * 2 +
@@ -32,32 +33,33 @@ class TestKpiProvider(TransactionCase):
             [{**base_move, 'move_type': 'in_receipt'}] * 8
         )
         self.assertCountEqual(self.env['kpi.provider'].get_account_kpi_summary(), [
-            {'id': 'account_move_type.entry', 'name': 'Journal Entry', 'type': 'integer', 'value': 2},
-            {'id': 'account_move_type.out_invoice', 'name': 'Customer Invoice', 'type': 'integer', 'value': 3},
-            {'id': 'account_move_type.out_refund', 'name': 'Customer Credit Note', 'type': 'integer', 'value': 4},
-            {'id': 'account_move_type.in_invoice', 'name': 'Vendor Bill', 'type': 'integer', 'value': 5},
-            {'id': 'account_move_type.in_refund', 'name': 'Vendor Credit Note', 'type': 'integer', 'value': 6},
-            {'id': 'account_move_type.out_receipt', 'name': 'Sales Receipt', 'type': 'integer', 'value': 7},
-            {'id': 'account_move_type.in_receipt', 'name': 'Purchase Receipt', 'type': 'integer', 'value': 8},
+            {'id': 'account_journal_type.general', 'name': 'Miscellaneous', 'type': 'integer', 'value': 2},
+            {'id': 'account_journal_type.sale', 'name': 'Sales', 'type': 'integer', 'value': 3 + 4 + 7},
+            {'id': 'account_journal_type.purchase', 'name': 'Purchase', 'type': 'integer', 'value': 5 + 6 + 8},
         ])
 
         all_moves[0].action_post()
         self.assertCountEqual(self.env['kpi.provider'].get_account_kpi_summary(), [
-            {'id': 'account_move_type.entry', 'name': 'Journal Entry', 'type': 'integer', 'value': 1},
-            {'id': 'account_move_type.out_invoice', 'name': 'Customer Invoice', 'type': 'integer', 'value': 3},
-            {'id': 'account_move_type.out_refund', 'name': 'Customer Credit Note', 'type': 'integer', 'value': 4},
-            {'id': 'account_move_type.in_invoice', 'name': 'Vendor Bill', 'type': 'integer', 'value': 5},
-            {'id': 'account_move_type.in_refund', 'name': 'Vendor Credit Note', 'type': 'integer', 'value': 6},
-            {'id': 'account_move_type.out_receipt', 'name': 'Sales Receipt', 'type': 'integer', 'value': 7},
-            {'id': 'account_move_type.in_receipt', 'name': 'Purchase Receipt', 'type': 'integer', 'value': 8},
+            {'id': 'account_journal_type.general', 'name': 'Miscellaneous', 'type': 'integer', 'value': 1},
+            {'id': 'account_journal_type.sale', 'name': 'Sales', 'type': 'integer', 'value': 14},
+            {'id': 'account_journal_type.purchase', 'name': 'Purchase', 'type': 'integer', 'value': 19},
         ])
 
         all_moves[1].action_post()
         self.assertCountEqual(self.env['kpi.provider'].get_account_kpi_summary(), [
-            {'id': 'account_move_type.out_invoice', 'name': 'Customer Invoice', 'type': 'integer', 'value': 3},
-            {'id': 'account_move_type.out_refund', 'name': 'Customer Credit Note', 'type': 'integer', 'value': 4},
-            {'id': 'account_move_type.in_invoice', 'name': 'Vendor Bill', 'type': 'integer', 'value': 5},
-            {'id': 'account_move_type.in_refund', 'name': 'Vendor Credit Note', 'type': 'integer', 'value': 6},
-            {'id': 'account_move_type.out_receipt', 'name': 'Sales Receipt', 'type': 'integer', 'value': 7},
-            {'id': 'account_move_type.in_receipt', 'name': 'Purchase Receipt', 'type': 'integer', 'value': 8},
+            {'id': 'account_journal_type.sale', 'name': 'Sales', 'type': 'integer', 'value': 14},
+            {'id': 'account_journal_type.purchase', 'name': 'Purchase', 'type': 'integer', 'value': 19},
+        ])
+
+        all_moves[2].action_post()
+        all_moves[2].to_check = True
+        self.assertCountEqual(self.env['kpi.provider'].get_account_kpi_summary(), [
+            {'id': 'account_journal_type.sale', 'name': 'Sales', 'type': 'integer', 'value': 14},
+            {'id': 'account_journal_type.purchase', 'name': 'Purchase', 'type': 'integer', 'value': 19},
+        ])
+
+        all_moves[2].button_set_checked()
+        self.assertCountEqual(self.env['kpi.provider'].get_account_kpi_summary(), [
+            {'id': 'account_journal_type.sale', 'name': 'Sales', 'type': 'integer', 'value': 13},
+            {'id': 'account_journal_type.purchase', 'name': 'Purchase', 'type': 'integer', 'value': 19},
         ])


### PR DESCRIPTION
The `kpi.provider:get_account_kpi_summary` method should count draft moves by category, but also include posted moves that still are to be checked by the accountant.

Task-id: 5062431