### PR TITLE
[FIX] l10n_*: fix access error with demo data whit fiscal localizations

### DIFF
--- a/addons/l10n_ae/demo/demo_company.xml
+++ b/addons/l10n_ae/demo/demo_company.xml
@@ -24,7 +24,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_ae'))]}"/>
     </function>
 

--- a/addons/l10n_ar/demo/exento_demo.xml
+++ b/addons/l10n_ar/demo/exento_demo.xml
@@ -25,7 +25,7 @@
     </record>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.company_exento'))]}"/>
     </function>
 

--- a/addons/l10n_ar/demo/mono_demo.xml
+++ b/addons/l10n_ar/demo/mono_demo.xml
@@ -25,7 +25,7 @@
     </record>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.company_mono'))]}"/>
     </function>
 

--- a/addons/l10n_ar/demo/respinsc_demo.xml
+++ b/addons/l10n_ar/demo/respinsc_demo.xml
@@ -26,7 +26,7 @@
     </record>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.company_ri'))]}"/>
     </function>
 

--- a/addons/l10n_at/demo/demo_company.xml
+++ b/addons/l10n_at/demo/demo_company.xml
@@ -30,7 +30,7 @@
   </function>
 
   <function model="res.users" name="write">
-    <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+    <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
     <value eval="{'company_ids':[(4, ref('base.demo_company_at'))]}"/>
   </function>
 

--- a/addons/l10n_au/demo/demo_company.xml
+++ b/addons/l10n_au/demo/demo_company.xml
@@ -24,7 +24,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_au'))]}"/>
     </function>
 

--- a/addons/l10n_bd/demo/demo_company.xml
+++ b/addons/l10n_bd/demo/demo_company.xml
@@ -24,7 +24,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_bd'))]}"/>
     </function>
 

--- a/addons/l10n_be/demo/demo_company.xml
+++ b/addons/l10n_be/demo/demo_company.xml
@@ -29,7 +29,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_be'))]}"/>
     </function>
 

--- a/addons/l10n_bf/demo/demo_company.xml
+++ b/addons/l10n_bf/demo/demo_company.xml
@@ -23,7 +23,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_bf'))]}"/>
     </function>
 

--- a/addons/l10n_bg/demo/demo_company.xml
+++ b/addons/l10n_bg/demo/demo_company.xml
@@ -30,7 +30,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_bg'))]}"/>
     </function>
 

--- a/addons/l10n_bh/demo/demo_company.xml
+++ b/addons/l10n_bh/demo/demo_company.xml
@@ -28,7 +28,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('l10n_bh.demo_company_bh'))]}"/>
     </function>
 

--- a/addons/l10n_bj/demo/demo_company.xml
+++ b/addons/l10n_bj/demo/demo_company.xml
@@ -23,7 +23,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_bj'))]}"/>
     </function>
 

--- a/addons/l10n_bo/demo/demo_company.xml
+++ b/addons/l10n_bo/demo/demo_company.xml
@@ -24,7 +24,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_bo'))]}"/>
     </function>
 

--- a/addons/l10n_br/demo/demo_company.xml
+++ b/addons/l10n_br/demo/demo_company.xml
@@ -24,7 +24,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_br'))]}"/>
     </function>
 

--- a/addons/l10n_ca/demo/demo_company.xml
+++ b/addons/l10n_ca/demo/demo_company.xml
@@ -25,7 +25,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [Command.link(ref('base.demo_company_ca'))]}"/>
     </function>
 

--- a/addons/l10n_cd/demo/demo_company.xml
+++ b/addons/l10n_cd/demo/demo_company.xml
@@ -23,7 +23,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_cd'))]}"/>
     </function>
 

--- a/addons/l10n_cf/demo/demo_company.xml
+++ b/addons/l10n_cf/demo/demo_company.xml
@@ -23,7 +23,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_cf'))]}"/>
     </function>
 

--- a/addons/l10n_cg/demo/demo_company.xml
+++ b/addons/l10n_cg/demo/demo_company.xml
@@ -23,7 +23,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_cg'))]}"/>
     </function>
 

--- a/addons/l10n_ch/demo/demo_company.xml
+++ b/addons/l10n_ch/demo/demo_company.xml
@@ -30,7 +30,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_ch'))]}"/>
     </function>
 

