### PR TITLE
[IMP] web: add modelSelector nbVisibleModels prop

### DIFF
--- a/addons/web/static/src/core/model_selector/model_selector.js
+++ b/addons/web/static/src/core/model_selector/model_selector.js
@@ -16,6 +16,7 @@ export class ModelSelector extends Component {
         // list of models technical name, if not set
         // we will fetch all models we have access to
         models: { type: Array, optional: true },
+        nbVisibleModels: { type: Number, optional: true },
     };
 
     setup() {
@@ -55,6 +56,10 @@ export class ModelSelector extends Component {
         };
     }
 
+    get nbVisibleModels() {
+        return this.props.nbVisibleModels || 8;
+    }
+
     onSelect(option) {
         this.props.onModelSelected({
             label: option.label,
@@ -64,7 +69,7 @@ export class ModelSelector extends Component {
 
     filterModels(name) {
         if (!name) {
-            const visibleModels = this.models.slice(0, 8);
+            const visibleModels = this.models.slice(0, this.nbVisibleModels);
             if (this.models.length - visibleModels.length > 0) {
                 visibleModels.push({
                     label: _t("Start typing..."),

--- a/addons/web/static/tests/core/model_selector.test.js
+++ b/addons/web/static/tests/core/model_selector.test.js
@@ -11,12 +11,18 @@ import {
 } from "@web/../tests/web_test_helpers";
 import { ModelSelector } from "@web/core/model_selector/model_selector";
 
-async function mountModelSelector(models = [], value = undefined, onModelSelected = () => {}) {
+async function mountModelSelector(
+    models = [],
+    value = undefined,
+    onModelSelected = () => {},
+    nbVisibleModels = undefined
+) {
     await mountWithCleanup(ModelSelector, {
         props: {
             models,
             value,
             onModelSelected,
+            nbVisibleModels,
         },
     });
 }
@@ -69,7 +75,19 @@ test("model_selector: displays model display names", async () => {
     expect(items[2]).toHaveText("Model 3");
 });
 
-test("model_selector: with 8 models", async () => {
+test("model_selector: with 8 models, showing 5", async () => {
+    await mountModelSelector(
+        ["model_1", "model_2", "model_3", "model_4", "model_5", "model_6", "model_7", "model_8"],
+        undefined,
+        undefined,
+        5
+    );
+    await contains(".o-autocomplete--input").click();
+    expect("li.o-autocomplete--dropdown-item").toHaveCount(6);
+    expect("li.o-autocomplete--dropdown-item:eq(5)").toHaveText("Start typing...");
+});
+
+test("model_selector: with 8 models, showing 8", async () => {
     await mountModelSelector([
         "model_1",
         "model_2",
@@ -84,7 +102,7 @@ test("model_selector: with 8 models", async () => {
     expect("li.o-autocomplete--dropdown-item").toHaveCount(8);
 });
 
-test("model_selector: with more than 8 models", async () => {
+test("model_selector: with more than 8 models, showing 8", async () => {
     await mountModelSelector([
         "model_1",
         "model_2",
@@ -100,6 +118,52 @@ test("model_selector: with more than 8 models", async () => {
     await contains(".o-autocomplete--input").click();
     expect("li.o-autocomplete--dropdown-item").toHaveCount(9);
     expect("li.o-autocomplete--dropdown-item:eq(8)").toHaveText("Start typing...");
+});
+
+test("model_selector: with more than 8 models, showing 9", async () => {
+    await mountModelSelector(
+        [
+            "model_1",
+            "model_2",
+            "model_3",
+            "model_4",
+            "model_5",
+            "model_6",
+            "model_7",
+            "model_8",
+            "model_9",
+            "model_10",
+        ],
+        undefined,
+        undefined,
+        9
+    );
+    await contains(".o-autocomplete--input").click();
+    expect("li.o-autocomplete--dropdown-item").toHaveCount(10);
+    expect("li.o-autocomplete--dropdown-item:eq(9)").toHaveText("Start typing...");
+});
+
+test("model_selector: with more than 8 models, showing all", async () => {
+    await mountModelSelector(
+        [
+            "model_1",
+            "model_2",
+            "model_3",
+            "model_4",
+            "model_5",
+            "model_6",
+            "model_7",
+            "model_8",
+            "model_9",
+            "model_10",
+        ],
+        undefined,
+        undefined,
+        10
+    );
+    await contains(".o-autocomplete--input").click();
+    expect("li.o-autocomplete--dropdown-item").toHaveCount(10);
+    expect("li.o-autocomplete--dropdown-item:eq(9)").toHaveText("Model 10");
 });
 
 test("model_selector: search content is not applied when opening the autocomplete", async () => {


### PR DESCRIPTION
In Documents, we have a static list of 9 items to
show with this widget. As there is no "Search more" available, and we're in stable, this is the minimal change to not change behavior.

Task-5075200

See related ENT PR (includes an integration test).