### PR TITLE
[FIX] sale: remove overflowing section options on combo line

### DIFF
--- a/addons/sale/static/src/js/sale_order_line_field/sale_order_line_field.xml
+++ b/addons/sale/static/src/js/sale_order_line_field/sale_order_line_field.xml
@@ -20,7 +20,7 @@
         <xpath expr="//td[hasclass('o_list_section_options')]" position="before">
             <td t-elif="isCombo(record)" class="o_list_section_options w-print-0 p-print-0 text-center">
                 <Dropdown position="'bottom-end'" t-if="!props.readonly">
-                    <button class="btn px-1 cursor-pointer">
+                    <button class="btn d-table-cell border-0 py-0 px-1 cursor-pointer">
                         <i class="fa fa-ellipsis-v"/>
                     </button>
                     <t t-set-slot="content">


### PR DESCRIPTION
In odoo/odoo@520bb2ff8eb165e4a9389db6300192f9b4a05dfd the styling applied on the `.o_list_section_options` was removed for utility classes. However these utilities were not applied on the combos, rendering an overflow after the ellipsis.

task-5089909

Issue:
<img width="961" height="583" alt="image" src="https://github.com/user-attachments/assets/fe4f7cd9-da3e-4ca5-98f5-0101d3a95012" />


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
