### PR TITLE
[IMP] auth_totp_mail, *: remove obsolete .btn-block

### DIFF
--- a/addons/auth_totp_mail/views/templates.xml
+++ b/addons/auth_totp_mail/views/templates.xml
@@ -14,7 +14,7 @@
             <form method="POST" t-if="user._mfa_type() == 'totp_mail'">
                 <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
                 <input type="hidden" name="send_email" value="1"/>
-                <button type="submit" class="btn btn-secondary btn-block">Re-send email</button>
+                <button type="submit" class="btn btn-secondary w-100">Re-send email</button>
             </form>
         </xpath>
         <xpath expr="//div[hasclass('border-top')]" position="before">

--- a/addons/spreadsheet/views/public_readonly_spreadsheet_templates.xml
+++ b/addons/spreadsheet/views/public_readonly_spreadsheet_templates.xml
@@ -16,7 +16,7 @@
                 <div class="fst-italic flex-fill ps-3">
                     <t t-if="is_frozen">Frozen and copied on <span t-field="share.create_date"/></t>
                     <div class="d-inline-flex" t-if="props['downloadExcelUrl']">
-                        <a class="btn btn-secondary btn-block o_download_btn" t-att-href="props['downloadExcelUrl']" title="Download"><i class="fa fa-download"/></a>
+                        <a class="btn btn-secondary o_download_btn" t-att-href="props['downloadExcelUrl']" title="Download"><i class="fa fa-download"/></a>
                     </div>
                 </div>
                 <div class="nav d-table my-auto">

--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -192,7 +192,7 @@
                     You are logged in.
                 </p>
                 <div t-attf-class="clearfix oe_login_buttons text-center mb-1 pt-3">
-                    <a class="btn btn-primary btn-block" href="/web/session/logout">Log out</a>
+                    <a class="btn btn-primary" href="/web/session/logout">Log out</a>
                 </div>
             </div>
         </t>

--- a/addons/website/data/website_demo.xml
+++ b/addons/website/data/website_demo.xml
@@ -517,10 +517,10 @@
                                                         <p class="small">Small text. Lorem <b>ipsum dolor sit amet</b>, consectetur adipiscing elit. <i>Integer posuere erat a ante</i>.</p>
                                                     </div>
                                                     <div class="col-5 border-start">
-                                                        <a href="#" class="mb-3 btn-block btn btn-primary">btn-primary</a>
-                                                        <a href="#" class="mb-3 btn-block btn btn-secondary">btn-secondary</a>
-                                                        <a href="#" class="mb-3 btn-block btn btn-outline-primary">btn-outline-primary</a>
-                                                        <a href="#" class="mb-3 btn-block btn btn-outline-secondary">btn-outline-secondary</a>
+                                                        <a href="#" class="mb-3 btn btn-primary">btn-primary</a>
+                                                        <a href="#" class="mb-3 btn btn-secondary">btn-secondary</a>
+                                                        <a href="#" class="mb-3 btn btn-outline-primary">btn-outline-primary</a>
+                                                        <a href="#" class="mb-3 btn btn-outline-secondary">btn-outline-secondary</a>
                                                     </div>
                                                 </div>
                                                 <hr class="my-4"/>
@@ -569,8 +569,8 @@
                                                     </div>
                                                     <div class="col-5 border-start">
                                                         <div t-foreach="['info', 'warning', 'danger', 'success']" t-as="btn">
-                                                            <a href="#" t-attf-class="mb-2 btn-block btn btn-#{btn}" t-out="'btn-' + btn"/>
-                                                            <a href="#" t-attf-class="mb-3 btn-block btn btn-outline-#{btn}" t-out="'btn-outline-' + btn"/>
+                                                            <a href="#" t-attf-class="mb-2 btn btn-#{btn}" t-out="'btn-' + btn"/>
+                                                            <a href="#" t-attf-class="mb-3 btn btn-outline-#{btn}" t-out="'btn-outline-' + btn"/>
                                                         </div>
                                                     </div>
                                                 </div>

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -2850,7 +2850,7 @@
                           </button>
                         </div>
                     </div>
