### PR TITLE
[FIX] mrp_repair: fix error when using kit in repair order

### DIFF
--- a/addons/mrp_repair/models/repair.py
+++ b/addons/mrp_repair/models/repair.py
@@ -81,7 +81,6 @@ class StockMove(models.Model):
         self.ensure_one()
         product = bom_line.product_id
         return {
-            'name': self.name,
             'repair_id': self.repair_id.id,
             'repair_line_type': self.repair_line_type,
             'product_id': product.id,


### PR DESCRIPTION
When user tries to set the kit as product parts in repair order,
A traceback will appear.

Steps to reproduce the error:
- Install ``mrp_repair`` module with demo data
- Create a new repair order > In Parts, Add a line > Product: ``Table Kit`` > Save

Traceback:
``AttributeError: 'stock.move' object has no attribute 'name'``

https://github.com/odoo/odoo/blob/83a8508b958ed88bbdbf80612039ec33817bc02c/addons/mrp_repair/models/repair.py#L84 The ``name`` field of ``stock.move`` was removed in the [commit](https://github.com/odoo/odoo/pull/211488/commits/f3fc7a5cfd6e77cbbcfff891383abeac930d41ac),
but it is still being referenced here.
So, It will lead to the above traceback.

sentry-6870866512

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
