### PR TITLE
[REF] mail, *: removed avatar_128 from _field_store_repr

### DIFF
--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -421,7 +421,10 @@ class DiscussChannel(models.Model):
 
     def _store_livechat_operator_id_fields(self):
         """Return the standard fields to include in Store for livechat_operator_id."""
-        return ["avatar_128", *self.env["res.partner"]._get_store_livechat_username_fields()]
+        return [
+            *self.env["res.partner"]._get_store_avatar_fields(),
+            *self.env["res.partner"]._get_store_livechat_username_fields()
+        ]
 
     def _to_store_defaults(self, target: Store.Target):
         fields = [

--- a/addons/im_livechat/models/discuss_channel_member.py
+++ b/addons/im_livechat/models/discuss_channel_member.py
@@ -156,9 +156,9 @@ class DiscussChannelMember(models.Model):
         if self.channel_id.channel_type == 'livechat':
             new_fields = [
                 "active",
-                "avatar_128",
                 Store.One("country_id", ["code", "name"]),
                 "is_public",
+                *self.env["res.partner"]._get_store_avatar_fields(),
                 *self.env["res.partner"]._get_store_im_status_fields(),
                 *self.env["res.partner"]._get_store_livechat_username_fields(),
             ]
@@ -171,10 +171,10 @@ class DiscussChannelMember(models.Model):
         self.ensure_one()
         if self.channel_id.channel_type == 'livechat':
             return [
-                "avatar_128",
                 Store.One("country_id", ["code", "name"]),
                 "name",
                 "offline_since",
+                *self.env["mail.guest"]._get_store_avatar_fields(),
                 *self.env["mail.guest"]._get_store_im_status_fields(),
             ]
         return super()._get_store_guest_fields(fields)

--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -349,7 +349,7 @@ class DiscussChannelMember(models.Model):
     def _to_store_persona(self, fields=None):
         if fields == "avatar_card":
             fields = [
-                "avatar_128",
+                *self.env["res.partner"]._get_store_avatar_fields(),
                 *self.env["res.partner"]._get_store_im_status_fields(),
                 "name"
             ]

--- a/addons/mail/models/discuss/mail_guest.py
+++ b/addons/mail/models/discuss/mail_guest.py
@@ -93,8 +93,8 @@ class MailGuest(models.Model):
             raise UserError(_("Guest's name is too long."))
         self.name = name
         for channel in self.channel_ids:
-            Store(bus_channel=channel).add(self, ["avatar_128", "name"]).bus_send()
-        Store(bus_channel=self).add(self, ["avatar_128", "name"]).bus_send()
+            Store(bus_channel=channel).add(self, [*self._get_store_avatar_fields(), "name"]).bus_send()
+        Store(bus_channel=self).add(self, [*self._get_store_avatar_fields(), "name"]).bus_send()
 
     def _update_timezone(self, timezone):
         query = """
@@ -116,13 +116,11 @@ class MailGuest(models.Model):
         self.ensure_one()
         return limited_field_access_token(self, "im_status", scope="mail.presence")
 
-    def _field_store_repr(self, field_name):
-        if field_name == "avatar_128":
-            return [
-                Store.Attr("avatar_128_access_token", lambda g: g._get_avatar_128_access_token()),
-                "write_date",
-            ]
-        return [field_name]
+    def _get_store_avatar_fields(self):
+        return [
+            Store.Attr("avatar_128_access_token", lambda g: g._get_avatar_128_access_token()),
+            "write_date",
+        ]
 
     def _get_store_im_status_fields(self):
         return [
@@ -131,7 +129,7 @@ class MailGuest(models.Model):
         ]
 
     def _to_store_defaults(self, target):
-        return ["avatar_128", *self._get_store_im_status_fields(), "name"]
+        return [*self._get_store_avatar_fields(), *self._get_store_im_status_fields(), "name"]
 
     def _set_auth_cookie(self):
         """Add a cookie to the response to identify the guest. Every route

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -1068,11 +1068,15 @@ class MailMessage(models.Model):
                 sudo=True,
             ),
             # sudo: mail.message: access to author_guest_id is allowed
-            Store.One("author_guest_id", ["avatar_128", "name"], sudo=True),
+            Store.One("author_guest_id", [*self.env["mail.guest"]._get_store_avatar_fields(), "name"], sudo=True),
             # sudo: mail.message: access to author_id is allowed
             Store.One(
                 "author_id",
-                ["avatar_128", "is_company", Store.One("main_user_id", "share")],
+                [
+                    "is_company",
+                    Store.One("main_user_id", "share"),
+                    *self.env["res.partner"]._get_store_avatar_fields(),
+                ],
                 dynamic_fields=lambda m: m._get_store_partner_name_fields(),
                 sudo=True,
             ),
