### PR TITLE
[FIX] point_of_sale: message closing session

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -331,7 +331,7 @@ export class PosStore extends WithLazyGetterTrap {
 
     async closingSessionNotification(data) {
         if (
-            parseInt(data.device_identifier) === this.device.identifier ||
+            data.device_identifier === this.device.identifier ||
             this.session.id !== parseInt(data.session_id)
         ) {
             return;

--- a/addons/point_of_sale/static/src/app/utils/devices_synchronisation.js
+++ b/addons/point_of_sale/static/src/app/utils/devices_synchronisation.js
@@ -57,7 +57,7 @@ export default class DevicesSynchronisation {
      * This method will collect the synchronization of records from the backend
      * to update the records in the frontend.
      * @param {Object} data - The data that needs to be synchronized.
-     * @param {Number} data.device_identifier - Session login number.
+     * @param {String} data.device_identifier - Session login number.
      * @param {Number} data.session_id - Current session id.
      * @param {Object} data.static_records - Records data that need to be synchronized.
      */


### PR DESCRIPTION
Issue:
When closing session on a pos the warning: "The session is being closed by another user. The page will be reloaded." was shown.

Fix:
The condition in the closingSessionNotification was strictly comparing an int with a string.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
