### PR TITLE
[FIX] mail: press 'Send' button reliably sends message in iOS PWA

### DIFF
--- a/addons/mail/static/src/core/common/composer.scss
+++ b/addons/mail/static/src/core/common/composer.scss
@@ -148,10 +148,6 @@
 
 .o-mail-Composer-bg {
 
-    &.o-iosPwa:not(:focus-within) {
-        margin-bottom: map-get($spacers, 5) !important;
-    }
-
     &:has(textarea:focus) {
         --border-opacity: 0.35;
         border-color: rgba($o-action, var(--border-opacity)) !important;


### PR DESCRIPTION
Before this commit, when using IOS PWA, pressing 'Send' button of in composer in discuss or chatter would sometimes not register the send.

This happens because in IOS PWA, the composer has a bottom margin as this is close to iOS persistent swipe bar. However, the margin should not be present when there's the soft-keyboard. Because of this dynamic margin based on input focus, when composing textual message and pressing "Send" button, the textarea looses focus and a fraction of second the margin-bottom is increased and moves the "Send" button. This leads to mis-clicking the "Send" button.

This commit removes the margin-bottom rule on non-focusin of textarea with iOS PWA. The composer is close to swipe bar so that's not as elegant as before, but at least this doesn't add the problem of non- working "Send" button.

opw-5028809