### PR TITLE
[FIX] calendar: compute stop date when updating start in quick-edit

### DIFF
--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -343,6 +343,12 @@
                 </div>
                 <div class="d-flex align-items-center" colspan="2">
                     <i class="fa fa-clock-o text-600" title="Dates"/>
+                    <!--when "stop" is set manually, "duration" is computed. When "start" is changed
+                    "stop" is computed based on the previously-computed "duration". Hence we need to
+                    keep the last computed duration in the front-end model and send it with "start"
+                    when it changes-->
+                    <!--field is also used for custom behavior in default_get, check before removing-->
+                    <field name="duration" invisible="1" force_save="1"/>
                     <field name="start" nolabel="1"
                         widget="daterange" options="{'end_date_field': 'stop'}"
                         placeholder="Dates" class="w-100 mb-0"


### PR DESCRIPTION
`CalendarEvent._compute_stop` relies on "duration" being somehow available when "start" is changed. In quick-create, where the duration is not stored we need to "store" it in the front-end between onchange calls.

For this reason "duration" needs to be force_save and invisible on the view so that it is not recomputed each time. Which otherwise defeats the purpose of the feature.

In appointment duration is also used in default_get hence fetching a default value for it by having it in view actually changes the behavior of the default values. Though this can be mitigated in other, more reliable ways, this fix is sufficient for that case too.

The field was removed during view refactoring in
odoo/enterprise@c8eb4fe4ba9938b1c7e07034e6ca7c08a0d6f215
and 81e51985f2e01ee3ff115477ab324e2ad75a1b77

task-5081903
