### PR TITLE
[FIX] hw_drivers: catch CUPS exception when adding printer

### DIFF
--- a/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_L.py
@@ -104,19 +104,23 @@ class PrinterDriver(Driver):
                 if model and model in PPDs[ppd]['ppd-product']:
                     ppd_file = ppd
                     break
-            with cups_lock:
-                if ppd_file:
-                    conn.addPrinter(name=device['identifier'], ppdname=ppd_file, device=device['url'])
-                else:
-                    conn.addPrinter(name=device['identifier'], device=device['url'])
+            with cups_lock, helpers.writable():
+                try:
+                    if ppd_file:
+                        conn.addPrinter(name=device['identifier'], ppdname=ppd_file, device=device['url'])
+                    else:
+                        conn.addPrinter(name=device['identifier'], device=device['url'])
 
-                conn.setPrinterInfo(device['identifier'], device['device-make-and-model'])
-                conn.enablePrinter(device['identifier'])
-                conn.acceptJobs(device['identifier'])
-                conn.setPrinterUsersAllowed(device['identifier'], ['all'])
-                conn.addPrinterOptionDefault(device['identifier'], "usb-no-reattach", "true")
-                conn.addPrinterOptionDefault(device['identifier'], "usb-unidir", "true")
-            return True
+                    conn.setPrinterInfo(device['identifier'], device['device-make-and-model'])
+                    conn.enablePrinter(device['identifier'])
+                    conn.acceptJobs(device['identifier'])
+                    conn.setPrinterUsersAllowed(device['identifier'], ['all'])
+                    conn.addPrinterOptionDefault(device['identifier'], "usb-no-reattach", "true")
+                    conn.addPrinterOptionDefault(device['identifier'], "usb-unidir", "true")
+                    return True
+                except IPPError:
+                    _logger.exception("Failed to add printer '%s'", device['identifier'])
+                    return False
         return False
 
     @classmethod


### PR DESCRIPTION
Before this commit, if CUPS raised an error when adding a printer in the `supported()` method of the printer driver, the exception would not be caught causing the printer interface to stop. This can happen for example if the filesystem is read-only or the printer has an invalid name.

After this commit, we catch any CUPS errors and log them, allowing the printer interface to continue running. We also enter write mode before adding the printer to prevent any read-only errors.

task-5086036

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
