### PR TITLE
[IMP] website: use slider for social media icon size (40-100px)

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_input_base.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_input_base.js
@@ -14,6 +14,7 @@ export const textInputBasePassthroughProps = {
     inputClasses: { type: String, optional: true },
     prefix: { type: String, optional: true },
     prefixIcon: { type: String, optional: true },
+    selectTextOnFocus: { type: Boolean, optional: true },
 };
 
 // Abstract Component
@@ -59,6 +60,9 @@ export class BuilderInputBase extends Component {
     }
 
     onFocus(ev) {
+        if (this.props.selectTextOnFocus) {
+            this.inputRef.el.select();
+        }
         this.props.onFocus?.(ev);
     }
 

--- a/addons/html_builder/static/src/core/building_blocks/builder_number_input.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_number_input.js
@@ -1,10 +1,10 @@
-import { convertNumericToUnit, getHtmlStyle } from "@html_editor/utils/formatting";
 import { Component, useState } from "@odoo/owl";
 import { effect } from "@web/core/utils/reactive";
 import {
     basicContainerBuilderComponentProps,
     useInputBuilderComponent,
     useBuilderComponent,
+    useBuilderNumberInputUnits,
     useInputDebouncedCommit,
 } from "../utils";
 import { BuilderComponent } from "./builder_component";
@@ -39,6 +39,11 @@ export class BuilderNumberInput extends Component {
             throw new Error("'unit' must be defined to use the 'saveUnit' props");
         }
 
