### PR TITLE
[FIX] project: allow normal tasks in project templates

### DIFF
--- a/addons/hr_timesheet/views/project_project_views.xml
+++ b/addons/hr_timesheet/views/project_project_views.xml
@@ -86,7 +86,7 @@
                     <t t-set="badgeColor" t-value="'border-danger'" t-if="record.remaining_hours.raw_value &lt; 0"/>
                     <t t-set="title" t-if="record.encode_uom_in_days.raw_value">Days Remaining</t>
                     <t t-set="title" t-else="">Time Remaining</t>
-                    <div t-if="!record.is_template.raw_value and  record.allow_timesheets.raw_value and record.allocated_hours.raw_value &gt; 0"
+                    <div t-if="!record.is_template.raw_value and record.allow_timesheets.raw_value and record.allocated_hours.raw_value &gt; 0"
                         t-attf-class="me-1 ms-1 bg-transparent badge border {{ badgeColor }}" t-att-title="title" groups="hr_timesheet.group_hr_timesheet_user">
                         <field name="remaining_hours" widget="timesheet_uom" class="p-0"/>
                     </div>
@@ -100,7 +100,7 @@
             <field name="inherit_id" ref="project.view_project_project_filter"/>
             <field name="arch" type="xml">
                 <filter name="late_milestones" position="before">
-                    <filter string="Timesheets &gt;100%" name="projects_in_overtime" domain="[('is_project_overtime', '=', True)]" groups="project.group_project_manager" invisible="context.get('default_is_template')"/>
+                    <filter string="Timesheets &gt;100%" name="projects_in_overtime" domain="[('is_project_overtime', '=', True)]" groups="project.group_project_manager"/>
                 </filter>
             </field>
         </record>

--- a/addons/hr_timesheet/views/project_task_views.xml
+++ b/addons/hr_timesheet/views/project_task_views.xml
@@ -8,12 +8,12 @@
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='child_ids']/list/field[@name='company_id']" position="after">
                     <field name="allocated_hours" widget="timesheet_uom_no_toggle" sum="Total Allocated Time" optional="hide" groups="hr_timesheet.group_hr_timesheet_user"/>
-                    <field name="effective_hours" widget="timesheet_uom" sum="Time Spent" optional="hide" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="context.get('default_is_template', False)"/>
-                    <field name="subtask_effective_hours" widget="timesheet_uom" sum="Sub-tasks Time Spent" optional="hide" groups="hr_timesheet.group_hr_timesheet_user"  column_invisible="context.get('default_is_template', False)"/>
-                    <field name="total_hours_spent" widget="timesheet_uom" sum="Total Time Spent" optional="hide" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="context.get('default_is_template', False)"/>
-                    <field name="remaining_hours" widget="timesheet_uom" sum="Time Remaining" optional="hide" decoration-danger="progress &gt;= 1" decoration-warning="progress &gt;= 0.8 and progress &lt; 1" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="context.get('default_is_template', False)"/>
+                    <field name="effective_hours" widget="timesheet_uom" sum="Time Spent" optional="hide" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="context.get('template_project')"/>
+                    <field name="subtask_effective_hours" widget="timesheet_uom" sum="Sub-tasks Time Spent" optional="hide" groups="hr_timesheet.group_hr_timesheet_user"  column_invisible="context.get('template_project')"/>
+                    <field name="total_hours_spent" widget="timesheet_uom" sum="Total Time Spent" optional="hide" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="context.get('template_project')"/>
+                    <field name="remaining_hours" widget="timesheet_uom" sum="Time Remaining" optional="hide" decoration-danger="progress &gt;= 1" decoration-warning="progress &gt;= 0.8 and progress &lt; 1" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="context.get('template_project')"/>
                     <field name="progress" widget="project_task_progressbar" optional="hide" options="{'overflow_class': 'bg-danger'}" groups="hr_timesheet.group_hr_timesheet_user"
-                    column_invisible="context.get('default_is_template', False)"/>
+                    column_invisible="context.get('template_project')"/>
                 </xpath>
                 <xpath expr="//group/field[@name='allocated_hours']" position="replace">
                     <field name="encode_uom_in_days" invisible="1"/>
@@ -25,13 +25,13 @@
                             (incl. <field name="subtask_allocated_hours" nolabel="1" widget="timesheet_uom_no_toggle" class="oe_inline"/> on
                             <span class="fw-bold text-dark"> Sub-tasks</span>)
                         </span>
