### PR TITLE
[FIX] mail_render_mixin: Fixed AI field prompt access rights

### DIFF
--- a/addons/mail/models/mail_render_mixin.py
+++ b/addons/mail/models/mail_render_mixin.py
@@ -310,7 +310,7 @@ class MailRenderMixin(models.AbstractModel):
         if add_context:
             variables.update(**add_context)
 
-        is_restricted = not self._unrestricted_rendering and not self.env.is_admin() and not self.env.user.has_group('mail.group_mail_template_editor')
+        is_restricted = not (self._unrestricted_rendering or (options or {}).get('_unrestricted_rendering', False)) and not self.env.is_admin() and not self.env.user.has_group('mail.group_mail_template_editor')
 
         for record in self.env[model].browse(res_ids):
             variables['object'] = record


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
'Member' users can use the AI field button when the prompt contains standard field references. When the prompt contains a Studio field reference, there is an error message stating 'email template editor' access is required.

Current behavior before PR:
-Create an internal 'Member' user
-Add a 'user' group for the app you want to test on (bug spotted in Helpdesk).
-Make a plain text Studio field
-Make a text AI field where the prompt references the plain text Studio field you just created.
 -Make a text AI field where the prompt references a standard available field.
-Log into the database as the 'Member' user
-Push the 'AI' button on each of the two fields you created.
 -The one referencing the standard field should populate as normal; the one referencing the Studio field will trigger an error message asking for 'Email template editor access'.


Desired behavior after PR is merged:

Allowing AI fields unrestricted rendering to avoid the access error when the studio field is used in the prompt.

Task-5016767

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
