### PR TITLE
[FIX] mail: prevent blur applied video stream freeze when switching tab

### DIFF
--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -1330,6 +1330,9 @@ export class Rtc extends Record {
                 );
                 this.store.settings.useBlur = false;
             }
+        } else if (!this.store.settings.useBlur && type === "camera") {
+            this.blurManager?.close();
+            this.blurManager = undefined;
         }
         switch (type) {
             case "camera": {

--- a/addons/mail/static/src/discuss/call/common/tick_worker.js
+++ b/addons/mail/static/src/discuss/call/common/tick_worker.js
@@ -1,0 +1,55 @@
+/* eslint-env worker */
+/* eslint-disable no-restricted-globals */
+
+let intervalId = null;
+let awaitingTock = false;
+let isRunning = false;
+
+function reset() {
+    if (intervalId) {
+        clearInterval(intervalId);
+        intervalId = null;
+    }
+    awaitingTock = false;
+    isRunning = false;
+}
+
+function startProcessing(fps) {
+    if (isRunning) {
+        return;
+    }
+    isRunning = true;
+    intervalId = setInterval(() => {
+        if (awaitingTock) {
+            return;
+        }
+        awaitingTock = true;
+        self.postMessage({ command: "tick" });
+    }, Math.floor(1000 / (fps || 30)));
+}
+
+self.onmessage = (e) => {
+    if (!e.data?.command) {
+        return;
+    }
+    const { command, fps } = e.data;
+    switch (command) {
+        case "start":
+            startProcessing(fps);
+            break;
+        case "tock":
+            awaitingTock = false;
+            break;
+        case "stop":
+            reset();
+            break;
+        default:
+            break;
+    }
+};
+
+self.onmessageerror = () => {
+    awaitingTock = false;
+};
+
+self.onerror = reset;


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
This PR fixes an issue where the video stream freezes when the background blur effect is enabled and the user switches to another browser tab during video calls.

**Current behavior before PR:**
When background blur is enabled during a video call, the user’s video stream freezes if they switch to another browser tab. This happens because currently frame scheduling relies on `requestAnimationFrame` and `setTimeout`, which modern browsers pause or throttle in inactive tabs to conserve system resources and battery life.

**Desired behavior after PR is merged:**
The user’s video stream continues to render with the background blur effect, even when the browser tab is inactive. This is achieved by moving the frame scheduling logic to a Web Worker, which runs in a separate thread and is not subject to browser throttling. As a result, a consistent frame rate is maintained at all times.

task-[4781227](https://www.odoo.com/odoo/project/1519/tasks/4781227)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
