### PR TITLE
[FIX] website: restore cover image option in dynamic snippet

### DIFF
--- a/addons/website/static/src/builder/plugins/options/dynamic_snippet_hook.js
+++ b/addons/website/static/src/builder/plugins/options/dynamic_snippet_hook.js
@@ -24,7 +24,6 @@ export function useDynamicSnippetOption(modelNameFilter, contextualFilterDomain 
         numberOfRecords: parseInt(editingElement.dataset.numberOfRecords),
         templateKey: editingElement.dataset.templateKey,
         isSingleMode: dynamicSnippetUtils.isSingleModeSnippet(editingElement.dataset),
-        snippetContentPosition: editingElement.querySelector(".s_dynamic_snippet_content_position"),
     }));
 
     async function fetchDynamicFiltersAndTemplates() {

--- a/addons/website/static/src/builder/plugins/options/dynamic_snippet_option.xml
+++ b/addons/website/static/src/builder/plugins/options/dynamic_snippet_option.xml
@@ -44,7 +44,7 @@
             </t>
         </BuilderSelect>
     </BuilderRow>
-    <BuilderRow label.translate="Cover Image" t-if="dynamicOptionParams.domState.snippetContentPosition">
+    <BuilderRow label.translate="Cover Image" t-if="isSingleMode">
         <BuilderButtonGroup>
             <BuilderButton title.translate="Left" classAction="'s_dynamic_snippet_cover_left'" iconImg="'/website/static/src/img/snippets_options/pos_left.svg'"/>
             <BuilderButton title.translate="Right" classAction="''" iconImg="'/website/static/src/img/snippets_options/pos_right.svg'"/>

--- a/addons/website_blog/static/tests/tours/snippet_blog_post.js
+++ b/addons/website_blog/static/tests/tours/snippet_blog_post.js
@@ -1,0 +1,33 @@
+import {
+    changeOptionInPopover,
+    clickOnSnippet,
+    insertSnippet,
+    registerWebsitePreviewTour,
+} from "@website/js/tours/tour_utils";
+
+registerWebsitePreviewTour(
+    "snippet_blog_bost",
+    {
+        url: "/",
+        edition: true,
+    },
+    () => [
+        // Check that the cover image option is only available when one blog post is displayed
+        ...insertSnippet({
+            id: "s_blog_posts_single_aside",
+            name: "Blog Post",
+            groupName: "Blogs",
+        }),
+        ...clickOnSnippet(".s_dynamic_snippet_blog_posts"),
+        ...changeOptionInPopover("Blog Post", "Fetched Elements", "[data-action-param='3']"),
+        {
+            content: "Check if the cover image option is not visible",
+            trigger: "[data-container-title='Blog Post']:not(:has([data-label='Cover Image']))",
+        },
+        ...changeOptionInPopover("Blog Post", "Fetched Elements", "[data-action-param='1']"),
+        {
+            content: "Check if the cover image option is visible",
+            trigger: "[data-container-title='Blog Post'] [data-label='Cover Image']",
+        },
+    ]
+);


### PR DESCRIPTION
Steps to reproduce:

1. Open Website Editor and drop a single aside blog snippet.
2. Change the Fetched Elements option to > 1.
   - The Cover Image option disappears (expected).
3. Change the Fetched Elements option back to 1.
   - The Cover Image option stays hidden (unexpected).

Issue:
The Cover Image option visibility is managed by useDomState. In dynamic snippets, the core snippet is rendered by an Interaction, while options are rendered before the Interaction starts. Since useDomState observed the element before the Interaction rendered the final one, the option visibility became desynchronized.

Fix:
Use the `isSingleMode` state to ensure the Cover Image option remains in sync when toggling between 1 and >1 fetched elements.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
