### PR TITLE
[FIX] mail: channels name not tracked when edited from settings

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -488,6 +488,9 @@ class DiscussChannel(models.Model):
 
         old_vals = {channel: get_vals(channel) for channel in self}
         result = super().write(vals)
+        if name := vals.get("name") and self.channel_type == "channel":
+            body = Markup('<div data-oe-type="channel_rename" class="o_mail_notification">%s</div>') % name
+            self.message_post(body=body, message_type="notification", subtype_xmlid="mail.mt_comment")
         for channel in self:
             new_subchannel_vals = get_vals(channel)
             for subchannel, values in new_subchannel_vals.items():
@@ -1461,8 +1464,6 @@ class DiscussChannel(models.Model):
     def channel_rename(self, name):
         self.ensure_one()
         self.write({'name': name})
-        body = Markup('<div data-oe-type="channel_rename" class="o_mail_notification">%s</div>') % name
-        self.message_post(body=body, message_type="notification", subtype_xmlid="mail.mt_comment")
 
     def channel_change_description(self, description):
         self.ensure_one()

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -103,8 +103,16 @@ test("should log notification when channel/thread is renamed", async () => {
     });
     onRpc("discuss.channel", "channel_rename", ({ route }) => expect.step(route));
     await start();
+    await openFormView("discuss.channel", channelId, {
+        arch: `<form><field name="name"/></form>`,
+    });
+    await insertText("[name=name] input", "funny", { replace: true });
+    await click(".o_form_button_save");
     await openDiscuss(channelId);
-    await click(".o-mail-DiscussContent-threadName:value(general)");
+    await contains(".o-mail-NotificationMessage", {
+        text: `${serverState.partnerName} changed the channel name to funny`,
+    });
+    await click(".o-mail-DiscussContent-threadName:value(funny)");
     await insertText(".o-mail-DiscussContent-threadName:enabled", "special", { replace: true });
     triggerHotkey("Enter");
     await expect.waitForSteps(["/web/dataset/call_kw/discuss.channel/channel_rename"]);

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
@@ -532,14 +532,6 @@ export class DiscussChannel extends models.ServerModel {
 
         const [channel] = this.browse(ids);
         this.write([channel.id], { name });
-        this.message_post(
-            channel.id,
-            makeKwArgs({
-                body: `<div data-oe-type="channel_rename" class="o_mail_notification">${name}</div>`,
-                message_type: "notification",
-                subtype_xmlid: "mail.mt_comment",
-            })
-        );
     }
 
     /**
@@ -930,6 +922,16 @@ export class DiscussChannel extends models.ServerModel {
             channels.map((channel) => [channel.id, this._channel_basic_info(channel.id)])
         );
         for (const channel of channels) {
+            if ("name" in values) {
+                this.message_post(
+                    channel.id,
+                    makeKwArgs({
+                        body: `<div data-oe-type="channel_rename" class="o_mail_notification">${values.name}</div>`,
+                        message_type: "notification",
+                        subtype_xmlid: "mail.mt_comment",
+                    })
+                );
+            }
             if ("image_128" in values) {
                 super.write(channel.id, {
                     avatar_cache_key: DateTime.utc().toFormat("yyyyMMddHHmmss"),


### PR DESCRIPTION
**Current behavior before PR:**

Channels name not tracked when edited from the advanced settings.

**Desired behavior after PR is merged:**

Channel name changes made from the settings form view are now tracked. this is because saving from the form view calls the `self.write` method directly, which previously did not log name changes this update ensures it does.

task-5076580

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
