### PR TITLE
[REM] hr: remove the hotfix for m2o field alignment

### DIFF
--- a/addons/hr/static/src/scss/hr.scss
+++ b/addons/hr/static/src/scss/hr.scss
@@ -54,13 +54,6 @@
     }
 }
 
-// Dirty hopefully temporary hack to keep the field aligned with the others
-.o_hr_user_preferences_form_view {
-    .o_address_state .o_many2one.text-truncate {
-        overflow: clip !important;
-    }
-}
-
 .o_hr_employee_kanban .o_kanban_renderer {
     .o_employee_availability {
         margin: unset !important;


### PR DESCRIPTION
This PR removes the hotfix for the alignment issue of the m2o field as it is fixed more properly by the PR https://github.com/odoo/odoo/pull/226214.

Task-5078736