-                         <span invisible="is_template">
+                         <span invisible="is_template or has_project_template">
                             (<field name="progress" invisible="not project_id" class="oe_inline" nolabel="1" decoration-danger="progress > 1.005" digits="[1, 0]" widget="percentage"/>)
                         </span>
                     </div>
                 </xpath>
                 <xpath expr="//t[@name='warning_section']" position="inside">
-                    <div class="alert alert-warning text-center mb-2" role="alert" invisible="analytic_account_active or not allow_timesheets or is_template" groups="hr_timesheet.group_hr_timesheet_user">
+                    <div class="alert alert-warning text-center mb-2" role="alert" invisible="analytic_account_active or not allow_timesheets or is_template or has_project_template" groups="hr_timesheet.group_hr_timesheet_user">
                         You cannot log timesheets on this project since it is linked to an inactive analytic account.<br/> Please change this account, or reactivate the current one to timesheet on the project.
                     </div>
                 </xpath>
@@ -40,7 +40,7 @@
                     <t groups="hr_timesheet.group_hr_timesheet_user">
                         <field name="analytic_account_active" invisible="1"/>
                     </t>
-                    <page string="Timesheets" name="page_timesheets" id="timesheets_tab" invisible="not allow_timesheets or has_template_ancestor or (not id and context.get('hide_timesheet_ids'))" groups="hr_timesheet.group_hr_timesheet_user">
+                    <page string="Timesheets" name="page_timesheets" id="timesheets_tab" invisible="not allow_timesheets or has_template_ancestor or has_project_template or (not id and context.get('hide_timesheet_ids'))" groups="hr_timesheet.group_hr_timesheet_user">
                     <field name="timesheet_ids" mode="list,kanban" readonly="not analytic_account_active" context="{'default_project_id': project_id, 'default_name': '', 'form_view_ref': 'hr_timesheet.timesheet_view_form_user'}">
                         <list editable="top" string="Timesheet Activities" decoration-muted="readonly_timesheet == True">
                             <field name="readonly_timesheet" column_invisible="True"/>
@@ -124,11 +124,11 @@
                 <xpath expr="//field[@name='depend_on_ids']/list//field[@name='company_id']" position="after">
                     <field name="progress" column_invisible="True" groups="hr_timesheet.group_hr_timesheet_user"/>
                     <field name="allocated_hours" widget="timesheet_uom_no_toggle" sum="Total Allocated Time" optional="hide" groups="hr_timesheet.group_hr_timesheet_user"/>
-                    <field name="effective_hours" widget="timesheet_uom" sum="Effective Hours" optional="hide" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="context.get('default_is_template', False)"/>
-                    <field name="subtask_effective_hours" widget="timesheet_uom" optional="hide" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="context.get('default_is_template', False)"/>
-                    <field name="total_hours_spent" widget="timesheet_uom" optional="hide" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="context.get('default_is_template', False)"/>
-                    <field name="remaining_hours" widget="timesheet_uom" sum="Time Remaining" optional="hide" decoration-danger="progress &gt;= 1" decoration-warning="progress &gt;= 0.8 and progress &lt; 1" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="context.get('default_is_template', False)"/>
-                    <field name="progress" widget="project_task_progressbar" optional="hide" options="{'overflow_class': 'bg-danger'}" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="context.get('default_is_template', False)"/>
+                    <field name="effective_hours" widget="timesheet_uom" sum="Effective Hours" optional="hide" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="context.get('template_project')"/>
+                    <field name="subtask_effective_hours" widget="timesheet_uom" optional="hide" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="context.get('template_project')"/>
+                    <field name="total_hours_spent" widget="timesheet_uom" optional="hide" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="context.get('template_project')"/>
+                    <field name="remaining_hours" widget="timesheet_uom" sum="Time Remaining" optional="hide" decoration-danger="progress &gt;= 1" decoration-warning="progress &gt;= 0.8 and progress &lt; 1" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="context.get('template_project')"/>
+                    <field name="progress" widget="project_task_progressbar" optional="hide" options="{'overflow_class': 'bg-danger'}" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="context.get('template_project')"/>
                 </xpath>
             </field>
         </record>
@@ -142,11 +142,11 @@
                     <field name="progress" column_invisible="True"/>
                     <field name="effective_hours" column_invisible="True"/>
                     <field name="allocated_hours" widget="timesheet_uom_no_toggle" sum="Total Allocated Time" invisible="allocated_hours == 0" optional="hide" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="not context.get('allow_timesheets', True)"/>
