### PR TITLE
[IMP] mail: enrich use suggestion in HTML composer

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -446,9 +446,7 @@ export class Composer extends Component {
                     ...props,
                     optionTemplate: "mail.Composer.suggestionThread",
                     options: suggestions.map((suggestion) => ({
-                        label: suggestion.parent_channel_id
-                            ? `${suggestion.parent_channel_id.displayName} > ${suggestion.displayName}`
-                            : suggestion.displayName,
+                        label: suggestion.fullNameWithParent,
                         thread: suggestion,
                         classList: "o-mail-Composer-suggestion",
                     })),

--- a/addons/mail/static/src/core/common/suggestion_service.js
+++ b/addons/mail/static/src/core/common/suggestion_service.js
@@ -33,9 +33,6 @@ export class SuggestionService {
         if (env?.inFrontendPortalChatter) {
             return [[":", undefined, 2]];
         }
-        if (this.composer.htmlEnabled) {
-            return [["::"], [":", undefined, 2]];
-        }
         return [["@"], ["#"], ["::"], [":", undefined, 2]];
     }
 

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -352,6 +352,13 @@ export class Thread extends Record {
         return ["channel", "group"].includes(this.channel_type);
     }
 
+    get fullNameWithParent() {
+        const text = this.parent_channel_id
+            ? `${this.parent_channel_id.displayName} > ${this.displayName}`
+            : this.displayName;
+        return text;
+    }
+
     get isTransient() {
         return !this.id || this.id < 0;
     }

--- a/addons/mail/static/src/utils/common/format.js
+++ b/addons/mail/static/src/utils/common/format.js
@@ -174,6 +174,63 @@ export function addLink(node, transformChildren) {
     return markup(node.outerHTML);
 }
 
+function generateMentionElement({ className, id, model, text }) {
+    const link = document.createElement("a");
+    setAttributes(link, {
+        href: router.stateToUrl({ model: model, resId: id }),
+        class: className,
+        "data-oe-id": id,
+        "data-oe-model": model,
+        target: "_blank",
+        contenteditable: "false",
+    });
+    link.textContent = text;
+    return link;
+}
+
+/** @param {import("models").ResPartner} partner */
+export function generatePartnerMentionElement(partner) {
+    return generateMentionElement({
+        className: "o_mail_redirect",
+        id: partner.id,
+        model: "res.partner",
+        text: `@${partner.name}`,
+    });
+}
+
+/** @param {import("models").ResRole} role */
+export function generateRoleMentionElement(role) {
+    return generateMentionElement({
+        className: "o-discuss-mention",
+        id: role.id,
+        model: "res.role",
+        text: `@${role.name}`,
+    });
+}
+
+/** @param {string} label */
+export function generateSpecialMentionElement(label) {
+    const link = document.createElement("a");
+    setAttributes(link, {
+        class: "o-discuss-mention",
+        contenteditable: "false",
+    });
+    link.textContent = `@${label}`;
+    return link;
+}
+
+/** @param {import("models").Thread} thread */
+export function generateThreadMentionElement(thread) {
+    return generateMentionElement({
+        className: `o_channel_redirect${
+            thread.parent_channel_id ? " o_channel_redirect_asThread" : ""
+        }`,
+        id: thread.id,
+        model: "discuss.channel",
+        text: `#${thread.fullNameWithParent}`,
+    });
+}
+
 /**
  * @param body {string|ReturnType<markup>}
  * @param validRecords {Object}
@@ -189,63 +246,41 @@ function generateMentionsLinks(
         const placeholder = `@-mention-partner-${partner.id}`;
         const text = `@${partner.name}`;
         mentions.push({
-            class: "o_mail_redirect",
-            id: partner.id,
-            model: "res.partner",
+            link: generatePartnerMentionElement(partner),
             placeholder,
-            text,
         });
         body = htmlReplace(body, text, placeholder);
     }
     for (const thread of threads) {
         const placeholder = `#-mention-channel-${thread.id}`;
-        let className, text;
-        if (thread.parent_channel_id) {
-            className = "o_channel_redirect o_channel_redirect_asThread";
-            text = `#${thread.parent_channel_id.displayName} > ${thread.displayName}`;
-        } else {
-            className = "o_channel_redirect";
-            text = `#${thread.displayName}`;
-        }
+        const text = `#${thread.fullNameWithParent}`;
         mentions.push({
-            class: className,
-            id: thread.id,
-            model: "discuss.channel",
+            link: generateThreadMentionElement(thread),
             placeholder,
-            text,
         });
         body = htmlReplace(body, text, placeholder);
     }
     for (const special of specialMentions) {
-        body = htmlReplace(
-            body,
-            `@${special}`,
-            markup`<a href="#" class="o-discuss-mention">@${special}</a>`
-        );
+        const text = `@${special}`;
+        const placeholder = `@-mention-special-${special}`;
+        mentions.push({
+            link: generateSpecialMentionElement(special),
+            placeholder,
+        });
+        body = htmlReplace(body, text, placeholder);
     }
     for (const role of roles) {
         const placeholder = `@-mention-role-${role.id}`;
         const text = `@${role.name}`;
         mentions.push({
-            class: "o-discuss-mention",
-            id: role.id,
-            model: "res.role",
+            link: generateRoleMentionElement(role),
             placeholder,
-            text,
         });
         body = htmlReplace(body, text, placeholder);
     }
     for (const mention of mentions) {
-        const link = document.createElement("a");
-        setAttributes(link, {
-            href: router.stateToUrl({ model: mention.model, resId: mention.id }),
-            class: mention.class,
-            "data-oe-id": mention.id,
-            "data-oe-model": mention.model,
-            target: "_blank",
-            contenteditable: "false",
-        });
-        link.textContent = mention.text;
+        const link = mention.link;
+        // markup: outerHTML is safe when used as a node
         body = htmlReplace(body, mention.placeholder, markup(link.outerHTML));
     }
     return htmlEscape(body);

--- a/addons/mail/static/tests/composer/composer.test.js
+++ b/addons/mail/static/tests/composer/composer.test.js
@@ -1456,7 +1456,7 @@ test("can quickly add emoji with ':' keyword", async () => {
     await click(".o-mail-NavigableList-item", { text: "😅:sweat_smile:" });
     await contains(".o-mail-Composer-html.odoo-editor-editable", { text: "😅" });
     await contains(".o-mail-Composer-suggestionList .o-open", { count: 0 });
-    await htmlInsertText(editor, ":sw");
+    await htmlInsertText(editor, " :sw");
     await contains(".o-mail-Composer-suggestionList .o-open");
     await contains(".o-mail-NavigableList-item", { text: "😅:sweat_smile:" });
     await htmlInsertText(editor, ":s", { replace: true });

--- a/addons/mail/static/tests/suggestion/suggestion.test.js
+++ b/addons/mail/static/tests/suggestion/suggestion.test.js
@@ -1,7 +1,10 @@
+import { insertText as htmlInsertText } from "@html_editor/../tests/_helpers/user_actions";
+
 import {
     click,
     contains,
     defineMailModels,
+    focus,
     insertText,
     onRpcBefore,
     openDiscuss,
@@ -14,6 +17,7 @@ import { Deferred, tick } from "@odoo/hoot-mock";
 import {
     asyncStep,
     Command,
+    getService,
     onRpc,
     patchWithCleanup,
     serverState,
@@ -34,7 +38,7 @@ beforeEach(() => {
     });
 });
 
-test('display partner mention suggestions on typing "@"', async () => {
+test('[text composer] display partner mention suggestions on typing "@"', async () => {
     const pyEnv = await startServer();
     const partnerId_1 = pyEnv["res.partner"].create({
         email: "testpartner@odoo.com",
@@ -59,7 +63,41 @@ test('display partner mention suggestions on typing "@"', async () => {
     await contains(".o-mail-Composer-suggestion strong", { count: 3 });
 });
 
-test("can @user in restricted (group_public_id) channels", async () => {
+test.tags("html composer");
+test("display partner mention suggestions on typing '@'", async () => {
+    const pyEnv = await startServer();
+    const partnerId_1 = pyEnv["res.partner"].create({
+        email: "testpartner@odoo.com",
+        name: "TestPartner",
+    });
+    const partnerId_2 = pyEnv["res.partner"].create({
+        email: "testpartner2@odoo.com",
+        name: "TestPartner2",
+    });
+    pyEnv["res.users"].create({ partner_id: partnerId_1 });
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "general",
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ partner_id: partnerId_1 }),
+            Command.create({ partner_id: partnerId_2 }),
+        ],
+    });
+    await start();
+    const composerService = getService("mail.composer");
+    composerService.setHtmlComposer();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Composer-html.odoo-editor-editable");
+    const editor = {
+        document,
+        editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
+    };
+    await focus(".o-mail-Composer-html.odoo-editor-editable");
+    await htmlInsertText(editor, "@");
+    await contains(".o-mail-Composer-suggestion strong", { count: 3 });
+});
+
+test("[text composer] can @user in restricted (group_public_id) channels", async () => {
     const pyEnv = await startServer();
     const groupId = pyEnv["res.groups"].create({
         name: "Custom Channel Group",
@@ -87,7 +125,44 @@ test("can @user in restricted (group_public_id) channels", async () => {
     await contains(".o-mail-Composer-suggestion strong", { count: 2 });
 });
 
-test('post a first message then display partner mention suggestions on typing "@"', async () => {
+test.tags("html composer");
+test("can @user in restricted (group_public_id) channels", async () => {
+    const pyEnv = await startServer();
+    const groupId = pyEnv["res.groups"].create({
+        name: "Custom Channel Group",
+    });
+    const [partnerId_1, partnerId_2] = pyEnv["res.partner"].create([
+        { email: "testpartner1@odoo.com", name: "TestPartner1" },
+        { email: "testpartner2@odoo.com", name: "TestPartner2" },
+    ]);
+    pyEnv["res.users"].create([
+        { partner_id: partnerId_1, group_ids: [Command.link(groupId)] },
+        { partner_id: partnerId_2 },
+    ]);
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "Restricted Channel",
+        group_public_id: groupId,
+        channel_type: "channel",
+    });
+    await start();
+    const composerService = getService("mail.composer");
+    composerService.setHtmlComposer();
+    await openDiscuss(channelId);
+    await click("button[title='Invite People']");
+    await contains(".o-discuss-ChannelInvitation-invitationBox", {
+        text: 'Access restricted to group "Custom Channel Group"',
+    });
+    await contains(".o-mail-Composer-html.odoo-editor-editable");
+    const editor = {
+        document,
+        editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
+    };
+    await focus(".o-mail-Composer-html.odoo-editor-editable");
+    await htmlInsertText(editor, "@");
+    await contains(".o-mail-Composer-suggestion strong", { count: 2 });
+});
+
+test("[text composer] post a first message then display partner mention suggestions on typing '@'", async () => {
     const pyEnv = await startServer();
     const partnerId_1 = pyEnv["res.partner"].create({
         email: "testpartner@odoo.com",
@@ -116,7 +191,44 @@ test('post a first message then display partner mention suggestions on typing "@
     await contains(".o-mail-Composer-suggestion strong", { count: 3 });
 });
 
-test('display partner mention suggestions on typing "@" in chatter', async () => {
+test.tags("html composer");
+test("post a first message then display partner mention suggestions on typing '@'", async () => {
+    const pyEnv = await startServer();
+    const partnerId_1 = pyEnv["res.partner"].create({
+        email: "testpartner@odoo.com",
+        name: "TestPartner",
+    });
+    const partnerId_2 = pyEnv["res.partner"].create({
+        email: "testpartner2@odoo.com",
+        name: "TestPartner2",
+    });
+    pyEnv["res.users"].create({ partner_id: partnerId_1 });
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "general",
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ partner_id: partnerId_1 }),
+            Command.create({ partner_id: partnerId_2 }),
+        ],
+    });
+    await start();
+    const composerService = getService("mail.composer");
+    composerService.setHtmlComposer();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Composer-html.odoo-editor-editable");
+    const editor = {
+        document,
+        editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
+    };
+    await focus(".o-mail-Composer-html.odoo-editor-editable");
+    await htmlInsertText(editor, "first message");
+    await press("Enter");
+    await contains(".o-mail-Message");
+    await htmlInsertText(editor, "@");
+    await contains(".o-mail-Composer-suggestion strong", { count: 3 });
+});
+
+test('[text composer] display partner mention suggestions on typing "@" in chatter', async () => {
     await startServer();
     await start();
     await openFormView("res.partner", serverState.partnerId);
@@ -125,7 +237,24 @@ test('display partner mention suggestions on typing "@" in chatter', async () =>
     await contains(".o-mail-Composer-suggestion strong", { text: "Mitchell Admin" });
 });
 
-test("Do not fetch if search more specific and fetch had no result", async () => {
+test.tags("html composer");
+test('display partner mention suggestions on typing "@" in chatter', async () => {
+    await startServer();
+    await start();
+    const composerService = getService("mail.composer");
+    composerService.setHtmlComposer();
+    await openFormView("res.partner", serverState.partnerId);
+    await click("button", { text: "Send message" });
+    await contains(".o-mail-Composer-html.odoo-editor-editable");
+    const editor = {
+        document,
+        editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
+    };
+    await htmlInsertText(editor, "@");
+    await contains(".o-mail-Composer-suggestion strong", { text: "Mitchell Admin" });
+});
+
+test("[text composer] Do not fetch if search more specific and fetch had no result", async () => {
     await startServer();
     onRpc("res.partner", "get_mention_suggestions", () => {
         asyncStep("get_mention_suggestions");
@@ -144,7 +273,35 @@ test("Do not fetch if search more specific and fetch had no result", async () =>
     await expect.waitForSteps([]);
 });
 
-test("show other channel member in @ mention", async () => {
+test.tags("html composer");
+test("Do not fetch if search more specific and fetch had no result", async () => {
+    await startServer();
+    onRpc("res.partner", "get_mention_suggestions", () => {
+        asyncStep("get_mention_suggestions");
+    });
+    await start();
+    const composerService = getService("mail.composer");
+    composerService.setHtmlComposer();
+    await openFormView("res.partner", serverState.partnerId);
+    await click("button", { text: "Send message" });
+    await contains(".o-mail-Composer-html.odoo-editor-editable");
+    const editor = {
+        document,
+        editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
+    };
+    await focus(".o-mail-Composer-html.odoo-editor-editable");
+    await htmlInsertText(editor, "@");
+    await contains(".o-mail-Composer-suggestion", { count: 3 }); // Mitchell Admin, Hermit, Public user
+    await contains(".o-mail-Composer-suggestion", { text: "Mitchell Admin" });
+    await expect.waitForSteps(["get_mention_suggestions"]);
+    await htmlInsertText(editor, "x");
+    await contains(".o-mail-Composer-suggestion", { count: 0 });
+    await expect.waitForSteps(["get_mention_suggestions"]);
+    await htmlInsertText(editor, "x");
+    await expect.waitForSteps([]);
+});
+
+test("[text composer] show other channel member in @ mention", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({
         email: "testpartner@odoo.com",
@@ -163,7 +320,35 @@ test("show other channel member in @ mention", async () => {
     await contains(".o-mail-Composer-suggestion strong", { text: "TestPartner" });
 });
 
-test("select @ mention insert mention text in composer", async () => {
+test.tags("html composer");
+test("show other channel member in @ mention", async () => {
+    const pyEnv = await startServer();
+    const partnerId = pyEnv["res.partner"].create({
+        email: "testpartner@odoo.com",
+        name: "TestPartner",
+    });
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "general",
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ partner_id: partnerId }),
+        ],
+    });
+    await start();
+    const composerService = getService("mail.composer");
+    composerService.setHtmlComposer();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Composer-html.odoo-editor-editable");
+    const editor = {
+        document,
+        editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
+    };
+    await focus(".o-mail-Composer-html.odoo-editor-editable");
+    await htmlInsertText(editor, "@");
+    await contains(".o-mail-Composer-suggestion strong", { text: "TestPartner" });
+});
+
+test("[text composer] select @ mention insert mention text in composer", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({
         email: "testpartner@odoo.com",
@@ -183,7 +368,36 @@ test("select @ mention insert mention text in composer", async () => {
     await contains(".o-mail-Composer-input", { value: "@TestPartner " });
 });
 
-test("select @ mention closes suggestions", async () => {
+test.tags("html composer");
+test("select @ mention insert mention text in composer", async () => {
+    const pyEnv = await startServer();
+    const partnerId = pyEnv["res.partner"].create({
+        email: "testpartner@odoo.com",
+        name: "TestPartner",
+    });
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "general",
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ partner_id: partnerId }),
+        ],
+    });
+    await start();
+    const composerService = getService("mail.composer");
+    composerService.setHtmlComposer();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Composer-html.odoo-editor-editable");
+    const editor = {
+        document,
+        editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
+    };
+    await focus(".o-mail-Composer-html.odoo-editor-editable");
+    await htmlInsertText(editor, "@");
+    await click(".o-mail-Composer-suggestion strong", { text: "TestPartner" });
+    await contains(".o-mail-Composer-html.odoo-editor-editable", { text: "@TestPartner" });
+});
+
+test("[text composer] select @ mention closes suggestions", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({
         email: "testpartner@odoo.com",
@@ -203,7 +417,36 @@ test("select @ mention closes suggestions", async () => {
     await contains(".o-mail-Composer-suggestion strong", { count: 0 });
 });
 
-test('display channel mention suggestions on typing "#"', async () => {
+test.tags("html composer");
+test("select @ mention closes suggestions", async () => {
+    const pyEnv = await startServer();
+    const partnerId = pyEnv["res.partner"].create({
+        email: "testpartner@odoo.com",
+        name: "TestPartner",
+    });
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "general",
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ partner_id: partnerId }),
+        ],
+    });
+    await start();
+    const composerService = getService("mail.composer");
+    composerService.setHtmlComposer();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Composer-html.odoo-editor-editable");
+    const editor = {
+        document,
+        editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
+    };
+    await focus(".o-mail-Composer-html.odoo-editor-editable");
+    await htmlInsertText(editor, "@");
+    await click(".o-mail-Composer-suggestion strong", { text: "TestPartner" });
+    await contains(".o-mail-Composer-suggestion strong", { count: 0 });
+});
+
+test('[text composer] display channel mention suggestions on typing "#"', async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({
         name: "General",
@@ -217,7 +460,30 @@ test('display channel mention suggestions on typing "#"', async () => {
     await contains(".o-mail-Composer-suggestionList .o-open");
 });
 
-test("mention a channel", async () => {
+test.tags("html composer");
+test('display channel mention suggestions on typing "#"', async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "General",
+        channel_type: "channel",
+    });
+    await start();
+    const composerService = getService("mail.composer");
+    composerService.setHtmlComposer();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Composer-html.odoo-editor-editable");
+    const editor = {
+        document,
+        editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
+    };
+    await focus(".o-mail-Composer-html.odoo-editor-editable");
+    await contains(".o-mail-Composer-suggestionList");
+    await contains(".o-mail-Composer-suggestionList .o-open", { count: 0 });
+    await htmlInsertText(editor, "#");
+    await contains(".o-mail-Composer-suggestionList .o-open");
+});
+
+test("[text composer] mention a channel", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({
         name: "General",
@@ -233,7 +499,32 @@ test("mention a channel", async () => {
     await contains(".o-mail-Composer-input", { value: "#General " });
 });
 
-test("mention a channel thread", async () => {
+test.tags("html composer");
+test("mention a channel", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "General",
+        channel_type: "channel",
+    });
+    await start();
+    const composerService = getService("mail.composer");
+    composerService.setHtmlComposer();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Composer-html.odoo-editor-editable");
+    const editor = {
+        document,
+        editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
+    };
+    await focus(".o-mail-Composer-html.odoo-editor-editable");
+    await contains(".o-mail-Composer-suggestionList");
+    await contains(".o-mail-Composer-suggestionList .o-open", { count: 0 });
+    await contains(".o-mail-Composer-html.odoo-editor-editable", { text: "" });
+    await htmlInsertText(editor, "#");
+    await click(".o-mail-Composer-suggestion");
+    await contains(".o-mail-Composer-html.odoo-editor-editable", { text: "#General" });
+});
+
+test("[text composer] mention a channel thread", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({
         name: "General",
@@ -264,7 +555,47 @@ test("mention a channel thread", async () => {
     await contains(".o-mail-DiscussSidebar-item.o-active", { text: "ThreadOne" });
 });
 
-test("Channel suggestions do not crash after rpc returns", async () => {
+test.tags("html composer");
+test("mention a channel thread", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "General",
+        channel_type: "channel",
+    });
+    pyEnv["discuss.channel"].create({
+        name: "ThreadOne",
+        parent_channel_id: channelId,
+    });
+    await start();
+    const composerService = getService("mail.composer");
+    composerService.setHtmlComposer();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Composer-html.odoo-editor-editable");
+    const editor = {
+        document,
+        editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
+    };
+    await focus(".o-mail-Composer-html.odoo-editor-editable");
+    await contains(".o-mail-Composer-suggestionList");
+    await contains(".o-mail-Composer-suggestionList .o-open", { count: 0 });
+    await contains(".o-mail-Composer-html.odoo-editor-editable", { text: "" });
+    await htmlInsertText(editor, "#");
+    await contains(".o-mail-Composer-suggestion", { count: 2 });
+    await contains(".o-mail-Composer-suggestion:eq(0):has(i.fa-hashtag)", { text: "General" });
+    await contains(".o-mail-Composer-suggestion:eq(1):has(i.fa-comments-o)", {
+        text: "GeneralThreadOne",
+    });
+    await click(".o-mail-Composer-suggestion:eq(1)");
+    await contains(".o-mail-Composer-html.odoo-editor-editable", { text: "#General > ThreadOne" });
+    await press("Enter");
+    await contains(".o-mail-Message a.o_channel_redirect:has(i.fa-comments-o)", {
+        text: "General > ThreadOne",
+    });
+    await click("a.o_channel_redirect", { text: "General > ThreadOne" });
+    await contains(".o-mail-DiscussSidebar-item.o-active", { text: "ThreadOne" });
+});
+
+test("[text composer] Channel suggestions do not crash after rpc returns", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "general" });
     const deferred = new Deferred();
@@ -282,7 +613,34 @@ test("Channel suggestions do not crash after rpc returns", async () => {
     await expect.waitForSteps(["get_mention_suggestions"]);
 });
 
-test("Suggestions are shown after delimiter was used in text (@)", async () => {
+test.tags("html composer");
+test("Channel suggestions do not crash after rpc returns", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "general" });
+    const deferred = new Deferred();
+    onRpc("discuss.channel", "get_mention_suggestions", () => {
+        asyncStep("get_mention_suggestions");
+        deferred.resolve();
+    });
+    await start();
+    const composerService = getService("mail.composer");
+    composerService.setHtmlComposer();
+    await openDiscuss(channelId);
+    pyEnv["discuss.channel"].create({ name: "foo" });
+    await contains(".o-mail-Composer-html.odoo-editor-editable");
+    const editor = {
+        document,
+        editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
+    };
+    await focus(".o-mail-Composer-html.odoo-editor-editable");
+    await htmlInsertText(editor, "#");
+    await tick();
+    await htmlInsertText(editor, "f");
+    await deferred;
+    await expect.waitForSteps(["get_mention_suggestions"]);
+});
+
+test("[text composer] Suggestions are shown after delimiter was used in text (@)", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     await start();
@@ -295,7 +653,29 @@ test("Suggestions are shown after delimiter was used in text (@)", async () => {
     await contains(".o-mail-Composer-suggestion strong", { text: "Mitchell Admin" });
 });
 
-test("Suggestions are shown after delimiter was used in text (#)", async () => {
+test.tags("html composer");
+test("Suggestions are shown after delimiter was used in text (@)", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    await start();
+    const composerService = getService("mail.composer");
+    composerService.setHtmlComposer();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Composer-html.odoo-editor-editable");
+    const editor = {
+        document,
+        editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
+    };
+    await focus(".o-mail-Composer-html.odoo-editor-editable");
+    await htmlInsertText(editor, "@");
+    await contains(".o-mail-Composer-suggestion");
+    await htmlInsertText(editor, "NonExistingUser");
+    await contains(".o-mail-Composer-suggestion strong", { count: 0 });
+    await htmlInsertText(editor, " @");
+    await contains(".o-mail-Composer-suggestion strong", { text: "Mitchell Admin" });
+});
+
+test("[text composer] Suggestions are shown after delimiter was used in text (#)", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     await start();
@@ -308,7 +688,29 @@ test("Suggestions are shown after delimiter was used in text (#)", async () => {
     await contains(".o-mail-Composer-suggestion strong", { text: "General" });
 });
 
-test("display partner mention when typing more than 2 words if they match", async () => {
+test.tags("html composer");
+test("Suggestions are shown after delimiter was used in text (#)", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    await start();
+    const composerService = getService("mail.composer");
+    composerService.setHtmlComposer();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Composer-html.odoo-editor-editable");
+    const editor = {
+        document,
+        editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
+    };
+    await focus(".o-mail-Composer-html.odoo-editor-editable");
+    await htmlInsertText(editor, "#");
+    await contains(".o-mail-Composer-suggestion");
+    await htmlInsertText(editor, "NonExistingChannel");
+    await contains(".o-mail-Composer-suggestion strong", { count: 0 });
+    await htmlInsertText(editor, " #");
+    await contains(".o-mail-Composer-suggestion strong", { text: "General" });
+});
+
+test("[text composer] display partner mention when typing more than 2 words if they match", async () => {
     const pyEnv = await startServer();
     pyEnv["res.partner"].create([
         {
@@ -336,7 +738,44 @@ test("display partner mention when typing more than 2 words if they match", asyn
     await contains(".o-mail-Composer-suggestion strong", { text: "My Test Partner" });
 });
 
-test("Internal user should be displayed first", async () => {
+test.tags("html composer");
+test("display partner mention when typing more than 2 words if they match", async () => {
+    const pyEnv = await startServer();
+    pyEnv["res.partner"].create([
+        {
+            email: "test1@example.com",
+            name: "My Best Partner",
+        },
+        {
+            email: "test2@example.com",
+            name: "My Test User",
+        },
+        {
+            email: "test3@example.com",
+            name: "My Test Partner",
+        },
+    ]);
+    await start();
+    const composerService = getService("mail.composer");
+    composerService.setHtmlComposer();
+    await openFormView("res.partner", serverState.partnerId);
+    await click("button", { text: "Send message" });
+    await contains(".o-mail-Composer-html.odoo-editor-editable");
+    const editor = {
+        document,
+        editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
+    };
+    await focus(".o-mail-Composer-html.odoo-editor-editable");
+    await htmlInsertText(editor, "@My ");
+    await contains(".o-mail-Composer-suggestion strong", { count: 3 });
+    await htmlInsertText(editor, "Test ");
+    await contains(".o-mail-Composer-suggestion strong", { count: 2 });
+    await htmlInsertText(editor, "Partner");
+    await contains(".o-mail-Composer-suggestion");
+    await contains(".o-mail-Composer-suggestion strong", { text: "My Test Partner" });
+});
+
+test("[text composer] Internal user should be displayed first", async () => {
     const pyEnv = await startServer();
     const [user1Id, user2Id] = pyEnv["res.users"].create([{}, {}]);
     const partnerIds = pyEnv["res.partner"].create([
@@ -348,13 +787,13 @@ test("Internal user should be displayed first", async () => {
     pyEnv["mail.followers"].create([
         {
             is_active: true,
-            partner_id: partnerIds[1], // B
+            partner_id: partnerIds[1],
             res_id: serverState.partnerId,
             res_model: "res.partner",
         },
         {
             is_active: true,
-            partner_id: partnerIds[3], // D
+            partner_id: partnerIds[3],
             res_id: serverState.partnerId,
             res_model: "res.partner",
         },
@@ -369,7 +808,49 @@ test("Internal user should be displayed first", async () => {
     await contains(":nth-child(4 of .o-mail-Composer-suggestion) strong", { text: "Person A" });
 });
 
-test("Current user that is a follower should be considered as such", async () => {
+test.tags("html composer");
+test("Internal user should be displayed first", async () => {
+    const pyEnv = await startServer();
+    const [user1Id, user2Id] = pyEnv["res.users"].create([{}, {}]);
+    const partnerIds = pyEnv["res.partner"].create([
+        { name: "Person A" },
+        { name: "Person B" },
+        { name: "Person C", user_ids: [user1Id] },
+        { name: "Person D", user_ids: [user2Id] },
+    ]);
+    pyEnv["mail.followers"].create([
+        {
+            is_active: true,
+            partner_id: partnerIds[1],
+            res_id: serverState.partnerId,
+            res_model: "res.partner",
+        },
+        {
+            is_active: true,
+            partner_id: partnerIds[3],
+            res_id: serverState.partnerId,
+            res_model: "res.partner",
+        },
+    ]);
+    await start();
+    const composerService = getService("mail.composer");
+    composerService.setHtmlComposer();
+    await openFormView("res.partner", serverState.partnerId);
+    await click("button", { text: "Send message" });
+    await contains(".o-mail-Composer-html.odoo-editor-editable");
+    const editor = {
+        document,
+        editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
+    };
+    await focus(".o-mail-Composer-html.odoo-editor-editable");
+    await htmlInsertText(editor, "@Person ");
+    await contains(":nth-child(1 of .o-mail-Composer-suggestion) strong", { text: "Person D" });
+    await contains(":nth-child(2 of .o-mail-Composer-suggestion) strong", { text: "Person C" });
+    await contains(":nth-child(3 of .o-mail-Composer-suggestion) strong", { text: "Person B" });
+    await contains(":nth-child(4 of .o-mail-Composer-suggestion) strong", { text: "Person A" });
+});
+
+test("[text composer] Current user that is a follower should be considered as such", async () => {
     const pyEnv = await startServer();
     const userId = pyEnv["res.users"].create({});
     pyEnv["res.partner"].create([
@@ -388,7 +869,7 @@ test("Current user that is a follower should be considered as such", async () =>
     await openFormView("res.partner", serverState.partnerId);
     await click("button", { text: "Send message" });
     await insertText(".o-mail-Composer-input", "@");
-    await contains(".o-mail-Composer-suggestion", { count: 5 }); // FIXME: should be 3, but +2 extra with Hermit / Public User
+    await contains(".o-mail-Composer-suggestion", { count: 5 });
     await contains(".o-mail-Composer-suggestion", {
         text: "Mitchell Admin",
         before: [".o-mail-Composer-suggestion", { text: "Person B(b@test.com)" }],
@@ -399,7 +880,46 @@ test("Current user that is a follower should be considered as such", async () =>
     });
 });
 
-test("Mention with @everyone", async () => {
+test.tags("html composer");
+test("Current user that is a follower should be considered as such", async () => {
+    const pyEnv = await startServer();
+    const userId = pyEnv["res.users"].create({});
+    pyEnv["res.partner"].create([
+        { email: "a@test.com", name: "Person A" },
+        { email: "b@test.com", name: "Person B", user_ids: [userId] },
+    ]);
+    pyEnv["mail.followers"].create([
+        {
+            is_active: true,
+            partner_id: serverState.partnerId,
+            res_id: serverState.partnerId,
+            res_model: "res.partner",
+        },
+    ]);
+    await start();
+    const composerService = getService("mail.composer");
+    composerService.setHtmlComposer();
+    await openFormView("res.partner", serverState.partnerId);
+    await click("button", { text: "Send message" });
+    await contains(".o-mail-Composer-html.odoo-editor-editable");
+    const editor = {
+        document,
+        editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
+    };
+    await focus(".o-mail-Composer-html.odoo-editor-editable");
+    await htmlInsertText(editor, "@");
+    await contains(".o-mail-Composer-suggestion", { count: 5 });
+    await contains(".o-mail-Composer-suggestion", {
+        text: "Mitchell Admin",
+        before: [".o-mail-Composer-suggestion", { text: "Person B(b@test.com)" }],
+    });
+    await contains(".o-mail-Composer-suggestion", {
+        text: "Person B(b@test.com)",
+        before: [".o-mail-Composer-suggestion", { text: "Person A(a@test.com)" }],
+    });
+});
+
+test("[text composer] Mention with @everyone", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({
         name: "General",
@@ -418,7 +938,35 @@ test("Mention with @everyone", async () => {
     await contains(".o-mail-Message a:contains('@everyone')");
 });
 
-test("Suggestions that begin with the search term should have priority", async () => {
+test.tags("html composer");
+test("Mention with @everyone", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "General",
+        channel_type: "channel",
+    });
+    await start();
+    const composerService = getService("mail.composer");
+    composerService.setHtmlComposer();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Composer-html.odoo-editor-editable");
+    const editor = {
+        document,
+        editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
+    };
+    await focus(".o-mail-Composer-html.odoo-editor-editable");
+    await contains(".o-mail-Composer-suggestionList");
+    await contains(".o-mail-Composer-suggestionList .o-open", { count: 0 });
+    await contains(".o-mail-Composer-html.odoo-editor-editable", { text: "" });
+    await htmlInsertText(editor, "@ever");
+    await click(".o-mail-Composer-suggestion");
+    await contains(".o-mail-Composer-html.odoo-editor-editable", { text: "@everyone" });
+    await press("Enter");
+    await contains(".o-mail-Message-bubble.o-orange");
+    await contains(".o-mail-Message a:contains('@everyone')");
+});
+
+test("[text composer] Suggestions that begin with the search term should have priority", async () => {
     const pyEnv = await startServer();
     pyEnv["res.partner"].create([{ name: "Party Partner" }, { name: "Best Partner" }]);
     await start();
@@ -436,6 +984,80 @@ test("Suggestions that begin with the search term should have priority", async (
     });
 });
 
+test.tags("html composer");
+test("Suggestions that begin with the search term should have priority", async () => {
+    const pyEnv = await startServer();
+    pyEnv["res.partner"].create([{ name: "Party Partner" }, { name: "Best Partner" }]);
+    await start();
+    const composerService = getService("mail.composer");
+    composerService.setHtmlComposer();
+    await openFormView("res.partner", serverState.partnerId);
+    await click("button", { text: "Send message" });
+    await contains(".o-mail-Composer-html.odoo-editor-editable");
+    const editor = {
+        document,
+        editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
+    };
+    await focus(".o-mail-Composer-html.odoo-editor-editable");
+    await htmlInsertText(editor, "@");
+    await contains(".o-mail-Composer-suggestion", {
+        text: "Best Partner",
+        before: [".o-mail-Composer-suggestion", { text: "Party Partner" }],
+    });
+    await htmlInsertText(editor, "part");
+    await contains(".o-mail-Composer-suggestion", {
+        text: "Party Partner",
+        before: [".o-mail-Composer-suggestion", { text: "Best Partner" }],
+    });
+});
+
+test("[text composer] Mention with @-role", async () => {
+    const pyEnv = await startServer();
+    const [roleId1, roleId2] = pyEnv["res.role"].create([
+        { name: "rd-Discuss" },
+        { name: "rd-JS" },
+    ]);
+    const [userId1, userId2, userId3] = pyEnv["res.users"].create([
+        {
+            role_ids: [roleId1],
+        },
+        {
+            role_ids: [roleId2],
+        },
+        {
+            role_ids: [roleId1, roleId2],
+        },
+    ]);
+    const [partnerId1, partnerId2, partnerId3] = pyEnv["res.partner"].create([
+        { name: "Person A", user_ids: [userId1] },
+        { name: "Person B", user_ids: [userId2] },
+        { name: "Person C", user_ids: [userId3] },
+    ]);
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "General",
+        channel_type: "channel",
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ partner_id: partnerId1 }),
+            Command.create({ partner_id: partnerId2 }),
+            Command.create({ partner_id: partnerId3 }),
+        ],
+    });
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Composer-suggestionList");
+    await contains(".o-mail-Composer-suggestionList .o-open", { count: 0 });
+    await contains(".o-mail-Composer-input", { value: "" });
+    await insertText(".o-mail-Composer-input", "@discuss");
+    await click(".o-mail-Composer-suggestion");
+    await contains(".o-mail-Composer-input", { value: "@rd-Discuss " });
+    await press("Enter");
+    await contains(".o-mail-Message a.o-discuss-mention", {
+        text: "@rd-Discuss",
+    });
+});
+
+test.tags("html composer");
 test("Mention with @-role", async () => {
     const pyEnv = await startServer();
     const [roleId1, roleId2] = pyEnv["res.role"].create([
@@ -469,35 +1091,37 @@ test("Mention with @-role", async () => {
         ],
     });
     await start();
+    const composerService = getService("mail.composer");
+    composerService.setHtmlComposer();
     await openDiscuss(channelId);
+    await contains(".o-mail-Composer-html.odoo-editor-editable");
+    const editor = {
+        document,
+        editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
+    };
+    await focus(".o-mail-Composer-html.odoo-editor-editable");
     await contains(".o-mail-Composer-suggestionList");
     await contains(".o-mail-Composer-suggestionList .o-open", { count: 0 });
-    await contains(".o-mail-Composer-input", { value: "" });
-    await insertText(".o-mail-Composer-input", "@discuss");
+    await contains(".o-mail-Composer-html.odoo-editor-editable", { text: "" });
+    await htmlInsertText(editor, "@discuss");
     await click(".o-mail-Composer-suggestion");
-    await contains(".o-mail-Composer-input", { value: "@rd-Discuss " });
+    await contains(".o-mail-Composer-html.odoo-editor-editable", { text: "@rd-Discuss" });
     await press("Enter");
     await contains(".o-mail-Message a.o-discuss-mention", {
         text: "@rd-Discuss",
     });
 });
 
-test("Mention with @-role send correct role id", async () => {
+test("[text composer] Mention with @-role send correct role id", async () => {
     const pyEnv = await startServer();
     const [roleId1, roleId2] = pyEnv["res.role"].create([
         { name: "rd-Discuss" },
         { name: "rd-JS" },
     ]);
     const [userId1, userId2, userId3] = pyEnv["res.users"].create([
-        {
-            role_ids: [roleId1],
-        },
-        {
-            role_ids: [roleId2],
-        },
-        {
-            role_ids: [roleId1, roleId2],
-        },
+        { role_ids: [roleId1] },
+        { role_ids: [roleId2] },
+        { role_ids: [roleId1, roleId2] },
     ]);
     const [partnerId1, partnerId2, partnerId3] = pyEnv["res.partner"].create([
         { name: "Person A", user_ids: [userId1] },
@@ -527,28 +1151,72 @@ test("Mention with @-role send correct role id", async () => {
     await click(".o-mail-Composer-suggestion");
     await contains(".o-mail-Composer-input", { value: "@rd-Discuss " });
     await press("Enter");
-    await contains(".o-mail-Message a.o-discuss-mention", {
-        text: "@rd-Discuss",
-    });
+    await contains(".o-mail-Message a.o-discuss-mention", { text: "@rd-Discuss" });
     await expect.waitForSteps(["message_post"]);
 });
 
-test("Mention with @-role trigger one RPC only", async () => {
+test.tags("html composer");
+test("Mention with @-role send correct role id", async () => {
     const pyEnv = await startServer();
     const [roleId1, roleId2] = pyEnv["res.role"].create([
         { name: "rd-Discuss" },
         { name: "rd-JS" },
     ]);
     const [userId1, userId2, userId3] = pyEnv["res.users"].create([
-        {
-            role_ids: [roleId1],
-        },
-        {
-            role_ids: [roleId2],
-        },
-        {
-            role_ids: [roleId1, roleId2],
-        },
+        { role_ids: [roleId1] },
+        { role_ids: [roleId2] },
+        { role_ids: [roleId1, roleId2] },
+    ]);
+    const [partnerId1, partnerId2, partnerId3] = pyEnv["res.partner"].create([
+        { name: "Person A", user_ids: [userId1] },
+        { name: "Person B", user_ids: [userId2] },
+        { name: "Person C", user_ids: [userId3] },
+    ]);
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "General",
+        channel_type: "channel",
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ partner_id: partnerId1 }),
+            Command.create({ partner_id: partnerId2 }),
+            Command.create({ partner_id: partnerId3 }),
+        ],
+    });
+    onRpcBefore("/mail/message/post", (args) => {
+        asyncStep("message_post");
+        expect(args.post_data.role_ids).toEqual([roleId1]);
+    });
+    await start();
+    const composerService = getService("mail.composer");
+    composerService.setHtmlComposer();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Composer-html.odoo-editor-editable");
+    const editor = {
+        document,
+        editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
+    };
+    await focus(".o-mail-Composer-html.odoo-editor-editable");
+    await contains(".o-mail-Composer-suggestionList");
+    await contains(".o-mail-Composer-suggestionList .o-open", { count: 0 });
+    await contains(".o-mail-Composer-html.odoo-editor-editable", { text: "" });
+    await htmlInsertText(editor, "@discuss");
+    await click(".o-mail-Composer-suggestion");
+    await contains(".o-mail-Composer-html.odoo-editor-editable", { text: "@rd-Discuss" });
+    await press("Enter");
+    await contains(".o-mail-Message a.o-discuss-mention", { text: "@rd-Discuss" });
+    await expect.waitForSteps(["message_post"]);
+});
+
+test("[text composer] Mention with @-role trigger one RPC only", async () => {
+    const pyEnv = await startServer();
+    const [roleId1, roleId2] = pyEnv["res.role"].create([
+        { name: "rd-Discuss" },
+        { name: "rd-JS" },
+    ]);
+    const [userId1, userId2, userId3] = pyEnv["res.users"].create([
+        { role_ids: [roleId1] },
+        { role_ids: [roleId2] },
+        { role_ids: [roleId1, roleId2] },
     ]);
     const [partnerId1, partnerId2, partnerId3] = pyEnv["res.partner"].create([
         { name: "Discuss guru", user_ids: [userId1] },
@@ -574,10 +1242,6 @@ test("Mention with @-role trigger one RPC only", async () => {
     await openDiscuss(channelId);
     await contains(".o-mail-Composer-suggestionList");
     await contains(".o-mail-Composer-suggestionList .o-open", { count: 0 });
-    /**
-     * Wait for messages and members to be fetched before listening to network calls to avoid
-     * catching irrelevant calls.
-     */
     await contains(".o-mail-Message", { text: "message fetched" });
     await contains(".o-discuss-ChannelMember", { text: "Discuss guru" });
     await contains(".o-mail-Composer-input", { value: "" });
@@ -588,6 +1252,67 @@ test("Mention with @-role trigger one RPC only", async () => {
         }
     });
     await insertText(".o-mail-Composer-input", "@discuss");
