### PR TITLE
[FIX] website, *: correct px rounding in theme tab

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_number_input.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_number_input.js
@@ -86,6 +86,10 @@ export class BuilderNumberInput extends Component {
                     unit,
                     getHtmlStyle(this.env.getEditingElement().ownerDocument)
                 );
+                // Round displayed px values to an integer for cleaner UX
+                if (unit === "px") {
+                    value = Math.round(parseFloat(value));
+                }
             }
             return value;
         });


### PR DESCRIPTION
Steps to reproduce:
- Go to Website > Edit
- Open the Theme tab
- Set the font size to 45 px
- Notice the value changes to 45.008

Fix rounding drift in "Font size" inputs. Values are now displayed as
whole px after rem > px conversion (e.g. 45 > 45 px instead of 45.008
px).
