### PR TITLE
[FIX] mail: fix selected rotting item color

### DIFF
--- a/addons/mail/static/src/scss/rotting_mixin.scss
+++ b/addons/mail/static/src/scss/rotting_mixin.scss
@@ -9,5 +9,8 @@
 
     .o_kanban_record.oe_kanban_card_rotting {
         background-color: rgba(255, 201, 201, 0.3);
+        &.o_record_selected {
+            background-color: var(--KanbanColumn__highlight-selected);
+        }
     }
 }


### PR DESCRIPTION
The new Rotting feature displays rotting items with a light reddish
background in Kanban view. However, they retain this color even as they
are selected, which makes the selection unclear.

This fix makes it so the rotting items look, once selected, the same
as any other selected kanban item.

task-5088907