### PR TITLE
[FIX] mrp: minimum workorder duration for planning

### DIFF
--- a/addons/mrp/models/mrp_workcenter.py
+++ b/addons/mrp/models/mrp_workcenter.py
@@ -336,7 +336,7 @@ class MrpWorkcenter(models.Model):
         get_workorder_intervals = partial(self.resource_calendar_id._leave_intervals_batch, domain=workorder_intervals_leaves_domain, resources=resource, tz=timezone(self.resource_calendar_id.tz))
         extra_leaves_slots_intervals = Intervals([(make_aware(start)[0], make_aware(stop)[0], self.env['resource.calendar.attendance']) for start, stop in extra_leaves_slots])
 
-        remaining = duration
+        remaining = duration = max(duration, 1 / 60)
         now = make_aware(datetime.now())[0]
         delta = timedelta(days=14)
         start_interval, stop_interval = None, None


### PR DESCRIPTION
Operation & Workorder duration is a float with 2 decimal digits to be expressed in minutes, meaning minimal duration is 1sec.
However one can encounter numbers like 0.001, 0.00001, ...
This can lead to :
AttributeError: 'NoneType' object has no attribute 'astimezone' in function _get_first_available_slot

task: 5090338

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
