### PR TITLE
[IMP] mail: discuss call pip uses meeting view

### DIFF
--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -198,7 +198,7 @@ export class Store extends BaseStore {
 
     shouldSimulateDarkTheme(ctx) {
         return (
-            (ctx?.env?.inDiscussCallView || ctx?.env?.inMeetingView) &&
+            ctx?.env?.inDiscussCallView &&
             this.isOdooWhiteTheme &&
             !ctx?.env.inMeetingSideActions &&
             !ctx?.env.inDiscussActionPanel

--- a/addons/mail/static/src/discuss/call/common/call.js
+++ b/addons/mail/static/src/discuss/call/common/call.js
@@ -3,16 +3,7 @@ import { CallActionList } from "@mail/discuss/call/common/call_action_list";
 import { CallParticipantCard } from "@mail/discuss/call/common/call_participant_card";
 import { PttAdBanner } from "@mail/discuss/call/common/ptt_ad_banner";
 
-import {
-    Component,
-    onMounted,
-    onPatched,
-    onWillUnmount,
-    toRaw,
-    useRef,
-    useState,
-    useSubEnv,
-} from "@odoo/owl";
+import { Component, onMounted, onPatched, onWillUnmount, toRaw, useRef, useState } from "@odoo/owl";
 
 import { browser } from "@web/core/browser/browser";
 import { isMobileOS } from "@web/core/browser/feature_detection";
@@ -22,6 +13,7 @@ import { isEventHandled, markEventHandled } from "@web/core/utils/misc";
 import { useCallActions } from "@mail/discuss/call/common/call_actions";
 import { ActionList } from "@mail/core/common/action_list";
 import { ACTION_TAGS } from "@mail/core/common/action";
+import { inDiscussCallViewProps, useInDiscussCallView } from "@mail/utils/common/hooks";
 
 /**
  * @typedef CardData
@@ -45,7 +37,7 @@ export class Call extends Component {
         CallParticipantCard,
         PttAdBanner,
     };
-    static props = ["thread?", "compact?", "isPip?", "hasOverlay?"];
+    static props = ["thread?", "compact?", "hasOverlay?", ...inDiscussCallViewProps];
     static defaultProps = { hasOverlay: true };
     static template = "discuss.Call";
 
@@ -82,14 +74,7 @@ export class Call extends Component {
         });
         useHotkey("shift+d", () => this.rtc.toggleDeafen());
         useHotkey("shift+m", () => this.rtc.toggleMicrophone());
-        const self = this;
-        useSubEnv({
-            inDiscussCallView: {
-                get isPip() {
-                    return self.props.isPip;
-                },
-            },
-        });
+        useInDiscussCallView();
     }
 
     get layoutActions() {
@@ -110,7 +95,7 @@ export class Call extends Component {
     }
 
     get minimized() {
-        if (this.rtc.state.isFullscreen || this.channel.activeRtcSession) {
+        if (this.rtc.state.isFullscreen || !this.channel || this.channel.activeRtcSession) {
             return false;
         }
         if (!this.isActiveCall || this.channel.videoCount === 0 || this.props.compact) {

--- a/addons/mail/static/src/discuss/call/common/meeting.js
+++ b/addons/mail/static/src/discuss/call/common/meeting.js
@@ -3,7 +3,11 @@ import { Thread } from "@mail/core/common/thread";
 import { Call } from "@mail/discuss/call/common/call";
 import { CallActionList } from "@mail/discuss/call/common/call_action_list";
 import { ChannelInvitation } from "@mail/discuss/core/common/channel_invitation";
-import { useMessageScrolling } from "@mail/utils/common/hooks";
+import {
+    inDiscussCallViewProps,
+    useInDiscussCallView,
+    useMessageScrolling,
+} from "@mail/utils/common/hooks";
 
 import { Component, onMounted, onWillUnmount, useChildSubEnv, useSubEnv } from "@odoo/owl";
 
@@ -22,7 +26,7 @@ import { useMessageSearch } from "@mail/core/common/message_search_hook";
  */
 export class Meeting extends Component {
     static template = "mail.Meeting";
-    static props = ["autoOpenAction?"];
+    static props = ["autoOpenAction?", ...inDiscussCallViewProps];
     static components = {
         Call,
         CallActionList,
@@ -44,6 +48,7 @@ export class Meeting extends Component {
                     ?.onSelected();
             }
         });
+        useInDiscussCallView();
         useSubEnv({
             inMeetingView: {
                 openChat: () =>

--- a/addons/mail/static/src/discuss/call/common/meeting.xml
+++ b/addons/mail/static/src/discuss/call/common/meeting.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.Meeting">
-        <div class="o-mail-Meeting h-100 w-100 d-flex flex-column" t-att-class="{'p-1 pb-3': !ui.isSmall}">
+        <div class="o-mail-Meeting h-100 w-100 d-flex flex-column" t-att-class="{'p-1': !ui.isSmall, 'pb-3': !ui.iSmall and !props.isPip}">
             <div class="d-flex flex-grow-1 h-100 o-min-height-0 gap-1 position-relative">
                 <div class="o-mail-Meeting-callContainer h-100 flex-grow-1 o-min-width-0" t-att-class="{'d-none': ui.isSmall and threadActions.activeAction?.actionPanelComponentCondition, 'pb-0': ui.isSmall}">
-                    <Call hasOverlay="false" />
+                    <Call hasOverlay="false" isPip="props.isPip"/>
                 </div>
                 <div t-if="threadActions.activeAction?.actionPanelComponentCondition" t-attf-class="{{ threadActions.activeAction.panelOuterClass }}" class="o-mail-DiscussContent-panelContainer o-mail-discussSidebarBgColor h-100 border-start border-secondary flex-shrink-0 rounded-2" t-att-class="{ 'w-100': ui.isSmall }">
                     <t t-component="threadActions.activeAction.actionPanelComponent" t-props="threadActions.activeAction.actionPanelComponentProps" thread="thread"/>

--- a/addons/mail/static/src/discuss/call/common/meeting_chat.xml
+++ b/addons/mail/static/src/discuss/call/common/meeting_chat.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.MeetingChat">
-        <ActionPanel title.translate="Chat" resizable="true" minWidth="300" initialWidth="400" icon="'fa fa-comments'" contentRef="panelContentRef">
+        <ActionPanel t-if="thread" title.translate="Chat" resizable="true" minWidth="300" initialWidth="400" icon="'fa fa-comments'" contentRef="panelContentRef">
             <Thread thread="thread" jumpPresent="state.jumpPresent"/>
             <t t-call="mail.ChatWindow.memberTyping"/>
             <Composer

--- a/addons/mail/static/src/discuss/call/common/pip_service.js
+++ b/addons/mail/static/src/discuss/call/common/pip_service.js
@@ -1,6 +1,6 @@
 import { registry } from "@web/core/registry";
-import { Call } from "@mail/discuss/call/common/call";
 import { reactive } from "@odoo/owl";
+import { Meeting } from "./meeting";
 
 export const callPipService = {
     dependencies: ["mail.popout"],
@@ -38,8 +38,8 @@ export const callPipService = {
             }
             state.active = true;
             const isShadowRoot = context?.root?.el?.getRootNode() instanceof ShadowRoot;
-            pipWindow = await popout.pip(Call, {
-                props: { isPip: true, thread: rtc.channel },
+            pipWindow = await popout.pip(Meeting, {
+                props: { isPip: true },
                 options: { useAlternativeAssets: isShadowRoot },
             });
             pipWindow.addEventListener("keydown", (ev) => {

--- a/addons/mail/static/src/utils/common/hooks.js
+++ b/addons/mail/static/src/utils/common/hooks.js
@@ -8,6 +8,7 @@ import {
     useEffect,
     useRef,
     useState,
+    useSubEnv,
     xml,
 } from "@odoo/owl";
 
@@ -644,4 +645,16 @@ export function useLongPress(refName, { action, predicate = () => true } = {}) {
     );
     useLazyExternalListener(() => ref.el, "touchend", reset);
     useLazyExternalListener(() => ref.el, "touchcancel", reset);
+}
+
+export const inDiscussCallViewProps = ["isPip?"];
+export function useInDiscussCallView() {
+    const component = useComponent();
+    useSubEnv({
+        inDiscussCallView: {
+            get isPip() {
+                return component.props.isPip;
+            },
+        },
+    });
 }


### PR DESCRIPTION
Before this commit, picture-in-picture in discuss call had only the call view in the picture-in-picture window.

Recently the fullscreen uses meeting view, which has call view in addition to panels and other features such as chat.

This commit makes picture-in-picture use the new meeting view, so that the picture-in-picture mode has more features.

Before
<img width="2552" height="1317" alt="Screenshot 2025-09-15 at 14 46 33" src="https://github.com/user-attachments/assets/d7e5ad67-fd68-4a65-9a19-b8ce11b9f66f" />

After
<img width="2559" height="1323" alt="Screenshot 2025-09-15 at 14 51 45" src="https://github.com/user-attachments/assets/e6cbc12d-2753-42c9-ab73-aaf4abcc6f1e" />



