### PR TITLE
[FIX] im_livechat: various meeting view fixes

### DIFF
--- a/addons/im_livechat/static/src/embed/external/boot.js
+++ b/addons/im_livechat/static/src/embed/external/boot.js
@@ -19,7 +19,7 @@ import { session } from "@web/session";
     if (session.test_mode) {
         await loadBundle("im_livechat.assets_livechat_support_tours");
     }
-    const env = Object.assign(makeEnv(), { embedLivechat: true });
+    const env = makeEnv();
     await startServices(env);
     odoo.isReady = true;
     const target = await makeShadow(makeRoot(document.body));

--- a/addons/im_livechat/static/tests/tours/support/im_livechat_meeting_view_tour.js
+++ b/addons/im_livechat/static/tests/tours/support/im_livechat_meeting_view_tour.js
@@ -1,0 +1,44 @@
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("im_livechat.meeting_view_tour", {
+    steps: () => [
+        {
+            trigger: ".o-livechat-root:shadow .o-livechat-LivechatButton",
+            run: "click",
+        },
+        {
+            trigger: ".o-livechat-root:shadow .o-mail-Thread[data-transient]",
+        },
+        {
+            trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+            run: "edit Hello!",
+        },
+        {
+            trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+            run: "press Enter",
+        },
+        {
+            trigger: ".o-livechat-root:shadow [title='Join Call']",
+            run: "click",
+        },
+        {
+            trigger: ".o-livechat-root:shadow .o-discuss-Call [title='Fullscreen']",
+            run: "click",
+        },
+        {
+            trigger: ".o-livechat-root:shadow .o-mail-Meeting",
+        },
+        {
+            trigger: ".o-livechat-root:shadow .o-mail-MeetingSideActions [name^='more-action:'] ",
+            run: "click",
+        },
+        {
+            trigger: ".o-livechat-root:shadow [name='call-settings']",
+            run: "click",
+        },
+        {
+            trigger:
+                ".o-livechat-root:shadow .o-mail-DiscussContent-panelContainer .o-mail-ActionPanel-header:contains('voice settings')",
+        },
+    ],
+});

--- a/addons/im_livechat/tests/__init__.py
+++ b/addons/im_livechat/tests/__init__.py
@@ -9,6 +9,7 @@ from . import test_discuss_channel
 from . import test_cors_livechat
 from . import test_get_discuss_channel
 from . import test_get_operator
+from . import test_im_livechat_calls
 from . import test_im_livechat_channel
 from . import test_im_livechat_report
 from . import test_im_livechat_support_page

--- a/addons/im_livechat/tests/test_im_livechat_calls.py
+++ b/addons/im_livechat/tests/test_im_livechat_calls.py
@@ -1,0 +1,29 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from functools import wraps
+from unittest.mock import patch
+
+from odoo.tests.common import tagged
+from odoo.addons.im_livechat.controllers.main import LivechatController
+from odoo.addons.im_livechat.tests.common import TestImLivechatCommon
+
+
+@tagged("post_install", "-at_install")
+class TestImLivechatCalls(TestImLivechatCommon):
+    def test_meeting_view(self):
+        og_get_session = LivechatController.get_session
+
+        def _patched_get_session(*args, **kwargs):
+            result = og_get_session(*args, **kwargs)
+            if kwargs["persisted"]:
+                self.env.flush_all()
+                channel = self.env["discuss.channel"].search([("id", "=", result["channel_id"])])
+                agent = channel.channel_member_ids.filtered(lambda m: m.partner_id)
+                agent.sudo()._rtc_join_call()
+            return result
+
+        with patch.object(LivechatController, "get_session", wraps(og_get_session)(_patched_get_session)):
+            self.start_tour(
+                f"/im_livechat/support/{self.livechat_channel.id}",
+                "im_livechat.meeting_view_tour",
+            )

--- a/addons/mail/static/src/core/common/mail_fullscreen.xml
+++ b/addons/mail/static/src/core/common/mail_fullscreen.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.Fullscreen">
-        <div t-if="fullscreen.component" class="fixed-top vw-100 vh-100">
-            <t t-component="fullscreen.component" t-props="fullscreen.props"/>
+        <div class="fixed-top vw-100 vh-100">
+            <t t-component="props.component" t-props="props.props"/>
         </div>
     </t>
 </templates>

--- a/addons/mail/static/src/discuss/call/common/call.js
+++ b/addons/mail/static/src/discuss/call/common/call.js
@@ -54,6 +54,7 @@ export class Call extends Component {
     setup() {
         super.setup();
         this.grid = useRef("grid");
+        this.root = useRef("root");
         this.notification = useService("notification");
         this.rtc = useService("discuss.rtc");
         this.isMobileOs = isMobileOS();

--- a/addons/mail/static/src/discuss/call/common/call.xml
+++ b/addons/mail/static/src/discuss/call/common/call.xml
@@ -12,7 +12,7 @@
             'o-hasVideo': channel.videoCount > 0,
             'o-selfInCall': isActiveCall,
             'border-bottom': !isActiveCall,
-        }">
+        }" t-ref="root">
             <div class="o-discuss-Call-main d-flex flex-grow-1 flex-column align-items-center justify-content-center position-relative overflow-auto o-scrollbar-thin" t-on-mouseleave="onMouseleaveMain">
                 <BlurPerformanceWarning t-if="store.settings.blurPerformanceWarning"/>
                 <div

