### PR TITLE
[IMP] web, *: adapt field alignment in list view

### DIFF
--- a/addons/hr_recruitment/wizard/applicant_refuse_reason_views.xml
+++ b/addons/hr_recruitment/wizard/applicant_refuse_reason_views.xml
@@ -6,7 +6,7 @@
             <field name="arch" type="xml">
                 <form string="Refuse Reason" disable_autofocus="true">
                     <group col="1">
-                        <field name="refuse_reason_id" string="Reason" widget="selection_badge" options="{'horizontal': true, 'no_create': True, 'no_open': True}"/>
+                        <field name="refuse_reason_id" string="Reason" widget="selection_badge" options="{'horizontal': true, 'no_create': True, 'no_open': True}" class="mb-3"/>
                         <group invisible="not refuse_reason_id">
                             <field name="duplicates"
                                 widget="boolean_toggle"

--- a/addons/web/static/src/views/fields/badge_selection/badge_selection_field.xml
+++ b/addons/web/static/src/views/fields/badge_selection/badge_selection_field.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.BadgeSelectionField">
-        <div class="d-flex flex-wrap gap-1 mb-3">
+        <div class="d-flex flex-wrap gap-1">
             <t t-if="props.readonly">
                 <span t-esc="string" t-att-raw-value="value" />
             </t>

--- a/addons/web/static/src/views/fields/badge_selection/list_badge_selection_field.xml
+++ b/addons/web/static/src/views/fields/badge_selection/list_badge_selection_field.xml
@@ -2,9 +2,6 @@
 <templates xml:space="preserve">
 
     <t t-name="web.ListBadgeSelectionField" t-inherit="web.BadgeSelectionField" t-inherit-mode="primary">
-        <xpath expr="//div" position="attributes">
-            <attribute name="class" separator=" " remove="mb-3"/>
-        </xpath>
         <xpath expr="//t[@t-if='props.readonly']/span[@t-esc='string']" position="attributes">
             <attribute name="class">badge rounded-pill</attribute>
             <attribute name="t-att-class">getBadgeClassNames()</attribute>

--- a/addons/web/static/src/views/fields/state_selection/state_selection_field.scss
+++ b/addons/web/static/src/views/fields/state_selection/state_selection_field.scss
@@ -6,3 +6,9 @@
         width: $h3-font-size;
     }
 }
+
+.o_list_renderer {
+    .o_field_state_selection {
+        margin-top: map-get($spacers, 1);
+    }
+}


### PR DESCRIPTION
Prior to this commit, when the `stage_id` and `state_selection` fields were rendered in a list view, they caused a misalignment.

This commit adapts these fields for the list view.

task-5073054

Example here : `/odoo/project/20/tasks/127/sale.order/81/127/all-tickets`

| Before | After |
|--------|--------|
| <img width="1922" height="638" alt="Capture d’écran 2025-09-29 à 08 42 36" src="https://github.com/user-attachments/assets/41a6d9d0-59b2-4fcc-8f6c-f66e830cec73" /> | <img width="1921" height="685" alt="Capture d’écran 2025-09-29 à 08 41 58" src="https://github.com/user-attachments/assets/78b6af1d-9fbf-4e85-93eb-6f9f1ac0794a" /> |
| <img width="1923" height="635" alt="Capture d’écran 2025-09-29 à 08 44 17" src="https://github.com/user-attachments/assets/a36832af-7027-4713-8610-0d188d6f0fee" /> | <img width="1921" height="553" alt="Capture d’écran 2025-09-29 à 08 44 11" src="https://github.com/user-attachments/assets/2f420e88-3c35-434d-9051-33fcdcef7faa" /> |







---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
