### PR TITLE
[FIX] point_of_sale: restore previous item list colors

### DIFF
--- a/addons/point_of_sale/static/src/scss/pos.scss
+++ b/addons/point_of_sale/static/src/scss/pos.scss
@@ -168,7 +168,6 @@ select > option {
 }
 
 // Set all the colors but the "no-color" one
-
 @for $size from 2 through length($o-colors) {
     .o_colorlist_item_color_transparent_#{$size - 1} {
         $-border-color: adjust-color(nth($o-colors, $size), $lightness: 15%, $saturation: 5%);
@@ -184,6 +183,13 @@ select > option {
         --bg: #{$-background-color};
         --border-color: #{$-border-color};
         --hover-bg: #{darken($-background-color, 5%)};
+    }
+
+    .o_colorlist_item_color_#{$size - 1} {
+        $-bg: adjust-color(nth($o-colors, $size), $lightness: 25%, $saturation: 15%);
+        $-color: adjust-color(nth($o-colors, $size), $lightness: -40%, $saturation: -15%);
+        @include o-print-color($-bg, background-color, bg-opacity);
+        @include o-print-color($-color, color, text-opacity);
     }
 }
 


### PR DESCRIPTION
Since this PR (https://github.com/odoo/odoo/pull/225887) the colors of the colorlist items was not set anymore (since the does not have the class `o_colorlist`). This was causing the colors of the categories or preset to be white. We'll uniformize the class with the new design theme later.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
