### PR TITLE
[FIX] payment: declare event listeners on setup

### DIFF
--- a/addons/payment/static/src/interactions/payment_button.js
+++ b/addons/payment/static/src/interactions/payment_button.js
@@ -8,11 +8,8 @@ export class PaymentButton extends Interaction {
         this.paymentButton = this.el;
         this.iconClass = this.paymentButton.dataset.iconClass;
         this._enable();
-    }
-
-    start() {
         this.env.bus.addEventListener('enablePaymentButton', this._enable.bind(this));
-        this.env.bus.addEventListener('disablePaymentButton',this._disable.bind(this));
+        this.env.bus.addEventListener('disablePaymentButton', this._disable.bind(this));
         this.env.bus.addEventListener('hidePaymentButton', this._hide.bind(this));
         this.env.bus.addEventListener('showPaymentButton', this._show.bind(this));
     }


### PR DESCRIPTION
In commit 3e5f87b5de143eadf80e9c96e61fe24e621a939e event listeners were initialized on start.

However when the event was triggered in payment_paypal it started to add the listeners.

So at the moment were the event was triggered there was no listeners on the button to execute.

Therefore The event listeners needed to be initialized on setup not on start.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
