### PR TITLE
[FIX] stock_account: prevent undefined display_name error when account is missing

### DIFF
--- a/addons/stock_account/static/src/stock_valuation/controller.js
+++ b/addons/stock_account/static/src/stock_valuation/controller.js
@@ -57,7 +57,7 @@ export class StockValuationReportController {
         for (let [accountId, data] of Object.entries(this.data.ending_stock.lines_by_account_id)) {
             const account = this.data.accounts_by_id[accountId];
             this.data.ending_stock.lines.push({
-                label: account.display_name,
+                label: account?.display_name,
                 value: data.value,
             });
             this.data.ending_stock.accounts.push(...data.accounts);


### PR DESCRIPTION
Issue before this commit:
=========================
Currently, when opening the Inventory Valuation menu without setting a Valuation Account in the settings, the system raises the error: `Cannot read properties of undefined (reading 'display_name').`

Steps to Reproduce:
=========================
- Install the account and stock_account modules.
- Switch to another company where the default Valuation Account is not set.
- Create a warehouse and a product with a cost.
- Create and validate a receipt for that product.
- Open the Inventory Valuation menu → traceback occurs.

Cause of the issue:
=========================
In this [PR](https://github.com/odoo/odoo/pull/224479), a new valuation report was added. At the [mentioned line](https://github.com/odoo/odoo/pull/224479/files#diff-8afed36c6f80919b83630d39c78510289ec8fecc632735d26824a84a517a1b7dR60), it's assumes the account always exists and attempts to access display_name directly, leading to the error.

With This Commit:
=========================
We ensure that display_name is only accessed if the account exists, preventing the traceback.
