### PR TITLE
[REM] orm: old check access methods

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3612,15 +3612,6 @@ class AccountMove(models.Model):
     # -------------------------------------------------------------------------
 
     @api.model
-    @api.deprecated("Override of a deprecated method")
-    def check_field_access_rights(self, operation, field_names):
-        result = super().check_field_access_rights(operation, field_names)
-        if not field_names:
-            weirdos = ['needed_terms', 'quick_encoding_vals', 'payment_term_details']
-            result = [fname for fname in result if fname not in weirdos]
-        return result
-
-    @api.model
     def _get_default_read_fields(self):
         weirdos = {'needed_terms', 'quick_encoding_vals', 'payment_term_details'}
         return [fname for fname in self.fields_get(attributes=()) if fname not in weirdos]

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1468,15 +1468,6 @@ class AccountMoveLine(models.Model):
     # -------------------------------------------------------------------------
 
     @api.model
-    @api.deprecated("Override of a deprecated method")
-    def check_field_access_rights(self, operation, field_names):
-        result = super().check_field_access_rights(operation, field_names)
-        if not field_names:
-            weirdos = ['term_key', 'epd_key', 'epd_needed', 'discount_allocation_key', 'discount_allocation_needed']
-            result = [fname for fname in result if fname not in weirdos]
-        return result
-
-    @api.model
     def _get_default_read_fields(self):
         weirdos = {'term_key', 'epd_key', 'epd_needed', 'discount_allocation_key', 'discount_allocation_needed'}
         return [fname for fname in self.fields_get(attributes=()) if fname not in weirdos]

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -349,18 +349,6 @@ class HrEmployee(models.Model):
             version.write({**vals.get('inherited', {})['hr.version'], 'employee_id': employee.id})
         return result
 
-    @api.model
-    @api.deprecated("Override of a deprecated method")
-    def check_field_access_rights(self, operation, field_names):
-        # DISCLAIMER: Dirty hack to avoid having to create a bridge module to override only a
-        # groups on a field which is not prefetched (because not stored) but would crash anyway
-        # if we try to read them directly (very uncommon use case). Don't add your field on this
-        # list if you can specify the group on the field directly (as all the other fields).
-        result = super().check_field_access_rights(operation, field_names)
-        if not self.env.user.has_group("hr.group_hr_user"):
-            result = [field for field in result if field not in ['activity_calendar_event_id', 'rating_ids', 'website_message_ids', 'message_has_sms_error']]
-        return result
-
     def _has_field_access(self, field, operation):
         # DISCLAIMER: Dirty hack to avoid having to create a bridge module to override only a
         # groups on a field which is not prefetched (because not stored) but would crash anyway

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -3425,43 +3425,6 @@ class BaseModel(metaclass=MetaModel):
 
         raise AccessError(error_msg)
 
-    @api.model
-    @api.deprecated(
-        "Deprecated since 19.0, use `_check_field_access` on models."
-        " To get the list of allowed fields, use `fields_get`.",
-    )
-    def check_field_access_rights(self, operation: str, field_names: list[str] | None) -> list[str]:
-        """Check the user access rights on the given fields.
-
-        If `field_names` is not provided, we list accessible fields to the user.
-        Otherwise, an error is raised if we try to access a forbidden field.
-        Note that this function ignores unknown (virtual) fields.
-
-        :param operation: one of ``create``, ``read``, ``write``, ``unlink``
-        :param field_names: names of the fields
-        :return: provided fields if fields is truthy (or the fields
-          readable by the current user).
-        :raise AccessError: if the user is not allowed to access
-          the provided fields.
-        """
-        if self.env.su:
-            return field_names or list(self._fields)
-
-        if not field_names:
-            return [
-                field_name
-                for field_name, field in self._fields.items()
-                if self._has_field_access(field, operation)
-            ]
-
-        for field_name in field_names:
-            # Unknown (or virtual) fields are considered accessible because they will not be read and nothing will be written to them.
-            field = self._fields.get(field_name)
-            if field is None:
-                continue
-            self._check_field_access(field, operation)
-        return field_names
-
     @api.readonly
     def read(self, fields: Sequence[str] | None = None, load: str = '_classic_read') -> list[ValuesType]:
         """Read the requested fields for the records in ``self``, and return their
@@ -4152,40 +4115,6 @@ class BaseModel(metaclass=MetaModel):
                 return forbidden, functools.partial(Rule._make_access_error, operation, forbidden)
 
         return None
-
-    @api.model
-    @api.deprecated("check_access_rights() is deprecated since 18.0; use check_access() instead.")
-    def check_access_rights(self, operation, raise_exception=True):
-        """ Verify that the given operation is allowed for the current user accord to ir.model.access.
-
-        :param str operation: one of ``create``, ``read``, ``write``, ``unlink``
-        :param bool raise_exception: whether an exception should be raise if operation is forbidden
-        :return: whether the operation is allowed
-        :rtype: bool
-        :raise AccessError: if the operation is forbidden and raise_exception is True
-        """
-        if raise_exception:
-            return self.browse().check_access(operation)
-        return self.browse().has_access(operation)
-
-    @api.deprecated("check_access_rule() is deprecated since 18.0; use check_access() instead.")
-    def check_access_rule(self, operation):
-        """ Verify that the given operation is allowed for the current user according to ir.rules.
-
-        :param str operation: one of ``create``, ``read``, ``write``, ``unlink``
-        :return: None if the operation is allowed
-        :raise UserError: if current ``ir.rules`` do not permit this operation.
-        """
-        self.check_access(operation)
-
-    @api.deprecated("_filter_access_rules() is deprecated since 18.0; use _filtered_access() instead.")
-    def _filter_access_rules(self, operation):
-        """ Return the subset of ``self`` for which ``operation`` is allowed. """
-        return self._filtered_access(operation)
-
-    @api.deprecated("_filter_access_rules_python() is deprecated since 18.0; use _filtered_access() instead.")
-    def _filter_access_rules_python(self, operation):
-        return self._filtered_access(operation)
 
     def unlink(self) -> typing.Literal[True]:
         """ Delete the records in ``self``.


### PR DESCRIPTION
The access methods were changed in 18.0 and 19.0. We remove the old methods and keep only the newer API.

odoo/enterprise#94448



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
