### PR TITLE
[FIX] survey: fix crash when clicking the "results" button

### DIFF
--- a/addons/survey/static/src/interactions/survey_session_manage.js
+++ b/addons/survey/static/src/interactions/survey_session_manage.js
@@ -457,12 +457,13 @@ export class SurveySessionManage extends Interaction {
      * @private
      */
     async onEndSessionClick(ev) {
+        // ev could not exist (onNextQuestionDone )
+        const showResults = ev?.currentTarget?.dataset?.showResults;
         await this.waitFor(
             this.services.orm.call("survey.survey", "action_end_session", [[this.surveyId]])
         );
         this.protectSyncAfterAsync(() => {
-            // ev could not exist (onNextQuestionDone )
-            if (ev?.currentTarget.dataset.showResults) {
+            if (showResults) {
                 window.location.href = `/survey/results/${encodeURIComponent(this.surveyId)}`;
             } else {
                 window.location.reload();


### PR DESCRIPTION
How to reproduce:
- Create a live survey with one scored question
- Do a live survey with one participant
- At the end of the survey, click on "Results" button

There is an error.

We solve the problem by reading the event to determine if the result should be displayed or not at the top of the method as it is modified later (by waitFor on orm call as observed).

Task-5090443