### PR TITLE
[FIX] hw_posbox_homepage: fix ngrok service check

### DIFF
--- a/addons/hw_posbox_homepage/controllers/homepage.py
+++ b/addons/hw_posbox_homepage/controllers/homepage.py
@@ -335,7 +335,7 @@ class IotBoxOwlHomePage(http.Controller):
     def enable_remote_connection(self, auth_token):
         # check if the service exists for retro-compatibility TODO: remove in v18.4
         p = subprocess.run(
-            ['systemctl', 'is-active', 'odoo-ngrok.service'],
+            ['systemctl', 'is-enabled', 'odoo-ngrok.service'],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             check=False,


### PR DESCRIPTION
Before this commit, the check in the ngrok controller for whether to use the new ngrok service or the old method of launching ngrok was flawed. The check used `systemctl is-active`, however this will only succeed if the service is up and running successfully, which isn't the case initially due to the missing token config.

After this commit, we use `systemctl is-enabled` instead. This command succeeds as long as the service exists and is not disabled, even if it is currently in error.

```bash
> systemctl is-active odoo-ngrok.service
activating
> echo $?
3

> systemctl is-enabled odoo-ngrok.service
enabled
> echo $?
0
```

task-5075770

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
