### PR TITLE
[IMP] website: reduce the number of queries for all pages.

### DIFF
--- a/addons/barcodes_gs1_nomenclature/models/barcode_nomenclature.py
+++ b/addons/barcodes_gs1_nomenclature/models/barcode_nomenclature.py
@@ -148,9 +148,9 @@ class BarcodeNomenclature(models.Model):
         """
         domain = Domain(domain)
         nomenclature = self.env.company.nomenclature_id
-        if not self.env.context.get('skip_preprocess_gs1') and nomenclature.is_gs1_nomenclature:
+        if not self.env.context.get('skip_preprocess_gs1'):
             def map_gs1_barcode(condition):
-                if condition.field_expr != field:
+                if condition.field_expr != field or not nomenclature.is_gs1_nomenclature:
                     return condition
                 # Check operator
                 # handle `in` first and check the rest

--- a/addons/test_website_modules/__manifest__.py
+++ b/addons/test_website_modules/__manifest__.py
@@ -15,6 +15,8 @@ installed.""",
         'website_blog',
         'website_event_sale',
         'website_slides',
+        'website_livechat',
+        'website_crm_iap_reveal',
     ],
     'installable': True,
     'assets': {

--- a/addons/test_website_modules/tests/__init__.py
+++ b/addons/test_website_modules/tests/__init__.py
@@ -3,3 +3,4 @@
 
 from . import test_configurator
 from . import test_controllers
+from . import test_performance

--- a/addons/test_website_modules/tests/test_performance.py
+++ b/addons/test_website_modules/tests/test_performance.py
@@ -1,0 +1,273 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import base64
+import io
+import re
+from PIL import Image
+from unittest.mock import patch
+import odoo
+from odoo.tests import tagged
+from odoo.addons.website.tests.test_performance import TestWebsitePerformanceCommon
+from odoo.addons.website_sale.tests.common import WebsiteSaleCommon
+from odoo.addons.website_sale.tests.test_website_sale_pricelist import TestWebsitePriceList
+
+
+class TestWebsiteAllPerformance(TestWebsitePerformanceCommon, TestWebsitePriceList, WebsiteSaleCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # Attachment needed for the replacement of images
+        cls.env['ir.attachment'].create({
+            'public': True,
+            'name': 's_default_image.jpg',
+            'type': 'url',
+            'url': f'{cls.base_url()}/web/image/website.s_banner_default_image.jpg',
+        })
+
+        # First image (blue) for the template.
+        color_blue = '#4169E1'
+        name_blue = 'Royal Blue'
+        # Red for the variant.
+        color_red = '#CD5C5C'
+        name_red = 'Indian Red'
+
+        # Create the color attribute.
+        cls.product_attribute = cls.env['product.attribute'].create({
+            'name': 'Beautiful Color',
+            'display_type': 'color',
+        })
+
+        # create the color attribute values
+        cls.attr_values = cls.env['product.attribute.value'].create([{
+            'name': name_blue,
+            'attribute_id': cls.product_attribute.id,
+            'html_color': color_blue,
+            'sequence': 1,
+        }, {
+            'name': name_red,
+            'attribute_id': cls.product_attribute.id,
+            'html_color': color_red,
+            'sequence': 2,
+        },
+        ])
+
+        # first image (blue) for the template
+        f = io.BytesIO()
+        Image.new('RGB', (1920, 1080), '#4169E1').save(f, 'JPEG')
+        f.seek(0)
+        blue_image = base64.b64encode(f.read())
+
+        # second image (red) for the variant 1
+        f = io.BytesIO()
+        Image.new('RGB', (800, 500), '#FF69E1').save(f, 'JPEG')
+        f.seek(0)
+        red_image = base64.b64encode(f.read())
+
+        cls.productA = cls.env['product.product'].create({
+            'name': 'Product A',
+            'list_price': 100,
+            'sale_ok': True,
+            'website_published': True,
+        })
+
+        cls.productB = cls.env['product.product'].create({
+            'name': 'Product B',
+            'list_price': 100,
+            'sale_ok': True,
+            'website_published': True,
+            'image_1920': red_image,
+        })
+
+        cls.templateC = cls.env['product.template'].create({
+            'name': 'Test Remove Image',
+            'image_1920': blue_image,
+        })
+        cls.productC = cls.templateC.product_variant_ids[0]
+        cls.productC.write({
+            'name': 'Product C',
+            'list_price': 100,
+            'sale_ok': True,
+            'website_published': True,
+        })
+        cls.product_images = cls.env['product.image'].with_context(default_product_tmpl_id=cls.productC.product_tmpl_id.id).create([{
+            'name': 'Template image',
+            'image_1920': blue_image,
+        }, {
+            'name': 'Variant image',
+            'image_1920': red_image,
+            'product_variant_id': cls.productC.id,
+        }])
+
+        for i in range(20):
+            template = cls.env['product.template'].create({
+                'name': f'Product test {i}',
+                'list_price': 100,
+                'sale_ok': True,
+                'website_published': True,
+                'image_1920': red_image,
+            })
+            images = [{
+                'name': 'Template image',
+                'image_1920': blue_image,
+            }]
+            if i % 2:
+                images.append({
+                    'name': 'Variant image',
+                    'image_1920': red_image,
+                    'product_variant_id': template.product_variant_ids[0].id,
+                })
+
+    def setUp(self):
+        super().setUp()
+        self.session = None
+        self.env['website'].search([]).channel_id = False
+
+    def test_perf_sql_queries_shop(self):
+        html = self.url_open('/shop').text
+        self.assertIn(f'<img src="/web/image/product.product/{self.productC.id}/', html)
+        self.assertIn(f'<img src="/web/image/product.template/{self.productA.product_tmpl_id.id}/', html)
+        self.assertIn(f'<img src="/web/image/product.image/{self.product_images.ids[1]}/', html)
+
+        self.assertEqual(self._get_url_hot_query('/shop'), 139)
+
+    def _get_cart_quantity(self):
+        return int(re.search(
+            r'my_cart_quantity.*?>([0-9.]+)</sup>',
+            self.url_open(self.page.url).text
+        ).group(1))
+
+    def test_website_user_id_public_user(self):
+        origin_serve_page = odoo.addons.website.models.ir_http.IrHttp._serve_page
+
+        def _serve_page():
+            request = odoo.http.request
+            self.assertTrue(request.env['website'].search([]).user_id._is_public(), 'The public user of the website is not public!')
+            self.assertTrue(request.env.user._is_public(), 'The visitor should not be logged')
+            return origin_serve_page()
+
+        with patch('odoo.addons.website.models.ir_http.IrHttp._serve_page', wraps=_serve_page) as mocked:
+            self.url_open(self.page.url)
+            mocked.assert_called_once()
+
+    def test_perf_sql_queries_page(self):
+        self.set_registry_readonly_mode(True)
+        self.page.track = False
+
+        # self.url_open('/web/set_profiling?profile=1&execution_context_qweb=1')
+
+        self.assertEqual(self._get_cart_quantity(), 0)
+        select_tables_perf = {
+            # website queries
+            'orm_signaling_registry': 1,
+            'ir_attachment': 1,
+            'website_page': 2,
+            'website_menu': 1,
+            'website': 1,
+            'ir_ui_view': 1,
+            'res_company': 1,
+            # website_livechat _post_process_response_from_cache queries
+            'website': 1,
+            # website_crm_iap_reveal _serve_page queries
+            'website_visitor': 1,
+            # website_sale queries
+            'res_users': 1,
+        }
+        expected_query_count = sum(select_tables_perf.values())
+        self._check_url_hot_query(self.page.url, expected_query_count, select_tables_perf, {})
+
+        self.url_open('/shop/cart/add', json={
+            "id": 0,
+            "jsonrpc": "2.0",
+            "method": "call",
+            "params": {
+                "product_template_id": self.productC.product_tmpl_id.id,
+                "product_id": self.productC.id,
+                "quantity": 1,
+                "uom_id": 1,
+                "product_custom_attribute_values": [],
+                "no_variant_attribute_value_ids": [],
+                "linked_products": []
+            }
+        })
+        self.assertEqual(self._get_cart_quantity(), 1)
+        select_tables_perf = {
+            # website queries
+            'orm_signaling_registry': 1,
+            'ir_attachment': 1,
+            'website_page': 2,
+            'website': 1,
+            'website_menu': 1,
+            'ir_ui_view': 1,
+            'res_company': 1,
+            # website_livechat _post_process_response_from_cache queries
+            'website': 1,
+            # website_crm_iap_reveal _serve_page queries
+            'website_visitor': 1,
+            # website_sale queries
+            'res_users': 1,
+            'sale_order': 2,
+            'sale_order_line': 2,
+            'product_product': 1,
+            'product_template': 1,
+            'payment_transaction': 1,
+        }
+        expected_query_count = sum(select_tables_perf.values())
+        self._check_url_hot_query(self.page.url, expected_query_count, select_tables_perf, {})
+
+        self.url_open('/shop/cart/update', json={
+            "id": 0,
+            "jsonrpc": "2.0",
+            "method": "call",
+            "params": {
+                "line_id": self.env['sale.order'].search([], limit=1).order_line.id,
+                "product_id": self.productC.id,
+                "quantity": 0
+            }
+        })
+
+        self.assertEqual(self._get_cart_quantity(), 0)
+        select_tables_perf = {
+            # website queries
+            'orm_signaling_registry': 1,
+            'ir_attachment': 1,
+            'website_page': 2,
+            'website': 1,
+            'website_menu': 1,
+            'ir_ui_view': 1,
+            'res_company': 1,
+            # website_livechat _post_process_response_from_cache queries
+            'website': 1,
+            # website_crm_iap_reveal _serve_page queries
+            'website_visitor': 1,
+            # website_sale queries
+            'res_users': 1,
+            'sale_order': 2,
+            'sale_order_line': 1,
+            'payment_transaction': 1,
+        }
+        expected_query_count = sum(select_tables_perf.values())
+        self._check_url_hot_query(self.page.url, expected_query_count, select_tables_perf, {})
+
+
+@tagged('post_install', '-at_install')
+class TestWebsiteAllPerformancePostInstall(TestWebsiteAllPerformance):
+
+    def test_perf_sql_queries_shop(self):
+        tax_group = self.env['account.tax.group'].create({'name': 'Tax 15%'})
+        tax = self.env['account.tax'].create({
+            'name': 'Tax 15%',
+            'amount': 15,
+            'type_tax_use': 'sale',
+            'tax_group_id': tax_group.id,
+            'country_id': self.env.company.country_id.id,
+        })
+        self.productB.taxes_id = tax
+
+        html = self.url_open('/shop').text
+        self.assertIn(f'<img src="/web/image/product.product/{self.productC.id}/', html)
+        self.assertIn(f'<img src="/web/image/product.template/{self.productA.product_tmpl_id.id}/', html)
+        self.assertIn(f'<img src="/web/image/product.image/{self.product_images.ids[1]}/', html)
+
+        self.assertEqual(self._get_url_hot_query('/shop'), 150)

--- a/addons/test_website_modules/tests/test_performance.py
+++ b/addons/test_website_modules/tests/test_performance.py
@@ -70,6 +70,7 @@ class TestWebsiteAllPerformance(TestWebsitePerformanceCommon, TestWebsitePriceLi
             'list_price': 100,
             'sale_ok': True,
             'website_published': True,
+            'website_sequence': 1,
         })
 
         cls.productB = cls.env['product.product'].create({
@@ -83,6 +84,7 @@ class TestWebsiteAllPerformance(TestWebsitePerformanceCommon, TestWebsitePriceLi
         cls.templateC = cls.env['product.template'].create({
             'name': 'Test Remove Image',
             'image_1920': blue_image,
+            'website_sequence': 1,
         })
         cls.productC = cls.templateC.product_variant_ids[0]
         cls.productC.write({
@@ -130,7 +132,7 @@ class TestWebsiteAllPerformance(TestWebsitePerformanceCommon, TestWebsitePriceLi
         self.assertIn(f'<img src="/web/image/product.template/{self.productA.product_tmpl_id.id}/', html)
         self.assertIn(f'<img src="/web/image/product.image/{self.product_images.ids[1]}/', html)
 
-        self.assertEqual(self._get_url_hot_query('/shop'), 139)
+        self.assertEqual(self._get_url_hot_query('/shop'), 37)  # To increase this number you must ask the permission to al
 
     def _get_cart_quantity(self):
         return int(re.search(
@@ -252,4 +254,4 @@ class TestWebsiteAllPerformancePostInstall(TestWebsiteAllPerformance):
         self.assertIn(f'<img src="/web/image/product.template/{self.productA.product_tmpl_id.id}/', html)
         self.assertIn(f'<img src="/web/image/product.image/{self.product_images.ids[1]}/', html)
 
-        self.assertEqual(self._get_url_hot_query('/shop'), 150)
+        self.assertEqual(self._get_url_hot_query('/shop'), 47)  # To increase this number you must ask the permission to al

--- a/addons/test_website_modules/tests/test_performance.py
+++ b/addons/test_website_modules/tests/test_performance.py
@@ -158,21 +158,25 @@ class TestWebsiteAllPerformance(TestWebsitePerformanceCommon, TestWebsitePriceLi
         # self.url_open('/web/set_profiling?profile=1&execution_context_qweb=1')
 
         self.assertEqual(self._get_cart_quantity(), 0)
+
+        origin_allow_to_use_cache = odoo.addons.website.models.website_page.WebsitePage._allow_to_use_cache
+
+        def _allow_to_use_cache(request):
+            can_use = origin_allow_to_use_cache(request.env['website.page'], request)
+            self.assertTrue(can_use, 'The homepage should be cached for the public user')
+
+        with patch('odoo.addons.website.models.website_page.WebsitePage._allow_to_use_cache', wraps=_allow_to_use_cache) as mocked:
+            self.url_open(self.page.url)
+            mocked.assert_called_once()
+
         select_tables_perf = {
             # website queries
             'orm_signaling_registry': 1,
             'ir_attachment': 1,
-            'website_page': 2,
-            'website_menu': 1,
-            'website': 1,
-            'ir_ui_view': 1,
-            'res_company': 1,
             # website_livechat _post_process_response_from_cache queries
             'website': 1,
             # website_crm_iap_reveal _serve_page queries
             'website_visitor': 1,
-            # website_sale queries
-            'res_users': 1,
         }
         expected_query_count = sum(select_tables_perf.values())
         self._check_url_hot_query(self.page.url, expected_query_count, select_tables_perf, {})
@@ -196,22 +200,10 @@ class TestWebsiteAllPerformance(TestWebsitePerformanceCommon, TestWebsitePriceLi
             # website queries
             'orm_signaling_registry': 1,
             'ir_attachment': 1,
-            'website_page': 2,
-            'website': 1,
-            'website_menu': 1,
-            'ir_ui_view': 1,
-            'res_company': 1,
             # website_livechat _post_process_response_from_cache queries
             'website': 1,
             # website_crm_iap_reveal _serve_page queries
             'website_visitor': 1,
-            # website_sale queries
-            'res_users': 1,
-            'sale_order': 2,
-            'sale_order_line': 2,
-            'product_product': 1,
-            'product_template': 1,
-            'payment_transaction': 1,
         }
         expected_query_count = sum(select_tables_perf.values())
         self._check_url_hot_query(self.page.url, expected_query_count, select_tables_perf, {})
@@ -232,20 +224,10 @@ class TestWebsiteAllPerformance(TestWebsitePerformanceCommon, TestWebsitePriceLi
             # website queries
             'orm_signaling_registry': 1,
             'ir_attachment': 1,
-            'website_page': 2,
-            'website': 1,
-            'website_menu': 1,
-            'ir_ui_view': 1,
-            'res_company': 1,
             # website_livechat _post_process_response_from_cache queries
             'website': 1,
             # website_crm_iap_reveal _serve_page queries
             'website_visitor': 1,
-            # website_sale queries
-            'res_users': 1,
-            'sale_order': 2,
-            'sale_order_line': 1,
-            'payment_transaction': 1,
         }
         expected_query_count = sum(select_tables_perf.values())
         self._check_url_hot_query(self.page.url, expected_query_count, select_tables_perf, {})

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -103,9 +103,6 @@ class Website(Home):
         Most DBs will just have a website.page with '/' as URL and keep the
         homepage_url setting empty.
         """
-        # prefetch all menus (it will prefetch website.page too)
-        top_menu = request.website.menu_id
-
         homepage_url = request.website._get_cached('homepage_url')
         if homepage_url and homepage_url != '/':
             request.reroute(homepage_url)
@@ -126,6 +123,9 @@ class Website(Home):
         # Fallback on first accessible menu
         def is_reachable(menu):
             return menu.is_visible and menu.url not in ('/', '', '#') and not menu.url.startswith(('/?', '/#', ' '))
+
+        # prefetch all menus (it will prefetch website.page too)
+        top_menu = request.website.menu_id
 
         reachable_menus = top_menu.child_id.filtered(is_reachable)
         if reachable_menus:

--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -301,7 +301,15 @@ class IrHttp(models.AbstractModel):
 
         def _search_page(comparator='='):
             page_domain = Domain('url', comparator, req_page) & request.website.website_domain()
-            return request.env['website.page'].sudo().search(page_domain, order='website_id asc', limit=1)
+
+            # fetch on all preffetchable fields to get all data at once (e.g., 'website_meta').
+            fields_to_fetch = [name for name, field in request.env['website.page']._fields.items() if field.prefetch]
+            page = request.env['website.page'].sudo().search_fetch(page_domain, field_names=fields_to_fetch, order='website_id asc', limit=1)
+
+            # fetch on all preffetchable fields to get all data at once (e.g., 'website_meta').
+            fields_to_fetch = [name for name, field in page.view_id._fields.items() if field.prefetch]
+            page.view_id.fetch(fields_to_fetch)
+            return page
 
         # specific page first
         page = _search_page()

--- a/addons/website/models/ir_ui_view.py
+++ b/addons/website/models/ir_ui_view.py
@@ -362,7 +362,7 @@ class IrUiView(models.Model):
 
     @api.model
     def _get_cached_template_prefetched_keys(self):
-        return super()._get_cached_template_prefetched_keys() + ['active', 'visibility']
+        return super()._get_cached_template_prefetched_keys() + ['active', 'visibility', 'track']
 
     @api.model
     def _get_template_minimal_cache_keys(self):

--- a/addons/website/models/website_technical_page.py
+++ b/addons/website/models/website_technical_page.py
@@ -21,7 +21,7 @@ class WebsiteTechnicalPage(models.Model):
         """
         return self.env["website"].get_client_action(self.website_url)
 
-    @ormcache()
+    @ormcache(cache='routing')
     def get_static_routes(self):
         """
         Returns a set of website content static routes.

--- a/addons/website/models/website_visitor.py
+++ b/addons/website/models/website_visitor.py
@@ -279,7 +279,7 @@ class WebsiteVisitor(models.Model):
             visitor_id, _ = self._upsert_visitor(access_token, force_track_values)
             return self.env['website.visitor'].sudo().browse(visitor_id)
 
-        visitor = self.env['website.visitor'].sudo().search([('access_token', '=', access_token)])
+        visitor = self.env['website.visitor'].sudo().search_fetch([('access_token', '=', access_token)])
 
         if not force_create and not self.env.cr.readonly and visitor and not visitor.timezone:
             tz = self._get_visitor_timezone()

--- a/addons/website/tests/test_performance.py
+++ b/addons/website/tests/test_performance.py
@@ -7,7 +7,7 @@ from contextlib import closing
 
 from odoo.sql_db import categorize_query
 from odoo.tools import mute_logger
-from odoo.tests.common import HttpCase, tagged
+from odoo.tests.common import tagged
 
 
 _logger = logging.getLogger(__name__)
@@ -113,7 +113,7 @@ class TestStandardPerformance(UtilPerf):
         # not published user, get the not found image placeholder
         self.assertEqual(self.env['res.users'].sudo().browse(2).website_published, False)
         url = '/web/image/res.users/2/image_256'
-        self.assertEqual(self._get_url_hot_query(url), 8)
+        self.assertEqual(self._get_url_hot_query(url), 7)
 
     @mute_logger('odoo.http')
     def test_11_perf_sql_img_controller(self):
@@ -124,9 +124,9 @@ class TestStandardPerformance(UtilPerf):
             'orm_signaling_registry': 1,
             'res_users': 2,
             'res_partner': 1,
-            'ir_attachment': 2,
+            'ir_attachment': 1,
         }
-        self._check_url_hot_query(url, 6, select_tables_perf)
+        self._check_url_hot_query(url, 5, select_tables_perf)
 
     @mute_logger('odoo.http')
     def test_20_perf_sql_img_controller_bis(self):

--- a/addons/website/tests/test_performance.py
+++ b/addons/website/tests/test_performance.py
@@ -28,7 +28,7 @@ class UtilPerf(HttpCaseWithUserPortal, HttpCaseWithUserDemo):
         if 'channel_id' in cls.env['website']:
             cls.env['website'].search([]).channel_id = False
 
-    def _get_url_hot_query(self, url, query_list=False):
+    def _get_url_hot_query(self, url, query_list=False, nocache=False):
         """ This method returns the number of SQL Queries used inside a request.
         The returned query number will be the same as a "real" (outside of test
         mode) case: the method takes care of removing the extra queries related
@@ -50,6 +50,8 @@ class UtilPerf(HttpCaseWithUserPortal, HttpCaseWithUserDemo):
         :rtype: int|tuple(int, list)
         """
         url += ('?' not in url and '?' or '')
+        if nocache:
+            url += '&nocache'
 
         # ensure worker is in hot state
         self.url_open(url)
@@ -72,8 +74,8 @@ class UtilPerf(HttpCaseWithUserPortal, HttpCaseWithUserDemo):
             return sql_count
         return sql_count, sql_queries
 
-    def _check_url_hot_query(self, url, expected_query_count, select_tables_perf=None, insert_tables_perf=None):
-        query_count, sql_queries = self._get_url_hot_query(url, query_list=True)
+    def _check_url_hot_query(self, url, expected_query_count, select_tables_perf=None, insert_tables_perf=None, nocache=False):
+        query_count, sql_queries = self._get_url_hot_query(url, query_list=True, nocache=nocache)
 
         sql_from_tables = {}
         sql_into_tables = {}
@@ -191,27 +193,14 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
                     'orm_signaling_registry': 1,
                     'ir_attachment': 1,
                     # `_get_serve_attachment` dispatcher fallback
-                    'website_page': 2,
-                    # 1. `_serve_page` search page matching URL..
-                    # 2. ..then reads it (`is_visible`)
-                    'website': 1,
-                    # menu and layout
-                    'website_menu': 1,
-                    'ir_ui_view': 1,
-                    'res_company': 1,
                 }
-                expected_query_count = 8
+                expected_query_count = 2
                 self._check_url_hot_query(self.page.url, expected_query_count, select_tables_perf)
                 self.assertEqual(self._get_url_hot_query(self.page.url), expected_query_count)
                 self.menu.unlink()  # page being or not in menu shouldn't add queries
                 self._check_url_hot_query(self.page.url, expected_query_count, select_tables_perf)
                 self.assertEqual(self._get_url_hot_query(self.page.url), expected_query_count)
 
-    def test_15_perf_sql_queries_page(self):
-        # standard tracked website.page
-        for readonly_enabled in (True, False):
-            self.set_registry_readonly_mode(readonly_enabled)
-            with self.subTest(readonly_enabled=readonly_enabled), closing(self.env.cr.savepoint()):
                 select_tables_perf = {
                     'orm_signaling_registry': 1,
                     'ir_attachment': 1,
@@ -226,6 +215,32 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
                     'res_company': 1,
                 }
                 expected_query_count = 8
+                self._check_url_hot_query(self.page.url, expected_query_count, select_tables_perf, nocache=True)
+                self.assertEqual(self._get_url_hot_query(self.page.url, nocache=True), expected_query_count)
+
+    def test_15_perf_sql_queries_page(self):
+        # standard tracked website.page
+        for readonly_enabled, cache in ((True, True), (False, True), (True, False), (False, False)):
+            self.set_registry_readonly_mode(readonly_enabled)
+            with self.subTest(readonly_enabled=readonly_enabled), closing(self.env.cr.savepoint()):
+                select_tables_perf = {
+                    'orm_signaling_registry': 1,
+                    'ir_attachment': 1,
+                    # `_get_serve_attachment` dispatcher fallback
+                } if cache else {
+                    'orm_signaling_registry': 1,
+                    'ir_attachment': 1,
+                    # `_get_serve_attachment` dispatcher fallback
+                    'website_page': 2,
+                    # 1. `_serve_page` search page matching URL..
+                    # 2. ..then reads it (`is_visible`)
+                    'website': 1,
+                    # menu and layout
+                    'website_menu': 1,
+                    'ir_ui_view': 1,
+                    'res_company': 1,
+                }
+                expected_query_count = 2 if cache else 8
                 insert_tables_perf = {}
                 if not readonly_enabled:
                     insert_tables_perf = {
@@ -236,14 +251,28 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
                 self.page.track = True
 
                 self.menu.unlink()  # page being or not in menu shouldn't add queries
-                self._check_url_hot_query(self.page.url, expected_query_count, select_tables_perf, insert_tables_perf)
-                self.assertEqual(self._get_url_hot_query(self.page.url), expected_query_count)
+                self._check_url_hot_query(self.page.url, expected_query_count, select_tables_perf, insert_tables_perf, nocache=not cache)
+                self.assertEqual(self._get_url_hot_query(self.page.url, nocache=not cache), expected_query_count)
 
     def test_20_perf_sql_queries_homepage(self):
         # homepage "/" has its own controller
         for readonly_enabled in (True, False):
             self.set_registry_readonly_mode(readonly_enabled)
             with self.subTest(readonly_enabled=readonly_enabled), closing(self.env.cr.savepoint()):
+                select_tables_perf = {
+                    'orm_signaling_registry': 1,
+                }
+                expected_query_count = 1
+                insert_tables_perf = {}
+                if not readonly_enabled:
+                    insert_tables_perf = {
+                        'website_visitor': 1,
+                        # Visitor upsert
+                    }
+                    expected_query_count += 1
+                self._check_url_hot_query('/', expected_query_count, select_tables_perf, insert_tables_perf)
+                self.assertEqual(self._get_url_hot_query('/'), expected_query_count)
+
                 select_tables_perf = {
                     'orm_signaling_registry': 1,
                     'website_menu': 1,
@@ -264,12 +293,21 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
                         # Visitor upsert
                     }
                     expected_query_count += 1
-                self._check_url_hot_query('/', expected_query_count, select_tables_perf, insert_tables_perf)
-                self.assertEqual(self._get_url_hot_query('/'), expected_query_count)
+                self._check_url_hot_query('/', expected_query_count, select_tables_perf, insert_tables_perf, nocache=True)
+                self.assertEqual(self._get_url_hot_query('/', nocache=True), expected_query_count)
 
     def test_30_perf_sql_queries_page_no_layout(self):
         # untrack website.page with no call to layout templates
         self.page.arch = '<div>I am a blank page</div>'
+
+        select_tables_perf = {
+            'orm_signaling_registry': 1,
+            'ir_attachment': 1,
+            # `_get_serve_attachment` dispatcher fallback
+        }
+        self._check_url_hot_query(self.page.url, 2, select_tables_perf)
+        self.assertEqual(self._get_url_hot_query(self.page.url), 2)
+
         select_tables_perf = {
             'orm_signaling_registry': 1,
             'ir_attachment': 1,
@@ -282,8 +320,8 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
             'ir_ui_view': 1,
             # Check if `view.track` to track visitor or not
         }
-        self._check_url_hot_query(self.page.url, 5, select_tables_perf)
-        self.assertEqual(self._get_url_hot_query(self.page.url), 5)
+        self._check_url_hot_query(self.page.url, 5, select_tables_perf, nocache=True)
+        self.assertEqual(self._get_url_hot_query(self.page.url, nocache=True), 5)
 
     def test_40_perf_sql_queries_page_multi_level_menu(self):
         # menu structure should not impact SQL requests
@@ -299,6 +337,14 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
             'orm_signaling_registry': 1,
             'ir_attachment': 1,
             # `_get_serve_attachment` dispatcher fallback
+        }
+        self._check_url_hot_query(self.page.url, 2, select_tables_perf)
+        self.assertEqual(self._get_url_hot_query(self.page.url), 2)
+
+        select_tables_perf = {
+            'orm_signaling_registry': 1,
+            'ir_attachment': 1,
+            # `_get_serve_attachment` dispatcher fallback
             'website_page': 2,
             # 1. `_serve_page` search page matching URL..
             # 2. ..then reads it (`is_visible`)
@@ -309,8 +355,8 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
             # layout content (company name, logo)
             'res_company': 1,
         }
-        self._check_url_hot_query(self.page.url, 8, select_tables_perf)
-        self.assertEqual(self._get_url_hot_query(self.page.url), 8)
+        self._check_url_hot_query(self.page.url, 8, select_tables_perf, nocache=True)
+        self.assertEqual(self._get_url_hot_query(self.page.url, nocache=True), 8)
 
 @tagged('-at_install', 'post_install')
 class TestWebsitePerformancePost(UtilPerf):

--- a/addons/website/tests/test_performance.py
+++ b/addons/website/tests/test_performance.py
@@ -191,16 +191,16 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
                     'orm_signaling_registry': 1,
                     'ir_attachment': 1,
                     # `_get_serve_attachment` dispatcher fallback
-                    'website_page': 3,
+                    'website_page': 2,
                     # 1. `_serve_page` search page matching URL..
                     # 2. ..then reads it (`is_visible`)
                     'website': 1,
                     # menu and layout
                     'website_menu': 1,
-                    'ir_ui_view': 2,
+                    'ir_ui_view': 1,
                     'res_company': 1,
                 }
-                expected_query_count = 10
+                expected_query_count = 8
                 self._check_url_hot_query(self.page.url, expected_query_count, select_tables_perf)
                 self.assertEqual(self._get_url_hot_query(self.page.url), expected_query_count)
                 self.menu.unlink()  # page being or not in menu shouldn't add queries
@@ -216,16 +216,16 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
                     'orm_signaling_registry': 1,
                     'ir_attachment': 1,
                     # `_get_serve_attachment` dispatcher fallback
-                    'website_page': 3,
+                    'website_page': 2,
                     # 1. `_serve_page` search page matching URL..
                     # 2. ..then reads it (`is_visible`)
                     'website': 1,
                     # menu and layout
                     'website_menu': 1,
-                    'ir_ui_view': 2,
+                    'ir_ui_view': 1,
                     'res_company': 1,
                 }
-                expected_query_count = 10
+                expected_query_count = 8
                 insert_tables_perf = {}
                 if not readonly_enabled:
                     insert_tables_perf = {
@@ -253,10 +253,10 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
                     # 2. find page matching the `/` url
                     'website': 1,
                     # layout
-                    'ir_ui_view': 2,
+                    'ir_ui_view': 1,
                     'res_company': 1,
                 }
-                expected_query_count = 8
+                expected_query_count = 7
                 insert_tables_perf = {}
                 if not readonly_enabled:
                     insert_tables_perf = {
@@ -274,7 +274,7 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
             'orm_signaling_registry': 1,
             'ir_attachment': 1,
             # `_get_serve_attachment` dispatcher fallback
-            'website_page': 2,
+            'website_page': 1,
             # 1. `_serve_page` search page matching URL..
             # 2. ..then reads it (`is_visible`)
             'website': 1,
@@ -282,8 +282,8 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
             'ir_ui_view': 1,
             # Check if `view.track` to track visitor or not
         }
-        self._check_url_hot_query(self.page.url, 6, select_tables_perf)
-        self.assertEqual(self._get_url_hot_query(self.page.url), 6)
+        self._check_url_hot_query(self.page.url, 5, select_tables_perf)
+        self.assertEqual(self._get_url_hot_query(self.page.url), 5)
 
     def test_40_perf_sql_queries_page_multi_level_menu(self):
         # menu structure should not impact SQL requests
@@ -299,18 +299,18 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
             'orm_signaling_registry': 1,
             'ir_attachment': 1,
             # `_get_serve_attachment` dispatcher fallback
-            'website_page': 3,
+            'website_page': 2,
             # 1. `_serve_page` search page matching URL..
             # 2. ..then reads it (`is_visible`)
             'website': 1,
             'website_menu': 1,
-            'ir_ui_view': 2,
+            'ir_ui_view': 1,
             # Check if `view.track` to track visitor or not
             # layout content (company name, logo)
             'res_company': 1,
         }
-        self._check_url_hot_query(self.page.url, 10, select_tables_perf)
-        self.assertEqual(self._get_url_hot_query(self.page.url), 10)
+        self._check_url_hot_query(self.page.url, 8, select_tables_perf)
+        self.assertEqual(self._get_url_hot_query(self.page.url), 8)
 
 @tagged('-at_install', 'post_install')
 class TestWebsitePerformancePost(UtilPerf):

--- a/addons/website/tests/test_website_visitor.py
+++ b/addons/website/tests/test_website_visitor.py
@@ -38,34 +38,34 @@ class WebsiteVisitorTestsCommon(MockVisitor, HttpCaseWithUserDemo):
         untracked_view = self.env['ir.ui.view'].create({
             'name': 'UntackedView',
             'type': 'qweb',
-            'arch': '''<t name="Homepage" t-name="website.base_view">
+            'arch': '''<t name="Homepage" t-name="test.untracked_page">
                         <t t-call="website.layout">
                             I am a generic page²
                         </t>
                     </t>''',
-            'key': 'test.base_view',
+            'key': 'test.untracked_page',
             'track': False,
         })
         tracked_view = self.env['ir.ui.view'].create({
             'name': 'TrackedView',
             'type': 'qweb',
-            'arch': '''<t name="Homepage" t-name="website.base_view">
+            'arch': '''<t name="Homepage" t-name="test.tracked_page">
                         <t t-call="website.layout">
                             I am a generic page
                         </t>
                     </t>''',
-            'key': 'test.base_view',
+            'key': 'test.tracked_page',
             'track': True,
         })
         tracked_view_2 = self.env['ir.ui.view'].create({
             'name': 'TrackedView2',
             'type': 'qweb',
-            'arch': '''<t name="OtherPage" t-name="website.base_view">
+            'arch': '''<t name="OtherPage" t-name="test.tracked_page_2">
                         <t t-call="website.layout">
                             I am a generic second page
                         </t>
                     </t>''',
-            'key': 'test.base_view',
+            'key': 'test.tracked_page_2',
             'track': True,
         })
         [self.untracked_page, self.tracked_page, self.tracked_page_2] = self.env['website.page'].create([

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -88,10 +88,10 @@
             'data-seo-object': repr(seo_object) if seo_object else None,
         }"/>
         <t t-if="not request.env.user._is_public()" t-set="nothing" t-value="html_data.update({
-            'data-is-published': 'website_published' in main_object.fields_get() and main_object.sudo().website_published,
-            'data-can-optimize-seo': 'website_meta_description' in main_object.fields_get(),
-            'data-can-publish': 'can_publish' in main_object.fields_get() and main_object.sudo(False).can_publish,
-            'data-editable-in-backend': edit_in_backend or ('website_published' in main_object.fields_get() and main_object._name != 'website.page'),
+            'data-is-published': 'website_published' in main_object._fields and main_object.sudo().website_published,
+            'data-can-optimize-seo': 'website_meta_description' in main_object._fields,
+            'data-can-publish': 'can_publish' in main_object._fields and main_object.sudo(False).can_publish,
+            'data-editable-in-backend': edit_in_backend or ('website_published' in main_object._fields and main_object._name != 'website.page'),
         })"/>
         <t t-if="editable or translatable" t-set="nothing" t-value="html_data.update({
             'data-editable': '1' if editable else None,

--- a/addons/website_hr_recruitment/models/__init__.py
+++ b/addons/website_hr_recruitment/models/__init__.py
@@ -6,3 +6,4 @@ from . import hr_job
 from . import hr_applicant
 from . import hr_recruitment_source
 from . import website
+from . import website_page

--- a/addons/website_hr_recruitment/models/website_page.py
+++ b/addons/website_hr_recruitment/models/website_page.py
@@ -1,0 +1,13 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models
+
+
+class WebsitePage(models.Model):
+    _inherit = 'website.page'
+
+    @api.model
+    def _allow_to_use_cache(self, request):
+        if request.httprequest.path == '/job-thank-you':
+            return False
+        return super()._allow_to_use_cache(request)

--- a/addons/website_livechat/models/__init__.py
+++ b/addons/website_livechat/models/__init__.py
@@ -8,3 +8,4 @@ from . import discuss_channel
 from . import res_config_settings
 from . import website
 from . import website_visitor
+from . import website_page

--- a/addons/website_livechat/models/website_page.py
+++ b/addons/website_livechat/models/website_page.py
@@ -1,0 +1,12 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models
+
+
+class WebsitePage(models.Model):
+    _inherit = 'website.page'
+
+    @api.model
+    def _post_process_response_from_cache(self, request, response):
+        super()._post_process_response_from_cache(request, response)
+        request.website._get_livechat_channel_info()

--- a/addons/website_project/models/__init__.py
+++ b/addons/website_project/models/__init__.py
@@ -1,3 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import project_task
+from . import website_page

--- a/addons/website_project/models/website_page.py
+++ b/addons/website_project/models/website_page.py
@@ -1,0 +1,13 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models
+
+
+class WebsitePage(models.Model):
+    _inherit = 'website.page'
+
+    @api.model
+    def _allow_to_use_cache(self, request):
+        if request.httprequest.path == '/your-task-has-been-submitted':
+            return False
+        return super()._allow_to_use_cache(request)

--- a/addons/website_sale/models/__init__.py
+++ b/addons/website_sale/models/__init__.py
@@ -26,6 +26,7 @@ from . import sale_order
 from . import sale_order_line
 from . import theme_utils
 from . import website
+from . import website_page
 from . import website_base_unit
 from . import website_checkout_step
 from . import website_menu

--- a/addons/website_sale/models/product_public_category.py
+++ b/addons/website_sale/models/product_public_category.py
@@ -111,8 +111,8 @@ class ProductPublicCategory(models.Model):
     def _compute_has_published_products(self):
         for category in self:
             category.has_published_products = (
-                any(category.mapped('product_tmpl_ids.is_published'))
-                or any(category.mapped('child_id.has_published_products'))
+                any(p.is_published for p in category.product_tmpl_ids)
+                or any(c.has_published_products for c in category.child_id)
             )
 
     # === CONSTRAINT METHODS === #

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -51,8 +51,12 @@ class SaleOrder(models.Model):
 
     @api.depends('order_line')
     def _compute_website_order_line(self):
+        # group saler.order.line to prefetch all in one query
+        order_lines = self.env['sale.order.line'].search_fetch([('order_id', 'in', self.ids)])
         for order in self:
-            order.website_order_line = order.order_line.filtered(lambda sol: sol._show_in_cart())
+            order.website_order_line = order_lines.filtered(
+                lambda sol: sol.order_id == order and sol._show_in_cart(),
+            )
 
     @api.depends('order_line.price_total', 'order_line.price_subtotal')
     def _compute_amount_delivery(self):

--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -9,7 +9,7 @@ from werkzeug import urls
 from werkzeug.exceptions import NotFound
 
 from odoo import SUPERUSER_ID, api, fields, models
-from odoo.exceptions import AccessError
+from odoo.exceptions import AccessError, MissingError
 from odoo.fields import Domain
 from odoo.http import request
 from odoo.tools import file_open, ormcache
@@ -271,7 +271,7 @@ class Website(models.Model):
         for website in self:
             website = website.with_company(website.company_id)
             ProductPricelist = website.env['product.pricelist']  # with correct company in env
-            website.pricelist_ids = ProductPricelist.sudo().search(
+            website.pricelist_ids = ProductPricelist.sudo().search_fetch(
                 ProductPricelist._get_website_pricelists_domain(website)
             )
 
@@ -783,12 +783,19 @@ class Website(models.Model):
         SaleOrderSudo = self.env['sale.order'].sudo()
 
         sale_order_sudo = SaleOrderSudo
-        partner_sudo = self.env.user.partner_id
         if CART_SESSION_CACHE_KEY in request.session:
             sale_order_sudo = SaleOrderSudo.browse(request.session[CART_SESSION_CACHE_KEY])
+
+            try:
+                # fetch the record field or raise a missingError
+                # avoids a query with the use of exists()
+                sale_order_sudo and sale_order_sudo.state
+            except MissingError:
+                self.sale_reset()
+                sale_order_sudo = SaleOrderSudo
+
             if sale_order_sudo and (
-                not sale_order_sudo.exists()
-                or sale_order_sudo.state != 'draft'
+                sale_order_sudo.state != 'draft'
                 or sale_order_sudo.get_portal_last_transaction().state in (
                     'pending', 'authorized', 'done'
                 )
@@ -802,20 +809,21 @@ class Website(models.Model):
             if (
                 sale_order_sudo
                 and not self.env.user._is_public()
-                and partner_sudo.id != sale_order_sudo.partner_id.id
+                and self.env.user.partner_id.id != sale_order_sudo.partner_id.id
                 and not request.env.cr.readonly
             ):
-                sale_order_sudo._update_address(partner_sudo.id, ['partner_id'])
+                sale_order_sudo._update_address(self.env.user.partner_id.id, ['partner_id'])
         elif (
             self.env.user
             and not self.env.user._is_public()
             # If the company of the partner doesn't allow them to buy from this website, updating
             # the cart customer would raise because of multi-company checks.
             # No abandoned cart should be returned in this situation.
-            and partner_sudo.filtered_domain(
+            and self.env.user.partner_id.filtered_domain(
                 self.env['res.partner']._check_company_domain(self.company_id.id)
             )
         ):  # Search for abandonned cart.
+            partner_sudo = self.env.user.partner_id
             abandonned_cart_sudo = SaleOrderSudo.search([
                 ('partner_id', '=', partner_sudo.id),
                 ('website_id', '=', self.id),

--- a/addons/website_sale/models/website_page.py
+++ b/addons/website_sale/models/website_page.py
@@ -1,0 +1,41 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import re
+from odoo import api, models
+
+
+class WebsitePage(models.Model):
+    _inherit = 'website.page'
+
+    @api.model
+    def _allow_cache_insertion(self, layout):
+        return ' data-order-id=' not in layout and super()._allow_cache_insertion(layout)
+
+    @api.model
+    def _post_process_response_from_cache(self, request, response):
+        super()._post_process_response_from_cache(request, response)
+
+        order_id = request.session.get('sale_order_id', '')
+        quantity = request.session.get('website_sale_cart_quantity', 0)
+        if not order_id or not quantity:
+            return
+
+        # update generated html from "webiste_sale.header_cart_link" used on all page
+
+        my_cart_quantity_re = re.compile(r"""
+            <sup\s
+            class="(?P<classname>my_cart_quantity[^"]*)"
+            (?P<attributes>[^>]*?)
+            >
+            (?P<quantity>[^<]*)
+            </sup>
+            """, re.VERBOSE)
+
+        html = response.response[0]
+        cache_quantity = re.search(my_cart_quantity_re, html)
+        classname = cache_quantity.group('classname').replace('d-none', '') + ('' if quantity else 'd-none')
+        attributes = cache_quantity.group('attributes') + (f' data-order-id="{order_id}"' if quantity else '')
+        html_quantity = f'''<sup class="{classname}"{attributes}>{quantity}</sup>'''
+        html = html.replace(cache_quantity.group(0), html_quantity)
+
+        response.response = [html]

--- a/addons/website_sale/tests/test_website_sale_pricelist.py
+++ b/addons/website_sale/tests/test_website_sale_pricelist.py
@@ -38,7 +38,6 @@ class TestWebsitePriceList(WebsiteSaleCommon):
     def setUpClass(cls):
         super().setUpClass()
         cls.env.user.partner_id.country_id = False  # Remove country to avoid property pricelist computed.
-        cls.website.user_id = cls.env.user
 
         cls.pricelist.name = "Public Pricelist" # reduce diff in existing tests
         cls.country_be = cls.env.ref('base.be')

--- a/addons/website_sale/views/delivery_form_templates.xml
+++ b/addons/website_sale/views/delivery_form_templates.xml
@@ -31,7 +31,7 @@
         <t t-set="delivery_type" t-value="dm.delivery_type + '_use_locations'"/>
         <t
             t-set="is_pickup_needed"
-            t-value="delivery_type in dm.fields_get() and dm[delivery_type]"
+            t-value="delivery_type in dm._fields and dm[delivery_type]"
         />
         <div class="d-flex justify-content-between gap-3">
             <div class="form-check flex-grow-1 cursor-pointer">

--- a/addons/website_sale/views/product_tile_templates.xml
+++ b/addons/website_sale/views/product_tile_templates.xml
@@ -56,10 +56,10 @@
                  if variant information should be shown later. -->
             <t
                 t-set="variant"
-                t-value="product_variant or request.env['product.product'].browse(product._get_first_possible_variant_id())"
+                t-value="product_variant or product_variants[product]"
             />
             <t
-                t-if="variant and variant.image_128"
+                t-if="variant and variant.with_context(bin_size=True).image_128"
                 t-set="all_images_list"
                 t-value="variant._get_images()"
             />

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -711,8 +711,9 @@
                                         t-att-data-editor-message="editor_msg"
                                     />
                                 </t>
-                                <t t-if="opt_wsale_categories_top"
+                                <t t-if="opt_wsale_categories_top and category_entries"
                                    t-call="website_sale.filmstrip_categories"
+                                   entries="category_entries"
                                 />
                                 <div
                                     t-if="not opt_wsale_floating_bar"
@@ -804,6 +805,7 @@
                                                     t-value="product._get_ribbon(
                                                         price_vals=template_price_vals,
                                                         auto_assign_ribbons=auto_assign_ribbons,
+                                                        variant=product_variants[product],
                                                     )"
                                                 />
                                                 <div
@@ -1423,21 +1425,7 @@
 
     <!-- Top-Nav Categories -->
     <template id="website_sale.filmstrip_categories" name="Categories Filmstrip">
-        <t t-if="category.id">
-            <t t-set="entries" t-value="not search and category.child_id or category.child_id.filtered(lambda c: category.id in search_categories_ids)"/>
-
-            <t t-if="not entries">
-                <t t-set="parent" t-value="category.parent_id"/>
-                <t t-set="entries" t-value="not search and parent.child_id or parent.child_id.filtered(lambda c: parent.id in search_categories_ids)"/>
-            </t>
-        </t>
-        <t t-else="">
-            <t t-set="entries" t-value="categories"/>
-        </t>
-        <t t-set="entries" t-value="request.env.user._is_internal() and entries or entries.filtered('has_published_products')"/>
-
         <div
-            t-if="entries"
             id="o_wsale_categories_filmstrip"
             class="o_wsale_filmstrip_container o_wsale_filmstrip_default d-flex align-items-stretch overflow-hidden"
             role="navigation"

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -8,7 +8,7 @@
             <a href="/shop/cart" t-attf-class="#{_link_class}" aria-label="eCommerce cart">
                 <div t-attf-class="#{_icon_wrap_class}">
                     <i t-if="_icon" class="fa fa-shopping-cart fa-stack"/>
-                    <sup t-attf-class="my_cart_quantity badge bg-primary #{_badge_class} #{'d-none' if (website_sale_cart_quantity == 0) else ''}" t-out="website_sale_cart_quantity" t-att-data-order-id="request.session.get('sale_order_id', '')"/>
+                    <sup t-attf-class="my_cart_quantity badge bg-primary #{_badge_class} #{'d-none' if (website_sale_cart_quantity == 0) else ''}" t-out="website_sale_cart_quantity" t-att-data-order-id="request.session.get('sale_order_id', None) if website_sale_cart_quantity else None"/>
                 </div>
                 <span t-if="_text" t-attf-class="#{_text_class}">My Cart</span>
             </a>

--- a/odoo/orm/fields_binary.py
+++ b/odoo/orm/fields_binary.py
@@ -158,7 +158,7 @@ class Binary(Field):
         bin_size = records.env.context.get('bin_size')
         data = {
             att.res_id: _encode(human_size(att.file_size)) if bin_size else att.datas
-            for att in records.env['ir.attachment'].sudo().search(domain)
+            for att in records.env['ir.attachment'].sudo().search_fetch(domain)
         }
         self._insert_cache(records, map(data.get, records._ids))
 


### PR DESCRIPTION
Drastic website performance improvements

This Pull Request brings together a series of optimizations designed to significantly improve website performance by reducing database queries and accelerating page rendering.

The key changes are as follows:

Query and Prefetch Optimization: The code has been refactored to make the best use of Odoo's ORM prefetch mechanism. These changes allow for consolidating multiple data fetching queries into a single one, which improves overall efficiency and performance.

XML View Refactoring: The slow fields_get() method has been replaced with the _fields attribute in the template.layout view. This change is sufficient to check for a field's presence without overloading the system with unnecessary processing, resulting in a gain of approximately 8ms per page.

High-level Cache Introduction: A new cache has been added to the website.page model to store published pages. This cache can be controlled via overridable methods (_allow_to_use_cache, _allow_cache_insertion, _post_process_response_from_cache), allowing us to optimize rendering time for static or semi-static content.
This high-level cache on the `website.page` model, similar to the one that existed before the `t-cache` directive was implemented in `ir.qweb`.

see t-cache information and high-level cache (removed when introduce t-cache):
- https://github.com/odoo/odoo/pull/224487
- https://github.com/odoo/odoo/pull/88276
When the previous high-level cache are removed: https://github.com/odoo/odoo/commit/0452d0701fcb8f4588b9b05dad9bbdd507539265