### PR TITLE
[FIX] point_of_sale: Sudo ir.module.module to get is_restaurant_installed

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -1188,7 +1188,7 @@ class PosConfig(models.Model):
         return {
             "has_pos_config": has_pos_config,
             "has_chart_template": has_chart_template,
-            "is_restaurant_installed": bool(self.env['ir.module.module'].search_count([('name', '=', 'pos_restaurant'), ('state', '=', 'installed')])),
+            "is_restaurant_installed": bool(self.env['ir.module.module'].sudo().search_count([('name', '=', 'pos_restaurant'), ('state', '=', 'installed')])),
             "is_main_company": main_company and self.env.company.id == main_company.id or False
         }
 

--- a/doc/cla/individual/tharcisse.md
+++ b/doc/cla/individual/tharcisse.md
@@ -1,0 +1,9 @@
+Kenya, 2025-09-07
+
+I hereby agree to the terms of the Odoo Individual Contributor License Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Tharcisse Mukundayi mukundayi@gmail.com https://github.com/tharcisse


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Access rights issue when opening point of sale kanban view by regular user

Current behavior before PR:
Generates access rights error for regular user

Desired behavior after PR is merged:
Should show point of sale kanban view of any POS user





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
