### PR TITLE
[FIX] hr_holidays: display full days off taken in hours correctly

### DIFF
--- a/addons/hr_holidays/static/src/views/calendar/year/calendar_year_renderer.js
+++ b/addons/hr_holidays/static/src/views/calendar/year/calendar_year_renderer.js
@@ -84,7 +84,7 @@ export class TimeOffCalendarYearRenderer extends CalendarYearRenderer {
         if (record?.rawRecord?.request_unit_hours && record.sameDay) {
             if (record.end.c.hour < 12) {
                 classesToAdd.push("o_event_half_left");
-            } else if (record.end.c.hour >= 12) {
+            } else if (record.end.c.hour >= 12 && record.start.c.hour >= 12) {
                 classesToAdd.push("o_event_half_right");
             }
         }


### PR DESCRIPTION
Steps to reproduce:

- Go to Time Off
- Create a time off type that can be taken in hours
- Take a full day of leave using this type of time off
- The time off will be displayed as half a day, even though it is a full day

Reason:

The check to display the time off as half a day did not check that the time off starts in the afternoon, which caused the issue.

How it was fixed:

The condition now checks if the time off starts in the afternoon so that the display is correct.

Task ID: 5072255