### PR TITLE
[FIX] html_editor: show replace title banner in popover

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -1155,6 +1155,9 @@ export class LinkPlugin extends Plugin {
                 const textNodeToReplace = selection.anchorNode.splitText(startOffset);
                 textNodeToReplace.splitText(match[0].length);
                 selection.anchorNode.parentElement.replaceChild(link, textNodeToReplace);
+                if (link.getAttribute("href") === link.textContent) {
+                    this.newlyInsertedLinks.add(link);
+                }
                 return nodeForSelectionRestore;
             }
         }


### PR DESCRIPTION
**Current behaviour before PR:**

Steps to reproduce:

- Type a full valid URL e.g. `https://odoo.com`
- Press space to create link.
- Open popover by clicking on link.

There is no banner at the bottom of popover showing "Replace URL with its title?" when a newly link is created. After merging this commit [1], When the link popover is opened for the first time, replace title option should be visible in the popover.

**Desired behaviour after PR:**

Now, replace title banner is shown at the bottom of popover if link is created by transformation.

[1]: https://github.com/odoo/odoo/commit/7da241d6fd3a3fa1e6d617b436d397b5b28320cf

task-5085975





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
