### PR TITLE
[FIX] mail: do not show chat hub compact in discuss app

### DIFF
--- a/addons/mail/static/src/core/common/chat_hub.xml
+++ b/addons/mail/static/src/core/common/chat_hub.xml
@@ -20,7 +20,7 @@
                         <DropdownItem t-if="position.dragged" class="'o-mail-ChatHub-option btn border-0 d-flex align-items-center gap-2 rounded-0 fw-normal px-2'" onSelected.bind="resetPosition"><i class="fa fa-fw fa-undo"></i>Reset initial position</DropdownItem>
                     </t>
                 </Dropdown>
-                <t t-if="store.chatHub.compact" t-call="mail.ChatHub.compactButton"/>
+                <t t-if="store.chatHub.compact and chatHub.showConversations" t-call="mail.ChatHub.compactButton"/>
                 <t t-else="">
                     <t t-foreach="chatHub.folded.slice(0, chatHub.maxFolded)" t-as="cw" t-key="cw.localId">
                         <ChatBubble t-if="cw.canShow" chatWindow="cw"/>

--- a/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
+++ b/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
@@ -352,6 +352,10 @@ test("Can compact chat hub", async () => {
     // alternative compact: click hidden button
     await click(".o-mail-ChatBubble", { text: "+13" });
     await contains(".o-mail-ChatBubble i.fa.fa-comments");
+    // don't show compact button in discuss app
+    await openDiscuss();
+    await contains(".o-mail-Discuss[data-active]");
+    await contains(".o-mail-ChatBubble i.fa.fa-comments", { count: 0 });
 });
 
 test("Compact chat hub is crosstab synced", async () => {


### PR DESCRIPTION
Before this commit, chat hub compact was visible in disucss app. This happens because while chat windows and bubbles are conditioned to not be shown in discuss app (with exceptions), the compact mode of chat hub was solely relying on compact mode on/off, ignoring the overall condition for whether some conversations are shown in chat hub (note: conversations in compact are still considered as "shown").

This commit adds extra condition on showing compact button to take into account chat hub showing some conversations. If no conversations are shown, then the compact mode should not be shown at all. Discuss app prevents showing of conversations in chat hub (with exceptions), as this is redundant with discuss app itself.

Backport of https://github.com/odoo/odoo/pull/227162