### PR TITLE
[FIX] Restricting Edit Access to Department

### DIFF
--- a/addons/hr/security/hr_security.xml
+++ b/addons/hr/security/hr_security.xml
@@ -42,6 +42,26 @@
         <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 
+    <record id="hr_dept_manager_access_rule" model="ir.rule">
+        <field name="name">Department Access For Managers</field>
+        <field name="model_id" ref="model_hr_department"/>
+        <field name="domain_force">[('has_read_access', '=', True)]</field>
+        <field name="groups" eval="[(4, ref('base.group_user'))]"/>
+        <field name="perm_read" eval="False"/>
+        <field name="perm_write" eval="True"/>
+    </record>
+
+    <record id="hr_dept_hr_officer_access_rule" model="ir.rule">
+        <field name="name">Department Access For HR Officers</field>
+        <field name="model_id" ref="hr.model_hr_department"/>
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="groups" eval="[(4, ref('hr.group_hr_user'))]"/>
+        <field name="perm_read" eval="False"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+    </record>
+
     <record id="hr_employee_public_comp_rule" model="ir.rule">
         <field name="name">Employee multi company rule</field>
         <field name="model_id" ref="model_hr_employee_public"/>


### PR DESCRIPTION
Before this commit:
any internal user could **edit** all departments

After this commit:
non-hr users can **edit**:
a) departments they manage
b) departments managed by one of their subordinates
c) children departments of a, b

Task-4948774
