### PR TITLE
[FIX] website: fix traceback when creating a new page in mobile view

### DIFF
--- a/addons/website/static/src/components/dialog/add_page_dialog.js
+++ b/addons/website/static/src/components/dialog/add_page_dialog.js
@@ -478,7 +478,7 @@ export class AddPageDialog extends Component {
         if (!this.cssLinkEls) {
             this.cssLinkEls = new Promise((resolve) => {
                 const container = document.querySelector(".o_website_preview .o_iframe_container");
-                const iframe = container?.lastElementChild;
+                const iframe = container?.querySelector('iframe:not([src="/website/iframefallback"])');
                 if (iframe?.contentDocument.body.getAttribute("is-ready") === "true") {
                     // If there is a fully loaded website preview, use it.
                     resolve(iframe.contentDocument.head.querySelectorAll("link[type='text/css']"));


### PR DESCRIPTION
Steps to reproduce:
1.open  website.
2.switch to mobile view.
3.click new button and  select new page option
4.a traceback occurs.

Before this commit:
Creating a new page in mobile view raised a traceback because
contentDocument was undefined due to an incorrect selector.

After this commit:
The issue is resolved by using the correct querySelector value, ensuring
that contentDocument can be accessed properly.
