### PR TITLE
[FIX] stock: correct text button in phone view

### DIFF
--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -264,6 +264,7 @@
                         <page string="Operations" name="operations">
                             <field name="move_ids" mode="list,kanban"
                                 widget="stock_move_one2many"
+                                add-label="Add a Product"
                                 readonly="state == 'done' and is_locked"
                                 context="{'default_company_id': company_id, 'default_date': scheduled_date, 'default_date_deadline': date_deadline, 'picking_type_code': picking_type_code, 'default_picking_id': id, 'form_view_ref': 'stock.view_stock_move_operations', 'address_in_id': partner_id, 'default_picking_type_id': picking_type_id, 'default_location_id': location_id, 'default_location_dest_id': location_dest_id, 'default_partner_id': partner_id}">
                                 <list decoration-muted="scrap_id or state == 'cancel' or (state == 'done' and is_locked == True)" string="Stock Moves" editable="bottom">


### PR DESCRIPTION
Have the "Add a Product" button correctly display that instead of "Add Stock Moves" while in phone view on a picking.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
