### PR TITLE
[FIX] web_tour: fix tour_list not found

### DIFF
--- a/addons/web_tour/__manifest__.py
+++ b/addons/web_tour/__manifest__.py
@@ -25,6 +25,8 @@ Odoo Web tours.
             'web_tour/static/src/js/tour_recorder/tour_recorder_state.js',
             'web_tour/static/src/tour_utils.js',
             'web_tour/static/src/js/onboarding_item.xml',
+            'web_tour/static/src/views/**/*',
+            'web_tour/static/src/widgets/**/*',
         ],
         'web.assets_frontend': [
             'web_tour/static/src/scss/**/*',
@@ -47,8 +49,6 @@ Odoo Web tours.
         'web_tour.interactive': [
             ('include', 'web_tour.common'),
             'web_tour/static/src/js/tour_interactive/**/*',
-            'web_tour/static/src/views/**/*',
-            'web_tour/static/src/widgets/**/*',
         ],
         'web_tour.automatic': [
             ('include', 'web_tour.common'),


### PR DESCRIPTION
Before this commit, if you don't have a running tour and try to access to the tours list view, you got a traceback.

Now, the traceback is fixed. The error was due to the new lazy load of the tours. The files that concerned the list view of the tours was in an asset that was loaded only when an interactive tour was running.

Lazy load pr: https://github.com/odoo/odoo/pull/224571

TASK-ID: 5089053



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
