### PR TITLE
[FIX] website: s_pricelist_*, adapt separators

### DIFF
--- a/addons/website/static/src/builder/plugins/options/pricelist_option/pricelist_boxed_option.xml
+++ b/addons/website/static/src/builder/plugins/options/pricelist_option/pricelist_boxed_option.xml
@@ -8,7 +8,7 @@
             actionParam="{ itemClass:'s_pricelist_boxed_item', descriptionClass: 's_pricelist_boxed_item_description' }"/>
     </BuilderRow>
     <BuilderContext applyTo="'.s_pricelist_boxed_item_line'">
-        <BorderConfigurator withRoundCorner="false" label.translate="Separator" direction="'top'"/>
+        <BorderConfigurator withRoundCorner="false" withBSClass="false" label.translate="Separator" direction="'top'"/>
     </BuilderContext>
 </t>
 

--- a/addons/website/static/src/builder/plugins/options/pricelist_option/pricelist_cafe_option.xml
+++ b/addons/website/static/src/builder/plugins/options/pricelist_option/pricelist_cafe_option.xml
@@ -8,7 +8,7 @@
             actionParam="{ itemClass:'s_pricelist_cafe_item', descriptionClass: 's_pricelist_cafe_item_description' }"/>
     </BuilderRow>
     <BuilderContext applyTo="'.s_pricelist_cafe_item_line'">
-        <BorderConfigurator withRoundCorner="false" label.translate="Separator" direction="'top'"/>
+        <BorderConfigurator withRoundCorner="false" withBSClass="false" label.translate="Separator" direction="'top'"/>
     </BuilderContext>
 </t>
 

--- a/addons/website/static/src/builder/plugins/options/pricelist_option/product_catalog_option.xml
+++ b/addons/website/static/src/builder/plugins/options/pricelist_option/product_catalog_option.xml
@@ -8,7 +8,7 @@
             actionParam="{ itemClass:'s_product_catalog_dish', descriptionClass: 's_product_catalog_dish_description' }"/>
     </BuilderRow>
     <BuilderContext applyTo="'.s_product_catalog_dish_dot_leaders'">
-        <BorderConfigurator withRoundCorner="false" label.translate="Separator" direction="'top'"/>
+        <BorderConfigurator withRoundCorner="false" withBSClass="false" label.translate="Separator" direction="'top'"/>
     </BuilderContext>
 </t>
 


### PR DESCRIPTION
Prior to this commit, the separators in the `s_product_catalog` and `s_pricelist_*` snippets didn't render correctly when changing the border values in the web editor.

Steps to reproduce:
- Open the Web Editor.
- Drag and drop a price list snippet (`s_product_catalog`, `s_pricelist_cafe`, or `s_pricelist_boxed`).
- Click on the snippet.
- Set the border value to `0`.

task-5081626

| Before | After |
|--------|--------|
| <img width="1914" height="646" alt="Capture d’écran 2025-09-11 à 09 30 11" src="https://github.com/user-attachments/assets/f7dc319f-e151-4fc4-9349-df70719aec9f" /> | <img width="1912" height="643" alt="Capture d’écran 2025-09-11 à 09 31 02" src="https://github.com/user-attachments/assets/dbbaacff-9f20-4ec4-9fec-f4cc3770952a" /> |
| <img width="1915" height="646" alt="Capture d’écran 2025-09-11 à 09 30 52" src="https://github.com/user-attachments/assets/f138bd04-60cd-4238-9338-2fa5921d7715" /> | <img width="1911" height="647" alt="Capture d’écran 2025-09-11 à 09 31 37" src="https://github.com/user-attachments/assets/c38e486a-2b23-4685-83f1-de363c15c881" /> |

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
