### PR TITLE
[FIX] account: ensure product is selected in section catalog tour

### DIFF
--- a/addons/account/static/src/js/tours/tour_utils.js
+++ b/addons/account/static/src/js/tours/tour_utils.js
@@ -32,7 +32,7 @@ export function addSectionFromProductCatalog() {
                     [...document.querySelectorAll('.o_kanban_record')].find(el =>
                         el.textContent.includes('Test Product')
                     )?.click();
-                }, 500);
+                }, 1000);
             },
         },
         {


### PR DESCRIPTION
Issue:
The tour was failing because the product was not being selected in time.
As a result, the subsequent step that checks whether the product is selected
was consistently failing.

Cause:
In the Romanian localization, the `FetchInvoicesCogMenu` component uses an
`isDisplayed` argument with async/await. This introduces a delay before the
component is fully rendered. Meanwhile, the tour step was executing too early,
before the product was actually selected.

Fix:
Increase the wait time to 1000ms to ensure the product is properly selected
before the following step is executed.
