### PR TITLE
[FIX] hr_holidays: multiple requests wizard not clickable

### DIFF
--- a/addons/hr_holidays/static/src/views/calendar/calendar_controller.xml
+++ b/addons/hr_holidays/static/src/views/calendar/calendar_controller.xml
@@ -15,4 +15,10 @@
         </xpath>
     </t>
 
+    <t t-name="hr_holidays.CalendarView.Buttons">
+        <button t-if="canCreateGroupTimeOff" class="btn btn-secondary" t-on-click="onNewGroupTimeOff">
+            New Group Time Off
+        </button>
+    </t>
+
 </templates>

--- a/addons/hr_holidays/static/src/views/calendar/calendar_view.js
+++ b/addons/hr_holidays/static/src/views/calendar/calendar_view.js
@@ -5,6 +5,23 @@ import { TimeOffCalendarModel } from './calendar_model';
 import { TimeOffCalendarRenderer, TimeOffDashboardCalendarRenderer } from './calendar_renderer';
 
 import { registry } from '@web/core/registry';
+import { user } from "@web/core/user";
+import { useService } from "@web/core/utils/hooks";
+import { onWillStart } from "@odoo/owl";
+
+class TimeOffCalendarControllerHrLeave extends TimeOffCalendarController {
+    setup() {
+        super.setup();
+        this.actionService = useService("action");
+        onWillStart(async () => {
+            this.canCreateGroupTimeOff = await user.hasGroup("hr_holidays.group_hr_holidays_responsible");
+        });
+    }
+
+    async onNewGroupTimeOff() {
+        await this.actionService.doAction("hr_holidays.action_hr_leave_generate_multi_wizard");
+    }
+}
 
 const TimeOffCalendarView = {
     ...calendarView,
@@ -14,7 +31,14 @@ const TimeOffCalendarView = {
     Model: TimeOffCalendarModel,
 }
 
+const TimeOffCalendarHrLeaveView = {
+    ...TimeOffCalendarView,
+    Controller: TimeOffCalendarControllerHrLeave,
+    buttonTemplate: "hr_holidays.CalendarView.Buttons",
+}
+
 registry.category('views').add('time_off_calendar', TimeOffCalendarView);
+registry.category('views').add('time_off_calendar_hr_leave', TimeOffCalendarHrLeaveView);
 registry.category('views').add('time_off_calendar_dashboard', {
     ...TimeOffCalendarView,
     Renderer: TimeOffDashboardCalendarRenderer,

--- a/addons/hr_holidays/static/src/views/list/holidays_list_controller.js
+++ b/addons/hr_holidays/static/src/views/list/holidays_list_controller.js
@@ -47,6 +47,8 @@ export class HolidaysListController extends ListController {
             } else {
                 this.onClickViewButton(params);
             }
+        } else {
+            this.onClickViewButton(params);
         }
     }
 

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -554,7 +554,7 @@
         <field name="name">hr.leave.view.calendar</field>
         <field name="model">hr.leave</field>
         <field name="arch" type="xml">
-            <calendar js_class="time_off_calendar"
+            <calendar js_class="time_off_calendar_hr_leave"
                     string="Time Off Request"
                     form_view_id="%(hr_holidays.hr_leave_view_form_dashboard_manager_new_time_off)d"
                     event_open_popup="true"


### PR DESCRIPTION
**Issue**
When clicking header buttons other than approve/refuse in Time Off list view, the actions are not processed correctly.

**Steps to Reproduce**
1. Navigate to Time Off > Management > Time Off or Allocations
2. Switch to List view
3. Click on New Group button
4. Action is not executed properly

**Root Cause**
Previously, handleViewButtonClick only processed approve/refuse actions and ignored other header button actions. Now, non-leave actions are correctly forwarded to the default handler.

Task ID: 5062846

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