--- a/addons/l10n_ci/demo/demo_company.xml
+++ b/addons/l10n_ci/demo/demo_company.xml
@@ -23,7 +23,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_ci'))]}"/>
     </function>
 

--- a/addons/l10n_cl/demo/demo_company.xml
+++ b/addons/l10n_cl/demo/demo_company.xml
@@ -26,7 +26,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_cl'))]}"/>
     </function>
 

--- a/addons/l10n_cm/demo/demo_company.xml
+++ b/addons/l10n_cm/demo/demo_company.xml
@@ -23,7 +23,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_cm'))]}"/>
     </function>
 

--- a/addons/l10n_cn/demo/demo_company.xml
+++ b/addons/l10n_cn/demo/demo_company.xml
@@ -24,7 +24,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_cn'))]}"/>
     </function>
 

--- a/addons/l10n_cn/demo/demo_company_asbe.xml
+++ b/addons/l10n_cn/demo/demo_company_asbe.xml
@@ -24,7 +24,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_asbe_company_cn'))]}"/>
     </function>
 

--- a/addons/l10n_co/demo/demo_company.xml
+++ b/addons/l10n_co/demo/demo_company.xml
@@ -24,7 +24,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_co'))]}"/>
     </function>
 

--- a/addons/l10n_cr/demo/demo_company.xml
+++ b/addons/l10n_cr/demo/demo_company.xml
@@ -24,7 +24,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_cr'))]}"/>
     </function>
 

--- a/addons/l10n_cy/demo/demo_company.xml
+++ b/addons/l10n_cy/demo/demo_company.xml
@@ -29,7 +29,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('l10n_cy.demo_company_cy'))]}"/>
     </function>
 

--- a/addons/l10n_cz/demo/demo_company.xml
+++ b/addons/l10n_cz/demo/demo_company.xml
@@ -30,7 +30,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_cz'))]}"/>
     </function>
 

--- a/addons/l10n_de/demo/demo_company.xml
+++ b/addons/l10n_de/demo/demo_company.xml
@@ -30,7 +30,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_de'))]}"/>
     </function>
 

--- a/addons/l10n_dk/demo/demo_company.xml
+++ b/addons/l10n_dk/demo/demo_company.xml
@@ -30,7 +30,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_dk'))]}"/>
     </function>
 

--- a/addons/l10n_do/demo/demo_company.xml
+++ b/addons/l10n_do/demo/demo_company.xml
@@ -24,7 +24,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_do'))]}"/>
     </function>
 

--- a/addons/l10n_dz/demo/demo_company.xml
+++ b/addons/l10n_dz/demo/demo_company.xml
@@ -23,7 +23,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_dz'))]}"/>
     </function>
 

--- a/addons/l10n_ec/demo/demo_company.xml
+++ b/addons/l10n_ec/demo/demo_company.xml
@@ -25,7 +25,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_ec'))]}"/>
     </function>
 

--- a/addons/l10n_ee/demo/demo_company.xml
+++ b/addons/l10n_ee/demo/demo_company.xml
@@ -30,7 +30,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_ee'))]}"/>
     </function>
 

--- a/addons/l10n_eg/demo/demo_company.xml
+++ b/addons/l10n_eg/demo/demo_company.xml
@@ -23,7 +23,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [Command.link(ref('base.demo_company_eg'))]}"/>
     </function>
 

--- a/addons/l10n_es/demo/demo_company.xml
+++ b/addons/l10n_es/demo/demo_company.xml
@@ -31,7 +31,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_es'))]}"/>
     </function>
 

--- a/addons/l10n_et/demo/demo_company.xml
+++ b/addons/l10n_et/demo/demo_company.xml
@@ -24,7 +24,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_et'))]}"/>
     </function>
 

--- a/addons/l10n_fi/demo/demo_company.xml
+++ b/addons/l10n_fi/demo/demo_company.xml
@@ -30,7 +30,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_fi'))]}"/>
     </function>
 

--- a/addons/l10n_fr/demo/demo_company.xml
+++ b/addons/l10n_fr/demo/demo_company.xml
@@ -31,7 +31,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_fr'))]}"/>
     </function>
 </odoo>

