### PR TITLE
[IMP] stock_picking_batch*: enhance batch/wave Kanban view

### DIFF
--- a/addons/stock_fleet/views/stock_picking_batch.xml
+++ b/addons/stock_fleet/views/stock_picking_batch.xml
@@ -109,15 +109,56 @@
         <field name="inherit_id" ref="stock_picking_batch.stock_picking_batch_kanban"/>
         <field name="arch" type="xml">
             <data>
-                <xpath expr="//footer" position="replace">
-                    <footer class="pt-0">
-                        <field name="dock_id"/>
+                <xpath expr="//field[@name='company_id']" position="after">
+                    <field name="estimated_shipping_weight"/>
+                    <field name="estimated_shipping_volume"/>
+                    <field name="vehicle_id"/>
+                    <field name="vehicle_weight_capacity"/>
+                    <field name="vehicle_volume_capacity"/>
+                </xpath>
+                <xpath expr="//field[@name='scheduled_date']" position="after">
+                    <i class="fa fa-long-arrow-right mx-2" title="Arrow"/>
+                    <field name="end_date"/>
+                </xpath>
+                <xpath expr="//div[field[@name='scheduled_date']]" position="after">
+                    <t t-set="total_vehicle_weight_capacity" t-value="record.vehicle_weight_capacity.raw_value"/>
+                    <t t-set="total_vehicle_volume_capacity" t-value="record.vehicle_volume_capacity.raw_value"/>
+                    <div t-if="record.vehicle_id.raw_value" class="d-flex">
                         <div>
-                            <field name="state" widget="state_selection" class="float-start pt-1 me-1"/>
-                            <field name="scheduled_date" readonly="state in ['cancel', 'done']"/>
+                            <i class="fa fa-truck text-primary me-2" title="Vehicle"/>
                         </div>
-                        <field name="user_id" widget="many2one_avatar_user" readonly="state not in ['draft', 'in_progress']" class="ms-auto"/>
-                    </footer>
+                        <div>
+                            <t t-out="record.vehicle_id.value"/>
+                            <span class="text-muted text-nowrap" t-if="total_vehicle_weight_capacity or total_vehicle_volume_capacity">
+                                (<t t-if="total_vehicle_weight_capacity">
+                                    <t t-out="total_vehicle_weight_capacity"/> <field name="weight_uom_name"/>
+                                    <t t-if="total_vehicle_volume_capacity">, </t>
+                                </t>
+                                <t t-if="total_vehicle_volume_capacity">
+                                    <t t-out="total_vehicle_volume_capacity"/> <field name="volume_uom_name"/>
+                                </t>)
+                            </span>
+                        </div>
+                    </div>
+                    <div t-if="record.dock_id.raw_value" class="text-truncate" invisible="not allowed_dock_ids" groups="stock.group_stock_multi_locations">
+                        <i class="fa fa-cubes text-primary me-2" title="Location"/>
+                        <field name="dock_id"/>
+                    </div>
+                </xpath>
+                <xpath expr="//span[@name='transfer_count']" position="after">
+                    <t t-set="total_estimated_shipping_weight" t-value="record.estimated_shipping_weight.raw_value"/>
+                    <t t-set="total_estimated_shipping_volume" t-value="record.estimated_shipping_volume.raw_value"/>
+                    <t t-set="insufficient_capacity" t-value="total_estimated_shipping_weight > total_vehicle_weight_capacity or total_estimated_shipping_volume > total_vehicle_volume_capacity"/>
+                    <span t-if="total_estimated_shipping_weight or total_estimated_shipping_volume"
+                          t-att-class="record.vehicle_id.raw_value and (insufficient_capacity ? 'text-danger' : 'text-success')">
+                        (<t t-if="total_estimated_shipping_weight">
+                            <t t-out="total_estimated_shipping_weight"/> <field name="weight_uom_name"/>
+                            <t t-if="total_estimated_shipping_volume">, </t>
+                        </t>
+                        <t t-if="total_estimated_shipping_volume">
+                            <t t-out="total_estimated_shipping_volume"/> <field name="volume_uom_name"/>
+                        </t>)
+                    </span>
                 </xpath>
             </data>
         </field>

