### PR TITLE
[FIX] mail: fix runbot error 231582 (no web_save when manually saving)

### DIFF
--- a/addons/mail/static/tests/inline/html_mail_field.test.js
+++ b/addons/mail/static/tests/inline/html_mail_field.test.js
@@ -6,6 +6,7 @@ import { after, before, beforeEach, expect, test } from "@odoo/hoot";
 import { press, queryOne } from "@odoo/hoot-dom";
 import { animationFrame, enableTransitions } from "@odoo/hoot-mock";
 import {
+    clickSave,
     contains,
     defineModels,
     fields,
@@ -93,7 +94,7 @@ test("HtmlMail save inline html", async function () {
     await press("enter");
     expect(".odoo-editor-editable").toHaveInnerHTML("<h1> first </h1>");
 
-    await contains(".o_form_button_save").click();
+    await clickSave();
     await expect.waitForSteps(["web_save"]);
 });
 
@@ -147,6 +148,6 @@ test("HtmlMail add icon and save inline html", async function () {
     await contains("a.nav-link:contains('Icons')").click();
     await contains("span.fa-glass").click();
 
-    await contains(".o_form_button_save").click();
+    await clickSave();
     await expect.waitForSteps(["web_save"]);
 });


### PR DESCRIPTION
This commit tries to solve runbot issues with mail html fields widget.

It seems clicking on the save button manually is not generating a call
to the backend. This could be due to the fact the button is not enabled
due to the data being invalid. Therefore using the clickSave util could
be useful in those situation since waiting that the button becomes
enabled.

This solution is not 100% sure to fix the issue in all cases but
manually disabling the button is creating the issue we can observe in
those runbots. There is a good chance it might work.

fixes-runbot-231582
fixes-runbot-233049

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
