### PR TITLE
[FIX] stock: fix forecast merge lines

### DIFF
--- a/addons/stock/static/src/stock_forecasted/forecasted_details.js
+++ b/addons/stock/static/src/stock_forecasted/forecasted_details.js
@@ -151,17 +151,19 @@ export class ForecastedDetails extends Component {
     _mergeLines(){
         let lines = this.lines;
         this.mergesLinesData = {};
-        let lastIndex;
+        let lastIndex = 0;
         for(let i = 0; i < lines.length-1; i++){
             const line = lines[i];
             const nextLine = lines[i + 1];
             if (line.product.id != nextLine.product.id || !this._sameLineRule(line, nextLine)) {
                 lastIndex = i+1;
+                continue;
+            }
+            if (!this.mergesLinesData[lastIndex]){
                 this.mergesLinesData[lastIndex] = {
                     rowcount: 1,
-                    tot_qty: nextLine.quantity,
+                    tot_qty: line.quantity,
                 };
-                continue;
             }
             this.mergesLinesData[lastIndex].rowcount += 1;
             this.mergesLinesData[lastIndex].tot_qty += nextLine.quantity;


### PR DESCRIPTION
Ensure correct initialization of lastIndex and mergeLinesData to also cover the case where line 0 is part of a merge.

Current behavior before PR:
 - `Caused by: TypeError: this.mergesLinesData[lastIndex] is undefined`
 - `TypeError: Cannot read properties of undefined (reading 'rowcount')`

Desired behavior after PR is merged:
lastIndex and mergesLinesData[lastIndex] are correctly initialized on first line too

To reproduce:
On a product with OnHand quantity, create multiple SO so that the first cell of the first lines are merged.
<img width="1896" height="230" alt="image" src="https://github.com/user-attachments/assets/d8eb550a-e9c8-4dbf-ade7-046f83b370ae" />


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
