### PR TITLE
[IMP] account: search taxes on amount field

### DIFF
--- a/addons/account/views/account_tax_views.xml
+++ b/addons/account/views/account_tax_views.xml
@@ -100,6 +100,7 @@
                 <search string="Search Taxes">
                     <field name="name_searchable" string="Name"/>
                     <field name="description"/>
+                    <field name="amount"/>
                     <field name="company_id" groups="base.group_multi_company"/>
                     <filter string="Sale" name="sale" domain="[('type_tax_use','=','sale')]" />
                     <filter string="Purchase" name="purchase" domain="[('type_tax_use','=','purchase')]" />


### PR DESCRIPTION
This commit improves the usability of the tax search view by including the `amount` field. Users can filter taxes based on their configured percentage or amount directly from the search bar.

task-5088050
