### PR TITLE
[FIX] {purchase,sale}_edi_ubl: fix sections interpeted as lines

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -505,5 +505,3 @@ class AccountEdiXmlUbl_Bis3(models.AbstractModel):
             order.message_post(body=Markup("<strong>%s</strong>") % _("Format used to import the document: %s", self._description))
             if logs:
                 order._create_activity_set_details(Markup("<ul>%s</ul>") % Markup().join(Markup("<li>%s</li>") % l for l in logs))
-
-        return True

--- a/addons/purchase_edi_ubl_bis3/models/purchase_edi_xml_ubl_bis3.py
+++ b/addons/purchase_edi_ubl_bis3/models/purchase_edi_xml_ubl_bis3.py
@@ -70,7 +70,7 @@ class PurchaseEdiXmlUbl_Bis3(models.AbstractModel):
         purchase_order = vals['purchase_order']
         AccountTax = self.env['account.tax']
 
-        base_lines = [line._prepare_base_line_for_taxes_computation() for line in purchase_order.order_line]
+        base_lines = [line._prepare_base_line_for_taxes_computation() for line in purchase_order.order_line.filtered(lambda line: not line.display_type)]
         AccountTax._add_tax_details_in_base_lines(base_lines, purchase_order.company_id)
         AccountTax._round_base_lines_tax_details(base_lines, purchase_order.company_id)
 

--- a/addons/sale_edi_ubl/models/sale_edi_xml_ubl_bis3.py
+++ b/addons/sale_edi_ubl/models/sale_edi_xml_ubl_bis3.py
@@ -69,7 +69,7 @@ class SaleEdiXmlUbl_Bis3(models.AbstractModel):
         sale_order = vals['sale_order']
         AccountTax = self.env['account.tax']
 
-        base_lines = [line._prepare_base_line_for_taxes_computation() for line in sale_order.order_line]
+        base_lines = [line._prepare_base_line_for_taxes_computation() for line in sale_order.order_line.filtered(lambda line: not line.display_type)]
         AccountTax._add_tax_details_in_base_lines(base_lines, sale_order.company_id)
         AccountTax._round_base_lines_tax_details(base_lines, sale_order.company_id)
 


### PR DESCRIPTION
Steps to reproduce:
- Create Sales/Purchase order with sections
- Print Sales/Purchase order as PDF
- Drop the PDF into purchase app

Problem:
- Sections are added as a normal order line with quantity, price, etc..
- `return True` was removed from `_import_order_ubl` because it
shows an incorrect warning in the chat log.
"Attachment {{name}}.xml not imported: True" whenever the attachment
is imported correctly and its supposed to show the reason if something
goes wrong not "True".

**Notes:**
- Orders were filtered to not include sections, because
UBL does NOT support sections.
- `return True` was removed from `_import_order_ubl` because it
shows an incorrect warning in the chat log.
"Attachment {{name}}.xml not imported: True" whenever the attachment
is imported correctly and its supposed to show the reason if something
goes wrong not "True".





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
