### PR TITLE
[FIX] sale_pdf_quote_builder: KeyError when generating PDF for incomplete sales orders

### DIFF
--- a/addons/sale_pdf_quote_builder/models/ir_actions_report.py
+++ b/addons/sale_pdf_quote_builder/models/ir_actions_report.py
@@ -21,6 +21,8 @@ class IrActionsReport(models.Model):
         orders = self.env['sale.order'].browse(res_ids)
 
         for order in orders:
+            if order.id not in result or 'stream' not in result[order.id]:
+                continue
             initial_stream = result[order.id]['stream']
             if initial_stream:
                 quotation_documents = order.quotation_document_ids


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR addresses a KeyError that occurs when attempting to generate a PDF quotation for multiple sales orders at once in Odoo. The issue arises when one or more selected orders do not have a valid PDF stream (e.g., due to missing data like order lines or incorrect templates). The error occurs because the system tries to access result[order.id]['stream'] for a sales order that doesn't have the stream generated, causing the server to fail.

Current behavior before PR:
Before this PR, when attempting to print the quotation for multiple sales orders, the system will throw a KeyError if any of the selected orders do not have a valid PDF stream generated. This can happen if a sales order is missing data (such as products or a client) or has an incomplete quotation template. The error prevents users from generating quotations for a group of sales orders, even if only one order is missing the necessary data.

Desired behavior after PR is merged:
After merging this PR, the system will check if the PDF stream exists before attempting to access it. If a sales order does not have a valid stream (due to missing data or other issues), it will be skipped without causing a server error. This allows users to print multiple quotations at once without the system failing due to one incomplete order. The feature will improve robustness when handling orders with missing or incomplete data and prevent unexpected crashes.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
