### PR TITLE
[IMP] mail: reduce call permission dialog size

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_permission_dialog.xml
+++ b/addons/mail/static/src/discuss/call/common/call_permission_dialog.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="discuss.CallPermissionDialog">
-        <Dialog title="''">
+        <Dialog title="''" size="'md'">
             <h5 class="fw-medium fs-2 mb-2" t-out="permissionPrompt"/>
             <small class="text-muted" t-out="permissionNote"/>
             <t t-set-slot="footer">


### PR DESCRIPTION
**Purpose of this PR:**

Reduce the size of the call permission dialog to eliminate extra empty space
on the right side.

**Before**
<img width="1355" height="643" alt="image" src="https://github.com/user-attachments/assets/e8366841-d07e-4c05-8f88-8710631bfd57" />

**After**
<img width="1901" height="932" alt="image" src="https://github.com/user-attachments/assets/9e13f665-8028-4c61-9170-9eaf9d3b00a0" />



task-[5091767](https://www.odoo.com/odoo/project.task/5091767)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
