### PR TITLE
[FIX] point_of_sale: fix POS screensaver reload handling

### DIFF
--- a/addons/point_of_sale/static/src/app/pos_app.js
+++ b/addons/point_of_sale/static/src/app/pos_app.js
@@ -25,9 +25,11 @@ export class Chrome extends Component {
             if (stopEventPropagation.includes(ev.type)) {
                 ev.stopPropagation();
             }
-            const page = this.pos.firstPage;
-            this.pos.navigate(page.page, page.params);
+            this.pos.navigateToFirstPage();
         });
+        if (this.pos.router.state.current === "SaverScreen") {
+            this.pos.navigateToFirstPage();
+        }
 
         const reactivePos = reactive(this.pos);
         window.posmodel = reactivePos;

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -180,6 +180,11 @@ export class PosStore extends WithLazyGetterTrap {
         this.router.navigate(routeName, routeParams);
     }
 
+    navigateToFirstPage() {
+        const page = this.firstPage;
+        this.navigate(page.page, page.params);
+    }
+
     navigateToOrderScreen(order) {
         const orderPage = order.getScreenData();
         const page = orderPage?.name || "ProductScreen";


### PR DESCRIPTION
Fix issue appearing when you reload the page while the ScreenSaver is active, which caused the ScreenSaver to be displayed again after the reload (and the user is stuck on that screen).

Steps to reproduce:
- Open POS
- Trigger screen ScreenSaver
- Reload the page (F5) (without triggering any user activity so we stay on the screen saver)
- The ScreenSaver is displayed again after the reload
- => The user is stuck on the saver, moving clicking or typing does not do anything, you have to close the tab and open it again

=> Now when refreshing the page while on the screen saver, we just directly navigate to the first page of the POS.

Description of the issue/feature this PR addresses:


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
