### PR TITLE
[FIX] calendar: bring back calendar event deletion wizard

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -989,11 +989,7 @@ class CalendarEvent(models.Model):
             _logger.warning('Template "calendar.calendar_template_delete_event" was not found. Cannot send delete notifications.')
             return {}
 
-        lang = self.env.context.get('lang')
-        if template.lang:
-            # This method ensures that the template is translated according
-            # to the user's or record's language settings.
-            lang = template._render_lang(self.ids)[self.id]
+        if self.ids and (lang := template._render_lang(self.ids)[self.id]):
             context = {
                 'default_use_template': bool(template),
                 'default_template_id': template.id,


### PR DESCRIPTION
Since [1], we removed the 'lang' value from mail templates, as we allow to use a fallback on main partner's lang instead.

However, when deleting a calendar.meeting (from Form or calendar) we usually (if no sync is on, and when deleting a single event) open the wizard of confirmation that allows to preview and send cancelation email to the attendees, in order for them to have the information before complete deletion. (see the following wizard: calendar.popover.delete.wizard)

Before [1], we wanted to make sure the template had a lang set. But we forgot to change that condition, resulting in a lot of cases where deletion is just not working, and redirects to the calendar view instead (default behavior), as the lang on the template is not set.

We now use the ´_render_lang´ method instead in order to compute the lang value and use it in the condition as well, actively opening the confirmation modal instead of doing nothing and redirecting to the calendar event.

[1]: odoo/odoo@dc016190e3f3fd90b10fb1eac07204e22d715109

Task-5079771