### PR TITLE
[IMP] website_slides: contextual fine-tuning

### DIFF
--- a/addons/website_slides/views/website_slides_templates_homepage.xml
+++ b/addons/website_slides/views/website_slides_templates_homepage.xml
@@ -4,7 +4,8 @@
 <template id="courses_home_side_bar">
     <div class="container o_wslides_home_main">
         <div class="row">
-            <t t-set="has_side_column" t-value="is_view_active('website_slides.toggle_leaderboard')"/>
+            <t t-set="has_side_column" t-value="not is_public_user"/>
+            <!-- To do: remove in Master since it’s no longer shown. -->
             <t t-if="is_public_user">
                 <div t-if="has_side_column">
                     <div class="row">
@@ -96,7 +97,7 @@
 <!-- Channels home template -->
 <template id='courses_home' name="Odoo Courses Homepage">
     <t t-set="body_classname" t-value="'o_wslides_body'"/>
-    <t t-set="has_side_column" t-value="not is_public_user or is_view_active('website_slides.toggle_leaderboard')"/>
+    <t t-set="has_side_column" t-value="not is_public_user"/>
     <t t-call="website.layout">
         <div id="wrap" class="wrap o_wslides_wrap">
             <div class="oe_structure oe_empty"/>
@@ -116,7 +117,7 @@
                                 </t>
                             </div>
                         </div>
-                        <div class="container o_wslides_home_content_section mb-3"
+                        <div class="container o_wslides_home_content_section mb-3 d-none"
                             t-if="not len(channels)">
                             <p class="h2">No Course created yet.</p>
                             <p groups="website_slides.group_website_slides_officer">Click on "New" in the top-right corner to write your first course.</p>
@@ -135,7 +136,7 @@
                     <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"/>
                 </div>
                 <div class="offcanvas-body o_wslides_home_aside_loggedin d-flex flex-column gap-4">
-                    <t t-if="is_public_user and has_side_column">
+                    <t t-if="is_public_user">
                         <t t-call="website_slides.slides_home_users_small"/>
                     </t>
                     <t t-else="">
@@ -285,7 +286,7 @@
                         class="position-absolute top-0 start-100 translate-middle border border-light rounded-circle bg-danger p-1"
                     />
                 </button>
-                <a class="btn d-block d-lg-none p-0" data-bs-toggle="offcanvas" href="#o_wslides_overview_offcanvas" role="button" aria-controls="o_wslides_overview_offcanvas">
+                <a t-if="not request.env.user._is_public()" class="btn d-block d-lg-none p-0" data-bs-toggle="offcanvas" href="#o_wslides_overview_offcanvas" role="button" aria-controls="o_wslides_overview_offcanvas">
                     <t t-call="website_slides.slides_misc_user_image">
                         <t t-set="img_class" t-value="'o_wslides_user_avatar rounded-circle'"/>
                     </t>
@@ -324,10 +325,10 @@
 
 <template id="courses_search_results">
     <div class="o_wslides_home_main pb-5">
-        <h2 t-if="not search_term and not search_slide_category and not search_my and not search_tags" class="h5 mb-3">All Courses</h2>
+        <h2 t-if="not search_term and not search_slide_category and not search_my and not search_tags and channels" class="h5 mb-3">All Courses</h2>
         <t t-call="website_slides.courses_search_tags"/>
-        <div t-if="not channels and not search_term and not search_slide_category and not search_my and not search_tags">
-            <p class="h2">No Course created yet.</p>
+        <div t-if="not channels and not search_term and not search_slide_category and not search_my and not search_tags" class="text-center">
+            <p class="h2 h3">No Course created yet.</p>
             <p groups="website_slides.group_website_slides_officer">Click on "New" in the top-right corner to write your first course.</p>
         </div>
         <div t-elif="search_term and not channels" class="alert alert-info mb-5">
@@ -458,7 +459,7 @@
 
 <template id="toggle_leaderboard" inherit_id="website_slides.slides_home_users_small" active="True" name='Display Leaderboard'>
     <xpath expr="//div[hasclass('o_wslides_home_aside')]" position="inside">
-        <div class="d-flex justify-content-between">
+        <div t-if="not is_public_user" class="d-flex justify-content-between">
             <h2 class="h6 mb-3">Leaderboard</h2>
             <a t-if="users" href="/profile/users">View all</a>
         </div>


### PR DESCRIPTION
This PR fine-tunes 3 different context within the `website_slides` homepage by taking the following actions :

1) Hide the leaderboard if the user is not logged in

2) Fix duplicated no search result message + All courses title appearing even when no result are found

3) Fine-tune empty screen hierarchy

task-5085463

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
