### PR TITLE
[IMP] hr_attendance: Run auto checkout cron for last 7 days

### DIFF
--- a/addons/hr_attendance/models/res_config_settings.py
+++ b/addons/hr_attendance/models/res_config_settings.py
@@ -46,6 +46,10 @@ class ResConfigSettings(models.TransientModel):
         if any(self[field] != company[field] for field in fields_to_check):
             company.write({field: self[field] for field in fields_to_check})
 
+        # run auto checkout cron immediatly one it gets enabled.
+        if self.auto_check_out:
+            self.env['hr.attendance']._cron_auto_check_out()
+
     def regenerate_kiosk_key(self):
         if self.env.user.has_group("hr_attendance.group_hr_attendance_user"):
             self.company_id._regenerate_attendance_kiosk_key()


### PR DESCRIPTION
Before:
- cron was running but taking only current day into consideration

After
- cron will take last 7 day attendance and checkout attendance automatically.
- checkout time will be, schedule work_hour for employee + checkout tolerance
- run cron immediately once it gets enabled.

task - 5072280

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
