### PR TITLE
[FIX] portal: allow editing partner address when country is not set, even if VAT is not editable

### DIFF
--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -186,7 +186,7 @@ class CustomerPortal(Controller):
         })
 
         if post and request.httprequest.method == 'POST':
-            if not partner.can_edit_vat():
+            if not partner.can_edit_vat() and partner.country_id:
                 post['country_id'] = str(partner.country_id.id)
 
             error, error_message = self.details_form_validate(post)

--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -488,7 +488,7 @@
         </div>
         <div t-attf-class="mb-3 #{error.get('country_id') and 'o_has_error' or ''} col-xl-6">
             <label class="col-form-label" for="country_id">Country</label>
-            <select name="country_id" t-attf-class="form-select #{error.get('country_id') and 'is-invalid' or ''}" t-att-disabled="None if partner_can_edit_vat else '1'">
+            <select name="country_id" t-attf-class="form-select #{error.get('country_id') and 'is-invalid' or ''}" t-att-disabled="None if (not partner.country_id or partner_can_edit_vat) else '1'">
                 <option value="">Country...</option>
                 <t t-foreach="countries or []" t-as="country">
                     <option t-att-value="country.id" t-att-selected="country.id == int(country_id) if country_id else country.id == partner.country_id.id">


### PR DESCRIPTION
After paying an invoice, a customer without a billing country cannot update
the country in their billing address because the form is disabled by the VAT
edition rule.

**Steps to reproduce:**
1. Create a customer without a billing country.
2. Generate an invoice for that customer.
3. Pay the invoice (possible with some payment providers).
4. Go to the customer portal and try to update the billing address.
The country field is disabled if VAT is not editable, preventing the customer
  from setting their country.

This fix ensures that if the partner has no country set, the field remains
editable even when the VAT field is locked.

NOTE: Some payment providers indeed do not allow paying an invoice or a sale
order without a country being set, but when this situation occurs the portal
must still allow the customer to complete their billing address afterwards.

**NOTE: This fix is applied starting from Odoo 17, but the issue mainly affects
later versions in the `website_sale` module, where the country field is blocked
in the checkout form.**

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr