### PR TITLE
[FIX] spreadsheet: force light theme

### DIFF
--- a/addons/spreadsheet/static/src/o_spreadsheet/o_spreadsheet_extended.dark.scss
+++ b/addons/spreadsheet/static/src/o_spreadsheet/o_spreadsheet_extended.dark.scss
@@ -41,6 +41,9 @@
   .o_domain_selector input{
     background-color: #333 !important;
   }
+  .pivot-dimension-search, .add-calculated-measure {
+    background-color: #fff !important;
+  }
   .btn {
     color:#374151;
   }
@@ -48,10 +51,10 @@
     border-color: #d5dae8 !important;
   }
   .border-bottom {
-    border-color: #d5dae8 !important;
+    border-bottom-color: #d5dae8 !important;
   }
   .border-top {
-    border-color: #d5dae8 !important;
+    border-top-color: #d5dae8 !important;
   }
 
 }


### PR DESCRIPTION
Spreadsheet doesn't support dark theme.
This fixes some style where dark and light themes are mixed.

Task: 5082593

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
