### PR TITLE
[FIX] payment_provider: set copy=False for credentials fields

### DIFF
--- a/addons/payment/models/payment_provider.py
+++ b/addons/payment/models/payment_provider.py
@@ -46,6 +46,7 @@ class PaymentProvider(models.Model):
         string="Published",
         help="Whether the provider is visible on the website or not. Tokens remain functional but "
              "are only visible on manage forms.",
+        copy=False,
     )
     company_id = fields.Many2one(  # Indexed to speed-up ORM searches (from ir_rule or others)
         string="Company", comodel_name='res.company', default=lambda self: self.env.company.id,

--- a/addons/payment_adyen/models/payment_provider.py
+++ b/addons/payment_adyen/models/payment_provider.py
@@ -21,20 +21,35 @@ class PaymentProvider(models.Model):
     adyen_merchant_account = fields.Char(
         string="Merchant Account",
         help="The code of the merchant account to use with this provider",
-        required_if_provider='adyen', groups='base.group_system')
+        required_if_provider='adyen',
+        groups='base.group_system',
+        copy=False,
+    )
     adyen_api_key = fields.Char(
-        string="API Key", help="The API key of the webservice user", required_if_provider='adyen',
-        groups='base.group_system')
+        string="API Key",
+        help="The API key of the webservice user",
+        required_if_provider='adyen',
+        groups='base.group_system',
+        copy=False,
+    )
     adyen_client_key = fields.Char(
-        string="Client Key", help="The client key of the webservice user",
-        required_if_provider='adyen')
+        string="Client Key",
+        help="The client key of the webservice user",
+        required_if_provider='adyen',
+        copy=False,
+    )
     adyen_hmac_key = fields.Char(
-        string="HMAC Key", help="The HMAC key of the webhook", required_if_provider='adyen',
-        groups='base.group_system')
+        string="HMAC Key",
+        help="The HMAC key of the webhook",
+        required_if_provider='adyen',
+        groups='base.group_system',
+        copy=False,
+    )
     adyen_api_url_prefix = fields.Char(
         string="API URL Prefix",
         help="The base URL for the API endpoints",
         required_if_provider='adyen',
+        copy=False,
     )
 
     # === CRUD METHODS === #

--- a/addons/payment_aps/models/payment_provider.py
+++ b/addons/payment_aps/models/payment_provider.py
@@ -21,22 +21,26 @@ class PaymentProvider(models.Model):
         string="APS Merchant Identifier",
         help="The code of the merchant account to use with this provider.",
         required_if_provider='aps',
+        copy=False,
     )
     aps_access_code = fields.Char(
         string="APS Access Code",
         help="The access code associated with the merchant account.",
         required_if_provider='aps',
         groups='base.group_system',
+        copy=False,
     )
     aps_sha_request = fields.Char(
         string="APS SHA Request Phrase",
         required_if_provider='aps',
         groups='base.group_system',
+        copy=False,
     )
     aps_sha_response = fields.Char(
         string="APS SHA Response Phrase",
         required_if_provider='aps',
         groups='base.group_system',
+        copy=False,
     )
 
     # === CRUD METHODS === #

--- a/addons/payment_asiapay/models/payment_provider.py
+++ b/addons/payment_asiapay/models/payment_provider.py
@@ -21,16 +21,19 @@ class PaymentProvider(models.Model):
                     ("siampay", "SiamPay"), ("bimopay", "BimoPay")],
         default='paydollar',
         required_if_provider='asiapay',
+        copy=False,
     )
     asiapay_merchant_id = fields.Char(
         string="AsiaPay Merchant ID",
         help="The Merchant ID solely used to identify your AsiaPay account.",
         required_if_provider='asiapay',
+        copy=False,
     )
     asiapay_secure_hash_secret = fields.Char(
         string="AsiaPay Secure Hash Secret",
         required_if_provider='asiapay',
         groups='base.group_system',
+        copy=False,
     )
     asiapay_secure_hash_function = fields.Selection(
         string="AsiaPay Secure Hash Function",
@@ -38,6 +41,7 @@ class PaymentProvider(models.Model):
         selection=[('sha1', "SHA1"), ('sha256', "SHA256"), ('sha512', 'SHA512')],
         default='sha1',
         required_if_provider='asiapay',
+        copy=False,
     )
 
     # ==== CONSTRAINT METHODS ===#

--- a/addons/payment_authorize/models/payment_provider.py
+++ b/addons/payment_authorize/models/payment_provider.py
@@ -21,15 +21,28 @@ class PaymentProvider(models.Model):
     code = fields.Selection(
         selection_add=[('authorize', 'Authorize.Net')], ondelete={'authorize': 'set default'})
     authorize_login = fields.Char(
-        string="API Login ID", help="The ID solely used to identify the account with Authorize.Net",
-        required_if_provider='authorize')
+        string="API Login ID",
+        help="The ID solely used to identify the account with Authorize.Net",
+        required_if_provider='authorize',
+        copy=False,
+    )
     authorize_transaction_key = fields.Char(
-        string="API Transaction Key", required_if_provider='authorize', groups='base.group_system')
+        string="API Transaction Key",
+        required_if_provider='authorize',
+        groups='base.group_system',
+        copy=False,
+    )
     authorize_signature_key = fields.Char(
-        string="API Signature Key", required_if_provider='authorize', groups='base.group_system')
+        string="API Signature Key",
+        required_if_provider='authorize',
+        groups='base.group_system',
+        copy=False,
+    )
     authorize_client_key = fields.Char(
         string="API Client Key",
-        help="The public client key. To generate directly from Odoo or from Authorize.Net backend.")
+        help="The public client key. To generate directly from Odoo or from Authorize.Net backend.",
+        copy=False,
+    )
 
     # === CONSTRAINT METHODS ===#
 

--- a/addons/payment_buckaroo/models/payment_provider.py
+++ b/addons/payment_buckaroo/models/payment_provider.py
@@ -15,10 +15,17 @@ class PaymentProvider(models.Model):
     code = fields.Selection(
         selection_add=[('buckaroo', "Buckaroo")], ondelete={'buckaroo': 'set default'})
     buckaroo_website_key = fields.Char(
-        string="Website Key", help="The key solely used to identify the website with Buckaroo",
-        required_if_provider='buckaroo')
+        string="Website Key",
+        help="The key solely used to identify the website with Buckaroo",
+        required_if_provider='buckaroo',
+        copy=False,
+    )
     buckaroo_secret_key = fields.Char(
-        string="Buckaroo Secret Key", required_if_provider='buckaroo', groups='base.group_system')
+        string="Buckaroo Secret Key",
+        required_if_provider='buckaroo',
+        groups='base.group_system',
+        copy=False,
+    )
 
     # === COMPUTE METHODS ===#
 

--- a/addons/payment_dpo/models/payment_provider.py
+++ b/addons/payment_dpo/models/payment_provider.py
@@ -15,11 +15,12 @@ class PaymentProvider(models.Model):
     _inherit = 'payment.provider'
 
     code = fields.Selection(selection_add=[('dpo', "DPO")], ondelete={'dpo': 'set default'})
-    dpo_service_ref = fields.Char(string="DPO Service ID", required_if_provider='dpo')
+    dpo_service_ref = fields.Char(string="DPO Service ID", required_if_provider='dpo', copy=False)
     dpo_company_token = fields.Char(
         string="DPO Company Token",
         required_if_provider='dpo',
         groups='base.group_system',
+        copy=False,
     )
 
     # === CRUD METHODS === #

--- a/addons/payment_flutterwave/models/payment_provider.py
+++ b/addons/payment_flutterwave/models/payment_provider.py
@@ -22,16 +22,19 @@ class PaymentProvider(models.Model):
         string="Flutterwave Public Key",
         help="The key solely used to identify the account with Flutterwave.",
         required_if_provider='flutterwave',
+        copy=False,
     )
     flutterwave_secret_key = fields.Char(
         string="Flutterwave Secret Key",
         required_if_provider='flutterwave',
         groups='base.group_system',
+        copy=False,
     )
     flutterwave_webhook_secret = fields.Char(
         string="Flutterwave Webhook Secret",
         required_if_provider='flutterwave',
         groups='base.group_system',
+        copy=False,
     )
 
     #=== COMPUTE METHODS ===#

--- a/addons/payment_iyzico/models/payment_provider.py
+++ b/addons/payment_iyzico/models/payment_provider.py
@@ -20,9 +20,12 @@ class PaymentProvider(models.Model):
     code = fields.Selection(
         selection_add=[('iyzico', "Iyzico")], ondelete={'iyzico': 'set default'}
     )
-    iyzico_key_id = fields.Char(string="Iyzico Key Id", required_if_provider='iyzico')
+    iyzico_key_id = fields.Char(string="Iyzico Key Id", required_if_provider='iyzico', copy=False)
     iyzico_key_secret = fields.Char(
-        string="Iyzico Key Secret", required_if_provider='iyzico', groups='base.group_system'
+        string="Iyzico Key Secret",
+        required_if_provider='iyzico',
+        groups='base.group_system',
+        copy=False,
     )
 
     # === COMPUTE METHODS === #

--- a/addons/payment_mercado_pago/models/payment_provider.py
+++ b/addons/payment_mercado_pago/models/payment_provider.py
@@ -33,20 +33,29 @@ class PaymentProvider(models.Model):
         inverse='_inverse_mercado_pago_account_country_id',
         domain=[('code', 'in', list(const.SUPPORTED_COUNTRIES))],
         required_if_provider='mercado_pago',
+        copy=False,
     )
 
     # OAuth fields
     mercado_pago_access_token = fields.Char(
-        string="Mercado Pago Access Token", groups='base.group_system'
+        string="Mercado Pago Access Token",
+        groups='base.group_system',
+        copy=False,
     )
     mercado_pago_access_token_expiry = fields.Datetime(
-        string="Mercado Pago Access Token Expiry", groups='base.group_system'
+        string="Mercado Pago Access Token Expiry",
+        groups='base.group_system',
+        copy=False,
     )
     mercado_pago_refresh_token = fields.Char(
-        string="Mercado Pago Refresh Token", groups='base.group_system'
+        string="Mercado Pago Refresh Token",
+        groups='base.group_system',
+        copy=False,
     )
     mercado_pago_public_key = fields.Char(
-        string="Mercado Pago Public Key", groups='base.group_system'
+        string="Mercado Pago Public Key",
+        groups='base.group_system',
+        copy=False,
     )
 
     # === COMPUTE METHODS === #

--- a/addons/payment_mollie/models/payment_provider.py
+++ b/addons/payment_mollie/models/payment_provider.py
@@ -19,7 +19,8 @@ class PaymentProvider(models.Model):
     mollie_api_key = fields.Char(
         string="Mollie API Key",
         help="The Test or Live API Key depending on the configuration of the provider",
-        required_if_provider="mollie", groups="base.group_system"
+        required_if_provider="mollie", groups="base.group_system",
+        copy=False,
     )
 
     # === COMPUTE METHODS === #

--- a/addons/payment_nuvei/models/payment_provider.py
+++ b/addons/payment_nuvei/models/payment_provider.py
@@ -21,17 +21,20 @@ class PaymentProvider(models.Model):
         string="Nuvei Merchant Identifier",
         help="The code of the merchant account to use with this provider.",
         required_if_provider='nuvei',
+        copy=False,
     )
     nuvei_site_identifier = fields.Char(
         string="Nuvei Site Identifier",
         help="The site identifier code associated with the merchant account.",
         required_if_provider='nuvei',
         groups='base.group_system',
+        copy=False,
     )
     nuvei_secret_key = fields.Char(
         string="Nuvei Secret Key",
         required_if_provider='nuvei',
         groups='base.group_system',
+        copy=False,
     )
 
     # === COMPUTE METHODS === #

--- a/addons/payment_paymob/models/payment_provider.py
+++ b/addons/payment_paymob/models/payment_provider.py
@@ -29,13 +29,29 @@ class PaymentProvider(models.Model):
         inverse='_inverse_paymob_account_country_id',
         domain=f'[("code", "in", {list(const.API_MAPPING.keys())})]',
         required_if_provider='paymob',
+        copy=False,
     )
-    paymob_public_key = fields.Char(string="Paymob Public Key", required_if_provider='paymob')
+    paymob_public_key = fields.Char(
+        string="Paymob Public Key",
+        required_if_provider='paymob',
+        copy=False,
+    )
     paymob_secret_key = fields.Char(
-        string="Paymob Secret Key", required_if_provider='paymob', groups='base.group_system'
+        string="Paymob Secret Key",
+        required_if_provider='paymob',
+        groups='base.group_system',
+        copy=False,
     )
-    paymob_hmac_key = fields.Char(string="Paymob HMAC Key", required_if_provider='paymob')
-    paymob_api_key = fields.Char(string="Paymob API Key", required_if_provider='paymob')
+    paymob_hmac_key = fields.Char(
+        string="Paymob HMAC Key",
+        required_if_provider='paymob',
+        copy=False,
+    )
+    paymob_api_key = fields.Char(
+        string="Paymob API Key",
+        required_if_provider='paymob',
+        copy=False,
+    )
 
     # === CONSTRAINT METHODS === #
 

