### PR TITLE
[FIX] base: fix test_lang_computation_form_view to run in single app

### DIFF
--- a/odoo/addons/base/tests/test_res_partner.py
+++ b/odoo/addons/base/tests/test_res_partner.py
@@ -1105,8 +1105,7 @@ class TestPartnerForm(TransactionCase):
     def test_lang_computation_form_view(self):
         """ Check computation of lang: coming from installed languages, forced
         default value and propagation from parent."""
-        default_lang_info = self.env['res.lang'].get_installed()[0]
-        default_lang_code = default_lang_info[0]
+        default_lang_code = self.env['ir.default']._get('res.partner', 'lang') or False
         self.assertNotEqual(default_lang_code, 'de_DE')  # should not be the case, just to ease test
         self.assertNotEqual(default_lang_code, 'fr_FR')  # should not be the case, just to ease test
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
test_lang_computation_form_view fails since l10n_gcc_invoice activated the arabic language during post_init since the default language expected becomes arabic instead of English even though the created partner's language is in English.

to reproduce:
- install l10n_gcc_invoice
- run the test test_lang_computation_form_view.
- will fail since it expects the partner default lang to be arabic but it is in english.

Current behavior before PR:
before this commit, test_lang_computation_form_view failed on l10n_gcc_invoice or any of the depending modules.
because activating arabic makes the test expect arabic as the default language when it is english.

Desired behavior after PR is merged:
with this commit the test is passed as we install the arabic language only during the activation of dual language in the company settings
rather than during the post_init.

runbot:231711

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
