### PR TITLE
[FIX] web,html_builder: remove unused function from action service

### DIFF
--- a/addons/html_builder/static/src/builder.js
+++ b/addons/html_builder/static/src/builder.js
@@ -222,12 +222,8 @@ export class Builder extends Component {
             triggerDomUpdated: this.triggerDomUpdated.bind(this),
             editColorCombination: this.editColorCombination.bind(this),
         });
-        // onMounted(() => {
-        //     // actionService.setActionMode("fullscreen");
-        // });
         onWillDestroy(() => {
             this.editor.destroy();
-            // actionService.setActionMode("current");
         });
 
         onMounted(() => {

--- a/addons/web/static/src/webclient/actions/action_container.js
+++ b/addons/web/static/src/webclient/actions/action_container.js
@@ -1,12 +1,9 @@
-import { ActionDialog } from "./action_dialog";
-
 import { Component, xml, onWillDestroy } from "@odoo/owl";
 
 // -----------------------------------------------------------------------------
 // ActionContainer (Component)
 // -----------------------------------------------------------------------------
 export class ActionContainer extends Component {
-    static components = { ActionDialog };
     static props = {};
     static template = xml`
         <t t-name="web.ActionContainer">

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -1842,10 +1842,6 @@ export function makeActionManager(env, router = _router) {
         doAction,
         doActionButton,
         switchView,
-        // to validate with framework team
-        setActionMode(mode) {
-            env.bus.trigger("ACTION_MANAGER:UI-UPDATED", mode);
-        },
         restore,
         loadState,
         async loadAction(actionRequest, context) {


### PR DESCRIPTION
A function has been recently added to the action service API, but it turns out that it wasn't useful (no even used by the PR adding it). This commit removes it.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
