### PR TITLE
[FIX] account: Fix sequence by partner for self-billing

### DIFF
--- a/addons/account_edi_ubl_cii/tests/test_files/bis3/test_vendor_bill.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/bis3/test_vendor_bill.xml
@@ -2,13 +2,13 @@
 <Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2">
   <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:selfbilling:3.0</cbc:CustomizationID>
   <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:selfbilling:01:1.0</cbc:ProfileID>
-  <cbc:ID>partner_a/2017/01/0001</cbc:ID>
+  <cbc:ID>___ignore___</cbc:ID>
   <cbc:IssueDate>2017-01-01</cbc:IssueDate>
   <cbc:DueDate>2017-01-01</cbc:DueDate>
   <cbc:InvoiceTypeCode>389</cbc:InvoiceTypeCode>
   <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
   <cac:OrderReference>
-    <cbc:ID>partner_a/2017/01/0001</cbc:ID>
+    <cbc:ID>___ignore___</cbc:ID>
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>___ignore___</cbc:ID>
@@ -88,7 +88,7 @@
   </cac:Delivery>
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode name="standing agreement">57</cbc:PaymentMeansCode>
-    <cbc:PaymentID>partner_a/2017/01/0001</cbc:PaymentID>
+    <cbc:PaymentID>___ignore___</cbc:PaymentID>
     <cac:PayeeFinancialAccount>
       <cbc:ID>BE90735788866632</cbc:ID>
     </cac:PayeeFinancialAccount>

--- a/addons/account_edi_ubl_cii/tests/test_files/bis3/test_vendor_bill_reverse_charge.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/bis3/test_vendor_bill_reverse_charge.xml
@@ -2,13 +2,13 @@
 <Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2">
   <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:selfbilling:3.0</cbc:CustomizationID>
   <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:selfbilling:01:1.0</cbc:ProfileID>
-  <cbc:ID>partner_a/2017/01/0001</cbc:ID>
+  <cbc:ID>___ignore___</cbc:ID>
   <cbc:IssueDate>2017-01-01</cbc:IssueDate>
   <cbc:DueDate>2017-01-01</cbc:DueDate>
   <cbc:InvoiceTypeCode>389</cbc:InvoiceTypeCode>
   <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
   <cac:OrderReference>
-    <cbc:ID>partner_a/2017/01/0001</cbc:ID>
+    <cbc:ID>___ignore___</cbc:ID>
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>___ignore___</cbc:ID>
@@ -89,7 +89,7 @@
   </cac:Delivery>
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode name="standing agreement">57</cbc:PaymentMeansCode>
-    <cbc:PaymentID>partner_a/2017/01/0001</cbc:PaymentID>
+    <cbc:PaymentID>___ignore___</cbc:PaymentID>
     <cac:PayeeFinancialAccount>
       <cbc:ID>BE90735788866632</cbc:ID>
     </cac:PayeeFinancialAccount>

--- a/addons/account_edi_ubl_cii/tests/test_files/bis3/test_vendor_credit_note.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/bis3/test_vendor_credit_note.xml
@@ -2,13 +2,13 @@
 <Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2">
   <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:selfbilling:3.0</cbc:CustomizationID>
   <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:selfbilling:01:1.0</cbc:ProfileID>
-  <cbc:ID>partner_a/2017/01/0001</cbc:ID>
+  <cbc:ID>___ignore___</cbc:ID>
   <cbc:IssueDate>2017-01-01</cbc:IssueDate>
   <cbc:DueDate>2017-01-01</cbc:DueDate>
   <cbc:InvoiceTypeCode>389</cbc:InvoiceTypeCode>
   <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
   <cac:OrderReference>
-    <cbc:ID>partner_a/2017/01/0001</cbc:ID>
+    <cbc:ID>___ignore___</cbc:ID>
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>___ignore___</cbc:ID>
@@ -88,7 +88,7 @@
   </cac:Delivery>
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode name="standing agreement">57</cbc:PaymentMeansCode>
-    <cbc:PaymentID>partner_a/2017/01/0001</cbc:PaymentID>
+    <cbc:PaymentID>___ignore___</cbc:PaymentID>
     <cac:PayeeFinancialAccount>
       <cbc:ID>BE15001559627230</cbc:ID>
     </cac:PayeeFinancialAccount>


### PR DESCRIPTION
- We prefer to use the partner's ID (padded to 5 digits to avoid confusion with the year) rather than the partner name
- We make sure the sequence is unique per commercial partner rather than per partner.

task-none