### PR TITLE
[FIX] purchase_stock: correctly compute monthly demand in multi-step deliveries

### DIFF
--- a/addons/purchase_stock/models/product.py
+++ b/addons/purchase_stock/models/product.py
@@ -124,7 +124,13 @@ class ProductProduct(models.Model):
 
     @api.model
     def _get_monthly_demand_moves_location_domain(self):
-        return [('location_dest_usage', 'in', ['customer', 'production'])]
+        return Domain.OR([
+            [('location_dest_usage', 'in', ['customer', 'production'])],
+            Domain.AND([
+                [('location_final_id.usage', '=', 'customer')],
+                [('move_dest_ids', '=', False)],
+            ])
+        ])
 
     def _get_quantity_in_progress(self, location_ids=False, warehouse_ids=False):
         if not location_ids:


### PR DESCRIPTION
Issue before this commit:
=========================
When confirming a sale quotation in a 1-step delivery route, the product's monthly demand in the vendor’s product catalog  in purchase RFQs was updated correctly for the scheduled sale order. However, in 2-step or 3-step delivery routes, confirming a sale quotation did not correctly update monthly demand for the scheduled sale order. Users may see lower than actual monthly demand in the product catalog, potentially causing confusion when planning purchases in multi-step delivery flows.

Steps to Reproduce:
=========================
-Install `Sales`, `Inventory`, and `Purchase` modules, and enable `multi-step routes` in configuration.
-Set the Outgoing Shipments in the warehouse to 2-step/3-step. 
-Create a product and assign a vendor in the Purchase tab.
-Create a sale quotation for the product and Confirm it. 
-Go to Purchase → Create RFQ for the vendor and open the Catalog
 `Observation`: Monthly demand of product is not updated for the confirmed sale
-Go to the Sale Order, open the delivery, and validate the intermediate transfer
 `Observation`: The monthly demand is now correctly calculated for the confirmed sale order.

Cause of the issue:
=========================
-In this [PR](https://github.com/odoo/odoo/pull/215363), the `move domain` was updated to include reserved moves (not only done moves) in monthly demand calculations. However, the method `_get_monthly_demand_moves_location_domain` only returns moves where `location_dest_usage` is `customer` or `production`.
-In 2-step or 3-step delivery routes, the final transfer move is only created after the intermediate transfer moves are validated. These intermediate transfer moves have `location_dest_usage` = `internal` and are therefore excluded from the domain.
-As a result, the product’s monthly demand is not fully reflected for confirmed sale quotations in multi-step delivery flows.

With This Commit:
=========================
-The method `_get_monthly_demand_moves_location_domain` is extended to also return moves whose `location_final_id.usage = customer` and `move_dest_ids = False`
-`location_final_id.usage = customer` ensures that only moves that eventually reach the customer location are counted as monthly demand,
-`move_dest_ids = False` ensures moves without subsequent transfers are counted. Without this, intermediate internal transfer moves would also be counted once the final move is created, which would incorrectly inflate the demand.
-These conditions ensure that intermediate moves in multi-step deliveries are correctly included in monthly demand calculations, while avoiding duplication once subsequent transfers exist.