### PR TITLE
[FIX] website: Use name_search instead of _search_display_name

### DIFF
--- a/addons/website/models/website_rewrite.py
+++ b/addons/website/models/website_rewrite.py
@@ -26,6 +26,15 @@ class WebsiteRoute(models.Model):
             self._refresh()
         return domain
 
+    @api.model
+    @api.readonly
+    def name_search(self, name='', domain=None, operator='ilike', limit=100):
+        result = super().name_search(name, domain=domain, operator=operator, limit=limit)
+        if not result:
+            self._refresh()
+            result = super().name_search(name, domain=domain, operator=operator, limit=limit)
+        return result
+
     def _refresh(self):
         _logger.debug("Refreshing website.route")
         ir_http = self.env['ir.http']


### PR DESCRIPTION
Since commit: https://github.com/odoo/odoo/commit/5ef007a2116e528b796ebe80fb291ba5f1a94c8f#diff-6b066af44f014202eb84d27b3eb63c8aee3e7643e6f814dd4169d0940d763536 _search_display_name is not getting called, the reason is when name_search is called with blank value then domain [('display_name', 'ilike', '')] is converted to [(1, '=', 1)] so _search_display_name is not getting called, this only happens when name_search is called with blank value.

The website.route have overridden _search_display_name where we have logic to generate website routes by calling refresh method.

steps to produce: Go to Website -> Redirects -> Create new Rewrite Then select Action = '308 Redirect / Rewrite' and then click on URL from field you will get blank result, dropdown will not have anything.

The reason is name_seach is called with blank value and hence domain is ultimately converted to [(1, '=', 1)] and due to this _search_display_name is not getting called, as refresh method is called from _search_display_name so it will not be called.

With this commit, we have implemented name_search instead of _search_display_name for this special case where we are generating database records when result is blank.

Task-5159334

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
