### PR TITLE
[FIX] l10n_es_edi_tbai_pos: do not print qr code on fail

### DIFF
--- a/addons/l10n_es_edi_tbai_pos/models/pos_order.py
+++ b/addons/l10n_es_edi_tbai_pos/models/pos_order.py
@@ -107,6 +107,7 @@ class PosOrder(models.Model):
         edi_document = self.account_move.l10n_es_tbai_post_document_id or self.l10n_es_tbai_post_document_id
         if edi_document and edi_document.state == 'accepted':
             return edi_document._get_tbai_qr()
+        return ''
 
     # -------------------------------------------------------------------------
     # WEB SERVICE CALL


### PR DESCRIPTION
Currently if the TicketBAI upload fails, a QR code is printed with the value `true`.

Steps to reproduce
-----
1. Validate a POS order
2. Have a request exception occur during the TicketBAI post
3. Receipt is printed with an incorrect QR code

Issue
-----
`get_l10n_es_pos_tbai_qrurl()` returns None if the edi document is not accepted. This is then interpreted as `true` by the client and a QR code is printed.

Solution
-----
Explicitly return an empty string if the edi document is not accepted.