### PR TITLE
[IMP] mail: delete thread action

### DIFF
--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -383,6 +383,12 @@ export class Message extends Record {
             if (this.notificationType === "call") {
                 return _t("%(caller)s started a call", { caller: this.authorName });
             }
+            if (this.notificationType === "thread_deletion") {
+                return _t('%(user)s deleted the thread "%(thread_name)s"', {
+                    user: this.authorName,
+                    thread_name: decorateEmojis(htmlToTextContentInline(this.body)),
+                });
+            }
             if (this.notificationType === "channel_rename") {
                 const name = htmlToTextContentInline(this.body);
                 const params = { user: this.authorName, name: markup`<b>${name}</b>` };

--- a/addons/mail/static/src/core/common/notification_message.xml
+++ b/addons/mail/static/src/core/common/notification_message.xml
@@ -7,7 +7,7 @@
             <t t-if="message.notificationType === 'call'">
                 <span class="text-muted" t-esc="callInformation"/>
             </t>
-            <t t-elif="message.notificationType === 'channel_rename'">
+            <t t-elif="['channel_rename', 'thread_deletion'].includes(message.notificationType)">
                 <span class="text-muted" t-out="message.inlineBody"/>
             </t>
             <t t-else="">

--- a/addons/mail/static/src/discuss/core/common/delete_thread_dialog.js
+++ b/addons/mail/static/src/discuss/core/common/delete_thread_dialog.js
@@ -1,0 +1,37 @@
+import { ActionPanel } from "@mail/discuss/core/common/action_panel";
+
+import { Component } from "@odoo/owl";
+
+import { rpc } from "@web/core/network/rpc";
+import { _t } from "@web/core/l10n/translation";
+import { useService } from "@web/core/utils/hooks";
+
+export class DeleteThreadDialog extends Component {
+    static components = { ActionPanel };
+    static props = ["thread", "close"];
+    static template = "discuss.DeleteThreadDialog";
+
+    setup() {
+        super.setup();
+        this.store = useService("mail.store");
+    }
+
+    async onConfirmation() {
+        let toOpenThread;
+        const threadName = this.props.thread.name;
+        if (this.store.discuss?.thread?.eq(this.props.thread) || this.env.inChatWindow) {
+            toOpenThread = this.props.thread.parent_channel_id;
+        }
+        await rpc("/discuss/channel/sub_channel/delete", {
+            sub_channel_id: this.props.thread.id,
+        });
+        if (toOpenThread?.exists()) {
+            toOpenThread.open();
+        }
+        this.props.close();
+        this.env.services.notification.add(
+            _t('Thread "%(thread_name)s" has been deleted', { thread_name: threadName }),
+            { type: "info" }
+        );
+    }
+}

--- a/addons/mail/static/src/discuss/core/common/delete_thread_dialog.xml
+++ b/addons/mail/static/src/discuss/core/common/delete_thread_dialog.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="discuss.DeleteThreadDialog">
+        <ActionPanel title.translate="Delete Thread" icon="'fa fa-trash'" resizable="false">
+            <div class="d-flex justify-content-between align-items-center">
+                <p class="fs-5 mb-0">Permanently delete this thread?</p>
+                <button class="btn btn-danger" t-on-click="onConfirmation">
+                    Delete Thread
+                </button>
+            </div>
+        </ActionPanel>
+    </t>
+</templates>

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
@@ -44,7 +44,7 @@ export class DiscussSidebarSubchannel extends Component {
     }
 
     get actionsTitle() {
-        return _t("Threads Actions");
+        return _t("Thread Actions");
     }
 
     get thread() {

--- a/addons/mail/static/tests/discuss/core/public_web/sub_channels.test.js
+++ b/addons/mail/static/tests/discuss/core/public_web/sub_channels.test.js
@@ -53,7 +53,7 @@ test("can manually unpin a sub-thread", async () => {
     await click("button[title='Threads']");
     await click("button[aria-label='Create Thread']");
     await contains(".o-mail-DiscussContent-threadName", { value: "New Thread" });
-    await click("[title='Threads Actions']");
+    await click("[title='Thread Actions']");
     await click(".o-dropdown-item:contains('Unpin Conversation')");
     await contains(".o-mail-DiscussSidebar-item", { text: "New Thread", count: 0 });
 });
@@ -326,4 +326,23 @@ test("show notification when clicking on deleted thread", async () => {
     await contains(".o_notification:has(.o_notification_bar.bg-danger)", {
         text: "This thread is no longer available.",
     });
+});
+
+test("Can delete channel thread as author of thread", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    const subChannelID = pyEnv["discuss.channel"].create({
+        name: "test thread",
+        parent_channel_id: channelId,
+    });
+    await start();
+    await openDiscuss(subChannelID);
+    await contains(".o-mail-DiscussContent-threadName[title='test thread']");
+    await click(".o-mail-DiscussSidebar-item:contains('test thread') [title='Thread Actions']");
+    await click(".o-dropdown-item:contains('Delete Thread')");
+    await click(".modal button:contains('Delete Thread')");
+    await contains(".o-mail-DiscussContent-threadName[title='General']");
+    await contains(
+        `.o-mail-NotificationMessage :contains(/^Mitchell Admin deleted the thread "test thread"$/)`
+    );
 });

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -321,6 +321,30 @@ async function discuss_channel_sub_channel_create(request) {
     );
 }
 
+registerRoute("/discuss/channel/sub_channel/delete", discuss_channel_sub_channel_delete);
+async function discuss_channel_sub_channel_delete(request) {
+    /** @type {import("mock_models").DiscussChannel} */
+    const DiscussChannel = this.env["discuss.channel"];
+    /** @type {import("mock_models").ResPartner} */
+    const ResPartner = this.env["res.partner"];
+    const { sub_channel_id } = await parseRequestParams(request);
+    const [partner] = ResPartner.read(this.env.user.partner_id);
+    const [subChannel] = DiscussChannel.read(sub_channel_id);
+    if (subChannel.author_id[0] !== partner.id) {
+        return;
+    }
+    const [sub_channel] = DiscussChannel.browse(sub_channel_id);
+    DiscussChannel.message_post(
+        sub_channel.parent_channel_id,
+        makeKwArgs({
+            body: `<div data-oe-type="thread_deletion" class="o_mail_notification">${sub_channel.name}</div>`,
+            message_type: "notification",
+            subtype_xmlid: "mail.mt_comment",
+        })
+    );
+    DiscussChannel.unlink([sub_channel_id]);
+}
+
 registerRoute("/discuss/channel/sub_channel/fetch", discuss_channel_sub_channel_fetch);
 async function discuss_channel_sub_channel_fetch(request) {
     /** @type {import("mock_models").DiscussChannel} */


### PR DESCRIPTION
purpose of Commit:

Added delete button to threads, visible only to the user who created the thread. Clicking the button opens a confirmation dialog, and upon confirmation, permanently deletes the thread.

This commit is available in discuss sidebar and chat window, similarly to "leave" / "unpin" action.

task-4629867

<img width="476" height="238" alt="Screenshot 2025-09-12 at 17 57 40" src="https://github.com/user-attachments/assets/4cafc7f5-bc20-4fde-b19e-1616ede6706d" />
