### PR TITLE
[FIX] l10n_it_edi: fix wrong name for data DatiFattureCollegate

### DIFF
--- a/addons/l10n_it_edi/data/invoice_it_template.xml
+++ b/addons/l10n_it_edi/data/invoice_it_template.xml
@@ -157,19 +157,19 @@
             <t t-if="reconciled_moves">
                 <DatiFattureCollegate t-foreach="reconciled_moves" t-as="reconciled_move">
                     <IdDocumento t-out="format_alphanumeric(reconciled_move.name, -20)"/>
-                    <DataDocumento t-out="format_date(reconciled_move.date if reconciled_move.l10n_it_edi_is_self_invoice else reconciled_move.invoice_date)"/>
+                    <Data t-out="format_date(reconciled_move.date if reconciled_move.l10n_it_edi_is_self_invoice else reconciled_move.invoice_date)"/>
                 </DatiFattureCollegate>
             </t>
             <t t-elif="record.reversed_entry_id">
                 <DatiFattureCollegate>
                     <IdDocumento t-out="format_alphanumeric(record.reversed_entry_id.name, -20)"/>
-                    <DataDocumento t-out="format_date(record.reversed_entry_id.date if record.reversed_entry_id.l10n_it_edi_is_self_invoice else record.reversed_entry_id.invoice_date)"/>
+                    <Data t-out="format_date(record.reversed_entry_id.date if record.reversed_entry_id.l10n_it_edi_is_self_invoice else record.reversed_entry_id.invoice_date)"/>
                 </DatiFattureCollegate>
             </t>
             <t t-elif="record.ref">
                 <DatiFattureCollegate>
                     <IdDocumento t-out="format_alphanumeric(record.ref, 20)"/>
-                    <DataDocumento t-out="format_date(record.invoice_date)"/>
+                    <Data t-out="format_date(record.invoice_date)"/>
                 </DatiFattureCollegate>
             </t>
             <DatiFattureCollegate t-foreach="downpayment_moves" t-as="downpayment_move">

--- a/addons/l10n_it_edi/tests/export_xmls/bill_reverse_charge.xml
+++ b/addons/l10n_it_edi/tests/export_xmls/bill_reverse_charge.xml
@@ -65,7 +65,7 @@
             </DatiGeneraliDocumento>
             <DatiFattureCollegate>
                 <IdDocumento>BILL/2022/04/0001</IdDocumento>
-                <DataDocumento>2022-03-24</DataDocumento>
+                <Data>2022-03-24</Data>
             </DatiFattureCollegate>
         </DatiGenerali>
         <DatiBeniServizi>

--- a/addons/l10n_it_edi/tests/export_xmls/bill_reverse_charge_2.xml
+++ b/addons/l10n_it_edi/tests/export_xmls/bill_reverse_charge_2.xml
@@ -65,7 +65,7 @@
             </DatiGeneraliDocumento>
             <DatiFattureCollegate>
                 <IdDocumento>BILL/2022/04/0001</IdDocumento>
-                <DataDocumento>2022-03-24</DataDocumento>
+                <Data>2022-03-24</Data>
             </DatiFattureCollegate>
         </DatiGenerali>
         <DatiBeniServizi>

--- a/addons/l10n_it_edi/tests/export_xmls/credit_note_negative_price.xml
+++ b/addons/l10n_it_edi/tests/export_xmls/credit_note_negative_price.xml
@@ -66,7 +66,7 @@
             </DatiGeneraliDocumento>
             <DatiFattureCollegate>
                 <IdDocumento>___ignore___</IdDocumento>
-                <DataDocumento>___ignore___</DataDocumento>
+                <Data>___ignore___</Data>
             </DatiFattureCollegate>
         </DatiGenerali>
         <DatiBeniServizi>

