### PR TITLE
[FIX] website_sale_comparison: increase `collapse` `z-index`

### DIFF
--- a/addons/website_sale_comparison/static/src/js/product_comparison_bottom_bar/product_comparison_bottom_bar.xml
+++ b/addons/website_sale_comparison/static/src/js/product_comparison_bottom_bar/product_comparison_bottom_bar.xml
@@ -4,7 +4,7 @@
         <div class="o_not_editable position-absolute top-0 start-0 bottom-0 end-0 d-flex align-items-end justify-content-end p-0 pe-none">
             <div
                 t-if="state.products.size"
-                class="o_wsale_comparison_bottom_bar sticky-bottom z-3 flex-shrink-0 w-100 bg-body pe-auto"
+                class="o_wsale_comparison_bottom_bar sticky-bottom flex-shrink-0 w-100 bg-body pe-auto"
                 name="comparison_bottom_bar"
             >
                 <div class="container">

--- a/addons/website_sale_comparison/static/src/scss/website_sale_comparison.scss
+++ b/addons/website_sale_comparison/static/src/scss/website_sale_comparison.scss
@@ -94,6 +94,11 @@
 }
 
 .o_wsale_comparison_bottom_bar {
+    z-index: var(--o-wsale-comparison-bottom-bar-z-index, 3);
+
+    &:where(:has(.collapsing, .collapse.show)) {
+        --o-wsale-comparison-bottom-bar-z-index: 4;
+    }
 
     box-shadow: 0px -12px 32px rgba($black, .175);
 


### PR DESCRIPTION
This PR increase the `z-index` property of the `collapse` element
within the comparison bottom bar when open.

| 19.0 and above | This PR |
|--------|--------|
| <img width="466" height="852" alt="image" src="https://github.com/user-attachments/assets/04cad4c6-b40f-402f-b667-5f3393f5a082" /> | <img width="489" height="844" alt="image" src="https://github.com/user-attachments/assets/39a289ca-26c4-47c4-a15a-121d5387acb6" /> | 

Prior to this PR, we set the `z-index` to `3`, which is below the `4`
of the floating bar. While this solved an issue on desktop, it introduced
a new one on mobile, where the collapse would unfold UNDER the floating
bar.

With this PR, we change the `z-index` when the collapse is open so
it is greater than the floating bar one.

task-5086473

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
