### PR TITLE
[FIX] website: restore contrast for active mobile icon

### DIFF
--- a/addons/html_builder/static/src/builder.variables.scss
+++ b/addons/html_builder/static/src/builder.variables.scss
@@ -20,7 +20,7 @@ $o-we-fg-lighter: #FFFFFF !default;
 
 $o-we-color-danger: #e6586c !default;
 $o-we-color-warning: #f0ad4e !default;
-$o-we-color-success: #00ff9e !default;
+$o-we-color-success: #40ad67 !default;
 $o-we-color-info: #6999a8 !default;
 $o-we-color-accent: #01bad2 !default;
 $o-we-color-global: #dbfe5c !default;


### PR DESCRIPTION
The active state of the mobile icon lost sufficient contrast. This PR restores its previous color to improve visibility.
