### PR TITLE
[FIX] survey: fix leaderboard score display

### DIFF
--- a/addons/survey/static/src/interactions/survey_session_leaderboard.js
+++ b/addons/survey/static/src/interactions/survey_session_leaderboard.js
@@ -15,79 +15,27 @@ export class SurveySessionLeaderboard extends Interaction {
             "t-on-showLeaderboard": this.showLeaderboard,
             "t-on-hideLeaderboard": this.hideLeaderboard,
         },
-        ".o_survey_session_leaderboard_bar": {
-            "t-att-style": this.getBarStyle,
-        },
         ".o_survey_session_leaderboard_bar_question": {
             "t-att-style": this.getBarQuestionStyle,
         },
     };
-
-    getBarStyle(barEl) {
-        if (this.leaderboardAnimationPhase === "prepareScores") {
-            // See also this.prepareScores
-            const currentScore = parseInt(
-                barEl.closest(".o_survey_session_leaderboard_item").dataset.currentScore
-            );
-            if (currentScore && currentScore !== 0) {
-                return {
-                    transition: "width 1s cubic-bezier(.4,0,.4,1)",
-                    width: this.BAR_MIN_WIDTH,
-                };
-            }
-        } else if (this.leaderboardAnimationPhase === "sumScores") {
-            // See also this.sumScores
-            const { baseRatio, questionRatio } = this.getBarRatios(barEl);
-            const updatedScoreRatio = 1 - questionRatio;
-            const updatedScoreWidth = `calc(calc(100% - ${this.BAR_WIDTH}) * ${
-                updatedScoreRatio * baseRatio
-            })`;
-            return {
-                transition: "width ease .5s cubic-bezier(.5,0,.66,1.11)",
-                width: updatedScoreWidth,
-                minWidth: "0px",
-            };
-        }
-        return {};
-    }
 
     getBarQuestionStyle(barEl) {
         if (this.leaderboardAnimationPhase === "showQuestionScores") {
             // See also this.showQuestionScores
             return {
                 transition: "width 1s ease-out",
-                width: `calc(calc(100% - ${this.BAR_WIDTH}) * ${barEl.dataset.widthRatio} + ${this.BAR_MIN_WIDTH})`,
-            };
-        } else if (this.leaderboardAnimationPhase === "sumScores") {
-            // See also this.sumScores
-            const { baseRatio, questionRatio } = this.getBarRatios(barEl);
-            // we keep a min fixed width of 3rem to be able to display "+ 5 p"
-            // even if the user already has 1,000,000 points
-            const questionWidth = `calc(calc(calc(100% - ${this.BAR_WIDTH}) * ${
-                questionRatio * baseRatio
-            }) + ${this.BAR_MIN_WIDTH})`;
-            return {
-                transition: "width ease .5s cubic-bezier(.5,0,.66,1.11)",
-                width: questionWidth,
+                width: `max(calc(calc(100% - ${this.BAR_RESERVED_WIDTH_REM}rem) * ${barEl.dataset.widthRatio}), ${this.BAR_QUEST_MIN_WIDTH_REM}rem)`,
             };
         }
         return {};
     }
 
