### PR TITLE
[FIX] mass_mailing: restore template model-lock

### DIFF
--- a/addons/mass_mailing/static/src/themes/theme_selector/theme_selector.xml
+++ b/addons/mass_mailing/static/src/themes/theme_selector/theme_selector.xml
@@ -3,6 +3,7 @@
         <div class="o_mailing_template_preview_wrapper d-inline-block w-100">
             <div t-foreach="favoriteTemplates" t-as="template" t-key="template_index"
                 class="o_mail_template_preview d-inline-block dropdown-item"
+                t-if="template.modelId === this.props.config.mailingModelId"
                 t-on-click="() => this.onSelectFavorite(template.html)">
                 <div class="d-inline-flex flex-row align-items-center border px-2 py-2 w-100">
                     <i class="fa fa-star text-warning me-2"/>


### PR DESCRIPTION
Previously, custom mailing templates (which could be created by marking
an existing mailing as Favorite) would only be accessible for new
mailings matching the template's target model.

This restriction was lost by the update to the new mailing editor; this
commit restores it.

task-5054968
