### PR TITLE
[FIX] hr_work_entry: work entries with different calendar types

### DIFF
--- a/addons/hr_contract/models/hr_employee.py
+++ b/addons/hr_contract/models/hr_employee.py
@@ -141,9 +141,9 @@ class Employee(models.Model):
         for contract in contracts:
             contracts_by_employee[contract.employee_id] += contract
         for employee in self:
-            employee_contracts = contracts_by_employee[employee.id]
+            employee_contracts = contracts_by_employee[employee]
             if employee_contracts:
-                res[employee.id] = contracts[0].resource_calendar_id.sudo(False)
+                res[employee.id] = employee_contracts[0].resource_calendar_id.sudo(False)
         return res
 
     def _get_calendar_periods(self, start, stop):

--- a/addons/hr_contract/models/resource_resource.py
+++ b/addons/hr_contract/models/resource_resource.py
@@ -54,3 +54,11 @@ class ResourceResource(models.Model):
                 self.env['resource.calendar.attendance']
             )])
         return calendars_within_period_per_resource
+
+    def _get_calendar_at(self, date_target, tz=False):
+        result = super()._get_calendar_at(date_target)
+        resources_with_employee = self.filtered(lambda r: r.employee_id)
+        employee_calendars = resources_with_employee.employee_id._get_calendars(date_target.astimezone(tz))
+        for resource in resources_with_employee:
+            result[resource] = employee_calendars[resource.employee_id.id]
+        return result

--- a/addons/hr_contract/tests/test_resource.py
+++ b/addons/hr_contract/tests/test_resource.py
@@ -100,7 +100,7 @@ class TestResource(TestContractCommon):
 
         start = utc.localize(datetime(2021, 9, 1, 0, 0, 0))
         end = utc.localize(datetime(2021, 11, 30, 23, 59, 59))
-        with self.assertQueryCount(15):
+        with self.assertQueryCount(18):
             work_intervals, _ = (employees_test | self.employee).resource_id._get_valid_work_intervals(start, end)
 
         self.assertEqual(len(work_intervals), 51)

--- a/addons/hr_work_entry_contract/models/hr_work_entry.py
+++ b/addons/hr_work_entry_contract/models/hr_work_entry.py
@@ -172,7 +172,10 @@ class HrWorkEntry(models.Model):
             datetime_start = min(entries.mapped('date_start'))
             datetime_stop = max(entries.mapped('date_stop'))
 
-            calendar_intervals = calendar._attendance_intervals_batch(pytz.utc.localize(datetime_start), pytz.utc.localize(datetime_stop))[False]
+            if calendar:
+                calendar_intervals = calendar._attendance_intervals_batch(pytz.utc.localize(datetime_start), pytz.utc.localize(datetime_stop))[False]
+            else:
+                calendar_intervals = WorkIntervals([(pytz.utc.localize(datetime_start), pytz.utc.localize(datetime_stop), self.env['resource.calendar.attendance'])])
             entries_intervals = entries._to_intervals()
             overlapping_entries = self._from_intervals(entries_intervals & calendar_intervals)
             outside_entries |= entries - overlapping_entries

--- a/addons/hr_work_entry_contract/tests/test_work_entry.py
+++ b/addons/hr_work_entry_contract/tests/test_work_entry.py
@@ -1,7 +1,7 @@
 # # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from datetime import datetime
+from datetime import date, datetime
 from dateutil.relativedelta import relativedelta
 from psycopg2 import IntegrityError
 import pytz
@@ -358,3 +358,168 @@ class TestWorkEntry(TestWorkEntryBase):
         self.assertEqual(work_entry.duration, 1, "The duration should be 1 hour")
         self.assertEqual(one_day_entry.duration, 24.5, "Duration should be 24 hours and half an hour")
         self.assertEqual(multi_day_entry.duration, 169, "Duration should be 169 hours (7 days and one hour)")
