### PR TITLE
[FIX] website_sale: prevent error when changing the delivery address

### DIFF
--- a/addons/website_sale/static/src/js/checkout.js
+++ b/addons/website_sale/static/src/js/checkout.js
@@ -24,6 +24,24 @@ publicWidget.registry.WebsiteSaleCheckout = publicWidget.Widget.extend({
         this.use_delivery_as_billing_toggle = document.querySelector('#use_delivery_as_billing');
         this.billingContainer = this.el.querySelector('#billing_container');
         await this._prepareDeliveryMethods();
+        // Monitor when the page is restored from the bfcache.
+        window.addEventListener('pageshow', this._onNavigationBack);
+    },
+
+    destroy() {
+        window.removeEventListener('pageshow', this._onNavigationBack);
+    },
+
+    /**
+     * Reload the page when the page is restored from the bfcache.
+     *
+     * @param {PageTransitionEvent} event - The pageshow event.
+     * @private
+     */
+    _onNavigationBack(event) {
+        if (event.persisted) {
+            window.location.reload();
+        }
     },
 
     // #=== EVENT HANDLERS ===#


### PR DESCRIPTION
Currently, an error occurs when the user changing the delivery address 
in the website.

**Steps to reproduce:**
- Install the `website_sale` module and enable the `Demo` payment provider.
- Go to `Website` > `Shop` > `Add a product to Cart` > `View cart` > `Checkout`.
- Ensure there are at least two different delivery addresses > `Confirm` > `Pay now`.
- Quickly press the browser’s `back button` twice.
- Select a different `delivery address`.

**Error:**
`ValueError: Expected singleton: sale.order()`

**Root Cause:**
At [1], the code calls `order.ensure_one()`. When the cart (`sale.order`) is empty, 
leads to an `error`.

**Fix:**
This commit prevents a traceback on the frontend when a user attempts to
change the delivery address and safely redirects them to the shop page.


[1]:
https://github.com/odoo/odoo/blob/88c9a45ee1ff8dde871865723c3387c059af8289/addons/delivery/models/delivery_carrier.py#L157

sentry-6869972801