### PR TITLE
[IMP] survey: prevent submission after showing answers

### DIFF
--- a/addons/survey/controllers/main.py
+++ b/addons/survey/controllers/main.py
@@ -527,6 +527,8 @@ class Survey(http.Controller):
 
         if answer_sudo.state == 'done':
             return {}, {'error': 'unauthorized'}
+        if answer_sudo.is_session_answer and not answer_sudo.test_entry and not survey_sudo.session_question_can_answer:
+            return {}, {'error': 'validation', 'fields': {survey_sudo.session_question_id.id: _('We do not accept submissions for this question anymore.')}}
 
         questions, page_or_question_id = survey_sudo._get_survey_questions(answer=answer_sudo,
                                                                            page_id=post.get('page_id'),

--- a/addons/survey/controllers/survey_session_manage.py
+++ b/addons/survey/controllers/survey_session_manage.py
@@ -65,6 +65,13 @@ class UserInputSession(http.Controller):
         # Note that at this stage survey.session_state can be False meaning that the survey has ended (session closed)
         return request.render('survey.user_input_session_manage', self._prepare_manage_session_values(survey))
 
+    @http.route('/survey/session/disable_answers/<string:survey_token>', type='jsonrpc', auth='user', website=True)
+    def survey_session_disable_answers(self, survey_token, **kwargs):
+        """ This route is called when the host shows answers to prevent more submissions. """
+        if (survey := self._fetch_from_token(survey_token)) and survey.session_state == 'in_progress':
+            survey.session_question_can_answer = False
+        return {}
+
     @http.route('/survey/session/next_question/<string:survey_token>', type='jsonrpc', auth='user', website=True)
     def survey_session_next_question(self, survey_token, go_back=False, **kwargs):
         """ This route is called when the host goes to the next question of the session.
@@ -99,6 +106,7 @@ class UserInputSession(http.Controller):
         if next_question:
             now = datetime.datetime.now()
             survey.write({
+                'session_question_can_answer': True,
                 'session_question_id': next_question.id,
                 'session_question_start_time': fields.Datetime.now() + relativedelta(seconds=1)
             })

--- a/addons/survey/models/survey_survey.py
+++ b/addons/survey/models/survey_survey.py
@@ -156,6 +156,7 @@ class SurveySurvey(models.Model):
     # live sessions - current question fields
     session_question_id = fields.Many2one('survey.question', string="Current Question", copy=False,
         help="The current question of the survey session.")
+    session_question_can_answer = fields.Boolean("Can Answer Current Question", default=True, copy=False)
     session_start_time = fields.Datetime("Current Session Start Time", copy=False)
     session_question_start_time = fields.Datetime("Current Question Start Time", copy=False,
         help="The time at which the current question has started, used to handle the timer for attendees.")

--- a/addons/survey/static/src/interactions/survey_session_manage.js
+++ b/addons/survey/static/src/interactions/survey_session_manage.js
@@ -206,13 +206,16 @@ export class SurveySessionManage extends Interaction {
      *
      * @param {Event} ev
      */
-    onNext(ev) {
+    async onNext(ev) {
         const screenToDisplay = this.getNextScreen();
         switch (screenToDisplay) {
             case "userInputs":
                 this.chartUpdateState({ showInputs: true });
                 break;
             case "results":
+                await this.waitFor(
+                    rpc(`/survey/session/disable_answers/${this.surveyAccessToken}`)
+                );
                 this.chartUpdateState({ showAnswers: true });
                 // when showing results, stop refreshing answers
                 clearInterval(this.resultsRefreshInterval);
@@ -476,10 +479,10 @@ export class SurveySessionManage extends Interaction {
      *
      * @param {KeyboardEvent} ev
      */
-    onKeyDown(ev) {
+    async onKeyDown(ev) {
         const hotkey = getActiveHotkey(ev);
         if (hotkey === "arrowright" || hotkey === "space") {
-            this.onNext(ev);
+            await this.onNext(ev);
         } else if (hotkey === "arrowleft") {
             this.onBack(ev);
         }
@@ -587,7 +590,7 @@ export class SurveySessionManage extends Interaction {
         if (this.timerEl && !questionTimeLimitReached && !hasAnswered && timeLimitMinutes) {
             this.addListener(surveyManagerEl, "time_up", async () => {
                 if (this.currentScreen === "question" && this.isScoredQuestion) {
-                    this.onNext();
+                    await this.onNext();
                 }
             });
             this.timerEl.dispatchEvent(

--- a/addons/survey/tests/common.py
+++ b/addons/survey/tests/common.py
@@ -230,6 +230,12 @@ class SurveyCase(common.TransactionCase):
         post_data.update(**additional_post_data)
         return post_data
 
+    def _session_next_question(self, survey):
+        return self.url_open(survey.get_base_url() + f'/survey/session/next_question/{survey.access_token}', json={})
+
+    def _session_disable_answers(self, survey):
+        return self.url_open(survey.get_base_url() + f'/survey/session/disable_answers/{survey.access_token}', json={})
+
     # ------------------------------------------------------------
     # UTILS / TOOLS
     # ------------------------------------------------------------


### PR DESCRIPTION
We prevent user to submit answer after having shown the correct answers.

Example of the problem we fix:
- Create a live survey
- Add a question to get the name and toggle the nickname option
- Add a question with an answer that grants 5 points
- Add a second question with 3 points
- Start a live session
- Register 2 participants: P1 and P2
- At the first question for P1, answer the correct answer for 5 pt and don't answer for P2.
- Go to the leaderboard to displays the score, P1 has 5 pt and P2 0pt.
- Before going to the next question, submit the correct answer for P2
- Go to the next question
- Answer correctly for both participant (they all get 3 points)
- Display the leaderboard

The 2 participants have 8 points while the P2 should only have 3 points.

[IMP] survey: remove unnecessary sudo

The sudo was present in the /survey/session/next_question/<token> route "to avoid potential access right issues" because "a user can create a live session from any survey but they can only write on their own survey.". But following the security configuration, user belonging to the survey_user group can write and see all surveys not restricted to other users (since commit 027a2a66). So a user have either full access or no access at all. That's why we remove here the sudos.

To avoid errors in the future, we avoid to return the survey in sudo in _fetch_from_session_code. Instead, we just return the start URL.

Task-5089292