### PR TITLE
[FIX] {purchase,sale}_edi_ubl: fix sections interpeted as lines

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -520,5 +520,3 @@ class AccountEdiXmlUbl_Bis3(models.AbstractModel):
             order.message_post(body=Markup("<strong>%s</strong>") % _("Format used to import the document: %s", self._description))
             if logs:
                 order._create_activity_set_details(Markup("<ul>%s</ul>") % Markup().join(Markup("<li>%s</li>") % l for l in logs))
-
-        return True

--- a/addons/purchase_edi_ubl_bis3/models/purchase_edi_xml_ubl_bis3.py
+++ b/addons/purchase_edi_ubl_bis3/models/purchase_edi_xml_ubl_bis3.py
@@ -16,6 +16,7 @@ class PurchaseEdiXmlUbl_Bis3(models.AbstractModel):
     # -------------------------------------------------------------------------
 
     def _export_order(self, purchase_order):
+        purchase_order.order_line = purchase_order.order_line.filtered(lambda l: not l.display_type)
         vals = {'purchase_order': purchase_order}
         document_node = self._get_purchase_order_node(vals)
         xml_content = dict_to_xml(document_node, template=Order, nsmap=self._get_document_nsmap(vals))

--- a/addons/sale_edi_ubl/models/sale_edi_xml_ubl_bis3.py
+++ b/addons/sale_edi_ubl/models/sale_edi_xml_ubl_bis3.py
@@ -16,6 +16,7 @@ class SaleEdiXmlUbl_Bis3(models.AbstractModel):
     # -------------------------------------------------------------------------
 
     def _export_order(self, sale_order):
+        sale_order.order_line = sale_order.order_line.filtered(lambda l: not l.display_type)
         vals = {'sale_order': sale_order}
         document_node = self._get_sale_order_node(vals)
         xml_content = dict_to_xml(document_node, template=Order, nsmap=self._get_document_nsmap(vals))


### PR DESCRIPTION
Steps to reproduce:
- Create Sales order with sections
- Print Sales order as PDF
- Drop the PDF into purchase app

Problem:
- Sections are added as a normal order line with quantity, price, etc..

Note: Orders were filtered to not included sections, because UBL does NOT support sections.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
