### PR TITLE
[FIX] web: fix color picker selected color visibility in dark mode

### DIFF
--- a/addons/web/static/src/core/colorlist/colorlist.scss
+++ b/addons/web/static/src/core/colorlist/colorlist.scss
@@ -18,7 +18,7 @@
         @for $size from 2 through length($o-colors) {
             &.o_colorlist_item_color_#{$size - 1} {
                 @include o-print-color(nth($o-colors, $size), background-color, bg-opacity);
-                @include o-print-color(#FFF, color, text-opacity);
+                @include o-print-color($o-white, color, text-opacity);
             }
         }
 


### PR DESCRIPTION
This PR fixes an issue related to Commit[^1], which used `#fff` to style the active color within the color picker. While this works fine in light mode as we do not tweak the `$o-colors` map that much, it does not provide good results in dark mode as the colors are drastically adjusted.

| 19.0 and above | This PR |
|--------|--------|
| <img width="192" height="89" alt="image" src="https://github.com/user-attachments/assets/c4eadd42-fbe4-4b34-85ad-2010103850a7" /> | <img width="153" height="102" alt="image" src="https://github.com/user-attachments/assets/0dcba0fa-69bc-48de-9c96-bcdf69ea7f1f" /> | 

With this PR, we use a dynamic value instead of a static one, ensuring it will provide good results in both light and dark mode.

task-5089121
related to task-5049476
[^1]: 1aa9b957afdd1413f6241ce2e408b96f9e934242
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr