### PR TITLE
[FIX] point_of_sale: show deposited amount

### DIFF
--- a/addons/point_of_sale/static/tests/tours/utils/partner_list_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/partner_list_util.js
@@ -21,6 +21,14 @@ export function checkDropDownItemText(text) {
     };
 }
 
+export function clickDropDownItem(text) {
+    return {
+        content: `click for dropdown item containing text`,
+        trigger: `.o-dropdown-item:contains("${text}")`,
+        run: "click",
+    };
+}
+
 export function checkContactValues(name, address = "", phone = "", mobile = "", email = "") {
     const steps = [
         {


### PR DESCRIPTION
The partner list in the PoS was never showing the deposited amount for the partners.

Steps to reproduce:
-------------------
* Open PoS and make a deposit for a partner using the Customer Account
* Check the partner list
> Observation: No deposited amount is shown

Why the fix:
------------
We backport the part of this fix https://github.com/odoo/enterprise/commit/bf4b6043b999b4a081b1afa73fc4113bf4db28f8 that changes the partner list to show the deposited amount.

opw-4954740