### PR TITLE
[FIX] sale_project: show task embedded action when opening task from SO

### DIFF
--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -204,7 +204,9 @@ class SaleOrder(models.Model):
         project_ids = self.with_context(active_test=False).project_ids
         partner = self.partner_shipping_id or self.partner_id
         if len(project_ids) == 1:
-            action = (self.env['ir.actions.actions']._for_xml_id('project.action_view_task'))
+            action = self.env['ir.actions.actions'].with_context(
+                active_id=self.project_ids.id,
+            )._for_xml_id('project.act_project_project_2_project_task_all')
             action['context'] = {
                 'active_id': project_ids.id,
                 'default_partner_id': partner.id,


### PR DESCRIPTION
**Steps to reproduce:**
  - Install `sale_project`
  - Create a service-type product
  - Create and confirm a Sales Order
  - Open the generated task
  - Check the top bar actions

**Issue:**
   The related task embedded actions do not appear when opening a task from a Sales Order.

**Cause:**
   The active_id  context was not passed when calling `_for_xml_id()`, and a different action (`action_view_task`) was used instead.

**Fix:**
   Pass the project in the context as active_id and use the correct action `act_project_project_2_project_task_all` instead of
   `action_view_task`.

task-4946932
