### PR TITLE
[FIX] hr_holidays: hide date range button for ´hr.leave´ dates

### DIFF
--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -374,7 +374,7 @@
                                     widget="daterange"
                                     readonly="state != 'confirm'"
                                     required="not date_from or not date_to"
-                                    options="{'end_date_field': 'request_date_to'}"/>
+                                    options="{'end_date_field': 'request_date_to', 'always_range': '1'}"/>
                                 <field name="request_date_to" invisible="1"/> <!-- For Form view test-->
                                 <div>
                                     ( <field name="duration_display" readonly="1" class="w-auto"/> )


### PR DESCRIPTION
Before this commit the ´o_toggle_range´ button was shown in the picker due to the following rule:
´´´
showRangeToggler:
    this.relatedField && !this.props.required && !this.props.alwaysRange
´´´

As we can see, the button does not appear when the field is required. However, in this case, the `request_date_from` field was not always required, which is why the button appeared.

To fix this issue, we now force it to be hidden by using `alwaysRange`.

task-5085529

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
