### PR TITLE
[FIX] web: prevent crash in command palette when no items

### DIFF
--- a/addons/web/static/src/views/fields/statusbar/statusbar_field.js
+++ b/addons/web/static/src/views/fields/statusbar/statusbar_field.js
@@ -144,8 +144,13 @@ export class StatusBarField extends Component {
                 {
                     category: "smart_action",
                     hotkey: "alt+x",
-                    isAvailable: () =>
-                        !this.props.isDisabled && !this.getAllItems().at(-1).isSelected,
+                    isAvailable: () => {
+                        if (this.props.isDisabled) {
+                            return false;
+                        }
+                        const items = this.getAllItems();
+                        return items.length && !items.at(-1).isSelected;
+                    }
                 }
             );
         }


### PR DESCRIPTION
**Steps to reproduce:**

- Installed industry_fsm (Field Service) module
- Navigate the menu Field Service -> Configuration -> Project
- Create a new project
- Then Navigate the menu My Tasks -> Tasks
- Create a new task with the new created project
- Then using the keyboard shortcut ctrl + k for command search, an error occurs

**Cause:**
- When the `stage_id` statusbar had no possible values,
`this.getAllItems()` returned an empty array.
- The command `isAvailable` unconditionally accessed
`this.getAllItems().at(-1).isSelected`, which is undefined,
causing a crash.[see](https://github.com/odoo/odoo/blob/17.0/addons/web/static/src/views/fields/statusbar/statusbar_field.js#L147-L148)

**Fix**
- Add safe check in the command action so it does not attempt
to select a non-existent "next" item.

**Result**
- The command palette no longer crashes when the `stage_id` field has no
available items. Instead, the command is simply unavailable.

opw-5084130
upg-3130405


Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
