### PR TITLE
[FIX] point_of_sale: clean ui for preparation capacity field

### DIFF
--- a/addons/point_of_sale/views/pos_preset_view.xml
+++ b/addons/point_of_sale/views/pos_preset_view.xml
@@ -25,7 +25,7 @@
                     <field name="image_512" widget="image" class="oe_avatar"/>
                     <div class="oe_title mb-2">
                         <label for="name"/>
-                        <h1><field name="name" placeholder="e.g. Cash" class="oe_inline"/></h1>
+                        <h1><field name="name" placeholder="e.g. Dine in"/></h1>
                     </div>
                     <group class="w-100" name="Presets">
                         <group>
@@ -33,16 +33,16 @@
                             <field name="fiscal_position_id" placeholder="Default"/>
                             <field name="use_timing" />
 
-                            <label for="resource_calendar_id" string="Schedule based on" class="fw-bold ms-2" />
+                            <label for="resource_calendar_id" string="Schedule based on" class="fw-bold" />
                             <div>
                                 <field name="resource_calendar_id" readonly="not use_timing" required="use_timing"/>
                             </div>
 
-                            <label for="slots_per_interval" string="Preparation capacity" class="fw-bold ms-2" />
-                            <div>
-                                <field name="slots_per_interval" class="oe_inline border-bottom text-center" readonly="not use_timing" />
+                            <label for="slots_per_interval" string="Preparation capacity" class="fw-bold" />
+                            <div class="o_row">
+                                <field name="slots_per_interval" class="text-center" readonly="not use_timing" />
                                 <label for="slots_per_interval" string="orders per" />
-                                <field name="interval_time" class="oe_inline border-bottom text-center" readonly="not use_timing" />
+                                <field name="interval_time" class="text-center" readonly="not use_timing" />
                                 <label for="interval_time" string="minutes" />
                             </div>
                         </group>


### PR DESCRIPTION
In this commit:
--------------
- The preparation capacity field was not properly displayed when manage orders by time is disabled, now we have added a additional class to make ui proper.

task: 5077509