--- a/addons/payment_paypal/models/payment_provider.py
+++ b/addons/payment_paypal/models/payment_provider.py
@@ -26,21 +26,32 @@ class PaymentProvider(models.Model):
         help="The public business email solely used to identify the account with PayPal",
         required_if_provider='paypal',
         default=lambda self: self.env.company.email,
+        copy=False,
     )
-    paypal_client_id = fields.Char(string="PayPal Client ID", required_if_provider='paypal')
-    paypal_client_secret = fields.Char(string="PayPal Client Secret", groups='base.group_system')
+    paypal_client_id = fields.Char(
+        string="PayPal Client ID",
+        required_if_provider='paypal',
+        copy=False,
+    )
+    paypal_client_secret = fields.Char(
+        string="PayPal Client Secret",
+        groups='base.group_system',
+        copy=False,
+    )
     paypal_access_token = fields.Char(
         string="PayPal Access Token",
         help="The short-lived token used to access Paypal APIs",
         groups='base.group_system',
+        copy=False,
     )
     paypal_access_token_expiry = fields.Datetime(
         string="PayPal Access Token Expiry",
         help="The moment at which the access token becomes invalid.",
         default='1970-01-01',
         groups='base.group_system',
+        copy=False,
     )
-    paypal_webhook_id = fields.Char(string="PayPal Webhook ID")
+    paypal_webhook_id = fields.Char(string="PayPal Webhook ID", copy=False)
 
     # === COMPUTE METHODS === #
 

--- a/addons/payment_razorpay/models/payment_provider.py
+++ b/addons/payment_razorpay/models/payment_provider.py
@@ -25,22 +25,46 @@ class PaymentProvider(models.Model):
         selection_add=[('razorpay', "Razorpay")], ondelete={'razorpay': 'set default'}
     )
     razorpay_key_id = fields.Char(
-        string="Razorpay Key Id", help="The key solely used to identify the account with Razorpay."
+        string="Razorpay Key Id",
+        help="The key solely used to identify the account with Razorpay.",
+        copy = False,
     )
-    razorpay_key_secret = fields.Char(string="Razorpay Key Secret", groups='base.group_system')
+    razorpay_key_secret = fields.Char(
+        string="Razorpay Key Secret",
+        groups='base.group_system',
+        copy=False,
+    )
     razorpay_webhook_secret = fields.Char(
-        string="Razorpay Webhook Secret", groups='base.group_system'
+        string="Razorpay Webhook Secret",
+        groups='base.group_system',
+        copy=False,
     )
 
     # OAuth fields
-    razorpay_account_id = fields.Char(string="Razorpay Account ID", groups='base.group_system')
-    razorpay_refresh_token = fields.Char(
-        string="Razorpay Refresh Token", groups='base.group_system'
+    razorpay_account_id = fields.Char(
+        string="Razorpay Account ID",
+        groups='base.group_system',
+        copy=False,
     )
-    razorpay_public_token = fields.Char(string="Razorpay Public Token", groups='base.group_system')
-    razorpay_access_token = fields.Char(string="Razorpay Access Token", groups='base.group_system')
+    razorpay_refresh_token = fields.Char(
+        string="Razorpay Refresh Token",
+        groups='base.group_system',
+        copy=False,
+    )
+    razorpay_public_token = fields.Char(
+        string="Razorpay Public Token",
+        groups='base.group_system',
+        copy=False,
+    )
+    razorpay_access_token = fields.Char(
+        string="Razorpay Access Token",
+        groups='base.group_system',
+        copy=False,
+    )
     razorpay_access_token_expiry = fields.Datetime(
-        string="Razorpay Access Token Expiry", groups='base.group_system'
+        string="Razorpay Access Token Expiry",
+        groups='base.group_system',
+        copy=False,
     )
 
     # === COMPUTE METHODS === #

--- a/addons/payment_redsys/models/payment_provider.py
+++ b/addons/payment_redsys/models/payment_provider.py
@@ -18,14 +18,21 @@ class PaymentProvider(models.Model):
     code = fields.Selection(
         selection_add=[('redsys', "Redsys")], ondelete={'redsys': 'set default'}
     )
-    redsys_merchant_code = fields.Char(string="Redsys Merchant Code", required_if_provider='redsys')
+    redsys_merchant_code = fields.Char(
+        string="Redsys Merchant Code",
+        required_if_provider='redsys',
+        copy=False,
+    )
     redsys_merchant_terminal = fields.Char(
-        string="Redsys Merchant Terminal", required_if_provider='redsys'
+        string="Redsys Merchant Terminal",
+        required_if_provider='redsys',
+        copy=False,
     )
     redsys_secret_key = fields.Char(
         string="Redsys Secret Key",
         required_if_provider='redsys',
         groups='base.group_system',
+        copy=False,
     )
 
     # === CRUD METHODS === #

--- a/addons/payment_stripe/models/payment_provider.py
+++ b/addons/payment_stripe/models/payment_provider.py
@@ -25,15 +25,24 @@ class PaymentProvider(models.Model):
     code = fields.Selection(
         selection_add=[('stripe', "Stripe")], ondelete={'stripe': 'set default'})
     stripe_publishable_key = fields.Char(
-        string="Publishable Key", help="The key solely used to identify the account with Stripe",
-        required_if_provider='stripe')
+        string="Publishable Key",
+        help="The key solely used to identify the account with Stripe",
+        required_if_provider='stripe',
+        copy=False,
+    )
     stripe_secret_key = fields.Char(
-        string="Secret Key", required_if_provider='stripe', groups='base.group_system')
+        string="Secret Key",
+        required_if_provider='stripe',
+        groups='base.group_system',
+        copy=False,
+    )
     stripe_webhook_secret = fields.Char(
         string="Webhook Signing Secret",
         help="If a webhook is enabled on your Stripe account, this signing secret must be set to "
              "authenticate the messages sent from Stripe to Odoo.",
-        groups='base.group_system')
+        groups='base.group_system',
+        copy=False,
+    )
 
     # === COMPUTE METHODS === #
 

