### PR TITLE
[FIX] mrp_subcontracting: make warehouse duplication test agnostic to purchase_stock

### DIFF
--- a/addons/mrp_subcontracting/tests/test_subcontracting.py
+++ b/addons/mrp_subcontracting/tests/test_subcontracting.py
@@ -28,7 +28,9 @@ class TestSubcontractingBasic(TransactionCase):
         Not reusing the existing routes and operation types"""
         wh_original = self.env['stock.warehouse'].search([], limit=1)
         wh_copy = wh_original.copy(default={'name': 'Dummy Warehouse (copy)', 'code': 'Dummy'})
-        wh_original.buy_to_resupply = False
+        if 'buy_to_resupply' in wh_original._fields:
+            # If purchase is installed, the buy route would be reused instead of duplicated.
+            wh_original.buy_to_resupply = False
         wh_original.manufacture_to_resupply = False
         # Check if warehouse routes got RECREATED (instead of reused)
         route_types = [


### PR DESCRIPTION
The test `test_duplicating_warehouses_recreates_their_routes_and_operation_types` was failing with:

    AttributeError: 'stock.warehouse' object has no attribute 'buy_to_resupply'

A recent change added to the test :

    wh_original.buy_to_resupply = False

However, `buy_to_resupply` is defined in `purchase_stock`. When this module is not installed, the field is absent and the test crashes.

Fix:
    Only assign the field if it exists on stock.warehouse.

[RB-232580](https://runbot.odoo.com/odoo/error/232580)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
