### PR TITLE
[FIX] mail: do not show chat hub compact in discuss app

### DIFF
--- a/addons/mail/static/src/core/common/chat_hub.xml
+++ b/addons/mail/static/src/core/common/chat_hub.xml
@@ -16,7 +16,7 @@
                         <ActionList actions="optionActions" dropdown="true"/>
                     </t>
                 </Dropdown>
-                <t t-if="store.chatHub.compact" t-call="mail.ChatHub.compactButton"/>
+                <t t-if="store.chatHub.compact and chatHub.showConversations" t-call="mail.ChatHub.compactButton"/>
                 <t t-else="">
                     <t t-foreach="chatHub.folded.slice(0, chatHub.maxFolded)" t-as="cw" t-key="cw.localId">
                         <ChatBubble t-if="cw.canShow" chatWindow="cw"/>

--- a/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
+++ b/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
@@ -348,6 +348,10 @@ test("Can compact chat hub", async () => {
     // alternative compact: click hidden button
     await click(".o-mail-ChatBubble", { text: "+13" });
     await contains(".o-mail-ChatBubble i.fa.fa-comments");
+    // don't show compact button in discuss app
+    await openDiscuss();
+    await contains(".o-mail-Discuss[data-active]");
+    await contains(".o-mail-ChatBubble i.fa.fa-comments", { count: 0 });
 });
 
 test("Compact chat hub is crosstab synced", async () => {


### PR DESCRIPTION
Before this commit, chat hub compact was visible in disucss app. This happens because while chat windows and bubbles are conditioned to not be shown in discuss app (with exceptions), the compact mode of chat hub was solely relying on compact mode on/off, ignoring the overall condition for whether some conversations are shown in chat hub (note: conversations in compact are still considered as "shown").

This commit adds extra condition on showing compact button to take into account chat hub showing some conversations. If no conversations are shown, then the compact mode should not be shown at all. Discuss app prevents showing of conversations in chat hub (with exceptions), as this is redundant with discuss app itself.

Task-5058838

Before
<img width="470" height="195" alt="Screenshot 2025-09-15 at 12 13 40" src="https://github.com/user-attachments/assets/f6e8ea32-7def-4654-858f-5d39fbcc97c1" />
After
<img width="490" height="232" alt="Screenshot 2025-09-15 at 12 13 20" src="https://github.com/user-attachments/assets/bc9feb62-6d84-4d73-8e10-674ab4260032" />
