### PR TITLE
[FIX] hr_work_entry: work entries with different calendar types

### DIFF
--- a/addons/hr/models/resource.py
+++ b/addons/hr/models/resource.py
@@ -98,3 +98,11 @@ class ResourceResource(models.Model):
                 self.env['resource.calendar.attendance']
             )])
         return calendars_within_period_per_resource
+
+    def _get_calendar_at(self, date_target, tz=False):
+        result = super()._get_calendar_at(date_target)
+        resources_with_employee = self.filtered(lambda r: r.employee_id)
+        employee_calendars = resources_with_employee.employee_id._get_calendars(date_target.astimezone(tz))
+        for resource in resources_with_employee:
+            result[resource] = employee_calendars[resource.employee_id.id]
+        return result

--- a/addons/hr_work_entry/models/hr_work_entry.py
+++ b/addons/hr_work_entry/models/hr_work_entry.py
@@ -268,7 +268,10 @@ class HrWorkEntry(models.Model):
             datetime_start = min(entries.mapped('date_start'))
             datetime_stop = max(entries.mapped('date_stop'))
 
-            calendar_intervals = calendar._attendance_intervals_batch(pytz.utc.localize(datetime_start), pytz.utc.localize(datetime_stop))[False]
+            if calendar:
+                calendar_intervals = calendar._attendance_intervals_batch(pytz.utc.localize(datetime_start), pytz.utc.localize(datetime_stop))[False]
+            else:
+                calendar_intervals = Intervals([(pytz.utc.localize(datetime_start), pytz.utc.localize(datetime_stop), self.env['resource.calendar.attendance'])])
             entries_intervals = entries._to_intervals()
             overlapping_entries = self._from_intervals(entries_intervals & calendar_intervals)
             outside_entries |= entries - overlapping_entries

--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -426,16 +426,17 @@ class ResourceCalendar(models.Model):
                     for val in base_result]
             for tz in resources_per_tz.keys()
         }
+        resource_calendars = resources._get_calendar_at(start_dt, tz)
         result_per_resource_id = dict()
-        for tz, resources in resources_per_tz.items():
+        for tz, tz_resources in resources_per_tz.items():
             res = result_per_tz[tz]
 
             res_intervals = Intervals(res, keep_distinct=True)
             start_datetime = start_dt.astimezone(tz)
             end_datetime = end_dt.astimezone(tz)
 
-            for resource in resources:
-                if resource and resource._is_fully_flexible():
+            for resource in tz_resources:
+                if resource and not resource_calendars.get(resource, False):
                     # If the resource is fully flexible, return the whole period from start_dt to end_dt with a dummy attendance
                     hours = (end_dt - start_dt).total_seconds() / 3600
                     days = hours / 24
@@ -443,8 +444,8 @@ class ResourceCalendar(models.Model):
                         'duration_hours': hours,
                         'duration_days': days,
                     })
-                    result_per_resource_id[resource.id] = Intervals([(start_dt, end_dt, dummy_attendance)], keep_distinct=True)
-                elif (resource and resource.calendar_id.flexible_hours) or self.flexible_hours:
+                    result_per_resource_id[resource.id] = Intervals([(start_datetime, end_datetime, dummy_attendance)], keep_distinct=True)
+                elif self.flexible_hours or (resource and resource_calendars[resource].flexible_hours):
                     # For flexible Calendars, we create intervals to fill in the weekly intervals with the average daily hours
                     # until the full time required hours are met. This gives us the most correct approximation when looking at a daily
                     # and weekly range for time offs and overtime calculations and work entry generation
@@ -452,10 +453,10 @@ class ResourceCalendar(models.Model):
                     end_datetime_adjusted = end_datetime - relativedelta(seconds=1)
                     end_date = end_datetime_adjusted.date()
 
-                    calendar_id = resource.calendar_id or self
+                    calendar = resource_calendars[resource] if resource else self
 
-                    full_time_required_hours = calendar_id.full_time_required_hours
-                    max_hours_per_day = calendar_id.hours_per_day
+                    full_time_required_hours = calendar.full_time_required_hours
+                    max_hours_per_day = calendar.hours_per_day
 
                     intervals = []
                     current_start_day = start_date

--- a/addons/resource/models/resource_resource.py
+++ b/addons/resource/models/resource_resource.py
@@ -217,6 +217,9 @@ class ResourceResource(models.Model):
         self.ensure_one()
         return not self.calendar_id
 
+    def _get_calendar_at(self, date_target, tz=False):
+        return {resource: resource.calendar_id for resource in self}
+
     def _is_flexible(self):
         """ An employee is considered flexible if the field flexible_hours is True on the calendar
             or the employee is not assigned any calendar, in which case is considered as Fully flexible.


### PR DESCRIPTION
- fixed work entries generation for employees with different working schedules types
- fixed a traceback when the method `_attendance_intervals_batch` is called without a calendar (because the employee is fully flexible) or with more than 1 calendar
- made work entries generation check for employee timezone in case the employee is fully flexible and doesn't have a calendar
- added method `_get_calendar_at` to get the calendar of the resource at a given date
- added `test_work_entry_different_calendars` for work entries generation for employees with contracts with different calendar types


task-id: 5065160