### PR TITLE
[FIX] website: hide video size div if cookies are not accepted

### DIFF
--- a/addons/website/static/src/interactions/video/media_video.js
+++ b/addons/website/static/src/interactions/video/media_video.js
@@ -8,13 +8,19 @@ import { setupAutoplay, triggerAutoplay } from "@website/utils/videos";
 export class MediaVideo extends Interaction {
     static selector = ".media_iframe_video";
 
+    dynamicContent = {
+        _document: {
+            "t-on-optionalCookiesAccepted": () => {
+                this.cookiesAccepted = true;
+            },
+        },
+        ":scope > .media_iframe_video_size": {
+            "t-att-class": () => ({ "d-none": !this.cookiesAccepted }),
+        },
+    };
+
     setup() {
-        if (this.el.dataset.needCookiesApproval) {
-            this.sizeContainerEl = this.el.querySelector(":scope > .media_iframe_video_size");
-            this.sizeContainerEl.classList.add("d-none");
-            this.addListener(document, "optionalCookiesAccepted", this.sizeContainerEl.classList.remove("d-none"))
-            this.registerCleanup(() => this.sizeContainerEl.classList.remove("d-none"));
-        }
+        this.cookiesAccepted = this.el.dataset.needCookiesApproval !== "true";
     }
 
     start() {


### PR DESCRIPTION
Commit [958b41c] introduced a way not to load videos if the user did not accept optional cookies. In doing so, the "video size" container was hidden.
However, since [b9b3a60], the code was wrong:
- Instead of a proper handler, the `optionalCookiesAccepted` listener wasn't a listener at all and immediately removed `d-none` on `media_iframe_video_size`.
- It was all done in the `setup` instead of the `start` or `dynamicContent`.

[958b41c]: https://github.com/odoo/odoo/commit/958b41c4acec7e1700ca4d6e0b25ee0ad2aac9f1
[b9b3a60]: https://github.com/odoo/odoo/commit/b9b3a605e0f4c5da3a258c980107d6162da7f44f