### PR TITLE
[IMP] stock,*: corrections in scrap location

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -190,11 +190,11 @@ class MrpProduction(models.Model):
         'stock.move', 'raw_material_production_id', 'Components',
         compute='_compute_move_raw_ids', store=True, readonly=False,
         copy=False,
-        domain=[('location_dest_usage', '!=', 'inventory')])
+        domain=[('scrap_id', '=', False)])
     move_finished_ids = fields.One2many(
         'stock.move', 'production_id', 'Finished Products', readonly=False,
         compute='_compute_move_finished_ids', store=True, copy=False,
-        domain=[('location_dest_usage', '!=', 'inventory')])
+        domain=[('scrap_id', '=', False)])
     # technical field: inverse field for `stock.move.raw_material_production_id`
     all_move_raw_ids = fields.One2many('stock.move', 'raw_material_production_id')
     # technical field: inverse field for `stock.move.production_id`

--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -244,7 +244,7 @@ class StockMove(models.Model):
         for values in vals_list:
             mo_id = values.get('raw_material_production_id', False) or values.get('production_id', False)
             location_dest = self.env['stock.location'].browse(values.get('location_dest_id'))
-            if mo_id and location_dest.usage != 'inventory':
+            if mo_id and not values.get('scrap_id'):
                 mo = mo_id_to_mo[mo_id]
                 if not mo:
                     mo = mo.browse(mo_id)

--- a/addons/mrp/models/stock_picking.py
+++ b/addons/mrp/models/stock_picking.py
@@ -75,7 +75,7 @@ class StockPickingType(models.Model):
     def _check_default_location(self):
         for record in self:
             if record.code == 'mrp_operation' and record.default_location_dest_id.usage == 'inventory':
-                raise ValidationError(_("You cannot set a scrap location as the destination location for a manufacturing type operation."))
+                raise ValidationError(self.env._("You cannot set a inventory loss location as the destination location for a manufacturing type operation."))
 
     def _get_mo_count(self):
         mrp_picking_types = self.filtered(lambda picking: picking.code == 'mrp_operation')

--- a/addons/mrp/models/stock_traceability.py
+++ b/addons/mrp/models/stock_traceability.py
@@ -7,11 +7,11 @@ class StockTraceabilityReport(models.TransientModel):
     @api.model
     def _get_reference(self, move_line):
         res_model, res_id, ref = super()._get_reference(move_line)
-        if move_line.move_id.production_id and move_line.move_id.location_dest_usage != 'inventory':
+        if move_line.move_id.production_id and not move_line.move_id.scrap_id:
             res_model = 'mrp.production'
             res_id = move_line.move_id.production_id.id
             ref = move_line.move_id.production_id.name
-        if move_line.move_id.raw_material_production_id and move_line.move_id.location_dest_usage != 'inventory':
+        if move_line.move_id.raw_material_production_id and not move_line.move_id.scrap_id:
             res_model = 'mrp.production'
             res_id = move_line.move_id.raw_material_production_id.id
             ref = move_line.move_id.raw_material_production_id.name

--- a/addons/mrp/tests/test_stock.py
+++ b/addons/mrp/tests/test_stock.py
@@ -254,14 +254,14 @@ class TestWarehouseMrp(common.TestMrpCommon):
         scrap_move = scrap_id.move_ids[0]
 
         self.assertTrue(scrap_move.raw_material_production_id)
-        self.assertEqual(scrap_move.location_dest_usage, 'inventory')
+        self.assertTrue(bool(scrap_move.scrap_id))
         self.assertEqual(scrap_move.location_dest_id, scrap_id.scrap_location_id)
         self.assertEqual(scrap_move.price_unit, scrap_move.product_id.standard_price)
 
         #Check scrap move is created for this production order.
         #TODO: should check with scrap objects link in between
 
