### PR TITLE
[IMP] orm: prevent use of falsy ids

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -1124,20 +1124,14 @@ class AccountJournal(models.Model):
         :return: A recordset with all the account.account used by this journal for inbound transactions.
         """
         self.ensure_one()
-        account_ids = set()
-        for line in self.inbound_payment_method_line_ids:
-            account_ids.add(line.payment_account_id.id)
-        return self.env['account.account'].browse(account_ids)
+        return self.inbound_payment_method_line_ids.payment_account_id
 
     def _get_journal_outbound_outstanding_payment_accounts(self):
         """
         :return: A recordset with all the account.account used by this journal for outbound transactions.
         """
         self.ensure_one()
-        account_ids = set()
-        for line in self.outbound_payment_method_line_ids:
-            account_ids.add(line.payment_account_id.id)
-        return self.env['account.account'].browse(account_ids)
+        return self.outbound_payment_method_line_ids.payment_account_id
 
     def _get_available_payment_method_lines(self, payment_type):
         """

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1840,7 +1840,7 @@ class AccountMoveLine(models.Model):
             # Log changes to move lines on each move
             tracked_fields = [fname for fname, f in self._fields.items() if hasattr(f, 'tracking') and f.tracking and not (hasattr(f, 'related') and f.related)]
             ref_fields = self.env['account.move.line'].fields_get(tracked_fields)
-            empty_line = self.browse([False])  # all falsy fields but not failing `ensure_one` checks
+            empty_line = self.browse()  # all falsy fields
             for move_id, modified_lines in self.grouped('move_id').items():
                 if not move_id.posted_before:
                     continue

--- a/addons/account/wizard/account_automatic_entry_wizard.py
+++ b/addons/account/wizard/account_automatic_entry_wizard.py
@@ -245,7 +245,7 @@ class AccountAutomaticEntryWizard(models.TransientModel):
                 })
 
         # Get the lowest child company based on accounts used to avoid access error
-        accounts = self.env['account.account'].browse([line['account_id'] for line in line_vals])
+        accounts = self.env['account.account'].browse(account_id for line in line_vals if (account_id := line['account_id']))
         companies = accounts.company_ids.filtered(lambda c: self.env.company in c.parent_ids) | self.env.company
         lowest_child_company = max(companies, key=lambda company: len(company.parent_ids))
 

--- a/addons/calendar/models/res_partner.py
+++ b/addons/calendar/models/res_partner.py
@@ -70,7 +70,7 @@ class ResPartner(models.Model):
             - calendar_model.js (calendar.CalendarModel)
         """
         attendees_details = []
-        meetings = self.env['calendar.event'].browse(meeting_ids)
+        meetings = self.env['calendar.event'].browse(filter(None, meeting_ids))
         for attendee in meetings.attendee_ids:
             if attendee.partner_id not in self:
                 continue

--- a/addons/google_calendar/utils/google_event.py
+++ b/addons/google_calendar/utils/google_event.py
@@ -93,7 +93,8 @@ class GoogleEvent(abc.Set):
         if unsure:
             unsure._load_odoo_ids_from_metadata(env, model)
 
-        return tuple(e._odoo_id for e in self)
+        # skip unmatched ids because we browse the result
+        return tuple(e._odoo_id for e in self if e._odoo_id)
 
     def _load_odoo_ids_from_metadata(self, env, model):
         unsure_odoo_ids = tuple(e._meta_odoo_id(env.cr.dbname) for e in self)

--- a/addons/mail/models/models.py
+++ b/addons/mail/models/models.py
@@ -220,6 +220,8 @@ class Base(models.AbstractModel):
     def _mail_track(self, tracked_fields, initial_values):
         """ For a given record, fields to check (tuple column name, column info)
         and initial values, return a valid command to create tracking values.
+        The method accepts a single record or an empty one (where all field
+        values will be falsy).
 
         :param dict tracked_fields: fields_get of updated fields on which
           tracking is checked and performed;
