### PR TITLE
[FIX] hr_skills_survey: certification line color not updated with time

### DIFF
--- a/addons/hr_skills_survey/models/hr_resume_line.py
+++ b/addons/hr_skills_survey/models/hr_resume_line.py
@@ -15,6 +15,7 @@ class ResumeLine(models.Model):
         ('expired', 'Expired'),
         ('expiring', 'Expiring'),
         ('valid', 'Valid')], compute='_compute_expiration_status', store=True)
+    expiration_status_ui = fields.Boolean(compute='_compute_expiration_status_ui')
 
     @api.depends('date_end')
     def _compute_expiration_status(self):
@@ -25,3 +26,8 @@ class ResumeLine(models.Model):
                     line.expiration_status = 'expired'
                 elif line.date_end + relativedelta(months=-3) <= fields.Date.today():
                     line.expiration_status = 'expiring'
+
+    @api.depends('date_end')
+    def _compute_expiration_status_ui(self):
+        self.expiration_status_ui = True
+        self._compute_expiration_status()

--- a/addons/hr_skills_survey/views/hr_employee_certification_views.xml
+++ b/addons/hr_skills_survey/views/hr_employee_certification_views.xml
@@ -12,6 +12,7 @@
                 <field name="date_start" string="Validity Start"/>
                 <field name="date_end" string="Validity End"/>
                 <field name="survey_id" optional="show"/>
+                <field name="expiration_status_ui" column_invisible="1"/>
                 <field name="expiration_status" column_invisible="1"/>
             </list>
         </field>


### PR DESCRIPTION
**Steps to reproduce:**
1. Install `hr_skills_survey`
2. Go to Employees > Reporting > Certifications.
3. Create a certification line with a future end date → record shows in black.
4. Change the system date to after the end date.

**Issue:**
- The line color is not updated when time passes.

**Cause:**
https://github.com/odoo/odoo/blob/76a8d6bc28eb5998bd976b3c41bf9772d325c8bf/addons/hr_skills_survey/models/hr_resume_line.py#L17
https://github.com/odoo/odoo/blob/76a8d6bc28eb5998bd976b3c41bf9772d325c8bf/addons/hr_skills_survey/views/hr_employee_certification_views.xml#L7
- The color was based on the stored computed field `expiration_status`,
which only depends on `date_end`. Since `date_end` does not change with time,
the field value is not recomputed daily.

**Solution:**
- Introduce a non-stored computed field `expiration_status_ui`, depending on
`date_end` and use it in the view to update expiration_status.

opw-5065185
