### PR TITLE
[FIX] hr_work_entry_holidays, hr_holidays: fix hr.version's description

### DIFF
--- a/addons/hr_holidays/models/hr_version.py
+++ b/addons/hr_holidays/models/hr_version.py
@@ -17,7 +17,7 @@ class HrVersion(models.Model):
     """
     # TODO BIOUTIFY ME (the whole file :)
     _inherit = 'hr.version'
-    _description = 'Employee Contract'
+    _description = 'Employee Record'
 
     @api.constrains('contract_date_start', 'contract_date_end')
     def _check_contracts(self):

--- a/addons/hr_work_entry_holidays/models/hr_version.py
+++ b/addons/hr_work_entry_holidays/models/hr_version.py
@@ -8,7 +8,7 @@ from odoo.fields import Domain
 
 class HrVersion(models.Model):
     _inherit = 'hr.version'
-    _description = 'Employee Contract'
+    _description = 'Employee Record'
 
     # override to add work_entry_type from leave
     def _get_leave_work_entry_type(self, leave):


### PR DESCRIPTION
#### Issue
In a Validation Error, the `hr.version` model's descriptive name was incorrect.

#### Fix
Changed the `hr.version` model's `_description` from 'Employee Contract' to 'Employee Record'.

task-5076634