### PR TITLE
[FIX] mail: reset bounce from incoming email

### DIFF
--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -1282,7 +1282,18 @@ class TestMailgateway(MailGatewayCommon):
         self.assertEqual(self.test_record.message_bounce, 0)
         self.assertEqual(other_record.message_bounce, 10)
         self.assertEqual(yet_other_record.message_bounce, 10)
+        # MAX_BOUNCE_LIMIT in discuss_channel is set to 10,
+        # If this partner exceeds the limit, remove them from the channel.
         self.assertNotIn(self.partner_1, test_channel.channel_partner_ids)
+
+        # On a new successful incoming email, the partner bounce counter should be reset.
+        self.format_and_process(
+            MAIL_TEMPLATE, self.partner_1.email_formatted,
+            f'groups@{self.alias_domain}',
+            subject='Test Working Email Subject',
+            extra=f'In-Reply-To:\r\n\t{self.fake_email.message_id}\n',
+        )
+        self.assertEqual(self.partner_1.message_bounce, 0)
 
     @mute_logger('odoo.addons.mail.models.mail_thread')
     def test_message_process_bounce_records_partner(self):


### PR DESCRIPTION
Incoming bounce email linked to a partner in the db is incrementing (in `message_receive_bounce`)
the message_bounce value during the handling of
the bounces (in `_routing_handle_bounce`)

If later, an email linked to a partner existing in the db (and having a message_bounce > 0) is received (and not bounce). The `_routing_reset_bounce` is
called to reset the message_bounce.

However, prior to this fix, due to not normalizing the `email_from` contained in the `msg_dict`,
well, the record having this value was never found and thus, not reset to 0.

In 4935208, some of the user were unlinked for
mail.discuss.channel when replying to one of the
received email.

opw-4935208

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
