### PR TITLE
[FIX] hr: fix error when editing resource of employee

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -1228,6 +1228,7 @@ We can redirect you to the public employee list."""
         # Only one write call for all the fields from hr.version
         new_vals = vals.copy()
         version_vals = {val: new_vals.pop(val) for val in vals if val in self._fields and self._fields[val].inherited}
+        self.env.flush_all()
         res = super().write(new_vals)
         if version_vals:
             version_vals['last_modified_date'] = fields.Datetime.now()


### PR DESCRIPTION
Assigning a user (already linked to an employee) to a resource (linked to another employee) generates a traceback.

Steps to reproduce the error:
- Create one Employee A
- Open the resource of Employee A > Set User: Administrator and unset working time > Save

Traceback:
```
UniqueViolation: duplicate key value violates unique constraint "hr_employee_user_uniq"
DETAIL:  Key (user_id, company_id)=(2, 1) already exists.
```

When editing the user and calendar on a resource, ``_inverse_calendar_id`` is triggered. This calls the ``write`` method on ``hr.employee``, which invokes ``super().write()``.
Afterwards, the compute method (``_compute_company_employee``) runs with an invalid user, which will raise the above traceback.

Fix: 
Flush pending operations using ``self.env.flush_all()`` before ``super().write()``,
so that constraints are applied correctly.

sentry-6860997758

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
