### PR TITLE
[IMP] website: reset background when applying color combination

### DIFF
--- a/addons/website/static/src/builder/plugins/customize_website_plugin.js
+++ b/addons/website/static/src/builder/plugins/customize_website_plugin.js
@@ -166,7 +166,7 @@ export class CustomizeWebsitePlugin extends Plugin {
                 const isColorCombination = /^o_cc[12345]$/.test(color);
                 if (isColorCombination) {
                     finalColors[combinationColor] = parseInt(color.substring(4));
-                    delete finalColors[colorName];
+                    finalColors[colorName] = "";
                 } else if (isCSSVariable(color)) {
                     const customProperty = color.match(/var\(--(.+?)\)/)[1];
                     finalColors[colorName] = this.getWebsiteVariableValue(customProperty);
@@ -921,14 +921,12 @@ export class CustomizeWebsiteColorAction extends BuilderAction {
                     // Do not touch CC if a gradient is being set
                     resetCcOnEmpty: !gradientValue,
                     // Reload bundle will be handled by setting gradient
-                    reloadBundles: isColorCombination,
+                    reloadBundles: false,
                 }
             );
-            if (!isColorCombination) {
-                await this.dependencies.customizeWebsite.customizeWebsiteVariables({
-                    [gradientColor]: gradientValue || nullValue,
-                }); // reloads bundles
-            }
+            await this.dependencies.customizeWebsite.customizeWebsiteVariables({
+                [gradientColor]: isColorCombination ? nullValue : gradientValue || nullValue,
+            }); // reloads bundles
         } else {
             await this.dependencies.customizeWebsite.customizeWebsiteColors(
                 { [color]: value },

--- a/addons/website/static/tests/builder/website_builder/customize_website_color.test.js
+++ b/addons/website/static/tests/builder/website_builder/customize_website_color.test.js
@@ -52,7 +52,8 @@ test("BuilderColorPicker with action “customizeWebsiteColor” is correctly di
     await def;
     expect.verifySteps([
         "set preset",
-        '/website/static/src/scss/options/colors/user_color_palette.scss {"test":4}',
+        '/website/static/src/scss/options/colors/user_color_palette.scss {"test-custom":"NULL","test":4}',
+        '/website/static/src/scss/options/user_values.scss {"test-gradient":"NULL"}',
         "asset reload",
     ]);
 
@@ -80,7 +81,8 @@ test("BuilderColorPicker with action “customizeWebsiteColor” is correctly di
     await def;
     expect.verifySteps([
         "set preset on solid color",
-        '/website/static/src/scss/options/colors/user_color_palette.scss {"test":3}',
+        '/website/static/src/scss/options/colors/user_color_palette.scss {"test-custom":"NULL","test":3}',
+        '/website/static/src/scss/options/user_values.scss {"test-gradient":"NULL"}',
         "asset reload",
     ]);
 
@@ -108,7 +110,8 @@ test("BuilderColorPicker with action “customizeWebsiteColor” is correctly di
     await def;
     expect.verifySteps([
         "set preset on gradient",
-        '/website/static/src/scss/options/colors/user_color_palette.scss {"test":4}',
+        '/website/static/src/scss/options/colors/user_color_palette.scss {"test-custom":"NULL","test":4}',
+        '/website/static/src/scss/options/user_values.scss {"test-gradient":"NULL"}',
         "asset reload",
     ]);
 


### PR DESCRIPTION
It was difficult for the user to understand how the background colorpicker works. The color combination would not be resetted when applying a solid color or a gradient, and vice versa.

To simplify the behavior, applying a color combination now resets the solid color or gradient previously applied. The user will then choose to reapply its previous choice or not.

task-5062183