### PR TITLE
[FIX] website: prevent alt description loss when reopening SEO dialog

### DIFF
--- a/addons/website/static/src/components/dialog/seo.js
+++ b/addons/website/static/src/components/dialog/seo.js
@@ -704,6 +704,7 @@ export class SeoChecks extends Component {
         this.imgUpdated = this.imgUpdated.bind(this);
         onWillStart(async () => {
             this.state.altAttributes = await this.getAltAttributes();
+            seoContext.updatedAlts = [];
         });
         onMounted(() => {
             this.getBrokenLinks();


### PR DESCRIPTION
Steps to reproduce:
1. Open Optimize SEO.
2. Mark an image as decorative.
3. Give a description(ALT) to that image from editor.
4. Open Optimize SEO again and save without doing anything.

Issue:
The description(ALT) on the image being set is lost.

Cause:
When reopening the `Optimize SEO` dialog, `seoContext.updatedAlts` still contained entries from previous edits. As a result, saving without making any further change triggered an call to `/website/update_alt_images` which reset the `alt` attribute to empty, effectively discarding the description.

This PR ensures `seoContext.updatedAlts` is reset when opening the dialog.