### PR TITLE
[FIX] html_builder, html_editor, website: replace `fa-times` with `oi-close`

### DIFF
--- a/addons/html_builder/i18n/html_builder.pot
+++ b/addons/html_builder/i18n/html_builder.pot
@@ -2876,6 +2876,12 @@ msgstr ""
 
 #. module: html_builder
 #. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_many2one.xml:0
+msgid "Unselect"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
 #: code:addons/html_builder/static/src/plugins/image/image_filter_option.xml:0
 msgid "Valencia"
 msgstr ""

--- a/addons/html_builder/static/src/core/building_blocks/builder_many2one.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_many2one.xml
@@ -16,17 +16,17 @@
 
             message="domState.selected?.display_name || props.defaultMessage"
         />
-        <button
-            t-if="domState.selected and props.allowUnselect"
-            type="button"
-            class="btn btn-primary fa fa-fw fa-times"
-            style="min-width: min-content;"
-            t-on-click="() => this.select()"
-            t-on-pointerenter="hasPreview ? () => this.preview() : undefined"
-            t-on-pointerleave="revert"
-            t-on-focusin="hasPreview ? () => this.preview() : undefined"
-            t-on-focusout="revert"
-        />
+        <button type="button"
+                t-if="domState.selected and props.allowUnselect"
+                class="o-hb-btn o-hb-btn-has-icon btn btn-secondary"
+                t-on-click="() => this.select()"
+                t-on-pointerenter="hasPreview ? () => this.preview() : undefined"
+                t-on-pointerleave="revert"
+                t-on-focusin="hasPreview ? () => this.preview() : undefined"
+                t-on-focusout="revert"
+                aria-label="Unselect">
+            <i class="oi oi-close" role="presentation"/>
+        </button>
     </BuilderComponent>
 </t>
 

--- a/addons/html_builder/static/src/core/building_blocks/select_many2x.xml
+++ b/addons/html_builder/static/src/core/building_blocks/select_many2x.xml
@@ -13,7 +13,7 @@
         onClosed.bind="onClosed"
         searchPlaceholder.translate="Search for records..."
         onInput.bind="onInput"
-        class="'o-hb-selectMany2X-wrapper'"
+        class="'o-hb-selectMany2X-wrapper min-w-0'"
         menuClass="'o-hb-select-dropdown o-hb-selectMany2X-dropdown'"
         togglerClass="'o-hb-selectMany2X-toggle btn-secondary'"
     >

--- a/addons/html_builder/static/src/plugins/background_option/background_shape_option.xml
+++ b/addons/html_builder/static/src/plugins/background_option/background_shape_option.xml
@@ -11,7 +11,7 @@
                 className="'o_hb_device btn-danger-color-active'">
             <Img src="'/html_builder/static/img/options/mobile_invisible.svg'" style="'width: 12px'" />
         </BuilderButton>
-        <BuilderButton action="'setBackgroundShape'" actionValue="''" preview="false" icon="'fa-times'"/>
+        <BuilderButton action="'setBackgroundShape'" actionValue="''" preview="false" icon="'oi-close'"/>
     </BuilderRow>
 
     <BuilderRow label.translate="Flip" level="2" t-if="isActiveItem('toggle_bg_shape_id')">

--- a/addons/html_builder/static/tests/builder_action.test.js
+++ b/addons/html_builder/static/tests/builder_action.test.js
@@ -230,7 +230,7 @@ describe("isPreviewing is passed to action's apply and clean", () => {
         expect.verifySteps(["apply true", "apply false"]);
 
         // clean
-        await contains(".o_select_menu + button.fa-times").click();
+        await contains(".o_select_menu + button > .oi-close").click();
         expect.verifySteps(["clean true", "clean false"]);
     });
 });

--- a/addons/html_editor/static/src/main/media/image_crop.xml
+++ b/addons/html_editor/static/src/main/media/image_crop.xml
@@ -33,8 +33,8 @@
                         <button type="button" title="Reset Image" t-on-click="this.onReset"><i class="fa fa-refresh"/> Reset Image</button>
                     </div>
                     <div class="btn-group" role="group">
-                        <button type="button" title="Apply" t-on-click="this.save" class="btn btn-primary"><i class="fa fa-check"/> Apply</button>
-                        <button type="button" title="Discard" t-on-click="this.closeCropper" class="btn btn-danger"><i class="fa fa-times"/> Discard</button>
+                        <button type="button" t-on-click="this.save" class="btn btn-primary"><i class="fa fa-check" role="presentation"/> Apply</button>
+                        <button type="button" t-on-click="this.closeCropper" class="btn btn-danger"><i class="oi oi-close" role="presentation"/> Discard</button>
                     </div>
                 </div>
             </div>

