### PR TITLE
[FIX] website: enable test of animation options for onHover

### DIFF
--- a/addons/website/static/tests/builder/website_builder/animate_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/animate_option.test.js
@@ -197,7 +197,7 @@ test("animation=onScroll should not be visible when the animation is limited", a
     await contains(".options-container [data-label='Animation'] .dropdown-toggle").click();
     expect(".o-dropdown--menu [data-action-value='onScroll']").not.toHaveCount();
 });
-test.skip("visibility of animation animation=onHover", async () => {
+test("visibility of animation animation=onHover", async () => {
     function expectOnHoverOptions(options) {
         const labels = [
             "Effect",


### PR DESCRIPTION
In commit 22c4ecff46d34a37549dfa3feda8cfe12cf00407, the test was disabled because it had non-deterministic failures

It was failing because the preview (that was made by the hover before the click) took sometimes long enough that `waitForEndOfOperation` was executed before preview finished, so it only waited for the end of the preview, not the end of the commit made by the click. Thus the `waitDomUpdated` that followed did not wait for the update caused by the commit (thus had nothing to wait for). And the assertions failed as the sidebar was not updated yet.

In order to wait enough, the helper `waitSidebarUpdated` has been introduced in commit 143c40bdb7eac35126d51ac85fb89e37ecb75f13. In this commit, we just un-skip the test (which was updated to use that helper)

task-4367641