### PR TITLE
[IMP] repair: split TestRepair from its commons

### DIFF
--- a/addons/repair/tests/test_repair.py
+++ b/addons/repair/tests/test_repair.py
@@ -7,8 +7,7 @@ from odoo.tests import tagged, common, Form, HttpCase
 from odoo.tools import float_compare, float_is_zero
 
 
-@tagged('post_install', '-at_install')
-class TestRepair(common.TransactionCase):
+class TestRepairCommon(common.TransactionCase):
 
     @classmethod
     def setUpClass(cls):
@@ -163,6 +162,10 @@ class TestRepair(common.TransactionCase):
             vals.append(qDict)
 
         return cls.env['stock.quant'].create(vals)
+
+
+@tagged('post_install', '-at_install')
+class TestRepair(TestRepairCommon):
 
     def test_01_repair_states_transition(self):
         repair = self._create_simple_repair_order()


### PR DESCRIPTION
Split out the classSetUp + its methods into separate class so it can be used in other modules

Supports task: 5067457

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
