### PR TITLE
[FIX] point_of_sale, pos_*: ensure local records are kept when syncing

### DIFF
--- a/addons/point_of_sale/static/src/app/models/data_service_options.js
+++ b/addons/point_of_sale/static/src/app/models/data_service_options.js
@@ -7,18 +7,17 @@ export class DataServiceOptions {
                 key: "uuid",
                 condition: (record) =>
                     record.finalized &&
-                    typeof record.id === "number" &&
+                    record.isSynced &&
                     record.pos_session_id !== parseInt(odoo.pos_session_id),
             },
             "pos.order.line": {
                 key: "uuid",
-                condition: (record) =>
-                    record.order_id?.finalized && typeof record.order_id.id === "number",
+                condition: (record) => record.order_id?.finalized && record.order_id.isSynced,
             },
             "pos.payment": {
                 key: "uuid",
                 condition: (record) =>
-                    record.pos_order_id?.finalized && typeof record.pos_order_id.id === "number",
+                    record.pos_order_id?.finalized && record.pos_order_id.isSynced,
             },
             "product.attribute.custom.value": {
                 key: "id",

--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -15,7 +15,7 @@ export class PosOrder extends Base {
     setup(vals) {
         super.setup(vals);
 
-        if (!this.session_id?.id && (!this.finalized || typeof this.id !== "number")) {
+        if (!this.session_id?.id && (!this.finalized || !this.isSynced)) {
             this.session_id = this.session;
 
             if (this.state === "draft" && this.lines.length == 0 && this.payment_ids.length == 0) {
@@ -108,7 +108,7 @@ export class PosOrder extends Base {
     }
 
     get isUnsyncedPaid() {
-        return this.finalized && typeof this.id === "string";
+        return this.finalized && !this.isSynced;
     }
 
     get originalSplittedOrder() {
@@ -302,7 +302,7 @@ export class PosOrder extends Base {
     }
 
     get isBooked() {
-        return Boolean(this.uiState.booked || !this.isEmpty() || typeof this.id === "number");
+        return Boolean(this.uiState.booked || !this.isEmpty() || this.isSynced);
     }
 
     get hasChange() {

--- a/addons/point_of_sale/static/src/app/models/related_models/base.js
+++ b/addons/point_of_sale/static/src/app/models/related_models/base.js
@@ -20,6 +20,10 @@ export class Base extends WithLazyGetterTrap {
         return this[RAW_SYMBOL].id;
     }
 
+    get isSynced() {
+        return typeof this.id === "number";
+    }
+
     get raw() {
         return deepImmutable(clone(this[RAW_SYMBOL]), "Raw data cannot be modified");
     }
@@ -30,7 +34,7 @@ export class Base extends WithLazyGetterTrap {
      * @param {*} _vals
      */
     setup(_vals) {
-        this._dirty = typeof this.id !== "number";
+        this._dirty = !this.isSynced;
     }
 
     /**

--- a/addons/point_of_sale/static/src/app/models/related_models/serialization.js
+++ b/addons/point_of_sale/static/src/app/models/related_models/serialization.js
@@ -53,13 +53,13 @@ const deepSerialization = (
                         continue;
                     }
 
-                    if (typeof childRecord.id === "number" && childRecord._dirty) {
+                    if (childRecord.isSynced && childRecord._dirty) {
                         toUpdate.push(childRecord);
 
                         if (!opts.keepCommands) {
                             childRecord._dirty = false;
                         }
-                    } else if (typeof childRecord.id !== "number") {
+                    } else if (!childRecord.isSynced) {
                         toCreate.push(childRecord);
                     }
                     serialized[relatedModel][childRecord.uuid] = childRecord.uuid;
@@ -87,7 +87,7 @@ const deepSerialization = (
                 result[fieldName] = record[fieldName]
                     .filter((childRecord) => childRecord.id)
                     .map((childRecord) => {
-                        if (typeof childRecord.id !== "number") {
+                        if (!childRecord.isSynced) {
                             throw new Error(
                                 `Trying to create a non serializable record '${relatedModel}'`
                             );
@@ -142,7 +142,7 @@ const deepSerialization = (
                     record.uuid &&
                     serialized[relatedModel][record[fieldName].uuid]
                 ) {
-                    if (typeof recordId !== "number") {
+                    if (!record[fieldName].isSynced) {
                         //  mapping is only needed for newly created records
                         uuidMapping[targetModel][record.uuid] ??= {};
                         uuidMapping[targetModel][record.uuid][fieldName] = record[fieldName].uuid;

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
@@ -84,7 +84,7 @@ export class ReceiptScreen extends Component {
         );
     async _sendReceiptToCustomer({ action, destination }) {
         const order = this.currentOrder;
-        if (typeof order.id !== "number") {
+        if (!order.isSynced) {
             this.dialog.add(ConfirmationDialog, {
                 title: _t("Unsynced order"),
                 body: _t(

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/invoice_button/invoice_button.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/invoice_button/invoice_button.js
@@ -34,15 +34,8 @@ export class InvoiceButton extends Component {
     }
     async _downloadInvoice(orderId) {
         try {
-            const result = await this.pos.data.callRelated(
-                "pos.order",
-                "read_pos_orders",
-                [[["id", "=", orderId]]],
-                {},
-                false,
-                true
-            );
-            const order = result["pos.order"][0];
+            const orders = await this.pos.data.loadServerOrders([["id", "=", orderId]]);
+            const order = orders[0];
             const accountMoveId = order.raw.account_move;
             if (accountMoveId) {
                 await this.invoiceService.downloadPdf(accountMoveId);

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -156,15 +156,8 @@ export class TicketScreen extends Component {
     async onClickScanOrder(qrcode) {
         if (qrcode) {
             const uuid = new URL(qrcode).searchParams.get("order_uuid");
-            const results = await this.pos.data.callRelated(
-                "pos.order",
-                "read_pos_orders",
-                [[["uuid", "=", uuid]]],
-                {},
-                false,
-                true
-            );
-            const order = results["pos.order"][0];
+            const orders = await this.pos.data.loadServerOrders([["uuid", "=", uuid]]);
+            const order = orders[0];
             if (order) {
                 this.state.filter = "SYNCED";
                 this.state.selectedOrder = order;
@@ -825,14 +818,9 @@ export class TicketScreen extends Component {
             .map((info) => info[0]);
 
         if (idsNotInCacheOrOutdated.length > 0) {
-            await this.pos.data.callRelated(
-                "pos.order",
-                "read_pos_orders",
-                [[["id", "in", Array.from(new Set(idsNotInCacheOrOutdated))]]],
-                {},
-                false,
-                true
-            );
+            await this.pos.data.loadServerOrders([
+                ["id", "in", Array.from(new Set(idsNotInCacheOrOutdated))],
+            ]);
         }
     }
     //#endregion

--- a/addons/point_of_sale/static/src/app/services/data_service.js
+++ b/addons/point_of_sale/static/src/app/services/data_service.js
@@ -452,10 +452,16 @@ export class PosData extends Reactive {
     }
 
     initListeners() {
-        this.models["pos.order"].addEventListener(
-            "update",
-            this.debouncedSynchronizeLocalDataInIndexedDB.bind(this)
-        );
+        for (const dynamicModel of this.opts.dynamicModels) {
+            if (!this.models[dynamicModel]) {
+                continue;
+            }
+
+            this.models[dynamicModel].addEventListener(
+                "update",
+                this.debouncedSynchronizeLocalDataInIndexedDB.bind(this)
+            );
+        }
 
         const ignore = Object.keys(this.opts.databaseTable);
         for (const model of Object.keys(this.relations)) {
@@ -777,23 +783,33 @@ export class PosData extends Reactive {
         this.syncInProgress = false;
     }
 
+    async loadServerOrders(domain) {
+        const result = await this.callRelated(
+            "pos.order",
+            "read_pos_orders",
+            [domain],
+            {},
+            false,
+            true
+        );
+        const config = this.models["pos.config"].get(odoo.pos_config_id);
+        const session = this.models["pos.session"].get(odoo.pos_session_id);
+        const orders = result["pos.order"] || [];
+        for (const order of orders) {
+            // Clear commands
+            order.serializeForORM();
+            order.config_id = config;
+            order.session_id = session;
+        }
+        return orders;
+    }
+
     async checkAndDeleteMissingOrders(results) {
         if (results && results["pos.order"]) {
-            const ids = new Set(
-                results["pos.order"].map((o) => o.id).filter((id) => typeof id === "number")
-            );
-
+            const ids = new Set(results["pos.order"].filter((o) => o.isSynced).map((o) => o.id));
             if (ids.size) {
-                const result = await this.callRelated(
-                    "pos.order",
-                    "read_pos_orders",
-                    [[["id", "in", [...ids]]]],
-                    {},
-                    false,
-                    true
-                );
-
-                const serverIds = result["pos.order"].map((r) => r.id);
+                const orders = await this.loadServerOrders([["id", "in", [...ids]]]);
+                const serverIds = orders.map((r) => r.id);
                 for (const id of [...ids]) {
                     if (!serverIds.includes(id)) {
                         this.localDeleteCascade(this.models["pos.order"].get(id));

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -344,7 +344,7 @@ export class PosStore extends WithLazyGetterTrap {
 
         try {
             const paidOrderNotSynced = this.models["pos.order"].filter(
-                (order) => order.state === "paid" && typeof order.id !== "number"
+                (order) => order.state === "paid" && !order.isSynced
             );
             this.addPendingOrder(paidOrderNotSynced.map((o) => o.id));
             await this.syncAllOrders({ throw: true });
@@ -363,7 +363,7 @@ export class PosStore extends WithLazyGetterTrap {
         } finally {
             // All orders saved on the server should be cancelled by the device that closes
             // the session. If some orders are not cancelled, we need to cancel them here.
-            const orders = this.models["pos.order"].filter((o) => typeof o.id === "number");
+            const orders = this.models["pos.order"].filter((o) => o.isSynced);
             for (const order of orders) {
                 if (!order.finalized) {
                     order.state = "cancel";
@@ -538,7 +538,7 @@ export class PosStore extends WithLazyGetterTrap {
             if (order && (await this._onBeforeDeleteOrder(order))) {
                 if (
                     !ignoreChange &&
-                    typeof order.id === "number" &&
+                    order.isSynced &&
                     Object.keys(order.last_order_preparation_change).length > 0
                 ) {
                     const orderPresetDate = DateTime.fromISO(order.preset_time);
@@ -555,7 +555,7 @@ export class PosStore extends WithLazyGetterTrap {
                 this.removePendingOrder(order);
                 if (!cancelled) {
                     return false;
-                } else if (typeof order.id === "number") {
+                } else if (order.isSynced) {
                     ids.add(order.id);
                 }
             } else {
@@ -612,14 +612,7 @@ export class PosStore extends WithLazyGetterTrap {
         const orderPathUuid = this.router.state.params.orderUuid;
         const order = this.models["pos.order"].find((order) => order.uuid === orderPathUuid);
         if (orderPathUuid && !order) {
-            await this.data.callRelated(
-                "pos.order",
-                "read_pos_orders",
-                [[["uuid", "=", orderPathUuid]]],
-                {},
-                false,
-                true
-            );
+            await this.data.loadServerOrders([["uuid", "=", orderPathUuid]]);
             const order = this.models["pos.order"].find((order) => order.uuid === orderPathUuid);
             if (order) {
                 this.setOrder(order);
@@ -1162,13 +1155,13 @@ export class PosStore extends WithLazyGetterTrap {
      */
     removeOrder(order, removeFromServer = true) {
         if (this.config.isShareable || removeFromServer) {
-            if (typeof order.id === "number" && !order.finalized) {
+            if (order.isSynced && !order.finalized) {
                 this.addPendingOrder([order.id], true);
                 this.syncAllOrdersDebounced();
             }
         }
 
-        if (typeof order.id === "string" && order.finalized) {
+        if (!order.isSynced && order.finalized) {
             this.addPendingOrder([order.id]);
             return;
         }
@@ -1249,8 +1242,6 @@ export class PosStore extends WithLazyGetterTrap {
 
         order.pos_reference = posReference;
         order.tracking_number = deviceIdentifier + `${parseInt(number) % 1000}`.padStart(3, "0");
-
-        this.data.debouncedSynchronizeLocalDataInIndexedDB();
     }
 
     selectNextOrder() {
@@ -1497,26 +1488,10 @@ export class PosStore extends WithLazyGetterTrap {
     }
     async getServerOrders() {
         await this.syncAllOrders();
-        return await this.loadServerOrders([
+        return await this.data.loadServerOrders([
             ["config_id", "in", [...this.config.raw.trusted_config_ids, this.config.id]],
             ["state", "=", "draft"],
         ]);
-    }
-    async loadServerOrders(domain) {
-        const result = await this.data.callRelated(
-            "pos.order",
-            "read_pos_orders",
-            [domain],
-            {},
-            false,
-            true
-        );
-        const orders = result["pos.order"] || [];
-        for (const order of orders) {
-            order.config_id = this.config;
-            order.session_id = this.session;
-        }
-        return orders;
     }
     async getProductInfo(productTemplate, quantity, priceExtra = 0, productProduct = false) {
         const order = this.getOrder();
@@ -1713,7 +1688,7 @@ export class PosStore extends WithLazyGetterTrap {
         );
         if (!printBillActionTriggered) {
             order.nb_print = order.nb_print ? order.nb_print + 1 : 1;
-            if (typeof order.id === "number" && result) {
+            if (order.isSynced && result) {
                 await this.data.write("pos.order", [order.id], { nb_print: order.nb_print });
             }
         } else if (!order.nb_print) {
@@ -1734,7 +1709,7 @@ export class PosStore extends WithLazyGetterTrap {
         return changesToOrder(order, skipped, orderPreparationCategories, cancelled);
     }
     async checkPreparationStateAndSentOrderInPreparation(order, opts = {}) {
-        if (typeof order.id !== "number") {
+        if (!order.isSynced) {
             return this.sendOrderInPreparation(order, opts);
         }
 
@@ -2110,14 +2085,7 @@ export class PosStore extends WithLazyGetterTrap {
             resModel: "pos.order",
             resId: order.id,
             onRecordSaved: async (record) => {
-                await this.data.callRelated(
-                    "pos.order",
-                    "read_pos_orders",
-                    [[["id", "=", record.evalContext.id]]],
-                    {},
-                    false,
-                    true
-                );
+                await this.data.loadServerOrders([["id", "=", record.evalContext.id]]);
                 this.action.doAction({
                     type: "ir.actions.act_window_close",
                 });

--- a/addons/point_of_sale/static/src/app/utils/devices_identifier_sequence.js
+++ b/addons/point_of_sale/static/src/app/utils/devices_identifier_sequence.js
@@ -99,7 +99,7 @@ export default class DeviceIdentifierSequence {
             return;
         }
         const numbers = orders
-            .filter((o) => typeof o.id === "string")
+            .filter((o) => !o.isSynced)
             .map((o) => this.extractNumberFromReference(o.pos_reference));
         const unsyncedNumberStack = new Set([...data.unsynced_number_stack, ...numbers]);
 

--- a/addons/point_of_sale/static/src/app/utils/devices_synchronisation.js
+++ b/addons/point_of_sale/static/src/app/utils/devices_synchronisation.js
@@ -90,7 +90,7 @@ export default class DevicesSynchronisation {
      * and synchronize the records with other devices.
      */
     async readDataFromServer() {
-        const serverOpenOrders = this.pos.getOpenOrders().filter((o) => typeof o.id === "number");
+        const serverOpenOrders = this.pos.getOpenOrders().filter((o) => o.isSynced);
         const { domain, recordIds } = this.constructOrdersDomain(serverOpenOrders);
         let response = {};
         try {
@@ -178,7 +178,7 @@ export default class DevicesSynchronisation {
 
         const recordIdsByModel = {};
         const domainByModel = Object.entries(recordsToCheck).reduce((acc, [model, records]) => {
-            const serverRecs = records.filter((r) => typeof r.id === "number");
+            const serverRecs = records.filter((r) => r.isSynced);
             const ids = serverRecs.map((r) => r.id);
             const config = this.pos.config;
             const domains = [];

--- a/addons/point_of_sale/static/tests/pos/tours/utils/payment_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/payment_screen_util.js
@@ -400,7 +400,7 @@ export function syncCurrentOrder() {
                 const currentOrder = posmodel.getOrder();
                 const order = await posmodel.syncAllOrders({ orders: [currentOrder] });
 
-                if (typeof order[0].id !== "number") {
+                if (!order[0].isSynced) {
                     throw new Error("Order ID is not a number after sync.");
                 }
             },

--- a/addons/point_of_sale/static/tests/unit/data/pos_order.data.js
+++ b/addons/point_of_sale/static/tests/unit/data/pos_order.data.js
@@ -13,8 +13,7 @@ export class PosOrder extends models.ServerModel {
 
     read_pos_orders(domain) {
         const results = this.search(domain, this._load_pos_data_fields(), false);
-        const ids = results.filter((record) => record.state === "draft").map((record) => record.id);
-        return this.read_pos_data(ids);
+        return this.read_pos_data(results);
     }
 
     _load_pos_data_fields() {

--- a/addons/point_of_sale/static/tests/unit/related_models/orm_serialization.test.js
+++ b/addons/point_of_sale/static/tests/unit/related_models/orm_serialization.test.js
@@ -389,7 +389,7 @@ describe("ORM serialization", () => {
             const result = models.serializeForORM(order);
             expect(keepCommandResult).toEqual(result);
 
-            expect(result.lines.length).toBe(1);
+            expect(result.lines.length).toBe(2);
             expect(result.lines[0][0]).toBe(3);
             expect(result.lines[0][1]).toBe(111);
             expect(result.relations_uuid_mapping).toBe(undefined);
@@ -400,7 +400,7 @@ describe("ORM serialization", () => {
             const keepCommandResult = models.serializeForORM(order, { keepCommands: true });
             const result = models.serializeForORM(order);
             expect(keepCommandResult).toEqual(result);
-            expect(result.lines).toBeEmpty();
+            expect(result.lines).toHaveLength(1);
         }
     });
 

--- a/addons/point_of_sale/static/tests/unit/related_models/related_models.test.js
+++ b/addons/point_of_sale/static/tests/unit/related_models/related_models.test.js
@@ -20,7 +20,7 @@ describe("Related Model", () => {
 
         // Id and uuid are generated
         expect(order.id).not.toBeEmpty();
-        expect(typeof order.id).toBe("string");
+        expect(order.isSynced).toBe(false);
         expect(order.uuid).not.toBeEmpty();
 
         // The generated id and uuid must be the same
@@ -593,7 +593,7 @@ describe("Related Model", () => {
 
         expect(order.lines.length).toBe(1);
         const oldLineId = order.lines[0].id;
-        expect(typeof oldOrderId).toBe("string");
+        expect(order.isSynced).toBe(false);
         expect(models["pos.order"].get(oldOrderId)).not.toBeEmpty();
 
         models.connectNewData({
@@ -630,7 +630,7 @@ describe("Related Model", () => {
         await makeMockServer();
         const models = getRelatedModelsInstance(false);
         const order = models["pos.order"].create({ total: 30 });
-        expect(typeof order.id).toBe("string");
+        expect(order.isSynced).toBe(false);
         expect(models["pos.order"].get(order.id)).toBe(order);
         expect(models["pos.order"].getBy("uuid", order.uuid)).toBe(order);
 

--- a/addons/point_of_sale/static/tests/unit/tools/server_synchronization.test.js
+++ b/addons/point_of_sale/static/tests/unit/tools/server_synchronization.test.js
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "@odoo/hoot";
+import { getFilledOrder, setupPosEnv } from "../utils";
+import { definePosModels } from "../data/generate_model_definitions";
+
+definePosModels();
+
+describe("server_synchronization.test.js", () => {
+    test("Related models must keep local records", async () => {
+        const store = await setupPosEnv();
+        const order = await getFilledOrder(store);
+        const product = store.models["product.template"].get(8);
+        expect(order.isSynced).toBe(false);
+        expect(order.lines.every((l) => l.isSynced === true)).toBe(false);
+        await store.syncAllOrders();
+        expect(order.isSynced).toBe(true);
+        expect(order.lines.every((l) => l.isSynced === true)).toBe(true);
+        await store.addLineToOrder(
+            {
+                product_tmpl_id: product,
+                qty: 1,
+            },
+            order
+        );
+        expect(order.lines.every((l) => l.isSynced === true)).toBe(false);
+
+        // Download the same order from server, the local unsynced line must be kept
+        await store.data.loadServerOrders([["id", "=", order.id]]);
+        expect(order.lines.every((l) => l.isSynced === true)).toBe(false);
+    });
+
+    test("Check behavior when deleting records", async () => {
+        const store = await setupPosEnv();
+        const order = await getFilledOrder(store);
+        expect(order.isSynced).toBe(false);
+        expect(order.lines.every((l) => l.isSynced === true)).toBe(false);
+        await store.syncAllOrders();
+        expect(order.isSynced).toBe(true);
+        expect(order.lines.every((l) => l.isSynced === true)).toBe(true);
+        order.removeOrderline(order.lines[0]);
+        expect(order.lines).toHaveLength(1);
+
+        // At this point if we download the same order from server,
+        // we must not lose the local deletion
+        await store.data.loadServerOrders([["id", "=", order.id]]);
+        expect(order.lines).toHaveLength(2);
+
+        // But if we sync before downloading, the deletion must be kept
+        order.removeOrderline(order.lines[0]);
+        expect(order.lines).toHaveLength(1);
+        await store.syncAllOrders({ orders: [order] });
+        await store.data.loadServerOrders([["id", "=", order.id]]);
+        expect(order.lines).toHaveLength(1);
+    });
+});

--- a/addons/pos_event/static/src/app/components/popup/event_configurator_popup/event_configurator_popup.js
+++ b/addons/pos_event/static/src/app/components/popup/event_configurator_popup/event_configurator_popup.js
@@ -48,7 +48,7 @@ export class EventConfiguratorPopup extends Component {
         }
         const ticketAvailability = this.props.availabilityPerTicket[ticket.id][this.slotId];
         const existingUnsyncRegistration = this.pos.models["event.registration"].filter(
-            (r) => typeof r.id === "string" && r.event_slot_id.id === this.slotId
+            (r) => !r.isSynced && r.event_slot_id.id === this.slotId
         );
         if (ticketAvailability === "unlimited") {
             return ticket.event_id.seats_limited ? ticket.event_id.seats_available : "unlimited";

--- a/addons/pos_loyalty/static/src/app/models/data_service_options.js
+++ b/addons/pos_loyalty/static/src/app/models/data_service_options.js
@@ -10,7 +10,7 @@ patch(DataServiceOptions.prototype, {
                 condition: (record) =>
                     record
                         .backLink("<-pos.order.line.coupon_id")
-                        .find((l) => !(l.order_id?.finalized && typeof l.order_id.id === "number")),
+                        .find((l) => !(l.order_id?.finalized && l.order_id.isSynced)),
             },
         };
     },

--- a/addons/pos_loyalty/static/src/app/screens/product_screen/order_summary/order_summary.js
+++ b/addons/pos_loyalty/static/src/app/screens/product_screen/order_summary/order_summary.js
@@ -175,9 +175,6 @@ patch(OrderSummary.prototype, {
 
                 await this._updateGiftCardOrderline(code, points);
                 this.currentOrder.processGiftCard(code, points, expirationDate);
-
-                // update indexedDB
-                this.pos.data.debouncedSynchronizeLocalDataInIndexedDB();
             },
         });
     },

--- a/addons/pos_online_payment/static/src/app/models/pos_order.js
+++ b/addons/pos_online_payment/static/src/app/models/pos_order.js
@@ -6,10 +6,7 @@ patch(PosOrder.prototype, {
     serializeForORM(opts) {
         // Avoid serializing online payments, as their creation is not allowed in the backend without "online_account_payment_id"
         const onlinePaymentUUIDs = this.payment_ids
-            .filter(
-                (payment) =>
-                    typeof payment.id !== "number" && payment.payment_method_id?.is_online_payment
-            )
+            .filter((payment) => !payment.isSynced && payment.payment_method_id?.is_online_payment)
             .map((payment) => payment.uuid);
 
         const serialized = super.serializeForORM(opts);

--- a/addons/pos_online_payment/static/src/app/services/pos_store.js
+++ b/addons/pos_online_payment/static/src/app/services/pos_store.js
@@ -11,15 +11,8 @@ patch(PosStore.prototype, {
             // notification to invite the local browser to do a safe RPC to
             // the server to check the new state of the order.
             const order = this.models["pos.order"].find((o) => o.id == id);
-            const result = await this.data.callRelated(
-                "pos.order",
-                "read_pos_orders",
-                [[["id", "=", id]]],
-                {},
-                false,
-                true
-            );
-            const updatedOrder = result["pos.order"][0];
+            const orders = await this.data.loadServerOrders([["id", "=", id]]);
+            const updatedOrder = orders[0];
             if (updatedOrder) {
                 order.state = updatedOrder.state;
             }

--- a/addons/pos_online_payment/static/src/app/utils/order_payment_validation.js
+++ b/addons/pos_online_payment/static/src/app/utils/order_payment_validation.js
@@ -152,7 +152,7 @@ patch(OrderPaymentValidation.prototype, {
 
             await this.afterPaidOrderSavedOnServer(lastOrderServerOPData.paid_order);
             return false; // Cancel normal flow because the current order is already saved on the server.
-        } else if (typeof this.order.id === "number") {
+        } else if (this.order.isSynced) {
             const orderServerOPData = await this.pos.updateOnlinePaymentsDataWithServer(
                 this.order,
                 0

--- a/addons/pos_online_payment/static/src/overrides/pos_overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_online_payment/static/src/overrides/pos_overrides/components/payment_screen/payment_screen.js
@@ -4,7 +4,7 @@ import { serializeDateTime } from "@web/core/l10n/dates";
 
 patch(PaymentScreen.prototype, {
     async addNewPaymentLine(paymentMethod) {
-        if (paymentMethod.is_online_payment && typeof this.currentOrder.id === "string") {
+        if (paymentMethod.is_online_payment && !this.currentOrder.isSynced) {
             this.currentOrder.date_order = serializeDateTime(luxon.DateTime.now());
             this.pos.addPendingOrder([this.currentOrder.id]);
             await this.pos.syncAllOrders();

--- a/addons/pos_restaurant/static/src/app/models/data_service_options.js
+++ b/addons/pos_restaurant/static/src/app/models/data_service_options.js
@@ -7,8 +7,7 @@ patch(DataServiceOptions.prototype, {
             ...super.databaseTable,
             "restaurant.order.course": {
                 key: "uuid",
-                condition: (record) =>
-                    record.order_id?.finalized && typeof record.order_id.id === "number",
+                condition: (record) => record.order_id?.finalized && record.order_id.isSynced,
             },
         };
     },

--- a/addons/pos_restaurant/static/src/app/models/restaurant_order_course.js
+++ b/addons/pos_restaurant/static/src/app/models/restaurant_order_course.js
@@ -20,9 +20,6 @@ export class RestaurantOrderCourse extends Base {
     isReadyToFire() {
         return !this.fired && !this.isEmpty();
     }
-    isNew() {
-        return typeof this.id === "string";
-    }
 }
 
 registry

--- a/addons/pos_restaurant/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/pos_restaurant/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -51,7 +51,7 @@ patch(TicketScreen.prototype, {
         for (const order of this.getFilteredOrderList()) {
             const amount = this.env.utils.parseValidFloat(order.uiState.TipScreen.inputTipAmount);
 
-            if (typeof order.id === "string") {
+            if (!order.isSynced) {
                 logPosMessage(
                     "TicketScreen",
                     "settleTips",

--- a/addons/pos_restaurant/static/src/app/screens/tip_screen/tip_screen.js
+++ b/addons/pos_restaurant/static/src/app/screens/tip_screen/tip_screen.js
@@ -49,7 +49,7 @@ export class TipScreen extends Component {
     async validateTip() {
         const amount = this.env.utils.parseValidFloat(this.state.inputTipAmount);
         const order = this.pos.getOrder();
-        const serverId = typeof order.id === "number" && order.id;
+        const serverId = order.isSynced && order.id;
 
         if (!serverId) {
             this.dialog.add(AlertDialog, {

--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -581,7 +581,7 @@ patch(PosStore.prototype, {
             startingValue: order.floating_order_name || "",
         });
         if (payload) {
-            if (typeof order.id == "number") {
+            if (order.isSynced) {
                 this.data.write("pos.order", [order.id], {
                     floating_order_name: payload,
                 });

--- a/addons/pos_restaurant/static/src/app/utils/devices_synchronisation.js
+++ b/addons/pos_restaurant/static/src/app/utils/devices_synchronisation.js
@@ -21,9 +21,9 @@ patch(DevicesSynchronisation.prototype, {
             if (orders.length > 1) {
                 // The only way to get here is if there is several waiters on the same table.
                 // In this case we take orderline of the local order and we add it to the synced order.
-                const localOrders = orders.filter((order) => typeof order.id !== "number");
+                const localOrders = orders.filter((order) => !order.isSynced);
                 const syncedOrder = orders
-                    .filter((order) => typeof order.id === "number")
+                    .filter((order) => order.isSynced)
                     .sort((a, b) => a.id - b.id);
 
                 if (

--- a/addons/pos_restaurant/static/tests/unit/models/restaurant_order_course.test.js
+++ b/addons/pos_restaurant/static/tests/unit/models/restaurant_order_course.test.js
@@ -37,11 +37,4 @@ describe("restaurant.order.course", () => {
         course.line_ids = [line];
         expect(course.isReadyToFire()).toBe(true);
     });
-
-    test("isNew", async () => {
-        const store = await setupPosEnv();
-        store.addNewOrder();
-        const course = store.addCourse();
-        expect(course.isNew()).toBe(true);
-    });
 });

--- a/addons/pos_sale/static/src/app/utils/order_payment_validation.js
+++ b/addons/pos_sale/static/src/app/utils/order_payment_validation.js
@@ -12,7 +12,6 @@ patch(OrderPaymentValidation.prototype, {
                 "sale.order.line",
                 orders.flatMap((o) => o.order_line).map((ol) => ol.id)
             );
-            this.pos.data.debouncedSynchronizeLocalDataInIndexedDB(this.pos.data.records);
         }
         await super.afterOrderValidation();
     },

--- a/addons/pos_self_order/static/src/app/models/pos_order.js
+++ b/addons/pos_self_order/static/src/app/models/pos_order.js
@@ -40,7 +40,7 @@ patch(PosOrder.prototype, {
     recomputeChanges() {
         const lines = this.lines;
         for (const line of lines) {
-            if (typeof line.id === "string") {
+            if (!line.isSynced) {
                 continue;
             }
 

--- a/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
+++ b/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
@@ -35,7 +35,7 @@ export class CartPage extends Component {
         return (
             this.selfOrder.config.self_ordering_mode === "mobile" &&
             this.selfOrder.config.self_ordering_pay_after === "each" &&
-            typeof this.selfOrder.currentOrder.id === "number"
+            this.selfOrder.currentOrder.isSynced
         );
     }
 

--- a/addons/pos_self_order/static/src/app/pages/confirmation_page/confirmation_page.js
+++ b/addons/pos_self_order/static/src/app/pages/confirmation_page/confirmation_page.js
@@ -108,7 +108,7 @@ export class ConfirmationPage extends Component {
                     this.updateHasPaper(true);
                 }
                 order.nb_print = 1;
-                if (typeof order.id === "number" && result) {
+                if (order.isSynced && result) {
                     await rpc("/pos_self_order/kiosk/increment_nb_print/", {
                         access_token: this.selfOrder.access_token,
                         order_id: order.id,

--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -648,7 +648,7 @@ export class SelfOrder extends Reactive {
     async getUserDataFromServer(tokens = []) {
         const tableIdentifier = this.router.getTableIdentifier([]);
         const dbAccessToken = this.models["pos.order"]
-            .filter((o) => o.state === "draft" && typeof o.id === "number")
+            .filter((o) => o.state === "draft" && o.isSynced)
             .map((order) => ({
                 access_token: order.access_token,
                 state: order.state,

--- a/addons/pos_self_order/static/src/overrides/models/pos_store.js
+++ b/addons/pos_self_order/static/src/overrides/models/pos_store.js
@@ -4,7 +4,7 @@ import { patch } from "@web/core/utils/patch";
 patch(PosStore.prototype, {
     async getServerOrders() {
         if (this.session._self_ordering) {
-            await this.loadServerOrders([
+            await this.data.loadServerOrders([
                 ["company_id", "=", this.config.company_id.id],
                 ["state", "=", "draft"],
                 ["source", "in", ["kiosk", "mobile"]],

--- a/addons/pos_self_order/tests/__init__.py
+++ b/addons/pos_self_order/tests/__init__.py
@@ -11,3 +11,4 @@ from . import test_self_order_common
 from . import test_webmanifest
 from . import test_self_order_sequence
 from . import test_self_order_preset
+from . import test_self_order_controller

--- a/addons/pos_self_order/tests/self_order_common_test.py
+++ b/addons/pos_self_order/tests/self_order_common_test.py
@@ -3,7 +3,7 @@
 
 import odoo.tests
 
-from odoo import Command
+from odoo import Command, fields
 from odoo.addons.mail.tests.common import mail_new_test_user
 from odoo.addons.point_of_sale.tests.common import archive_products
 
@@ -236,3 +236,63 @@ class SelfOrderCommonTest(odoo.tests.HttpCase):
         # A new tax is added to each product and this tax is from a different company.
         # This is important in the test because the added tax should not be used in the tour.
         self._add_tax_to_product_from_different_company()
+
+    def create_backend_pos_order(self, data):
+        pos_config = data.get('pos_config', self.pos_config)
+        order_data = data.get('order_data', {})
+        line_product_ids = [line_data['product_id'] for line_data in data.get('line_data', [])]
+        product_by_id = {p.id: p for p in self.env['product.product'].browse(line_product_ids)}
+        refund = False
+
+        if not pos_config.current_session_id:
+            pos_config.open_ui()
+
+        order = self.env['pos.order'].create({
+            'amount_total': 0,
+            'amount_paid': 0,
+            'amount_tax': 0,
+            'amount_return': 0,
+            'date_order': fields.Datetime.to_string(fields.Datetime.now()),
+            'company_id': self.env.company.id,
+            'session_id': pos_config.current_session_id.id,
+            'lines': [
+                Command.create({
+                    'price_unit': product_by_id[line_data['product_id']].lst_price,
+                    'price_subtotal': product_by_id[line_data['product_id']].lst_price,
+                    'tax_ids': [(6, 0, product_by_id[line_data['product_id']].taxes_id.ids)],
+                    'price_subtotal_incl': 0,
+                    **line_data,
+                }) for line_data in data.get('line_data', [])
+            ],
+            **order_data,
+        })
+
+        # Re-trigger prices computation
+        order.lines._onchange_amount_line_all()
+        order._compute_prices()
+
+        if data.get('payment_data'):
+            payment_context = {"active_ids": order.ids, "active_id": order.id}
+            for payment in data['payment_data']:
+                make_payment = {'payment_method_id': payment['payment_method_id']}
+                if payment.get('amount'):
+                    make_payment['amount'] = payment['amount']
+                order_payment = self.env['pos.make.payment'].with_context(**payment_context).create(make_payment)
+                order_payment.with_context(**payment_context).check()
+
+        if data.get('refund_data'):
+            refund_action = order.refund()
+            refund = self.env['pos.order'].browse(refund_action['res_id'])
+            payment_context = {"active_ids": refund.ids, "active_id": refund.id}
+
+            if data.get('order_data') and data['order_data'].get('to_invoice', False):
+                refund.to_invoice = True
+
+            for refund_data in data['refund_data']:
+                make_refund = {'payment_method_id': refund_data['payment_method_id']}
+                if refund_data.get('amount'):
+                    make_refund['amount'] = refund_data['amount']
+                refund_payment = self.env['pos.make.payment'].with_context(**payment_context).create(make_refund)
+                refund_payment.with_context(**payment_context).check()
+
+        return order, refund

--- a/addons/pos_self_order/tests/test_self_order_controller.py
+++ b/addons/pos_self_order/tests/test_self_order_controller.py
@@ -1,0 +1,114 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import json
+import odoo.tests
+from datetime import timedelta
+from odoo.addons.pos_self_order.tests.self_order_common_test import SelfOrderCommonTest
+
+@odoo.tests.tagged('post_install', '-at_install')
+class TestSelfOrderController(SelfOrderCommonTest):
+    def make_request_to_controller(self, url, params):
+        response = self.url_open(url, json.dumps({'jsonrpc': '2.0', 'params': params}),
+            method='POST',
+            headers={
+                'Content-Type': 'application/json',
+            }
+        )
+        return response.json().get('result')
+
+    def test_get_orders_by_access_token(self):
+        self.pos_config.self_ordering_mode = 'mobile'
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.pos_config.current_session_id.set_opening_control(0, '')
+        data = {
+            'order_data': {
+                'name': 'Order/0001',
+                'table_id': self.pos_table_1.id,
+            },
+            'line_data': [{
+                'qty': 3,
+                'price_unit': 1.0,
+                'product_id': self.cola.id,
+            }],
+            'payment_data': [
+                {'payment_method_id': self.bank_payment_method.id}
+            ]
+        }
+
+        order1, _ = self.create_backend_pos_order(data)
+        data['payment_data'] = []
+        order2, _ = self.create_backend_pos_order(data)
+        params = {
+            'access_token': order1.config_id.access_token,
+            'order_access_tokens': [{
+                'access_token': order1.access_token,
+                'state': order1.state,
+                'write_date': order1.write_date.strftime('%Y-%m-%d %H:%M:%S')
+            }],
+        }
+
+        # At this point there is no change on the order, so no data is returned
+        data = self.make_request_to_controller('/pos-self-order/get-user-data', params)
+        self.assertEqual(data, {})
+
+        # Changing state in params should return the order to update it
+        params['order_access_tokens'][0]['state'] = 'draft'  # Server order is paid
+        data = self.make_request_to_controller('/pos-self-order/get-user-data', params)
+        self.assertEqual(len(data['pos.order']), 1)
+
+        # No order access token should return no order
+        params['order_access_tokens'] = []
+        data = self.make_request_to_controller('/pos-self-order/get-user-data', params)
+        self.assertEqual(data, {})
+
+        # Two outdated order write_date should return both orders
+        params['order_access_tokens'] = [{
+            'access_token': order1.access_token,
+            'state': order1.state,
+            'write_date': (order1.write_date - timedelta(minutes=1)).strftime('%Y-%m-%d %H:%M:%S')
+        }, {
+            'access_token': order2.access_token,
+            'state': order2.state,
+            'write_date': (order2.write_date - timedelta(minutes=1)).strftime('%Y-%m-%d %H:%M:%S')
+        }]
+        data = self.make_request_to_controller('/pos-self-order/get-user-data', params)
+        self.assertEqual(len(data['pos.order']), 2)
+
+        # Only one outdated order write_date should return one order
+        params['order_access_tokens'] = [{
+            'access_token': order1.access_token,
+            'state': order1.state,
+            'write_date': (order1.write_date - timedelta(minutes=1)).strftime('%Y-%m-%d %H:%M:%S')
+        }, {
+            'access_token': order2.access_token,
+            'state': order2.state,
+            'write_date': order2.write_date.strftime('%Y-%m-%d %H:%M:%S')
+        }]
+        data = self.make_request_to_controller('/pos-self-order/get-user-data', params)
+        self.assertEqual(len(data['pos.order']), 1)
+        self.assertEqual(data['pos.order'][0]['id'], order1.id)
+
+        # A cancelled order should be returned
+        order2.action_pos_order_cancel()
+        params['order_access_tokens'] = [{
+            'access_token': order2.access_token,
+            'state': 'paid',
+            'write_date': order2.write_date.strftime('%Y-%m-%d %H:%M:%S')
+        }]
+        data = self.make_request_to_controller('/pos-self-order/get-user-data', params)
+        self.assertEqual(len(data['pos.order']), 1)
+        self.assertEqual(data['pos.order'][0]['id'], order2.id)
+        self.assertEqual(data['pos.order'][0]['state'], 'cancel')
+
+        # Up to date data should return no order
+        params['order_access_tokens'] = [{
+            'access_token': order1.access_token,
+            'state': order1.state,
+            'write_date': order1.write_date.strftime('%Y-%m-%d %H:%M:%S')
+        }, {
+            'access_token': order2.access_token,
+            'state': order2.state,
+            'write_date': order2.write_date.strftime('%Y-%m-%d %H:%M:%S')
+        }]
+        data = self.make_request_to_controller('/pos-self-order/get-user-data', params)
+        self.assertEqual(data, {})

--- a/addons/pos_self_order/tests/test_self_order_controller.py
+++ b/addons/pos_self_order/tests/test_self_order_controller.py
@@ -5,6 +5,7 @@ import odoo.tests
 from datetime import timedelta
 from odoo.addons.pos_self_order.tests.self_order_common_test import SelfOrderCommonTest
 
+
 @odoo.tests.tagged('post_install', '-at_install')
 class TestSelfOrderController(SelfOrderCommonTest):
     def make_request_to_controller(self, url, params):


### PR DESCRIPTION
## Commit 1:
*: point_of_sale, pos_loyalty, pos_online_payment, pos_sale,
pos_self_order

Before this commit, when syncing records from the server, local
records that were not yet synced (isSynced=false) could be lost
if they were not present in the server response. This could happen
for example when a record was created locally and the server
response did not include it.

This commit fixes this issue by ensuring that local records are
always kept when syncing, even if they are not present in the
server response. This is done by merging the local records with
the server records based on their keys.

---

This commit also replace all checks of the form `typeof id === "number"`
with `isSynced` checks. This is because the `id` of a record can be a
temporary string id before it is synced with the server.


## Commit 2
Before this commit, `table_access_token` was used to retrieve a
customer's orders, making it possible to “share” orders between multiple
devices by scanning the same QR code.

This caused comprehension and synchronization issues. This commit
rectifies this by only taking into account order-related information.
- `write_date`
- `state`
- `access_token`

If a user's device contains this information, they will be able to
retrieve their orders.

These changes are related to commit
https://github.com/odoo/odoo/commit/b903acd72142757bfdfc31c51d78b39c8e8786b9,
which adds the `self_ordering_table_id` field, allowing multiple orders
from Self Order to be linked to the same table at the same time.
