### PR TITLE
[FIX] website: fix animation trigger for footer elements

### DIFF
--- a/addons/website/static/src/interactions/animation.js
+++ b/addons/website/static/src/interactions/animation.js
@@ -165,14 +165,10 @@ export class Animation extends Interaction {
             // case specifically instead of a generic solution using
             // elementFromPoint as it is a rare case and the implementation
             // would have been too complicated for such a small use case.
-            const actualScroll = this.wrapwrapEl.scrollTop + windowsHeight;
-            const totalScrollHeight = this.wrapwrapEl.scrollHeight;
             const heightFromFooter = this.getElementOffsetTop(el, footerEl);
-            visible = actualScroll >=
-                totalScrollHeight - heightFromFooter - elHeight + elOffset;
+            visible = scrollTop >= windowsHeight + heightFromFooter + elHeight - elOffset;
         } else {
-            visible = windowsHeight > (elTop + elOffset) &&
-                0 < (elTop + elHeight - elOffset);
+            visible = windowsHeight > (elTop + elOffset) && 0 < (elTop + elHeight - elOffset);
         }
         if (this.isAnimateOnScroll) {
             if (visible) {


### PR DESCRIPTION
Before this commit, using animation on text within the footer elements would not work if the footer was set on "slide over". The formula used to compute when to start the animation was incorrect.

This commit fixes the formula.

Steps to reproduce:
- Set the Footer slideout to "Slide Over"
- Set the Animation of an element to "On Appearance"
- Save (when scrolling down, the animated element stay hidden)
