### PR TITLE
[FIX] mail: slightly more coherent look of discuss call actions

### DIFF
--- a/addons/mail/static/src/core/common/action_list.xml
+++ b/addons/mail/static/src/core/common/action_list.xml
@@ -6,7 +6,7 @@
         <t t-set="groupAttClass" t-value="{
             [props.groupClass]: true,
             'flex-column w-100 bg-transparent': !props.inline,
-            'o-inline': props.inline,
+            'o-inline rounded-3': props.inline,
             'o-rounded-bubble': props.inline and !hasBtnBg,
         }"/>
         <t t-foreach="groups" t-as="group" t-key="group_index">
@@ -55,6 +55,8 @@
         'o-odooControlPanelSwitchStyle': props.odooControlPanelSwitchStyle,
         'o-hasBtnBg': hasBtnBg,
         'rounded-circle': isComposerRoundedBtn or isThreadRoundedBtn,
+        'rounded-start-3': !isComposerRoundedBtn and !isThreadRoundedBtn and props.inline and props.isFirstInGroup,
+        'rounded-end-3': !isComposerRoundedBtn and !isThreadRoundedBtn and props.inline and props.isLastInGroup,
         'o-p-1_5': props.inline and hasBtnBg and !action.tags.includes('JOIN_LEAVE_CALL'),
         'o-p-1_5 d-flex align-items-center': props.inline and hasBtnBg and action.tags.includes('JOIN_LEAVE_CALL') and !env.inChatWindow,
         'p-1 d-flex align-items-center': props.inline and hasBtnBg and action.tags.includes('JOIN_LEAVE_CALL') and env.inChatWindow,


### PR DESCRIPTION
Before this commit, all call actions but the special buttons "join" / "leave" were almost squared, whereas the "join" / "leave" buttons were circles.

The circle design of the "join" / "leave" buttons is very much what we want, for recognizable shape and consistent in all Odoo such as with VoIP app. The other buttons are not circle because it looks best when inline and grouped. However, the square buttons with rounded circle look slightly off as if there's a clash of design.

This commit remedies the problem by adding slight roundness to the square discuss actions that are not circle. This is almost unnoticeable when just looking at the square buttons, but when next to the circle button this looks like they fit together more than before.

Before / After
<img width="354" height="169" alt="Screenshot 2025-09-15 at 13 59 25" src="https://github.com/user-attachments/assets/f1505ae3-abfd-4b64-94bf-c554ed74e9c8" />
<img width="354" height="167" alt="Screenshot 2025-09-15 at 13 59 05" src="https://github.com/user-attachments/assets/b41100e0-b3bc-408f-8206-6dc2a77aa6c9" />
