### PR TITLE
[FIX] website_sale: fix displaying salesperson in SO if already set

### DIFF
--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -340,6 +340,7 @@ class Website(models.Model):
 
             'team_id': self.salesteam_id.id,
             'website_id': self.id,
+            'user_id': self.salesperson_id.id,
         }
 
     def _get_and_cache_current_pricelist(self):

--- a/addons/website_sale/static/tests/tours/website_sale_buy.js
+++ b/addons/website_sale/static/tests/tours/website_sale_buy.js
@@ -16,3 +16,16 @@ registry.category("web_tour.tours").add('shop_buy_product', {
         ...tourUtils.payWithTransfer({ redirect: true }),
     ]
 });
+
+registry.category("web_tour.tours").add('add_product_to_cart', {
+    url: '/shop',
+    steps: () => [
+        ...tourUtils.searchProduct("Storage Box", { select: true }),
+        {
+            content: "click on add to cart",
+            trigger: '#product_detail form #add_to_cart',
+            run: "click",
+        },
+        tourUtils.goToCart(),
+    ]
+});

--- a/addons/website_sale/tests/test_website_sale_mail.py
+++ b/addons/website_sale/tests/test_website_sale_mail.py
@@ -50,8 +50,11 @@ class TestWebsiteSaleMail(HttpCase):
                                                      ('body_html', 'ilike', 'https://my-test-domain.com')],
                                                     order='create_date DESC', limit=None)
             self.assertTrue(new_mail)
-            self.assertIn('Your', new_mail.body_html)
-            self.assertIn('order', new_mail.body_html)
+            # Check the sale order confirmation mail for the customer
+            self.assertIn('Your', new_mail[0].body_html)
+            self.assertIn('order', new_mail[0].body_html)
+            # Check the sale order assignment mail for the salesperson
+            self.assertIn('assigned', new_mail[1].body_html)
 
 
 @tagged('post_install', '-at_install', 'mail_thread')


### PR DESCRIPTION
**Steps to Reproduce:**
- Add a default salesperson in Website Setting
- Go to Shop > Add a product to cart > Go to cart
- Check the quotation created
- Go to Other Info tab and check the salesperson(user_id) value

**Issue:**
The salesperson is not assigned automatically, even if it is set in Settings.

**Fix:**
While preparing the SO values, the field wasn't set which resulted into this bug.

**Affected Version:** 18.2~master
**opw**-5071123