### PR TITLE
[FIX] mass_mailing: post-refactoring follow-up fixes

### DIFF
--- a/addons/mass_mailing/static/src/builder/fontfamily_picker.js
+++ b/addons/mass_mailing/static/src/builder/fontfamily_picker.js
@@ -17,6 +17,7 @@ export class FontFamilyPicker extends BaseOptionComponent {
     static props = {
         action: String,
         actionParam: Object,
+        extraClass: { type: String, optional: true },
     };
     FONT_FAMILIES = FONT_FAMILIES;
 }

--- a/addons/mass_mailing/static/src/builder/fontfamily_picker.xml
+++ b/addons/mass_mailing/static/src/builder/fontfamily_picker.xml
@@ -1,6 +1,6 @@
 <templates>
     <t t-name="mass_mailing.FontFamilyPicker">
-        <BuilderSelect className="'ps-2'" action="this.props.action" actionParam="this.props.actionParam">
+        <BuilderSelect className="props.extraClass" action="this.props.action" actionParam="this.props.actionParam">
             <t t-foreach="this.FONT_FAMILIES" t-as="fontFamily" t-key="fontFamily">
                 <BuilderSelectItem t-out="fontFamily" actionValue="fontFamily_value"/>
             </t>

--- a/addons/mass_mailing/static/src/builder/plugins/border_option_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/border_option_plugin.js
@@ -25,8 +25,7 @@ export class BorderOptionPlugin extends Plugin {
             withSequence(VERTICAL_ALIGNMENT, {
                 template: "mass_mailing.BorderOption",
                 selector: ".row > div",
-                exclude:
-                    ".o_mail_wrapper_td, .s_col_no_bgcolor, .s_col_no_bgcolor.row > div, .s_image_gallery .row > div",
+                exclude: ".o_mail_wrapper_td, .s_image_gallery .row > div",
             }),
         ],
     };

--- a/addons/mass_mailing/static/src/builder/plugins/layout_column_option_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/layout_column_option_plugin.js
@@ -3,6 +3,8 @@ import { before, WIDTH } from "@html_builder/utils/option_sequence";
 import { Plugin } from "@html_editor/plugin";
 import { withSequence } from "@html_editor/utils/resource";
 import { registry } from "@web/core/registry";
+import { isEmptyBlock } from "@html_editor/utils/dom_info";
+import { closestElement } from "@html_editor/utils/dom_traversal";
 
 class MassMailingLayoutColumnPlugin extends Plugin {
     static id = "mass_mailing.LayoutColumnPlugin";
@@ -16,7 +18,35 @@ class MassMailingLayoutColumnPlugin extends Plugin {
                 applyTo: ":scope > *:has(> .row:not(.s_nb_column_fixed)), * > .s_allow_columns",
             }),
         ],
+        normalize_handlers: this.normalize.bind(this),
     };
+
+    normalize(element) {
+        const emptyRowCandidates = element.querySelectorAll(".container > .row:not(:has(> *))");
+        const emptyContainerCandidates = new Set();
+        const emptySectionCandidates = new Set();
+
+        for (const emptyRowCandidate of emptyRowCandidates) {
+            if (isEmptyBlock(emptyRowCandidate)) {
+                emptyContainerCandidates.add(emptyRowCandidate.parentElement);
+                emptyRowCandidate.remove();
+            }
+        }
+        for (const emptyContainerCandidate of emptyContainerCandidates) {
+            if (isEmptyBlock(emptyContainerCandidate)) {
+                const section = closestElement(emptyContainerCandidate, "section");
+                if (section) {
+                    emptySectionCandidates.add(section);
+                }
+                emptyContainerCandidate.remove();
+            }
+        }
+        for (const emptySectionCandidate of emptySectionCandidates) {
+            if (isEmptyBlock(emptySectionCandidate)) {
+                emptySectionCandidate.remove();
+            }
+        }
+    }
 }
 
 registry

--- a/addons/mass_mailing/static/src/builder/tabs/design_tab.xml
+++ b/addons/mass_mailing/static/src/builder/tabs/design_tab.xml
@@ -93,7 +93,7 @@
             <BuilderNumberInput title.translate="Bottom" unit="'px'" saveUnit="'px'" actionParam="{ variable: `${marginPrefix}margin-bottom` }" default="0"/>
         </BuilderRow>
         <BuilderRow>
