### PR TITLE
[FIX] l10n_in_ewaybill_stock:  LazyGettext traceback and missing response

### DIFF
--- a/addons/l10n_in_ewaybill_stock/i18n/l10n_in_ewaybill_stock.pot
+++ b/addons/l10n_in_ewaybill_stock/i18n/l10n_in_ewaybill_stock.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.0+e\n"
+"Project-Id-Version: Odoo Server 18.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-05-23 09:39+0000\n"
-"PO-Revision-Date: 2025-05-23 09:39+0000\n"
+"POT-Creation-Date: 2025-09-11 13:53+0000\n"
+"PO-Revision-Date: 2025-09-11 13:53+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -18,7 +18,6 @@ msgstr ""
 #. module: l10n_in_ewaybill_stock
 #. odoo-python
 #: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
-#, python-format
 msgid "%s has been generated"
 msgstr ""
 
@@ -40,42 +39,37 @@ msgstr ""
 #. module: l10n_in_ewaybill_stock
 #. odoo-python
 #: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
-#, python-format
 msgid "- Country is required"
 msgstr ""
 
 #. module: l10n_in_ewaybill_stock
 #. odoo-python
 #: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
-#, python-format
 msgid "- State is required"
 msgstr ""
 
 #. module: l10n_in_ewaybill_stock
 #. odoo-python
 #: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
-#, python-format
 msgid "- TIN number not set in state %s"
 msgstr ""
 
 #. module: l10n_in_ewaybill_stock
 #. odoo-python
 #: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
-#, python-format
+#: code:addons/l10n_in_ewaybill_stock/tests/test_ewaybill_stock.py:0
 msgid "- Transporter %s does not have a GST Number"
 msgstr ""
 
 #. module: l10n_in_ewaybill_stock
 #. odoo-python
 #: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
-#, python-format
 msgid "- Vehicle type can not be regular when the transportation mode is ship"
 msgstr ""
 
 #. module: l10n_in_ewaybill_stock
 #. odoo-python
 #: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
-#, python-format
 msgid "- Zip code required and should be 6 digits"
 msgstr ""
 
@@ -236,7 +230,6 @@ msgstr ""
 #: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
 #: model:ir.model,name:l10n_in_ewaybill_stock.model_l10n_in_ewaybill_cancel
 #: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.view_ewaybill_cancel_form
-#, python-format
 msgid "Cancel Ewaybill"
 msgstr ""
 
@@ -278,9 +271,7 @@ msgstr ""
 #. module: l10n_in_ewaybill_stock
 #. odoo-python
 #: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
-#: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
 #: model:ir.model.fields.selection,name:l10n_in_ewaybill_stock.selection__l10n_in_ewaybill__state__challan
-#, python-format
 msgid "Challan"
 msgstr ""
 
@@ -408,7 +399,6 @@ msgstr ""
 #. module: l10n_in_ewaybill_stock
 #. odoo-python
 #: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
-#, python-format
 msgid "Document number should be set and not more than 16 characters"
 msgstr ""
 
@@ -431,7 +421,6 @@ msgstr ""
 #. module: l10n_in_ewaybill_stock
 #. odoo-python
 #: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
-#, python-format
 msgid "E-Waybill"
 msgstr ""
 
@@ -449,7 +438,6 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_in_ewaybill_stock/tools/ewaybill_api.py:0
 #: model:ir.model.fields.selection,name:l10n_in_ewaybill_stock.selection__l10n_in_ewaybill__blocking_level__error
-#, python-format
 msgid "Error"
 msgstr ""
 
@@ -479,7 +467,6 @@ msgstr ""
 #. module: l10n_in_ewaybill_stock
 #. odoo-python
 #: code:addons/l10n_in_ewaybill_stock/models/stock_picking.py:0
-#, python-format
 msgid "Ewaybill already created for this picking."
 msgstr ""
 
@@ -546,7 +533,6 @@ msgstr ""
 #. module: l10n_in_ewaybill_stock
 #. odoo-python
 #: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
-#, python-format
 msgid "HSN code is not set in product %s"
 msgstr ""
 
