### PR TITLE
[IMP] website_profile,website_sale,*: remove href=#

### DIFF
--- a/addons/website_profile/views/website_profile.xml
+++ b/addons/website_profile/views/website_profile.xml
@@ -45,7 +45,7 @@
                             </div>
 
                             <div class="btn-group flex-grow-1">
-                                <a class="btn bg-black-25 text-white dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Nav</a>
+                                <button class="btn bg-black-25 text-white dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Nav</button>
 
                                 <ul class="dropdown-menu">
                                     <a class="dropdown-item" t-att-href="home_url or '/'">Home</a>
@@ -55,7 +55,7 @@
                             </div>
 
                             <div class="btn-group">
-                                <a class="btn bg-black-25 text-white dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-search"></i></a>
+                                <button class="btn bg-black-25 text-white dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-search"></i></button>
                                 <div class="dropdown-menu dropdown-menu-end w-100">
                                     <form class="px-3" t-attf-action="/profile/users" role="search" method="get">
                                         <div class="input-group">
@@ -198,10 +198,10 @@
                             </div>
                             <div t-if="user.partner_id.website_description" class="mb32">
                                 <t t-if="request.env.user == user and user.karma != 0 or request.env.user._is_admin()">
-                                    <a href="#" class="o_wprofile_editor btn btn-link float-end"
+                                    <button class="o_wprofile_editor btn btn-link float-end"
                                         t-att-data-user-id="user.id" data-focus-website-description="true">
                                         <i class="fa fa-pencil me-1"/>Edit
-                                    </a>
+                                    </button>
                                 </t>
                                 <h5 class="border-bottom pb-1">Biography</h5>
                                 <span class="o_forum_profile_bio text-break" t-field="user.partner_id.website_description"/>
@@ -572,13 +572,13 @@
         <div t-elif="not validation_email_sent and not is_public_user and user.karma == 0" t-att-class="send_alert_classes" role="alert">
             <button type="button" class="btn-close validation_email_close" data-bs-dismiss="alert" aria-label="Close"/>
             Your Account has not yet been verified.<br/>
-            Click <a class="send_validation_email alert-link" href="#" t-att-data-redirect_url="redirect_url"><u>here</u></a> to receive a verification email<t t-out="additional_validation_email_message"/>!
+            Click <button class="send_validation_email alert-link border-0 bg-transparent p-0" t-att-data-redirect_url="redirect_url"><u>here</u></button> to receive a verification email<t t-out="additional_validation_email_message"/>!
         </div>
         <div t-elif="validation_email_sent and not validation_email_done" t-att-class="done_alert_classes">
             <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
             Verification Email sent to <t t-out="user.email"/>!<br/>
             Did not receive it? <a class="alert-link" t-att-href="my_account_redirect"><u>Correct your email address</u></a> 
-            or <a class="send_validation_email alert-link" href="#" t-att-data-redirect_url="redirect_url"><u>Send Again</u></a>.
+            or <button class="send_validation_email alert-link border-0 bg-transparent p-0" t-att-data-redirect_url="redirect_url"><u>Send Again</u></button>.
         </div>
         <div t-if="validation_email_done" t-att-class="done_alert_classes" role="status">
             <button type="button" class="btn-close validated_email_close" data-bs-dismiss="alert" aria-label="Close"/>

