### PR TITLE
[FIX] barcodes: prevent error on installing module

### DIFF
--- a/addons/barcodes/models/barcode_nomenclature.py
+++ b/addons/barcodes/models/barcode_nomenclature.py
@@ -1,6 +1,7 @@
 import re
 
-from odoo import models, fields, api
+from odoo import models, fields, api, _
+from odoo.exceptions import UserError
 from odoo.tools.barcode import check_barcode_encoding, get_barcode_check_digit
 
 
@@ -201,3 +202,12 @@ class BarcodeNomenclature(models.Model):
             'type': 'package',
             'value': sscc,
         }]
+
+    @api.ondelete(at_uninstall=False)
+    def _unlink_except_default(self):
+        default_record = self.env.ref("barcodes.default_barcode_nomenclature", raise_if_not_found=False)
+        if default_record and default_record in self:
+            raise UserError(_(
+                "You cannot delete '%(name)s' because it's the default barcode nomenclature.",
+                name=default_record.display_name
+            ))


### PR DESCRIPTION
The system will crash with error when user tries to enable barcode scanner in settings.

**Steps to produce: -**
- Install `Inventory` module.
- `Inventory > configuration > products > Barcode Nomenclatures`.
- Delete the `Default Nomenclature` record.
- Go to settings uncheck `Barcode Scanner` and save settings.
- Now, again `enable` that and save.

Error: -
```py
ValueError: External ID not found in the system: barcodes.default_barcode_nomenclature

ParseError: while parsing /home/odoo/src/enterprise/saas-18.4/stock_barcode/data/data.xml:40, somewhere inside <record id='scale_up_alias_1' model='barcode.rule'>
            <field name='name'>Scale Up Receipt</field>
            <field name='type'>alias</field>
            <field name='pattern'>WH-RECEIPTS</field>
            <field name='alias'>WHIN</field>
            <field name='barcode_nomenclature_id' ref='barcodes.default_barcode_nomenclature'/>
            <field name='sequence'>0</field>
        </record>
```

**Root cause: -**
- At [1], the records use the ref of `default_barcode_nomenclature` which is defined in barcode module. So, when the ref is deleted and we are trying to use it then it gives error.

**Solution: -**
- This commit resolves the error by prevent the deletion of `default nomenclature`.

[1]: https://github.com/odoo/enterprise/blob/400171c9cebc46ecdd907ada210c65f3bbd2dd66/stock_barcode/data/data.xml#L40-L71

**sentry-6823596992**

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
