### PR TITLE
[IMP] mail: show '...' action button next to message in mobile

### DIFF
--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -257,7 +257,7 @@ export class Message extends Component {
 
     get attClass() {
         return {
-            "user-select-none": isMobileOS(),
+            "user-select-none o-isMobileOS": isMobileOS(),
             [this.props.className]: true,
             "o-card p-2 ps-1 mx-1 mt-1 mb-1 border border-dark rounded-2": this.props.asCard,
             "pt-1": !this.props.asCard && !this.props.squashed,
@@ -313,6 +313,9 @@ export class Message extends Component {
 
     /** Max amount of quick actions, including "..." */
     get quickActionCount() {
+        if (isMobileOS()) {
+            return 1;
+        }
         return this.env.inChatWindow || this.env.inMeetingChat ? 2 : 4;
     }
 

--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -135,6 +135,10 @@
     --o-mail-ActionList-Button-aspect-ratio: 0.65;
     --o-mail-ActionList-Button-opacity: #{$o-opacity-muted};
     --o-mail-ActionList-Button-opacity--hover: 1;
+
+    .o-mail-Message.o-isMobileOS & i.oi-ellipsis-v {
+        opacity: 15%;
+    }
 }
 
 .o-mail-Message-moreMenu {

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -17,7 +17,7 @@
                 t-if="message.exists()"
             >
                 <div class="o-mail-Message-jumpTarget position-absolute top-0 pe-none"/>
-                <div t-if="props.asCard and isMobileOS" class="position-absolute end-0 z-1"><t t-call="mail.Message.actions"/></div>
+                <div t-if="props.asCard and isMobileOS" class="position-absolute end-0 z-1 m-n2"><t t-call="mail.Message.actions"/></div>
                 <div class="o-mail-Message-core position-relative d-flex flex-shrink-0 bg-inherit" t-att-class="{ 'ps-xl-2': env.inDiscussApp and !ui.isSmall }">
                     <div class="o-mail-Message-sidebar d-flex flex-shrink-0 align-items-center flex-column bg-inherit" t-att-class="{ 'align-items-start': !isAlignedRight, 'o-inChatWindow': env.inChatWindow }">
                         <t t-if="!props.squashed">
@@ -169,15 +169,13 @@
                 </t>
             </Dropdown>
         </t>
-        <t t-else="">
-            <t t-set="isReverse" t-value="env.inChatWindow and isAlignedRight"/>
-            <div class="d-flex rounded-1 overflow-hidden gap-1" t-att-class="{ 'flex-row-reverse': isReverse }">
-                <ActionList actions="actions" inline="true" fw="false" groupClass="'gap-1'"/>
-                <t t-foreach="Array.from({ length: quickActionCount - quickActions.length - 1 })" t-as="emptyQuickAction" t-key="emptyQuickAction_index">
-                    <t t-call="mail.Message.emptyQuickAction"/>
-                </t>
-            </div>
-        </t>
+        <t t-set="isReverse" t-value="env.inChatWindow and isAlignedRight"/>
+        <div class="d-flex rounded-1 overflow-hidden gap-1" t-att-class="{ 'flex-row-reverse': isReverse }">
+            <ActionList actions="actions" inline="true" fw="false" groupClass="'gap-1'"/>
+            <t t-foreach="Array.from({ length: quickActionCount - quickActions.length - 1 })" t-as="emptyQuickAction" t-key="emptyQuickAction_index">
+                <t t-call="mail.Message.emptyQuickAction"/>
+            </t>
+        </div>
     </div>
 </t>
 


### PR DESCRIPTION
This was removed when adding support for long press, as it feels unnecessary with long press feature.

However there are still arguments to keep showing the "..." button:
- it's not that obvious that action are triggered from long press, especially when this is a rare case it works in Odoo
- long press experience is still not the best on some mobile device, e.g. iOS really wants to select text. Even though the whole message is not selectable to minimize the issue, it can still trigger selection of text somewhere else.
- debugging mobile in responsive mode of browser requires long-press but this usually also lead to accidentally pressing the message action that is immediately shown in bottom sheet.
- It looks weird for bubbles to go too much on the other end of the screen: avatars should be their own lane, no bubble should touch it. Having the "..." button is not wasted space as the bubble wouldn't really use it.

This commit reintroduce "..." button shown in mobile next to all messages. Same as before: the opacity is fine-tuned to be visible but not distracting compared to message and their content.

Before
<img width="444" height="831" alt="Screenshot 2025-09-15 at 15 58 53" src="https://github.com/user-attachments/assets/a1ec6b0b-1ae2-4b30-abe5-e012e2d43d78" />

After
<img width="442" height="830" alt="Screenshot 2025-09-15 at 15 57 52" src="https://github.com/user-attachments/assets/d4aa7e46-d7b8-4b5c-b59e-6b8146fd098b" />

