### PR TITLE
[FIX] website: change the visibility option of footer&header from panel

### DIFF
--- a/addons/website/static/src/builder/plugins/options/website_page_config_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/website_page_config_option_plugin.js
@@ -13,7 +13,7 @@ export const HIDE_FOOTER = after(FOOTER_COPYRIGHT);
 
 class WebsitePageConfigOptionPlugin extends Plugin {
     static id = "websitePageConfigOptionPlugin";
-    static dependencies = ["history", "visibility"];
+    static dependencies = ["history", "visibility", "builderActions"];
     static shared = ["setDirty", "setFooterVisible", "getVisibilityItem", "getFooterVisibility"];
     resources = {
         builder_actions: {
@@ -112,9 +112,17 @@ class WebsitePageConfigOptionPlugin extends Plugin {
     }
 
     onTargetVisibilityToggle(show, target) {
-        if (target.matches("#wrapwrap > header, #wrapwrap > footer")) {
-            this.dependencies.history.ignoreDOMMutations(() => {
-                target.classList.toggle("d-none", !show);
+        if (show && target.matches("#wrapwrap > header")) {
+            this.dependencies.builderActions.applyAction("setWebsiteHeaderVisibility", {
+                editingElement: target,
+                value: "regular",
+                isPreviewing: false,
+            });
+        }
+        if (show && target.matches("#wrapwrap > footer")) {
+            this.dependencies.builderActions.applyAction("setWebsiteFooterVisible", {
+                editingElement: target,
+                isPreviewing: false,
             });
         }
     }

--- a/addons/website/static/tests/tours/website_page_options.js
+++ b/addons/website/static/tests/tours/website_page_options.js
@@ -96,8 +96,8 @@ registerWebsitePreviewTour('website_page_options', {
     },
     ...clickOnSave(),
     {
-        content: "Check that the header is hidden",
-        trigger: ":iframe #wrapwrap:has(header#top.d-none.o_snippet_invisible)",
+        content: "Check that the header is visible",
+        trigger: ":iframe #wrapwrap header#top:not(.d-none)",
     },
     {
         content: "Check that the footer is hidden",


### PR DESCRIPTION
With the initial [website builder refactor], clicking on the eye of the entry of the footer or the header in the "Invisible Elements" panel only temporarily changed their visibility. Additional clicks in the options were needed for their visibility to persist.

This commit restores the previous behavior where clicking on the eye in the "Invisible Elements" panel for the header and the footer would also change the option.

Steps to reproduce:
- Open website builder
- Click on the footer
- Disable "Page Visibility"
- Click on the eye next to "Footer" in the "Invisible Elements" panel
- Save
- Bug: the footer is invisible, but it was just before save


[website builder refactor]: 9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
task-4367641
