### PR TITLE
[FIX] point_of_sale: clean ui for preparation capacity field

### DIFF
--- a/addons/point_of_sale/views/pos_preset_view.xml
+++ b/addons/point_of_sale/views/pos_preset_view.xml
@@ -39,7 +39,7 @@
                             </div>
 
                             <label for="slots_per_interval" string="Preparation capacity" class="fw-bold ms-2" />
-                            <div>
+                            <div class="o_row">
                                 <field name="slots_per_interval" class="oe_inline border-bottom text-center" readonly="not use_timing" />
                                 <label for="slots_per_interval" string="orders per" />
                                 <field name="interval_time" class="oe_inline border-bottom text-center" readonly="not use_timing" />


### PR DESCRIPTION
In this commit:
--------------
- The preparation capacity field was not properly displayed when
manage orders by time is disabled, now we have added a additional
class to make ui proper.

task: 5077509