### PR TITLE
[FIX] crm: set date_open only if opp has user during duplication

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -926,9 +926,9 @@ class Lead(models.Model):
         context = dict(self._context)
         context.setdefault('default_type', self.type)
         context.setdefault('default_team_id', self.team_id.id)
-        # Set date_open to today if it is an opp
+        # Set date_open to today if it is an opp and has an active user
         default = default or {}
-        default['date_open'] = self.env.cr.now() if self.type == 'opportunity' else False
+        default['date_open'] = self.env.cr.now() if self.type == 'opportunity' and self.user_id.active else False
         # Do not assign to an archived user
         if not self.user_id.active:
             default['user_id'] = False

--- a/addons/crm/tests/test_crm_lead_assignment.py
+++ b/addons/crm/tests/test_crm_lead_assignment.py
@@ -493,6 +493,26 @@ class TestLeadAssign(TestLeadAssignCommon):
         self.assertEqual(leads[5].team_id, self.sales_team_convert, 'Assigned lead should not be reassigned')
         self.assertEqual(leads[5].user_id, self.user_sales_manager, 'Assigned lead should not be reassigned')
 
+    def test_assign_team_and_salesperson_on_duplicate_lead(self):
+        """Ensure leads duplicated from an existing lead are assigned correctly."""
+        duplicate_lead = self.env['crm.lead'].create({
+            'name': 'Test Lead',
+            'type': 'opportunity',
+            'probability': 15,
+            'partner_id': self.contact_1.id,
+            'team_id': False,
+            'user_id': False,
+        }).copy()
+        self.assertFalse(duplicate_lead.date_open)
+
+        sales_team = self.sales_team_1
+        sales_team.assignment_domain = [('user_id', '=', False)]
+        with self.with_user('user_sales_manager'):
+            sales_team._action_assign_leads(work_days=2)
+
+        self.assertEqual(duplicate_lead.team_id, sales_team)
+        self.assertTrue(duplicate_lead.user_id)
+
     @mute_logger('odoo.models.unlink')
     def test_merge_assign_keep_master_team(self):
         """ Check existing opportunity keep its team and salesman when merged with a new lead """


### PR DESCRIPTION
Currently, leads are not automatically assigned via rule-based assignment 
when duplicating an existing lead, even if the duplicated lead matches 
the assignment criteria.

**Pre-requisites:**
1) Set up rule-based lead assignment in the CRM settings. 
2) Configure the sales team's assignment domain:
   `[("user_id", "=", False)]`
3) Configure the sales team members' domain:
   `[("probability", ">=", 10)]`

**Steps to Reproduce:**

1) Create a lead that matches the above assignment rules. 
2) Remove the salesperson (user_id) and sales team from the lead. 
3) Duplicate the lead.
4) Update the probability to a valid value (e.g., ≥ 10). 
5) Manually trigger the `Rule-Based Assignment`.

**Issue:**
The original lead gets assigned, but the duplicated one does not.

**Cause:**
When duplicating, the system sets date_open to the current date by default, 
even if the duplicated and original leads have no assigned users.

https://github.com/odoo/odoo/blob/3e7d85cf25386615dea559d954cebb1424b62f35/addons/crm/models/crm_lead.py#L929-L931

However, `rule-based assignment` only considers leads where `date_open` is False https://github.com/odoo/odoo/blob/3e7d85cf25386615dea559d954cebb1424b62f35/addons/crm/models/crm_team_member.py#L136-L141

**Solution:**
Set `date_open` to False during duplication if the original lead has no `user_id`. 
This ensures the new lead remains eligible for assignment.

opw-5003529