--- a/addons/stock_picking_batch/models/stock_picking_batch.py
+++ b/addons/stock_picking_batch/models/stock_picking_batch.py
@@ -84,7 +84,7 @@ class StockPickingBatch(models.Model):
             estimated_shipping_volume = 0
             done_package_ids = set()
             # packs
-            for pack in self.move_line_ids.result_package_id:
+            for pack in batch.move_line_ids.result_package_id:
                 p_type = pack.package_type_id
                 if pack.shipping_weight:
                     # shipping_weight was computed, so base_weight should be included.
@@ -94,7 +94,7 @@ class StockPickingBatch(models.Model):
                     estimated_shipping_weight += p_type.base_weight or 0
                     estimated_shipping_volume += (p_type.packaging_length * p_type.width * p_type.height) / 1000.0**3
             # move without packs
-            for move_line in self.picking_ids.move_ids.move_line_ids:
+            for move_line in batch.picking_ids.move_ids.move_line_ids:
                 if move_line.result_package_id.id in done_package_ids:
                     continue
                 estimated_shipping_weight += move_line.product_id.weight * move_line.quantity_product_uom

--- a/addons/stock_picking_batch/models/stock_picking_batch.py
+++ b/addons/stock_picking_batch/models/stock_picking_batch.py
@@ -5,12 +5,14 @@ from markupsafe import Markup
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
 
+from odoo.addons.stock.models.stock_move import PROCUREMENT_PRIORITIES
+
 
 class StockPickingBatch(models.Model):
     _name = 'stock.picking.batch'
     _inherit = ['mail.thread', 'mail.activity.mixin']
     _description = "Batch Transfer"
-    _order = "name desc"
+    _order = "priority desc, name desc"
 
     name = fields.Char(
         string='Batch Transfer', default='New',
@@ -44,6 +46,7 @@ class StockPickingBatch(models.Model):
         ('cancel', 'Cancelled')], default='draft',
         store=True, compute='_compute_state',
         copy=False, tracking=True, required=True, readonly=True, index=True)
+    priority = fields.Selection(PROCUREMENT_PRIORITIES, string='Priority', default='0')
     picking_type_id = fields.Many2one(
         'stock.picking.type', 'Operation Type', check_company=True, copy=False,
         index=True)

--- a/addons/stock_picking_batch/views/stock_picking_batch_views.xml
+++ b/addons/stock_picking_batch/views/stock_picking_batch_views.xml
@@ -134,7 +134,10 @@
                             groups="stock.group_reception_report"/>
                     </div>
                     <div class="oe_title">
-                        <h1><field name="name" class="oe_inline"/></h1>
+                        <h1>
+                            <field name="priority" widget="priority" class="me-3"/>
+                            <field name="name" class="oe_inline"/>
+                        </h1>
                     </div>
                     <group>
                         <group id="batch_delivery_data">
@@ -170,6 +173,7 @@
         <field name="arch" type="xml">
             <list string="Stock Batch Transfer" multi_edit="1" sample="1" class="oe_stock_picking_batch">
                 <field name="company_id" column_invisible="True"/>
+                <field name="priority" optional="show" widget="priority" nolabel="1"/>
                 <field name="name" decoration-bf="1"/>
                 <field name="description"/>
                 <field name="scheduled_date" readonly="state in ['cancel', 'done']"/>
@@ -188,18 +192,32 @@
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile oe_stock_picking_batch" sample="1">
                 <field name="company_id"/>
+                <field name="picking_ids"/>
                 <templates>
                     <t t-name="card">
                         <div class="d-flex">
-                            <field name="name" class="fw-bolder fs-5"/>
-                            <field name="state" widget="label_selection" class="ms-auto"/>
+                            <field name="priority" widget="priority" class="pt-1"/>
+                            <field name="name" class="fw-bolder fs-5 ms-1"/>
+                            <field name="state" widget="label_selection" options="{'classes': {'draft': 'default', 'in_progress': 'primary', 'done': 'success', 'cancel': 'danger'}}" class="ms-auto ps-3"/>
                         </div>
-                        <field name="description" class="fw-bold mb-2"/>
-                        <footer class="pt-0">
-                            <field name="picking_type_id" readonly="state != 'draft'"/>
-                            <div class="d-flex">
-                                <field name="scheduled_date" readonly="state in ['cancel', 'done']"/>
-                                <field name="user_id" widget="many2one_avatar_user" readonly="state not in ['draft', 'in_progress']"/>
+                        <div class="fw-bold mb-1 w-75 text-truncate">
+                            <field name="description"/>
+                        </div>
+                        <div t-if="record.scheduled_date.raw_value">
+                            <i class="fa fa-calendar text-primary me-2" title="Calendar"/>
+                            <field name="scheduled_date"/>
+                        </div>
+                        <footer class="mt-auto">
+                            <div>
+                                <span name="transfer_count" class="fw-bold text-muted">
+                                    <t t-out="record.picking_ids.raw_value.length"/>
+                                    <t t-if="record.picking_ids.raw_value.length == 1"> Transfer</t>
+                                    <t t-else=""> Transfers</t>
+                                </span>
+                            </div>
+                            <div class="d-flex ms-auto align-items-center">
+                                <field name="user_id" widget="many2one_avatar_user" readonly="state not in ['draft', 'in_progress']" class="me-1"/>
+                                <field name="activity_ids" widget="kanban_activity"/>
                             </div>
                         </footer>
                     </t>
@@ -258,7 +276,7 @@
         <field name="path">batch-transfers</field>
         <field name="view_mode">list,kanban,form</field>
         <field name="domain">[('is_wave', '=', False)]</field>
-        <field name="context">{'search_default_draft': True, 'search_default_in_progress': True}</field>
+        <field name="context">{'search_default_draft': True, 'search_default_in_progress': True, 'skip_acquisition_date': True}</field>
         <field name="search_view_id" ref="stock_picking_batch_filter"/>
         <field name="help" type="html">
             <div class="container mt-5">

--- a/addons/stock_picking_batch/views/stock_picking_wave_views.xml
+++ b/addons/stock_picking_batch/views/stock_picking_wave_views.xml
@@ -59,7 +59,7 @@
         <field name="res_model">stock.picking.batch</field>
         <field name="path">wave-transfers</field>
         <field name="view_mode">list,kanban,form</field>
-        <field name="context">{'search_default_draft': True, 'search_default_in_progress': True}</field>
+        <field name="context">{'search_default_draft': True, 'search_default_in_progress': True, 'skip_acquisition_date': True}</field>
         <field name="view_ids" eval="[(5, 0, 0),
             (0, 0, {'view_mode': 'list', 'view_id': ref('stock_picking_batch.stock_picking_wave_tree')}),
             (0, 0, {'view_mode': 'kanban', 'view_id': ref('stock_picking_batch.stock_picking_wave_kanban')})]"/>


### PR DESCRIPTION
*: stock_fleet

## **Before This PR:**
The current Kanban view for Batches/Waves in Inventory
doesn’t provide enough information for effective planning.
When used with Dispatch Management, it becomes harder for
users to quickly see key details like schedules, vehicles or transfers.
This reduces planning efficiency and forces users to open
each record individually to get the full information.

**Kanban view before this PR:**
<img width="1304" height="279" alt="image" src="https://github.com/user-attachments/assets/692e0cb7-edf8-496d-8b48-2d633cd8d67d" />


## **With This PR:**
The Kanban view for Batches/Waves is enhanced with clearer details:
- Added a new priority field (also added in form and list view),
- Proper batch name and description,
- Scheduled date and time,
- Number of transfers in each batch,
- Allowed scheduling of activities directly from the card,
- If Dispatch Management is enabled, also displays:
  - Vehicle with admitted weight/volume,
  - Dock location.

Users now can see key batch details directly in kanban card,
reducing the need to open each record individually and improving
planning efficiency.

**Kanban view after this PR:**
<img width="1570" height="282" alt="image" src="https://github.com/user-attachments/assets/a6d49d1e-bc6f-4223-ae6b-9a2c6745cd3c" />


**★** Also added a fix to correctly compute and display per-batch
estimated shipping weight and volume in the kanban view
instead of showing aggregated totals

Task - [4766636](https://www.odoo.com/odoo/project/966/tasks/4766636)