### PR TITLE
[FIX] mail: correct store fallback in action constructor

### DIFF
--- a/addons/mail/static/src/core/common/action.js
+++ b/addons/mail/static/src/core/common/action.js
@@ -60,11 +60,12 @@ export class Action {
         this.owner = owner;
         const rawOwner = toRaw(owner);
         this.store =
-            store ?? rawOwner[STORE_SYM]
+            store ??
+            (rawOwner[STORE_SYM]
                 ? owner
                 : isRecord(owner)
                 ? owner.store
-                : useService("mail.store");
+                : useService("mail.store"));
     }
 
     get params() {

--- a/addons/mail/static/tests/core/common/action.test.js
+++ b/addons/mail/static/tests/core/common/action.test.js
@@ -1,0 +1,17 @@
+import { Action } from "@mail/core/common/action";
+
+import { describe, expect, test } from "@odoo/hoot";
+
+describe.current.tags("desktop");
+
+test("store is correctly set on actions", async () => {
+    const storeSym = Symbol("STORE");
+    const ownerSym = Symbol("COMPONENT");
+    const action = new Action({
+        owner: ownerSym,
+        id: "test",
+        definition: {},
+        store: storeSym,
+    });
+    expect(action.store).toBe(storeSym);
+});


### PR DESCRIPTION
In Discuss, actions can be defined globally (registry) or locally (components). When defined from a component, the store must be explicitly provided. If not, the constructor falls back to the owner if it is a store, or to the `mail.store` service.

The fallback condition was incorrectly grouped due to missing parentheses, so the owner was always used even when a store was given. This could result in actions being bound to the wrong store, causing unexpected errors.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
