### PR TITLE
[IMP] l10n_in_edi: prevent generation of IRN for cancelled invoice

### DIFF
--- a/addons/l10n_in_edi/models/account_move.py
+++ b/addons/l10n_in_edi/models/account_move.py
@@ -147,6 +147,7 @@ class AccountMove(models.Model):
         return (
             self.country_code == 'IN'
             and self.company_id.l10n_in_edi_feature
+            and not self.l10n_in_edi_status == 'cancelled'
             and self.is_sale_document(include_receipts=True)
             and self.journal_id.type == 'sale'
             and self.l10n_in_gst_treatment in (


### PR DESCRIPTION
Once cancelled, the same document (with same document number)
can't be reported again for generation of IRN.

In this commit:
---
Updated the `_l10n_in_check_einvoice_eligible()` method to exclude invoices
with `l10n_in_edi_status` set to `cancelled`. which Ensures that
cancelled invoices are not sent again for IRN generation.
