### PR TITLE
[FIX] web: show weekends affect month range

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_controller.js
+++ b/addons/web/static/src/views/calendar/calendar_controller.js
@@ -167,7 +167,7 @@ export class CalendarController extends Component {
     get rendererProps() {
         return {
             model: this.model,
-            isWeekendVisible: this.model.scale === "day" || this.state.isWeekendVisible,
+            isWeekendVisible: ["day", "year"].includes(this.model.scale) || this.state.isWeekendVisible,
             createRecord: this.createRecord.bind(this),
             deleteRecord: this.deleteRecord.bind(this),
             editRecord: this.editRecord.bind(this),

--- a/addons/web/static/src/views/view_components/view_scale_selector.xml
+++ b/addons/web/static/src/views/view_components/view_scale_selector.xml
@@ -20,7 +20,7 @@
                     <div t-if="this.props.isWeekendVisible !== undefined" class="dropdown-divider" role="separator"/>
                     <DropdownItem
                             t-if="this.props.isWeekendVisible !== undefined"
-                            class="`o_show_weekends ${props.isWeekendVisible ? 'active' : ''} ${props.currentScale === 'day' ? 'disabled' : ''}`"
+                            class="`o_show_weekends ${props.isWeekendVisible ? 'active' : ''} ${['day', 'year'].includes(props.currentScale) ? 'disabled' : ''}`"
                             onSelected="props.toggleWeekendVisibility"
                         >
                         Show weekends

--- a/addons/web/static/tests/views/view_components/view_scale_selector.test.js
+++ b/addons/web/static/tests/views/view_components/view_scale_selector.test.js
@@ -66,7 +66,7 @@ test("basic ViewScaleSelector component usage", async () => {
     await contains(".dropdown-item:contains(Yearly)").click();
     await click(".scale_button_selection");
     await contains(".dropdown-item:last").click();
-    expect.verifySteps(["year", "toggleWeekendVisibility"]);
+    expect.verifySteps(["year"]);
 });
 
 test("ViewScaleSelector with only one scale available", async () => {


### PR DESCRIPTION
To reproduce:
=============
1- go to accounting > reporting > management
2- go to analytic report and click on grid view
3- From the year dropdown, uncheck "Show weekends".
→ Some months disappear unexpectedly.

Problem:
=========
Weekend filtering was applied even in year range.
In year view, each column is already a full month, so filtering out weekends is incorrect.

Fix:
====
Adjust the condition to skip filtering when range is ["year" or "day"].

opw-5078200

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
