### PR TITLE
[FIX] l10n_account_withholding_tax: prevent error when no repartition_line_ids

### DIFF
--- a/addons/l10n_account_withholding_tax/__init__.py
+++ b/addons/l10n_account_withholding_tax/__init__.py
@@ -20,7 +20,7 @@ def _l10n_account_wth_post_init(env):
 def _make_demo_tax(chart_template, chart_template_data):
     # We take the accounts from the first purchase tax we find in the template data.
     tax_data = chart_template_data.get('account.tax')
-    purchase_taxes = [tax for tax in tax_data if tax_data[tax]['type_tax_use'] == 'purchase']
+    purchase_taxes = [tax for tax in tax_data if tax_data[tax]['type_tax_use'] == 'purchase' and tax_data[tax].get('repartition_line_ids')]
     if not purchase_taxes:
         return
 


### PR DESCRIPTION
Traceback when no `repartition_line_ids` found in tax data.

Steps to reproduce:-
- Install `l10n_in` module with demo data.
- Install `l10n_account_withholding_tax` module.

Error:-
```
File /data/build/odoo/addons/l10n_account_withholding_tax/__init__.py, line 27, in _make_demo_tax
tax_repartition_lines = [line[2] for line in tax_data[purchase_taxes[0]]['repartition_line_ids'] if line[2]['repartition_type'] == 'tax']

KeyError: 'repartition_line_ids'
```

Root Cause: At [1], No `repartition_line_ids` found in
`tax_data[purchase_taxes[0]]`.

Solution: Select only purchase taxes having `repartition_line_ids`.

[1]: https://github.com/odoo/odoo/blob/9805d09dff64de835de0c764da8c6e213d6b88aa/addons/l10n_account_withholding_tax/__init__.py#L27