### PR TITLE
[FIX] website_sale_loyalty: allow removing promotion from cart lines

### DIFF
--- a/addons/website_sale_loyalty/models/sale_order.py
+++ b/addons/website_sale_loyalty/models/sale_order.py
@@ -176,7 +176,7 @@ class SaleOrder(models.Model):
             and order_line.reward_id.reward_type == 'discount'
         ):
             # When a reward line is deleted we remove it from the auto claimable rewards
-            self = self.with_context(website_sale_loyalty_delete=True)  # noqa: PLW0642
+            order_line = order_line.with_context(website_sale_loyalty_delete=True)
 
         return super()._cart_update_order_line(order_line, quantity, **kwargs)
 


### PR DESCRIPTION
Steps:
- Add a loyalty program of type promotion
- Program trigger should be Automatic
- Go to Shop > Add a product that triggers the reward of promotion
- Try to remove the promotion added from the cart lines

Issue:
- Remove does not work for the automatically applied promotion reward

Cause:
- Context is not properly passed to the unlink method that removes the cart line of the promotion reward.
- Since the unlink method is not receiving context properly, removal is bypassed

Fix:
- Instead of adding context in `self`, adding it directly in the `order_line` context fixes the issue.

task-5076061