### PR TITLE
[FIX] website_sale: adapt attribute previewer in /shop

### DIFF
--- a/addons/website_sale/static/src/interactions/product/product_variant_preview.js
+++ b/addons/website_sale/static/src/interactions/product/product_variant_preview.js
@@ -99,3 +99,7 @@ export class ProductVariantPreview extends Interaction {
 registry
     .category('public.interactions')
     .add('website_sale.product_variant_preview', ProductVariantPreview);
+
+registry
+    .category("public.interactions.edit")
+    .add("website.product_variant_preview", { Interaction: ProductVariantPreview });

--- a/addons/website_sale/static/src/scss/product_tile.scss
+++ b/addons/website_sale/static/src/scss/product_tile.scss
@@ -529,6 +529,9 @@
         @include media-breakpoint-down(sm) {
             --o-wsale-card-btn-submit-order: 1;
         }
+        @include media-breakpoint-down(md) {
+            --o-wsale-card-info-attributes-display: contents;
+        }
         @include media-breakpoint-between(md, xl) {
             --o-wsale-card-info-text-width: 200px;
             --o-wsale-card-btn-submit-order: -2;
@@ -678,7 +681,7 @@
     &.o_wsale_products_opt_layout_list {
         --o-wsale-card-info-attributes-display: flex;
         --o-wsale-card-info-margin: 0;
-        --o-wsale-card-attribute-previewer-width: 100%;
+        --o-wsale-card-attribute-previewer-width: var(--o-wsale-card-info-text-width);
         --o-wsale-card-sub-display: contents;
         --o-wsale-card-price-display: flex;
         --o-wsale-card-btn-label-display: none;
@@ -686,6 +689,9 @@
         --o-wsale-card-btns-align-items: center;
         --o-wsale-card-info-attributes-justify-content: start;
 
+        @include media-breakpoint-down(md) {
+            --o-wsale-card-info-attributes-display: contents;
+        }
         @include media-breakpoint-between(md, xl) {
             --o-wsale-card-btns-flex-direction: column;
             --o-wsale-card-btns-justify-content: center;


### PR DESCRIPTION
Prior to this commit, the attribute previewer was not properly rendered on mobile in the "List thumbnails" and "List grid" product designs.

Also, since the attribute previewer was not updated when resizing the window in edit mode, it caused layout issues.

This commit updates the attribute previewer to ensure it renders correctly in all cases.

task-5016573

---

### Update attribute preview in edit mode
| | edit mode | normal mode |
|--------|--------|--------|
| 19.0 | <img width="1065" height="932" alt="Capture d’écran 2025-09-11 à 11 43 47" src="https://github.com/user-attachments/assets/33c3386e-c07b-4b60-bde5-69152c1b91c5" /> | <img width="1065" height="933" alt="Capture d’écran 2025-09-11 à 11 43 57" src="https://github.com/user-attachments/assets/9e046721-7afe-4109-8a2f-6168f5ada89e" /> |
| this branch | <img width="1346" height="975" alt="Capture d’écran 2025-09-11 à 14 48 35" src="https://github.com/user-attachments/assets/8166fbad-41ba-4bf1-9aff-78daf532f112" /> | <img width="1355" height="929" alt="Capture d’écran 2025-09-11 à 14 48 54" src="https://github.com/user-attachments/assets/61b3ad5a-bf15-43cf-8ab2-e04886d8b876" /> |

### Attribute preview in mobile

| | 19.0 | this branch |
|--------|--------|----------|
| List thumbnail | <img width="410" height="211" alt="Capture d’écran 2025-09-11 à 14 53 12" src="https://github.com/user-attachments/assets/c7cadadd-87dd-4e33-9d78-39027fd68602" /> | <img width="409" height="200" alt="Capture d’écran 2025-09-11 à 14 53 26" src="https://github.com/user-attachments/assets/9f938485-6421-453d-89fa-61cd0db26e72" /> |
| List thumbnail | <img width="818" height="386" alt="image" src="https://github.com/user-attachments/assets/ce87f4a1-9387-4cad-9098-0bb9ca085162" /> | <img width="406" height="178" alt="Capture d’écran 2025-09-11 à 14 54 29" src="https://github.com/user-attachments/assets/08496b4a-14c8-4090-85a5-db09dcf47bf0" /> |
| List grid | <img width="405" height="184" alt="Capture d’écran 2025-09-11 à 14 58 53" src="https://github.com/user-attachments/assets/ff10b4ce-8cb1-49c9-823e-34f354a25b81" /> | <img width="404" height="175" alt="Capture d’écran 2025-09-11 à 14 59 37" src="https://github.com/user-attachments/assets/eb01f787-17bd-4c02-b840-09d74b24a274" /> |
|List grid | <img width="409" height="159" alt="Capture d’écran 2025-09-11 à 14 59 57" src="https://github.com/user-attachments/assets/c6e73b57-eb02-4450-b52d-872aed179671" /> | <img width="408" height="144" alt="Capture d’écran 2025-09-11 à 15 00 07" src="https://github.com/user-attachments/assets/cce19acc-3d26-4ae4-8945-55025bc64490" /> |

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
