### PR TITLE
[FIX] im_livechat: allow to open meeting chat on embed live chat

### DIFF
--- a/addons/im_livechat/static/src/embed/common/disabled_features.js
+++ b/addons/im_livechat/static/src/embed/common/disabled_features.js
@@ -12,7 +12,13 @@ patch(Thread.prototype, {
     },
 });
 
-const allowedThreadActions = new Set(["fold-chat-window", "close", "restart", "call-settings"]);
+const allowedThreadActions = new Set([
+    "fold-chat-window",
+    "close",
+    "restart",
+    "call-settings",
+    "meeting-chat",
+]);
 for (const [actionName] of threadActionsRegistry.getEntries()) {
     if (!allowedThreadActions.has(actionName)) {
         threadActionsRegistry.remove(actionName);


### PR DESCRIPTION
The embed live chat has a subset of allowed thread actions. The meeting chat action was added but not added to the allowed thread actions.

In the future, we will allow most of the thread actions, at least the ones allowed for guests. Environment should not impact feature availability.

However for now, let's just enable the missing action.