### PR TITLE
[FIX] cloud_storage: avoid uploading to cloud storage

### DIFF
--- a/addons/cloud_storage/models/ir_attachment.py
+++ b/addons/cloud_storage/models/ir_attachment.py
@@ -84,3 +84,8 @@ class CloudStorageAttachment(models.Model):
                 upload request
         """
         raise NotImplementedError()
+
+    def _get_cloud_storage_unsupported_models(self):
+        # Some models may use their attachments' data in the business code
+        # We should avoid those attachments to be uploaded to the cloud storage
+        return list(self.env.registry.descendants(['mail.thread.main.attachment'], '_inherit', '_inherits'))

--- a/addons/cloud_storage/models/ir_http.py
+++ b/addons/cloud_storage/models/ir_http.py
@@ -12,4 +12,5 @@ class IrHttp(models.AbstractModel):
         ICP = self.env['ir.config_parameter'].sudo()
         if ICP.get_param('cloud_storage_provider'):
             res['cloud_storage_min_file_size'] = ICP.get_param('cloud_storage_min_file_size', DEFAULT_CLOUD_STORAGE_MIN_FILE_SIZE)
+            res['cloud_storage_unsupported_models'] = self.env['ir.attachment']._get_cloud_storage_unsupported_models()
         return res

--- a/addons/cloud_storage/static/src/core/common/attachment_upload_service_patch.js
+++ b/addons/cloud_storage/static/src/core/common/attachment_upload_service_patch.js
@@ -84,7 +84,8 @@ patch(AttachmentUploadService.prototype, {
     async _upload(thread, composer, file, options, tmpId, tmpURL) {
         if (
             session.cloud_storage_min_file_size !== undefined &&
-            file.size > session.cloud_storage_min_file_size
+            file.size > session.cloud_storage_min_file_size &&
+            !session.cloud_storage_unsupported_models.includes(thread.model)
         ) {
             // store the file in the this.uploadingCloudFiles map
             this.uploadingCloudFiles.set(tmpId, file);


### PR DESCRIPTION
some models use attachments for data for business logics for example,
``account_move.message_main_attachment_id.datas``
``hr_expense_sheet`` will use all bounded attachments to generate report

This commit prevents uploading attachments to cloud storage for some models if they ``_inherit`` or ``_inherits`` model ``mail.thread.main.attachment``


This PR is also a supplement for https://github.com/odoo/odoo/pull/226094

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
