### PR TITLE
[FIX] spreadsheet,spreadsheet_dashboard: fix mobile dashboard panel

### DIFF
--- a/addons/spreadsheet/static/src/components/share_button/share_button.scss
+++ b/addons/spreadsheet/static/src/components/share_button/share_button.scss
@@ -8,3 +8,11 @@
     display: block;
   }
 }
+
+.o_bottom_sheet .spreadsheet_share_dropdown {
+  width: 100%;
+
+  .o_loading_state {
+    height: 40px;
+  }
+}

--- a/addons/spreadsheet/static/src/components/share_button/share_button.xml
+++ b/addons/spreadsheet/static/src/components/share_button/share_button.xml
@@ -13,7 +13,7 @@
         Share
       </button>
       <t t-set-slot="content">
-        <t t-if="state.url">
+        <t>
           <div class="d-flex px-3">
             <div class="align-self-center d-flex justify-content-center align-items-center flex-shrink-0">
               <i class="fa fa-globe fa-2x" title="Share to web"></i>
@@ -24,15 +24,15 @@
             </div>
           </div>
           <div class=" px-3 o_field_widget o_readonly_modifier o_field_CopyClipboardChar">
-            <div class="d-grid rounded-2 overflow-hidden">
+            <div t-if="state.url" class="d-grid rounded-2 overflow-hidden">
               <span t-out="state.url"/>
               <CopyButton className="'o_btn_char_copy btn-sm'" content="state.url" successText="copiedText" icon="'fa-clipboard'"/>
             </div>
+            <div t-else="" class="o_loading_state d-flex align-items-center justify-content-center">
+              <i class="fa fa-circle-o-notch fa-spin px-2"/><span>Generating sharing link</span>
+            </div>
           </div>
         </t>
-        <div t-else="" class="d-flex align-items-center justify-content-center h-100">
-          <i class="fa fa-circle-o-notch fa-spin px-2"/><span>Generating sharing link</span>
-        </div>
       </t>
     </Dropdown>
   </t>

--- a/addons/spreadsheet/static/src/global_filters/components/filter_values_list/filter_values_list.scss
+++ b/addons/spreadsheet/static/src/global_filters/components/filter_values_list/filter_values_list.scss
@@ -6,3 +6,11 @@
         height: 36px;
     }
 }
+
+.o_bottom_sheet .o-filter-values {
+    min-width: unset;
+    .o-filter-item  .o-autocomplete .dropdown-item {
+        --dropdown-item-padding-y: 3px;
+        font-weight: 400;
+    }
+}

--- a/addons/spreadsheet/static/src/global_filters/components/filter_values_list/filter_values_list.xml
+++ b/addons/spreadsheet/static/src/global_filters/components/filter_values_list/filter_values_list.xml
@@ -7,6 +7,7 @@
                     t-as="item"
                     t-key="item_index"
                     class="d-flex o-filter-item align-items-center"
+                    t-att-class="env.isSmall ? 'dropdown-item' : ''"
                     t-att-data-id="item.globalFilter.id">
                 <div class="me-1 w-25">
                     <t t-esc="getTranslatedFilterLabel(item.globalFilter)"/>

--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.js
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.js
@@ -11,6 +11,7 @@ import { SpreadsheetShareButton } from "@spreadsheet/components/share_button/sha
 import { useSpreadsheetPrint } from "@spreadsheet/hooks";
 import { Registry } from "@odoo/o-spreadsheet";
 import { router } from "@web/core/browser/router";
+import { useSearchBarToggler } from "@web/search/search_bar/search_bar_toggler";
 
 import { Component, onWillStart, useState, useEffect } from "@odoo/owl";
 import { DashboardSearchBar } from "./dashboard_search_bar/dashboard_search_bar";
