### PR TITLE
[FIX] cli,tools: Move the http-interface deprecation warning

### DIFF
--- a/odoo/addons/base/tests/test_configmanager.py
+++ b/odoo/addons/base/tests/test_configmanager.py
@@ -11,10 +11,6 @@ EMPTY_CONFIG_PATH = file_path('base/tests/config/empty.conf')
 PROJECT_PATH = odoo.tools.config.root_path.removesuffix('/odoo')
 DEFAULT_DATADIR = odoo.tools.config._default_options['data_dir']
 
-MISSING_HTTP_INTERFACE = """\
-WARNING:odoo.tools.config:missing --http-interface/http_interface, \
-using 0.0.0.0 by default, will change to 127.0.0.1 in 20.0"""
-
 
 class TestConfigManager(TransactionCase):
     maxDiff = None
@@ -458,13 +454,11 @@ class TestConfigManager(TransactionCase):
 
     def test_05_repeat_parse_config(self):
         """Emulate multiple calls to parse_config()"""
-        with self.assertLogs('odoo.tools.config', 'WARNING') as capture:
-            config = configmanager()
-            config._parse_config()
-            config._warn_deprecated_options()
-            config._parse_config()
-            config._warn_deprecated_options()
-        self.assertEqual(capture.output, [MISSING_HTTP_INTERFACE] * 2)
+        config = configmanager()
+        config._parse_config()
+        config._warn_deprecated_options()
+        config._parse_config()
+        config._warn_deprecated_options()
 
     def test_06_cli(self):
         with file_open('base/tests/config/cli') as file:

--- a/odoo/cli/server.py
+++ b/odoo/cli/server.py
@@ -114,6 +114,21 @@ def main(args):
 
     stop = config["stop_after_init"]
 
+    # Deprecated option warning
+    if not stop:
+        for map_ in config.options.maps:
+            if 'http_interface' in map_:
+                if map_ is config._file_options and map_['http_interface'] == '':  # noqa: PLC1901
+                    del map_['http_interface']
+                elif map_ is config._default_options:
+                    config._log(
+                        logging.WARNING,
+                        "missing %s, using 0.0.0.0 by default, will change to 127.0.0.1 in 20.0",
+                        config.options_index['http_interface'],
+                    )
+                else:
+                    break
+
     setup_pid_file()
     rc = server.start(preload=config['db_name'], stop=stop)
     sys.exit(rc)

--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -720,15 +720,6 @@ class configmanager:
                     "Empty %s, tests won't run", self.options_index['db_name'])
 
     def _warn_deprecated_options(self):
-        for map_ in self.options.maps:
-            if 'http_interface' in map_:
-                if map_ is self._file_options and map_['http_interface'] == '':  # noqa: PLC1901
-                    del map_['http_interface']
-                elif map_ is self._default_options:
-                    self._log(logging.WARNING, "missing %s, using 0.0.0.0 by default, will change to 127.0.0.1 in 20.0", self.options_index['http_interface'])
-                else:
-                    break
-
         for old_option_name, new_option_name in self.aliases.items():
             for source_name, deprecated_value in self._get_sources(old_option_name).items():
                 if deprecated_value is EMPTY:


### PR DESCRIPTION
The deprecation warning for `--http-interface` not being present in the config file was also shown for commands that don't start the database, while it's something directly related to it.