### PR TITLE
[FIX] pos_restaurant_urban_piper : Correct name spelling

### DIFF
--- a/odoo/addons/base/i18n/base.pot
+++ b/odoo/addons/base/i18n/base.pot
@@ -29526,7 +29526,7 @@ msgstr ""
 
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_pos_restaurant_urban_piper
-msgid "POS Restaurant Urban Piper"
+msgid "POS Restaurant UrbanPiper"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/zh_TW.po
+++ b/odoo/addons/base/i18n/zh_TW.po
@@ -35457,8 +35457,8 @@ msgstr "POS 餐廳 Stripe"
 
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_pos_restaurant_urban_piper
-msgid "POS Restaurant Urban Piper"
-msgstr "POS 餐廳 Urban Piper"
+msgid "POS Restaurant UrbanPiper"
+msgstr "POS 餐廳 UrbanPiper"
 
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_pos_self_order


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Correct the spelling 

Current behavior before PR:

Urban Piper was in 2 words. No space needed 

Desired behavior after PR is merged:

UrbanPiper in one word


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
