### PR TITLE
[REF] mail, *: removed im_status from _field_store_repr

### DIFF
--- a/addons/im_livechat/models/discuss_channel_member.py
+++ b/addons/im_livechat/models/discuss_channel_member.py
@@ -158,8 +158,8 @@ class DiscussChannelMember(models.Model):
                 "active",
                 "avatar_128",
                 Store.One("country_id", ["code", "name"]),
-                "im_status",
                 "is_public",
+                *self.env["res.partner"]._get_store_im_status_fields(),
                 *self.env["res.partner"]._get_store_livechat_username_fields(),
             ]
             if self.livechat_member_type == "visitor":
@@ -173,9 +173,9 @@ class DiscussChannelMember(models.Model):
             return [
                 "avatar_128",
                 Store.One("country_id", ["code", "name"]),
-                "im_status",
                 "name",
                 "offline_since",
+                *self.env["mail.guest"]._get_store_im_status_fields(),
             ]
         return super()._get_store_guest_fields(fields)
 

--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -348,7 +348,11 @@ class DiscussChannelMember(models.Model):
 
     def _to_store_persona(self, fields=None):
         if fields == "avatar_card":
-            fields = ["avatar_128", "im_status", "name"]
+            fields = [
+                "avatar_128",
+                *self.env["res.partner"]._get_store_im_status_fields(),
+                "name"
+            ]
         return [
             # sudo: res.partner - reading partner related to a member is considered acceptable
             Store.Attr(

--- a/addons/mail/models/discuss/mail_guest.py
+++ b/addons/mail/models/discuss/mail_guest.py
@@ -122,15 +122,16 @@ class MailGuest(models.Model):
                 Store.Attr("avatar_128_access_token", lambda g: g._get_avatar_128_access_token()),
                 "write_date",
             ]
-        if field_name == "im_status":
-            return [
-                "im_status",
-                Store.Attr("im_status_access_token", lambda g: g._get_im_status_access_token()),
-            ]
         return [field_name]
 
+    def _get_store_im_status_fields(self):
+        return [
+            "im_status",
+            Store.Attr("im_status_access_token", lambda g: g._get_im_status_access_token()),
+        ]
+
     def _to_store_defaults(self, target):
-        return ["avatar_128", "im_status", "name"]
+        return ["avatar_128", *self._get_store_im_status_fields(), "name"]
 
     def _set_auth_cookie(self):
         """Add a cookie to the response to identify the guest. Every route

--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -253,14 +253,20 @@ class ResPartner(models.Model):
         self.ensure_one()
         return limited_field_access_token(self, "id", scope="mail.message_mention")
 
+    def _get_store_im_status_fields(self):
+        return [
+            "im_status",
+            Store.Attr("im_status_access_token", lambda p: p._get_im_status_access_token()),
+        ]
+
     def _get_store_mention_fields(self):
         return [Store.Attr("mention_token", lambda p: p._get_mention_token())]
 
     def _get_store_avatar_card_fields(self, target):
         fields = [
-            "im_status",
             "name",
             "partner_share",
+            *self._get_store_im_status_fields(),
         ]
         if target.is_internal(self.env):
             fields.extend(["email", "phone"])
@@ -272,18 +278,13 @@ class ResPartner(models.Model):
                 Store.Attr("avatar_128_access_token", lambda p: p._get_avatar_128_access_token()),
                 "write_date",
             ]
-        if field_name == "im_status":
-            return [
-                "im_status",
-                Store.Attr("im_status_access_token", lambda p: p._get_im_status_access_token()),
-            ]
         return [field_name]
 
     def _to_store_defaults(self, target: Store.Target):
         res = [
             "active",
             "avatar_128",
-            "im_status",
+            *self._get_store_im_status_fields(),
             "is_company",
             Store.One("main_user_id", ["share"]),
             "name",

--- a/addons/mail/models/res_users.py
+++ b/addons/mail/models/res_users.py
@@ -411,7 +411,6 @@ class ResUsers(models.Model):
                     [
                         "active",
                         "avatar_128",
-                        "im_status",
                         Store.One(
                             "main_user_id",
                             [
@@ -422,6 +421,7 @@ class ResUsers(models.Model):
                             ],
                         ),
                         "name",
+                        *self.env["res.partner"]._get_store_im_status_fields(),
                     ],
                 ),
                 settings=settings._res_users_settings_format(),

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -2196,7 +2196,12 @@ class ProjectTask(models.Model):
         partners = self.env["res.partner"].sudo()._search_mention_suggestions(domain, limit)
         return (
             Store()
-            .add(partners, ["email", "im_status", "name", *partners._get_store_mention_fields()])
+            .add(partners, [
+                "email",
+                "name",
+                *partners._get_store_im_status_fields(),
+                *partners._get_store_mention_fields()
+            ])
             .get_result()
         )
 


### PR DESCRIPTION
* = im_livechat, project

This commit moves the `im_status` Store fields from the `_field_store_repr` to a dedicated method for `res.partner` and `mail.guest`.

task-4855079
task-4855077