### PR TITLE
[FIX] point_of_sale: center preset informations on receipt receipt

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml
@@ -17,15 +17,15 @@
                     <div>Served by: <t t-esc="order.getCashierName()" /></div>
                 </div>
             </div>
-        </div>
-        <div t-if="order?.presetDateTime" class="pt-2">
-            <span>
-                <t t-out="order.preset_id.name"/>: <t t-out="order.presetDateTime"/>
-            </span>
-        </div>
-        <div t-if="order.preset_id?.identification === 'address'" t-attf-class="{{ order?.presetDateTime ? '' : 'pt-2'}}">
-            <div class="text-break">
-                <span class="fw-bolder" t-out="order.partner_id.name"/> (<span t-out="partnerAddress"/>)
+            <div t-if="order?.presetDateTime" class="pt-2 text-center">
+                <span>
+                    <t t-out="order.preset_id.name"/>: <t t-out="order.presetDateTime"/>
+                </span>
+            </div>
+            <div t-if="order.preset_id?.identification === 'address'" class="text-center" t-attf-class="{{ order?.presetDateTime ? '' : 'pt-2'}}">
+                <div class="text-break">
+                    <span class="fw-bolder" t-out="order.partner_id.name"/> (<span t-out="partnerAddress"/>)
+                </div>
             </div>
         </div>
     </t>


### PR DESCRIPTION
We now want to center preset infos on receipt header (customer address or time slot) in POS.

task-id: 5048706





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
