### PR TITLE
[IMP] mail: same 'disconnect' style as 'start call' in discuss sidebar

### DIFF
--- a/addons/mail/static/src/core/common/action_list.scss
+++ b/addons/mail/static/src/core/common/action_list.scss
@@ -80,7 +80,7 @@
                 transform: translateY(.5px);
             }
         }
-        &.o-dropdown-item.btn-danger {
+        &.o-dropdown-item.btn-danger:not(.o-tag-JOIN_LEAVE_CALL) {
             &.focus {
                 background-color: rgba($danger, 0.75);
                 color: white;

--- a/addons/mail/static/src/discuss/call/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/call/common/thread_actions.js
@@ -47,5 +47,5 @@ registerThreadAction("disconnect", {
     name: _t("Disconnect"),
     sequence: 30,
     sequenceGroup: 10,
-    tags: ACTION_TAGS.DANGER,
+    tags: [ACTION_TAGS.DANGER, ACTION_TAGS.JOIN_LEAVE_CALL],
 });


### PR DESCRIPTION
Before this commit, "disconnect" discuss sidebar button had the same style as any usual danger action like "leave" / "unpin" conversation.

The style is fine by itself, but the "join" / "start" call button has a special style compared to all other thread actions: this is a circled icon with success background color. This style is intended for all join/leave discuss actions, which is properly done for success actions and some danger ones like "disconnect" in call actions, but the thread action "disconnect" was missing it.

This commit changes the style of "disconnect" thread action so that it matches the style of other join/leave call actions.

Before
<img width="467" height="198" alt="Screenshot 2025-09-15 at 17 05 51" src="https://github.com/user-attachments/assets/6a63266d-5760-41b0-b2dc-f63be143e40e" />

After
<img width="475" height="179" alt="Screenshot 2025-09-15 at 16 52 09" src="https://github.com/user-attachments/assets/c75abb7d-ccff-44b4-9a9e-8686dcdf70f5" />