--- a/addons/l10n_fr_hr_holidays/data/l10n_fr_hr_holidays_demo.xml
+++ b/addons/l10n_fr_hr_holidays/data/l10n_fr_hr_holidays_demo.xml
@@ -76,7 +76,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_fr'))]}"/>
     </function>
 </odoo>

--- a/addons/l10n_ga/demo/demo_company.xml
+++ b/addons/l10n_ga/demo/demo_company.xml
@@ -23,7 +23,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_ga'))]}"/>
     </function>
 

--- a/addons/l10n_gn/demo/demo_company.xml
+++ b/addons/l10n_gn/demo/demo_company.xml
@@ -23,7 +23,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_gn'))]}"/>
     </function>
 

--- a/addons/l10n_gq/demo/demo_company.xml
+++ b/addons/l10n_gq/demo/demo_company.xml
@@ -23,7 +23,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_gq'))]}"/>
     </function>
 

--- a/addons/l10n_gr/demo/demo_company.xml
+++ b/addons/l10n_gr/demo/demo_company.xml
@@ -30,7 +30,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_gr'))]}"/>
     </function>
 

--- a/addons/l10n_gt/demo/demo_company.xml
+++ b/addons/l10n_gt/demo/demo_company.xml
@@ -24,7 +24,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_gt'))]}"/>
     </function>
 

--- a/addons/l10n_gw/demo/demo_company.xml
+++ b/addons/l10n_gw/demo/demo_company.xml
@@ -23,7 +23,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_gw'))]}"/>
     </function>
 

--- a/addons/l10n_hk/demo/demo_company.xml
+++ b/addons/l10n_hk/demo/demo_company.xml
@@ -25,7 +25,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_hk'))]}"/>
     </function>
 

--- a/addons/l10n_hn/demo/demo_company.xml
+++ b/addons/l10n_hn/demo/demo_company.xml
@@ -24,7 +24,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_hn'))]}"/>
     </function>
 

--- a/addons/l10n_hr/demo/demo_company.xml
+++ b/addons/l10n_hr/demo/demo_company.xml
@@ -30,7 +30,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_hr'))]}"/>
     </function>
 

--- a/addons/l10n_hr_kuna/demo/demo_company.xml
+++ b/addons/l10n_hr_kuna/demo/demo_company.xml
@@ -24,7 +24,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_hr_kuna'))]}"/>
     </function>
 

--- a/addons/l10n_hu/demo/demo_company.xml
+++ b/addons/l10n_hu/demo/demo_company.xml
@@ -28,7 +28,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_hu'))]}"/>
     </function>
 

--- a/addons/l10n_id/demo/demo_company.xml
+++ b/addons/l10n_id/demo/demo_company.xml
@@ -24,7 +24,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_id'))]}"/>
     </function>
 

--- a/addons/l10n_ie/demo/demo_company.xml
+++ b/addons/l10n_ie/demo/demo_company.xml
@@ -30,7 +30,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_ie'))]}"/>
     </function>
 

--- a/addons/l10n_il/demo/demo_company.xml
+++ b/addons/l10n_il/demo/demo_company.xml
@@ -24,7 +24,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_il'))]}"/>
     </function>
 

--- a/addons/l10n_in/demo/demo_company.xml
+++ b/addons/l10n_in/demo/demo_company.xml
@@ -25,7 +25,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_in'))]}"/>
     </function>
 

--- a/addons/l10n_iq/demo/demo_company.xml
+++ b/addons/l10n_iq/demo/demo_company.xml
@@ -23,7 +23,7 @@
         </function>
 
         <function model="res.users" name="write">
-            <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]" />
+            <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
             <value eval="{'company_ids': [(4, ref('l10n_iq.demo_company_iq'))]}" />
         </function>
 

--- a/addons/l10n_it/demo/demo_company.xml
+++ b/addons/l10n_it/demo/demo_company.xml
@@ -30,7 +30,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_it'))]}"/>
     </function>
 

--- a/addons/l10n_jo/demo/demo_company.xml
+++ b/addons/l10n_jo/demo/demo_company.xml
@@ -22,7 +22,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [Command.link(ref('base.demo_company_jo'))]}"/>
     </function>
 