@@ -74,6 +75,7 @@ export class SpreadsheetDashboardAction extends Component {
         useSpreadsheetPrint(() => this.loader.getActiveDashboard()?.model);
         /** @type {{ sidebarExpanded: boolean}} */
         this.state = useState({ sidebarExpanded: true });
+        this.searchBarToggler = useSearchBarToggler();
     }
 
     get dashboardButton() {
@@ -84,7 +86,9 @@ export class SpreadsheetDashboardAction extends Component {
      * @returns {number | undefined}
      */
     get activeDashboardId() {
-        return this.loader.getActiveDashboard() ? this.loader.getActiveDashboard().data.id : undefined;
+        return this.loader.getActiveDashboard()
+            ? this.loader.getActiveDashboard().data.id
+            : undefined;
     }
 
     /**

--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.scss
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.scss
@@ -73,21 +73,34 @@
         min-width: 0;
     }
 
+    /* Not in mobile */
+    @media (min-width: 768px){
+        .o_control_panel_actions {
+            max-height: 200px;
+            /* Place the search bar before the navigation buttons */
+            order: 1 !important;
+        }
+    }
+
+    /* In mobile */
+    @media (max-width: 768px){
+        .o_control_panel_navigation {
+            /* DashboardMobileSearchPanel is added in navigation buttons in mobile, and should be aligned left*/
+            justify-content: start !important;
+        }
+
+        .o_control_panel_main {
+            /* We don't want a gap before the DashboardMobileSearchPanel */
+            column-gap: 0px !important;
+        }
+    }
+
     .o_control_panel_actions {
         gap: map-get($spacers, 2);
-        max-height: 200px;
         overflow: auto;
         flex-wrap: wrap;
         justify-content: start !important;
         align-items: start !important;
-        order: 1 !important;
-
-        .o_filter_value_container {
-            width: 235px;
-            max-height: 150px;
-            overflow: hidden auto;
-            padding-right: 18px;
-        }
 
         .o-filter-value {
             min-height: 25px;
@@ -102,10 +115,6 @@
                     flex: 1 0 1rem;
                 }
             }
-        }
-
-        .o-filter-value-double-size {
-            flex-basis: 200px;
         }
     }
 

--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.xml
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.xml
@@ -4,33 +4,37 @@
         <ControlPanel display="controlPanelDisplay">
             <t t-set-slot="layout-actions" t-if="!loader.getActiveDashboard()?.isSample">
                 <t t-set="status" t-value="loader.getActiveDashboard() and loader.getActiveDashboard().status"/>
-                <div class="d-flex flex-wrap">
+                <div class="d-flex flex-wrap w-100">
                     <DashboardSearchBar t-if="status === Status.Loaded and loader.getActiveDashboard().model.getters.getGlobalFilters().length"
                                         t-key="activeDashboardId"
                                         model="loader.getActiveDashboard().model"
+                                        toggler="searchBarToggler"
                     />
                 </div>
             </t>
             <t t-set-slot="control-panel-navigation-additional" t-if="!loader.getActiveDashboard()?.isSample">
+                <!-- Dashboard selection -->
+                <t t-if="env.isSmall">
+                    <DashboardMobileSearchPanel
+                        onDashboardSelected="(dashboardId) => this.openDashboard(dashboardId)"
+                        activeDashboard="dashboard"
+                        groups="getDashboardGroups()"/>
+                </t>
                 <SpreadsheetShareButton t-key="activeDashboardId" model="loader.getActiveDashboard()?.model" onSpreadsheetShared.bind="shareSpreadsheet" togglerClass="'btn-light'"/>
                 <a
                     t-if="loader.getActiveDashboard()"
                     title="Toggle favorite"
                     t-on-click="toggleFavorite"
-                    t-attf-class="o_dashboard_star fa fa-lg fa-star{{!loader.getActiveDashboard().data.is_favorite ? '-o' : ''}}"
+                    t-attf-class="o_dashboard_star align-middle lh-base fa fa-lg fa-star{{!loader.getActiveDashboard().data.is_favorite ? '-o' : ''}}"
                 />
+                <div class="ms-1 o_search_toggler" t-if="env.isSmall">
+                    <t t-component="searchBarToggler.component" t-props="searchBarToggler.props"/>
+                </div>
             </t>
         </ControlPanel>
         <t t-set="dashboard" t-value="loader.getActiveDashboard()"/>
         <div class="o_content o_component_with_search_panel" t-att-class="{ o_mobile_dashboard: env.isSmall }">
-            <!-- Dashboard selection -->
-            <t t-if="env.isSmall">
-                <DashboardMobileSearchPanel
-                    onDashboardSelected="(dashboardId) => this.openDashboard(dashboardId)"
-                    activeDashboard="dashboard"
-                    groups="getDashboardGroups()"/>
-            </t>
-            <t t-else="">
+            <t t-if="!env.isSmall">
                 <t t-if="state.sidebarExpanded" t-call="spreadsheet_dashboard.DashboardAction.Expanded"/>
                 <t t-else="" t-call="spreadsheet_dashboard.DashboardAction.Collapsed"/>
             </t>

