### PR TITLE
[FIX] point_of_sale: pricelist with datetime

### DIFF
--- a/addons/point_of_sale/static/src/utils.js
+++ b/addons/point_of_sale/static/src/utils.js
@@ -1,4 +1,4 @@
-import { parseDateTime, deserializeDate } from "@web/core/l10n/dates";
+import { parseDateTime, deserializeDateTime } from "@web/core/l10n/dates";
 import { roundDecimals, floatIsZero } from "@web/core/utils/numbers";
 
 /*
@@ -195,11 +195,10 @@ export function computeProductPricelistCache(service, data = []) {
     };
 
     const pricelistRules = {};
-
     for (const item of pricelistItems) {
         if (
-            (item.date_start && deserializeDate(item.date_start) > date) ||
-            (item.date_end && deserializeDate(item.date_end) < date)
+            (item.date_start && deserializeDateTime(item.date_start) > date) ||
+            (item.date_end && deserializeDateTime(item.date_end) < date)
         ) {
             continue;
         }


### PR DESCRIPTION
Pricelist that have a start and end datetime that are the same day but with different hours were not correctly applied in the POS.

Steps to reproduce:
-------------------
* Create a pricelist with a start datetime of 2025-01-01 08:00:00 and an end datetime of 2025-01-01 18:00:00.
* Create a product and assign it to the pricelist with a fixed price.
* Add the pricelist to the PoS config.
* Open a session and select the pricelist.
* Add the product to the order
> Observation: The price is not correctly applied.

Note:
-----------
To update the pricelist when the datetime has been crossed the user will need to refresh the PoS.

opw-4934183