--- a/addons/l10n_jp/demo/demo_company.xml
+++ b/addons/l10n_jp/demo/demo_company.xml
@@ -24,7 +24,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_jp'))]}"/>
     </function>
 

--- a/addons/l10n_ke/demo/demo_company.xml
+++ b/addons/l10n_ke/demo/demo_company.xml
@@ -23,7 +23,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_ke'))]}"/>
     </function>
 

--- a/addons/l10n_kh/demo/demo_company.xml
+++ b/addons/l10n_kh/demo/demo_company.xml
@@ -19,7 +19,7 @@
         <value eval="[ref('l10n_kh.demo_company_kh')]"/>
     </function>
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(Command.link(ref('l10n_kh.demo_company_kh')))]}"/>
     </function>
     <function model="account.chart.template" name="try_loading">

--- a/addons/l10n_km/demo/demo_company.xml
+++ b/addons/l10n_km/demo/demo_company.xml
@@ -23,7 +23,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_km'))]}"/>
     </function>
 

--- a/addons/l10n_kr/demo/demo_company.xml
+++ b/addons/l10n_kr/demo/demo_company.xml
@@ -23,7 +23,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_kr'))]}"/>
     </function>
 

--- a/addons/l10n_kw/demo/demo_company.xml
+++ b/addons/l10n_kw/demo/demo_company.xml
@@ -24,7 +24,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('l10n_kw.demo_company_kw'))]}"/>
     </function>
 

--- a/addons/l10n_kz/demo/demo_company.xml
+++ b/addons/l10n_kz/demo/demo_company.xml
@@ -22,7 +22,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_kz'))]}"/>
     </function>
 

--- a/addons/l10n_lb_account/demo/demo_company.xml
+++ b/addons/l10n_lb_account/demo/demo_company.xml
@@ -31,7 +31,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]" />
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_lb'))]}" />
     </function>
 

--- a/addons/l10n_lt/demo/demo_company.xml
+++ b/addons/l10n_lt/demo/demo_company.xml
@@ -30,7 +30,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_lt'))]}"/>
     </function>
 

--- a/addons/l10n_lu/demo/demo_company.xml
+++ b/addons/l10n_lu/demo/demo_company.xml
@@ -30,7 +30,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_lu'))]}"/>
     </function>
 

--- a/addons/l10n_lv/demo/demo_company.xml
+++ b/addons/l10n_lv/demo/demo_company.xml
@@ -29,7 +29,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_lv'))]}"/>
     </function>
 

--- a/addons/l10n_ma/demo/demo_company.xml
+++ b/addons/l10n_ma/demo/demo_company.xml
@@ -23,7 +23,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_ma'))]}"/>
     </function>
 

--- a/addons/l10n_ml/demo/demo_company.xml
+++ b/addons/l10n_ml/demo/demo_company.xml
@@ -23,7 +23,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_ml'))]}"/>
     </function>
 

--- a/addons/l10n_mn/demo/demo_company.xml
+++ b/addons/l10n_mn/demo/demo_company.xml
@@ -24,7 +24,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_mn'))]}"/>
     </function>
 

--- a/addons/l10n_mt/demo/demo_company.xml
+++ b/addons/l10n_mt/demo/demo_company.xml
@@ -29,7 +29,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('l10n_mt.demo_company_mt'))]}"/>
     </function>
 

--- a/addons/l10n_mu_account/demo/demo_company.xml
+++ b/addons/l10n_mu_account/demo/demo_company.xml
@@ -29,7 +29,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('l10n_mu_account.demo_company_mu'))]}"/>
     </function>
 

--- a/addons/l10n_mx/demo/demo_company.xml
+++ b/addons/l10n_mx/demo/demo_company.xml
@@ -25,7 +25,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_mx'))]}"/>
     </function>
 

--- a/addons/l10n_my/demo/demo_company.xml
+++ b/addons/l10n_my/demo/demo_company.xml
@@ -25,7 +25,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_my'))]}"/>
     </function>
 

--- a/addons/l10n_mz/demo/demo_company.xml
+++ b/addons/l10n_mz/demo/demo_company.xml
@@ -24,7 +24,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_mz'))]}"/>
     </function>
 

--- a/addons/l10n_ne/demo/demo_company.xml
+++ b/addons/l10n_ne/demo/demo_company.xml
@@ -23,7 +23,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_ne'))]}"/>
     </function>
 

