### PR TITLE
[IMP] account_reports: add possibility to join currency table on query

### DIFF
--- a/addons/account/report/account_invoice_report.py
+++ b/addons/account/report/account_invoice_report.py
@@ -142,7 +142,7 @@ class AccountInvoiceReport(models.Model):
                 LEFT JOIN uom_uom uom_template ON uom_template.id = template.uom_id
                 INNER JOIN account_move move ON move.id = line.move_id
                 LEFT JOIN res_partner commercial_partner ON commercial_partner.id = move.commercial_partner_id
-                JOIN %(currency_table)s ON account_currency_table.company_id = line.company_id
+                JOIN %(currency_table)s AS account_currency_table ON account_currency_table.company_id = line.company_id
             ''',
             currency_table=self.env['res.currency']._get_simple_currency_table(self.env.companies),
         )

--- a/addons/pos_sale/report/sale_report.py
+++ b/addons/pos_sale/report/sale_report.py
@@ -122,7 +122,7 @@ class SaleReport(models.Model):
             LEFT JOIN pos_session session ON session.id = pos.session_id
             LEFT JOIN pos_config config ON config.id = session.config_id
             LEFT JOIN stock_picking_type picking ON picking.id = config.picking_type_id
-            JOIN {currency_table} ON account_currency_table.company_id = pos.company_id
+            JOIN {currency_table} AS account_currency_table ON account_currency_table.company_id = pos.company_id
             """.format(
             currency_table=self.env.cr.mogrify(currency_table).decode(self.env.cr.connection.encoding),
             )

--- a/addons/purchase/report/purchase_report.py
+++ b/addons/purchase/report/purchase_report.py
@@ -107,7 +107,7 @@ class PurchaseReport(models.Model):
                 left join res_company C ON C.id = po.company_id
                 left join uom_uom line_uom on (line_uom.id=l.product_uom_id)
                 left join uom_uom product_uom on (product_uom.id=t.uom_id)
-                left join %(currency_table)s ON account_currency_table.company_id = po.company_id
+                left join %(currency_table)s AS account_currency_table ON account_currency_table.company_id = po.company_id
             """,
             currency_table=self.env['res.currency']._get_simple_currency_table(self.env.companies),
         )

--- a/addons/sale/report/sale_report.py
+++ b/addons/sale/report/sale_report.py
@@ -188,7 +188,7 @@ class SaleReport(models.Model):
             LEFT JOIN product_template t ON p.product_tmpl_id=t.id
             LEFT JOIN uom_uom u ON u.id=l.product_uom_id
             LEFT JOIN uom_uom u2 ON u2.id=t.uom_id
-            JOIN {currency_table} ON account_currency_table.company_id = s.company_id
+            JOIN {currency_table} AS account_currency_table ON account_currency_table.company_id = s.company_id
             """
 
     def _where_sale(self):


### PR DESCRIPTION
This is a syntaxic change.

The first change is to allow the currency table to be joined on a
`Query` object.  This was not possible because
`_currency_table_aml_join` returned raw sql.
This is a syntax improvement, as it then allows to fully exploit
the `Query` class methods, notably `select`, which generates the SQL
directly from the object.  Without having to write
`SQL("SELECT %s FROM %s WHERE %s GROUP BY %s", ...)`.
In order to do this change, `_get_monocurrency_currency_table_sql` had
to be modified, as the sql returned by this method could not be
understood by the `Query` object.  Not possible to join a table that is
created on the fly.  That is because it expects an alias to be an
identifier, and not something of the form
`account_currency_table(company_id, ...)`.

Because of this change, it is possible to do a second syntax
improvement, which is to directly join the currency table on the `Query`
object created in `_get_report_query`.  This is done by setting the new
kwarg `join_currency_table` to `True`.

Enterprise PR: https://github.com/odoo/enterprise/pull/94886