--- a/addons/payment_worldline/models/payment_provider.py
+++ b/addons/payment_worldline/models/payment_provider.py
@@ -21,16 +21,30 @@ class PaymentProvider(models.Model):
     code = fields.Selection(
         selection_add=[('worldline', "Worldline")], ondelete={'worldline': 'set default'}
     )
-    worldline_pspid = fields.Char(string="Worldline PSPID", required_if_provider='worldline')
-    worldline_api_key = fields.Char(string="Worldline API Key", required_if_provider='worldline')
+    worldline_pspid = fields.Char(
+        string="Worldline PSPID",
+        required_if_provider='worldline',
+        copy=False,
+    )
+    worldline_api_key = fields.Char(
+        string="Worldline API Key",
+        required_if_provider='worldline',
+        copy=False,
+    )
     worldline_api_secret = fields.Char(
-        string="Worldline API Secret", required_if_provider='worldline'
+        string="Worldline API Secret",
+        required_if_provider='worldline',
+        copy=False,
     )
     worldline_webhook_key = fields.Char(
-        string="Worldline Webhook Key", required_if_provider='worldline'
+        string="Worldline Webhook Key",
+        required_if_provider='worldline',
+        copy=False,
     )
     worldline_webhook_secret = fields.Char(
-        string="Worldline Webhook Secret", required_if_provider='worldline'
+        string="Worldline Webhook Secret",
+        required_if_provider='worldline',
+        copy=False,
     )
 
     # === COMPUTE METHODS === #

--- a/addons/payment_xendit/models/payment_provider.py
+++ b/addons/payment_xendit/models/payment_provider.py
@@ -16,13 +16,22 @@ class PaymentProvider(models.Model):
         selection_add=[('xendit', "Xendit")], ondelete={'xendit': 'set default'}
     )
     xendit_public_key = fields.Char(
-        string="Xendit Public Key", groups='base.group_system', required_if_provider='xendit'
+        string="Xendit Public Key",
+        groups='base.group_system',
+        required_if_provider='xendit',
+        copy=False,
     )
     xendit_secret_key = fields.Char(
-        string="Xendit Secret Key", groups='base.group_system', required_if_provider='xendit'
+        string="Xendit Secret Key",
+        groups='base.group_system',
+        required_if_provider='xendit',
+        copy=False,
     )
     xendit_webhook_token = fields.Char(
-        string="Xendit Webhook Token", groups='base.group_system', required_if_provider='xendit'
+        string="Xendit Webhook Token",
+        groups='base.group_system',
+        required_if_provider='xendit',
+        copy=False,
     )
 
     # === COMPUTE METHODS === #


### PR DESCRIPTION
Since different companies typically require distinct credentials, we avoid copying them during company creation by setting copy=False. Additionally, because credentials are necessary for proper setup, payment providers should not be published automatically when a new company is created.

opw-5083526

