### PR TITLE
[FIX] web: prevent clearing while drawing signature

### DIFF
--- a/addons/web/static/lib/signature_pad/signature_pad.umd.js
+++ b/addons/web/static/lib/signature_pad/signature_pad.umd.js
@@ -334,6 +334,9 @@
             };
         }
         _strokeBegin(event) {
+            if (document.activeElement) {
+                document.activeElement.blur();
+            }
             const cancelled = !this.dispatchEvent(new CustomEvent('beginStroke', { detail: event, cancelable: true }));
             if (cancelled) {
                 return;


### PR DESCRIPTION
To reproduce:
=============
- upload a doc, add a signature field, sign now, open the signature wizard
- go in draw mode
- draw something
- erase
- draw something, keep the click on and go outside the box
- press enter, this will remove the content
- release the click --> box is blank and "sign" and "sign all" buttons are available and can sign the doc.

Problem:
========
when clearing while drawing, the listner for mousedown is still active and when releasing the click outside the box, it triggers the mouseup event which makes `isEmpty=false` and enables the sign button.

Solution:
=========
don't allow clearing while drawing.

opw-5071981
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
