### PR TITLE
[IMP] mail: set notification as done on opening record

### DIFF
--- a/addons/mail/static/src/core/web/message_patch.js
+++ b/addons/mail/static/src/core/web/message_patch.js
@@ -79,6 +79,7 @@ patch(Message.prototype, {
     },
 
     openRecord() {
+        this.message.setDone();
         this.message.thread.open({ focus: true });
         this.message.thread.highlightMessage = this.message;
     },


### PR DESCRIPTION
With this commit, when opening the record related to a user_notification from the inbox, the notification will be set as done.

task-5092464