### PR TITLE
[FIX] base: get_view: always return the closest primary id

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -2551,6 +2551,8 @@ class Model(models.AbstractModel):
         if view_id:
             # read the view with inherited views applied
             view = View.browse(view_id)
+            while view.mode != "primary":
+                view = view.inherit_id
             arch = view._get_combined_arch()
         else:
             # fallback on default views methods if no ir.ui.view could be found

--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -3319,6 +3319,26 @@ Forbidden attribute used in arch (t-attf-data-tooltip-template)."""
 Forbidden use of `__comp__` in arch."""
         )
 
+    def test_get_view_with_inherited(self):
+        main = self.env["ir.ui.view"].create({
+            "name": "test",
+            "model": "res.partner",
+            "type": "tree",
+            "arch": """<tree><field name="display_name" /></tree>"""
+        })
+        inherit = self.env["ir.ui.view"].create({
+            "name": "test",
+            "mode": "extension",
+            "inherit_id": main.id,
+            "model": "res.partner",
+            "type": "tree",
+            "arch": """<xpath position="after" expr="//field[@name='display_name']">
+                <field name="function" />
+                </xpath>
+            """
+        })
+        result = self.env["res.partner"].get_view(inherit.id)
+        self.assertEqual(result["id"], main.id)
 
 @tagged('post_install', '-at_install')
 class TestDebugger(common.TransactionCase):


### PR DESCRIPTION
Before this commit, when executing `ir.ui.view.get_view(view_id)` where view_id points to an extension view, the method return the correct arch but the inherited view's id.

After this commit, it returns the id of the closest primary view.

opw-4930800

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
