### PR TITLE
[FIX] base,tools: prevent error on attribute nodes with no name

### DIFF
--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -2199,6 +2199,16 @@ class TestViews(ViewCase):
                 'inherit_id': False,
             })
 
+    def test_attribute_node_with_no_name(self):
+        """Ensure that an attribute node with no name raises ValidationError"""
+        with self.assertRaises(ValidationError):
+            self.View.create({
+                'name': 'also_invalid_view',
+                'type': 'list',
+                'arch': '<attribute></attribute>',
+                'inherit_id': False,
+            })
+
     def test_context_in_view(self):
         arch = """
             <form string="View">

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -80,6 +80,8 @@ TRANSLATED_ATTRS = {
 TRANSLATED_ATTRS.update({f't-attf-{attr}' for attr in TRANSLATED_ATTRS})
 
 def is_translatable_attrib(key):
+    if not key:
+        return False
     return key in TRANSLATED_ATTRS or key.endswith('.translate')
 
 def is_translatable_attrib_value(node):


### PR DESCRIPTION
Currently, an error occurs when user tries to save a view with an attribute node without name.

**Steps to replicate:**
- Initialize a DB and open Views.
- Create a new view and fill in random values for name and give a View Type.
- In the Architecture give value as `<attribute></attribute>`.
- Save and you will get the error.

 (Same error can also be produced with Web Studio report editor.)

**Error:**
`AttributeError: 'NoneType' object has no attribute 'endswith'`

**Cause:**
- The error occurred because we received **key** as `None` at [1], as it was called from an attribute node with no name [2].
- In `saas-18.2`, we only checked if `node.get('name') not in TRANSLATED_ATTRS`. Since `node.get('name')` was `None` and `None` was not included in the `TRANSLATED_ATTRS` list, no error occurred.

**Solution:**
- Added a conditional check, so that attributes with no name skip the function call.

[1]: https://github.com/odoo/odoo/blob/f254da2253e7ce9426e51112b513fa9e6a474ce4/odoo/tools/translate.py#L83

[2]: https://github.com/odoo/odoo/blob/f254da2253e7ce9426e51112b513fa9e6a474ce4/odoo/tools/translate.py#L190

[3]: https://github.com/odoo/odoo/blob/0b700ec3c08ecd9c6f1597f9d10f6c1eee06bcee/odoo/tools/translate.py#L255

sentry-6877030439
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
