### PR TITLE
[FIX] website_sale: compute website currency in backend request

### DIFF
--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -174,7 +174,8 @@ class Website(models.Model):
     def _compute_currency_id(self):
         for website in self:
             website.currency_id = (
-                request and request.pricelist.currency_id or website.company_id.sudo().currency_id
+                request and hasattr(request, 'pricelist') and request.pricelist.currency_id
+                or website.company_id.sudo().currency_id
             )
 
     #=== SELECTION METHODS ===#


### PR DESCRIPTION
Prior to this commit, the website currency was computed using the request pricelist. However, this logic assumed that the compute method could only be called from a frontend request.

However, via `web_studio`, a user can add fields linked to a website, which triggers the computation in a backend request, causing the following traceback:

```
Traceback (most recent call last):
  ...
  File "/data/build/odoo/addons/website_sale/models/website.py", line 282, in _compute_currency_id
    request and request.pricelist.currency_id or website.company_id.sudo().currency_id
                ^^^^^^^^^^^^^^^^^
AttributeError: 'Request' object has no attribute 'pricelist'
```

This commit fixes the issue by first ensuring that the pricelist exists and falling back to the company currency if it does not.

opw-5068581
