### PR TITLE
[FIX] hr_holidays_contract: Recompute duration after changing contracts

### DIFF
--- a/addons/hr_holidays_contract/models/hr_contract.py
+++ b/addons/hr_holidays_contract/models/hr_contract.py
@@ -56,6 +56,10 @@ class HrContract(models.Model):
                     if len(overlapping_contracts.resource_calendar_id) <= 1:
                         if overlapping_contracts and leave.resource_calendar_id != overlapping_contracts[0].resource_calendar_id:
                             leave.resource_calendar_id = overlapping_contracts[0].resource_calendar_id
+                            if ((contract._is_fully_flexible() or contract.resource_calendar_id.flexible_hours)
+                                    and vals.get('state') == 'open' and contract.state == 'draft'):
+                                self.env.add_to_compute(self.env['hr.leave']._fields['number_of_days'], leave)
+                                self.env.add_to_compute(self.env['hr.leave']._fields['duration_display'], leave)
                         continue
                     if leave.id not in leaves_state:
                         leaves_state[leave.id] = leave.state


### PR DESCRIPTION
### Steps to reproduce:
	- define a time-off type in hours
	- create working schedules :
		standard 40h (fixed hours)
		standard 20h (fixed hours)
		Flexible 40h (flex hours)
		Flexible 20h (flex hours)
	- create 2 employees: employee 1 with fixed hours ; employee 2 with flexible hours
	- create contract 1 Fix 100% (start in 01/01/2025 - standard 40h) and set it to running
	- create contract 2 Flex 100% (start in 01/01/2025 - Flexible 40h) and set it to running
	- register a 1st week t-o for each employee (ex: 08/03/2025-08/09/2025) ==> 40h and validate
	- register a 2nd week t-o for each employee (09/07/2025-09/13/2025) ==> 40h and validate
	- expire current contract (100%) for each employee and launch a new contract (50%) : 
		- Standard 20h (Fixed hours) for employee 1 ; 
		- Flexible 20h (flex hours) for employee 2 (start on 08/24/2025)
			==> set them to running

### Cause:
While we are recomputing the duration of the overlapping leaves
the resource_calendar for the employee is not yet changed so when
getting the work_intervals we are calculating it using the old hours_per_day.

Also since we are still writing to the contract and it is not yet
in running state so we won't be able to use _get_calendars_validity_within_period


### Fix:
We add the number of days and duration display to the compute queue
so it will be recomputed after we already change the employee's resource_calendar

opw-5010995