### PR TITLE
[FIX] website_sale: snippets strikethrough price

### DIFF
--- a/addons/website_sale/data/product_snippet_template_data.xml
+++ b/addons/website_sale/data/product_snippet_template_data.xml
@@ -131,6 +131,7 @@
                       name="product_price"
                       t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"/>
                 <del
+                    t-if="data.get('has_discounted_price')"
                     aria-label="Original price"
                     t-attf-class="text-muted me-1 mb-0"
                     style="white-space: nowrap;"

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -605,7 +605,7 @@ class ProductTemplate(models.Model):
                 currency=currency,
             )
 
-        has_discounted_price = price_before_discount > pricelist_price
+        has_discounted_price = currency.compare_amounts(price_before_discount, pricelist_price) == 1
         combination_info = {
             'list_price': max(pricelist_price, price_before_discount),
             'price': pricelist_price,


### PR DESCRIPTION
Commit 43d5226b500d64c3902eb1528e5d8e461766982c removed the condition on when discount should be shown So it was always shown by default.

Additionally, we use the currency compare amounts method to make sure rounding values are respected.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
