### PR TITLE
[IMP] *: add Other option to radio/select and focus first invalid field

### DIFF
--- a/addons/html_builder/static/src/utils/utils_css.js
+++ b/addons/html_builder/static/src/utils/utils_css.js
@@ -264,15 +264,6 @@ export function getBgImageURLFromEl(el) {
     return getBgImageURLFromURL(string);
 }
 /**
- * Generates a string ID.
- *
- * @private
- * @returns {string}
- */
-export function generateHTMLId() {
-    return `o${Math.random().toString(36).substring(2, 15)}`;
-}
-/**
  * Returns the class of the element that matches the specified prefix.
  *
  * @private

--- a/addons/web/static/src/core/utils/strings.js
+++ b/addons/web/static/src/core/utils/strings.js
@@ -245,3 +245,12 @@ export function uuid() {
     }
     return id;
 }
+/**
+ * Generates a string ID.
+ *
+ * @param {string} prefix
+ * @returns {string}
+ */
+export function generateHTMLId(prefix = "o") {
+    return `${prefix}${Math.random().toString(36).substring(2, 15)}`;
+}

--- a/addons/website/static/src/builder/plugins/form/form_field_option.js
+++ b/addons/website/static/src/builder/plugins/form/form_field_option.js
@@ -201,6 +201,10 @@ export class FormFieldOption extends BaseOptionComponent {
         const el = this.env.getEditingElement();
         return !isFieldCustom(el) && this.state.fields[getFieldName(el)].type === "many2many";
     }
