### PR TITLE
[FIX] website_*: allow registration to slots on all pages of an event

### DIFF
--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -6,7 +6,6 @@ import werkzeug
 
 from ast import literal_eval
 from collections import Counter
-from datetime import datetime
 from werkzeug.exceptions import NotFound
 
 from odoo import fields, http, _
@@ -216,20 +215,12 @@ class WebsiteEventController(http.Controller):
         urls = lazy(event._get_event_resource_urls)
         return {
             'event': event,
-            'slots': event.event_slot_ids.filtered(
-                        lambda s: s.start_datetime > datetime.now()
-                        and any(
-                            availability is None or availability > 0
-                            for availability in event._get_seats_availability([
-                                (s, ticket) for ticket in event.event_ticket_ids or [False]
-                            ])
-                        )
-                    ).grouped('date'),
             'main_object': event,
             'range': range,
             'google_url': lazy(lambda: urls.get('google_url')),
             'iCal_url': lazy(lambda: urls.get('iCal_url')),
             'registration_error_code': post.get('registration_error_code'),
+            'slots': event.event_slot_ids._filter_open_slots().grouped('date'),
             'website_visitor_timezone': request.env['website.visitor']._get_visitor_timezone(),
         }
 
@@ -477,6 +468,7 @@ class WebsiteEventController(http.Controller):
             'google_url': urls.get('google_url'),
             'iCal_url': urls.get('iCal_url'),
             'slot': slot,
+            'slots': event.event_slot_ids._filter_open_slots().grouped('date'),
             'website_visitor_timezone': request.env['website.visitor']._get_visitor_timezone(),
         }
 

--- a/addons/website_event/models/__init__.py
+++ b/addons/website_event/models/__init__.py
@@ -3,6 +3,7 @@
 
 from . import event_event
 from . import event_registration
+from . import event_slot
 from . import event_tag_category
 from . import event_tag
 from . import event_type

--- a/addons/website_event/models/event_slot.py
+++ b/addons/website_event/models/event_slot.py
@@ -1,0 +1,18 @@
+from datetime import datetime
+
+from odoo import models
+
+
+class EventSlot(models.Model):
+    _inherit = "event.slot"
+
+    def _filter_open_slots(self):
+        return self.filtered(
+            lambda slot: slot.start_datetime > datetime.now()
+            and any(
+                availability is None or availability > 0
+                for availability in slot.event_id._get_seats_availability([
+                    (slot, ticket) for ticket in slot.event_id.event_ticket_ids or [False]
+                ])
+            )
+        )

--- a/addons/website_event_booth/controllers/event_booth.py
+++ b/addons/website_event_booth/controllers/event_booth.py
@@ -73,6 +73,7 @@ class WebsiteEventBoothController(WebsiteEventController):
             'event_booths': event_booths,
             'hide_sponsors': True,
             'redirect_url': werkzeug.urls.url_quote(request.httprequest.full_path),
+            'slots': event.event_slot_ids._filter_open_slots().grouped('date'),
         }
 
     @http.route('/event/<model("event.event"):event>/booth/confirm',
@@ -130,6 +131,7 @@ class WebsiteEventBoothController(WebsiteEventController):
             'main_object': event_sudo,
             'selected_booth_category_id': (chosen_booth_category or default_booth_category).id,
             'selected_booth_ids': booth_ids if booth_category_id == chosen_booth_category.id and booth_ids else False,
+            'slots': event.event_slot_ids._filter_open_slots().grouped('date'),
         }
 
     def _prepare_booth_registration_values(self, event, kwargs):

--- a/addons/website_event_exhibitor/controllers/exhibitor.py
+++ b/addons/website_event_exhibitor/controllers/exhibitor.py
@@ -106,6 +106,7 @@ class ExhibitorController(WebsiteEventController):
             # event information
             'event': event,
             'main_object': event,
+            'slots': event.event_slot_ids._filter_open_slots().grouped('date'),
             'sponsor_categories': sponsor_categories,
             'hide_sponsors': True,
             # search information
@@ -162,6 +163,7 @@ class ExhibitorController(WebsiteEventController):
             # event information
             'event': event,
             'main_object': sponsor,
+            'slots': event.event_slot_ids._filter_open_slots().grouped('date'),
             'sponsor': sponsor,
             'hide_sponsors': True,
             # sidebar

--- a/addons/website_event_track/controllers/event_track.py
+++ b/addons/website_event_track/controllers/event_track.py
@@ -164,6 +164,7 @@ class EventTrackController(http.Controller):
             # event information
             'event': event,
             'main_object': event,
+            'slots': event.event_slot_ids._filter_open_slots().grouped('date'),
             # tracks display information
             'tracks': tracks_sudo,
             'tracks_by_day': tracks_by_day,
@@ -196,6 +197,7 @@ class EventTrackController(http.Controller):
             'event': event,
             'main_object': event,
             'seo_object': seo_object,
+            'slots': event.event_slot_ids._filter_open_slots().grouped('date'),
             'tag': tag,
             'is_event_user': request.env.user.has_group('event.group_event_user'),
             'website_visitor_timezone': request.env['website.visitor']._get_visitor_timezone(),
@@ -385,6 +387,7 @@ class EventTrackController(http.Controller):
             # event information
             'event': event,
             'main_object': track,
+            'slots': event.event_slot_ids._filter_open_slots().grouped('date'),
             'track': track,
             # sidebar
             'tracks_other': tracks_other,
@@ -466,6 +469,7 @@ class EventTrackController(http.Controller):
             'event': event,
             'main_object': event,
             'seo_object': event.track_proposal_menu_ids,
+            'slots': event.event_slot_ids._filter_open_slots().grouped('date'),
         })
 
     @http.route(['''/event/<model("event.event"):event>/track_proposal/post'''], type='http', auth="public", methods=['POST'], website=True)

--- a/addons/website_event_track_quiz/controllers/community.py
+++ b/addons/website_event_track_quiz/controllers/community.py
@@ -33,7 +33,7 @@ class WebsiteEventTrackQuizCommunityController(EventCommunityController):
 
     def _get_community_leaderboard_render_values(self, event, search_term, page):
         values = self._get_leaderboard(event, search_term)
-        values.update({'event': event, 'search': search_term})
+        values.update({'event': event, 'search': search_term, 'slots': event.event_slot_ids._filter_open_slots().grouped('date')})
 
         user_count = len(values['visitors'])
         if user_count:


### PR DESCRIPTION
* = event, event_booth, event_exhibitor, event_track, event_track_quiz

The "register" button displays open slots only on the registration page of an event, and not on the other pages of this one. This PR fixes this issue by making available the open slots from the event.event model for the modal_slot_registration template as an instance of this one is always present in the context of those pages.

Reproduce:
Create an event with the "Multiple Slots" option checked and link it to a slot of tomorrow. The "register" button will display the slot on the registration page of the event but not on the page of the talks.

Task-5083175