### PR TITLE
[FIX] website, http_routing: set homepage while on non default lang

### DIFF
--- a/addons/website/models/website_page_properties.py
+++ b/addons/website/models/website_page_properties.py
@@ -64,7 +64,7 @@ class WebsitePagePropertiesBase(models.TransientModel):
     @api.depends('url', 'website_id.homepage_url')
     def _compute_is_homepage(self):
         for record in self:
-            url = record.url
+            url = self.env['ir.http']._remove_lang_from_url(record.url)
             current_homepage_url = record.website_id.homepage_url or '/'
             # If the url field matches the website's homepage_url, we know this
             # is the homepage.
@@ -77,6 +77,7 @@ class WebsitePagePropertiesBase(models.TransientModel):
         self.ensure_one()
         url = self.url
         if self.is_homepage:
+            url = self.env['ir.http']._remove_lang_from_url(url)
             if url and url != '/':
                 self.website_id.homepage_url = url
         else:


### PR DESCRIPTION
Problem:
When setting a non basic page (like `/shop`) as a homepage while editing in a not default language, the homepage URL saved has the language prefix, which makes the homepage not accessible from `/`.

To reproduce:
- Open the website app and set a second language for the website
- Add a new non standard page (product, job position...)
- Change the website language to the second language added before
- Set the new page as homepage
- Try to access to the homepage via `/`
- Redirected to the closest menu
 
If only one addon is installed for the website, it might not be visible because it will redirect to himself.
For example, `/fr/shop` is set as homepage, then click on `/`, it will look like it works because `/shop` is also the nearest menu from home, so it will redirect to the correct URL `/shop`.

Fix:
Removed the language prefix before setting and checking the homepage.

task-4563867

