### PR TITLE
[FIX] website: prevent error when submitting the 'Send Email' form

### DIFF
--- a/addons/website/static/src/builder/plugins/form/form_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/form/form_option_plugin.js
@@ -355,6 +355,15 @@ export class FormOptionPlugin extends Plugin {
                 );
                 locationEl.insertAdjacentElement("beforebegin", renderField(_field));
             });
+            // Special case: handle hidden fields separately.
+            // In some forms (e.g., contact forms), the "email_to" field must be included as hidden.
+            // For example, this may force the 'email_to' value to a dummy/default one on the
+            // contact us form just by interacting with it.
+            formInfo.fields?.forEach(field => {
+                if (field.defaultValue) {
+                    this.addHiddenField(el, field.defaultValue, field.name);
+                }
+            });
         }
     }
     /**

--- a/addons/website/static/tests/builder/website_builder/form_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/form_option.test.js
@@ -423,3 +423,23 @@ test("Last list entry cannot be removed", async () => {
     await contains(".options-container .builder_list_add_item").click();
     expect(".options-container .builder_list_remove_item").toHaveCount(2);
 });
+
+test("Form using the Outgoing Mails model includes hidden email_to field", async () => {
+    await setupWebsiteBuilder(
+        `<section class="s_website_form">
+            <form data-model_name="mail.mail">
+                <div class="s_website_form_submit">
+                    <div class="s_website_form_label"/>
+                    <a>Submit</a>
+                </div>
+            </form>
+        </section>`
+    );
+
+    await contains(":iframe section").click();
+    await contains("div:has(>span:contains('Action')) + div button").click();
+    await contains("div.o-dropdown-item:contains('Send an E-mail')").click();
+
+    expect(":iframe input[type='hidden'][name='email_to']").toHaveCount(1);
+    expect(":iframe input[type='hidden'][name='email_to']").toHaveValue("info@yourcompany.example.com");
+});


### PR DESCRIPTION
Currently, an error occurs when submitting the 'Send Email' form.

**Steps to Reproduce:**

 - Install the `website` module.
 - Go to `website` > `Click on Edit` > `Drag and drop form.`
 - Click the form and in actions select again `Send an E-mail` action 
   and `save`.
 - `Submit the form`, and the error appears in the logs.

**Error**:
KeyError: 'website_form_signature'

**Cause:**
This error occurs when submitting the "Send Email" form from the
website. When the user chooses the model Outgoing Mails (mail.mail),
the email_to hidden field is not added. This is because email_to is only
added when the recipient email value is changed from the sidebar via
apply [1]. As a result, the email_to hidden field is missing from the form.
And the website_form_signature is added from [2], but due to the
condition at [3], the code at [2] is not executed. When it is accessed
at [4], KeyError is raised.

**FIX:**
This commit ensures that when the user selects the action model,
if there are hidden field , it is added to the form with its
default value.

[1]: https://github.com/odoo/odoo/blob/3b16debc6d6557334082fdf841b20ef0e31fc9d2/addons/website/static/src/builder/plugins/form/form_option_plugin.js#L863

[2]: https://github.com/odoo/odoo/blob/82639728f2bcb4e7786f120de2aeba3f5fbab209/addons/website/tools.py#L252

[3]: https://github.com/odoo/odoo/blob/82639728f2bcb4e7786f120de2aeba3f5fbab209/addons/website/tools.py#L236

[4]: https://github.com/odoo/odoo/blob/82639728f2bcb4e7786f120de2aeba3f5fbab209/addons/website/controllers/form.py#L88

sentry-6746753251

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