+    await contains(".o-mail-Composer-suggestion strong", { text: "Discuss guru" });
+    await contains(".o-mail-Composer-suggestion strong", { text: "rd-Discuss" });
+    await expect.waitForSteps([
+        "/web/dataset/call_kw/res.partner/get_mention_suggestions_from_channel",
+    ]);
+});
+
+test.tags("html composer");
+test("Mention with @-role trigger one RPC only", async () => {
+    const pyEnv = await startServer();
+    const [roleId1, roleId2] = pyEnv["res.role"].create([
+        { name: "rd-Discuss" },
+        { name: "rd-JS" },
+    ]);
+    const [userId1, userId2, userId3] = pyEnv["res.users"].create([
+        { role_ids: [roleId1] },
+        { role_ids: [roleId2] },
+        { role_ids: [roleId1, roleId2] },
+    ]);
+    const [partnerId1, partnerId2, partnerId3] = pyEnv["res.partner"].create([
+        { name: "Discuss guru", user_ids: [userId1] },
+        { name: "Person B", user_ids: [userId2] },
+        { name: "Person C", user_ids: [userId3] },
+    ]);
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "General",
+        channel_type: "channel",
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ partner_id: partnerId1 }),
+            Command.create({ partner_id: partnerId2 }),
+            Command.create({ partner_id: partnerId3 }),
+        ],
+    });
+    pyEnv["mail.message"].create({
+        body: "message fetched",
+        model: "discuss.channel",
+        res_id: channelId,
+    });
+    await start();
+    const composerService = getService("mail.composer");
+    composerService.setHtmlComposer();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Composer-html.odoo-editor-editable");
+    const editor = {
+        document,
+        editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
+    };
+    await focus(".o-mail-Composer-html.odoo-editor-editable");
+    await contains(".o-mail-Composer-suggestionList");
+    await contains(".o-mail-Composer-suggestionList .o-open", { count: 0 });
+    await contains(".o-mail-Message", { text: "message fetched" });
+    await contains(".o-discuss-ChannelMember", { text: "Discuss guru" });
+    await contains(".o-mail-Composer-html.odoo-editor-editable", { text: "" });
+    onRpc("/*", (request) => {
+        const route = new URL(request.url).pathname;
+        if (route !== "/discuss/channel/notify_typing") {
+            expect.step(route);
+        }
+    });
+    await htmlInsertText(editor, "@discuss");
     await contains(".o-mail-Composer-suggestion strong", { text: "Discuss guru" });
     await contains(".o-mail-Composer-suggestion strong", { text: "rd-Discuss" });
     await expect.waitForSteps([


### PR DESCRIPTION
This commit improves the use suggestion feature in the HTML composer by adding support for partners, channels, roles and special mentions.

Also, this commit allows rendering the suggestions in the HTML composer instead of doing it after sending the message. This way, the user can immediately see the formatted suggestions in the composer.

task-5022239


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
