### PR TITLE
[IMP] web: calendar: uniform cursor during interactions

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_popover.scss
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_popover.scss
@@ -118,3 +118,18 @@ $o-web-calendar-colors: o-build-web-calendar-colors();
         }
     }
 }
+
+.o_interacting .fc-event,
+.o_interacting .fc-day,
+.o_interacting .fc-more-link {
+    cursor: inherit !important;
+}
+
+.o_multi_create_mode.o_selecting,
+.o_multi_create_mode .fc-day {
+    cursor: cell;
+}
+
+.o_grabbing {
+    cursor: move;
+}

--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
@@ -12,7 +12,7 @@ import { useCalendarPopover } from "@web/views/calendar/hooks/calendar_popover_h
 import { useFullCalendar } from "@web/views/calendar/hooks/full_calendar_hook";
 import { useSquareSelection } from "@web/views/calendar/hooks/square_selection_hook";
 
-import { Component, useEffect } from "@odoo/owl";
+import { Component, useEffect, useRef } from "@odoo/owl";
 
 const SCALE_TO_FC_VIEW = {
     day: "timeGridDay",
@@ -85,6 +85,8 @@ export class CalendarCommonRenderer extends Component {
             },
             () => [this.fc.el]
         );
+
+        this.ref = useRef("fullCalendar");
         useSquareSelection({
             cellIsSelectable: this.constructor.cellIsSelectable,
         });
@@ -334,6 +336,7 @@ export class CalendarCommonRenderer extends Component {
     onEventDrop(info) {
         this.fc.api.unselect();
         this.props.model.updateRecord(this.fcEventToRecord(info.event));
+        this.ref.el.classList.remove("o_interacting", "o_grabbing");
     }
     onEventResize(info) {
         this.fc.api.unselect();
@@ -383,6 +386,7 @@ export class CalendarCommonRenderer extends Component {
         info.el.classList.add(info.view.type);
         this.fc.api.unselect();
         this.highlightEvent(info.event, "o_cw_custom_highlight");
+        this.ref.el.classList.add("o_interacting", "o_grabbing");
     }
     onEventResizeStart(info) {
         this.props.cleanSquareSelection();

--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.xml
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.CalendarCommonRenderer">
-        <div class="o_calendar_widget" t-ref="fullCalendar" />
+        <div class="o_calendar_widget" t-att-class="{ o_multi_create_mode: this.props.model.hasMultiCreate }" t-ref="fullCalendar" />
     </t>
 
     <t t-name="web.CalendarCommonRenderer.event">

--- a/addons/web/static/src/views/calendar/hooks/square_selection_hook.js
+++ b/addons/web/static/src/views/calendar/hooks/square_selection_hook.js
@@ -97,6 +97,9 @@ const useBlockSelection = makeDraggableHook({
     onDrop({ ctx }) {
         return getSelectedCellsInBlock(ctx);
     },
+    onDragEnd() {
+        return {};
+    },
 });
 
 export function useSquareSelection(params = {}) {
@@ -155,6 +158,7 @@ export function useSquareSelection(params = {}) {
             prevSelectedCell = null;
             action = ctrlPressed ? "add" : "replace";
             update({ selectedCells });
+            ref.el.classList.add("o_interacting", "o_selecting");
         },
         onDrag: update,
         onDrop: ({ selectedCells }) => {
@@ -162,6 +166,9 @@ export function useSquareSelection(params = {}) {
             action = null;
             highlight({ selectedCells: allSelectedCells });
             component.props.onSquareSelection([...allSelectedCells]);
+        },
+        onDragEnd() {
+            ref.el.classList.remove("o_interacting", "o_selecting");
         },
     });
 


### PR DESCRIPTION
In multi create mode, the cursor on a cell will now be cell. We also make the cursor be more consistent. Before this commit, start an interaction (i.e. a drag & drop) and hover various elements during that interaction would change the cursor according to the type of hovered elements. Now the cursor is constant through the duration of the interaction and related to the type of interaction.

Task ID: 5076037