--- a/addons/l10n_it_edi/tests/export_xmls/credit_note_refund_no_reconcile.xml
+++ b/addons/l10n_it_edi/tests/export_xmls/credit_note_refund_no_reconcile.xml
@@ -62,7 +62,7 @@
       </DatiGeneraliDocumento>
       <DatiFattureCollegate>
         <IdDocumento>BILL/2022/03/0001</IdDocumento>
-        <DataDocumento>2022-03-24</DataDocumento>
+        <Data>2022-03-24</Data>
       </DatiFattureCollegate>
     </DatiGenerali>
     <DatiBeniServizi>

--- a/addons/l10n_it_edi/tests/export_xmls/credit_note_reverse_charge.xml
+++ b/addons/l10n_it_edi/tests/export_xmls/credit_note_reverse_charge.xml
@@ -65,11 +65,11 @@
             </DatiGeneraliDocumento>
             <DatiFattureCollegate>
                 <IdDocumento>BILL/2022/04/0001</IdDocumento>
-                <DataDocumento>2022-04-01</DataDocumento>
+                <Data>2022-04-01</Data>
             </DatiFattureCollegate>
             <DatiFattureCollegate>
                 <IdDocumento>BILL/2022/04/0002</IdDocumento>
-                <DataDocumento>2022-04-01</DataDocumento>
+                <Data>2022-04-01</Data>
             </DatiFattureCollegate>
         </DatiGenerali>
         <DatiBeniServizi>

--- a/addons/l10n_it_edi/tests/export_xmls/invoice_exclude_postdated_moves.xml
+++ b/addons/l10n_it_edi/tests/export_xmls/invoice_exclude_postdated_moves.xml
@@ -63,7 +63,7 @@
       </DatiGeneraliDocumento>
       <DatiFattureCollegate>
         <IdDocumento>INV/2022/00001</IdDocumento>
-        <DataDocumento>2022-03-24</DataDocumento>
+        <Data>2022-03-24</Data>
       </DatiFattureCollegate>
     </DatiGenerali>
     <DatiBeniServizi>

--- a/addons/l10n_it_edi/tests/export_xmls/split_payment_cn.xml
+++ b/addons/l10n_it_edi/tests/export_xmls/split_payment_cn.xml
@@ -63,7 +63,7 @@
             </DatiGeneraliDocumento>
             <DatiFattureCollegate>
                 <IdDocumento>INV/2022/00001</IdDocumento>
-                <DataDocumento>2022-03-24</DataDocumento>
+                <Data>2022-03-24</Data>
             </DatiFattureCollegate>
         </DatiGenerali>
         <DatiBeniServizi>

--- a/addons/l10n_it_edi_ndd/tests/export_xmls/credit_note_export_document_type.xml
+++ b/addons/l10n_it_edi_ndd/tests/export_xmls/credit_note_export_document_type.xml
@@ -65,7 +65,7 @@
             </DatiGeneraliDocumento>
             <DatiFattureCollegate>
                 <IdDocumento>BILL/2022/04/0001</IdDocumento>
-                <DataDocumento>2022-04-01</DataDocumento>
+                <Data>2022-04-01</Data>
             </DatiFattureCollegate>
         </DatiGenerali>
         <DatiBeniServizi>


### PR DESCRIPTION
The name for the date in DatiFattureCollegate (56e08bb091d39a18ea1c8e7699321b953a8823e1) is wrong. It is not DataDocumento but Data as per https://fex-app.com/FatturaElettronica/FatturaElettronicaBody/DatiGenerali/DatiFattureCollegate/Data/18

How to reproduce the issue:

- With l10n_it, create an invoice and fill the customer reference field.
- Generate the xml and validate through https://fex-app.com/servizi/verifica
- The following error related to the date happens: E-invoicing (Italy) La fattura elettronica è stata rifiutata dall'SdI. File non conforme al formato : Invalid content was found starting with element 'DataDocumento'. One of '{Data, NumItem, CodiceCommessaConvenzione, CodiceCUP, CodiceCIG}' is expected. riga: 80 - colonna: 24

opw-5082016


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
