### PR TITLE
[FIX] website_sale, portal: address selector's responsive design

### DIFF
--- a/addons/portal/views/address_templates.xml
+++ b/addons/portal/views/address_templates.xml
@@ -101,7 +101,7 @@
             t-att-data-address-type="address_type"
             t-att-data-partner-id="contact.id"
         >
-            <div class="card-body d-flex flex-column flex-md-row justify-content-between gap-3">
+            <div class="card-body d-flex flex-column flex-md-row justify-content-between gap-2">
                 <t
                     t-out="contact"
                     t-options="dict(widget='contact', fields=['name', 'address'], no_marker=True, no_tag_br=True)"
@@ -126,7 +126,7 @@
                     >
                         Billing Address
                     </span>
-                    <div t-if="can_be_edited" class="d-flex gap-1 mt-auto me-n2 mb-n2">
+                    <div t-if="can_be_edited" class="d-flex gap-1 mt-auto ms-n2 ms-md-auto me-auto me-md-n2 mb-n2">
                         <t
                             t-set="address_update_url"
                             t-value="address_update_url or (new_address_url + '&amp;partner_id=' + str(contact.id))"

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -3619,7 +3619,7 @@
 
     <template id="address_edit_button" name="Address edit button">
         <t t-if="xmlid != 'website_sale.confirmation'">
-            <a t-if="order.partner_invoice_id.country_id" class="float-end no-decoration pe-1" href="/shop/checkout">
+            <a t-if="order.partner_invoice_id.country_id" class="float-end no-decoration ms-2" href="/shop/checkout">
                 <i class="fa fa-pencil me-1"/>Edit
             </a>
             <a
@@ -3642,10 +3642,10 @@
                     t-set="use_delivery_as_billing"
                     t-value="order.partner_invoice_id == order.partner_shipping_id and not order.pickup_location_data"
                 />
-                <div class="row">
+                <div class="d-flex flex-column flex-md-row gap-4">
                     <div
                         t-if="not use_delivery_as_billing and order._has_deliverable_products()"
-                        t-attf-class="{{not use_delivery_as_billing and not only_services and 'col-md-6'}}"
+                        t-attf-class="{{not use_delivery_as_billing and not only_services and 'col'}}"
                     >
                         <t t-if="order.pickup_location_data">
                             <p t-att-class="delivery_title_classes">Deliver to pickup point</p>
@@ -3669,7 +3669,7 @@
                             />
                         </t>
                     </div>
-                    <div t-attf-class="{{not use_delivery_as_billing and not only_services and 'col-md-6'}}">
+                    <div t-attf-class="{{not use_delivery_as_billing and not only_services and 'col'}}">
                         <p t-if="use_delivery_as_billing and not only_services" t-att-class="delivery_title_classes">Delivery &amp; Billing</p>
                         <p t-else="" t-att-class="delivery_title_classes">Billing</p>
                         <t


### PR DESCRIPTION
This PR fixes some issues regarding the mobile design of the address selector, mainly by adapting the margins and paddings in and between the components.

1. The 'edit' icon placement was changing if there was no badge on the card (address checkout & portal page).
2. Refine the spaces in the address & billing summary on the payment method page.

task-5081875


| &nbsp; | Before | After |
|--------|--------|--------|
| 1 | <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/33faf30b-3b6c-47ce-acef-12265b50df0d" /> | <img width="368" height="802" alt="image" src="https://github.com/user-attachments/assets/1432d00e-9d41-488d-b482-b64728319206" /> |
| 2 | <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/195da2f4-9f0e-4cc8-bb4d-df55fc887216" /> | <img width="1095" height="2040" alt="image" src="https://github.com/user-attachments/assets/046f1353-df4b-4b4b-b14c-1fe4d7db85c1" /> |

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
