### PR TITLE
[FIX] website_sale, *: address & payment method design

### DIFF
--- a/addons/payment/views/payment_form_templates.xml
+++ b/addons/payment/views/payment_form_templates.xml
@@ -238,7 +238,7 @@
         </div>
         <!-- === Provider name (only for mobile) === -->
         <p name="o_payment_secured_by_mobile"
-           t-att-class="'align-self-end d-block d-md-none mb-0 small text-600'
+           t-att-class="'align-self-center d-block d-md-none mb-0 small text-600'
                         + (' d-none' if hide_secured_by else '')"
         >
             <span><i class="fa fa-lock"/> Secured by</span>
@@ -329,8 +329,8 @@
             >
                 <t t-set="provider_id" t-value="provider_sudo.id"/>
             </t>
-            <div class="d-flex flex-column flex-md-row align-md-items-center justify-content-between
-                        gap-2 mt-2"
+            <div class="d-flex flex-column flex-sm-row align-md-items-center justify-content-between
+                        gap-3 mt-2"
             >
                 <!-- === Tokenization checkbox === -->
                 <div t-if="mode == 'payment'
@@ -350,7 +350,7 @@
                 <!-- === Provider name === -->
                 <t t-set="hide_secured_by" t-value="False"/>
                 <p name="o_payment_secured_by"
-                   t-att-class="'align-self-end mb-0 ms-auto small text-600'
+                   t-att-class="'align-self-end mb-0 mx-auto me-sm-0 small text-600'
                                 + (' d-none' if hide_secured_by else '')"
                 >
                     <span><i class="fa fa-lock"/> Secured by</span>

--- a/addons/portal/views/address_templates.xml
+++ b/addons/portal/views/address_templates.xml
@@ -101,7 +101,7 @@
             t-att-data-address-type="address_type"
             t-att-data-partner-id="contact.id"
         >
-            <div class="card-body d-flex flex-column flex-md-row justify-content-between gap-3">
+            <div class="card-body d-flex flex-column flex-md-row justify-content-between gap-2">
                 <t
                     t-out="contact"
                     t-options="dict(widget='contact', fields=['name', 'address'], no_marker=True, no_tag_br=True)"
@@ -126,7 +126,7 @@
                     >
                         Billing Address
                     </span>
-                    <div t-if="can_be_edited" class="d-flex gap-1 mt-auto me-n2 mb-n2">
+                    <div t-if="can_be_edited" class="d-flex gap-1 mt-auto ms-n2 ms-md-auto me-auto me-md-n2 mb-n2">
                         <t
                             t-set="address_update_url"
                             t-value="address_update_url or (new_address_url + '&amp;partner_id=' + str(contact.id))"

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -3616,12 +3616,12 @@
 
     <template id="address_edit_button" name="Address edit button">
         <t t-if="xmlid != 'website_sale.confirmation'">
-            <a t-if="order.partner_invoice_id.country_id" class="float-end no-decoration pe-1" href="/shop/checkout">
+            <a t-if="order.partner_invoice_id.country_id" class="float-end no-decoration" href="/shop/checkout">
                 <i class="fa fa-pencil me-1"/>Edit
             </a>
             <a
                 t-else=""
-                class="float-end no-decoration pe-1"
+                class="float-end no-decoration"
                 t-attf-href="/shop/address?partner_id={{order.partner_invoice_id.id}}&amp;address_type=billing"
             >
                 <i class="fa fa-pencil me-1"/>Want an invoice?
@@ -3639,10 +3639,10 @@
                     t-set="use_delivery_as_billing"
                     t-value="order.partner_invoice_id == order.partner_shipping_id and not order.pickup_location_data"
                 />
-                <div class="row">
+                <div class="d-flex flex-column flex-md-row gap-4">
                     <div
                         t-if="not use_delivery_as_billing and order._has_deliverable_products()"
-                        t-attf-class="{{not use_delivery_as_billing and not only_services and 'col-md-6'}}"
+                        t-attf-class="{{not use_delivery_as_billing and not only_services and 'col'}}"
                     >
                         <t t-if="order.pickup_location_data">
                             <p t-att-class="delivery_title_classes">Deliver to pickup point</p>
@@ -3666,7 +3666,7 @@
                             />
                         </t>
                     </div>
-                    <div t-attf-class="{{not use_delivery_as_billing and not only_services and 'col-md-6'}}">
+                    <div t-attf-class="{{not use_delivery_as_billing and not only_services and 'col'}}">
                         <p t-if="use_delivery_as_billing and not only_services" t-att-class="delivery_title_classes">Delivery &amp; Billing</p>
                         <p t-else="" t-att-class="delivery_title_classes">Billing</p>
                         <t


### PR DESCRIPTION
*: portal, payment.

This PR fixes some issues regarding the mobile design of the address selector & method payment, mainly by adapting the margins and paddings in and between the components.

1. The 'edit' icon placement was changing if there was no badge on the card (address checkout & portal page).
2. Refine the spaces in the address & billing summary on the payment method page.
3. The label 'secured by […]' is now on its own line and centered horizontally on mobile.

task-5081875

Requires: 
- https://github.com/odoo/enterprise/pull/94884


| &nbsp; | Before | After |
|--------|--------|--------|
| 1 | <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/33faf30b-3b6c-47ce-acef-12265b50df0d" /> | <img width="368" height="802" alt="image" src="https://github.com/user-attachments/assets/1432d00e-9d41-488d-b482-b64728319206" /> |
| 2 | <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/195da2f4-9f0e-4cc8-bb4d-df55fc887216" /> | <img width="1095" height="2040" alt="image" src="https://github.com/user-attachments/assets/046f1353-df4b-4b4b-b14c-1fe4d7db85c1" /> |
| 3 | <img width="704" height="538" alt="image" src="https://github.com/user-attachments/assets/e19388fe-eccd-403b-855f-2a0b2197c87a" /> | <img width="341" height="276" alt="image" src="https://github.com/user-attachments/assets/2f9b24a0-60ee-4cf2-8206-31abed565b90" /> |


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
