### PR TITLE
[FIX] html_builder: change mobile preview button color

### DIFF
--- a/addons/html_builder/static/src/builder.xml
+++ b/addons/html_builder/static/src/builder.xml
@@ -9,7 +9,7 @@
                 <button type="button"  t-on-click="() => this.redo()" class="o-hb-btn btn fa fa-repeat" t-att-disabled="!state.canRedo"/>
             </div>
             <div class="d-flex gap-1">
-                <button t-on-click="onMobilePreviewClick" type="button" class="o-hb-btn btn d-flex align-items-center" t-att-class="{ active: props.isMobile }" data-action="mobile" title="Mobile Preview" accesskey="m" style="--btn-font-size: 20px"><span class="fa fa-mobile" role="img"/></button>
+                <button t-on-click="onMobilePreviewClick" type="button" class="o-hb-btn btn btn-success-color-active d-flex align-items-center" t-att-class="{ active: props.isMobile }" data-action="mobile" title="Mobile Preview" accesskey="m" style="--btn-font-size: 20px"><span class="fa fa-mobile" role="img"/></button>
                 <t t-if="props.slots?.extraActions" t-slot="extraActions"/>
             </div>
         </div>

--- a/addons/website/static/src/client_actions/website_preview/mobile_preview_systray.scss
+++ b/addons/website/static/src/client_actions/website_preview/mobile_preview_systray.scss
@@ -1,5 +1,5 @@
 .o_mobile_preview_active {
     span.fa {
-        color: $o-we-color-success;
+        color: $o-success;
     }
 }

--- a/addons/website/static/src/client_actions/website_preview/mobile_preview_systray.xml
+++ b/addons/website/static/src/client_actions/website_preview/mobile_preview_systray.xml
@@ -5,7 +5,7 @@
          t-att-class="{ 'o_mobile_preview_active': this.state.isMobile }">
         <a href="#" accesskey="v" class="o_nav_entry mx-1 px-3"
            t-on-click="onClick">
-            <span title="Mobile preview" role="img" aria-label="Mobile preview" class="fa fa-lg fa-mobile"/>
+            <span title="Mobile preview" role="img" aria-label="Mobile preview" class="fa fa-2x fa-mobile"/>
         </a>
     </div>
 </t>


### PR DESCRIPTION
- The mobile preview button color is changed at two places:
 1. In the website systray menu.
 2. In the HTML builder top-bar.

Before:
<img width="222" height="103" alt="outsidediff" src="https://github.com/user-attachments/assets/b2d3997a-4011-440f-8d14-22b5ebaf295c" />
<img width="428" height="104" alt="indiff" src="https://github.com/user-attachments/assets/2cb07173-2f20-42b0-abb2-289ed7476347" />
After:
<img width="251" height="89" alt="image" src="https://github.com/user-attachments/assets/2c6f516c-96a7-495e-bea4-0e6e7b39ae8c" />
<img width="409" height="92" alt="image" src="https://github.com/user-attachments/assets/ea939d9d-d47c-472f-b62d-db1dc8bd81c4" />



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
