### PR TITLE
[FIX] project, mass_mailing: systray activity count is too high

### DIFF
--- a/addons/mass_mailing_sms/models/res_users.py
+++ b/addons/mass_mailing_sms/models/res_users.py
@@ -20,20 +20,27 @@ class ResUsers(models.Model):
         for activity in activities:
             if activity.get('model') == 'mailing.mailing':
                 activities.remove(activity)
-                query = """SELECT m.mailing_type, count(*), act.res_model as model, act.res_id,
-                            CASE
-                                WHEN %(today)s::date - act.date_deadline::date = 0 Then 'today'
-                                WHEN %(today)s::date - act.date_deadline::date > 0 Then 'overdue'
-                                WHEN %(today)s::date - act.date_deadline::date < 0 Then 'planned'
-                            END AS states
-                        FROM mail_activity AS act
-                        JOIN mailing_mailing AS m ON act.res_id = m.id
-                        WHERE act.res_model = 'mailing.mailing' AND act.user_id = %(user_id)s  
-                        GROUP BY m.mailing_type, states, act.res_model, act.res_id;
+                query = """
+                        WITH mailing_states AS (
+                            SELECT m.mailing_type, act.res_id,
+                                CASE
+                                    WHEN %(today)s::date - MIN(act.date_deadline)::date = 0 Then 'today'
+                                    WHEN %(today)s::date - MIN(act.date_deadline)::date > 0 Then 'overdue'
+                                    WHEN %(today)s::date - MIN(act.date_deadline)::date < 0 Then 'planned'
+                                END AS states
+                            FROM mail_activity AS act
+                            JOIN mailing_mailing AS m ON act.res_id = m.id
+                            WHERE act.res_model = 'mailing.mailing' AND act.user_id = %(user_id)s AND act.active in (TRUE, %(active)s)
+                            GROUP BY m.mailing_type, act.res_id
+                        )
+                        SELECT mailing_type, states, array_agg(res_id) AS res_ids, COUNT(res_id) AS count
+                        FROM mailing_states
+                        GROUP BY mailing_type, states
                         """
                 self.env.cr.execute(query, {
                     'today': fields.Date.context_today(self),
                     'user_id': self.env.uid,
+                    'active': self._context.get('active_test', True),
                 })
                 activity_data = self.env.cr.dictfetchall()
                 
@@ -59,7 +66,7 @@ class ResUsers(models.Model):
                             'res_ids': res_ids,
                             "view_type": view_type,
                         }
-                    user_activities[act['mailing_type']]['res_ids'].add(act['res_id'])
+                    user_activities[act['mailing_type']]['res_ids'].update(act['res_ids'])
                     user_activities[act['mailing_type']]['%s_count' % act['states']] += act['count']
                     if act['states'] in ('today', 'overdue'):
                         user_activities[act['mailing_type']]['total_count'] += act['count']

--- a/addons/project_todo/tests/__init__.py
+++ b/addons/project_todo/tests/__init__.py
@@ -2,4 +2,5 @@
 
 from . import test_access_rights
 from . import test_mail_activity_todo_create
+from . import test_mail_activity_systray_counter
 from . import test_todo_ui

--- a/addons/project_todo/tests/test_mail_activity_systray_counter.py
+++ b/addons/project_todo/tests/test_mail_activity_systray_counter.py
@@ -1,0 +1,109 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import datetime
+from odoo.tests.common import TransactionCase
+from odoo import fields
+
+
+class TestActivitySystrayCounter(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.test_user = cls.env['res.users'].create({
+            'name': 'Test User',
+            'login': 'testuser',
+        })
+        cls.test_project = cls.env['project.project'].create({
+            'name': 'Test Project',
+        })
+
+        cls._create_task_scenarios(is_todo=False)
+        cls._create_task_scenarios(is_todo=True)
+
+    @classmethod
+    def _create_task_scenarios(cls, is_todo=False):
+        """
+        Helper method to create a standard set of test tasks/to-dos and activities.
+        :param bool is_todo: If True, creates tasks without a project_id (To-Dos).
+                             If False, creates tasks with a project_id.
+        """
+        today = fields.Date.today()
+        yesterday = today - datetime.timedelta(days=1)
+        tomorrow = today + datetime.timedelta(days=1)
+
+        task_details = {'user_ids': [(6, 0, [cls.test_user.id])]}
+        if not is_todo:
+            task_details['project_id'] = cls.test_project.id
+
+        name_prefix = "To-Do" if is_todo else "Task"
+
+        # SCENARIO 1: A single record with TWO overdue activities.
+        record_overdue = cls.env['project.task'].create({**task_details, 'name': f'{name_prefix} Overdue Record'})
+        cls.env['mail.activity'].create([
+            {
+                'res_id': record_overdue.id,
+                'res_model_id': cls.env.ref('project.model_project_task').id,
+                'user_id': cls.test_user.id,
+                'date_deadline': yesterday,
+                'summary': 'Overdue 1',
+            },
+            {
+                'res_id': record_overdue.id,
+                'res_model_id': cls.env.ref('project.model_project_task').id,
+                'user_id': cls.test_user.id,
+                'date_deadline': yesterday,
+                'summary': 'Overdue 2',
+            },
+        ])
+
+        # SCENARIO 2: A single record with 'today' and 'planned' activities.
+        record_today = cls.env['project.task'].create({**task_details, 'name': f'{name_prefix} Today Record'})
+        cls.env['mail.activity'].create([
+            {
+                'res_id': record_today.id,
+                'res_model_id': cls.env.ref('project.model_project_task').id,
+                'user_id': cls.test_user.id,
+                'date_deadline': today,
+                'summary': 'Today Activity',
+            },
+            {
+                'res_id': record_today.id,
+                'res_model_id': cls.env.ref('project.model_project_task').id,
+                'user_id': cls.test_user.id,
+                'date_deadline': tomorrow,
+                'summary': 'Planned Activity',
+            },
+        ])
+
+        # SCENARIO 3: A single record with one 'planned' activity.
+        record_planned = cls.env['project.task'].create({**task_details, 'name': f'{name_prefix} Planned Record'})
+        cls.env['mail.activity'].create({
+            'res_id': record_planned.id,
+            'res_model_id': cls.env.ref('project.model_project_task').id,
+            'user_id': cls.test_user.id,
+            'date_deadline': tomorrow,
+            'summary': 'Planned',
+        })
+
+    def test_systray_task_and_todo_split(self):
+        """Tests that activities are correctly split into Task and To-Do groups."""
+        activity_groups = self.env['res.users'].with_user(self.test_user)._get_activity_groups()
+
+        task_group = next((g for g in activity_groups if g.get('name') == 'Task'), None)
+        todo_group = next((g for g in activity_groups if g.get('name') == 'To-Do'), None)
+
+        # 1. Check that both groups were created
+        self.assertTrue(task_group)
+        self.assertTrue(todo_group)
+
+        # 2. Check counts for the 'Task' group
+        self.assertEqual(task_group['overdue_count'], 1)
+        self.assertEqual(task_group['today_count'], 1)
+        self.assertEqual(task_group['planned_count'], 1)
+        self.assertEqual(task_group['total_count'], 2, "Task total_count should be: overdue + today")
+
+        # 3. Check counts for the 'To-Do' group
+        self.assertEqual(todo_group['overdue_count'], 1)
+        self.assertEqual(todo_group['today_count'], 1)
+        self.assertEqual(todo_group['planned_count'], 1)
+        self.assertEqual(todo_group['total_count'], 2, "To-Do total_count should be: overdue + today")


### PR DESCRIPTION
Issue:
When multiple activities were created on a single record (e.g., a Task,
To-Do, or Mass Mailing), the systray counters for late/today/future
activities would incorrectly count *all* of them. The standard behavior
is to count only one (the most urgent) per record.

Cause:
Modules that split activity groups: `project` (for Tasks/To-Dos)
and `mass_mailing` (for Email/SMS), used custom counting logic. This
logic was outdated and did not follow the "one count per record" rule.

Solution:
Refactor the custom activity-grouping logic to make the count conform to 
the general rule again.

This aligns all systray counters, ensuring Tasks, To-Dos,
and Mailings are now correctly counted only once, based on their most
urgent activity.

Task-5059640
