### PR TITLE
[REF] html_builder, *: update `assets_edit_frontend` bundle name

### DIFF
--- a/addons/html_builder/__manifest__.py
+++ b/addons/html_builder/__manifest__.py
@@ -44,9 +44,8 @@
         'web.assets_web_dark': [
             'html_builder/static/src/**/*.dark.scss',
         ],
-        'html_builder.assets_edit_frontend': [
+        'html_builder.assets_inside_builder_iframe': [
             ('include', 'web._assets_helpers'),
-
             'web/static/src/scss/bootstrap_overridden.scss',
             'html_builder/static/src/**/*.edit.*',
             'html_editor/static/src/main/chatgpt/chatgpt_plugin.scss',

--- a/addons/mass_mailing/__manifest__.py
+++ b/addons/mass_mailing/__manifest__.py
@@ -102,7 +102,7 @@
             'web/static/src/scss/ui.scss',
             'web/static/src/scss/fontawesome_overridden.scss',
 
-            ('include', 'html_builder.assets_edit_frontend'),
+            ('include', 'html_builder.assets_inside_builder_iframe'),
             'mass_mailing/static/src/scss/mass_mailing_mail.scss',
             'mass_mailing/static/src/iframe_assets/**/*',
         ],

--- a/addons/portal/__manifest__.py
+++ b/addons/portal/__manifest__.py
@@ -109,7 +109,7 @@ a dependency towards website editing and customization capabilities.""",
             ("remove", "mail/static/src/**/*.dark.scss"),
             "portal/static/src/chatter/scss/shadow.scss",
         ],
-        'website.assets_edit_frontend': [
+        'website.assets_inside_builder_iframe': [
             'portal/static/src/scss/portal.edit.*'
         ],
     },

--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -280,8 +280,8 @@
             ('remove', 'website/static/src/js/content/redirect.js'),
             ('remove', 'website/static/src/js/content/adapt_content.js'),
         ],
-        'website.assets_edit_frontend': [
-            ('include', 'html_builder.assets_edit_frontend'),
+        'website.assets_inside_builder_iframe': [
+            ('include', 'html_builder.assets_inside_builder_iframe'),
             'website/static/src/**/*.edit.*',
             'website/static/src/core/website_edit_service.js',
         ],

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -296,12 +296,12 @@ export class WebsiteBuilderClientAction extends Component {
         // at this point, the iframe should be loaded. In a normal user flow, the
         // iframe had the time to load and start the js, and has an environment
         // with services. But it could happen (most likely in tours or tests) that
-        // the js is not loaded yet. If we load the assets_edit_frontend bundle
+        // the js is not loaded yet. If we load the assets_inside_builder_iframe bundle
         // now, and if it comes first, we'll get a crash. So we make sure that we
         // properly wait for the iframe to be completely ready.
         await this.waitForIframeReady();
         await Promise.all([
-            loadBundle("website.assets_edit_frontend", {
+            loadBundle("website.assets_inside_builder_iframe", {
                 targetDoc: this.websiteContent.el.contentDocument,
             }),
         ]);

--- a/addons/website/static/tests/builder/website_helpers.js
+++ b/addons/website/static/tests/builder/website_helpers.js
@@ -157,7 +157,7 @@ export async function setupWebsiteBuilder(
             // (location, rpc, ...). So we don't load the js part of the bundle
 
             if (loadIframeBundles) {
-                await loadBundle("website.assets_edit_frontend", {
+                await loadBundle("website.assets_inside_builder_iframe", {
                     targetDoc: queryOne("iframe[data-src^='/website/force/1']").contentDocument,
                     js: false,
                 });

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -316,7 +316,7 @@ class TestUi(HttpCaseWithWebsiteUser):
         self.start_tour("/", 'website_navbar_menu')
 
     def test_05_specific_website_editor(self):
-        asset_bundle_xmlid = "website.assets_edit_frontend"
+        asset_bundle_xmlid = "website.assets_inside_builder_iframe"
         website_default = self.env['website'].search([], limit=1)
 
         new_website = self.env['website'].create({'name': 'New Website'})
@@ -332,7 +332,7 @@ class TestUi(HttpCaseWithWebsiteUser):
 
         self.env['ir.asset'].create({
             'name': 'EditorExtension',
-            'bundle': "website.assets_edit_frontend",
+            'bundle': "website.assets_inside_builder_iframe",
             'path': custom_url,
             'website_id': new_website.id,
         })
@@ -342,7 +342,7 @@ class TestUi(HttpCaseWithWebsiteUser):
         base_website_css_version = base_website_bundle.get_version('css')
         base_website_js_version = base_website_bundle.get_version('js')
 
-        new_website_bundle_modified = self.env['ir.qweb']._get_asset_bundle("website.assets_edit_frontend", assets_params={'website_id': new_website.id})
+        new_website_bundle_modified = self.env['ir.qweb']._get_asset_bundle("website.assets_inside_builder_iframe", assets_params={'website_id': new_website.id})
         self.assertIn(custom_url, [f['url'] for f in new_website_bundle_modified.files])
         self.assertEqual(new_website_bundle_modified.get_version('css'), base_website_css_version)
         self.assertNotEqual(new_website_bundle_modified.get_version('js'), base_website_js_version, "js version for new website should now have been changed")

--- a/addons/website_mail/__manifest__.py
+++ b/addons/website_mail/__manifest__.py
@@ -20,7 +20,7 @@ Module holding mail improvements for website. It holds the follow widget.
             'website_mail/static/src/interactions/follow.js',
             'website_mail/static/src/css/website_mail.scss',
         ],
-        'web.assets_edit_frontend': [
+        'web.assets_inside_builder_iframe': [
             'website/static/src/interactions/follow.edit.js',
         ],
     },

--- a/addons/website_mail_group/__manifest__.py
+++ b/addons/website_mail_group/__manifest__.py
@@ -18,7 +18,7 @@
             'website_mail_group/static/src/snippets/**/*.js',
             ('remove', 'website_mail_group/static/src/**/*.edit.js'),
         ],
-        'website.assets_edit_frontend': [
+        'website.assets_inside_builder_iframe': [
             'website_mail_group/static/src/**/*.edit.js',
         ],
         'website.website_builder_assets': [

--- a/addons/website_mass_mailing/__manifest__.py
+++ b/addons/website_mass_mailing/__manifest__.py
@@ -31,7 +31,7 @@ On a simple click, your visitors can subscribe to mailing lists managed in the E
             'website_mass_mailing/static/src/website_builder/**/*',
             ('remove', 'website_mass_mailing/static/src/website_builder/**/*.edit.*'),
         ],
-        'website.assets_edit_frontend': [
+        'website.assets_inside_builder_iframe': [
             'website_mass_mailing/static/src/website_builder/mailing_list_subscribe_option.edit.*',
         ],
         'web.assets_tests': [

--- a/addons/website_payment/__manifest__.py
+++ b/addons/website_payment/__manifest__.py
@@ -29,7 +29,7 @@ This is a bridge module that adds multi-website support for payment providers.
             'website_payment/static/src/snippets/**/*.js',
             ('remove', 'website_payment/static/src/snippets/**/*.edit.js'),
         ],
-        'website.assets_edit_frontend': [
+        'website.assets_inside_builder_iframe': [
             'website_payment/static/src/**/*.edit.js',
         ],
         'web.assets_tests': [

--- a/addons/website_payment/views/snippets/s_supported_payment_methods.xml
+++ b/addons/website_payment/views/snippets/s_supported_payment_methods.xml
@@ -13,7 +13,7 @@
 
     <record id="s_supported_payment_methods_OOO_edit_xml" model="ir.asset">
         <field name="name">Supported Payment Methods 000 XML (edit)</field>
-        <field name="bundle">website.assets_edit_frontend</field>
+        <field name="bundle">website.assets_inside_builder_iframe</field>
         <field name="path">/website_payment/static/src/snippets/s_supported_payment_methods/000.edit.xml</field>
     </record>
 

--- a/addons/website_profile/__manifest__.py
+++ b/addons/website_profile/__manifest__.py
@@ -28,7 +28,7 @@
             ('remove', 'website_profile/static/src/interactions/**/*.edit.js'),
             ('include', 'html_editor.assets_editor'),
         ],
-        'website.assets_edit_frontend': [
+        'website.assets_inside_builder_iframe': [
             'website_profile/static/src/**/*.edit.js',
         ],
         'web.assets_tests': [

--- a/addons/website_sale/__manifest__.py
+++ b/addons/website_sale/__manifest__.py
@@ -165,7 +165,7 @@
             'website_sale/static/src/xml/website_sale_utils.xml',
             'website_sale/static/src/xml/website_sale_editor_previews.xml',
         ],
-        'website.assets_edit_frontend': [
+        'website.assets_inside_builder_iframe': [
             'web/static/lib/bootstrap/scss/_variables.scss',
             'website_sale/static/src/website_builder/**/*.edit.*',
         ],


### PR DESCRIPTION
*: mass_mailing, portal, website, website_mail, website_mail_group, website_mass_mailing, website_payment, website_profile, website_sale

The new html_builder is used by both website and mass_mailing. While the old name `[html_builder|website].assets_edit_frontend` makes sense in the context of the website builder, where the iframe is indeed used to "edit the frontend", it is not the case in mass_mailing, where the email being composed is not a "frontend". A more generic name is more appropriate.