### PR TITLE
[FIX] website: blog tags do not get removed on refresh or search

### DIFF
--- a/addons/website_blog/controllers/main.py
+++ b/addons/website_blog/controllers/main.py
@@ -183,11 +183,20 @@ class WebsiteBlog(http.Controller):
 
         date_begin, date_end = opt.get('date_begin'), opt.get('date_end')
 
-        if tag and request.httprequest.method == 'GET':
-            # redirect get tag-1,tag-2 -> get tag-1
+        # Checking referrer and search to see if the GET request is from
+        # a SEO bot, in which case every tag but one should be removed to
+        # avoid combinatorial explosion
+        if tag and request.httprequest.method == 'GET' and request.env['ir.http'].is_a_bot():
+            # Redirect `tag-1,tag-2` to `tag-1` to disallow multi tags
+            # in GET request for proper bot indexation;
             tags = tag.split(',')
             if len(tags) > 1:
                 url = QueryURL('' if blog else '/blog', ['blog', 'tag'], blog=blog, tag=tags[0], date_begin=date_begin, date_end=date_end, search=search)()
+                # The vast majority of bots will follow the links in the
+                # client side, which are protected by the nofollow
+                # attribute of the tags links
+                # This redirect is used to stop combinatorial explosions
+                # from bots that send direct requests
                 return request.redirect(url, code=302)
 
         values = self._prepare_blog_values(blogs=blogs, blog=blog, tags=tag, page=page, search=search, **opt)


### PR DESCRIPTION
Before the change in the blog/slides pages of a website every tag but one disappears when opening the editor or when the search bar is used.

Steps to reproduce:

- Log in Odoo with a user that can access the website editor Open the Website
- Install the blog app if it is not already present
- Open the blog app
- Click on two or more tags to add them to the filter Open the Website editor or use the search bar
- Every tag but one will be removed

After the change all the tags will be kept when opening the editor or using the searchbar.

task-4216129
Fixes #164577
