### PR TITLE
[FIX] point_of_sale: robust note parsing in preparation ticket printing

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1838,11 +1838,31 @@ export class PosStore extends WithLazyGetterTrap {
     }
 
     getStrNotes(note) {
-        return note && typeof note === "string"
-            ? JSON.parse(note)
-                  .map((n) => n.text)
-                  .join(", ")
-            : "";
+        if (!note) {
+            return "";
+        }
+        if (Array.isArray(note)) {
+            return note.map((n) => (typeof n === "string" ? n : n.text)).join(", ");
+        }
+        if (typeof note === "string") {
+            try {
+                const parsed = JSON.parse(note);
+                if (Array.isArray(parsed)) {
+                    return parsed.map((n) => (typeof n === "string" ? n : n.text)).join(", ");
+                }
+                return note;
+            } catch (error) {
+                logPosMessage(
+                    "Store",
+                    "getStrNotes",
+                    "Error while parsing note, not valid JSON",
+                    CONSOLE_COLOR,
+                    [error]
+                );
+                return note;
+            }
+        }
+        return "";
     }
 
     getOrderData(order, reprint) {

--- a/addons/point_of_sale/static/tests/unit/services/pos_service.test.js
+++ b/addons/point_of_sale/static/tests/unit/services/pos_service.test.js
@@ -32,6 +32,16 @@ describe("pos_store.js", () => {
         expect(order.lines.length).toBe(3); // 2 original lines + 1 tip line
     });
 
+    test("orderNoteFormat", async () => {
+        const store = await setupPosEnv();
+        const str = store.getStrNotes("string");
+        expect(str).toBeOfType("string");
+        expect(str).toBe("string");
+        const json2str = store.getStrNotes([{ text: "json", colorIndex: 0 }]);
+        expect(json2str).toBeOfType("string");
+        expect(json2str).toBe("json");
+    });
+
     describe("syncAllOrders", () => {
         test("simple sync", async () => {
             const store = await setupPosEnv();


### PR DESCRIPTION
Normalize getStrNotes() to handle multiple note formats (JSON array string, array, plain string) and avoid crashes when printing preparation tickets to multiple printers.

Steps to reproduce:
-------------------
* Configure two preparation printers for a pos_restaurant with food categorie.
* Create an order with a note in that restaurant.
* Send the order to the kitchen.
> Observation:
The second printer fails to print the ticket with an (uncaught) JSON parse error (Unexpected token), while the first prints correctly.

Why the fix:
------------
`getStrNotes()` assumed notes were always JSON strings like [{"text":"...","colorIndex":0}]. In practice, notes can be plain strings or already-parsed arrays depending on the update path and last printed changes.
The function now:
- returns joined texts for arrays,
- tries to parse JSON strings and joins texts if it’s an array,
- falls back to the raw string if parsing fails. This makes note rendering stable across printers and prevents the error, ensuring tickets are printed consistently.

opw-5029870