### PR TITLE
[FIX] {website_sale_,}loyalty: prevent error when applying a code

### DIFF
--- a/addons/loyalty/tests/test_loyalty.py
+++ b/addons/loyalty/tests/test_loyalty.py
@@ -27,6 +27,16 @@ class TestLoyalty(TransactionCase):
             'list_price': 20.0,
         })
 
+    def create_program_with_code(self, code):
+        return self.env['loyalty.program'].create({
+            'name': "Discount delivery",
+            'program_type': 'promo_code',
+            'rule_ids': [Command.create({
+                'code': code,
+                'minimum_amount': 0,
+            })],
+        })
+
     def test_loyalty_program_default_values(self):
         # Test that the default values are correctly set when creating a new program
         program = self.env['loyalty.program'].create({'name': "Test"})
@@ -310,3 +320,25 @@ class TestLoyalty(TransactionCase):
             "Free Product - [Test Product, Test Product 2]",
             "Reward description for reward with tag should be 'Free Product - [Test Product, Test Product 2]'"
         )
+
+    def test_prevent_unarchive_when_conflicting_active_program_exists(self):
+        """Unarchiving a program should fail if another active program already has the same rule
+           code."""
+        program = self.create_program_with_code("FREE")
+        program.action_archive()
+        # create another active program with the same rule code
+        self.create_program_with_code("FREE")
+        # attempt to unarchive the first program
+        with self.assertRaises(ValidationError):
+            program.action_unarchive()
+
+    def test_prevent_unarchive_when_batch_contains_duplicate_codes(self):
+        """Unarchiving multiple programs at once should fail if they share the same rule code."""
+        program1 = self.create_program_with_code("FREE")
+        program1.action_archive()
+        # create another program with the same rule code and archive it
+        program2 = self.create_program_with_code("FREE")
+        program2.action_archive()
+        # attempt to unarchive both programs together
+        with self.assertRaises(ValidationError):
+            (program1 + program2).action_unarchive()

--- a/addons/website_sale_loyalty/tests/test_website_sale_loyalty_delivery.py
+++ b/addons/website_sale_loyalty/tests/test_website_sale_loyalty_delivery.py
@@ -2,6 +2,7 @@
 
 from odoo import Command
 from odoo.tests import HttpCase, tagged
+from odoo.exceptions import ValidationError
 
 from odoo.addons.base.tests.common import DISABLED_MAIL_CONTEXT
 from odoo.addons.payment import utils as payment_utils
@@ -30,6 +31,8 @@ class TestWebsiteSaleDelivery(HttpCase, WebsiteSaleCommon):
 
         cls.partner_admin = cls.env.ref('base.partner_admin')
         cls.partner_admin.write(cls.dummy_partner_address_values)
+
+        cls.website2 = cls.env['website'].create({'name': 'website 2'})
 
         cls.env['product.product'].create({
             'name': "Plumbus",
@@ -133,6 +136,17 @@ class TestWebsiteSaleDelivery(HttpCase, WebsiteSaleCommon):
             'product_id': delivery_product2.id,
         }])
 
+    def create_program_with_code(self, code, website_id):
+        return self.env['loyalty.program'].create({
+            'name': "Discount delivery",
+            'program_type': 'promo_code',
+            'website_id': website_id.id,
+            'rule_ids': [Command.create({
+                'code': code,
+                'minimum_amount': 0,
+            })],
+        })
+
     def test_shop_sale_gift_card_keep_delivery(self):
         # Get admin user and set his preferred shipping method to normal delivery
         # This test also tests that we can indeed pay delivery fees with gift cards/ewallet
@@ -222,3 +236,33 @@ class TestWebsiteSaleDelivery(HttpCase, WebsiteSaleCommon):
             payment_values = WebsiteSale()._get_express_shop_payment_values(self.cart)
 
         self.assertEqual(payment_values['minor_amount'], amount_without_delivery)
+
+    def test_prevent_unarchive_when_conflicting_active_program_exists_on_same_website(self):
+        """Unarchiving a program should fail if another active program already has the same
+           rule code on the same website."""
+        program = self.create_program_with_code("FREE", self.website)
+        program.action_archive()
+        self.create_program_with_code("FREE", self.website)
+
+        with self.assertRaises(ValidationError):
+            program.action_unarchive()
+
+    def test_unarchive_when_conflicting_active_program_exists_on_different_website(self):
+        """Unarchiving a program should succeed when another active program already has the
+           same rule code on a different website."""
+        program = self.create_program_with_code("FREE", self.website)
+        program.action_archive()
+
+        self.create_program_with_code("FREE", self.website2)
+        program.action_unarchive()
+
+    def test_prevent_unarchive_when_batch_contains_duplicate_codes_on_same_website(self):
+        """Unarchiving multiple programs at once should fail if they share the same rule code
+           on the same website."""
+        program1 = self.create_program_with_code("FREE", self.website)
+        program1.action_archive()
+        program2 = self.create_program_with_code("FREE", self.website)
+        program2.action_archive()
+
+        with self.assertRaises(ValidationError):
+            (program1 + program2).action_unarchive()


### PR DESCRIPTION
Currently, an error occurs when a user applies a discount code to the cart.

Steps to reproduce:

 - Install the `website_sale_loyalty` module.
 - Go to `Discount & Loyalty` and create a new program with `Program Type = Discount Code`.
 - Under the `Rules & Rewards` tab, add a rule with a `code (e.g., demo)`.
 - `Archive` the program record.
 - Repeat `steps 2 and 3`.
 - `Unarchive` the first record.
 - Go to `Website` > `Shop`, add a product to the cart, and go to the cart page.
-  Apply the code `demo`.

`ValueError: Expected singleton: loyalty.program(2, 3)`

This error occurs when a user creates a sale loyalty program and adds a loyalty rule with a code, then archives that record. If the user creates the same record again and later unarchive the first record, there will be two rules with the same code, resulting in two loyalty programs [1], which raises the error [2].

This commit ensures that the system also checks archived records when unarchiving and verifies that there are no two or 
more programs with the same code being unarchived, so that no conflicting rules are activated.

[1]- https://github.com/odoo/odoo/blob/76a8d6bc28eb5998bd976b3c41bf9772d325c8bf/addons/sale_loyalty/models/sale_order.py#L1351

[2]- https://github.com/odoo/odoo/blob/76a8d6bc28eb5998bd976b3c41bf9772d325c8bf/addons/sale_loyalty/models/sale_order.py#L1371

sentry-6871330244

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
