### PR TITLE
[FIX] website_sale: make quick reorder button title translatable and updated

### DIFF
--- a/addons/website_sale/static/src/js/website_sale_utils.js
+++ b/addons/website_sale/static/src/js/website_sale_utils.js
@@ -1,5 +1,6 @@
 import { markup } from '@odoo/owl';
 import { browser } from '@web/core/browser/browser';
+import { _t } from '@web/core/l10n/translation';
 import { setElementContent } from '@web/core/utils/html';
 
 function animateClone($cart, $elem, offsetTop, offsetLeft) {
@@ -127,9 +128,11 @@ function updateQuickReorderSidebar(data) {
             'afterbegin', data['website_sale.quick_reorder_history']
         );
         quickReorderButton.removeAttribute('disabled');
+        quickReorderButton.parentElement.title = "";
     } else {
         quickReorderButton.click();
         quickReorderButton.setAttribute('disabled', 'true');
+        quickReorderButton.parentElement.title = _t("No previous products available for reorder.");
     }
 }
 

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -3124,13 +3124,10 @@
     </template>
 
     <template id="quick_reorder_button">
-        <!-- TODO SHRM: Make title translatable -->
-        <t
-            t-set="quick_reorder_button_title"
-            t-value="'Login to reorder' if request.website.is_public_user()
-                     else 'No previous products available for reorder.' if not order_history
-                     else ''"
-        />
+        <t t-set="quick_reorder_button_title">
+            <t t-if="request.website.is_public_user()">Login to reorder</t>
+            <t t-elif="not order_history">No previous products available for reorder.</t>
+        </t>
         <span t-att-title="quick_reorder_button_title">
             <button
                 id="quick_reorder_button"


### PR DESCRIPTION
Before this fix:
- The quick reorder button title was not translatable.
- After the quick reorder sidebar became empty, the button was disabled but its title was not updated accordingly. A page reload was required to see the correct title.

After this fix:
- The button title is now translatable.
- The title is refreshed immediately when the button state changes, without needing a page reload.