### PR TITLE
[FIX] website_sale_comparison: rollback to the use of `cookies`

### DIFF
--- a/addons/website_sale_comparison/static/src/js/website_sale_comparison_utils.js
+++ b/addons/website_sale_comparison/static/src/js/website_sale_comparison_utils.js
@@ -1,27 +1,26 @@
-const COMPARISON_PRODUCT_IDS_SESSION_NAME = 'comparison_product_ids';
+import { cookie } from '@web/core/browser/cookie';
+
+const COMPARISON_PRODUCT_IDS_COOKIE_NAME = 'comparison_product_ids';
 const MAX_COMPARISON_PRODUCTS = 4;
 const COMPARISON_EVENT = 'comparison_products_changed'
 
 /**
- * Get the IDs of the products to compare from the session.
+ * Get the IDs of the products to compare from the cookie.
  *
  * @return {Array<number>} The IDs of the products to compare.
  */
 function getComparisonProductIds() {
-    return JSON.parse(sessionStorage.getItem(COMPARISON_PRODUCT_IDS_SESSION_NAME) || '[]');
+    return JSON.parse(cookie.get(COMPARISON_PRODUCT_IDS_COOKIE_NAME) || '[]');
 }
 
 /**
- * Set the IDs of the products to compare in the session.
+ * Set the IDs of the products to compare in the cookie.
  *
  * @param {ArrayLike<number>} productIds The IDs of the products to compare.
  * @param {EventBus} bus
  */
 function setComparisonProductIds(productIds, bus) {
-    sessionStorage.setItem(
-        COMPARISON_PRODUCT_IDS_SESSION_NAME,
-        JSON.stringify(Array.from(productIds),
-    ));
+    cookie.set(COMPARISON_PRODUCT_IDS_COOKIE_NAME, JSON.stringify(Array.from(productIds)));
     notifyComparisonListeners(bus);
 }
 
@@ -56,7 +55,7 @@ function removeComparisonProduct(productId, bus) {
  */
 function clearComparisonProducts(bus) {
     const productIds = getComparisonProductIds();
-    sessionStorage.removeItem(COMPARISON_PRODUCT_IDS_SESSION_NAME);
+    cookie.delete(COMPARISON_PRODUCT_IDS_COOKIE_NAME);
     notifyComparisonListeners(bus);
     enableDisabledProducts(productIds);
 }


### PR DESCRIPTION
This PR rollback to the use of `cookies` instead of `sessionStorage` for the products comparison features. With Commit[^1], we introduced a fresh new look for the comparison feature, and this redesign included switching from `cookies` to `sessionStorage`. Unfortunately, this approach presents downside (e.g when using multiple tabs).

To avoid any issue, we switch back to the use of `cookies`.

task-5086187

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
[^1]: https://github.com/odoo/odoo/commit/524c968eb647a65119a935ed820602b57820a418
