### PR TITLE
[FIX] html_builder: hide shape option on unsupported images

### DIFF
--- a/addons/html_builder/static/src/plugins/image/image_shape_option.js
+++ b/addons/html_builder/static/src/plugins/image/image_shape_option.js
@@ -3,6 +3,7 @@ import { toRatio } from "@html_builder/utils/utils";
 import { _t } from "@web/core/l10n/translation";
 import { ShapeSelector } from "@html_builder/plugins/shape/shape_selector";
 import { deepCopy } from "@web/core/utils/objects";
+import { loadImageInfo } from "@html_editor/utils/image_processing";
 
 export class ImageShapeOption extends BaseOptionComponent {
     static template = "html_builder.ImageShapeOption";
@@ -17,12 +18,17 @@ export class ImageShapeOption extends BaseOptionComponent {
         this.customizeTabPlugin = this.env.editor.shared.customizeTab;
         this.imageShapeOption = this.env.editor.shared.imageShapeOption;
         this.toRatio = toRatio;
-        this.state = useDomState((editingElement) => {
+        this.state = useDomState(async (editingElement) => {
             let shape = editingElement.dataset.shape;
+            const hasOriginalSrc = {
+                ...editingElement.dataset,
+                ...(await loadImageInfo(editingElement)),
+            }.originalSrc;
             if (shape) {
                 shape = shape.replace("web_editor", "html_builder");
             }
             return {
+                canUseImageShape: hasOriginalSrc,
                 hasShape: !!shape && !this.imageShapeOption.isTechnicalShape(shape),
                 shapeLabel: this.imageShapeOption.getShapeLabel(shape),
                 showImageShape0: this.isShapeVisible(editingElement, 0),

--- a/addons/html_builder/static/src/plugins/image/image_shape_option.xml
+++ b/addons/html_builder/static/src/plugins/image/image_shape_option.xml
@@ -2,59 +2,61 @@
 <templates xml:space="preserve">
 
 <t t-name="html_builder.ImageShapeOption">
-    <BuilderRow label.translate="Shape">
-        <div class="btn-group o-hb-button-group">
-            <div
-                class="o-hb-btn btn btn-secondary o-dropdown dropdown-toggle dropdown"
-                t-att-class="{'border-end-0 rounded-end-0': state.hasShape}"
-                role="button"
-                tabindex="0"
-                t-on-click="this.showImageShapes"
-                t-out="state.shapeLabel"
-            />
-            <BuilderButton
-                action="'setImageShape'"
-                actionValue=""
-                preview="false"
-                icon="'oi-close'"
-                className="'btn-danger-color-hover rounded-start-0 m-0 py-0 flex-grow-0'"
-                t-if="state.hasShape"/>
-        </div>
-    </BuilderRow>
-    <t t-if="this.state.hasShape">
-        <t t-set="enabledTabs" t-value="['solid', 'custom']" />
-        <BuilderRow label.translate="Colors" level="2">
-            <BuilderColorPicker action="'setImgShapeColor'" actionParam="{index: 0}" t-if="this.state.showImageShape0" enabledTabs="enabledTabs" />
-            <BuilderColorPicker action="'setImgShapeColor'" actionParam="{index: 1}" t-if="this.state.showImageShape1" enabledTabs="enabledTabs" />
-            <BuilderColorPicker action="'setImgShapeColor'" actionParam="{index: 2}" t-if="this.state.showImageShape2" enabledTabs="enabledTabs" />
-            <BuilderColorPicker action="'setImgShapeColor'" actionParam="{index: 3}" t-if="this.state.showImageShape3" enabledTabs="enabledTabs" />
-            <BuilderColorPicker action="'setImgShapeColor'" actionParam="{index: 4}" t-if="this.state.showImageShape4" enabledTabs="enabledTabs" />
+    <t t-if="this.state.canUseImageShape">
+        <BuilderRow label.translate="Shape">
+            <div class="btn-group o-hb-button-group">
+                <div
+                    class="o-hb-btn btn btn-secondary o-dropdown dropdown-toggle dropdown"
+                    t-att-class="{'border-end-0 rounded-end-0': state.hasShape}"
+                    role="button"
+                    tabindex="0"
+                    t-on-click="this.showImageShapes"
+                    t-out="state.shapeLabel"
+                />
+                <BuilderButton
+                    action="'setImageShape'"
+                    actionValue=""
+                    preview="false"
+                    icon="'oi-close'"
+                    className="'btn-danger-color-hover rounded-start-0 m-0 py-0 flex-grow-0'"
+                    t-if="state.hasShape"/>
+            </div>
         </BuilderRow>
+        <t t-if="this.state.hasShape">
+            <t t-set="enabledTabs" t-value="['solid', 'custom']" />
+            <BuilderRow label.translate="Colors" level="2">
+                <BuilderColorPicker action="'setImgShapeColor'" actionParam="{index: 0}" t-if="this.state.showImageShape0" enabledTabs="enabledTabs" />
+                <BuilderColorPicker action="'setImgShapeColor'" actionParam="{index: 1}" t-if="this.state.showImageShape1" enabledTabs="enabledTabs" />
+                <BuilderColorPicker action="'setImgShapeColor'" actionParam="{index: 2}" t-if="this.state.showImageShape2" enabledTabs="enabledTabs" />
+                <BuilderColorPicker action="'setImgShapeColor'" actionParam="{index: 3}" t-if="this.state.showImageShape3" enabledTabs="enabledTabs" />
+                <BuilderColorPicker action="'setImgShapeColor'" actionParam="{index: 4}" t-if="this.state.showImageShape4" enabledTabs="enabledTabs" />
+            </BuilderRow>
 
-        <BuilderRow label.translate="Transform" level="1" t-if="this.state.showImageShapeTransform" preview="false">
-            <BuilderButton title.translate="Horizontal mirror" icon="'oi-arrows-h'"
-                action="'flipImageShape'" actionParam="{axis: 'x'}"/>
-            <BuilderButton title.translate="Vertical mirror" icon="'oi-arrows-v'"
-                action="'flipImageShape'" actionParam="{axis: 'y'}"/>
-            <BuilderButton title.translate="Rotate left" icon="'fa-rotate-left'"
-                action="'rotateImageShape'" actionParam="{side: 'left'}" />
-            <BuilderButton title.translate="Rotate right" icon="'fa-rotate-right'"
-                action="'rotateImageShape'" actionParam="{side: 'right'}" />
-        </BuilderRow>
+            <BuilderRow label.translate="Transform" level="1" t-if="this.state.showImageShapeTransform" preview="false">
+                <BuilderButton title.translate="Horizontal mirror" icon="'oi-arrows-h'"
+                    action="'flipImageShape'" actionParam="{axis: 'x'}"/>
+                <BuilderButton title.translate="Vertical mirror" icon="'oi-arrows-v'"
+                    action="'flipImageShape'" actionParam="{axis: 'y'}"/>
+                <BuilderButton title.translate="Rotate left" icon="'fa-rotate-left'"
+                    action="'rotateImageShape'" actionParam="{side: 'left'}" />
+                <BuilderButton title.translate="Rotate right" icon="'fa-rotate-right'"
+                    action="'rotateImageShape'" actionParam="{side: 'right'}" />
+            </BuilderRow>
 
-        <BuilderRow label.translate="Speed" level="1" t-if="this.state.showImageShapeAnimation" preview="false">
-            <BuilderRange
-                action="'setImageShapeSpeed'"
-                min="-2"
-                max="2"
-                step="0.1"
-                displayRangeValue="true"
-                computedOutput="this.toRatio" />
-        </BuilderRow>
+            <BuilderRow label.translate="Speed" level="1" t-if="this.state.showImageShapeAnimation" preview="false">
+                <BuilderRange
+                    action="'setImageShapeSpeed'"
+                    min="-2"
+                    max="2"
+                    step="0.1"
+                    displayRangeValue="true"
+                    computedOutput="this.toRatio" />
+            </BuilderRow>
 
-        <BuilderRow label.translate="Stretch" level="1" t-if="this.state.togglableRatio" preview="false">
-            <BuilderCheckbox action="'toggleImageShapeRatio'" />
-        </BuilderRow>
+            <BuilderRow label.translate="Stretch" level="1" t-if="this.state.togglableRatio" preview="false">
+                <BuilderCheckbox action="'toggleImageShapeRatio'" />
+            </BuilderRow>
+        </t>
     </t>
 </t>
 


### PR DESCRIPTION
Applying a shape to an image without a corresponding record triggers a runtime error. Since such images are not compatible with shapes, this commit hides the shape option for them, preventing the error.

Steps to reproduce:
1. Enter edit mode in Website Builder.
2. Add the `s_attributes_vertical` snippet.
3. Add a shape to any of its images.
4. Observe the runtime error.
