### PR TITLE
[FIX] html_editor, website: issues when pasting tables

### DIFF
--- a/addons/html_editor/static/src/core/clipboard_plugin.js
+++ b/addons/html_editor/static/src/core/clipboard_plugin.js
@@ -1,7 +1,7 @@
-import { isTextNode, isParagraphRelatedElement } from "../utils/dom_info";
+import { isTextNode, isParagraphRelatedElement, isEmptyBlock } from "../utils/dom_info";
 import { Plugin } from "../plugin";
 import { closestBlock } from "../utils/blocks";
-import { unwrapContents, wrapInlinesInBlocks, splitTextNode } from "../utils/dom";
+import { unwrapContents, wrapInlinesInBlocks, splitTextNode, fillEmpty } from "../utils/dom";
 import { childNodes, closestElement } from "../utils/dom_traversal";
 import { parseHTML } from "../utils/html";
 import {
@@ -459,6 +459,13 @@ export class ClipboardPlugin extends Plugin {
                 node = this.dependencies.dom.setTagName(node, "TD");
             }
             if (node.nodeName === "TD") {
+                // Insert base container into empty TD.
+                if (isEmptyBlock(node)) {
+                    const baseContainer = this.dependencies.baseContainer.createBaseContainer();
+                    fillEmpty(baseContainer);
+                    node.replaceChildren(baseContainer);
+                }
+
                 if (node.hasAttribute("bgcolor") && !node.style["background-color"]) {
                     node.style["background-color"] = node.getAttribute("bgcolor");
                 }

--- a/addons/html_editor/static/src/core/clipboard_plugin.js
+++ b/addons/html_editor/static/src/core/clipboard_plugin.js
@@ -536,7 +536,7 @@ export class ClipboardPlugin extends Plugin {
      * @returns {boolean}
      */
     isWhitelisted(item) {
-        if (item instanceof Attr) {
+        if (item.nodeType === Node.ATTRIBUTE_NODE) {
             return CLIPBOARD_WHITELISTS.attributes.includes(item.name);
         } else if (typeof item === "string") {
             return CLIPBOARD_WHITELISTS.classes.some((okClass) =>

--- a/addons/html_editor/static/tests/paste.test.js
+++ b/addons/html_editor/static/tests/paste.test.js
@@ -72,6 +72,38 @@ describe("Html Paste cleaning - whitelist", () => {
         });
     });
 
+    test("should insert a base container inside empty <td> on paste", async () => {
+        await testEditor({
+            contentBefore: `
+                <p>[]<br></p>
+            `,
+            stepFunction: async (editor) => {
+                pasteHtml(
+                    editor,
+                    unformat(`
+                        <table>
+                            <tbody>
+                                <tr>
+                                    <td></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    `)
+                );
+            },
+            contentAfter: unformat(`
+                <table class="table table-bordered">
+                    <tbody>
+                        <tr>
+                            <td><p><br></p></td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p>[]<br></p>
+            `),
+        });
+    });
+
     test("should not keep span", async () => {
         await testEditor({
             contentBefore: "<p>123[]</p>",

--- a/addons/website/static/tests/builder/editor.test.js
+++ b/addons/website/static/tests/builder/editor.test.js
@@ -1,4 +1,4 @@
-import { insertText } from "@html_editor/../tests/_helpers/user_actions";
+import { insertText, pasteHtml } from "@html_editor/../tests/_helpers/user_actions";
 import { expect, test, describe } from "@odoo/hoot";
 import { animationFrame } from "@odoo/hoot-mock";
 import { contains, patchWithCleanup } from "@web/../tests/web_test_helpers";
@@ -133,6 +133,19 @@ test("should preserve iframe in the toolbar's font size input", async () => {
     iframeEl = queryOne(".o-we-toolbar [name='font_size_selector'] iframe");
     newInputEl = iframeEl.contentWindow.document?.querySelector("input");
     expect(newInputEl).toBe(inputEl); // The input shouldn't have been changed.
+});
+
+test("should apply default table classes on paste", async () => {
+    const { getEditor } = await setupWebsiteBuilder(`<p><br></p>`);
+    const editor = getEditor();
+    const p = editor.document.querySelector("p");
+    editor.shared.selection.focusEditable();
+    editor.shared.selection.setSelection({
+        anchorNode: p,
+        anchorOffset: 0,
+    });
+    pasteHtml(editor, `<table><tr><td>1234</td></tr></table>`);
+    expect(editor.document.querySelector("table")).toHaveClass("table table-bordered");
 });
 
 describe("toolbar dropdowns", () => {


### PR DESCRIPTION
### Steps to Reproduce:

- Go to the website.
- Copy a table from Google Docs.
- Paste the table into the editor.
- Observe that the table is not visible because some required classes are missing.
- Notice that there is no base container inside the empty `<td>` elements.

### Description of the issue/feature this PR addresses:

- When content is pasted from other source (e.g., Google Docs inside iframe), attribute nodes coming from another JavaScript context do not match the `Attr` prototype of the current context.

### Desired behavior after PR is merged:

- Use `item.nodeType === Node.ATTRIBUTE_NODE` instead of `instanceof Attr` to detect attribute nodes.
- Insert a base container into empty `<td>` elements when pasting tables from external sources.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
