### PR TITLE
[FIX] account_edi_ubl_cii: fix division by 0 when <BaseQuantity> is 0

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -640,7 +640,7 @@ class AccountEdiCommon(models.AbstractModel):
         """
         xpath_dict = self._get_line_xpaths(document_type, qty_factor)
         # basis_qty (optional)
-        basis_qty = float(self._find_value(xpath_dict['basis_qty'], tree) or 1)
+        basis_qty = float(self._find_value(xpath_dict['basis_qty'], tree) or 1) or 1.0
 
         # gross_price_unit (optional)
         gross_price_unit = None


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting
- Go to "Accounting / Customers / Invoices"
- Import a UBL file having a value of 0 for a `<cbc:BaseQuantity>` element

**Issue:**
The import fails due to a division by 0 at:
`price_unit = (net_price_unit + rebate) / basis_qty`

**Cause:**
"basis_qty" is retrieved as followed:
`basis_qty = float(self._find_value(xpath_dict['basis_qty'], tree) or 1)` 
If the element is not defined, it will fall back on 1. 
But if the element exists with a value of 0, the "_find_value" method will retrieve the string "0" which is not False and will not fall back on 1. 
Then it will become `0.0` once converted to float.

opw-5062985




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
