### PR TITLE
[IMP] website,*: render backend menu without waiting for iframe

### DIFF
--- a/addons/test_website/static/tests/tours/site_menu_dynamic_items.js
+++ b/addons/test_website/static/tests/tours/site_menu_dynamic_items.js
@@ -1,0 +1,33 @@
+import { registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
+
+registerWebsitePreviewTour(
+    "website_site_menu_dynamic_items",
+    {
+        url: "/",
+    },
+    () => [
+        {
+            content: "Ensure the preview is visible",
+            trigger: ".o_website_preview .o_iframe_container iframe"
+        },
+        {
+            content: "Open Site backend menu as early possible",
+            trigger: 'button[data-menu-xmlid="website.menu_site"]',
+            run: "click",
+        },
+        {
+            content: "Menu is open",
+            trigger: '.o_menu_sections [data-menu-xmlid="website.menu_site"].show',
+        },
+        {
+            content: "Dynamic Page Properties item appears in open menu",
+            trigger: '[data-menu-xmlid="website.menu_page_properties"]',
+            timeout: 3000,
+        },
+        {
+            content: "Menu editor remains visible with dynamic items",
+            trigger: '[data-menu-xmlid="website.menu_edit_menu"]',
+        },
+    ]
+);
+

--- a/addons/test_website/tests/test_menu.py
+++ b/addons/test_website/tests/test_menu.py
@@ -41,3 +41,7 @@ class TestWebsiteMenu(HttpCase):
             tree = html.fromstring(self.url_open(record_url).content)
             menu_link_el = tree.xpath(".//*[@id='top_menu']//a[@href='%s' and hasclass('active')]" % record_url)
             self.assertEqual(len(menu_link_el), 1, "The menu link related to the current record should be active")
+
+    def test_site_menu_dynamic_items(self):
+        """Ensure dynamic Site menu items appear while the menu is already open."""
+        self.start_tour('/', 'website_site_menu_dynamic_items', login='admin')

--- a/addons/website/static/src/client_actions/website_preview/edit_website_systray_item.js
+++ b/addons/website/static/src/client_actions/website_preview/edit_website_systray_item.js
@@ -13,7 +13,7 @@ export class EditWebsiteSystrayItem extends Component {
     static props = {
         onNewPage: { type: Function },
         onEditPage: { type: Function },
-        iframeEl: { type: HTMLElement },
+        iframeEl: { type: HTMLElement, optional: true },
     };
     static components = {
         Dropdown,
@@ -53,14 +53,16 @@ export class EditWebsiteSystrayItem extends Component {
             const recordsOnPage = {
                 [pageModelAndId.model]: pageModelAndId.id,
             };
-            const otherRecordEls = this.props.iframeEl.querySelectorAll(
-                "[data-res-model][data-res-id]:not([data-res-model='ir.ui.view']), [data-oe-model][data-oe-id]:not([data-oe-model='ir.ui.view'])"
-            );
-            for (const el of otherRecordEls) {
-                const model = el.dataset.resModel || el.dataset.oeModel;
-                if (!recordsOnPage[model]) {
-                    // Keep one record of each type.
-                    recordsOnPage[model] = parseInt(el.dataset.resId || el.dataset.oeId);
+            if (this.props.iframeEl) {
+                const otherRecordEls = this.props.iframeEl.querySelectorAll(
+                    "[data-res-model][data-res-id]:not([data-res-model='ir.ui.view']), [data-oe-model][data-oe-id]:not([data-oe-model='ir.ui.view'])"
+                );
+                for (const el of otherRecordEls) {
+                    const model = el.dataset.resModel || el.dataset.oeModel;
+                    if (!recordsOnPage[model]) {
+                        // Keep one record of each type.
+                        recordsOnPage[model] = parseInt(el.dataset.resId || el.dataset.oeId);
+                    }
                 }
             }
             await rpc("/website/check_can_modify_any", {

--- a/addons/website/static/src/components/dialog/add_page_dialog.js
+++ b/addons/website/static/src/components/dialog/add_page_dialog.js
@@ -499,7 +499,8 @@ export class AddPageDialog extends Component {
             this.cssLinkEls = new Promise((resolve) => {
                 const container = document.querySelector(".o_website_preview .o_iframe_container");
                 const iframe = container?.lastElementChild;
-                if (iframe?.contentDocument.body.getAttribute("is-ready") === "true") {
+                const isReady = iframe?.contentDocument?.body?.getAttribute("is-ready") === "true";
+                if (isReady) {
                     // If there is a fully loaded website preview, use it.
                     resolve(iframe.contentDocument.head.querySelectorAll("link[type='text/css']"));
                 } else {

--- a/addons/website/static/src/components/navbar/navbar.js
+++ b/addons/website/static/src/components/navbar/navbar.js
@@ -26,6 +26,8 @@ patch(NavBar.prototype, {
         // is updated, we need to adapt the navbar so that the "more" menu
         // can be computed.
         let adaptCounter = 0;
+        const getSiteDropdownButton = () =>
+            document.querySelector('nav .o_menu_sections button[data-menu-xmlid="website.menu_site"]');
         const renderAndAdapt = () => {
             this.render(true);
             adaptCounter++;
@@ -36,6 +38,11 @@ patch(NavBar.prototype, {
                 // as the super class already does it.
                 if (adaptCounter > 0) {
                     this.adapt();
+                    const siteBtnEl = getSiteDropdownButton();
+                    if (siteBtnEl?.classList.contains("show")) {
+                        siteBtnEl.click();
+                        siteBtnEl.click();
+                    }
                 }
             },
             () => [adaptCounter]


### PR DESCRIPTION
*: test_website

Before this commit, the Website systray item was rendered only after the website iframe had finished loading. This extra wait introduced a visible delay before the backend menu appeared and could also lead to inconsistent states after a page refresh.

With this change:
- The systray is mounted immediately, without awaiting `iframeLoaded`.
- The iframe element is resolved asynchronously and stored in state when it becomes available.
- Dynamic entries (Page properties, Optimize SEO, HTML / CSS Editor) re-render  automatically once the iframe sends updated metadata.

This improves perceived responsiveness: the backend menu is visible immediately after refresh, while still updating correctly as soon as the iframe and page metadata are loaded.


