### PR TITLE
[FIX] website: use youtube-play icon in social links

### DIFF
--- a/addons/website/views/snippets/s_mega_menu_odoo_menu.xml
+++ b/addons/website/views/snippets/s_mega_menu_odoo_menu.xml
@@ -75,7 +75,7 @@
                             <i class="fa fa-2x fa-github m-1 o_editable_media"/>
                         </a>
                         <a href="/website/social/youtube" class="s_social_media_youtube me-3 ms-3" target="_blank" aria-label="YouTube">
-                            <i class="fa fa-2x fa-youtube m-1 o_editable_media"/>
+                            <i class="fa fa-2x fa-youtube-play m-1 o_editable_media"/>
                         </a>
                         <a href="/website/social/instagram" class="s_social_media_instagram me-3 ms-3" target="_blank" aria-label="Instagram">
                             <i class="fa fa-2x fa-instagram m-1 o_editable_media"/>

--- a/addons/website/views/snippets/s_social_media.xml
+++ b/addons/website/views/snippets/s_social_media.xml
@@ -18,7 +18,7 @@ title stay editable after a save (see SOCIAL_MEDIA_TITLE_CONTENTEDITABLE).
             <i class="fa fa-linkedin rounded shadow-sm o_editable_media small_social_icon"/>
         </a>
         <a href="/website/social/youtube" class="s_social_media_youtube" target="_blank" aria-label="YouTube">
-            <i class="fa fa-youtube rounded shadow-sm o_editable_media small_social_icon"/>
+            <i class="fa fa-youtube-play rounded shadow-sm o_editable_media small_social_icon"/>
         </a>
         <a href="/website/social/instagram" class="s_social_media_instagram" target="_blank" aria-label="Instagram">
             <i class="fa fa-instagram rounded shadow-sm o_editable_media small_social_icon"/>


### PR DESCRIPTION
Replaced `fa-youtube` with `fa-youtube-play` in both mega menu and social media snippet templates.

This ensures consistent display of the YouTube icon across the website and aligns with the intended design.