### PR TITLE
[IMP] im_livechat, mail: info side panel tags improvements

### DIFF
--- a/addons/im_livechat/controllers/channel.py
+++ b/addons/im_livechat/controllers/channel.py
@@ -50,3 +50,12 @@ class LivechatChannelController(ChannelController):
             channel.sudo().livechat_conversation_tag_ids = [
                 Command.unlink(tag_id) for tag_id in tag_ids
             ]
+        if channel.livechat_status == "need_help":
+            request.env.ref("im_livechat.im_livechat_group_user")._bus_send(
+                "im_livechat.looking_for_help/tags",
+                {
+                    "channel_id": channel.id,
+                    "tag_ids": channel.sudo().livechat_conversation_tag_ids.ids,
+                },
+                subchannel="LOOKING_FOR_HELP",
+            )

--- a/addons/im_livechat/static/src/core/web/livechat_channel_info_list.js
+++ b/addons/im_livechat/static/src/core/web/livechat_channel_info_list.js
@@ -25,6 +25,7 @@ export class LivechatChannelInfoList extends Component {
         this.tagEditPopover = usePopover(ConversationTagEdit, {
             closeOnClickAway: true,
             position: "left",
+            useBottomSheet: this.ui.isSmall,
         });
         this.tagsContainer = useRef("tagsContainer");
         useSubEnv({ inLivechatInfoPanel: true });

--- a/addons/im_livechat/static/src/core/web/livechat_channel_info_list.xml
+++ b/addons/im_livechat/static/src/core/web/livechat_channel_info_list.xml
@@ -29,13 +29,13 @@
                     <span class="pt-3 mb-1">Tags</span>
                     <button t-if="!conversationTags.length" class="btn opacity-75 opacity-100-hover rounded-3 btn-light bg-transparent p-0 border-transparent ms-auto" t-on-click="onClickEditTags">
                         <div class="d-flex w-100 align-items-center gap-2">
-                            <i class="fa fa-plus smaller"/>
+                            <i class="fa fa-plus smaller text-success"/>
                         </div>
                     </button>
                 </h6>
                 <div t-if="conversationTags.length" class="d-flex flex-wrap flex-grow-1 gap-1">
                     <TagsList displayText="true" tags="conversationTags"/>
-                    <button t-if="this.store.has_access_livechat" class="btn btn-sm btn-primary lh-1 position-relative d-flex align-items-center justify-content-center rounded-4 gap-1" t-on-click="onClickEditTags">
+                    <button t-if="this.store.has_access_livechat" class="btn btn-sm btn-success lh-1 position-relative d-flex align-items-center justify-content-center rounded-4 gap-1" t-on-click="onClickEditTags">
                         <div class="d-flex w-100 align-items-center gap-2">
                             <i class="fa fa-pencil smaller"/>
                         </div>

--- a/addons/im_livechat/static/src/core/web/livechat_conversation_tag_edit.js
+++ b/addons/im_livechat/static/src/core/web/livechat_conversation_tag_edit.js
@@ -1,13 +1,15 @@
-import { Component, onWillStart, useEffect, useState } from "@odoo/owl";
+import { Component, onWillStart, useEffect, useState, xml } from "@odoo/owl";
 
 import { useAutofocus, useService } from "@web/core/utils/hooks";
 import { useSequential } from "@mail/utils/common/hooks";
+import { highlightText } from "@web/core/utils/html";
 import { useDebounced } from "@web/core/utils/timing";
 import { escapeRegExp } from "@web/core/utils/strings";
 import { rpc } from "@web/core/network/rpc";
+import { NavigableList } from "@mail/core/common/navigable_list";
 
 export class ConversationTagEdit extends Component {
-    static components = {};
+    static components = { NavigableList };
     static props = ["thread", "autofocus?", "close?"];
     static template = "im_livechat.ConversationTagEdit";
 
@@ -48,6 +50,21 @@ export class ConversationTagEdit extends Component {
         return this.state.selectableTags.filter(
             (tag) => !tag.in(this.props.thread.livechat_conversation_tag_ids)
         );
+    }
+
+    get navigableListProps() {
+        return {
+            onSelect: (ev, option) => {
+                this.toggleSelectedTag(option.tag);
+                this.state.searchStr = "";
+            },
+            optionTemplate: xml`<t t-out="option.label"/>`,
+            options: this.remainingSelectableTags.map((tag) => ({
+                tag,
+                label: highlightText(this.state.searchStr.trim(), tag.name, "text-primary"),
+                buttonClass: "btn",
+            })),
+        };
     }
 
     async toggleSelectedTag(tag) {

--- a/addons/im_livechat/static/src/core/web/livechat_conversation_tag_edit.scss
+++ b/addons/im_livechat/static/src/core/web/livechat_conversation_tag_edit.scss
@@ -3,14 +3,14 @@
     width: 300px;
 }
 
-.o-livechat-ConversationTagEdit-selectable {
-    &.o-odd {
+.o-livechat-ConversationTagEdit .o-mail-NavigableList-item {
+    &:nth-child(odd) {
         background-color: $gray-100 !important;;
     }
     &:hover {
         background-color: mix($gray-100, $gray-200) !important;
     }
-}
+} 
 
 .o-livechat-ConversationTagEdit-selectedList {
     max-height: 100px;

--- a/addons/im_livechat/static/src/core/web/livechat_conversation_tag_edit.xml
+++ b/addons/im_livechat/static/src/core/web/livechat_conversation_tag_edit.xml
@@ -2,10 +2,10 @@
 <templates xml:space="preserve">
 
     <t t-name="im_livechat.ConversationTagEdit">
-        <div class="o-livechat-ConversationTagEdit rounded d-flex flex-column p-2 flex-grow-1 bg-inherit">
+        <div class="o-livechat-ConversationTagEdit rounded d-flex flex-column p-2 flex-grow-1 bg-inherit mx-auto">
             <div class="d-flex">
                 <input class="o-livechat-ConversationTagEdit-search form-control lh-1 px-2 bg-view shadow-sm" t-model="state.searchStr" t-ref="autofocus" placeholder="Search or create new tags" t-on-keydown="onKeydownSearchInput"/>
-                <button class="btn btn-secondary ms-1" t-att-disabled="!state.searchStr || allSelectableTagNames.includes(state.searchStr)" t-on-click="onClickCreateToggle">
+                <button class="btn btn-secondary ms-1" t-att-disabled="!state.searchStr.trim() || allSelectableTagNames.includes(state.searchStr)" t-on-click="onClickCreateToggle">
                     Create
                 </button>
             </div>
@@ -16,13 +16,7 @@
                 <div t-elif="remainingSelectableTags.length === 0" class="smaller fst-italic text-muted mx-1 opacity-50">
                     No tags found
                 </div>
-                <t t-foreach="remainingSelectableTags" t-as="selectableTag" t-key="selectableTag.id">
-                    <li class="o-livechat-ConversationTagEdit-selectable object-fit-cover d-flex align-items-center p-1 gap-1 btn list-group-item border-0 rounded-0" t-att-class="{ 'o-odd': selectableTag_index % 2 === 1 }" t-on-click="() => this.toggleSelectedTag(selectableTag)">
-                        <div class="d-flex flex-grow-1 mx-2 overflow-hidden align-items-baseline">
-                            <span class="text-truncate" t-esc="selectableTag.name"/>
-                        </div>
-                    </li>
-                </t>
+                <NavigableList inline="true" t-props="navigableListProps"/>
             </ul>
             <div t-if="props.thread.livechat_conversation_tag_ids.length > 0" class="overflow-auto pt-2">
                 <div class="o-livechat-ConversationTagEdit-selectedList d-flex flex-wrap overflow-auto o-scrollbar-thin">

--- a/addons/im_livechat/static/src/views/livechat_looking_for_help_controller_mixin.js
+++ b/addons/im_livechat/static/src/views/livechat_looking_for_help_controller_mixin.js
@@ -14,16 +14,19 @@ export const LivechatLookingForHelpReloadMixin = (ViewController) =>
             const busService = useService("bus_service");
             this.reloadDebounced = useDebounced(() => this.model.load(), RELOAD_DEBOUNCE_DELAY);
             this.lookingForHelpOnUpdate = this.lookingForHelpOnUpdate.bind(this);
+            this.tagsOnUpdate = this.tagsOnUpdate.bind(this);
             busService.addChannel("im_livechat.looking_for_help");
             busService.subscribe(
                 "im_livechat.looking_for_help/update",
                 this.lookingForHelpOnUpdate
             );
+            busService.subscribe("im_livechat.looking_for_help/tags", this.tagsOnUpdate);
             onWillDestroy(() => {
                 busService.unsubscribe(
                     "im_livechat.looking_for_help/update",
                     this.lookingForHelpOnUpdate
                 );
+                busService.unsubscribe("im_livechat.looking_for_help/tags", this.tagsOnUpdate);
                 busService.deleteChannel("im_livechat.looking_for_help");
             });
         }
@@ -42,6 +45,16 @@ export const LivechatLookingForHelpReloadMixin = (ViewController) =>
                 .filter(Boolean);
             if (recordIdsToRemove.length) {
                 this.model.root._removeRecords(recordIdsToRemove);
+            }
+        }
+
+        tagsOnUpdate({ channel_id, tag_ids }) {
+            const channel = this.model.root.records.find((r) => r.resId === channel_id);
+            if (
+                JSON.stringify(channel?.data.livechat_conversation_tag_ids._currentIds) !==
+                JSON.stringify(tag_ids)
+            ) {
+                channel.load();
             }
         }
     };

--- a/addons/im_livechat/views/im_livechat_conversation_tag_views.xml
+++ b/addons/im_livechat/views/im_livechat_conversation_tag_views.xml
@@ -5,7 +5,8 @@
             <field name="name">im.livechat.channel.conversation.tag.list</field>
             <field name="model">im_livechat.conversation.tag</field>
             <field name="arch" type="xml">
-                <list string="Tags" editable="bottom" sample="1">
+                <list string="Tags" editable="bottom" sample="1" duplicate="0">
+                    <field name="sequence" widget="handle"/>
                     <field name="name"/>
                     <field name="color" widget="color_picker"/>
                 </list>

--- a/addons/mail/static/src/core/common/navigable_list.js
+++ b/addons/mail/static/src/core/common/navigable_list.js
@@ -18,10 +18,12 @@ export class NavigableList extends Component {
         options: { type: Array },
         optionTemplate: { type: String, optional: true },
         position: { type: String, optional: true },
+        inline: { type: Boolean, optional: true },
         isLoading: { type: Boolean, optional: true },
     };
     static defaultProps = {
         position: "bottom",
+        inline: false,
         isLoading: false,
     };
 
@@ -81,6 +83,9 @@ export class NavigableList extends Component {
     }
 
     close() {
+        if (this.props.inline) {
+            return;
+        }
         this.state.open = false;
         this.state.activeIndex = null;
     }

--- a/addons/mail/static/src/core/common/navigable_list.xml
+++ b/addons/mail/static/src/core/common/navigable_list.xml
@@ -3,7 +3,7 @@
 
     <t t-name="mail.NavigableList">
         <div class="o-mail-NavigableList bg-view m-0 p-0 shadow-sm" t-ref="root" t-att-class="props.class">
-            <div t-if="show" class="o-open border d-flex flex-column bg-inherit" t-on-mousedown.prevent="">
+            <div t-if="show" class="o-open d-flex flex-column bg-inherit" t-attf-class="{{ props.inline ? border-0 : border }}" t-on-mousedown.prevent="">
                 <div t-if="state.showLoading" t-att-class="{ 'position-absolute bg-inherit smaller o-mail-NavigableList-floatingLoading': props.options.length, 'bg-300': props.options.length and state.activeIndex === 0, 'o-mail-NavigableList-item': !props.options.length }">
                     <t t-call="mail.NavigableList.spinner"/>
                 </div>


### PR DESCRIPTION
This commit introduces the following improvements to the livechat info side panel tags feature:
- Characters in the tags matching the search term are highlighted.
- The list of tags is navigable and the active item is highlighted.
- Add and Edit tags icons are now green following convention.
- Tags are kept synchronized in the "looking for help" sessions view.
- Tags have a sequence number and are displayed ordered on that.
- On mobile the tag list is now show in the bottom sheet.

This commit also fixes the issue of creating a tag with only whitespace.

task-5065034