### PR TITLE
[FIX] html_editor: display correct size for small font size

### DIFF
--- a/addons/web_editor/static/src/scss/bootstrap_overridden.scss
+++ b/addons/web_editor/static/src/scss/bootstrap_overridden.scss
@@ -94,6 +94,6 @@ $o-color-system-initialized: true;
 // "small" font size. Grep: SMALLER_FONT_SIZE_RATIO.
 $small-font-size: if(
     variable-exists('font-size-base'),
-    ($o-small-font-size / $font-size-base) * 1em,
+    ($o-small-font-size / $font-size-base) * 1rem,
     null
 ) !default;


### PR DESCRIPTION
Steps to reproduce:
1. Drop a Banner snippet
2. Select the text and change the size to "Small"
   - The font size is shown as 16px instead of 14px

Cause:
The "Small" font size was calculated using `em`, while other sizes were calculated using `rem`.

Fix:
Use `rem` for the small font size as well, ensuring consistent calculation across all font sizes.


| Before  | After |
|-----------------------------|---------------------------------|
| <img width="545" height="604" alt="image" src="https://github.com/user-attachments/assets/0f6b754c-e010-490f-aac1-ee0b9ba80d72" />| <img width="545" height="613" alt="image" src="https://github.com/user-attachments/assets/0ee4c756-965e-48c5-8764-3085b49a3c48" /> |





