### PR TITLE
[FIX] html_builder, website: avoid nan on invalid number input

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_number_input.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_number_input.js
@@ -128,8 +128,8 @@ export class BuilderNumberInput extends Component {
                 // Only keep the first "."
                 .replace(/^([^.]*)\.?(.*)/, (_, a, b) => a + (b ? "." + b.replace(/\./g, "") : ""));
         }
-        displayValue = displayValue.split(" ").map(this.clampValue.bind(this)).join(" ");
-
+        displayValue =
+            displayValue.split(" ").map(this.clampValue.bind(this)).join(" ") || this.props.default;
         return this.convertSpaceSplitValues(displayValue, (value) => {
             if (value === "") {
                 return value;

--- a/addons/website/static/src/builder/plugins/options/progress_bar_option.xml
+++ b/addons/website/static/src/builder/plugins/options/progress_bar_option.xml
@@ -3,7 +3,7 @@
 
 <t t-name="website.ProgressBarOption">
     <BuilderRow label.translate="Value">
-        <BuilderNumberInput action="'progressBarValue'" unit="'%'"/>
+        <BuilderNumberInput action="'progressBarValue'" unit="'%'" saveUnit="'%'"/>
     </BuilderRow>
     <BuilderRow label.translate="Label">
         <BuilderSelect>

--- a/addons/website/static/tests/builder/custom_tab/builder_components/builder_number_input.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/builder_number_input.test.js
@@ -845,6 +845,19 @@ describe("sanitized values", () => {
         await contains(":iframe .test-options-target").click();
         await contains(".options-container input").edit(" a&$*+>");
         expect(".options-container input").toHaveValue("0");
+        expect(":iframe .test-options-target").toHaveAttribute("data-number", "0");
+    });
+    test("after input, displayed value is cleaned to match only numbers (default=null)", async () => {
+        addOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderNumberInput dataAttributeAction="'number'" default="null"/>`,
+        });
+        await setupWebsiteBuilder(`
+            <div class="test-options-target" data-number="10">Test</div>
+        `);
+        await contains(":iframe .test-options-target").click();
+        await contains(".options-container input").edit(" a&$*+>");
+        expect(".options-container input").toHaveValue("");
         expect(":iframe .test-options-target").not.toHaveAttribute("data-number");
     });
     test("after copy / pasting, displayed value is cleaned to match only numbers", async () => {


### PR DESCRIPTION
Before this commit, putting an invalid input in the progressbar value would lead to a traceback. Moreover, the input could display "0%%" (one being in the input, the other being the displayed unit).

This commit solves this issue by defining a saveUnit for the input and using the defaultValue when an input is invalid.