### PR TITLE
[IMP] point_of_sale: enhance date picker for ship later and customer dialog ui

### DIFF
--- a/addons/l10n_es_pos/static/tests/tours/spanish_pos_tour.js
+++ b/addons/l10n_es_pos/static/tests/tours/spanish_pos_tour.js
@@ -32,13 +32,12 @@ registry.category("web_tour.tours").add("spanish_pos_tour", {
             Dialog.confirm(),
 
             PaymentScreen.clickInvoiceButton(),
+            PaymentScreen.isInvoiceOptionSelected(),
             PaymentScreen.clickValidate(),
             // verify that the pos requires the selection of a partner
             Dialog.confirm(),
             PartnerList.clickPartner(""),
 
-            PaymentScreen.isInvoiceOptionSelected(),
-            PaymentScreen.clickValidate(),
             FeedbackScreen.isShown(),
             FeedbackScreen.checkTicketData({
                 cssRules: [

--- a/addons/point_of_sale/static/src/app/components/popups/date_picker_popup/date_picker_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/date_picker_popup/date_picker_popup.js
@@ -1,10 +1,12 @@
 import { Dialog } from "@web/core/dialog/dialog";
+import { DateTimeInput } from "@web/core/datetime/datetime_input";
 import { _t } from "@web/core/l10n/translation";
-import { Component, onMounted, useRef, useState } from "@odoo/owl";
+import { Component, onMounted, useState } from "@odoo/owl";
+const { DateTime } = luxon;
 
 export class DatePickerPopup extends Component {
     static template = "point_of_sale.DatePickerPopup";
-    static components = { Dialog };
+    static components = { Dialog, DateTimeInput };
     static props = {
         title: { type: String, optional: true },
         confirmLabel: { type: String, optional: true },
@@ -18,17 +20,24 @@ export class DatePickerPopup extends Component {
 
     setup() {
         super.setup();
-        this.state = useState({ shippingDate: this._today() });
-        this.inputRef = useRef("input");
-        onMounted(() => this.inputRef.el.focus());
+        this.state = useState({
+            shippingDate: DateTime.now(),
+        });
+        onMounted(() => {
+            const input = document.querySelector(".shipping-date-selector input");
+            if (input) {
+                input.classList.remove("o_input");
+                input.classList.add("form-control", "form-control-lg");
+                input.focus();
+            }
+        });
+    }
+    onDateChange(date) {
+        this.state.shippingDate = date;
     }
     confirm() {
-        this.props.getPayload(
-            this.state.shippingDate < this._today() ? this._today() : this.state.shippingDate
-        );
+        const selected = this.state.shippingDate.toISODate();
+        this.props.getPayload(selected);
         this.props.close();
-    }
-    _today() {
-        return new Date().toISOString().split("T")[0];
     }
 }

--- a/addons/point_of_sale/static/src/app/components/popups/date_picker_popup/date_picker_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/date_picker_popup/date_picker_popup.xml
@@ -1,10 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="point_of_sale.DatePickerPopup">
-        <Dialog title="props.title">
-            <input class="form-control form-control-lg w-75 mx-auto" type="date" t-model="state.shippingDate" t-ref="input" t-att-min="_today()"/>
+        <Dialog title="props.title" size="'sm'">
+            <div class="mb-3 w-100 d-flex flex-column flex-sm-row align-items-center">
+                <span class="me-3 fs-5 text-center text-sm-start" style="white-space: nowrap;">
+                    Select Date:
+                </span>
+                <div class="flex-grow-1 w-100 shipping-date-selector">
+                    <DateTimeInput
+                        type="'date'"
+                        value="state.shippingDate"
+                        onChange.bind="onDateChange"
+                        minDate="'today'"
+                    />
+                </div>
+            </div>
             <t t-set-slot="footer">
-                <button class="btn btn-lg btn-primary" t-on-click="confirm" t-esc="props.confirmLabel" />
+                <button
+                    class="btn btn-lg btn-primary w-100"
+                    t-on-click="confirm"
+                    t-esc="props.confirmLabel"
+                />
             </t>
         </Dialog>
     </t>

--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -2,7 +2,7 @@ import { registry } from "@web/core/registry";
 import { _t } from "@web/core/l10n/translation";
 import { computeComboItems } from "./utils/compute_combo_items";
 import { localization } from "@web/core/l10n/localization";
-import { formatDate, serializeDateTime } from "@web/core/l10n/dates";
+import { serializeDateTime } from "@web/core/l10n/dates";
 import { getStrNotes } from "./utils/order_change";
 import { PosOrderAccounting } from "./accounting/pos_order_accounting";
 
@@ -26,7 +26,7 @@ export class PosOrder extends PosOrderAccounting {
         this.name = vals.name || "/";
         this.nb_print = vals.nb_print || 0;
         this.to_invoice = vals.to_invoice || false;
-        this.setShippingDate(vals.shipping_date);
+        this.shipping_date = vals.shipping_date;
         this.state = vals.state || "draft";
 
         if (!vals.last_order_preparation_change) {
@@ -652,16 +652,6 @@ export class PosOrder extends PosOrderAccounting {
         if (!this.config.use_presets || !this.preset_id?.pricelist_id) {
             this.setPricelist(newPartnerPricelist);
         }
-    }
-
-    /* ---- Ship later --- */
-    //FIXME remove this
-    setShippingDate(shippingDate) {
-        this.shipping_date = shippingDate;
-    }
-    //FIXME remove this
-    getShippingDate() {
-        return formatDate(this.shipping_date);
     }
 
     getHasRefundLines() {

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -255,15 +255,15 @@ export class PaymentScreen extends Component {
         pLine.setAmount(pLine.getAmount() + tipToAdd);
     }
     async toggleShippingDatePicker() {
-        if (!this.currentOrder.getShippingDate()) {
+        if (!this.currentOrder.shipping_date) {
             this.dialog.add(DatePickerPopup, {
                 title: _t("Select the shipping date"),
                 getPayload: (shippingDate) => {
-                    this.currentOrder.setShippingDate(shippingDate);
+                    this.currentOrder.shipping_date = shippingDate;
                 },
             });
         } else {
-            this.currentOrder.setShippingDate(false);
+            this.currentOrder.shipping_date = false;
         }
     }
     deletePaymentLine(uuid) {

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.xml
@@ -142,11 +142,11 @@
                     t-on-click="openCashbox">
                     <i class="fa fa-archive me-2" />Open Cashbox 
                 </button>
-                <button t-if="pos.config.ship_later" class="button btn btn-secondary btn-lg d-flex justify-content-between align-items-baseline w-100 lh-lg" t-att-class="{ 'highlight active text-action': currentOrder.getShippingDate() }"
+                <button t-if="pos.config.ship_later" class="button btn btn-secondary btn-lg d-flex justify-content-between align-items-baseline w-100 lh-lg" t-att-class="{ 'highlight active text-action': currentOrder.shipping_date }"
                     t-on-click="toggleShippingDatePicker">
-                    <span t-attf-class="{{currentOrder.getShippingDate() ? 'me-auto' : 'mx-auto' }}"><i class="fa fa-clock-o me-2" />Ship Later</span>
-                    <span t-if="currentOrder.getShippingDate()">
-                        <t t-esc="currentOrder.getShippingDate()" />
+                    <span t-attf-class="{{currentOrder.shipping_date ? 'me-auto' : 'mx-auto' }}"><i class="fa fa-clock-o me-2" />Ship Later</span>
+                    <span t-if="currentOrder.shipping_date">
+                        <t t-esc="currentOrder.formatDateOrTime('shipping_date', 'date')" />
                     </span>
                 </button>
             </div>

--- a/addons/point_of_sale/static/src/app/utils/order_payment_validation.js
+++ b/addons/point_of_sale/static/src/app/utils/order_payment_validation.js
@@ -276,25 +276,25 @@ export default class OrderPaymentValidation {
             return false;
         }
 
-        if (
-            (this.order.isToInvoice() || this.order.getShippingDate()) &&
-            !this.order.getPartner()
-        ) {
+        if ((this.order.isToInvoice() || this.order.shipping_date) && !this.order.getPartner()) {
             const confirmed = await ask(this.pos.dialog, {
                 title: _t("Please select the Customer"),
-                body: _t(
-                    "You need to select the customer before you can invoice or ship an order."
-                ),
+                body: _t("Select a customer with a valid address."),
+                confirmLabel: _t("Customer"),
             });
             if (confirmed) {
-                this.pos.selectPartner();
+                const partner = await this.pos.selectPartner();
+                if (!partner) {
+                    return false;
+                }
+            } else {
+                return false;
             }
-            return false;
         }
 
         const partner = this.order.getPartner();
         if (
-            this.order.getShippingDate() &&
+            this.order.shipping_date &&
             !(partner.name && partner.street && partner.city && partner.country_id)
         ) {
             this.pos.dialog.add(AlertDialog, {

--- a/addons/point_of_sale/static/tests/pos/tours/shipping_date_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/shipping_date_tour.js
@@ -4,6 +4,7 @@ import * as ProductScreen from "@point_of_sale/../tests/pos/tours/utils/product_
 import * as PaymentScreen from "@point_of_sale/../tests/pos/tours/utils/payment_screen_util";
 import { registry } from "@web/core/registry";
 import * as FeedbackScreen from "@point_of_sale/../tests/pos/tours/utils/feedback_screen_util";
+import * as PartnerList from "@point_of_sale/../tests/pos/tours/utils/partner_list_util";
 
 registry.category("web_tour.tours").add("test_pos_order_shipping_date", {
     steps: () =>
@@ -12,8 +13,6 @@ registry.category("web_tour.tours").add("test_pos_order_shipping_date", {
             Chrome.startPoS(),
             Dialog.confirm("Open Register"),
             ProductScreen.addOrderline("Whiteboard Pen", "1"),
-            ProductScreen.clickPartnerButton(),
-            ProductScreen.clickCustomer("Partner Test with Address"),
             ProductScreen.clickPayButton(),
             PaymentScreen.clickPaymentMethod("Cash"),
             {
@@ -23,9 +22,9 @@ registry.category("web_tour.tours").add("test_pos_order_shipping_date", {
             },
             {
                 content: "pick a date",
-                trigger: '.modal-body input[type="date"]',
+                trigger: ".modal-body .o_datetime_input",
                 run: () => {
-                    const input = document.querySelector('.modal-body input[type="date"]');
+                    const input = document.querySelector(".modal-body .o_datetime_input");
                     const nextYear = new Date().getFullYear() + 1;
                     input.value = `${nextYear}-05-30`;
                     input.dispatchEvent(new Event("input", { bubbles: true }));
@@ -45,13 +44,15 @@ registry.category("web_tour.tours").add("test_pos_order_shipping_date", {
                         ...document.querySelectorAll(".payment-buttons .d-flex .btn span"),
                     ];
                     const nextYear = new Date().getFullYear() + 1;
-                    const expectedDate = `05/30/${nextYear}`;
+                    const expectedDate = `5/30/${nextYear}`;
                     if (!spans.some((span) => span.innerText === expectedDate)) {
                         throw new Error("Expected shipping date is not set");
                     }
                 },
             },
             PaymentScreen.clickValidate(),
+            Dialog.confirm(),
+            PartnerList.clickPartner("Partner Test with Address"),
             FeedbackScreen.isShown(),
             FeedbackScreen.checkTicketData({
                 is_shipping_date: true,

--- a/addons/point_of_sale/static/tests/unit/models/pos_order.test.js
+++ b/addons/point_of_sale/static/tests/unit/models/pos_order.test.js
@@ -219,12 +219,11 @@ test("setShippingDate and getShippingDate with Luxon", async () => {
     const order = store.addNewOrder();
 
     const testDate = "2019-03-11";
-    order.setShippingDate(testDate);
+    order.shipping_date = testDate;
 
     expect(order.shipping_date.toISODate()).toBe(testDate);
-    expect(typeof order.getShippingDate()).toBe("string");
-    order.setShippingDate(null);
-    expect(order.getShippingDate()).toBeEmpty();
+    order.shipping_date = null;
+    expect(order.shipping_date).toBeEmpty();
 });
 
 test("[get prices] check prices and taxes", async () => {

--- a/addons/pos_sale/static/src/app/models/pos_order_line.js
+++ b/addons/pos_sale/static/src/app/models/pos_order_line.js
@@ -10,7 +10,7 @@ patch(PosOrderline.prototype, {
         // that some fields has already been assigned. Therefore, we only set the options
         // when the original value is falsy.
         if (this.sale_order_origin_id?.shipping_date) {
-            this.order_id.setShippingDate(this.sale_order_origin_id.shipping_date);
+            this.order_id.shipping_date = this.sale_order_origin_id.shipping_date;
         }
     },
     get saleDetails() {


### PR DESCRIPTION
PURPOSE:
Improve the UX of customer confirmation and shipping date selection in POS.

BEFORE:
- Customer dialog used a generic OK button with unclear text.
- Shipping date selection input was a plain date type in a large dialog.

AFTER:
- Customer dialog uses clearer wording with a dedicated Customer button.
- Shipping date is selected via a compact date picker with better layout and usability.

-------------------------------------------------------------------------------

Task-5055738
