### PR TITLE
[IMP] html_editor: add syntax highlighting to code blocks

### DIFF
--- a/addons/html_editor/__manifest__.py
+++ b/addons/html_editor/__manifest__.py
@@ -110,6 +110,9 @@ This addon provides an extensible, maintainable editor.
         'web._assets_frontend_helpers': [
             ('prepend', 'html_editor/static/src/scss/bootstrap_overridden.scss'),
         ],
+        'html_editor.assets_prism': [
+            'web/static/lib/prismjs/prism.js',
+        ],
     },
     'license': 'LGPL-3'
 }

--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -468,6 +468,7 @@ export class SelectionPlugin extends Plugin {
         const documentSelection =
             selection?.anchorNode && selection?.focusNode
                 ? Object.freeze({
+                      isCollapsed: selection.isCollapsed,
                       anchorNode: selection.anchorNode,
                       anchorOffset: selection.anchorOffset,
                       focusNode: selection.focusNode,

--- a/addons/html_editor/static/src/others/embedded_components/backend/syntax_highlighting/syntax_highlighting.js
+++ b/addons/html_editor/static/src/others/embedded_components/backend/syntax_highlighting/syntax_highlighting.js
@@ -44,7 +44,7 @@ export class EmbeddedSyntaxHighlightingComponent extends Component {
 
     setup() {
         super.setup();
-        this.loadBundle("html_editor.assets_prism");
+        this.loadPrism();
         this.state = useState({
             isActive: false,
             host: this.props.host,
@@ -120,6 +120,14 @@ export class EmbeddedSyntaxHighlightingComponent extends Component {
         );
     }
 
+    /**
+     * Load the Prism library. This function exists only so it can be overridden
+     * in tests.
+     */
+    loadPrism() {
+        return loadBundle("html_editor.assets_prism");
+    }
+
     openCodeToolbar() {
         this.props.codeToolbar.open({
             target: this.state.host,
@@ -179,7 +187,7 @@ export class EmbeddedSyntaxHighlightingComponent extends Component {
      */
     async highlight(focus = this.document.activeElement === this.textarea) {
         if (!window.Prism) {
-            await this.loadBundle("html_editor.assets_prism");
+            await this.loadPrism();
             if (!window.Prism) {
                 console.error("The Prism library couldn't be found.");
                 return;

--- a/addons/html_editor/static/src/others/embedded_components/backend/syntax_highlighting/syntax_highlighting.js
+++ b/addons/html_editor/static/src/others/embedded_components/backend/syntax_highlighting/syntax_highlighting.js
@@ -1,0 +1,345 @@
+/* global Prism */
+import {
+    applyObjectPropertyDifference,
+    getEmbeddedProps,
+    StateChangeManager,
+} from "@html_editor/others/embedded_component_utils";
+import { Component, onMounted, useEffect, useRef, useState, onWillDestroy } from "@odoo/owl";
+import { loadBundle } from "@web/core/assets";
+import { newlinesToLineBreaks } from "../../plugins/syntax_highlighting_plugin/syntax_highlighting_plugin";
+import { cookie } from "@web/core/browser/cookie";
+
+const LANGUAGES = {
+    plaintext: "Plain Text",
+    markdown: "Markdown",
+    javascript: "Javascript",
+    typescript: "Typescript",
+    jsdoc: "JSDoc",
+    java: "Java",
+    python: "Python",
+    html: "HTML",
+    xml: "XML",
+    svg: "SVG",
+    json: "JSON",
+    css: "CSS",
+    sass: "SASS",
+    scss: "SCSS",
+    sql: "SQL",
+    diff: "Diff",
+};
+export const DEFAULT_LANGUAGE_ID = "plaintext";
+
+export class EmbeddedSyntaxHighlightingComponent extends Component {
+    static template = "html_editor.EmbeddedSyntaxHighlighting";
+
+    static props = {
+        initialValue: { type: String },
+        autofocus: { type: Boolean },
+        codeToolbar: { type: Object },
+        onTextareaFocus: { type: Function },
+        addHistoryStep: { type: Function },
+        getPreValue: { type: Function },
+        host: { type: Object },
+    };
+
+    setup() {
+        super.setup();
+        this.loadBundle("html_editor.assets_prism");
+        this.state = useState({
+            isActive: false,
+            host: this.props.host,
+        });
+        this.preRef = useRef("pre");
+        this.textareaRef = useRef("textarea");
+
+        onMounted(() => {
+            this.pre = this.preRef.el;
+            this.textarea = this.textareaRef.el;
+            this.document = this.textarea.ownerDocument;
+
+            // Load the CSS.
+            const theme = cookie.get("color_scheme") === "dark" ? "okaida" : "default";
+            const prismStyleLink = document.createElement("link");
+            prismStyleLink.rel = "stylesheet";
+            prismStyleLink.href = `/web/static/lib/prismjs/themes/${theme}.css`;
+            this.document.head.append(prismStyleLink);
+
+            // Activate and focus the textarea if required.
+            if (this.props.autofocus) {
+                this.state.isActive = true;
+                if (this.textarea !== this.document.activeElement) {
+                    this.textarea.focus();
+                    this.props.onTextareaFocus();
+                }
+            }
+
+            // Set the initial values and highlight the pre.
+            this.initialValue =
+                this.state.host.dataset.syntaxHighlightingValue || this.props.initialValue;
+            this.initialLanguageId = this.state.host.dataset.languageId || DEFAULT_LANGUAGE_ID;
+            this.commitToHost(
+                {
+                    value: this.initialValue,
+                    languageId: this.initialLanguageId,
+                },
+                false
+            ).then((didHighlight) => !didHighlight && this.highlight());
+
+            // Ensure the values of the dataset and the content match.
+            this.observer = new MutationObserver((mutations) => {
+                if (mutations.some((mutation) => mutation.oldValue !== null)) {
+                    // Prevent UNDO from returning to a state where the dataset
+                    // was not yet defined.
+                    if (!("syntaxHighlightingValue" in this.state.host.dataset)) {
+                        this.state.host.dataset.syntaxHighlightingValue = this.initialValue;
+                    }
+                    if (!("languageId" in this.state.host.dataset)) {
+                        this.state.host.dataset.languageId = this.initialLanguageId;
+                    }
+                    this.highlight();
+                }
+            });
+            this.observer.observe(this.state.host, {
+                attributeFilter: ["data-syntax-highlighting-value", "data-language-id"],
+                attributeOldValue: true,
+            });
+        });
+        onWillDestroy(() => {
+            this.observer?.disconnect();
+        });
+
+        // Activate/deactivate the code toolbar.
+        useEffect(
+            () => {
+                this.props.codeToolbar.close();
+                if (this.state.isActive) {
+                    this.openCodeToolbar();
+                }
+            },
+            () => [this.state.isActive]
+        );
+    }
+
+    openCodeToolbar() {
+        this.props.codeToolbar.open({
+            target: this.state.host,
+            props: {
+                target: this.state.host,
+                prismSource: this.textarea,
+                languages: LANGUAGES,
+                onLanguageChange: this.onLanguageChange.bind(this),
+            },
+        });
+    }
+
+    /**
+     * Set the value and/or the language ID in the host's dataset so they can be
+     * saved. If anything changed, highlight the pre and add a history step
+     * (unless `addStep` is false).
+     *
+     * @param {{ value?: string, languageId?: string }} values
+     * @param {boolean} [addStep = true]
+     * @returns {Promise<boolean>} true if anything changed.
+     */
+    async commitToHost(values, addStep = true) {
+        let hasChanged = false;
+        if ("value" in values && this.state.host.dataset.syntaxHighlightingValue !== values.value) {
+            hasChanged = true;
+            this.state.host.dataset.syntaxHighlightingValue = values.value;
+        }
+        if ("languageId" in values && this.state.host.dataset.languageId !== values.languageId) {
+            hasChanged = true;
+            this.state.host.dataset.languageId = values.languageId;
+        }
+        if (hasChanged) {
+            await this.highlight();
+            if (addStep) {
+                this.props.addHistoryStep();
+            }
+        }
+        return hasChanged;
+    }
+
+    /**
+     * Get the saved value or language ID from the host's dataset.
+     *
+     * @param {"value" | "languageId"} key
+     * @returns {string | undefined}
+     */
+    getFromHostDataset(key) {
+        return this.state.host.dataset[key == "value" ? "syntaxHighlightingValue" : key];
+    }
+
+    /**
+     * Use the Prism library to highlight the pre using the value and language
+     * stored on the host's dataset. Ensure the values (pre, host, textarea)
+     * match and commit the value if it changed in the process.
+     *
+     * @param {boolean} [focus = this.document.activeElement === this.textarea]
+     */
+    async highlight(focus = this.document.activeElement === this.textarea) {
+        if (!window.Prism) {
+            await this.loadBundle("html_editor.assets_prism");
+            if (!window.Prism) {
+                console.error("The Prism library couldn't be found.");
+                return;
+            }
+        }
+        const languageId = this.getFromHostDataset("languageId");
+        // We need a temporary element because directly changing the HTML of the
+        // PRE, or using replaceChildren both mess up the history by not
+        // recording the removal of the contents.
+        const fakeElement = this.document.createElement("pre");
+        fakeElement.innerHTML = Prism.highlight(
+            this.getFromHostDataset("value"),
+            Prism.languages[languageId],
+            languageId
+        );
+
+        // Post-process highlighted HTML.
+        newlinesToLineBreaks(fakeElement, this.document);
+
+        // Replace the PRE's contents with the highlighted ones.
+        [...this.pre.childNodes].forEach((child) => child.remove());
+        [...fakeElement.childNodes].forEach((child) => this.pre.append(child));
+
+        // Ensure the values match.
+        const preValue = this.props.getPreValue(this.pre);
+        if (this.textarea.value !== preValue) {
+            this.textarea.value = preValue;
+        }
+        if (focus) {
+            this.textarea.focus({ preventScroll: true });
+            this.props.onTextareaFocus();
+        }
+        await this.commitToHost({ value: this.textarea.value });
+    }
+
+    onInput() {
+        this.textarea.focus();
+        this.props.onTextareaFocus();
+        this.commitToHost({ value: this.textarea.value });
+    }
+
+    /**
+     * Handle tabulation in the textarea.
+     *
+     * @param {KeyboardEvent} ev
+     */
+    onKeydown(ev) {
+        if (ev.key === "Tab") {
+            ev.preventDefault();
+            const tabSize = +getComputedStyle(this.textarea).tabSize || 4;
+            const tab = " ".repeat(tabSize);
+            const { selectionStart, selectionEnd } = this.textarea;
+            const collapsed = selectionStart === selectionEnd;
+            let start = this.textarea.value.slice(0, selectionStart).lastIndexOf("\n");
+            start = start === -1 ? 0 : start;
+            let newValue = "";
+            let spacesRemovedAtStart = 0;
+            if (ev.shiftKey) {
+                // Remove tabs.
+                let end = this.textarea.value
+                    .slice(selectionEnd, this.textarea.value.length)
+                    .indexOf("\n");
+                end = end === -1 ? 0 : end;
+                end = selectionEnd + end;
+                // From 0 to the last \n before selection start.
+                newValue = this.textarea.value.slice(0, start);
+                // From the last \n before selection start to selection end.
+                const regex = new RegExp(`(\n|^)( |\u00A0){1,${tabSize}}`, "g");
+                const startSlice = this.textarea.value.slice(start, selectionStart);
+                const cleanStartSlice = startSlice.replace(regex, "$1");
+                spacesRemovedAtStart = startSlice.length - cleanStartSlice.length;
+                newValue += cleanStartSlice;
+                newValue += this.textarea.value
+                    .slice(selectionStart, selectionEnd)
+                    .replace(regex, "$1");
+                newValue += this.textarea.value.slice(selectionEnd, end).replace(regex, "$1");
+                // From selection end to end.
+                newValue += this.textarea.value.slice(end, this.textarea.value.length);
+            } else {
+                // Insert tabs.
+                if (collapsed && /\S/.test(this.textarea.value.slice(start, selectionStart))) {
+                    newValue =
+                        this.textarea.value.slice(0, selectionStart) +
+                        tab +
+                        this.textarea.value.slice(selectionStart, this.textarea.value.length);
+                } else {
+                    // From 0 to the last \n before selection start.
+                    newValue = start ? this.textarea.value.slice(0, start) : tab;
+                    // From the last \n before selection start to selection end.
+                    newValue += this.textarea.value
+                        .slice(start, selectionEnd)
+                        .replaceAll("\n", `\n${tab}`);
+                    // From selection end to end.
+                    newValue += this.textarea.value.slice(selectionEnd, this.textarea.value.length);
+                }
+            }
+            const insertedChars = newValue.length - this.textarea.value.length;
+            this.textarea.value = newValue;
+            const newStart = selectionStart + (ev.shiftKey ? -spacesRemovedAtStart : tabSize);
+            const newEnd = collapsed ? newStart : selectionEnd + insertedChars;
+            this.textarea.setSelectionRange(newStart, newEnd, this.textarea.selectionDirection);
+            this.commitToHost({ value: this.textarea.value });
+        }
+    }
+
+    /**
+     * Ensure the pre and textarea's scrolls match so they remain aligned.
+     */
+    onScroll() {
+        this.pre.scrollTop = this.textarea.scrollTop;
+        this.pre.scrollLeft = this.textarea.scrollLeft;
+    }
+
+    onHover() {
+        const isLanguageSelectorOpen = !!this.document.querySelector(
+            ".dropdown-menu.o_language_selector"
+        );
+        if (!isLanguageSelectorOpen) {
+            this.state.isActive = true;
+        }
+    }
+
+    onLeave(ev) {
+        const isLanguageSelectorOpen = !!this.document.querySelector(
+            ".dropdown-menu.o_language_selector"
+        );
+        if (!isLanguageSelectorOpen && !ev.relatedTarget?.closest?.(".o_code_toolbar")) {
+            this.state.isActive = false;
+        }
+    }
+
+    /**
+     * Change the language when selecting a new one via the code toolbar.
+     *
+     * @param {string} languageId
+     */
+    onLanguageChange(languageId) {
+        if (this.getFromHostDataset("languageId") !== languageId) {
+            this.props.codeToolbar.close();
+            this.textarea.focus();
+            this.props.onTextareaFocus();
+            this.commitToHost({ languageId }).then(() => {
+                this.openCodeToolbar();
+            });
+        }
+    }
+}
+
+export const syntaxHighlightingEmbedding = {
+    name: "syntaxHighlighting",
+    Component: EmbeddedSyntaxHighlightingComponent,
+    getProps: (host) => ({ host, ...getEmbeddedProps(host) }),
+    getStateChangeManager: (config) =>
+        new StateChangeManager(
+            Object.assign(config, {
+                propertyUpdater: {
+                    value: (state, previous, next) => {
+                        applyObjectPropertyDifference(state, "value", previous.value, next.value);
+                    },
+                },
+            })
+        ),
+};

--- a/addons/html_editor/static/src/others/embedded_components/backend/syntax_highlighting/syntax_highlighting.xml
+++ b/addons/html_editor/static/src/others/embedded_components/backend/syntax_highlighting/syntax_highlighting.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates>
+    <!-- syntax highlighting template -->
+    <t t-name="html_editor.EmbeddedSyntaxHighlighting">
+        <pre t-ref="pre"/>
+        <textarea t-ref="textarea" class="o_prism_source" contenteditable="true"
+            t-on-input="onInput"
+            t-on-scroll="onScroll"
+            t-on-keydown="onKeydown"
+            t-on-mouseover="onHover" t-on-pointerdown="onHover"
+            t-on-mouseleave="onLeave" t-on-pointerleave="onLeave"
+            t-on-focus="props.onTextareaFocus"></textarea>
+    </t>
+</templates>

--- a/addons/html_editor/static/src/others/embedded_components/embedding_sets.js
+++ b/addons/html_editor/static/src/others/embedded_components/embedding_sets.js
@@ -8,6 +8,7 @@ import {
 import { toggleBlockEmbedding } from "@html_editor/others/embedded_components/core/toggle_block/toggle_block";
 import { videoEmbedding } from "@html_editor/others/embedded_components/backend/video/video";
 import { readonlyVideoEmbedding } from "@html_editor/others/embedded_components/core/video/readonly_video";
+import { syntaxHighlightingEmbedding } from "@html_editor/others/embedded_components/backend/syntax_highlighting/syntax_highlighting";
 
 export const MAIN_EMBEDDINGS = [
     fileEmbedding,
@@ -15,6 +16,7 @@ export const MAIN_EMBEDDINGS = [
     toggleBlockEmbedding,
     videoEmbedding,
     captionEmbedding,
+    syntaxHighlightingEmbedding,
 ];
 
 export const READONLY_MAIN_EMBEDDINGS = [
@@ -23,4 +25,5 @@ export const READONLY_MAIN_EMBEDDINGS = [
     toggleBlockEmbedding,
     readonlyVideoEmbedding,
     captionEmbedding,
+    syntaxHighlightingEmbedding,
 ];

--- a/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/code_toolbar.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/code_toolbar.js
@@ -1,0 +1,30 @@
+import { Component, useEffect, useState } from "@odoo/owl";
+import { CopyButton } from "@web/core/copy_button/copy_button";
+import { Dropdown } from "@web/core/dropdown/dropdown";
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+
+export class CodeToolbar extends Component {
+    static template = "html_editor.CodeToolbar";
+    static props = {
+        target: { validate: (el) => el.nodeType === Node.ELEMENT_NODE },
+        prismSource: { validate: (el) => el.nodeType === Node.ELEMENT_NODE },
+        languages: { type: Object },
+        onLanguageChange: { type: Function },
+    };
+    static components = { Dropdown, DropdownItem, CopyButton };
+
+    setup() {
+        super.setup();
+        this.state = useState({
+            language: this.props.target.dataset.languageId,
+        });
+        useEffect(
+            () => this.props.onLanguageChange(this.state.language),
+            () => [this.state.language]
+        );
+    }
+
+    selectLanguage(language) {
+        this.state.language = language;
+    }
+}

--- a/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/code_toolbar.scss
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/code_toolbar.scss
@@ -1,0 +1,19 @@
+.o_code_toolbar {
+    position: absolute;
+    top: 0;
+    right: 0;
+    padding: 3px 4px;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+
+    button {
+        display: inline-flex;
+        align-items: center;
+        height: 20px;
+        padding: 0 3px 0 0;
+        font-size: 12px;
+        --btn-hover-bg: #{$o-gray-200};
+    }
+}

--- a/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/code_toolbar.xml
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/code_toolbar.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates>
+    <t t-name="html_editor.CodeToolbar">
+        <div class="o_code_toolbar">
+            <div data-prevent-closing-overlay="true">
+                <Dropdown menuClass="'o_language_selector'">
+                    <button class="btn" t-att-title="props.languages[state.language]" name="language">
+                        <span class="px-1" t-esc="props.languages[state.language]"/>
+                        <i class="fa fa-caret-down"></i>
+                    </button>
+                    <t t-set-slot="content">
+                        <t t-foreach="Object.entries(props.languages)" t-as="language" t-key="language[0]">
+                            <DropdownItem
+                                attrs="{ name: language[1] }"
+                                onSelected="() => this.selectLanguage(language[0])" t-on-pointerdown.prevent="() => {}">
+                                <t t-esc="language[1]"/>
+                            </DropdownItem>
+                        </t>
+                    </t>
+                </Dropdown>
+                <CopyButton content="() => props.prismSource.value" copyText.translate="Copy" successText.translate="Code copied to the clipboard."/>
+            </div>
+        </div>
+    </t>
+</templates>

--- a/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_blueprint.xml
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_blueprint.xml
@@ -1,0 +1,6 @@
+<templates>
+    <t t-name="html_editor.EmbeddedSyntaxHighlightingBlueprint">
+        <div t-att-data-embedded-props="embeddedProps" data-embedded="syntaxHighlighting"
+            data-oe-protected="true" contenteditable="false" class="o_syntax_highlighting"/>
+    </t>
+</templates>

--- a/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin.dark.scss
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin.dark.scss
@@ -1,0 +1,3 @@
+.o_syntax_highlighting textarea.o_prism_source {
+    caret-color: white !important;
+}

--- a/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin.js
@@ -1,0 +1,155 @@
+import { Plugin } from "@html_editor/plugin";
+import { CodeToolbar } from "./code_toolbar";
+import { renderToElement } from "@web/core/utils/render";
+import { withSequence } from "@html_editor/utils/resource";
+import { descendants, lastLeaf } from "@html_editor/utils/dom_traversal";
+import { fillEmpty } from "@html_editor/utils/dom";
+
+const CODE_BLOCK_CLASS = "o_syntax_highlighting";
+const CODE_BLOCK_SELECTOR = `div.${CODE_BLOCK_CLASS}`;
+
+export const newlinesToLineBreaks = (element, doc = element.ownerDocument || document) => {
+    // 1. Replace \n with <br>.
+    for (const node of descendants(element).filter((node) => node.nodeType === Node.TEXT_NODE)) {
+        let newline = node.textContent.indexOf("\n");
+        while (newline !== -1) {
+            node.before(doc.createTextNode(node.textContent.slice(0, newline)));
+            node.before(doc.createElement("BR"));
+            node.textContent = node.textContent.slice(newline + 1);
+            newline = node.textContent.indexOf("\n");
+        }
+        if (!node.textContent) {
+            node.remove(); // Prevent empty trailing text node that would become the last leaf.
+        }
+    }
+    // 2. Handle trailing BRs. Eg, <span>ab\n</span> -> <span>ab</span><br><br>
+    const trailingBr = lastLeaf(element);
+    if (trailingBr?.nodeName === "BR") {
+        element.append(trailingBr); // <span>ab<br></span> -> <span>ab</span><br>
+        trailingBr.after(doc.createElement("BR")); // <br></pre> -> <br><br></pre>
+    }
+    // 3. Fill empty.
+    fillEmpty(element);
+};
+
+export class SyntaxHighlightingPlugin extends Plugin {
+    static id = "syntaxHighlighting";
+    static dependencies = [
+        "overlay",
+        "history",
+        "selection",
+        "protectedNode",
+        "embeddedComponents",
+    ];
+    resources = {
+        mount_component_handlers: this.setupNewCodeBlock.bind(this),
+        normalize_handlers: (root) => this.addCodeBlocks(root, true),
+        post_undo_handlers: () => this.addCodeBlocks(this.editable, true),
+        post_redo_handlers: () => this.addCodeBlocks(this.editable, true),
+        clean_for_save_handlers: withSequence(0, ({ root }) => this.cleanForSave(root)),
+        // Ensure focus can be preserved within the textarea:
+        is_node_editable_predicates: (node) => node?.classList?.contains("o_prism_source"),
+    };
+
+    setup() {
+        /** @type {import("@html_editor/core/overlay_plugin").Overlay} */
+        this.codeToolbar = this.dependencies.overlay.createOverlay(CodeToolbar, {
+            positionOptions: {
+                position: "top-fit",
+                flip: false,
+            },
+            closeOnPointerdown: false,
+        });
+        this.addDomListener(this.document, "scroll", this.codeToolbar.close, true);
+        this.addCodeBlocks();
+    }
+
+    cleanForSave(root) {
+        for (const codeBlock of root.querySelectorAll("div.o_syntax_highlighting")) {
+            // Save only the `<pre>` element, with information to rebuild the
+            // embedded component, so the saved DOM is independent of this plugin.
+            const pre = codeBlock.querySelector("pre");
+            const value = codeBlock.dataset.syntaxHighlightingValue;
+            pre.dataset.languageId = codeBlock.dataset.languageId;
+            codeBlock.before(pre);
+            codeBlock.remove();
+            // Remove highlighting.
+            pre.textContent = value;
+            newlinesToLineBreaks(pre);
+        }
+    }
+
+    /**
+     * Take all `<pre>` element in the given `root` that aren't in an embedded
+     * syntax highlighting block, and replace them with an embedded syntax
+     * highlighting block. If `preserveFocus` is true, set the currently
+     * targeted `<pre>` element to be focused.
+     *
+     * @param {Element} [root = this.editable]
+     * @param {boolean} [preserveFocus = false]
+     */
+    addCodeBlocks(root = this.editable, preserveFocus = false) {
+        const targetedNodes = this.dependencies.selection.getTargetedNodes();
+        const nonEmbeddedPres = [...root.querySelectorAll("pre")].filter(
+            (pre) => !pre.closest(CODE_BLOCK_SELECTOR)
+        );
+        for (const pre of nonEmbeddedPres) {
+            const isPreInSelection = !targetedNodes.some((node) => !pre.contains(node));
+            const codeBlock = renderToElement("html_editor.EmbeddedSyntaxHighlightingBlueprint", {
+                embeddedProps: JSON.stringify({
+                    initialValue: this.getPreValue(pre),
+                    autofocus: preserveFocus && isPreInSelection,
+                }),
+            });
+            // Transfer the data from the `<pre>` element back to the embedded
+            // component (see `cleanForSave`).
+            if (pre.hasAttribute("data-language-id")) {
+                codeBlock.dataset.languageId = pre.dataset.languageId;
+            }
+            pre.before(codeBlock);
+            if (isPreInSelection) {
+                // Removing the pre will make us lose the selection. The DOM
+                // would try to set it in the root, which would get corrected,
+                // preventing us from directly writing inside the textarea.
+                this.document.getSelection().removeAllRanges();
+            }
+            pre.remove();
+        }
+    }
+
+    /**
+     * Return the given `<pre>` element's inner text, cleaned of any zero-width
+     * characters or trailing invisible newline characters (a trailing `<br>` in
+     * the element's HTML is invisible but results in an visible `\n` in its
+     * `innerText` property, which would be visible if kept).
+     *
+     * @param {HTMLPreElement} pre
+     * @returns {string}
+     */
+    getPreValue(pre) {
+        // Trailing br gives \n in innerText but should not be visible.
+        const trailingBrs = pre.innerHTML.match(/(<br>)+$/)?.length || 0;
+        return pre.innerText
+            .slice(0, pre.innerText.length - (trailingBrs > 1 ? trailingBrs - 1 : trailingBrs))
+            .replace(/[\u200B\uFEFF]/g, "");
+    }
+
+    setupNewCodeBlock({ name, props }) {
+        if (name === "syntaxHighlighting") {
+            let initialValue = props.initialValue || "";
+            if (props.host.hasAttribute("data-syntax-highlighting-value")) {
+                // Preserve any saved value as initial value of the current
+                // editing session.
+                initialValue = props.host.dataset.syntaxHighlightingValue;
+            }
+            Object.assign(props, {
+                codeToolbar: this.codeToolbar,
+                autofocus: props.autofocus || false,
+                initialValue,
+                onTextareaFocus: () => this.dependencies.history.stageFocus(),
+                getPreValue: (pre) => this.getPreValue(pre),
+                addHistoryStep: () => this.dependencies.history.addStep(),
+            });
+        }
+    }
+}

--- a/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin.scss
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin.scss
@@ -1,0 +1,31 @@
+.o_syntax_highlighting {
+    position: relative;
+    padding: 0;
+    margin: 0;
+    tab-size: 4;
+    font: 13px / 19.5px SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+
+    pre, textarea.o_prism_source {
+        margin: 0px 0px 16px;
+        padding: 8px 16px;
+    }
+
+    pre {
+        font: inherit;
+        tab-size: inherit;
+        white-space: pre;
+    }
+
+    textarea.o_prism_source {
+        position: absolute;
+        top: 0;
+        right: 0;
+        height: 100%;
+        caret-color: black;
+        color: transparent;
+        border: 0;
+        outline: none;
+        background: transparent;
+        resize: none;
+    }
+}

--- a/addons/html_editor/static/src/plugin_sets.js
+++ b/addons/html_editor/static/src/plugin_sets.js
@@ -68,6 +68,7 @@ import { EmbeddedVideoPlugin } from "@html_editor/others/embedded_components/plu
 import { EmbeddedYoutubePlugin } from "./others/embedded_components/plugins/video_plugin/embedded_youtube_plugin";
 import { CaptionPlugin } from "@html_editor/others/embedded_components/plugins/caption_plugin/caption_plugin";
 import { EmbeddedFilePlugin } from "@html_editor/others/embedded_components/plugins/embedded_file_plugin/embedded_file_plugin";
+import { SyntaxHighlightingPlugin } from "@html_editor/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin";
 import { QWebPlugin } from "./others/qweb_plugin";
 import { EditorVersionPlugin } from "./core/editor_version_plugin";
 import { ImagePostProcessPlugin } from "./main/media/image_post_process_plugin";
@@ -202,6 +203,7 @@ export const EMBEDDED_COMPONENT_PLUGINS = [
     EmbeddedYoutubePlugin,
     CaptionPlugin,
     EmbeddedFilePlugin,
+    SyntaxHighlightingPlugin,
 ];
 
 export const NO_EMBEDDED_COMPONENTS_FALLBACK_PLUGINS = [FilePlugin, VideoPlugin, YoutubePlugin];

--- a/addons/html_editor/static/tests/_helpers/syntax_highlighting.js
+++ b/addons/html_editor/static/tests/_helpers/syntax_highlighting.js
@@ -1,0 +1,156 @@
+import { patchWithCleanup } from "@web/../tests/web_test_helpers";
+import { unformat } from "./format";
+import {
+    DEFAULT_LANGUAGE_ID,
+    EmbeddedSyntaxHighlightingComponent,
+} from "@html_editor/others/embedded_components/backend/syntax_highlighting/syntax_highlighting";
+import { expect } from "@odoo/hoot";
+import { animationFrame } from "@odoo/hoot-dom";
+import { toExplicitString } from "@web/../lib/hoot/hoot_utils";
+
+/** @typedef {import("@html_editor/plugin").Editor} Editor */
+/**
+ * @typedef {Object} HighlightedContent
+ * @property {string} value
+ * @property {string} [language]
+ * @property {number | [number, number]} [textareaRange = null] if defined, the
+ *                                       focus will be set in the textarea and
+ *                                       its selection will be tested
+ * @property {boolean} [wrapped = true] if true, the value will be wrapped
+ *                                      inside a syntax highlighting block
+ */
+/**
+ * @typedef {Object} FocusedTextarea
+ * @property {HTMLTextAreaElement} el
+ * @property {string} value
+ * @property {number | [number, number]} range
+ */
+
+/**
+ * Simulate Prism's `highlight` function by wrapping the given `html` string
+ * inside a `<span>` element matching with the given `languageId` as `id`
+ * attribute.
+ * If `ejectBr` is true, take any trailing `<br>` in `html` and insert it after
+ * the `<span>` element instead.
+ *
+ * @param {string} html
+ * @param {string} [languageId = DEFAULT_LANGUAGE_ID]
+ * @param {boolean} [ejectBr = false]
+ * @returns {string}
+ */
+const highlight = (html, languageId = DEFAULT_LANGUAGE_ID, ejectBr = false) =>
+    `<span id="${languageId}">${ejectBr ? html.replace(/((<br>)*)$/, "") : html}</span>${
+        ejectBr ? html.match(/(?:<br>)+$/)?.[0] || "" : ""
+    }`;
+
+/**
+ * Patch the function that loads the Prism library so it doesn't crash when
+ * testing and so that its `highlight` function simply wraps the HTML using
+ * `highlight`.
+ *
+ * @see highlight
+ */
+export const patchPrism = () => {
+    patchWithCleanup(EmbeddedSyntaxHighlightingComponent.prototype, {
+        async loadPrism() {
+            window.Prism = {
+                highlight: (html, l, languageId = DEFAULT_LANGUAGE_ID) =>
+                    highlight(html, languageId),
+                languages: {},
+            };
+        },
+    });
+};
+
+/**
+ * Test that the document selection is targeting the given `<textarea>` element,
+ * that the focus is in it, that is value is the given value, and that its range
+ * is the given range.
+ *
+ * @param {Editor} editor
+ * @param {FocusedTextarea} focusedTextarea
+ * @param {string} [message]
+ */
+export const testTextareaRange = (editor, { el, value, range }, message) => {
+    range = Array.isArray(range) ? range : [range];
+    const start = range[0];
+    const end = range.length > 1 ? range[1] : start;
+    const { anchorNode, anchorOffset, focusNode, focusOffset } = editor.document.getSelection();
+    expect({
+        activeElement: editor.document.activeElement,
+        anchorTarget: anchorNode.childNodes[anchorOffset],
+        focusTarget: focusNode.childNodes[focusOffset],
+        textareaValue: el.value,
+        textareaRange: [el.selectionStart, el.selectionEnd],
+    }).toEqual(
+        {
+            activeElement: el,
+            anchorTarget: el,
+            focusTarget: el,
+            textareaValue: value,
+            textareaRange: [start, end],
+        },
+        { message: `Selection should be correct in the textarea${message ? ":\n" + message : ""}` }
+    );
+};
+
+/**
+ * Clean the given content to facilitate testing and parse the expected result
+ * given as a `HighlightedContent` object (or an array thereof), then compare
+ * the two values. If a `textareaRange` key is passed in some of the expected
+ * content, test the range and focus in its `<textarea>` element.
+ *
+ * @param {string} content
+ * @param {HighlightedContent | HighlightedContent[]} expected
+ * @param {string} phase
+ * @param {Editor} editor
+ */
+export const compareHighlightedContent = async (content, expected, phase, editor) => {
+    const cleanedContent = content
+        // Ignore embedded props
+        .replaceAll(/data-embedded-props='([^']|\n)*' /g, "")
+        // Ignore dataset order
+        .replaceAll(
+            /data-language-id="([^"]+)" data-syntax-highlighting-value="(([^"]|\n)+)"/g,
+            `data-syntax-highlighting-value="$2" data-language-id="$1"`
+        );
+    const message = `(testEditor) ${toExplicitString(
+        phase
+    )} is strictly equal to "${toExplicitString(expected)}"`;
+    await animationFrame();
+    // See if `highlightedPre` included textarea range data. If so, parse it,
+    // test it, and remove it.
+    const strings = expected.split("<textarea");
+    strings.shift();
+    const textareaIndex = strings.findIndex((str) => str.startsWith("~~~"));
+    if (textareaIndex !== -1) {
+        const el = editor.editable.querySelectorAll("textarea")[textareaIndex];
+        const [range, value] = strings[textareaIndex].match(/~~~([^~]+)~~~/)[1].split("°°°");
+        const parsedRange = range.split(",").map((v) => +v.replace(/[[\]]/g, "").trim());
+        testTextareaRange(editor, { el, range: parsedRange, value }, message);
+        expected = expected.replace(/<textarea~~~[^~]+~~~/g, "<textarea");
+    }
+    // Now test the content.
+    expect(cleanedContent).toBe(expected, { message });
+};
+
+export const highlightedPre = ({
+    value,
+    language = DEFAULT_LANGUAGE_ID,
+    textareaRange = null,
+    preHtml = value.replaceAll("\n", "<br>"),
+}) =>
+    unformat(
+        `<div data-embedded="syntaxHighlighting" data-oe-protected="true" contenteditable="false"
+            class="o_syntax_highlighting"
+            data-syntax-highlighting-value="${value}" data-language-id="${language.toLowerCase()}">
+            <pre>//PRE//</pre>${textareaRange === null ? "" : "[]"}
+            <textarea //TEXTAREA// class="o_prism_source" contenteditable="true"></textarea>
+        </div>`
+    )
+        // Do not trim spaces within the PRE and in the textarea data:
+        .replace("//PRE//", highlight(preHtml || "<br>", language, true))
+        .replace(
+            " //TEXTAREA// ",
+            textareaRange ? "~~~" + textareaRange + "°°°" + value + "~~~ " : " "
+        );

--- a/addons/html_editor/static/tests/delete/backward.test.js
+++ b/addons/html_editor/static/tests/delete/backward.test.js
@@ -7,6 +7,13 @@ import { setupEditor, testEditor } from "../_helpers/editor";
 import { unformat } from "../_helpers/format";
 import { getContent, setSelection } from "../_helpers/selection";
 import { deleteBackward, insertText, tripleClick, undo } from "../_helpers/user_actions";
+import { EMBEDDED_COMPONENT_PLUGINS, MAIN_PLUGINS } from "@html_editor/plugin_sets";
+import {
+    compareHighlightedContent,
+    highlightedPre,
+    patchPrism,
+} from "../_helpers/syntax_highlighting";
+import { MAIN_EMBEDDINGS } from "@html_editor/others/embedded_components/embedding_sets";
 
 /**
  * content of the "deleteBackward" sub suite in editor.test.js
@@ -802,79 +809,208 @@ describe("Selection collapsed", () => {
     });
 
     describe("Pre", () => {
-        test("should delete a character in a pre", async () => {
-            await testEditor({
-                contentBefore: "<pre>ab[]cd</pre>",
-                stepFunction: deleteBackward,
-                contentAfter: "<pre>a[]cd</pre>",
+        describe("with syntax highlighting", () => {
+            const configWithEmbeddings = {
+                Plugins: [...MAIN_PLUGINS, ...EMBEDDED_COMPONENT_PLUGINS],
+                resources: { embedded_components: MAIN_EMBEDDINGS },
+            };
+            const testDeleteInCodeBlock = (selectionStart) => async (editor) => {
+                // Set the given selection in the textarea.
+                const textarea = editor.editable.querySelector("textarea");
+                textarea.focus();
+                textarea.setSelectionRange(selectionStart, selectionStart, "forward");
+                // Trigger native delete backward.
+                await editor.document.execCommand("delete", false, null);
+                // Wait for the input event to resolve so the content is
+                // highlighted and the focus is in the textarea.
+                await animationFrame();
+            };
+
+            beforeEach(patchPrism);
+
+            test("should delete a character in a pre", async () => {
+                await testEditor({
+                    compareFunction: compareHighlightedContent,
+                    contentBefore: "<pre>abcd</pre>",
+                    contentBeforeEdit: highlightedPre({ value: "abcd" }),
+                    stepFunction: testDeleteInCodeBlock(2),
+                    contentAfterEdit: highlightedPre({ value: "acd", textareaRange: 1 }),
+                    contentAfter: `<pre data-language-id="plaintext">acd</pre>[]`,
+                    config: configWithEmbeddings,
+                });
+            });
+
+            test("should delete a character in a pre (space before)", async () => {
+                await testEditor({
+                    compareFunction: compareHighlightedContent,
+                    contentBefore: "<pre>     abcd</pre>",
+                    contentBeforeEdit: highlightedPre({ value: "     abcd" }),
+                    stepFunction: testDeleteInCodeBlock(7), // ab[]cd
+                    contentAfterEdit: highlightedPre({ value: "     acd", textareaRange: 6 }),
+                    contentAfter: `<pre data-language-id="plaintext">     acd</pre>[]`,
+                    config: configWithEmbeddings,
+                });
+            });
+
+            test("should delete a character in a pre (space after)", async () => {
+                await testEditor({
+                    compareFunction: compareHighlightedContent,
+                    contentBefore: "<pre>abcd     </pre>",
+                    contentBeforeEdit: highlightedPre({ value: "abcd     " }),
+                    stepFunction: testDeleteInCodeBlock(2),
+                    contentAfterEdit: highlightedPre({ value: "acd     ", textareaRange: 1 }),
+                    contentAfter: `<pre data-language-id="plaintext">acd     </pre>[]`,
+                    config: configWithEmbeddings,
+                });
+            });
+
+            test("should delete a character in a pre (space before and after)", async () => {
+                await testEditor({
+                    compareFunction: compareHighlightedContent,
+                    contentBefore: "<pre>     abcd     </pre>",
+                    contentBeforeEdit: highlightedPre({ value: "     abcd     " }),
+                    stepFunction: testDeleteInCodeBlock(7), // ab[]cd
+                    contentAfterEdit: highlightedPre({ value: "     acd     ", textareaRange: 6 }),
+                    contentAfter: `<pre data-language-id="plaintext">     acd     </pre>[]`,
+                    config: configWithEmbeddings,
+                });
+            });
+
+            test("should delete a space in a pre", async () => {
+                await testEditor({
+                    compareFunction: compareHighlightedContent,
+                    contentBefore: "<pre>     ab</pre>",
+                    contentBeforeEdit: highlightedPre({ value: "     ab" }),
+                    stepFunction: testDeleteInCodeBlock(3), // "   []  ab"
+                    contentAfterEdit: highlightedPre({ value: "    ab", textareaRange: 2 }),
+                    contentAfter: `<pre data-language-id="plaintext">    ab</pre>[]`,
+                    config: configWithEmbeddings,
+                });
+            });
+
+            test("should delete a newline in a pre", async () => {
+                await testEditor({
+                    compareFunction: compareHighlightedContent,
+                    contentBefore: "<pre>ab\ncd</pre>",
+                    contentBeforeEdit: highlightedPre({ value: "ab\ncd" }),
+                    stepFunction: testDeleteInCodeBlock(3), // ab\n[]cd
+                    contentAfterEdit: highlightedPre({ value: "abcd", textareaRange: 2 }),
+                    contentAfter: `<pre data-language-id="plaintext">abcd</pre>[]`,
+                    config: configWithEmbeddings,
+                });
+            });
+
+            test("should delete all leading space in a pre", async () => {
+                await testEditor({
+                    compareFunction: compareHighlightedContent,
+                    contentBefore: "<pre>     ab</pre>",
+                    contentBeforeEdit: highlightedPre({ value: "     ab" }),
+                    stepFunction: async (editor) => {
+                        await testDeleteInCodeBlock(5)(editor); // "     []ab"
+                        await testDeleteInCodeBlock(4)(editor); // "    []ab"
+                        await testDeleteInCodeBlock(3)(editor); // "   []ab"
+                        await testDeleteInCodeBlock(2)(editor); // "  []ab"
+                        await testDeleteInCodeBlock(1)(editor); // " []ab"
+                    },
+                    contentAfterEdit: highlightedPre({ value: "ab", textareaRange: 0 }),
+                    contentAfter: `<pre data-language-id="plaintext">ab</pre>[]`,
+                    config: configWithEmbeddings,
+                });
+            });
+
+            test("should delete all trailing space in a pre", async () => {
+                await testEditor({
+                    compareFunction: compareHighlightedContent,
+                    contentBefore: "<pre>ab     </pre>",
+                    contentBeforeEdit: highlightedPre({ value: "ab     " }),
+                    stepFunction: async (editor) => {
+                        await testDeleteInCodeBlock(7)(editor); // "ab     []"
+                        await testDeleteInCodeBlock(6)(editor); // "ab    []"
+                        await testDeleteInCodeBlock(5)(editor); // "ab   []"
+                        await testDeleteInCodeBlock(4)(editor); // "ab  []"
+                        await testDeleteInCodeBlock(3)(editor); // "ab []"
+                    },
+                    contentAfterEdit: highlightedPre({ value: "ab", textareaRange: 2 }),
+                    contentAfter: `<pre data-language-id="plaintext">ab</pre>[]`,
+                    config: configWithEmbeddings,
+                });
             });
         });
-
-        test("should delete a character in a pre (space before)", async () => {
-            await testEditor({
-                contentBefore: "<pre>     ab[]cd</pre>",
-                stepFunction: deleteBackward,
-                contentAfter: "<pre>     a[]cd</pre>",
+        describe("without syntax highlighting", () => {
+            test("should delete a character in a pre", async () => {
+                await testEditor({
+                    contentBefore: "<pre>ab[]cd</pre>",
+                    stepFunction: deleteBackward,
+                    contentAfter: "<pre>a[]cd</pre>",
+                });
             });
-        });
 
-        test("should delete a character in a pre (space after)", async () => {
-            await testEditor({
-                contentBefore: "<pre>ab[]cd     </pre>",
-                stepFunction: deleteBackward,
-                contentAfter: "<pre>a[]cd     </pre>",
+            test("should delete a character in a pre (space before)", async () => {
+                await testEditor({
+                    contentBefore: "<pre>     ab[]cd</pre>",
+                    stepFunction: deleteBackward,
+                    contentAfter: "<pre>     a[]cd</pre>",
+                });
             });
-        });
 
-        test("should delete a character in a pre (space before and after)", async () => {
-            await testEditor({
-                contentBefore: "<pre>     ab[]cd     </pre>",
-                stepFunction: deleteBackward,
-                contentAfter: "<pre>     a[]cd     </pre>",
+            test("should delete a character in a pre (space after)", async () => {
+                await testEditor({
+                    contentBefore: "<pre>ab[]cd     </pre>",
+                    stepFunction: deleteBackward,
+                    contentAfter: "<pre>a[]cd     </pre>",
+                });
             });
-        });
 
-        test("should delete a space in a pre", async () => {
-            await testEditor({
-                contentBefore: "<pre>   []  ab</pre>",
-                stepFunction: deleteBackward,
-                contentAfter: "<pre>  []  ab</pre>",
+            test("should delete a character in a pre (space before and after)", async () => {
+                await testEditor({
+                    contentBefore: "<pre>     ab[]cd     </pre>",
+                    stepFunction: deleteBackward,
+                    contentAfter: "<pre>     a[]cd     </pre>",
+                });
             });
-        });
 
-        test("should delete a newline in a pre", async () => {
-            await testEditor({
-                contentBefore: "<pre>ab\n[]cd</pre>",
-                stepFunction: deleteBackward,
-                contentAfter: "<pre>ab[]cd</pre>",
+            test("should delete a space in a pre", async () => {
+                await testEditor({
+                    contentBefore: "<pre>   []  ab</pre>",
+                    stepFunction: deleteBackward,
+                    contentAfter: "<pre>  []  ab</pre>",
+                });
             });
-        });
 
-        test("should delete all leading space in a pre", async () => {
-            await testEditor({
-                contentBefore: "<pre>     []ab</pre>",
-                stepFunction: async (BasicEditor) => {
-                    deleteBackward(BasicEditor);
-                    deleteBackward(BasicEditor);
-                    deleteBackward(BasicEditor);
-                    deleteBackward(BasicEditor);
-                    deleteBackward(BasicEditor);
-                },
-                contentAfter: "<pre>[]ab</pre>",
+            test("should delete a newline in a pre", async () => {
+                await testEditor({
+                    contentBefore: "<pre>ab\n[]cd</pre>",
+                    stepFunction: deleteBackward,
+                    contentAfter: "<pre>ab[]cd</pre>",
+                });
             });
-        });
 
-        test("should delete all trailing space in a pre", async () => {
-            await testEditor({
-                contentBefore: "<pre>ab     []</pre>",
-                stepFunction: async (BasicEditor) => {
-                    deleteBackward(BasicEditor);
-                    deleteBackward(BasicEditor);
-                    deleteBackward(BasicEditor);
-                    deleteBackward(BasicEditor);
-                    deleteBackward(BasicEditor);
-                },
-                contentAfter: "<pre>ab[]</pre>",
+            test("should delete all leading space in a pre", async () => {
+                await testEditor({
+                    contentBefore: "<pre>     []ab</pre>",
+                    stepFunction: async (editor) => {
+                        deleteBackward(editor);
+                        deleteBackward(editor);
+                        deleteBackward(editor);
+                        deleteBackward(editor);
+                        deleteBackward(editor);
+                    },
+                    contentAfter: "<pre>[]ab</pre>",
+                });
+            });
+
+            test("should delete all trailing space in a pre", async () => {
+                await testEditor({
+                    contentBefore: "<pre>ab     []</pre>",
+                    stepFunction: async (editor) => {
+                        deleteBackward(editor);
+                        deleteBackward(editor);
+                        deleteBackward(editor);
+                        deleteBackward(editor);
+                        deleteBackward(editor);
+                    },
+                    contentAfter: "<pre>ab[]</pre>",
+                });
             });
         });
     });

--- a/addons/html_editor/static/tests/insert/paragraph_break.test.js
+++ b/addons/html_editor/static/tests/insert/paragraph_break.test.js
@@ -1,12 +1,18 @@
-import { describe, test } from "@odoo/hoot";
-import { waitFor } from "@odoo/hoot-dom";
+import { beforeEach, describe, test } from "@odoo/hoot";
+import { animationFrame, waitFor } from "@odoo/hoot-dom";
 import { tick } from "@odoo/hoot-mock";
 import { testEditor } from "../_helpers/editor";
 import { insertText, splitBlock } from "../_helpers/user_actions";
 import { unformat } from "../_helpers/format";
-import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
+import { EMBEDDED_COMPONENT_PLUGINS, MAIN_PLUGINS } from "@html_editor/plugin_sets";
 import { QWebPlugin } from "@html_editor/others/qweb_plugin";
 import { findInSelection } from "@html_editor/utils/selection";
+import {
+    compareHighlightedContent,
+    highlightedPre,
+    patchPrism,
+} from "../_helpers/syntax_highlighting";
+import { MAIN_EMBEDDINGS } from "@html_editor/others/embedded_components/embedding_sets";
 
 describe("Selection collapsed", () => {
     describe("Basic", () => {
@@ -115,472 +121,524 @@ describe("Selection collapsed", () => {
     });
 
     describe("Pre", () => {
-        test("should insert a line break within the pre", async () => {
-            await testEditor({
-                contentBefore: "<pre>ab[]cd</pre>",
-                stepFunction: splitBlock,
-                contentAfter: "<pre>ab<br>[]cd</pre>",
+        describe("with syntax highlighting", () => {
+            const configWithEmbeddings = {
+                Plugins: [...MAIN_PLUGINS, ...EMBEDDED_COMPONENT_PLUGINS],
+                resources: { embedded_components: MAIN_EMBEDDINGS },
+            };
+            const testEnterInCodeBlock = (selectionStart) => async (editor) => {
+                // Set the given selection in the textarea.
+                const textarea = editor.editable.querySelector("textarea");
+                textarea.focus();
+                textarea.setSelectionRange(selectionStart, selectionStart, "forward");
+                // Trigger native paragraph break.
+                await editor.document.execCommand("insertParagraph", false, null);
+                // Wait for the input event to resolve so the content is
+                // highlighted and the focus is in the textarea.
+                await animationFrame();
+            };
+            beforeEach(patchPrism);
+
+            test("should insert a line break within the pre", async () => {
+                await testEditor({
+                    compareFunction: compareHighlightedContent,
+                    contentBefore: "<pre>abcd</pre>",
+                    contentBeforeEdit: highlightedPre({ value: "abcd" }),
+                    stepFunction: testEnterInCodeBlock(2), // "ab[]cd"
+                    contentAfterEdit: highlightedPre({
+                        value: "ab\ncd",
+                        textareaRange: 3, // "ab\n[]cd"
+                    }),
+                    contentAfter: `<pre data-language-id="plaintext">ab<br>cd</pre>[]`,
+                    config: configWithEmbeddings,
+                });
+            });
+            test("should insert a new line at the end of the pre", async () => {
+                await testEditor({
+                    compareFunction: compareHighlightedContent,
+                    contentBefore: "<pre>abc</pre>",
+                    contentBeforeEdit: highlightedPre({ value: "abc" }),
+                    stepFunction: testEnterInCodeBlock(3), // "abc[]"
+                    contentAfterEdit: highlightedPre({
+                        value: "abc\n",
+                        preHtml: "abc<br><br>",
+                        textareaRange: 4, // "abc\n[]"
+                    }),
+                    contentAfter: `<pre data-language-id="plaintext">abc<br><br></pre>[]`,
+                    config: configWithEmbeddings,
+                });
             });
         });
-        test("should insert a line break within the pre containing inline element", async () => {
-            await testEditor({
-                contentBefore: "<pre>a<strong>b[]c</strong>d</pre>",
-                stepFunction: splitBlock,
-                contentAfter: "<pre>a<strong>b<br>[]c</strong>d</pre>",
+        describe("without syntax highlighting", () => {
+            test("should insert a line break within the pre", async () => {
+                await testEditor({
+                    contentBefore: "<pre>ab[]cd</pre>",
+                    stepFunction: splitBlock,
+                    contentAfter: "<pre>ab<br>[]cd</pre>",
+                });
             });
-        });
-        test("should insert a line break within the pre containing inline elementd", async () => {
-            await testEditor({
-                contentBefore: "<pre><em>a<strong>b[]c</strong>d</em></pre>",
-                stepFunction: splitBlock,
-                contentAfter: "<pre><em>a<strong>b<br>[]c</strong>d</em></pre>",
+            test("should insert a line break within the pre containing inline element", async () => {
+                await testEditor({
+                    contentBefore: "<pre>a<strong>b[]c</strong>d</pre>",
+                    stepFunction: splitBlock,
+                    contentAfter: "<pre>a<strong>b<br>[]c</strong>d</pre>",
+                });
+            });
+            test("should insert a line break within the pre containing inline elementd", async () => {
+                await testEditor({
+                    contentBefore: "<pre><em>a<strong>b[]c</strong>d</em></pre>",
+                    stepFunction: splitBlock,
+                    contentAfter: "<pre><em>a<strong>b<br>[]c</strong>d</em></pre>",
+                });
+            });
+
+            test("should insert a new paragraph after the pre", async () => {
+                await testEditor({
+                    contentBefore: "<pre>abc[]</pre>",
+                    stepFunction: splitBlock,
+                    contentAfter: "<pre>abc</pre><p>[]<br></p>",
+                });
+            });
+            test("should insert a new paragraph after the pre containing inline element", async () => {
+                await testEditor({
+                    contentBefore: "<pre>ab<strong>c[]</strong></pre>",
+                    stepFunction: splitBlock,
+                    contentAfter: "<pre>ab<strong>c</strong></pre><p>[]<br></p>",
+                });
+            });
+            test("should insert a new paragraph after the pre containing inline elements", async () => {
+                await testEditor({
+                    contentBefore: "<pre><em>ab<strong>c[]</strong></em></pre>",
+                    stepFunction: splitBlock,
+                    contentAfter: "<pre><em>ab<strong>c</strong></em></pre><p>[]<br></p>",
+                });
+            });
+
+            test("should be able to break out of an empty pre", async () => {
+                await testEditor({
+                    contentBefore: "<pre>[]<br></pre>",
+                    stepFunction: splitBlock,
+                    contentAfter: "<pre><br></pre><p>[]<br></p>",
+                });
+            });
+            test("should insert a new line within the pre", async () => {
+                await testEditor({
+                    contentBefore: "<pre><p>abc</p><p>def[]</p></pre>",
+                    stepFunction: splitBlock,
+                    contentAfter: "<pre><p>abc</p><p>def</p><p>[]<br></p></pre>",
+                });
+            });
+            test("should insert a new line after pre", async () => {
+                await testEditor({
+                    contentBefore: "<pre><p>abc</p><p>def</p><p>[]<br></p></pre>",
+                    stepFunction: splitBlock,
+                    contentAfter: "<pre><p>abc</p><p>def</p></pre><p>[]<br></p>",
+                });
+            });
+            test("should insert a new paragraph after a pre tag with rtl direction", async () => {
+                await testEditor({
+                    contentBefore: `<pre dir="rtl">ab[]</pre>`,
+                    stepFunction: splitBlock,
+                    contentAfter: `<pre dir="rtl">ab</pre><p dir="rtl">[]<br></p>`,
+                });
+            });
+            test("should insert a new paragraph after a pre tag with rtl direction (2)", async () => {
+                await testEditor({
+                    contentBefore: `<pre><p dir="rtl">abc</p><p dir="rtl">[]<br></p></pre>`,
+                    stepFunction: splitBlock,
+                    contentAfter: `<pre><p dir="rtl">abc</p></pre><p dir="rtl">[]<br></p>`,
+                });
             });
         });
 
-        test("should insert a new paragraph after the pre", async () => {
-            await testEditor({
-                contentBefore: "<pre>abc[]</pre>",
-                stepFunction: splitBlock,
-                contentAfter: "<pre>abc</pre><p>[]<br></p>",
+        describe("Consecutive", () => {
+            test("should duplicate an empty paragraph twice", async () => {
+                await testEditor({
+                    contentBefore: "<p>[]<br></p>",
+                    stepFunction: async (editor) => {
+                        splitBlock(editor);
+                        splitBlock(editor);
+                    },
+                    contentAfter: "<p><br></p><p><br></p><p>[]<br></p>",
+                });
+                // TODO this cannot actually be tested currently as a
+                // backspace/delete in that case is not even detected
+                // (no input event to rollback)
+                // await testEditor({
+                //     contentBefore: '<p>[<br>]</p>',
+                //     stepFunction: async (editor) => {
+                //         splitBlock(editor);
+                //         splitBlock(editor);
+                //     },
+                //     contentAfter: '<p><br></p><p><br></p><p>[]<br></p>',
+                // });
+                await testEditor({
+                    contentBefore: "<p><br>[]</p>",
+                    stepFunction: async (editor) => {
+                        splitBlock(editor);
+                        splitBlock(editor);
+                    },
+                    contentAfter: "<p><br></p><p><br></p><p>[]<br></p>",
+                });
             });
-        });
-        test("should insert a new paragraph after the pre containing inline element", async () => {
-            await testEditor({
-                contentBefore: "<pre>ab<strong>c[]</strong></pre>",
-                stepFunction: splitBlock,
-                contentAfter: "<pre>ab<strong>c</strong></pre><p>[]<br></p>",
+
+            test("should insert two empty paragraphs before a paragraph", async () => {
+                await testEditor({
+                    contentBefore: "<p>[]abc</p>",
+                    stepFunction: async (editor) => {
+                        splitBlock(editor);
+                        splitBlock(editor);
+                    },
+                    contentAfter: "<p><br></p><p><br></p><p>[]abc</p>",
+                });
             });
-        });
-        test("should insert a new paragraph after the pre containing inline elements", async () => {
-            await testEditor({
-                contentBefore: "<pre><em>ab<strong>c[]</strong></em></pre>",
-                stepFunction: splitBlock,
-                contentAfter: "<pre><em>ab<strong>c</strong></em></pre><p>[]<br></p>",
+
+            test("should split a paragraph in three", async () => {
+                await testEditor({
+                    contentBefore: "<p>ab[]cd</p>",
+                    stepFunction: async (editor) => {
+                        splitBlock(editor);
+                        splitBlock(editor);
+                    },
+                    contentAfter: "<p>ab</p><p><br></p><p>[]cd</p>",
+                });
+            });
+
+            test("should split a paragraph in four", async () => {
+                await testEditor({
+                    contentBefore: "<p>ab[]cd</p>",
+                    stepFunction: async (editor) => {
+                        splitBlock(editor);
+                        splitBlock(editor);
+                        splitBlock(editor);
+                    },
+                    contentAfter: "<p>ab</p><p><br></p><p><br></p><p>[]cd</p>",
+                });
+            });
+
+            test("should insert two empty paragraphs after a paragraph", async () => {
+                await testEditor({
+                    contentBefore: "<p>abc[]</p>",
+                    stepFunction: async (editor) => {
+                        splitBlock(editor);
+                        splitBlock(editor);
+                    },
+                    contentAfter: "<p>abc</p><p><br></p><p>[]<br></p>",
+                });
             });
         });
 
-        test("should be able to break out of an empty pre", async () => {
-            await testEditor({
-                contentBefore: "<pre>[]<br></pre>",
-                stepFunction: splitBlock,
-                contentAfter: "<pre><br></pre><p>[]<br></p>",
+        describe("Format", () => {
+            test("should split a paragraph before a format node", async () => {
+                await testEditor({
+                    contentBefore: "<p>abc[]<b>def</b></p>",
+                    stepFunction: splitBlock,
+                    contentAfter: "<p>abc</p><p><b>[]def</b></p>",
+                });
+                await testEditor({
+                    // That selection is equivalent to []<b>
+                    contentBefore: "<p>abc<b>[]def</b></p>",
+                    stepFunction: splitBlock,
+                    contentAfter: "<p>abc</p><p><b>[]def</b></p>",
+                });
+                await testEditor({
+                    contentBefore: "<p>abc <b>[]def</b></p>",
+                    stepFunction: splitBlock,
+                    // The space is converted to a non-breaking
+                    // space so it is visible (because it's after a
+                    // <br>).
+                    contentAfter: "<p>abc&nbsp;</p><p><b>[]def</b></p>",
+                });
+                await testEditor({
+                    contentBefore: "<p>abc<b>[] def </b></p>",
+                    stepFunction: splitBlock,
+                    // The space is converted to a non-breaking
+                    // space so it is visible (because it's before a
+                    // <br>).
+                    // JW cAfter: '<p>abc</p><p><b>[]&nbsp;def</b></p>',
+                    contentAfter: "<p>abc</p><p><b>[]&nbsp;def </b></p>",
+                });
             });
-        });
-        test("should insert a new line within the pre", async () => {
-            await testEditor({
-                contentBefore: "<pre><p>abc</p><p>def[]</p></pre>",
-                stepFunction: splitBlock,
-                contentAfter: "<pre><p>abc</p><p>def</p><p>[]<br></p></pre>",
-            });
-        });
-        test("should insert a new line after pre", async () => {
-            await testEditor({
-                contentBefore: "<pre><p>abc</p><p>def</p><p>[]<br></p></pre>",
-                stepFunction: splitBlock,
-                contentAfter: "<pre><p>abc</p><p>def</p></pre><p>[]<br></p>",
-            });
-        });
-        test("should insert a new paragraph after a pre tag with rtl direction", async () => {
-            await testEditor({
-                contentBefore: `<pre dir="rtl">ab[]</pre>`,
-                stepFunction: splitBlock,
-                contentAfter: `<pre dir="rtl">ab</pre><p dir="rtl">[]<br></p>`,
-            });
-        });
-        test("should insert a new paragraph after a pre tag with rtl direction (2)", async () => {
-            await testEditor({
-                contentBefore: `<pre><p dir="rtl">abc</p><p dir="rtl">[]<br></p></pre>`,
-                stepFunction: splitBlock,
-                contentAfter: `<pre><p dir="rtl">abc</p></pre><p dir="rtl">[]<br></p>`,
-            });
-        });
-    });
 
-    describe("Consecutive", () => {
-        test("should duplicate an empty paragraph twice", async () => {
-            await testEditor({
-                contentBefore: "<p>[]<br></p>",
-                stepFunction: async (editor) => {
-                    splitBlock(editor);
-                    splitBlock(editor);
-                },
-                contentAfter: "<p><br></p><p><br></p><p>[]<br></p>",
+            test("should split a paragraph after a format node", async () => {
+                await testEditor({
+                    contentBefore: "<p><b>abc</b>[]def</p>",
+                    stepFunction: splitBlock,
+                    contentAfterEdit: "<p><b>abc</b></p><p>[]def</p>",
+                    contentAfter: "<p><b>abc</b></p><p>[]def</p>",
+                });
+                await testEditor({
+                    // That selection is equivalent to </b>[]
+                    contentBefore: "<p><b>abc[]</b>def</p>",
+                    stepFunction: splitBlock,
+                    contentAfterEdit: `<p><b>abc</b></p><p><b data-oe-zws-empty-inline="">[]\u200b</b>def</p>`,
+                    contentAfter: "<p><b>abc</b></p><p>[]def</p>",
+                });
+                await testEditor({
+                    contentBefore: "<p><b>abc[]</b> def</p>",
+                    stepFunction: splitBlock,
+                    // The space is converted to a non-breaking
+                    // space so it is visible.
+                    contentAfterEdit: `<p><b>abc</b></p><p><b data-oe-zws-empty-inline="">[]\u200b</b>&nbsp;def</p>`,
+                    contentAfter: "<p><b>abc</b></p><p>[]&nbsp;def</p>",
+                });
+                await testEditor({
+                    contentBefore: "<p><b>abc []</b>def</p>",
+                    stepFunction: splitBlock,
+                    // The space is converted to a non-breaking
+                    // space so it is visible (because it's before a
+                    // <br>).
+                    contentAfterEdit: `<p><b>abc&nbsp;</b></p><p><b data-oe-zws-empty-inline="">[]\u200b</b>def</p>`,
+                    contentAfter: "<p><b>abc&nbsp;</b></p><p>[]def</p>",
+                });
             });
-            // TODO this cannot actually be tested currently as a
-            // backspace/delete in that case is not even detected
-            // (no input event to rollback)
-            // await testEditor({
-            //     contentBefore: '<p>[<br>]</p>',
-            //     stepFunction: async (editor) => {
-            //         splitBlock(editor);
-            //         splitBlock(editor);
-            //     },
-            //     contentAfter: '<p><br></p><p><br></p><p>[]<br></p>',
-            // });
-            await testEditor({
-                contentBefore: "<p><br>[]</p>",
-                stepFunction: async (editor) => {
-                    splitBlock(editor);
-                    splitBlock(editor);
-                },
-                contentAfter: "<p><br></p><p><br></p><p>[]<br></p>",
-            });
-        });
 
-        test("should insert two empty paragraphs before a paragraph", async () => {
-            await testEditor({
-                contentBefore: "<p>[]abc</p>",
-                stepFunction: async (editor) => {
-                    splitBlock(editor);
-                    splitBlock(editor);
-                },
-                contentAfter: "<p><br></p><p><br></p><p>[]abc</p>",
+            test("should split a paragraph at the beginning of a format node", async () => {
+                await testEditor({
+                    contentBefore: "<p>[]<b>abc</b></p>",
+                    stepFunction: splitBlock,
+                    contentAfterEdit: `<p><b data-oe-zws-empty-inline="">\u200b</b></p><p><b>[]abc</b></p>`,
+                    contentAfter: "<p><br></p><p><b>[]abc</b></p>",
+                });
+                await testEditor({
+                    contentBefore: "<p><b>[]abc</b></p>",
+                    stepFunction: splitBlock,
+                    contentAfterEdit: `<p><b data-oe-zws-empty-inline="">\u200b</b></p><p><b>[]abc</b></p>`,
+                    contentAfter: "<p><br></p><p><b>[]abc</b></p>",
+                });
+                await testEditor({
+                    contentBefore: "<p><b>[] abc</b></p>",
+                    stepFunction: splitBlock,
+                    contentAfterEdit: `<p><b data-oe-zws-empty-inline="">\u200b</b></p><p><b>[] abc</b></p>`,
+                    // The space should have been parsed away.
+                    // JW cAfter: '<p><br></p><p><b>[]abc</b></p>',
+                    contentAfter: "<p><br></p><p><b>[] abc</b></p>",
+                });
             });
-        });
 
-        test("should split a paragraph in three", async () => {
-            await testEditor({
-                contentBefore: "<p>ab[]cd</p>",
-                stepFunction: async (editor) => {
-                    splitBlock(editor);
-                    splitBlock(editor);
-                },
-                contentAfter: "<p>ab</p><p><br></p><p>[]cd</p>",
+            test("should split a paragraph within a format node", async () => {
+                await testEditor({
+                    contentBefore: "<p><b>ab[]cd</b></p>",
+                    stepFunction: splitBlock,
+                    contentAfter: "<p><b>ab</b></p><p><b>[]cd</b></p>",
+                });
+                await testEditor({
+                    contentBefore: "<p><b>ab []cd</b></p>",
+                    stepFunction: splitBlock,
+                    // The space is converted to a non-breaking
+                    // space so it is visible.
+                    contentAfter: "<p><b>ab&nbsp;</b></p><p><b>[]cd</b></p>",
+                });
+                await testEditor({
+                    contentBefore: "<p><b>ab[] cd</b></p>",
+                    stepFunction: splitBlock,
+                    // The space is converted to a non-breaking
+                    // space so it is visible.
+                    contentAfter: "<p><b>ab</b></p><p><b>[]&nbsp;cd</b></p>",
+                });
             });
-        });
 
-        test("should split a paragraph in four", async () => {
-            await testEditor({
-                contentBefore: "<p>ab[]cd</p>",
-                stepFunction: async (editor) => {
-                    splitBlock(editor);
-                    splitBlock(editor);
-                    splitBlock(editor);
-                },
-                contentAfter: "<p>ab</p><p><br></p><p><br></p><p>[]cd</p>",
+            test("should split a paragraph at the end of a format node", async () => {
+                await testEditor({
+                    contentBefore: "<p><b>abc</b>[]</p>",
+                    stepFunction: splitBlock,
+                    contentAfterEdit: `<p><b>abc</b></p><p o-we-hint-text='Type "/" for commands' class="o-we-hint"><b data-oe-zws-empty-inline="">[]\u200b</b></p>`,
+                    contentAfter: "<p><b>abc</b></p><p>[]<br></p>",
+                });
+                await testEditor({
+                    // That selection is equivalent to </b>[]
+                    contentBefore: "<p><b>abc[]</b></p>",
+                    stepFunction: splitBlock,
+                    contentAfterEdit: `<p><b>abc</b></p><p o-we-hint-text='Type "/" for commands' class="o-we-hint"><b data-oe-zws-empty-inline="">[]\u200b</b></p>`,
+                    contentAfter: "<p><b>abc</b></p><p>[]<br></p>",
+                });
+                await testEditor({
+                    contentBefore: "<p><b>abc[] </b></p>",
+                    stepFunction: splitBlock,
+                    // The space should have been parsed away.
+                    contentAfterEdit: `<p><b>abc</b></p><p o-we-hint-text='Type "/" for commands' class="o-we-hint"><b data-oe-zws-empty-inline="">[]\u200b</b></p>`,
+                    contentAfter: "<p><b>abc</b></p><p>[]<br></p>",
+                });
             });
-        });
 
-        test("should insert two empty paragraphs after a paragraph", async () => {
-            await testEditor({
-                contentBefore: "<p>abc[]</p>",
-                stepFunction: async (editor) => {
-                    splitBlock(editor);
-                    splitBlock(editor);
-                },
-                contentAfter: "<p>abc</p><p><br></p><p>[]<br></p>",
-            });
-        });
-    });
-
-    describe("Format", () => {
-        test("should split a paragraph before a format node", async () => {
-            await testEditor({
-                contentBefore: "<p>abc[]<b>def</b></p>",
-                stepFunction: splitBlock,
-                contentAfter: "<p>abc</p><p><b>[]def</b></p>",
-            });
-            await testEditor({
-                // That selection is equivalent to []<b>
-                contentBefore: "<p>abc<b>[]def</b></p>",
-                stepFunction: splitBlock,
-                contentAfter: "<p>abc</p><p><b>[]def</b></p>",
-            });
-            await testEditor({
-                contentBefore: "<p>abc <b>[]def</b></p>",
-                stepFunction: splitBlock,
-                // The space is converted to a non-breaking
-                // space so it is visible (because it's after a
-                // <br>).
-                contentAfter: "<p>abc&nbsp;</p><p><b>[]def</b></p>",
-            });
-            await testEditor({
-                contentBefore: "<p>abc<b>[] def </b></p>",
-                stepFunction: splitBlock,
-                // The space is converted to a non-breaking
-                // space so it is visible (because it's before a
-                // <br>).
-                // JW cAfter: '<p>abc</p><p><b>[]&nbsp;def</b></p>',
-                contentAfter: "<p>abc</p><p><b>[]&nbsp;def </b></p>",
-            });
-        });
-
-        test("should split a paragraph after a format node", async () => {
-            await testEditor({
-                contentBefore: "<p><b>abc</b>[]def</p>",
-                stepFunction: splitBlock,
-                contentAfterEdit: "<p><b>abc</b></p><p>[]def</p>",
-                contentAfter: "<p><b>abc</b></p><p>[]def</p>",
-            });
-            await testEditor({
-                // That selection is equivalent to </b>[]
-                contentBefore: "<p><b>abc[]</b>def</p>",
-                stepFunction: splitBlock,
-                contentAfterEdit: `<p><b>abc</b></p><p><b data-oe-zws-empty-inline="">[]\u200b</b>def</p>`,
-                contentAfter: "<p><b>abc</b></p><p>[]def</p>",
-            });
-            await testEditor({
-                contentBefore: "<p><b>abc[]</b> def</p>",
-                stepFunction: splitBlock,
-                // The space is converted to a non-breaking
-                // space so it is visible.
-                contentAfterEdit: `<p><b>abc</b></p><p><b data-oe-zws-empty-inline="">[]\u200b</b>&nbsp;def</p>`,
-                contentAfter: "<p><b>abc</b></p><p>[]&nbsp;def</p>",
-            });
-            await testEditor({
-                contentBefore: "<p><b>abc []</b>def</p>",
-                stepFunction: splitBlock,
-                // The space is converted to a non-breaking
-                // space so it is visible (because it's before a
-                // <br>).
-                contentAfterEdit: `<p><b>abc&nbsp;</b></p><p><b data-oe-zws-empty-inline="">[]\u200b</b>def</p>`,
-                contentAfter: "<p><b>abc&nbsp;</b></p><p>[]def</p>",
-            });
-        });
-
-        test("should split a paragraph at the beginning of a format node", async () => {
-            await testEditor({
-                contentBefore: "<p>[]<b>abc</b></p>",
-                stepFunction: splitBlock,
-                contentAfterEdit: `<p><b data-oe-zws-empty-inline="">\u200b</b></p><p><b>[]abc</b></p>`,
-                contentAfter: "<p><br></p><p><b>[]abc</b></p>",
-            });
-            await testEditor({
-                contentBefore: "<p><b>[]abc</b></p>",
-                stepFunction: splitBlock,
-                contentAfterEdit: `<p><b data-oe-zws-empty-inline="">\u200b</b></p><p><b>[]abc</b></p>`,
-                contentAfter: "<p><br></p><p><b>[]abc</b></p>",
-            });
-            await testEditor({
-                contentBefore: "<p><b>[] abc</b></p>",
-                stepFunction: splitBlock,
-                contentAfterEdit: `<p><b data-oe-zws-empty-inline="">\u200b</b></p><p><b>[] abc</b></p>`,
-                // The space should have been parsed away.
-                // JW cAfter: '<p><br></p><p><b>[]abc</b></p>',
-                contentAfter: "<p><br></p><p><b>[] abc</b></p>",
-            });
-        });
-
-        test("should split a paragraph within a format node", async () => {
-            await testEditor({
-                contentBefore: "<p><b>ab[]cd</b></p>",
-                stepFunction: splitBlock,
-                contentAfter: "<p><b>ab</b></p><p><b>[]cd</b></p>",
-            });
-            await testEditor({
-                contentBefore: "<p><b>ab []cd</b></p>",
-                stepFunction: splitBlock,
-                // The space is converted to a non-breaking
-                // space so it is visible.
-                contentAfter: "<p><b>ab&nbsp;</b></p><p><b>[]cd</b></p>",
-            });
-            await testEditor({
-                contentBefore: "<p><b>ab[] cd</b></p>",
-                stepFunction: splitBlock,
-                // The space is converted to a non-breaking
-                // space so it is visible.
-                contentAfter: "<p><b>ab</b></p><p><b>[]&nbsp;cd</b></p>",
-            });
-        });
-
-        test("should split a paragraph at the end of a format node", async () => {
-            await testEditor({
-                contentBefore: "<p><b>abc</b>[]</p>",
-                stepFunction: splitBlock,
-                contentAfterEdit: `<p><b>abc</b></p><p o-we-hint-text='Type "/" for commands' class="o-we-hint"><b data-oe-zws-empty-inline="">[]\u200b</b></p>`,
-                contentAfter: "<p><b>abc</b></p><p>[]<br></p>",
-            });
-            await testEditor({
-                // That selection is equivalent to </b>[]
-                contentBefore: "<p><b>abc[]</b></p>",
-                stepFunction: splitBlock,
-                contentAfterEdit: `<p><b>abc</b></p><p o-we-hint-text='Type "/" for commands' class="o-we-hint"><b data-oe-zws-empty-inline="">[]\u200b</b></p>`,
-                contentAfter: "<p><b>abc</b></p><p>[]<br></p>",
-            });
-            await testEditor({
-                contentBefore: "<p><b>abc[] </b></p>",
-                stepFunction: splitBlock,
-                // The space should have been parsed away.
-                contentAfterEdit: `<p><b>abc</b></p><p o-we-hint-text='Type "/" for commands' class="o-we-hint"><b data-oe-zws-empty-inline="">[]\u200b</b></p>`,
-                contentAfter: "<p><b>abc</b></p><p>[]<br></p>",
-            });
-        });
-
-        async function splitBlockA(editor) {
-            // splitBlock in an <a> tag will open the linkPopover which will take the focus.
-            // So we need to wait for it to open and put the selection back into the editor.
-            splitBlock(editor);
-            const editableSelection = editor.shared.selection.getSelectionData().editableSelection;
-            if (findInSelection(editableSelection, "a:not([href])")) {
-                await waitFor(".o-we-linkpopover");
+            async function splitBlockA(editor) {
+                // splitBlock in an <a> tag will open the linkPopover which will take the focus.
+                // So we need to wait for it to open and put the selection back into the editor.
+                splitBlock(editor);
+                const editableSelection =
+                    editor.shared.selection.getSelectionData().editableSelection;
+                if (findInSelection(editableSelection, "a:not([href])")) {
+                    await waitFor(".o-we-linkpopover");
+                }
+                editor.shared.selection.focusEditable();
+                await tick();
             }
-            editor.shared.selection.focusEditable();
-            await tick();
-        }
 
-        // @todo: re-evaluate this possibly outdated comment:
-        // skipping these tests cause with the link isolation the cursor can be put
-        // inside/outside the link so the user can choose where to insert the line break
-        // see `anchor.nodeName === "A" && brEls.includes(anchor.firstChild)` in line_break_plugin.js
-        test("should insert line breaks outside the edges of an anchor in unbreakable", async () => {
-            await testEditor({
-                contentBefore: `<div class="oe_unbreakable">ab<a href="http://test.test/">[]cd</a></div>`,
-                stepFunction: splitBlockA,
-                contentAfter: `<div class="oe_unbreakable">ab<br><a href="http://test.test/">[]cd</a></div>`,
+            // @todo: re-evaluate this possibly outdated comment:
+            // skipping these tests cause with the link isolation the cursor can be put
+            // inside/outside the link so the user can choose where to insert the line break
+            // see `anchor.nodeName === "A" && brEls.includes(anchor.firstChild)` in line_break_plugin.js
+            test("should insert line breaks outside the edges of an anchor in unbreakable", async () => {
+                await testEditor({
+                    contentBefore: `<div class="oe_unbreakable">ab<a href="http://test.test/">[]cd</a></div>`,
+                    stepFunction: splitBlockA,
+                    contentAfter: `<div class="oe_unbreakable">ab<br><a href="http://test.test/">[]cd</a></div>`,
+                });
+                await testEditor({
+                    contentBefore: `<div class="oe_unbreakable"><a href="http://test.test/">a[]b</a></div>`,
+                    stepFunction: splitBlockA,
+                    contentAfter: `<div class="oe_unbreakable"><a href="http://test.test/">a<br>[]b</a></div>`,
+                });
+                await testEditor({
+                    contentBefore: `<div class="oe_unbreakable"><a href="http://test.test/">ab[]</a></div>`,
+                    stepFunction: splitBlockA,
+                    contentAfter: `<div class="oe_unbreakable"><a href="http://test.test/">ab</a><br><br>[]</div>`,
+                });
+                await testEditor({
+                    contentBefore: `<div class="oe_unbreakable"><a href="http://test.test/">ab[]</a>cd</div>`,
+                    stepFunction: splitBlockA,
+                    contentAfter: `<div class="oe_unbreakable"><a href="http://test.test/">ab</a><br>[]cd</div>`,
+                });
+                await testEditor({
+                    contentBefore: `<div class="oe_unbreakable"><a href="http://test.test/" style="display: block;">ab[]</a></div>`,
+                    stepFunction: splitBlockA,
+                    contentAfter: `<div class="oe_unbreakable"><a href="http://test.test/" style="display: block;">ab</a>[]<br></div>`,
+                });
             });
-            await testEditor({
-                contentBefore: `<div class="oe_unbreakable"><a href="http://test.test/">a[]b</a></div>`,
-                stepFunction: splitBlockA,
-                contentAfter: `<div class="oe_unbreakable"><a href="http://test.test/">a<br>[]b</a></div>`,
-            });
-            await testEditor({
-                contentBefore: `<div class="oe_unbreakable"><a href="http://test.test/">ab[]</a></div>`,
-                stepFunction: splitBlockA,
-                contentAfter: `<div class="oe_unbreakable"><a href="http://test.test/">ab</a><br><br>[]</div>`,
-            });
-            await testEditor({
-                contentBefore: `<div class="oe_unbreakable"><a href="http://test.test/">ab[]</a>cd</div>`,
-                stepFunction: splitBlockA,
-                contentAfter: `<div class="oe_unbreakable"><a href="http://test.test/">ab</a><br>[]cd</div>`,
-            });
-            await testEditor({
-                contentBefore: `<div class="oe_unbreakable"><a href="http://test.test/" style="display: block;">ab[]</a></div>`,
-                stepFunction: splitBlockA,
-                contentAfter: `<div class="oe_unbreakable"><a href="http://test.test/" style="display: block;">ab</a>[]<br></div>`,
-            });
-        });
 
-        test("should insert a paragraph break outside the starting edge of an anchor at start of block", async () => {
-            await testEditor({
-                contentBefore: '<p><a href="http://test.test/">[]ab</a></p>',
-                stepFunction: splitBlockA,
-                contentAfterEdit:
-                    '<p><br></p><p>\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeff[]ab\ufeff</a>\ufeff</p>',
-                contentAfter: '<p><br></p><p><a href="http://test.test/">[]ab</a></p>',
+            test("should insert a paragraph break outside the starting edge of an anchor at start of block", async () => {
+                await testEditor({
+                    contentBefore: '<p><a href="http://test.test/">[]ab</a></p>',
+                    stepFunction: splitBlockA,
+                    contentAfterEdit:
+                        '<p><br></p><p>\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeff[]ab\ufeff</a>\ufeff</p>',
+                    contentAfter: '<p><br></p><p><a href="http://test.test/">[]ab</a></p>',
+                });
             });
-        });
-        test("should insert a paragraph break outside the starting edge of an anchor after some text", async () => {
-            await testEditor({
-                contentBefore: '<p>ab<a href="http://test.test/">[]cd</a></p>',
-                stepFunction: splitBlockA,
-                contentAfterEdit:
-                    '<p>ab</p><p>\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeff[]cd\ufeff</a>\ufeff</p>',
-                contentAfter: '<p>ab</p><p><a href="http://test.test/">[]cd</a></p>',
+            test("should insert a paragraph break outside the starting edge of an anchor after some text", async () => {
+                await testEditor({
+                    contentBefore: '<p>ab<a href="http://test.test/">[]cd</a></p>',
+                    stepFunction: splitBlockA,
+                    contentAfterEdit:
+                        '<p>ab</p><p>\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeff[]cd\ufeff</a>\ufeff</p>',
+                    contentAfter: '<p>ab</p><p><a href="http://test.test/">[]cd</a></p>',
+                });
             });
-        });
-        test("should insert a paragraph break in the middle of an anchor", async () => {
-            await testEditor({
-                contentBefore: '<p><a href="http://test.test/">a[]b</a></p>',
-                stepFunction: splitBlockA,
-                contentAfterEdit:
-                    '<p>\ufeff<a href="http://test.test/">\ufeffa\ufeff</a>\ufeff</p><p>\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeff[]b\ufeff</a>\ufeff</p>',
-                contentAfter:
-                    '<p><a href="http://test.test/">a</a></p><p><a href="http://test.test/">[]b</a></p>',
+            test("should insert a paragraph break in the middle of an anchor", async () => {
+                await testEditor({
+                    contentBefore: '<p><a href="http://test.test/">a[]b</a></p>',
+                    stepFunction: splitBlockA,
+                    contentAfterEdit:
+                        '<p>\ufeff<a href="http://test.test/">\ufeffa\ufeff</a>\ufeff</p><p>\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeff[]b\ufeff</a>\ufeff</p>',
+                    contentAfter:
+                        '<p><a href="http://test.test/">a</a></p><p><a href="http://test.test/">[]b</a></p>',
+                });
             });
-        });
-        test("should insert a paragraph break outside the ending edge of an anchor", async () => {
-            await testEditor({
-                contentBefore: '<p><a href="http://test.test/">ab[]</a></p>',
-                stepFunction: splitBlockA,
-                contentAfterEdit: `<p>\ufeff<a href="http://test.test/">\ufeffab\ufeff</a>\ufeff</p><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`,
-                contentAfter: `<p><a href="http://test.test/">ab</a></p><p>[]<br></p>`,
+            test("should insert a paragraph break outside the ending edge of an anchor", async () => {
+                await testEditor({
+                    contentBefore: '<p><a href="http://test.test/">ab[]</a></p>',
+                    stepFunction: splitBlockA,
+                    contentAfterEdit: `<p>\ufeff<a href="http://test.test/">\ufeffab\ufeff</a>\ufeff</p><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`,
+                    contentAfter: `<p><a href="http://test.test/">ab</a></p><p>[]<br></p>`,
+                });
             });
-        });
-        test("should insert a paragraph break outside the ending edge of an anchor (2)", async () => {
-            await testEditor({
-                contentBefore: '<p><a href="http://test.test/">ab[]</a>cd</p>',
-                stepFunction: splitBlockA,
-                contentAfterEdit:
-                    '<p>\ufeff<a href="http://test.test/">\ufeffab\ufeff</a>\ufeff</p><p>[]cd</p>',
-                contentAfter: '<p><a href="http://test.test/">ab</a></p><p>[]cd</p>',
-            });
-        });
-    });
-
-    describe("With attributes", () => {
-        test("should insert an empty paragraph before a paragraph with a span with a class", async () => {
-            await testEditor({
-                contentBefore: '<p><span class="a">ab</span></p><p><span class="b">[]cd</span></p>',
-                stepFunction: splitBlock,
-                contentAfter:
-                    '<p><span class="a">ab</span></p><p><span class="b">\u200b</span><br></p><p><span class="b">[]cd</span></p>',
+            test("should insert a paragraph break outside the ending edge of an anchor (2)", async () => {
+                await testEditor({
+                    contentBefore: '<p><a href="http://test.test/">ab[]</a>cd</p>',
+                    stepFunction: splitBlockA,
+                    contentAfterEdit:
+                        '<p>\ufeff<a href="http://test.test/">\ufeffab\ufeff</a>\ufeff</p><p>[]cd</p>',
+                    contentAfter: '<p><a href="http://test.test/">ab</a></p><p>[]cd</p>',
+                });
             });
         });
 
-        test("should split a paragraph with a span with a bold in two", async () => {
-            await testEditor({
-                contentBefore: '<p><span class="a"><b>ab[]cd</b></span></p>',
-                stepFunction: splitBlock,
-                contentAfter:
-                    '<p><span class="a"><b>ab</b></span></p><p><span class="a"><b>[]cd</b></span></p>',
+        describe("With attributes", () => {
+            test("should insert an empty paragraph before a paragraph with a span with a class", async () => {
+                await testEditor({
+                    contentBefore:
+                        '<p><span class="a">ab</span></p><p><span class="b">[]cd</span></p>',
+                    stepFunction: splitBlock,
+                    contentAfter:
+                        '<p><span class="a">ab</span></p><p><span class="b">\u200b</span><br></p><p><span class="b">[]cd</span></p>',
+                });
+            });
+
+            test("should split a paragraph with a span with a bold in two", async () => {
+                await testEditor({
+                    contentBefore: '<p><span class="a"><b>ab[]cd</b></span></p>',
+                    stepFunction: splitBlock,
+                    contentAfter:
+                        '<p><span class="a"><b>ab</b></span></p><p><span class="a"><b>[]cd</b></span></p>',
+                });
+            });
+
+            test("should split a paragraph at its end, with a paragraph after it, and both have the same class", async () => {
+                await testEditor({
+                    contentBefore: '<p class="a">a[]</p><p class="a"><br></p>',
+                    stepFunction: splitBlock,
+                    contentAfter: '<p class="a">a</p><p class="a">[]<br></p><p class="a"><br></p>',
+                });
             });
         });
 
-        test("should split a paragraph at its end, with a paragraph after it, and both have the same class", async () => {
-            await testEditor({
-                contentBefore: '<p class="a">a[]</p><p class="a"><br></p>',
-                stepFunction: splitBlock,
-                contentAfter: '<p class="a">a</p><p class="a">[]<br></p><p class="a"><br></p>',
+        describe("POC extra tests", () => {
+            test("should insert a paragraph after an empty h1", async () => {
+                await testEditor({
+                    contentBefore: "<h1>[]<br></h1>",
+                    stepFunction: splitBlock,
+                    contentAfter: "<h1><br></h1><p>[]<br></p>",
+                });
             });
-        });
-    });
 
-    describe("POC extra tests", () => {
-        test("should insert a paragraph after an empty h1", async () => {
-            await testEditor({
-                contentBefore: "<h1>[]<br></h1>",
-                stepFunction: splitBlock,
-                contentAfter: "<h1><br></h1><p>[]<br></p>",
+            test("should insert a paragraph after an empty h1 with styles and a zero-width space", async () => {
+                await testEditor({
+                    contentBefore:
+                        '<h1><font style="color: red;" data-oe-zws-empty-inline="">[]\u200B</font></h1>',
+                    stepFunction: splitBlock,
+                    contentAfterEdit:
+                        '<h1><font style="color: red;" data-oe-zws-empty-inline="">\u200b</font></h1>' +
+                        `<p o-we-hint-text='Type "/" for commands' class="o-we-hint"><font style="color: red;" data-oe-zws-empty-inline="">[]\u200b</font></p>`,
+                    contentAfter: "<h1><br></h1><p>[]<br></p>",
+                });
             });
-        });
 
-        test("should insert a paragraph after an empty h1 with styles and a zero-width space", async () => {
-            await testEditor({
-                contentBefore:
-                    '<h1><font style="color: red;" data-oe-zws-empty-inline="">[]\u200B</font></h1>',
-                stepFunction: splitBlock,
-                contentAfterEdit:
-                    '<h1><font style="color: red;" data-oe-zws-empty-inline="">\u200b</font></h1>' +
-                    `<p o-we-hint-text='Type "/" for commands' class="o-we-hint"><font style="color: red;" data-oe-zws-empty-inline="">[]\u200b</font></p>`,
-                contentAfter: "<h1><br></h1><p>[]<br></p>",
+            test("should insert a new paragraph after an h1 with style", async () => {
+                await testEditor({
+                    contentBefore: `<h1 style="color: red">ab[]</h1>`,
+                    stepFunction: splitBlock,
+                    contentAfterEdit: `<h1 style="color: red">ab</h1><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`,
+                    contentAfter: `<h1 style="color: red">ab</h1><p>[]<br></p>`,
+                });
+            });
+            test("should insert a new paragraph after a heading tag with rtl direction", async () => {
+                await testEditor({
+                    contentBefore: `<h1 dir="rtl">ab[]</h1>`,
+                    stepFunction: splitBlock,
+                    contentAfter: `<h1 dir="rtl">ab</h1><p dir="rtl">[]<br></p>`,
+                });
             });
         });
-
-        test("should insert a new paragraph after an h1 with style", async () => {
-            await testEditor({
-                contentBefore: `<h1 style="color: red">ab[]</h1>`,
-                stepFunction: splitBlock,
-                contentAfterEdit: `<h1 style="color: red">ab</h1><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`,
-                contentAfter: `<h1 style="color: red">ab</h1><p>[]<br></p>`,
-            });
-        });
-        test("should insert a new paragraph after a heading tag with rtl direction", async () => {
-            await testEditor({
-                contentBefore: `<h1 dir="rtl">ab[]</h1>`,
-                stepFunction: splitBlock,
-                contentAfter: `<h1 dir="rtl">ab</h1><p dir="rtl">[]<br></p>`,
-            });
-        });
-    });
-    describe("Styles", () => {
-        test("should split a paragraph at the end of style node", async () => {
-            await testEditor({
-                contentBefore: '<p><font style="color: red;">abc[]</font></p>',
-                stepFunction: splitBlock,
-                contentAfterEdit: `<p><font style="color: red;">abc</font></p><p o-we-hint-text='Type "/" for commands' class="o-we-hint"><font style="color: red;" data-oe-zws-empty-inline="">[]\u200b</font></p>`,
-                contentAfter: `<p><font style="color: red;">abc</font></p><p>[]<br></p>`,
-            });
-            await testEditor({
-                contentBefore: '<p><font style="background-color: red;">abc[]</font></p>',
-                stepFunction: splitBlock,
-                contentAfterEdit: `<p><font style="background-color: red;">abc</font></p><p o-we-hint-text='Type "/" for commands' class="o-we-hint"><font style="background-color: red;" data-oe-zws-empty-inline="">[]\u200b</font></p>`,
-                contentAfter: `<p><font style="background-color: red;">abc</font></p><p>[]<br></p>`,
-            });
-            await testEditor({
-                contentBefore: '<p><span style="font-size: 36px;">abc[]</span></p>',
-                stepFunction: splitBlock,
-                contentAfterEdit: `<p><span style="font-size: 36px;">abc</span></p><p o-we-hint-text='Type "/" for commands' class="o-we-hint"><span style="font-size: 36px;" data-oe-zws-empty-inline="">[]\u200b</span></p>`,
-                contentAfter: `<p><span style="font-size: 36px;">abc</span></p><p>[]<br></p>`,
+        describe("Styles", () => {
+            test("should split a paragraph at the end of style node", async () => {
+                await testEditor({
+                    contentBefore: '<p><font style="color: red;">abc[]</font></p>',
+                    stepFunction: splitBlock,
+                    contentAfterEdit: `<p><font style="color: red;">abc</font></p><p o-we-hint-text='Type "/" for commands' class="o-we-hint"><font style="color: red;" data-oe-zws-empty-inline="">[]\u200b</font></p>`,
+                    contentAfter: `<p><font style="color: red;">abc</font></p><p>[]<br></p>`,
+                });
+                await testEditor({
+                    contentBefore: '<p><font style="background-color: red;">abc[]</font></p>',
+                    stepFunction: splitBlock,
+                    contentAfterEdit: `<p><font style="background-color: red;">abc</font></p><p o-we-hint-text='Type "/" for commands' class="o-we-hint"><font style="background-color: red;" data-oe-zws-empty-inline="">[]\u200b</font></p>`,
+                    contentAfter: `<p><font style="background-color: red;">abc</font></p><p>[]<br></p>`,
+                });
+                await testEditor({
+                    contentBefore: '<p><span style="font-size: 36px;">abc[]</span></p>',
+                    stepFunction: splitBlock,
+                    contentAfterEdit: `<p><span style="font-size: 36px;">abc</span></p><p o-we-hint-text='Type "/" for commands' class="o-we-hint"><span style="font-size: 36px;" data-oe-zws-empty-inline="">[]\u200b</span></p>`,
+                    contentAfter: `<p><span style="font-size: 36px;">abc</span></p><p>[]<br></p>`,
+                });
             });
         });
     });

--- a/addons/html_editor/static/tests/syntax_highlighting.test.js
+++ b/addons/html_editor/static/tests/syntax_highlighting.test.js
@@ -1,0 +1,939 @@
+import { beforeEach, expect, test } from "@odoo/hoot";
+import { getContent } from "./_helpers/selection";
+import { animationFrame, click, pointerUp, press, queryOne, waitFor } from "@odoo/hoot-dom";
+import { insertText, splitBlock } from "./_helpers/user_actions";
+import {
+    compareHighlightedContent,
+    highlightedPre,
+    patchPrism,
+    testTextareaRange,
+} from "./_helpers/syntax_highlighting";
+import { patchWithCleanup } from "@web/../tests/web_test_helpers";
+import { browser } from "@web/core/browser/browser";
+import { setupEditor, testEditor } from "./_helpers/editor";
+import { EMBEDDED_COMPONENT_PLUGINS, MAIN_PLUGINS } from "@html_editor/plugin_sets";
+import { MAIN_EMBEDDINGS } from "@html_editor/others/embedded_components/embedding_sets";
+import { unformat } from "./_helpers/format";
+
+const insertPre = async (editor) => {
+    await insertText(editor, "/code");
+    await animationFrame();
+    expect(".active .o-we-command-name").toHaveText("Code");
+    await press("enter");
+    await animationFrame();
+};
+
+const changeLanguage = async (textarea, from, to) => {
+    await click(textarea);
+    // Code Toolbar should open.
+    await waitFor(`.o_code_toolbar button[name='language'][title='${from}']`);
+    await click(`.o_code_toolbar button[name='language'][title='${from}']`);
+    // Language selector dropdown should open.
+    await waitFor(`.o_language_selector .o-dropdown-item[name='${to}']`);
+    await click(`.o_language_selector .o-dropdown-item[name='${to}']`);
+    // Code Toolbar should show the new language name.
+    await waitFor(`.o_code_toolbar button[name='language'][title='${to}']`);
+};
+
+const configWithEmbeddings = {
+    Plugins: [...MAIN_PLUGINS, ...EMBEDDED_COMPONENT_PLUGINS],
+    resources: { embedded_components: MAIN_EMBEDDINGS },
+};
+
+beforeEach(patchPrism);
+
+test("starting edition with a pre activates syntax highlighting", async () => {
+    await testEditor({
+        compareFunction: compareHighlightedContent,
+        contentBefore: "<pre>some code</pre>",
+        contentBeforeEdit: highlightedPre({ value: "some code" }),
+        stepFunction: async () => press(["ctrl", "z"]),
+        contentAfterEdit: highlightedPre({ value: "some code" }), // Undo did nothing.
+        contentAfter: `<pre data-language-id="plaintext">some code</pre>`,
+        config: configWithEmbeddings,
+    });
+});
+
+test("starting edition with a pre activates syntax highlighting (with dataset values)", async () => {
+    await testEditor({
+        compareFunction: compareHighlightedContent,
+        contentBefore: `<pre data-language-id="javascript">Hello world!</pre>`,
+        // The DIV should now be filled with a highlighted pre and a textarea,
+        // the respective values of which match the dataset.
+        contentBeforeEdit: highlightedPre({ value: "Hello world!", language: "javascript" }),
+        stepFunction: async (editor) => {
+            await press(["ctrl", "z"]);
+            await compareHighlightedContent(
+                getContent(editor.editable),
+                highlightedPre({ value: "Hello world!", language: "javascript" }),
+                "Undo should have done nothing.",
+                editor
+            );
+            await click("textarea");
+            await press("a");
+            await compareHighlightedContent(
+                getContent(editor.editable),
+                highlightedPre({
+                    value: "Hello world!a",
+                    language: "javascript",
+                    textareaRange: 13, // "Hello world!a[]"
+                }),
+                "Should have written at the end of the textarea.",
+                editor
+            );
+            await press(["ctrl", "z"]);
+            await press(["ctrl", "z"]);
+        },
+        contentAfterEdit: highlightedPre({
+            value: "Hello world!",
+            language: "javascript",
+            textareaRange: 12, // "Hello world![]"
+        }), // Undo did nothing.
+        contentAfter: `<pre data-language-id="javascript">Hello world!</pre>[]`,
+        config: configWithEmbeddings,
+    });
+});
+
+test("inserting a code block activates syntax highlighting plugin, typing triggers highlight", async () => {
+    await testEditor({
+        compareFunction: compareHighlightedContent,
+        contentBefore: "<p>[]abc</p>",
+        stepFunction: async (editor) => {
+            await insertPre(editor);
+            await compareHighlightedContent(
+                getContent(editor.editable),
+                highlightedPre({ value: "abc", textareaRange: 3 }),
+                "The syntax highlighting wrapper was inserted, the paragraph's content is its value and the selection in at the end of the textarea.",
+                editor
+            );
+            await press("d");
+        },
+        contentAfterEdit: highlightedPre({ value: "abcd", textareaRange: 4 }), // The change of value in the textarea is reflected in the pre.
+        contentAfter: `<pre data-language-id="plaintext">abcd</pre>[]`,
+        config: configWithEmbeddings,
+    });
+});
+
+test("inserting an empty code block activates syntax highlighting plugin with an empty textarea", async () => {
+    await testEditor({
+        compareFunction: compareHighlightedContent,
+        contentBefore: "<p><br>[]</p>",
+        stepFunction: insertPre,
+        contentAfterEdit: highlightedPre({ value: "", textareaRange: 0 }),
+        contentAfter: `<pre data-language-id="plaintext"><br></pre>[]`,
+        config: configWithEmbeddings,
+    });
+});
+
+test("inserting a code block in an empty paragraph with a style placeholder activates syntax highlighting plugin with an empty textarea", async () => {
+    await testEditor({
+        compareFunction: compareHighlightedContent,
+        contentBefore: "<p><br>[]</p>",
+        stepFunction: async (editor) => {
+            await press(["ctrl", "b"]);
+            expect(getContent(editor.editable)).toBe(
+                `<p o-we-hint-text='Type "/" for commands' class="o-we-hint"><strong data-oe-zws-empty-inline="">[]\u200B</strong></p>`,
+                { message: "The style placeholder was inserted." }
+            );
+            splitBlock(editor);
+            expect(getContent(editor.editable)).toBe(
+                `<p><strong data-oe-zws-empty-inline="">\u200B</strong></p>` +
+                    `<p o-we-hint-text='Type "/" for commands' class="o-we-hint"><strong data-oe-zws-empty-inline="">[]\u200B</strong></p>`,
+                { message: "The paragraph was split." }
+            );
+            await insertPre(editor);
+        },
+        contentAfterEdit: unformat(
+            `<p><strong data-oe-zws-empty-inline="">\u200B</strong></p>
+            ${highlightedPre({
+                value: "", // There should be no content (the zws is stripped)
+                textareaRange: 0,
+            })}`
+        ),
+        contentAfter: `<p><br></p><pre data-language-id="plaintext"><br></pre>[]`,
+        config: configWithEmbeddings,
+    });
+});
+
+test.tags();
+test("changing languages in a code block changes its highlighting", async () => {
+    await testEditor({
+        compareFunction: compareHighlightedContent,
+        contentBefore: "<pre>some code</pre>",
+        contentBeforeEdit: highlightedPre({ value: "some code", language: "plaintext" }),
+        stepFunction: async () => {
+            await changeLanguage(queryOne("textarea"), "Plain Text", "Javascript");
+        },
+        contentAfterEdit: highlightedPre({
+            value: "some code",
+            language: "javascript",
+            textareaRange: 9,
+        }),
+        contentAfter: `<pre data-language-id="javascript">some code</pre>[]`,
+        config: configWithEmbeddings,
+    });
+});
+
+test("should fill an empty pre", async () => {
+    await testEditor({
+        compareFunction: compareHighlightedContent,
+        contentBefore: "<pre>abc</pre>",
+        contentBeforeEdit: highlightedPre({ value: "abc" }),
+        stepFunction: async () => {
+            const textarea = queryOne("textarea");
+            await click(textarea);
+            textarea.select();
+            await press("backspace");
+        },
+        contentAfterEdit: highlightedPre({ value: "", textareaRange: 0 }), // Note: the BR is outside the highlight.
+        contentAfter: `<pre data-language-id="plaintext"><br></pre>[]`,
+        config: configWithEmbeddings,
+    });
+});
+
+test("the textarea should never contains zws", async () => {
+    await testEditor({
+        compareFunction: compareHighlightedContent,
+        contentBefore: "<pre>a\u200bb\ufeffc</pre>",
+        contentBeforeEdit: highlightedPre({ value: "abc" }),
+        stepFunction: async () => {
+            const textarea = queryOne("textarea");
+            await click(textarea);
+        },
+        contentAfterEdit: highlightedPre({ value: "abc", textareaRange: 3 }),
+        contentAfter: `<pre data-language-id="plaintext">abc</pre>[]`,
+        config: configWithEmbeddings,
+    });
+});
+
+test.tags();
+test("can copy content with the copy button", async () => {
+    patchWithCleanup(browser.navigator.clipboard, {
+        async writeText(text) {
+            expect.step(text);
+        },
+    });
+    await testEditor({
+        compareFunction: compareHighlightedContent,
+        contentBefore: "<pre>abc</pre>",
+        contentBeforeEdit: highlightedPre({ value: "abc" }),
+        stepFunction: async (editor) => {
+            const textarea = queryOne("textarea");
+            await click(textarea);
+            testTextareaRange(editor, { el: textarea, value: "abc", range: 3 });
+            await animationFrame();
+            await waitFor(".o_code_toolbar");
+            // Copy "abc".
+            await click(".o_code_toolbar .o_clipboard_button");
+            expect.verifySteps(["abc"]);
+            // Change text.
+            await click(textarea);
+            testTextareaRange(editor, { el: textarea, value: "abc", range: 3 });
+            await press("d");
+            testTextareaRange(editor, { el: textarea, value: "abcd", range: 4 });
+            // Copy "abcd"
+            await click(".o_code_toolbar .o_clipboard_button");
+            expect.verifySteps(["abcd"]);
+            textarea.focus();
+        },
+        contentAfterEdit: highlightedPre({ value: "abcd", textareaRange: 4 }),
+        contentAfter: `<pre data-language-id="plaintext">abcd</pre>[]`,
+        config: configWithEmbeddings,
+    });
+});
+
+test("tab in code block inserts 4 spaces", async () => {
+    await testEditor({
+        compareFunction: compareHighlightedContent,
+        contentBefore: "<pre>code</pre>",
+        contentBeforeEdit: highlightedPre({ value: "code" }),
+        stepFunction: async () => {
+            await click("textarea");
+            const textarea = queryOne("textarea");
+            textarea.setSelectionRange(2, 2); // "co[]de"
+            await press("tab");
+        },
+        contentAfterEdit: highlightedPre({
+            value: "co    de",
+            textareaRange: 6, // "co    []de"
+        }),
+        contentAfter: `<pre data-language-id="plaintext">co    de</pre>[]`,
+        config: configWithEmbeddings,
+    });
+});
+
+test("tab in selection in code block indents each selected line", async () => {
+    const valueAfter = "    a\n    b c\n     d";
+    await testEditor({
+        compareFunction: compareHighlightedContent,
+        contentBefore: "<pre>a<br>b c<br> d</pre>",
+        contentBeforeEdit: highlightedPre({ value: "a\nb c\n d" }),
+        stepFunction: async (editor) => {
+            await click("textarea");
+            const textarea = queryOne("textarea");
+            textarea.setSelectionRange(1, 7); // "a[\nb c\n ]d"
+            await press("tab");
+        },
+        contentAfterEdit: highlightedPre({
+            value: valueAfter,
+            textareaRange: [5, 19], // "    a[\n    b c\n     ]d"
+        }),
+        contentAfter: `<pre data-language-id="plaintext">${valueAfter.replaceAll(
+            "\n",
+            "<br>"
+        )}</pre>[]`,
+        config: configWithEmbeddings,
+    });
+});
+
+test("shift+tab in code block outdents the current line", async () => {
+    const valueAfter = "    some\nco    de\n    for you";
+    await testEditor({
+        compareFunction: compareHighlightedContent,
+        contentBefore: "<pre>    some<br>       co    de<br>    for you</pre>",
+        contentBeforeEdit: highlightedPre({ value: "    some\n       co    de\n    for you" }),
+        stepFunction: async (editor) => {
+            await click("textarea");
+            const textarea = queryOne("textarea");
+            textarea.setSelectionRange(22, 22); // "    some\n       co    []de\n    for you"
+            await press(["shift", "tab"]);
+            await compareHighlightedContent(
+                getContent(editor.editable),
+                highlightedPre({
+                    value: "    some\n   co    de\n    for you",
+                    textareaRange: 18, // "    some\n   co    []de\n    for you"
+                }),
+                "The content was outdented a first time.",
+                editor
+            );
+            await press(["shift", "tab"]);
+        },
+        contentAfterEdit: highlightedPre({
+            value: valueAfter,
+            textareaRange: 15, // "    some\nco    []de\n    for you"
+        }),
+        contentAfter: `<pre data-language-id="plaintext">${valueAfter.replaceAll(
+            "\n",
+            "<br>"
+        )}</pre>[]`,
+        config: configWithEmbeddings,
+    });
+});
+
+test("shift+tab in selection in code block outdents each selected line", async () => {
+    await testEditor({
+        compareFunction: compareHighlightedContent,
+        contentBefore: "<pre>    a<br>    b c<br>     d</pre>",
+        contentBeforeEdit: highlightedPre({ value: "    a\n    b c\n     d" }),
+        stepFunction: async (editor) => {
+            await click("textarea");
+            const textarea = queryOne("textarea");
+            textarea.setSelectionRange(5, 19); // "a[\nb c\n ]d"
+            await press(["shift", "tab"]);
+            await compareHighlightedContent(
+                getContent(editor.editable),
+                highlightedPre({
+                    value: "a\nb c\n d",
+                    textareaRange: [1, 7], // "a[\nb c\n ]d"
+                }),
+                "The content was outdented a first time.",
+                editor
+            );
+            // Remove the last remaining leading space.
+            await press(["shift", "tab"]);
+        },
+        contentAfterEdit: highlightedPre({
+            value: "a\nb c\nd",
+            textareaRange: [1, 6], // "a[\nb c\n]d"
+        }),
+        config: configWithEmbeddings,
+        contentAfter: `<pre data-language-id="plaintext">a<br>b c<br>d</pre>[]`,
+    });
+});
+
+test.tags("focus required");
+test("can switch between code blocks without issues", async () => {
+    const { editor } = await setupEditor(`<p>ab</p><pre>de</pre><p>gh</p><pre>jk</pre>`, {
+        config: configWithEmbeddings,
+    });
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        unformat(
+            `<p>ab</p>
+            ${highlightedPre({ value: "de" })}
+            <p>gh</p>
+            ${highlightedPre({ value: "jk" })}`
+        ),
+        "The content was highlighted",
+        editor
+    );
+    const [p1, textarea1, p2, textarea2] = editor.document.querySelectorAll("p, textarea");
+    await click(textarea1);
+    testTextareaRange(editor, { el: textarea1, value: "de", range: 2 });
+    await click(textarea2);
+    testTextareaRange(editor, { el: textarea2, value: "jk", range: 2 });
+    // Action 1: insert "l" in second pre.
+    await press("l");
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        unformat(
+            `<p>ab</p>
+            ${highlightedPre({ value: "de" })}
+            <p>gh</p>
+            ${highlightedPre({ value: "jkl", textareaRange: 3 })}`
+        ),
+        `1. Inserted "l" into the second pre and highlighted it.`,
+        editor
+    );
+    await click(textarea1);
+    testTextareaRange(editor, { el: textarea1, value: "de", range: 2 });
+    // Action 2: insert "f" in first pre.
+    await press("f");
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        unformat(
+            `<p>ab</p>
+            ${highlightedPre({ value: "def", textareaRange: 3 })}
+            <p>gh</p>
+            ${highlightedPre({ value: "jkl" })}`
+        ),
+        `2. Inserted "f" into the first pre and highlighted it.`,
+        editor
+    );
+    await click(p1);
+    editor.shared.selection.setCursorEnd(p1);
+    // Action 3: insert "c" in first paragraph.
+    await insertText(editor, "c");
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        unformat(
+            `<p>abc[]</p>
+            ${highlightedPre({ value: "def" })}
+            <p>gh</p>
+            ${highlightedPre({ value: "jkl" })}`
+        ),
+        `3. Inserted "c" into the first paragraph.`,
+        editor
+    );
+    await click(p2);
+    editor.shared.selection.setCursorEnd(p2);
+    // Action 4: insert "i" in second paragraph.
+    await insertText(editor, "i");
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        unformat(
+            `<p>abc</p>
+            ${highlightedPre({ value: "def" })}
+            <p>ghi[]</p>
+            ${highlightedPre({ value: "jkl" })}`
+        ),
+        `4. Inserted "i" into the second paragraph.`,
+        editor
+    );
+    // Action 5: change the language of first textarea.
+    await changeLanguage(textarea1, "Plain Text", "Javascript");
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        unformat(
+            `<p>abc</p>
+            ${highlightedPre({ value: "def", language: "javascript", textareaRange: 3 })}
+            <p>ghi</p>
+            ${highlightedPre({ value: "jkl" })}`
+        ),
+        `5. Changed the language of the first textarea to "javascript".`,
+        editor
+    );
+    // Action 6: change the language of second textarea.
+    await changeLanguage(textarea2, "Plain Text", "Python");
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        unformat(
+            `<p>abc</p>
+            ${highlightedPre({ value: "def", language: "javascript" })}
+            <p>ghi</p>
+            ${highlightedPre({ value: "jkl", language: "python", textareaRange: 3 })}`
+        ),
+        `6. Changed the language of the second textarea to "python".`,
+        editor
+    );
+
+    // UNDO
+    // ----
+
+    // UNDO action 6: change the language of second textarea.
+    await press(["ctrl", "z"]);
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        unformat(
+            `<p>abc</p>
+            ${highlightedPre({ value: "def", language: "javascript" })}
+            <p>ghi</p>
+            ${highlightedPre({ value: "jkl", textareaRange: 3 })}`
+        ),
+        // TODO: is it correct to not move the focus?
+        `Undo 6 changed back the language of the second textarea to "plaintext" (without losing the current focus, editor).`,
+        editor
+    );
+    // UNDO action 5: change the language of first textarea.
+    await press(["ctrl", "z"]);
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        unformat(
+            `<p>abc</p>
+            ${highlightedPre({ value: "def", textareaRange: 3 })}
+            <p>ghi</p>
+            ${highlightedPre({ value: "jkl" })}`
+        ),
+        // TODO: is it correct to move the focus?
+        `Undo 5 changed back the language of the first textarea to "plaintext" (and move the focus to the last focused textarea, editor).`,
+        editor
+    );
+    // UNDO action 4: insert "i" in second paragraph.
+    await press(["ctrl", "z"]);
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        unformat(
+            `<p>abc</p>
+            ${highlightedPre({ value: "def" })}
+            <p>gh[]</p>
+            ${highlightedPre({ value: "jkl" })}`
+        ),
+        `Undo 4 removed the "i" from the second paragraph.`,
+        editor
+    );
+    // UNDO action 3: insert "c" in first paragraph.
+    await press(["ctrl", "z"]);
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        unformat(
+            `<p>ab[]</p>
+            ${highlightedPre({ value: "def" })}
+            <p>gh</p>
+            ${highlightedPre({ value: "jkl" })}`
+        ),
+        `Undo 3 removed the "c" from the first paragraph.`,
+        editor
+    );
+    // UNDO action 2: insert "f" in first pre.
+    await press(["ctrl", "z"]);
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        unformat(
+            `<p>ab</p>
+            ${highlightedPre({ value: "de", textareaRange: 2 })}
+            <p>gh</p>
+            ${highlightedPre({ value: "jkl" })}`
+        ),
+        `Undo 2 removed the "f" from the first pre and un-highlighted it.`,
+        editor
+    );
+    // UNDO action 1: insert "l" in second pre.
+    await press(["ctrl", "z"]);
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        unformat(
+            `<p>ab</p>
+            ${highlightedPre({ value: "de" })}
+            <p>gh</p>
+            ${highlightedPre({ value: "jk", textareaRange: 2 })}`
+        ),
+        `Undo 1 removed the "l" from the second pre and un-highlighted it.`,
+        editor
+    );
+    // UNDO nothing.
+    await press(["ctrl", "z"]);
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        unformat(
+            `<p>ab</p>
+            ${highlightedPre({ value: "de" })}
+            <p>gh</p>
+            ${highlightedPre({ value: "jk", textareaRange: 2 })}`
+        ),
+        "Undo did nothing.",
+        editor
+    );
+
+    // REDO
+    // ----
+
+    // REDO action 1: insert "l" in second pre.
+    await press(["ctrl", "y"]);
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        unformat(
+            `<p>ab</p>
+            ${highlightedPre({ value: "de" })}
+            <p>gh</p>
+            ${highlightedPre({ value: "jkl", textareaRange: 3 })}`
+        ),
+        `Redo 1 reinserted "l" into the second pre and re-highlighted it.`,
+        editor
+    );
+    // REDO action 2: insert "f" in first pre.
+    await press(["ctrl", "y"]);
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        unformat(
+            `<p>ab</p>
+            ${highlightedPre({ value: "def", textareaRange: 3 })}
+            <p>gh</p>
+            ${highlightedPre({ value: "jkl" })}`
+        ),
+        `Redo 2 reinserted "f" into the first pre and re-highlighted it.`,
+        editor
+    );
+    // REDO action 3: insert "c" in first paragraph.
+    await press(["ctrl", "y"]);
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        unformat(
+            `<p>abc[]</p>
+            ${highlightedPre({ value: "def" })}
+            <p>gh</p>
+            ${highlightedPre({ value: "jkl" })}`
+        ),
+        `Redo 3 reinserted "c" into the first paragraph.`,
+        editor
+    );
+    // REDO action 4: insert "i" in second paragraph.
+    await press(["ctrl", "y"]);
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        unformat(
+            `<p>abc</p>
+            ${highlightedPre({ value: "def" })}
+            <p>ghi[]</p>
+            ${highlightedPre({ value: "jkl" })}`
+        ),
+        `Redo 4 reinserted "i" into the second paragraph.`,
+        editor
+    );
+    // REDO action 5: change the language of first textarea.
+    await press(["ctrl", "y"]);
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        unformat(
+            `<p>abc</p>
+            ${highlightedPre({ value: "def", language: "javascript", textareaRange: 3 })}
+            <p>ghi</p>
+            ${highlightedPre({ value: "jkl" })}`
+        ),
+        `Redo 5 changed back the language of the first textarea to "javascript".`,
+        editor
+    );
+    // REDO action 6: change the language of second textarea.
+    await press(["ctrl", "y"]);
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        unformat(
+            `<p>abc</p>
+            ${highlightedPre({ value: "def", language: "javascript" })}
+            <p>ghi</p>
+            ${highlightedPre({ value: "jkl", language: "python", textareaRange: 3 })}`
+        ),
+        `Redo 6 changed back the language of the second textarea to "python".`,
+        editor
+    );
+    // REDO nothing.
+    await press(["ctrl", "y"]);
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        unformat(
+            `<p>abc</p>
+            ${highlightedPre({ value: "def", language: "javascript" })}
+            <p>ghi</p>
+            ${highlightedPre({ value: "jkl", language: "python", textareaRange: 3 })}`
+        ),
+        "Redo did nothing.",
+        editor
+    );
+});
+
+test.tags("focus required");
+test("multiple ctrl+z in a highlighted code block undo changes in the block and any other changes before (all redone with ctrl+y or ctrl+shift+z)", async () => {
+    const { editor } = await setupEditor(`<pre>some code</pre><p>hell[]</p>`, {
+        config: configWithEmbeddings,
+    });
+
+    // Perform a series of actions to undo later.
+    // ------------------------------------------
+
+    const actions = [];
+    const listActions = (...actionNumbers) =>
+        actionNumbers
+            .map((actionNumber) => `${actionNumber}. ${actions[actionNumber - 1]}`)
+            .join("\n");
+
+    // Perform a series of actions to undo later.
+    // ------------------------------------------
+
+    // Write in the P.
+    actions.push("type: insert 'o' into the paragraph", "type: insert '!' into the paragraph");
+    await insertText(editor, "o!"); // <wrapper><pre>some code</pre></wrapper><p>hello![]</p>
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        unformat(`
+            ${highlightedPre({ value: "some code" })}
+            <p>hello![]</p>
+        `),
+        listActions(1, 2),
+        editor
+    );
+    // Change the language -> code gets highlighted.
+    actions.push("language: change the language to javascript and highlight the code");
+    const textarea = queryOne("textarea");
+    await changeLanguage(textarea, "Plain Text", "Javascript"); // <wrapper><highlight><pre>some code</pre></highlight></wrapper><p>hello!</p>
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        unformat(`
+            ${highlightedPre({ value: "some code", language: "javascript", textareaRange: 9 })}
+            <p>hello!</p>
+        `),
+        listActions(3),
+        editor
+    );
+    // Write in the TEXTAREA.
+    actions.push("type: insert 'n' into the pre", "type: insert 'o' into the pre");
+    await click("textarea");
+    await press("n"); // <wrapper><highlight><pre>some coden</pre></highlight></wrapper><p>hello!</p>
+    await press("o"); // <wrapper><highlight><pre>some codeno</pre></highlight></wrapper><p>hello!</p>
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        unformat(`
+            ${highlightedPre({ value: "some codeno", language: "javascript", textareaRange: 11 })}
+            <p>hello!</p>
+        `),
+        listActions(4, 5),
+        editor
+    );
+    actions.push(
+        "type: remove 'o' from the pre",
+        "type: remove 'n' from the pre",
+        "type: insert 'y' into the pre",
+        "type: insert 'e' into the pre",
+        "type: insert 's' into the pre"
+    );
+    await press("Backspace"); // <wrapper><highlight><pre>some coden</pre></highlight></wrapper><p>hello!</p>
+    await press("Backspace"); // <wrapper><highlight><pre>some code</pre></highlight></wrapper><p>hello!</p>
+    await press("y"); // <wrapper><highlight><pre>some codey</pre></highlight></wrapper><p>hello!</p>
+    await press("e"); // <wrapper><highlight><pre>some codeye</pre></highlight></wrapper><p>hello!</p>
+    await press("s"); // <wrapper><highlight><pre>some codeyes</pre></highlight></wrapper><p>hello!</p>
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        unformat(`
+            ${highlightedPre({ value: "some codeyes", language: "javascript", textareaRange: 12 })}
+            <p>hello!</p>
+        `),
+        listActions(6, 7, 8, 9, 10),
+        editor
+    );
+    // Write in the P again.
+    actions.push("type: insert 'o' into the paragraph", "type: insert 'k' into the paragraph");
+    editor.shared.selection.setCursorEnd(queryOne("p"));
+    await pointerUp("p");
+    await insertText(editor, "ok"); // <wrapper><highlight><pre>some codeyes</pre></highlight></wrapper><p>hello!ok[]</p>
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        unformat(`
+            ${highlightedPre({ value: "some codeyes", language: "javascript" })}
+            <p>hello!ok[]</p>
+        `),
+        listActions(11, 12),
+        editor
+    );
+    // Write in the TEXTAREA again.
+    actions.push("type: insert 'h' into the pre");
+    await click("textarea");
+    await press("h"); // <wrapper><highlight><pre>some codeyesh</pre></highlight></wrapper><p>hello!ok[]</p>
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        unformat(`
+            ${highlightedPre({ value: "some codeyesh", language: "javascript", textareaRange: 13 })}
+            <p>hello!ok</p>
+        `),
+        listActions(13),
+        editor
+    );
+
+    // Undo everything.
+    // ----------------
+
+    await press(["ctrl", "z"]); // <wrapper><highlight><pre>some codeyes</pre></highlight></wrapper><p>hello!ok</p>
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        unformat(`
+            ${highlightedPre({ value: "some codeyes", language: "javascript", textareaRange: 12 })}
+            <p>hello!ok</p>
+        `),
+        `undo:\n${listActions(13)}`,
+        editor
+    );
+    await press(["ctrl", "z"]); // <wrapper><highlight><pre>some codeyes</pre></highlight></wrapper><p>hello!o[]</p>
+    await press(["ctrl", "z"]); // <wrapper><highlight><pre>some codeyes</pre></highlight></wrapper><p>hello![]</p>
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        unformat(`
+            ${highlightedPre({ value: "some codeyes", language: "javascript" })}
+            <p>hello![]</p>
+        `),
+        `undo:\n${listActions(12, 11)}`,
+        editor
+    );
+    await press(["ctrl", "z"]); // <wrapper><highlight><pre>some codeye</pre></highlight></wrapper><p>hello!</p>
+    await press(["ctrl", "z"]); // <wrapper><highlight><pre>some codey</pre></highlight></wrapper><p>hello!</p>
+    await press(["ctrl", "z"]); // <wrapper><highlight><pre>some code</pre></highlight></wrapper><p>hello!</p>
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        unformat(`
+            ${highlightedPre({ value: "some code", language: "javascript", textareaRange: 9 })}
+            <p>hello!</p>
+        `),
+        `undo:\n${listActions(10, 9, 8)}`,
+        editor
+    );
+    await press(["ctrl", "z"]); // <wrapper><highlight><pre>some coden</pre></highlight></wrapper><p>hello!</p>
+    await press(["ctrl", "z"]); // <wrapper><highlight><pre>some codeno</pre></highlight></wrapper><p>hello!</p>
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        unformat(`
+            ${highlightedPre({ value: "some codeno", language: "javascript", textareaRange: 11 })}
+            <p>hello!</p>
+        `),
+        `undo:\n${listActions(7, 6)}`,
+        editor
+    );
+    await press(["ctrl", "z"]); // <wrapper><highlight><pre>some coden</pre></highlight></wrapper><p>hello!</p>
+    await press(["ctrl", "z"]); // <wrapper><highlight><pre>some code</pre></highlight></wrapper><p>hello!</p>
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        unformat(`
+            ${highlightedPre({ value: "some code", language: "javascript", textareaRange: 9 })}
+            <p>hello!</p>
+        `),
+        `undo:\n${listActions(5, 4)}`,
+        editor
+    );
+    await press(["ctrl", "z"]); // <wrapper><pre>some code</pre></wrapper><p>hello!</p>
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        unformat(`
+            ${highlightedPre({ value: "some code", textareaRange: 9 })}
+            <p>hello!</p>
+        `),
+        `undo:\n${listActions(3)}`,
+        editor
+    );
+    await press(["ctrl", "z"]); // <wrapper><pre>some code</pre></wrapper><p>hello</p>
+    await press(["ctrl", "z"]); // <wrapper><pre>some code</pre></wrapper><p>hell</p>
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        unformat(`
+            ${highlightedPre({ value: "some code" })}
+            <p>hell[]</p>
+        `),
+        `undo:\n${listActions(2, 1)}`,
+        editor
+    );
+    await press(["ctrl", "z"]); // <wrapper><pre>some code</pre></wrapper><p>hell</p>
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        unformat(`
+            ${highlightedPre({ value: "some code" })}
+            <p>hell[]</p>
+        `),
+        "undo: should have done nothing",
+        editor
+    );
+
+    // Redo everything.
+    // ----------------
+
+    await press(["ctrl", "y"]); // <wrapper><pre>some code</pre></wrapper><p>hello</p>
+    await press(["ctrl", "y"]); // <wrapper><pre>some code</pre></wrapper><p>hello!</p>
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        unformat(
+            `${highlightedPre({ value: "some code" })}
+            <p>hello![]</p>`
+        ),
+        `redo:\n${listActions(1, 2)}`,
+        editor
+    );
+    await press(["ctrl", "shift", "z"]); // <wrapper><highlight><pre>some code</pre></highlight></wrapper><p>hello!</p>
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        unformat(`
+            ${highlightedPre({ value: "some code", language: "javascript", textareaRange: 9 })}
+            <p>hello!</p>
+        `),
+        `redo:\n${listActions(3)}`,
+        editor
+    );
+    await press(["ctrl", "y"]); // <wrapper><highlight><pre>some coden</pre></highlight></wrapper><p>hello!</p>
+    await press(["ctrl", "y"]); // <wrapper><highlight><pre>some codeno</pre></highlight></wrapper><p>hello!</p>
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        unformat(`
+            ${highlightedPre({ value: "some codeno", language: "javascript", textareaRange: 11 })}
+            <p>hello!</p>
+        `),
+        `redo:\n${listActions(4, 5)}`,
+        editor
+    );
+    await press(["ctrl", "shift", "z"]); // <wrapper><highlight><pre>some coden</pre></highlight></wrapper><p>hello!</p>
+    await press(["ctrl", "shift", "z"]); // <wrapper><highlight><pre>some code</pre></highlight></wrapper><p>hello!</p>
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        unformat(`
+            ${highlightedPre({ value: "some code", language: "javascript", textareaRange: 9 })}
+            <p>hello!</p>
+        `),
+        `redo:\n${listActions(6, 7)}`,
+        editor
+    );
+    await press(["ctrl", "y"]); // <wrapper><highlight><pre>some codey</pre></highlight></wrapper><p>hello!</p>
+    await press(["ctrl", "y"]); // <wrapper><highlight><pre>some codeye</pre></highlight></wrapper><p>hello!</p>
+    await press(["ctrl", "y"]); // <wrapper><highlight><pre>some codeyes</pre></highlight></wrapper><p>hello!</p>
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        unformat(`
+            ${highlightedPre({ value: "some codeyes", language: "javascript", textareaRange: 12 })}
+            <p>hello!</p>
+        `),
+        `redo:\n${listActions(8, 9, 10)}`,
+        editor
+    );
+    await press(["ctrl", "shift", "z"]); // <wrapper><highlight><pre>some codeyes</pre></highlight></wrapper><p>hello!o</p>
+    await press(["ctrl", "shift", "z"]); // <wrapper><highlight><pre>some codeyes</pre></highlight></wrapper><p>hello!ok</p>
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        unformat(`
+            ${highlightedPre({ value: "some codeyes", language: "javascript" })}
+            <p>hello!ok[]</p>
+        `),
+        `redo:\n${listActions(11, 12)}`,
+        editor
+    );
+    await press(["ctrl", "y"]); // <wrapper><highlight><pre>some codeyes</pre></highlight></wrapper><p>hello!ok</p>
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        unformat(`
+            ${highlightedPre({ value: "some codeyesh", language: "javascript", textareaRange: 13 })}
+            <p>hello!ok</p>
+        `),
+        `redo:\n${listActions(13)}`,
+        editor
+    );
+    await press(["ctrl", "shift", "z"]); // <wrapper><highlight><pre>some codeyes</pre></highlight></wrapper><p>hello!ok</p>
+    await press(["ctrl", "y"]); // <wrapper><highlight><pre>some codeyes</pre></highlight></wrapper><p>hello!ok</p>
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        unformat(`
+            ${highlightedPre({ value: "some codeyesh", language: "javascript", textareaRange: 13 })}
+            <p>hello!ok</p>
+        `),
+        "redo: should have done nothing",
+        editor
+    );
+});

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -80,6 +80,7 @@ safe_attrs = defs.safe_attrs | frozenset(
      'data-ai-field', 'data-ai-record-id',
      'data-heading-link-id',
      'data-mimetype-before-conversion',
+     'data-language-id', 'data-syntax-highlighting-value'
      ])
 SANITIZE_TAGS = {
     # allow new semantic HTML5 tags


### PR DESCRIPTION
This integrates the PrismJS library to provide syntax highlighting to code blocks. Whenever a `pre` element is in the editor, it gets wrapped into a `contenteditable=false` container, with an invisible editable `textarea` element overlayed on top of the `pre`. Whenever the contents of the `textarea` change, they pass through the library to get highlighted in the `pre`. A special toolbar appears at the top of the code block, for the user to pick a language and copy the code in plain text.

task-4585835

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