+        const { formatRawValue, parseDisplayValue, clampValue } = useBuilderNumberInputUnits();
+        this.formatRawValue = formatRawValue;
+        this.parseDisplayValue = parseDisplayValue;
+        this.clampValue = clampValue;
+
         useBuilderComponent();
         const { state, commit, preview } = useInputBuilderComponent({
             id: this.props.id,
@@ -58,98 +63,6 @@ export class BuilderNumberInput extends Component {
         );
         this.inputRef = useChildRef();
         this.debouncedCommitValue = useInputDebouncedCommit(this.inputRef);
-    }
-
-    /**
-     * @param {string | number} values - Values separated by spaces or a number
-     * @param {(string) => string} convertSingleValueFn - Convert a single value
-     */
-    convertSpaceSplitValues(values, convertSingleValueFn) {
-        if (typeof values === "number") {
-            return convertSingleValueFn(values.toString());
-        }
-        if (values === null) {
-            return values;
-        }
-        if (!values) {
-            return "";
-        }
-        return values.trim().split(/\s+/g).map(convertSingleValueFn).join(" ");
-    }
-
-    formatRawValue(rawValue) {
-        return this.convertSpaceSplitValues(rawValue, (value) => {
-            const unit = this.props.unit;
-            const { savedValue, savedUnit } = value.match(
-                /(?<savedValue>[\d.e+-]+)(?<savedUnit>\w*)/
-            ).groups;
-            if (savedUnit || this.props.saveUnit) {
-                // Convert value from saveUnit to unit
-                value = convertNumericToUnit(
-                    parseFloat(savedValue),
-                    savedUnit || this.props.saveUnit,
-                    unit,
-                    getHtmlStyle(this.env.getEditingElement().ownerDocument)
-                );
-            }
-            // Put *at most* 3 decimal digits
-            return parseFloat(parseFloat(value).toFixed(3)).toString();
-        });
-    }
-
-    clampValue(value) {
-        if (this.props.composable && !value && value !== 0) {
-            return value;
-        }
-        value = parseFloat(value);
-        if (value < this.props.min) {
-            return `${this.props.min}`;
-        }
-        if (value > this.props.max) {
-            return `${this.props.max}`;
-        }
-        return +value.toFixed(3);
-    }
-
-    parseDisplayValue(displayValue) {
-        if (!displayValue) {
-            return displayValue;
-        }
-        if (this.props.composable) {
-            displayValue = displayValue
-                .trim()
-                .replace(/,/g, ".")
-                .replace(/[^0-9.-\s]/g, "")
-                // Only accept "-" at the start or after a space
-                .replace(/(?<!^|\s)-/g, "");
-        }
-        displayValue =
-            displayValue.split(" ").map(this.clampValue.bind(this)).join(" ") || this.props.default;
-        return this.convertSpaceSplitValues(displayValue, (value) => {
-            if (value === "") {
-                return value;
-            }
-            const unit = this.props.unit;
-            const saveUnit = this.props.saveUnit;
-            const applyWithUnit = this.props.applyWithUnit;
-            if (unit && saveUnit) {
-                // Convert value from unit to saveUnit
-                value = convertNumericToUnit(
-                    value,
-                    unit,
-                    saveUnit,
-                    getHtmlStyle(this.env.getEditingElement().ownerDocument)
-                );
-            }
-            if (unit && applyWithUnit) {
-                if (saveUnit || saveUnit === "") {
-                    value = value + saveUnit;
-                } else {
-                    value = value + unit;
-                }
-            }
-            return value;
-        });
     }
 
     get displayValue() {

--- a/addons/html_builder/static/src/core/building_blocks/builder_range.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_range.js
@@ -1,12 +1,17 @@
 import { Component, useRef } from "@odoo/owl";
+import { useChildRef } from "@web/core/utils/hooks";
 import {
     basicContainerBuilderComponentProps,
     useActionInfo,
     useBuilderComponent,
     useInputBuilderComponent,
     useInputDebouncedCommit,
+    useBuilderNumberInputUnits,
 } from "../utils";
 import { BuilderComponent } from "./builder_component";
+import { BuilderNumberInputBase } from "./builder_number_input_base";
+import { textInputBasePassthroughProps } from "./builder_input_base";
+import { pick } from "@web/core/utils/objects";
 
 export class BuilderRange extends Component {
     static template = "html_builder.BuilderRange";
@@ -15,20 +20,41 @@ export class BuilderRange extends Component {
         min: { type: Number, optional: true },
         max: { type: Number, optional: true },
         step: { type: Number, optional: true },
+        default: { type: Number, optional: true },
         displayRangeValue: { type: Boolean, optional: true },
         computedOutput: { type: Function, optional: true },
         unit: { type: String, optional: true },
+        saveUnit: { type: String, optional: true },
+        applyWithUnit: { type: Boolean, optional: true },
+        withNumberInput: { type: Boolean, optional: true },
     };
     static defaultProps = {
         ...BuilderComponent.defaultProps,
         min: 0,
         max: 100,
         step: 1,
+        default: 0,
         displayRangeValue: false,
+        applyWithUnit: true,
+        withNumberInput: false,
     };
-    static components = { BuilderComponent };
+    static components = { BuilderComponent, BuilderNumberInputBase };
 
     setup() {
+        if (this.props.saveUnit && !this.props.unit) {
+            throw new Error("'unit' must be defined to use the 'saveUnit' props");
+        }
+
+        if (this.props.withNumberInput) {
+            this.inputRefNumber = useChildRef();
+            this.debouncedCommitNumberValue = useInputDebouncedCommit(this.inputRefNumber);
+        }
+
+        const { formatRawValue, parseDisplayValue, clampValue } = useBuilderNumberInputUnits();
+        this.formatRawValue = formatRawValue;
+        this.parseDisplayValue = parseDisplayValue;
+        this.clampValue = clampValue;
+
         this.info = useActionInfo();
         useBuilderComponent();
         const { state, commit, preview } = useInputBuilderComponent({
@@ -37,43 +63,35 @@ export class BuilderRange extends Component {
             parseDisplayValue: this.parseDisplayValue.bind(this),
         });
 
-        this.inputRef = useRef("inputRef");
-        this.debouncedCommitValue = useInputDebouncedCommit(this.inputRef);
+        this.inputRefRange = useRef("inputRefRange");
+        this.debouncedCommitRangeValue = useInputDebouncedCommit(this.inputRefRange);
 
         this.commit = commit;
-        this.preview = preview;
+        this.preview = (value) => {
+            if (this.props.withNumberInput) {
+                // Syncronize the values of range and text inputs during preview
+                this.inputRefNumber.el.value = value;
+                this.inputRefRange.el.value = value;
+                this.state.value = this.parseDisplayValue(value);
+            }
+            return preview(value);
+        };
         this.state = state;
     }
 
-    formatRawValue(value) {
-        if (this.props.unit) {
-            // Remove the unit
-            value = value.slice(0, -this.props.unit.length);
-        }
-        return value;
-    }
-
-    parseDisplayValue(value) {
-        if (this.props.unit) {
-            // Add the unit
-            value = `${value}${this.props.unit}`;
-        }
-        return value;
-    }
-
-    onChange(e) {
+    onChangeRange(e) {
         const normalizedDisplayValue = this.commit(e.target.value);
         e.target.value = normalizedDisplayValue;
     }
 
-    onInput(e) {
+    onInputRange(e) {
         this.preview(e.target.value);
         if (this.props.displayRangeValue) {
             this.state.value = this.parseDisplayValue(e.target.value);
         }
     }
 
-    onKeydown(e) {
+    onKeydownRange(e) {
         if (!["ArrowLeft", "ArrowUp", "ArrowDown", "ArrowRight"].includes(e.key)) {
             return;
         }
@@ -85,22 +103,30 @@ export class BuilderRange extends Component {
             value = Math.min(this.max, value + this.props.step);
         }
         e.target.value = value;
-        this.onInput(e);
-        this.debouncedCommitValue();
+        this.onInputRange(e);
+        this.debouncedCommitRangeValue();
     }
 
-    get rangeInputValue() {
+    onKeydownNumber() {
+        this.debouncedCommitNumberValue();
+    }
+
+    get inputValueRange() {
         return this.state.value ? this.formatRawValue(this.state.value) : "0";
     }
 
-    get displayValue() {
-        let value = this.rangeInputValue;
+    get displayValueRange() {
+        let value = this.inputValueRange;
         if (this.props.computedOutput) {
             value = this.props.computedOutput(value);
         } else if (this.props.unit) {
             value = `${value}${this.props.unit}`;
         }
         return value;
+    }
+
+    get displayValueNumber() {
+        return this.formatRawValue(this.state.value).toString();
     }
 
     get className() {
@@ -114,5 +140,9 @@ export class BuilderRange extends Component {
 
     get max() {
         return this.props.min > this.props.max ? this.props.min : this.props.max;
+    }
+
+    get textInputBaseProps() {
+        return pick(this.props, ...Object.keys(textInputBasePassthroughProps));
     }
 }

--- a/addons/html_builder/static/src/core/building_blocks/builder_range.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_range.xml
@@ -3,7 +3,8 @@
 
 <t t-name="html_builder.BuilderRange">
     <BuilderComponent>
-        <div class="o-hb-range d-flex flex-row flex-nowrap align-items-center"
+        <div
+            t-attf-class="o-hb-range d-flex flex-row flex-nowrap align-items-center {{ props.withNumberInput ? 'me-2' : '' }}"
             t-att-data-action-id="info.actionId"
             t-att-data-action-param="info.actionParam"
             t-att-data-action-value="info.actionValue"
@@ -13,19 +14,33 @@
             t-att-data-attribute-action="info.attributeAction"
             t-att-data-attribute-action-value="info.attributeActionValue">
             <input
-            type="range"
-            class="o-hb-rangeInput"
-            t-ref="inputRef"
-            t-att-class="className"
-            t-att-min="min"
-            t-att-max="max"
-            t-att-step="props.step"
-            t-att-value="rangeInputValue"
-            t-on-change="onChange"
-            t-on-input="onInput"
-            t-on-keydown="onKeydown" />
-            <output t-if="props.displayRangeValue" t-out="displayValue" class="ms-1"/>
+                type="range"
+                class="o-hb-rangeInput"
+                t-ref="inputRefRange"
+                t-att-class="className"
+                t-att-min="min"
+                t-att-max="max"
+                t-att-step="props.step"
+                t-att-value="inputValueRange"
+                t-on-change="onChangeRange"
+                t-on-input="onInputRange"
+                t-on-keydown="onKeydownRange"/>
+            <output t-if="props.displayRangeValue" t-out="displayValueRange" class="ms-1" />
         </div>
+        <BuilderNumberInputBase
+            t-if="props.withNumberInput"
+            t-props="textInputBaseProps"
+            inputRef="inputRefNumber"
+            value="displayValueNumber"
+            classes="'o-hb-input-field-number justify-content-end'"
+            inputClasses="'o-hb-input-number text-end'"
+            commit="commit"
+            preview="preview"
+            clampValue.bind="clampValue"
+            onKeydown.bind="onKeydownNumber"
+            selectTextOnFocus="true">
+            <span class="o-hb-input-field-unit" t-out="props.unit"/>
+        </BuilderNumberInputBase>
     </BuilderComponent>
 </t>
 

--- a/addons/html_builder/static/src/core/utils.js
+++ b/addons/html_builder/static/src/core/utils.js
@@ -790,8 +790,10 @@ export function useInputBuilderComponent({
             ({ actionId }) => getAction(actionId).getValue
         );
         const { actionId, actionParam } = actionWithGetValue;
-        const actionValue =
-            getAction(actionId).getValue({ editingElement, params: actionParam }) || defaultValue;
+        let actionValue = getAction(actionId).getValue({ editingElement, params: actionParam });
+        if (actionValue === undefined) {
+            actionValue = defaultValue;
+        }
         return {
             value: actionValue,
         };

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_number_input.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_number_input.test.js
@@ -198,6 +198,40 @@ test("input should remove invalid char", async () => {
     expect(".options-container:last input").toHaveValue("67 67 67");
 });
 
+test("should select input value on focus only if selectTextOnFocus prop is set", async () => {
+    addBuilderAction({
+        customAction: class extends BuilderAction {
+            static id = "customAction";
+            getValue({ editingElement }) {
+                return editingElement.innerHTML;
+            }
+        },
+    });
+    addBuilderOption(
+        class extends BaseOptionComponent {
+            static selector = ".test-options-target-1";
+            static template = xml`<BuilderNumberInput action="'customAction'" selectTextOnFocus="true"/>`;
+        }
+    );
+    addBuilderOption(
+        class extends BaseOptionComponent {
+            static selector = ".test-options-target-2";
+            static template = xml`<BuilderNumberInput action="'customAction'"/>`;
+        }
+    );
+    await setupHTMLBuilder(`
+                <div class="test-options-target-1">10</div>
+                <div class="test-options-target-2">10</div>
+            `);
+    await contains(":iframe .test-options-target-1").click();
+    await contains(".options-container input").click();
+    expect(window.getSelection().toString()).toBe("10");
+
+    await contains(":iframe .test-options-target-2").click();
+    await contains(".options-container input").click();
+    expect(window.getSelection().toString()).toBe("");
+});
+
 describe("default value", () => {
     test("should use the default value when there is no value onChange", async () => {
         addBuilderAction({

--- a/addons/website/static/src/builder/plugins/options/social_media_option.xml
+++ b/addons/website/static/src/builder/plugins/options/social_media_option.xml
@@ -20,12 +20,16 @@
     </BuilderRow>
 
     <BuilderRow label.translate="Size">
-        <BuilderSelect applyTo="'.fa, .social_media_img'">
-            <BuilderSelectItem classAction="'small_social_icon'">Small</BuilderSelectItem>
-            <BuilderSelectItem classAction="''">Medium</BuilderSelectItem>
-            <BuilderSelectItem classAction="'fa-2x'">Large</BuilderSelectItem>
-            <BuilderSelectItem classAction="'fa-3x'">Huge</BuilderSelectItem>
-        </BuilderSelect>
+    <BuilderRange
+        withNumberInput="true"
+        action="'resetSocialMediaIconSize'"
+        applyTo="'.fa, .social_media_img'"
+        styleAction="{ mainParam: '--fa-icon-size', extraClass: 'o_sm_custom_size' }"
+        unit="'px'"
+        saveUnit="'rem'"
+        min="40"
+        max="100"
+        step="1"/>
     </BuilderRow>
 
     <BuilderRow label.translate="Color" tooltip.translate="Keep the original icon color">

--- a/addons/website/static/src/builder/plugins/options/social_media_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/social_media_option_plugin.js
@@ -155,6 +155,7 @@ class SocialMediaOptionPlugin extends Plugin {
         ],
         so_content_addition_selector: [".s_share", ".s_social_media"],
         builder_actions: {
+            ResetSocialMediaIconSizeAction,
             DeleteSocialMediaLinkAction,
             ToggleRecordedSocialMediaLinkAction,
             EditRecordedSocialMediaLinkAction,
@@ -382,6 +383,15 @@ class SocialMediaOptionPlugin extends Plugin {
         } else {
             return link;
         }
+    }
+}
+
+export class ResetSocialMediaIconSizeAction extends BuilderAction {
+    static id = "resetSocialMediaIconSize";
+    apply({ editingElement }) {
+        [...editingElement.classList]
+            .filter((className) => /^fa-[2-5]x$/.test(className))
+            .forEach((className) => editingElement.classList.remove(className));
     }
 }
 

--- a/addons/website/static/src/snippets/s_share/000.scss
+++ b/addons/website/static/src/snippets/s_share/000.scss
@@ -1,6 +1,9 @@
 
 .s_share {
     user-select: none;
+    // Default icon size used by the builder RangeWithNumberInput control
+    // Inherit to icons so the option panel reads 40px initially
+    --fa-icon-size: 40px;
     $-size: map-get($spacers, 5);
     > * {
         display: inline-block;
@@ -14,6 +17,18 @@
             display: flex;
             justify-content: center;
             align-items: center;
+            // Custom size via builder RangeWithNumberInput control
+            &.o_sm_custom_size {
+                // Always scale the icon glyph size, regardless of layout
+                // Keep roughly the default 16px glyph for a 40px disk (0.4 ratio)
+                font-size: calc(var(--fa-icon-size) * 0.4) !important;
+            }
+            // For non-stack layouts, also control the visual container
+            &.o_sm_custom_size:not(.fa-stack) {
+                width: var(--fa-icon-size) !important;
+                height: var(--fa-icon-size) !important;
+                line-height: var(--fa-icon-size) !important;
+            }
             &[class*="o_cc"] {
                 background-color: var(--o-cc-bg);
             }

--- a/addons/website/static/src/snippets/s_social_media/000.scss
+++ b/addons/website/static/src/snippets/s_social_media/000.scss
@@ -1,6 +1,9 @@
 
 .s_social_media {
     user-select: none;
+    // Default icon size used by the builder RangeWithNumberInput control
+    // Inherit to icons so the option panel reads 40px initially
+    --fa-icon-size: 40px;
     $-size: map-get($spacers, 5);
     > * {
         display: inline-block;
@@ -14,6 +17,18 @@
             display: flex;
             justify-content: center;
             align-items: center;
+            // Custom size via builder RangeWithNumberInput control
+            &.o_sm_custom_size {
+                // Always scale the icon glyph size, regardless of layout
+                // Keep roughly the default 16px glyph for a 40px disk (0.4 ratio)
+                font-size: calc(var(--fa-icon-size) * 0.4) !important;
+            }
+            // For non-stack layouts, also control the visual container
+            &.o_sm_custom_size:not(.fa-stack) {
+                width: var(--fa-icon-size) !important;
+                height: var(--fa-icon-size) !important;
+                line-height: var(--fa-icon-size) !important;
+            }
             &[class*="o_cc"] {
                 background-color: var(--o-cc-bg);
             }

--- a/addons/website/static/tests/interactions/snippets/social_media_and_share.test.js
+++ b/addons/website/static/tests/interactions/snippets/social_media_and_share.test.js
@@ -1,4 +1,4 @@
-import { animationFrame, click, queryOne, waitFor } from "@odoo/hoot-dom";
+import { animationFrame, click, edit, queryOne, waitFor } from "@odoo/hoot-dom";
 import { defineWebsiteModels, setupWebsiteBuilderWithSnippet } from "../../builder/website_helpers";
 import { expect, test } from "@odoo/hoot";
 import { onRpc } from "@web/../tests/web_test_helpers";
@@ -74,34 +74,20 @@ async function testSocialSnippetOptions(snippetName, containerTitle, iconName) {
         snippetSelector,
         "[data-icon-underline='always']"
     );
-    await setDropdownOption(
-        containerTitle,
-        "Size",
-        "Small",
-        snippetSelector,
-        " i:first-child.small_social_icon"
+
+    await click(
+        `[data-container-title='${containerTitle}'] [data-label='Size'] input[type='range']`
     );
-    await setDropdownOption(
-        containerTitle,
-        "Size",
-        "Medium",
-        snippetSelector,
-        " i:first-child:not(.small_social_icon):not(.fa-2x):not(.fa-3x)"
+    await edit("70");
+    await animationFrame();
+    expect(`${snippetSelector} > a > i`).toHaveStyle("--fa-icon-size: 4.375rem");
+
+    await click(
+        `[data-container-title='${containerTitle}'] [data-label='Size'] input[type='number']`
     );
-    await setDropdownOption(
-        containerTitle,
-        "Size",
-        "Large",
-        snippetSelector,
-        " i:first-child.fa-2x"
-    );
-    await setDropdownOption(
-        containerTitle,
-        "Size",
-        "Huge",
-        snippetSelector,
-        " i:first-child.fa-3x"
-    );
+    await edit("100");
+    await animationFrame();
+    expect(`${snippetSelector} > a > i`).toHaveStyle("--fa-icon-size: 6.25rem");
 }
 
 test("Social Media snippet options are correct", async () => {


### PR DESCRIPTION
This PR improves the resizing of social media icons, affecting the snippets `s_share` and `s_social_media`. Before, the icon size was limited to a few fixed presets. Now, the size can be edited both via a slider and via a numerical input.
To achieve this, the component `BuilderRange` has been modified to support an optional numeric input to the right of the slider. A new mechanism has been introduced to syncronize previews among different components controlling the same quantity.

task-5136166

