### PR TITLE
[FIX] sale_stock: include cogs credit note after downpayment

### DIFF
--- a/addons/sale_stock/tests/test_anglo_saxon_valuation.py
+++ b/addons/sale_stock/tests/test_anglo_saxon_valuation.py
@@ -1784,6 +1784,72 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
             {'debit': 60, 'credit': 0, 'account_id': account_expense.id, 'reconciled': False},
         ])
 
+    def test_anglo_saxon_cogs_partial_down_payment_credit_note(self):
+        """Create a SO with a product invoiced on ordered quantity.
+        Do a partial down payment, invoice the rest.
+        Create a credit note. The credit note should reverse the cogs"""
+        self.product.standard_price = 4
+        self.env['stock.quant'].with_context(inventory_mode=True).create({
+            'product_id': self.product.id,
+            'inventory_quantity': 20,
+            'location_id': self.company_data['default_warehouse'].lot_stock_id.id,
+        }).action_apply_inventory()
+
+        # Create the SO
+        so = self.env['sale.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [
+                Command.create({
+                    'name': self.product.name,
+                    'product_id': self.product.id,
+                    'product_uom_qty': 10.0,
+                    'product_uom': self.product.uom_id.id,
+                    'price_unit': 10,
+                    'tax_id': False,
+                })],
+        })
+        so.action_confirm()
+
+        # Do a 25% down payment
+        down_payment = self.env['sale.advance.payment.inv'].create({
+            'advance_payment_method': 'percentage',
+            'amount': 25,
+            'sale_order_ids': so.ids,
+        })
+        down_payment.create_invoices()
+        # Invoice the the down payment
+        down_payment_invoices = so.invoice_ids
+        down_payment_invoices.action_post()
+
+        # Invoice the rest
+        invoice_wizard = self.env['sale.advance.payment.inv'].with_context(
+            active_ids=so.ids
+        ).create({})
+        action = invoice_wizard.create_invoices()
+        invoice = self.env['account.move'].browse(action['res_id'])
+        invoice.action_post()
+
+        move_reversal = self.env['account.move.reversal'].with_context(active_model="account.move", active_ids=invoice.ids).create({
+            'journal_id': invoice.journal_id.id,
+        })
+        reversal = move_reversal.refund_moves()
+        credit_note = self.env['account.move'].browse(reversal['res_id'])
+        credit_note.action_post()
+
+        # Check the resulting accounting entries
+        account_stock_out = self.company_data['default_account_stock_out']
+        account_expense = self.company_data['default_account_expense']
+        invoice_cogs = invoice.line_ids.filtered(lambda l: l.display_type == 'cogs').sorted('debit')
+        credit_note_cogs = credit_note.line_ids.filtered(lambda l: l.display_type == 'cogs').sorted('debit')
+        self.assertRecordValues(invoice_cogs, [
+            {'debit': 0, 'credit': 40, 'account_id': account_stock_out.id},
+            {'debit': 40, 'credit': 0, 'account_id': account_expense.id},
+        ])
+        self.assertRecordValues(credit_note_cogs, [
+            {'debit': 0, 'credit': 40, 'account_id': account_expense.id},
+            {'debit': 40, 'credit': 0, 'account_id': account_stock_out.id},
+        ])
+
     def test_anglo_saxon_cogs_validate_invoice(self):
         """ Having some FIFO + real-time valued product with an established price i.e., from an in
         move: generating a delivery via sale, processing that delivery in multiple parts, and


### PR DESCRIPTION
**Problem:**
When we do a downpayment on an invoice then pay the rest and do a credit note, the credit note does not reverse the cogs

**Steps to reproduce:**
- create a storable product invoiced on ordered quantity
- set the category of the product as avco and "inventory valuation"
of the category as automated
- set an onhand quantity and a positive cost
- create a SO for 1 quantity of this product and confirm
- click on create invoice, select downpayment percentage and 25%
- click on create draft and confirm it
- click on create invoice, select regular, create draft
- confirm and select credit note
- write something in the reason field and click on reserve
- confirm it

**Current behavior:**
if you open the "Journal Items" page of the credit note you'll see that there is no line revresing the cogs (there would be if we didn't do a downpayment but invoiced all at once)

**Expected behavior:**
There should be:
- A line crediting "600000 Expenses" (or the account that was debited for the cogs on the original invoice) with the amount being the cost of your product.
- A line debiting "110300 stock interim (delivered)"(or the account that was credited for the cogs on the original invoice) with the amount being the cost of your product.

**Cause of the issue:**
Since this commit https://github.com/odoo/odoo/pull/163251/commits/d7b0510908d341c205461ca18b1730c93b88e445 (slightly modfified for efficieny reasons by this commit https://github.com/odoo/odoo/commit/4f9c52c03c65a497937053530e8d6c775d305e35), when _stock_account_prepare_anglo_saxon_out_lines_vals is called on the account move (the credit note) it calls _get_anglo_saxon_price_ctx.
https://github.com/odoo/odoo/blob/76a8d6bc28eb5998bd976b3c41bf9772d325c8bf/addons/stock_account/models/account_move.py#L114 One of the invoice lines of the account move is linked via sale_line_ids attribute to a sale order line that is a downpayment. As a consequence, inside _get_anglo_saxon_price_ctx, move_is_downpayment will be populated with this line. https://github.com/odoo/odoo/blob/76a8d6bc28eb5998bd976b3c41bf9772d325c8bf/addons/sale_stock/models/account_move.py#L136-L139 Then _stock_account_prepare_anglo_saxon_out_lines_vals calls _stock_account_get_anglo_saxon_price_unit.
https://github.com/odoo/odoo/blob/76a8d6bc28eb5998bd976b3c41bf9772d325c8bf/addons/stock_account/models/account_move.py#L131

Inside this method, because move_is_downpayment is populated, is_line_reversing will stay false
https://github.com/odoo/odoo/blob/76a8d6bc28eb5998bd976b3c41bf9772d325c8bf/addons/sale_stock/models/account_move.py#L163-L164

As a consequence,
- qty_to_invoice will become - qty_to_invoice
- account_move will be populated
- therefore posted_cogs will be populated https://github.com/odoo/odoo/blob/76a8d6bc28eb5998bd976b3c41bf9772d325c8bf/addons/sale_stock/models/account_move.py#L166-L174 So _compute average price will be called with a qty_invoiced of 1 instead of 0 and a qty_to_invoice of -1 instead of 1. So it will return 0 instead of the cost of the product because "missing" will be negative.
https://github.com/odoo/odoo/blob/76a8d6bc28eb5998bd976b3c41bf9772d325c8bf/addons/stock_account/models/product.py#L915

**fix**
The use case of this commit https://github.com/odoo/odoo/pull/163251/commits/d7b0510908d341c205461ca18b1730c93b88e445 is this one :
- SO for qty of 10 (product invoiced on delivered qty).
- 100% downpayment.
- deliver 6.
- invoice. 
In that case the invoice is actually a credit note but it still has to include the cogs (not reversed), so move_is_downpayment needs to be populated

However in our use case the cogs has to be reversed (so move_is_downpayment has to be None). One difference between those two use case is that in our use case the account move has a reversed_entry_id.

opw-5041783