### PR TITLE
[FIX] l10n_my*: more precise tests

### DIFF
--- a/addons/l10n_my_edi/tests/test_file_generation.py
+++ b/addons/l10n_my_edi/tests/test_file_generation.py
@@ -84,7 +84,7 @@ class L10nMyEDITestFileGeneration(AccountTestInvoicingCommon):
         """
         Simply test that with a valid configuration, we can generate the file.
         """
-        invoice = self.init_invoice('out_invoice', products=self.product_a, post=True)
+        invoice = self.init_invoice('out_invoice', taxes=self.company_data['default_tax_sale'], products=self.product_a, post=True)
         myinvois_document = invoice._create_myinvois_document()
 
         file, errors = myinvois_document._myinvois_generate_xml_file()
@@ -213,7 +213,7 @@ class L10nMyEDITestFileGeneration(AccountTestInvoicingCommon):
         Set a few optional fields, and ensure that they appear as expecting in the file.
         """
         invoice = self.init_invoice(
-            'out_invoice', currency=self.other_currency, products=self.product_a
+            'out_invoice', currency=self.other_currency, taxes=self.company_data['default_tax_sale'], products=self.product_a
         )
         invoice.write({
             'invoice_incoterm_id': self.env.ref('account.incoterm_CFR').id,
@@ -280,7 +280,7 @@ class L10nMyEDITestFileGeneration(AccountTestInvoicingCommon):
         uuid is present in an adjustment invoice.
         """
         invoice = self.init_invoice(
-            'out_invoice', currency=self.other_currency, products=self.product_a, post=True,
+            'out_invoice', currency=self.other_currency, taxes=self.company_data['default_tax_sale'], products=self.product_a, post=True,
         )
         invoice_document = invoice._create_myinvois_document()
         # Simulate that the document was sent
@@ -615,7 +615,7 @@ class L10nMyEDITestFileGeneration(AccountTestInvoicingCommon):
         Ensure that when an invoice contains a customs number; it is treated as an importation and not exportation.
         """
         invoice = self.init_invoice(
-            'out_invoice', products=self.product_a, post=True
+            'out_invoice', taxes=self.company_data['default_tax_sale'], products=self.product_a, post=True
         )
         myinvois_document = invoice._create_myinvois_document()
 
@@ -637,7 +637,7 @@ class L10nMyEDITestFileGeneration(AccountTestInvoicingCommon):
         """
         Ensure the prepaid amount is present in the UBL XML under <cac:PrepaidPayment>
         """
-        invoice = self.init_invoice('out_invoice', currency=self.other_currency, products=self.product_a, post=True)
+        invoice = self.init_invoice('out_invoice', currency=self.other_currency, taxes=self.company_data['default_tax_sale'], products=self.product_a, post=True)
         myinvois_document = invoice._create_myinvois_document()
 
         self.env['account.payment.register'].with_context(active_model='account.move', active_ids=invoice.ids).create({
@@ -660,7 +660,7 @@ class L10nMyEDITestFileGeneration(AccountTestInvoicingCommon):
         when the two codes differ.
         """
         invoice = self.init_invoice(
-            'out_invoice', products=self.product_a,
+            'out_invoice', taxes=self.company_data['default_tax_sale'], products=self.product_a,
         )
         invoice.line_ids[0].write({
             'l10n_my_edi_classification_code': '002',

--- a/addons/l10n_my_edi/tests/test_submissions.py
+++ b/addons/l10n_my_edi/tests/test_submissions.py
@@ -53,14 +53,12 @@ class L10nMyEDITestNewSubmission(TestAccountMoveSendCommon):
         cls.product_a.l10n_my_edi_classification_code = "001"
 
         # We can reuse this invoice for the flow tests.
-        cls.basic_invoice = cls.init_invoice('out_invoice', products=cls.product_a)
+        cls.basic_invoice = cls.init_invoice('out_invoice', taxes=cls.company_data['default_tax_sale'], products=cls.product_a)
         cls.basic_invoice.action_post()
 
         # For simplicity, we will test everything using a 'test' mode user, but we create it using demo to avoid triggering any api calls.
         cls.proxy_user = cls.env['account_edi_proxy_client.user']._register_proxy_user(cls.company_data['company'], 'l10n_my_edi', 'demo')
         cls.proxy_user.edi_mode = 'test'
-
-        cls.env['ir.config_parameter'].set_param('l10n_my_edi.disable.send_and_print.first', 'True')
 
     @freeze_time('2024-07-15 10:00:00')
     def test_01_new_basic_submission(self):
@@ -364,7 +362,7 @@ class L10nMyEDITestNewSubmission(TestAccountMoveSendCommon):
             first_batch = self.env['account.move']
             for i in range(5):
                 first_batch |= self.init_invoice(
-                    'out_invoice', products=self.product_a, post=True,
+                    'out_invoice', taxes=self.company_data['default_tax_sale'], products=self.product_a, post=True,
                 )
             with freeze_time('2024-07-15 10:00:00'):
                 first_batch.action_l10n_my_edi_send_invoice()
@@ -377,7 +375,7 @@ class L10nMyEDITestNewSubmission(TestAccountMoveSendCommon):
             second_batch = self.basic_invoice
             for i in range(4):
                 second_batch |= self.init_invoice(
-                    'out_invoice', products=self.product_a, post=True,
+                    'out_invoice', taxes=self.company_data['default_tax_sale'], products=self.product_a, post=True,
                 )
             with freeze_time('2024-07-15 10:00:00'):
                 second_batch.action_l10n_my_edi_send_invoice()

--- a/addons/l10n_my_ubl_pint/tests/test_my_ubl_pint.py
+++ b/addons/l10n_my_ubl_pint/tests/test_my_ubl_pint.py
@@ -54,7 +54,7 @@ class TestMyUBLPint(AccountTestInvoicingCommon):
         )
 
     def test_invoice_with_sst(self):
-        invoice = self.init_invoice('out_invoice', currency=self.other_currency, products=self.product_a)
+        invoice = self.init_invoice('out_invoice', taxes=self.company_data['default_tax_sale'], currency=self.other_currency, products=self.product_a)
 
         invoice.write({
             'invoice_incoterm_id': self.env.ref('account.incoterm_CFR').id,


### PR DESCRIPTION
Improve reliability of both malaysian modules
which work with xml files and invoices by ensuring that we precise the tax we expect to see in the file when creating the invoice.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