+
+    def test_work_entry_different_calendars(self):
+        """ Test work entries are correctly created for employees with contracts that have different calendar types. """
+        flexible_calendar = self.env['resource.calendar'].create({
+            'name': 'flexible calendar',
+            'flexible_hours': True,
+            'full_time_required_hours': 21,
+            'hours_per_day': 3,
+        })
+        # create 4 employees that have contracts corresponding to these 4 cases:
+        # flexible calendar then standard calendar
+        # standard calendar then flexible calendar
+        # no calendar (fully flexible) then standard calendar
+        # standard calendar then no calendar (fully flexible)
+        # the cases of flexible then fully flexible and fully flexible then flexible are similar in logic to the last 2
+        # so they should work if last 2 are working properly
+        emp_flex_std, emp_std_flex, emp_fullyflex_std, emp_std_fullyflex = self.env['hr.employee'].create([
+            {'name': 'emp flex std'},
+            {'name': 'emp std flex'},
+            {'name': 'emp fullyflex std'},
+            {'name': 'emp fullyflex std'},
+        ])
+        self.env['hr.contract'].create([{
+            'employee_id': emp_flex_std.id,
+            'resource_calendar_id': flexible_calendar.id,
+            'date_start': datetime(2025, 9, 1),
+            'date_end': datetime(2025, 9, 15),
+            'name': 'Flex Contract',
+            'wage': 5000.0,
+            'state': 'open',
+        },
+        {
+            'employee_id': emp_flex_std.id,
+            'resource_calendar_id': self.resource_calendar_id.id,
+            'date_start': datetime(2025, 9, 16),
+            'date_end': datetime(2025, 9, 30),
+            'name': 'Std Contract',
+            'wage': 5000.0,
+            'state': 'open',
+        },
+        {
+            'employee_id': emp_std_flex.id,
+            'resource_calendar_id': self.resource_calendar_id.id,
+            'date_start': datetime(2025, 9, 1),
+            'date_end': datetime(2025, 9, 15),
+            'name': 'Std Contract',
+            'wage': 5000.0,
+            'state': 'open',
+        },
+        {
+            'employee_id': emp_std_flex.id,
+            'resource_calendar_id': flexible_calendar.id,
+            'date_start': datetime(2025, 9, 16),
+            'date_end': datetime(2025, 9, 30),
+            'name': 'Flex Contract',
+            'wage': 5000.0,
+            'state': 'open',
+        },
+        {
+            'employee_id': emp_fullyflex_std.id,
+            'resource_calendar_id': False,
+            'date_start': datetime(2025, 9, 1),
+            'date_end': datetime(2025, 9, 15),
+            'name': 'FullyFlex Contract',
+            'wage': 5000.0,
+            'state': 'open',
+        },
+        {
+            'employee_id': emp_fullyflex_std.id,
+            'resource_calendar_id': self.resource_calendar_id.id,
+            'date_start': datetime(2025, 9, 16),
+            'date_end': datetime(2025, 9, 30),
+            'name': 'Std Contract',
+            'wage': 5000.0,
+            'state': 'open',
+        },
+        {
+            'employee_id': emp_std_fullyflex.id,
+            'resource_calendar_id': self.resource_calendar_id.id,
+            'date_start': datetime(2025, 9, 1),
+            'date_end': datetime(2025, 9, 15),
+            'name': 'Std Contract',
+            'wage': 5000.0,
+            'state': 'open',
+        },
+        {
+            'employee_id': emp_std_fullyflex.id,
+            'resource_calendar_id': False,
+            'date_start': datetime(2025, 9, 16),
+            'date_end': datetime(2025, 9, 30),
+            'name': 'FullyFlex Contract',
+            'wage': 5000.0,
+            'state': 'open',
+        }])
+
+        # localizing the used dates to the timezones of the employees
+        tz = self.tz
+        half1_date_start = tz.localize(datetime(2025, 9, 1, 0, 0))
+        half1_date_end = tz.localize(datetime(2025, 9, 15, 23, 59, 59, 999999))
+        half2_date_start = tz.localize(datetime(2025, 9, 16, 0, 0))
+        half2_date_end = tz.localize(datetime(2025, 9, 30, 23, 59, 59, 999999))
+
+        # generate work entries for the 4 employees between (2025, 9, 1) and (2025, 9, 30)
+        # then split them into 2 halves (each half corresponding to the work entries generated by 1 contract)
+        # the timezones are considered in the split
+        all_work_entries = (emp_flex_std + emp_std_flex + emp_fullyflex_std + emp_std_fullyflex).generate_work_entries(date(2025, 9, 1), date(2025, 9, 30))
+        flex_std_work_entries = all_work_entries.filtered(lambda e: e.employee_id == emp_flex_std)
+        self.assertEqual(len(flex_std_work_entries), 37)
+        half1_entries = flex_std_work_entries.filtered(lambda e:
+            e.date_start.astimezone(tz) >= half1_date_start
+            and e.date_stop.astimezone(tz) <= half1_date_end)
+        half2_entries = flex_std_work_entries.filtered(lambda e:
+            e.date_start.astimezone(tz) >= half2_date_start
+            and e.date_stop.astimezone(tz) <= half2_date_end)
+        self.assertEqual(len(half1_entries), 15)  # 1 work entry per day (including weekend)
+        self.assertTrue(all(entry.duration == 3 for entry in half1_entries))
+        self.assertTrue(all(entry.contract_id.name == 'Flex Contract' for entry in half1_entries))
+        self.assertEqual(len(half2_entries), 22)  # 2 work entries per day, no work entries for weekend
+        self.assertTrue(all(entry.duration == 4 for entry in half2_entries))
+        self.assertTrue(all(entry.contract_id.name == 'Std Contract' for entry in half2_entries))
+
+        std_flex_work_entries = all_work_entries.filtered(lambda e: e.employee_id == emp_std_flex)
+        self.assertEqual(len(std_flex_work_entries), 37)
+        half1_entries = std_flex_work_entries.filtered(lambda e:
+            e.date_start.astimezone(tz) >= half1_date_start
+            and e.date_stop.astimezone(tz) <= half1_date_end)
+        half2_entries = std_flex_work_entries.filtered(lambda e:
+            e.date_start.astimezone(tz) >= half2_date_start
+            and e.date_stop.astimezone(tz) <= half2_date_end)
+        self.assertEqual(len(half1_entries), 22)  # 2 work entries per day, no work entries for weekend
+        self.assertTrue(all(entry.duration == 4 for entry in half1_entries))
+        self.assertTrue(all(entry.contract_id.name == 'Std Contract' for entry in half1_entries))
+        self.assertEqual(len(half2_entries), 15)  # 1 work entry per day (including weekend)
+        self.assertTrue(all(entry.duration == 3 for entry in half2_entries))
+        self.assertTrue(all(entry.contract_id.name == 'Flex Contract' for entry in half2_entries))
+
+        fullyflex_std_work_entries = all_work_entries.filtered(lambda e: e.employee_id == emp_fullyflex_std)
+        self.assertEqual(len(fullyflex_std_work_entries), 23)
+        half1_entries = fullyflex_std_work_entries.filtered(lambda e:
+            e.date_start.astimezone(tz) >= half1_date_start
+            and e.date_stop.astimezone(tz) <= half1_date_end)
+        half2_entries = fullyflex_std_work_entries.filtered(lambda e:
+            e.date_start.astimezone(tz) >= half2_date_start
+            and e.date_stop.astimezone(tz) <= half2_date_end)
+        self.assertEqual(len(half1_entries), 1)  # 1 work entry for the entire duration
+        self.assertEqual(half1_entries.duration, 15 * 24)
+        self.assertTrue(all(entry.contract_id.name == 'FullyFlex Contract' for entry in half1_entries))
+        self.assertEqual(len(half2_entries), 22)  # 2 work entries per day, no work entries for weekend
+        self.assertTrue(all(entry.duration == 4 for entry in half2_entries))
+        self.assertTrue(all(entry.contract_id.name == 'Std Contract' for entry in half2_entries))
+
+        std_fullyflex_work_entries = all_work_entries.filtered(lambda e: e.employee_id == emp_std_fullyflex)
+        self.assertEqual(len(std_fullyflex_work_entries), 23)
+        half1_entries = std_fullyflex_work_entries.filtered(lambda e:
+            e.date_start.astimezone(tz) >= half1_date_start
+            and e.date_stop.astimezone(tz) <= half1_date_end)
+        half2_entries = std_fullyflex_work_entries.filtered(lambda e:
+            e.date_start.astimezone(tz) >= half2_date_start
+            and e.date_stop.astimezone(tz) <= half2_date_end)
+        self.assertEqual(len(half1_entries), 22)  # 2 work entries per day, no work entries for weekend
+        self.assertTrue(all(entry.duration == 4 for entry in half1_entries))
+        self.assertTrue(all(entry.contract_id.name == 'Std Contract' for entry in half1_entries))
+        self.assertEqual(len(half2_entries), 1)  # 1 work entry for the entire duration
+        self.assertEqual(half2_entries.duration, 15 * 24)
+        self.assertTrue(all(entry.contract_id.name == 'FullyFlex Contract' for entry in half2_entries))

