### PR TITLE
[FIX] * : allow applying shapes on GIF images

### DIFF
--- a/addons/html_builder/static/src/plugins/image/image_size.js
+++ b/addons/html_builder/static/src/plugins/image/image_size.js
@@ -30,9 +30,6 @@ export class ImageSize extends BaseOptionComponent {
                 imageCacheSize.set(src, size);
             }
         }
-        if (size === undefined) {
-            return;
-        }
         return `${(size / 1024).toFixed(1)} kB`;
     }
 }

--- a/addons/website/static/tests/builder/image_shape.test.js
+++ b/addons/website/static/tests/builder/image_shape.test.js
@@ -3,7 +3,7 @@ import { animationFrame, queryFirst, waitFor } from "@odoo/hoot-dom";
 import { contains } from "@web/../tests/web_test_helpers";
 import { defineWebsiteModels, setupWebsiteBuilder } from "./website_helpers";
 import { delay } from "@web/core/utils/concurrency";
-import { testImg } from "./image_test_helpers";
+import { testGifImg, testImg } from "./image_test_helpers";
 
 defineWebsiteModels();
 
@@ -40,6 +40,42 @@ test("Should set a shape on an image", async () => {
     expect(":iframe .test-options-target img").toHaveAttribute(
         "data-file-name",
         "s_text_image.svg"
+    );
+    expect(":iframe .test-options-target img").toHaveAttribute("data-shape-colors", ";;;;");
+});
+test("Should set a shape on a GIF image", async () => {
+    const { getEditor } = await setupWebsiteBuilder(`
+        <div class="test-options-target">
+            ${testGifImg}
+        </div>
+    `);
+    const editor = getEditor();
+
+    await contains(":iframe .test-options-target img").click();
+    await contains("[data-label='Shape'] .dropdown").click();
+    await contains("[data-action-value='html_builder/geometric/geo_shuriken']").click();
+    // ensure the shape has been applied
+    await editor.shared.operation.next(() => {});
+
+    const img = queryFirst(":iframe .test-options-target img");
+    expect(":iframe .test-options-target img").toHaveAttribute("data-original-id", "456");
+    expect(":iframe .test-options-target img").toHaveAttribute("data-mimetype", "image/svg+xml");
+    expect(img.src.startsWith("data:image/svg+xml;base64,")).toBe(true);
+    expect(":iframe .test-options-target img").toHaveAttribute(
+        "data-original-src",
+        "/website/static/src/img/snippets_options/header_effect_fade_out.gif"
+    );
+    expect(":iframe .test-options-target img").toHaveAttribute(
+        "data-mimetype-before-conversion",
+        "image/gif"
+    );
+    expect(":iframe .test-options-target img").toHaveAttribute(
+        "data-shape",
+        "html_builder/geometric/geo_shuriken"
+    );
+    expect(":iframe .test-options-target img").toHaveAttribute(
+        "data-file-name",
+        "header_effect_fade_out.svg"
     );
     expect(":iframe .test-options-target img").toHaveAttribute("data-shape-colors", ";;;;");
 });

--- a/addons/website/static/tests/builder/image_size.test.js
+++ b/addons/website/static/tests/builder/image_size.test.js
@@ -39,7 +39,7 @@ function expectAround(value, expected, delta = 0.2) {
     expect(value).toBeLessThan(expected + delta);
 }
 
-test("the GIF image should NOT show its size", async () => {
+test("the GIF image should show its size", async () => {
     const { waitDomUpdated } = await setupWebsiteBuilder(`
         <div class="test-options-target">
             ${testGifImg}
@@ -47,10 +47,13 @@ test("the GIF image should NOT show its size", async () => {
     `);
     await contains(":iframe .test-options-target img").click();
     await waitDomUpdated();
-    expect(`[data-label="Image"] [title="Size"]`).toHaveCount(0);
+    const selector = `[data-container-title="Image"] [title="Size"]`;
+    await waitFor(selector);
+    const size = parseFloat(document.querySelector(selector).innerHTML);
+    expectAround(size, 325.2);
 });
 
-test("the GIF background image should NOT show its size", async () => {
+test("the GIF background image should show its size", async () => {
     const { waitDomUpdated } = await setupWebsiteBuilder(`
         <div class="test-options-target">
             <section style="background-image: url(${testGifImgSrc});">text</section>
@@ -58,5 +61,8 @@ test("the GIF background image should NOT show its size", async () => {
     `);
     await contains(":iframe .test-options-target section").click();
     await waitDomUpdated();
-    expect(`[data-label="Image"] [title="Size"]`).toHaveCount(0);
+    const selector = `[data-label="Image"] [title="Size"]`;
+    await waitFor(selector);
+    const size = parseFloat(document.querySelector(selector).innerHTML);
+    expectAround(size, 325.2);
 });


### PR DESCRIPTION
\* = html_builder, html_editor, website

Before this fix, applying a shape on a GIF image in the website editor
failed.

The issue came from the `_processImage` function, which is called before
applying a shape. In this function, GIFs were handled as a special case,
but that branch returned a different value than expected, causing the
shape application to fail on GIFs.

This commit fixes the return value for the GIF-specific branch so it
matches the expected structure, making shape application work
consistently across all image types.

As a side effect, this also fixes the display of GIF file sizes in the
website editor. When selecting an image or setting one as a background,
the builder sidebar normally shows the image size. For GIFs, it showed
"NaN kb" due to the same broken function.
A past [PR](https://github.com/odoo/odoo/pull/223424) worked around this by hiding sizes for GIFs entirely. Since the
root cause is now fixed, the size is correctly displayed again.

task-[5071548](https://www.odoo.com/odoo/project/974/tasks/5071548)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
