### PR TITLE
[FIX] product: add product name with description

### DIFF
--- a/addons/product/static/src/product_name_and_description/product_name_and_description.js
+++ b/addons/product/static/src/product_name_and_description/product_name_and_description.js
@@ -130,7 +130,11 @@ export class ProductNameAndDescriptionField extends Component {
 
     updateLabel(value) {
         this.props.record.update({
-            [this.descriptionColumn]: value || this.productName,
+            [this.descriptionColumn]: (
+                this.productName && value && this.productName.concat("\n", value)
+                || !value && this.productName
+                || value
+            ),
         });
     }
 


### PR DESCRIPTION
Step to reproduce:
- install account
- create a invoice with any product
- add description
- print any report

Observation:
- We see that only description is printed, not the name of product
in description column of report

Expected:
- The name and description, both should be printed

Cause:
- the `ProductNameAndDescriptionField` component is introduced in [1] sets label
as only description or product name, instead of including it both if they are
available
https://github.com/odoo/odoo/blob/f74cdf84ffbaccea2fbf03bfb17a9e7bfcaae524/addons/product/static/src/product_name_and_description/product_name_and_description.js#L131-L136

Fix:
- we fix the `updateLabel` method for `ProductNameAndDescriptionField`
to get the expected outcome i.e `productname+\n+description`

Before:
<img width="297" height="175" alt="image" src="https://github.com/user-attachments/assets/803b53ce-c031-4192-874c-11ebfd8c7e9b" />

After:
<img width="281" height="184" alt="image" src="https://github.com/user-attachments/assets/0dce4f67-94bf-42f2-bf09-c03a07c800d0" />


[1]: https://github.com/odoo/odoo/commit/7e553d25890d1e236123f0fa7e11ce86f59448ab

opw-5063048

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
