### PR TITLE
[FIX] core: Make `fetch()` more robust against invalid recordset

### DIFF
--- a/odoo/addons/test_performance/tests/test_performance.py
+++ b/odoo/addons/test_performance/tests/test_performance.py
@@ -168,6 +168,19 @@ class TestPerformance(SavepointCaseWithUserDemo):
             #  on 'value', and none of them are in cache
             records.fetch(['indirect_computed_value'])
 
+        # Test that new/false records are ignored. We generally make the assumption that
+        # new records and real record shouldn't mix together but for the sake of robustness
+        # we ignore new/false records in fetch.
+        real_record = records[0]
+        new_record_origin = records.new(origin=real_record)
+        new_record_ref = records.new(ref='virtual_')
+        new_record = records.new({'name': 'aaa'})
+        # Because the ORM "works" for records.browse([False]).name, fetch should "work" too.
+        false_record = records.browse([False])
+        records = real_record + new_record_origin + new_record_ref + new_record + false_record
+        with self.assertQueryCount(1):
+            records.fetch(['name'])
+
     @warmup
     def test_search_fetch(self):
         """ Search and fetch all at once. """

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -4125,6 +4125,7 @@ class BaseModel(metaclass=MetaModel):
         This method is implemented thanks to methods :meth:`_search` and
         :meth:`_fetch_query`, and should not be overridden.
         """
+        self = self._origin  # noqa: PLW0642 filtered out new records
         if not self or not field_names:
             return
 


### PR DESCRIPTION
This commit addresses two corner cases that cause `fetch()` to crash:

Mixing new and real records:
- Issue: If a recordset contains both new and real records, `fetch()` raises an `AccessError`.
- Rationale: While we typically assume that new and real records are never mixed, certain recordset operations can inadvertently lead to this state. Handling this case improves the overall robustness of the ORM.

Using `False` as a record id:
- Issue: Using a record with a `False` id, such as `browse([False])`, causes a SQL error when `fetch()` is called.
- Rationale: Other operations, like `browse([False]).name`, work without crashing. To ensure consistency across the ORM, `fetch()` should also handle `False` ids without error.

