### PR TITLE
[FIX] stock_account: fix traceback on grouping by location

### DIFF
--- a/addons/stock_account/models/stock_quant.py
+++ b/addons/stock_account/models/stock_quant.py
@@ -67,12 +67,12 @@ class StockQuant(models.Model):
     def _read_group_select(self, aggregate_spec, query):
         # flag value as aggregatable, and manually sum the values from the
         # records in the group
-        if aggregate_spec == 'value:sum':
+        if aggregate_spec in ('value:sum', 'value:sum_currency'):
             return super()._read_group_select('id:recordset', query)
         return super()._read_group_select(aggregate_spec, query)
 
     def _read_group_postprocess_aggregate(self, aggregate_spec, raw_values):
-        if aggregate_spec == 'value:sum':
+        if aggregate_spec in ('value:sum', 'value:sum_currency'):
             column = super()._read_group_postprocess_aggregate('id:recordset', raw_values)
             return (sum(records.mapped('value')) for records in column)
         return super()._read_group_postprocess_aggregate(aggregate_spec, raw_values)


### PR DESCRIPTION
Steps to reproduce:
- Have `stock_account` module installed
- Navigate to stock locations
- Group by location

Problem:
Traceback "ValueError: Cannot convert stock.quant.value to SQL because it is not stored"



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
