### PR TITLE
[IMP] web: include stacktrace when converting a run() error to a MacroError

### DIFF
--- a/addons/web/static/src/core/macro.js
+++ b/addons/web/static/src/core/macro.js
@@ -36,9 +36,11 @@ async function performAction(trigger, action) {
     try {
         return await action(trigger);
     } catch (error) {
-        throw new MacroError("Action", `ERROR during perform action:\n${error.message}`, {
-            cause: error,
-        });
+        throw new MacroError(
+            "Action",
+            error.stack || `ERROR during perform action: ${error.message}`,
+            {cause: error}
+        );
     }
 }
 

--- a/addons/web_tour/static/tests/check_undeterminisms.test.js
+++ b/addons/web_tour/static/tests/check_undeterminisms.test.js
@@ -11,7 +11,7 @@ import { registry } from "@web/core/registry";
 describe.current.tags("desktop");
 
 const mainErrorMessage = (trigger) =>
-    `ERROR during perform action:\nPotential non deterministic behavior found in 300ms for trigger ${trigger}.`;
+    `Error: Potential non deterministic behavior found in 300ms for trigger ${trigger}.`;
 
 let macro;
 async function waitForMacro() {
@@ -69,7 +69,10 @@ beforeEach(async () => {
     });
     patchWithCleanup(browser.console, {
         log: (s) => expect.step(`log: ${s}`),
-        error: (s) => expect.step(`error: ${s}`),
+        error: (s) => {
+            s = s.replace(/\n +at.*/g, ""); // strip stack trace
+            expect.step(`error: ${s}`)
+        },
         warn: () => {},
         dir: () => {},
     });

--- a/addons/web_tour/static/tests/tour_automatic.test.js
+++ b/addons/web_tour/static/tests/tour_automatic.test.js
@@ -135,7 +135,10 @@ test("a failing tour logs the step that failed in run", async () => {
         groupCollapsed: (s) => expect.step(`log: ${s}`),
         log: (s) => expect.step(`log: ${s}`),
         warn: (s) => {},
-        error: (s) => expect.step(`error: ${s}`),
+        error: (s) => {
+            s = s.replace(/\n +at.*/g, ""); // strip stack trace
+            expect.step(`error: ${s}`)
+        },
     });
     class Root extends Component {
         static components = {};
@@ -172,8 +175,7 @@ test("a failing tour logs the step that failed in run", async () => {
         `log: [2/2] Tour tour2 → Step .button1`,
         [
             "error: FAILED: [2/2] Tour tour2 → Step .button1.",
-            `ERROR during perform action:
-Cannot read properties of null (reading 'click')`,
+            `TypeError: Cannot read properties of null (reading 'click')`,
         ].join("\n"),
     ];
     expect.verifySteps(expectedError);


### PR DESCRIPTION
Because it only embeds the error message, and because it ultimately gets `console.error`-ed, an error during a `run()` function is currently extremely unhelpful e.g.

    Cannot read properties of undefined (reading 'ownerDocument')

might be all you get. And despite what one might assume, browsers (or at least chrome) don't seem to chain stacktraces when using `{cause}`, so even printing stacktraces on `console.error` does not yield useful information, the stacktrace point to `performAction` instead of a useful location.

So use the `Error#stack` if it's available. In chrome that includes both the error message and the full stack, so a formatted error message is unnecessary. Fall back on a formatted error message if the error has no stack for some reason.
