### PR TITLE
[FIX] mail: reduce bottom spacing of chat window composer

### DIFF
--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -19,11 +19,10 @@
                     'o-hasSelfAvatar': showComposerAvatar,
                     'o-focused': props.composer.isFocused,
                     'o-editing': props.composer.message,
-                    'o-chatWindow mx-2': env.inChatWindow,
-                    'mb-3': env.inChatWindow and !props.composer.message,
+                    'o-chatWindow mx-2 my-1': env.inChatWindow,
+                    'mb-2': env.inChatWindow and !props.composer.message,
                     'o-discussApp pt-1 ps-2 pe-4 pb-2': env.inDiscussApp,
                     'ps-xl-3': env.inDiscussApp and !ui.isSmall,
-                    'm-1': env.inChatWindow,
                 }" t-attf-class="{{ props.className }}">
             <FileUploader t-if="allowUpload" multiUpload="isMultiUpload" onUploaded.bind="(data) => { attachmentUploader.uploadData(data) }">
                 <t t-set-slot="toggler">


### PR DESCRIPTION
This makes consistent spacing of bottom and horizontal, and also has the benefit to show more message list in viewport.

Before
<img width="1169" height="644" alt="Screenshot 2025-09-11 at 11 52 03" src="https://github.com/user-attachments/assets/7863dc04-d572-4c37-b182-6d519956a041" />

After
<img width="1167" height="647" alt="Screenshot 2025-09-11 at 11 48 21" src="https://github.com/user-attachments/assets/8980a2a2-93fc-4016-8e76-5b5b3fa6899a" />

