### PR TITLE
[FIX] stock: correctly display description when using product name

### DIFF
--- a/addons/stock/static/src/views/picking_form/stock_move_product_label.js
+++ b/addons/stock/static/src/views/picking_form/stock_move_product_label.js
@@ -14,8 +14,8 @@ export class MoveProductLabelField extends ProductNameAndDescriptionField {
         const record = this.props.record.data;
         let label = record[this.descriptionColumn];
         const productName = record.product_id.display_name;
-        if (label.includes(productName)) {
-            label = label.replace(productName, "");
+        if (label === productName) {
+            label = "";
         }
         return label.trim();
     }


### PR DESCRIPTION
Steps to reproduce:
- Create a product
- Set a description for receipts that uses the product name somewhere in the text
- Create a reception for that product

Issue:
The product name will be removed from the reception instructions.

The intended behavior was to avoid displaying the same information if the description was the same as the product's display_name. So we only check that now, rahter than do a replace in the description.

Task-4901289

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
