### PR TITLE
[FIX] website_sale: GMC multi-company

### DIFF
--- a/addons/website_sale/models/product_feed.py
+++ b/addons/website_sale/models/product_feed.py
@@ -65,7 +65,7 @@ class ProductFeed(models.Model):
     feed_cache = fields.Binary(compute='_compute_feed_cache', store=True, readonly=True)
     cache_expiry = fields.Datetime(readonly=True, required=True, default=fields.Datetime.now)
 
-    @api.depends('target')
+    @api.depends('website_id', 'target', 'access_token')
     def _compute_url(self):
         """Compute the full feed url."""
         for feed in self:

--- a/addons/website_sale/models/res_config_settings.py
+++ b/addons/website_sale/models/res_config_settings.py
@@ -116,13 +116,8 @@ class ResConfigSettings(models.TransientModel):
         if self.website_id:
             website = self.with_context(website_id=self.website_id.id).website_id
 
-            # Pre-populate the website feeds if none already exists.
-            if (
-                self.group_gmc_feed
-                and not self.env['product.feed'].search_count(
-                    [('website_id', '=', website.id)], limit=1
-                )
-            ):
+            # Pre-populate the website product feeds if none already exist (company-independent).
+            if self.group_gmc_feed and not self.env['product.feed'].sudo().search([], limit=1):
                 website._populate_product_feeds()
         # if Request ratings option is enabled activate Customer Reviews view
         if self.send_order_rating_emails:

--- a/addons/website_sale/security/ir_rules.xml
+++ b/addons/website_sale/security/ir_rules.xml
@@ -68,4 +68,10 @@
         <field name="groups" eval="[(4, ref('sales_team.group_sale_manager'))]"/>
     </record>
 
+    <record id="product_feed_comp_rule" model="ir.rule">
+        <field name="name">Product feed (company rule)</field>
+        <field name="model_id" ref="website_sale.model_product_feed"/>
+        <field name="domain_force">[('website_id.company_id', 'in', company_ids)]</field>
+    </record>
+
 </odoo>

--- a/addons/website_sale/views/product_feed_views.xml
+++ b/addons/website_sale/views/product_feed_views.xml
@@ -73,6 +73,7 @@
                     width="100px"
                     nolabel="1"
                     options="{'btn_class': 'primary btn-sm'}"
+                    invisible="not id"
                 />
             </list>
         </field>
@@ -88,7 +89,12 @@
                         <h1><field name="name"/></h1>
                     </div>
                     <div name="button_box">
-                        <field name="url" string="Copy URL" widget="CopyClipboardButton"/>
+                        <field
+                            name="url"
+                            string="Copy URL"
+                            widget="CopyClipboardButton"
+                            invisible="not id"
+                        />
                     </div>
                     <group>
                         <field name="website_id"/>


### PR DESCRIPTION
This commit addresses a couple of small issues related to the reintroduction of GMC in [^1]:

1. The `product.feed` model was accessible across all companies. This commit introduces an `ir.rule` to ensure that product feed visibility is restricted to the company of its associated website.

2. When creating a new product feed, a temporary ID is used until it is saved in the database. This caused issues if a user attempted to copy the URL before saving the feed as the URL depends on the record ID. This commit hides the copy to clipboard button until the feed is saved.

[^1]: https://github.com/odoo/odoo/pull/224889
