### PR TITLE
[FIX] point_of_sale: show variant in combo order

### DIFF
--- a/addons/point_of_sale/static/src/app/models/utils/compute_combo_items.js
+++ b/addons/point_of_sale/static/src/app/models/utils/compute_combo_items.js
@@ -28,11 +28,14 @@ export const computeComboItems = (
         if (comboItem.id == childLineConf[childLineConf.length - 1].combo_item_id.id) {
             priceUnit += remainingTotal;
         }
-        const attribute_value_ids = conf.configuration?.attribute_value_ids?.map(
-            (id) => productTemplateAttributeValueById[id]
-        );
+        const attribute_value_ids =
+            conf.configuration?.attribute_value_ids?.map(
+                (id) => productTemplateAttributeValueById[id]
+            ) || conf.combo_item_id?.product_id?.product_template_attribute_value_ids;
         const attributesPriceExtra = (attribute_value_ids ?? [])
-            .map((attr) => attr?.price_extra || 0)
+            .map((attr) =>
+                attr?.attribute_id?.create_variant === "always" ? 0 : attr?.price_extra || 0
+            )
             .reduce((acc, price) => acc + price, 0);
         const totalPriceExtra = priceUnit + attributesPriceExtra + comboItem.extra_price;
         comboItems.push({

--- a/addons/point_of_sale/static/tests/pos/tours/pos_combo_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/pos_combo_tour.js
@@ -15,6 +15,22 @@ registry.category("web_tour.tours").add("ProductComboPriceTaxIncludedTour", {
         [
             Chrome.startPoS(),
             Dialog.confirm("Open Register"),
+            ...ProductScreen.clickDisplayedProduct("Sofa Combo"),
+            combo.select("Combo Product Sofa (L)"),
+            Dialog.confirm(),
+            inLeftSide([
+                ...Order.hasLine({
+                    withoutClass: ".selected",
+                    productName: "Combo Product Sofa",
+                    run: "click",
+                    quantity: "1",
+                    attributeLine: "L",
+                    priceUnit: 34.5,
+                }),
+                Numpad.click("⌫"),
+                Numpad.click("⌫"),
+                ...Order.doesNotHaveLine(),
+            ]),
             scan_barcode("SuperCombo"),
             combo.select("Combo Product 3"),
             combo.isConfirmationButtonDisabled(),

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1052,10 +1052,68 @@ class TestUi(TestPointOfSaleHttpCommon):
     def test_07_product_combo(self):
         self.env['decimal.precision'].search([('name', '=', 'Product Price')]).digits = 4
         setup_product_combo_items(self)
+        combo_product_sofa = self.env["product.product"].create(
+            {
+                "name": "Combo product Sofa",
+                "is_storable": True,
+                "available_in_pos": True,
+                "list_price": 40,
+            }
+        )
+        sofa_size_attribute = self.env['product.attribute'].create({
+            'name': 'Size',
+            'display_type': 'radio',
+            'create_variant': 'always',
+        })
+        sofa_size_L = self.env['product.attribute.value'].create({
+            'name': 'L',
+            'attribute_id': sofa_size_attribute.id,
+        })
+        sofa_size_M = self.env['product.attribute.value'].create({
+            'name': 'M',
+            'attribute_id': sofa_size_attribute.id,
+        })
+
+        product_attribute_size = self.env['product.template.attribute.line'].create({
+            'product_tmpl_id': combo_product_sofa.product_tmpl_id.id,
+            'attribute_id': sofa_size_attribute.id,
+            'value_ids': [(6, 0, [sofa_size_M.id, sofa_size_L.id])],
+
+        })
+        product_attribute_size.product_template_value_ids[0].price_extra = 50
+        product_attribute_size.product_template_value_ids[1].price_extra = 100
+        self.sofa_combo = self.env["product.combo"].create(
+            {
+                "name": "Chairs Combo",
+                "combo_item_ids": [
+                    Command.create({
+                        "product_id": combo_product_sofa.product_tmpl_id.product_variant_ids[0].id,
+                        "extra_price": 5,
+                    }),
+                    Command.create({
+                        "product_id": combo_product_sofa.product_tmpl_id.product_variant_ids[1].id,
+                        "extra_price": 10,
+                    }),
+                ],
+            }
+        )
+        self.sofa_combo = self.env["product.product"].create(
+            {
+                "available_in_pos": True,
+                "list_price": 20,
+                "name": "Sofa Combo",
+                "type": "combo",
+                "uom_id": self.env.ref("uom.product_uom_unit").id,
+                "combo_ids": [
+                    (6, 0, [self.sofa_combo.id])
+                ],
+            }
+        )
         self.office_combo.write({
             'lst_price': 50,
             'barcode': 'SuperCombo',
         })
+
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('ProductComboPriceTaxIncludedTour')
         order = self.env['pos.order'].search([])


### PR DESCRIPTION
In POS, if in a combo, one of option has instantly created variant it will not show the variant name in the order

### Steps to reproduce:

* Create a product with instantly generated variants
* Create a combo choice and add one of his variants
* Create a combo product and add the combo
* Open an store that sells this combo
* Select the combo and choose the product with variant and confirm the selection

Issue : On the left size in the order the variant name will not appear.

### Observation:

When it tries to retrieve the attribute information for the variant https://github.com/odoo/odoo/blob/942b7a21d7e0eb15133f4af1b47e68f48dec70c7/addons/point_of_sale/static/src/app/services/pos_store.js#L1048 It is empty since during the call of computeComboItems the attribute was not retrieved for this scenario. https://github.com/odoo/odoo/blob/942b7a21d7e0eb15133f4af1b47e68f48dec70c7/addons/point_of_sale/static/src/app/models/utils/compute_combo_items.js#L31-L33

------------
When adding a always variant to a combo they are considered like their own product, and attribute.extra_price should not be considered.
The extra price for an always variant is setup in the combo with comboItem.extra_price like stand alone products.

opw-5037355