--- a/addons/l10n_ng/demo/demo_company.xml
+++ b/addons/l10n_ng/demo/demo_company.xml
@@ -30,7 +30,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('l10n_ng.demo_company_ng'))]}"/>
     </function>
 

--- a/addons/l10n_nl/demo/demo_company.xml
+++ b/addons/l10n_nl/demo/demo_company.xml
@@ -30,7 +30,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_nl'))]}"/>
     </function>
 

--- a/addons/l10n_no/demo/demo_company.xml
+++ b/addons/l10n_no/demo/demo_company.xml
@@ -31,7 +31,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_no'))]}"/>
     </function>
 

--- a/addons/l10n_nz/demo/demo_company.xml
+++ b/addons/l10n_nz/demo/demo_company.xml
@@ -25,7 +25,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_nz'))]}"/>
     </function>
 

--- a/addons/l10n_om/demo/demo_company.xml
+++ b/addons/l10n_om/demo/demo_company.xml
@@ -22,7 +22,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_om'))]}"/>
     </function>
 

--- a/addons/l10n_pa/demo/demo_company.xml
+++ b/addons/l10n_pa/demo/demo_company.xml
@@ -23,7 +23,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_pa'))]}"/>
     </function>
 

--- a/addons/l10n_pe/demo/demo_company.xml
+++ b/addons/l10n_pe/demo/demo_company.xml
@@ -25,7 +25,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_pe'))]}"/>
     </function>
 

--- a/addons/l10n_ph/demo/demo_company.xml
+++ b/addons/l10n_ph/demo/demo_company.xml
@@ -23,7 +23,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_ph'))]}"/>
     </function>
 

--- a/addons/l10n_pk/demo/demo_company.xml
+++ b/addons/l10n_pk/demo/demo_company.xml
@@ -25,7 +25,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_pk'))]}"/>
     </function>
 

--- a/addons/l10n_pl/demo/demo_company.xml
+++ b/addons/l10n_pl/demo/demo_company.xml
@@ -30,7 +30,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_pl'))]}"/>
     </function>
 

--- a/addons/l10n_pt/demo/demo_company.xml
+++ b/addons/l10n_pt/demo/demo_company.xml
@@ -31,7 +31,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_pt'))]}"/>
     </function>
 

--- a/addons/l10n_qa/demo/demo_company.xml
+++ b/addons/l10n_qa/demo/demo_company.xml
@@ -24,7 +24,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('l10n_qa.demo_company_qa'))]}"/>
     </function>
 

--- a/addons/l10n_ro/demo/demo_company.xml
+++ b/addons/l10n_ro/demo/demo_company.xml
@@ -30,7 +30,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_ro'))]}"/>
     </function>
 

--- a/addons/l10n_rs/demo/demo_company.xml
+++ b/addons/l10n_rs/demo/demo_company.xml
@@ -29,7 +29,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_rs'))]}"/>
     </function>
 

--- a/addons/l10n_rw/demo/demo_company.xml
+++ b/addons/l10n_rw/demo/demo_company.xml
@@ -29,7 +29,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('l10n_rw.demo_company_rw'))]}"/>
     </function>
 

--- a/addons/l10n_sa/demo/demo_company.xml
+++ b/addons/l10n_sa/demo/demo_company.xml
@@ -26,7 +26,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_sa'))]}"/>
     </function>
 

--- a/addons/l10n_se/demo/demo_company.xml
+++ b/addons/l10n_se/demo/demo_company.xml
@@ -31,7 +31,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_se'))]}"/>
     </function>
 

--- a/addons/l10n_sg/demo/demo_company.xml
+++ b/addons/l10n_sg/demo/demo_company.xml
@@ -24,7 +24,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_sg'))]}"/>
     </function>
 

--- a/addons/l10n_si/demo/demo_company.xml
+++ b/addons/l10n_si/demo/demo_company.xml
@@ -29,7 +29,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_si'))]}"/>
     </function>
 

--- a/addons/l10n_sk/demo/demo_company.xml
+++ b/addons/l10n_sk/demo/demo_company.xml
@@ -29,7 +29,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_sk'))]}"/>
     </function>
 

