### PR TITLE
[FIX] hr: fix employee avatar size

### DIFF
--- a/addons/hr/views/hr_employee_public_views.xml
+++ b/addons/hr/views/hr_employee_public_views.xml
@@ -43,7 +43,7 @@
                         </div>
                         <div class="row flex-column flex-sm-row align-items-center">
                             <div class="o_employee_avatar ms-2 p-0 h-100 mw-25 align-self-start align-self-sm-center">
-                                <field name="image_1920" widget='image' class="m-0" options='{"zoom": true, "preview_image":"avatar_128"}'/>
+                                <field name="image_1920" widget='image' class="m-0" options='{"size": [128,158], "zoom": true, "preview_image":"avatar_128"}'/>
                                 <field name="show_hr_icon_display" invisible="1" />
                             </div>
                             <div class="align-self-start o_employee_form_header_info">

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -112,7 +112,7 @@
                         </div>
                         <div class="row flex-column flex-sm-row align-items-center">
                             <div class="o_employee_avatar ms-2 p-0 h-100 mw-25 align-self-start align-self-sm-center">
-                                <field name="image_1920" widget='image' class="m-0" options='{"zoom": true, "preview_image":"avatar_128"}'/>
+                                <field name="image_1920" widget='image' class="m-0" options='{"size": [128,158], "zoom": true, "preview_image":"avatar_128"}'/>
                                 <field name="show_hr_icon_display" invisible="1" />
                             </div>
                             <div class="align-self-start o_employee_form_header_info">


### PR DESCRIPTION
The changes made in this PR: https://github.com/odoo/odoo/pull/215597 were wrongly reverted in this PR: https://github.com/odoo/odoo/pull/218194 This PR re-introduces the changes (the employee avatar image has a fixed size).

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
