### PR TITLE
[FIX] im_livechat: exclude unrated sessions from rating percentage in dashboard

### DIFF
--- a/addons/im_livechat/report/im_livechat_report_channel.py
+++ b/addons/im_livechat/report/im_livechat_report_channel.py
@@ -100,7 +100,7 @@ class Im_LivechatReportChannel(models.Model):
                     ELSE C.livechat_failure
                 END AS session_outcome,
                 C.country_id,
-                C.rating_last_value AS rating,
+                NULLIF(C.rating_last_value, 0) AS rating,
                 CASE
                     WHEN C.rating_last_value = 1 THEN 'Unhappy'
                     WHEN C.rating_last_value = 5 THEN 'Happy'

--- a/addons/im_livechat/tests/test_im_livechat_report.py
+++ b/addons/im_livechat/tests/test_im_livechat_report.py
@@ -64,6 +64,11 @@ class TestImLivechatReport(TestImLivechatCommon):
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]["time_to_answer:avg"], 7800 / 3600)
         self.assertEqual(int(result[0]['duration:avg']), 160)
+        channel = self.env["discuss.channel"].search([("livechat_channel_id", "=", self.livechat_channel.id)])
+        rated_channel = channel.copy({"rating_last_value": 5})
+        self._create_message(rated_channel, self.operator, "2023-03-18 11:00:00")
+        result = self.env["im_livechat.report.channel"].formatted_read_group([], aggregates=["rating:avg"])
+        self.assertEqual(result[0]["rating:avg"], 5, "Rating average should be 5, excluding unrated sessions")
 
     @classmethod
     def _create_message(cls, channel, author, date):


### PR DESCRIPTION
**Description of the issue this PR addresses:**
------------------------------------------------

Before this change, the live chat rating percentage in the dashboard
included sessions that were not rated, which made the overall rating
misleading. While the sessions reporting view allowed filtering on
"rating is set", the dashboard did not provide this option.

**Current behavior before PR:**
---------------------------------

- Unrated sessions are included in the dashboard rating percentage  
- The percentage is misleading compared to the sessions reporting view  

**Desired behavior after PR is merged:**
-----------------------------------------

- The dashboard rating percentage only considers sessions with a rating  
- Unrated sessions are excluded, resulting in a more accurate rating display  

**Task:** 5048700

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr