### PR TITLE
[IMP] project: hide task templates from portal users

### DIFF
--- a/addons/project/security/project_security.xml
+++ b/addons/project/security/project_security.xml
@@ -202,6 +202,7 @@
         <field name="model_id" ref="project.model_project_task"/>
         <field name="domain_force">[
             ('project_id.privacy_visibility', 'in', ['invited_users', 'portal']),
+            ('has_template_ancestor', '=', False),
             ('active', '=', True),
             '|',
                 ('message_partner_ids', 'child_of', [user.partner_id.commercial_partner_id.id]),
@@ -223,6 +224,7 @@
         <field name="active">0</field>
         <field name="domain_force">[
             ('project_id.privacy_visibility', 'in', ['invited_users', 'portal']),
+            ('has_template_ancestor', '=', False),
             ('active', '=', True),
             '|',
                 ('message_partner_ids', 'child_of', [user.partner_id.commercial_partner_id.id]),


### PR DESCRIPTION
- Refined the domain of portal task record rules (`project_task_rule_portal` and `project_task_rule_portal_project_sharing`) by adding the condition `('has_template_ancestor', '=', False)`. This ensures that tasks are excluded from portal user views and cannot be accessed via the portal access and project sharing.

task-5079337

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