-                    <field name="effective_hours" widget="timesheet_uom" sum="Effective Hours" optional="show" invisible="effective_hours == 0" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="not context.get('allow_timesheets', True) or context.get('default_is_template', False)"/>
-                    <field name="subtask_effective_hours" widget="timesheet_uom" sum="Time Spent on Sub-Tasks" optional="hide" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="not context.get('allow_timesheets', True) or context.get('default_is_template', False)"/>
-                    <field name="total_hours_spent" widget="timesheet_uom" sum="Total Time Spent" optional="hide" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="not context.get('allow_timesheets', True) or context.get('default_is_template', False)"/>
-                    <field name="remaining_hours" widget="timesheet_uom" sum="Time Remaining on SO" optional="hide" decoration-danger="progress &gt;= 1" decoration-warning="progress &gt;= 0.8 and progress &lt; 1" invisible="allocated_hours == 0" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="not context.get('allow_timesheets', True) or context.get('default_is_template', False)"/>
-                    <field name="progress" widget="project_task_progressbar" avg="Average of Progress" optional="show" groups="hr_timesheet.group_hr_timesheet_user" invisible="allocated_hours == 0" options="{'overflow_class': 'bg-danger'}" column_invisible="not context.get('allow_timesheets', True) or context.get('default_is_template', False)"/>
+                    <field name="effective_hours" widget="timesheet_uom" sum="Effective Hours" optional="show" invisible="effective_hours == 0" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="not context.get('allow_timesheets', True) or context.get('template_project')"/>
+                    <field name="subtask_effective_hours" widget="timesheet_uom" sum="Time Spent on Sub-Tasks" optional="hide" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="not context.get('allow_timesheets', True) or context.get('template_project')"/>
+                    <field name="total_hours_spent" widget="timesheet_uom" sum="Total Time Spent" optional="hide" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="not context.get('allow_timesheets', True) or context.get('template_project')"/>
+                    <field name="remaining_hours" widget="timesheet_uom" sum="Time Remaining on SO" optional="hide" decoration-danger="progress &gt;= 1" decoration-warning="progress &gt;= 0.8 and progress &lt; 1" invisible="allocated_hours == 0" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="not context.get('allow_timesheets', True) or context.get('template_project')"/>
+                    <field name="progress" widget="project_task_progressbar" avg="Average of Progress" optional="show" groups="hr_timesheet.group_hr_timesheet_user" invisible="allocated_hours == 0" options="{'overflow_class': 'bg-danger'}" column_invisible="not context.get('allow_timesheets', True) or context.get('template_project')"/>
                 </field>
             </field>
         </record>
@@ -188,10 +188,10 @@
                     <filter string="Timesheets 80%" name="timesheet_80"
                         domain="[('remaining_hours_percentage', '&gt;', 0.0), ('remaining_hours_percentage', '&lt;=', 0.2)]"
                         groups="hr_timesheet.group_hr_timesheet_user"
-                        invisible="not context.get('allow_timesheets') or context.get('default_is_template')"/>
+                        invisible="not context.get('allow_timesheets') or context.get('template_project')"/>
                     <filter string="Timesheets &gt;100%" name="timesheet_exceeded" domain="[('overtime', '&gt;', 0)]"
                         groups="hr_timesheet.group_hr_timesheet_user"
-                        invisible="not context.get('allow_timesheets') or context.get('default_is_template')"/>
+                        invisible="not context.get('allow_timesheets') or context.get('template_project')"/>
                     <separator/>
                 </xpath>
             </field>

