### PR TITLE
[FIX] project: fix task template visibility in portal view

### DIFF
--- a/addons/project/controllers/portal.py
+++ b/addons/project/controllers/portal.py
@@ -382,8 +382,7 @@ class ProjectCustomerPortal(CustomerPortal):
 
         Task = request.env['project.task']
 
-        if not domain:
-            domain = []
+        domain = Domain.AND([domain or [], [('has_template_ancestor', '=', False)]])
         if not su and Task.has_access('read'):
             domain = AND([domain, request.env['ir.rule']._compute_domain(Task._name, 'read')])
         Task_sudo = Task.sudo()

--- a/addons/project/views/project_sharing_project_task_views.xml
+++ b/addons/project/views/project_sharing_project_task_views.xml
@@ -331,7 +331,7 @@
         <field name="path">project_sharing</field>
         <field name="view_mode">kanban,list,form</field>
         <field name="search_view_id" ref="project.project_sharing_project_task_view_search"/>
-        <field name="domain">[('project_id', '=', active_id)]</field>
+        <field name="domain">[('project_id', '=', active_id), ('has_template_ancestor', '=', False)]</field>
         <field name="context">{
             'default_project_id': active_id,
             'active_id_chatter': active_id,


### PR DESCRIPTION
Steps to Reproduce
- Log in as a portal user.
- Go to My Tasks and notice that task templates are visible with tasks.
- Share it with the portal user, giving edit access.
- Open the project sharing view and observe that task templates are visible there.


Cause
- The domains used to filter tasks in both the portal view and the project sharing view did not exclude task templates and it's sub-tasks. As a result, task templates were incorrectly shown alongside real tasks.

Solution
- Added `('has_template_ancestor', '=', False)` to the domain in the `_prepare_tasks_values` method to hide templates in the portal.
- Added `('has_template_ancestor', '=', False)` to the domain in the project sharing action to hide templates when listing tasks.

task-5079337



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
