### PR TITLE
[FIX] l10n_cl: fix error when submitting invoiced PoS orders

### DIFF
--- a/addons/l10n_cl/views/report_invoice.xml
+++ b/addons/l10n_cl/views/report_invoice.xml
@@ -148,9 +148,9 @@
 
         <xpath expr="//t[@t-set='layout_document_title']" position="replace"/>
 
-        <t t-set="section_subtotal" t-value="line.get_section_subtotal()" position="before">
+        <xpath expr="//t[@t-foreach='lines_to_report']/t" position="before">
             <t t-set="line_amounts" t-value="line._l10n_cl_get_line_amounts()"/>
-        </t>
+        </xpath>
 
         <xpath expr="//span[@t-field='line.price_unit']" position="before">
             <t t-if="'second_currency' in line_amounts" t-set="line_second_currency_round" t-value="line_amounts['second_currency']['round_currency']"/>


### PR DESCRIPTION
**Steps to reproduce:**
 - Install l10n_cl_edi_pos
 - Create a PoS order and enable the invoice option.
 - When clicking on the validate button, the following traceback appears
 - Error :-  `Error while rendering the template`
 - Please see [issue](https://www.loom.com/share/24f02eca5b2344c083bf7e0b990d3979?sid=d20f31e8-2776-4dda-a6bc-819a76eb3275)

**Cause**:
 - In [this commit](https://github.com/odoo/odoo/pull/223686/files#diff-c85e75bc27fc841662ca0598c09a22670e0a0b4e5120815934c0a50999ff02bfL175), we removed the 'current_total' section.
 
**Solution:**
 - Correct the XPath according to the new commit