### PR TITLE
[FIX] web: Prevent HomeMenu navigation when in dropdown and SelectMenu sort fix

### DIFF
--- a/addons/web/static/src/core/dropdown/_behaviours/dropdown_nesting.js
+++ b/addons/web/static/src/core/dropdown/_behaviours/dropdown_nesting.js
@@ -122,7 +122,7 @@ export function useDropdownNesting(state) {
             hotkeys: {
                 escape: () => current.close(),
                 arrowleft: {
-                    isAvailable: ({ target }) => current.parent || (isRTL() && isDropdown(target)),
+                    isAvailable: () => true,
                     callback: (navigator) => {
                         if (isRTL() && isDropdown(navigator.activeItem?.target)) {
                             navigator.activeItem?.select();
@@ -132,7 +132,7 @@ export function useDropdownNesting(state) {
                     },
                 },
                 arrowright: {
-                    isAvailable: ({ target }) => isDropdown(target) || (isRTL() && current.parent),
+                    isAvailable: () => true,
                     callback: (navigator) => {
                         if (isRTL() && current.parent) {
                             current.close();

--- a/addons/web/static/src/core/select_menu/select_menu.js
+++ b/addons/web/static/src/core/select_menu/select_menu.js
@@ -345,9 +345,7 @@ export class SelectMenu extends Component {
 
         const _choices = [];
         const _sections = new Set();
-        groupsList.sort((a, b) =>
-            a.section && b.section ? a.section.localeCompare(b.section) : 1
-        );
+        groupsList.sort((a, b) => (a.section || "").localeCompare(b.section || ""));
 
         for (const group of groupsList) {
             let filteredOptions = group.choices || [];

--- a/addons/web/static/src/core/select_menu/select_menu.xml
+++ b/addons/web/static/src/core/select_menu/select_menu.xml
@@ -78,7 +78,7 @@
 
     <t t-name="web.SelectMenu.ChoiceItem">
         <div
-            t-if="choice.isGroup"
+            t-if="choice.isGroup and choice.label"
             class="o_select_menu_group position-sticky start-0 px-1 fw-bolder user-select-none"
             t-att-class="{'o_select_menu_searchable_group': displayInputInDropdown, 'ms-2': !!choice.section }"
         >

--- a/addons/web/static/tests/core/select_menu.test.js
+++ b/addons/web/static/tests/core/select_menu.test.js
@@ -1,5 +1,5 @@
 import { expect, test } from "@odoo/hoot";
-import { click, edit, press, queryAllTexts, queryOne } from "@odoo/hoot-dom";
+import { click, edit, press, queryAllTexts, queryOne, queryAll } from "@odoo/hoot-dom";
 import { animationFrame, runAllTimers } from "@odoo/hoot-mock";
 import { Component, useState, xml } from "@odoo/owl";
 import {
@@ -1289,4 +1289,56 @@ test("In the BottomSheet, a 'Clear' button is present", async () => {
     expect(".o_select_menu_menu .o_clear_button").toHaveCount(1);
     await contains(".o_select_menu_menu .o_clear_button").click();
     expect.verifySteps(["Cleared"]);
+});
+
+test("Ensure items are properly sorted", async () => {
+    class MyParent extends Component {
+        static props = ["*"];
+        static components = { SelectMenu };
+        static template = xml`
+            <SelectMenu
+                groups="state.groups"
+                choices="state.choices"
+            />
+        `;
+
+        setup() {
+            this.state = useState({
+                choices: [{ label: "item-group-none", value: 0 }],
+                groups: [
+                    {
+                        label: "Group Z",
+                        section: "Group Z",
+                        choices: [{ label: "item-group-z", value: 1 }],
+                    },
+                    {
+                        label: "Group A",
+                        section: "Group A",
+                        choices: [{ label: "item-group-a", value: 2 }],
+                    },
+                    {
+                        section: "Z",
+                        choices: [{ label: "item-z", value: 3 }],
+                    },
+                    {
+                        section: "World",
+                        choices: [{ label: "item-world", value: 5 }],
+                    },
+                ],
+            });
+        }
+    }
+
+    await mountSingleApp(MyParent);
+    await click(".o_select_menu_toggler");
+    await animationFrame();
+
+    const elements = [...queryAll(".o_select_menu_group, .o_select_menu_item")];
+    expect(elements[0]).toHaveText("item-group-none");
+    expect(elements[1]).toHaveText("Group A");
+    expect(elements[2]).toHaveText("item-group-a");
+    expect(elements[3]).toHaveText("Group Z");
+    expect(elements[4]).toHaveText("item-group-z");
+    expect(elements[5]).toHaveText("item-world");
+    expect(elements[6]).toHaveText("item-z");
 });


### PR DESCRIPTION
#### First fix because SelectMenu tests where not passing as I just switched to Firefox:

The groups sorting function in the SelectMenu component (`groupsList.sort`)
was not anti-symmetric, when either group_1 or group_2 was falsy, both
sortFn(group_1, group_2) and sortFn(group_2, group_1) would return 1 where
it should return -1 in one of the cases.

This issue only occured as Firefox seem to have a slightly different sorting
algorithm, which would cause (group_2, group_1) to be called instead of
(group_1, group_2), raking the group_2 before group_1.

Thi commit fixes that by making the function more consistant at handling
falsy values.

This is probably better explained here:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#description

#### And the task related fix:

This commit prevents arrowleft and arrowright hotkeys to trigger on other
parts of the UI when navigating a dropdown.

Enterprise: https://github.com/odoo/enterprise/pull/94478
Task: [5048895](https://www.odoo.com/odoo/project.task/5048895)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
