### PR TITLE
[FIX] account_edi_ubl_cii: only one PartyIdentification for customer

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -146,7 +146,7 @@ class AccountEdiXmlUBL20(models.AbstractModel):
     def _get_partner_party_vals(self, partner, role):
         return {
             'partner': partner,
-            'party_identification_vals': self._get_partner_party_identification_vals_list(partner.commercial_partner_id),
+            'party_identification_vals': self.with_context(ubl_partner_role=role)._get_partner_party_identification_vals_list(partner.commercial_partner_id),
             'party_name_vals': [{'name': partner.display_name}],
             'postal_address_vals': self._get_partner_address_vals(partner),
             'party_tax_scheme_vals': self._get_partner_party_tax_scheme_vals_list(partner.commercial_partner_id, role),

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/nlcius_out_invoice.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/nlcius_out_invoice.xml
@@ -59,9 +59,6 @@
     <cac:Party>
       <cbc:EndpointID schemeID="9944">NL41452B11</cbc:EndpointID>
       <cac:PartyIdentification>
-        <cbc:ID>ref_partner_2</cbc:ID>
-      </cac:PartyIdentification>
-      <cac:PartyIdentification>
         <cbc:ID>NL41452B11</cbc:ID>
       </cac:PartyIdentification>
       <cac:PartyName>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/nlcius_out_refund.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/nlcius_out_refund.xml
@@ -63,9 +63,6 @@
     <cac:Party>
       <cbc:EndpointID schemeID="9944">NL41452B11</cbc:EndpointID>
       <cac:PartyIdentification>
-        <cbc:ID>ref_partner_2</cbc:ID>
-      </cac:PartyIdentification>
-      <cac:PartyIdentification>
         <cbc:ID>NL41452B11</cbc:ID>
       </cac:PartyIdentification>
       <cac:PartyName>


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting and Contacts
- Use a company based in Netherlands

- In Contacts, configure the company:
  * eInvoice format: Netherlands (NLCIUS)
  * Peppol endpoint: [anything]
  * Reference ("Sales & Purchase" tab): [anything]
- Create a Dutch contact with a peppol endpoint and a reference

- Create an invoice for the Dutch contact
- Confirm the invoice
- Send the invoice
- Check the generated NLCIUS xml

**Issue:**
In the XML there are 2 "<cac:PartyIdentification>" for each party.
One with the peppol endpoint and one with the partner reference.
For "<cac:AccountingCustomerParty>", only one Party Identification is allowed, triggering the following validation error:
[UBL-SR-16] Buyer identifier shall occur maximum once

**Cause:**
By default (UBL 2.0), the partner reference is used as Party Identification.
But in the case of a Dutch partner, the peppol endpoint is also added in BIS3.

**Solution:**
Only use the peppol endpoint for Dutch partners.

opw-5059667




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
