### PR TITLE
[FIX] l10n_din5008: remove phone and vat from DIN

### DIFF
--- a/addons/l10n_din5008/models/account_move.py
+++ b/addons/l10n_din5008/models/account_move.py
@@ -24,6 +24,8 @@ class AccountMove(models.Model):
                 data.append((_("Source"), record.invoice_origin))
             if record.ref:
                 data.append((_("Reference"), record.ref))
+            if record.partner_id.commercial_partner_id == record.partner_id and record.partner_id.commercial_partner_id.vat:
+                data.append((_("VAT"), record.partner_id.commercial_partner_id.vat))
 
     def _compute_l10n_din5008_document_title(self):
         for record in self:

--- a/addons/l10n_din5008/report/din5008_account_move_layout.xml
+++ b/addons/l10n_din5008/report/din5008_account_move_layout.xml
@@ -5,11 +5,7 @@
             <xpath expr="//t[@t-set='address']" position="before">
                 <t t-if="o and o._name == 'account.move' and o.partner_id">
                     <t t-set="address">
-                        <address class="mb-0" t-field="o.partner_id" t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True}'/>
-                        <div t-if="o.partner_id.commercial_partner_id == o.partner_id and o.partner_id.commercial_partner_id.vat" id="partner_vat_address_same_as_shipping">
-                            <t t-if="o.company_id.account_fiscal_country_id.vat_label" t-out="o.company_id.account_fiscal_country_id.vat_label" id="inv_tax_id_label"/>
-                            <t t-else="">Tax ID</t>: <span t-field="o.partner_id.vat"/>
-                        </div>
+                        <address class="mb-0" t-field="o.partner_id" t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}'/>
                     </t>
                 </t>
             </xpath>


### PR DESCRIPTION
This commit removes the phone number from the DIN5008 report layout. The customer's VAT is also no longer displayed in the customer's address section. The VAT is moved to another section.

Description of the issue/feature this PR addresses:

Current behavior before PR:
The customer's phone number and VAT are displayed in the customer's address in the DIN5008 report layout.

Desired behavior after PR is merged:
The customer's phone number is no longer displayed and VAT moved to another section in the DIN5008 report layout.

opw-5049074

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
