### PR TITLE
[FIX] website_sale: create ribbon not working

### DIFF
--- a/addons/website_sale/static/src/website_builder/product_ribbon_options_plugin.js
+++ b/addons/website_sale/static/src/website_builder/product_ribbon_options_plugin.js
@@ -194,7 +194,31 @@ class ProductsRibbonOptionPlugin extends Plugin {
             );
         }
 
-        return Promise.all(promises);
+        let res = []
+        try {
+            res = await Promise.all(promises);
+            for (const ribbonId in ribbonTemplates) {
+                const parsedId = parseInt(ribbonId);
+                if (!currentIds.includes(parsedId)) continue;
+
+                const newId = localToServer[parsedId]?.id;
+                if (!newId) continue;
+
+                const ribbon = this.ribbons.find(r => r.id === parsedId);
+                if (ribbon) ribbon.id = newId;
+
+                this.productTemplatesRibbons =
+                    this.productTemplatesRibbons.filter(r => r.ribbonId !== parsedId);
+                this.editable.querySelectorAll(`[data-ribbon-id="${ribbonId}"]`)
+                    .forEach(el => el.dataset.ribbonId = newId);
+                this.ribbonsObject[newId] = this.ribbonsObject[parsedId];
+                delete this.ribbonsObject[parsedId];
+            }
+            this.originalRibbons = JSON.parse(JSON.stringify(this.ribbonsObject));
+        } catch (error) {
+            console.error(error)
+        }
+        return res;
     }
 
     /**


### PR DESCRIPTION
Steps:
- on /shop page open web editor
- create a new ribbon
- change any of ribbon's properties
- save

Issue:
- ribbon not assigned on the product and an extra ribbon is created

Cause:
- _saveRibbon does not reset js class variables

Fix:
- ribbon option plugin's variable are set to expected state once ribbon is saved

opw - 5072279

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
