### PR TITLE
[FIX] website: autofetch options in many2x field

### DIFF
--- a/addons/website/static/tests/builder/custom_tab/builder_components/basic_many2many.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/basic_many2many.test.js
@@ -25,11 +25,17 @@ defineModels([Test]);
 
 test.tags("focus required");
 test("basic many2many: find tag, select tag, unselect tag", async () => {
-    onRpc("test", "name_search", () => [
-        [1, "First"],
-        [2, "Second"],
-        [3, "Third"],
-    ]);
+    let executeCount = 0;
+    onRpc("test", "name_search", ({ kwargs }) => {
+        expect.step("name_search");
+        executeCount++;
+        if (executeCount === 1) {
+            expect(kwargs.domain).toEqual([]);
+        }
+        if (executeCount === 2) {
+            expect(kwargs.domain).toEqual([["id", "not in", [1]]]);
+        }
+    });
     const selection = reactive([]);
     class TestComponent extends BaseOptionComponent {
         static selector = ".test-options-target";
@@ -76,4 +82,68 @@ test("basic many2many: find tag, select tag, unselect tag", async () => {
     expect(selection).toEqual([{ id: 2, name: "Second", display_name: "Second" }]);
     expect("table tr").toHaveCount(1);
     expect("table input").toHaveValue("Second");
+    expect.verifySteps(["name_search", "name_search"]);
+});
+
+test("basic many2many: toggle dropdown without changing search term or selection does not trigger a new search", async () => {
+    let executeCount = 0;
+    onRpc("test", "name_search", ({ kwargs }) => {
+        expect.step("name_search");
+        executeCount++;
+        if (executeCount === 1) {
+            expect(kwargs.domain).toEqual([]);
+        }
+    });
+    const selection = reactive([]);
+    class TestComponent extends BaseOptionComponent {
+        static selector = ".test-options-target";
+        static template = xml`<BasicMany2Many selection="this.selection" model="'test'" setSelection="this.setSelection.bind(this)" limit="1"/>`;
+        selection = selection;
+        setSelection(newSelection) {
+            selection.length = 0;
+            for (const item of newSelection) {
+                selection.push(item);
+            }
+        }
+    }
+    addBuilderOption(TestComponent);
+    await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
+
+    await contains(":iframe .test-options-target").click();
+    expect(".options-container").toBeDisplayed();
+    expect("table tr").toHaveCount(0);
+    expect(selection).toEqual([]);
+
+    // Click to open, 1st search should be done
+    await contains(".btn.o-dropdown").click();
+    await delay(300); // debounce
+    await animationFrame();
+    expect(selection).toEqual([]);
+    expect(executeCount).toBe(1);
+    await contains(".btn.o-dropdown").click();
+
+    // Toogle dropdown, no new search should be done
+    await contains(".btn.o-dropdown").click();
+    await delay(300); // debounce
+    await animationFrame();
+    expect(selection).toEqual([]);
+    // Still same as no item is selected
+    expect(executeCount).toBe(1);
+    await contains(".btn.o-dropdown").click();
+    await contains(".btn.o-dropdown").click();
+    await delay(300); // debounce
+    await animationFrame();
+    expect(selection).toEqual([]);
+    expect("span.o-dropdown-item").toHaveCount(1);
+    await contains("span.o-dropdown-item").click();
+    expect("table tr").toHaveCount(1);
+
+    // Open again, now a second search should be done because selection changed
+    await contains(".btn.o-dropdown").click();
+    await delay(300); // debounce
+    await animationFrame();
+    expect("span.o-dropdown-item").toHaveCount(1);
+    expect(selection).toEqual([{ id: 1, name: "First", display_name: "First" }]);
+    expect(executeCount).toBe(2);
+    expect.verifySteps(["name_search", "name_search"]);
 });

--- a/addons/website/static/tests/builder/custom_tab/builder_components/builder_many2many.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/builder_many2many.test.js
@@ -25,11 +25,17 @@ defineWebsiteModels();
 defineModels([Test]);
 
 test("many2many: find tag, select tag, unselect tag", async () => {
-    onRpc("test", "name_search", () => [
-        [1, "First"],
-        [2, "Second"],
-        [3, "Third"],
-    ]);
+    let executeCount = 0;
+    onRpc("test", "name_search", ({ kwargs }) => {
+        expect.step("name_search");
+        executeCount++;
+        if (executeCount === 1) {
+            expect(kwargs.domain).toEqual([]);
+        }
+        if (executeCount === 2) {
+            expect(kwargs.domain).toEqual([["id", "not in", [1]]]);
+        }
+    });
     addBuilderOption(
         class extends BaseOptionComponent {
             static selector = ".test-options-target";
@@ -70,6 +76,7 @@ test("many2many: find tag, select tag, unselect tag", async () => {
     expect("table tr").toHaveCount(2);
 
     await contains("button.fa-minus").click();
+    expect.verifySteps(["name_search", "name_search"]);
     expect(editableContent).toHaveInnerHTML(
         `<div class="test-options-target o-paragraph" data-test="[{&quot;id&quot;:2,&quot;display_name&quot;:&quot;Second&quot;,&quot;name&quot;:&quot;Second&quot;}]">b</div>`
     );

--- a/addons/website/static/tests/builder/custom_tab/builder_components/model_many2many.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/model_many2many.test.js
@@ -37,11 +37,17 @@ defineWebsiteModels();
 defineModels([Test, TestBase]);
 
 test("model many2many: find tag, select tag, unselect tag", async () => {
-    onRpc("test", "name_search", () => [
-        [1, "First"],
-        [2, "Second"],
-        [3, "Third"],
-    ]);
+    let executeCount = 0;
+    onRpc("test", "name_search", ({ kwargs }) => {
+        expect.step("name_search");
+        executeCount++;
+        if (executeCount === 1) {
+            expect(kwargs.domain).toEqual([]);
+        }
+        if (executeCount === 2) {
+            expect(kwargs.domain).toEqual([["id", "not in", [1]]]);
+        }
+    });
     addBuilderOption(
         class extends BaseOptionComponent {
             static selector = ".test-options-target";
@@ -92,4 +98,5 @@ test("model many2many: find tag, select tag, unselect tag", async () => {
     await contains(":iframe .test-options-target").click();
     expect("table tr").toHaveCount(1);
     expect("table input").toHaveValue("Second");
+    expect.verifySteps(["name_search", "name_search"]);
 });


### PR DESCRIPTION
With the initial [website builder refactor], only 4 options appeared in
the `many2x` dropdown when user try to re-select.

This commit fixes the issue so the dropdown now fetches all required
options through passing domain in rpc call instead of filtering after
rpc call this makes sure we only fetch required data by avoiding
already selected ids.

Steps to Reproduce:
1. Open the website builder.
2. Drop any snippet onto the page.
3. Set the visibility option to conditionally.
4. In the UTM medium dropdown, select any social media option.
5. Try changing the selection again.
6. Only 4 options are shown.

Expected: Dropdown should always display 5 options.

[website builder refactor]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2