### PR TITLE
[FIX] stock_fleet: fix incorrect label for deliveries

### DIFF
--- a/addons/stock_fleet/views/stock_picking_type.xml
+++ b/addons/stock_fleet/views/stock_picking_type.xml
@@ -49,7 +49,8 @@
                 <div class="o_row gap-3">
                     <field name="dispatch_management"/>
                     <div class="d-flex gap-3" invisible="not dispatch_management" groups="stock.group_stock_multi_locations">
-                        <span class="fw-bold">To</span>
+                        <span class="fw-bold" invisible= "code !='outgoing'">From</span>
+                        <span class="fw-bold" invisible= "code =='outgoing'">To</span>
                         <field name="dock_ids" placeholder="Dock Locations" widget="many2many_tags" context="{'for_dock_location': True}"/>
                     </div>
                 </div>


### PR DESCRIPTION
Deliveries send goods from the dock location. Therefore, If the operation type is a delivery it will show "From" instead of "To".

Description of the issue/feature this PR addresses:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