--- a/addons/html_editor/static/src/main/media/media_dialog/file_selector.xml
+++ b/addons/html_editor/static/src/main/media/media_dialog/file_selector.xml
@@ -23,7 +23,7 @@
             <div class="d-flex align-items-center">
                 <span t-if="state.urlInput and state.isValidatingUrl" class="o_we_url_loading mx-2 fa fa-lg fa-circle-o-notch fa-spin" title="Loading..."/>
                 <span t-elif="state.urlInput and state.isValidUrl and state.isValidFileFormat" class="o_we_url_success text-success mx-2 fa fa-lg fa-check" title="The URL seems valid."/>
-                <span t-elif="state.urlInput and !state.isValidUrl" class="o_we_url_error text-danger mx-2 fa fa-lg fa-times" title="The URL does not seem to work."/>
+                <span t-elif="state.urlInput and !state.isValidUrl" class="o_we_url_error text-danger mx-2 oi oi-large oi-close" title="The URL does not seem to work."/>
                 <span t-elif="props.urlWarningTitle and state.urlInput and state.isValidUrl and !state.isValidFileFormat" class="o_we_url_warning text-warning mx-2 fa fa-lg fa-warning" t-att-title="props.urlWarningTitle"/>
             </div>
         </div>

--- a/addons/html_editor/static/src/main/media/media_dialog/upload_progress_toast/upload_progress_toast.xml
+++ b/addons/html_editor/static/src/main/media/media_dialog/upload_progress_toast/upload_progress_toast.xml
@@ -7,7 +7,7 @@
     </small>
     <small t-if="props.uploaded or props.hasError" class="d-flex align-items-center mt-1">
         <span t-if="props.uploaded" class="text-success"><i class="fa fa-check my-1 me-1"/> File has been uploaded</span>
-        <span t-else="" class="text-danger"><i class="fa fa-times float-start my-1 me-1"/> <span class="o_we_error_text" t-esc="errorMessage"/></span>
+        <span t-else="" class="text-danger"><i class="oi oi-close float-start my-1 me-1"/> <span class="o_we_error_text" t-esc="errorMessage"/></span>
     </small>
     <div t-else="" class="progress mt-2">
         <div class="progress-bar bg-info progress-bar-striped progress-bar-animated" role="progressbar" t-attf-style="width: {{this.progress}}%;" aria-label="Progress bar"><span t-esc="this.progress + '%'"/></div>

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -1329,17 +1329,17 @@ test("should not close image cropper while loading media", async () => {
     await animationFrame();
     await click('.btn[name="image_crop"]');
 
-    await waitFor('.btn[title="Discard"]', { timeout: 1000 });
-    await click('.btn[title="Discard"]');
+    await waitFor('.btn:contains("Discard")', { timeout: 1000 });
+    await click('.btn:contains("Discard")');
     await animationFrame();
 
     // Cropper should not close as the cropper still loading the image.
-    expect('.btn[title="Discard"]').toHaveCount(1);
+    expect('.btn:contains("Discard")').toHaveCount(1);
 
     // Once the image loaded we should be able to close
     await cropperReadyPromise;
-    await click('.btn[title="Discard"]');
-    await waitForNone('.btn[title="Discard"]', { timeout: 1500 });
+    await click('.btn:contains("Discard")');
+    await waitForNone('.btn:contains("Discard")', { timeout: 1500 });
 });
 
 test("toolbar shouldn't be visible if can_display_toolbar === false", async () => {

--- a/addons/website/static/src/components/views/theme_preview.xml
+++ b/addons/website/static/src/components/views/theme_preview.xml
@@ -71,7 +71,7 @@
         <xpath expr="//div[hasclass('o_control_panel_actions')]" position="replace"/>
         <xpath expr="//div[hasclass('o_control_panel_navigation')]" position="replace">
             <a class="btn btn-secondary align-self-center" t-on-click="this.close" aria-label="Close" data-tooltip="Close">
-                <i class="fa fa-times" role="img" aria-label="close"/>
+                <i class="oi oi-close" role="img" aria-label="close"/>
             </a>
         </xpath>
     </t>


### PR DESCRIPTION
This commit replaces occurrences of `fa-times` in the html builder and editor with our own `oi-close` icon, which is less bulky and more elegant.

It also corrects button structures where icon classes were placed directly on the `button`, ensuring they are applied to a child `<i>` element as intended.

It also ensures `.o-hb-selectMany2X-wrapper` has `min-w-0` so the dropdown is truncated properly without pushing the remove button out of the screen.

task-5090805

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
