### PR TITLE
[FIX] resource: Incorrect computation of total hours duration

### DIFF
--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -677,7 +677,7 @@ class ResourceCalendar(models.Model):
         self.ensure_one()
         hour_count = 0.0
         for attendance in self._get_global_attendances():
-            hour_count += attendance.hour_to - attendance.hour_from
+            hour_count += attendance.duration_hours
         return hour_count / 2 if self.two_weeks_calendar else hour_count
 
     def _get_hours_per_day(self):

--- a/addons/resource/models/resource_calendar_attendance.py
+++ b/addons/resource/models/resource_calendar_attendance.py
@@ -86,14 +86,20 @@ class ResourceCalendarAttendance(models.Model):
             for attendance in attendances:
                 if attendance.day_period == 'full_day':
                     period_duration = attendance.duration_hours / 2
-                    attendance.hour_to = 12 + period_duration
-                    attendance.hour_from = 12 - period_duration
+                    attendance.write({
+                        'hour_from': 12 - period_duration,
+                        'hour_to': 12 + period_duration,
+                    })
                 elif attendance.day_period == 'morning':
-                    attendance.hour_to = 12
-                    attendance.hour_from = 12 - attendance.duration_hours
+                    attendance.write({
+                        'hour_from': 12 - attendance.duration_hours,
+                        'hour_to': 12,
+                    })
                 elif attendance.day_period == 'afternoon':
-                    attendance.hour_to = 12 + attendance.duration_hours
-                    attendance.hour_from = 12
+                    attendance.write({
+                        'hour_from': 12,
+                        'hour_to': 12 + attendance.duration_hours,
+                    })
 
     @api.depends('day_period')
     def _compute_duration_days(self):


### PR DESCRIPTION
previous behavior:
- total duration (hours/week) is computed as sum of `hour_to - hour_from` for each line

current behavior:
- made hours duration computed depending on the duration of each line instead of `hour_to - hour_from` (because the correct `hour_to` and `hour_from` get computed afterwards)
- added a test for duration based calendar to check if `hours_per_week` is computed correctly

task-id: task-5059812
