### PR TITLE
[IMP] project: remove unused method

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -522,11 +522,6 @@ class ProjectTask(models.Model):
                     else:
                         task[f] = False
 
-    def _is_recurrence_valid(self):
-        self.ensure_one()
-        return self.repeat_interval > 0 and\
-                (self.repeat_type != 'until' or self.repeat_until and self.repeat_until > fields.Date.today())
-
     @api.depends('recurrence_id')
     def _compute_recurring_count(self):
         self.recurring_count = 0


### PR DESCRIPTION
The method `_is_recurrence_valid()` was previously used in `_compute_recurrence_message()`. Since the recurrence message was removed in below commit, this method is no longer used.

commit- https://github.com/odoo/odoo/commit/85e9290711c5376660941122dffb3b335b223091#diff-dcdc6e8a2e65aff0582c53d72c3890c1b56725a8b9fcf7abbb0378097b5999af

task-5068036