@@ -590,8 +576,7 @@ msgstr ""
 #. module: l10n_in_ewaybill_stock
 #. odoo-python
 #: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
-#, python-format
-msgid "Invalid HSN Code (%s) in product %s"
+msgid "Invalid HSN Code (%(hsn_code)s) in product %(product)s"
 msgstr ""
 
 #. module: l10n_in_ewaybill_stock
@@ -709,7 +694,6 @@ msgstr ""
 #. module: l10n_in_ewaybill_stock
 #. odoo-python
 #: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
-#, python-format
 msgid "Only Delivery Challan and Cancelled E-waybill can be reset to pending."
 msgstr ""
 
@@ -745,14 +729,12 @@ msgstr ""
 #: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
 #: code:addons/l10n_in_ewaybill_stock/tests/test_ewaybill_stock.py:0
 #: model:ir.model.fields.selection,name:l10n_in_ewaybill_stock.selection__l10n_in_ewaybill__state__pending
-#, python-format
 msgid "Pending"
 msgstr ""
 
 #. module: l10n_in_ewaybill_stock
 #. odoo-python
 #: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
-#, python-format
 msgid ""
 "Please generate the E-Waybill or mark the document as a Challan to print it."
 msgstr ""
@@ -760,7 +742,6 @@ msgstr ""
 #. module: l10n_in_ewaybill_stock
 #. odoo-python
 #: code:addons/l10n_in_ewaybill_stock/models/stock_picking.py:0
-#, python-format
 msgid ""
 "Please set HSN code in below products: \n"
 "%s"
@@ -836,7 +817,6 @@ msgstr ""
 #. module: l10n_in_ewaybill_stock
 #. odoo-python
 #: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
-#, python-format
 msgid "Set GST Treatment for in %s"
 msgstr ""
 
@@ -852,12 +832,11 @@ msgstr ""
 
 #. module: l10n_in_ewaybill_stock
 #. odoo-python
-#: code:addons/l10n_in_ewaybill_stock/tools/ewaybill_api.py:0
-#, python-format
+#: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
 msgid ""
 "Somehow this E-waybill has been %s in the government portal before. You can "
 "verify by checking the details into the government "
-"(https://ewaybillgst.gov.in/Others/EBPrintnew.asp)"
+"(https://ewaybillgst.gov.in/Others/EBPrintnew.aspx)"
 msgstr ""
 
 #. module: l10n_in_ewaybill_stock
@@ -917,14 +896,12 @@ msgstr ""
 #. module: l10n_in_ewaybill_stock
 #. odoo-python
 #: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
-#, python-format
 msgid "The challan can only be generated in the Pending state."
 msgstr ""
 
 #. module: l10n_in_ewaybill_stock
 #. odoo-python
 #: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
-#, python-format
 msgid "This document is being sent by another process already."
 msgstr ""
 
@@ -1016,7 +993,6 @@ msgstr ""
 #. module: l10n_in_ewaybill_stock
 #. odoo-python
 #: code:addons/l10n_in_ewaybill_stock/tools/ewaybill_api.py:0
-#, python-format
 msgid ""
 "Unable to connect to the E-WayBill service.The web service may be temporary "
 "down. Please try again in a moment."
@@ -1025,7 +1001,6 @@ msgstr ""
 #. module: l10n_in_ewaybill_stock
 #. odoo-python
 #: code:addons/l10n_in_ewaybill_stock/tools/ewaybill_api.py:0
-#, python-format
 msgid ""
 "Unable to send E-waybill.Create an API user in NIC portal, and set it using "
 "the top menu: Configuration > Settings."
@@ -1074,7 +1049,6 @@ msgstr ""
 #. module: l10n_in_ewaybill_stock
 #. odoo-python
 #: code:addons/l10n_in_ewaybill_stock/tools/ewaybill_api.py:0
-#, python-format
 msgid ""
 "We don't know the error message for this error code. Please contact support."
 msgstr ""
@@ -1092,9 +1066,14 @@ msgstr ""
 #. module: l10n_in_ewaybill_stock
 #. odoo-python
 #: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
