### PR TITLE
[FIX] account: hide archived taxes from group by in product view

### DIFF
--- a/addons/account/models/product.py
+++ b/addons/account/models/product.py
@@ -59,6 +59,20 @@ class ProductTemplate(models.Model):
         help="Tags to be set on the base and tax journal items created for this product.")
     fiscal_country_codes = fields.Char(compute='_compute_fiscal_country_codes')
 
+    def _read_group(self, domain, groupby=(), aggregates=(), having=(), offset=0, limit=None, order=None):
+        res = super()._read_group(domain, groupby, aggregates, having, offset, limit, order)
+        if "taxes_id" in groupby:
+            filtered = []
+            for r in res:
+                tax_record = r[0]
+                if not tax_record:
+                    filtered.append(r)
+                else:
+                    if tax_record.active:
+                        filtered.append(r)
+            res = filtered
+        return res
+
     def _get_product_accounts(self):
         return {
             'income': self.property_account_income_id or self.categ_id.property_account_income_categ_id,


### PR DESCRIPTION
**Issue**
When a sales tax is archived, it still shows up as a group when using "Group By → Customer Taxes" in the product list view.

**Steps to Reproduce**
1. Create a new sales tax.
2. Add the new tax onto a product.
3. Archive the sales tax.
4. Go to the product list view and group by Customer Taxes.
5. The archived tax is still displayed as a grouping.

Video for reference:
https://drive.google.com/file/d/1C-OA42UdjP19mPmvyjFnK7JY-kjCr9JL/view

**Root Cause**
Grouping on many2many fields (`taxes_id`) relies on raw SQL queries that fetch all related values, without considering the `active` flag of `account.tax`. As a result, archived taxes linked to products continue to appear as distinct groups.

**Fix**
Override `_read_group` to filter out inactive
taxes from the group-by results, while keeping the "No Tax" bucket
intact. This ensures that only active taxes are available for grouping

Opw-4926227
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
