### PR TITLE
[FIX] html_editor: prevent color applied on non-editable file box

### DIFF
--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -204,7 +204,6 @@ export class SelectionPlugin extends Plugin {
     resources = {
         user_commands: { id: "selectAll", run: this.selectAll.bind(this) },
         shortcuts: [{ hotkey: "control+a", commandId: "selectAll" }],
-        is_node_editable_predicates: (node) => node.parentElement?.isContentEditable,
     };
 
     setup() {
@@ -1029,7 +1028,13 @@ export class SelectionPlugin extends Plugin {
     }
 
     isNodeEditable(node) {
-        return this.getResource("is_node_editable_predicates").some((p) => p(node));
+        const results = this.getResource("is_node_editable_predicates")
+            .map((p) => p(node))
+            .filter((r) => r !== undefined);
+        if (!results.length) {
+            return node.parentElement?.isContentEditable;
+        }
+        return results.every((r) => r);
     }
 
     focusEditable() {

--- a/addons/html_editor/static/src/main/media/file_plugin.js
+++ b/addons/html_editor/static/src/main/media/file_plugin.js
@@ -45,6 +45,11 @@ export class FilePlugin extends Plugin {
         selectors_for_feff_providers: () => ".o_file_box",
         functional_empty_node_predicates: (node) =>
             node?.nodeName === "SPAN" && node.classList.contains("o_file_box"),
+        is_node_editable_predicates: (node) => {
+            if (node?.nodeName === "SPAN" && node.classList.contains("o_file_box")) {
+                return false;
+            }
+        },
     };
 
     get recordInfo() {

--- a/addons/html_editor/static/src/main/media/media_plugin.js
+++ b/addons/html_editor/static/src/main/media/media_plugin.js
@@ -8,6 +8,7 @@ import {
     isProtected,
     isProtecting,
     paragraphRelatedElementsSelector,
+    isContentEditable,
 } from "@html_editor/utils/dom_info";
 import { _t } from "@web/core/l10n/translation";
 import { MediaDialog, TABS } from "./media_dialog/media_dialog";
@@ -110,10 +111,12 @@ export class MediaPlugin extends Plugin {
     }
 
     isEditableMediaElement(node) {
-        return (
+        if (
             (isMediaElement(node) || node.nodeName === "IMG") &&
-            node.classList.contains(EDITABLE_MEDIA_CLASS)
-        );
+            (node.classList.contains(EDITABLE_MEDIA_CLASS) || isContentEditable(node))
+        ) {
+            return true;
+        }
     }
 
     replaceImage() {

--- a/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin.js
@@ -48,7 +48,11 @@ export class SyntaxHighlightingPlugin extends Plugin {
         post_redo_handlers: () => this.addCodeBlocks(this.editable, true),
         clean_for_save_handlers: withSequence(0, ({ root }) => this.cleanForSave(root)),
         // Ensure focus can be preserved within the textarea:
-        is_node_editable_predicates: (node) => node?.classList?.contains("o_prism_source"),
+        is_node_editable_predicates: (node) => {
+            if (node?.classList?.contains("o_prism_source")) {
+                return true;
+            }
+        },
     };
 
     setup() {

--- a/addons/html_editor/static/tests/editor.test.js
+++ b/addons/html_editor/static/tests/editor.test.js
@@ -82,6 +82,29 @@ test("Remove odoo-editor-editable class after every plugin is destroyed", async 
     expect.verifySteps(["operation"]);
 });
 
+test("Element is not editable if any plugin marks it non-editable", async () => {
+    class TestPlugin extends Plugin {
+        static id = "test";
+        resources = {
+            is_node_editable_predicates: (node) => {
+                if (node.classList.contains("o-will-break-if-edited")) {
+                    return false;
+                }
+            },
+        };
+    }
+    const Plugins = [...MAIN_PLUGINS, TestPlugin];
+    const { el, plugins } = await setupEditor(
+        `<div>[<img class="o-editable-media o-will-break-if-edited">]</div>`,
+        {
+            config: { Plugins },
+        }
+    );
+    const img = el.querySelector(".o-editable-media");
+    const selectionPlugin = plugins.get("selection");
+    await expect(selectionPlugin.isNodeEditable(img)).toBe(false);
+});
+
 test("clean_for_save_listeners is done last", async () => {
     // This test uses custom elements tag `c-div` to make sure they won't fall into
     // a case where they won't be merged anyway.

--- a/addons/html_editor/static/tests/file.test.js
+++ b/addons/html_editor/static/tests/file.test.js
@@ -12,6 +12,7 @@ import { setupEditor } from "./_helpers/editor";
 import { getContent } from "./_helpers/selection";
 import { insertText } from "./_helpers/user_actions";
 import { execCommand } from "./_helpers/userCommands";
+import { expandToolbar } from "./_helpers/toolbar";
 
 const configWithEmbeddedFile = {
     Plugins: [...MAIN_PLUGINS, ...EMBEDDED_COMPONENT_PLUGINS],
@@ -68,6 +69,28 @@ describe("file command", () => {
         // No download button in file card.
         expect(".o_file_box .fa-download").toHaveCount(0);
     });
+});
+
+test("Should not apply color to file box", async () => {
+    const { editor } = await setupEditor("<p>a[]b</p>", {
+        config: configWithEmbeddedFile,
+    });
+    const mockedUpload = patchUpload(editor);
+    await insertText(editor, "/file");
+    await animationFrame();
+    await press("Enter");
+    await animationFrame();
+    expect(".o_select_media_dialog").toHaveCount(0);
+    await mockedUpload;
+    await press(["Ctrl", "a"]);
+    await animationFrame();
+    await expandToolbar();
+    await click(".o-we-toolbar .o-select-color-foreground");
+    await animationFrame();
+    await click('.o_colorpicker_section [data-color="o-color-1"]');
+    await animationFrame();
+    const fileBox = queryOne(".o_file_box");
+    expect(fileBox).not.toHaveClass("text-o-color-1");
 });
 
 describe("document tab in media dialog", () => {


### PR DESCRIPTION
Problem:
When having the `o_file_box` in the selected nodes and applying color, the file box gets the color applied even though it has `contenteditable=false`.

Cause:
`SelectionPlugin.resources.is_node_editable_predicates` only checks if the parent element is editable for a node. But the node itself can be non-editable even if its parent is editable.

Solution:
Use `isContentEditable` utils which properly check if a node is editable.

Steps to reproduce:
1. Add file.
2. Press CTRL+A and apply a font color.
3. The color style is applied to the node.

opw-5080082

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
