### PR TITLE
[IMP] point_of_sale, pos_self_order: not redirect to ui when closing kiosk

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -789,6 +789,9 @@ class PosConfig(models.Model):
 
         return self._action_to_open_ui()
 
+    def close_ui(self):
+        return self.open_ui()
+
     def open_existing_session_cb(self):
         """ close session button
 

--- a/addons/point_of_sale/models/res_config_settings.py
+++ b/addons/point_of_sale/models/res_config_settings.py
@@ -221,6 +221,9 @@ class ResConfigSettings(models.TransientModel):
             'res_id': False,
         }
 
+    def pos_close_ui(self):
+        return self.pos_open_ui()
+
     def pos_open_ui(self):
         if self.env.context.get('pos_config_id'):
             pos_config_id = self.env.context['pos_config_id']

--- a/addons/point_of_sale/views/pos_config_view.xml
+++ b/addons/point_of_sale/views/pos_config_view.xml
@@ -23,7 +23,7 @@
                     <div invisible="context.get('pos_config_create_mode', False)">
                         <div class="o_notification_alert alert alert-warning" invisible="not has_active_session" role="alert">
                             A session is currently opened for this PoS. Some settings can only be changed after the session is closed.
-                            <button class="btn" style="padding:0" name="open_ui" type="object">Click here to close the session</button>
+                            <button class="btn" style="padding:0" name="close_ui" type="object">Click here to close the session</button>
                         </div>
                         <div class="o_notification_alert alert alert-warning" invisible="company_has_template" role="alert">
                             There is no Chart of Accounts configured on the company. Please go to the invoicing settings to install a Chart of Accounts.

--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -36,7 +36,7 @@
                         </div>
                         <div class="o_notification_alert alert alert-warning mt-1 mb-0" invisible="not pos_has_active_session" role="alert">
                             A session is currently opened for this PoS. Some settings can only be changed after the session is closed.
-                            <button class="btn-link" style="padding:0" name="pos_open_ui" type="object" context="{'pos_config_id': pos_config_id}">Click here to close the session</button>
+                            <button class="btn-link" style="padding:0" name="pos_close_ui" type="object" context="{'pos_config_id': pos_config_id}">Click here to close the session</button>
                         </div>
                         <div class="o_notification_alert alert alert-warning" invisible="pos_company_has_template or chart_template" role="alert">
                             There is no Chart of Accounts configured on the company. Please go to the invoicing settings to install a Chart of Accounts.

--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -352,6 +352,11 @@ class PosConfig(models.Model):
         for record in self:
             record.self_ordering_url = record.get_base_url() + record._get_self_order_route()
 
+    def close_ui(self):
+        if self.self_ordering_mode == "kiosk":
+            return self.action_close_kiosk_session()
+        return super().close_ui()
+
     def action_close_kiosk_session(self):
         if self.current_session_id and self.current_session_id.order_ids:
             self.current_session_id.order_ids.filtered(lambda o: o.state == 'draft').unlink()

--- a/addons/pos_self_order/models/res_config_settings.py
+++ b/addons/pos_self_order/models/res_config_settings.py
@@ -193,6 +193,14 @@ class ResConfigSettings(models.TransientModel):
             }
         )
 
+    def pos_close_ui(self):
+        if self.pos_self_ordering_mode == "kiosk":
+            if self.env.context.get('pos_config_id'):
+                pos_config_id = self.env.context['pos_config_id']
+                pos_config = self.env['pos.config'].browse(pos_config_id)
+                return pos_config.action_close_kiosk_session()
+        return super().pos_close_ui()
+
     def preview_self_order_app(self):
         self.ensure_one()
         return self.pos_config_id.preview_self_order_app()


### PR DESCRIPTION
Currently when you're on the config of a kiosk, the link `Click here to close the session` opens the session. This was never intended when we have a kiosk.

Now, if we have a kiosk, when selecting this link it will close the session the same way it does when selecting the button `Close Session` on the dashboard.

opw-5024837