### PR TITLE
[FIX] mail: performance of _get_recipient_data()

### DIFF
--- a/addons/mail/models/mail_followers.py
+++ b/addons/mail/models/mail_followers.py
@@ -206,28 +206,17 @@ class MailFollowers(models.Model):
       JOIN sub_followers ON sub_followers.pid = partner.id
                         AND (sub_followers.internal IS NOT TRUE OR partner.partner_share IS NOT TRUE)
  LEFT JOIN LATERAL (
-        WITH RECURSIVE all_groups AS (
-            SELECT users.id AS uid,
-                   users.share AS share,
-                   users.notification_type AS notification_type,
-                   groups_rel.gid
-              FROM res_users users
-         LEFT JOIN res_groups_users_rel groups_rel ON groups_rel.uid = users.id
-             WHERE users.partner_id = partner.id AND users.active
-          UNION
-            SELECT ag.uid, ag.share, ag.notification_type, implied.hid
-              FROM all_groups ag
-              JOIN res_groups_implied_rel implied ON ag.gid = implied.gid
-        )
-        SELECT uid,
-               share,
-               notification_type,
-               ARRAY_AGG(DISTINCT gid) AS groups
-          FROM all_groups
-      GROUP BY uid,
-               share,
-               notification_type
-      ORDER BY share ASC NULLS FIRST, uid ASC
+        SELECT users.id AS uid,
+               users.share AS share,
+               users.notification_type AS notification_type,
+               ARRAY_AGG(groups_rel.gid) FILTER (WHERE groups_rel.gid IS NOT NULL) AS groups
+          FROM res_users users
+     LEFT JOIN res_groups_users_rel groups_rel ON groups_rel.uid = users.id
+         WHERE users.partner_id = partner.id AND users.active
+      GROUP BY users.id,
+               users.share,
+               users.notification_type
+      ORDER BY users.share ASC NULLS FIRST, users.id ASC
          FETCH FIRST ROW ONLY
          ) sub_user ON TRUE
 
@@ -256,28 +245,17 @@ class MailFollowers(models.Model):
                               AND fol.res_model = %s
                               AND fol.res_id IN %s
  LEFT JOIN LATERAL (
-        WITH RECURSIVE all_groups AS (
-            SELECT users.id AS uid,
-                   users.share AS share,
-                   users.notification_type AS notification_type,
-                   groups_rel.gid
-              FROM res_users users
-         LEFT JOIN res_groups_users_rel groups_rel ON groups_rel.uid = users.id
-             WHERE users.partner_id = partner.id AND users.active
-          UNION
-            SELECT ag.uid, ag.share, ag.notification_type, implied.hid
-              FROM all_groups ag
-              JOIN res_groups_implied_rel implied ON ag.gid = implied.gid
-        )
-        SELECT uid,
-               share,
-               notification_type,
-               ARRAY_AGG(DISTINCT gid) AS groups
-          FROM all_groups
-      GROUP BY uid,
-               share,
-               notification_type
-      ORDER BY share ASC NULLS FIRST, uid ASC
+        SELECT users.id AS uid,
+               users.share AS share,
+               users.notification_type AS notification_type,
+               ARRAY_AGG(groups_rel.gid) FILTER (WHERE groups_rel.gid IS NOT NULL) AS groups
+          FROM res_users users
+     LEFT JOIN res_groups_users_rel groups_rel ON groups_rel.uid = users.id
+         WHERE users.partner_id = partner.id AND users.active
+      GROUP BY users.id,
+               users.share,
+               users.notification_type
+      ORDER BY users.share ASC NULLS FIRST, users.id ASC
          FETCH FIRST ROW ONLY
          ) sub_user ON TRUE
 
@@ -319,28 +297,17 @@ class MailFollowers(models.Model):
            FALSE as is_follower
       FROM res_partner partner
  LEFT JOIN LATERAL (
-        WITH RECURSIVE all_groups AS (
-            SELECT users.id AS uid,
-                   users.share AS share,
-                   users.notification_type AS notification_type,
-                   groups_rel.gid
-              FROM res_users users
-         LEFT JOIN res_groups_users_rel groups_rel ON groups_rel.uid = users.id
-             WHERE users.partner_id = partner.id AND users.active
-          UNION
-            SELECT ag.uid, ag.share, ag.notification_type, implied.hid
-              FROM all_groups ag
-              JOIN res_groups_implied_rel implied ON ag.gid = implied.gid
-        )
-        SELECT uid,
-               share,
-               notification_type,
-               ARRAY_AGG(DISTINCT gid) AS groups
-          FROM all_groups
-      GROUP BY uid,
-               share,
-               notification_type
-      ORDER BY share ASC NULLS FIRST, uid ASC
+        SELECT users.id AS uid,
+               users.share AS share,
+               users.notification_type AS notification_type,
+               ARRAY_AGG(groups_rel.gid) FILTER (WHERE groups_rel.gid IS NOT NULL) AS groups
+          FROM res_users users
+     LEFT JOIN res_groups_users_rel groups_rel ON groups_rel.uid = users.id
+         WHERE users.partner_id = partner.id AND users.active
+      GROUP BY users.id,
+               users.share,
+               users.notification_type
+      ORDER BY users.share ASC NULLS FIRST, users.id ASC
          FETCH FIRST ROW ONLY
          ) sub_user ON TRUE
 
@@ -364,6 +331,10 @@ class MailFollowers(models.Model):
             pshare, uid, ushare, notif, groups, res_id, is_follower
         ) in res:
             to_update = [res_id] if res_id else res_ids
+            # add transitive closure of implied groups; note that the field
+            # all_implied_ids relies on ormcache'd data, which shouldn't add
+            # more queries
+            groups = self.env['res.groups'].browse(set(groups or [])).all_implied_ids.ids
             for res_id_to_update in to_update:
                 # avoid updating already existing information, unnecessary dict update
                 if not res_id and partner_id in doc_infos[res_id_to_update]:


### PR DESCRIPTION
The commit 2e63fe11624b8abd9205ae94b6721fce660751db introduced a severe performance regression in some SQL query, going from 1.2ms to 450ms! Instead of computing the transitive closure of collected groups in pure SQL with a "WITH RECURSIVE", we use the computed field all_implied_ids. As the latter is based on ormcache'd data, the new solution has no marginal cost in terms of SQL queries.