--- a/addons/hr_work_entry_holidays/tests/test_performance.py
+++ b/addons/hr_work_entry_holidays/tests/test_performance.py
@@ -32,7 +32,7 @@ class TestWorkEntryHolidaysPerformance(TestWorkEntryHolidaysBase):
         self.richard_emp.generate_work_entries(date(2018, 1, 1), date(2018, 1, 2))
         leave = self.create_leave(datetime(2018, 1, 1, 7, 0), datetime(2018, 1, 1, 18, 0))
 
-        with self.assertQueryCount(__system__=117, admin=118):  # com 96/97
+        with self.assertQueryCount(__system__=118, admin=119):  # com 96/97
             leave.action_validate()
         leave.action_refuse()
 

--- a/addons/resource/models/resource_resource.py
+++ b/addons/resource/models/resource_resource.py
@@ -215,6 +215,9 @@ class ResourceResource(models.Model):
         self.ensure_one()
         return not self.calendar_id
 
+    def _get_calendar_at(self, date_target, tz=False):
+        return {resource: resource.calendar_id for resource in self}
+
     def _is_flexible(self):
         """ An employee is considered flexible if the field flexible_hours is True on the calendar
             or the employee is not assigned any calendar, in which case is considered as Fully flexible.


### PR DESCRIPTION
- fix work entries generation for employees with different working schedules types
- made work entries generation check for employee timezone in case the employee is fully flexible and doesn't have a calendar
- added method `_get_calendar_at` to get the calendar of the resource at a given date
- added `test_work_entry_different_calendars` for work entries generation for employees with contracts with different calendar types

task-id: 5065160