### PR TITLE
[IMP] stock_account: rename stock valuation account

### DIFF
--- a/addons/stock_account/views/stock_location_views.xml
+++ b/addons/stock_account/views/stock_location_views.xml
@@ -9,7 +9,9 @@
                 <xpath expr="//group[@name='additional_info']" position="after">
                     <div>
                         <group string="Accounting Information" invisible="usage not in ('inventory', 'production')">
-                            <field name="valuation_account_id" options="{'no_create': True}"/>
+                            <label for="valuation_account_id" string="Cost of Production" invisible="usage != 'production'"/>
+                            <label for="valuation_account_id" string="Inventory Variation" invisible="usage != 'inventory'"/>
+                            <field name="valuation_account_id" nolabel="1" options="{'no_create': True}"/>
                         </group>
                     </div>
                 </xpath>


### PR DESCRIPTION
With this commit:
---------------------------------
- Renamed stock valuation accounts based on the location type.
  If the location type is 'Inventory Loss', the valuation account is set to
  'Inventory Variation' and if the location type is 'Production', the
  valuation account is set to 'Cost of Production'.
- This change improves clarity and helps users better understand the purpose of
  each valuation account.