### PR TITLE
[FIX] website_sale: allow selecting excluded attributes

### DIFF
--- a/addons/website_sale/static/src/js/sale_variant_mixin.js
+++ b/addons/website_sale/static/src/js/sale_variant_mixin.js
@@ -232,7 +232,6 @@ var VariantMixin = {
         $parent
             .find('option, input, label, .o_variant_pills')
             .removeClass('css_not_available')
-            .removeAttr('disabled')
             .filter('option, input')
             .closest('li')
             .removeAttr('title')
@@ -334,7 +333,7 @@ var VariantMixin = {
     _disableInput: function ($parent, attributeValueId, excludedBy, attributeNames, productName) {
         var $input = $parent
             .find('option[value=' + attributeValueId + '], input[value=' + attributeValueId + ']');
-        $input.addClass('css_not_available').prop('disabled', true);
+        $input.addClass('css_not_available');
         $input.closest('label').addClass('css_not_available');
         $input.closest('.o_variant_pills').addClass('css_not_available');
 

--- a/addons/website_sale/static/src/scss/product_configurator.scss
+++ b/addons/website_sale/static/src/scss/product_configurator.scss
@@ -126,7 +126,6 @@ select.form-select.css_attribute_select {
     label, .o_variant_pills {
         &.css_not_available {
             opacity: 0.6;
-            pointer-events: none;
         }
     }
 }

--- a/addons/website_sale/static/tests/tours/website_sale_shop_archived_variant_multi.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_archived_variant_multi.js
@@ -31,8 +31,8 @@ registry.category("web_tour.tours").add('tour_shop_archived_variant_multi', {
         run: "click",
     },
     {
-        content: "check that brand b is not clickable",
-        trigger: '.css_not_available input[disabled]',
+        content: "check that brand b is not available",
+        trigger: '.css_not_available input.css_not_available',
     },
     {
         content: "change second variant to make brand b available",
@@ -40,8 +40,8 @@ registry.category("web_tour.tours").add('tour_shop_archived_variant_multi', {
         run: "click",
     },
     {
-        content: "check if brand b is clickable again",
-        trigger: 'input[data-attribute_name="Brand"][data-value_name="Brand B"]',
+        content: "check if brand b is available again",
+        trigger: 'input[data-value_name="Brand B"]:not(:has(.css_not_available))',
         run: "click",
     },
 ]});

--- a/addons/website_sale/static/tests/tours/website_sale_shop_multi_checkbox.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_multi_checkbox.js
@@ -21,8 +21,8 @@ registry.category("web_tour.tours").add('tour_shop_multi_checkbox', {
         run: "click",
     },
     {
-        content: 'check third option is not selectable',
-        trigger: 'input[data-attribute_name="Options"][data-value_name="Option 3"][disabled]',
+        content: "check third option is not available",
+        trigger: 'input[data-attribute_name="Options"][data-value_name="Option 3"].css_not_available',
     },
     {
         content: 'click on the second option to select it',


### PR DESCRIPTION
Versions
--------
- saas-18.4+

Steps
-----
1. Create a product with attributes A & B;
2. for attribute A, create values A1 & A2;
3. for attribute B, create values B1 & B2;
4. add an attribute exclusion on A1 for B2;
5. add an attribute exclusion on A2 for B1;
6. open the product's website page.

Issue
-----
It's impossible to change attributes.

Cause
-----
Commit bbb2d98d9ab97 prevents selecting impossible combinations, as a consequence, it's impossible change product variants whose attributes exclude each other.

Solution
--------
Do not add the `disabled` attribute for excluded attributes, but maintaining the visual cues.

Suggestion for future [IMP]: disable attributes as they were defined, without also disabling their inverse, e.g. if A1 is selected, disable B2, but don't disable A2 because B1 is selected.

opw-5019677
opw-5050472