### PR TITLE
[FIX] base_import: add context in import records

### DIFF
--- a/addons/account/tests/__init__.py
+++ b/addons/account/tests/__init__.py
@@ -65,3 +65,4 @@ from . import test_account_move_attachment
 from . import test_account_bill_deductibility
 from . import test_dict_to_xml
 from . import test_duplicate_res_partner_bank
+from . import test_account_move_import_template

--- a/addons/account/tests/test_account_move_import_template.py
+++ b/addons/account/tests/test_account_move_import_template.py
@@ -1,0 +1,30 @@
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestAccountMoveImportTemplate(TransactionCase):
+
+    def setUp(self):
+        super().setUp()
+        self.AccountMove = self.env['account.move']
+
+    def fetch_template_for_type(self, move_type):
+        return self.AccountMove.with_context(default_move_type=move_type).get_import_templates()
+
+    def test_import_template(self):
+
+        def test_template(move_type, file_name):
+            template = self.fetch_template_for_type(move_type)
+            self.assertEqual(len(template), 1)
+            self.assertEqual(template[0].get('template'), file_name)
+
+        test_template('entry', '/account/static/xls/misc_operations_import_template.xlsx')
+        test_template('out_invoice', '/account/static/xls/customer_invoices_credit_notes_import_template.xlsx')
+        test_template('out_refund', '/account/static/xls/customer_invoices_credit_notes_import_template.xlsx')
+        test_template('in_invoice', '/account/static/xls/vendor_bills_refunds_import_template.xlsx')
+        test_template('in_refund', '/account/static/xls/vendor_bills_refunds_import_template.xlsx')
+
+        template = self.fetch_template_for_type('unknown_type')
+        self.assertEqual(template, [])
+        template = self.fetch_template_for_type(None)
+        self.assertEqual(template, [])

--- a/addons/base_import/static/src/import_records/import_records.js
+++ b/addons/base_import/static/src/import_records/import_records.js
@@ -27,9 +27,11 @@ export class ImportRecords extends Component {
     //---------------------------------------------------------------------
 
     importRecords() {
+        const { context } = this.env.searchModel;
         this.action.doAction({
             type: "ir.actions.client",
             tag: "import",
+            params: { context },
         });
     }
 }

--- a/addons/base_import/static/tests/import_records.test.js
+++ b/addons/base_import/static/tests/import_records.test.js
@@ -36,6 +36,7 @@ test(`import in cog menu dropdown in list`, async () => {
     mockService("action", {
         doAction(action, options) {
             expect.step(action.tag);
+            expect(action.params.context.foo).toBe("bar");
             return super.doAction(action, options);
         },
     });
@@ -46,6 +47,9 @@ test(`import in cog menu dropdown in list`, async () => {
         arch: `<list><field name="foo"/></list>`,
         config: {
             actionType: "ir.actions.act_window",
+        },
+        context: {
+            foo: "bar",
         },
     });
     await toggleActionMenu();
@@ -102,6 +106,7 @@ test(`import in cog menu dropdown in kanban`, async () => {
     mockService("action", {
         doAction(action, options) {
             expect.step(action.tag);
+            expect(action.params.context.foo).toBe("bar");
             return super.doAction(action, options);
         },
     });
@@ -120,6 +125,9 @@ test(`import in cog menu dropdown in kanban`, async () => {
         `,
         config: {
             actionType: "ir.actions.act_window",
+        },
+        context: {
+            foo: "bar",
         },
     });
     await toggleActionMenu();

--- a/addons/hr_timesheet/tests/__init__.py
+++ b/addons/hr_timesheet/tests/__init__.py
@@ -7,3 +7,4 @@ from . import test_portal_timesheet
 from . import test_project_project
 from . import test_project_template
 from . import test_employee_delete_wizard
+from . import test_timesheet_import_template

--- a/addons/hr_timesheet/tests/test_timesheet_import_template.py
+++ b/addons/hr_timesheet/tests/test_timesheet_import_template.py
@@ -1,0 +1,23 @@
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestHrTimesheetImportTemplate(TransactionCase):
+
+    def setUp(self):
+        super().setUp()
+        self.AccountLine = self.env['account.analytic.line']
+
+    def fetch_template_for_timesheet(self, is_timesheet):
+        return self.AccountLine.with_context(is_timesheet=is_timesheet).get_import_templates()
+
+    def test_import_template(self):
+        template = self.fetch_template_for_timesheet(True)
+        self.assertEqual(len(template), 1)
+        self.assertEqual(
+            template[0]['template'], '/hr_timesheet/static/xls/timesheets_import_template.xlsx',
+        )
+        template = self.fetch_template_for_timesheet(False)
+        self.assertEqual(template, [])
+        template = self.fetch_template_for_timesheet(None)
+        self.assertEqual(template, [])


### PR DESCRIPTION
The context was removed in a previous change (#222793), which caused the "Import Template" button to disappear in `account.move` and `hr.timesheet`.
These models rely on context keys in `get_import_template` to display the correct label and link.

This commit adds the `context` back and tests for both models.
