### PR TITLE
[FIX] mail: align systray entry `:hover` with the other ones

### DIFF
--- a/addons/mail/static/src/core/common/core.dark.scss
+++ b/addons/mail/static/src/core/common/core.dark.scss
@@ -10,12 +10,6 @@ a.o-discuss-mention {
     @include o-mention-variant(rgba(lighten($o-action, 5%), .075), rgba(lighten($o-action, 10%), .25), lighten($o-action, 10%), rgba(lighten($o-action, 5%), .075), rgba(lighten($o-action, 10%), .25), lighten($o-action, 10%));
 }
 
-.o-mail-DiscussSystray-class {
-    &:hover, &.show {
-        background-color: $white;
-    }
-}
-
 .o-secondary {
     --o-secondary: #{$o-gray-700};
 }

--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -353,10 +353,6 @@ a.o-discuss-mention {
     margin-bottom: - $o-navbar-padding-v; // cancel navbar padding
     display: flex;
     align-items: center;
-
-    &:hover, &.show {
-        background-color: rgba(0, 0, 0, 0.075);
-    }
 }
 
 .o-mail-systrayFullscreenDropdownMenu {


### PR DESCRIPTION
This PR removes a custom `:hover` effect applied on the `mail`
systray entry, which was not consistent with the items of the systray.

task-4632971

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
