### PR TITLE
[IMP] account_peppol: Check 0208 and 9925 + remove warnings

### DIFF
--- a/addons/account_peppol/models/res_partner.py
+++ b/addons/account_peppol/models/res_partner.py
@@ -194,4 +194,15 @@ class ResPartner(models.Model):
             edi_identification = f'{self.peppol_eas}:{self.peppol_endpoint}'.lower()
             self.account_peppol_validity_last_check = fields.Date.context_today(self)
             self.account_peppol_is_endpoint_valid = bool(self._check_peppol_participant_exists(edi_identification, ubl_cii_format=self.ubl_cii_format))
+
+            if (
+                not self.account_peppol_is_endpoint_valid
+                and self.peppol_eas in ('0208', '9925')
+            ):
+                inverse_eas = '9925' if self.peppol_eas == '0208' else '0208'
+                inverse_endpoint = f'BE{self.peppol_endpoint}' if self.peppol_eas == '0208' else self.peppol_endpoint[2:]
+                if self._check_peppol_participant_exists(f'{inverse_eas}:{inverse_endpoint}', ubl_cii_format=self.ubl_cii_format):
+                    self.peppol_eas = inverse_eas
+                    self.peppol_endpoint = inverse_endpoint
+                    self.account_peppol_is_endpoint_valid = True
         return False

--- a/addons/account_peppol/tests/test_peppol_messages.py
+++ b/addons/account_peppol/tests/test_peppol_messages.py
@@ -139,12 +139,12 @@ class TestPeppolMessage(TestAccountMoveSendCommon):
     def _request_handler(cls, s: Session, r: PreparedRequest, /, **kw):
         response = Response()
         response.status_code = 200
-        if r.url.endswith('iso6523-actorid-upis%3A%3A0208%3A0477472701'):
+        if r.url.endswith('iso6523-actorid-upis%3A%3A0208%3A0477472701') or r.url.endswith('iso6523-actorid-upis%3A%3A9925%3ABE0477472701'):
             response._content = b"""<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n<smp:ServiceGroup xmlns:wsa="http://www.w3.org/2005/08/addressing" xmlns:id="http://busdox.org/transport/identifiers/1.0/" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:smp="http://busdox.org/serviceMetadata/publishing/1.0/"><id:ParticipantIdentifier scheme="iso6523-actorid-upis">0208:0477472701</id:ParticipantIdentifier>'
             '<smp:ServiceMetadataReferenceCollection><smp:ServiceMetadataReference href="https://iap-services.odoo.com/iso6523-actorid-upis%3A%3A0208%3A0477472701/services/busdox-docid-qns%3A%3Aurn%3Aoasis%3Anames%3Aspecification%3Aubl%3Aschema%3Axsd%3AInvoice-2%3A%3AInvoice%23%23urn%3Acen.eu%3Aen16931%3A2017%23compliant%23urn%3Afdc%3Apeppol.eu%3A2017%3Apoacc%3Abilling%3A3.0%3A%3A2.1"/>'
             '</smp:ServiceMetadataReferenceCollection></smp:ServiceGroup>"""
             return response
-        if r.url.endswith('iso6523-actorid-upis%3A%3A0208%3A3141592654'):
+        if r.url.endswith('iso6523-actorid-upis%3A%3A0208%3A3141592654') or r.url.endswith('iso6523-actorid-upis%3A%3A9925%3ABE3141592654'):
             response.status_code = 404
             return response
         if r.url.endswith('iso6523-actorid-upis%3A%3A0208%3A2718281828'):

--- a/addons/account_peppol/views/res_config_settings_views.xml
+++ b/addons/account_peppol/views/res_config_settings_views.xml
@@ -25,12 +25,6 @@
                                      invisible="not account_peppol_endpoint_warning">
                                     <field name="account_peppol_endpoint_warning"/>
                                 </div>
-                                <div class="alert alert-warning mt-3"
-                                     colspan="2"
-                                     role="alert"
-                                     invisible="country_code != 'BE' or account_peppol_eas in (False, '0208')">
-                                    The recommended EAS code for Belgium is 0208. The Endpoint should be the Company Registry number.
-                                </div>
                                 <div class="pt-3">
                                     <div class="row">
                                         <label string="Peppol EAS"

--- a/addons/account_peppol/views/res_partner_views.xml
+++ b/addons/account_peppol/views/res_partner_views.xml
@@ -9,12 +9,6 @@
             <data>
                 <xpath expr="//field[@name='ubl_cii_format']" position="before">
                     <field name="bank_account_count" invisible="1"/>
-                    <div class="alert alert-warning mb-0"
-                         colspan="2"
-                         role="alert"
-                         invisible="country_code != 'BE' or ubl_cii_format in (False, 'facturx') or peppol_eas in (False, '0208')">
-                         The recommended EAS code for Belgium is 0208. The Endpoint should be the Company Registry number.
-                    </div>
                     <div class="alert alert-warning"
                          colspan="2"
                          role="alert"


### PR DESCRIPTION
1. For belgian partner, we now check for 0208 and 9925 which are the two most used EAS when looking for partner existence on the Peppol network.

2. Remove the warnings about the recommended EAS: 0208 is now the mandatory EAS, this will be handled directly on IAP where the Peppol Access Point will try to register 0208 in all cases with an alias system.

Note that we have always computed 0208 as recommended value in registration process.

task-4852903