### PR TITLE
[FIX] website: display image icon for broken icon links

### DIFF
--- a/addons/website/static/src/components/dialog/seo.js
+++ b/addons/website/static/src/components/dialog/seo.js
@@ -797,6 +797,9 @@ export class SeoChecks extends Component {
                     if (imgLinkEl?.src) {
                         label = imgLinkEl.src.split('/').pop();
                         isImageLink = true;
+                    } else if (el.querySelector(".fa")) {
+                        label = el.ariaLabel || el.title || el.href.split('/').filter(Boolean).pop();
+                        isImageLink = true;
                     }
                 }
                 return {

--- a/addons/website/static/src/components/dialog/seo.xml
+++ b/addons/website/static/src/components/dialog/seo.xml
@@ -117,7 +117,7 @@
                 <t t-if="!seoContext.brokenLinks.filter(link => link.broken).length">
                     <p><i class="fa fa-check text-success me-2"></i>No broken link</p>
                 </t>
-                <t t-foreach="seoContext.brokenLinks" t-as="link" t-key="link.oldLink">
+                <t t-foreach="seoContext.brokenLinks" t-as="link" t-key="link_index">
                      <div t-if="!link.remove" class="row align-items-center mb-2">
                         <BrokenLink link="link"/>
                     </div>


### PR DESCRIPTION
In SEO, check for broken links there are some empty spaces before the link for icon links (e.g. social media snippet).

<hr/>

Before this commit, the SEO dialog flagged the "social media" snippet
as a broken link because it followed the redirect to the "YouTube
consent" page and the browser stopped the call.

After this commit, we first run a "normal fetch" so internal redirects
still reach their final page, then we try a "manual" redirect only when
the browser blocks the call, counting "opaqueredirect" answers as valid.
This keeps "controller proxies" green while we still report the real
"4xx" errors.

This commit also slightly improves the performance of broken link
detection.