### PR TITLE
[FIX] mrp: prefill first SN on generation and correct next SN

### DIFF
--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -5257,21 +5257,22 @@ class TestMrpOrder(TestMrpCommon):
         # Check the first generated serial numbers
         self.assertEqual(mo.lot_producing_ids.mapped('name'), ['sn#01', 'sn#02', 'sn#03', 'sn#04', 'sn#05'])
         mo.button_mark_done()
-        # Make a second one with a quantity of 3
+        # Make a second one with a quantity of 3 and a custom serial number
         mo_form = Form(self.env['mrp.production'])
+        p_final.serial_prefix_format = "customMRPSerial"
         mo_form.product_id = p_final
         mo_form.product_qty = 3
         mo2 = mo_form.save()
         mo2.action_confirm()
         res_dict = mo2.action_generate_serial()
         serials_wizard = Form.from_action(self.env, res_dict)
-        self.assertEqual(serials_wizard.lot_name, 'sn#06')
+        self.assertEqual(serials_wizard.lot_name, 'customMRPSerial0000001')
         serials_wizard.lot_quantity = mo2.product_uom_qty
         res_dict = serials_wizard.save().action_generate_serial_numbers()
         serials_wizard = Form.from_action(self.env, res_dict)
         serials_wizard.save().action_apply()
         # Check that the serial numbers follow the sequence
-        self.assertEqual(mo2.lot_producing_ids.mapped('name'), ['sn#06', 'sn#07', 'sn#08'])
+        self.assertEqual(mo2.lot_producing_ids.mapped('name'), ['customMRPSerial0000001', 'customMRPSerial0000002', 'customMRPSerial0000003'])
 
 
 @tagged('-at_install', 'post_install')

--- a/addons/mrp/wizard/mrp_production_serial_numbers.py
+++ b/addons/mrp/wizard/mrp_production_serial_numbers.py
@@ -24,7 +24,7 @@ class MrpProductionSerials(models.TransientModel):
                 continue
             wizard.lot_name = self.production_id.lot_producing_ids[:1].name
             if not wizard.lot_name:
-                wizard.lot_name = self.env['stock.lot']._get_next_serial(self.production_id.company_id, self.production_id.product_id)
+                wizard.lot_name = self.production_id.product_id.serial_prefix_format + self.production_id.product_id.next_serial
 
     @api.depends('production_id')
     def _compute_lot_quantity(self):
@@ -59,6 +59,12 @@ class MrpProductionSerials(models.TransientModel):
         for lot_name in lots:
             if lot_name in existing_lot_names:
                 continue
+
+            if self.lot_name == self.production_id.product_id.serial_prefix_format + self.production_id.product_id.next_serial:
+                if self.production_id.product_id.lot_sequence_id:
+                    lot_name = self.production_id.product_id.lot_sequence_id.next_by_id()
+                else:
+                    lot_name = self.env['ir.sequence'].next_by_code('stock.lot.serial')
             new_lots.append({
                 'name': lot_name,
                 'product_id': self.production_id.product_id.id


### PR DESCRIPTION
Back port of https://github.com/odoo/odoo/pull/226046 intended to target 19.0






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
