### PR TITLE
[FIX] account: adapt invoice report to new UoM system

### DIFF
--- a/addons/account/report/account_invoice_report.py
+++ b/addons/account/report/account_invoice_report.py
@@ -100,7 +100,7 @@ class AccountInvoiceReport(models.Model):
                 move.invoice_date_due,
                 uom_template.id                                             AS product_uom_id,
                 template.categ_id                                           AS product_categ_id,
-                line.quantity / NULLIF(COALESCE(uom_line.factor, 1) / COALESCE(uom_template.factor, 1), 0.0) * (CASE WHEN move.move_type IN ('in_invoice','out_refund','in_receipt') THEN -1 ELSE 1 END)
+                line.quantity * COALESCE(uom_line.factor, 1) / NULLIF(COALESCE(uom_template.factor, 1), 0.0) * (CASE WHEN move.move_type IN ('in_invoice','out_refund','in_receipt') THEN -1 ELSE 1 END)
                                                                             AS quantity,
                 line.price_subtotal * (CASE WHEN move.move_type IN ('in_invoice','out_refund','in_receipt') THEN -1 ELSE 1 END)
                                                                             AS price_subtotal_currency,
@@ -114,15 +114,15 @@ class AccountInvoiceReport(models.Model):
                    -- Average line price
                    (line.balance / NULLIF(line.quantity, 0.0)) * (CASE WHEN move.move_type IN ('in_invoice','out_refund','in_receipt') THEN -1 ELSE 1 END)
                    -- convert to template uom
-                   * (NULLIF(COALESCE(uom_line.factor, 1), 0.0) / NULLIF(COALESCE(uom_template.factor, 1), 0.0)),
+                   / NULLIF(COALESCE(uom_line.factor, 1), 0.0) * COALESCE(uom_template.factor, 1),
                    0.0) * account_currency_table.rate                               AS price_average,
                 CASE
                     WHEN move.move_type NOT IN ('out_invoice', 'out_receipt', 'out_refund') THEN 0.0
-                    WHEN move.move_type = 'out_refund' THEN account_currency_table.rate * (-line.balance + (line.quantity / NULLIF(COALESCE(uom_line.factor, 1) / COALESCE(uom_template.factor, 1), 0.0)) * COALESCE(product.standard_price -> line.company_id::text, to_jsonb(0.0))::float)
-                    ELSE account_currency_table.rate * (-line.balance - (line.quantity / NULLIF(COALESCE(uom_line.factor, 1) / COALESCE(uom_template.factor, 1), 0.0)) * COALESCE(product.standard_price -> line.company_id::text, to_jsonb(0.0))::float)
+                    WHEN move.move_type = 'out_refund' THEN account_currency_table.rate * (-line.balance + (line.quantity * COALESCE(uom_line.factor, 1) / NULLIF(COALESCE(uom_template.factor, 1), 0.0)) * COALESCE(product.standard_price -> line.company_id::text, to_jsonb(0.0))::float)
+                    ELSE account_currency_table.rate * (-line.balance - (line.quantity * COALESCE(uom_line.factor, 1) / NULLIF(COALESCE(uom_template.factor, 1), 0.0)) * COALESCE(product.standard_price -> line.company_id::text, to_jsonb(0.0))::float)
                 END
                                                                             AS price_margin,
-                account_currency_table.rate * line.quantity / NULLIF(COALESCE(uom_line.factor, 1) / COALESCE(uom_template.factor, 1), 0.0) * (CASE WHEN move.move_type IN ('out_invoice','in_refund','out_receipt') THEN -1 ELSE 1 END)
+                account_currency_table.rate * line.quantity * COALESCE(uom_line.factor, 1) / NULLIF(COALESCE(uom_template.factor, 1), 0.0) * (CASE WHEN move.move_type IN ('out_invoice','in_refund','out_receipt') THEN -1 ELSE 1 END)
                     * COALESCE(product.standard_price -> line.company_id::text, to_jsonb(0.0))::float                    AS inventory_value,
                 COALESCE(partner.country_id, commercial_partner.country_id) AS country_id,
                 line.currency_id                                            AS currency_id


### PR DESCRIPTION
#### Issue:
Quantity, average price, margin and inventory value are wrong in Invoice analysis for invoice lines using packagings.

#### Step to reproduce:
- Choose a product
- Make sure it has a cost, and it differs from sales price
- In the sales sheet, add a packaging
- Create a sale order
- Add the product using the package
- Confirm
- Go to delivery, validate
- Back to sale order create an invoice and confirm it
- Go to "Invoice Analysis"
- Go to Pivot View
- In "Measures" select:
	- Average Price,
	- Inventory Value,
	- Margin,
	- Product Quantity
- In "Total" select:
	- Product

#### Current behavior:
- Those fields display wrong values as they were miscalculated:
	- Average Price		line_balance / number_of_packages * number_of_unit_in_package
	- Inventory Values	account_currency_table.rate * number_of_packages / number_of_unit_in_package
	- Margin			margin_on_one_unit * number_of_packages / number_of_unit_in_package
	- Product Quantity 	number_of_packages / number_of_unit_in_package

#### Expected behavior:
- These fields should be right:
	- Average Price		line_balance / number_of_packages / number_of_unit_in_package
	- Inventory Values	account_currency_table.rate * number_of_packages * number_of_unit_in_package
	- Margin			margin_on_one_unit * number_of_packages * number_of_unit_in_package
	- Product Quantity	number_of_packages * number_of_unit_in_package

#### Cause of the issue:
- As per the refactor of the UoM and packaging, the uom factor field is now the mathematical inverse of the previous uom factor field. This model wasn't updated and used wrong formulas.

opw-5031495

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
