### PR TITLE
[FIX] point_of_sale, **: guard pos data read with access check

### DIFF
--- a/addons/point_of_sale/models/pos_load_mixin.py
+++ b/addons/point_of_sale/models/pos_load_mixin.py
@@ -48,7 +48,7 @@ class PosLoadMixin(models.AbstractModel):
             raise ValueError("config must be provided to read PoS data.")
 
         fields = self._load_pos_data_fields(config)
-        records = records.read(fields, load=False)
+        records = records._filtered_access("read").read(fields, load=False)
         return records or []
 
     def _unrelevant_records(self, config):

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1224,7 +1224,7 @@ class PosOrder(models.Model):
 
     def read_pos_data(self, data, config):
         # If the previous session is closed, the order will get a new session_id due to _get_valid_session in _process_order
-        account_moves = self.sudo().account_move | self.sudo().payment_ids.account_move_id
+        account_moves = self.sudo().account_move | self.sudo().payment_ids.account_move_id | self.sudo().session_move_id
         return {
             'pos.order': self._load_pos_data_read(self, config) if config else [],
             'pos.session': [],

--- a/addons/point_of_sale/static/tests/pos/tours/ticket_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/ticket_screen_tour.js
@@ -516,6 +516,17 @@ registry.category("web_tour.tours").add("test_order_invoice_search", {
             TicketScreen.selectFilter("Paid"),
             TicketScreen.search("Invoice Number", "00001"),
             TicketScreen.nthRowContains(1, "001", false),
+            Chrome.clickMenuOption("Close Register"),
+            {
+                content: `Select button close register`,
+                trigger: `button:contains(close register)`,
+                run: "click",
+                expectUnloadPage: true,
+            },
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            Chrome.clickOrders(),
+            TicketScreen.selectFilter("Paid"),
         ].flat(),
 });
 

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -3067,6 +3067,7 @@ class TestUi(TestPointOfSaleHttpCommon):
 
     def test_order_invoice_search(self):
         self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.pos_user.group_ids = [Command.link(self.env.ref('account.group_account_invoice').id)]
         self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'test_order_invoice_search', login="pos_user")
 
     def test_automatic_receipt_printing(self):

--- a/addons/pos_hr/models/hr_employee.py
+++ b/addons/pos_hr/models/hr_employee.py
@@ -24,7 +24,13 @@ class HrEmployee(models.Model):
 
     @api.model
     def _load_pos_data_read(self, records, config):
-        read_records = super()._load_pos_data_read(records, config)
+        # NOTE:
+        # hr.employee have a public fallback mechanism
+        # where users without read access may still receive records from
+        # the corresponding public model (hr.employee.public) so thats why we are bypassing
+        # the access right.
+        fields = self._load_pos_data_fields(config)
+        read_records = records.read(fields, load=False)
         manager_ids = records.filtered(lambda emp: config.group_pos_manager_id.id in emp.user_id.all_group_ids.ids).ids
 
         employees_barcode_pin = records.get_barcodes_and_pin_hashed()


### PR DESCRIPTION
**: pos_hr

Before this commit:
---
- POS data was read directly from records without validating read access.
- This could raise `AccessError` when the user lacked permissions, breaking POS
  data loading.

After this commit:
---
- Check read access on records before calling `read`.
- Prevent POS crashes caused by unauthorized model reads.

runbot-231708

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
