### PR TITLE
[FIX] website_sale_comparison: barcode

### DIFF
--- a/addons/mrp/data/mrp_demo.xml
+++ b/addons/mrp/data/mrp_demo.xml
@@ -95,6 +95,7 @@
             <field name="default_code">FURN_9666</field>
             <field name="tracking">serial</field>
             <field name="image_1920" type="base64" file="mrp/static/img/table.png"/>
+            <field name="barcode">10133785575283</field>
         </record>
         <record id="stock_warehouse_orderpoint_table" model="stock.warehouse.orderpoint">
             <field name="product_max_qty">0.0</field>
@@ -119,6 +120,7 @@
             <field name="tracking">serial</field>
             <field name="image_1920" type="base64" file="mrp/static/img/table_top.png"/>
             <field name="route_ids" eval="[Command.link(ref('mrp.route_warehouse0_manufacture'))]"/>
+            <field name="barcode">10133785575282</field>
         </record>
         <record id="product_product_computer_desk_leg" model="product.product">
             <field name="name">Table Leg</field>
@@ -132,6 +134,7 @@
             <field name="default_code">FURN_2333</field>
             <field name="tracking">lot</field>
             <field name="image_1920" type="base64" file="mrp/static/img/table_leg.png"/>
+            <field name="barcode">10133785575281</field>
         </record>
         <record id="product_supplierinfo_1" model="product.supplierinfo">
             <field name="product_tmpl_id" ref="product_product_computer_desk_leg_product_template"/>
@@ -160,6 +163,7 @@
             <field name="description">Stainless steel screw full (dia - 5mm, Length - 10mm)</field>
             <field name="default_code">CONS_89957</field>
             <field name="image_1920" type="base64" file="mrp/static/img/product_product_computer_desk_bolt.png"/>
+            <field name="barcode">20133785543124</field>
         </record>
         <record id="product_product_computer_desk_screw" model="product.product">
             <field name="name">Screw</field>

--- a/addons/pos_restaurant/data/scenarios/bar_demo_data.xml
+++ b/addons/pos_restaurant/data/scenarios/bar_demo_data.xml
@@ -66,6 +66,7 @@
 			<field name="available_in_pos" eval="True"/>
 			<field name="categ_id" ref="product_category_drinks"/>
 			<field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_cocktails')])]" />
+			<field name="barcode">30164785566333</field>
 		</record>
 		<record model="product.product" id="product_old_fashioned">
 			<field name="name">Old Fashioned</field>

--- a/addons/product/data/product_demo.xml
+++ b/addons/product/data/product_demo.xml
@@ -72,6 +72,7 @@
             <field name="uom_id" ref="uom.product_uom_unit"/>
             <field name="default_code">FURN_8888</field>
             <field name="image_1920" type="base64" file="product/static/img/product_lamp.png"/>
+            <field name="barcode">40164785534112</field>
         </record>
 
         <record id="product_order_01" model="product.product">
@@ -153,6 +154,10 @@
                 'record': obj().env.ref('product.product_4_attribute_1_product_template_attribute_line').product_template_value_ids[1],
                 'noupdate': True,
             }, {
+                'xml_id': 'product.product_4_attribute_1_value_3',
+                'record': obj().env.ref('product.product_4_attribute_1_product_template_attribute_line').product_template_value_ids[2],
+                'noupdate': True,
+            }, {
                 'xml_id': 'product.product_4_attribute_2_value_1',
                 'record': obj().env.ref('product.product_4_attribute_2_product_template_attribute_line').product_template_value_ids[0],
                 'noupdate': True,
@@ -175,6 +180,14 @@
             }, {
                 'xml_id': 'product.product_product_4c',
                 'record': obj().env.ref('product.product_product_4_product_template')._get_variant_for_combination(obj().env.ref('product.product_4_attribute_1_value_2') + obj().env.ref('product.product_4_attribute_2_value_1')),
+                'noupdate': True,
+            }, {
+                'xml_id': 'product.product_product_4e',
+                'record': obj().env.ref('product.product_product_4_product_template')._get_variant_for_combination(obj().env.ref('product.product_4_attribute_1_value_3') + obj().env.ref('product.product_4_attribute_2_value_1')),
+                'noupdate': True,
+            }, {
+                'xml_id': 'product.product_product_4f',
+                'record': obj().env.ref('product.product_product_4_product_template')._get_variant_for_combination(obj().env.ref('product.product_4_attribute_1_value_3') + obj().env.ref('product.product_4_attribute_2_value_2')),
                 'noupdate': True,
             },]"/>
         </function>
@@ -539,6 +552,7 @@
             <field name="uom_id" ref="uom.product_uom_unit"/>
             <field name="default_code">FURN_9001</field>
             <field name="image_1920" type="base64" file="product/static/img/product_product_20-image.png"/>
+            <field name="barcode">40164785512001</field>
         </record>
         <record id="product_product_22" model="product.product">
             <field name="name">Desk Stand with Screen</field>
