### PR TITLE
[FIX] {pos}_event_sale: add pos_event to report

### DIFF
--- a/addons/pos_event_sale/report/__init__.py
+++ b/addons/pos_event_sale/report/__init__.py
@@ -1,3 +1,3 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from . import models
-from . import report
+
+from . import event_sale_report

--- a/addons/pos_event_sale/report/event_sale_report.py
+++ b/addons/pos_event_sale/report/event_sale_report.py
@@ -1,0 +1,73 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class EventSaleReport(models.Model):
+    _inherit = "event.sale.report"
+
+    def _query(self, with_=None, select=None, join=None, group_by=None, where=None):
+        where_clause = """event_registration.pos_order_line_id IS NULL"""
+        res = super()._query(with_, select, join, group_by, (where or []) + [where_clause])
+        return (
+            res
+            + f"""UNION ALL (
+            SELECT {self._select_pos(*(select or []))}
+            FROM {self._from_pos()}
+            WHERE {self._where_pos()}
+            )
+        """
+        )
+
+    def _where_pos(self):
+        return """pos_order_line.event_ticket_id is not NULL"""
+
+    def _select_pos(self):
+        # Extra clauses formatted as `cte1.column1 AS new_column1`, `table1.column2 AS new_column2`...
+        select_query = """
+ROW_NUMBER() OVER (ORDER BY event_registration.id) AS id,
+event_registration.id AS event_registration_id,
+event_registration.company_id AS company_id,
+event_registration.event_id AS event_id,
+event_registration.event_ticket_id AS event_ticket_id,
+event_registration.create_date AS event_registration_create_date,
+event_registration.name AS event_registration_name,
+event_registration.state AS event_registration_state,
+event_registration.active AS active,
+event_registration.sale_order_id AS sale_order_id,
+event_registration.sale_order_line_id AS sale_order_line_id,
+event_registration.sale_status AS sale_status,
+event_event.event_type_id AS event_type_id,
+event_event.date_begin AS event_date_begin,
+event_event.date_end AS event_date_end,
+event_event_ticket.price AS event_ticket_price,
+pos_order.date_order AS sale_order_date,
+pos_order.partner_id AS invoice_partner_id,
+pos_order.partner_id AS sale_order_partner_id,
+pos_order.state AS sale_order_state,
+pos_order.user_id AS sale_order_user_id,
+pos_order_line.product_id AS product_id,
+CASE
+    WHEN pos_order_line.qty = 0 THEN 0
+    ELSE
+    pos_order_line.price_subtotal_incl / pos_order_line.qty
+END AS sale_price,
+CASE
+    WHEN pos_order_line.qty = 0 THEN 0
+    ELSE
+    pos_order_line.price_subtotal / pos_order_line.qty
+END AS sale_price_untaxed"""
+        additional_fields = self._select_additional_fields()
+        if additional_fields:
+            select_query += ",\n    " + ",\n    ".join(f"{v} AS {k}" for k, v in additional_fields.items())
+        return select_query
+
+    def _from_pos(self, *join_):
+        # Extra clauses formatted as `column1`, `column2`...
+        return """
+event_registration event_registration
+LEFT JOIN pos_order_line ON pos_order_line.id= event_registration.pos_order_line_id
+LEFT JOIN pos_order ON pos_order.id = pos_order_line.order_id
+LEFT JOIN event_event ON event_event.id = event_registration.event_id
+LEFT JOIN event_event_ticket ON event_event_ticket.id = event_registration.event_ticket_id
+""" + ("\n".join(join_) + "\n" if join_ else "")

--- a/addons/pos_event_sale/tests/__init__.py
+++ b/addons/pos_event_sale/tests/__init__.py
@@ -1,2 +1,3 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from . import test_frontend
+from . import test_sale_report

--- a/addons/pos_event_sale/tests/test_sale_report.py
+++ b/addons/pos_event_sale/tests/test_sale_report.py
@@ -1,0 +1,72 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo.tests import tagged
+from odoo.addons.pos_event.tests.test_frontend import TestUi
+from odoo import fields, Command
+
+
+@tagged('post_install', '-at_install')
+class TestPoSEventSaleReport(TestUi):
+    def test_sale_event_report(self):
+        self.pos_user.write({
+            'groups_id': [
+                (4, self.env.ref('event.group_event_user').id),
+            ]
+        })
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+
+        order_data = {
+            "amount_paid": 100,
+            "amount_tax": 0,
+            "amount_return": 0,
+            "amount_total": 100,
+            "date_order": fields.Datetime.to_string(fields.Datetime.now()),
+            "fiscal_position_id": False,
+            "lines": [
+                Command.create({
+                    "discount": 0,
+                    "pack_lot_ids": [],
+                    "price_unit": 100.0,
+                    "product_id": self.product_event.id,
+                    "price_subtotal": 100.0,
+                    "price_subtotal_incl": 100.0,
+                    "tax_ids": [],
+                    "qty": 1,
+                    "event_ticket_id": self.test_event.event_ticket_ids[0].id,
+                    "event_registration_ids": [
+                        (0, 0, {
+                            "event_id": self.test_event.id,
+                            "event_ticket_id": self.test_event.event_ticket_ids[0].id,
+                            "name": "Test Name",
+                            "email": "Test Email",
+                            "phone": "047123123198",
+                        }),
+                    ],
+                }),
+            ],
+            "name": "Order 12345-123-1234",
+            "partner_id": self.partner_a.id,
+            "session_id": self.main_pos_config.current_session_id.id,
+            "sequence_number": 2,
+            "payment_ids": [
+                    Command.create({
+                        "amount": 100,
+                        "name": fields.Datetime.now(),
+                        "payment_method_id": self.bank_payment_method.id,
+                    }),
+            ],
+            "uuid": "12345-123-1234",
+            "last_order_preparation_change": "{}",
+            "user_id": self.env.uid,
+            "to_invoice": False,
+        }
+
+        self.env['pos.order'].sync_from_ui([order_data])
+        report = self.env['event.sale.report'].search([])
+        self.assertEqual(len(report), 1)
+        self.assertRecordValues(report, [{
+            'event_registration_name': "Test Name",
+            'event_id': self.test_event.id,
+            'sale_order_id': False,
+            'sale_price': 100.0,
+            'sale_price_untaxed': 100.0,
+        }])

--- a/addons/website_event_sale/report/event_sale_report.py
+++ b/addons/website_event_sale/report/event_sale_report.py
@@ -9,5 +9,7 @@ class EventSaleReport(models.Model):
 
     is_published = fields.Boolean('Published Events', readonly=True)
 
-    def _select_clause(self, *select):
-        return super()._select_clause('event_event.is_published as is_published', *select)
+    def _select_additional_fields(self):
+        res = super()._select_additional_fields()
+        res['is_published'] = 'event_event.is_published'
+        return res


### PR DESCRIPTION
Add event registration sold through PoS to the event sale report.

Steps to reproduce:
-------------------
* Create an event with tickets
* Sell a ticket through the PoS
* Go to the event sale report
> Observation: The ticket sold through PoS is not included in the report

Why the fix:
------------
We modify the SQL query of the event sale report to include event registrations sold through PoS. We also make sure to remove duplicates from the original query.

opw-4935195