### PR TITLE
[FIX] project: Don't use sequence as key

### DIFF
--- a/addons/project/static/src/components/project_right_side_panel/project_right_side_panel.xml
+++ b/addons/project/static/src/components/project_right_side_panel/project_right_side_panel.xml
@@ -14,7 +14,7 @@
                         class="oe_button_box o-form-buttonbox d-print-none d-grid"
                         t-attf-style="grid-template-columns: repeat({{ state.gridTemplateColumns }}, 1fr);"
                     >
-                        <t t-foreach="state.data.buttons" t-as="button" t-key="button.sequence">
+                        <t t-foreach="state.data.buttons" t-as="button" t-key="button_index">
                             <ViewButton
                                 t-if="button.show"
                                 defaultRank="'oe_stat_button'"


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

If a sequence in function _get_stat_buttons in project.project is repeated, the view view fail because we are using the sequence as key

Current behavior before PR:

If we repeat a sequence in two independent modules, the view fails.

Desired behavior after PR is merged:

The view works as expected

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
