### PR TITLE
[FIX] mail: message body empty check for html

### DIFF
--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -1,3 +1,5 @@
+import { isEmptyBlock } from "@html_editor/utils/dom_info";
+
 import { fields, Record } from "@mail/core/common/record";
 import {
     EMOJI_REGEX,
@@ -316,22 +318,7 @@ export class Message extends Record {
     });
     isBodyEmpty = fields.Attr(undefined, {
         compute() {
-            return (
-                !this.body ||
-                [
-                    "",
-                    "<p></p>",
-                    "<p><br></p>",
-                    "<p><br/></p>",
-                    "<div></div>",
-                    "<div><br></div>",
-                    "<div><br/></div>",
-                ].includes(
-                    this.body
-                        .replace('<span class="o-mail-Message-edited"></span>', "")
-                        .replace(/\s/g, "")
-                )
-            );
+            return !this.body || isEmptyBlock(createElementWithContent("div", this.body));
         },
     });
 

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -1892,7 +1892,7 @@ test("warning on send with shortcut when attempting to post message with still-u
     await contains(".o_notification", { text: "Please wait while the file is uploading." });
 });
 
-test("post attachment-only message shows optimistically the new message with attachment", async () => {
+test("[text composer] Can post message with only attachment", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "test" });
     onRpcBefore("/mail/message/post", async () => await new Deferred());
@@ -1907,6 +1907,28 @@ test("post attachment-only message shows optimistically the new message with att
     await press("Enter");
     await contains(".o-mail-Message");
     await contains(".o-mail-Message .o-mail-AttachmentContainer:contains('text.txt')");
+    await contains(".o-mail-Message .o-mail-Message-bubble", { count: 0 });
+});
+
+test.tags("html composer");
+test("Can post message with only attachment", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "test" });
+    onRpcBefore("/mail/message/post", async () => await new Deferred());
+    await start();
+    const composerService = getService("mail.composer");
+    composerService.setHtmlComposer();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Composer input[type=file]");
+    const file = new File(["hello, world"], "text.txt", { type: "text/plain" });
+    await editInput(document.body, ".o-mail-Composer input[type=file]", [file]);
+    await contains(
+        ".o-mail-AttachmentContainer:not(.o-isUploading):contains('text.txt'):not(:has(.fa.fa-circle-o-notch))"
+    );
+    await press("Enter");
+    await contains(".o-mail-Message");
+    await contains(".o-mail-Message .o-mail-AttachmentContainer:contains('text.txt')");
+    await contains(".o-mail-Message .o-mail-Message-bubble", { count: 0 });
 });
 
 test("failure on loading messages should display error", async () => {


### PR DESCRIPTION
This commit fixes the issue where messages with HTML content were
incorrectly considered empty.

The problem is because the isBodyEmpty is not correctly computed in
message model. In this case, there will be an empty message bubble
shown in the thread.

To reproduce the issue:
1. Go to Discuss app.
2. Send an attachment only message.
3. There should be a message bubble with empty body shown in the thread.

task-5077500

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
