### PR TITLE
[FIX] website_sale: balance perceived size of product tiles

### DIFF
--- a/addons/website_sale/static/src/scss/product_tile.scss
+++ b/addons/website_sale/static/src/scss/product_tile.scss
@@ -239,7 +239,7 @@
         order: var(--o-wsale-card-info-order, 4);
     }
     .o_wsale_products_item_title {
-        font-size: var(--o-wsale-card-info-title-font-size, inherit);
+        font-size: var(--o-wsale-card-info-title-font-size, 1.1em);
         font-weight: var(--o-wsale-card-info-title-font-weight, 500);
         margin-bottom:  var(--o-wsale-card-info-title-margin-bottom, #{map-get($spacers, 2)});
 
@@ -297,7 +297,7 @@
         justify-content: var(--o-wsale-card-price-justify-content);
         gap: 0 map-get($spacers, 2);
         min-width: var(--o-wsale-card-price-min-width);
-        font-size: var(--o-wsale-card-price-font-size);
+        font-size: var(--o-wsale-card-price-font-size, 0.94em);
         order: var(--o-wsale-card-price-order, 6);
         flex-wrap: wrap;
     }


### PR DESCRIPTION
Despite "Title" and "Price" use exactly the same font-size, the latter was perceived as "bigger".

Root causes:
- Price is enforced bold, while Title defaults to regular (can be set bold via options, but that's not obvious).
- They use different font families: the default title font 'InterTight' is more condensed than the font used for the Price, making the Title look smaller.

This PR:
- Slightly increased the Title font size.
- Slightly decreased the Price font size.

Combined, these changes create a ~16% size difference, ensuring hierarchy remains clear even when misleading conditions occur (custom fonts, bold titles...).
Adjusting the Price alone was risky since reducing it by ~16% would have brought it uncomfortably close to the description font-size.

task-5086427

---
19.0
| Default | Bold Title | Other fonts - No bold title |
|--------|--------|--------|
| <img width="333" height="431" alt="image" src="https://github.com/user-attachments/assets/915ba7c0-6148-4fd9-9d00-b44c93f35e0e" /> | <img width="336" height="430" alt="image" src="https://github.com/user-attachments/assets/b509eccc-fc0c-4823-93d9-8e9fcce5b961" /> | <img width="332" height="426" alt="image" src="https://github.com/user-attachments/assets/41b680ca-b994-4b87-ad83-09640ca32699" /> |

---
This PR

| Default | Bold Title | Other fonts - No bold title |
|--------|--------|--------|
| <img width="332" height="419" alt="image" src="https://github.com/user-attachments/assets/caa1a040-93c2-41ff-95a7-c816d7ae26da" /> | <img width="327" height="418" alt="image" src="https://github.com/user-attachments/assets/afe78b8c-9045-446c-add8-1a11dfa738e4" /> | <img width="322" height="416" alt="image" src="https://github.com/user-attachments/assets/a6460b87-6af6-417c-83e8-51828c04deb5" /> |


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
