### PR TITLE
[FIX] base_import,*: import date like values in char like fields

### DIFF
--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -1404,6 +1404,18 @@ class Base_ImportImport(models.TransientModel):
                 'error': e
             })
 
+    @api.model
+    def _stringify_date_like_objects(self, data, options):
+        # As imported string like datas might be automatically interpreted and imported as date/datetime
+        # object by the spreedsheet a reconversion might be needed
+        if isinstance(data, datetime.datetime):
+            return data.strftime(options.get('datetime_format') or DEFAULT_SERVER_DATETIME_FORMAT)
+        elif isinstance(data, datetime.date):
+            return data.strftime(options.get('date_format') or DEFAULT_SERVER_DATE_FORMAT)
+        else:
+            return data
+
+    # TODO remove in master
     def _build_import_error_msg(self, message, record, row_index, field=None):
         return {
             'type': 'error',
@@ -1413,6 +1425,7 @@ class Base_ImportImport(models.TransientModel):
             'rows': {'from': row_index + 1, 'to': row_index + 1},
         }
 
+    # TODO remove in master
     def _parse_datetime_data(self, import_fields, input_file_data):
         errors = []
         field_types = self.env[self.res_model].fields_get(import_fields, ['type'])
@@ -1463,8 +1476,6 @@ class Base_ImportImport(models.TransientModel):
 
         try:
             input_file_data, import_fields = self._convert_import_data(fields, options)
-            if errors := self._parse_datetime_data(import_fields, input_file_data):
-                return {'messages': errors}
             # Parse date and float field
             input_file_data = self._parse_import_data(input_file_data, import_fields, options)
         except ImportValidationError as error:
@@ -1474,7 +1485,7 @@ class Base_ImportImport(models.TransientModel):
 
         binary_filenames = self._extract_binary_filenames(import_fields, input_file_data)
 
-        import_fields, merged_data = self._handle_multi_mapping(import_fields, input_file_data)
+        import_fields, merged_data = self.with_context(import_options=options)._handle_multi_mapping(import_fields, input_file_data)
 
         if options.get('fallback_values'):
             merged_data = self._handle_fallback_values(import_fields, merged_data, options['fallback_values'])
@@ -1524,7 +1535,7 @@ class Base_ImportImport(models.TransientModel):
             # pad front as data doesn't contain anythig for skipped lines
             r = import_result['name'] = [''] * skipped
             # only add names for the window being imported
-            r.extend(x[index_of_name] for x in input_file_data[:import_limit])
+            r.extend(self._stringify_date_like_objects(x[index_of_name], options) for x in input_file_data[:import_limit])
             # pad back (though that's probably not useful)
             r.extend([''] * (len(input_file_data) - (import_limit or 0)))
         else:
@@ -1603,6 +1614,7 @@ class Base_ImportImport(models.TransientModel):
         for idx, field in enumerate(field for field in import_fields if field):
             mapped_field_indexes.setdefault(field, list()).append(idx)
         import_fields = list(mapped_field_indexes.keys())
+        import_options = self.env.context.get('import_options', {})
 
         # recreate data and merge duplicates (applies only on text or char fields)
         # Also handles multi-mapping on "field of relation fields".
@@ -1622,16 +1634,29 @@ class Base_ImportImport(models.TransientModel):
                     if field != target_field and field in self.env[target_model]:
                         target_model = self.env[target_model][field]._name
 
-                field = self.env[target_model]._fields.get(target_field)
+                field = self.env[target_model]._fields.get(target_field.split('.')[0])
                 field_type = field.type if field else ''
 
                 # merge data if necessary
                 if field_type == 'char':
-                    new_record.append(' '.join(record[idx] for idx in indexes if record[idx]))
+                    new_record.append(
+                        ' '.join(
+                            self._stringify_date_like_objects(record[idx], import_options)
+                            for idx in indexes if record[idx]
+                        )
+                    )
                 elif field_type == 'text':
-                    new_record.append('\n'.join(record[idx] for idx in indexes if record[idx]))
+                    new_record.append(
+                        '\n'.join(
+                            self._stringify_date_like_objects(record[idx], import_options)
+                            for idx in indexes if record[idx]
+                        )
+                    )
                 elif field_type == 'many2many':
                     new_record.append(','.join(record[idx] for idx in indexes if record[idx]))
+                elif field_type == 'properties':
+                    # for property fields date and datetime objects are not suitable for JSON values
+                    new_record.append(self._stringify_date_like_objects(record[indexes[0]], import_options))
                 else:
                     new_record.append(record[indexes[0]])
 

--- a/addons/test_import_export/models/models_import.py
+++ b/addons/test_import_export/models/models_import.py
@@ -77,6 +77,7 @@ class ImportO2mChild(models.Model):
     _name = 'import.o2m.child'
     _description = 'Tests: Base Import Model, One to Many child'
 
+    name = fields.Char()
     parent_id = fields.Many2one('import.o2m')
     value = fields.Integer()
 

