### PR TITLE
[FIX] point_of_sale: don't traceback when no user

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1124,7 +1124,7 @@ export class PosStore extends WithLazyGetterTrap {
         return this.user;
     }
     getCashierUserId() {
-        return this.user.id;
+        return this.user?.id;
     }
     cashierHasPriceControlRights() {
         return !this.config.restrict_price_control || this.getCashier()._role == "manager";


### PR DESCRIPTION
When there is no user, you get a traceback when it tries to access user.id. As the code that call getCashierUserId handles the fact that a falsy value is returned, we return undefiened when there is no user.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
