### PR TITLE
[FIX] hr: align state field with city and zip in private address

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -153,9 +153,11 @@
                                         <div class="o_address_format">
                                             <field name="private_street" placeholder="Street..." class="o_address_street"/>
                                             <field name="private_street2" placeholder="Street 2..." class="o_address_street"/>
-                                            <field name="private_city" placeholder="City" class="o_address_city"/>
-                                            <field name="private_state_id" class="o_address_state" placeholder="State" options="{'no_open': True, 'no_quick_create': True}" context="{'default_country_id': private_country_id}"/>
-                                            <field name="private_zip" placeholder="ZIP" class="o_address_zip"/>
+                                            <div class="d-flex align-items-center">
+                                                <field name="private_city" placeholder="City" class="o_address_city"/>
+                                                <field name="private_state_id" class="o_address_state" placeholder="State" options="{'no_open': True, 'no_quick_create': True}" context="{'default_country_id': private_country_id}"/>
+                                                <field name="private_zip" placeholder="ZIP" class="o_address_zip"/>
+                                            </div>
                                             <field name="private_country_id" placeholder="Country" class="o_address_country" options='{"no_open": True, "no_create": True}'/>
                                         </div>
                                         <field name="private_email" placeholder="e.g. myprivateemail@example.com"/>

--- a/addons/hr/views/res_users.xml
+++ b/addons/hr/views/res_users.xml
@@ -137,9 +137,11 @@
                                 <div class="o_address_format">
                                     <field name="private_street" placeholder="Street..." class="o_address_street" readonly="not can_edit"/>
                                     <field name="private_street2" placeholder="Street 2..." class="o_address_street" readonly="not can_edit"/>
-                                    <field name="private_city" placeholder="City" class="o_address_city" readonly="not can_edit"/>
-                                    <field name="private_state_id" class="o_address_state" placeholder="State" options="{'no_open': True, 'no_quick_create': True}" context="{'default_country_id': private_country_id}" readonly="not can_edit"/>
-                                    <field name="private_zip" placeholder="ZIP" class="o_address_zip" readonly="not can_edit"/>
+                                    <div class="d-flex align-items-center">
+                                        <field name="private_city" placeholder="City" class="o_address_city" readonly="not can_edit"/>
+                                        <field name="private_state_id" class="o_address_state" placeholder="State" options="{'no_open': True, 'no_quick_create': True}" context="{'default_country_id': private_country_id}" readonly="not can_edit"/>
+                                        <field name="private_zip" placeholder="ZIP" class="o_address_zip" readonly="not can_edit"/>
+                                    </div>
                                     <field name="private_country_id" placeholder="Country" class="o_address_country" options='{"no_open": True, "no_create": True}' readonly="not can_edit"/>
                                 </div>
                                 <field name="private_email" string="Email" readonly="not can_edit"/>


### PR DESCRIPTION
Wrap private address city, state, and zip fields in a flexbox container to ensure proper horizontal alignment on the employee form view.

task-5082714