### PR TITLE
[FIX] core: support theme_customization manifest key for themes

### DIFF
--- a/odoo/addons/base/tests/test_module.py
+++ b/odoo/addons/base/tests/test_module.py
@@ -67,6 +67,7 @@ class TestModuleManifest(BaseCase):
             'static_path': None,
             'summary': '',
             'test': [],
+            'theme_customizations': {},
             'update_xml': [],
             'uninstall_hook': '',
             'version': f'{major_version}.1.0',

--- a/odoo/modules/module.py
+++ b/odoo/modules/module.py
@@ -86,6 +86,7 @@ _DEFAULT_MANIFEST = {
     'sequence': 100,
     'summary': '',
     'test': [],
+    'theme_customizations': {},  # themes
     'update_xml': [],
     'uninstall_hook': '',
     'version': '1.0',


### PR DESCRIPTION
Follow-up of PR https://github.com/odoo/design-themes/pull/1137 that introduced `theme_customizations` in design theme manifests for eCommerce block customizations.

For Error https://runbot.odoo.com/odoo/runbot.build.error/232249 :

Issue:
- `ManifestLinter.test_manifests` errors in multiple theme modules.
- The error was caused by the `theme_customizations` key being unrecognized in manifests and flagged as unknown.

Fix:
- Added `theme_customizations` to the list of allowed manifest keys, so the linter accepts it in theme module manifests.