### PR TITLE
[IMP] mail: small discuss (composer) style improvements

### DIFF
--- a/addons/mail/static/src/core/common/action_list.js
+++ b/addons/mail/static/src/core/common/action_list.js
@@ -18,7 +18,7 @@ const actionListProps = [
 class Action extends Component {
     static props = [
         "action",
-        "group",
+        "group?",
         "isFirstInGroup?",
         "isLastInGroup?",
         "style?",
@@ -53,10 +53,6 @@ class Action extends Component {
 
     get action() {
         return this.props.action;
-    }
-
-    get groupSize() {
-        return this.props.group.length;
     }
 
     get hasBtnBg() {

--- a/addons/mail/static/src/core/common/action_list.xml
+++ b/addons/mail/static/src/core/common/action_list.xml
@@ -60,9 +60,9 @@
         'p-1 d-flex align-items-center': props.inline and hasBtnBg and action.tags.includes('JOIN_LEAVE_CALL') and env.inChatWindow,
         'o-inline': props.inline,
         'p-0': props.inline and !hasBtnBg and !env.inComposer,
-        'p-1': props.inline and !hasBtnBg and !(ui.isSmall and props.inline) and env.inComposer,
-        'border-0': props.inline and !hasBtnBg and (action.iconLage ?? action.icon),
-        'border-2 o-px-0_5 o-mx-0_5': props.inline and !hasBtnBg and !(action.iconLage ?? action.icon),
+        'p-1': props.inline and !hasBtnBg and env.inComposer,
+        'border-0': props.inline and !hasBtnBg and action.icon,
+        'border-2 o-px-0_5 o-mx-0_5': props.inline and !hasBtnBg and !action.icon,
         'px-3 py-2': props.dropdown and ui.isSmall,
         'py-1': props.dropdown and !ui.isSmall,
         'text-start px-2': !props.inline and !ui.isSmall,
@@ -74,7 +74,7 @@
     })"/>
     <t t-set="attrs" t-value="{ 'aria-label': action.name, 'disabled': action.disabledCondition, 'name': action.id, 'data-sequence': action.sequence, 'data-sequence-group': action.sequenceGroup, 'data-sequence-quick': action.sequenceQuick }"/>
     <t t-if="action.component and action.componentCondition" t-component="action.component" t-props="action.componentProps"/>
-    <DropdownItem t-elif="props.dropdown" class="btnClass + ' d-flex align-items-center gap-1'" tag="'button'" onSelected="(ev) => this.onSelected(action, ev)" attrs="attrs">
+    <DropdownItem t-elif="props.dropdown" class="btnClass + ' d-flex align-items-center ' + (ui.isSmall ? 'gap-2' : 'gap-1')" tag="'button'" onSelected="(ev) => this.onSelected(action, ev)" attrs="attrs">
         <t t-call="mail.Action.content"/>
     </DropdownItem>
     <button t-else="" t-att-class="btnClass" t-att="Object.assign(attrs, { 'title': action.name })" t-on-click="(ev) => this.onSelected(action, ev)" t-att-data-hotkey="action.hotkey" t-att-style="props.style">

--- a/addons/mail/static/src/core/common/composer.scss
+++ b/addons/mail/static/src/core/common/composer.scss
@@ -61,7 +61,9 @@
             padding: map-get($spacers, 2) !important;
         }
         &.o-sendMessageActive {
-            background-color: $primary;
+            background-color: lighten($primary, 7.5%);
+            outline: 1px solid $primary;
+            outline-offset: -1px;
             opacity: 100% !important;
             &:focus-visible {
                 outline: darken($o-action, 15%) solid 1px;
@@ -220,7 +222,7 @@
     }
 
     &:has(textarea:focus) {
-        --border-color: #{$o-component-active-border};
+        --border-color: #{rgba($o-component-active-border, .65)};
     }
 
     &:has(.o-mail-Composer-html:focus) {


### PR DESCRIPTION
1. Send button in discuss app and chat window has lighter primary color so this looks best in white and dark theme in addition to green outline on input focus

2. Send button has darker outline, so the button feels slightly smaller so it has more visual spacing with input

3. input focus outline has its effect reduced (100% to 65%), so this is less distracting especially in dark theme

4. Composer buttons in mobile are rounded and no oval-shaped.

5. Discuss actions in bottom sheet have better (more) spacing in-between icon and label

Before / After
<img width="456" height="799" alt="Screenshot 2025-09-12 at 14 44 19" src="https://github.com/user-attachments/assets/5db8971a-bf1b-4269-b4dd-19a0632d3a7b" />
<img width="454" height="798" alt="Screenshot 2025-09-12 at 18 05 19" src="https://github.com/user-attachments/assets/2965e6ab-57dd-4861-86e1-3a6ccb6cccc7" />


Before / After
<img width="445" height="800" alt="Screenshot 2025-09-12 at 14 44 30" src="https://github.com/user-attachments/assets/9e8d9b7e-2fa7-4d4f-b5b2-9a57bedbbe56" />
<img width="444" height="797" alt="Screenshot 2025-09-12 at 14 45 20" src="https://github.com/user-attachments/assets/1ee8a33e-8fe4-4184-add6-9788582d925f" />