--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_facet/dashboard_facet.xml
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_facet/dashboard_facet.xml
@@ -11,7 +11,7 @@
             </div>
             <div class="o_facet_values position-relative d-flex flex-wrap align-items-center rounded-end-2 text-wrap overflow-hidden">
                 <span><small class="o_facet_values_sep small mx-1 opacity-50" t-esc="props.facet.operator" t-att-title="props.facet.operator"/></span>
-                <span t-foreach="props.facet.values" t-as="value" t-key="value_index">
+                <span t-foreach="props.facet.values" t-as="value" t-key="value_index" class="d-flex">
                     <em t-if="!value_first" class="o_facet_values_sep small fw-bold mx-1 opacity-50" t-esc="props.facet.separator"/>
                     <small class="o_facet_value text-truncate" t-esc="value" t-att-title="value"/>
                 </span>

--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_search_bar/dashboard_search_bar.js
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_search_bar/dashboard_search_bar.js
@@ -23,7 +23,7 @@ export class DashboardSearchBar extends Component {
         Dropdown,
         DropdownItem,
     };
-    static props = { model: Object };
+    static props = { model: Object, toggler: Object };
 
     setup() {
         this.facets = [];
@@ -41,6 +41,7 @@ export class DashboardSearchBar extends Component {
             query: "",
             subItemsLimits: {},
         });
+        this.visibilityState = useState(this.props.toggler.state);
 
         this.items = useState([]);
         this.subItems = {};

--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_search_bar/dashboard_search_bar.scss
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_search_bar/dashboard_search_bar.scss
@@ -1,3 +1,24 @@
 .o_sp_dashboard_search {
     min-width: 50vw;
+
+    .o_sp_date_filter_button {
+        height: fit-content;
+    }
+
+    .o_searchview {
+        overflow-y: auto;
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
+    }
+
+    @media (min-width: 768px){
+        .o_searchview {
+            max-height: 200px;
+        }
+    }
+
+    .o_searchview_dropdown_toggler {
+        margin-left: calc(var(--border-width) * -1);
+    }
+
 }

--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_search_bar/dashboard_search_bar.xml
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_search_bar/dashboard_search_bar.xml
@@ -1,64 +1,66 @@
 <?xml version="1.0" encoding="utf-8"?>
 <templates>
     <t t-name="spreadsheet_dashboard.DashboardSearchBar">
-        <div class="o_sp_dashboard_search d-flex input-group mt-1 mt-md-0">
-            <Dropdown
-                state="inputDropdownState"
-                manual="true"
-                noClasses="true"
-                position="'bottom-fit'"
-                menuClass="'o_searchview_autocomplete'"
-                navigationOptions="inputDropdownNavOptions"
-                onStateChanged.bind="onInputDropdownChanged"
-                menuRef="menuRef"
-                bottomSheet="false"
-            >
+        <div class="o_sp_dashboard_search d-flex flex-wrap flex-lg-nowrap gap-1 gap-lg-2 w-100 w-lg-auto">
+            <div class="d-flex flex-grow-1 w-100 w-lg-auto" t-if="visibilityState.showSearchBar" >
+                <Dropdown
+                    state="inputDropdownState"
+                    manual="true"
+                    noClasses="true"
+                    position="'bottom-fit'"
+                    menuClass="'o_searchview_autocomplete'"
+                    navigationOptions="inputDropdownNavOptions"
+                    onStateChanged.bind="onInputDropdownChanged"
+                    menuRef="menuRef"
+                    bottomSheet="false"
+                >
 
-                <div
-                    class="o_searchview form-control d-flex align-items-center py-1 border-end-0 gap-1">
-                    <button class="btn border-0 p-0" t-on-click="onSearchClick">
-                        <i class="oi oi-search me-2"></i>
-                    </button>
                     <div
