### PR TITLE
[FIX] hr: align state field with city and zip in private address

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -294,11 +294,13 @@
                                         <div class="o_address_format">
                                             <field name="private_street" placeholder="Street..." class="o_address_street"/>
                                             <field name="private_street2" placeholder="Street 2..." class="o_address_street"/>
-                                            <field name="private_city" placeholder="City" class="o_address_city"/>
-                                            <field name="private_state_id" class="o_address_state" placeholder="State" 
-                                                options='{"no_open": True, "no_create": True}' context="{'default_country_id': private_country_id}"
-                                                domain="[('id', 'in', allowed_country_state_ids)]"/>
-                                            <field name="private_zip" placeholder="ZIP" class="o_address_zip"/>
+                                            <div class="d-flex align-items-center">
+                                                <field name="private_city" placeholder="City" class="o_address_city"/>
+                                                <field name="private_state_id" class="o_address_state" placeholder="State" 
+                                                    options='{"no_open": True, "no_create": True}' context="{'default_country_id': private_country_id}"
+                                                    domain="[('id', 'in', allowed_country_state_ids)]"/>
+                                                <field name="private_zip" placeholder="ZIP" class="o_address_zip"/>
+                                            </div>
                                             <field name="private_country_id" placeholder="Country" class="o_address_country" options='{"no_open": True, "no_create": True}'/>
                                         </div>
                                         <label for="distance_home_work"/>


### PR DESCRIPTION
Wrap private address city, state, and zip fields in a flexbox container to ensure proper horizontal alignment on the employee form view.

task-5082714