### PR TITLE
[FIX] mrp: prevent MO creation via MTO when BoM type is non-normal

### DIFF
--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -72,7 +72,7 @@ class StockRule(models.Model):
 
     def _filter_warehouse_routes(self, product, warehouses, route):
         if any(rule.action == 'manufacture' for rule in route.rule_ids):
-            if product.bom_ids:
+            if any(bom.type == 'normal' for bom in product.bom_ids):
                 return super()._filter_warehouse_routes(product, warehouses, route)
             return False
         return super()._filter_warehouse_routes(product, warehouses, route)


### PR DESCRIPTION
Issue before this commit:
=========================
When a product has a non-normal BoM type (e.g. subcontracting or kit) and the MTO route is enabled, and creating a Sale Order generates a blank MO.

Steps to Reproduce:
=========================
- Install the mrp module.
- Create a product with a BoM of type Subcontracting (or Kit).
- Enable the MTO route on that product.
- Create a Sale Order for the product. → A blank MO is created, which should not happen.

Cause of the issue:
=========================
In this [PR](https://github.com/odoo/odoo/pull/223685), MRP route are now defined at the warehouse level, so by default, the MRP route becomes applicable to every product, and is excluded only under specific conditions.

For the MRP route, we only checked whether the product had a BoM [here](https://github.com/odoo/odoo/pull/223685/files#diff-6d86bc8c3e9aa22586656b702849c5bbbb00c9b97ffd08bc0842e0e68f8948f9R75) without considering the BoM type when filtering the mrp route. This led to the creation of an MO for a subcontracting BoM.

With This Commit:
=========================
- We ensure that the MRP route is filtering based on the BoM type, not only on the existence of a BoM.
- This prevents the creation of an MO when the BoM type is non-normal (e.g. subcontracting or kit).
