### PR TITLE
[FIX] account: remove warning when selecting trusted bank account

### DIFF
--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -393,7 +393,7 @@ class AccountPaymentRegister(models.TransientModel):
 
             wizard.batches = batch_vals
 
-    @api.depends('payment_method_line_id', 'line_ids', 'group_payment')
+    @api.depends('payment_method_line_id', 'line_ids', 'group_payment', 'partner_bank_id')
     def _compute_trust_values(self):
         for wizard in self:
             total_payment_count = 0
@@ -405,7 +405,8 @@ class AccountPaymentRegister(models.TransientModel):
             for batch in wizard.batches:
                 payment_count = 1 if wizard.group_payment else len(batch['lines'])
                 total_payment_count += payment_count
-                batch_account = wizard._get_batch_account(batch)
+                # Use the currently selected partner_bank_id if in edit mode, otherwise use batch account
+                batch_account = wizard.partner_bank_id or wizard._get_batch_account(batch)
                 if wizard.require_partner_bank_account:
                     if not batch_account:
                         missing_account_partners += batch['lines'].partner_id


### PR DESCRIPTION
**Steps to reproduce:**
1. Install the modules: `accounting` and `account_iso20022`.
2. Configure a bank journal with SEPA credit transfer in *Outgoing payment methods*.
3. Create a partner with two bank accounts: one trusted, one untrusted.
4. Create a vendor bill for this partner.
5. Register a payment using the SEPA credit transfer method.
6. Manually select the trusted bank account from the dropdown.

**Observed behavior:**
* A warning banner is shown when the trusted account is selected.

**Root cause:**
* `_compute_trust_values` only validated the bank account from the batch (original invoice data) and ignored the `partner_bank_id` if the user changed it manually in the wizard.

**Solution:**
* Update `_compute_trust_values` to also validate the currently selected `partner_bank_id`, ensuring the trust check reflects the user’s actual selection.
* added testcase for the same in account_iso20022 [#95124](https://github.com/odoo/enterprise/pull/95124)

opw-5059740
