### PR TITLE
[IMP] resource: Remove duration_days field from resource calendar attendance views

### DIFF
--- a/addons/resource/views/resource_calendar_attendance_views.xml
+++ b/addons/resource/views/resource_calendar_attendance_views.xml
@@ -14,7 +14,6 @@
                 <field name="duration_hours" force_save="1" column_invisible="not parent.duration_based"/>
                 <field name="hour_from" widget="float_time" column_invisible="parent.duration_based"/>
                 <field name="hour_to" widget="float_time" column_invisible="parent.duration_based"/>
-                <field name="duration_days" optional="show" readonly="1"/>
                 <field name="week_type" readonly="1" force_save="1" optional="hide"/>
             </list>
         </field>
@@ -35,7 +34,6 @@
                         <field name="hour_to" widget="float_time"/>
                     </div>
                     <field name="day_period"/>
-                    <field name="duration_days"/>
                 </group>
                 </sheet>
             </form>


### PR DESCRIPTION
Removed the field duration_days from views of resource calendar attendance because it can be misleading

Task-5083067

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
