### PR TITLE
[FIX] l10n_in_hr_holidays: update sandwich rule and half-day calculations

### DIFF
--- a/addons/l10n_in_hr_holidays/models/hr_leave.py
+++ b/addons/l10n_in_hr_holidays/models/hr_leave.py
@@ -16,7 +16,7 @@ class HolidaysRequest(models.Model):
             return
         date_from = self.request_date_from
         date_to = self.request_date_to
-        total_leaves = (self.request_date_to - self.request_date_from).days + 1
+        total_leaves = (self.request_date_to - self.request_date_from).days + (0.5 if self.request_unit_half else 1)
 
         def is_non_working_day(calendar, date):
             return not calendar._works_on_date(date) or any(
@@ -36,14 +36,12 @@ class HolidaysRequest(models.Model):
 
         calendar = self.resource_calendar_id
         total_leaves += count_sandwich_days(calendar, date_from, -1) + count_sandwich_days(calendar, date_to, 1)
-        if is_non_working_day(calendar, date_from):
+        while is_non_working_day(calendar, date_from):
             total_leaves -= 1
-            if is_non_working_day(calendar, date_from + timedelta(days=+1)):
-                total_leaves -= 1
-        if is_non_working_day(calendar, date_to):
+            date_from += timedelta(days=1)
+        while is_non_working_day(calendar, date_to):
             total_leaves -= 1
-            if is_non_working_day(calendar, date_to + timedelta(days=-1)):
-                total_leaves -= 1
+            date_to -= timedelta(days=1)
         return total_leaves
 
     def _get_durations(self, check_leave_type=True, resource_calendar=None):

--- a/addons/l10n_in_hr_holidays/tests/test_sandwich_leave.py
+++ b/addons/l10n_in_hr_holidays/tests/test_sandwich_leave.py
@@ -78,3 +78,34 @@ class TestSandwichLeave(TransactionCase):
         })
         approved_leave.action_approve()
         self.assertIsNotNone(approved_leave.with_user(self.demo_user).leave_type_increases_duration)
+
+    def test_long_sandwich_leave(self):
+        public_holiday = self.env['resource.calendar.leaves'].create({
+            'name': "Independence Day",
+            'date_from': "2025-08-15",
+            'date_to': "2025-08-15",
+            'resource_id': False,
+            'company_id': self.indian_company.id,
+        })
+        holiday_leave = self.env['hr.leave'].create({
+            'name': "Test Leave",
+            'employee_id': self.demo_employee.id,
+            'holiday_status_id': self.leave_type.id,
+            'request_date_from': "2025-08-13",
+            'request_date_to': "2025-08-17",
+        })
+        leave = holiday_leave._l10n_in_apply_sandwich_rule(public_holiday, holiday_leave)
+        self.assertEqual(leave, 2, "The total leaves should be 2")
+
+    def test_half_day_leave(self):
+        half_leave = self.env['hr.leave'].create({
+                'name': "Half Day Leave",
+                'employee_id': self.demo_employee.id,
+                'holiday_status_id': self.leave_type.id,
+                'request_date_from': "2025-08-29",
+                'request_date_to': "2025-08-29",
+                'request_unit_half': True
+            })
+
+        leave = half_leave._get_durations()
+        self.assertEqual(leave[half_leave.id][0], 0.5, "The total leaves should be 0.5")


### PR DESCRIPTION
**Steps to reproduce:**
- Install l10n_in and l10n_in_hr_holidays module
- Time off > configuration > Public holidays
- Create a public holiday for Independence Day (15/08/2025)
- Go to Time off > configuration > 'Time off Types',
- Create a Time off type with
   - 'Sandwich leave' ticked and `Take Time Off in` to half a day
- Go to Time off > Management > Time off
- Case 1: Create a paid time off leave for the employee from 13/08 to 17//08/2025 
- Case 2: Create a paid time off with any date and mark it as a half-day

**Observation:**
- Case 1: You will see Duration 3 days with the sandwich leave policy.
- Case 2: Half-day leave shows 1 day instead of 0.5

**Root Cause:**
- Case 1: For the sandwich leave rule, here we checked only one day after and before, leave start and leave end, respectively. It will cause an issue if an employee applies leave that starts or ends with 3 non-working days.
https://github.com/odoo/odoo/blob/5d2f1510c08d5570fc2c6c8de0cb4042bacf12d6/addons/l10n_in_hr_holidays/models/hr_leave.py#L39-L46
- Case 2: We forcefully added a 1-day leave, without checking if the leave is half day or not.
https://github.com/odoo/odoo/blob/5d2f1510c08d5570fc2c6c8de0cb4042bacf12d6/addons/l10n_in_hr_holidays/models/hr_leave.py#L19

**Solution:**
- Case 1: Extend the sandwich leave logic to check every day before and after until a working day is found.
- Case 2: Fixed duration calculation to add 0.5 for half-day leaves.

opw-5025766

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
