### PR TITLE
[FIX] payment: allow portal payments if partner has access to company

### DIFF
--- a/addons/payment/controllers/portal.py
+++ b/addons/payment/controllers/portal.py
@@ -472,7 +472,10 @@ class PaymentPortal(portal.CustomerPortal):
     def _can_partner_pay_in_company(partner, document_company):
         """ Return whether the provided partner can pay in the provided company.
 
-        The payment is allowed either if the partner's company is not set or if the companies match.
+        The payment is allowed if one of the following is true:
+            - the partner's company is not set
+            - the partner's company matches the document company
+            - the partner has a user account with access to the document company
 
         :param recordset partner: The partner on behalf on which the payment is made, as a
                                   `res.partner` record.
@@ -481,7 +484,11 @@ class PaymentPortal(portal.CustomerPortal):
         :return: Whether the payment is allowed.
         :rtype: str
         """
-        return not partner.company_id or partner.company_id == document_company
+        return (
+            not partner.company_id
+            or partner.company_id == document_company
+            or document_company in partner.user_ids.company_ids
+        )
 
     @staticmethod
     def _validate_transaction_kwargs(kwargs, additional_allowed_keys=()):


### PR DESCRIPTION
Steps
-----
1. Set up a 2nd company with Brazilian l10n;
2. set up Stripe with the boleto payment method;
3. generate a sales order in BRL for BR company;
4. have the salesperson's default company be the 1st company;
5. open sale order preview;
6. attempt to generate a boleto to send to the customer.

Issue
-----
It wants you to switch to the other company. To do this, you either need change the company on your partner record, or your user's default company (which also changes the partner record).

Changing the company in the company selector doesn't work.

Cause
-----
Portal payments are currently only allowed if the partner has no company, or if the partner's company matches the quotation's company.

Solution
--------
Also allow payments if the partner has a user profile with access to the document's company.

opw-4937531