### PR TITLE
[FIX] point_of_sale: fix customer display auto scroll

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -232,6 +232,7 @@
             "point_of_sale/static/tests/pos/tours/utils/common.js",
             "point_of_sale/static/tests/generic_helpers/order_widget_util.js",
             "point_of_sale/static/tests/generic_helpers/utils.js",
+            "point_of_sale/static/tests/customer_display/customer_display_utils.js",
             "point_of_sale/static/tests/customer_display/customer_display_tour.js",
         ],
         'point_of_sale.assets_debug': [

--- a/addons/point_of_sale/static/src/app/customer_display/customer_display_adapter.js
+++ b/addons/point_of_sale/static/src/app/customer_display/customer_display_adapter.js
@@ -60,6 +60,7 @@ export class CustomerDisplayPosAdapter {
                 line.getUnitDisplayPriceBeforeDiscount(),
                 line.currency
             ),
+            isSelected: line.isSelected(),
         };
     }
 

--- a/addons/point_of_sale/static/src/customer_display/customer_display.js
+++ b/addons/point_of_sale/static/src/customer_display/customer_display.js
@@ -1,4 +1,4 @@
-import { Component, useEffect, whenReady } from "@odoo/owl";
+import { Component, useEffect, whenReady, useRef } from "@odoo/owl";
 import { OdooLogo } from "@point_of_sale/app/components/odoo_logo/odoo_logo";
 import { useSingleDialog } from "@point_of_sale/customer_display/utils";
 import { MainComponentsContainer } from "@web/core/main_components_container";