-                        class="o_searchview_input_container d-flex flex-grow-1 flex-wrap gap-1 mw-100">
-                        <t t-foreach="facets" t-as="facet" t-key="facet.id">
-                            <DashboardFacet facet="facet"
-                                clearFilter="() => this.clearFilter(facet.id)"
-                                onClick.bind="openFilterValueDropdown" />
+                        class="o_searchview form-control d-flex align-items-center py-1 border-end-0 gap-1">
+                        <button class="btn border-0 p-0" t-on-click="onSearchClick">
+                            <i class="oi oi-search me-2"></i>
+                        </button>
+                        <div
+                            class="o_searchview_input_container d-flex flex-grow-1 flex-wrap gap-1 mw-100">
+                            <t t-foreach="facets" t-as="facet" t-key="facet.id">
+                                <DashboardFacet facet="facet"
+                                    clearFilter="() => this.clearFilter(facet.id)"
+                                    onClick.bind="openFilterValueDropdown" />
+                            </t>
+                            <input type="text"
+                                class="o_searchview_input o_input d-print-none flex-grow-1 w-auto border-0"
+                                t-att-tabindex="env.isSmall ? -1 : 0"
+                                accesskey="Q"
+                                placeholder="Search..."
+                                role="searchbox"
+                                t-ref="autofocus"
+                                t-on-click="onSearchClick"
+                                t-on-input="onSearchInput"
+                                t-on-keydown="onSearchInputKeydown"
+                                t-on-pointerdown="onSearchInputPointerDown"
+                            />
+                        </div>
+                        <t t-set-slot="content">
+                            <t t-call="web.SearchBar.QuickSearchItems" />
                         </t>
-                        <input type="text"
-                            class="o_searchview_input o_input d-print-none flex-grow-1 w-auto border-0"
-                            t-att-tabindex="env.isSmall ? -1 : 0"
-                            accesskey="Q"
-                            placeholder="Search..."
-                            role="searchbox"
-                            t-ref="autofocus"
-                            t-on-click="onSearchClick"
-                            t-on-input="onSearchInput"
-                            t-on-keydown="onSearchInputKeydown"
-                            t-on-pointerdown="onSearchInputPointerDown"
-                        />
-                    </div>
-                    <t t-set-slot="content">
-                        <t t-call="web.SearchBar.QuickSearchItems" />
-                    </t>
 
-                </div>
-            </Dropdown>
-            <Dropdown menuClass="'pt-0 px-2'"
-                manual="true"
-                position="'bottom-end'"
-                state="filtersValuesDropdown">
-                <button
-                    class="o_searchview_dropdown_toggler btn btn-outline-secondary o-dropdown-caret rounded-start-0 o-dropdown dropdown-toggle dropdown"
-                    t-on-click="toggleFilterValueDropdown" />
-                <t t-set-slot="content">
-                    <div class="p-2">
-                        <FilterValuesList model="props.model" close.bind="closeFilterValueDropdown" />
                     </div>
-                </t>
-            </Dropdown>
-            <div class="o_sp_date_filter_button ms-2 d-flex" t-if="firstDateFilter">
+                </Dropdown>
+                <Dropdown menuClass="'pt-0 px-2'"
+                    manual="true"
+                    position="'bottom-end'"
+                    state="filtersValuesDropdown">
+                    <button
+                        class="o_searchview_dropdown_toggler btn btn-outline-secondary o-dropdown-caret rounded-start-0 o-dropdown dropdown-toggle dropdown"
+                        t-on-click="toggleFilterValueDropdown" />
+                    <t t-set-slot="content">
+                        <div class="p-2">
+                            <FilterValuesList model="props.model" close.bind="closeFilterValueDropdown" />
+                        </div>
+                    </t>
+                </Dropdown>
+            </div>
+            <div class="o_sp_date_filter_button d-flex" t-if="firstDateFilter">
                 <DashboardDateFilter value="firstDateFilterValue"
                                 update.bind="updateFirstDateFilter" />
             </div>

--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/mobile_search_panel/mobile_search_panel.xml
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/mobile_search_panel/mobile_search_panel.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <templates>
-    <div t-name="spreadsheet_dashboard.DashboardMobileSearchPanel" class="o_search_panel o_search_panel_summary btn w-100 overflow-visible border-bottom">
+    <div t-name="spreadsheet_dashboard.DashboardMobileSearchPanel" class="btn flex-grow-1 ps-0">
         <t t-if="state.isOpen">
             <t t-portal="'body'">
                 <div class="o_spreadsheet_dashboard_search_panel o_search_panel o_searchview o_mobile_search">

