### PR TITLE
[FIX] website_payment: show activated methods only

### DIFF
--- a/addons/website_payment/controllers/portal.py
+++ b/addons/website_payment/controllers/portal.py
@@ -192,6 +192,7 @@ class PaymentPortal(payment_portal.PaymentPortal):
         brands_domain = Domain([
             ('is_primary', '=', False),
             ('primary_payment_method_id.provider_ids', 'in', compatible_providers_sudo.ids),
+            ('primary_payment_method_id.active', '=', True),
         ])
         # Or, select the primary payment methods without any brands. E.g., PayPal.
         primary_without_brands_domain = Domain([


### PR DESCRIPTION
On the Support Payment Methods widget, we only wanna display the brands where the associated primary method
is active, as those are the ones we can actually pay with.

When deactivating the Card (primary) payment method, the related brands (Mastercard, VISA, ...) will be removed from display.
<img width="555" height="272" alt="image" src="https://github.com/user-attachments/assets/473f816d-d709-4c71-bdc5-9c31789d31bc" />

opw-5083539