### PR TITLE
[FIX] crm: remove markup when selecting record in many2one_avatar_leader_user

### DIFF
--- a/addons/crm/models/res_users.py
+++ b/addons/crm/models/res_users.py
@@ -4,11 +4,14 @@ from odoo import _, api, models
 class ResUsers(models.Model):
     _inherit = "res.users"
 
-    @api.depends_context('crm_formatted_display_name_team')
+    @api.depends_context(
+        'crm_formatted_display_name_team',
+        'formatted_display_name')
     def _compute_display_name(self):
         super()._compute_display_name()
+        formatted_display_name = self.env.context.get('formatted_display_name')
         team_id = self.env.context.get('crm_formatted_display_name_team', 0)
-        if team_id:
+        if formatted_display_name and team_id:
             leader_id = self.env['crm.team'].browse(team_id).user_id
             for user in self.filtered(lambda u: u == leader_id):
                 user.display_name += " --%s--" % _("(Team Leader)")

--- a/addons/mail/static/src/views/web/fields/avatar_autocomplete/avatar_many2x_autocomplete.scss
+++ b/addons/mail/static/src/views/web/fields/avatar_autocomplete/avatar_many2x_autocomplete.scss
@@ -1,0 +1,9 @@
+.o_field_many2one_avatar_leader_user {
+    .dropdown-item {
+        text-indent: 0 !important;
+        .o_icon {
+            height: var(--Avatar-size, #{$o-avatar-size});
+            aspect-ratio: 1;
+        }
+    }
+}

--- a/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/many2one_avatar_user_field.xml
+++ b/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/many2one_avatar_user_field.xml
@@ -8,8 +8,12 @@
             </t>
             <Many2OneAvatarUser t-props="m2oProps" cssClass="'w-100'">
                 <t t-set-slot="inviteTeammates" t-slot-scope="inviteTeammatesScope">
-                    <i class="fa fa-envelope-o fa-lg me-2 d-inline"/>
-                    <t t-out="inviteTeammatesScope.label"/>
+                    <div class="d-flex align-items-center">
+                        <div class="o_icon d-flex align-items-center justify-content-center me-2">
+                            <i class="fa fa-envelope-o fa-lg"/>
+                        </div>
+                        <span t-out="inviteTeammatesScope.label"/>
+                    </div>
                 </t>
                 <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
                     <div class="o_avatar_many2x_autocomplete d-flex align-items-center">


### PR DESCRIPTION
When suggesting records, the `Many2XAutocomplete` component relies on the `web_name_search` method to fetch data. This method returns a dictionary with two keys: `display_name` and `__formatted_display_name`. The latter is used as the label for suggestions, while `display_name` is used when selecting a record or as a fallback if no formatted value is available.

In the `many2one_avatar_leader_user` field, the suggestions currently include the `--(Team Leader)--` markup. However, this markup is also shown in the selected record, where it appears as raw text since markups are not rendered in that context.

Step to reproduce the issue:
1. Open a lead on CRM
2. Click on the "Salesperson" field
3. Select "Mitchell Admin"
4. Click on the "Salesperson" field
5. Select "Mitchell Admin"

=> The field displays `Mitchell Admin --(Team Leader)--`

TO BE: The field should display `Mitchell Admin` without markup.

To fix this, we will update the `_compute_display_name` override on the `res.users` model in CRM so that markups are added only when the `formatted_display_name` context key is set to `True`.

Currently, both `display_name` and `__formatted_display_name` are computed through `_compute_display_name`. The difference is that the `web_name_search` method explicitly sets the context key `formatted_display_name` to `True` when computing `__formatted_display_name`.

With this commit, the `_compute_display_name` method will add the `--(Team Leader)--` markup only when computing `__formatted_display_name`. The widget `many2one_avatar_leader_user` should then not show any markup when selecting a record from the suggestions.

Task-5093192

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