--- a/addons/mail/static/src/discuss/call/common/meeting.xml
+++ b/addons/mail/static/src/discuss/call/common/meeting.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.Meeting">
-        <div class="o-mail-Meeting h-100 w-100 d-flex flex-column" t-att-class="{'p-1 pb-3 gap-2': !ui.isSmall}">
+        <div class="o-mail-Meeting h-100 w-100 d-flex flex-column" t-att-class="{'p-1 pb-3': !ui.isSmall}">
             <div class="d-flex flex-grow-1 h-100 o-min-height-0 gap-1 position-relative">
                 <div class="o-mail-Meeting-callContainer h-100 flex-grow-1 o-min-width-0" t-att-class="{'d-none': ui.isSmall and threadActions.activeAction?.actionPanelComponentCondition, 'pb-0': ui.isSmall}">
                     <Call hasOverlay="false" />
@@ -10,7 +10,7 @@
                     <t t-component="threadActions.activeAction.actionPanelComponent" t-props="threadActions.activeAction.actionPanelComponentProps" thread="thread"/>
                 </div>
             </div>
-            <div class="d-flex justify-content-between overflow-x-auto" style="flex-shrink: 0;" t-att-class="{'p-2 pb-3': ui.isSmall}">
+            <div class="pt-2 d-flex justify-content-between overflow-x-auto flex-shrink-0" t-att-class="{'p-2 pb-3': ui.isSmall}">
                 <div/>
                 <CallActionList thread="store.rtc.channel"/>
                 <MeetingSideActions threadActions="threadActions"/>

--- a/addons/mail/static/src/discuss/call/common/meeting_chat.js
+++ b/addons/mail/static/src/discuss/call/common/meeting_chat.js
@@ -1,6 +1,7 @@
 import { Composer } from "@mail/core/common/composer";
 import { Thread } from "@mail/core/common/thread";
 import { ActionPanel } from "@mail/discuss/core/common/action_panel";
+import { Typing } from "@mail/discuss/typing/common/typing";
 
 import { Component, useState, useSubEnv } from "@odoo/owl";
 
@@ -18,6 +19,7 @@ export class MeetingChat extends Component {
         ActionPanel,
         Composer,
         Thread,
+        Typing,
     };
     static props = ["thread?"];
 

--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -718,6 +718,7 @@ export class Rtc extends Record {
             id: CALL_FULLSCREEN_ID,
             keepBrowserHeader: true,
             props,
+            rootId: this.rootEl?.getRootNode()?.host?.id,
         });
     }
 

--- a/addons/mail/static/src/discuss/core/common/action_panel.js
+++ b/addons/mail/static/src/discuss/core/common/action_panel.js
@@ -40,4 +40,12 @@ export class ActionPanel extends Component {
             rounded: !this.props.resizable,
         });
     }
+
+    get minWidth() {
+        return this.props.minWidth;
+    }
+
+    get initialWidth() {
+        return this.props.initialWidth;
+    }
 }

--- a/addons/mail/static/src/discuss/core/common/action_panel.xml
+++ b/addons/mail/static/src/discuss/core/common/action_panel.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.ActionPanel">
-        <ResizablePanel t-if="props.resizable and !env.inChatWindow and !env.inChatter and !ui.isSmall" class="classNames" handleSide="'start'" initialWidth="props.initialWidth ?? store.discuss.INSPECTOR_WIDTH" minWidth="props.minWidth ?? store.discuss.INSPECTOR_WIDTH">
+        <ResizablePanel t-if="props.resizable and !env.inChatWindow and !env.inChatter and !ui.isSmall" class="classNames" handleSide="'start'" initialWidth="initialWidth" minWidth="minWidth">
             <t t-call="mail.ActionPanel.content"/>
         </ResizablePanel>
         <div t-else="" t-att-class="classNames">

--- a/addons/mail/static/src/discuss/core/public_web/action_panel_patch.js
+++ b/addons/mail/static/src/discuss/core/public_web/action_panel_patch.js
@@ -1,0 +1,11 @@
+import { patch } from "@web/core/utils/patch";
+import { ActionPanel } from "@mail/discuss/core/common/action_panel";
+
+patch(ActionPanel.prototype, {
+    get initialWidth() {
+        return super.initialWidth || this.store.discuss.INSPECTOR_WIDTH;
+    },
+    get minWidth() {
+        return super.minWidth || this.store.discuss.INSPECTOR_WIDTH;
+    },
+});


### PR DESCRIPTION
This PR fixes several issues with the call meeting view:
- crash when opening call settings
- wrong style in website, because the full screen component is not mounted 
in the shadow DOM.
- permission icons are cropped
- crash when typing component is shown
- pip assets are not loaded in the live chat