### PR TITLE
[FIX] portal: allow editing partner country when not set

### DIFF
--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -436,7 +436,7 @@ class CustomerPortal(Controller):
             ),
             'address_type': address_type,
             'can_edit_vat': can_edit_vat,
-            'can_edit_country': not partner_sudo or partner_sudo._can_edit_country() or not partner_sudo.country_id,
+            'can_edit_country': not partner_sudo.country_id or partner_sudo._can_edit_country(),
             'callback': callback,
             'country': country_sudo,
             'countries': request.env['res.country'].sudo().search([]),

--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -436,7 +436,7 @@ class CustomerPortal(Controller):
             ),
             'address_type': address_type,
             'can_edit_vat': can_edit_vat,
-            'can_edit_country': not partner_sudo or partner_sudo._can_edit_country(),
+            'can_edit_country': not partner_sudo or partner_sudo._can_edit_country() or not partner_sudo.country_id,
             'callback': callback,
             'country': country_sudo,
             'countries': request.env['res.country'].sudo().search([]),


### PR DESCRIPTION
After paying an invoice or sale order, a customer without a billing country cannot update
the country in their billing address because the form is disabled by the
portal's country edition rule.

**Steps to reproduce:**
1. Create a customer without a billing country.
2. Generate an invoice or sale order for that customer.
3. Pay the invoice/order (possible with some payment providers).
4. Go to the customer portal and try to update the billing address.
The country field is disabled, preventing the customer from setting their country.

This fix ensures that if the partner has no country set, the field remains
editable even when normal country edition restrictions apply. 

This issue also affects the `website_sale` module, specifically the checkout
process, where the country field may be blocked if not handled properly.
