### PR TITLE
[IMP] l10n_in: adjust upload button UI in PAN entity for TDS certificate

### DIFF
--- a/addons/l10n_in/static/src/components/tds_certificate_upload/tds_certificate_binary_field.js
+++ b/addons/l10n_in/static/src/components/tds_certificate_upload/tds_certificate_binary_field.js
@@ -1,0 +1,13 @@
+import { registry } from "@web/core/registry";
+import { BinaryField, binaryField } from "@web/views/fields/binary/binary_field";
+
+export class TdsCertificateBinaryField extends BinaryField {
+	static template = "l10n_in.TdsCertificateBinaryField";
+}
+
+export const tdsCertificateBinaryField = {
+	...binaryField,
+	component: TdsCertificateBinaryField,
+}
+
+registry.category("fields").add("tds_binary_field", tdsCertificateBinaryField);

--- a/addons/l10n_in/static/src/components/tds_certificate_upload/tds_certificate_binary_field.xml
+++ b/addons/l10n_in/static/src/components/tds_certificate_upload/tds_certificate_binary_field.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+
+    <t t-name="l10n_in.TdsCertificateBinaryField" t-inherit="web.BinaryField" t-inherit-mode="primary">
+        <xpath expr="//label[hasclass('o_select_file_button')]" position="attributes">
+            <attribute name="class" remove="btn-primary" add="text-sm btn-secondary fa fa-upload" separator=" " />
+        </xpath>
+        <xpath expr="//label[hasclass('o_select_file_button')]//t[@t-set-slot='toggler']" position="replace">
+            Upload
+        </xpath>
+    </t>
+
+</templates>

--- a/addons/l10n_in/views/l10n_in_pan_entity_views.xml
+++ b/addons/l10n_in/views/l10n_in_pan_entity_views.xml
@@ -16,7 +16,7 @@
                             <field name="partner_ids" widget="many2many_tags_avatar" options="{'no_create': True}"/>
                             <field name="tds_deduction" required="1"/>
                             <field name="tds_certificate"
-                                   widget="binary"
+                                   widget="tds_binary_field"
                                    filename="tds_certificate_filename"
                                    options="{'accepted_file_extensions': '.pdf', 'allowed_mime_type' : 'application/pdf'}"
                             />


### PR DESCRIPTION
### Commit Message

**Improve UI for TDS Certificate Upload Button in PAN Entity**

---

#### Before this commit:
- The TDS certificate upload button in the PAN entity form displayed the generic **"Upload your file"** label.  
- It used the **purple primary button style**.

#### After this commit:
- The button now uses a **gray secondary style**.  
- The label has been updated to **"Upload"** and includes an **upload icon**, providing a clearer UI.

---

### Visual Comparison

<table>
  <tr>
    <td align="center"><b>Before</b></td>
    <td align="center"><b>After</b></td>
  </tr>
  <tr>
    <td>
      <img width="276" height="52" alt="before" src="https://github.com/user-attachments/assets/ea564f0a-51d9-4f32-8448-4978100ac72c" />
    </td>
    <td>
      <img width="265" height="69" alt="after" src="https://github.com/user-attachments/assets/d12168ef-6015-4b13-991c-bcb93cc7dc0f" />
    </td>
  </tr>
</table>


