### PR TITLE
[FIX] l10n_ar_withholding: duplicated taxes when demo is installed.

### DIFF
--- a/addons/l10n_ar_withholding/demo/account_demo.py
+++ b/addons/l10n_ar_withholding/demo/account_demo.py
@@ -31,6 +31,4 @@ class AccountChartTemplate(models.AbstractModel):
             earnings_wth_tax_78.l10n_ar_withholding_sequence_id = wth_sequence_id
             self.env['l10n_ar.partner.tax'].create({'tax_id': arba_wth_applied.id, 'partner_id': self.env.ref('l10n_ar.res_partner_mipyme').id, 'company_id': company.id})
 
-            # Because in demo we want to skip the config, while in data we want to require them to configure
-            self.env['account.tax'].search([('l10n_ar_withholding_payment_type', '!=', False), ('l10n_ar_tax_type', 'in', ('iibb_untaxed', 'iibb_total'))]).copy(default={'amount_type': 'percent', 'amount': 1})
         return result


### PR DESCRIPTION
**Description of the issue/feature this PR addresses**:
This pr is to avoid duplicated taxes when the demo data is installed.

**Steps to reproduce**:
1. Install l10n_ar_withholding module with demo data.
2. Take position in "(AR) Responsable Inscripto" company.
3. Check the taxes created on "Invoicing > Configuration > Accounting > Taxes".
4. Delete the filter "Sale or Purchase".
5. Add custom filter: Argentina Withholding Payment Tax type (l10n_ar_withholding_payment_type) is in ["supplier", "customer"].
6. You will see that there are duplicated taxes (duplicated names) with suffix (Copy).

**Current behavior before PR**:
Duplicated taxes are created when demo data is installed.
<img width="1597" height="795" alt="image" src="https://github.com/user-attachments/assets/51b65037-bb89-4ec7-8adf-21636b68e405" />

**Desired behavior after PR is merged**:
No duplicated taxes are created when demo data is installed.

_Task latam side_: 1360.
_Task Adhoc side_: 57627.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
