### PR TITLE
[FIX] project_mrp: fix access error

### DIFF
--- a/addons/project_mrp/__manifest__.py
+++ b/addons/project_mrp/__manifest__.py
@@ -8,6 +8,7 @@
     'category': 'Services/Project',
     'depends': ['mrp', 'project'],
     'data': [
+        'security/ir.model.access.csv',
         'views/mrp_bom_views.xml',
         'views/mrp_production_views.xml',
         'views/project_project_views.xml',

--- a/addons/project_mrp/security/ir.model.access.csv
+++ b/addons/project_mrp/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_mrp_bom_project_user,mrp.bom,mrp.model_mrp_bom,project.group_project_user,1,0,0,0
+access_mrp_bom_line_project_user,mrp.bom.line,mrp.model_mrp_bom_line,project.group_project_user,1,0,0,0


### PR DESCRIPTION
**Steps to reproduce:**
 - Install mrp and industry_fsm_sale.
 - Create a user with only Field Service access (no Sale and no MRP access).
 - Create a task and add a product.

**Issue:**
    A Field Service user encounters an access error when trying  to open a product.

**Cause:**
   The FSM user lacks permission to access the BoM (Bill of Materials), which causes the error.

**Fix:**
  This commit grants bom and bom line access to the project user.

**Technical details:**
   Before saas-18.4, an FSM user with Sale access could see the product stat button on a fsm task. In below commit, even FSM-only users (without Sale access) can view the product button and add products. [commit](https://github.com/odoo/enterprise/pull/82946/files#diff-ee2018939189dc64406b2b49ff5caacbb6ffce63ae2ce1a8a0f2d28865d4bb5cR294)

task-5077522
