### PR TITLE
[FIX] html_editor: enter before the star element

### DIFF
--- a/addons/html_editor/static/src/core/line_break_plugin.js
+++ b/addons/html_editor/static/src/core/line_break_plugin.js
@@ -36,6 +36,8 @@ export class LineBreakPlugin extends Plugin {
             // this.shared.collapseIfZWS();
             this.dependencies.delete.deleteSelection();
             selection = this.dependencies.selection.getEditableSelection();
+        } else if (!closestElement(selection.anchorNode).isContentEditable) {
+            selection = this.dependencies.selection.getEditableSelection();
         }
 
         const targetNode = selection.anchorNode;

--- a/addons/html_editor/static/src/core/split_plugin.js
+++ b/addons/html_editor/static/src/core/split_plugin.js
@@ -86,6 +86,8 @@ export class SplitPlugin extends Plugin {
             // this.shared.collapseIfZWS();
             this.dependencies.delete.deleteSelection();
             selection = this.dependencies.selection.getEditableSelection();
+        } else if (!closestElement(selection.anchorNode).isContentEditable) {
+            selection = this.dependencies.selection.getEditableSelection();
         }
 
         return this.splitBlockNode({

--- a/addons/html_editor/static/tests/icon.test.js
+++ b/addons/html_editor/static/tests/icon.test.js
@@ -3,7 +3,7 @@ import { click, tick, waitFor } from "@odoo/hoot-dom";
 import { setupEditor } from "./_helpers/editor";
 import { animationFrame } from "@odoo/hoot-mock";
 import { getContent, setContent, setSelection } from "./_helpers/selection";
-import { undo } from "./_helpers/user_actions";
+import { splitBlock, undo } from "./_helpers/user_actions";
 import { contains } from "@web/../tests/web_test_helpers";
 import { expectElementCount } from "./_helpers/ui_expectations";
 
@@ -314,5 +314,19 @@ test("Icon should be fully selected if the selection covers the ZWS inside the s
     await tick();
     expect(getContent(el)).toBe(
         `<p>\ufeff[<span class="fa fa-glass" contenteditable="false">\u200b</span>]\ufeff</p>`
+    );
+});
+
+test("should insert two empty paragraphs when Enter is pressed twice before the icon element", async () => {
+    const { el, editor } = await setupEditor(
+        `<p>[]<span class="fa fa-glass" contenteditable="false"></span></p>`
+    );
+    splitBlock(editor);
+    expect(getContent(el)).toBe(
+        `<p><br></p><p>\ufeff[]<span class="fa fa-glass" contenteditable="false">\u200B</span>\ufeff</p>`
+    );
+    splitBlock(editor);
+    expect(getContent(el)).toBe(
+        `<p><br></p><p><br></p><p>\ufeff[]<span class="fa fa-glass" contenteditable="false">\u200B</span>\ufeff</p>`
     );
 });

--- a/addons/html_editor/static/tests/insert/line_break.test.js
+++ b/addons/html_editor/static/tests/insert/line_break.test.js
@@ -141,6 +141,16 @@ describe("Selection collapsed", () => {
                 contentAfter: "<p>abc<br><br>[]<br></p>",
             });
         });
+        test("should insert two line breaks (2 <br>) before contenteditable false element", async () => {
+            await testEditor({
+                contentBefore: `<p>a[]<span contenteditable="false">b</span></p>`,
+                stepFunction: async (editor) => {
+                    await insertLineBreak(editor);
+                    await insertLineBreak(editor);
+                },
+                contentAfter: `<p>a<br><br>[]<span contenteditable="false">b</span></p>`,
+            });
+        });
     });
 
     describe("Format", () => {

--- a/addons/html_editor/static/tests/rating_star.test.js
+++ b/addons/html_editor/static/tests/rating_star.test.js
@@ -1,7 +1,7 @@
 import { expect, test } from "@odoo/hoot";
 import { click, press } from "@odoo/hoot-dom";
 import { setupEditor, testEditor } from "./_helpers/editor";
-import { deleteBackward, insertText } from "./_helpers/user_actions";
+import { deleteBackward, insertText, splitBlock } from "./_helpers/user_actions";
 import { getContent } from "./_helpers/selection";
 import { animationFrame } from "@odoo/hoot-mock";
 import { expectElementCount } from "./_helpers/ui_expectations";
@@ -55,6 +55,34 @@ test("select star rating", async () => {
     await animationFrame();
     expect(getContent(el)).toBe(
         `<p>\u200B<span contenteditable="false" class="o_stars">\ufeff<i class="fa fa-star-o" contenteditable="false">\u200B</i>\ufeff<i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i>\ufeff<i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i>\ufeff</span>\u200B[]</p>`
+    );
+});
+
+test("should insert two empty paragraphs when Enter is pressed twice before the star element", async () => {
+    const { el, editor } = await setupEditor(
+        `<p>\u200B[]<span contenteditable="false" class="o_stars o_three_stars"><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i></span>\u200B</p>`
+    );
+    splitBlock(editor);
+    expect(getContent(el)).toBe(
+        `<p><br></p><p>[]<span contenteditable="false" class="o_stars o_three_stars">\ufeff<i class="fa fa-star-o" contenteditable="false">\u200B</i>\ufeff<i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i>\ufeff<i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i>\ufeff</span>\u200B</p>`
+    );
+    splitBlock(editor);
+    expect(getContent(el)).toBe(
+        `<p><br></p><p><br></p><p>[]<span contenteditable="false" class="o_stars o_three_stars">\ufeff<i class="fa fa-star-o" contenteditable="false">\u200B</i>\ufeff<i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i>\ufeff<i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i>\ufeff</span>\u200B</p>`
+    );
+});
+
+test("should insert two empty paragraphs when Enter is pressed twice after the star element", async () => {
+    const { el, editor } = await setupEditor(
+        `<p>\u200B<span contenteditable="false" class="o_stars o_three_stars"><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i></span>\u200B[]</p>`
+    );
+    splitBlock(editor);
+    expect(getContent(el)).toBe(
+        `<p>\u200B<span contenteditable="false" class="o_stars o_three_stars">\ufeff<i class="fa fa-star-o" contenteditable="false">\u200B</i>\ufeff<i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i>\ufeff<i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i>\ufeff</span></p><p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>`
+    );
+    splitBlock(editor);
+    expect(getContent(el)).toBe(
+        `<p>\u200B<span contenteditable="false" class="o_stars o_three_stars">\ufeff<i class="fa fa-star-o" contenteditable="false">\u200B</i>\ufeff<i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i>\ufeff<i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i>\ufeff</span></p><p><br></p><p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>`
     );
 });
 


### PR DESCRIPTION
**Current behavior before PR:**

- When pressing Enter twice before a star rating (3-star or 5-star), the previous paragraph incorrectly ended up containing a single star.
- When performing a line break next to a contenteditable false element, `deepEditableSelection` returned a selection whose anchor was inside that non-editable element. Since the selection was inside a contenteditable false element, the `insertLineBreakElement` method returned early without doing anything.

**Desired behavior after PR is merged:**

- Pressing Enter before the star rating no longer duplicates a star in the previous paragraph.
-  When `deepEditableSelection` returns a selection whose anchor lies inside a contenteditable false element, we now use an editable selection instead. This prevents the anchor from ending up inside a non-editable element and allows the line break to work correctly.

task-5079270