### PR TITLE
[IMP] mail: show live chat status in messaging menu item

### DIFF
--- a/addons/im_livechat/static/src/core/web/discuss_sidebar_category_patch.xml
+++ b/addons/im_livechat/static/src/core/web/discuss_sidebar_category_patch.xml
@@ -27,9 +27,9 @@
     <t t-name="im_livechat.LivechatStatusLabelOfThread">
         <t t-set="livechatThread" t-value="templateParams.livechatThread"/>
         <span t-if="livechatThread.channel_type === 'livechat' and (['waiting', 'need_help'].includes(livechatThread.livechat_status) or livechatThread.livechat_end_dt)" class="o-livechat-LivechatStatusLabel" t-att-title="livechatThread.livechatStatusLabel" t-att-class="{
-            'position-absolute top-0 start-0': env.inDiscussSidebar or env.inChatBubble,
+            'position-absolute top-0 start-0': env.inDiscussSidebar or env.inChatBubble or env.inNotificationItem,
             'o-livechat-LivechatStatusLabel-Sidebar end-0 bottom-0 rounded-2 border': env.inDiscussSidebar,
-            'm-n2 z-1': env.inChatBubble,
+            'm-n2 z-1 bg-opacity-100': env.inChatBubble or env.inNotificationItem,
             'text-warning': livechatThread.livechat_status === 'waiting',
             'o-help': livechatThread.livechat_status === 'need_help',
             'bg-warning': livechatThread.livechat_status === 'waiting' and env.inDiscussSidebar,

--- a/addons/im_livechat/static/src/core/web/notification_item_patch.xml
+++ b/addons/im_livechat/static/src/core/web/notification_item_patch.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-inherit="mail.NotificationItem" t-inherit-mode="extension">
+        <xpath expr="//*[hasclass('o-mail-NotificationItem-avatarContainer')]" position="inside">
+            <t t-if="props.thread?.channel_type === 'livechat'" t-call="im_livechat.LivechatStatusLabelOfThread">
+                <t t-set="templateParams" t-value="{ livechatThread: props.thread }"/>
+            </t>
+        </xpath>
+    </t>
+</templates>

--- a/addons/im_livechat/static/tests/livechat_channel_info_list.test.js
+++ b/addons/im_livechat/static/tests/livechat_channel_info_list.test.js
@@ -107,6 +107,11 @@ test("shows live chat status in discuss sidebar", async () => {
     await click(".o-livechat-ChannelInfoList button", { text: "Looking for help" });
     await contains(".o-livechat-ChannelInfoList button.active", { text: "Looking for help" });
     await contains(".o-mail-DiscussSidebar-item span[title='Looking for help']");
+    // live chat status icon also in messaging menu item
+    await click(".o_menu_systray i[aria-label='Messages']");
+    await contains(
+        ".o-mail-MessagingMenu .o-mail-NotificationItem:contains('Visitor #20') [title='Looking for help']"
+    );
 });
 
 test("editing livechat status is synced between tabs", async () => {

--- a/addons/mail/static/src/core/public_web/messaging_menu.xml
+++ b/addons/mail/static/src/core/public_web/messaging_menu.xml
@@ -25,6 +25,7 @@
                     onSwipeLeft="hasTouch() and canUnpinItem(thread) ? { action: () => thread.unpin(), icon: 'fa-times-circle', bgColor: 'bg-danger' } : undefined"
                     nameMaxLine="1"
                     textMaxLine="2"
+                    thread="thread"
                 >
                     <t t-set-slot="name">
                         <div t-if="thread.parent_channel_id" class="d-flex align-items-center">

--- a/addons/mail/static/src/core/public_web/notification_item.js
+++ b/addons/mail/static/src/core/public_web/notification_item.js
@@ -1,8 +1,7 @@
-import { ImStatus } from "@mail/core/common/im_status";
 import { isToday } from "@mail/utils/common/dates";
 import { useHover } from "@mail/utils/common/hooks";
 
-import { Component, useRef } from "@odoo/owl";
+import { Component, useRef, useSubEnv } from "@odoo/owl";
 
 import { ActionSwiper } from "@web/core/action_swiper/action_swiper";
 import { useService } from "@web/core/utils/hooks";
@@ -10,7 +9,7 @@ import { useService } from "@web/core/utils/hooks";
 const { DateTime } = luxon;
 
 export class NotificationItem extends Component {
-    static components = { ActionSwiper, ImStatus };
+    static components = { ActionSwiper };
     static props = [
         "counter?",
         "datetime?",
@@ -26,6 +25,7 @@ export class NotificationItem extends Component {
         "isActive?",
         "nameMaxLine?",
         "textMaxLine?",
+        "thread?",
     ];
     static defaultProps = {
         counter: 0,
@@ -38,8 +38,10 @@ export class NotificationItem extends Component {
         this.isToday = isToday;
         this.DateTime = DateTime;
         this.ui = useService("ui");
+        this.store = useService("mail.store");
         this.markAsReadRef = useRef("markAsRead");
         this.rootHover = useHover("root");
+        useSubEnv({ inNotificationItem: true });
     }
 
     get dateText() {


### PR DESCRIPTION
Live chat status icon is visible in discuss sidebar, in chat window header, in chat bubble... It's missing in messaging menu, which this commit fixes.

Before
<img width="479" height="612" alt="Screenshot 2025-09-11 at 17 33 23" src="https://github.com/user-attachments/assets/100c19e9-fb37-4def-822e-ed8886e87a83" />

After
<img width="481" height="612" alt="Screenshot 2025-09-11 at 17 32 45" src="https://github.com/user-attachments/assets/57947070-e31d-4629-8114-7ae6e3d6ce97" />
