### PR TITLE
[IMP] account_peppol: client-side rate limit and canard feats

### DIFF
--- a/addons/account/models/account_move_send.py
+++ b/addons/account/models/account_move_send.py
@@ -766,6 +766,12 @@ class AccountMoveSend(models.AbstractModel):
         ) if 'sending_methods' in custom_settings else True
 
     @api.model
+    def _apply_sending_method_rate_limits(self, moves_data: dict) -> None:
+        # TO EXTEND
+        # a hook to fallback to another sending method early if a rate limit would be exceeded
+        return
+
+    @api.model
     def _generate_and_send_invoices(self, moves, from_cron=False, allow_raising=True, allow_fallback_pdf=False, **custom_settings):
         """ Generate and send the moves given custom_settings if provided, else their default configuration set on related partner/company.
         :param moves: account.move to process

--- a/addons/account_peppol/data/cron.xml
+++ b/addons/account_peppol/data/cron.xml
@@ -35,4 +35,13 @@
         <field name="code">model._cron_peppol_webhook_keepalive()</field>
         <field name="state">code</field>
     </record>
+
+    <record id="ir_cron_peppol_update_metadata" model="ir.cron">
+        <field name="name">PEPPOL: update metadata</field>
+        <field name="interval_number">2</field>
+        <field name="interval_type">hours</field>
+        <field name="model_id" ref="model_account_edi_proxy_client_user"/>
+        <field name="code">model._cron_peppol_update_metadata()</field>
+        <field name="state">code</field>
+    </record>
 </odoo>

--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -188,6 +188,11 @@ class Account_Edi_Proxy_ClientUser(models.Model):
         edi_users = self.search([('company_id.account_peppol_proxy_state', 'in', ['sender', 'receiver'])])
         edi_users._peppol_reset_webhook()
 
+    def _cron_peppol_update_metadata(self):
+        edi_users = self.search([('proxy_type', '=', 'peppol')])
+        for edi_user in edi_users:
+            edi_user._peppol_update_metadata()
+
     # -------------------------------------------------------------------------
     # BUSINESS ACTIONS
     # -------------------------------------------------------------------------
@@ -576,3 +581,21 @@ class Account_Edi_Proxy_ClientUser(models.Model):
     def _peppol_reset_webhook(self):
         for edi_user in self:
             edi_user._call_peppol_proxy('/api/peppol/2/set_webhook', params={'webhook_url': edi_user.company_id._get_peppol_webhook_endpoint(), 'token': edi_user._generate_webhook_token()})
+
+    def _peppol_update_metadata(self):
+        self.ensure_one()
+        try:
+            features_flags = self._call_peppol_proxy(
+                '/api/peppol/1/get_features',
+                params={
+                    'client_features': list(self.company_id._peppol_get_default_feature_flags().keys())
+                }
+            )
+        except AccountEdiProxyError:
+            features_flags = {}  # fallback to default if error occurs
+        out = self.company_id.sudo().peppol_metadata or {}
+
+        out['features'] = self.company_id._peppol_get_default_feature_flags() | features_flags
+
+        self.company_id.sudo().peppol_metadata = out
+        self.company_id.sudo().peppol_metadata_updated_at = self.env.cr.now()

--- a/addons/account_peppol/models/account_move_send.py
+++ b/addons/account_peppol/models/account_move_send.py
@@ -1,9 +1,13 @@
 from base64 import b64encode
 from datetime import timedelta
+from functools import reduce
+from operator import or_
 
 from odoo import api, fields, models, _
+
 from odoo.addons.account.models.company import PEPPOL_LIST
 from odoo.addons.account_edi_proxy_client.models.account_edi_proxy_user import AccountEdiProxyError
+
 
 class AccountMoveSend(models.AbstractModel):
     _inherit = 'account.move.send'
@@ -19,6 +23,35 @@ class AccountMoveSend(models.AbstractModel):
             return {'email', 'peppol'}
 
         return {'email'}
+
+    @api.model
+    def _apply_sending_method_rate_limits(self, moves_data):
+        # EXTENDS 'account'
+        # fallback to mail if by sending the whole
+        super()._apply_sending_method_rate_limits(moves_data)
+
+        peppol_moves_data = {move: data for move, data in moves_data.items() if 'peppol' in data['sending_methods']}
+
+        if not peppol_moves_data:
+            return
+
+        peppol_moves_by_company = reduce(or_, peppol_moves_data.keys(), self.env['account.move']).grouped('company_id')
+
+        for company, moves in peppol_moves_by_company.items():
+            if not company.peppol_can_send or not (remaining_quota := company._peppol_get_remaining_send_quota()):
+                continue
+
+            if remaining_quota >= len(moves):
+                continue
+
+            # Fallback to email for moves of THIS company only
+            for move in moves:
+                data = moves_data[move]
+                data['sending_methods'].discard('peppol')
+                if not data['sending_methods']:
+                    data['sending_methods'].add('email')
+
+                data['peppol_rate_limited'] = True
 
     @api.model
     def _get_move_constraints(self, move):
@@ -67,12 +100,30 @@ class AccountMoveSend(models.AbstractModel):
                 },
             },
         }
-        info_always_on_countries = {'BE', 'FI', 'LU', 'LV', 'NL', 'NO', 'SE'}
         any_moves_not_sent_peppol = any(move.peppol_move_state not in ('processing', 'done') for move in moves)
         always_on_companies = moves.company_id.filtered(
-            lambda c: c.country_code in info_always_on_countries and not c.peppol_can_send
+            lambda c: c.country_code in (c._peppol_get_proactive_peppol_prompt_countries() or []) and not c.peppol_can_send
         )
-        if all((
+        rate_limited_count = sum(1 for m in moves if moves_data[m].get('peppol_rate_limited'))
+        if rate_limited_count:
+            if rate_limited_count == 1:
+                msg = self.env._("You reached today's Peppol sending limit.")
+            else:
+                msg = self.env._("You either reached or will reach your Peppol daily limit by sending these invoices")
+            alerts['account_peppol_warning_quota'] = {
+                'level': 'warning',
+                'message': msg,
+            }
+            if help_url := next((c._peppol_get_rate_limiting_doc_url() for c in moves.company_id), None):
+                alerts['account_peppol_warning_quota'].update({
+                    'action_text': self.env._("Check out why"),
+                    'action': {
+                        'type': 'ir.actions.act_url',
+                        'target': 'new',
+                        'url': help_url,
+                    },
+                })
+        elif all((
             always_on_companies,
             any_moves_not_sent_peppol,
             not filter_peppol_state(moves, ['not_valid', 'not_verified']),

--- a/addons/account_peppol/models/res_company.py
+++ b/addons/account_peppol/models/res_company.py
@@ -2,19 +2,28 @@
 
 import contextlib
 import re
+import logging
+from functools import wraps
+from typing import Optional
+
 import requests
 from lxml import etree
-from stdnum import get_cc_module, ean
+from stdnum import ean, get_cc_module
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 from odoo.tools.urls import urljoin
+
 from odoo.addons.account.models.company import PEPPOL_LIST
+from odoo.addons.account_edi_proxy_client.models.account_edi_proxy_user import AccountEdiProxyError
 
 try:
     import phonenumbers
 except ImportError:
     phonenumbers = None
+
+
+_logger = logging.getLogger(__name__)
 
 
 def _cc_checker(country_code, code_type):
@@ -49,6 +58,32 @@ PEPPOL_ENDPOINT_SANITIZERS = {
     '0208': _re_sanitizer(r'\d{10}'),
 }
 TIMEOUT = 10
+
+
+def peppol_feature(code: str, /, *, expected_kwargs=()):
+    assert isinstance(expected_kwargs, (list, tuple)), "expected_kwargs must be a list or tuple of strings"
+    expected = tuple(expected_kwargs or ())
+
+    def deco(func):
+        @wraps(func)
+        def wrapper(self, *args, **kwargs):
+            self.ensure_one()
+
+            all_features = (self.sudo().peppol_metadata or {}).get('features', None) or self._peppol_get_default_feature_flags()
+            if not (feat := all_features.get(code, {})):
+                return
+
+            if isinstance(feat, bool):
+                if expected:
+                    return
+                return func(self, *args, **kwargs)
+            if isinstance(feat, dict):
+                if any(k not in feat for k in expected):
+                    return
+                return func(self, *args, **kwargs, **{k: feat[k] for k in expected})
+            return
+        return wrapper
+    return deco
 
 
 class ResCompany(models.Model):
@@ -94,9 +129,10 @@ class ResCompany(models.Model):
     peppol_external_provider = fields.Char(tracking=True)
     peppol_can_send = fields.Boolean(compute='_compute_peppol_can_send')
     peppol_parent_company_id = fields.Many2one(comodel_name='res.company', compute='_compute_peppol_parent_company_id')
-    # IAP-driven metadata with additive keys
-    peppol_metadata = fields.Json(string='Peppol Metadata')
-    peppol_metadata_updated_at = fields.Datetime(string='Peppol meta updated at')
+
+    # schema: {"features": {"feature1": true, "feature2": {"arg1": "value"}}, "state": {"key": "value"}}
+    peppol_metadata = fields.Json(string='Peppol Metadata', groups='base.group_system')
+    peppol_metadata_updated_at = fields.Datetime(string='Peppol meta updated at', groups='base.group_system')
 
     peppol_activate_self_billing_sending = fields.Boolean(
         string="Activate self-billing sending",
@@ -152,6 +188,7 @@ class ResCompany(models.Model):
         self.account_peppol_proxy_state = 'not_registered'
         self.account_peppol_migration_key = False
         if not soft:
+            self.sudo().peppol_metadata = {}
             self.peppol_external_provider = False
             self.peppol_eas = False
             self.peppol_endpoint = False
@@ -454,3 +491,47 @@ class ResCompany(models.Model):
             return
 
         mail_template.send_mail(self.id, force_send=True)
+
+    def _peppol_get_default_feature_flags(self):
+        self.ensure_one()
+        return {
+            'rate_limiting_ui': True,
+            'proactive_peppol_prompt_countries': {
+                'country_codes': [
+                    'BE', 'FI', 'LU', 'LV', 'NL', 'NO', 'SE',
+                ]
+            }
+        }
+
+    @peppol_feature('rate_limiting_ui', expected_kwargs=('help_url',))
+    def _peppol_get_rate_limiting_doc_url(self, help_url: Optional[str]) -> Optional[str]:
+        return help_url
+
+    @peppol_feature('proactive_peppol_prompt_countries', expected_kwargs=('country_codes',))
+    def _peppol_get_proactive_peppol_prompt_countries(self, country_codes: Optional[list[str]]) -> Optional[list[str]]:
+        return country_codes
+
+    @peppol_feature('rate_limiting_ui')
+    def _peppol_get_remaining_send_quota(self) -> int | None:
+        # this is not accessed often, but needs to be up-to-date when accessed
+        # so we keep it in the metadata state, and update it if the result is older than 1 min
+        metadata = self.sudo().peppol_metadata or {}
+        quota = metadata.setdefault('state', {}).setdefault('quota', {})
+
+        # use transaction time to avoid fetching multiple times in the same transaction
+        if quota.get('last_update', 0) < self.env.cr.now().timestamp() - 30:
+            try:
+                quota_info = self.account_peppol_edi_user._call_peppol_proxy('/api/peppol/1/get_quota')
+            except AccountEdiProxyError as e:
+                _logger.error('Error while fetching Peppol quota information: %s', e)
+                return
+            else:
+                if (remaining_quota := quota_info.get('remaining_quota')) is not None:
+                    quota.update({
+                        'remaining_quota': remaining_quota,
+                        'last_update': self.env.cr.now().timestamp(),
+                    })
+                    self.sudo().peppol_metadata = metadata
+
+        if 'remaining_quota' in quota:
+            return quota['remaining_quota']

--- a/addons/account_peppol/tools/demo_utils.py
+++ b/addons/account_peppol/tools/demo_utils.py
@@ -91,6 +91,7 @@ def _mock_call_peppol_proxy(func, self, endpoint, params=None):
         'add_services': lambda _user: {},
         'get_services': lambda _user:  {'services': self.env['res.company']._peppol_supported_document_types()},
         'remove_services': lambda _user: {},
+        'get_features': lambda _user: {},
     }[endpoint](self)
 
 


### PR DESCRIPTION
Add support for rate limit UI client side. When the Peppol quota is low, invoices can fall back to email instead of failing. Users will see a warning when the daily limit is reached or would be exceeded.

Add canard features on the client side. The client now fetches remote feature flags from the proxy and stores them in company metadata. This lets us enable or disable features, and test new ones with canary rollouts.

IAP: https://github.com/odoo/iap-apps/pull/1200

task-4498045