### PR TITLE
[FIX] website_sale: fix the tour add_to_cart_snippet_tour

### DIFF
--- a/addons/website_sale/static/tests/tours/website_sale_add_to_cart_snippet_tour.js
+++ b/addons/website_sale/static/tests/tours/website_sale_add_to_cart_snippet_tour.js
@@ -43,12 +43,12 @@ registerWebsitePreviewTour('add_to_cart_snippet_tour', {
         ...changeOptionInPopover("Add to Cart Button", "Product", "Product Yes Variant 1", true),
         ...clickOnSave(),
         clickOnElement("add to cart button", ":iframe .s_add_to_cart_btn"),
-        clickOnElement("continue shopping", ":iframe .modal button:contains(Continue Shopping)"),
+        clickOnElement("add to cart", ":iframe .modal button:contains(Add to Cart)"),
         checkQuanityInCart("2"),
 
         // Product with 2 variants with a variant selected
         ...editAddToCartSnippet(),
-        ...changeOptionInPopover("Add to Cart Button", "Product", "Product Yes Variant 2", true),
+        ...changeOptionInPopover("Add to Cart Button", "Product", "Product Yes Variant 2"),
         {
             content: "Check if variant option is visible",
             trigger: "[data-container-title='Add to Cart Button'] [data-label='Variant']"
@@ -73,12 +73,16 @@ registerWebsitePreviewTour('add_to_cart_snippet_tour', {
             content: "Check if the pink variant is selected",
             trigger: ":iframe .modal li:contains(Pink) input:checked",
         },
-        clickOnElement('continue shopping', ':iframe .modal button:contains(Continue Shopping)',),
+        clickOnElement('add to cart', ':iframe .modal button:contains(Add to Cart)'),
         checkQuanityInCart("3"),
 
         // Basic product with no variants and action=buy now
         ...editAddToCartSnippet(),
-        ...changeOptionInPopover("Add to Cart Button", "Product", "Product No Variant", true),
+        ...changeOptionInPopover("Add to Cart Button", "Product", "Product No Variant"),
+        {
+            content: "Check if action option is visible",
+            trigger: "[data-container-title='Add to Cart Button'] [data-label='Action']"
+        },
         ...changeOptionInPopover("Add to Cart Button", "Action", "Buy Now", false),
         // At this point the "Add to cart" button was changed to a "Buy Now" button
         ...clickOnSave(),


### PR DESCRIPTION
The add_to_cart_snippet_tour was unstable due to race conditions. some steps executed before their target elements were actually present, causing failures in subsequent steps.

This commit ensures the tour runs reliably by adding explicit wait conditions between the affected steps, so the elements are guaranteed to exist before moving on.

In addition, the tour is updated to reflect the recent change where the button label was renamed from "Continue Shopping" to "Add to Cart" [1].

[1] https://github.com/odoo/odoo/commit/786c6c00701bcc30c1f2aa04d7fd9ee7bd4c511b#diff-5ac64dbfc12558f048e995a7d75f91d915161063741ddf36281062b273598a51

runbot-231474
