### PR TITLE
[FIX] website: fix TOC snippet drop issue

### DIFF
--- a/addons/html_builder/static/src/sidebar/block_tab.js
+++ b/addons/html_builder/static/src/sidebar/block_tab.js
@@ -91,8 +91,9 @@ export class BlockTab extends Component {
                                         el.getBoundingClientRect().top >= viewPortCenterPoint.y / 2
                                 );
                                 const closestDropzoneEl =
-                                    closest(validDropzoneEls, viewPortCenterPoint) ||
-                                    dropzoneEls.at(-1);
+                                    validDropzoneEls.find((el) =>
+                                        el.classList.contains("o_dropzone_highlighted")
+                                    ) || dropzoneEls.at(-1);
 
                                 // Insert the selected snippet.
                                 closestDropzoneEl.after(snippetEl);


### PR DESCRIPTION
Previously, adding a snippet from the snippet modal to the TOC snippet would place it in the middle of the snippet. Ideally, it should be dropped at the end of the TOC snippet unless manually dragged and dropped.