### PR TITLE
[FIX] mass_mailing: update favorite templates

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
@@ -67,7 +67,7 @@ export class MassMailingHtmlField extends HtmlField {
         });
 
         useRecordObserver((record) => {
-            if ("mailing_model_id" in record.data) {
+            if (record.data.mailing_model_id) {
                 this._onModelChange(record);
             }
         });


### PR DESCRIPTION
In mass_mailing, when creating a new mailing, the theme selector allows
users to select base templates for their mailings. Users can also add
their own model-specific templates by marking mailings as "Favorite"s,
which will cause them to show up in model selectors if the template's
target model matches the new mailing's target model.

However, in some circumstances, changing the target model does not cause
the available template mailings to update. This is due to the callback
responsible for updating the templates not reading the model variable
correctly, causing useRecordObserver to not being called every time it
is updated.

This commit fixes this issue, therefore causing favorite templates to
be updated more reliably.

task-5054968