### PR TITLE
[FIX] account_peppol,account_edi_proxy_client: Peppol neutralization

### DIFF
--- a/addons/account_edi_proxy_client/data/neutralize.sql
+++ b/addons/account_edi_proxy_client/data/neutralize.sql
@@ -2,7 +2,7 @@
 -- for malaysian edi, this script can cause issue as you could have both a demo and prod user, in which case it breaks the unique constrain. Another neutralize in the malaysian module disable the clients instead.
 UPDATE account_edi_proxy_client_user
 SET edi_mode = CASE
-                    WHEN proxy_type = 'l10n_it_edi' THEN 'demo'
+                    WHEN proxy_type IN ('l10n_it_edi', 'peppol') THEN 'demo'
                     ELSE 'test'
                END
 WHERE proxy_type != 'l10n_my_edi';

--- a/addons/account_edi_proxy_client/views/account_edi_proxy_user_views.xml
+++ b/addons/account_edi_proxy_client/views/account_edi_proxy_user_views.xml
@@ -11,6 +11,7 @@
                             <group>
                                 <field name="company_id" groups="base.group_multi_company" invisible="1"/>
                                 <field name="proxy_type" readonly="1" options="{'no_open': True}"/>
+                                <field name="edi_mode" readonly="1"/>
                                 <field name="id_client" readonly="1"/>
                                 <field name="edi_identification" readonly="1"/>
                                 <field name="private_key_filename" invisible="1"/>
@@ -31,6 +32,8 @@
                 <tree create="false" delete="false" edit="false" decoration-muted="not active">
                     <field name="active" invisible="1"/>  <!-- Required for the decoration -->
                     <field name="company_id" groups="base.group_multi_company" column_invisible="True"/>
+                    <field name="proxy_type" readonly="1"/>
+                    <field name="edi_mode" readonly="1"/>
                     <field name="id_client" readonly="1"/>
                     <field name="edi_identification" readonly="1"/>
                     <field name="private_key_filename" column_invisible="True"/>

--- a/addons/account_peppol/data/neutralize.sql
+++ b/addons/account_peppol/data/neutralize.sql
@@ -1,0 +1,3 @@
+UPDATE ir_config_parameter
+SET value = 'test'
+WHERE key = 'account_peppol.edi.mode';


### PR DESCRIPTION
Previously existing Peppol connections were only switched to `test`. This is not enough and incorrect:
- someone connected in production does not necessarily have a registration on the test network, therefore the database is in an inconsistent state, and calls to the test network are very likely to fail
- if you create a new connection to Peppol on a neutralized database, since the system parameter was not changed, the new connection was on production

After this commit:
- existing connections are switched in `demo` where everything is mocked locally, no call to the network (whether it's `test` or `prod` can happen)
- the system parameter is switched to `test`, therefore new connections will register to the Peppol test network
- Also added some fields on the Edi Proxy User to display the mode of the user, as well as the proxy_type in list view.
(Those records are only accessible in debug already.)

<img width="579" height="333" alt="image" src="https://github.com/user-attachments/assets/87847726-d954-4f68-8336-07771747365f" />

task-none (report from PMAX + WTA)
