### PR TITLE
[FIX] sale_edi_ubl: fix price on emply product line

### DIFF
--- a/addons/sale_edi_ubl/models/sale_edi_xml_ubl_bis3.py
+++ b/addons/sale_edi_ubl/models/sale_edi_xml_ubl_bis3.py
@@ -288,6 +288,9 @@ class SaleEdiXmlUbl_Bis3(models.AbstractModel):
     def _import_order_ubl(self, order, file_data, new):
         # Overriding the main method to recalculate the price unit and discount
         res = super()._import_order_ubl(order, file_data, new)
+        lines_with_products = order.order_line.filtered('product_id')
         # Recompute product price and discount according to sale price
-        order._recompute_prices()
+        lines_with_products._compute_price_unit()
+        lines_with_products._compute_discount()
+
         return res

--- a/addons/test_sale_purchase_edi_ubl/tests/test_order_ubl_bis3.py
+++ b/addons/test_sale_purchase_edi_ubl/tests/test_order_ubl_bis3.py
@@ -268,7 +268,6 @@ class TestOrderEdiUbl(TestAccountEdiUblCii):
             # Raise user error if line does not have product set
             so.action_confirm()
         line_vals[0]['product_id'] = False
-        line_vals[0]['price_unit'] = 0.0
         # Should set other values properly
         self.assertRecordValues(so.order_line, line_vals)
         # Should create an activity if product is not found


### PR DESCRIPTION
Steps:
- Install Purchase in first db and sale in second db.
- Ensure RFQ contain product which does not exist in second db.
- Export RFQ and import it in sale order view.

Issue:
- Price is always 0 on sol if it didn't find related product.

Cause:
- In [this] PR we always recompute price on all sol instead sol with product

Fix:
- Recompute price and discount only on sol with product.

[this]: https://github.com/odoo/odoo/pull/190310