### PR TITLE
[FIX] website_sale: fix products kanban layout

### DIFF
--- a/addons/website_sale/static/src/scss/website_sale_backend.scss
+++ b/addons/website_sale/static/src/scss/website_sale_backend.scss
@@ -39,6 +39,20 @@
     }
 }
 
+.o_kanban_view.o_wsale_products_kanban .o_kanban_record {
+    flex-wrap: wrap;
+
+    main {
+        flex-basis: 50%;
+        height: auto;
+    }
+
+    footer {
+        width: 100%;
+        justify-content: flex-start !important;
+    }
+}
+
 .o_website_sale_image_modal {
     .o_website_sale_image_modal_container {
         border-left: 1px solid map-get($grays, '400');

--- a/addons/website_sale/views/website_pages_views.xml
+++ b/addons/website_sale/views/website_pages_views.xml
@@ -47,6 +47,7 @@
         <field name="arch" type="xml">
             <kanban position="attributes">
                 <attribute name="js_class">website_pages_kanban</attribute>
+                <attribute name="class" add="o_wsale_products_kanban" separator=" "/>
                 <attribute name="type">object</attribute>
                 <attribute name="action">open_website_url</attribute>
             </kanban>


### PR DESCRIPTION
This PR fixes an issue about the products kanban view being too condensed due to a toggle rendered next to the `<main>` tag. This was especially impacting the mobile due to the screen size and the width of the content.

| 19.0 | This PR |
|--------|--------|
| <img width="357" height="383" alt="image" src="https://github.com/user-attachments/assets/d377a99a-b192-468a-8d74-7841cecd469e" /> | <img width="358" height="409" alt="image" src="https://github.com/user-attachments/assets/db1490bc-a84d-4f8c-a401-8b92f74f49e9" /> | 

With this PR, we tweak the flex layout to ensure a good visual result across breakpoints, mainly by rendering the toggle below the other elements of the record.

task-5090547

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
