### PR TITLE
[FIX] website_sale: prevent error when retrying payment from cart

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1623,6 +1623,8 @@ class WebsiteSale(payment_portal.PaymentPortal):
         :return int: The order's partner id.
         """
         order_sudo = request.website.sale_get_order()
+        if not order_sudo:
+            return []
 
         # Update the partner with all the information
         self._include_country_and_state_in_address(billing_address)


### PR DESCRIPTION
This error occurs when trying to make a payment again from the cart.

Steps to reproduce:
---
- Install the **website_sale** module (with demo)
- Activate **Demo** payment provider
- Go to Website > Shop > Add a **Warranty** product to Cart > View cart
- Pay with Demo > Pay
- Click the back button(chrome navbar)(Instantly)
- Now again Pay with Demo > Pay

Traceback:
---
`ValueError: Expected singleton: sale.order()`

At [1], this error occurs because **order_sudo** is empty. This happens when there is no product in the cart — typically because, upon clicking **Pay**, a sale order is created for the product, and when the user navigates back, the cart is empty.

[1]- https://github.com/odoo/odoo/blob/125fc3028debb311e9f6ad25d8c46699b77525f0/addons/website_sale/controllers/main.py#L1307-L1312

sentry-5682671428

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