-            <FontFamilyPicker action="'mass_mailing.CustomizeMailingVariable'" actionParam="{variable: `${prefix}font-family`}"/>
+            <FontFamilyPicker extraClass="'ps-2'" action="'mass_mailing.CustomizeMailingVariable'" actionParam="{variable: `${prefix}font-family`}"/>
             <BuilderButton icon="'fa-fw fa-bold'" actionParam="{ variable: `${prefix}font-weight` }" actionValue="'bolder'"/>
             <BuilderButton icon="'fa-fw fa-italic'" actionParam="{ variable: `${prefix}font-style` }" actionValue="'italic'"/>
             <BuilderButton icon="'fa-fw fa-underline'" actionParam="{ variable: `${prefix}text-decoration-line`}" actionValue="'underline'"/>

--- a/addons/mass_mailing/static/src/fields/html_field/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/fields/html_field/mass_mailing_html_field.js
@@ -122,7 +122,7 @@ export class MassMailingHtmlField extends HtmlField {
     }
 
     get withBuilder() {
-        return this.state.activeTheme !== "basic";
+        return !this.props.readonly && this.state.activeTheme !== "basic";
     }
 
     resetIframe() {
@@ -202,7 +202,12 @@ export class MassMailingHtmlField extends HtmlField {
      * @override
      */
     getReadonlyConfig() {
-        return super.getReadonlyConfig();
+        const config = super.getReadonlyConfig();
+        config.value =
+            config.value && config.value.toString()
+                ? config.value
+                : this.props.record.data[this.props.inlineField];
+        return config;
     }
 
     getBuilderConfig() {

--- a/addons/mass_mailing/static/src/scss/themes/theme_basic.scss
+++ b/addons/mass_mailing/static/src/scss/themes/theme_basic.scss
@@ -35,7 +35,7 @@
 .o_basic_theme {
     &.o_layout {
         margin: 0;
-        padding: 24px 16px 10px;
+        padding: 0;
 
         p {
             margin-bottom: 0px;

--- a/addons/mass_mailing/static/src/scss/themes/theme_default.scss
+++ b/addons/mass_mailing/static/src/scss/themes/theme_default.scss
@@ -2,33 +2,6 @@
 // Mass Mailing "Theme Default"
 // ============================
 
-// ===== Default Theme palette =====
-$o-mm-def-color-1: #f5f5f5;
-$o-mm-def-color-2: #ffffff;
-$o-mm-def-color-3: #706482;
-$o-mm-def-color-4: #464646;
-$o-mm-def-color-5: darken($o-mm-def-color-3, 5%);
-$o-mm-def-color-6: #706482;
-$o-mm-def-color-7: #87a6b5;
-
-// ===== Default Theme variables =====
-$o-mm-def-body-width    : 600px;
-$o-mm-def-body-bobile   : 480px;
-$o-mm-def-b-radius      : 2px;
-$o-mm-def-body-bg       : $o-mm-def-color-2;
-
-$o-mm-def-font          : -apple-system, "HelveticaNeue", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
-$o-mm-def-text-color    : $o-mm-def-color-4;
-
-$o-mm-def-btn-bg        : $o-mm-def-color-3;
-$o-mm-def-btn-text      : $o-mm-def-color-2;
-
-// ===== Colors =====
-@include bg-variant(".bg-o-color-2", $o-mm-def-color-6);
-@include text-emphasis-variant(".text-o-color-2", $o-mm-def-color-6);
-@include bg-variant(".bg-o-color-4", $o-mm-def-color-7);
-@include bg-variant(".bg-gray-lighter", $o-mm-def-color-1);
-
 div.col:not([align]) {
     // Default browser style but needed so that alignment works on some mail
     // clients (see convert_inline)

--- a/addons/mass_mailing/static/src/themes/theme_selector/theme_selector.scss
+++ b/addons/mass_mailing/static/src/themes/theme_selector/theme_selector.scss
@@ -136,6 +136,9 @@
             width: 20px;
             height: 20px;
         }
+        i.fa-star {
+            color: $o-main-favorite-color;
+        }
     }
 }
 

--- a/addons/mass_mailing/static/src/themes/theme_selector/theme_selector.xml
+++ b/addons/mass_mailing/static/src/themes/theme_selector/theme_selector.xml
@@ -6,7 +6,7 @@
                 t-if="template.modelId === this.props.config.mailingModelId"
                 t-on-click="() => this.onSelectFavorite(template.html)">
                 <div class="d-inline-flex flex-row align-items-center border px-2 py-2 w-100">
-                    <i class="fa fa-star text-warning me-2"/>
+                    <i class="fa fa-star me-2"/>
                     <span class="text-truncate" t-out="template.subject"/>
                     <div class="ms-auto">
                         <i class="o_mail_template_remove_favorite fa fa-trash ps-2 me-1" t-att-data-id="template.id" title="Remove from Templates"

--- a/addons/mass_mailing/views/snippets/mass_mailing_columns_snippets.xml
+++ b/addons/mass_mailing/views/snippets/mass_mailing_columns_snippets.xml
@@ -3,7 +3,7 @@
     <section class="s_three_columns o_mail_snippet_general o_cc o_cc2 pt32 pb32">
         <div class="container">
             <div class="row d-flex align-items-stretch">
-                <div class="col-md-4 s_col_no_bgcolor pt16 pb16 col-12">
+                <div class="col-md-4 o_mail_no_colorpicker pt16 pb16 col-12">
                     <div class="card text-bg-white h-100">
                         <div class="o_not_editable">
                             <img class="card-img-top o_editable_media" src="/web/image/mass_mailing.s_three_columns_default_image_1" alt=""/>
@@ -14,7 +14,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="col-md-4 s_col_no_bgcolor pt16 pb16 col-12">
+                <div class="col-md-4 o_mail_no_colorpicker pt16 pb16 col-12">
                     <div class="card text-bg-white h-100">
                         <div class="o_not_editable">
                             <img class="card-img-top o_editable_media" src="/web/image/mass_mailing.s_three_columns_default_image_2" alt=""/>
@@ -25,7 +25,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="col-md-4 s_col_no_bgcolor pt16 pb16 col-12">
+                <div class="col-md-4 o_mail_no_colorpicker pt16 pb16 col-12">
                     <div class="card text-bg-white h-100">
                         <div class="o_not_editable">
                             <img class="card-img-top o_editable_media" src="/web/image/mass_mailing.s_three_columns_default_image_3" alt=""/>
@@ -65,7 +65,7 @@
         <div class="container">
             <div class="row s_nb_column_fixed">
                 <div class="col-md-12 s_media_list_item pt16 pb16 col-12" data-name="Media item">
-                    <div class="row s_col_no_resize s_col_no_bgcolor g-0 align-items-center o_colored_level o_cc o_cc1">
+                    <div class="row s_col_no_resize o_mail_no_colorpicker g-0 align-items-center o_colored_level o_cc o_cc1">
                         <div class="col-md-4 align-self-stretch s_media_list_img_wrapper o_not_editable col-12">
                             <img src="/web/image/mass_mailing.s_media_list_default_image_1" class="s_media_list_img o_editable_media h-100 w-100" alt=""/>
                         </div>
@@ -77,7 +77,7 @@
                     </div>
                 </div>
                 <div class="col-md-12 s_media_list_item pt16 pb16" data-name="Media item">
-                    <div class="row s_col_no_resize s_col_no_bgcolor g-0 align-items-center o_colored_level o_cc o_cc1">
+                    <div class="row s_col_no_resize o_mail_no_colorpicker g-0 align-items-center o_colored_level o_cc o_cc1">
                         <div class="col-md-4 align-self-stretch s_media_list_img_wrapper o_not_editable  col-12">
                             <img src="/web/image/mass_mailing.s_media_list_default_image_2" class="s_media_list_img o_editable_media h-100 w-100" alt=""/>
                         </div>
@@ -88,7 +88,7 @@
                     </div>
                 </div>
                 <div class="col-md-12 s_media_list_item pt16 pb16" data-name="Media item">
-                    <div class="row s_col_no_resize s_col_no_bgcolor g-0 align-items-center o_colored_level o_cc o_cc1">
+                    <div class="row s_col_no_resize o_mail_no_colorpicker g-0 align-items-center o_colored_level o_cc o_cc1">
                         <div class="col-md-4 align-self-stretch s_media_list_img_wrapper o_not_editable">
                             <img src="/web/image/mass_mailing.s_media_list_default_image_3" class="s_media_list_img o_editable_media h-100 w-100" alt=""/>
                         </div>
@@ -109,7 +109,7 @@
         <div class="container">
             <div class="row">
                 <div class="s_attributes_horizontal_col col-md-4 pt24 pb24 col-12" data-name="Column">
-                    <div class="row align-items-center h-100 mx-0 s_col_no_resize s_col_no_bgcolor">
+                    <div class="row align-items-center h-100 mx-0 s_col_no_resize o_mail_no_colorpicker">
                         <div class="col-2 col-md-3 px-0">
                             <div class="o_not_editable">
                                 <img
@@ -130,7 +130,7 @@
                     </div>
                 </div>
                 <div class="s_attributes_horizontal_col col-md-4 pt24 pb24 col-12" data-name="Column">
-                    <div class="row align-items-center h-100 mx-0 s_col_no_resize s_col_no_bgcolor">
+                    <div class="row align-items-center h-100 mx-0 s_col_no_resize o_mail_no_colorpicker">
                         <div class="col-2 col-md-3 px-0">
                             <div class="o_not_editable">
                                 <img
@@ -151,7 +151,7 @@
                     </div>
                 </div>
                 <div class="s_attributes_horizontal_col col-md-4 pt24 pb24 col-12" data-name="Column">
-                    <div class="row align-items-center h-100 mx-0 s_col_no_resize s_col_no_bgcolor">
+                    <div class="row align-items-center h-100 mx-0 s_col_no_resize o_mail_no_colorpicker">
                         <div class="col-2 col-md-3 px-0">
                             <div class="o_not_editable">
                                 <img
@@ -201,7 +201,7 @@
     <section class="s_mail_block_event o_mail_snippet_general bg-100">
         <div class="container">
             <div class="row align-items-center">
-                <div class="s_col_no_bgcolor col-md-6 pt32 pb32 col-12">
+                <div class="o_mail_no_colorpicker col-md-6 pt32 pb32 col-12">
                     <div class="card bg-white h-100 rounded" style="border-radius: 5px !important; border-color: rgb(233, 236, 239) !important;">
                         <div class="o_not_editable">
                             <img class="card-img-top o_editable_media" src="/web/image/mass_mailing.s_event_default_image_1" alt=""/>
@@ -218,7 +218,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="s_col_no_bgcolor col-md-6 pt32 pb32 col-12">
+                <div class="o_mail_no_colorpicker col-md-6 pt32 pb32 col-12">
                     <div class="card bg-white h-100 rounded" style="border-radius: 5px !important; border-color: rgb(233, 236, 239) !important;">
                         <div class="o_not_editable">
                             <img class="card-img-top o_editable_media" src="/web/image/mass_mailing.s_event_default_image_2" alt=""/>
@@ -268,7 +268,7 @@
                             <img src="/web/image/mass_mailing.s_product_list_default_image_3" alt="" class="img img-fluid o_editable_media mx-auto"/>
                         </a>
                     </div>
-                    <h3 class="card-title" style="text-align: center;"><a ref="#"><span class="h5-fs">Balanced</span></a></h3>
+                    <h3 class="card-title" style="text-align: center;"><a href="#"><span class="h5-fs">Balanced</span></a></h3>
                 </div>
             </div>
         </div>

--- a/addons/mass_mailing/views/snippets/mass_mailing_headings_snippets.xml
+++ b/addons/mass_mailing/views/snippets/mass_mailing_headings_snippets.xml
@@ -38,7 +38,7 @@
 
 <template id="s_hr_title" name="Separator Title">
     <section class="s_hr_title o_mail_snippet_general pt16 pb16">
-        <div class="container s_allow_columns">
+        <div class="container">
             <div class="row align-items-center">
                 <div class="col-md-4 col-12">
                     <t t-call="mass_mailing.s_hr"/>

--- a/addons/mass_mailing/views/snippets/mass_mailing_marketing_snippets.xml
+++ b/addons/mass_mailing/views/snippets/mass_mailing_marketing_snippets.xml
@@ -144,7 +144,7 @@
         </p>
         <table border="0" cellpadding="0" cellspacing="0" align="center" class="border" style="border-collapse:collapse; mso-table-lspace:0pt; mso-table-rspace:0pt;">
             <tr>
-                <td width="50" height="50" align="center" class="o_mail_no_resize mx-auto o_cc o_cc3" style="width:50px!important; min-width: 50px; max-width:5.6rem; text-align: center;"><span class="fa fa-2x fa-ticket"/></td>
+                <td width="50" height="50" align="center" class="o_mail_no_options mx-auto o_cc o_cc3" style="width:50px!important; min-width: 50px; max-width:5.6rem; text-align: center;"><span class="fa fa-2x fa-ticket"/></td>
                 <td width="200" height="50" align="center" class="o_cc" style="font-size: 15px; line-height: 22px; font-weight: 700; min-width: 150px; width: 200px; text-align: center;"><p class="mb0">ENDOFSUMMER20</p></td>
             </tr>
         </table>

--- a/addons/mass_mailing/views/snippets/mass_mailing_people_snippets.xml
+++ b/addons/mass_mailing/views/snippets/mass_mailing_people_snippets.xml
@@ -8,7 +8,7 @@
             </div>
             <div class="row">
                 <div class="col-md-6 col-12 pt32 pb32" data-name="Team Member">
-                    <div class="row s_col_no_resize s_col_no_bgcolor">
+                    <div class="row s_col_no_resize o_mail_no_colorpicker">
                         <div class="col-md-3 col-12 pb24 o_not_editable" contenteditable="false">
                             <img src="/html_editor/image_shape/mass_mailing.s_company_team_default_image_1/html_builder/geometric_round/geo_round_circle.svg" data-shape="html_builder/geometric_round/geo_round_circle" data-original-src="/web/image/mass_mailing.s_company_team_default_image_1" class="img-fluid rounded-circle o_editable_media"/>
                         </div>
@@ -24,7 +24,7 @@
                     </div>
                 </div>
                 <div class="col-md-6 col-12 pt32 pb32" data-name="Team Member">
-                    <div class="row s_col_no_resize s_col_no_bgcolor">
+                    <div class="row s_col_no_resize o_mail_no_colorpicker">
                         <div class="col-md-3 col-12 pb24 o_not_editable" contenteditable="false">
                             <img alt="" src="/html_editor/image_shape/mass_mailing.s_company_team_default_image_2/html_builder/geometric_round/geo_round_circle.svg" data-shape="html_builder/geometric_round/geo_round_circle" data-original-src="/web/image/mass_mailing.s_company_team_default_image_2" class="img-fluid rounded-circle o_editable_media"/>
                         </div>
@@ -36,7 +36,7 @@
                     </div>
                 </div>
                 <div class="col-md-6 col-12 pt32 pb32" data-name="Team Member">
-                    <div class="row s_col_no_resize s_col_no_bgcolor">
+                    <div class="row s_col_no_resize o_mail_no_colorpicker">
                         <div class="col-md-3 col-12 pb24 o_not_editable" contenteditable="false">
                             <img alt="" src="/html_editor/image_shape/mass_mailing.s_company_team_default_image_3/html_builder/geometric_round/geo_round_circle.svg" data-shape="html_builder/geometric_round/geo_round_circle" data-original-src="/web/image/mass_mailing.s_company_team_default_image_3" class="img-fluid rounded-circle o_editable_media"/>
                         </div>
@@ -48,7 +48,7 @@
                     </div>
                 </div>
                 <div class="col-md-6 col-12 pt32 pb32" data-name="Team Member">
-                    <div class="row s_col_no_resize s_col_no_bgcolor">
+                    <div class="row s_col_no_resize o_mail_no_colorpicker">
                         <div class="col-md-3 col-12 pb24 o_not_editable" contenteditable="false">
                             <img alt="" src="/html_editor/image_shape/mass_mailing.s_company_team_default_image_4/html_builder/geometric_round/geo_round_circle.svg" data-shape="html_builder/geometric_round/geo_round_circle" data-original-src="/web/image/mass_mailing.s_company_team_default_image_4" class="img-fluid rounded-circle o_editable_media"/>
                         </div>

--- a/addons/mass_mailing_themes/views/mass_mailing_themes_templates.xml
+++ b/addons/mass_mailing_themes/views/mass_mailing_themes_templates.xml
@@ -90,7 +90,7 @@
             <div class="container">
                 <div class="row s_nb_column_fixed">
                     <div class="col-md-12 s_media_list_item pt0 pb0" data-name="Media item">
-                        <div class="row s_col_no_resize s_col_no_bgcolor align-items-center o_cc o_cc1">
+                        <div class="row s_col_no_resize o_mail_no_colorpicker align-items-center o_cc o_cc1">
                             <div class="col-md-5 s_media_list_img_wrapper align-self-stretch px-0">
                                 <img src="/mass_mailing_themes/static/src/img/theme_event/s_default_image_media_list_1.jpg" class="s_media_list_img h-100 w-100" style="padding: 10px;"/>
                             </div>
@@ -102,7 +102,7 @@
                         </div>
                     </div>
                     <div class="col-md-12 s_media_list_item pt16 pb0" data-name="Media item">
-                        <div class="row s_col_no_resize s_col_no_bgcolor align-items-center o_cc o_cc1">
+                        <div class="row s_col_no_resize o_mail_no_colorpicker align-items-center o_cc o_cc1">
                             <div class="col-md-5 s_media_list_img_wrapper align-self-stretch px-0">
                                 <img src="/mass_mailing_themes/static/src/img/theme_event/s_default_image_media_list_2.jpg" class="s_media_list_img h-100 w-100" style="padding: 10px;"/>
                             </div>
@@ -114,7 +114,7 @@
                         </div>
                     </div>
                     <div class="col-md-12 s_media_list_item pt16 pb0" data-name="Media item">
-                        <div class="row s_col_no_resize s_col_no_bgcolor align-items-center o_cc o_cc1">
+                        <div class="row s_col_no_resize o_mail_no_colorpicker align-items-center o_cc o_cc1">
                             <div class=" col-md-5 s_media_list_img_wrapper align-self-stretch px-0">
                                 <img src="/mass_mailing_themes/static/src/img/theme_event/s_default_image_media_list_3.jpg" class="s_media_list_img h-100 w-100" style="padding: 10px;"/>
                             </div>
@@ -243,9 +243,9 @@
         </div>
         <section class="s_media_list o_mail_snippet_general o_cc o_cc2 pb0 pt0 bg-white" style="padding-left: 15px; padding-right: 15px;" data-snippet="s_media_list" data-vcss="001" data-name="Media List">
             <div class="container">
-                <div class="row s_nb_column_fixed s_col_no_bgcolor">
+                <div class="row s_nb_column_fixed o_mail_no_colorpicker">
                     <div class="col-md-12 s_media_list_item pb0 pt0" data-name="Media item">
-                        <div class="row s_col_no_resize s_col_no_bgcolor align-items-center o_cc o_cc1">
+                        <div class="row s_col_no_resize o_mail_no_colorpicker align-items-center o_cc o_cc1">
                             <div class="col-md-4 s_media_list_img_wrapper align-self-stretch px-0">
                                 <img src="/mass_mailing_themes/static/src/img/theme_blogging/s_default_image_media_list_1.jpg" class="s_media_list_img h-100 w-100"/>
                             </div>
@@ -259,7 +259,7 @@
                         </div>
                     </div>
                     <div class="col-md-12 s_media_list_item pt0 pb0" data-name="Media item">
-                        <div class="row s_col_no_resize s_col_no_bgcolor align-items-center o_cc o_cc1">
+                        <div class="row s_col_no_resize o_mail_no_colorpicker align-items-center o_cc o_cc1">
                             <div class="col-md-12 s_media_list_img_wrapper align-self-stretch px-0">
                                 <div class="s_hr o_mail_snippet_general pt16 pb16" data-snippet="s_hr" data-name="Separator">
                                     <hr class="s_hr_1px s_hr_solid"/>
@@ -268,7 +268,7 @@
                         </div>
                     </div>
                     <div class="col-md-12 s_media_list_item pb0 pt0" data-name="Media item">
-                        <div class="row s_col_no_resize s_col_no_bgcolor align-items-center o_cc o_cc1">
+                        <div class="row s_col_no_resize o_mail_no_colorpicker align-items-center o_cc o_cc1">
                             <div class="col-md-4 s_media_list_img_wrapper align-self-stretch px-0">
                                 <img src="/mass_mailing_themes/static/src/img/theme_blogging/s_default_image_media_list_2.jpg" class="s_media_list_img h-100 w-100"/>
                             </div>
@@ -280,7 +280,7 @@
                         </div>
                     </div>
                     <div class="col-md-12 s_media_list_item pt0 pb0" data-name="Media item">
-                        <div class="row s_col_no_resize s_col_no_bgcolor align-items-center o_cc o_cc1">
+                        <div class="row s_col_no_resize o_mail_no_colorpicker align-items-center o_cc o_cc1">
                             <div class="col-md-12 s_media_list_img_wrapper align-self-stretch px-0">
                                 <div class="s_hr o_mail_snippet_general pt16 pb16" data-snippet="s_hr" data-name="Separator">
                                     <hr class="s_hr_1px s_hr_solid"/>
@@ -289,7 +289,7 @@
                         </div>
                     </div>
                     <div class="col-md-12 s_media_list_item pt0 pb0" data-name="Media item">
-                        <div class="row s_col_no_resize s_col_no_bgcolor align-items-center o_cc o_cc1">
+                        <div class="row s_col_no_resize o_mail_no_colorpicker align-items-center o_cc o_cc1">
                             <div class="col-md-4 s_media_list_img_wrapper align-self-stretch px-0">
                                 <img src="/mass_mailing_themes/static/src/img/theme_blogging/s_default_image_media_list_3.jpg" class="s_media_list_img h-100 w-100"/>
                             </div>
@@ -396,7 +396,7 @@
             <p style="text-align: center;"><font class="text-white">Here's your coupon code*:</font></p>
             <table cellpadding="0" cellspacing="0" align="center" class="border" style="background-color: rgb(36, 37, 48) !important; border-collapse: collapse; border-color: rgb(198, 150, 120) !important;">
                 <tr>
-                    <td width="50" height="50" align="center" class="o_mail_no_resize" style="min-width: 50px; max-width: 5.6rem; width: 50px !important; background-color: rgb(198, 150, 120) !important; text-align: center;"><i class="fa fa-2x fa-ticket" style="color: rgb(36, 37, 48) !important;"/></td>
+                    <td width="50" height="50" align="center" class="o_mail_no_options" style="min-width: 50px; max-width: 5.6rem; width: 50px !important; background-color: rgb(198, 150, 120) !important; text-align: center;"><i class="fa fa-2x fa-ticket" style="color: rgb(36, 37, 48) !important;"/></td>
                     <td width="200" height="50" align="center" style="min-width: 150px; width: 200px;"><p class="mb0"><span style="font-weight: bolder;"><font class="text-white">VIP10</font></span></p></td>
                 </tr>
             </table>
@@ -797,7 +797,7 @@
             </p>
             <table cellpadding="0" cellspacing="0" align="center" class="border" style="border-collapse: collapse; border-color: rgb(255, 187, 0) !important; border-width: 3px !important; mso-table-lspace:0pt; mso-table-rspace:0pt;">
                 <tr>
-                    <td width="50" height="50" align="center" class="o_mail_no_resize o_cc" style="width:50px!important; min-width: 50px; max-width:5.6rem; text-align: center"><i class="fa fa-2x fa-ticket" style="color: rgb(255, 187, 0) !important;"></i></td>
+                    <td width="50" height="50" align="center" class="o_mail_no_options o_cc" style="width:50px!important; min-width: 50px; max-width:5.6rem; text-align: center"><i class="fa fa-2x fa-ticket" style="color: rgb(255, 187, 0) !important;"></i></td>
                     <td width="200" height="50" align="center" class="o_cc" style="min-width: 150px; width: 200px; text-align: center;"><p class="mb0">ENDOFSUMMER20</p></td>
                 </tr>
             </table>
@@ -1487,7 +1487,7 @@
         <section class="s_mail_block_event o_mail_snippet_general bg-white o_colored_level" data-snippet="s_event" data-name="Event" contenteditable="false">
             <div class="container" contenteditable="true">
                 <div class="row align-items-center">
-                    <div class="s_col_no_bgcolor pt32 pb0 o_colored_level col-md-10 offset-md-1" style="padding-left: 0px; padding-right: 0px;">
+                    <div class="o_mail_no_colorpicker pt32 pb0 o_colored_level col-md-10 offset-md-1" style="padding-left: 0px; padding-right: 0px;">
                         <div class="card bg-white h-100 border" style="border-radius: 5px !important; border-color: rgb(233, 236, 239) !important; border-width: 0px !important;">
                             <div class="card-body">
                                 <div class="s_title o_mail_snippet_general pb0 pt0 o_colored_level" data-snippet="s_title" data-name="Title">


### PR DESCRIPTION
This task bundles fixes for issues introduced with the mass_mailing [refactoring]:

[FIX] mass_mailing: align fontFamilyPicker option
Some options have different alignments, this commit introduces usage of an
extra class to adapt the alignment of the fontFamilyPicker option so that it
displays nicely with other options.

[FIX] mass_mailing: remove empty containers and sections
Prior to this commit, removing all columns from a container would make a
snippet unusable but it would still be in the DOM.

After this commit, empty rows, containers and sections (snippets) are removed.

[FIX] mass_mailing: use o_mail_no_colorpicker instead of s_col_no_bgcolor

Update usages of s_col_no_bgcolor to use o_mail_no_colorpicker instead, and this
class hides the option to change the background color.

[FIX] mass_mailing: remove erroneous mass_mailing style
Prior to this commit, some colors were not accurate when using the ColorPicker,
notably `o-color-2` had a different color when previewed in the `ColorPicker`
than when actually applied in the DOM (Beige vs Purple).

[FIX] mass_mailing: fix separator title snippet
Prior to this commit, the separator title snippet had the option to have "None"
column, which didn't make much sense. This commit removes that option.

[FIX] mass_mailing: fix theme selector favorite template star color
Prior to this commit, the color for `fa-star` element in the Theme Selector,
when a user selects a mailing saved as a favorite, was darker than usual.

[FIX] mass_mailing: display mailings without body_arch in readonly
After the `mass_mailing` [refactoring], sent mailings with a `body_html` but
without a `body_arch` where not properly displayed in the `MassMailingHtmlField`
widget.

How to reproduce:
- Create a new mailing by selecting multiple CRM Leads in the list view
- Click on the "Email" action of the control panel
- Write and send an Email
- Go to the Email Marketing app and open the email

Issue:
- The email is displayed empty.

Resolution:
Display the `body_html` if the `body_arch` is empty.

[FIX] mass_mailing: prevent infinite scrolling when viewing mails
Since the mass_mailing [refactoring], viewing some emails in readonly could
result in the page growing its `scrollHeight` indefinitely:

How to reproduce:
- Write and send a mailing with the basic theme (normal editor)
- Open the mailing in readonly

Issue:
- The scroll views grows its `scrollHeight` indefinitely.

Resolution:
Remove layout padding for the basic theme, since it will interfere with the
automatic iframe sizing process. Adding a padding there would make it impossible
to reconcile the height of the iframe content with the height of the iframe
itself, and that computation is required to prevent the iframe from having an
overflow (functional spec. is that the Form view should scroll the content, and
no scrollbar should appear in the iframe).

[refactoring]: https://github.com/odoo/odoo/commit/82969dc5c6c36a7a91194cf15b33c9abb560a8e7

task-5134263

Co-authored-by: Damien Abeloos <abd@odoo.com>
Co-authored-by: Thomas Josse <thjo@odoo.com>