@@ -234,7 +236,8 @@ class Base(models.AbstractModel):
 
         Override this method on a specific model to implement model-specific
         behavior. Also consider inheriting from ``mail.thread``. """
-        self.ensure_one()
+        if len(self) > 1:
+            raise ValueError(f"Expected empty or single record: {self}")
         updated = set()
         tracking_value_ids = []
 

--- a/addons/mail/models/res_users.py
+++ b/addons/mail/models/res_users.py
@@ -475,7 +475,7 @@ class ResUsers(models.Model):
             'mail.activity': {'overdue_count': 0, 'today_count': 0, 'planned_count': 0, 'total_count': 0}
         }
         for model_name, activities_by_record in activities_rec_groups.items():
-            res_ids = activities_by_record.keys()
+            res_ids = [id_ for id_ in activities_by_record if id_]
             Model = self.env[model_name]
             has_model_access_right = Model.has_access('read')
             if has_model_access_right:

--- a/addons/mail/tests/test_mail_render.py
+++ b/addons/mail/tests/test_mail_render.py
@@ -227,7 +227,7 @@ class TestMailRender(TestMailRenderCommon):
         partner = self.render_object.with_env(self.env)
         for res_ids in ([], (), [False], [''], [None], [False, partner.id]):  # various corner cases
             for fname, expected_obj, expected_void in zip(['subject', 'body_html'], self.base_rendered, self.base_rendered_void):
-                with self.subTest():
+                with self.subTest(res_ids=res_ids, fname=fname):
                     rendered_all = template._render_field(
                         fname,
                         res_ids,

--- a/addons/point_of_sale/models/account_journal.py
+++ b/addons/point_of_sale/models/account_journal.py
@@ -38,11 +38,10 @@ class AccountJournal(models.Model):
         return super().action_archive()
 
     def _get_journal_inbound_outstanding_payment_accounts(self):
-        res = super()._get_journal_inbound_outstanding_payment_accounts()
-        account_ids = set(res.ids)
-        for payment_method in self.sudo().pos_payment_method_ids:
-            account_ids.add(payment_method.outstanding_account_id.id)
-        return self.env['account.account'].browse(account_ids)
+        return (
+            super()._get_journal_inbound_outstanding_payment_accounts()
+            | self.sudo().pos_payment_method_ids.outstanding_account_id.with_env(self.env)
+        )
 
     @api.model
     def _ensure_company_account_journal(self):

--- a/addons/stock/models/stock_package.py
+++ b/addons/stock/models/stock_package.py
@@ -171,7 +171,7 @@ class StockPackage(models.Model):
     def _compute_picking_ids(self):
         children_by_dest_pack, all_pack_ids = self._get_all_children_package_dest_ids()
         groups = self.env['stock.move.line']._read_group(
-            domain=[('state', 'not in', ['done', 'cancel']), ('result_package_id', 'in', all_pack_ids)],
+            domain=[('state', 'not in', ['done', 'cancel']), ('result_package_id', 'in', all_pack_ids), ('picking_id', '!=', False)],
             groupby=['result_package_id'], aggregates=['picking_id:array_agg'])
         pickings_by_package = {package.id: picking_ids for package, picking_ids in groups}
 

--- a/odoo/addons/base/tests/test_api.py
+++ b/odoo/addons/base/tests/test_api.py
@@ -657,17 +657,6 @@ class TestAPI(SavepointCaseWithUserDemo):
             {'name': "james", 'function': "host"},
             {'name': "rhod", 'function': "guest"}
         ])
-        pn = self.env['res.partner'].new({'name': 'alex', 'function': "host"})
-
-        with self.subTest("Should work with mixes of db and new records"):
-            self.assertEqual(
-                (p0 | p1 | p2 | pn).grouped('function'),
-                {'guest': p0 | p2, 'host': p1 | pn}
-            )
-            self.assertEqual(
-                (p0 | p1 | p2 | pn).grouped(lambda r: len(r.name)),
-                {3: p0, 4: p2 | pn, 5: p1},
-            )
 
         with self.subTest("Should allow cross-group prefetching"):
             byfn = (p0 | p1 | p2).grouped('function')

--- a/odoo/addons/base/tests/test_orm.py
+++ b/odoo/addons/base/tests/test_orm.py
@@ -148,8 +148,9 @@ class TestORM(TransactionCase):
         recs = partner.new({})
         self.assertTrue(recs.exists())
 
-        # check that there is no record with id 0
-        recs = partner.browse([0])
+        # check that there is no record with id -1
+        # (it is technically valid, but should not exist)
+        recs = partner.browse([-1])
         self.assertFalse(recs.exists())
 
     def test_lock_for_update(self):

--- a/odoo/addons/test_orm/tests/test_fields.py
+++ b/odoo/addons/test_orm/tests/test_fields.py
@@ -1951,9 +1951,6 @@ class TestFields(TransactionCaseWithUserDemo, TransactionExpressionCase):
         with self.assertRaises(MissingError):
             deleted.categories
 
-        # special case: should not fail
-        Discussion.browse([None]).read(['categories'])
-
     def test_40_real_vs_new(self):
         """ test field access on new records vs real records. """
         Model = self.env['test_orm.category']

--- a/odoo/addons/test_orm/tests/test_performance.py
+++ b/odoo/addons/test_orm/tests/test_performance.py
@@ -172,9 +172,7 @@ class TestPerformance(SavepointCaseWithUserDemo):
         new_record_origin = records.new(origin=real_record)
         new_record_ref = records.new(ref='virtual_')
         new_record = records.new({'name': 'aaa'})
-        # Because the ORM "works" for records.browse([False]).name, fetch should "work" too.
-        false_record = records.browse([False])
-        records = real_record + new_record_origin + new_record_ref + new_record + false_record
+        records = real_record + new_record_origin + new_record_ref + new_record
         with self.assertQueryCount(1):
             records.fetch(['name'])
 

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -5228,6 +5228,7 @@ class BaseModel(metaclass=MetaModel):
             ids = (ids,)
         else:
             ids = tuple(ids)
+            assert all(ids) or all(isinstance(x, NewId) or x for x in ids), "Invalid falsy real id"
         return self.__class__(self.env, ids, ids)
 
     #
@@ -6219,8 +6220,8 @@ class BaseModel(metaclass=MetaModel):
                         rec_ids = OrderedSet()
                         for rec in self:
                             try:
-                                if rec[invf.model_field] == field.model_name:
-                                    rec_ids.add(rec[invf.name])
+                                if rec[invf.model_field] == field.model_name and (rec_id := rec[invf.name]):
+                                    rec_ids.add(rec_id)
                             except MissingError:
                                 continue
                         records = model.browse(rec_ids)

--- a/odoo/orm/utils.py
+++ b/odoo/orm/utils.py
@@ -1,5 +1,6 @@
 import re
 import warnings
+from collections.abc import Reversible
 from collections.abc import Set as AbstractSet
 
 import dateutil.relativedelta
@@ -126,7 +127,7 @@ def expand_ids(id0, ids):
             seen.add(id_)
 
 
-class OriginIds:
+class OriginIds(Reversible):
     """ A reversible iterable returning the origin ids of a collection of ``ids``.
         Actual ids are returned as is, and ids without origin are not returned.
     """
@@ -137,13 +138,10 @@ class OriginIds:
 
     def __iter__(self):
         for id_ in self.ids:
-            if id_ := id_ or getattr(id_, 'origin', None):
+            if id_ := id_ or id_.origin:
                 yield id_
 
     def __reversed__(self):
         for id_ in reversed(self.ids):
-            if id_ := id_ or getattr(id_, 'origin', None):
+            if id_ := id_ or id_.origin:
                 yield id_
-
-
-origin_ids = OriginIds

--- a/odoo/tools/convert.py
+++ b/odoo/tools/convert.py
@@ -191,6 +191,11 @@ def _eval_xml(self, node, env):
             pass  # already bound to an empty recordset
         else:
             record_ids, *args = args
+            # skip falsy ids
+            try:
+                record_ids = tuple(record_id for record_id in record_ids if record_id)
+            except TypeError:
+                record_ids = (record_ids,) if record_ids else ()
             model = model.browse(record_ids)
             method = getattr(model, method_name)
         # invoke method


### PR DESCRIPTION
Having a falsy real id is a programming mistake.
The following should be unusable `model.browse([False])`.

Add asserts that will check this and remove code from `OriginIds` that supports this case.

odoo/enterprise#95117

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
