### PR TITLE
[FIX] l10n_in: remove duplicate 'type' field from PAN entity list view

### DIFF
--- a/addons/l10n_in/views/l10n_in_pan_entity_views.xml
+++ b/addons/l10n_in/views/l10n_in_pan_entity_views.xml
@@ -41,7 +41,6 @@
                 <field name="name"/>
                 <field name="type"/>
                 <field name="partner_ids" widget="many2many_tags_avatar" options="{'no_create': True}"/>
-                <field name="type"/>
             </list>
         </field>
     </record>


### PR DESCRIPTION
Before:
- The list view in `l10n_in_pan_entity_view_tree` included  `type` field twice, causing redundancy.

After:
- The duplicate field has been removed

