### PR TITLE
[FIX] project,sale_timesheet: fix project tours at project creation step

### DIFF
--- a/addons/project/static/src/js/tours/project.js
+++ b/addons/project/static/src/js/tours/project.js
@@ -28,6 +28,12 @@ registry.category("web_tour.tours").add('project_tour', {
     tooltipPosition: 'bottom',
     run: "click",
 }, {
+    isActive: ["body:has(.o-project-form-dropdown-menu)"],
+    trigger: ".dropdown-item:contains('New Project')",
+    content: markup(_t("Let\'s create a regular <b>project</b>.")),
+    tooltipPosition: "right",
+    run: "click",
+}, {
     trigger: '.o_project_name input',
     content: markup(_t('Choose a <b>name</b> for your project. <i>It can be anything you want: the name of a customer, of a product, of a team, of a construction site, etc.</i>')),
     tooltipPosition: 'right',

--- a/addons/project/static/tests/tours/project_tour.js
+++ b/addons/project/static/tests/tours/project_tour.js
@@ -15,6 +15,10 @@ registry.category("web_tour.tours").add('project_test_tour', {
         trigger: '.o-kanban-button-new',
         run: "click",
     }, {
+        isActive: ["body:has(.o-project-form-dropdown-menu)"],
+        trigger: ".dropdown-item:contains('New Project')",
+        run: "click",
+    }, {
         trigger: '.o_project_name input',
         run: 'edit New Project',
         id: 'project_creation',

--- a/addons/project/static/tests/tours/project_update_tour_tests.js
+++ b/addons/project/static/tests/tours/project_update_tour_tests.js
@@ -14,6 +14,10 @@ registry.category("web_tour.tours").add('project_update_tour', {
     trigger: '.o-kanban-button-new',
     run: "click",
 }, {
+    isActive: ["body:has(.o-project-form-dropdown-menu)"],
+    trigger: ".dropdown-item:contains('New Project')",
+    run: "click",
+}, {
     trigger: '.o_project_name input',
     run: "edit New Project",
 }, {

--- a/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
+++ b/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
@@ -33,6 +33,12 @@ registry.category("web_tour.tours").add('sale_timesheet_tour', {
     content: 'Add a new project.',
     run: "click",
 }, {
+    isActive: ["body:has(.o-project-form-dropdown-menu)"],
+    trigger: ".dropdown-item:contains('New Project')",
+    content: 'Let\'s create a regular project.',
+    tooltipPosition: "right",
+    run: "click",
+}, {
     trigger: '.o_field_widget.o_project_name input',
     content: 'Select your project name (e.g. Project for Freeman)',
     run: "edit Project for Freeman",
@@ -144,6 +150,12 @@ registry.category("web_tour.tours").add('sale_timesheet_tour', {
 }, {
     trigger: 'button.o_list_button_add',
     content: 'Click on Create button to create a new project and see the different configuration available for the project.',
+    run: "click",
+}, {
+    isActive: ["body:has(.o-project-form-dropdown-menu)"],
+    trigger: ".dropdown-item:contains('New Project')",
+    content: 'Let\'s create a regular project.',
+    tooltipPosition: "right",
     run: "click",
 },
 {


### PR DESCRIPTION
Before this commit, the project tours could fail at the project creation step because the 'New' button might open a dropdown menu instead of the project creation form, depending on whether project templates exist in the DB or not. After this commit, we add a conditional step to handle that case.

version: saas-18.4

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
