### PR TITLE
[FIX] website: prevent Safari from prematurely closing dropdown on focusout

### DIFF
--- a/addons/website/static/src/client_actions/configurator/configurator.js
+++ b/addons/website/static/src/client_actions/configurator/configurator.js
@@ -28,6 +28,7 @@ import {
 import { standardActionServiceProps } from "@web/webclient/actions/action_service";
 import { addLoadingEffect as addButtonLoadingEffect } from "@web/core/utils/ui";
 import { fuzzyLevenshteinLookup } from "@web/core/utils/search";
+import { isBrowserSafari } from "@web/core/browser/feature_detection";
 
 export const ROUTES = {
     descriptionScreen: 2,
@@ -362,9 +363,14 @@ export class DescriptionScreen extends Component {
      * @param {FocusEvent} ev
      */
     onDropdownFocusout(ev) {
-        if (ev.relatedTarget?.closest(".dropdown") !== ev.currentTarget) {
-            window.Dropdown.getOrCreateInstance(ev.currentTarget).hide();
-        }
+        const dropdown = ev.currentTarget;
+        const delay = isBrowserSafari() ? 100 : 0;
+
+        setTimeout(() => {
+            if (dropdown && !dropdown.contains(document.activeElement)) {
+                window.Dropdown.getOrCreateInstance(dropdown).hide();
+            }
+        }, delay);
     }
 
     onAutocompleteInput({ inputValue }) {


### PR DESCRIPTION
Problem
In Safari, when selecting a website type from the dropdown, the menu
closes immediately before the selection registers, so the user cannot
choose an option.

Steps to reproduce
1. Open Odoo in Safari.
2. Navigate to Website > Create new website.
3. At the step "I want [dropdown] for my ...", click the dropdown.
4. Try to select a website type (e.g., blog, store).
→ The dropdown closes immediately and the selection is not made.

Cause
Safari’s `focusout` event fires before `document.activeElement` is
updated. This makes the logic
`if (!dropdown.contains(document.activeElement)) hide();`
evaluate incorrectly and close the dropdown too early.

This is a known WebKit bug:
- WebKit Bug 22261 — *Clicking on a non-text input element does not give it focus*  
  https://bugs.webkit.org/show_bug.cgi?id=22261
- See also *Fixing Focus for Safari*  
  https://scribe.rip/itnext.io/fixing-focus-for-safari-b5916fef1064

Fix
Delay the dropdown closing with `setTimeout` and apply it only for Safari
(using `isBrowserSafari()`), to ensure `document.activeElement` is
properly updated before checking containment.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
