### PR TITLE
[FIX] website: fix dependency error in debug mode

### DIFF
--- a/addons/website/static/src/builder/plugins/options/google_maps_option/google_maps_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/google_maps_option/google_maps_option_plugin.js
@@ -4,7 +4,7 @@ import { renderToElement } from "@web/core/utils/render";
 import { Plugin } from "@html_editor/plugin";
 import { GoogleMapsApiKeyDialog } from "./google_maps_api_key_dialog";
 import { GoogleMapsOption } from "./google_maps_option";
-import { Deferred } from "@odoo/hoot-dom";
+import { Deferred } from "@web/core/utils/concurrency";
 import { BuilderAction } from "@html_builder/core/builder_action";
 
 /**


### PR DESCRIPTION
Steps to reproduce:
1. Install the website module.
2. Enable debug mode and open edit mode. 
  -  A dependency error appears.

Issue:
A wrong import caused a dependency error when opening edit mode with debug enabled.

Fix:
Correct the import to resolve the dependency error.