### PR TITLE
[FIX] web/core: macro.js export waitUntil

### DIFF
--- a/addons/web/static/src/core/macro.js
+++ b/addons/web/static/src/core/macro.js
@@ -63,7 +63,7 @@ async function waitForTrigger(trigger) {
     }
 }
 
-async function waitUntil(predicate) {
+export async function waitUntil(predicate) {
     const result = predicate();
     if (result) {
         return Promise.resolve(result);


### PR DESCRIPTION
Because waitUntil maybe used in its own sake to periodically check a predicate (in studio) and because macro.js is a standard framework tool, we export its waitUntil function

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
