### PR TITLE
[FIX] pos_online_payment_self_order: self order route missing access_token

### DIFF
--- a/addons/pos_online_payment_self_order/tests/test_self_order_mobile.py
+++ b/addons/pos_online_payment_self_order/tests/test_self_order_mobile.py
@@ -47,7 +47,6 @@ class TestSelfOrderMobile(SelfOrderCommonTest, OnlinePaymentCommon):
         """
         Verify that when making an order from kiosk with online payment, a QR code is generated
         """
-        self_route = self.pos_config._get_self_order_route()
         self.pos_config.write({
             'self_ordering_mode': 'kiosk',
             'self_ordering_service_mode': 'counter',
@@ -56,4 +55,5 @@ class TestSelfOrderMobile(SelfOrderCommonTest, OnlinePaymentCommon):
         })
         self.pos_config.with_user(self.pos_user).open_ui()
         self.pos_config.current_session_id.set_opening_control(0, "")
+        self_route = self.pos_config._get_self_order_route()
         self.start_tour(self_route, "test_online_payment_kiosk_qr_code")


### PR DESCRIPTION
A call to `_get_self_order_route` in the `test_online_payment_kiosk_qr_code` test was happening too early, resulting on getting the self order url missing the `access_token`.

This resulted in making the test fail due to the override of the `iot_http` service in `pos_self_order_iot`, relying on this token to get the IoT WebSocket channel.

Enterprise PR: odoo/enterprise#93895