### PR TITLE
[FIX] web: no crash when monetary field is column invisible

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -191,6 +191,7 @@ export class ListRenderer extends Component {
             this.debugOpenView = exprToBoolean(browser.localStorage.getItem(this.keyDebugOpenView));
             this.columns = this.getActiveColumns();
             this.withHandleColumn = this.columns.some((col) => col.widget === "handle");
+            this.aggregates = this.computeAggregates();
         });
         this.multiCurrencyPopover = usePopover(MultiCurrencyPopover, {
             position: "right",
@@ -675,7 +676,7 @@ export class ListRenderer extends Component {
         }
     }
 
-    get aggregates() {
+    computeAggregates() {
         let values;
         if (this.props.list.selection.length) {
             values = this.props.list.selection.map((r) => r.data);

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -685,7 +685,7 @@ export class ListRenderer extends Component {
             values = this.props.list.records.map((r) => r.data);
         }
         const aggregates = {};
-        for (const column of this.allColumns) {
+        for (const column of this.columns) {
             if (column.type !== "field") {
                 continue;
             }

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -4718,6 +4718,32 @@ test(`monetary aggregates in grouped list (!= currencies in same group, delete)`
     expect(`.o_group_header:last`).toHaveText("Yes (0)\n 0.00");
 });
 
+test(`list with monetary field with attribute column_invisible="1"`, async () => {
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `
+            <list>
+                <field name="foo"/>
+                <field name="qux" widget="monetary" sum="Sum" column_invisible="1"/>
+                <field name="currency_id"/>
+            </list>
+        `,
+    });
+
+    expect(`.o_data_row`).toHaveCount(4);
+    expect(queryAllTexts(`.o_data_cell`)).toEqual([
+        "yop",
+        "EUR",
+        "blip",
+        "USD",
+        "gnap",
+        "USD",
+        "blip",
+        "USD",
+    ]);
+});
+
 test(`handle false values in aggregates`, async () => {
     Foo._fields.false_amount = fields.Monetary({ currency_field: "currency_test" });
     Foo._fields.currency_test = fields.Many2one({ relation: "res.currency", default: 1 });


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
