### PR TITLE
[FIX] auth_totp: synchronization on webclient boot

### DIFF
--- a/addons/auth_totp/static/tests/totp_flow.js
+++ b/addons/auth_totp/static/tests/totp_flow.js
@@ -231,7 +231,7 @@ registry.category("web_tour.tours").add('totp_login_device', {
         await animationFrame();
         await new Promise((resolve) => {
             const bus = odoo.__WOWL_DEBUG__.root.env.services.bus_service;
-            bus.addEventListener("BUS:CONNECT", resolve, { once: true });
+            bus.addEventListener("connect", resolve, { once: true });
             if (bus.workerState === WORKER_STATE.CONNECTED) {
                 resolve();
             }


### PR DESCRIPTION
Should actually fix what #224161 tried to: I didn't notice that the events had been renamed (#220852) and since the test was still disabled (and the fixing PR was set to the master one) all the CIs ran without the test, thus not testing the fix in any way.

It could have passed anyway as it's a non-deterministic issue, but it's at best a 50/50 that it succeeds so over 3 stagings I'd most likely have seen it...

https://runbot.odoo.com/odoo/error/231316
https://runbot.odoo.com/odoo/error/181862 (the original of the same)
