### PR TITLE
[FIX] mrp: prevent reusing a component with the same SN in multiple MOs

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -2631,10 +2631,10 @@ class MrpProduction(models.Model):
         consumed_sn_ids = []
         sn_error_msg = {}
         for move in self.move_raw_ids:
-            if move.has_tracking != 'serial' or not move.picked:
+            if move.has_tracking != 'serial':
                 continue
             for move_line in move.move_line_ids:
-                if not move_line.picked or float_is_zero(move_line.quantity, precision_rounding=move_line.product_uom_id.rounding) or\
+                if float_is_zero(move_line.quantity, precision_rounding=move_line.product_uom_id.rounding) or\
                         not move_line.lot_id:
                     continue
                 sml_sn = move_line.lot_id


### PR DESCRIPTION
**Issue**
A Manufacturing Order in *in progress* state can reuse a component
with a serial number that was already consumed in another MO.

**Steps to reproduce**
- Create two products A and B, both tracked by serial number.
- Create a BoM for product A: 1 A requires 1 B.
- Manufacture two units of product B with SNs 001 and 002.
- Manufacture one unit of product A using product B with SN 001.
- Create a new MO for product A:
   - Start the MO to set it *in progress*.
   - Assign product B with SN 001 again.
- Click on *Produce All* and observe that no error is raised.

**Cause**
The method `_check_sn_uniqueness` ignores raw moves that are not yet
picked ([see code](https://github.com/odoo/odoo/blob/73af26879b353cc17b2bed6ae5f0823a67f668ab/addons/mrp/models/mrp_production.py#L2634)).
In this flow, the component is still unpicked when the uniqueness check runs, so the error is never triggered. The move will only be marked as picked later in `_set_qty_producing` ([here](https://github.com/odoo-dev/odoo/blob/c96ae2ffd6c8064f783e57ac157defd351e4acfb/addons/mrp/models/mrp_production.py#L1301)), triggered by [`_set_quantities`](https://github.com/odoo-dev/odoo/blob/c96ae2ffd6c8064f783e57ac157defd351e4acfb/addons/mrp/models/mrp_production.py#L2198).

**Solution**
Remove the restriction on picked moves when checking for SN uniqueness. This makes the behavior consistent and avoids relying on the timing of the `picked` flag.

The first alternative considered was to always set `picked = True` before `_check_sn_uniqueness`, but that introduces complications since some logic still depends on the `picked` flag
([here](https://github.com/odoo-dev/odoo/blob/c96ae2ffd6c8064f783e57ac157defd351e4acfb/addons/mrp/models/mrp_production.py#L2189)). Moreover `_check_sn_uniqueness` is only called from
`_button_mark_done_sanity_checks`, which in turn is only used in `pre_button_mark_done` where `_set_quantities` is called. So, if the approach is to always set `picked = True` before calling `_check_sn_uniqueness` to avoid ignoring the move, then it is clearer and more efficient to simply remove the `picked` condition altogether.