### PR TITLE
[FIX] website_sale_stock: Update Out of Stock Message

### DIFF
--- a/addons/website_sale_stock/static/src/xml/website_sale_stock_product_availability.xml
+++ b/addons/website_sale_stock/static/src/xml/website_sale_stock_product_availability.xml
@@ -10,7 +10,7 @@
             <div t-if="free_qty lte 0 and !cart_qty" t-attf-class="availability_message_#{product_template} mb-1">
                 <div id="out_of_stock_message" class="mb-3">
                     <t t-if="has_out_of_stock_message">
-                        <div class="d-flex align-items-center badge text-bg-danger">
+                        <div class="d-inline-flex align-items-center badge text-bg-danger text-wrap">
                             <i class="fa fa-circle text-danger me-2"/>
                             <t t-out="out_of_stock_message"/>
                         </div>


### PR DESCRIPTION
When the Out-of-Stock message contains a long string of text at certain screen sizes, the text is longer than the parent div

Steps to reproduce
--------------------
1. Have a tracked product with Continue Selling off and a long custom Out-of-Stock Message.
2. View the product shop page on the website.
3. Reduce the horizontal screen size until the text goes over the edge of the parent div(red rounded box).

Cause
-----
No CSS to handle when the text is longer than the parent element.

Solution
--------
Add text-wrap to parent div so the child element text wraps when necessary.

opw-5056843