### PR TITLE
[FIX] web: fix opened groups of web_read_group

### DIFF
--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -327,8 +327,9 @@ class Base(models.AbstractModel):
         :param limit: The maximum number of top-level groups to return. see :meth:`~.formatted_read_group`
         :param offset: The offset for the top-level groups. see :meth:`~.formatted_read_group`
         :param order: A sort string, as used in :meth:`~.search`
-        :param auto_unfold: If `True`, unfolds the 10 first groups regardless of its `__fold` status.
-            Typically `True` for kanban views and `False` for list views.
+        :param auto_unfold: If `True`, automatically unfolds the first 10 groups according to their
+            `__fold` key, if present; otherwise, it is unfolded by default.
+            This is typically `True` for kanban views and `False` for list views.
         :param opening_info: The state of currently opened groups, used for reloading.
           ::
 
@@ -550,13 +551,8 @@ class Base(models.AbstractModel):
             fold_info = '__fold' in group
             fold = group.pop('__fold', False)
 
-            # Apply the limit of unfolded if there is whatever the parent_opening_info
-            # That's weird, but keeps the old behavior
-            if nb_opened_group >= max_number_opened_group:
-                continue
-
             groupby_value = group[groupby_spec]
-            # For relational field
+            # For relational/date/datetime field
             raw_groupby_value = groupby_value[0] if isinstance(groupby_value, tuple) else groupby_value
 
             limit = unfold_read_default_limit
@@ -574,6 +570,7 @@ class Base(models.AbstractModel):
             elif (
                 # Auto Fold/unfold
                 (not auto_unfold and not fold_info)
+                or nb_opened_group >= max_number_opened_group
                 or fold
                 # Empty recordset is folded by default
                 or (field.relational and not group[groupby_spec])


### PR DESCRIPTION
[FIX] web: Fix opened groups of web_read_group

This commit fixes an issue where groups manually opened by the user were not correctly restored, leading to a traceback.

Steps to reproduce:

In a kanban views, when we have already 10 columns opened automatically and others closed ones:
- Manually open a closed group after the first 10 opened groups.
- Navigate to another view.
- Return to the kanban view.
We got a traceback: 
`TypeError: can't access property "map", data.records is undefined`

The `web_read_group` function does not reopen the manually opened group when the `MAX_NUMBER_OPENED_GROUPS` limit has been reached. The web client does not handle this case gracefully, as it expects the manually opened group to still be opened.

Solution:

Manually opened groups should remain open regardless of the `MAX_NUMBER_OPENED_GROUPS` limit. This approach is more functionally sound and aligns with the behavior the web client expects.