### PR TITLE
[FIX] mrp: add move line when workorder is in progress

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -923,6 +923,10 @@ class MrpProduction(models.Model):
                     moves_to_reassign |= production.move_raw_ids
 
         res = super(MrpProduction, self).write(vals)
+        if any(wo.state == "progress" for wo in self.workorder_ids) and any(move.state == "assigned" for move in self.move_raw_ids) and "move_raw_ids" in vals:
+            for i in range(len(vals['move_raw_ids'])):
+                if any(isinstance(x, dict) and x.get("state") == "draft" for x in vals['move_raw_ids'][0]):
+                    self.move_raw_ids[-(i + 1)].state = 'draft'
 
         for production in self:
             if 'date_start' in vals and not self.env.context.get('force_date', False):


### PR DESCRIPTION
_______________________________________
## Short functional explanation of the error
After starting a work order on a manufacturing order, it is possible to add products in the component tab. However, the corresponding move line won't be created.

## Reproduction Steps
1. Create a Bom for a product. Set a component and an operation.
2. Create a new Manufacturing order. Select a product and a quantity. The corresponding components and
work order should fill automatically.
3. Click on confirm. Click on Work Orders tab and start the timer.
4. Add a new line with a product already in the form.

### Expected behavior
When clicking on Product Move, an additional move
line should be present.

### Unexpected behavior
No new move line is created.

## Origin of the issue
In the file stock_move.py, a check is performed
to change the state of the move.
https://github.com/odoo/odoo/blob/0a1f10929cc6bd20012d2060493b86ee2a20befc/addons/stock/models/stock_move.py#L2158-L2159

However, it doesn't take into account this corner
case, as it automatically sets the move at assigned, which prevents the move to be created. Indeed, in
order to be created, the code has to go through this: https://github.com/odoo/odoo/blob/0a1f10929cc6bd20012d2060493b86ee2a20befc/addons/mrp/models/mrp_production.py#L1354-L1356 _________________________________________
opw-5034409

---




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
