### PR TITLE
[FIX] mrp: prevent traceback when some workorders have no leave_id

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1578,7 +1578,7 @@ class MrpProduction(models.Model):
         for workorder in final_workorders:
             workorder._plan_workorder(replan)
 
-        workorders = self.workorder_ids.filtered(lambda w: w.state not in ['done', 'cancel'])
+        workorders = self.workorder_ids.filtered(lambda w: w.leave_id and w.state not in ['done', 'cancel'])
         if not workorders:
             return
 

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -5239,6 +5239,22 @@ class TestMrpOrder(TestMrpCommon):
         self.assertEqual(unbuild_order.state, 'done')
         self.assertEqual(unbuild_order.product_qty, 1.23456)
 
+    def test_workorders_without_worcenter_planned_slots(self):
+        """
+        Test that updating a workorder duration does not crash when others are unplanned.
+        """
+        mo = self.env['mrp.production'].create({
+            'product_id': self.product_6.id,
+            'product_qty': 1.0,
+            'bom_id': self.bom_3.id,
+        })
+        mo.action_confirm()
+
+        mo.workorder_ids[0].button_start()  # Start first workorder
+        with Form(mo) as mo_form:
+            with mo_form.workorder_ids.edit(1) as second_wo_line:
+                second_wo_line.duration = 12.0  # Edit the duration of the second workorder
+
 
 @tagged('-at_install', 'post_install')
 class TestTourMrpOrder(HttpCase):


### PR DESCRIPTION
**Steps to reproduce:**
1. In Settings, enable "Work Orders".
2. Create a product with a BOM that has 2 operations: op1 and op2.
3. Create and confirm an MO for 1 unit.
4. Start op1 and change the Real Duration of op2.
5. Try to save.

**Issue:**
- Traceback : 
`'<' not supported between instances of 'datetime.datetime' and 'bool'`

**Cause of the issue:**
Starting the first operation launches a call of the `button_start` method creating
a `resource.calendar.leaves` to set on the `leave_id` of this first operation:
https://github.com/odoo/odoo/blob/97a70e71c32ea6183f87fd5eb558b32bcbd2d231/addons/mrp/models/mrp_workorder.py#L630-L641

Then, setting the duration of the second operation from the form view of the MO
and saving triggers a call of the write of the MO containing the
`[Command.update(op_2.id, new_duration)]` as vals.This, in turn, calls 
`_plan_workorders`:
https://github.com/odoo/odoo/blob/97a70e71c32ea6183f87fd5eb558b32bcbd2d231/addons/mrp/models/mrp_production.py#L939-L942
while the first operation has a set `leave_id` but the second do not

However, the `min` operator will be applied to both the set and the unset values,
comparing a `boolean` with a `datetime`:
https://github.com/odoo/odoo/blob/97a70e71c32ea6183f87fd5eb558b32bcbd2d231/addons/mrp/models/mrp_production.py#L1581-L1588

**Solution:**
Only workorders with a `leave_id` (i.e., those planned in work-center schedule)
should be considered when computing MO `date_start` and `date_finished`.
Workorders without a `leave_id` are not yet scheduled and therefore should not influence MO start and end dates.

As both `date_start` and `date_finished` of a workorder are related to the `leave_id` record. As per `mrp_workorder._compute_dates`, these dates reflect the work-center scheduling (`leave_id.date_from` and `leave_id.date_to`).
https://github.com/odoo/odoo/blob/6a075fa3c090920499ccbd5fe673819da7e3f95e/addons/mrp/models/mrp_workorder.py#L250-L260
Therefore, when computing MO dates, it logically follows that only workorders with an assigned `leave_id` should be used. This avoids mixing unscheduled operations (`leave_id = False`) with scheduled ones, preventing invalid comparisons and ensuring accurate production timing.


**opw-5068080**

