### PR TITLE
[FIX] sale_project: missing default project when creating milestone from SO

### DIFF
--- a/addons/project/views/project_milestone_views.xml
+++ b/addons/project/views/project_milestone_views.xml
@@ -48,6 +48,7 @@
                 <field name="sequence" widget="handle"/>
                 <field name="name"/>
                 <field name="deadline" optional="show"/>
+                <field name="project_id" column_invisible="1"/>
                 <field name="is_reached" optional="show"/>
                 <button name="action_view_tasks"
                         type="object"


### PR DESCRIPTION
**Steps to reproduce:**
Create a service product with invoicing policy set to Based on milestones. Create and confirm a Sales Order with this product. Open the Sales Order and click on the Milestones stat button. In the milestones list view, click New to create a milestone.

**Cause:**
The default logic that was supposed to select the default project from context or active_id so it used the active_id which is Sales Order ID.

**Issue:**
When creating a milestone from a Sales Order, the project was not set correctly, which caused an error.

**Fix:**
Add the project_id field in list view to avoide default method call.

task-5090316




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