-#        scrap_move = production_3.move_raw_ids.filtered(lambda x: x.product_id == self.product_2 and x.location_dest_usage == 'inventory')
+#        scrap_move = production_3.move_raw_ids.filtered(lambda x: x.product_id == self.product_2 and x.scrap_id)
 #        self.assertTrue(scrap_move, "There are no any scrap move created for production order.")
 
     def test_putaway_after_manufacturing_3(self):

--- a/addons/purchase_mrp/models/purchase.py
+++ b/addons/purchase_mrp/models/purchase.py
@@ -60,7 +60,7 @@ class PurchaseOrderLine(models.Model):
         for line in lines_stock:
             kit_bom = kits_by_company[line.company_id].get(line.product_id)
             if kit_bom:
-                moves = line.move_ids.filtered(lambda m: m.state == 'done' and m.location_dest_usage != 'inventory')
+                moves = line.move_ids.filtered(lambda m: m.state == 'done' and not m.scrap_id)
                 order_qty = line.product_uom_id._compute_quantity(line.product_uom_qty, kit_bom.product_uom_id)
                 filters = {
                     'incoming_moves': lambda m:

--- a/addons/purchase_stock/models/purchase_order.py
+++ b/addons/purchase_stock/models/purchase_order.py
@@ -200,7 +200,7 @@ class PurchaseOrder(models.Model):
         for order_line in order_lines:
             moves_to_cancel_ids.update(order_line.move_ids.filtered(lambda move: move.state != 'done').ids)
             if order_line.move_dest_ids:
-                move_dest_ids = order_line.move_dest_ids.filtered(lambda move: move.state != 'done' and move.location_dest_usage != 'inventory')
+                move_dest_ids = order_line.move_dest_ids.filtered(lambda move: move.state != 'done' and not move.scrap_id)
                 moves_to_mts = move_dest_ids.filtered(lambda move: move.rule_id.route_id != move.location_dest_id.warehouse_id.reception_route_id)
                 move_dest_ids -= moves_to_mts
                 moves_to_recompute_ids.update(moves_to_mts.ids)

--- a/addons/purchase_stock/models/purchase_order_line.py
+++ b/addons/purchase_stock/models/purchase_order_line.py
@@ -391,7 +391,7 @@ class PurchaseOrderLine(models.Model):
         outgoing_moves = self.env['stock.move']
         incoming_moves = self.env['stock.move']
 
-        for move in self.move_ids.filtered(lambda r: r.state != 'cancel' and r.location_dest_usage != 'inventory' and self.product_id == r.product_id):
+        for move in self.move_ids.filtered(lambda r: r.state != 'cancel' and not r.scrap_id and self.product_id == r.product_id):
             if move._is_purchase_return() and (move.to_refund or not move.origin_returned_move_id):
                 outgoing_moves |= move
             elif move.location_dest_id.usage != "supplier":

--- a/addons/sale_mrp/models/sale_order_line.py
+++ b/addons/sale_mrp/models/sale_order_line.py
@@ -64,7 +64,7 @@ class SaleOrderLine(models.Model):
                         else:
                             order_line.qty_delivered = order_line.product_uom_qty
                         continue
-                    moves = order_line.move_ids.filtered(lambda m: m.state == 'done' and m.location_dest_usage != 'inventory')
+                    moves = order_line.move_ids.filtered(lambda m: m.state == 'done' and not m.scrap_id)
                     filters = {
                         # in/out perspective w/ respect to moves is flipped for sale order document
                         'incoming_moves': lambda m:
@@ -139,13 +139,13 @@ class SaleOrderLine(models.Model):
 
         return {
             'incoming_moves': lambda m: (
-                m.state != 'cancel' and m.location_dest_usage != 'inventory'
+                m.state != 'cancel' and not m.scrap_id
                 and m.rule_id.id in triggering_rule_ids
                 and m.location_final_id.usage == 'customer'
                 and (not m.origin_returned_move_id or (m.origin_returned_move_id and m.to_refund)
             )),
             'outgoing_moves': lambda m: (
-                m.state != 'cancel' and m.location_dest_usage != 'inventory'
+                m.state != 'cancel' and not m.scrap_id
                 and m.location_id.usage == 'customer' and m.to_refund
             ),
         }
@@ -157,7 +157,7 @@ class SaleOrderLine(models.Model):
         # kits that are currently in delivery
         bom = self.env['mrp.bom'].sudo()._bom_find(self.product_id, bom_type='phantom', company_id=self.company_id.id)[self.product_id]
         if bom and self.move_ids:
-            moves = self.move_ids.filtered(lambda r: r.state != 'cancel' and r.location_dest_usage != 'inventory')
+            moves = self.move_ids.filtered(lambda r: r.state != 'cancel' and not r.scrap_id)
             filters = self._get_incoming_outgoing_moves_filter()
             order_qty = previous_product_uom_qty.get(self.id, 0) if previous_product_uom_qty else self.product_uom_qty
             order_qty = self.product_uom_id._compute_quantity(order_qty, bom.product_uom_id)

--- a/addons/sale_stock/models/sale_order_line.py
+++ b/addons/sale_stock/models/sale_order_line.py
@@ -192,7 +192,7 @@ class SaleOrderLine(models.Model):
             if not line.is_expense and line.product_id.type == 'consu':
                 line.qty_delivered_method = 'stock_move'
 
-    @api.depends('move_ids.state', 'move_ids.location_dest_usage', 'move_ids.quantity', 'move_ids.product_uom')
+    @api.depends('move_ids.state', 'move_ids.scrap_id', 'move_ids.quantity', 'move_ids.product_uom')
     def _compute_qty_delivered(self):
         super(SaleOrderLine, self)._compute_qty_delivered()
 
@@ -300,7 +300,7 @@ class SaleOrderLine(models.Model):
         outgoing_moves_ids = set()
         incoming_moves_ids = set()
 
-        moves = self.move_ids.filtered(lambda r: r.state != 'cancel' and r.location_dest_usage != 'inventory' and self.product_id == r.product_id)
+        moves = self.move_ids.filtered(lambda r: r.state != 'cancel' and not r.scrap_id and self.product_id == r.product_id)
         if moves and not strict:
             # The first move created was the one created from the intial rule that started it all.
             sorted_moves = moves.sorted('id')

--- a/addons/stock/models/res_company.py
+++ b/addons/stock/models/res_company.py
@@ -149,7 +149,9 @@ class ResCompany(models.Model):
     @api.model
     def create_missing_scrap_location(self):
         company_ids  = self.env['res.company'].search([])
-        companies_having_scrap_loc = self.env['stock.location'].search([('usage', '=', 'inventory')]).mapped('company_id')
+        inventory_loss_product_template_field = self.env['ir.model.fields']._get('product.template', 'property_stock_inventory')
+        inv_loss_loc_ids = self.env['ir.default'].search([('field_id', '=', inventory_loss_product_template_field.id)]).mapped('json_value')
+        companies_having_scrap_loc = self.env['stock.location'].search([('usage', '=', 'inventory'), ('id', 'not in', inv_loss_loc_ids)]).mapped('company_id')
         company_without_property = company_ids - companies_having_scrap_loc
         company_without_property._create_scrap_location()
 

--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -195,7 +195,7 @@ class StockLocation(models.Model):
     def _check_scrap_location(self):
         for record in self:
             if record.usage == 'inventory' and self.env['stock.picking.type'].search_count([('code', '=', 'mrp_operation'), ('default_location_dest_id', '=', record.id)], limit=1):
-                raise ValidationError(_("You cannot set a location as a scrap location when it is assigned as a destination location for a manufacturing type operation."))
+                raise ValidationError(self.env._("You cannot set a location as a inventory loss location when it is assigned as a destination location for a manufacturing type operation."))
 
     @api.ondelete(at_uninstall=False)
     def _unlink_except_master_data(self):

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -342,7 +342,7 @@ class StockMove(models.Model):
         for move in self:
             move.is_quantity_done_editable = move.product_id
 
-    @api.depends('picking_id.name', 'scrap_id.name', 'location_dest_usage', 'is_inventory', 'inventory_name')
+    @api.depends('picking_id.name', 'scrap_id', 'is_inventory', 'inventory_name')
     def _compute_reference(self):
         for move in self:
             if move.scrap_id:
@@ -920,7 +920,7 @@ Please change the quantity done or the rounding precision in your settings.""",
     def _do_unreserve(self):
         moves_to_unreserve = OrderedSet()
         for move in self:
-            if move.state == 'cancel' or (move.state == 'done' and move.location_dest_usage == 'inventory') or move.picked:
+            if move.state == 'cancel' or (move.state == 'done' and move.scrap_id) or move.picked:
                 # We may have cancelled move in an open picking in a "propagate_cancel" scenario.
                 # We may have done move in an open picking in a scrap scenario.
                 continue
@@ -2005,9 +2005,9 @@ Please change the quantity done or the rounding precision in your settings.""",
         StockMove.browse(moves_to_redirect).move_line_ids._apply_putaway_strategy()
 
     def _action_cancel(self):
-        if any(move.state == 'done' and move.location_dest_usage != 'inventory' for move in self):
+        if any(move.state == 'done' and not move.scrap_id for move in self):
             raise UserError(_('You cannot cancel a stock move that has been set to \'Done\'. Create a return in order to reverse the moves which took place.'))
-        moves_to_cancel = self.filtered(lambda m: m.state != 'cancel' and not (m.state == 'done' and m.location_dest_usage == 'inventory'))
+        moves_to_cancel = self.filtered(lambda m: m.state != 'cancel' and not (m.state == 'done' and m.scrap_id))
         moves_to_cancel.picked = False
         # self cannot contain moves that are either cancelled or done, therefore we can safely
         # unlink all associated move_line_ids
@@ -2471,7 +2471,7 @@ Please change the quantity done or the rounding precision in your settings.""",
         """ Open the form view of the move's reference document, if one exists, otherwise open form view of self
         """
         self.ensure_one()
-        if not self.is_inventory and self.location_dest_usage == 'inventory':
+        if self.scrap_id:
             return {
                 'res_model': 'stock.scrap',
                 'type': 'ir.actions.act_window',

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -820,8 +820,8 @@ class StockPicking(models.Model):
                 'any_draft': picking_moves_state_map[picking_id.id].get('any_draft', False) or move_state == 'draft',
                 'all_cancel': picking_moves_state_map[picking_id.id].get('all_cancel', True) and move_state == 'cancel',
                 'all_cancel_done': picking_moves_state_map[picking_id.id].get('all_cancel_done', True) and move_state in ('cancel', 'done'),
-                'all_done_are_scrapped': picking_moves_state_map[picking_id.id].get('all_done_are_scrapped', True) and (move.location_dest_usage == 'inventory' if move_state == 'done' else True),
-                'any_cancel_and_not_scrapped': picking_moves_state_map[picking_id.id].get('any_cancel_and_not_scrapped', False) or (move_state == 'cancel' and move.location_dest_usage != 'inventory'),
+                'all_done_are_scrapped': picking_moves_state_map[picking_id.id].get('all_done_are_scrapped', True) and (move.scrap_id if move_state == 'done' else True),
+                'any_cancel_and_not_scrapped': picking_moves_state_map[picking_id.id].get('any_cancel_and_not_scrapped', False) or (move_state == 'cancel' and not move.scrap_id),
             })
             picking_move_lines[picking_id.id].add(move.id)
         for picking in self:
@@ -918,7 +918,7 @@ class StockPicking(models.Model):
         result = {
             picking
             for [picking] in self.env['stock.move']._read_group(
-                [('picking_id', 'in', self.ids), ('location_dest_usage', '=', 'inventory')],
+                [('picking_id', 'in', self.ids), ('scrap_id', '!=', False)],
                 ['picking_id'],
             )
         }
@@ -1142,7 +1142,7 @@ class StockPicking(models.Model):
         if 'partner_id' in vals:
             after_vals['partner_id'] = vals['partner_id']
         if after_vals:
-            self.move_ids.filtered(lambda move: move.location_dest_usage != 'inventory').write(after_vals)
+            self.move_ids.filtered(lambda move: not move.scrap_id).write(after_vals)
         if vals.get('move_ids'):
             self._autoconfirm_picking()
 
@@ -1455,7 +1455,7 @@ class StockPicking(models.Model):
             for move in picking.move_ids:
                 if move.quantity:
                     has_quantity = True
-                if move.location_dest_usage == 'inventory':
+                if move.scrap_id:
                     continue
                 if move.picked:
                     has_pick = True

--- a/addons/stock/report/stock_traceability.py
+++ b/addons/stock/report/stock_traceability.py
@@ -93,7 +93,7 @@ class StockTraceabilityReport(models.TransientModel):
             res_model = 'stock.move'
             res_id = move_line.move_id.id
             ref = 'Inventory Adjustment'
-        elif move_line.move_id.location_dest_usage == 'inventory' and move_line.move_id.scrap_id:
+        elif move_line.move_id.scrap_id and move_line.move_id.scrap_id:
             res_model = 'stock.scrap'
             res_id = move_line.move_id.scrap_id.id
             ref = move_line.move_id.scrap_id.name

--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -4483,7 +4483,7 @@ class TestStockMove(TestStockCommon):
         move = scrap.move_ids[0]
         self.assertEqual(move.state, 'done')
         self.assertEqual(move.quantity, 1)
-        self.assertEqual(move.location_dest_usage, 'inventory')
+        self.assertTrue(bool(move.scrap_id))
         self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, self.stock_location), 0)
 
     def test_scrap_2(self):
@@ -4503,7 +4503,7 @@ class TestStockMove(TestStockCommon):
         move = scrap.move_ids[0]
         self.assertEqual(move.state, 'done')
         self.assertEqual(move.quantity, 1)
-        self.assertEqual(move.location_dest_usage, 'inventory')
+        self.assertTrue(bool(move.scrap_id))
         self.assertEqual(self.env['stock.quant']._get_available_quantity(self.product_consu, self.stock_location), 0)
 
     def test_scrap_3(self):

--- a/addons/stock/wizard/stock_picking_return.py
+++ b/addons/stock/wizard/stock_picking_return.py
@@ -118,7 +118,7 @@ class StockReturnPicking(models.TransientModel):
             for move in wizard.picking_id.move_ids:
                 if move.state == 'cancel':
                     continue
-                if move.location_dest_usage == 'inventory':
+                if move.scrap_id:
                     continue
                 product_return_moves_data = dict(product_return_moves_data_tmpl)
                 product_return_moves_data.update(wizard._prepare_stock_return_picking_line_vals_from_move(move))
@@ -224,7 +224,7 @@ class StockReturnPicking(models.TransientModel):
         self.ensure_one()
         for return_move in self.product_return_moves:
             stock_move = return_move.move_id
-            if not stock_move or stock_move.state == 'cancel' or stock_move.location_dest_usage == 'inventory':
+            if not stock_move or stock_move.state == 'cancel' or stock_move.scrap_id:
                 continue
             quantity = stock_move.quantity
             for move in stock_move.move_dest_ids:


### PR DESCRIPTION
*: mrp, purchase_mrp, purchase_stock, sale_mrp, sale_stock

This PR is a follow-up of odoo/odoo#215517

- Changed the domain for scrapped moves from `location_dest_usage != 'inventory'`
to `scrap_id`, because using the location usage could not distinguish between
scrap moves and inventory adjustment moves.

- Fixed missing scrap location creation when a company is created
before installing Inventory.

- Update validation error messages to reflect the replacement of
`scrap_location` with `Inventory Loss`.

TaskId : 4728397