### PR TITLE
[FIX] website_sale: replace media multiple times

### DIFF
--- a/addons/website_sale/static/src/website_builder/dynamic_snippet_category_item_option_plugin.js
+++ b/addons/website_sale/static/src/website_builder/dynamic_snippet_category_item_option_plugin.js
@@ -36,7 +36,7 @@ class SetCategoryImageAction extends BuilderAction {
                     attachment_id: selectedMedia[0]['id'],
                 });
                 if (!(selectedImageEl instanceof HTMLImageElement)) return;
-                categoryImage.replaceWith(selectedImageEl);
+                categoryImage.src = selectedImageEl.src;
                 this.dependencies['builderOptions'].updateContainers(selectedImageEl);
             },
         });


### PR DESCRIPTION
steps:
- add category list snippet to website
- replace image for any category
- click replace for the same category again

issue:
- replace button does not work

cause:
- replace button checks for an element with name category_image which is removed when the image is first replaced

fix:
- name category_image attribute is re added when image is first replaced.

opw-5082517

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
