### PR TITLE
[FIX] hr: fix write method on employee versions

### DIFF
--- a/addons/hr/tests/test_hr_version.py
+++ b/addons/hr/tests/test_hr_version.py
@@ -479,3 +479,101 @@ class TestHrVersion(TransactionCase):
         for version in versions[1:]:
             self.assertEqual(version.job_id.id, jobB.id)
             self.assertEqual(version.contract_date_end, date(2020, 9, 30))
+
+    def test_multi_edit_multi_employees_no_contract(self):
+        """
+        Test the multi-edit when there is one version per employee, without contract
+        """
+        employee_john, employee_rob = self.env['hr.employee'].create([
+            {
+                'name': 'John Doe',
+                'date_version': '2020-01-01',
+            },
+            {
+                'name': 'Rob Carter',
+                'date_version': '2020-10-18',
+            }
+        ])
+        versions = (employee_john | employee_rob).version_id
+        versions.write({
+            'contract_date_start': '2021-10-10'
+        })
+        self.assertEqual(versions[0].contract_date_start, date(2021, 10, 10))
+        self.assertEqual(versions[1].contract_date_start, date(2021, 10, 10))
+
+    def test_multi_edit_multi_employees_mix_contract(self):
+        """
+        Test the multi-edit when there is one version per employee, some with contract
+        """
+        employee_john, employee_rob = self.env['hr.employee'].create([
+            {
+                'name': 'John Doe',
+                'date_version': '2020-01-01',
+                'contract_date_start': '2020-01-01',
+            },
+            {
+                'name': 'Rob Carter',
+                'date_version': '2020-10-18',
+            }
+        ])
+        versions = (employee_john | employee_rob).version_id
+        versions.write({
+            'contract_date_start': '2021-10-10'
+        })
+        self.assertEqual(versions[0].contract_date_start, date(2021, 10, 10))
+        self.assertEqual(versions[1].contract_date_start, date(2021, 10, 10))
+
+    def test_multi_edit_multi_employees_all_contract(self):
+        """
+        Test the multi-edit when there is one version per employee, all with different contract
+        """
+        employee_john, employee_rob = self.env['hr.employee'].create([
+            {
+                'name': 'John Doe',
+                'date_version': '2020-01-01',
+                'contract_date_start': '2020-01-01',
+            },
+            {
+                'name': 'Rob Carter',
+                'date_version': '2020-10-18',
+                'contract_date_start': '2020-10-18',
+            }
+        ])
+        versions = (employee_john | employee_rob).version_id
+        versions |= employee_john.create_version({
+            'date_version': '2021-08-01',
+            'contract_date_start': '2020-01-01',
+        })
+        versions.write({
+            'contract_date_start': '2021-10-10'
+        })
+        self.assertEqual(versions[0].contract_date_start, date(2021, 10, 10))
+        self.assertEqual(versions[1].contract_date_start, date(2021, 10, 10))
+        self.assertEqual(versions[2].contract_date_start, date(2021, 10, 10))
+
+    def test_multi_edit_multi_employees_incompatible(self):
+        """
+        Test the multi-edit when there is one version per employee, one with incompatible dates
+        """
+        employee_john, employee_rob = self.env['hr.employee'].create([
+            {
+                'name': 'John Doe',
+                'date_version': '2020-01-01',
+                'contract_date_start': '2020-01-01',
+                'contract_date_end': '2020-10-10'
+            },
+            {
+                'name': 'Rob Carter',
+                'date_version': '2020-10-18',
+                'contract_date_start': '2020-10-18',
+            }
+        ])
+        versions = (employee_john | employee_rob).version_id
+        versions |= employee_john.create_version({
+            'date_version': '2021-08-01',
+            'contract_date_start': '2021-08-01',
+        })
+        with self.assertRaises(ValidationError):
+            versions.write({
+                'contract_date_start': '2021-10-10'
+            })


### PR DESCRIPTION
Problem: the write method on the version is not working if the versions are coming from multiple employees. This commit fixes the issue by taking care if the versions belong to different employees.

task-5085086

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
