### PR TITLE
[FIX] website: wrap text in form submit button

### DIFF
--- a/addons/website/static/src/snippets/s_website_form/001.scss
+++ b/addons/website/static/src/snippets/s_website_form/001.scss
@@ -53,6 +53,16 @@
         display: none;
     }
 
+    .s_website_form_submit {
+        & .btn,
+        & .s_website_form_send {
+            white-space: normal !important;
+            word-break: break-word;
+            overflow-wrap: break-word;
+            max-width: 100%;
+        }
+    }
+
     .s_website_form_submit, .s_website_form_recaptcha {
         .s_website_form_label {
             float: left;


### PR DESCRIPTION
Ensure buttons inside `.s_website_form_submit` handle long or localized labels without breaking the layout.

Changes:
- Enable text wrapping with `white-space: normal`.
- Add `word-break` and `overflow-wrap` for long words.
- Constrain button width to `max-width: 100%`.

This keeps form buttons responsive across templates and avoids layout shifts caused by overflowing text.