### PR TITLE
[FIX] mail: no flicker on messaging menu item hover

### DIFF
--- a/addons/mail/static/src/core/public_web/notification_item.scss
+++ b/addons/mail/static/src/core/public_web/notification_item.scss
@@ -52,8 +52,7 @@
 }
 
 .o-mail-NotificationItem-markAsRead {
-    background-color: transparent !important;
-    font-size: 0.85rem !important;
+    background-color: $o-view-background-color;
     color: $success !important;
     outline: 1px solid rgba($success, .75);
     outline-offset: -1px;
@@ -62,7 +61,8 @@
     &:hover {
         outline-color: rgba(darken($success, 10%), 1);
         color: darken($success, 10%) !important;
-        background-color: transparent !important;
+        background-color: mix($o-view-background-color, $success, 75%);
+        filter: brightness(1.1);
         box-shadow: $box-shadow-sm
     }
 }

--- a/addons/mail/static/src/core/public_web/notification_item.xml
+++ b/addons/mail/static/src/core/public_web/notification_item.xml
@@ -36,8 +36,12 @@
                         <t t-if="props.slots?.body" name="notificationBody" t-slot="body"/>
                     </div>
                     <div class="flex-grow-1"/>
-                    <div class="d-flex align-items-start">
-                        <span t-if="props.hasMarkAsReadButton and rootHover.isHover" class="o-mail-NotificationItem-badge o-discuss-badgeShape text-success d-flex align-items-center justify-content-center m-0 rounded fw-bold o-mail-NotificationItem-markAsRead fa fa-check text-600 opacity-75 opacity-100-hover cursor-pointer shadow-sm" t-att-class="{ invisible: !rootHover.isHover }" title="Mark As Read" t-ref="markAsRead"/>
+                    <div class="d-flex align-items-start position-relative">
+                        <span class="position-absolute" t-if="props.hasMarkAsReadButton">
+                            <span t-if="rootHover.isHover" class="ms-1 bg-view">
+                                <span class="o-mail-NotificationItem-badge o-discuss-badgeShape d-flex align-items-center justify-content-center mx-1 my-0 rounded fw-bold o-mail-NotificationItem-markAsRead text-600 cursor-pointer shadow-sm position-absolute top-0 end-0 z-1" title="Mark As Read" t-ref="markAsRead"><i class="fa fa-check text-success"/></span>
+                            </span>
+                        </span>
                         <span t-if="!props.muted" t-attf-class="o-mail-NotificationItem-badge o-discuss-badge {{ props.counter > 0 and props.muted === 2 ? 'o-muted' : '' }} {{ props.important ? 'o-important' : '' }} {{ props.counter === 0 ? 'o-empty me-1' : '' }} d-flex align-items-center justify-content-center m-0 o-mx-0_5 badge rounded-pill fw-bold o-mail-NotificationItem-counter shadow-sm"><t t-if="props.counter" t-esc="props.counter"/></span>
                     </div>
                 </div>


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/225145

PR above made a few visual changes, one of which was to show mark as read button in messaging menu item in addition to keeping the badge unread / important on hover. This is motivated by the fact that item is considered important thanks to this badge, and when hovering it it gives a wrong impression the item is no longer important when this is just on hover.

Solution of PR above was to keep display of badge even when mouse-hovering, so mouse hover shows both the badge and the mark as read button.

However, if the notification item text takes almost a full single line, mouse-hovering made the item grow bigger due to being on 2 lines forced by mark as read button on hover. This flicker is not great UX.

This commit fixes the issue by keeping badge and mark as read button visible on hover, but the mark as read button now overlaps the notification item text rather than collide. As a result, the text part of notification item doesn't change its visual of lines and word break per line just on mouse hovering.

Before / After
![before](https://github.com/user-attachments/assets/b5e1012d-94fe-4746-b320-82b31f6cd883) ![after](https://github.com/user-attachments/assets/e6484084-8a6b-4548-9a12-80943a56ad9a)
