### PR TITLE
[FIX] pos_sale: show only selected customer orders in POS

### DIFF
--- a/addons/pos_sale/static/src/overrides/components/control_buttons/control_buttons.js
+++ b/addons/pos_sale/static/src/overrides/components/control_buttons/control_buttons.js
@@ -6,15 +6,26 @@ import { SelectCreateDialog } from "@web/views/view_dialogs/select_create_dialog
 
 patch(ControlButtons.prototype, {
     onClickQuotation() {
+        let domain = [
+            ["state", "!=", "cancel"],
+            ["invoice_status", "!=", "invoiced"],
+            ["currency_id", "=", this.pos.currency.id],
+        ];
+        if (this.pos.get_order()?.get_partner()) {
+            domain = [
+                ...domain,
+                [
+                    "partner_id",
+                    "any",
+                    [["id", "child_of", [this.pos.get_order().get_partner().id]]],
+                ],
+            ];
+        }
         this.dialog.add(SelectCreateDialog, {
             resModel: "sale.order",
             noCreate: true,
             multiSelect: false,
-            domain: [
-                ["state", "!=", "cancel"],
-                ["invoice_status", "!=", "invoiced"],
-                ["currency_id", "=", this.pos.currency.id],
-            ],
+            domain,
             onSelected: async (resIds) => {
                 await this.pos.onClickSaleOrder(resIds[0]);
             },

--- a/addons/pos_sale/static/tests/tours/pos_sale_tour.js
+++ b/addons/pos_sale/static/tests/tours/pos_sale_tour.js
@@ -523,3 +523,20 @@ registry.category("web_tour.tours").add("test_multiple_lots_sale_order_2", {
             ReceiptScreen.isShown(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_selected_partner_quotation_loading", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("A Test Partner 1"),
+            PosSale.settleNthOrder(1),
+            ProductScreen.selectedOrderlineHas("Product A", "1.00"),
+            Chrome.createFloatingOrder(),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("A Test Partner 2"),
+            PosSale.settleNthOrder(1),
+            ProductScreen.selectedOrderlineHas("Product B", "2.00"),
+        ].flat(),
+});

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -1610,3 +1610,38 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         self.assertEqual(picking.move_ids.move_line_ids[0].quantity, 1)
         self.assertEqual(picking.move_ids.move_line_ids[1].lot_id.name, '1002')
         self.assertEqual(picking.move_ids.move_line_ids[1].quantity, 2)
+
+    def test_selected_partner_quotation_loading(self):
+        """
+        Tests that when a partner is selected in the PoS, then a quotation for this partner is loaded
+        """
+        product_a = self.env['product.product'].create({
+            'name': 'Product A',
+            'available_in_pos': True,
+            'lst_price': 10.0,
+        })
+        product_b = self.env['product.product'].create({
+            'name': 'Product B',
+            'available_in_pos': True,
+            'lst_price': 5.0,
+        })
+        partner_1 = self.env['res.partner'].create({'name': 'A Test Partner 1'})
+        partner_2 = self.env['res.partner'].create({'name': 'A Test Partner 2'})
+        self.env['sale.order'].create({
+            'partner_id': partner_1.id,
+            'order_line': [(0, 0, {
+                'product_id': product_a.id,
+                'product_uom_qty': 1,
+                'price_unit': product_a.lst_price,
+            })]
+        })
+        self.env['sale.order'].create({
+            'partner_id': partner_2.id,
+            'order_line': [(0, 0, {
+                'product_id': product_b.id,
+                'product_uom_qty': 2,
+                'price_unit': product_b.lst_price,
+            })]
+        })
+        self.main_pos_config.open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_selected_partner_quotation_loading', login="accountman")


### PR DESCRIPTION
Before this commit, when selecting a customer in the POS and clicking Actions → Quotation/Order, all quotations and orders were displayed instead of filtering by the selected customer.

This commit ensures that only the quotations/orders of the selected customer are shown.

opw-5074052

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
