### PR TITLE
[FIX] html_builder, *: remember last used tab in 'BuilderColorPicker'

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
@@ -1,6 +1,10 @@
 import { ColorSelector } from "@html_editor/main/font/color_selector";
 import { Component, useComponent, useRef } from "@odoo/owl";
-import { useColorPicker } from "@web/core/color_picker/color_picker";
+import {
+    useColorPicker,
+    DEFAULT_COLORS,
+    DEFAULT_THEME_COLOR_VARS,
+} from "@web/core/color_picker/color_picker";
 import { BuilderComponent } from "./builder_component";
 import {
     basicContainerBuilderComponentProps,
@@ -17,6 +21,7 @@ export function useColorPickerBuilderComponent() {
     const comp = useComponent();
     const { getAllActions, callOperation } = getAllActionsAndOperations(comp);
     const getAction = comp.env.editor.shared.builderActions.getAction;
+    let selectedTab;
     const state = useDomState(getState);
     const applyOperation = comp.env.editor.shared.history.makePreviewableAsyncOperation(
         (applySpecs, isPreviewing) => {
@@ -47,6 +52,9 @@ export function useColorPickerBuilderComponent() {
         const { actionId, actionParam } = actionWithGetValue;
         const actionValue = getAction(actionId).getValue({ editingElement, params: actionParam });
         return {
+            // defaultTab is the tab to open if the user has not done a selection yet.
+            // If the user has already selected a color, the tab of the last selection is opened
+            defaultTab: comp.props.selectedTab,
             mode: actionParam.mainParam || actionId,
             selectedColor: actionValue || comp.props.defaultColor,
             selectedColorCombination: comp.env.editor.shared.color.getColorCombination(
@@ -54,6 +62,7 @@ export function useColorPickerBuilderComponent() {
                 actionParam
             ),
             getTargetedElements: () => [editingElement],
+            selectedTab,
         };
     }
     function getColor(colorValue) {
@@ -64,6 +73,7 @@ export function useColorPickerBuilderComponent() {
 
     let preventNextPreview = false;
     function onApply(colorValue) {
+        selectedTab = comp.getCorrespondingColorPickerTab(colorValue);
         preventNextPreview = false;
         callOperation(applyOperation.commit, { userInputValue: getColor(colorValue) });
     }
@@ -118,6 +128,7 @@ export class BuilderColorPicker extends Component {
     static defaultProps = {
         enabledTabs: ["theme", "gradient", "custom"],
         defaultColor: "#FFFFFF00",
+        selectedTab: "theme",
     };
     static components = {
         ColorSelector: ColorSelector,
@@ -129,7 +140,6 @@ export class BuilderColorPicker extends Component {
         const { state, onApply, onPreview, onPreviewRevert } = useColorPickerBuilderComponent();
         this.colorButton = useRef("colorButton");
         this.state = state;
-        this.state.defaultTab = this.props.selectedTab || "solid"; // TODO: select the correct tab based on the color
         useColorPicker(
             "colorButton",
             {
@@ -180,5 +190,34 @@ export class BuilderColorPicker extends Component {
 
     getUsedCustomColors() {
         return getAllUsedColors(this.env.editor.editable);
+    }
+
+    getCorrespondingColorPickerTab(selectedColor) {
+        if (!selectedColor) {
+            return;
+        }
+
+        selectedColor = selectedColor.replace(/color-prefix-/g, "");
+        const isTabEnabled = (tab) => this.props.enabledTabs.includes(tab);
+
+        if (isTabEnabled("gradient") && isColorGradient(selectedColor)) {
+            return "gradient";
+        }
+
+        const solidTabColors = [
+            ...DEFAULT_COLORS.flat(),
+            ...DEFAULT_THEME_COLOR_VARS.map((color) => color.toUpperCase()),
+        ];
+        if (isTabEnabled("solid") && solidTabColors.includes(selectedColor.toUpperCase())) {
+            return "solid";
+        }
+
+        if (isTabEnabled("theme") && /^o_cc\d+$/.test(selectedColor)) {
+            return "theme";
+        }
+
+        if (isTabEnabled("custom")) {
+            return "custom";
+        }
     }
 }

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_colorpicker.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_colorpicker.test.js
@@ -190,23 +190,6 @@ test("should revert preview on escape", async () => {
     expect(":iframe .test-options-target").toHaveStyle({ "background-color": "rgba(0, 0, 0, 0)" });
 });
 
-test("should mark default color as selected when it is selected", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderColorPicker enabledTabs="['custom']" styleAction="'background-color'"/>`;
-        }
-    );
-    await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
-    await contains(":iframe .test-options-target").click();
-    expect(".options-container").toBeDisplayed();
-    await contains(".we-bg-options-container .o_we_color_preview").click();
-    await contains(".o-overlay-item [data-color='900']").click();
-    expect(":iframe .test-options-target").toHaveClass("bg-900");
-    await contains(".we-bg-options-container .o_we_color_preview").click();
-    expect(".o-overlay-item [data-color='900']").toHaveClass("selected");
-});
-
 test("should apply transparent color if no color is defined", async () => {
     addBuilderAction({
         customAction: class extends BuilderAction {
@@ -238,4 +221,42 @@ test("should apply transparent color if no color is defined", async () => {
     expect(".o-overlay-item .o_hex_input").not.toHaveValue("#FFFFFF00");
     expect(":iframe .test-options-target").toHaveAttribute("data-color");
     expect.verifySteps(["getValue"]);
+});
+
+test("should open the last used tab", async () => {
+    addBuilderOption(
+        class extends BaseOptionComponent {
+            static selector = ".test-options-target";
+            static template = xml`<BuilderColorPicker styleAction="'background-color'"/>`;
+        }
+    );
+    await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
+    await contains(":iframe .test-options-target").click();
+    expect(".options-container").toBeDisplayed();
+
+    await contains(".we-bg-options-container .o_we_color_preview").click();
+    await click(".theme-tab");
+    await animationFrame();
+    expect(".theme-tab.active").toHaveCount(1);
+
+    await click(".custom-tab");
+    await animationFrame();
+    await click(".o_red_input");
+    await press("enter");
+    await press("escape");
+    await animationFrame();
+    await contains(".we-bg-options-container .o_we_color_preview").click();
+    expect(".custom-tab.active").toHaveCount(1);
+
+    await click(".gradient-tab");
+    await animationFrame();
+    await click(".o_gradient_color_button");
+    await animationFrame();
+    await contains(".we-bg-options-container .o_we_color_preview").click();
+    expect(".gradient-tab.active").toHaveCount(1);
+
+    await click("button[title='Reset']");
+    await animationFrame();
+    await contains(".we-bg-options-container .o_we_color_preview").click();
+    expect(".theme-tab.active").toHaveCount(1);
 });

--- a/addons/html_editor/static/src/main/font/color_selector.js
+++ b/addons/html_editor/static/src/main/font/color_selector.js
@@ -47,7 +47,8 @@ export class ColorSelector extends Component {
         effect(
             (selectedColors) => {
                 this.state.selectedColor = selectedColors[this.props.mode];
-                this.state.defaultTab = this.getCorrespondingColorTab(
+                this.state.defaultTab = "solid";
+                this.state.selectedTab = this.getCorrespondingColorTab(
                     selectedColors[this.props.mode]
                 );
                 this.state.getTargetedElements = this.props.getTargetedElements;

--- a/addons/html_editor/static/tests/color_selector.test.js
+++ b/addons/html_editor/static/tests/color_selector.test.js
@@ -1,4 +1,3 @@
-import { getCSSVariableValue, getHtmlStyle } from "@html_editor/utils/formatting";
 import { describe, expect, test } from "@odoo/hoot";
 import {
     click,
@@ -674,6 +673,10 @@ test("custom tab color navigation using keys", async () => {
     await expandToolbar();
     await click(".o-we-toolbar .o-select-color-foreground");
     await animationFrame();
+    await click(".o_color_button[data-color='#FF0000']");
+    await animationFrame();
+    await click(".o-we-toolbar .o-select-color-foreground");
+    await animationFrame();
     await press("Tab");
     expect(getActiveElement()).toBe(queryFirst('.o_font_color_selector button:contains("Custom")'));
     await press("Enter");
@@ -682,10 +685,8 @@ test("custom tab color navigation using keys", async () => {
     await press("Tab");
     await press("Tab");
     await press("Tab");
-    const htmlStyle = getHtmlStyle(document);
-    const defaultColor = getCSSVariableValue("body-color", htmlStyle);
     expect(getActiveElement()).toBe(
-        queryFirst(`.o_font_color_selector button[data-color="${defaultColor.toLowerCase()}"]`)
+        queryFirst(`.o_font_color_selector button[data-color="#ff0000"]`)
     );
     await press("ArrowDown");
     expect(getActiveElement()).toBe(
@@ -696,7 +697,7 @@ test("custom tab color navigation using keys", async () => {
         queryFirst('.o_font_color_selector button[data-color="black"]') // Should do nothing
     );
     await press("Enter");
-    expect(getContent(el)).toBe(`<p><font class="text-black">[test]</font></p>`);
+    expect(getContent(el)).toBe(`<p><font style="" class="text-black">[test]</font></p>`);
 });
 
 describe.tags("desktop");

--- a/addons/web/static/tests/core/color_picker.test.js
+++ b/addons/web/static/tests/core/color_picker.test.js
@@ -313,7 +313,7 @@ test("custom gradient must be defined", async () => {
     await mountWithCleanup(ColorPicker, {
         props: {
             state: {
-                selectedColor: "#FF0000", //linear-gradient(0deg, rgb(0,0,0) 0%, rgb(100,100,100) 100%)",
+                selectedColor: "linear-gradient(0deg, rgb(0,0,0) 0%, rgb(100,100,100) 100%)",
                 defaultTab: "gradient",
             },
             getUsedCustomColors: () => [],
@@ -326,4 +326,26 @@ test("custom gradient must be defined", async () => {
     await click(".o_custom_gradient_button");
     await animationFrame();
     expect(".gradient-colors input[type='range']").toHaveCount(2);
+});
+
+test("should mark default color as selected when it is selected", async () => {
+    defineStyle(`
+        :root {
+            --900: #212527;
+        }
+    `);
+    await mountWithCleanup(ColorPicker, {
+        props: {
+            state: {
+                selectedColor: "#212527",
+                defaultTab: "custom",
+            },
+            getUsedCustomColors: () => [],
+            applyColor() {},
+            applyColorPreview() {},
+            applyColorResetPreview() {},
+            colorPrefix: "",
+        },
+    });
+    expect(".o_color_button[data-color='900']").toHaveClass("selected");
 });

--- a/addons/website/static/tests/builder/website_builder/customize_website_color.test.js
+++ b/addons/website/static/tests/builder/website_builder/customize_website_color.test.js
@@ -75,6 +75,7 @@ test("BuilderColorPicker with action “customizeWebsiteColor” is correctly di
     // Setting preset does not impact solid color
     expect.step("set preset on solid color");
     await contains("button.o_we_color_preview").click();
+    await contains("button.theme-tab").click();
     await contains("button[data-color='o_cc3'").click();
     // Should wait for 2 ticks (debounced): customizeWebsiteColors, reloadBundles
     await def;
@@ -103,6 +104,7 @@ test("BuilderColorPicker with action “customizeWebsiteColor” is correctly di
     // Setting preset does not impact gradient
     expect.step("set preset on gradient");
     await contains("button.o_we_color_preview").click();
+    await contains("button.theme-tab").click();
     await contains("button[data-color='o_cc4'").click();
     // Should wait for 2 ticks (debounced): customizeWebsiteColors, reloadBundles
     await def;

--- a/addons/website/static/tests/tours/snippet_background_edition.js
+++ b/addons/website/static/tests/tours/snippet_background_edition.js
@@ -84,7 +84,7 @@ function checkAndUpdateBackgroundColor({
         changeBackgroundColor(),
     ];
 
-    addCheck(steps, checkCC, checkNoCC, 'cc', true);
+    addCheck(steps, checkCC, checkNoCC, 'cc');
     addCheck(steps, checkBg, checkNoBg, 'bg');
     addCheck(steps, checkGradient, checkNoGradient, 'gradient');
 

--- a/addons/website/static/tests/tours/website_page_options.js
+++ b/addons/website/static/tests/tours/website_page_options.js
@@ -24,7 +24,7 @@ registerWebsitePreviewTour('website_page_options', {
     ...clickOnEditAndWaitEditMode(),
     ...clickOnSnippet({id: 'o_header_standard', name: 'Header'}),
     {
-        content: "Open the color picker to change the backaground color of the header",
+        content: "Open the color picker to change the background color of the header",
         trigger:"div[data-container-title='Header'] .hb-row-sublevel-1[data-label='Background'] button",
         run: "click",
     },


### PR DESCRIPTION
*web, website

Before this commit, `BuilderColorPicker` had no memory of the last used tab and always opened on the first tab, regardless of whether the user had previously selected a color.

After this commit, if the user has done a selection, the color picker opens on the tab of that selection.

How to reproduce the problem:
1. Drop a new snippet, e.g. `s_text_block`,
2. Click on the snippet, then open the "Background" color picker
3. Pick a custom color or a gradient
4. If the color picker is stil open, press ESC
5. Open the color picker again
6. PROBLEM: the color picker is opened on the "theme" tab

task-4367641