### PR TITLE
[FIX] point_of_sale: ignore number buffer input when using Ctrl/Alt

### DIFF
--- a/addons/point_of_sale/static/src/app/utils/number_buffer_service.js
+++ b/addons/point_of_sale/static/src/app/utils/number_buffer_service.js
@@ -180,6 +180,10 @@ class NumberBuffer extends EventBus {
             if (["INPUT", "TEXTAREA"].includes(event.target.tagName) || !this.eventsBuffer) {
                 return;
             }
+            // Ignore any input if combined with Ctrl, Cmd, or Alt
+            if (event.ctrlKey || event.metaKey || event.altKey) {
+                return;
+            }
             clearTimeout(this._timeout);
             this.eventsBuffer.push(event);
             this._timeout = setTimeout(handler, this.maxTimeBetweenKeys);

--- a/addons/point_of_sale/static/tests/tours/chrome_tour.js
+++ b/addons/point_of_sale/static/tests/tours/chrome_tour.js
@@ -263,3 +263,29 @@ registry.category("web_tour.tours").add("test_click_all_orders_keep_customer", {
             },
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_ctrl_number_ignored", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.addOrderline("Whiteboard Pen", "1", "6", "6.0"),
+            {
+                trigger: "body",
+                run: () => {
+                    window.dispatchEvent(new KeyboardEvent("keyup", { key: "5", ctrlKey: true }));
+                },
+            },
+            {
+                trigger: "body",
+                run: () =>
+                    new Promise((resolve) => {
+                        setTimeout(resolve, 300); // wait 300ms so NumberBuffer timeout runs
+                    }),
+            },
+            inLeftSide([
+                { ...ProductScreen.clickLine("Whiteboard Pen")[0], isActive: ["mobile"] },
+                ...ProductScreen.selectedOrderlineHasDirect("Whiteboard Pen", "1", "6.0"),
+            ]),
+        ].flat(),
+});

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -2127,6 +2127,9 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.assertAlmostEqual(lines[3].balance, 352.59)
         self.assertAlmostEqual(lines[4].balance, 7771.01)
 
+    def test_ctrl_number_ignored(self):
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_ctrl_number_ignored', login="pos_user")
+
     def test_click_all_orders_keep_customer(self):
         """Verify that clicking on 'All Orders' keeps the customer selected."""
         self.main_pos_config.with_user(self.pos_user).open_ui()


### PR DESCRIPTION
Before this commit, the NumberBuffer was listening to all keyup events. This caused unintended behavior when the user pressed browser/system shortcuts such as:

- `Ctrl +` / `Ctrl -` on Windows/Linux (zoom in/out)
- `⌘ +` / `⌘ -` on macOS (zoom in/out)
- `Alt + <number>` or `Alt + <arrow>` (browser tab navigation, menu accelerators)

Because the key itself (e.g. `"+"`, `"-"`, `"1"`) was part of `INPUT_KEYS`, the NumberBuffer captured the event and updated its state leading to unexpected inputs being added to the PoS order lines.

opw-4965429

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
