### PR TITLE
[FIX] hr_holidays: leave hours change when changing time off type

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -257,16 +257,14 @@ class HrLeave(models.Model):
         env_company_calendar = self.env.company.resource_calendar_id
         for leave in self:
             calendar = leave.resource_calendar_id or env_company_calendar
-            if not (leave.request_unit_hours
-                and leave.employee_id
-                and leave.request_date_from
-                and leave.request_date_to
-                and calendar):
-                continue
-
-            hour_from, hour_to = leave._get_hour_from_to(leave.request_date_from, leave.request_date_to)
-            leave.request_hour_from = hour_from
-            leave.request_hour_to = hour_to
+            if (not leave.request_unit_hours
+                    and leave.employee_id
+                    and leave.request_date_from
+                    and leave.request_date_to
+                    and calendar):
+                hour_from, hour_to = leave._get_hour_from_to(leave.request_date_from, leave.request_date_to)
+                leave.request_hour_from = hour_from
+                leave.request_hour_to = hour_to
 
     @api.depends('employee_id', 'leave_type_request_unit', 'request_date_from', 'request_date_to',
             'request_hour_from', 'request_hour_to', 'request_date_from_period', 'request_date_to_period')

--- a/addons/hr_work_entry_holidays/tests/test_performance.py
+++ b/addons/hr_work_entry_holidays/tests/test_performance.py
@@ -41,14 +41,14 @@ class TestWorkEntryHolidaysPerformance(TestWorkEntryHolidaysBase):
     def test_performance_leave_write(self):
         leave = self.create_leave(datetime(2018, 1, 1, 7, 0), datetime(2018, 1, 1, 18, 0))
 
-        with self.assertQueryCount(__system__=14, admin=14):
+        with self.assertQueryCount(__system__=16, admin=16):
             leave.date_to = datetime(2018, 1, 1, 19, 0)
         leave.action_refuse()
 
     @users('__system__', 'admin')
     @warmup
     def test_performance_leave_create(self):
-        with self.assertQueryCount(__system__=56, admin=56):
+        with self.assertQueryCount(__system__=58, admin=58):
             leave = self.create_leave(datetime(2018, 1, 1, 7, 0), datetime(2018, 1, 1, 18, 0))
         leave.action_refuse()
 


### PR DESCRIPTION
- made `request_hour_from` and `request_hour_to` stay unchanged when switching between time off types

task-id: 5085389

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
