### PR TITLE
[FIX] web: add actionXmlId to view subenv config

### DIFF
--- a/addons/web/static/src/views/view.js
+++ b/addons/web/static/src/views/view.js
@@ -106,6 +106,7 @@ export function getDefaultConfig() {
     const config = {
         actionId: false,
         actionType: false,
+        actionXmlId: false,
         embeddedActions: [],
         currentEmbeddedActionId: false,
         parentActionId: false,

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -751,6 +751,7 @@ export function makeActionManager(env, router = _router) {
                 actionId: action.id,
                 actionName: action.name,
                 actionType: "ir.actions.act_window",
+                actionXmlId: action.xml_id,
                 embeddedActions,
                 parentActionId,
                 currentEmbeddedActionId,


### PR DESCRIPTION
This information is required so that the studio can determine whether the action can be edited.

opw-5066488