### PR TITLE
19.0 read bypass search access krma

### DIFF
--- a/addons/mail/models/mail_activity_mixin.py
+++ b/addons/mail/models/mail_activity_mixin.py
@@ -48,7 +48,6 @@ class MailActivityMixin(models.AbstractModel):
 
     activity_ids = fields.One2many(
         'mail.activity', 'res_id', 'Activities',
-        bypass_search_access=True,
         groups="base.group_user",)
     activity_state = fields.Selection([
         ('overdue', 'Overdue'),

--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -928,6 +928,8 @@ class One2many(_RelationalMulti):
         comodel = records.env[self.comodel_name].with_context(**context)
         inverse = self.inverse_name
         inverse_field = comodel._fields[inverse]
+        if self.bypass_search_access:
+            comodel = comodel.sudo()
 
         # optimization: fetch the inverse and active fields with search()
         domain = self.get_comodel_domain(records) & Domain(inverse, 'in', records.ids)
@@ -1355,6 +1357,8 @@ class Many2many(_RelationalMulti):
         context = {'active_test': False}
         context.update(self.context)
         comodel = records.env[self.comodel_name].with_context(**context)
+        if self.bypass_search_access:
+            comodel = comodel.sudo()
 
         # make the query for the lines
         domain = self.get_comodel_domain(records)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:

Alternative to #226845. Align the behavior of o2m and m2m. 

Todo: test performance for activities. It seems that having access to a record does not grant access to all linked activities? To check this as well. 

Closes #226845

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
