### PR TITLE
[IMP] l10n_it: removed obsolete l10n_it_tax_exemption_reason

### DIFF
--- a/addons/l10n_it/__manifest__.py
+++ b/addons/l10n_it/__manifest__.py
@@ -2,7 +2,7 @@
 {
     'name': 'Italy - Accounting',
     'countries': ['it'],
-    'version': '0.7',
+    'version': '0.8',
     'depends': [
         'account',
         'base_iban',

--- a/addons/l10n_it/migrations/0.8/pre-migrate.py
+++ b/addons/l10n_it/migrations/0.8/pre-migrate.py
@@ -1,0 +1,11 @@
+def migrate(cr, version):
+
+    cr.execute("""
+        UPDATE account_tax
+           SET l10n_it_exempt_reason = CASE
+               WHEN l10n_it_exempt_reason = 'N2' THEN 'N2.2'
+               WHEN l10n_it_exempt_reason = 'N3' THEN 'N3.6'
+               WHEN l10n_it_exempt_reason = 'N6' THEN 'N6.9'
+               END
+          WHERE l10n_it_exempt_reason IN ('N2', 'N3', 'N6')
+    """)

--- a/addons/l10n_it/models/account_tax.py
+++ b/addons/l10n_it/models/account_tax.py
@@ -1,5 +1,5 @@
 from odoo import _, api, fields, models
-from odoo.exceptions import ValidationError, UserError
+from odoo.exceptions import UserError, ValidationError
 from odoo.tools import float_compare
 
 
@@ -9,10 +9,8 @@ class AccountTax(models.Model):
     l10n_it_exempt_reason = fields.Selection(
         selection=[
             ("N1", "[N1] Escluse ex art. 15"),
-            ("N2", "[N2] Non soggette"),
             ("N2.1", "[N2.1] Non soggette ad IVA ai sensi degli artt. Da 7 a 7-septies del DPR 633/72"),
             ("N2.2", "[N2.2] Non soggette - altri casi"),
-            ("N3", "[N3] Non imponibili"),
             ("N3.1", "[N3.1] Non imponibili - esportazioni"),
             ("N3.2", "[N3.2] Non imponibili - cessioni intracomunitarie"),
             ("N3.3", "[N3.3] Non imponibili - cessioni verso San Marino"),
@@ -21,7 +19,6 @@ class AccountTax(models.Model):
             ("N3.6", "[N3.6] Non imponibili - altre operazioni che non concorrono alla formazione del plafond"),
             ("N4", "[N4] Esenti"),
             ("N5", "[N5] Regime del margine / IVA non esposta in fattura"),
-            ("N6", "[N6] Inversione contabile (per le operazioni in reverse charge ovvero nei casi di autofatturazione per acquisti extra UE di servizi ovvero per importazioni di beni nei soli casi previsti)"),
             ("N6.1", "[N6.1] Inversione contabile - cessione di rottami e altri materiali di recupero"),
             ("N6.2", "[N6.2] Inversione contabile - cessione di oro e argento puro"),
             ("N6.3", "[N6.3] Inversione contabile - subappalto nel settore edile"),
@@ -31,7 +28,7 @@ class AccountTax(models.Model):
             ("N6.7", "[N6.7] Inversione contabile - prestazioni comparto edile esettori connessi"),
             ("N6.8", "[N6.8] Inversione contabile - operazioni settore energetico"),
             ("N6.9", "[N6.9] Inversione contabile - altri casi"),
-            ("N7", "[N7] IVA assolta in altro stato UE (prestazione di servizi di telecomunicazioni, tele-radiodiffusione ed elettronici ex art. 7-octies, comma 1 lett. a, b, art. 74-sexies DPR 633/72)")
+            ("N7", "[N7] IVA assolta in altro stato UE (prestazione di servizi di telecomunicazioni, tele-radiodiffusione ed elettronici ex art. 7-octies, comma 1 lett. a, b, art. 74-sexies DPR 633/72)"),
         ],
         string="Exoneration",
         help="Exoneration type",


### PR DESCRIPTION
There are old Natura (l10n_it_tax_exemption_reason) that are deprecated in favour of more detailed ones.
We already have the detailed ones, but we allow the old values, but the Tax Agency considers them invalid already.

ref: https://fex-app.com/FatturaElettronica/FatturaElettronicaBody/DatiBeniServizi/DatiRiepilogo/Natura