+    get isOtherOptionSupported() {
+        const el = this.env.getEditingElement();
+        return isFieldCustom(el) && ["selection", "many2one"].includes(el.dataset.type);
+    }
     get isMultipleInputs() {
         const el = this.env.getEditingElement();
         return !!getMultipleInputs(el);

--- a/addons/website/static/src/builder/plugins/form/form_option.xml
+++ b/addons/website/static/src/builder/plugins/form/form_option.xml
@@ -166,12 +166,12 @@
     <BuilderRow label.translate="Description">
         <BuilderCheckbox action="'toggleDescription'" preview="false"/>
     </BuilderRow>
-    <BuilderRow label.translate="Placeholder">
+    <BuilderRow label.translate="Placeholder" t-if="!isOtherOptionSupported">
         <BuilderTextInput attributeAction="'placeholder'"
             applyTo="`input[type='text'], input[type='email'], input[type='number'], input[type='tel'], input[type='url'], textarea`"
         />
     </BuilderRow>
-    <BuilderRow label.translate="Default Value">
+    <BuilderRow label.translate="Default Value" t-if="!isOtherOptionSupported">
         <BuilderTextInput action="'selectTextareaValue'" applyTo="'textarea'"/>
         <BuilderCheckbox attributeAction="'checked'" attributeActionValue="'checked'"
             applyTo="`.col-sm > * > input[type='checkbox']`" preview="false"
@@ -229,6 +229,15 @@
                 forbidLastItemRemoval="true"
                 records="state.valueList.availableRecords" />
         </div>
+    </BuilderRow>
+    <BuilderRow label.translate="Add Other" t-if="isOtherOptionSupported" tooltip.translate="Allow people to add their own option">
+        <BuilderCheckbox id="'otherOption'" dataAttributeAction="'otherOptionAllowed'" dataAttributeActionValue="'true'" preview="false"/>
+    </BuilderRow>
+    <BuilderRow label.translate="Label" t-if="isActiveItem('otherOption')" tooltip.translate="Label for other option" level="1">
+        <BuilderTextInput dataAttributeAction="'otherOptionLabel'" default.translate="Other"/>
+    </BuilderRow>
+    <BuilderRow label.translate="Placeholder" t-if="isActiveItem('otherOption')" level="1">
+        <BuilderTextInput dataAttributeAction="'otherOptionPlaceholder'"/>
     </BuilderRow>
     <BuilderRow label.translate="Requirement"
             t-if="domStateCurrentFieldInput.hasDateTimePicker or domStateCurrentFieldInput.isTextArea or canHaveTextValidationCondition.includes(domStateCurrentFieldInput.type)">

--- a/addons/website/static/src/builder/plugins/form/utils.js
+++ b/addons/website/static/src/builder/plugins/form/utils.js
@@ -1,6 +1,6 @@
 import { _t } from "@web/core/l10n/translation";
 import { renderToElement } from "@web/core/utils/render";
-import { generateHTMLId } from "@html_builder/utils/utils_css";
+import { generateHTMLId } from "@web/core/utils/strings";
 import { isSmallInteger } from "@html_builder/utils/utils";
 
 export const VISIBILITY_DATASET = [
@@ -295,6 +295,16 @@ export function replaceFieldElement(oldFieldEl, fieldEl) {
     [...fieldEl.childNodes].forEach((node) => oldFieldEl.appendChild(node));
     [...fieldEl.attributes].forEach((el) => oldFieldEl.removeAttribute(el.nodeName));
     [...fieldEl.attributes].forEach((el) => oldFieldEl.setAttribute(el.nodeName, el.nodeValue));
+    if (!["selection", "many2one"].includes(oldFieldEl.dataset.type)) {
+        const dataAttributesToRemove = [
+            "otherOptionAllowed",
+            "otherOptionLabel",
+            "otherOptionPlaceholder",
+        ];
+        for (const dataAttribute of dataAttributesToRemove) {
+            delete oldFieldEl.dataset[dataAttribute];
+        }
+    }
     if (hasConditionalVisibility) {
         oldFieldEl.classList.add("s_website_form_field_hidden_if", "d-none");
     }
@@ -514,9 +524,13 @@ export function getListItems(fieldEl) {
     const multipleInputsEl = getMultipleInputs(fieldEl);
     let options = [];
     if (selectEl) {
-        options = [...selectEl.querySelectorAll("option")];
+        options = [...selectEl.querySelectorAll("option:not([value='_other'])")];
     } else if (multipleInputsEl) {
-        options = [...multipleInputsEl.querySelectorAll(".checkbox input, .radio input")];
+        options = [
+            ...multipleInputsEl.querySelectorAll(
+                ".checkbox input, .radio input:not([value='_other'])"
+            ),
+        ];
     }
     return options.map((opt) => {
         const name = selectEl ? opt : opt.nextElementSibling;

--- a/addons/website/static/src/snippets/s_website_form/add_other_option.edit.js
+++ b/addons/website/static/src/snippets/s_website_form/add_other_option.edit.js
@@ -1,0 +1,29 @@
+import { registry } from "@web/core/registry";
+import { AddOtherOption } from "./add_other_option";
+
+const AddOtherOptionEdit = (I) =>
+    class extends I {
+        dynamicContent = {
+            ".o_other_input": {
+                "t-att-class": () => ({ "d-none": false }),
+            },
+        };
+
+        shouldStop() {
+            // Always restart the interaction as some option changes only modify
+            // the DOM and do not trigger an automatic restart. Forcing it here
+            // ensures interaction-managed elements (e.g., the "Other" input)
+            // are correctly re-initialized
+            return true;
+        }
+
+        start() {
+            super.start();
+            this.services.website_edit.callShared("builderOverlay", "refreshOverlays");
+        }
+    };
+
+registry.category("public.interactions.edit").add("website.form.add_other_option", {
+    Interaction: AddOtherOption,
+    mixin: AddOtherOptionEdit,
+});

--- a/addons/website/static/src/snippets/s_website_form/add_other_option.js
+++ b/addons/website/static/src/snippets/s_website_form/add_other_option.js
@@ -1,0 +1,100 @@
+import { registry } from "@web/core/registry";
+import { generateHTMLId } from "@web/core/utils/strings";
+import { _t } from "@web/core/l10n/translation";
+import { Interaction } from "@web/public/interaction";
+
+export class AddOtherOption extends Interaction {
+    static selector = "[data-other-option-allowed]";
+    dynamicContent = {
+        ".form-select, .s_website_form_multiple": {
+            "t-on-change": this.onChangeSelectOrRadio,
+        },
+        ".o_other_input": {
+            "t-att-class": () => ({ "d-none": !this.isOtherSelected }),
+            "t-att-required": () => this.isOtherSelected,
+        },
+    };
+
+    setup() {
+        this.selectOrRadioEl = this.el.querySelector(".form-select, .s_website_form_multiple");
+        this.isOtherSelected = false;
+    }
+
+    start() {
+        if (!this.selectOrRadioEl) {
+            return;
+        }
+        this.createOtherOption();
+        this.createOtherInput();
+        // Refresh the `dynamicContent` to ensure `dynamicContent` related to
+        // newly inserted nodes are applied
+        this.updateContent();
+    }
+
+    /**
+     * Creates and inserts the "Other" option for select/radio fields.
+     */
+    createOtherOption() {
+        const otherId = generateHTMLId();
+        const otherLabel = this.el.dataset.otherOptionLabel || _t("Other");
+        let otherOptionEl;
+
+        if (this.selectOrRadioEl.tagName === "SELECT") {
+            // Create dropdown option element
+            otherOptionEl = new Option(otherLabel, "_other");
+        } else {
+            //  Clone last radio button to preserve styling, then update its
+            //  attributes
+            otherOptionEl = this.selectOrRadioEl.lastElementChild.cloneNode(true);
+
+            const inputEl = otherOptionEl.querySelector("input");
+            inputEl.removeAttribute("checked");
+            inputEl.id = otherId;
+            inputEl.value = "_other";
+
+            const labelEl = otherOptionEl.querySelector("label");
+            labelEl.htmlFor = otherId;
+            labelEl.textContent = otherLabel;
+        }
+
+        // Append the "Other" option to the field
+        this.insert(otherOptionEl, this.selectOrRadioEl, "beforeend");
+    }
+
+    /**
+     * Creates and inserts a hidden text input field that will be shown
+     * when the "Other" option is selected.
+     */
+    createOtherInput() {
+        const otherInputEl = Object.assign(document.createElement("input"), {
+            type: "text",
+            name: this.selectOrRadioEl.name || this.selectOrRadioEl.dataset.name,
+            placeholder: this.el.dataset.otherOptionPlaceholder || "",
+            className: "form-control s_website_form_input o_other_input mt-3",
+        });
+        this.insert(otherInputEl, this.selectOrRadioEl, "afterend");
+    }
+
+    /**
+     * Handle change events on select dropdowns or radio button groups.
+     *
+     * Shows/hides the custom "Other" input field based on whether "_other" is
+     * selected. The input becomes required when visible and optional when
+     * hidden.
+     *
+     * @param {Event} ev
+     */
+    onChangeSelectOrRadio(ev) {
+        const targetEl = ev.currentTarget;
+
+        // Get selected value based on element type
+        const selectedValue =
+            targetEl.tagName === "SELECT"
+                ? targetEl.value
+                : targetEl.querySelector("input[type='radio']:checked").value;
+
+        this.isOtherSelected = selectedValue === "_other";
+    }
+}
+
+registry.category("public.interactions").add("website.form.add_other_option", AddOtherOption);

--- a/addons/website/static/src/snippets/s_website_form/form.js
+++ b/addons/website/static/src/snippets/s_website_form/form.js
@@ -550,6 +550,7 @@ export class Form extends Interaction {
 
     checkErrorFields(errorFields) {
         let formValid = true;
+        let firstInvalidInput = null;
         // Loop on all fields
         for (const fieldEl of this.el.querySelectorAll(".form-field, .s_website_form_field")) {
             // !compatibility
@@ -644,8 +645,16 @@ export class Form extends Interaction {
                     });
                     popover.show();
                 }
+                if (!firstInvalidInput) {
+                    firstInvalidInput = invalidInputs[0] || controlEls[0];
+                }
                 formValid = false;
             }
+        }
+        // Highlight the first invalid field
+        if (firstInvalidInput) {
+            firstInvalidInput.focus();
+            firstInvalidInput.scrollIntoView({ behavior: "smooth", block: "center" });
         }
         return formValid;
     }

--- a/addons/website/static/src/snippets/s_website_form/form.js
+++ b/addons/website/static/src/snippets/s_website_form/form.js
@@ -332,7 +332,12 @@ export class Form extends Interaction {
         }
 
         const formFields = [];
+        // List of placeholder values to ignore for submission
+        const valuesToIgnore = ["_other"];
         new FormData(this.el).forEach((value, key) => {
+            if (valuesToIgnore.includes(value)) {
+                return;
+            }
             const inputElement = this.el.querySelector(`[name="${CSS.escape(key)}"]`);
             if (inputElement && inputElement.type !== "file") {
                 formFields.push({ name: key, value: value });

--- a/addons/website/static/tests/builder/website_builder/form_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/form_option.test.js
@@ -17,6 +17,7 @@ import {
     setupWebsiteBuilder,
     setupWebsiteBuilderWithSnippet,
 } from "@website/../tests/builder/website_helpers";
+import { formSelectXml } from "@website/../tests/interactions/snippets/helpers";
 
 class HrJob extends models.Model {
     _name = "hr.job";
@@ -820,4 +821,27 @@ describe("Many2one Field", () => {
             expect(".modal-dialog .o_right_panel .o_list_item").toHaveCount(2);
         });
     });
+});
+
+test("other option attributes are preserved when switching between radio and select, removed for other field types", async () => {
+    onRpc("get_authorized_fields", () => ({}));
+    await setupWebsiteBuilder(formSelectXml);
+    await contains(":iframe .s_website_form_field").click();
+    expect(":iframe .s_website_form_field").toHaveAttribute("data-other-option-allowed", "true");
+    expect(":iframe .s_website_form_field").toHaveAttribute("data-other-option-label");
+    expect(":iframe .s_website_form_field").toHaveAttribute("data-other-option-placeholder");
+
+    await contains("button[id='type_opt']").click();
+    await contains("[data-action-value='selection']").click();
+    expect(":iframe .s_website_form_field").toHaveAttribute("data-other-option-allowed", "true");
+    expect(":iframe .s_website_form_field").toHaveAttribute("data-other-option-label");
+    expect(":iframe .s_website_form_field").toHaveAttribute("data-other-option-placeholder");
+
+    await contains("button[id='type_opt']").click();
+    await contains("[data-action-value='selection']").click();
+    await contains(".options-container [data-label='Type'] button").click();
+    await contains(".o_popover [data-action-value='one2many']").click();
+    expect(":iframe .s_website_form_field").not.toHaveAttribute("data-other-option-allowed");
+    expect(":iframe .s_website_form_field").not.toHaveAttribute("data-other-option-label");
+    expect(":iframe .s_website_form_field").not.toHaveAttribute("data-other-option-placeholder");
 });

--- a/addons/website/static/tests/interactions/snippets/form.edit.test.js
+++ b/addons/website/static/tests/interactions/snippets/form.edit.test.js
@@ -2,8 +2,9 @@ import { describe, expect, test } from "@odoo/hoot";
 import { setupInteractionWhiteList, startInteractions } from "@web/../tests/public/helpers";
 import { onRpc } from "@web/../tests/web_test_helpers";
 import { switchToEditMode } from "../../helpers";
+import { formSelectXml } from "@website/../tests/interactions/snippets/helpers";
 
-setupInteractionWhiteList("website.form");
+setupInteractionWhiteList(["website.form", "website.form.add_other_option"]);
 
 describe.current.tags("interaction_dev");
 
@@ -80,4 +81,13 @@ test("form is NOT prefilled in translate mode", async () => {
     const { core } = await startInteractions(formXml, { waitForStart: true, translateMode: true });
     expect(core.interactions).toHaveLength(1);
     expect("form input[name=company]").toHaveValue("");
+});
+
+test("should show 'other option' input field in edit mode by default when enabled 'Add other' option", async () => {
+    setupUser();
+    const { core } = await startInteractions(formSelectXml);
+    await switchToEditMode(core);
+    expect(core.interactions).toHaveLength(1);
+    expect(".o_other_input").toBeDisplayed();
+    expect(".o_other_input").toHaveAttribute("placeholder", "Other option...");
 });

--- a/addons/website/static/tests/interactions/snippets/form.test.js
+++ b/addons/website/static/tests/interactions/snippets/form.test.js
@@ -1,12 +1,21 @@
 import { setupInteractionWhiteList, startInteractions } from "@web/../tests/public/helpers";
 
 import { describe, expect, test } from "@odoo/hoot";
-import { animationFrame, clear, click, fill, queryOne, setInputFiles } from "@odoo/hoot-dom";
+import {
+    animationFrame,
+    clear,
+    click,
+    fill,
+    queryOne,
+    select,
+    setInputFiles,
+} from "@odoo/hoot-dom";
 import { advanceTime } from "@odoo/hoot-mock";
 
-import { contains, onRpc } from "@web/../tests/web_test_helpers";
+import { contains, onRpc, patchWithCleanup } from "@web/../tests/web_test_helpers";
+import { browser } from "@web/core/browser/browser";
 
-setupInteractionWhiteList(["website.form", "website.post_link"]);
+setupInteractionWhiteList(["website.form", "website.post_link", "website.form.add_other_option"]);
 
 describe.current.tags("interaction_dev");
 
@@ -214,6 +223,38 @@ const formWithVisibilityRulesTemplate = /* html */ `
                     </div>
                 </form>
             </div>
+        </section>
+    </div>
+`;
+
+const formTemplateWithRadioAndSelect = /* html */ `
+    <div id="wrapwrap">
+        <section class="s_website_form">
+            <form action="/website/form/" method="post" enctype="multipart/form-data" class="o_mark_required" data-model_name="mail.mail">
+                <div data-name="Field" class="s_website_form_field">
+                    <input class="form-control s_website_form_input" type="email" name="email_from" id="o15u8g10ugoy">
+                </div>
+                <div data-name="Field" class="s_website_form_field">
+                    <input class="form-control s_website_form_input" type="text" name="subject" id="o7r4gf8heilh">
+                </div>
+                <div data-name="Field" class="s_website_form_field s_website_form_custom" data-type="selection" data-other-option-allowed="true" data-other-option-label="Other" data-other-option-placeholder="Other option... (radio)">
+                    <div class="row s_website_form_multiple" data-name="Radio Button">
+                        <div class="form-check">
+                            <input type="radio" class="s_website_form_input form-check-input" id="obd2szn9ilqn0" name="Radio Button" value="Option 1" required="">
+                            <label class="form-check-label s_website_form_check_label" for="obd2szn9ilqn0">Option 1</label>
+                        </div>
+                    </div>
+                </div>
+                <div data-name="Field" class="s_website_form_field s_website_form_custom" data-type="many2one" data-other-option-allowed="true" data-other-option-label="Other" data-other-option-placeholder="Other option... (select)">
+                    <select class="form-select s_website_form_input" name="Select" required="" id="oo7t6wykitto">
+                        <option id="oo7t6wykitto0" value="Option 1" selected>Option 1</option>
+                    </select>
+                </div>
+                <div class="s_website_form_submit">
+                    <span id="s_website_form_result"></span>
+                    <a href="#" role="button" class="btn btn-primary s_website_form_send" contenteditable="true">Submit</a>
+                </div>
+            </form>
         </section>
     </div>
 `;
@@ -655,4 +696,30 @@ test("form elements chained conditional visibility", async () => {
     await advanceTime(400); // Debounce delay.
     checkField(fieldB, true, false);
     checkField(fieldC, true, false);
+});
+
+test("should make 'Other' input fields required when 'Other' option is selected", async () => {
+    await startInteractions(formTemplateWithRadioAndSelect);
+    const selectOtherInputEl = queryOne(".o_other_input[placeholder='Other option... (select)']");
+    const radioOtherInputEl = queryOne(".o_other_input[placeholder='Other option... (radio)']");
+    await contains("input[name=email_from]").fill("a@b.com");
+    await contains("input[name=subject]").fill("Subject");
+    await click(".form-select");
+    await select("_other");
+    await click("a.s_website_form_send");
+    checkField(selectOtherInputEl, true, true);
+    await contains(selectOtherInputEl).fill("Other option input for select");
+    await click(".s_website_form_input[value='_other']");
+    await click("a.s_website_form_send");
+    checkField(radioOtherInputEl, true, true);
+    await contains(radioOtherInputEl).fill("Other option input for radio");
+    patchWithCleanup(browser, {
+        fetch(_url, { body: formData }) {
+            expect(formData.get("Radio Button")).toBe("Other option input for radio");
+            expect(formData.get("Select")).toBe("Other option input for select");
+        },
+    });
+    // Wait for the debounced input event to update the form state.
+    await advanceTime(400);
+    await click("a.s_website_form_send");
 });

--- a/addons/website/static/tests/interactions/snippets/helpers.js
+++ b/addons/website/static/tests/interactions/snippets/helpers.js
@@ -44,3 +44,20 @@ export async function doubleScroll(wrapwrapEl, target, source) {
     await scroll(wrapwrapEl, { y: target });
     await endTransition();
 }
+
+export const formSelectXml = `
+    <form data-model_name="mail.mail">
+        <div data-name="Field" class="s_website_form_field s_website_form_custom" data-type="many2one" data-other-option-allowed="true" data-other-option-label="Other" data-other-option-placeholder="Other option...">
+            <div class="row s_col_no_resize s_col_no_bgcolor">
+                <label class="col-form-label col-sm-auto s_website_form_label" for="o291di1too21">
+                    <span class="s_website_form_label_content">Form Select</span>
+                </label>
+                <div class="col-sm">
+                    <select class="form-select s_website_form_input" name="Form Select" id="field1">
+                        <option value="Option 1" id="o291di1too22">Option 1</option>
+                    </select>
+                </div>
+            </div>
+        </div>
+    </form>
+`;


### PR DESCRIPTION
*=website

This commit improves the website form builder by allowing radio and
selection fields to include an "Other" option when the 'Add other'
toggle (with id `_other`) is enabled.

When a user selects the "Other" option, an additional input field 
becomes visible and is marked as required to ensure it is properly
filled.

Additionally, upon form submission, the first invalid field in the form
will automatically receive focus to enhance user experience and form
usability.

task-4629851

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
