### PR TITLE
[IMP] sale, (website_)payment: improve payment onboarding buttons

### DIFF
--- a/addons/account_payment/static/tests/interactions/portal_invoice_page_payment.test.js
+++ b/addons/account_payment/static/tests/interactions/portal_invoice_page_payment.test.js
@@ -121,7 +121,7 @@ test("portal_invoice_page_payment is started with #portal_pay", async () => {
                                                                     data-oe-field="arch"
                                                                     data-oe-xpath="/t[1]/div[1]/div[2]/a[1]"
                                                                  >
-                                                                     ACTIVATE <t t-out="onboarding_provider.upper()"/>
+                                                                     CONNECT <t t-out="onboarding_provider.upper()"/>
                                                                 </a>
                                                                 <a role="button" type="action" class="btn-link alert-warning me-2" href="/odoo/action-payment.action_payment_provider" data-oe-model="ir.ui.view" data-oe-id="612" data-oe-field="arch" data-oe-xpath="/t[1]/div[1]/div[2]/a[3]">
                                                                 <strong><i class="oi oi-arrow-right"></i> Payment Providers</strong>

--- a/addons/payment/views/payment_form_templates.xml
+++ b/addons/payment/views/payment_form_templates.xml
@@ -430,7 +430,7 @@
                     role="button"
                     class="btn btn-primary me-2"
                 >
-                    ACTIVATE <t t-out="onboarding_provider.upper()"/>
+                    CONNECT <t t-out="onboarding_provider.upper()"/>
                 </a>
                 <a
                     t-if="availability_report"

--- a/addons/sale/wizard/res_config_settings_views.xml
+++ b/addons/sale/wizard/res_config_settings_views.xml
@@ -79,7 +79,7 @@
                                         name="action_sale_start_payment_onboarding"
                                         class="btn-primary"
                                     >
-                                        Activate
+                                        Connect
                                         <field
                                             name="onboarding_payment_module"
                                             nolabel="1"
@@ -93,7 +93,7 @@
                                     class="oe_inline"
                                 >
                                     <button
-                                        string="Activate Stripe" class="btn btn-primary" disabled=""
+                                        string="Connect Stripe" class="btn btn-primary" disabled=""
                                     />
                                 </div>
                                 <button

--- a/addons/website_payment/views/res_config_settings_views.xml
+++ b/addons/website_payment/views/res_config_settings_views.xml
@@ -26,7 +26,7 @@
                                 name="action_w_payment_start_payment_onboarding"
                                 class="btn btn-link px-1"
                             >
-                                Activate
+                                Connect
                                 <field name="onboarding_payment_module" nolabel="1"/>
                             </button>
                         </div>
@@ -36,7 +36,7 @@
                             class="d-flex align-self-baseline oe_inline px-0"
                         >
                             <button
-                                string="Activate Stripe"
+                                string="Connect Stripe"
                                 class="btn btn-link px-1"
                                 disabled=""
                             />
@@ -91,7 +91,7 @@
                                         name="action_w_payment_start_payment_onboarding"
                                         class="btn btn-primary"
                                     >
-                                        Activate
+                                        Connect
                                         <field
                                             name="onboarding_payment_module"
                                             nolabel="1"
@@ -105,7 +105,7 @@
                                     class="oe_inline pe-0"
                                 >
                                     <button
-                                        string="Activate Stripe" class="btn btn-primary" disabled=""
+                                        string="Connect Stripe" class="btn btn-primary" disabled=""
                                     />
                                 </div>
                                 <button


### PR DESCRIPTION
The label "Connect" is a better fit than "Activate" for the payment onboarding buttons, as they redirect the user to the provider's authorization page, rather than enabling the provider.

task-5083530