--- a/addons/project/static/src/views/components/project_task_template_dropdown.js
+++ b/addons/project/static/src/views/components/project_task_template_dropdown.js
@@ -41,7 +41,7 @@ export class ProjectTaskTemplateDropdown extends Component {
     }
 
     async onWillStart() {
-        if (this.props.projectId && !this.props.context.default_is_template) {
+        if (this.props.projectId) {
             this.state.taskTemplates = await this.orm
                 .cache({
                     type: "disk",

--- a/addons/project/static/src/views/project_model_mixin.js
+++ b/addons/project/static/src/views/project_model_mixin.js
@@ -2,7 +2,7 @@ import { Domain } from "@web/core/domain";
 
 export const ProjectModelMixin = (T) => class ProjectModelMixin extends T {
     _processSearchDomain(domain) {
-        if (this.env.searchModel.context?.render_templates) {
+        if (this.env.searchModel.context?.render_project_templates) {
             return Domain.and([
                 Domain.removeDomainLeaves(domain, ['is_template']).toList(),
                 [['is_template', '=', true]],

--- a/addons/project/static/src/views/project_task_model_mixin.js
+++ b/addons/project/static/src/views/project_task_model_mixin.js
@@ -11,7 +11,7 @@ export const ProjectTaskModelMixin = (T) => class ProjectTaskModelMixin extends 
                 [['display_in_project', '=', true]],
             ]).toList({});
         }
-        if (this.env.searchModel.context?.render_templates) {
+        if (this.env.searchModel.context?.render_task_templates) {
             domain = Domain.and([
                 Domain.removeDomainLeaves(domain, ['has_template_ancestor']).toList(),
                 [['has_template_ancestor', '=', true]],

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -162,7 +162,7 @@
                     <filter string="Start Date" name="start_date" date="date_start" end_month="1" end_year="1"/>
                     <filter string="End Date" name="end_date" date="date" end_month="1" end_year="1"/>
                     <separator/>
-                    <filter string="Templates" context="{'render_templates': True}" name="templates" domain="[('is_template', '=', True)]"/>
+                    <filter string="Templates" context="{'render_project_templates': True}" name="templates" domain="[('is_template', '=', True)]"/>
                     <separator/>
                     <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
                     <separator invisible="1"/>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -11,7 +11,7 @@
                     <field name="tag_ids"/>
                     <field name="stage_id"/>
                     <field name="milestone_id" groups="project.group_project_milestone" invisible="not context.get('allow_milestones', True)"/>
-                    <field name="partner_id" operator="child_of" invisible="context.get('default_is_template')"/>
+                    <field name="partner_id" operator="child_of" invisible="context.get('template_project')"/>
                     <filter string="Unassigned" name="unassigned" domain="[('user_ids', '=', False)]"/>
                     <separator invisible="context.get('default_project_id')"/>
                     <filter string="Favorite Projects" name="favorite_projects" domain="[('project_id.is_favorite', '=', True)]" invisible="context.get('default_project_id')"/>
@@ -23,19 +23,19 @@
                     <filter string="Open" name="open_tasks" domain="[('is_closed', '=', False)]"/>
                     <filter string="Closed" name="closed_tasks" domain="[('is_closed', '=', True)]"/>
                     <filter string="Closed On" name="closed_on" domain="[('is_closed', '=', True)]" date="date_last_stage_update"
-                        invisible="context.get('default_is_template')">
+                        invisible="context.get('template_project')">
                         <filter name="create_date_last_30_days" string="Last 30 Days" domain="[('date_last_stage_update', '&gt;=', 'today -30d +1d')]"/>
                         <filter name="create_date_last_365_days" string="Last 365 Days" domain="[('date_last_stage_update', '&gt;=', 'today -365d +1d')]"/>
                     </filter>
                     <separator/>
-                    <filter string="Templates" context="{'render_templates': True}" name="templates" domain="[('has_template_ancestor', '=', True)]"/>
+                    <filter string="Templates" context="{'render_task_templates': True}" name="templates" domain="[('has_template_ancestor', '=', True)]"/>
                     <group>
                         <filter string="Stage" name="stage" context="{'group_by': 'stage_id'}"/>
                         <filter string="Milestone" name="milestone" context="{'group_by': 'milestone_id'}" groups="project.group_project_milestone" invisible="not context.get('allow_milestones', True)"/>
                         <filter string="Priority" name="groupby_priority" context="{'group_by': 'priority'}"/>
                         <filter string="Tags" name="tags" context="{'group_by': 'tag_ids'}"/>
                          <filter string="Customer" name="customer" context="{'group_by': 'partner_id'}"
-                            invisible="context.get('default_is_template')"/>
+                            invisible="context.get('template_project')"/>
                         <filter string="Company" name="company_id" context="{'group_by': 'company_id'}" groups="base.group_multi_company"/>
                         <filter string="Creation Date" name="create_date" context="{'group_by': 'create_date'}"/>
                     </group>
@@ -355,7 +355,7 @@
                         <span id="start_rating_buttons" invisible="1"/>
                         <field name="rating_avg" invisible="1"/>
                         <field name="rating_active" invisible="1"/>
-                        <button name="action_open_ratings" type="object" invisible="rating_count == 0 or not rating_active or has_template_ancestor" class="oe_stat_button">
+                        <button name="action_open_ratings" type="object" invisible="rating_count == 0 or not rating_active or has_template_ancestor or has_project_template" class="oe_stat_button">
                             <i class="fa fa-fw o_button_icon fa-smile-o text-success" invisible="rating_avg &lt; 3.66" title="Happy"/>
                             <i class="fa fa-fw o_button_icon fa-meh-o text-warning" invisible="rating_avg &lt; 2.33 or rating_avg &gt;= 3.66" title="Neutral"/>
                             <i class="fa fa-fw o_button_icon fa-frown-o text-danger" invisible="rating_avg &gt;= 2.33" title="Unhappy"/>
@@ -404,13 +404,13 @@
                         <h1 class="d-flex w-100">
                             <field name="name" options="{'line_breaks': False}" widget="text" class="o_task_name text-truncate w-md-75 w-100 pe-2" placeholder="Task Title..."/>
                         </h1>
-                        <div class="d-flex justify-content-end align-items-center px-1" invisible="not active or is_template">
+                        <div class="d-flex justify-content-end align-items-center px-1" invisible="not active or is_template or has_project_template">
                             <field name="priority" class="h3 pe-2" widget="priority_switch"/>
                         </div>
-                        <div class="d-flex justify-content-end o_state_container" invisible="not active or is_template">
+                        <div class="d-flex justify-content-end o_state_container" invisible="not active or is_template or has_project_template">
                             <field name="state" widget="project_task_state_selection" class="o_task_state_widget" />
                         </div>
-                        <div class="d-flex justify-content-start align-items-center w-100 w-md-50 w-lg-25" invisible="active and not is_template">
+                        <div class="d-flex justify-content-start align-items-center w-100 w-md-50 w-lg-25" invisible="active and not (is_template or has_project_template)">
                             <field name="priority" class="h3 pe-2" widget="priority_switch"/>
                             <field name="state" widget="project_task_state_selection" class="o_task_state_widget" />
                         </div>
@@ -418,7 +418,7 @@
                     <group>
                         <group>
                             <field name="project_id"
-                                domain="[('active', '=', True), '|', ('company_id', '=', False), ('company_id', '=?', company_id), ('is_template', 'in', [is_template, False])]"
+                                domain="[('active', '=', True), '|', ('company_id', '=', False), ('company_id', '=?', company_id)]"
                                 required="parent_id or child_ids or is_template"
                                 widget="project"/>
                             <field name="milestone_id"
@@ -429,12 +429,12 @@
                                 class="o_task_user_field"
                                 options="{'no_open': True}"
                                 widget="many2many_avatar_user"/>
-                            <field name="role_ids" invisible="not (is_template and has_project_template)" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}" placeholder="Assign at project creation"/>
+                            <field name="role_ids" invisible="not has_project_template or is_template" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}" placeholder="Assign at project creation"/>
                         </group>
                         <group>
                             <field name="active" invisible="1"/>
                             <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}" context="{'project_id': project_id}"/>
-                            <field name="partner_id" nolabel="0" widget="res_partner_many2one" class="o_task_customer_field" invisible="not project_id or has_template_ancestor"/>
+                            <field name="partner_id" nolabel="0" widget="res_partner_many2one" class="o_task_customer_field" invisible="not project_id or has_template_ancestor or has_project_template"/>
                             <label for="date_deadline"/>
                             <div id="date_deadline_and_recurring_task" class="d-inline-flex w-100">
                                 <field name="date_deadline" nolabel="1" decoration-danger="date_deadline and date_deadline &lt; current_date and state not in ['1_done', '1_canceled']"/>
@@ -472,7 +472,6 @@
                                         'default_parent_id': id,
                                         'default_partner_id': partner_id,
                                         'default_milestone_id': allow_milestones and milestone_id,
-                                        'default_is_template': False,
                                         'kanban_view_ref': 'project.project_sub_task_view_kanban_mobile',
                                         'closed_X2M_count': closed_subtask_count,
                                         'default_is_template': is_template,
@@ -497,7 +496,7 @@
                                         context="{'default_project_id': project_id}"
                                         column_invisible="not parent.allow_milestones"
                                         invisible="not allow_milestones"/>
-                                    <field name="partner_id" optional="hide" widget="res_partner_many2one" invisible="not project_id" column_invisible="parent.has_template_ancestor"/>
+                                    <field name="partner_id" optional="hide" widget="res_partner_many2one" invisible="not project_id" column_invisible="parent.has_template_ancestor or parent.has_project_template"/>
                                     <field name="user_ids" widget="many2many_avatar_user" optional="show"/>
                                     <field name="company_id" groups="base.group_multi_company" optional="hide"/>
                                     <field name="company_id" column_invisible="True"/>
@@ -543,7 +542,7 @@
                                         context="{'default_project_id': project_id}"
                                         column_invisible="not parent.allow_milestones"
                                         invisible="not allow_milestones"/>
-                                    <field name="partner_id" optional="hide" widget="res_partner_many2one" invisible="not project_id" column_invisible="parent.has_template_ancestor"/>
+                                    <field name="partner_id" optional="hide" widget="res_partner_many2one" invisible="not project_id" column_invisible="parent.has_template_ancestor or parent.has_project_template"/>
                                     <field name="parent_id" optional="hide" groups="base.group_no_one"/>
                                     <field name="user_ids" widget="many2many_avatar_user" optional="show"/>
                                     <field name="company_id" optional="hide" groups="base.group_multi_company" />
@@ -567,9 +566,9 @@
                                     <field name="parent_id" invisible="not project_id" groups="base.group_no_one" context="{'search_view_ref' : 'project.view_task_search_form', 'search_default_project_id': project_id, 'default_project_id': project_id}"/>
                                     <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}" placeholder="Visible to all"/>
                                     <field name="sequence" groups="base.group_no_one"/>
-                                    <field name="email_cc" groups="base.group_no_one" invisible="is_template"/>
+                                    <field name="email_cc" groups="base.group_no_one" invisible="is_template or has_project_template"/>
                                 </group>
-                                <group invisible="is_template">
+                                <group invisible="is_template or has_project_template">
                                     <field name="date_assign" groups="base.group_no_one"/>
                                     <field name="date_last_stage_update" groups="base.group_no_one"/>
                                 </group>
@@ -613,7 +612,7 @@
                                invisible="context.get('default_project_id', False)"
                                placeholder="Private"
                                class="o_project_task_project_field"
-                               domain="[('type_ids', 'in', context.get('default_stage_id')), ('is_template', 'in', [is_template, False])] if context.get('default_stage_id') else [('is_template', 'in', [is_template, False])]"
+                               domain="[('type_ids', 'in', context.get('default_stage_id'))] if context.get('default_stage_id') else []"
                                required="is_template"
                         />
                         <field name="user_ids" options="{'no_open': True}"
@@ -670,6 +669,7 @@
                     <field name="state" />
                     <field name="subtask_count"/>
                     <field name="is_template"/>
+                    <field name="has_project_template"/>
                     <progressbar field="state" colors='{"1_done": "success-done", "1_canceled": "danger", "03_approved": "success", "02_changes_requested": "warning", "04_waiting_normal": "info", "01_in_progress": "200" }'/>
                     <templates>
                         <t t-name="menu" t-if="!selection_mode" groups="base.group_user">
@@ -685,7 +685,7 @@
                                 <div class="text-muted d-flex flex-column">
                                     <field t-if="record.parent_id.raw_value" invisible="context.get('default_parent_id', False)" name="parent_id"/>
                                     <field invisible="context.get('default_project_id', False)" name="project_id" options="{'no_open': True}"/>
-                                    <field name="partner_id" invisible="context.get('default_is_template', False)"/>
+                                    <field name="partner_id" invisible="context.get('template_project')"/>
                                     <field t-if="record.allow_milestones.raw_value and record.milestone_id.raw_value" t-att-class="record.has_late_and_unreached_milestone.raw_value and !record.state.raw_value.startsWith('1_') ? 'text-danger' : ''" name="milestone_id" options="{'no_open': True}"/>
                                 </div>
                                 <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
@@ -751,7 +751,7 @@
                     <field name="name" string="Title" widget="name_with_subtask_count"/>
                     <field name="project_id" widget="project" optional="show" options="{'no_open': 1}" readonly="1" column_invisible="context.get('default_project_id')"/>
                     <field name="milestone_id" invisible="not allow_milestones" context="{'default_project_id': project_id}" groups="project.group_project_milestone" optional="hide" column_invisible="not context.get('allow_milestones', True)"/>
-                    <field name="partner_id" optional="hide" widget="res_partner_many2one" invisible="not project_id" options="{'no_open': True}" column_invisible="context.get('default_is_template', False)"/>
+                    <field name="partner_id" optional="hide" widget="res_partner_many2one" invisible="not project_id" options="{'no_open': True}" column_invisible="context.get('template_project')"/>
                     <field name="user_ids" optional="show" widget="many2many_avatar_user"/>
                     <field name="company_id" groups="base.group_multi_company" optional="hide" column_invisible="context.get('default_project_id')" options="{'no_create': True}"/>
                     <field name="company_id" column_invisible="True"/>
@@ -759,7 +759,7 @@
                     <field name="priority" widget="priority" optional="show" width="70px"/>
                     <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="show" context="{'project_id': project_id}"/>
                     <field name="create_date" optional="hide"/>
-                    <field name="date_last_stage_update" optional="hide" column_invisible="context.get('default_is_template', False)"/>
+                    <field name="date_last_stage_update" optional="hide" column_invisible="context.get('template_project')"/>
                     <field name="state" widget="project_task_state_selection" nolabel="1" width="20px" options="{'is_toggle_mode': false}"/>
                     <field name="stage_id_color" column_invisible="1"/>
                     <field name="is_rotting" column_invisible="True"/>
@@ -788,7 +788,7 @@
                         decoration-warning="rating_last_text == 'ok'" decoration-success="rating_last_text == 'top'"
                         invisible="not rating_active or rating_last_text == 'none'"
                         class="fw-bold" widget="badge" optional="hide"
-                        column_invisible="context.get('default_is_template', False)"/>
+                        column_invisible="context.get('template_project')"/>
                 </field>
                 <list position="inside">
                     <field name="task_properties"/>
@@ -799,7 +799,7 @@
                 </xpath>
                 <xpath expr="//field[@name='stage_id']" position="after">
                     <field name="personal_stage_type_id" string="Personal Stage" optional="hide"
-                        column_invisible="context.get('default_is_template', False)"/>
+                        column_invisible="context.get('template_project')"/>
                 </xpath>
             </field>
         </record>
@@ -1333,7 +1333,7 @@
             </field>
             <field name="partner_id" position="replace"/>
             <field name="user_ids" position="after">
-                <field name="role_ids" optional="hide" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}" invisible="not (is_template and has_project_template)"/>
+                <field name="role_ids" optional="hide" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}" invisible="not has_project_template or is_template"/>
             </field>
         </field>
     </record>

--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -161,7 +161,7 @@
             <xpath expr="//span[@id='start_rating_buttons']" position="before">
                 <button class="oe_stat_button"
                         type="object" name="action_view_so" icon="fa-dollar"
-                        invisible="not sale_order_id or has_template_ancestor"
+                        invisible="not sale_order_id or has_template_ancestor or has_project_template"
                         groups="sales_team.group_sale_salesman">
                         <div class="o_stat_info">
                             <span class="o_stat_text">Sales Order</span>
@@ -172,16 +172,16 @@
                 <attribute name="context">{'default_project_id': project_id, 'default_sale_line_id': sale_line_id}</attribute>
             </xpath>
             <xpath expr="//field[@name='partner_id']" position="attributes">
-                <attribute name="invisible">not allow_billable or has_template_ancestor</attribute>
+                <attribute name="invisible">not allow_billable or has_template_ancestor or has_project_template</attribute>
             </xpath>
             <xpath expr="//field[@name='partner_id']" position="after">
                 <field name="project_sale_order_id" invisible="1"/>
                 <field name="sale_order_id" invisible="True" groups="sales_team.group_sale_salesman"/>
-                <label for="sale_line_id" invisible="not allow_billable or not project_id or not partner_id or has_template_ancestor"/>
+                <label for="sale_line_id" invisible="not allow_billable or not project_id or not partner_id or has_template_ancestor or has_project_template"/>
                 <div 
                     name="sale_line_div"
                     class="o_row"
-                    invisible="not allow_billable or not project_id or not partner_id or has_template_ancestor">
+                    invisible="not allow_billable or not project_id or not partner_id or has_template_ancestor or has_project_template">
                     <field name="sale_line_id"
                         groups="!sales_team.group_sale_salesman"
                         string="Sales Order Item"
@@ -220,8 +220,8 @@
                        placeholder="Non-billable"
                        groups="sales_team.group_sale_salesman"
                        invisible="not allow_billable"
-                       column_invisible="parent.has_template_ancestor"/>
-                <field name="sale_line_id" optional="hide" options="{'no_open': True}" readonly="1" groups="!sales_team.group_sale_salesman" column_invisible="parent.has_template_ancestor"/>
+                       column_invisible="parent.has_template_ancestor or parent.has_project_template"/>
+                <field name="sale_line_id" optional="hide" options="{'no_open': True}" readonly="1" groups="!sales_team.group_sale_salesman" column_invisible="parent.has_template_ancestor or parent.has_project_template"/>
                 <field name="allow_billable" column_invisible="True"/>
             </xpath>
             <xpath expr="//field[@name='child_ids']/list/field[@name='partner_id']" position="attributes">
@@ -229,8 +229,8 @@
                 <attribute name="invisible">not allow_billable</attribute>
             </xpath>
             <xpath expr="//field[@name='depend_on_ids']/list/field[@name='partner_id']" position="after">
-                <field name="sale_line_id" optional="hide" readonly="1" groups="sales_team.group_sale_salesman" column_invisible="parent.has_template_ancestor"/>
-                <field name="sale_line_id" optional="hide" options="{'no_open': True}" readonly="1" groups="!sales_team.group_sale_salesman" column_invisible="parent.has_template_ancestor"/>
+                <field name="sale_line_id" optional="hide" readonly="1" groups="sales_team.group_sale_salesman" column_invisible="parent.has_template_ancestor or parent.has_project_template"/>
+                <field name="sale_line_id" optional="hide" options="{'no_open': True}" readonly="1" groups="!sales_team.group_sale_salesman" column_invisible="parent.has_template_ancestor or parent.has_project_template"/>
                 <field name="allow_billable" column_invisible="True"/>
             </xpath>
             <xpath expr="//field[@name='depend_on_ids']/list/field[@name='partner_id']" position="attributes">
@@ -264,8 +264,8 @@
         <field name="inherit_id" ref="project.project_task_view_tree_base"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='partner_id']" position="after">
-                <field name="sale_line_id" optional="hide" groups="sales_team.group_sale_salesman" options="{'no_create': True}" column_invisible="not context.get('allow_billable') or context.get('default_is_template')"/>
-                <field name="sale_line_id" optional="hide" options="{'no_open': True}" readonly="1" groups="!sales_team.group_sale_salesman" column_invisible="not context.get('allow_billable') or context.get('default_is_template')"/>
+                <field name="sale_line_id" optional="hide" groups="sales_team.group_sale_salesman" options="{'no_create': True}" column_invisible="not context.get('allow_billable') or context.get('template_project')"/>
+                <field name="sale_line_id" optional="hide" options="{'no_open': True}" readonly="1" groups="!sales_team.group_sale_salesman" column_invisible="not context.get('allow_billable') or context.get('template_project')"/>
             </xpath>
         </field>
     </record>
@@ -278,13 +278,13 @@
             <field name="partner_id" position="after">
                 <field name="sale_order_id"
                     filter_domain="['|', ('sale_order_id', 'ilike', self), ('sale_line_id', 'ilike', self)]"
-                    invisible="context.get('default_is_template')"/>
+                    invisible="context.get('template_project')"/>
             </field>
             <field name="partner_id" position="attributes">
-                <attribute name="invisible">context.get('hide_partner') or context.get('default_is_template')</attribute>
+                <attribute name="invisible">context.get('hide_partner') or context.get('template_project')</attribute>
             </field>
             <filter name="customer" position="attributes">
-                <attribute name="invisible">context.get('hide_partner') or context.get('default_is_template')</attribute>
+                <attribute name="invisible">context.get('hide_partner') or context.get('template_project')</attribute>
             </filter>
         </field>
     </record>

--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -159,7 +159,7 @@
                     <field name="sale_line_id" column_invisible="True"/>
                     <field name="remaining_hours_available" column_invisible="True"/>
                     <field name="remaining_hours_so" invisible="not sale_line_id or not remaining_hours_available" widget="timesheet_uom" optional="hide"
-                        groups="hr_timesheet.group_hr_timesheet_user" column_invisible="not (context.get('allow_billable', True) and context.get('allow_timesheets', True)) or context.get('default_is_template', False)"/>
+                        groups="hr_timesheet.group_hr_timesheet_user" column_invisible="not (context.get('allow_billable', True) and context.get('allow_timesheets', True)) or context.get('template_project')"/>
                 </xpath>
             </field>
         </record>


### PR DESCRIPTION
This feature was supposed to be introduced in 19 but got lost with [the reversal](https://github.com/odoo/odoo/pull/225953) of [the templates refactor](https://github.com/odoo/odoo/pull/220311).

When converting a project to a template, the tasks should retain their template status.
Task templates in project templates are treated the same as task templates in normal projects.
Project roles should be configured only on normal tasks and not on task templates.

Task-5087632