### PR TITLE
[FIX] web: avoid traceback when deleting all grouped list entries

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -779,9 +779,10 @@ export class ListRenderer extends Component {
         }
         if (this.props.list.isGrouped && !this.props.list.selection.length) {
             return values.reduce((set, value) => {
-                value[currencyField].forEach((c) => {
-                    set.add(c);
-                });
+                const currVal = value[currencyField];
+                if (Array.isArray(currVal)) {
+                    currVal.forEach((c) => set.add(c));
+                }
                 return set;
             }, new Set());
         }


### PR DESCRIPTION
After this commit [1], deleting all entries of a grouped list may trigger the following traceback:

```
TypeError: value[currencyField].forEach is not a function
```

This happens because the `currency_id` of an empty group becomes `0`, so `forEach` is called on a non-iterable value.

This fix ensures that `currency_id` is correctly handled to prevent such error.

[1] odoo@98f7462