-#, python-format
 msgid ""
 "You cannot delete a generated E-waybill. Instead, you should cancel it."
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#. odoo-python
+#: code:addons/l10n_in_ewaybill_stock/tools/ewaybill_api.py:0
+msgid "cancelled"
 msgstr ""
 
 #. module: l10n_in_ewaybill_stock
@@ -1126,6 +1105,12 @@ msgstr ""
 #. module: l10n_in_ewaybill_stock
 #: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
 msgid "eway Bill No:"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#. odoo-python
+#: code:addons/l10n_in_ewaybill_stock/tools/ewaybill_api.py:0
+msgid "generated"
 msgstr ""
 
 #. module: l10n_in_ewaybill_stock

--- a/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py
@@ -292,6 +292,15 @@ class Ewaybill(models.Model):
         self.ensure_one()
         return self._get_gst_treatment()[1] in ('overseas', 'special_economic_zone')
 
+    @api.model
+    def _get_default_help_message(self, status):
+        return self.env._(
+            "Somehow this E-waybill has been %s in the government portal before. "
+            "You can verify by checking the details into the government "
+            "(https://ewaybillgst.gov.in/Others/EBPrintnew.aspx)",
+            status
+        )
+
     def _check_configuration(self):
         error_message = []
         methods_to_check = [

--- a/addons/l10n_in_ewaybill_stock/tools/ewaybill_api.py
+++ b/addons/l10n_in_ewaybill_stock/tools/ewaybill_api.py
@@ -9,8 +9,7 @@ from markupsafe import Markup
 from odoo import fields
 from odoo.exceptions import AccessError
 from odoo.addons.l10n_in_edi_ewaybill.models.error_codes import ERROR_CODES
-from odoo.tools import _, LazyTranslate
-_lt = LazyTranslate(__name__)
+from odoo.tools import _
 
 
 _logger = logging.getLogger(__name__)
@@ -45,12 +44,6 @@ class EWayBillError(Exception):
 
 
 class EWayBillApi:
-
-    DEFAULT_HELP_MESSAGE = _lt(
-        "Somehow this E-waybill has been %s in the government portal before. "
-        "You can verify by checking the details into the government "
-        "(https://ewaybillgst.gov.in/Others/EBPrintnew.asp)"
-    )
 
     def __init__(self, company):
         company.ensure_one()
@@ -143,7 +136,9 @@ class EWayBillApi:
                 return {
                     'odoo_warning': [{
                         'message': Markup("%s<br/>%s:<br/>%s") % (
-                            self.DEFAULT_HELP_MESSAGE % 'cancelled',
+                            self.env['l10n.in.ewaybill']._get_default_help_message(
+                                self.env._('cancelled')
+                            ),
                             _("Error"),
                             e.get_all_error_message()
                         ),
@@ -178,7 +173,9 @@ class EWayBillApi:
         # Add warning that ewaybill was already generated
         response.update({
             'odoo_warning': [{
-                'message': self.DEFAULT_HELP_MESSAGE % 'generated',
+                'message': self.env['l10n.in.ewaybill']._get_default_help_message(
+                    self.env._('generated')
+                ),
                 'message_post': True
             }]
         })


### PR DESCRIPTION


backport of https://github.com/odoo/odoo/commit/b7b987c4077c064fdfdb6b956379455cbdd93de3 on generating ewaybill through irn following traceback is produced

```py
File "/home/odoo/src/odoo/addons/l10n_in_ewaybill_stock/tools/ewaybill_api.py", line 165, in _ewaybill_generate

return self._ewaybill_make_transaction("generate", json_payload)

^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

File "/home/odoo/src/odoo/addons/l10n_in_ewaybill_stock/tools/ewaybill_api.py", line 157, in _ewaybill_make_transaction

response = self._ewaybill_get_by_consigner(

^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

File "/home/odoo/src/odoo/addons/l10n_in_ewaybill_stock/tools/ewaybill_api.py", line 181, in _ewaybill_get_by_consigner

'message': self.DEFAULT_HELP_MESSAGE % 'generated',

~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~

TypeError: unsupported operand type(s) for %: 'LazyGettext' and 'str'
```

In this commit we resolve this issue
opw-5079789


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
