### PR TITLE
[FIX] mail: no double call is talking outline

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_participant_card.xml
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.xml
@@ -31,7 +31,7 @@
             <CallParticipantVideo t-elif="hasVideo" session="rtcSession" type="props.cardData.type" inset="props.inset"/>
             <div t-else="" class="o-discuss-CallParticipantCard-avatar d-flex align-items-center justify-content-center h-100 w-100 rounded-1" t-att-class="{ 'o-minimized': props.minimized, 'o-isRemoteVideo': isRemoteVideo }" draggable="false">
                 <img t-if="!showRemoteWarning" alt="Avatar" class="h-100 rounded-circle border-5 object-fit-cover" t-att-src="channelMember?.avatarUrl" draggable="false" t-att-class="{
-                    'o-isTalking': isTalking,
+                    'o-isTalking': isTalking and props.minimized,
                     'o-isInvitation': !rtcSession,
                 }"/>
             </div>


### PR DESCRIPTION
Before this commit, when in a discuss call, a participant that talks while sending no video stream (both camera and screen-sharing off) would display double "is talking" green outline.

This happens when the card is not minimized, such as when this is the active main card or another participant has camera or screen-sharing on. In that case, the "is talking" outline effect is shown twice: one around the card border like card with video stream, and one around the participant avatar.

The outline around the card like video stream is intended, the one around image should only happen when not around the card.

This commit fixes by setting the "is talking" around image only when the card is minimized.

Before
<img width="498" height="315" alt="Screenshot 2025-09-11 at 15 41 09" src="https://github.com/user-attachments/assets/52334553-8ef9-460c-9162-805f44db5980" />

After
<img width="499" height="314" alt="Screenshot 2025-09-11 at 15 33 39" src="https://github.com/user-attachments/assets/119ea12f-d90c-4f9d-a131-8fd6b15ec858" />
