### PR TITLE
[IMP] stock: show 'On Hand' in qty smartbutton when UoMs are disabled

### DIFF
--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -458,6 +458,7 @@
                                     <div class="o_field_widget o_stat_info flex-column align-items-start gap-1">
                                         <span class="o_stat_value">
                                             <field name="uom_name" widget="statinfo" nolabel="1" groups="uom.group_uom"/>
+                                            <span groups="!uom.group_uom">On Hand</span>
                                         </span>
                                         <span class="o_stat_value text-muted">
                                             Forecasted


### PR DESCRIPTION
## **Before This Commit:**
When UoMs are not activated, the product quantity smartbutton
in product form looked strange and less informative,
as there are two stat values and only one stat info 'forecasted'.
This could be confusing for users.

<img width="159" height="48" alt="image" src="https://github.com/user-attachments/assets/20004b80-c475-4307-8cdc-07bd42de518d" />

## **With This Commit:**
The smartbutton now displays two stat infos
'On Hand' and 'forecasted' when UoMs are disabled,
so the information looks complete and easier to understand.

<img width="167" height="43" alt="image" src="https://github.com/user-attachments/assets/b0481d9a-f16e-459a-95ab-2355556085d4" />
