### PR TITLE
[IMP] mail: html composer focus state

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -293,6 +293,8 @@ export class Composer extends Component {
             Plugins: this.ui.isSmall ? MAIL_SMALL_UI_PLUGINS : MAIL_PLUGINS,
             composerPluginDependencies: {
                 onBeforePaste: (selection, ev) => this.onPaste(ev),
+                onFocusin: this.onFocusin.bind(this),
+                onFocusout: this.onFocusout.bind(this),
                 onInput: this.onInput.bind(this),
                 onKeydown: this.onKeydown.bind(this),
             },

--- a/addons/mail/static/src/core/common/composer.scss
+++ b/addons/mail/static/src/core/common/composer.scss
@@ -222,6 +222,10 @@
     &:has(textarea:focus) {
         --border-color: #{$o-component-active-border};
     }
+
+    &:has(.o-mail-Composer-html:focus) {
+        --border-color: #{$o-component-active-border};
+    }
 }
 
 .o-mail-Composer-pickerContainer.o-active {

--- a/addons/mail/static/src/core/common/plugin/mail_composer_plugin.js
+++ b/addons/mail/static/src/core/common/plugin/mail_composer_plugin.js
@@ -38,5 +38,15 @@ export class MailComposerPlugin extends Plugin {
             "keydown",
             this.config.composerPluginDependencies.onKeydown
         );
+        this.addDomListener(
+            this.editable,
+            "focusin",
+            this.config.composerPluginDependencies.onFocusin
+        );
+        this.addDomListener(
+            this.editable,
+            "focusout",
+            this.config.composerPluginDependencies.onFocusout
+        );
     }
 }


### PR DESCRIPTION
This commit binding the focusin and focusout handlers to the HTML composer, making the mark as read feature working as expected.

Also, this commit improves the border styling of the composer with focus state.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
