### PR TITLE
[FIX] web_editor: safeguard queryselector

### DIFF
--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -932,10 +932,10 @@ function formatTables($editable) {
     const editable = $editable.get(0);
     const writes = [];
     for (const table of editable.querySelectorAll('table.o_mail_snippet_general, .o_mail_snippet_general table')) {
-        const tablePaddingTop = parseFloat(_getStylePropertyValue(table, 'padding-top').match(RE_PADDING)[1]);
-        const tablePaddingRight = parseFloat(_getStylePropertyValue(table, 'padding-right').match(RE_PADDING)[1]);
-        const tablePaddingBottom = parseFloat(_getStylePropertyValue(table, 'padding-bottom').match(RE_PADDING)[1]);
-        const tablePaddingLeft = parseFloat(_getStylePropertyValue(table, 'padding-left').match(RE_PADDING)[1]);
+        const tablePaddingTop = parseFloat((_getStylePropertyValue(table, 'padding-top').match(RE_PADDING) || [0, 0])[1]);
+        const tablePaddingRight = parseFloat((_getStylePropertyValue(table, 'padding-right').match(RE_PADDING) || [0, 0])[1]);
+        const tablePaddingBottom = parseFloat((_getStylePropertyValue(table, 'padding-bottom').match(RE_PADDING) || [0, 0])[1]);
+        const tablePaddingLeft = parseFloat((_getStylePropertyValue(table, 'padding-left').match(RE_PADDING) || [0, 0])[1]);
         const rows = [...table.querySelectorAll('tr')].filter(tr => tr.closest('table') === table);
         const columns = [...table.querySelectorAll('td')].filter(td => td.closest('table') === table);
         for (const column of columns) {


### PR DESCRIPTION


If we copy "Event Promo" design from mailing.mailing to mail.template JS will fail.
The quesryselector can fail so better to safeguard the working function.

To reproduce the bug:

 - open mailing.mailing and create a new record
 - Choose "Event Promo" to be mail body
 - copy the HTML of the body
 - go to mail.template and create a new record
 - paste that HTML in the body of mail.template new record
 - switch between Content and Settings tabs and observe.

The next error will raise up

UncaughtPromiseError > TypeError Uncaught Promise > can't access property 1 of null TypeError: can't access property 1 of null formatTables@http://localhost:8069/web/assets/319-85bee19/web.assets_backend.min.js:13286:268 toInline@http://localhost:8069/web/assets/319-85bee19/web.assets_backend.min.js:13275:478
