### PR TITLE
[IMP] mail: auto-open odoobot chat on first discuss launch

### DIFF
--- a/addons/mail/static/src/core/public_web/discuss_client_action.js
+++ b/addons/mail/static/src/core/public_web/discuss_client_action.js
@@ -68,6 +68,11 @@ export class DiscussClientAction extends Component {
         if (!parsedActiveId) {
             this.store.discuss.thread = undefined;
             this.store.discuss.hasRestoredThread = true;
+            const odoobotChat = this.store.odoobot?.searchChat();
+            const selfMember = odoobotChat?.self_member_id;
+            if (odoobotChat && selfMember?.is_pinned && !selfMember.seen_message_id) {
+                odoobotChat.setAsDiscussThread(false);
+            }
             return;
         }
         const [model, id] = parsedActiveId;

--- a/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.js
@@ -268,7 +268,7 @@ export class DiscussCommandPalette {
                 action: async () => {
                     const name = this.options.searchValue.trim();
                     if (name) {
-                        makeNewChannel(name, this.store);
+                        await makeNewChannel(name, this.store);
                     } else {
                         this.dialog.add(CreateChannelDialog);
                     }

--- a/addons/mail/static/tests/discuss/core/web/discuss.test.js
+++ b/addons/mail/static/tests/discuss/core/web/discuss.test.js
@@ -167,6 +167,22 @@ test("Chat is pinned on other tabs when joined", async () => {
     await contains(`${env2.selector} .o-mail-DiscussSidebar-item`, { text: "Jerry Golay" });
 });
 
+test("Auto-open OdooBot chat when opening discuss for the first time", async () => {
+    // Odoobot chat has onboarding for using Discuss app.
+    // We assume pinned odoobot chat without any message seen means user just started using Discuss app.
+    const pyEnv = await startServer();
+    pyEnv["discuss.channel"].create({
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ partner_id: serverState.odoobotId }),
+        ],
+        channel_type: "chat",
+    });
+    await start();
+    await openDiscuss();
+    await contains(".o-mail-DiscussContent-threadName", { value: "OdooBot" });
+});
+
 test("no conversation selected when opening non-existing channel in discuss", async () => {
     await startServer();
     await start();


### PR DESCRIPTION
**Purpose of this PR:**

- Before this commit, opening Discuss for the first time showed “No conversation selected”, leaving users without a clear starting point.
- This commit changes the behavior so that the OdooBot chat opens automatically on first launch, providing users with an immediate conversation instead of an empty state.

Task - 5072374