### PR TITLE
[IMP] web: use indexedDB for menu cache

### DIFF
--- a/addons/web/static/tests/_framework/mock_indexed_db.hoot.js
+++ b/addons/web/static/tests/_framework/mock_indexed_db.hoot.js
@@ -1,11 +1,20 @@
+import { afterEach } from "@odoo/hoot";
+
 export function mockIndexedDB(_name, { fn }) {
     return (requireModule, ...args) => {
         const indexedDBModule = fn(requireModule, ...args);
 
         const { IndexedDB } = indexedDBModule;
+        let dbs = {};
+        afterEach(() => {
+            dbs = {};
+        });
         class MockedIndexedDB {
-            constructor() {
-                this.mockIndexedDB = {};
+            constructor(name) {
+                if (!dbs[name]) {
+                    dbs[name] = {};
+                }
+                this.mockIndexedDB = dbs[name];
             }
 
             write(table, key, value) {


### PR DESCRIPTION
This commit modifies the menu service so that it uses IndexedDB to cache data instead of localStorage.

LocalStorage is more limited in size and is used by all other caches.