### PR TITLE
[FIX] website: disable remove slide option on last slide

### DIFF
--- a/addons/website/static/src/builder/plugins/carousel_item_header_buttons.js
+++ b/addons/website/static/src/builder/plugins/carousel_item_header_buttons.js
@@ -1,4 +1,5 @@
 import { useOperation } from "@html_builder/core/operation_plugin";
+import { useDomState } from "@html_builder/core/utils";
 import { Component } from "@odoo/owl";
 
 export class CarouselItemHeaderMiddleButtons extends Component {
@@ -11,6 +12,12 @@ export class CarouselItemHeaderMiddleButtons extends Component {
 
     setup() {
         this.callOperation = useOperation();
+        this.state = useDomState((editingElement) => {
+            const carouselItemsNumber = editingElement.parentElement.children.length;
+            return {
+                disableRemove: carouselItemsNumber === 1,
+            };
+        });
     }
 
     slide(direction) {

--- a/addons/website/static/src/builder/plugins/carousel_option.xml
+++ b/addons/website/static/src/builder/plugins/carousel_option.xml
@@ -85,6 +85,8 @@
         <span class="oi fa-fw oi-plus"/>
     </button>
     <button class="btn btn-danger py-0 px-1"
+            t-att-class="{ disabled: state.disableRemove }"
+            t-att-disabled="state.disableRemove"
             title="Remove Slide"
             aria-label="Remove Slide"
             t-on-click="removeSlide">


### PR DESCRIPTION
Steps to reproduce:
- Drop a carousel snippet
- In the builder options, click on the "-" button to remove all items except the last one.
=> The button is still displayed as working (not disabled), even though clicking on it won't remove the last slide.

To clarify that this is the expected behavior, we disable the button if there is only one carousel item left.