### PR TITLE
[FIX] stock: fix test_stock_route_diagram_report to run in single-app

### DIFF
--- a/addons/stock/tests/test_report_tours.py
+++ b/addons/stock/tests/test_report_tours.py
@@ -13,6 +13,7 @@ class TestStockReportTour(HttpCase):
     def test_stock_route_diagram_report(self):
         """ Open the route diagram report."""
         # Do not make the test rely on demo data
+        self.env.ref('stock.route_warehouse0_mto').active = True
         self.env['product.template'].search([('type', '!=', 'service')]).write({'active': False})
         self.env['product.template'].create({
             'name': 'Test Storable Product',


### PR DESCRIPTION
Issue Before This Commit:
============================
The test_stock_route_diagram_report tour fails when only the stock module is installed. The tour breaks because the element `.btn[id="stock.view_diagram_button"]` is not found.

Steps to Reproduce:
============================
- Install only the `stock` module.
- Run the `test_stock_route_diagram_report` test.
- The tour breaks because the element `.btn[id="stock.view_diagram_button"]` is not found.

Cause of the Issue:
===========================
The tour breaks due to a recent [PR](https://github.com/odoo/odoo/pull/223685) that hides the `view_diagram_button`
when no routes are available for the product.

With This Commit:
============================
Ensure the tour runs successfully by activating a default MTO route in the test setup, so the required element is present.

runbot-232573