### PR TITLE
[FIX] website: bg image replaceable in banner categories columns

### DIFF
--- a/addons/website/static/src/builder/plugins/options/utils.js
+++ b/addons/website/static/src/builder/plugins/options/utils.js
@@ -10,5 +10,5 @@ export const ONLY_BG_IMAGE_SELECTOR = BASE_ONLY_BG_IMAGE_SELECTOR;
 export const ONLY_BG_IMAGE_EXLUDE = "";
 
 export const BOTH_BG_COLOR_IMAGE_SELECTOR =
-    "section, .carousel-item, .s_masonry_block .row > div, .s_color_blocks_2 .row > div, .parallax, .s_text_cover .row > .o_not_editable, .s_website_form_cover .row > .o_not_editable, .s_split_intro .row > .o_not_editable, .s_bento_grid .row > div";
+    "section, .carousel-item, .s_masonry_block .row > div, .s_color_blocks_2 .row > div, .parallax, .s_text_cover .row > .o_not_editable, .s_website_form_cover .row > .o_not_editable, .s_split_intro .row > .o_not_editable, .s_bento_grid .row > div, .o_background_image";
 export const BOTH_BG_COLOR_IMAGE_EXCLUDE = `${BASE_ONLY_BG_IMAGE_SELECTOR}, .s_carousel_wrapper, .s_image_gallery .carousel-item, .s_google_map, .s_map, [data-snippet] :not(.oe_structure) > [data-snippet], .s_masonry_block .s_col_no_resize, .s_quotes_carousel_wrapper, .s_carousel_intro_wrapper, .s_carousel_cards_item, .s_dynamic_snippet_category .s_dynamic_snippet_title`;

--- a/addons/website/static/tests/tours/banner_categories_image_replaceable_tour.js
+++ b/addons/website/static/tests/tours/banner_categories_image_replaceable_tour.js
@@ -1,0 +1,29 @@
+import { registerWebsitePreviewTour, insertSnippet } from "@website/js/tours/tour_utils";
+
+function checkReplaceButton(columnIndex) {
+    return [
+        {
+            content: `Click inside the dropped banner categories snippet (column ${columnIndex}) to load its options`,
+            trigger: `:iframe .s_banner_categories div[class='container'] div div:nth-child(${columnIndex})`,
+            run: "click",
+        },
+        {
+            content: "Check on the replace button",
+            trigger: "[data-container-title='Column'] [data-action-id='replaceBgImage']",
+        },
+    ];
+}
+
+registerWebsitePreviewTour("banner_categories_image_replaceable", {
+    url: "/",
+    edition: true,
+}, () => [
+    ...insertSnippet({
+        id: "s_banner_categories",
+        name: "Banner Categories",
+        groupName: "Catalog",
+    }),
+    ...checkReplaceButton(2),
+    ...checkReplaceButton(3),
+    ...checkReplaceButton(4),
+]);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -725,3 +725,6 @@ class TestUi(HttpCaseWithWebsiteUser):
 
     def test_create_missing_page(self):
         self.start_tour("/", "create_missing_page", login="admin")
+
+    def test_banner_categories_image_replaceable(self):
+        self.start_tour("/", "banner_categories_image_replaceable", login="admin")

--- a/addons/website/views/snippets/s_banner_categories.xml
+++ b/addons/website/views/snippets/s_banner_categories.xml
@@ -25,7 +25,7 @@
                         </a>
                     </p>
                 </div>
-                <div class="o_grid_item o_colored_level o_cc o_cc5 o_bg_img_center oe_img_bg justify-content-end g-col-lg-4 g-height-6 col-lg-4 col-10 offset-1 offset-lg-0"
+                <div class="o_grid_item o_colored_level o_cc o_cc5 o_bg_img_center oe_img_bg justify-content-end g-col-lg-4 g-height-6 col-lg-4 col-10 offset-1 offset-lg-0 o_background_image"
                         style="grid-area: 8 / 1 / 14 / 5; z-index: 2;background-image: url('/web/image/website.shop_category_1_1x1'); --grid-item-padding-y: 32px; --grid-item-padding-x: 32px;">
                     <div class="o_we_bg_filter"
                         style="background-image: linear-gradient(0deg, rgba(36, 36, 36, 0.52) 0%, rgba(255, 255, 255, 0) 50%);"/>
@@ -34,7 +34,7 @@
                         <a href="#" class="o_translate_inline text-reset">Shop all →</a>
                     </p>
                 </div>
-                <div class="o_grid_item o_cc o_cc5 o_colored_level o_bg_img_center oe_img_bg justify-content-end g-height-6 g-col-lg-4 col-lg-4 col-10 offset-1 offset-lg-0"
+                <div class="o_grid_item o_cc o_cc5 o_colored_level o_bg_img_center oe_img_bg justify-content-end g-height-6 g-col-lg-4 col-lg-4 col-10 offset-1 offset-lg-0 o_background_image"
                         style="grid-area: 8 / 5 / 14 / 9; z-index: 3;background-image: url('/web/image/website.shop_category_2_1x1'); --grid-item-padding-y: 32px; --grid-item-padding-x: 32px;">
                     <div class="o_we_bg_filter"
                         style="background-image: linear-gradient(0deg, rgba(36, 36, 36, 0.52) 0%, rgba(255, 255, 255, 0) 50%);"/>
@@ -43,7 +43,7 @@
                         <a href="#" class="o_translate_inline text-reset">Shop all →</a>
                     </p>
                 </div>
-                <div class="o_grid_item o_cc o_cc5 o_colored_level o_bg_img_center oe_img_bg justify-content-end g-height-6 g-col-lg-4 col-lg-4 offset-1 offset-lg-0 col-10"
+                <div class="o_grid_item o_cc o_cc5 o_colored_level o_bg_img_center oe_img_bg justify-content-end g-height-6 g-col-lg-4 col-lg-4 offset-1 offset-lg-0 col-10 o_background_image"
                         style="grid-area: 8 / 9 / 14 / 13; z-index: 4;background-image: url('/web/image/website.shop_category_3_1x1'); --grid-item-padding-y: 32px; --grid-item-padding-x: 32px;">
                     <div class="o_we_bg_filter"
                         style="background-image: linear-gradient(0deg, rgba(36, 36, 36, 0.52) 0%, rgba(255, 255, 255, 0) 50%);"/>


### PR DESCRIPTION
Steps to reproduce:
1. Go to Website > Edit Mode.
2. Add a Banner Categories snippet from catalog.
3. Click on the image of a category (including sofas, drawers or desks) to replace it.
4. There will be no replace media button.

Issue:
The banner categories snippet does not contain a selector through which replace option was triggered.

Fix:
Added a generic selector named o_background_image to both the banner categories snippet and the replace media options. As, it is the generic selector, It can be used for other snippets too.