@@ -1092,7 +1096,10 @@ class MailMessage(models.Model):
             "message_type",
             "model",  # keep for iOS app
             # sudo: res.partner: reading limited data of recipients is acceptable
-            Store.Many("partner_ids", ["avatar_128", "name"], sort="id", sudo=True),
+            Store.Many("partner_ids", [
+                *self.env["res.partner"]._get_store_avatar_fields(),
+                "name"
+            ], sort="id", sudo=True),
             "pinned_at",
             # sudo: mail.message - reading reactions on accessible message is allowed
             Store.Attr("reactions", value=lambda m: Store.Many(m.sudo().reaction_ids)),

--- a/addons/mail/models/mail_message_reaction.py
+++ b/addons/mail/models/mail_message_reaction.py
@@ -32,11 +32,14 @@ class MailMessageReaction(models.Model):
             data = {
                 "content": content,
                 "count": len(reactions),
-                "guests": Store.Many(reactions.guest_id, ["avatar_128", "name"]),
+                "guests": Store.Many(reactions.guest_id, [*self.env["mail.guest"]._get_store_avatar_fields(), "name"]),
                 "message": message.id,
                 "partners": Store.Many(
                     reactions.partner_id,
-                    ["avatar_128", *message._get_store_partner_name_fields()],
+                    [
+                        *self.env["res.partner"]._get_store_avatar_fields(),
+                        *message._get_store_partner_name_fields()
+                    ],
                 ),
                 "sequence": min(reactions.ids),
             }

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -4942,7 +4942,7 @@ class MailThread(models.AbstractModel):
         res = [
             Store.Many("attachment_ids", sort="id"),
             "body",
-            Store.Many("partner_ids", ["avatar_128", "name"]),
+            Store.Many("partner_ids", [*self.env["res.partner"]._get_store_avatar_fields(), "name"]),
             "pinned_at",
             "write_date",
             *message._get_store_linked_messages_fields(),

--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -253,6 +253,12 @@ class ResPartner(models.Model):
         self.ensure_one()
         return limited_field_access_token(self, "id", scope="mail.message_mention")
 
+    def _get_store_avatar_fields(self):
+        return [
+            Store.Attr("avatar_128_access_token", lambda p: p._get_avatar_128_access_token()),
+            "write_date",
+        ]
+
     def _get_store_im_status_fields(self):
         return [
             "im_status",
@@ -272,18 +278,10 @@ class ResPartner(models.Model):
             fields.extend(["email", "phone"])
         return fields
 
-    def _field_store_repr(self, field_name):
-        if field_name == "avatar_128":
-            return [
-                Store.Attr("avatar_128_access_token", lambda p: p._get_avatar_128_access_token()),
-                "write_date",
-            ]
-        return [field_name]
-
     def _to_store_defaults(self, target: Store.Target):
         res = [
             "active",
-            "avatar_128",
+            *self._get_store_avatar_fields(),
             *self._get_store_im_status_fields(),
             "is_company",
             Store.One("main_user_id", ["share"]),

--- a/addons/mail/models/res_users.py
+++ b/addons/mail/models/res_users.py
@@ -410,7 +410,6 @@ class ResUsers(models.Model):
                     self.env.user.partner_id,
                     [
                         "active",
-                        "avatar_128",
                         Store.One(
                             "main_user_id",
                             [
@@ -421,6 +420,7 @@ class ResUsers(models.Model):
                             ],
                         ),
                         "name",
+                        *self.env["res.partner"]._get_store_avatar_fields(),
                         *self.env["res.partner"]._get_store_im_status_fields(),
                     ],
                 ),
@@ -428,7 +428,7 @@ class ResUsers(models.Model):
             )
         if guest := self.env["mail.guest"]._get_guest_from_context():
             # sudo() => adding current guest data is acceptable
-            store.add_global_values(self_guest=Store.One(guest.sudo(), ["avatar_128", "name"]))
+            store.add_global_values(self_guest=Store.One(guest.sudo(), [*guest._get_store_avatar_fields(), "name"]))
 
     def _init_messaging(self, store: Store):
         self.ensure_one()

--- a/addons/portal/controllers/portal_thread.py
+++ b/addons/portal/controllers/portal_thread.py
@@ -49,9 +49,9 @@ class PortalChatter(ThreadController):
                                 portal_partner,
                                 fields=[
                                     "active",
-                                    "avatar_128",
                                     Store.One("main_user_id", "share"),
                                     "name",
+                                    *portal_partner._get_store_avatar_fields(),
                                 ],
                             )
                         },


### PR DESCRIPTION
* = im_livechat, portal

This commit moves the `avatar_128` Store fields from the `_field_store_repr` to a dedicated method for `res.partner` and `mail.guest`.

task-4855078
task-4855076