--- a/addons/test_import_export/tests/test_import.py
+++ b/addons/test_import_export/tests/test_import.py
@@ -9,7 +9,7 @@ import unittest
 from PIL import Image
 
 from odoo.tests.common import TransactionCase, can_import, RecordCapturer
-from odoo.tools import mute_logger
+from odoo.tools import mute_logger, DEFAULT_SERVER_DATE_FORMAT, DEFAULT_SERVER_DATETIME_FORMAT
 from odoo.tools.misc import file_open
 from odoo.addons.base_import.models.base_import import ImportValidationError
 
@@ -203,6 +203,9 @@ class TestO2M(BaseImportCase):
                                  'fields': [], 'type': 'id'},
                             ]
                         },
+                        {'id': 'name', 'name': 'name', 'string': 'Name',
+                         'required': False, 'fields': [], 'type': 'char', 'model_name': 'import.o2m.child',
+                        },
                         {'id': 'value', 'name': 'value', 'string': 'Value',
                          'required': False, 'fields': [], 'type': 'integer', 'model_name': 'import.o2m.child',
                         },
@@ -234,6 +237,9 @@ class TestO2M(BaseImportCase):
                                     'string': 'Database ID', 'required': False,
                                     'fields': [], 'type': 'id'},
                                 ]
+                            },
+                            {'id': 'name', 'name': 'name', 'string': 'Name',
+                             'required': False, 'fields': [], 'type': 'char', 'model_name': 'import.o2m.child',
                             },
                             {'id': 'value', 'name': 'value', 'string': 'Value',
                             'required': False, 'fields': [], 'type': 'integer', 'model_name': 'import.o2m.child',
@@ -961,12 +967,12 @@ foo3,US,0,persons\n""",
                 self.assertFalse(response.get('messages'))
 
     @unittest.skipUnless(can_import('xlwt') and can_import('openpyxl'), "xlwt/openpyxl not available")
-    def test_xlsx_datetime_values_assigned_to_wrong_field(self):
-        """Test that importing datetime values into any field that is not DateTime triggers an error."""
+    def test_xlsx_datetime_values_assigned_to_char_field(self):
+        """Test that importing datetime values to char field is converted"""
 
         file_content = generate_xlsx({
-            'Some Value': [1, datetime.date(2025, 7, 1)],  # Invalid Datetime object in an integer field
-            'Name': ['foo', datetime.date(2025, 7, 1)]     # Invalid Datetime object in an char field
+            'Some Value': [1, 3, 5],
+            'Name': ['foo', datetime.datetime(2020, 1, 6, 8, 10), datetime.date(2025, 7, 1)]   # Invalid Date like object in a char field
         })
 
         file_type = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
@@ -977,9 +983,7 @@ foo3,US,0,persons\n""",
             'file_type': file_type,
         })
 
