### PR TITLE
[IMP] html_editor: toolbar visibility on line break only selection

### DIFF
--- a/addons/html_builder/static/src/builder.js
+++ b/addons/html_builder/static/src/builder.js
@@ -173,9 +173,6 @@ export class Builder extends Component {
                     }),
                     unsplittable_node_predicates: (/** @type {Node} */ node) =>
                         node.querySelector?.("[data-oe-translation-source-sha]"),
-                    can_display_toolbar: (namespace) => !["image", "icon"].includes(namespace),
-
-                    // disable the toolbar for images and icons
                 },
                 localOverlayContainers: {
                     key: this.env.localOverlayContainerKey,

--- a/addons/html_builder/static/src/core/core_plugins.js
+++ b/addons/html_builder/static/src/core/core_plugins.js
@@ -11,6 +11,8 @@ import { BuilderOverlayPlugin } from "./builder_overlay/builder_overlay_plugin";
 import { CachedModelPlugin } from "./cached_model_plugin";
 import { ClonePlugin } from "./clone_plugin";
 import { ColorUIPlugin } from "./color_ui_plugin";
+import { ImagePlugin } from "./image_plugin";
+import { IconPlugin } from "./icon_plugin";
 import { CoreBuilderActionPlugin } from "./core_builder_action_plugin";
 import { CompositeActionPlugin } from "./composite_action_plugin";
 import { CustomizeTabPlugin } from "./customize_tab_plugin";
@@ -45,6 +47,8 @@ const mainEditorPluginsToRemove = [
     "FontFamilyPlugin",
     // Replaced plugins:
     "ColorUIPlugin",
+    "ImagePlugin",
+    "IconPlugin",
 ];
 
 export const MAIN_PLUGINS = [
@@ -53,6 +57,8 @@ export const MAIN_PLUGINS = [
         mainEditorPluginsToRemove
     ),
     ColorUIPlugin,
+    ImagePlugin,
+    IconPlugin,
 ];
 
 export const CORE_PLUGINS = [

--- a/addons/html_builder/static/src/core/icon_plugin.js
+++ b/addons/html_builder/static/src/core/icon_plugin.js
@@ -1,0 +1,6 @@
+import { IconPlugin as EditorIconPlugin } from "@html_editor/main/media/icon_plugin";
+import { DISABLED_NAMESPACE } from "@html_editor/main/toolbar/toolbar_plugin";
+
+export class IconPlugin extends EditorIconPlugin {
+    toolbarNamespace = DISABLED_NAMESPACE;
+}

--- a/addons/html_builder/static/src/core/image_plugin.js
+++ b/addons/html_builder/static/src/core/image_plugin.js
@@ -1,0 +1,6 @@
+import { ImagePlugin as EditorImagePlugin } from "@html_editor/main/media/image_plugin";
+import { DISABLED_NAMESPACE } from "@html_editor/main/toolbar/toolbar_plugin";
+
+export class ImagePlugin extends EditorImagePlugin {
+    toolbarNamespace = DISABLED_NAMESPACE;
+}

--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -51,6 +51,7 @@ import { weakMemoize } from "@html_editor/utils/functions";
  * @property { boolean } documentSelectionIsInEditable
  * @property { boolean } documentSelectionIsProtected
  * @property { boolean } documentSelectionIsProtecting
+ * @property { boolean } currentSelectionIsInEditable
  */
 
 /**

--- a/addons/html_editor/static/src/main/media/icon_plugin.js
+++ b/addons/html_editor/static/src/main/media/icon_plugin.js
@@ -8,6 +8,7 @@ import { ICON_SELECTOR, isElement } from "@html_editor/utils/dom_info";
 export class IconPlugin extends Plugin {
     static id = "icon";
     static dependencies = ["history", "selection", "dialog"];
+    toolbarNamespace = "icon";
     /** @type {import("plugins").EditorResources} */
     resources = {
         user_commands: [
@@ -55,17 +56,20 @@ export class IconPlugin extends Plugin {
                 isAvailable: isHtmlContentSupported,
             },
         ],
-        toolbar_namespaces: [
-            {
-                id: "icon",
-                isApplied: (targetedNodes) =>
+        toolbar_namespace_providers: [
+            (targetedNodes) => {
+                if (
+                    targetedNodes.length &&
                     targetedNodes.every(
+                        // All nodes should be icons, its ZWS child or its ancestors
                         (node) =>
-                            // All nodes should be icons, its ZWS child or its ancestors
                             node.classList?.contains("fa") ||
                             node.parentElement.classList.contains("fa") ||
                             (node.querySelector?.(".fa") && node.isContentEditable !== false)
-                    ),
+                    )
+                ) {
+                    return this.toolbarNamespace;
+                }
             },
         ],
         toolbar_groups: [

--- a/addons/html_editor/static/src/main/media/image_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_plugin.js
@@ -51,6 +51,7 @@ export class ImagePlugin extends Plugin {
     static dependencies = ["history", "dom", "selection", "overlay"];
     static shared = ["getTargetedImage", "previewImage", "resetImageTransformation"];
     static defaultConfig = { allowImageTransform: true };
+    toolbarNamespace = "image";
     /** @type {import("plugins").EditorResources} */
     resources = {
         user_commands: [
@@ -102,14 +103,17 @@ export class ImagePlugin extends Plugin {
                 isAvailable: isHtmlContentSupported,
             },
         ],
-        toolbar_namespaces: [
-            {
-                id: "image",
-                isApplied: (targetedNodes) =>
+        toolbar_namespace_providers: [
+            (targetedNodes) => {
+                if (
+                    targetedNodes.length &&
                     targetedNodes.every(
                         // All nodes should be images or its ancestors
                         (node) => node.nodeName === "IMG" || node.querySelector?.("img")
-                    ),
+                    )
+                ) {
+                    return this.toolbarNamespace;
+                }
             },
         ],
         toolbar_groups: [

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -111,6 +111,13 @@ export class TablePlugin extends Plugin {
                 isAvailable: isHtmlContentSupported,
             },
         ],
+        toolbar_namespace_providers: [
+            withSequence(
+                90,
+                (targetedNodes, editableSelection) =>
+                    closestElement(editableSelection.anchorNode, ".o_selected_td") && "compact"
+            ),
+        ],
 
         /** Handlers */
         selectionchange_handlers: this.updateSelectionTable.bind(this),
@@ -131,8 +138,6 @@ export class TablePlugin extends Plugin {
         fully_selected_node_predicates: (node) => !!closestElement(node, ".o_selected_td"),
         targeted_nodes_processors: this.adjustTargetedNodes.bind(this),
         move_node_whitelist_selectors: "table",
-        collapsed_selection_toolbar_predicate: (selectionData) =>
-            !!closestElement(selectionData.editableSelection.anchorNode, ".o_selected_td"),
         selection_blocker_predicates: (node) => {
             if (node.nodeName === "TABLE") {
                 return true;

--- a/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
+++ b/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
@@ -93,6 +93,8 @@ import { closestElement } from "@html_editor/utils/dom_traversal";
 const DELAY_TOOLBAR_OPEN = 300;
 /** Number of buttons below which toolbar will open directly in its expanded form */
 const MIN_SIZE_FOR_COMPACT = 7;
+/** Special namespace that prevents the toolbar from opening */
+export const DISABLED_NAMESPACE = "disabled";
 
 /**
  * @typedef { Object } ToolbarShared
@@ -179,9 +181,10 @@ export class ToolbarPlugin extends Plugin {
             description: _t("Expand toolbar"),
             icon: "oi-ellipsis-v",
         },
-        toolbar_namespaces: [
-            withSequence(99, { id: "compact", isApplied: () => !this.isToolbarExpanded }),
-            withSequence(100, { id: "expanded", isApplied: () => true }),
+        toolbar_namespace_providers: [
+            withSequence(100, (targetedNodes, editableSelection) =>
+                this.isToolbarVisible(targetedNodes, editableSelection) ? "compact" : undefined
+            ),
         ],
     };
 
@@ -194,7 +197,7 @@ export class ToolbarPlugin extends Plugin {
             groupIds.add(group.id);
         }
         this.buttonGroups = this.getButtonGroups();
-        this.buttonsByNamespace = this.getButtonsByNamespace();
+        this.buttonsByNamespace = { DISABLED_NAMESPACE: [] };
 
         this.isMobileToolbar = hasTouch() && window.visualViewport;
 
@@ -222,12 +225,9 @@ export class ToolbarPlugin extends Plugin {
             // Mouse interaction behavior:
             // Close toolbar on mousedown and prevent it from opening until mouseup.
             this.addDomListener(this.editable, "mousedown", (ev) => {
-                // Don't close if the mousedown is on an overlay.
-                if (!ev.target?.closest?.(".o-overlay-item")) {
-                    this.closeToolbar();
-                    this.debouncedUpdateToolbar.cancel();
-                    this.onSelectionChangeActive = false;
-                }
+                this.closeToolbar(this.dependencies.selection.getSelectionData());
+                this.debouncedUpdateToolbar.cancel();
+                this.onSelectionChangeActive = false;
             });
             this.addGlobalDomListener("mouseup", (ev) => {
                 if (ev.detail >= 2) {
@@ -253,7 +253,7 @@ export class ToolbarPlugin extends Plugin {
                 // On Chrome, if there is a password saved for a login page,
                 // a mouse click trigger a keydown event without any key
                 if (ev.key?.startsWith("Arrow")) {
-                    this.closeToolbar();
+                    this.closeToolbar(this.dependencies.selection.getSelectionData());
                     this.onSelectionChangeActive = false;
                 }
             });
@@ -322,17 +322,17 @@ export class ToolbarPlugin extends Plugin {
     }
 
     /**
-     * @returns {Object<string, ToolbarButton[]>}
+     * @returns ToolbarButton[]
      */
-    getButtonsByNamespace() {
-        const namespaces = this.getResource("toolbar_namespaces").map((ns) => ns.id);
-        const buttonsByNamespace = {};
-        for (const namespace of namespaces) {
-            buttonsByNamespace[namespace] = this.buttonGroups.flatMap((group) =>
-                group.buttons.filter((btn) => btn.namespaces.includes(namespace))
-            );
+    getButtonsForNamespace(namespace) {
+        if (this.buttonsByNamespace[namespace]) {
+            return this.buttonsByNamespace[namespace];
         }
-        return buttonsByNamespace;
+        const button = this.buttonGroups.flatMap((group) =>
+            group.buttons.filter((btn) => btn.namespaces.includes(namespace))
+        );
+        this.buttonsByNamespace[namespace] = button;
+        return button;
     }
 
     getToolbarInfo() {
@@ -354,18 +354,56 @@ export class ToolbarPlugin extends Plugin {
      */
     updateToolbar = debounce(this._updateToolbar, 0, { trailing: true });
     _updateToolbar(selectionData = this.dependencies.selection.getSelectionData()) {
-        const targetedNodes = this.getFilteredTargetedNodes();
-        this.updateNamespace(targetedNodes);
-        this.updateToolbarVisibility(selectionData, targetedNodes);
-        if (!this.overlay.isOpen) {
+        // Prevent toolbar to open if the selection is not in the editable area,
+        // or if the selection is protected or protecting.
+        if (
+            !selectionData.currentSelectionIsInEditable ||
+            selectionData.documentSelectionIsProtected ||
+            selectionData.documentSelectionIsProtecting
+        ) {
+            this.closeToolbar();
             return;
         }
-        this.updateButtonsStates(selectionData.editableSelection, targetedNodes);
+        // Prevent toolbar to open if the selection is only non-editable nodes.
+        const targetedNodes = this.dependencies.selection.getTargetedNodes();
+        if (targetedNodes.every((node) => !this.dependencies.selection.isNodeEditable(node))) {
+            this.closeToolbar();
+            return;
+        }
+        // Determine the namespace to use
+        let currentNamespace = null;
+        let filteredtargetedNodes = [];
+        filteredtargetedNodes = this.getFilteredTargetedNodes(targetedNodes);
+        for (const fn of this.getResource("toolbar_namespace_providers")) {
+            currentNamespace = fn(filteredtargetedNodes, selectionData.editableSelection);
+            if (currentNamespace) {
+                break;
+            }
+        }
+
+        if (currentNamespace === DISABLED_NAMESPACE) {
+            this.closeToolbar();
+            return;
+        }
+
+        if (currentNamespace === "compact" && this.isToolbarExpanded) {
+            currentNamespace = "expanded";
+        }
+
+        if (currentNamespace) {
+            this.state.namespace = currentNamespace;
+            // Do not reposition the toolbar if it's already open.
+            if (!this.overlay.isOpen) {
+                this.overlay.open({ props: this.toolbarProps });
+            }
+            this.updateButtonsStates(selectionData.editableSelection, filteredtargetedNodes);
+        } else {
+            this.closeToolbar();
+        }
     }
 
-    getFilteredTargetedNodes() {
-        return this.dependencies.selection
-            .getTargetedNodes()
+    getFilteredTargetedNodes(targetedNodes) {
+        return targetedNodes
             .filter(
                 (node) =>
                     this.dependencies.selection.isNodeEditable(node) &&
@@ -378,55 +416,46 @@ export class ToolbarPlugin extends Plugin {
             });
     }
 
-    updateToolbarVisibility(selectionData, targetedNodes) {
-        if (this.shouldBeVisible(selectionData, targetedNodes)) {
-            // Do not reposition the toolbar if it's already open.
-            if (!this.overlay.isOpen) {
-                this.overlay.open({ props: this.toolbarProps });
-            }
-        } else if (this.overlay.isOpen && !this.shouldPreventClosing()) {
-            this.closeToolbar();
-        }
-    }
-
-    shouldBeVisible(selectionData, targetedNodes) {
-        const inEditable =
-            selectionData.currentSelectionIsInEditable &&
-            !selectionData.documentSelectionIsProtected &&
-            !selectionData.documentSelectionIsProtecting;
-        if (!inEditable) {
-            return false;
-        }
-        const canDisplayToolbar = this.getResource("can_display_toolbar").every((fn) =>
-            fn(this.state.namespace)
-        );
-        if (!canDisplayToolbar) {
-            return false;
-        }
+    isToolbarVisible(targetedNodes, editableSelection) {
         if (this.isMobileToolbar) {
             return true;
         }
-        const isCollapsed = selectionData.editableSelection.isCollapsed;
+
+        const isCollapsed = editableSelection.isCollapsed;
         if (isCollapsed) {
-            return this.getResource("collapsed_selection_toolbar_predicate").some((fn) =>
-                fn(selectionData)
-            );
+            return false;
         }
-        return !!targetedNodes.length;
+        // Only allow the toolbar to open if the selection contains visible selected characters.
+        const selectionText = editableSelection.textContent();
+        const textCleaned = selectionText.replace(/(\r\n|\n|\r|\u200B|\uFEFF)/gm, "");
+        if (textCleaned.length) {
+            return true;
+        }
+        // Even without textContent we display the toolbar if the selection contains a <br>
+        return targetedNodes.some(
+            (node) => node.nodeType === Node.ELEMENT_NODE && node.tagName === "BR"
+        );
     }
 
-    shouldPreventClosing() {
-        // Should check in the document with overlays.
-        const preventClosing = document
-            .getSelection()
-            ?.anchorNode?.closest?.("[data-prevent-closing-overlay]");
-        return preventClosing?.dataset?.preventClosingOverlay === "true";
-    }
-
-    updateNamespace(targetedNodes) {
-        const namespaces = this.getResource("toolbar_namespaces");
-        const activeNamespace = namespaces.find((ns) => ns.isApplied(targetedNodes));
-        this.state.namespace = activeNamespace?.id;
+    /**
+     * @param {SelectionData} selectionData
+     */
+    closeToolbar(selectionData = null) {
+        if (!this.overlay.isOpen) {
+            return;
+        }
+        // TODO: refactor candidate : Remove data-prevent-closing-overlay
+        const anchor = selectionData?.documentSelectionIsInEditable
+            ? selectionData.editableSelection?.anchorNode
+            : document.getSelection()?.anchorNode;
+        const shouldPreventClosing =
+            anchor?.closest?.("[data-prevent-closing-overlay]")?.dataset?.preventClosingOverlay ===
+            "true";
+        if (!shouldPreventClosing) {
+            this.overlay.close();
+            this.isToolbarExpanded = false;
+            this.state.namespace = null;
+        }
     }
 
     /**
@@ -435,7 +464,7 @@ export class ToolbarPlugin extends Plugin {
      */
     updateButtonsStates(selection, targetedNodes) {
         const availableButtons = this.getAvailableButtonsSet(selection);
-        const buttonGroups = this.buttonGroups
+        this.state.buttonGroups = this.buttonGroups
             .map((group) => ({
                 id: group.id,
                 buttons: group.buttons
@@ -454,8 +483,6 @@ export class ToolbarPlugin extends Plugin {
             }))
             // Filter out groups left empty
             .filter((group) => group.buttons.length > 0);
-
-        this.state.buttonGroups = buttonGroups;
     }
 
     /**
@@ -469,7 +496,7 @@ export class ToolbarPlugin extends Plugin {
             return this.getAvailableButtonsCompact(selection);
         }
         const isAvailable = (button) => button.isAvailable(selection);
-        return new Set(this.buttonsByNamespace[this.state.namespace].filter(isAvailable));
+        return new Set(this.getButtonsForNamespace(this.state.namespace).filter(isAvailable));
     }
 
     /**
@@ -482,8 +509,8 @@ export class ToolbarPlugin extends Plugin {
      */
     getAvailableButtonsCompact(selection) {
         const isAvailable = memoize((button) => button.isAvailable(selection));
-        const compact = this.buttonsByNamespace["compact"].filter(isAvailable);
-        const expanded = this.buttonsByNamespace["expanded"].filter(isAvailable);
+        const compact = this.getButtonsForNamespace("compact").filter(isAvailable);
+        const expanded = this.getButtonsForNamespace("expanded").filter(isAvailable);
         const shouldDisplayCompactToolbar =
             // Expanded version is big enough
             expanded.length >= MIN_SIZE_FOR_COMPACT &&
@@ -494,11 +521,6 @@ export class ToolbarPlugin extends Plugin {
         }
         this.state.namespace = "expanded";
         return new Set(expanded);
-    }
-
-    closeToolbar() {
-        this.overlay.close();
-        this.isToolbarExpanded = false;
     }
 }
 

--- a/addons/website/static/src/builder/plugins/highlight/highlight_plugin.js
+++ b/addons/website/static/src/builder/plugins/highlight/highlight_plugin.js
@@ -46,6 +46,13 @@ export class HighlightPlugin extends Plugin {
                 isAvailable: isHtmlContentSupported,
             },
         ],
+        toolbar_namespace_providers: [
+            withSequence(
+                90,
+                (targetedNodes, editableSelection) =>
+                    closestElement(editableSelection.anchorNode, ".o_text_highlight") && "compact"
+            ),
+        ],
         normalize_handlers: (root) => {
             for (const node of root.querySelectorAll(".o_text_highlight")) {
                 // Signal to the interaction that there is (maybe) a new element
@@ -54,8 +61,6 @@ export class HighlightPlugin extends Plugin {
         },
         format_class_predicates: (className) => className.startsWith("o_text_highlight"),
         selectionchange_handlers: this.updateSelectedHighlight.bind(this),
-        collapsed_selection_toolbar_predicate: (selectionData) =>
-            !!closestElement(selectionData.editableSelection.anchorNode, ".o_text_highlight"),
         remove_all_formats_handlers: () => {
             // we rely on the normalize handler to start it again
             this.dependencies.edit_interaction.stopInteraction("website.text_highlight");

--- a/addons/website/static/src/builder/plugins/options/animate_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/animate_option_plugin.js
@@ -47,6 +47,13 @@ export class AnimateOptionPlugin extends Plugin {
                 isAvailable: isHtmlContentSupported,
             },
         ],
+        toolbar_namespace_providers: [
+            withSequence(90, (targetedNodes, editableSelection) =>
+                closestElement(editableSelection.commonAncestorContainer, ".o_animated_text")
+                    ? "compact"
+                    : undefined
+            ),
+        ],
         system_classes: ["o_animating"],
         builder_actions: {
             SetAnimationModeAction,
@@ -57,11 +64,6 @@ export class AnimateOptionPlugin extends Plugin {
         normalize_handlers: this.normalize.bind(this),
         clean_for_save_handlers: this.cleanForSave.bind(this),
         unsplittable_node_predicates: (node) => node.classList?.contains("o_animated_text"),
-        collapsed_selection_toolbar_predicate: (selectionData) =>
-            !!closestElement(
-                selectionData.editableSelection.commonAncestorContainer,
-                ".o_animated_text"
-            ),
         lower_panel_entries: withSequence(10, { Component: EmphasizeAnimatedText }),
     };
 

--- a/addons/website/static/tests/tours/snippet_editor_panel_options.js
+++ b/addons/website/static/tests/tours/snippet_editor_panel_options.js
@@ -8,6 +8,7 @@ import {
     selectFullText,
 } from "@website/js/tours/tour_utils";
 import { browser } from "@web/core/browser/browser";
+import { delay } from "@web/core/utils/concurrency";
 
 const checkIfParagraphSelected = (trigger) => ({
     content: "Check if the paragraph is selected.",
@@ -99,6 +100,14 @@ registerWebsitePreviewTour(
             name: "Text",
             groupName: "Text",
         }),
+		{
+		    content: "Wait for the Scroll to finish",
+		    trigger: ":iframe .s_text_block",
+		    run: async function() {
+		        // Default scroll duration is 600ms
+		        await delay(610);
+		    },
+		},
         selectFullText("first paragraph", ".s_text_block p:not([data-selection-placeholder])"),
         checkIfParagraphSelected(":iframe .s_text_block p:not([data-selection-placeholder])"),
         checkIfTextToolbarVisible,


### PR DESCRIPTION
Prevent the toolbar to open if the selection is not clearly visible to the user. for example, line break only selection.


task-4945676

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
