### PR TITLE
[FIX] website_sale: secondary image scroll behavior

### DIFF
--- a/addons/website_sale/static/src/interactions/product_tile_secondary_image.js
+++ b/addons/website_sale/static/src/interactions/product_tile_secondary_image.js
@@ -1,0 +1,27 @@
+import { Interaction } from '@web/public/interaction';
+import { registry } from '@web/core/registry';
+
+export class ProductTileSecondaryImage extends Interaction {
+    static selector = '.oe_product_image_link_has_secondary';
+    dynamicContent = {
+        _root: {
+            "t-att-class": () => ({ "o_product_tile_scrolled": this.isSecondImgInView }),
+            "t-on-scroll": (ev) => this.onScroll(ev),
+        }
+    };
+
+    setup() {
+        this.isSecondImgInView = false;
+    }
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+    onScroll(ev) {
+        this.isSecondImgInView = ev.target.scrollLeft > ev.target.scrollWidth * 0.25;
+    }
+}
+
+registry
+    .category("public.interactions")
+    .add("website.website_sale_product_tile_secondary_image", ProductTileSecondaryImage);

--- a/addons/website_sale/static/src/scss/product_tile.scss
+++ b/addons/website_sale/static/src/scss/product_tile.scss
@@ -1042,27 +1042,37 @@ $_wsale_products_roundness_map: (
                 flex-shrink: 0;
                 scroll-snap-stop: always;
                 scroll-snap-align: start;
+            }
+        }
 
-                &:before, &:after {
-                    content: "";
-                    @include o-position-absolute($bottom: .5rem, $left: 50%);
-                    display: var(--o-wsale-card-img-wrapper-secondary-display, block);
-                    height: .5rem;
-                    aspect-ratio: 1;
-                    border-radius: 100em;
-                    background-color: black;
-                    transform: translateX(-80%);
-                    outline: 1px solid white;
-                    z-index: 1;
-                }
-                &:after {
-                    transform: translateX(80%);
-                }
+        .oe_product_image:has(.oe_product_image_link_has_secondary) {
+            &:before, &:after {
+                content: "";
+                @include o-position-absolute($bottom: .5rem, $left: 50%);
+                display: var(--o-wsale-card-img-wrapper-secondary-display, block);
+                height: .5rem;
+                aspect-ratio: 1;
+                border-radius: 100em;
+                background-color: black;
+                transform: translateX(-80%);
+                outline: 1px solid white;
+                z-index: 1;
+            }
 
-                &.oe_product_image_img_wrapper_primary:after,
-                &.oe_product_image_img_wrapper_secondary:before {
+            &:after {
+                transform: translateX(80%);
+                background-color: rgba(black, .5);
+                outline-color: rgba(white, .25);
+            }
+
+            &:has(.o_product_tile_scrolled) {
+                &:before {
                     background-color: rgba(black, .5);
                     outline-color: rgba(white, .25);
+                }
+                &:after {
+                    background-color: black;
+                    outline-color: white;
                 }
             }
         }


### PR DESCRIPTION
This pr fixes a confusing behavior when interacting with products' secondary images on mobile.
The previous implementation showcased two dots for each image (4 tot.), one of which "active". The attempt was of emulating carousel indicators.

Unfortunately, since dots were absolute positioned, the design failed to correctly communicate the user the actual behavior, leading to confusion and to the impression that the element itself was affected by a bug.

This commit simply toggle a class, triggering the right design when necessary.
Note that this implementation doesn't need to be scoped for specific resolutions, since cards are scroll-able only on mobile. Debouching is not required neither since the events are fired when the user intentionally interact with the element only.

task-5082527

---

Before


https://github.com/user-attachments/assets/8cbe6040-2e5d-48d6-951a-65f8fe0aae6c



----

After


https://github.com/user-attachments/assets/9f3671ec-77eb-478b-840f-676f91bf50e2



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
