### PR TITLE
[FIX] website_sale: product template packaging preview

### DIFF
--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -1280,8 +1280,12 @@ $-product-radius-map: (
     .o_wsale_product_details_content_section_attributes {
         display: none;
 
-        &:where(:has(li.variant_attribute:not(.d-none))) {
+        &:where(:has(li.variant_attribute:not(.d-none))), &:where(:has(li.o_variant_pills:not(.d-none))) {
             display: block;
+        }
+
+        .o_wsale_product_page_variants.d-none + .o_wsale_product_page_variants{
+            margin-top: 0 !important;
         }
     }
 }

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2118,7 +2118,7 @@
                                             t-att-value="product.type"
                                         />
                                         <div
-                                            t-attf-class="o_wsale_product_details_content_section o_wsale_product_details_content_section_attributes mb-4 {{not product.valid_product_template_attribute_line_ids and 'd-none' or ' '}}"
+                                            t-attf-class="o_wsale_product_details_content_section o_wsale_product_details_content_section_attributes mb-4 {{not (product.valid_product_template_attribute_line_ids or product._has_multiple_uoms()) and 'd-none' or ''}}"
                                         >
                                             <t t-call="website_sale.variants">
                                                 <t t-set="ul_class" t-valuef="flex-column" />


### PR DESCRIPTION
Packaging options was only viewable if a product had variants.
Modify condition to view product packaging when it has multiple uoms.

opw-5104189

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
