### PR TITLE
[FIX] sale_stock: change qty from so using personalized route

### DIFF
--- a/addons/sale_stock/tests/test_sale_stock.py
+++ b/addons/sale_stock/tests/test_sale_stock.py
@@ -2415,3 +2415,55 @@ class TestSaleStock(TestSaleStockCommon, ValuationReconciliationTestCommon):
         self.assertRecordValues(moves, [
             {'product_uom_qty': 12, 'product_packaging_qty': 4, 'product_packaging_id': pack3.id},
         ])
+
+    def test_create_route_update_so_quantity(self):
+        """
+        Check that moves created from user-created push rules does not interfere with updating the
+        quantity of pickings when the quanityt of the SO is updated
+        """
+        warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
+        warehouse.delivery_steps = 'pick_pack_ship'
+        stock_location = warehouse.lot_stock_id
+        pack_location, out_location, _ = warehouse.delivery_route_id.rule_ids.picking_type_id.default_location_dest_id
+
+        self.product_a.is_storable = True
+        self.env['stock.quant']._update_available_quantity(self.product_a, stock_location, 5)
+        loc_perso = self.env['stock.location'].create({
+                'name': 'Locperso',
+                'location_id': stock_location.id,
+        })
+        warehouse.delivery_route_id.rule_ids = [
+            Command.create({
+                'name': 'Push stock->Locperso',
+                'action': 'push',
+                'location_src_id': loc_perso.id,
+                'location_dest_id': out_location.id,
+                'picking_type_id': warehouse.int_type_id.id,
+                'propagate_cancel': False,
+                'procure_method': 'make_to_stock',
+            }),
+        ]
+        so = self.env['sale.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [Command.create({
+                'name': self.product_a.name,
+                'product_id': self.product_a.id,
+                'product_uom_qty': 1,
+                'product_uom': self.product_a.uom_id.id,
+                'price_unit': self.product_a.list_price,
+            })],
+        })
+        so.action_confirm()
+        picking_1 = so.picking_ids
+        self.assertRecordValues(picking_1, [
+            {'location_id': stock_location.id, 'location_dest_id': pack_location.id},
+        ])
+        picking_1.location_dest_id = loc_perso
+        picking_1.button_validate()
+        so.order_line.product_uom_qty = 2
+
+        self.assertRecordValues(so.picking_ids.move_ids.sorted("id"), [
+            {'location_id': stock_location.id, 'location_dest_id': loc_perso.id, 'quantity': 1},
+            {'location_id': loc_perso.id, 'location_dest_id': out_location.id, 'quantity': 1},
+            {'location_id': stock_location.id, 'location_dest_id': pack_location.id, 'quantity': 1},
+        ])

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -272,7 +272,7 @@ class StockRule(models.Model):
             'picking_id': False,
             'picking_type_id': self.picking_type_id.id,
             'propagate_cancel': self.propagate_cancel,
-            'warehouse_id': self.warehouse_id.id,
+            'warehouse_id': self.warehouse_id.id or move_to_copy.location_dest_id.warehouse_id.id,
             'procure_method': 'make_to_order',
             'description_picking': move_to_copy.product_id.with_context(lang=move_to_copy._get_lang())._get_description(
                 self.picking_type_id) or move_to_copy.description_picking,


### PR DESCRIPTION
**Steps to reproduce:**
- enable multi-step routes setting.
- navigate to warehouse management/locations create a new location
(the "test location").
- select "internal location" for the location type.
- select WH for the parent location
- navigate to warehouse management/warehouses and select the warehouse
corresponding to WH.
- set the warehouse in 3 steps delivery.
- click on the routes smart button.
- click on the "deliver in 3 steps (pick+pack+ship)" route.
- add a rule, for the action select "push to", for the operation type 
select "internal transfers", for the source location select the "test 
location" you just created and for destination location select "WH/Output".
- save.
- create a storable product and set an on-hand quantity
- create a new sale order for 1 quantity of this product and confirm it
- click on the picking smart button, change the destination location to the
test location and validate
- open the sale order and change the quantity to 3


**Current behavior:**
A new picking is created from stock to packing zone (which is the 
expected behavior) but the quantity is 1 

**Expected behavior:**
The quantity should be 2.
If we only increase the quantity by 1 on the sale order it does not even 
create the new picking

**Cause of the issue:**
The warehouse_id field is invisible in stock.rule form view when the 
action is push. Therefore, the rule is created without a warehouse_id.
Also, moves created from a rule have the same warehouse_id as the rule. 
https://github.com/odoo/odoo/blob/a729578afb7fed79aac2d622aae4da4c0917f8e5/addons/stock/models/stock_rule.py#L275
So, when we validated our first move (from stock to the test location), 
this created a second move (from test location to output) that does not 
have a warehouse id (because it was created from our own push rule that
we created).
When we update the quantity of the sale ordre line, 
_action_launch_stock_rule calls _get_quantity_procurement to compute 
the current quantity on the moves.
This method then calls _get_outgoing_incoming_moves to get the initial 
move created from the rule. In this case this should return only the 
first move created.
But because the second move does not have a warehouse_id, it's rule.id
is added to triggering_rule_ids.
https://github.com/odoo/odoo/blob/a729578afb7fed79aac2d622aae4da4c0917f8e5/addons/sale_stock/models/sale_order_line.py#L315-L317
And the move is later added to the outgoing moves that will be returned.
https://github.com/odoo/odoo/blob/a729578afb7fed79aac2d622aae4da4c0917f8e5/addons/sale_stock/models/sale_order_line.py#L322-L329

So the two moves are returned and the sum of the quantities of the moves
is 2 instead of 1.
https://github.com/odoo/odoo/blob/a729578afb7fed79aac2d622aae4da4c0917f8e5/addons/sale_stock/models/sale_order_line.py#L292-L294
So the product quantity for the procurement will be 1 (3-2) 
instead of 2 (3-1).
https://github.com/odoo/odoo/blob/a729578afb7fed79aac2d622aae4da4c0917f8e5/addons/sale_stock/models/sale_order_line.py#L386

opw-5039249