### PR TITLE
[FIX] base: set default kanban view priority for res.partner

### DIFF
--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -343,6 +343,7 @@
         <record model="ir.ui.view" id="res_partner_kanban_view">
             <field name="name">res.partner.kanban</field>
             <field name="model">res.partner</field>
+            <field name="priority">1</field>
             <field name="arch" type="xml">
                 <kanban sample="1">
                     <field name="avatar_128"/>


### PR DESCRIPTION
This commit sets the priority of the res.partner kanban view to 1, ensuring it is used as the default when opening a kanban on partners.

Without this fix, certain contexts (e.g., opening a res.partner many2one field from mobile apps like Field Service) could incorrectly default to the equity-specific kanban view instead of the standard one.

task-5077712