@@ -18,6 +18,13 @@ export class CustomerDisplay extends Component {
         this.dialog = useService("dialog");
         this.order = useService("customer_display_data");
         const singleDialog = useSingleDialog();
+
+        this.scrollableRef = useRef("scrollable");
+        useEffect(() => {
+            this.scrollableRef.el
+                ?.querySelector(".orderline.selected")
+                ?.scrollIntoView({ behavior: "smooth", block: "start" });
+        });
 
         useEffect(
             (qrPaymentData) => {

--- a/addons/point_of_sale/static/src/customer_display/customer_display.xml
+++ b/addons/point_of_sale/static/src/customer_display/customer_display.xml
@@ -11,7 +11,7 @@
             </div>
             <div class="o_customer_display_main d-flex flex-column flex-grow-1 overflow-auto">
                 <div t-if="Object.keys(order).length and order.lines.length > 0 and !order.finalized" class="d-flex flex-column flex-grow-1 rounded-3 bg-white overflow-hidden">
-                    <div style="scroll-snap-type: y mandatory;" class="gap-0 p-0 mx-2 pb-3 bg-view order-container d-flex flex-column flex-grow-1 overflow-y-auto text-start">
+                    <div t-ref="scrollable" style="scroll-snap-type: y mandatory;" class="gap-0 p-0 mx-2 pb-3 bg-view order-container d-flex flex-column flex-grow-1 overflow-y-auto text-start">
                          <li t-foreach="order.lines" t-as="line" t-key="line_index"  class="orderline position-relative d-flex align-items-center p-2 lh-sm cursor-pointer o_customer_display_orderline bg-white fs-3 rounded-0" t-attf-class="{{ line.comboParent ? 'orderline-combo ms-4 fst-italic' : '' }} {{ line.isSelected ? 'selected' : '' }}">
                             <div class="o_line_container d-flex align-items-center justify-content-center">
                                 <img t-attf-style="border-radius: 1rem;" t-att-src="`/web/image/product.product/${line.productId}/image_128`"/>

--- a/addons/point_of_sale/static/tests/customer_display/customer_display_tour.js
+++ b/addons/point_of_sale/static/tests/customer_display/customer_display_tour.js
@@ -1,123 +1,38 @@
 import * as Order from "@point_of_sale/../tests/generic_helpers/order_widget_util";
+import * as CustomerDisplay from "@point_of_sale/../tests/customer_display/customer_display_utils";
 import { registry } from "@web/core/registry";
-import { run } from "@point_of_sale/../tests/generic_helpers/utils";
-
-export function postMessage(message, description = "") {
-    return run(() => {
-        window.customerDisplayChannel.postMessage(
-            typeof message === "string" ? JSON.parse(message) : message
-        );
-    }, `send message to customer display: ${description},  with value: ${message}`);
-}
-
-export function amountIs(method, amount) {
-    return {
-        content: `Check that the ${method} amount is ${amount}`,
-        trigger: `div.row:has(div:contains('${method}')):has(div:contains('${amount}'))`,
-    };
-}
-const ADD_PRODUCT =
-    '{"lines":[{"productName":"Letter Tray","price":"$ 2,972.75","qty":"1.00","unit":"Units","unitPrice":"$ 2,972.75","customerNote":"","internalNote":"[]","comboParent":"","packLotLines":[],"price_without_discount":"$ 2,972.75","isSelected":false,"imageSrc":"/web/image/product.product/855/image_128"}],"finalized":false,"amount":"2,972.75","paymentLines":[],"change":0,"onlinePaymentData":{}}';
-export const ADD_PRODUCT_SELECTED =
-    '{"lines":[{"productName":"Letter Tray","price":"$ 2,972.75","qty":"1.00","unit":"Units","unitPrice":"$ 2,972.75","customerNote":"","internalNote":"[]","comboParent":"","packLotLines":[],"price_without_discount":"$ 2,972.75","isSelected":true,"imageSrc":"/web/image/product.product/855/image_128"}],"finalized":false,"amount":"2,972.75","paymentLines":[],"change":0,"onlinePaymentData":{}}';
-const PAY_WITH_CASH =
-    '{"lines":[{"productName":"Letter Tray","price":"$ 2,972.75","qty":"1.00","unit":"Units","unitPrice":"$ 2,972.75","customerNote":"","internalNote":"[]","comboParent":"","packLotLines":[],"price_without_discount":"$ 2,972.75","isSelected":true,"imageSrc":"/web/image/product.product/855/image_128"}],"finalized":false,"amount":"2,972.75","paymentLines":[{"name":"Cash","amount":"2,972.75"}],"change":0,"onlinePaymentData":{}}';
-export const ORDER_IS_FINALIZED =
-    '{"lines":[{"productName":"Letter Tray","price":"$ 2,972.75","qty":"1.00","unit":"Units","unitPrice":"$ 2,972.75","customerNote":"","internalNote":"[]","comboParent":"","packLotLines":[],"price_without_discount":"$ 2,972.75","isSelected":false,"imageSrc":"/web/image/product.product/855/image_128"}],"finalized":true,"amount":"2,972.75","paymentLines":[{"name":"Cash","amount":"2,972.75"}],"change":0,"onlinePaymentData":{}}';
-export const NEW_ORDER =
-    '{"lines":[],"finalized":false,"amount":"0.00","paymentLines":[],"change":0,"onlinePaymentData":{}}';
-
-const QR_URL =
-    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==";
-
-const PAY_WITH_CARD = {
-    lines: [
-        {
-            productName: "Letter Tray",
-            price: "$ 2,972.75",
-            qty: "1.00",
-            unit: "Units",
-            unitPrice: "$ 2,972.75",
-            oldUnitPrice: "",
-            customerNote: "",
-            internalNote: "",
-            comboParent: "",
-            packLotLines: [],
-            price_without_discount: "$ 2,972.75",
-            isSelected: true,
-            imageSrc: "/web/image/product.product/855/image_128",
-        },
-    ],
-    finalized: false,
-    amount: "2,972.75",
-    paymentLines: [{ name: "CARD", amount: "2,972.75" }],
-    change: 0,
-    onlinePaymentData: {},
-    qrPaymentData: null,
-};
-
-const SEND_QR = {
-    lines: [
-        {
-            productName: "Letter Tray",
-            price: "$ 2,972.75",
-            qty: "1.00",
-            unit: "Units",
-            unitPrice: "$ 2,972.75",
-            oldUnitPrice: "",
-            customerNote: "",
-            internalNote: "",
-            comboParent: "",
-            packLotLines: [],
-            price_without_discount: "$ 2,972.75",
-            isSelected: true,
-            imageSrc: "/web/image/product.product/855/image_128",
-        },
-    ],
-    finalized: false,
-    amount: "2,972.75",
-    paymentLines: [{ name: "CARD", amount: "2,972.75" }],
-    change: 0,
-    onlinePaymentData: {},
-    qrPaymentData: {
-        amount: "$ 2,972.75",
-        name: "CARD",
-        qrCode: QR_URL,
-    },
-};
+import { isVisible } from "@web/core/utils/ui";
 
 registry.category("web_tour.tours").add("CustomerDisplayTour", {
     steps: () =>
         [
-            {
-                trigger: "div:contains('Welcome.')",
-                run: () => {
-                    window.customerDisplayChannel = new BroadcastChannel("UPDATE_CUSTOMER_DISPLAY");
-                    postMessage(ADD_PRODUCT, "add product").run();
-                },
-            },
+            CustomerDisplay.addProduct(CustomerDisplay.ADD_PRODUCT, "add product"),
             Order.hasLine({ productName: "Letter Tray", price: "2,972.75" }),
             {
                 content: "An order line with `isSelected: false` should not have 'selected' class",
                 trigger: ".order-container .orderline:last-child:not(.selected)",
             },
-            amountIs("Total", "2,972.75"),
-            postMessage(PAY_WITH_CASH, "pay with cash"),
-            amountIs("Cash", "2,972.75"),
-            postMessage(ORDER_IS_FINALIZED, "order is finalized"),
+            CustomerDisplay.amountIs("Total", "2,972.75"),
+            CustomerDisplay.postMessage(CustomerDisplay.PAY_WITH_CASH, "pay with cash"),
+            CustomerDisplay.amountIs("Cash", "2,972.75"),
+            CustomerDisplay.postMessage(CustomerDisplay.ORDER_IS_FINALIZED, "order is finalized"),
             {
                 content: "Check that we are now on the 'Thank you' screen",
                 trigger: "div:contains('Thank you.')",
             },
-            postMessage(NEW_ORDER, "new order"),
+            CustomerDisplay.postMessage(CustomerDisplay.NEW_ORDER, "new order"),
             {
                 trigger: " div:contains('Welcome.')",
             },
             Order.doesNotHaveLine({}),
-            amountIs("Total", "0.00"),
+            CustomerDisplay.amountIs("Total", "0.00"),
             {
                 trigger: "body",
-                run: () => postMessage(ADD_PRODUCT_SELECTED, "add products").run(),
+                run: () =>
+                    CustomerDisplay.postMessage(
+                        CustomerDisplay.ADD_PRODUCT_SELECTED,
+                        "add products"
+                    ).run(),
             },
             {
                 content: "An order line with `isSelected: true` should have 'selected' class",
@@ -126,23 +41,67 @@ registry.category("web_tour.tours").add("CustomerDisplayTour", {
         ].flat(),
 });
 
+registry.category("web_tour.tours").add("CustomerDisplayTourScroll", {
+    steps: () =>
+        [
+            CustomerDisplay.addProduct(CustomerDisplay.ADD_MULTI_PRODUCTS, "add 20 products"),
+            {
+                content: "An order line with `isSelected: true` should have 'selected' class",
+                trigger: ".order-container .orderline:last-child.selected",
+                run: async () =>
+                    await new Promise((resolve) => {
+                        const orderLine = document.querySelector(
+                            ".order-container .orderline:last-child.selected"
+                        );
+                        const animationDuration = parseFloat(
+                            getComputedStyle(orderLine).animationDuration
+                        );
+                        if (animationDuration === 0) {
+                            return resolve();
+                        }
+                        orderLine.onanimationend = function (event) {
+                            if (event.target === orderLine && event.animationName === "item_in") {
+                                resolve(event);
+                            }
+                        };
+                    }),
+            },
+            {
+                content: "The order container should have scrolled to show the selected order line",
+                trigger: ".order-container",
+                run: async () => {
+                    const orderContainer = document.querySelector(".order-container");
+                    const orderLine = document.querySelector(
+                        ".order-container .orderline:last-child.selected"
+                    );
+                    await new Promise((resolve) => {
+                        const checkScroll = () => {
+                            requestAnimationFrame(() => {
+                                if (orderContainer.scrollTop > 0 && isVisible(orderLine)) {
+                                    resolve();
+                                } else {
+                                    setTimeout(checkScroll, 1000);
+                                }
+                            });
+                        };
+                        checkScroll();
+                    });
+                },
+            },
+        ].flat(),
+});
+
 registry.category("web_tour.tours").add("CustomerDisplayTourWithQr", {
     steps: () =>
         [
-            {
-                trigger: "div:contains('Welcome.')",
-                run: () => {
-                    window.customerDisplayChannel = new BroadcastChannel("UPDATE_CUSTOMER_DISPLAY");
-                    postMessage(ADD_PRODUCT, "add product").run();
-                },
-            },
+            CustomerDisplay.addProduct(CustomerDisplay.ADD_PRODUCT, "add product"),
             Order.hasLine({ productName: "Letter Tray", price: "2,972.75" }),
-            amountIs("Total", "2,972.75"),
-            postMessage(PAY_WITH_CARD, "pay with card"),
-            postMessage(SEND_QR, "send qr code"),
+            CustomerDisplay.amountIs("Total", "2,972.75"),
+            CustomerDisplay.postMessage(CustomerDisplay.PAY_WITH_CARD, "pay with card"),
+            CustomerDisplay.postMessage(CustomerDisplay.SEND_QR, "send qr code"),
             { trigger: "img[alt='QR Code']" },
-            postMessage(PAY_WITH_CARD, "confirm payment"),
-            postMessage(ORDER_IS_FINALIZED, "order is finalized"),
+            CustomerDisplay.postMessage(CustomerDisplay.PAY_WITH_CARD, "confirm payment"),
+            CustomerDisplay.postMessage(CustomerDisplay.ORDER_IS_FINALIZED, "order is finalized"),
             {
                 content: "Check that we are now on the 'Thank you' screen",
                 trigger: "div:contains('Thank you.')",

--- a/addons/point_of_sale/static/tests/customer_display/customer_display_utils.js
+++ b/addons/point_of_sale/static/tests/customer_display/customer_display_utils.js
@@ -1,0 +1,186 @@
+import { run } from "@point_of_sale/../tests/generic_helpers/utils";
+
+export function postMessage(message, description = "") {
+    return run(() => {
+        window.customerDisplayChannel.postMessage(
+            typeof message === "string" ? JSON.parse(message) : message
+        );
+    }, `send message to customer display: ${description},  with value: ${message}`);
+}
+
+export function amountIs(method, amount) {
+    return {
+        content: `Check that the ${method} amount is ${amount}`,
+        trigger: `div.row:has(div:contains('${method}')):has(div:contains('${amount}'))`,
+    };
+}
+
+export function addProduct(product, description = "") {
+    return {
+        trigger: "div:contains('Welcome.')",
+        run: async () => {
+            window.customerDisplayChannel = new BroadcastChannel("UPDATE_CUSTOMER_DISPLAY");
+            postMessage(product, description).run();
+        },
+    };
+}
+
+export const ADD_PRODUCT =
+    '{"lines":[{"productName":"Letter Tray","price":"$ 2,972.75","qty":"1.00","unit":"Units","unitPrice":"$ 2,972.75","customerNote":"","internalNote":"[]","comboParent":"","packLotLines":[],"price_without_discount":"$ 2,972.75","isSelected":false,"imageSrc":"/web/image/product.product/855/image_128"}],"finalized":false,"amount":"2,972.75","paymentLines":[],"change":0,"onlinePaymentData":{}}';
+
+export const ADD_PRODUCT_SELECTED =
+    '{"lines":[{"productName":"Letter Tray","price":"$ 2,972.75","qty":"1.00","unit":"Units","unitPrice":"$ 2,972.75","customerNote":"","internalNote":"[]","comboParent":"","packLotLines":[],"price_without_discount":"$ 2,972.75","isSelected":true,"imageSrc":"/web/image/product.product/855/image_128"}],"finalized":false,"amount":"2,972.75","paymentLines":[],"change":0,"onlinePaymentData":{}}';
+
+export const ADD_MULTI_PRODUCTS = (() => {
+    const count = 20;
+    const lines = Array.from({ length: count }, (_, i) => {
+        const price = (Math.random() * 100 + 1).toFixed(2);
+        return {
+            productName: `Product ${i + 1}`,
+            price: `$${price}`,
+            qty: "1.00",
+            unit: "Units",
+            unitPrice: `$${price}`,
+            customerNote: "",
+            internalNote: "[]",
+            comboParent: "",
+            packLotLines: [],
+            price_without_discount: `$${price}`,
+            isSelected: i === count - 1,
+            imageSrc: "/web/image/product.product/855/image_128",
+        };
+    });
+    const amount = lines
+        .reduce((sum, line) => sum + parseFloat(line.price.replace("$", "")), 0)
+        .toFixed(2);
+    return JSON.stringify({
+        lines,
+        finalized: false,
+        amount,
+        paymentLines: [],
+        change: 0,
+        onlinePaymentData: {},
+    });
+})();
+
+export const PAY_WITH_CASH =
+    '{"lines":[{"productName":"Letter Tray","price":"$ 2,972.75","qty":"1.00","unit":"Units","unitPrice":"$ 2,972.75","customerNote":"","internalNote":"[]","comboParent":"","packLotLines":[],"price_without_discount":"$ 2,972.75","isSelected":true,"imageSrc":"/web/image/product.product/855/image_128"}],"finalized":false,"amount":"2,972.75","paymentLines":[{"name":"Cash","amount":"2,972.75"}],"change":0,"onlinePaymentData":{}}';
+
+export const ORDER_IS_FINALIZED =
+    '{"lines":[{"productName":"Letter Tray","price":"$ 2,972.75","qty":"1.00","unit":"Units","unitPrice":"$ 2,972.75","customerNote":"","internalNote":"[]","comboParent":"","packLotLines":[],"price_without_discount":"$ 2,972.75","isSelected":false,"imageSrc":"/web/image/product.product/855/image_128"}],"finalized":true,"amount":"2,972.75","paymentLines":[{"name":"Cash","amount":"2,972.75"}],"change":0,"onlinePaymentData":{}}';
+
+export const NEW_ORDER =
+    '{"lines":[],"finalized":false,"amount":"0.00","paymentLines":[],"change":0,"onlinePaymentData":{}}';
+
+export const QR_URL =
+    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==";
+
+export const PAY_WITH_CARD = {
+    lines: [
+        {
+            productName: "Letter Tray",
+            price: "$ 2,972.75",
+            qty: "1.00",
+            unit: "Units",
+            unitPrice: "$ 2,972.75",
+            oldUnitPrice: "",
+            customerNote: "",
+            internalNote: "",
+            comboParent: "",
+            packLotLines: [],
+            price_without_discount: "$ 2,972.75",
+            isSelected: true,
+            imageSrc: "/web/image/product.product/855/image_128",
+        },
+    ],
+    finalized: false,
+    amount: "2,972.75",
+    paymentLines: [{ name: "CARD", amount: "2,972.75" }],
+    change: 0,
+    onlinePaymentData: {},
+    qrPaymentData: null,
+};
+
+export const SEND_QR = {
+    lines: [
+        {
+            productName: "Letter Tray",
+            price: "$ 2,972.75",
+            qty: "1.00",
+            unit: "Units",
+            unitPrice: "$ 2,972.75",
+            oldUnitPrice: "",
+            customerNote: "",
+            internalNote: "",
+            comboParent: "",
+            packLotLines: [],
+            price_without_discount: "$ 2,972.75",
+            isSelected: true,
+            imageSrc: "/web/image/product.product/855/image_128",
+        },
+    ],
+    finalized: false,
+    amount: "2,972.75",
+    paymentLines: [{ name: "CARD", amount: "2,972.75" }],
+    change: 0,
+    onlinePaymentData: {},
+    qrPaymentData: {
+        amount: "$ 2,972.75",
+        name: "CARD",
+        qrCode: QR_URL,
+    },
+};
+
+export const PAY_ONLINE = {
+    lines: [
+        {
+            productName: "Letter Tray",
+            price: "$ 2,972.75",
+            qty: "1.00",
+            unit: "Units",
+            unitPrice: "$ 2,972.75",
+            oldUnitPrice: "",
+            customerNote: "",
+            internalNote: "",
+            comboParent: "",
+            packLotLines: [],
+            price_without_discount: "$ 2,972.75",
+            isSelected: true,
+            imageSrc: "/web/image/product.product/855/image_128",
+        },
+    ],
+    finalized: false,
+    amount: "2,972.75",
+    paymentLines: [{ name: "ONLINE", amount: "2,972.75" }],
+    change: 0,
+    onlinePaymentData: {
+        formattedAmount: "$ 2,972.75",
+        orderName: "/",
+        qrCode: QR_URL,
+    },
+};
+
+export const PAID = {
+    lines: [
+        {
+            productName: "Letter Tray",
+            price: "$ 2,972.75",
+            qty: "1.00",
+            unit: "Units",
+            unitPrice: "$ 2,972.75",
+            oldUnitPrice: "",
+            customerNote: "",
+            internalNote: "",
+            comboParent: "",
+            packLotLines: [],
+            price_without_discount: "$ 2,972.75",
+            isSelected: true,
+            imageSrc: "/web/image/product.product/855/image_128",
+        },
+    ],
+    finalized: false,
+    amount: "2,972.75",
+    paymentLines: [{ name: "ONLINE", amount: "2,972.75" }],
+    change: 0,
+    onlinePaymentData: {},
+};

--- a/addons/point_of_sale/static/tests/unit/customer_display/customer_display_adapter.test.js
+++ b/addons/point_of_sale/static/tests/unit/customer_display/customer_display_adapter.test.js
@@ -1,0 +1,20 @@
+import { test, expect, describe } from "@odoo/hoot";
+import { getFilledOrder, setupPosEnv } from "../utils";
+import { definePosModels } from "../data/generate_model_definitions";
+import { CustomerDisplayPosAdapter } from "@point_of_sale/app/customer_display/customer_display_adapter";
+
+definePosModels();
+
+describe("customer_display_adapter.js", () => {
+    test("getOrderlineData", async () => {
+        const store = await setupPosEnv();
+        const order = await getFilledOrder(store);
+
+        const adapter = new CustomerDisplayPosAdapter();
+        adapter.formatOrderData(order);
+
+        expect(adapter.data.lines).toHaveLength(2);
+        expect(adapter.data.lines[0].isSelected).toBe(false);
+        expect(adapter.data.lines[1].isSelected).toBe(true);
+    });
+});

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1521,6 +1521,9 @@ class TestUi(TestPointOfSaleHttpCommon):
     def test_customer_display(self):
         self.start_tour(f"/pos_customer_display/{self.main_pos_config.id}/{self.main_pos_config.access_token}", 'CustomerDisplayTour', login="pos_user")
 
+    def test_customer_display_scroll(self):
+        self.start_tour(f"/pos_customer_display/{self.main_pos_config.id}/{self.main_pos_config.access_token}", 'CustomerDisplayTourScroll', login="pos_user")
+
     def test_customer_display_with_qr(self):
         self.start_tour(f"/pos_customer_display/{self.main_pos_config.id}/{self.main_pos_config.access_token}", 'CustomerDisplayTourWithQr', login="pos_user")
 

--- a/addons/pos_online_payment/static/tests/tours/customer_display_tour.js
+++ b/addons/pos_online_payment/static/tests/tours/customer_display_tour.js
@@ -1,107 +1,38 @@
 import * as Order from "@point_of_sale/../tests/generic_helpers/order_widget_util";
+import * as CustomerDisplay from "@point_of_sale/../tests/customer_display/customer_display_utils";
 import { registry } from "@web/core/registry";
-import {
-    postMessage,
-    amountIs,
-    ADD_PRODUCT_SELECTED,
-    ORDER_IS_FINALIZED,
-    NEW_ORDER,
-} from "@point_of_sale/../tests/customer_display/customer_display_tour";
-
-const QR_URL =
-    "/report/barcode/QR/http%3A%2F%2Flocalhost%3A1740%2Fpos%2Fpay%2F6%3Faccess_token%3D5bb78d6c-bf8e-44ed-8de2-e4ae5b8696ec?width=200&height=200";
-
-const PAY_ONLINE = {
-    lines: [
-        {
-            productName: "Letter Tray",
-            price: "$ 2,972.75",
-            qty: "1.00",
-            unit: "Units",
-            unitPrice: "$ 2,972.75",
-            oldUnitPrice: "",
-            customerNote: "",
-            internalNote: "",
-            comboParent: "",
-            packLotLines: [],
-            price_without_discount: "$ 2,972.75",
-            isSelected: true,
-            imageSrc: "/web/image/product.product/855/image_128",
-        },
-    ],
-    finalized: false,
-    amount: "2,972.75",
-    paymentLines: [{ name: "ONLINE", amount: "2,972.75" }],
-    change: 0,
-    onlinePaymentData: {
-        formattedAmount: "$ 2,972.75",
-        orderName: "/",
-        qrCode: QR_URL,
-    },
-};
-
-const PAID = {
-    lines: [
-        {
-            productName: "Letter Tray",
-            price: "$ 2,972.75",
-            qty: "1.00",
-            unit: "Units",
-            unitPrice: "$ 2,972.75",
-            oldUnitPrice: "",
-            customerNote: "",
-            internalNote: "",
-            comboParent: "",
-            packLotLines: [],
-            price_without_discount: "$ 2,972.75",
-            isSelected: true,
-            imageSrc: "/web/image/product.product/855/image_128",
-        },
-    ],
-    finalized: false,
-    amount: "2,972.75",
-    paymentLines: [{ name: "ONLINE", amount: "2,972.75" }],
-    change: 0,
-    onlinePaymentData: {},
-};
 
 registry.category("web_tour.tours").add("CustomerDisplayTourOnlinePayment", {
     steps: () =>
         [
-            {
-                trigger: "div:contains('Welcome.')",
-                run: () => {
-                    window.customerDisplayChannel = new BroadcastChannel("UPDATE_CUSTOMER_DISPLAY");
-                    postMessage(ADD_PRODUCT_SELECTED, "add product").run();
-                },
-            },
+            CustomerDisplay.addProduct(CustomerDisplay.ADD_PRODUCT_SELECTED, "add product"),
             Order.hasLine({ productName: "Letter Tray", price: "2,972.75" }),
-            amountIs("Total", "2,972.75"),
-            postMessage(PAY_ONLINE, "pay with cash"),
+            CustomerDisplay.amountIs("Total", "2,972.75"),
+            CustomerDisplay.postMessage(CustomerDisplay.PAY_ONLINE, "pay with cash"),
             {
-                trigger: `.modal-content img[alt='QR Code to pay'][src='${QR_URL}']`,
+                trigger: `.modal-content img[alt='QR Code to pay'][src='${CustomerDisplay.QR_URL}']`,
             },
-            postMessage(PAID, "payment approved"),
-            postMessage(ORDER_IS_FINALIZED, "order is finalized"),
+            CustomerDisplay.postMessage(CustomerDisplay.PAID, "payment approved"),
+            CustomerDisplay.postMessage(CustomerDisplay.ORDER_IS_FINALIZED, "order is finalized"),
             {
                 content: "Check that we are now on the 'Thank you' screen",
                 trigger: "div:contains('Thank you.')",
                 run: "click",
             },
-            postMessage(NEW_ORDER, "new order"),
+            CustomerDisplay.postMessage(CustomerDisplay.NEW_ORDER, "new order"),
             {
                 trigger: "div:contains('Welcome.')",
             },
             Order.doesNotHaveLine({}),
-            amountIs("Total", "0.00"),
+            CustomerDisplay.amountIs("Total", "0.00"),
 
             // Make a new order
-            postMessage(ADD_PRODUCT_SELECTED, "add product"),
+            CustomerDisplay.postMessage(CustomerDisplay.ADD_PRODUCT_SELECTED, "add product"),
             Order.hasLine({ productName: "Letter Tray", price: "2,972.75" }),
-            amountIs("Total", "2,972.75"),
-            postMessage(PAY_ONLINE, "pay with cash"),
+            CustomerDisplay.amountIs("Total", "2,972.75"),
+            CustomerDisplay.postMessage(CustomerDisplay.PAY_ONLINE, "pay with cash"),
             {
-                trigger: `.modal-content img[alt='QR Code to pay'][src='${QR_URL}']`,
+                trigger: `.modal-content img[alt='QR Code to pay'][src='${CustomerDisplay.QR_URL}']`,
             },
         ].flat(),
 });


### PR DESCRIPTION
Steps to reproduce:

- Turn on customer display in point of sale
- Add some order lines
- Customer display doesn't auto scroll

Current behavior:

- Customer display doesn't auto scroll

Expected result:

- Customer display should scroll to the selected lines