-                    <button type="submit" class="h4 btn btn-primary btn-block">Access to this page</button>
+                    <button type="submit" class="h4 btn btn-primary">Access to this page</button>
                 </form>
             </div>
         </div>

--- a/addons/website_event/views/event_templates_page_registration.xml
+++ b/addons/website_event/views/event_templates_page_registration.xml
@@ -211,12 +211,12 @@
 <template id="event_calendar_links">
     <h5>Add to your calendar</h5>
     <div id="add_to_calendar" class="o_event_add_to_calendar_btns d-flex flex-wrap gap-3 mt-2">
-        <a role="button" class="o_outlook_calendar btn btn-block bg-white"
+        <a role="button" class="o_outlook_calendar btn bg-white"
             t-att-href="iCal_url">
             <img src="/event/static/src/img/outlook-calendar.svg" alt="Outlook" loading="lazy"/>
             Add to iCal/Outlook
         </a>
-        <a role="button" class="o_google_calendar btn btn-block bg-white"
+        <a role="button" class="o_google_calendar btn bg-white"
             t-att-href="google_url">
             <img src="/event/static/src/img/google-calendar.svg" alt="Google Agenda" loading="lazy"/>
             Add to Google Agenda

--- a/addons/website_event_booth/views/event_booth_templates.xml
+++ b/addons/website_event_booth/views/event_booth_templates.xml
@@ -105,7 +105,7 @@
                                 </div>
                                 <div class="pt24 pb48" name="booth_registration_submit">
                                     <div class="d-flex align-items-center justify-content-end gap-2">
-                                        <button type="submit" class="o_wbooth_registration_submit btn btn-primary btn-block" disabled="true">
+                                        <button type="submit" class="o_wbooth_registration_submit btn btn-primary" disabled="true">
                                             <span>Book my Booth<small>(s)</small></span>
                                         </button>
                                     </div>

--- a/addons/website_event_track/views/event_templates.xml
+++ b/addons/website_event_track/views/event_templates.xml
@@ -67,8 +67,8 @@
                             </span>
                             <p>This page hasn't been saved for offline reading yet.<br/>Please check your network connection.</p>
                             <p>
-                                <a t-att-href="url_for('/event')" class="btn btn-primary btn-block o_translate_inline">Home page</a>
-                                <button onclick="history.back();" class="btn btn-secondary btn-block">Previous page</button>
+                                <a t-att-href="url_for('/event')" class="btn btn-primary o_translate_inline">Home page</a>
+                                <button onclick="history.back();" class="btn btn-secondary">Previous page</button>
                             </p>
                         </div>
                     </div>

--- a/addons/website_slides/views/website_slides_templates_course.xml
+++ b/addons/website_slides/views/website_slides_templates_course.xml
@@ -326,7 +326,7 @@
                     </div>
                 </div>
             </div>
-            <a t-else="" role="button" class="btn btn-primary btn-block o_wslides_js_course_join_link"
+            <a t-else="" role="button" class="btn btn-primary o_wslides_js_course_join_link"
                title="Start Course" aria-label="Start Course" href="#"
                t-att-data-channel-id="channel.id"
                t-att-data-channel-enroll="channel.enroll"


### PR DESCRIPTION
* spreadsheet, web, website, website_event, website_event_booth, website_event_track, website_slides

This PR removes the `btn-block` utility Bootstrap class because it's obsolete since Bootstrap 5.

In the auth_totp_mail template, a class was added to make the button take the full width, as this is the desired behavior.
| Before | After |
|--------|--------|
| <img width="401" height="196" alt="Screenshot 2025-09-15 at 10 08 02" src="https://github.com/user-attachments/assets/f6b3c60e-c151-4010-9ffb-0801b1f67988" /> | <img width="334" height="179" alt="Screenshot 2025-09-15 at 10 10 20" src="https://github.com/user-attachments/assets/3c4fc824-01fd-4251-9a1f-066866a501e4" /> |

task-4637091

PR-enterprise: https://github.com/odoo/enterprise/pull/94730
PR-design-themes: https://github.com/odoo/design-themes/pull/1149

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