@@ -590,6 +604,11 @@
         <function model="ir.model.data" name="_update_xmlids">
             <value model="base" eval="[
                 {
+                    'xml_id': 'product.acoustic_ptav_white',
+                    'record': obj().env.ref('product.product_template_acoustic_bloc_screens').attribute_line_ids[0].product_template_value_ids[0],
+                    'noupdate': True,
+                },
+                {
                     'xml_id': 'product.acoustic_ptav_black',
                     'record': obj().env.ref('product.product_template_acoustic_bloc_screens').attribute_line_ids[0].product_template_value_ids[1],
                     'noupdate': True,
@@ -598,6 +617,11 @@
         </function>
         <function model="ir.model.data" name="_update_xmlids">
             <value model="base" eval="[
+                {
+                    'xml_id': 'product.product_product_acoustic_bloc_screens_white',
+                    'record': obj().env.ref('product.product_template_acoustic_bloc_screens')._get_variant_for_combination(obj().env.ref('product.acoustic_ptav_white')),
+                    'noupdate': True,
+                },
                 {
                     'xml_id': 'product.product_product_acoustic_bloc_screens_black',
                     'record': obj().env.ref('product.product_template_acoustic_bloc_screens')._get_variant_for_combination(obj().env.ref('product.acoustic_ptav_black')),

--- a/addons/sale/data/product_demo.xml
+++ b/addons/sale/data/product_demo.xml
@@ -125,36 +125,12 @@
         <field name="expense_policy">cost</field>
     </record>
 
-    <!--
-    Handle automatically created product.template.attribute.value.
-    Check "product.product_4_attribute_1_value_2" for more information about this
-    -->
-    <function model="ir.model.data" name="_update_xmlids">
-        <value model="base" eval="[{
-            'xml_id': 'sale.product_4_attribute_1_value_3',
-            'record': obj().env.ref('product.product_4_attribute_1_product_template_attribute_line').product_template_value_ids[2],
-            'noupdate': True,
-        }]"/>
-    </function>
-
-    <function model="ir.model.data" name="_update_xmlids">
-        <value model="base" eval="[{
-            'xml_id': 'sale.product_product_4e',
-            'record': obj().env.ref('product.product_product_4_product_template')._get_variant_for_combination(obj().env.ref('sale.product_4_attribute_1_value_3') + obj().env.ref('product.product_4_attribute_2_value_1')),
-            'noupdate': True,
-        }, {
-            'xml_id': 'sale.product_product_4f',
-            'record': obj().env.ref('product.product_product_4_product_template')._get_variant_for_combination(obj().env.ref('sale.product_4_attribute_1_value_3') + obj().env.ref('product.product_4_attribute_2_value_2')),
-            'noupdate': True,
-        },]"/>
-    </function>
-
-    <record id="product_product_4e" model="product.product">
+    <record id="product.product_product_4e" model="product.product">
         <field name="default_code">DESK0005</field>
         <field name="weight">0.01</field>
     </record>
 
-    <record id="product_product_4f" model="product.product">
+    <record id="product.product_product_4f" model="product.product">
         <field name="default_code">DESK0006</field>
         <field name="weight">0.01</field>
     </record>

--- a/addons/sale_stock/data/sale_order_demo.xml
+++ b/addons/sale_stock/data/sale_order_demo.xml
@@ -145,16 +145,16 @@
 
 
         <!-- Inventory for new Customizable Desks -->
-        <record id="sale.product_product_4f" model="product.product">
+        <record id="product.product_product_4f" model="product.product">
             <field name="is_storable" eval="True"/>
         </record>
         <record id="stock_inventory_7e" model="stock.quant">
-            <field name="product_id" ref="sale.product_product_4e"/>
+            <field name="product_id" ref="product.product_product_4e"/>
             <field name="inventory_quantity">65.0</field>
             <field name="location_id" model="stock.location" eval="obj().env.ref('stock.warehouse0').lot_stock_id.id"/>
         </record>
         <record id="stock_inventory_7f" model="stock.quant">
-            <field name="product_id" ref="sale.product_product_4f"/>
+            <field name="product_id" ref="product.product_product_4f"/>
             <field name="inventory_quantity">70.0</field>
             <field name="location_id" model="stock.location" eval="obj().env.ref('stock.warehouse0').lot_stock_id.id"/>
         </record>

--- a/addons/stock/data/stock_demo.xml
+++ b/addons/stock/data/stock_demo.xml
@@ -39,6 +39,10 @@
             <field name="packaging_length">562</field>
         </record>
 
+        <record id="picking_type_out" model="stock.picking.type">
+            <field name="use_create_lots">True</field>
+        </record>
+
         <!-- Resource: stock.quant, i.e. initial inventory -->
 
         <record id="stock_inventory_1" model="stock.quant">

--- a/addons/website_sale_comparison/data/website_sale_comparison_demo.xml
+++ b/addons/website_sale_comparison/data/website_sale_comparison_demo.xml
@@ -56,6 +56,10 @@
         <field name="category_id" ref="product_attribute_category_dimensions"/>
     </record>
 
+    <function model="product.product" name="write">
+        <value model="product.product" search="[('product_tmpl_id', '=', ref('product.product_product_6_product_template'))]"/>
+        <value eval="{'barcode': ''}"/>
+    </function>
     <record id="product_6_length_template_attribute_line" model="product.template.attribute.line">
         <field name="product_tmpl_id" ref="product.product_product_6_product_template"/>
         <field name="attribute_id" ref="product.pa_height"/>
@@ -67,5 +71,12 @@
                 ref('product.pav_height_100'),
         ])]"/>
     </record>
+    <function model="product.product" name="write">
+        <value model="product.product" search="[
+        ('product_tmpl_id', '=', ref('product.product_product_6_product_template')),
+        ('product_template_attribute_value_ids.product_attribute_value_id', '=', ref('product.pav_height_45'))
+        ]"/>
+        <value eval="{'barcode': '6016478556509'}"/>
+    </function>
 
 </odoo>


### PR DESCRIPTION
Since variants are created for 'Large cabinet', we need to move the barcode to one of those variants.

task 5089956

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
