### PR TITLE
[FIX] im_livechat: prevent duplicate channel members in livechat

### DIFF
--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -300,7 +300,8 @@ class Im_LivechatChannel(models.Model):
             operator_model=operator_model,
             **kwargs
         ))]
-        if guest := self.env["mail.guest"]._get_guest_from_context():
+        guest = self.env["mail.guest"]._get_guest_from_context()
+        if guest and self.env.user._is_public():
             members_to_add.append(
                 Command.create({"livechat_member_type": "visitor", "guest_id": guest.id})
             )


### PR DESCRIPTION
Before this PR,
when a logged-in user had a guest in context and started a livechat, 2 discuss.channel.member records were created: one for the guest and one for the logged-in user. This prevented the feedback panel from being shown after the livechat ended.

This PR fixes the issue by only adding the guest as a channel member when the user is not logged in.

Steps to reproduce:
- Start a livechat as a visitor and end it -> feedback panel is shown.
- Log in as any user.
- Start a livechat and end it -> feedback panel is not shown when clicking Continue or Close.