### PR TITLE
[FIX] website_sale: do not allow autocomplete use_delivery_as_billing

### DIFF
--- a/addons/portal/views/address_templates.xml
+++ b/addons/portal/views/address_templates.xml
@@ -52,6 +52,7 @@
                             id="use_delivery_as_billing"
                             class="form-check-input"
                             t-att-checked="use_delivery_as_billing"
+                            autocomplete="off"
                         /> Same as delivery address
                     </label>
                 </div>


### PR DESCRIPTION
Steps to reproduce:
1) Add a product and go to checkout
2) Uncheck use_delivery_as_billing
3) Click to edit the main address for example
4) Return to the previous page via the browser button 'back'

See that use_delivery_as_billing is unchecked but the billing address row is hidden, it happens due to the browser's autocomplete.
