### PR TITLE
[FIX] payment: fix traceback on payment status

### DIFF
--- a/addons/payment/models/payment_provider.py
+++ b/addons/payment/models/payment_provider.py
@@ -7,6 +7,7 @@ import requests
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
+from odoo.tools.mail import is_html_empty
 
 from odoo.addons.payment import utils as payment_utils
 from odoo.addons.payment.const import REPORT_REASONS_MAPPING, SENSITIVE_KEYS
@@ -1023,3 +1024,19 @@ class PaymentProvider(models.Model):
         """
         self.ensure_one()
         return self.code
+
+    def _get_status_message(self, status):
+        match status:
+            case 'pending':
+                status_message = self.pending_msg
+            case 'authorized':
+                status_message = self.auth_msg
+            case 'done':
+                status_message = self.done_msg
+            case 'cancel':
+                status_message = self.cancel_msg
+            case _:
+                status_message = ''
+        if not is_html_empty(status_message):
+            return status_message
+        return ''

--- a/addons/payment/views/portal_templates.xml
+++ b/addons/payment/views/portal_templates.xml
@@ -283,6 +283,7 @@
         <t t-set="waiting_heading">
             <p>Please wait...</p>
         </t>
+        <t t-set="tx_status_message" t-value="tx.provider_id.sudo()._get_status_message(tx.state)"/>
         <t t-if="tx.state == 'draft'">
             <t t-set="alert_style" t-value="'warning'"/>
             <t t-if="is_processing" t-set="status_heading" t-value="waiting_heading"/>
@@ -296,12 +297,12 @@
             <t t-if="tx.operation == 'validation'" t-set="status_message">
                 <p>Saving your payment method.</p>
             </t>
-            <t t-else="" t-set="status_message" t-value="tx.provider_id.sudo().pending_msg"/>
+            <t t-else="" t-set="status_message" t-value="tx_status_message"/>
         </t>
         <t t-elif="tx.state == 'authorized'">
             <t t-set="alert_style" t-value="'success'"/>
             <t t-if="is_processing" t-set="status_heading" t-value="waiting_heading"/>
-            <t t-set="status_message" t-value="tx.provider_id.sudo().auth_msg"/>
+            <t t-set="status_message" t-value="tx_status_message"/>
         </t>
         <t t-elif="tx.state == 'done'">
             <t t-set="alert_style" t-value="'success'"/>
@@ -311,14 +312,14 @@
             <t t-if="tx.operation == 'validation'" t-set="status_message">
                 <p>Your payment method has been saved.</p>
             </t>
-            <t t-else="" t-set="status_message" t-value="tx.provider_id.sudo().done_msg"/>
+            <t t-else="" t-set="status_message" t-value="tx_status_message"/>
         </t>
         <t t-elif="tx.state == 'cancel'">
             <t t-set="alert_style" t-value="'danger'"/>
             <t t-if="tx.operation == 'validation'" t-set="status_message">
                 <p>The saving of your payment method has been canceled.</p>
             </t>
-            <t t-else="" t-set="status_message" t-value="tx.provider_id.sudo().cancel_msg"/>
+            <t t-else="" t-set="status_message" t-value="tx_status_message"/>
         </t>
         <t t-elif="tx.state == 'error'">
             <t t-set="alert_style" t-value="'danger'"/>
@@ -330,7 +331,7 @@
             </t>
         </t>
 
-        <t t-if="is_html_empty(status_message)" t-set="status_message" t-value="''"/>
+        <t t-if="not status_message" t-set="status_message" t-value="''"/>
         <t t-set="o_payment_status_alert_class"
            t-value="'alert alert-'+ alert_style +' d-flex gap-3'"
         />


### PR DESCRIPTION
Status message in some cases was evaluated as Qweb Template instead of HTML and is_html_empty() doesn't evaluate Qweb.

The solution is to only check is_html_empty() when a custom status message is set.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
