### PR TITLE
[FIX] website: prevent setting website on internal user


### DIFF
--- a/addons/website/i18n/website.pot
+++ b/addons/website/i18n/website.pot
@@ -8069,6 +8069,12 @@ msgid "Interaction History<br/>(optional)"
 msgstr ""
 
 #. module: website
+#. odoo-python
+#: code:addons/website/models/res_users.py:0
+msgid "Internal user cannot be restricted to a website."
+msgstr ""
+
+#. module: website
 #: model_terms:ir.ui.view,arch_db:website.snippets
 msgid "Intro"
 msgstr ""

--- a/addons/website/tests/test_res_users.py
+++ b/addons/website/tests/test_res_users.py
@@ -131,3 +131,9 @@ class TestWebsiteResUsers(TransactionCase):
                 Command.link(self.env.ref('base.group_user').id),
                 Command.unlink(self.env.ref('base.group_portal').id),
             ]
+
+    def test_internal_user_no_website(self):
+        website = self.env['website'].create({'name': "Awesome Website"})
+        internal_user = new_test_user(self.env, login='Internal', groups='base.group_user')
+        with self.assertRaises(ValidationError):
+            internal_user.website_id = website


### PR DESCRIPTION
Scenario:

- Install website and set a website on an internal user
- Install helpdesk

Result: installation fails with a traceback containing the message
"Remove website on related partner before they become internal user.".

Cause: 479e8d0cae98f7e086e5fb4a0ca4e33ed24bfc12 added a constraint so
when the groups are changed, we raise an error if the user is internal
and as a website_id set.

But if we do it the other way (setting a website_id on an internal
user), no restraint prevent this, but if at any moment the groups of the
user are changed (which helpdesk does by adding implied_ids groups) we
get an unexpected error.

Fix: change the constraint to be triggered by both website_id and
groups_id change so the user is aware sooner than he should not do it.

Note: the current code also prefetched all internal users and would not
work with non-active user, so this code simplifies that by just
prefetching the groups of the current users.

opw-5077601

PR note: putting this in draft since this is breaking some tests that I need to check