### PR TITLE
[IMP] sms_twilio: make some ui changes

### DIFF
--- a/addons/mass_mailing_sms/models/mailing_trace.py
+++ b/addons/mass_mailing_sms/models/mailing_trace.py
@@ -70,34 +70,6 @@ class MailingTrace(models.Model):
                 values['sms_code'] = self._get_random_code()
         return super().create(vals_list)
 
-    @api.model
-    def fields_get(self, allfields=None, attributes=None):
-        # As we are adding keys in stable, better be sure no-one is getting crashes
-        # due to missing translations
-        # TODO: remove in master
-        res = super().fields_get(allfields=allfields, attributes=attributes)
-
-        existing_selection = res.get('failure_type', {}).get('selection')
-        if existing_selection is None:
-            return res
-
-        updated_stable = {
-            'twilio_authentication', 'twilio_callback',
-            'twilio_from_missing', 'twilio_from_to',
-        }
-        need_update = updated_stable - set(dict(self._fields['failure_type'].selection))
-        if need_update:
-            self.env['ir.model.fields'].invalidate_model(['selection_ids'])
-            self.env['ir.model.fields.selection']._update_selection(
-                self._name,
-                'failure_type',
-                self._fields['failure_type'].selection,
-            )
-            self.env.registry.clear_cache()
-            return super().fields_get(allfields=allfields, attributes=attributes)
-
-        return res
-
     def _get_random_code(self):
         """ Generate a random code for trace. Uniqueness is not really necessary
         as it serves as obfuscation when unsubscribing. A valid trio

--- a/addons/sms_twilio/__manifest__.py
+++ b/addons/sms_twilio/__manifest__.py
@@ -16,6 +16,11 @@ up their account to start sending SMS messages.
         'wizard/sms_twilio_account_manage_views.xml',
         'security/ir.model.access.csv'
     ],
+    'assets': {
+        'web.assets_backend': [
+            'sms_twilio/static/src/**/*',
+        ],
+    },
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
 }

--- a/addons/sms_twilio/models/mail_notification.py
+++ b/addons/sms_twilio/models/mail_notification.py
@@ -1,4 +1,4 @@
-from odoo import api, fields, models
+from odoo import fields, models
 
 
 class MailNotification(models.Model):
@@ -13,34 +13,3 @@ class MailNotification(models.Model):
             ('twilio_wrong_credentials', 'Twilio Wrong Credentials'),
         ],
     )
-
-    # CRUD
-    # ------------------------------------------------------------
-
-    @api.model
-    def fields_get(self, allfields=None, attributes=None):
-        # As we are adding keys in stable, better be sure no-one is getting crashes
-        # due to missing translations
-        # TODO: remove in master
-        res = super().fields_get(allfields=allfields, attributes=attributes)
-
-        existing_selection = res.get('failure_type', {}).get('selection')
-        if existing_selection is None:
-            return res
-
-        updated_stable = {
-            'twilio_authentication', 'twilio_callback',
-            'twilio_from_missing', 'twilio_from_to',
-        }
-        need_update = updated_stable - set(dict(self._fields['failure_type'].selection))
-        if need_update:
-            self.env['ir.model.fields'].invalidate_model(['selection_ids'])
-            self.env['ir.model.fields.selection']._update_selection(
-                self._name,
-                'failure_type',
-                self._fields['failure_type'].selection,
-            )
-            self.env.registry.clear_cache()
-            return super().fields_get(allfields=allfields, attributes=attributes)
-
-        return res

--- a/addons/sms_twilio/models/mail_notification.py
+++ b/addons/sms_twilio/models/mail_notification.py
@@ -10,6 +10,7 @@ class MailNotification(models.Model):
             ('twilio_callback', 'Incorrect callback URL'),
             ('twilio_from_missing', 'Missing From Number'),
             ('twilio_from_to', 'From / To identic'),
+            ('twilio_wrong_credentials', 'Twilio Wrong Credentials'),
         ],
     )
 

--- a/addons/sms_twilio/models/sms_sms.py
+++ b/addons/sms_twilio/models/sms_sms.py
@@ -27,31 +27,6 @@ class SmsSms(models.Model):
             vals['record_company_id'] = vals.get('record_company_id') or self.env.company.id  # TODO RIGR in master: move this field to SmsSms, and populate it via vals_list from all flows
         return super().create(vals_list)
 
-    @api.model
-    def fields_get(self, allfields=None, attributes=None):
-        # As we are adding keys in stable, better be sure no-one is getting crashes
-        # due to missing translations
-        # TODO: remove in master
-        res = super().fields_get(allfields=allfields, attributes=attributes)
-
-        existing_selection = res.get('failure_type', {}).get('selection')
-        if existing_selection is None:
-            return res
-
-        updated_stable = {'twilio_from_missing', 'twilio_from_to'}
-        need_update = updated_stable - set(dict(self._fields['failure_type'].selection))
-        if need_update:
-            self.env['ir.model.fields'].invalidate_model(['selection_ids'])
-            self.env['ir.model.fields.selection']._update_selection(
-                self._name,
-                'failure_type',
-                self._fields['failure_type'].selection,
-            )
-            self.env.registry.clear_cache()
-            return super().fields_get(allfields=allfields, attributes=attributes)
-
-        return res
-
     # SEND
     # ------------------------------------------------------------
 

--- a/addons/sms_twilio/models/sms_sms.py
+++ b/addons/sms_twilio/models/sms_sms.py
@@ -14,6 +14,7 @@ class SmsSms(models.Model):
             ('twilio_callback', 'Incorrect callback URL'),
             ('twilio_from_missing', 'Missing From Number'),
             ('twilio_from_to', 'From / To identic'),
+            ('twilio_wrong_credentials', 'Twilio Wrong Credentials'),
         ],
     )
 

--- a/addons/sms_twilio/models/sms_twilio_number.py
+++ b/addons/sms_twilio/models/sms_twilio_number.py
@@ -18,9 +18,3 @@ class SmsTwilioNumber(models.Model):
     def _compute_display_name(self):
         for record in self:
             record.display_name = f"{record.number} ({record.country_id.name})"
-
-    def action_unlink(self):
-        # First create the action while self exists as it's going to be unlink right after
-        action = self.company_id._action_open_sms_twilio_account_manage()
-        self.unlink()
-        return action

--- a/addons/sms_twilio/static/src/core/notification_model.js
+++ b/addons/sms_twilio/static/src/core/notification_model.js
@@ -1,0 +1,24 @@
+import { Notification } from "@mail/core/common/notification_model";
+import { _t } from "@web/core/l10n/translation";
+import { patch } from "@web/core/utils/patch";
+
+/** @type {import("models").Notification} */
+const notificationPatch = {
+    get failureMessage() {
+        switch (this.failure_type) {
+            case "twilio_authentication":
+                return _t("Authentication Error");
+            case "twilio_callback":
+                return _t("Incorrect callback URL");
+            case "twilio_from_missing":
+                return _t("Missing From Number");
+            case "twilio_from_to":
+                return _t("From / To identic");
+            case "twilio_wrong_credentials":
+                return _t("Twilio Wrong Credentials");
+            default:
+                return super.failureMessage;
+        }
+    },
+};
+patch(Notification.prototype, notificationPatch);

--- a/addons/sms_twilio/tools/sms_api.py
+++ b/addons/sms_twilio/tools/sms_api.py
@@ -15,6 +15,7 @@ class SmsApiTwilio(SmsApiBase):
         'twilio_callback': 'twilio_callback',
         'twilio_from_missing': 'twilio_from_missing',
         'twilio_from_to': 'twilio_from_to',
+        'twilio_wrong_credentials': 'twilio_wrong_credentials',
     }
 
     def _sms_twilio_send_request(self, session, to_number, body, uuid):
@@ -95,6 +96,8 @@ class SmsApiTwilio(SmsApiBase):
         elif error_code == 21609:
             # Twilio StatusCallback URL is incorrect
             return "twilio_callback"
+        elif error_code == 20003:
+            return "twilio_wrong_credentials"
         _logger.warning('Twilio SMS: Unknown error "%s" (code: %s)', response_json.get('message'), error_code)
         return "unknown"
 
@@ -110,6 +113,7 @@ class SmsApiTwilio(SmsApiBase):
             'twilio_from_missing': ("A 'From' number is required to send a message"),
             'twilio_from_to': _("'To' and 'From' numbers cannot be the same"),
             'wrong_number_format': _("The number you're trying to reach is not correctly formatted"),
+            'twilio_wrong_credentials': _("Recheck your credentials"),
             # fallback
             'unknown': _("Unknown error, please contact Odoo support"),
         })

--- a/addons/sms_twilio/wizard/sms_twilio_account_manage.py
+++ b/addons/sms_twilio/wizard/sms_twilio_account_manage.py
@@ -74,6 +74,7 @@ class SmsTwilioAccountManage(models.TransientModel):
     def action_send_test(self):
         if not self.test_number:
             raise UserError(_("Please set the number to which you want to send a test SMS."))
+        self.company_id._assert_twilio_sid()
         composer = self.env['sms.composer'].create({
             'body': _("This is a test SMS from Odoo"),
             'composition_mode': 'numbers',

--- a/addons/sms_twilio/wizard/sms_twilio_account_manage_views.xml
+++ b/addons/sms_twilio/wizard/sms_twilio_account_manage_views.xml
@@ -11,8 +11,8 @@
                     <label for="sms_twilio_account_sid"/>
                     <div class="d-flex align-items-center">
                         <field name="sms_twilio_account_sid" placeholder="ACabcde12345abcde12345abcde12345ab"
-                            required="1"/>
-                        <a target="_blank" class="btn btn-link ms-1 w-25"
+                            required="1" class="w-75"/>
+                        <a target="_blank" class="btn btn-link ms-1 w-25 p-0"
                             role="button"
                             href="https://www.odoo.com/documentation/latest/applications/marketing/sms_marketing/twilio.html">
                             Need help ?
@@ -20,26 +20,25 @@
                         </a>
                     </div>
                     <field name="sms_twilio_auth_token" password="True" placeholder="abcde12345abcde12345abcde12345ab"
-                        required="1"/>
+                        required="1" class="w-75"/>
                     <label for="test_number"/>
                     <div class="d-flex align-items-center">
-                        <field name="test_number" placeholder="+1 555-123-4567"/>
+                        <field name="test_number" placeholder="+1 555-123-4567" class="w-auto"/>
                         <button name="action_send_test" string="Send test SMS"
                             icon="fa-send" type="object"
-                            class="btn btn-link w-25 ms-1"/>
+                            class="btn btn-link w-auto ms-1 p-0"/>
                     </div>
                 </group>
                 <group string="Phone Numbers">
                     <button
                         class="btn btn-secondary" colspan="2"
                         type="object" name="action_reload_numbers"
-                        string="Reload Numbers from Twilio" icon="fa-refresh"/>
+                        string="Load from Twilio" icon="fa-refresh"/>
                     <field name="sms_twilio_number_ids" colspan="2" nolabel="1">
-                        <list editable="bottom" delete="0">
+                        <list editable="bottom">
                             <field name="sequence" widget="handle"/>
                             <field name="country_id"/>
                             <field name="number" placeholder="+1 555-123-4567"/>
-                            <button name="action_unlink" title="Delete" icon="fa-trash" type="object"/>
                         </list>
                     </field>
                 </group>


### PR DESCRIPTION
This PR makes the following ui changes when configuring the Twilio account.

- Align the `test_number` and `sms_twilio_account_sid` fields with their labels
  and also reduce the width of both fields.
- Allow deleting phone number lines before saving the record.
- Used the `_assert_twilio_sid` method before calling the
  `_action_send_sms` method, so if the format is not even correct, we can avoid
  the entire call stack of `_action_send_sms` and earlier, with the previous
  flow when the UserError was raised by `_assert_twilio_sid` was handled as an
  exception in the `_send_with_api` method, so we just get the Server error as a
  notification, which doesn't give much info related to what went wrong, now
  with the current flow, UserError will be raised in UI.
- Added the new failure_type `wrong_credentials` when we get a credentials
  mismatch error from Twilio.
- Patched the failureMessage method to add Twilio's failure notification.
- Remove the overrides of fields_get, which were added here https://github.com/odoo/odoo/commit/c4255062ecc2789522516ab988b0474f6b49f589 for
  translation purposes in a stable.

Task-5085099