### PR TITLE
[FIX] l10n_in: make name mandatory on PAN entity

### DIFF
--- a/addons/l10n_in/models/l10n_in_pan_entity.py
+++ b/addons/l10n_in/models/l10n_in_pan_entity.py
@@ -11,7 +11,7 @@ class L10nInPanEntity(models.Model):
     _inherit = ['mail.thread', 'mail.activity.mixin']
     _description = 'Indian PAN Entity'
 
-    name = fields.Char(string="PAN", tracking=1)
+    name = fields.Char(string="PAN", tracking=1, required=True)
     type = fields.Selection([
         ('a', 'Association of Persons'),
         ('b', 'Body of Individuals'),


### PR DESCRIPTION
Cause:
When saving a PAN Entity without a PAN, `record.name` is False. The create() method calls `record.name.upper()`, which crashes with "AttributeError: 'bool' object has no attribute 'upper'".

Before this commit:
It was possible to save a PAN Entity without a name, leading to a traceback during record creation.

After this commit:
The PAN field is marked as required.

Ref - https://pastebin.com/Gu15zLwA

