### PR TITLE
[FIX] web: prevent accessing restricted document

### DIFF
--- a/addons/web/static/src/core/position/position_hook.js
+++ b/addons/web/static/src/core/position/position_hook.js
@@ -105,7 +105,12 @@ export function usePosition(refName, getTarget, options = {}) {
                     targetDocument.defaultView &&
                     targetDocument.defaultView.top !== targetDocument.defaultView
                 ) {
-                    documents.push(targetDocument.defaultView.top.document);
+                    try {
+                        documents.push(targetDocument.defaultView.top.document);
+                    } catch {
+                        // Don't access the top document if it is not allowed.
+                        // (i.e. iframe origin or sandbox restriction)
+                    }
                 }
             }
             for (const document of documents) {


### PR DESCRIPTION
This [commit] introduced a cross-origin/sandbox access violation. `window.top` properties must never be accessed without guarding.

Known issue: embedded livechat.

[commit]: https://github.com/odoo/odoo/commit/27a85d650dee8345a4ec701bf7456eec07851718

task-5083154