### PR TITLE
[FIX] iot_drivers: clean old lockfile before checkout

### DIFF
--- a/addons/iot_box_image/overwrite_after_init/etc/rc.local
+++ b/addons/iot_box_image/overwrite_after_init/etc/rc.local
@@ -41,6 +41,7 @@ localremote=$(sudo -u odoo git config branch.$localbranch.remote)
 mount -o remount,rw /
 mount -o remount,rw /root_bypass_ramdisks
 
+sudo -u odoo rm -f /home/pi/odoo/.git/shallow.lock
 sudo -u odoo git remote set-url "${localremote}" "https://github.com/odoo/odoo.git"
 
 sudo -u odoo GIT_SSL_NO_VERIFY=1 git fetch "${localremote}" "${localbranch}" --depth=1

--- a/addons/iot_drivers/tools/upgrade.py
+++ b/addons/iot_drivers/tools/upgrade.py
@@ -10,6 +10,7 @@ from odoo.addons.iot_drivers.tools.helpers import (
     path_file,
     require_db,
     toggleable,
+    unlink_file,
     writable,
 )
 
@@ -99,6 +100,7 @@ def check_git_branch(server_url=None):
         _logger.info("IoT Box git branch: %s / Associated Odoo db's git branch: %s", local_branch, db_branch)
 
         if db_branch != local_branch:
+            unlink_file("odoo/.git/shallow.lock")  # In case of previous crash/power-off, clean old lockfile
             with writable():
                 # Repository updates
                 checkout(db_branch)


### PR DESCRIPTION
Before this commit, if the IoT box were to crash or lose power during a git checkout, it would then become stuck unable to checkout again due to the lockfile never being deleted.

After this commit, we remove the lockfile if it exists to ensure we can't get stuck in this way.

task-5059113

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
