### PR TITLE
[FIX] {purchase_,}stock: fix replenishment wizard

### DIFF
--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -238,3 +238,12 @@ class StockRule(models.Model):
         new_move_vals['production_group_id'] = move_to_copy.production_group_id.id
         new_move_vals['production_id'] = False
         return new_move_vals
+
+
+class StockRoute(models.Model):
+    _inherit = "stock.route"
+
+    def _is_valid_resupply_route_for_product(self, product):
+        if any(rule.action == 'manufacture' for rule in self.rule_ids):
+            return any(bom.type == 'normal' for bom in product.bom_ids)
+        return super()._is_valid_resupply_route_for_product(product)

--- a/addons/mrp_subcontracting/tests/test_subcontracting.py
+++ b/addons/mrp_subcontracting/tests/test_subcontracting.py
@@ -920,6 +920,18 @@ class TestSubcontractingFlows(TestMrpSubcontractingCommon):
             {'product_qty': 19.8, 'qty_producing': 19.8, 'state': 'done'},
         ])
 
+    def test_replenish_with_subcontracting_bom(self):
+        """ Checks that a subcontracting bom cannot trigger a 'Manufacture' replenish.
+        """
+        self.assertEqual(self.finished.bom_ids.type, 'subcontract')
+        replenish_wizard = self.env['product.replenish'].create({
+            'product_id': self.finished.id,
+            'product_tmpl_id': self.finished.product_tmpl_id.id,
+            'product_uom_id': self.finished.uom_id.id,
+            'quantity': 1,
+            'warehouse_id': self.warehouse.id,
+        })
+        self.assertFalse(replenish_wizard.allowed_route_ids)
 
 @tagged('post_install', '-at_install')
 class TestSubcontractingTracking(TransactionCase):

--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -245,13 +245,6 @@ class StockWarehouseOrderpoint(models.Model):
 
         return result
 
-    def _filter_warehouse_routes(self, product, warehouses, route):
-        if any(rule.action == 'buy' for rule in route.rule_ids):
-            if product.seller_ids:
-                return super()._filter_warehouse_routes(product, warehouses, route)
-            return False
-        return super()._filter_warehouse_routes(product, warehouses, route)
-
     def _get_default_route(self):
         route_ids = self.env['stock.rule'].search([
             ('action', '=', 'buy')

--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -162,6 +162,13 @@ class StockRule(models.Model):
                         po.date_order = order_date_planned
             self.env['purchase.order.line'].sudo().create(po_line_values)
 
+    def _filter_warehouse_routes(self, product, warehouses, route):
+        if any(rule.action == 'buy' for rule in route.rule_ids):
+            if product.seller_ids:
+                return super()._filter_warehouse_routes(product, warehouses, route)
+            return False
+        return super()._filter_warehouse_routes(product, warehouses, route)
+
     def _get_matching_supplier(self, product_id, product_qty, product_uom, company_id, values):
         supplier = False
         # Get the schedule date in order to find a valid seller
@@ -377,3 +384,12 @@ class StockRule(models.Model):
 
     def _get_partner_id(self, values, rule):
         return values.get("supplierinfo_name") or (values.get("force_uom") and values.get("partner"))
+
+
+class StockRoute(models.Model):
+    _inherit = "stock.route"
+
+    def _is_valid_resupply_route_for_product(self, product):
+        if any(rule.action == 'buy' for rule in self.rule_ids):
+            return bool(product.seller_ids)
+        return super()._is_valid_resupply_route_for_product(product)

--- a/addons/purchase_stock/tests/test_replenish_wizard.py
+++ b/addons/purchase_stock/tests/test_replenish_wizard.py
@@ -39,6 +39,9 @@ class TestReplenishWizard(PurchaseTestCommon):
         a purchase order is created with the correct values
         """
         self.product_uom_qty = 42
+        # Even though product1 doesn't have the 'Buy' route enabled, as it is enable through the wh it should pick it up regardless.
+        self.wh.buy_to_resupply = True
+        self.product1.route_ids = [Command.clear()]
 
         replenish_wizard = self.env['product.replenish'].with_context(default_product_tmpl_id=self.product1.product_tmpl_id.id).create({
             'product_id': self.product1.id,

--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -587,3 +587,6 @@ class StockRoute(models.Model):
                         rule_company=rule.company_id.display_name,
                         route_company=route.company_id.display_name,
                     ))
+
+    def _is_valid_resupply_route_for_product(self, product):
+        return False

--- a/addons/stock/wizard/product_replenish.py
+++ b/addons/stock/wizard/product_replenish.py
@@ -88,8 +88,6 @@ class ProductReplenish(models.TransientModel):
         return fields.Datetime.add(now, days=delay)
 
     def launch_replenishment(self):
-        if not self.route_id:
-            raise UserError(_("You need to select a route to replenish your products"))
         try:
             now = self.env.cr.now()
             self.env['stock.rule'].with_context(clean_context(self.env.context)).run([


### PR DESCRIPTION
Steps to reproduce:
- Create a product
- Open the forecast report
- Click "Replenish"

Issue:
Cannot replenish as now by default the buy/manufacture routes are set on the warehouse and no longer on the product itself

We can simply remove the check on the route in the wizard, as now the procurement is smarter and can find the appropriate rules.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