-    getBarRatios(barEl) {
-        const item = barEl.closest(".o_survey_session_leaderboard_item");
-        const updatedScore = parseInt(item.dataset.updatedScore);
-        const questionScore = parseInt(item.dataset.questionScore);
-        const maxUpdatedScore = parseInt(item.dataset.maxUpdatedScore);
-        const baseRatio = maxUpdatedScore ? updatedScore / maxUpdatedScore : 1;
-        const questionRatio = questionScore / (updatedScore || 1);
-        return { baseRatio, questionRatio };
-    }
-
     setup() {
         this.fadeInOutTime = 400;
-        this.BAR_MIN_WIDTH = "3rem";
-        this.BAR_WIDTH = "24rem";
+        this.BAR_QUEST_MIN_WIDTH_REM = 3.7;
+        // Score width + margin + Bar score min width (css) + BAR_QUEST_MIN_WIDTH_REM + margin + nickname width
+        this.BAR_RESERVED_WIDTH_REM = 6.5 + 1 + 3.7 + this.BAR_QUEST_MIN_WIDTH_REM + 1 + 7.5;
         this.BAR_HEIGHT = "3.8rem";
         this.surveyAccessToken = this.el.closest(
             ".o_survey_session_manage"
@@ -153,7 +101,6 @@ export class SurveySessionLeaderboard extends Interaction {
                     });
                 fadeIn(this.el, this.fadeInOutTime, async () => {
                     if (ev.detail.isScoredQuestion) {
-                        await this.waitFor(this.prepareScores());
                         await this.waitFor(this.showQuestionScores());
                         await this.waitFor(this.sumScores());
                         await this.waitFor(this.reorderScores());
@@ -216,27 +163,6 @@ export class SurveySessionLeaderboard extends Interaction {
     }
 
     /**
-     * Takes the leaderboard prior to the current question results
-     * and reduce all scores bars to a small width (3rem).
-     * We keep the small score bars on screen for 1s.
-     *
-     * This visually prepares the display of points for the current question.
-     *
-     * @private
-     */
-    async prepareScores() {
-        let animationDone;
-        const animationPromise = new Promise(function (resolve) {
-            animationDone = resolve;
-        });
-        this.waitForTimeout(() => {
-            this.leaderboardAnimationPhase = "prepareScores";
-            this.waitForTimeout(animationDone, 1000);
-        }, 300);
-        return animationPromise;
-    }
-
-    /**
      * Now that we have summed the score for the current question to the total score
      * of the user and re-weighted the bars accordingly, we need to re-order everything
      * to match the new ranking.
@@ -280,7 +206,7 @@ export class SurveySessionLeaderboard extends Interaction {
      *   (faded out bar right next to the global score one)
      * - animate the score for the question (ex: from + 0 p to + 40 p)
      *
-     * (We keep a minimum width of 3rem to be able to display '+30 p' within the bar).
+     * (We keep a minimum width to be able to display '+30 p' within the bar, see getBarQuestionStyle).
      *
      * @private
      */
@@ -316,28 +242,9 @@ export class SurveySessionLeaderboard extends Interaction {
     }
 
     /**
-     * After displaying the score for the current question, we sum the total score
-     * of the user so far with the score of the current question.
-     *
-     * Ex:
-     * We have ('#' for total score before question and '=' for current question score):
-     * 210 p ####=================================== +30 p John
-     * We want:
-     * 240 p ###################################==== +30 p John
-     *
-     * Of course, we also have to weight the bars based on the maximum score.
-     * So if John here has 50% of the points of the leader user, both the question score bar
-     * and the total score bar need to have their width divided by 2:
-     * 240 p ##################== +30 p John
-     *
-     * The width of both bars move at the same time to reach their new position,
-     * with an animation on the width property.
-     * The new width of the "question bar" should represent the ratio of won points
-     * when compared to the total points.
-     * (We keep a minimum width of 3rem to be able to display '+30 p' within the bar).
-     *
-     * The updated total score is animated towards the new value.
-     * we keep this on screen for 500ms before reordering the bars.
+     * After displaying the score for the current question on top of the current score,
+     * we update the total score on the left with an animation by summing both and fade
+     * out the "+ x p" on the question score bar.
      *
      * @private
      */
@@ -351,7 +258,7 @@ export class SurveySessionLeaderboard extends Interaction {
             this.el.querySelectorAll(".o_survey_session_leaderboard_item").forEach((item) => {
                 const currentScore = parseInt(item.dataset.currentScore);
                 const updatedScore = parseInt(item.dataset.updatedScore);
-                let increment = parseInt(item.dataset.maxQuestionScore / 40);
+                let increment = parseInt(item.dataset.maxQuestionScore) / 40;
                 if (!increment || increment === 0) {
                     increment = 1;
                 }
@@ -361,6 +268,10 @@ export class SurveySessionLeaderboard extends Interaction {
                     updatedScore,
                     increment,
                     false
+                );
+                fadeOut(
+                    item.querySelector(".o_survey_session_leaderboard_bar_question_score"),
+                    500
                 );
                 this.waitForTimeout(animationDone, 500);
             });

--- a/addons/survey/static/src/scss/survey_templates_form.scss
+++ b/addons/survey/static/src/scss/survey_templates_form.scss
@@ -440,7 +440,7 @@ _::-webkit-full-page-media, _:future, :root .o_survey_wrap {
         }
 
         .o_survey_session_leaderboard_bar {
-            min-width: 3rem;
+            min-width: 3.7rem;
             background-color: #007A77;
             z-index: 2;
         }

--- a/addons/survey/views/survey_templates_user_input_session.xml
+++ b/addons/survey/views/survey_templates_user_input_session.xml
@@ -79,6 +79,7 @@
         <t t-set="is_scored_question" t-value="any(answer.answer_score for answer in question.suggested_answer_ids)" />
         <t t-set="show_bar_chart" t-value="question.question_type in ['simple_choice', 'multiple_choice', 'scale']" />
         <t t-set="show_text_answers" t-value="question.question_type in ['char_box', 'date', 'datetime'] and not question.save_as_email and not question.save_as_nickname" />
+        <t t-set="bar_reserved_with_rem" t-value="23.4"/> <!-- See setup of SurveySessionLeaderboard -->
         <div class="wrap min-vh-100 align-items-center justify-content-center d-flex flex-column o_survey_session_manage invisible"
             t-att-style="'display: none;' if is_rpc_call else ''"
             t-att-data-is-rpc-call="is_rpc_call"
@@ -168,7 +169,9 @@
                         </div>
                     </div>
                 </div>
-                <div class="o_survey_session_leaderboard w-100 flex-column flex-grow-1 min-vw-75 d-none" style="max-height: 80vh; min-width: 50vw">
+                <!-- BAR_RESERVED_WIDTH_REM + 15rem (where BAR_RESERVED_WIDTH_REM is the place for the score, nickname, ...) -->
+                <div class="o_survey_session_leaderboard w-100 flex-column flex-grow-1 min-vw-75 d-none"
+                    t-attf-style="max-height: 80vh; min-width: max(50vw, #{bar_reserved_with_rem + 15}rem)">
                     <!--Set question to false to avoid background miss match when no question are displayed.-->
                     <t t-set="question" t-value="False"/>
                     <div class="d-flex flex-wrap">
@@ -188,35 +191,33 @@
     </template>
 
     <template id="user_input_session_leaderboard" name="Survey User Input Leaderboard">
+        <t t-set="bar_reserved_with_rem" t-value="23.4"/> <!-- See setup of SurveySessionLeaderboard -->
         <div t-if="leaderboard" class="position-relative mb-5" t-attf-style="height: calc(3.8rem * #{len(leaderboard)});">
-            <t t-set="max_score" t-value="max(score.get('scoring_total', 1) for score in leaderboard) or 1" />
-            <t t-set="max_updated_score" t-value="max(score.get('updated_score', 1) for score in leaderboard)" />
+            <t t-set="max_updated_score" t-value="max(score.get('updated_score', 1) for score in leaderboard) or 1" />
             <t t-foreach="leaderboard" t-as="score">
+                <t t-set="current_score" t-value="score.get('scoring_total', 0)"/>
+                <t t-set="question_score" t-value="score.get('question_score', 0)"/>
+                <t t-set="max_question_score" t-value="score.get('max_question_score', 1)"/>
                 <div class="o_survey_session_leaderboard_item ms-2 d-flex position-absolute"
                     t-attf-style="top: calc(#{score_index} * 3.8rem);"
                     t-att-data-current-position="str(score_index)"
                     t-att-data-new-position="str(score.get('leaderboard_position', score_index))"
-                    t-att-data-question-score="str(round(score.get('question_score', 0)))"
-                    t-att-data-current-score="str(round(score.get('scoring_total', 0)))"
+                    t-att-data-question-score="str(round(question_score))"
+                    t-att-data-current-score="str(current_score)"
                     t-att-data-updated-score="str(round(score.get('updated_score', 0)))"
-                    t-att-data-max-question-score="round(score.get('max_question_score', 1))"
-                    t-att-data-max-updated-score="round(max_updated_score)">
+                    t-att-data-max-question-score="str(round(max_question_score))">
                     <div class="d-inline-block fw-bold align-top">
                         <div class="d-inline-block me-2 o_survey_session_leaderboard_score" t-esc="'%.0f p' % score['scoring_total']" />
                     </div>
-                    <!-- We keep "18rem" of space to display the points / nickname.
-                    Then, the length of the bar is a percentage of the attendee's score compared to the max_score. -->
-                    <t t-set="width_ratio" t-value="round(round(score['scoring_total'], 3) / round(max_score, 3), 3)"/>
-                    <t t-set="width_ratio_question" t-value="str(round(round(score.get('question_score', 0), 3) / round(score.get('max_question_score', 1), 3), 3))"/>
+                    <t t-set="width_ratio" t-value="round(current_score / max_updated_score, 3)"/>
                     <div class="o_survey_session_leaderboard_bar ms-2 align-top d-inline-block text-end fw-bold"
-                        t-att-style="'width: calc(calc(%s - 18rem) * %s)' % ('100%', width_ratio)"
-                        t-att-data-width-ratio="width_ratio">
+                        t-attf-style="width: calc(calc(100% - #{bar_reserved_with_rem}rem) * #{width_ratio})">
                     </div>
                     <div class="o_survey_session_leaderboard_bar_question me-2 align-top d-inline-block text-end fw-bold position-relative"
-                        style="width: 0px;"
-                        t-att-data-width-ratio="width_ratio_question"
-                        t-att-data-max-question-score="str(score.get('max_question_score', 1))"
-                        t-att-data-question-score="str(score.get('question_score', 0))">
+                        style="width: 0;"
+                        t-att-data-width-ratio="str(round(question_score / max_updated_score, 3))"
+                        t-att-data-max-question-score="str(max_question_score)"
+                        t-att-data-question-score="str(question_score)">
                         <div class="o_survey_session_leaderboard_bar_question_score position-absolute"></div>
                     </div>
                     <div class="o_survey_session_leaderboard_name d-inline-block">


### PR DESCRIPTION
The way the score bars were animated was a bit confusing. We simplify the animation by:
- Showing the score accumulated so far without the question
- Animating the score bar towards the accumulated score with the question
- Animating the numerical score on the left towards the accumulated score with the question while fading the numerical score increment on the bar ("+ x p")
- (reordering participants)

Task-4893763