### PR TITLE
[FIX] pos_adyen: correctly handle errors

### DIFF
--- a/addons/pos_adyen/static/src/app/utils/payment/payment_adyen.js
+++ b/addons/pos_adyen/static/src/app/utils/payment/payment_adyen.js
@@ -153,6 +153,7 @@ export class PaymentAdyen extends PaymentInterface {
                     )
                 );
             }
+            return true;
         });
     }
 
@@ -176,7 +177,7 @@ export class PaymentAdyen extends PaymentInterface {
     _adyenHandleResponse(response) {
         var line = this.pendingAdyenline();
 
-        if (response.error && response.error.status_code == 401) {
+        if (!response || (response.error && response.error.status_code == 401)) {
             this._show_error(_t("Authentication failed. Please check your Adyen credentials."));
             line.setPaymentStatus("force_done");
             return false;


### PR DESCRIPTION
When we try to cancel a processing payment, we can get stuck with a in the state waiting card, if there is no anwser from adyen.

Also when we call Adyen to process payment, the value returned by data.silentCall is false, so we don't get error when the service is not available

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
