### PR TITLE
[REF] *: remove all attributes of group in search view

### DIFF
--- a/addons/account/views/account_analytic_line_views.xml
+++ b/addons/account/views/account_analytic_line_views.xml
@@ -56,7 +56,7 @@
                     <xpath expr="//filter[@name='month']" position="after">
                         <filter name="fiscal_date" string="From last fiscal year" domain="[('fiscal_year_search', '=', True)]" invisible="1"/>
                     </xpath>
-                    <xpath expr="//group[@name='groupby']" position="inside">
+                    <xpath expr="//group" position="inside">
                         <separator/>
                         <filter name="account_id" context="{'group_by': 'account_id'}"/>
                         <separator/>

--- a/addons/analytic/views/analytic_line_views.xml
+++ b/addons/analytic/views/analytic_line_views.xml
@@ -33,8 +33,7 @@
                 <field name="date"/>
                 <separator/>
                 <filter name="month" string="Date" date="date"/>
-                <group name="groupby">
-                    <separator/>
+                <group>
                     <filter string="Date" name="group_date" context="{'group_by': 'date'}"/>
                 </group>
             </search>

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -1017,8 +1017,7 @@
                         domain="[('my_activity_date_deadline', '=', 'today')]"/>
                     <filter invisible="1" string="Future Activities" name="activities_upcoming_all"
                         domain="[('my_activity_date_deadline', '&gt;', 'today')]"/>
-                    <separator/>
-                    <group colspan="16">
+                    <group>
                         <filter string="Salesperson" name="salesperson" context="{'group_by':'user_id'}"/>
                         <filter string="Sales Team" name="saleschannel" context="{'group_by':'team_id'}"/>
                         <filter name="stage" string="Stage" context="{'group_by':'stage_id'}"/>

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -453,7 +453,7 @@
                         domain="[('my_activity_date_deadline', '&gt;', 'today')]"/>
 
                     <!-- Group bys -->
-                    <group name="group_filters">
+                    <group>
                         <filter string="Employee" name="employee" domain="[]" context="{'group_by': 'employee_id'}"/>
                         <filter string="Category" name="product" domain="[]" context="{'group_by': 'product_id'}"/>
                         <filter string="Status" name="status" domain="[]" context="{'group_by': 'state'}"/>
@@ -524,7 +524,7 @@
             <field name="inherit_id" ref="hr_expense_view_search"/>
             <field name="mode">primary</field>
             <field name="arch" type="xml">
-                <xpath expr="//group[@name='group_filters']" position='after'>
+                <xpath expr="//group" position='after'>
                     <searchpanel>
                         <field name="state" expand="1" select="multi" icon="fa-check-square-o" enable_counters="1"/>
                         <field name="employee_id"  limit="20" hierarchize="0" select="one" icon="fa-users"/>

--- a/addons/hr_holidays_attendance/views/hr_leave_attendance_report_views.xml
+++ b/addons/hr_holidays_attendance/views/hr_leave_attendance_report_views.xml
@@ -99,7 +99,7 @@
                 <separator/>
                 <filter string="Archived Employees" name="archived_employees"
                     domain="[('active', '=', False)]"/>
-                <group name="groupby">
+                <group>
                     <filter string="Date" name="group_by_date" context="{'group_by': 'date'}"/>
                     <filter string="Employees" name="group_by_employees" context="{'group_by': 'employee_id'}"/>
                     <separator/>

--- a/addons/hr_maintenance/views/maintenance_views.xml
+++ b/addons/hr_maintenance/views/maintenance_views.xml
@@ -70,7 +70,7 @@
           <field name="employee_id"/>
           <field name="department_id"/>
         </field>
-        <group position="inside">
+        <group>
           <filter string="Employee" name="employee" domain="[]" context="{'group_by': 'employee_id'}"/>
           <filter string="Department" name="department" domain="[]" context="{'group_by': 'department_id'}"/>
         </group>

--- a/addons/hr_timesheet/views/hr_timesheet_views.xml
+++ b/addons/hr_timesheet/views/hr_timesheet_views.xml
@@ -223,7 +223,7 @@
                         ('date', '&lt;', '=week_start'),
                     ]"/>
                 </filter>
-                <xpath expr="//group[@name='groupby']" position="before">
+                <xpath expr="//group" position="before">
                     <field name="employee_id"/>
                     <field name="project_id"/>
                     <field name="task_id"/>
@@ -231,7 +231,7 @@
                     <field name="department_id"/>
                     <field name="manager_id"/>
                 </xpath>
-                <xpath expr="//group[@name='groupby']" position="inside">
+                <xpath expr="//group" position="inside">
                     <filter string="Project" name="groupby_project" domain="[]" context="{'group_by': 'project_id'}"/>
                     <filter string="Parent Task" name="groupby_parent_task" domain="[]" context="{'group_by': 'parent_task_id'}"/>
                     <filter string="Task" name="groupby_task" domain="[]" context="{'group_by': 'task_id'}"/>

