### PR TITLE
[FIX] mail: fixes runbot error 66304

### DIFF
--- a/addons/mail/static/tests/crosstab/crosstab.test.js
+++ b/addons/mail/static/tests/crosstab/crosstab.test.js
@@ -11,6 +11,8 @@ import {
 import { describe, test } from "@odoo/hoot";
 import { press } from "@odoo/hoot-dom";
 import { mockDate } from "@odoo/hoot-mock";
+
+import { inputFiles } from "@web/../tests/utils";
 import {
     asyncStep,
     getService,
@@ -18,8 +20,6 @@ import {
     serverState,
     waitForSteps,
 } from "@web/../tests/web_test_helpers";
-
-import { rpc } from "@web/core/network/rpc";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -114,7 +114,7 @@ test.skip("Channel subscription is renewed when channel is added from invite", a
 test("Adding attachments", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "Hogwarts Legacy" });
-    const messageId = pyEnv["mail.message"].create({
+    pyEnv["mail.message"].create({
         body: "Hello world!",
         model: "discuss.channel",
         res_id: channelId,
@@ -124,15 +124,18 @@ test("Adding attachments", async () => {
     const env2 = await start({ asTab: true });
     await openDiscuss(channelId, { target: env1 });
     await openDiscuss(channelId, { target: env2 });
-    const attachmentId = pyEnv["ir.attachment"].create({
-        name: "test.txt",
-        mimetype: "text/plain",
-    });
-    rpc("/mail/message/update_content", {
-        body: "Hello world!",
-        attachment_ids: [attachmentId],
-        message_id: messageId,
-    });
+    const file = new File(["file content"], "test.txt", { type: "text/plain" });
+    await contains(`${env1.selector} .o-mail-Message:contains('Hello world!')`);
+    await contains(`${env2.selector} .o-mail-Message:contains('Hello world!')`);
+    await click(`${env1.selector} .o-mail-Message button[title='Edit']`);
+    await click(`${env1.selector} .o-mail-Message .o-mail-Composer button[title='More Actions']`);
+    await click(`${env1.selector} .o_popover button[name='upload-files']`);
+    await inputFiles(`${env1.selector} .o-mail-Message .o-mail-Composer .o_input_file`, [file]);
+    await contains(
+        `${env1.selector} .o-mail-AttachmentCard:not(.o-isUploading):contains(test.txt) .fa-check`
+    );
+    await click(`${env1.selector} .o-mail-Message .o-mail-Composer a[data-type='save']`);
+
     await contains(
         `${env2.selector} .o-mail-AttachmentCard:not(.o-isUploading):contains(test.txt)`
     );

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -720,7 +720,7 @@ async function mail_message_update_content(request) {
         IrAttachment.write(
             attachments.map((attachment) => attachment.id),
             {
-                model: message.model,
+                res_model: message.model,
                 res_id: message.res_id,
             }
         );


### PR DESCRIPTION
Before this commit, the test could experience a race condition where the load of the message and the update of the content of that message happen at the same time, if that happens and the update of the content is received by bus before the load of the message (which therefore does not contain any attachment), then the store was overriding the attachment.

This commit should solve the problem in the test by waiting for the messages at the beginning of the test as well as updating the attachments in the ui and not by rpc directly.

The race conditions should be fixed globally and are not only linked to this issue.

fixes-runbot-66304

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
