### PR TITLE
[FIX] html_builder, website: hide image width option for image cards

### DIFF
--- a/addons/website/static/src/builder/plugins/image/image_tool_option.xml
+++ b/addons/website/static/src/builder/plugins/image/image_tool_option.xml
@@ -1,0 +1,8 @@
+<templates>
+    <t t-inherit="html_builder.ImageToolOption" t-inherit-mode="extension">
+        <!-- Hide the image "Size" option when card cover width control is available -->
+        <xpath expr="//BuilderRow[@label.translate='Size']" position="attributes">
+            <attribute name="t-if">!this.env.getEditingElement().closest('.o_card_img_wrapper')</attribute>
+        </xpath>
+    </t>
+</templates>


### PR DESCRIPTION
When converting the options to Owl, the behavior from commit [1], which
hid the image width option for images inside cards, was lost. We are
reintroducing it here.

[1]: https://github.com/odoo/odoo/commit/4dcd1f9607ecc1ea932e02128a3e6f01d652cba6