### PR TITLE
[FIX] web: calendar year view resizing

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
@@ -4,7 +4,6 @@ import { _t } from "@web/core/l10n/translation";
 import { is24HourFormat } from "@web/core/l10n/dates";
 import { localization } from "@web/core/l10n/localization";
 import { renderToString } from "@web/core/utils/render";
-import { useDebounced } from "@web/core/utils/timing";
 import { getColor } from "../colors";
 import { useCalendarPopover, useClickHandler, useFullCalendar } from "../hooks";
 import { CalendarCommonPopover } from "./calendar_common_popover";
@@ -49,7 +48,6 @@ export class CalendarCommonRenderer extends Component {
         this.fc = useFullCalendar("fullCalendar", this.options);
         this.click = useClickHandler(this.onClick, this.onDblClick);
         this.popover = useCalendarPopover(this.constructor.components.Popover);
-        this.onWindowResizeDebounced = useDebounced(this.onWindowResize, 200);
 
         onMounted(() => {
             if (this.props.model.scale === "day" || this.props.model.scale === "week") {
@@ -117,7 +115,7 @@ export class CalendarCommonRenderer extends Component {
             weekNumberCalculation: (date) => getWeekNumber(date, this.props.model.firstDayOfWeek),
             weekNumbers: true,
             weekNumbersWithinDays: !this.env.isSmall,
-            windowResize: this.onWindowResizeDebounced,
+            windowResize: this.onWindowResize,
             columnHeaderHtml: this.getHeaderHtml,
         };
     }

--- a/addons/web/static/src/views/calendar/calendar_year/calendar_year_renderer.js
+++ b/addons/web/static/src/views/calendar/calendar_year/calendar_year_renderer.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
 import { localization } from "@web/core/l10n/localization";
-import { useDebounced } from "@web/core/utils/timing";
 import { getColor } from "../colors";
 import { useCalendarPopover, useFullCalendar } from "../hooks";
 import { CalendarYearPopover } from "./calendar_year_popover";
@@ -21,7 +20,6 @@ export class CalendarYearRenderer extends Component {
         }
         this.popover = useCalendarPopover(this.constructor.components.Popover);
         this.rootRef = useRef("root");
-        this.onWindowResizeDebounced = useDebounced(this.onWindowResize, 200);
 
         useEffect(() => {
             this.updateSize();
@@ -61,7 +59,7 @@ export class CalendarYearRenderer extends Component {
             unselectAuto: false,
             weekNumberCalculation: (date) => getWeekNumber(date, this.props.model.firstDayOfWeek),
             weekNumbers: false,
-            windowResize: this.onWindowResizeDebounced,
+            windowResize: this.onWindowResize,
         };
     }
 


### PR DESCRIPTION
FullCalendar already applies a debounce on the `windowResize` handler.

Thus, doing it again in our renderer is a duplicated effort.

Also, in the Year calendar renderer, the debounced version of the handler is initialized after the FullCalendar instances (one for each month) are created... which prevents it from being run at all.

This commit fixes and cleans this up by directly passing our handler to FullCalendar, letting him do the rest.

task-4809668

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
