### PR TITLE
[FIX] project,sale_project: enable milestones on generated projects from SO

### DIFF
--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -1396,7 +1396,9 @@ class ProjectProject(models.Model):
         """
         Whitelist of fields that can be set through the `default_` context keys when creating a project from a template.
         """
-        return []
+        return [
+            "allow_milestones",
+        ]
 
     @api.model
     def _get_template_field_blacklist(self):

--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -189,6 +189,7 @@ class SaleOrder(models.Model):
                 'default_company_id': self.company_id.id,
                 'generate_milestone': default_sale_line.product_id.service_policy == 'delivered_milestones',
                 'default_name': self.name,
+                'default_allow_milestones': 'delivered_milestones' in self.order_line.product_id.mapped('service_policy'),
             },
         }
 

--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -182,7 +182,6 @@ class SaleOrderLine(models.Model):
             'company_id': self.company_id.id,
             'allow_billable': True,
             'user_id': self.product_id.project_template_id.user_id.id,
-            'allow_milestones': self.product_id.service_type == 'milestones',
         }
 
     def _timesheet_create_project(self):
@@ -433,6 +432,8 @@ class SaleOrderLine(models.Model):
         self.ensure_one()
         if self.product_id.service_policy != 'delivered_milestones':
             return
+        if not self.project_id.allow_milestones:
+            self.project_id.allow_milestones = True
         if (milestones := project.milestone_ids.filtered(lambda milestone: not milestone.sale_line_id)):
             milestones.write({
                 'sale_line_id': self.id,

--- a/addons/sale_project/tests/test_sale_project.py
+++ b/addons/sale_project/tests/test_sale_project.py
@@ -1820,3 +1820,19 @@ class TestSaleProject(TestSaleProjectCommon):
             task_with_context.sale_line_id, sol2,
             "Task with context should pick the original SOL even if removed from project"
         )
+
+    def test_enable_milestones_settings_of_project_on_so_confirmation(self):
+        self.product_service_delivered_milestone.service_tracking = 'project_only'
+        so = self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+            'order_line': [
+                Command.create({'product_id': self.product_order_service4.id, 'sequence': 1}),  # service_tracking: 'project_only', not based on project template, invoice policy: order
+                Command.create({'product_id': self.product_service_delivered_milestone.id, 'sequence': 2}),  # service_tracking: 'project_only', not based on project template, invoice policy: milestones
+            ],
+        })
+        so.action_confirm()
+        self.assertEqual(len(so.project_ids), 1, 'One project should be generated and linked to the SO.')
+        self.assertTrue(
+            so.project_ids.allow_milestones,
+            'The generated project should have the "Allow Milestones" setting enabled, as one of the products has invoice policy based on milestones.',
+        )


### PR DESCRIPTION
This commit fixes two issues related to the milestones settings of generated projects in SO:

First issue:
* Steps to reproduce:
    - Create a product whose invoicing is based on milestones
    - Add this product to an SO
    - Confirm the SO
    - Create a project from the action button in the SO form view ('Create a Project'), with or without a project template
    - The generated project does not have the milestone setting enabled

* Expected behavior:
    => When creating a project from the SO in which there is at least 1 product with invoicing based in milestone, the setting "Milestone" should be checked by default

Second issue:
* Steps to reproduce:
    - Create a product with an invoice policy based on milestones
    - Create another product with another policy
        => Both products must be configured to create a project on SO confirmation, without a project template
    - Create a new SO with both products as SOLs
        => Set the second product (other policy) in first sequence, then the first product (milestones based) in second sequence, as the order of SOLs
    - Confirm the SO
    - The generated project does not have the milestone setting enabled

* Expected behavior:
    => The generated project should have the milestone setting enabled, as at least one product with an invoicing policy based on milestones has triggered the generation of that project

task-5090253
version: 19.0

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
