### PR TITLE
[IMP] stock: show 'On Hand' in qty smartbutton when UoMs are disabled

### DIFF
--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -342,6 +342,7 @@
                                     <div class="o_field_widget o_stat_info flex-column align-items-start gap-1">
                                         <span class="o_stat_value">
                                             <field name="uom_name" widget="statinfo" nolabel="1" groups="uom.group_uom"/>
+                                            <span groups="!uom.group_uom">On Hand</span>
                                         </span>
                                         <span class="o_stat_value text-muted">
                                             Forecasted


### PR DESCRIPTION
Backport of #226418, as the target should have been `19.0` in the first place :man_facepalming: 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
