### PR TITLE
[FIX] stock: fix alignment in delivery slip report

### DIFF
--- a/addons/stock/report/report_deliveryslip.xml
+++ b/addons/stock/report/report_deliveryslip.xml
@@ -75,14 +75,14 @@
                                         <span t-field="move.description_picking">Description on transfer</span>
                                     </p>
                                 </td>
-                                <td>
+                                <td class="align-top">
                                     <span t-field="move.product_uom_qty">3.00</span>
                                     <span t-field="move.product_uom" groups="uom.group_uom">units</span>
                                     <span t-if="move.product_packaging_id">
                                         (<span t-field="move.product_packaging_qty" t-options='{"widget": "integer"}'/> <span t-field="move.product_packaging_id"/>)
                                     </span>
                                 </td>
-                                <td>
+                                <td class="align-top">
                                     <span t-field="move.quantity">3.00</span>
                                     <span t-field="move.product_uom" groups="uom.group_uom">units</span>
                                     <span t-if="move.product_packaging_id">


### PR DESCRIPTION
**Steps to reproduce:**

1.Install Stock and l10n_din5008 modules.
2.Change the document layout to DIN 5008.
3.Create a Delivery/Picking with two stock moves:
-  First product without `Description for Delivery Orders`
-  Second product with `Description for Delivery Orders`

4.Download/Print the Delivery Slip.
5.Observe the quantity alignment in the report.

**Issue:**

- The Ordered and Delivered quantity columns are misaligned in the Delivery Slip report.

**Solution:**
- Add a CSS class to properly align the quantity columns in the Delivery Slip.
---
**After Fix**

<img width="735" height="290" alt="image" src="https://github.com/user-attachments/assets/69a941ff-a3a6-4e9a-993f-ad26af714b18" />

**Before Fix**

<img width="757" height="274" alt="image" src="https://github.com/user-attachments/assets/7a4d0f78-112b-47ad-9037-da97e0399c8f" />

---

**opw- 4904727**

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