--- a/addons/stock/views/stock_move_line_views.xml
+++ b/addons/stock/views/stock_move_line_views.xml
@@ -151,8 +151,7 @@
                 <filter string="Last 12 Months" name="filter_last_12_months" domain="[('date','&gt;=', 'today -12m')]"/>
                 <separator/>
                 <filter string="Inventory Adjustments" name="inventory" domain="[('is_inventory', '=', True)]"/>
-                <separator/>
-                <group name="groupby">
+                <group>
                     <filter string="Product" name="groupby_product_id" domain="[]" context="{'group_by': 'product_id'}"/>
                     <filter string="Status" name="by_state" domain="[]"  context="{'group_by': 'state'}"/>
                     <filter string="Date" name="by_date" domain="[]" context="{'group_by': 'date'}"/>

--- a/addons/stock_delivery/views/stock_move_line_views.xml
+++ b/addons/stock_delivery/views/stock_move_line_views.xml
@@ -19,7 +19,7 @@
             <xpath expr="//field[@name='owner_id']" position="after">
                 <field name="carrier_id" invisible="1" string="Carrier name"/>
             </xpath>
-            <xpath expr="//group[@name='groupby']" position="inside">
+            <xpath expr="//group" position="inside">
                 <filter string="Carrier" name="by_carrier" context="{'group_by': 'carrier_id'}"/>
             </xpath>
         </field>

--- a/addons/stock_picking_batch/views/stock_picking_batch_views.xml
+++ b/addons/stock_picking_batch/views/stock_picking_batch_views.xml
@@ -308,7 +308,7 @@
         <field name="model">stock.move.line</field>
         <field name="inherit_id" ref="stock.stock_move_line_view_search"/>
         <field name="arch" type="xml">
-            <xpath expr="//group[@name='groupby']" position="inside">
+            <xpath expr="//group" position="inside">
                 <filter string="Batch Transfer" name="by_batch_id" context="{'group_by': 'batch_id'}"/>
             </xpath>
         </field>

--- a/addons/website/views/website_controller_pages_views.xml
+++ b/addons/website/views/website_controller_pages_views.xml
@@ -93,7 +93,7 @@
     <field name="arch" type="xml">
         <search>
             <field name="model" filter_domain="[('model','=', self)]" string="Model"/>
-            <group colspan="4">
+            <group>
                 <filter string="Model" name="page_model" domain="[]" context="{'group_by':'model'}"/>
                 <filter string="Website" name="page_website_id" domain="[]" context="{'group_by':'website_id'}"/>
             </group>

--- a/odoo/addons/base/views/ir_actions_views.xml
+++ b/odoo/addons/base/views/ir_actions_views.xml
@@ -132,7 +132,7 @@
                         filter_domain="['|', '|', '|', '|', ('name','ilike',self), ('model','ilike',self), ('type','ilike',self), ('report_name','ilike',self), ('report_type','ilike',self)]"
                         string="Report"/>
                     <field name="model" filter_domain="[('model','=', self)]" string="Model"/>
-                    <group colspan="4">
+                    <group>
                         <filter string="Report Type" name="report_type" domain="[]" context="{'group_by':'report_type'}"/>
                         <filter string="Report Model" name="report_model" domain="[]" context="{'group_by':'model'}"/>
                     </group>
@@ -581,7 +581,7 @@ env['res.partner'].create({'name': partner_name})
                     <field name="model_id"/>
                     <field name="state"/>
                     <filter string="Top-level actions" name="toplevel_actions" domain="[('parent_id', '=', False)]"/>
-                    <group colspan="4" col="4">
+                    <group>
                         <filter string="Action Type" name="action_type" domain="[]" context="{'group_by':'state'}"/>
                         <filter string="Model" name="model" domain="[]" context="{'group_by':'model_id'}"/>
                         <filter string="Usage" name="usage" domain="[]" context="{'group_by':'usage'}"/>

--- a/odoo/addons/base/views/ir_model_views.xml
+++ b/odoo/addons/base/views/ir_model_views.xml
@@ -690,7 +690,7 @@
                     <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
                     <field name="model_id"/>
                     <field name="group_id"/>
-                    <group colspan="11" col="11" groups="base.group_no_one">
+                    <group groups="base.group_no_one">
                         <filter string="Group" name="group" domain="[]" context="{'group_by': 'group_id'}"/>
                         <filter string="Model" name="group_by_object" domain="[]" context="{'group_by': 'model_id'}"/>
                     </group>

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -328,8 +328,7 @@
                     <separator/>
                     <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
                     <field name="properties"/>
-                    <separator/>
-                    <group name="group_by">
+                    <group>
                         <filter name="salesperson" string="Salesperson" domain="[]" context="{'group_by' : 'user_id'}" />
                         <filter name="group_company" string="Company" context="{'group_by': 'parent_id'}"/>
                         <filter name="group_country" string="Country" context="{'group_by': 'country_id'}"/>


### PR DESCRIPTION
- Remove all attributes from group element in search view.
- Remove the tags separator before a group tag (separator and group do the same thing)

Enterprise PR : https://github.com/odoo/enterprise/pull/94576

task-5005075

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
