### PR TITLE
[FIX] html_editor: respect `list-unstyled` padding

### DIFF
--- a/addons/html_editor/static/src/main/list/list.scss
+++ b/addons/html_editor/static/src/main/list/list.scss
@@ -2,12 +2,6 @@ li p {
     margin-bottom: 0px;
 }
 
-.odoo-editor-editable {
-    ol, ul {
-        padding-inline-start: 2rem;
-    }
-}
-
 // Checklist
 ul.o_checklist {
     > li {


### PR DESCRIPTION
Problem:
The default Bootstrap padding is being forced on all lists inside the
editor, including those with the `list-unstyled` class. This class is
supposed to enforce `0px` padding, but the current rule overrides it.

Solution:
Remove the style as `2rem` is already the Bootstrap default list
padding.
Done here: https://github.com/odoo/odoo/commit/1593f25b0160a68d356dd5bba3887ff5a6298c60

Steps to reproduce:
1. Open website.
2. Open the editor.
3. Notice the footer list (with `list-unstyled`) is incorrectly
   indented.
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
