### PR TITLE
[FIX] web: correctly reset currency aggregates for empty groups

### DIFF
--- a/addons/web/static/src/model/relational_model/relational_model.js
+++ b/addons/web/static/src/model/relational_model/relational_model.js
@@ -605,7 +605,8 @@ export class RelationalModel extends Model {
                 ) {
                     const aggregates = Object.assign({}, group.aggregates);
                     for (const key in aggregates) {
-                        aggregates[key] = 0;
+                        // the `array_agg_distinct` aggregator's value is an array
+                        aggregates[key] = Array.isArray(aggregates[key]) ? [] : 0;
                     }
                     groups.splice(
                         index,

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -4670,7 +4670,7 @@ test(`monetary aggregates in grouped list`, async () => {
     expect(".o_multi_currency_popover").toHaveText("2,800.00 € at $ 0.50");
 });
 
-test(`monetary aggregates in grouped list (different currencies in same group)`, async () => {
+test(`monetary aggregates in grouped list (!= currencies in same group)`, async () => {
     await mountView({
         resModel: "foo",
         type: "list",
@@ -4689,6 +4689,33 @@ test(`monetary aggregates in grouped list (different currencies in same group)`,
     expect(`.o_group_header:first`).toHaveText("No (1)\n $ 0.00");
     expect(`.o_group_header:last`).toHaveText("Yes (3)\n $ 2,000.00?");
     expect(`.o_list_footer .o_list_number span`).toHaveText("$ 2,000.00?");
+});
+
+test(`monetary aggregates in grouped list (!= currencies in same group, delete)`, async () => {
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `
+            <list>
+                <field name="foo"/>
+                <field name="amount" widget="monetary" sum="Sum"/>
+                <field name="currency_id"/>
+            </list>
+        `,
+        groupBy: ["bar"],
+        actionMenus: {},
+    });
+    expect(`.o_group_header`).toHaveCount(2);
+    expect(`.o_group_header:last`).toHaveText("Yes (3)\n $ 2,000.00?");
+    await contains(`.o_group_header:last`).click();
+    expect(`.o_data_row`).toHaveCount(3);
+    await selectAllRecords();
+    expect(`.o_data_row_selected`).toHaveCount(3);
+    await toggleActionMenu();
+    await toggleMenuItem("Delete");
+    await contains(`.o_dialog footer .btn-primary`).click(); // confirm
+    expect(`.o_data_row`).toHaveCount(0);
+    expect(`.o_group_header:last`).toHaveText("Yes (0)\n 0.00");
 });
 
 test(`handle false values in aggregates`, async () => {


### PR DESCRIPTION
Be in a grouped list view with a monetary field aggregate and a group with different currencies. Open that group, select all its records and delete them. Before this commit, it crashed.

Since [1], we use the new aggregator `array_agg_distinct` which returns the list of currencies of aggregated records. When a group disappears after a reload (which is the case in our flow as we deleted all its records), we keep it in the UI for UX reasons. However, as that group is no longer returned by web_read_group, we manually reset its aggregate values to 0. Before [1], that was correct as all aggregate values were numbers. Now, it can also be arrays (for currencies, with the `array_agg_distinct` operator). This commit properly handles that case.

[1] https://github.com/odoo/odoo/pull/224667

closes #226566

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
