### PR TITLE
[FIX] hr_holidays: holiday responsible access error on multi request

### DIFF
--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -378,7 +378,7 @@ class HrEmployee(models.Model):
             ('company_id', 'in', self.env.companies.ids),
             '|',
             ('resource_calendar_id', '=', False),
-            ('resource_calendar_id', '=', self.resource_calendar_id.id),
+            ('resource_calendar_id', 'in', self.resource_calendar_id.ids),
         ]
 
         if self.job_id:

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -125,7 +125,7 @@ class HrLeave(models.Model):
 
     # description
     name = fields.Char('Description', compute='_compute_description', inverse='_inverse_description', search='_search_description', compute_sudo=False, copy=False)
-    private_name = fields.Char('Time Off Description', groups='hr_holidays.group_hr_holidays_user')
+    private_name = fields.Char('Time Off Description', groups='hr_holidays.group_hr_holidays_responsible')
     state = fields.Selection([
         ('confirm', 'To Approve'),
         ('refuse', 'Refused'),

--- a/addons/hr_holidays/wizard/hr_leave_generate_multi_wizard.py
+++ b/addons/hr_holidays/wizard/hr_leave_generate_multi_wizard.py
@@ -44,7 +44,7 @@ class HrLeaveGenerateMultiWizard(models.TransientModel):
     def _get_employees_from_allocation_mode(self):
         self.ensure_one()
         if self.allocation_mode == 'employee':
-            employees = self.employee_ids
+            employees = self.employee_ids or self.env['hr.employee'].search(self._get_employee_domain())
         elif self.allocation_mode == 'category':
             employees = self.category_id.employee_ids.filtered(lambda e: e.company_id in self.env.companies)
         elif self.allocation_mode == 'company':


### PR DESCRIPTION
purpose: fix the issue when a user who is `hr_holiday_responsible` creates a multi timeoff request, where an access right error appears because they don't have access on Employee.

Steps to reproduce:
- login as someone who has `group_hr_holidays_responsible`
- create group leaves for employees you are responsible for
- create conflicting leaves
- you get access right error because you can't read field `private_name`

Current behavior:
- fixed access right error on creating group leaves for `group_hr_holidays_responsible`
- added `test_create_conflicting_group_leave_without_hr_right` for creating conflicting group leave with `group_hr_holidays_responsible` access right
- added `test_create_group_leave_form_allocation_mode_without_hr_right` for creating group leave directly from allocation mode (without choosing specific employees) with `group_hr_holidays_responsible` access right
- added `test_create_differnt_calendars_group_leave_without_hr_right` for creating group leaves for employees with different calendars with `group_hr_holidays_responsible` access right

task-id: 5051859

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
