### PR TITLE
[FIX] mail: fix batching of _inverse_message_partner_ids

### DIFF
--- a/addons/test_mail/tests/test_mail_followers.py
+++ b/addons/test_mail/tests/test_mail_followers.py
@@ -207,6 +207,18 @@ class BaseFollowersTest(MailCommon):
         test_record.write({'message_partner_ids': [(4, partner0.id), (4, partner1.id)]})
         self.assertEqual(test_record.message_follower_ids.partner_id, partner1)
 
+        # Test when the method inverse is called in batch
+        other_record = test_record.create({
+            'name': 'Other',
+        })
+        records = test_record + other_record
+
+        records.message_partner_ids = (partner2 + partner3)
+        self.assertEqual(records.message_partner_ids, partner2 + partner3)
+
+        records.message_partner_ids -= partner2
+        self.assertEqual(records.message_partner_ids, partner3)
+
     @mute_logger('odoo.addons.base.models.ir_model', 'odoo.models')
     def test_followers_inverse_message_partner_access_rights(self):
         """ Make sure we're not bypassing security checks by setting a partner


### PR DESCRIPTION
When updating `message_partner_ids` on a batch of records, the previous implementation of the inverse method could lead to incorrect results if the new value implied unsubscription.

The `message_unsubscribe()` method, called inside the loop over the records, unlinks `mail.followers`. This `unlink` operation invalidates all the fields cache. As a result, when processing the next record in the batch, its cached fields (the new value of `message_follower_ids`) were erased, causing the logic to fail.

This commit fixes the issue by postponing all unsubscription operations.

opw-5050023