### PR TITLE
[FIX] mrp: correctly compute BoM cost in Mo overview

### DIFF
--- a/addons/mrp/report/mrp_report_mo_overview.py
+++ b/addons/mrp/report/mrp_report_mo_overview.py
@@ -531,7 +531,8 @@ class ReportMoOverview(models.AbstractModel):
         real_cost = currency.round(self._get_component_real_cost(move_raw, current_quantity if move_raw.picked else 0))
         if production.bom_id:
             if move_raw.bom_line_id:
-                bom_cost = currency.round(self._get_component_real_cost(move_raw, move_raw.bom_line_id.product_qty * production.product_uom_qty / production.bom_id.product_qty))
+                qty_in_bom_uom = production.product_uom_id._compute_quantity(production.product_qty, production.bom_id.product_uom_id)
+                bom_cost = currency.round(self._get_component_real_cost(move_raw, move_raw.bom_line_id.product_qty * qty_in_bom_uom / production.bom_id.product_qty))
             else:
                 bom_cost = False
         else:
@@ -688,7 +689,8 @@ class ReportMoOverview(models.AbstractModel):
         free_qty = max(0, product.uom_id._compute_quantity(product.free_qty, move_raw.product_uom))
         available_qty = reserved_quantity + free_qty + total_ordered
         missing_quantity = quantity - available_qty
-        bom_missing_quantity = production.product_uom_qty * move_raw.bom_line_id.product_qty - (reserved_quantity + free_qty + total_ordered)
+        qty_in_bom_uom = production.product_uom_id._compute_quantity(production.product_qty, production.bom_id.product_uom_id)
+        bom_missing_quantity = qty_in_bom_uom * move_raw.bom_line_id.product_qty - (reserved_quantity + free_qty + total_ordered)
 
         if product.is_storable and production.state not in ('done', 'cancel')\
            and float_compare(missing_quantity, 0, precision_rounding=move_raw.product_uom.rounding) > 0:

--- a/addons/mrp/tests/test_stock_report.py
+++ b/addons/mrp/tests/test_stock_report.py
@@ -635,3 +635,32 @@ class TestMrpStockReports(TestReportsCommon):
         mo.move_raw_ids.filtered(lambda m: m.product_id == black_white_product and m.bom_line_id.bom_id.type != 'phantom').unlink()
         mo_report = self.env['report.mrp.report_mo_overview'].get_report_values(mo.id)
         self.assertEqual(mo_report['data']['extras']['unit_bom_cost'], mo_report['data']['extras']['unit_mo_cost'] + missing_product.standard_price + black_white_product.standard_price, 'The BoM unit cost should take the missing components into account, which are the deleted MO lines')
+
+    def test_mo_overview_with_different_uom(self):
+        """Ensure that the MO overview correctly computes costs
+        when the product UoM differs from the BoM UoM.
+        In this case, the product is defined in Unit while the BoM
+        is defined in Dozen.
+        """
+        self.env['mrp.bom'].create({
+            'product_id': self.product.id,
+            'product_tmpl_id': self.product.product_tmpl_id.id,
+            'product_uom_id': self.env.ref('uom.product_uom_dozen').id,
+            'product_qty': 1.0,
+            'bom_line_ids': [Command.create({
+                'product_id': self.product1.id,
+                'product_qty': 12.0,
+            })],
+        })
+        self.product1.standard_price = 10
+        # create MO for 1 dozen of the product
+        mo = self.env['mrp.production'].create({
+            'name': 'MO',
+            'bom_id': self.product.bom_ids.id
+        })
+
+        mo.action_confirm()
+        # check that the mo and bom cost are correctly calculated after mo confirmation
+        overview_values = self.env['report.mrp.report_mo_overview'].get_report_values(mo.id)
+        self.assertEqual(overview_values['data']['components'][0]['summary']['bom_cost'], 120)
+        self.assertEqual(overview_values['data']['components'][0]['summary']['mo_cost'], 120)


### PR DESCRIPTION
Backport of:
https://github.com/odoo/odoo/pull/223730/commits/b32c0ac7a7a29f9d185d5291edd3e3abe259510b

Steps to reproduce:
- Create a storable product “P1”:
    - UoM: Unit
    - BoM:
        - Pack of 6 of P1
        - Components:
            - C1: 6 units (price = $5)
            - C2: 6 units (price = $10)

- Create a manufacturing order:
    - 1 Pack of 6 of P1
- Confirm the MO
- Go to the MO overview

Issue:
- MO cost = $90 → ($5 * 6) + ($10 * 6) → correct
- BoM cost = $540 → ($5 * 36) + ($10 * 36) → wrong

Cause:
The BoM cost calculation uses `product_uom_qty` (6 units) of the production instead of computing the real quantity needed with the correct UoM.
As a result, component quantities are multiplied twice.

opw-4954953
