### PR TITLE
[FIX] hr_recruitment: prevent access error on talent pool

### DIFF
--- a/addons/hr_recruitment/wizard/talent_pool_add_applicants.py
+++ b/addons/hr_recruitment/wizard/talent_pool_add_applicants.py
@@ -50,7 +50,7 @@ class TalentPoolAddApplicants(models.TransientModel):
         return talents
 
     def action_add_applicants_to_pool(self):
-        talents = self._add_applicants_to_pool()
+        talents = self.sudo()._add_applicants_to_pool()
         if len(talents) == 1:
             return {
                 "type": "ir.actions.act_window",


### PR DESCRIPTION
Steps to reproduce:
====================
1. Grant admin access for Recruitment to demo user.
2. Go to the Recruitment app.
3. Open Applications > Talent Pool.
4. Select a talent pool.
5. Click "Add to pool".

Problem:
=========
If the user lacks read access on Employees, an access error occurs. This happens because `_add_applicants_to_pool` tries to access `proposed_contracts`,
https://github.com/odoo/enterprise/blob/95b9942316c962950ace6b899faa6f1e6c8fee9a/hr_contract_salary/models/hr_applicant.py#L17 which triggers a read on `hr.version`.

Since `hr.version` uses `_order`,
https://github.com/odoo/odoo/blob/f0eb0c792b77fbaf0ef3738ea88d9c2bae880a85/addons/hr/models/hr_version.py#L28 it tries to sort the result,
leading to a access rights error.

Fix:
====
Use `sudo` when calling _add_applicants_to_pool.

opw-5074018
