### PR TITLE
[IMP] base: remove confusing multiaction help text

### DIFF
--- a/odoo/addons/base/i18n/base.pot
+++ b/odoo/addons/base/i18n/base.pot
@@ -22886,12 +22886,6 @@ msgid ""
 msgstr ""
 
 #. module: base
-#: model_terms:ir.ui.view,arch_db:base.view_server_action_form
-msgid ""
-"If several actions return an action, only the last one will be executed."
-msgstr ""
-
-#. module: base
 #: model:ir.model.fields,help:base.field_res_users__action_id
 msgid ""
 "If specified, this action will be opened at log on for this user, in "

--- a/odoo/addons/base/views/ir_actions_views.xml
+++ b/odoo/addons/base/views/ir_actions_views.xml
@@ -468,9 +468,6 @@
                                     'is_modal': 1,
                                     'default_model_id': model_id,
                                 }"/>
-                                <p class="opacity-50 mb-1 mt-3 mt-md-n2 mt-lg-0">
-                                    If several actions return an action, only the last one will be executed.
-                                </p>
                             </t>
                             <notebook>
                                 <page string="Code" invisible="state != 'code'">


### PR DESCRIPTION
This help message was not really helpful, and was actually confusing for users.

Task: task-5085285
