### PR TITLE
[FIX] payment_adyen: skip validation when redirect payment

### DIFF
--- a/addons/payment_adyen/models/payment_transaction.py
+++ b/addons/payment_adyen/models/payment_transaction.py
@@ -304,6 +304,11 @@ class PaymentTransaction(models.Model):
         if self.provider_code != 'adyen':
             return super()._extract_amount_data(payment_data)
 
+        # Redirection payments don't have the amount or currency in their payment_data, but
+        # processing them results in a pending transaction anyway.
+        if payment_data.get('action', {}).get('type') == 'redirect':
+            return None  # Skip the validation
+
         amount_data = payment_data.get('amount', {})
         amount = payment_utils.to_major_currency_units(
             amount_data.get('value', 0),


### PR DESCRIPTION
Amount and currency validation is skipped for redirect transactions.