### PR TITLE
[FIX] {sale_,}stock: move sale order to correct place

### DIFF
--- a/addons/sale_stock/views/stock_picking_views.xml
+++ b/addons/sale_stock/views/stock_picking_views.xml
@@ -22,7 +22,7 @@
         <field name="model">stock.picking</field>
         <field name="inherit_id" ref="stock.view_picking_form"></field>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='picking_type_code']" position="after">
+            <xpath expr="//field[@name='move_type']" position="before">
                 <field name="sale_id"/>
             </xpath>
         </field>

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -326,7 +326,6 @@
                         <page string="Additional Info" name="extra">
                             <group>
                                 <group string="Other Information" name="other_infos">
-                                    <field name="picking_type_code" invisible="1"/>
                                     <field name="move_type" invisible="picking_type_code == 'incoming'" readonly="state in ['cancel', 'done']"/>
                                     <field name="user_id" widget="many2one_avatar_user" domain="[('share', '=', False)]" readonly="state in ['cancel', 'done']"/>
                                     <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}" force_save="1"/>


### PR DESCRIPTION
The picking form had two times the field `picking_type_code` in the arch. One next to the name, and the other in the Additionnal info tab. In 2713876dbc70d, the xpath in `sale_stock` adds `sale_id` after picking_type_code. It was placed right next the the picking name. This commit uses another field (unique this time) to place the sale_id at a more suitable place.

Task: 5073894

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
