### PR TITLE
[FIX] orm: allow bypassing read access in search if defined

### DIFF
--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -1227,6 +1227,9 @@ class Many2many(_RelationalMulti):
         :meth:`~odoo.models.Model._check_company`. Add a default company
         domain depending on the field attributes.
 
+    :param bool bypass_search_access: whether access rights are bypassed on the
+        comodel (default: ``False``)
+
     """
     type = 'many2many'
 
@@ -1359,7 +1362,7 @@ class Many2many(_RelationalMulti):
         # make the query for the lines
         domain = self.get_comodel_domain(records)
         try:
-            query = comodel._search(domain, order=comodel._order)
+            query = comodel._search(domain, order=comodel._order, bypass_access=self.bypass_search_access)
         except AccessError as e:
             raise AccessError(records.env._("Failed to read field %s", self) + '\n' + str(e)) from e
 


### PR DESCRIPTION
Recently, we have changed how Many2many fields are read. Before we used 
`_apply_ir_rules` to give `read` access to comodels, now we're using
`_search` directly.  We have `bypass_search_access` to bypass access checks,
but it's not handled when we do a `_search` from the `read` method.

This commit allows bypassing access checks for the Many2many field, where
`bypass_search_access` is True.

Ref: https://github.com/odoo/odoo/commit/9a21edd99e7f50a785b8b7720f55654254d5f481 , https://github.com/odoo/odoo/pull/217277


Task-5081728