--- a/addons/website_sale/static/src/interactions/cart_line.js
+++ b/addons/website_sale/static/src/interactions/cart_line.js
@@ -11,7 +11,7 @@ export class CartLine extends Interaction {
         '.css_quantity > input.js_quantity': {
             't-on-change.withTarget': this.locked(this.debounced(this.changeQuantity, 500)),
         },
-        '.css_quantity > a': {
+        '.css_quantity > button': {
             't-on-click.prevent.withTarget': this.locked(this.incOrDecQuantity),
         },
         '.js_delete_product': { 't-on-click.prevent': this.locked(this.deleteProduct) },

--- a/addons/website_sale/static/src/interactions/product_page.js
+++ b/addons/website_sale/static/src/interactions/product_page.js
@@ -16,7 +16,7 @@ export class ProductPage extends Interaction {
     static selector = '.o_wsale_product_page';
     dynamicContent = {
         '.js_product input[name="add_qty"]': { 't-on-change': this.onChangeAddQuantity },
-        'a.js_add_cart_json': { 't-on-click.prevent': this.incOrDecQuantity },
+        'button.js_add_cart_json': { 't-on-click.prevent': this.incOrDecQuantity },
         '.o_wsale_product_page_variants': { 't-on-change': this.onChangeVariant },
         '.o_product_page_reviews_link': { 't-on-click': this.onClickReviewsLink },
         '.css_attribute_color input': { 't-on-change': this.onChangeColorAttribute },

--- a/addons/website_sale/static/src/js/tours/tour_utils.js
+++ b/addons/website_sale/static/src/js/tours/tour_utils.js
@@ -23,7 +23,7 @@ export function goToProductPage({
 export function increaseProductPageQuantity() {
     return {
         content: "Increase product quantity",
-        trigger: '.css_quantity a.js_add_cart_json i.oi-plus',
+        trigger: '.css_quantity button.js_add_cart_json i.oi-plus',
         run: "click",
     }
 }
@@ -385,7 +385,7 @@ export function selectPriceList(pricelist) {
     return [
         {
             content: "Click on pricelist dropdown",
-            trigger: "div.o_pricelist_dropdown a[data-bs-toggle=dropdown]",
+            trigger: "div.o_pricelist_dropdown button[data-bs-toggle=dropdown]",
             run: "click",
         },
         {

--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -2021,7 +2021,7 @@ $-product-radius-map: (
 }
 
 @include media-breakpoint-down(md) {
-    .css_quantity > a {
+    .css_quantity > button {
         --btn-padding-x: 0.6rem;
     }
 }

--- a/addons/website_sale/static/tests/tours/shop_editor_tours.js
+++ b/addons/website_sale/static/tests/tours/shop_editor_tours.js
@@ -13,11 +13,11 @@ registerWebsitePreviewTour(
     () => [
         {
             content: "Click on pricelist dropdown",
-            trigger: ":iframe div.o_pricelist_dropdown a[data-bs-toggle=dropdown]",
+            trigger: ":iframe div.o_pricelist_dropdown button[data-bs-toggle=dropdown]",
             run: "click",
         },
         {
-            trigger: ":iframe div.o_pricelist_dropdown a[data-bs-toggle=dropdown][aria-expanded=true]",
+            trigger: ":iframe div.o_pricelist_dropdown button[data-bs-toggle=dropdown][aria-expanded=true]",
         },
         {
             trigger: ":iframe input[name=search]",
@@ -25,14 +25,14 @@ registerWebsitePreviewTour(
             run: "click",
         },
         {
-            trigger: ":iframe div.o_pricelist_dropdown a[data-bs-toggle=dropdown][aria-expanded=false]",
+            trigger: ":iframe div.o_pricelist_dropdown button[data-bs-toggle=dropdown][aria-expanded=false]",
         },
         {
-            trigger: ":iframe div.o_pricelist_dropdown a[data-bs-toggle=dropdown]",
+            trigger: ":iframe div.o_pricelist_dropdown button[data-bs-toggle=dropdown]",
             content: "Click on the pricelist again.",
             run: "click",
         }, {
-            trigger: ":iframe div.o_pricelist_dropdown a[data-bs-toggle=dropdown][aria-expanded=true]",
+            trigger: ":iframe div.o_pricelist_dropdown button[data-bs-toggle=dropdown][aria-expanded=true]",
             content: "Check pricelist dropdown opened",
         }
     ]

--- a/addons/website_sale/static/tests/tours/update_cart.js
+++ b/addons/website_sale/static/tests/tours/update_cart.js
@@ -43,7 +43,7 @@ registry.category('web_tour.tours').add('website_sale.update_cart', {
         },
         {
             content: "remove Storage Box",
-            trigger: '#cart_products div:has(a[name="o_cart_line_product_link"]>h6:contains("Storage Box")) a:has(i.oi-minus)',
+            trigger: '#cart_products div:has(a[name="o_cart_line_product_link"]>h6:contains("Storage Box")) button:has(i.oi-minus)',
             run: "click",
         },
         {
@@ -51,7 +51,7 @@ registry.category('web_tour.tours').add('website_sale.update_cart', {
         },
         {
             content: "add one more",
-            trigger: '#cart_products div:has(a[name="o_cart_line_product_link"]>h6:contains("Conference Chair")) a:has(i.oi-plus)',
+            trigger: '#cart_products div:has(a[name="o_cart_line_product_link"]>h6:contains("Conference Chair")) button:has(i.oi-plus)',
             run: "click",
         },
         {

--- a/addons/website_sale/templates/checkout/cart_templates.xml
+++ b/addons/website_sale/templates/checkout/cart_templates.xml
@@ -178,14 +178,13 @@
             t-attf-name="{{'website_sale_cart_line_quantity' if not is_mobile else 'website_sale_cart_line_quantity_mobile'}}"
         >
             <t t-if="should_show_quantity_selector and line._is_sellable()">
-                <a
-                    href="#"
+                <button
                     class="btn btn-link d-inline-block border-end-0"
                     aria-label="Remove one"
                     title="Remove one"
                 >
                     <i class="oi oi-minus position-relative z-1"/>
-                </a>
+                </button>
                 <input
                     type="text"
                     class="js_quantity quantity form-control border-0"
@@ -194,24 +193,23 @@
                     t-att-value="line._get_displayed_quantity()"
                 />
                 <t t-if="line._get_shop_warning(clear=False)">
-                    <a href="#" class="btn btn-link">
+                    <button class="btn btn-link">
                         <i
                             class="fa fa-warning text-warning"
                             t-att-title="line._get_shop_warning()"
                             role="img"
                             aria-label="Warning"
                         />
-                    </a>
+                    </button>
                 </t>
-                <a
+                <button
                     t-else=""
-                    href="#"
                     class="btn btn-link d-inline-block border-start-0"
                     aria-label="Add one"
                     title="Add one"
                 >
                     <i class="oi oi-plus position-relative z-1"/>
-                </a>
+                </button>
             </t>
             <t t-else="">
                 <input

--- a/addons/website_sale/templates/product_page_templates.xml
+++ b/addons/website_sale/templates/product_page_templates.xml
@@ -868,15 +868,14 @@
                 t-attf-class="css_quantity input-group {{'d-none' if combination_info['prevent_zero_price_sale'] else 'd-inline-flex order-first'}} align-middle border"
                 contenteditable="false"
             >
-                <a
-                    t-attf-href="#"
+                <button
                     class="btn btn-link pe-2 js_add_cart_json border-0"
                     aria-label="Remove one"
                     title="Remove one"
                     name="remove_one"
                 >
                     <i class="oi oi-minus text-600"/>
-                </a>
+                </button>
                 <input
                     type="text"
                     t-attf-class="form-control quantity text-center border-0"
@@ -884,14 +883,13 @@
                     name="add_qty"
                     t-att-value="1"
                 />
-                <a
-                    t-attf-href="#"
+                <button
                     class="btn btn-link ps-2 js_add_cart_json border-0"
                     aria-label="Add one"
                     title="Add one"
                 >
                     <i class="oi oi-plus text-600"/>
-                </a>
+                </button>
             </div>
         </div>
     </template>

--- a/addons/website_sale/templates/shop_page_templates.xml
+++ b/addons/website_sale/templates/shop_page_templates.xml
@@ -111,16 +111,14 @@
         <t t-set="pricelist" t-value="request.pricelist"/>
         <t t-set="pricelist_label">Pricelist</t>
         <div t-attf-class="o_pricelist_dropdown dropdown #{_classes if hasPricelistDropdown else 'd-none'}">
-            <a
-                role="button"
-                href="#"
+            <button
                 t-attf-class="dropdown-toggle btn px-2"
                 data-bs-toggle="dropdown"
             >
                 <small class="d-none d-md-inline opacity-75"><t t-out="pricelist_label"/>:</small>
                 <span class="d-none d-md-inline" t-out="pricelist and pricelist.name or ' - '" />
                 <span class="d-md-none"><t t-out="pricelist_label"/></span>
-            </a>
+            </button>
             <div class="dropdown-menu" role="menu">
                 <t t-foreach="website_sale_pricelists" t-as="pl">
                     <t t-set="_is_active" t-value="pricelist.id == pl.id"/>
@@ -390,16 +388,14 @@
                                                 <t t-call="website_sale.search" placeholder="placeholder" search="original_search or search"/>
                                             </div>
                                             <!-- Mobile Search button -->
-                                            <a
+                                            <button
                                                 t-attf-class="btn o_not_editable d-inline-block d-sm-none me-auto btn-{{navClass}}"
                                                 data-bs-target="#o_wsale_search_modal"
                                                 data-bs-toggle="modal"
-                                                role="button"
                                                 title="Search Products"
-                                                href="#"
                                             >
                                                 <i class="oi oi-search" role="img"/>
-                                            </a>
+                                            </button>
                                         </t>
                                         <div t-attf-class="{{'d-lg-none' if not hasPricelistDropdown and not is_view_active('website_sale.sort') else ''}} o_wsale_products_header_dropdown_wrap d-flex gap-3">
                                             <t
@@ -632,9 +628,7 @@
                 t-value="isSortingBy and isSortingBy[0][0] or website.shop_default_sort"
             />
             <t t-set="_sort_label">Sort By</t>
-            <a
-                role="button"
-                href="#"
+            <button
                 t-attf-class="dropdown-toggle btn px-2"
                 data-bs-toggle="dropdown"
             >
@@ -646,7 +640,7 @@
                     <span t-else="" t-out="dict(website_sale_sortable)[website.shop_default_sort]"/>
                 </span>
                 <i t-if="_icon_classes" t-attf-class="fa fa-sort {{_icon_classes}}" role="img"/>
-            </a>
+            </button>
             <div class="dropdown-menu dropdown-menu-end" role="menu">
                 <t t-foreach="website_sale_sortable" t-as="sortby">
                     <t t-set="_is_active" t-value="_current_sort == sortby[0]"/>
@@ -1266,16 +1260,14 @@
                     t-attf-class="navbar position-sticky d-flex gap-1 gap-lg-2 flex-shrink-0 bg-body rounded mb-2 px-2 px-lg-3 shadow {{floatBar_hasSearch and 'ps-1 ps-lg-1'}}"
                 >
                     <div t-if="floatBar_hasSearch">
-                        <a
+                        <button
                             t-attf-class="btn o_not_editable {{(wsale_has_filters_btn or floatBar_hasSort or floatBar_hasPricelist) and 'me-n2'}}"
                             data-bs-target="#o_wsale_search_modal"
                             data-bs-toggle="modal"
-                            role="button"
                             title="Search Products"
-                            href="#"
                         >
                             <i class="oi oi-search" role="img"/>
-                        </a>
+                        </button>
                     </div>
                     <span
                         t-if="floatBar_hasSearch and (wsale_has_filters_btn or floatBar_hasSort or floatBar_hasPricelist)"

--- a/addons/website_sale_collect/static/src/js/click_and_collect_availability/click_and_collect_availability.xml
+++ b/addons/website_sale_collect/static/src/js/click_and_collect_availability/click_and_collect_availability.xml
@@ -33,10 +33,10 @@
                     <div t-else="" class="text-muted">
                         <i class="fa fa-fw fa-circle text-danger"/> Not available
                     </div>
-                    <a t-if="this.props.showSelectStoreButton" role="button" href="#">
+                    <button t-if="this.props.showSelectStoreButton">
                         <t t-if="this.state.selectedLocationData.id">Change store</t>
                         <t t-elif="this.state.inStoreStockData.in_stock">Select store</t>
-                    </a>
+                    </button>
                 </div>
             </div>
             <div


### PR DESCRIPTION
*website_sale_collect,website_sale_wishlist

We use `href=#` to activate <a> elements, but the default behavior of clicking this link is prevented. However, this creates an inconsistency for middle-click and Ctrl+Click, as these events are not prevented by default.

This commit removes `href=#` and replaces it with the appropriate element or class to activate the <a> elements correctly.

task-4380519



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
