### PR TITLE
[FIX] stock_account: standard price on outgoing fifo product

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -333,6 +333,10 @@ class ProductProduct(models.Model):
         for product in self:
             if product.cost_method == 'standard':
                 continue
+            elif product.cost_method == 'fifo':
+                fifo_price = product.total_value / product.qty_available if product.qty_available else 0
+                product.with_context(disable_auto_revaluation=True).standard_price = fifo_price
+                continue
             product.with_context(disable_auto_revaluation=True).standard_price = product._run_avco()[0]
 
 

--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -131,6 +131,8 @@ class StockMove(models.Model):
         moves_in = moves.filtered(lambda m: m.is_in or m.is_dropship)
         moves_in._set_value()
         moves._create_account_move()
+        # Update standard price on outgoing fifo products
+        moves_out.product_id.filtered(lambda p: p.cost_method == 'fifo')._update_standard_price()
         return moves
 
     def _create_account_move(self):


### PR DESCRIPTION
Ensure that the standard price is correctly computed when a FIFO product has outgoing stock moves.

Due to the need of the old FIFO value before marking the moves as 'done', `_update_standard_price` has to be called in `_action_done` instead of `_set_value`.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