--- a/addons/spreadsheet_dashboard/static/tests/dashboard/dashboard_action.test.js
+++ b/addons/spreadsheet_dashboard/static/tests/dashboard/dashboard_action.test.js
@@ -253,9 +253,10 @@ test("share dashboard from dashboard view", async function () {
     expect(".spreadsheet_share_dropdown").toHaveCount(0);
     await contains("i.fa-share-alt").click();
     await animationFrame();
-    expect(".spreadsheet_share_dropdown").toHaveText("Generating sharing link");
+    expect(".spreadsheet_share_dropdown .o_loading_state").toHaveText("Generating sharing link");
     def.resolve();
     await animationFrame();
+    expect(".spreadsheet_share_dropdown .o_loading_state").toHaveCount(0);
     expect.verifySteps(["dashboard_shared", "share url copied"]);
     expect(".o_field_CopyClipboardChar").toHaveText("localhost:8069/share/url/132465");
     await contains(".fa-clipboard").click();

--- a/addons/spreadsheet_dashboard/static/tests/dashboard/dashboard_action_mobile.test.js
+++ b/addons/spreadsheet_dashboard/static/tests/dashboard/dashboard_action_mobile.test.js
@@ -35,6 +35,18 @@ function getServerData(spreadsheetData) {
     return serverData;
 }
 
+test("Search input can be toggled", async () => {
+    const productFilter = { id: "1", type: "relation", label: "Product", modelName: "product" };
+    const spreadsheetData = { globalFilters: [productFilter] };
+    const serverData = getServerData(spreadsheetData);
+    await createSpreadsheetDashboard({ serverData });
+
+    expect(".o_searchview_input").toHaveCount(0);
+
+    await contains(".o_search_toggler button").click();
+    expect(".o_searchview_input").toHaveCount(1);
+});
+
 test("Search input is not focusable in mobile", async () => {
     const productFilter = {
         id: "1",
@@ -46,6 +58,7 @@ test("Search input is not focusable in mobile", async () => {
     const serverData = getServerData(spreadsheetData);
     await createSpreadsheetDashboard({ serverData });
 
+    await contains(".o_search_toggler button").click();
     await contains(".o_searchview_input").click();
 
     const input = getFixture().querySelector(".o_searchview_input");

--- a/addons/spreadsheet_dashboard/static/tests/mobile/mobile_dashboard_action.test.js
+++ b/addons/spreadsheet_dashboard/static/tests/mobile/mobile_dashboard_action.test.js
@@ -75,7 +75,7 @@ test("double clicking on a figure doesn't open the side panel", async () => {
 
 test("can switch dashboard", async () => {
     await createSpreadsheetDashboard();
-    expect(".o_search_panel_summary").toHaveText("Dashboard CRM 1");
+    expect(".o_search_panel_current_selection").toHaveText("Dashboard CRM 1");
     await contains(".o_search_panel_current_selection").click();
     const dashboardElements = queryAll("section header.list-group-item", { root: document.body });
     expect(dashboardElements[0]).toHaveClass("active");
@@ -85,14 +85,14 @@ test("can switch dashboard", async () => {
         "Dashboard Accounting 1",
     ]);
     await contains(dashboardElements[1]).click();
-    expect(".o_search_panel_summary").toHaveText("Dashboard CRM 2");
+    expect(".o_search_panel_current_selection").toHaveText("Dashboard CRM 2");
 });
 
 test("can go back from dashboard selection", async () => {
     await createSpreadsheetDashboard();
     expect(".o_mobile_dashboard").toHaveCount(1);
-    expect(".o_search_panel_summary").toHaveText("Dashboard CRM 1");
+    expect(".o_search_panel_current_selection").toHaveText("Dashboard CRM 1");
     await contains(".o_search_panel_current_selection").click();
     await contains(document.querySelector(".o_mobile_search_button")).click();
-    expect(".o_search_panel_summary").toHaveText("Dashboard CRM 1");
+    expect(".o_search_panel_current_selection").toHaveText("Dashboard CRM 1");
 });


### PR DESCRIPTION
The control panel of a dashboard (search bar + navigation buttons) was really ugly on mobile. This commit fixes most issues:

- the global fitler values dropdown is now correctly rendered
- there is now a button to hide/show the navbar
- the layout of the share/search bar/date filter is now responsive
- the search bar facets are now correctly truncated
- the button to open the list of dashboard is now at the same level as the sahre button

Task: [4996784](https://www.odoo.com/odoo/2328/tasks/4996784)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
