### PR TITLE
[FIX] website: avoid importing hoot for Deferred

### DIFF
--- a/addons/website/static/src/builder/plugins/options/google_maps_option/google_maps_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/google_maps_option/google_maps_option_plugin.js
@@ -4,7 +4,7 @@ import { renderToElement } from "@web/core/utils/render";
 import { Plugin } from "@html_editor/plugin";
 import { GoogleMapsApiKeyDialog } from "./google_maps_api_key_dialog";
 import { GoogleMapsOption } from "./google_maps_option";
-import { Deferred } from "@odoo/hoot-dom";
+import { Deferred } from "@web/core/utils/concurrency";
 import { BuilderAction } from "@html_builder/core/builder_action";
 
 /**


### PR DESCRIPTION
The commit 47e971086ea57219a628a99d35e36354c71a4192 uses `Deferred` in the implementation of the google maps options plugin. But imported it from hoot.

This commit fixes the import to use `concurrency.js` instead.

task-4367641