-        result = import_wizard.parse_preview({'has_headers': True})
-
-        options = result.get('options', {})
+        import_wizard.parse_preview({'has_headers': True})
 
         response = import_wizard.execute_import(
             ['somevalue', 'name'],
@@ -988,18 +992,80 @@ foo3,US,0,persons\n""",
                 'has_headers': True,
                 'quoting': '"',
                 'separator': ',',
-                'date_format': options.get('date_format'),
-                'datetime_format': options.get('datetime_format'),
+                'datetime_format': '%H:%M:%S %d/%m/%Y',
+                'date_format': '%d/%m/%Y',
             }
         )
-        self.assertTrue(response.get('messages'), "Expected error messages due to date/time values in non-date fields")
-        self.assertEqual(len(response['messages']), 2)
+        self.assertFalse(response.get('messages'))
+        self.assertEqual(response['name'], ['foo', '08:10:00 06/01/2020', '01/07/2025', '', '', ''])
 
-        self.assertEqual(response['messages'][0]['type'], 'error')
-        self.assertIn("Field 'somevalue' does not accept date/time values.", response['messages'][0]['message'])
+    @unittest.skipUnless(can_import('xlwt') and can_import('openpyxl'), "xlwt/openpyxl not available")
+    def test_xlsx_datetime_values_assigned_to_related_char_field(self):
+        """Test that importing datetime values to a related char field is converted"""
+        file_content = generate_xlsx(
+            {
+                'Child/Name': ['foo', datetime.datetime(2020, 1, 6, 8, 10), datetime.date(2024, 7, 1)],
+            }
+        )
+        file_type = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        import_wizard = self.env["base_import.import"].create({
+            'res_model': "import.o2m",
+            'file': file_content,
+            'file_type': file_type,
+        })
+        import_wizard.parse_preview({'has_headers': True})
+        response = import_wizard.execute_import(
+            ["value/name"],
+            ["Child/Name"],
+            {
+                'quoting': '"', 'separator': ',', 'has_headers': True,
+                'datetime_format': '%H:%M:%S %d/%m/%Y', 'date_format': '%d/%m/%Y',
+            }
+        )
+        self.assertFalse(response.get('messages'))
+        self.assertEqual(
+            self.env['import.o2m'].browse(response['ids']).value.mapped('name'),
+            ['foo', '08:10:00 06/01/2020', '01/07/2024']
+        )
 
-        self.assertEqual(response['messages'][1]['type'], 'error')
-        self.assertIn("Field 'name' does not accept date/time values.", response['messages'][1]['message'])
+    @unittest.skipUnless(can_import('xlwt') and can_import('openpyxl'), "xlwt/openpyxl not available")
+    def test_xlsx_datetime_values_assigned_to_property_char_field(self):
+        """Test that importing datetime values to a property char field is converted"""
+        def_record = self.env['import.properties.definition'].create([
+            {
+                'properties_definition': [
+                    {'name': 'char_prop', 'type': 'char', 'string': 'TextType'},
+                    {'name': 'date_prop', 'type': 'date', 'string': 'DateType'},
+                ]
+            },
+        ])
+        file_content = generate_xlsx({
+            "Property Definition": [def_record.id, def_record.id],
+            f"TextType ({def_record.display_name})": [datetime.datetime(2020, 1, 6, 8, 10), datetime.date(2025, 7, 1)],
+            f"DateType ({def_record.display_name})": [datetime.datetime(2020, 2, 6, 8, 10), datetime.date(2025, 7, 2)],
+        })
+        file_type = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        import_wizard = self.env['base_import.import'].create({
+            'res_model': 'import.properties',
+            'file': file_content,
+            'file_type': file_type,
+        })
+        import_wizard.parse_preview({'has_headers': True})
+        response = import_wizard.execute_import(
+            ["record_definition_id", "properties.char_prop", "properties.date_prop"],
+            ["Property Definition", "Property/TextType", "Property/DateType"],
+            {
+                'quoting': '"', 'separator': ',', 'has_headers': True,
+            }
+        )
+        self.assertFalse(response.get('messages'))
+        self.assertEqual(
+            [prop['char_prop'] for prop in self.env['import.properties'].browse(response['ids']).mapped('properties')],
+            [
+                datetime.datetime(2020, 1, 6, 8, 10).strftime(DEFAULT_SERVER_DATETIME_FORMAT),
+                datetime.date(2025, 7, 1).strftime(DEFAULT_SERVER_DATE_FORMAT),
+            ],
+        )
 
 
 class TestBatching(TransactionCase):


### PR DESCRIPTION
*: test_import_export

### Steps to reproduce:

- Go to Sales/Prodcuts/Pricelists
- Create a new pricelist with a rule with a set Valid Period
- Export that record adding the Pricelist Rule/Start Date (item_ids/date_start) as XLSX format
- Delete the record and test the import the XLSX file
#### Uncaught Promise:
> Invalid props for component 'ImportDataColumnError' :'resultNames' is undefined (should be a array)

### Cause of the Issue:

The issue is raised by the error message:
https://github.com/odoo/odoo/blob/32bdff8bc603a03038d3f9e38463809883319305/addons/base_import/models/base_import.py#L1428-L1432
which is not properly handled by the `ImportDataColumnError` component. However, in the present situation, the issue is just that this error message itself should not be raised in the first place.

#### Details:

Since commit 630b2683d3aad203b0bbf7d2d63b88cd4d3bd9d7, date and datetime formatted cells in spreadsheets are no longer Char field. Instead, they are imported as date and datetime objects. This was intended to allow importing columns with mixed encodings (e.g., some values stored as strings, others as dates in the spreadsheet).

However, a side effect of this change is that if a char-type field contains values that a spreadsheet interprets as dates or datetimes, the import fails. For example, an account move name "21/12/2025" may be interpreted as a date. Attempting to perform a join on this string expected value causes a traceback here: https://github.com/odoo/odoo/blob/32bdff8bc603a03038d3f9e38463809883319305/addons/base_import/models/base_import.py#L1628-L1632

To address this discrepancy, commit 91dca74b3e395c8ee410db18784990ba3a6a7e6e introduced a check raising an error if the imported field type is not appropriate to carry a `date/datetime` value.

This fix has two major issues:

1) It still does not handle the above use case correctly—it remains impossible to import "21/12/2025" as a record name. 
2) (The present issue) It does not properly check the type of related fields. For example, a field like "company_id/partner_id/membership_start" is not considered as an allowed date field. The current check on allowed date fields being overly simplistic:
https://github.com/odoo/odoo/blob/32bdff8bc603a03038d3f9e38463809883319305/addons/base_import/models/base_import.py#L1416-L1421

### Fix:

We propose reverting commit 91dca74b3e395c8ee410db18784990ba3a6a7e6e. And instead of recursively computing the related model and the appropriate types of related fields (including property-type relational fields), we will simply stringify values when they are written into char-like fields (e.g., char or text).

Note: this may also require an adjustment in master for the html type.

opw-4935423
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