--- a/addons/l10n_sn/demo/demo_company.xml
+++ b/addons/l10n_sn/demo/demo_company.xml
@@ -23,7 +23,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_sn'))]}"/>
     </function>
 

--- a/addons/l10n_td/demo/demo_company.xml
+++ b/addons/l10n_td/demo/demo_company.xml
@@ -23,7 +23,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_td'))]}"/>
     </function>
 

--- a/addons/l10n_tg/demo/demo_company.xml
+++ b/addons/l10n_tg/demo/demo_company.xml
@@ -23,7 +23,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_tg'))]}"/>
     </function>
 

--- a/addons/l10n_th/demo/demo_company.xml
+++ b/addons/l10n_th/demo/demo_company.xml
@@ -24,7 +24,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_th'))]}"/>
     </function>
 

--- a/addons/l10n_tn/demo/demo_company.xml
+++ b/addons/l10n_tn/demo/demo_company.xml
@@ -22,7 +22,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_tn'))]}"/>
     </function>
 

--- a/addons/l10n_tr/demo/demo_company.xml
+++ b/addons/l10n_tr/demo/demo_company.xml
@@ -30,7 +30,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_tr'))]}"/>
     </function>
 

--- a/addons/l10n_tw/demo/demo_company.xml
+++ b/addons/l10n_tw/demo/demo_company.xml
@@ -24,7 +24,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_tw'))]}"/>
     </function>
 

--- a/addons/l10n_tz_account/demo/demo_company.xml
+++ b/addons/l10n_tz_account/demo/demo_company.xml
@@ -29,7 +29,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('l10n_tz_account.demo_company_tz'))]}"/>
     </function>
 

--- a/addons/l10n_ua/demo/demo_company.xml
+++ b/addons/l10n_ua/demo/demo_company.xml
@@ -24,7 +24,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_ua'))]}"/>
     </function>
 

--- a/addons/l10n_ug/demo/demo_company.xml
+++ b/addons/l10n_ug/demo/demo_company.xml
@@ -24,7 +24,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_ug'))]}"/>
     </function>
 

--- a/addons/l10n_uk/demo/demo_company.xml
+++ b/addons/l10n_uk/demo/demo_company.xml
@@ -30,7 +30,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_uk'))]}"/>
     </function>
 

--- a/addons/l10n_uy/demo/demo_company.xml
+++ b/addons/l10n_uy/demo/demo_company.xml
@@ -25,7 +25,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_uy'))]}"/>
     </function>
 

--- a/addons/l10n_ve/demo/demo_company.xml
+++ b/addons/l10n_ve/demo/demo_company.xml
@@ -24,7 +24,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_ve'))]}"/>
     </function>
 

--- a/addons/l10n_vn/demo/demo_company.xml
+++ b/addons/l10n_vn/demo/demo_company.xml
@@ -24,7 +24,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_vn'))]}"/>
     </function>
 

--- a/addons/l10n_za/demo/demo_company.xml
+++ b/addons/l10n_za/demo/demo_company.xml
@@ -24,7 +24,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('base.demo_company_za'))]}"/>
     </function>
 

--- a/addons/l10n_zm_account/demo/demo_company.xml
+++ b/addons/l10n_zm_account/demo/demo_company.xml
@@ -24,7 +24,7 @@
     </function>
 
     <function model="res.users" name="write">
-        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo'), ref('base.demo_user0')]"/>
         <value eval="{'company_ids': [(4, ref('l10n_zm_account.demo_company_zm'))]}"/>
     </function>
 


### PR DESCRIPTION
Steps to reproduce:
- Install Project, Accounting and Phone (VoIP)
- Install any l10n_**_hr_payroll
- Switch to the newly created company in the country of the l10n installed
- Go to the settings of Accounting
- Change fiscal localization to the company's country
- Get an Access Error

Reason:
During the setup of the fiscal localization, VoIP tries to retrieve the information related to "phonecall" activities in the installed modules. In Project, one of the project has Joel Willis (portal demo user) as the client. However, he is not created automatically for a localization when the demo data from a l10n module is loaded, which then causes an Access Error.

How it was fixed:
Adding the portal demo user to every "demo_company.xml" of l10n modules resolves this issue.

Task ID: 5048487