### PR TITLE
[REF] mail,im_livechat: make correspondent avatarUrl the default

### DIFF
--- a/addons/im_livechat/static/src/core/public_web/thread_model_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/thread_model_patch.js
@@ -60,13 +60,6 @@ patch(Thread.prototype, {
         return this.correspondent.name;
     },
 
-    get avatarUrl() {
-        if (this.channel_type === "livechat" && this.correspondent) {
-            return this.correspondent.avatarUrl;
-        }
-        return super.avatarUrl;
-    },
-
     get inChathubOnNewMessage() {
         return this.channel_type === "livechat" || super.inChathubOnNewMessage;
     },

--- a/addons/mail/static/src/discuss/core/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_model_patch.js
@@ -231,7 +231,7 @@ const threadPatch = {
                 unique: this.avatar_cache_key,
             });
         }
-        if (this.channel_type === "chat" && this.correspondent) {
+        if (this.correspondent) {
             return this.correspondent.avatarUrl;
         }
         return super.avatarUrl;


### PR DESCRIPTION
Most of the override of avatarUrl inside thread_model is to use the avatar of the correspondent.
This PR makes it the default value and removes most of the overrides.

PR enterprise: https://github.com/odoo/enterprise/pull/94895