### PR TITLE
[FIX] account: adapt init_invoice for invisible journal_id field

### DIFF
--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -537,7 +537,8 @@ class AccountTestInvoicingCommon(ProductCommon):
         if not move_form._get_modifier('date', 'invisible'):
             move_form.date = move_form.invoice_date
         move_form.partner_id = partner or cls.partner_a
-        if journal:
+        # The journal_id field is invisible when there is only one available journal for the move type.
+        if journal and not move_form._get_modifier('journal_id', 'invisible'):
             move_form.journal_id = journal
         if currency:
             move_form.currency_id = currency


### PR DESCRIPTION
- Before [#222209](https://github.com/odoo/odoo/pull/222209), the `journal_id` field was always visible, so `init_invoice` could reliably set the `journal_id` value in tests. Now that the field is only shown when two or more journals exist, this PR updates `init_invoice` to handle cases where `journal_id` may be invisible, preventing test failures.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
