### PR TITLE
[FIX] web: fix primary button active state

### DIFF
--- a/addons/web/static/src/scss/primary_variables.scss
+++ b/addons/web/static/src/scss/primary_variables.scss
@@ -239,9 +239,9 @@ $o-btns-bs-override: map-merge((
         hover-border: darken($o-brand-primary, 20%),
         hover-color: $o-white,
 
-        active-background: darken($o-brand-primary, 20%),
-        active-border: darken($o-brand-primary, 20%),
-        active-color: $o-white,
+        active-background: mix($o-brand-primary, $o-white, 10%),
+        active-border: $o-brand-primary,
+        active-color: darken($o-brand-primary, 20%),
     ),
     "secondary": (
         background: $o-gray-300,


### PR DESCRIPTION
This PR introduces a clear visual distinction between the `:hover` and `:active` state of our primary buttons.

| 19.0 and below | This PR |
|--------|--------|
| <img width="129" height="45" alt="image" src="https://github.com/user-attachments/assets/204b0c4e-622c-467e-8394-750cc79ee6e4" /> | <img width="135" height="52" alt="image" src="https://github.com/user-attachments/assets/096a5c34-56b2-41d8-9d9e-d6b9195b17d5" /> | 

Prior to this PR, the active state was using a `darken()`, which was similar to the approach in use for the `:hover` effect, which could result in a confusing behaviour for users.

With this PR, we now align the behaviour of our buttons `:active` state across all the bundles.

task-5087169

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
