### PR TITLE
[FIX] website_sale: keep CarouselProduct indicators centered on load

### DIFF
--- a/addons/website_sale/static/src/interactions/carousel_product.js
+++ b/addons/website_sale/static/src/interactions/carousel_product.js
@@ -75,7 +75,6 @@ export class CarouselProduct extends Interaction {
         let indicatorsPositionDiff = (indicatorPosition + (indicatorSize / 2)) - (indicatorsDivSize / 2);
         indicatorsPositionDiff = Math.min(indicatorsPositionDiff, scrollSize - indicatorsDivSize);
         this.updateJustifyContent();
-        this.updateContent();
         const indicatorsPositionX = isVertical ? "0" : "-" + indicatorsPositionDiff;
         const indicatorsPositionY = isVertical ? "-" + indicatorsPositionDiff : "0";
         const translate3D = indicatorsPositionDiff > 0 ? "translate3d(" + indicatorsPositionX + "px," + indicatorsPositionY + "px,0)" : "";
@@ -86,16 +85,14 @@ export class CarouselProduct extends Interaction {
         this.indicatorJustify = "start";
         if (uiUtils.getSize() <= SIZES.MD) {
             const indicatorsDivEl = this.el.querySelector(".carousel-indicators");
-            const indicatorsDivRect = indicatorsDivEl.getBoundingClientRect();
-            const lastIndicatorEl = indicatorsDivEl.children[indicatorsDivEl.children.length - 1];
-            const lastIndicatorRect = lastIndicatorEl.getBoundingClientRect();
-            const lastIndicatorStyle = window.getComputedStyle(lastIndicatorEl);
-            const firstLiEl = indicatorsDivEl.querySelector("li");
-            const firstLiRect = firstLiEl.getBoundingClientRect();
-            if ((lastIndicatorRect.left - indicatorsDivRect.left - parseFloat(lastIndicatorStyle.marginLeft) + firstLiRect.width) < indicatorsDivRect.width) {
+            const firstIndicatorEl = indicatorsDivEl.firstElementChild;
+            const lastIndicatorEl = indicatorsDivEl.lastElementChild;
+            const { left: lastIndicatorLeft } = lastIndicatorEl.getBoundingClientRect();
+            if (lastIndicatorLeft + firstIndicatorEl.offsetWidth < indicatorsDivEl.offsetWidth) {
                 this.indicatorJustify = "center";
             }
         }
+        this.updateContent();
     }
 
     /**


### PR DESCRIPTION
Since the introduction of interactions with [22e777c] in 18.2, the
indicators on the CarouselProduct interaction were wrongly computed on
mobile: on page load, the indicators appeared on the left instead of
centered.

This is because an explicit `updateContent()` has to be done at the end
of the `updateJustifyContent` method, since it modifies a parameter that
impacts the `dynamicContent`.

We also take the opportunity to simplify the code of
`updateJustifyContent`, which became needlessly complicated after
[22e777c].

[22e777c]: https://github.com/odoo/odoo/commit/22e777c046521f3f89b62caa5876680beb7f5aba

task-5080057