### PR TITLE
[IMP] hr_recruitment_skills: Removed Skill Matching from talent pools

### DIFF
--- a/addons/hr_recruitment_skills/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment_skills/views/hr_applicant_views.xml
@@ -26,7 +26,7 @@
                                 </field>
                             </group>
                             <group>
-                                <field name="matching_score" nolabel="1" widget="skill_match_gauge_field" options="{'max_value': 100}" />
+                                <field name="matching_score" invisible="is_pool_applicant" nolabel="1" widget="skill_match_gauge_field" options="{'max_value': 100}" />
                             </group>
                         </group>
                     </div>


### PR DESCRIPTION
Removed skill matching from the talent pool view,
it now appears only whenever the applicant applies on a specific job 
task:5083092

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
