### PR TITLE
[IMP] html_editor: pass `sortAttrs` from `testEditor`

### DIFF
--- a/addons/html_editor/static/tests/_helpers/editor.js
+++ b/addons/html_editor/static/tests/_helpers/editor.js
@@ -192,7 +192,7 @@ export async function testEditor(config) {
     if (contentBeforeEdit) {
         // we should do something before (sanitize)
         await compareFunction(
-            getContent(el),
+            getContent(el, config.options),
             contentBeforeEdit,
             "Editor content, before edit",
             editor
@@ -205,7 +205,7 @@ export async function testEditor(config) {
 
     if (contentAfterEdit) {
         await compareFunction(
-            getContent(el),
+            getContent(el, config.options),
             contentAfterEdit,
             "Editor content, after edit",
             editor
@@ -216,7 +216,12 @@ export async function testEditor(config) {
         const content = editor.getContent(); // Saved value.
         dispatchCleanForSave(editor, { root: el, preserveSelection: true });
         const innerHTML = el.innerHTML; // Cleaned value without cursors.
-        await compareFunction(getContent(el), contentAfter, "Editor content, after clean", editor);
+        await compareFunction(
+            getContent(el, config.options),
+            contentAfter,
+            "Editor content, after clean",
+            editor
+        );
         // Test that the saved value matches the cleaned value tested above.
         await compareFunction(content, innerHTML, "Value from editor.getContent()", editor);
     }

--- a/addons/html_editor/static/tests/_helpers/selection.js
+++ b/addons/html_editor/static/tests/_helpers/selection.js
@@ -65,6 +65,10 @@ function getElemContent(el, selection, options) {
     const tag = el.tagName.toLowerCase();
     let attributes = [...el.attributes];
     if (options.sortAttrs) {
+        if (el.className) {
+            el.className = [...el.classList].sort().join(" ");
+            attributes = [...el.attributes];
+        }
         attributes.sort((attr1, attr2) => {
             if (attr1.name === attr2.name) {
                 return 0;


### PR DESCRIPTION
The `getContent` test util has an `options` parameter with a useful `sortAttr` property. This adapts `testEditor` so it can pass that parameter from its `config` to `getContent`.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
