### PR TITLE
[FIX] website: display description when the title is inside of another tag

### DIFF
--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -28,6 +28,7 @@ import {
     isUnprotecting,
     listElementSelector,
     isEditorTab,
+    isPhrasingContent,
 } from "../utils/dom_info";
 import {
     childNodes,
@@ -609,6 +610,7 @@ export class DomPlugin extends Plugin {
             if (
                 isParagraphRelatedElement(block) ||
                 isListItemElement(block) ||
+                isPhrasingContent(block) ||
                 block.nodeName === "BLOCKQUOTE"
             ) {
                 if (newCandidate.matches(baseContainerGlobalSelector) && isListItemElement(block)) {


### PR DESCRIPTION
After the new options for s_tabs_images were added in [1], it wouldn't display the active description if the title was inside of another tag.

Steps to see the issue:
- Open website and start editing
- Drop the s_tabs_images snippet and click on the first slide title
- Change the Descriptions option from "All items" to "Active only"
- Select the title and change the font style from "Normal" to "Paragraph"

=> Observe that the description isn't displayed

[1]: https://github.com/odoo/odoo/commit/e2e26bb8ad239fe13c504f0f811eab9cae1fb376