### PR TITLE
[IMP] hr: Show employees in cycle in a list view

### DIFF
--- a/addons/hr/data/hr_demo.xml
+++ b/addons/hr/data/hr_demo.xml
@@ -224,7 +224,6 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="wage">7540.00</field>
             <field name="job_id" ref="hr.job_cto"/>
             <field name="department_id" ref="dep_management"/>
-            <field name="parent_id" ref="employee_admin"/>
             <field name="resource_calendar_id" ref="resource.resource_calendar_std_38h"/>
             <field name="private_street">215 Vine St</field>
             <field name="private_city">Scranton</field>

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -1336,6 +1336,63 @@ class HrEmployee(models.Model):
         })
         return employee
 
+    @api.model
+    def cycles_in_hierarchy_read(self, domain):
+        """
+        Detect cycles in a parent-child hierarchy using Floyd's Tortoise and Hare algorithm.
+        The algorithm works iff each child in the hierarchy has at most one parent.
+
+        :param domain: A domain used to search for records in the hierarchy.
+        :type domain: list
+
+        :return: List of record IDs that are part of a cycle in a model.
+        :rtype: list[int]
+        """
+        records = self.search_fetch(domain=domain, field_names=['parent_id'])
+        parent_map = defaultdict(
+            lambda: None,
+            {
+                record.id: record.parent_id.id if record.parent_id else None
+                for record in records
+            },
+        )
+        visited = set()
+        in_cycle = set()
+
+        for record in records:
+            record_id = record.id
+            if record in visited:
+                continue
+
+            # Floyd's Tortoise and Hare cycle detection
+            parent = record_id
+            grand_parent = record_id
+
+            while True:
+                parent = parent_map.get(parent)
+                grand_parent = parent_map.get(parent_map.get(grand_parent))
+
+                if parent is None or grand_parent is None:
+                    break
+
+                if parent == grand_parent or parent in in_cycle or grand_parent in in_cycle:
+                    cycle_node = record_id
+                    while cycle_node not in in_cycle:
+                        in_cycle.add(cycle_node)
+                        visited.add(cycle_node)
+                        cycle_node = parent_map.get(cycle_node)
+                    break
+
+                if parent in visited or grand_parent in visited:
+                    break
+
+            # Mark the current traversal as visited
+            current = record_id
+            while current is not None and current not in visited:
+                visited.add(current)
+                current = parent_map.get(current)
+        return list(in_cycle)
+
     @api.model_create_multi
     def create(self, vals_list):
         vals_per_company = defaultdict(list)

--- a/addons/hr/static/src/views/hr_employee_hierarchy/hr_employee_hierarchy_model.js
+++ b/addons/hr/static/src/views/hr_employee_hierarchy/hr_employee_hierarchy_model.js
@@ -1,0 +1,23 @@
+import { HierarchyModel } from "@web_hierarchy/hierarchy_model";
+import { KeepLast } from "@web/core/utils/concurrency";
+
+export class HrEmployeeHierarchyModel extends HierarchyModel {
+    /**@override */
+    setup(params, { notification }) {
+        super.setup(params, { notification });
+        this.KeepLastInCycle = new KeepLast();
+    }
+
+    /** @override */
+    async load(params = {}) {
+        await super.load(params);
+        this.nodesInCycle = await this.KeepLastInCycle.add(this._loadNodesInCycle());
+    }
+
+    async _loadNodesInCycle() {
+        const domain = [["company_id", "in", this.context.allowed_company_ids || []]];
+        return await this.orm.call("hr.employee", "cycles_in_hierarchy_read", [
+            domain,
+        ]);
+    }
+}

--- a/addons/hr/static/src/views/hr_employee_hierarchy/hr_employee_hierarchy_renderer.js
+++ b/addons/hr/static/src/views/hr_employee_hierarchy/hr_employee_hierarchy_renderer.js
@@ -1,4 +1,5 @@
 import { Avatar } from "@mail/views/web/fields/avatar/avatar";
+import { useService } from "@web/core/utils/hooks";
 
 import { HierarchyRenderer } from "@web_hierarchy/hierarchy_renderer";
 import { HrEmployeeHierarchyCard } from "./hr_employee_hierarchy_card";
@@ -10,4 +11,29 @@ export class HrEmployeeHierarchyRenderer extends HierarchyRenderer {
         HierarchyCard: HrEmployeeHierarchyCard,
         Avatar,
     };
+
+    setup() {
+        super.setup();
+        this.action = useService("action");
+    }
+
+    get employeesInCycleIds() {
+        return this.props.model.nodesInCycle;
+    }
+
+    _displayEmployeesInCycle() {
+        const { model } = this.props;
+        const resModel = model.resModel;
+
+        this.action.doAction({
+            type: "ir.actions.act_window",
+            res_model: resModel,
+            domain: [["id", "in", this.employeesInCycleIds]],
+            views: [
+                [false, "list"],
+                [false, "form"],
+            ],
+            target: "current",
+        });
+    }
 }

--- a/addons/hr/static/src/views/hr_employee_hierarchy/hr_employee_hierarchy_renderer.xml
+++ b/addons/hr/static/src/views/hr_employee_hierarchy/hr_employee_hierarchy_renderer.xml
@@ -2,6 +2,15 @@
 <templates>
 
     <t t-name="hr.HrEmployeeHierarchyRenderer" t-inherit="web_hierarchy.HierarchyRenderer">
+        <xpath expr="//div[hasclass('o_hierarchy_renderer')]" position="attributes">
+            <attribute name="class" add="flex-column align-items-center" separator=" "/>
+        </xpath>
+        <xpath expr="//div[hasclass('o_hierarchy_container')]" position="before">
+            <div t-if="employeesInCycleIds.length" class="my-custom-header alert alert-warning mb-2 w-100 text-center">
+                Some employees are present in a loop.
+                Click <a class="cursor-pointer p-0" t-on-click.prevent="_displayEmployeesInCycle">here</a> to see those employees.
+            </div>
+        </xpath>
         <xpath expr="//div[hasclass('o_hierarchy_parent_node_container')]/span" position="replace">
             <Avatar
                 resModel="row.parentNode.model.resModel"

--- a/addons/hr/static/src/views/hr_employee_hierarchy/hr_employee_hierarchy_view.js
+++ b/addons/hr/static/src/views/hr_employee_hierarchy/hr_employee_hierarchy_view.js
@@ -2,10 +2,12 @@ import { registry } from "@web/core/registry";
 
 import { hierarchyView } from "@web_hierarchy/hierarchy_view";
 import { HrEmployeeHierarchyRenderer } from "./hr_employee_hierarchy_renderer";
+import { HrEmployeeHierarchyModel } from "./hr_employee_hierarchy_model";
 
 export const hrEmployeeHierarchyView = {
     ...hierarchyView,
     Renderer: HrEmployeeHierarchyRenderer,
+    Model: HrEmployeeHierarchyModel,
 };
 
 registry.category("views").add("hr_employee_hierarchy", hrEmployeeHierarchyView);

--- a/addons/hr/static/tests/mock_server/mock_models/hr_employee_hierarchy.js
+++ b/addons/hr/static/tests/mock_server/mock_models/hr_employee_hierarchy.js
@@ -1,0 +1,57 @@
+import { onRpc } from "@web/../tests/web_test_helpers";
+
+onRpc("cycles_in_hierarchy_read", function findCyclesInHierarchy({ model, args }) {
+    const [domain] = args;
+    const result = this.env[model].search(domain);
+    const records = result._records || [];
+
+    // Build parent map: {id: parent_id}
+    const parentMap = { null: null };
+    for (const record of records) {
+        parentMap[record.id] =
+            record["parent_id"] && record["parent_id"] !== false ? record["parent_id"] : null;
+    }
+
+    const visited = new Set();
+    const inCycle = new Set();
+
+    for (const record of records) {
+        const recordId = record.id;
+        if (visited.has(recordId)) {
+            continue;
+        }
+
+        // Floyd's Tortoise and Hare
+        let parent = recordId;
+        let grandParent = recordId;
+        const firstIteration = true;
+        while (firstIteration) {
+            parent = parentMap[parent];
+            grandParent = parentMap[parentMap[grandParent]];
+            if (parent == null || grandParent == null) {
+                break;
+            }
+            if (parent === grandParent || inCycle.has(parent) || inCycle.has(grandParent)) {
+                // Found a cycle, mark all nodes in the cycle
+                let cycleNode = recordId;
+                while (!inCycle.has(cycleNode)) {
+                    inCycle.add(cycleNode);
+                    visited.add(cycleNode);
+                    cycleNode = parentMap[cycleNode];
+                }
+                break;
+            }
+            if (visited.has(grandParent) || visited.has(parent)) {
+                break;
+            }
+        }
+        // Mark the current traversal as visited
+        let current = recordId;
+        while (current != null && !visited.has(current)) {
+            visited.add(current);
+            current = parentMap[current];
+        }
+    }
+    // Return records that are part of a cycle
+    return Array.from(inCycle);
+});


### PR DESCRIPTION
This commit adds a warning message in the employee hierarchy view
when a cycle is detected in the employee-manager relationships.
It also provides a button to view the employees involved in the cycle
in a list view, making it easier to manage and resolve the cycle.

task-5022670

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
