### PR TITLE
[FIX] website: prevent creation of model page for non-stored models

### DIFF
--- a/addons/website/models/website_controller_page.py
+++ b/addons/website/models/website_controller_page.py
@@ -1,6 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from ast import literal_eval
-from odoo import api, fields, models
+
+from odoo import api, fields, models, _
+from odoo.exceptions import ValidationError
+
+from odoo.addons.website.tools import get_stored_models
 
 
 class WebsiteControllerPage(models.Model):
@@ -82,6 +86,10 @@ class WebsiteControllerPage(models.Model):
         return False
 
     def write(self, vals):
+        if self.model_id.model not in get_stored_models(self.env):
+            raise ValidationError(_(
+                "You cannot create Model Page with Exposed Model '%(model)s'", model=self.model_id.model
+            ))
         res = super().write(vals)
         for rec in self:
             rec.menu_ids.write({

--- a/addons/website/tools.py
+++ b/addons/website/tools.py
@@ -270,3 +270,13 @@ def create_image_attachment(env, image_path, image_name):
         'url': Attachments.get_base_url() + image_path,
     })
     return img
+
+
+def get_stored_models(env):
+    """ Returns the list of models that are stored in the database.
+    This excludes models with attribute `_auto = False`
+    """
+    return [
+        model_name for model_name, model in env.items()
+        if getattr(model, '_auto', True)
+    ]


### PR DESCRIPTION
Steps to Reproduce:
1) Install the following modules:  website, stock_account, web_studio. 
2) On the homepage, create a new custom app using Studio. 
3) Fill in these details:
- App Name: Test App
- In the `Create your First Menu section`, select 'Existing Model', choose 'Stock Quantity Report' to link this app, and click Create your App.
4) Navigate to 'Model Pages' and create a new model page and click on
   'go to website' magic button.

Before this commit:
By following the above steps, User can set non-stored models as default model. Due to which on creating a Model Page the dafault value for 'Exposed Model' will be set as default model(e.g. Stock Quantity Report) and user can save it later on which leads to an issue.

After this commit:
If 'Exposed Model' is set to a non-stored model ValidationError will be raised.

Related Enterprise PR: https://github.com/odoo/enterprise/pull/94286

sentry-6842596566
