### PR TITLE
[FIX] hr_holidays: typo in UserError message overlapping time off

### DIFF
--- a/addons/hr_holidays/i18n/hr_holidays.pot
+++ b/addons/hr_holidays/i18n/hr_holidays.pot
@@ -3622,6 +3622,14 @@ msgid "Small Unemployment"
 msgstr ""
 
 #. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/wizard/hr_leave_generate_multi_wizard.py:0
+msgid ""
+"Some employees already have time off requests in hours that overlap with the selected period, Odoo cannot automatically adjust or split hourly leaves during batch generation. Conflicting time off:\n"
+"%s"
+msgstr ""
+
+#. module: hr_holidays
 #. odoo-javascript
 #: code:addons/hr_holidays/static/src/dashboard/time_off_card.xml:0
 msgid "Some leaves cannot be linked to any allocation. To see those leaves,"

--- a/addons/hr_holidays/wizard/hr_leave_generate_multi_wizard.py
+++ b/addons/hr_holidays/wizard/hr_leave_generate_multi_wizard.py
@@ -91,7 +91,7 @@ class HrLeaveGenerateMultiWizard(models.TransientModel):
             # YTI: More complex use cases could be managed later
             invalid_time_off = conflicting_leaves.filtered(lambda leave: leave.leave_type_request_unit == 'hour')
             if invalid_time_off:
-                raise UserError(self.env_('Automatic time off spliting during batch generation is not managed for ovelapping time off declared in hours. Conflicting time off:\n%s', '\n'.join(f"- {l.display_name}" for l in invalid_time_off)))
+                raise UserError(self.env._('Some employees already have time off requests in hours that overlap with the selected period, Odoo cannot automatically adjust or split hourly leaves during batch generation. Conflicting time off:\n%s', '\n'.join(f"- {l.display_name}" for l in invalid_time_off)))
             one_day_leaves = conflicting_leaves.filtered(lambda leave: leave.request_date_from == leave.request_date_to)
             one_day_leaves.action_refuse()
             (conflicting_leaves - one_day_leaves)._split_leaves(self.date_from, self.date_to + timedelta(days=1))


### PR DESCRIPTION
Issue:
When generating a new group time off, if the leave type uses "hour" as the request unit (e.g., unpaid or extra hours), and there is a conflicting leave request for the same time period, a traceback occurs.

Steps to Reproduce:
- Generate a group time off using this leave type.
- Ensure there is an existing leave request that overlaps with the requested time.
- Observe the traceback error.

Root Cause:
The translation function _ is invoked incorrectly in the error message, and there are typos in the message text.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
