### PR TITLE
[FIX] payment_razorpay_oauth: prevent error when csrf is missing

### DIFF
--- a/addons/payment_razorpay_oauth/controllers/onboarding.py
+++ b/addons/payment_razorpay_oauth/controllers/onboarding.py
@@ -34,7 +34,7 @@ class RazorpayController(Controller):
         # Retrieve the Razorpay data and Odoo metadata from the redirect data.
         provider_id = int(data['provider_id'])
         authorization_code = data.get('authorization_code')
-        csrf_token = data['csrf_token']
+        csrf_token = data.get('csrf_token')
         provider_sudo = request.env['payment.provider'].sudo().browse(provider_id).exists()
         if not provider_sudo or provider_sudo.code != 'razorpay':
             raise ValidationError(_("Could not find Razorpay provider with id %s", provider_sudo))


### PR DESCRIPTION
Before this commit, the return endpoint expected `csrf_token` in the data. If it was missing, a `KeyError` was raised at line [1].

**Error:**
`KeyError: 'csrf_token'`

**Solution:**
Now we use `.get('csrf_token')` and explicitly handle the missing case. If the token is missing or invalid, the controller raises `Forbidden()` [2], ensuring the request is rejected gracefully and securely.

[1]: https://github.com/odoo/odoo/blob/ae8ce340b8a397582899cdee0fd252d8613c12b5/addons/payment_razorpay_oauth/controllers/onboarding.py#L37

[2]: https://github.com/odoo/odoo/blob/ae8ce340b8a397582899cdee0fd252d8613c12b5/addons/payment_razorpay_oauth/controllers/onboarding.py#L43-L45

sentry-6869319716
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
