### PR TITLE
[FIX] point_of_sale: ensure customer is loaded before selection

### DIFF
--- a/addons/point_of_sale/static/tests/pos/tours/utils/payment_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/payment_screen_util.js
@@ -393,7 +393,7 @@ export function clickPartnerButton() {
 }
 
 export function clickCustomer(name) {
-    return [PartnerList.clickPartner(name)];
+    return [...PartnerList.searchCustomerValue(name), PartnerList.clickPartner(name)];
 }
 
 export function shippingLaterHighlighted() {

--- a/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
@@ -209,7 +209,11 @@ export function clickPartnerButton() {
     ];
 }
 export function clickCustomer(name) {
-    return [PartnerList.clickPartner(name), { ...back(), isActive: ["mobile"] }];
+    return [
+        ...PartnerList.searchCustomerValue(name),
+        PartnerList.clickPartner(name),
+        { ...back(), isActive: ["mobile"] },
+    ];
 }
 export function selectPreset(selectedPreset, presetToSelect) {
     return [

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_loyalty_program_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_loyalty_program_tour.js
@@ -1,4 +1,3 @@
-import * as PartnerList from "@point_of_sale/../tests/pos/tours/utils/partner_list_util";
 import * as PosLoyalty from "@pos_loyalty/../tests/tours/utils/pos_loyalty_util";
 import * as ProductScreen from "@point_of_sale/../tests/pos/tours/utils/product_screen_util";
 import * as PaymentScreen from "@point_of_sale/../tests/pos/tours/utils/payment_screen_util";
@@ -141,7 +140,6 @@ registry.category("web_tour.tours").add("PosLoyaltyChangeRewardQty", {
         [
             Chrome.startPoS(),
             ProductScreen.clickPartnerButton(),
-            PartnerList.searchCustomerValue("DDD Test Partner"),
             ProductScreen.clickCustomer("DDD Test Partner"),
             ProductScreen.addOrderline("Desk Organizer", "1"),
             PosLoyalty.isRewardButtonHighlighted(true),


### PR DESCRIPTION
### After this commit:
- In test cases, before selecting a customer, perform a search to ensure the customer is loaded into the list if it is not already present.

Runbot Err: 230518

task: 5068285