### PR TITLE
[FIX] website_blog: restore RSS link in blog sidebar

### DIFF
--- a/addons/website_blog/views/website_blog_components.xml
+++ b/addons/website_blog/views/website_blog_components.xml
@@ -199,6 +199,7 @@ Options:
 <template id="sidebar_blog_index" name="Sidebar - Blog page">
     <div id="o_wblog_sidebar" class="w-100">
         <div class="oe_structure" id="oe_structure_blog_sidebar_index_1"/>
+        <a t-if="blog" title="RSS" t-attf-href="/blog/#{slug(blog)}/feed" class="fa fa-rss-square float-end"/>
         <div class="o_wblog_sidebar_block pb-5">
             <h6 class="text-uppercase pb-2 mb-4 border-bottom fw-bold">About us</h6>
             <div>


### PR DESCRIPTION
Commit [1] changed the "follow us" social media snippet in the blog sidebar to not be dynamic anymore (meaning, it uses the website related social media by default but they are not added/removed automatically based on if they are set or not)... but doing so it removed the custom "RSS" button by mistake.

This commit restores it, placing it at the top right of the sidebar, instead of being a part of the "follow us" social media. This keeps everything as static as possible + it actually makes sense to have this dedicated button outside of the more general "follow us" which is more website related than blog related.

[1]: https://github.com/odoo/odoo/commit/8b7e44c8c6a7b5c267da39f438e0dfc20699befd
