### PR TITLE
[IMP] account_edi_ubl_cii,account_peppol: Improve logging on XML import

### DIFF
--- a/addons/account_peppol/models/__init__.py
+++ b/addons/account_peppol/models/__init__.py
@@ -1,5 +1,4 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
+from . import account_edi_common
 from . import account_edi_proxy_user
 from . import account_edi_ubl_xml
 from . import account_journal

--- a/addons/account_peppol/models/account_edi_common.py
+++ b/addons/account_peppol/models/account_edi_common.py
@@ -1,0 +1,18 @@
+from odoo import models
+
+
+class AccountEdiCommon(models.AbstractModel):
+    _inherit = 'account.edi.common'
+
+    def _add_logs_import_invoice_ubl_cii(self, invoice, invoice_logs=None):
+        # EXTENDS 'account_edi_ubl_cii'
+        logs = super()._add_logs_import_invoice_ubl_cii(invoice, invoice_logs=invoice_logs)
+        if uuid := invoice.peppol_message_uuid:
+            logs = [self.env._("Peppol document UUID: %s", uuid)] + logs
+        return logs
+
+    def _log_import_invoice_ubl_cii(self, invoice, title_logs=None, invoice_logs=None, attachments=None):
+        # EXTENDS 'account_edi_ubl_cii'
+        if invoice.peppol_message_uuid:
+            title_logs = self.env._("Peppol invoice received")
+        super()._log_import_invoice_ubl_cii(invoice, title_logs=title_logs, invoice_logs=invoice_logs, attachments=attachments)

--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -252,13 +252,6 @@ class Account_Edi_Proxy_ClientUser(models.Model):
             move.is_in_extractable_state = False
 
         move._extend_with_attachments([file_data], new=True)
-        move._message_log(
-            body=_(
-                "Peppol document (UUID: %(uuid)s) has been received successfully",
-                uuid=uuid,
-            ),
-            attachment_ids=attachment.ids,
-        )
         attachment.write({'res_model': 'account.move', 'res_id': move.id})
         return {'uuid': uuid, 'move': move}
 


### PR DESCRIPTION
Previously, the import of an XML was doing many consecutive logs into the chatter in a weird order.
We now have one single log that formats the import in a reliable way. We also display the XML itself into the chatter.

**Before:**
<img width="717" height="597" alt="image" src="https://github.com/user-attachments/assets/f65d75a1-c79e-4597-8134-a82e42a22701" />

**After:**
- Regular XML import
<img width="719" height="266" alt="image" src="https://github.com/user-attachments/assets/5e58a81c-e89e-4a74-95ae-8af0021097fa" />

- Peppol reception
<img width="533" height="264" alt="image" src="https://github.com/user-attachments/assets/0249c061-85e3-4664-a6bd-e7a57c90f581" />


task-none (feedback from AL + DLE)