### PR TITLE
[FIX] website_forum: make navigation more consistent

### DIFF
--- a/addons/website_forum/static/src/scss/website_forum.scss
+++ b/addons/website_forum/static/src/scss/website_forum.scss
@@ -26,8 +26,38 @@ $-forum-sidebar-width: map-get($container-max-widths, sm) / 2;
     --o-post-header-height: var(--o-avatar-height);
 
     .o_wforum_content_wrapper {
-        .o_searchbar_form {
-            min-width: 200px;
+        #o_wforum_nav {
+            align-items: center;
+
+            .o_wforum_breadcrumb_root_list_or_edit h1 {
+                margin: 0 !important;
+                font-size: var(--h4-font-size) !important;
+
+                span {
+                    font-weight: $headings-font-weight !important;
+                }
+            }
+
+            .breadcrumb-item {
+                padding-top: calc(#{$btn-padding-y} + #{$btn-border-width});
+                padding-bottom: calc(#{$btn-padding-y} + #{$btn-border-width});
+                font-size: $btn-font-size;
+                line-height: $btn-line-height;
+
+                h1 {
+                    font-size: $btn-font-size !important;
+                    font-family: var(--body-font-family);
+                }
+
+                span.fw-bold, strong {
+                    color: $text-muted;
+                    font-weight: var(--body-font-weight) !important;
+                }
+            }
+
+            .o_searchbar_form {
+                min-width: 200px;
+            }
         }
     }
 


### PR DESCRIPTION
This commit fixes typography in the forum by refining the style of breadcrumbs and headings, making navigation more consistent.

| Before | After |
|--------|--------|
| <img width="369" height="104" alt="Screenshot 2025-09-16 at 10 54 29" src="https://github.com/user-attachments/assets/545ade80-beb9-4846-a83a-6cccbaff66d5" /> | <img width="341" height="106" alt="Screenshot 2025-09-16 at 10 53 54" src="https://github.com/user-attachments/assets/f8752432-c1ea-4f63-a48c-eb1b2a4316d4" /> | 

task-5079831

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
