### PR TITLE
[FIX] *: redirect documentation url to correct version

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,7 +4,7 @@ contact_links:
     url: https://www.odoo.com/help
     about: "Please favour opening an official ticket if you have an active subscription."
   - name: "Code contribution"
-    url: https://www.odoo.com/documentation/master/contributing/development.html#make-your-first-contribution
+    url: https://www.odoo.com/documentation/latest/contributing/development.html#make-your-first-contribution
     about: "If you have an idea of the change to apply in the codebase, please open a pull request to speed up the process."
   - name: "Translation Change"
     url: https://explore.transifex.com/odoo/

--- a/addons/auth_totp/views/templates.xml
+++ b/addons/auth_totp/views/templates.xml
@@ -9,7 +9,7 @@
                     <div class="mb-2 mt-2 text-muted">
                         To login, enter below the six-digit authentication code provided by your Authenticator app.
                         <br/>
-                        <a href="https://www.odoo.com/documentation/master/applications/general/auth/2fa.html"
+                        <a href="https://www.odoo.com/documentation/latest/applications/general/auth/2fa.html"
                            title="Learn More" target="_blank">Learn More</a>
                     </div>
                     <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>

--- a/addons/auth_totp_mail/data/security_notifications_template.xml
+++ b/addons/auth_totp_mail/data/security_notifications_template.xml
@@ -6,7 +6,7 @@
             <xpath expr="//div[hasclass('o_mail_account_security_suggestions')]" position="after">
                 <div t-if="suggest_2fa">
                     <span>Consider also</span>
-                    <a href="https://www.odoo.com/documentation/master/applications/general/auth/2fa.html">
+                    <a href="https://www.odoo.com/documentation/latest/applications/general/auth/2fa.html">
                         activating Two-factor Authentication
                     </a>
                 </div>

--- a/addons/auth_totp_mail/views/templates.xml
+++ b/addons/auth_totp_mail/views/templates.xml
@@ -21,7 +21,7 @@
             <div class="mb-2" t-if="user._mfa_type() == 'totp_mail'">
                 We strongly recommend enabling the two-factor authentication using an authenticator app to help secure your account.
                 <br/>
-                <a href="https://www.odoo.com/documentation/master/applications/general/auth/2fa.html" title="Learn More" target="_blank">Learn More</a>
+                <a href="https://www.odoo.com/documentation/latest/applications/general/auth/2fa.html" title="Learn More" target="_blank">Learn More</a>
             </div>
         </xpath>
     </template>

--- a/addons/auth_totp_portal/views/templates.xml
+++ b/addons/auth_totp_portal/views/templates.xml
@@ -13,7 +13,7 @@
             <section>
                 <h4>
                     Two-factor authentication
-                    <a href="https://www.odoo.com/documentation/master/applications/general/auth/2fa.html" target="_blank">
+                    <a href="https://www.odoo.com/documentation/latest/applications/general/auth/2fa.html" target="_blank">
                         <i title="Documentation" class="fa fa-fw o_button_icon fa-info-circle"></i>
                     </a>
                 </h4>

--- a/addons/crm/static/src/views/crm_form/crm_pls_tooltip_button.xml
+++ b/addons/crm/static/src/views/crm_form/crm_pls_tooltip_button.xml
@@ -69,7 +69,7 @@
                 <span t-if="isSampleData" class="text-primary fw-bold">Close opportunities to get insights.</span>
                 <span t-else="">Computed by Odoo AI using your data.</span>
                 <a role="button" class="ms-2 btn-link"
-                    href="https://www.odoo.com/documentation/master/applications/sales/crm/track_leads/lead_scoring.html#predictive-lead-scoring" target="_blank">
+                    href="https://www.odoo.com/documentation/latest/applications/sales/crm/track_leads/lead_scoring.html#predictive-lead-scoring" target="_blank">
                     <i class="fa fa-info-circle pe-1"/>Learn More
                 </a>
             </div>

--- a/addons/hr_attendance/views/res_config_settings_views.xml
+++ b/addons/hr_attendance/views/res_config_settings_views.xml
@@ -12,7 +12,7 @@
                         <setting string="Kiosk Mode" company_dependent="1" help="Define the way the user will be identified by the application.">
                             <field name="attendance_kiosk_mode" required="1" class="w-75"/>
                             <div>
-                                <a href="https://www.odoo.com/documentation/master/applications/hr/attendances/hardware.html"
+                                <a href="https://www.odoo.com/documentation/latest/applications/hr/attendances/hardware.html"
                                     target="_blank"><i class="fa fa-fw fa-arrow-right"/>Installation Manual</a>
                             </div>
                         </setting>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_6.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_6.xml
@@ -57,7 +57,7 @@
             <field name="model">discuss.channel</field>
             <field name="res_id" ref="im_livechat.livechat_channel_session_6"/>
             <field name="author_id" ref="base.partner_admin"/>
-            <field name="body">Yes, of course, you can find it here: https://www.odoo.com/documentation/master/</field>
+            <field name="body">Yes, of course, you can find it here: https://www.odoo.com/documentation/latest/</field>
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-3, days=-5, minutes=1)" name="date"/>

--- a/addons/im_livechat/tests/chatbot_common.py
+++ b/addons/im_livechat/tests/chatbot_common.py
@@ -93,7 +93,7 @@ class ChatbotCase(common.HttpCase):
             'chatbot_script_id': cls.chatbot_script.id,
         }, {
             'step_type': 'text',
-            'message': 'Please find documentation at https://www.odoo.com/documentation/19.0/',
+            'message': 'Please find documentation at https://www.odoo.com/documentation/latest/',
             'triggering_answer_ids': [(4, cls.step_dispatch_documentation.id)],
             'chatbot_script_id': cls.chatbot_script.id,
         }])

--- a/addons/im_livechat/tests/chatbot_common.py
+++ b/addons/im_livechat/tests/chatbot_common.py
@@ -93,7 +93,7 @@ class ChatbotCase(common.HttpCase):
             'chatbot_script_id': cls.chatbot_script.id,
         }, {
             'step_type': 'text',
-            'message': 'Please find documentation at https://www.odoo.com/documentation/18.0/',
+            'message': 'Please find documentation at https://www.odoo.com/documentation/19.0/',
             'triggering_answer_ids': [(4, cls.step_dispatch_documentation.id)],
             'chatbot_script_id': cls.chatbot_script.id,
         }])

--- a/addons/iot_box_image/overwrite_after_init/var/www/html/502.html
+++ b/addons/iot_box_image/overwrite_after_init/var/www/html/502.html
@@ -83,13 +83,13 @@
             <ol>
                 <li>Force restart the IoT Box by unplugging the IoT power supply then plugging it in again</li>
                 <li>Re-flash the SD card of the IoT Box, see:
-                    <a href="https://www.odoo.com/documentation/18.0/applications/general/iot/config/updating_iot.html#flashing-the-sd-card-on-iot-box" target="_blank">documentation</a>
+                    <a href="https://www.odoo.com/documentation/19.0/applications/general/iot/iot_advanced/updating_iot.html#iot-updating-iot-image-code" target="_blank">documentation</a>
                 </li>
             </ol>
         </div>
         <div class="footer">
             <a target="_blank" href="https://www.odoo.com/help">Help</a>
-            <a target="_blank" href="https://www.odoo.com/documentation/18.0/applications/productivity/iot.html">Documentation</a>
+            <a target="_blank" href="https://www.odoo.com/documentation/19.0/applications/productivity/iot.html">Documentation</a>
         </div>
     </body>
 </html>

--- a/addons/iot_box_image/overwrite_after_init/var/www/html/502.html
+++ b/addons/iot_box_image/overwrite_after_init/var/www/html/502.html
@@ -83,13 +83,13 @@
             <ol>
                 <li>Force restart the IoT Box by unplugging the IoT power supply then plugging it in again</li>
                 <li>Re-flash the SD card of the IoT Box, see:
-                    <a href="https://www.odoo.com/documentation/19.0/applications/general/iot/iot_advanced/updating_iot.html#iot-updating-iot-image-code" target="_blank">documentation</a>
+                    <a href="https://www.odoo.com/documentation/latest/applications/general/iot/iot_advanced/updating_iot.html#iot-updating-iot-image-code" target="_blank">documentation</a>
                 </li>
             </ol>
         </div>
         <div class="footer">
             <a target="_blank" href="https://www.odoo.com/help">Help</a>
-            <a target="_blank" href="https://www.odoo.com/documentation/19.0/applications/productivity/iot.html">Documentation</a>
+            <a target="_blank" href="https://www.odoo.com/documentation/latest/applications/productivity/iot.html">Documentation</a>
         </div>
     </body>
 </html>

--- a/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
+++ b/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
@@ -55,7 +55,7 @@ odoo_help() {
   echo 'odoo_origin <branch>  Resets Odoo on the specified branch from the odoo repository'
   echo 'devtools              Enables/Disables specific functions for development (more help with devtools help)'
   echo ''
-  echo 'Odoo IoT online help: <https://www.odoo.com/documentation/master/applications/general/iot.html>'
+  echo 'Odoo IoT online help: <https://www.odoo.com/documentation/latest/applications/general/iot.html>'
 }
 
 odoo_dev() {

--- a/addons/iot_drivers/static/src/app/Homepage.js
+++ b/addons/iot_drivers/static/src/app/Homepage.js
@@ -171,7 +171,7 @@ export class Homepage extends Component {
                 <FooterButtons />
                 <div class="d-flex justify-content-center gap-2 mt-2" t-if="!store.base.is_access_point_up">
                     <a href="https://www.odoo.com/fr_FR/help" target="_blank" class="link-primary">Help</a>
-                    <a href="https://www.odoo.com/documentation/master/applications/general/iot.html" target="_blank" class="link-primary">Documentation</a>
+                    <a href="https://www.odoo.com/documentation/latest/applications/general/iot.html" target="_blank" class="link-primary">Documentation</a>
                 </div>
             </div>
         </div>

--- a/addons/iot_drivers/static/src/app/components/dialog/UpdateDialog.js
+++ b/addons/iot_drivers/static/src/app/components/dialog/UpdateDialog.js
@@ -90,7 +90,7 @@ export class UpdateDialog extends Component {
             <t t-set-slot="header">
                 <div>
                     Update
-                    <a href="https://www.odoo.com/documentation/19.0/applications/general/iot/iot_advanced/updating_iot.html" class="fa fa-question-circle text-decoration-none text-dark" target="_blank"></a>
+                    <a href="https://www.odoo.com/documentation/latest/applications/general/iot/iot_advanced/updating_iot.html" class="fa fa-question-circle text-decoration-none text-dark" target="_blank"></a>
                 </div>
             </t>
             <t t-set-slot="body">
@@ -108,7 +108,7 @@ export class UpdateDialog extends Component {
                     </div>
                     <div t-else="" class="alert alert-warning small mb-0">
                         A new version of the operating system is available, see:
-                        <a href="https://www.odoo.com/documentation/19.0/applications/general/iot/iot_advanced/updating_iot.html#iot-updating-iot-image-code" target="_blank" class="alert-link">
+                        <a href="https://www.odoo.com/documentation/latest/applications/general/iot/iot_advanced/updating_iot.html#iot-updating-iot-image-code" target="_blank" class="alert-link">
                             Flashing the SD Card on IoT Box
                         </a>
                     </div>

--- a/addons/iot_drivers/static/src/app/components/dialog/UpdateDialog.js
+++ b/addons/iot_drivers/static/src/app/components/dialog/UpdateDialog.js
@@ -90,7 +90,7 @@ export class UpdateDialog extends Component {
             <t t-set-slot="header">
                 <div>
                     Update
-                    <a href="https://www.odoo.com/documentation/18.0/applications/general/iot/config/updating_iot.html" class="fa fa-question-circle text-decoration-none text-dark" target="_blank"></a>
+                    <a href="https://www.odoo.com/documentation/19.0/applications/general/iot/iot_advanced/updating_iot.html" class="fa fa-question-circle text-decoration-none text-dark" target="_blank"></a>
                 </div>
             </t>
             <t t-set-slot="body">
@@ -108,7 +108,7 @@ export class UpdateDialog extends Component {
                     </div>
                     <div t-else="" class="alert alert-warning small mb-0">
                         A new version of the operating system is available, see:
-                        <a href="https://www.odoo.com/documentation/18.0/applications/general/iot/config/updating_iot.html#flashing-the-sd-card-on-iot-box" target="_blank" class="alert-link">
+                        <a href="https://www.odoo.com/documentation/19.0/applications/general/iot/iot_advanced/updating_iot.html#iot-updating-iot-image-code" target="_blank" class="alert-link">
                             Flashing the SD Card on IoT Box
                         </a>
                     </div>

--- a/addons/l10n_ae/__manifest__.py
+++ b/addons/l10n_ae/__manifest__.py
@@ -2,7 +2,7 @@
 {
     'name': 'United Arab Emirates - Accounting',
     'author': 'Odoo S.A.',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/united_arab_emirates.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations/united_arab_emirates.html',
     'icon': '/account/static/description/l10n.png',
     'countries': ['ae'],
     'category': 'Accounting/Localizations/Account Charts',

--- a/addons/l10n_ar/__manifest__.py
+++ b/addons/l10n_ar/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Argentina - Accounting',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/argentina.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations/argentina.html',
     'countries': ['ar'],
     'icon': '/base/static/img/country_flags/ar.png',
     'version': "3.7",

--- a/addons/l10n_at/__manifest__.py
+++ b/addons/l10n_at/__manifest__.py
@@ -5,7 +5,7 @@
     'countries': ['at'],
     'version': '3.2.1',
     'author': 'WT-IO-IT GmbH, Wolfgang Taferner (https://www.wt-io-it.at)',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations.html',
     'category': 'Accounting/Localizations/Account Charts',
     'summary': 'Austrian Standardized Charts & Tax',
     'description': """

--- a/addons/l10n_au/__manifest__.py
+++ b/addons/l10n_au/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     'name': 'Australia - Accounting',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/australia.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations/australia.html',
     'icon': '/account/static/description/l10n.png',
     'countries': ['au'],
     'version': '1.1',

--- a/addons/l10n_bd/__manifest__.py
+++ b/addons/l10n_bd/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Bangladesh - Accounting',
-    'website': 'https://www.odoo.com/documentation/19.0/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations.html',
     'icon': '/account/static/description/l10n.png',
     'countries': ['bd'],
     'version': '1.0',

--- a/addons/l10n_bd/__manifest__.py
+++ b/addons/l10n_bd/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Bangladesh - Accounting',
-    'website': 'https://www.odoo.com/documentation/18.0/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/19.0/applications/finance/fiscal_localizations.html',
     'icon': '/account/static/description/l10n.png',
     'countries': ['bd'],
     'version': '1.0',

--- a/addons/l10n_be/__manifest__.py
+++ b/addons/l10n_be/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Belgium - Accounting',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/belgium.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations/belgium.html',
     'version': '2.0',
     'icon': '/account/static/description/l10n.png',
     'countries': ['be'],

--- a/addons/l10n_bg/__manifest__.py
+++ b/addons/l10n_bg/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Bulgaria - Accounting',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations.html',
     'icon': '/account/static/description/l10n.png',
     'countries': ['bg'],
     'version': '1.0',

--- a/addons/l10n_bo/__manifest__.py
+++ b/addons/l10n_bo/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Bolivia - Accounting',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations.html',
     'icon': '/account/static/description/l10n.png',
     'countries': ['bo'],
     'version': '2.0',

--- a/addons/l10n_br/__manifest__.py
+++ b/addons/l10n_br/__manifest__.py
@@ -2,7 +2,7 @@
 {
     'name': 'Brazilian - Accounting',
     'version': '1.0',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/brazil.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations/brazil.html',
     'icon': '/account/static/description/l10n.png',
     'countries': ['br'],
     'category': 'Accounting/Localizations/Account Charts',

--- a/addons/l10n_ca/__manifest__.py
+++ b/addons/l10n_ca/__manifest__.py
@@ -5,7 +5,7 @@
     'icon': '/account/static/description/l10n.png',
     'countries': ['ca'],
     'author': 'Savoir-faire Linux (https://www.savoirfairelinux.com); Odoo SA',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations.html',
     'category': 'Accounting/Localizations/Account Charts',
     'description': """
 This is the module to manage the Canadian accounting chart in Odoo.

--- a/addons/l10n_ch/__manifest__.py
+++ b/addons/l10n_ch/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Switzerland - Accounting',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/switzerland.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations/switzerland.html',
     'icon': '/account/static/description/l10n.png',
     'countries': ['ch'],
     'description': """

--- a/addons/l10n_cl/__manifest__.py
+++ b/addons/l10n_cl/__manifest__.py
@@ -9,7 +9,7 @@ Chilean accounting chart and tax localization.
 Plan contable chileno e impuestos de acuerdo a disposiciones vigentes.
     """,
     'author': 'Blanco Martín & Asociados',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/chile.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations/chile.html',
     'category': 'Accounting/Localizations/Account Charts',
     'depends': [
         'contacts',

--- a/addons/l10n_cn/__manifest__.py
+++ b/addons/l10n_cn/__manifest__.py
@@ -7,7 +7,7 @@
     'category': 'Accounting/Localizations/Account Charts',
     'author': 'openerp-china',
     'maintainer': 'jeff@osbzr.com',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations.html',
     'description': r"""
 Includes the following data for the Chinese localization
 ========================================================

--- a/addons/l10n_co/__manifest__.py
+++ b/addons/l10n_co/__manifest__.py
@@ -7,7 +7,7 @@
     'category': 'Accounting/Localizations/Account Charts',
     'description': 'Colombian Accounting and Tax Preconfiguration',
     'author': 'David Arnold (XOE Solutions)',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/colombia.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations/colombia.html',
     'depends': [
         'account_debit_note',
         'l10n_latam_base',

--- a/addons/l10n_cr/__manifest__.py
+++ b/addons/l10n_cr/__manifest__.py
@@ -5,7 +5,7 @@
     'countries': ['cr'],
     'url': 'https://github.com/CLEARCORP/odoo-costa-rica',
     'author': 'ClearCorp S.A.',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations.html',
     'category': 'Accounting/Localizations/Account Charts',
     'description': """
 Chart of accounts for Costa Rica.

--- a/addons/l10n_cz/__manifest__.py
+++ b/addons/l10n_cz/__manifest__.py
@@ -5,7 +5,7 @@
     'countries': ['cz'],
     'version': '1.1',
     'author': '26HOUSE (http://www.26house.com)',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations.html',
     'category': 'Accounting/Localizations/Account Charts',
     'description': """
 Czech accounting chart and localization.  With Chart of Accounts with taxes and basic fiscal positions.

--- a/addons/l10n_de/__manifest__.py
+++ b/addons/l10n_de/__manifest__.py
@@ -7,7 +7,7 @@
     'countries': ['de'],
     'author': 'openbig.org (http://www.openbig.org)',
     'version': '2.1',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/germany.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations/germany.html',
     'category': 'Accounting/Localizations/Account Charts',
     'description': """
 Dieses  Modul beinhaltet einen deutschen Kontenrahmen basierend auf dem SKR03 oder SKR04.

--- a/addons/l10n_dk/__manifest__.py
+++ b/addons/l10n_dk/__manifest__.py
@@ -5,7 +5,7 @@
     'countries': ['dk'],
     'version': '1.3',
     'author': 'Odoo House ApS, VK DATA ApS, FlexERP ApS',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations.html',
     'category': 'Accounting/Localizations/Account Charts',
     'description': """
 

--- a/addons/l10n_do/__manifest__.py
+++ b/addons/l10n_do/__manifest__.py
@@ -73,7 +73,7 @@ en Odoo):
 11010101 Caja General
     """,
     'author': 'Gustavo Valverde - iterativo | Consultores de Odoo (http://iterativo.do)',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations.html',
     'depends': [
         'account',
         'base_iban',

--- a/addons/l10n_dz/__manifest__.py
+++ b/addons/l10n_dz/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Algeria - Accounting',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations.html',
     'icon': '/account/static/description/l10n.png',
     'countries': ['dz'],
     'version': '1.0',

--- a/addons/l10n_ec/__manifest__.py
+++ b/addons/l10n_ec/__manifest__.py
@@ -36,7 +36,7 @@ Master Data:
     'author': 'TRESCLOUD (https://trescloud.com)',
     'category': 'Accounting/Localizations/Account Charts',
     'maintainer': 'TRESCLOUD',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/ecuador.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations/ecuador.html',
     'license': 'LGPL-3',
     'depends': [
         'base',

--- a/addons/l10n_ee/__manifest__.py
+++ b/addons/l10n_ee/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Estonia - Accounting',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations.html',
     'version': '1.3',
     'icon': '/account/static/description/l10n.png',
     'countries': ['ee'],

--- a/addons/l10n_eg/__manifest__.py
+++ b/addons/l10n_eg/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': "Egypt - Accounting",
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/egypt.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations/egypt.html',
     'icon': '/account/static/description/l10n.png',
     'countries': ['eg'],
     'description': """

--- a/addons/l10n_es/__manifest__.py
+++ b/addons/l10n_es/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Spain - Accounting (PGCE 2008)',
-    'website': 'https://www.odoo.com/documentation/18.0/applications/finance/fiscal_localizations/spain.html',
+    'website': 'https://www.odoo.com/documentation/19.0/applications/finance/fiscal_localizations/spain.html',
     'version': '5.4',
     'icon': '/account/static/description/l10n.png',
     'countries': ['es'],

--- a/addons/l10n_es/__manifest__.py
+++ b/addons/l10n_es/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Spain - Accounting (PGCE 2008)',
-    'website': 'https://www.odoo.com/documentation/19.0/applications/finance/fiscal_localizations/spain.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations/spain.html',
     'version': '5.4',
     'icon': '/account/static/description/l10n.png',
     'countries': ['es'],

--- a/addons/l10n_es_edi_verifactu/__manifest__.py
+++ b/addons/l10n_es_edi_verifactu/__manifest__.py
@@ -5,7 +5,7 @@
     'version': '1.0',
     'category': 'Accounting/Localizations/EDI',
     'summary': "Module for sending Spanish Veri*Factu XML to the AEAT",
-    'website': "https://www.odoo.com/documentation/18.0/applications/finance/fiscal_localizations/spain.html#veri-factu",
+    'website': "https://www.odoo.com/documentation/19.0/applications/finance/fiscal_localizations/spain.html#veri-factu",
     'depends': ['l10n_es'],
     'data': [
         'security/ir.model.access.csv',

--- a/addons/l10n_es_edi_verifactu/__manifest__.py
+++ b/addons/l10n_es_edi_verifactu/__manifest__.py
@@ -5,7 +5,7 @@
     'version': '1.0',
     'category': 'Accounting/Localizations/EDI',
     'summary': "Module for sending Spanish Veri*Factu XML to the AEAT",
-    'website': "https://www.odoo.com/documentation/19.0/applications/finance/fiscal_localizations/spain.html#veri-factu",
+    'website': "https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations/spain.html#veri-factu",
     'depends': ['l10n_es'],
     'data': [
         'security/ir.model.access.csv',

--- a/addons/l10n_et/__manifest__.py
+++ b/addons/l10n_et/__manifest__.py
@@ -16,7 +16,7 @@ This is the latest Ethiopian Odoo localization and consists of:
     - Regional State listings
     """,
     'author': 'Michael Telahun Makonnen <mmakonnen@gmail.com>',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations.html',
     'depends': [
         'account',
     ],

--- a/addons/l10n_fi/__manifest__.py
+++ b/addons/l10n_fi/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Finland - Accounting',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations.html',
     'icon': '/account/static/description/l10n.png',
     'countries': ['fi'],
     'version': '13.0.2',

--- a/addons/l10n_fr_account/__manifest__.py
+++ b/addons/l10n_fr_account/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'France - Accounting',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/france.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations/france.html',
     'icon': '/account/static/description/l10n.png',
     'version': '2.2',
     'countries': ['fr'],

--- a/addons/l10n_gt/__manifest__.py
+++ b/addons/l10n_gt/__manifest__.py
@@ -13,7 +13,7 @@ Agrega una nomenclatura contable para Guatemala. También icluye impuestos y
 la moneda del Quetzal. -- Adds accounting chart for Guatemala. It also includes
 taxes and the Quetzal currency.""",
     'author': 'José Rodrigo Fernández Menegazzo',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations.html',
     'depends': [
         'base',
         'account',

--- a/addons/l10n_hk/__manifest__.py
+++ b/addons/l10n_hk/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Hong Kong - Accounting',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/hong_kong.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations/hong_kong.html',
     'icon': '/account/static/description/l10n.png',
     'countries': ['hk'],
     'version': '1.0',

--- a/addons/l10n_hn/__manifest__.py
+++ b/addons/l10n_hn/__manifest__.py
@@ -13,7 +13,7 @@ Agrega una nomenclatura contable para Honduras. También incluye impuestos y la
 moneda Lempira. -- Adds accounting chart for Honduras. It also includes taxes
 and the Lempira currency.""",
     'author': 'Salvatore Josue Trimarchi Pinto',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations.html',
     'depends': [
         'base',
         'account',

--- a/addons/l10n_hr/__manifest__.py
+++ b/addons/l10n_hr/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Croatia - Accounting (Euro)',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations.html',
     'icon': '/account/static/description/l10n.png',
     'countries': ['hr'],
     'description': """

--- a/addons/l10n_hu/__manifest__.py
+++ b/addons/l10n_hu/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Hungary - Accounting',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations.html',
     'icon': '/account/static/description/l10n.png',
     'countries': ['hu'],
     'version': '3.0',

--- a/addons/l10n_id/__manifest__.py
+++ b/addons/l10n_id/__manifest__.py
@@ -11,7 +11,7 @@ This is the latest Indonesian Odoo localisation necessary to run Odoo accounting
     - generic Indonesian chart of accounts
     - tax structure""",
     'author': 'vitraining.com',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/indonesia.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations/indonesia.html',
     'depends': [
         'account',
         'base_iban',

--- a/addons/l10n_il/__manifest__.py
+++ b/addons/l10n_il/__manifest__.py
@@ -14,7 +14,7 @@ This module consists of:
  - Taxes and tax report
  - Multiple Fiscal positions
  """,
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations.html',
     'depends': [
         'account',
     ],

--- a/addons/l10n_in/__manifest__.py
+++ b/addons/l10n_in/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Indian - Accounting',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/india.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations/india.html',
     'icon': '/account/static/description/l10n.png',
     'countries': ['in'],
     'version': '2.0',

--- a/addons/l10n_it/__manifest__.py
+++ b/addons/l10n_it/__manifest__.py
@@ -17,7 +17,7 @@ Piano dei conti italiano di un'impresa generica.
 Italian accounting chart and localization.
     """,
     'category': 'Accounting/Localizations/Account Charts',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/italy.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations/italy.html',
     'data': [
         'data/account_account_tag.xml',
         'data/tax_report/annual_report_sections/va.xml',

--- a/addons/l10n_it_edi_doi/__manifest__.py
+++ b/addons/l10n_it_edi_doi/__manifest__.py
@@ -11,7 +11,7 @@
     Add support for the Declaration of Intent (Dichiarazione di Intento) to the Italian localization.
     """,
     'category': 'Accounting/Localizations',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/italy.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations/italy.html',
     'data': [
         'security/ir.model.access.csv',
         'data/invoice_it_template.xml',

--- a/addons/l10n_it_edi_sale/__manifest__.py
+++ b/addons/l10n_it_edi_sale/__manifest__.py
@@ -7,7 +7,7 @@
     ],
     'description': 'Sale modifications for Italy E-invoicing',
     'category': 'Accounting/Localizations/EDI',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/italy.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations/italy.html',
     'data': [
         'views/sale_order_views.xml',
     ],

--- a/addons/l10n_jp/__manifest__.py
+++ b/addons/l10n_jp/__manifest__.py
@@ -22,7 +22,7 @@ Note:
 
     """,
     'author': 'Quartile Limited (https://www.quartile.co/)',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations.html',
     'depends': [
         'account',
     ],

--- a/addons/l10n_ke/__manifest__.py
+++ b/addons/l10n_ke/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Kenya - Accounting',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/kenya.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations/kenya.html',
     'icon': '/account/static/description/l10n.png',
     'countries': ['ke'],
     'version': '1.0',

--- a/addons/l10n_kh/__manifest__.py
+++ b/addons/l10n_kh/__manifest__.py
@@ -8,7 +8,7 @@
     'description': """
     Chart Of Account and Taxes for Cambodia.
     """,
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations.html',
     'depends': [
         'account_qr_code_emv',
         'l10n_account_withholding_tax',

--- a/addons/l10n_kz/__manifest__.py
+++ b/addons/l10n_kz/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Kazakhstan - Accounting',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations.html',
     'icon': '/account/static/description/l10n.png',
     'countries': ['kz'],
     'version': '1.0',

--- a/addons/l10n_lt/__manifest__.py
+++ b/addons/l10n_lt/__manifest__.py
@@ -17,7 +17,7 @@ This module also includes:
     """,
     'license': 'LGPL-3',
     'author': 'Focusate',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations.html',
     'category': 'Accounting/Localizations/Account Charts',
     'depends': [
         'account',

--- a/addons/l10n_lu/__manifest__.py
+++ b/addons/l10n_lu/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Luxembourg - Accounting',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/luxembourg.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations/luxembourg.html',
     'icon': '/account/static/description/l10n.png',
     'countries': ['lu'],
     'version': '2.2',

--- a/addons/l10n_mn/__manifest__.py
+++ b/addons/l10n_mn/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Mongolia - Accounting',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations.html',
     'version': '1.1',
     'icon': '/account/static/description/l10n.png',
     'countries': ['mn'],

--- a/addons/l10n_mt/__manifest__.py
+++ b/addons/l10n_mt/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Malta - Accounting',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations.html',
     'icon': '/account/static/description/l10n.png',
     'countries': ['mt'],
     'description': """

--- a/addons/l10n_mx/__manifest__.py
+++ b/addons/l10n_mx/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Mexico - Accounting',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/mexico.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations/mexico.html',
     'icon': '/account/static/description/l10n.png',
     'countries': ['mx'],
     'version': '2.3',

--- a/addons/l10n_my/__manifest__.py
+++ b/addons/l10n_my/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Malaysia - Accounting',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations.html',
     'icon': '/account/static/description/l10n.png',
     'countries': ['my'],
     'author': 'Odoo PS',

--- a/addons/l10n_mz/__manifest__.py
+++ b/addons/l10n_mz/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Mozambique - Accounting',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations.html',
     'description': """
 Mozambican Accounting localization
     """,

--- a/addons/l10n_ng/__manifest__.py
+++ b/addons/l10n_ng/__manifest__.py
@@ -6,7 +6,7 @@
 Nigerian localization.
 =========================================================
     """,
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations.html',
     'version': '1.0',
     'icon': '/account/static/description/l10n.png',
     'countries': ['ng'],

--- a/addons/l10n_nl/__manifest__.py
+++ b/addons/l10n_nl/__manifest__.py
@@ -6,7 +6,7 @@
     'version': '3.4',
     'category': 'Accounting/Localizations/Account Charts',
     'author': 'Onestein (http://www.onestein.eu)',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/netherlands.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations/netherlands.html',
     'depends': [
         'base_iban',
         'base_vat',

--- a/addons/l10n_no/__manifest__.py
+++ b/addons/l10n_no/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Norway - Accounting',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations.html',
     'icon': '/account/static/description/l10n.png',
     'countries': ['no'],
     'version': '2.1',

--- a/addons/l10n_nz/__manifest__.py
+++ b/addons/l10n_nz/__manifest__.py
@@ -16,7 +16,7 @@ Also:
     - sets up New Zealand taxes.
     """,
     'author': 'Odoo S.A., Richard deMeester - Willow IT',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations.html',
     'depends': [
         'account',
     ],

--- a/addons/l10n_pa/__manifest__.py
+++ b/addons/l10n_pa/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Panama - Accounting',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations.html',
     'icon': '/account/static/description/l10n.png',
     'countries': ['pa'],
     'description': """

--- a/addons/l10n_pe/__manifest__.py
+++ b/addons/l10n_pe/__manifest__.py
@@ -6,7 +6,7 @@
     'version': '3.0',
     'category': 'Accounting/Localizations/Account Charts',
     'author': 'Vauxoo, Odoo S.A.',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/peru.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations/peru.html',
     'license': 'LGPL-3',
     'depends': [
         'base_vat',

--- a/addons/l10n_ph/__manifest__.py
+++ b/addons/l10n_ph/__manifest__.py
@@ -7,7 +7,7 @@
     'category': 'Accounting/Localizations/Account Charts',
     'version': '1.1',
     'author': 'Odoo PS',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/philippines.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations/philippines.html',
     'depends': [
         'account',
         'base_vat',

--- a/addons/l10n_pk/__manifest__.py
+++ b/addons/l10n_pk/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Pakistan - Accounting',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations.html',
     'icon': '/account/static/description/l10n.png',
     'countries': ['pk'],
     'version': '1.1',

--- a/addons/l10n_pl/__manifest__.py
+++ b/addons/l10n_pl/__manifest__.py
@@ -5,7 +5,7 @@
     'countries': ['pl'],
     'version': '2.0',
     'author': 'Odoo S.A., Grzegorz Grzelak (OpenGLOBE) (http://www.openglobe.pl)',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations.html',
     'category': 'Accounting/Localizations/Account Charts',
     'description': """
 This is the module to manage the accounting chart and taxes for Poland in Odoo.

--- a/addons/l10n_pt/__manifest__.py
+++ b/addons/l10n_pt/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Portugal - Accounting',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations.html',
     'icon': '/account/static/description/l10n.png',
     'countries': ['pt'],
     'version': '1.0',

--- a/addons/l10n_ro/__manifest__.py
+++ b/addons/l10n_ro/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Romania - Accounting',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/romania.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations/romania.html',
     'author': 'Fekete Mihai (NextERP Romania SRL), Odoo S.A.',
     'icon': '/account/static/description/l10n.png',
     'countries': ['ro'],

--- a/addons/l10n_rs/__manifest__.py
+++ b/addons/l10n_rs/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Serbia - Accounting',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations.html',
     'icon': '/account/static/description/l10n.png',
     'countries': ['rs'],
     'version': '1.0',

--- a/addons/l10n_sa/__manifest__.py
+++ b/addons/l10n_sa/__manifest__.py
@@ -6,7 +6,7 @@
     'version': '2.0',
     'author': 'Odoo S.A., DVIT.ME (http://www.dvit.me)',
     'category': 'Accounting/Localizations/Account Charts',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/saudi_arabia.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations/saudi_arabia.html',
     'description': """
 Saudi Arabia Accounting Module
 ===========================================================

--- a/addons/l10n_se/__manifest__.py
+++ b/addons/l10n_se/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Sweden - Accounting',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations.html',
     'icon': '/account/static/description/l10n.png',
     'countries': ['se'],
     'version': '1.1',

--- a/addons/l10n_sg/__manifest__.py
+++ b/addons/l10n_sg/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Singapore - Accounting',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/singapore.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations/singapore.html',
     'icon': '/account/static/description/l10n.png',
     'countries': ['sg'],
     'author': 'Tech Receptives',

--- a/addons/l10n_si/__manifest__.py
+++ b/addons/l10n_si/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Slovenian - Accounting',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations.html',
     'icon': '/account/static/description/l10n.png',
     'countries': ['si'],
     'version': '1.1',

--- a/addons/l10n_sk/__manifest__.py
+++ b/addons/l10n_sk/__manifest__.py
@@ -5,7 +5,7 @@
     'countries': ['sk'],
     'version': '1.0',
     'author': '26HOUSE (http://www.26house.com)',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations.html',
     'category': 'Accounting/Localizations/Account Charts',
     'description': """
 Slovakia accounting chart and localization: Chart of Accounts 2020, basic VAT rates +

--- a/addons/l10n_th/__manifest__.py
+++ b/addons/l10n_th/__manifest__.py
@@ -12,7 +12,7 @@ Chart of Accounts for Thailand.
 Thai accounting chart and localization.
     """,
     'author': 'Almacom (http://almacom.co.th/)',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/thailand.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations/thailand.html',
     'depends': [
         'account_qr_code_emv',
         'account',

--- a/addons/l10n_tw/__manifest__.py
+++ b/addons/l10n_tw/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Taiwan - Accounting',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations.html',
     'icon': '/account/static/description/l10n.png',
     'countries': ['tw'],
     'author': 'Odoo PS',

--- a/addons/l10n_ua/__manifest__.py
+++ b/addons/l10n_ua/__manifest__.py
@@ -4,7 +4,7 @@
     'icon': '/account/static/description/l10n.png',
     'countries': ['ua'],
     'author': 'ERP Ukraine (https://erp.co.ua)',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations.html',
     'version': '1.4',
     'description': """
 Ukraine - Chart of accounts.

--- a/addons/l10n_uk/__manifest__.py
+++ b/addons/l10n_uk/__manifest__.py
@@ -13,7 +13,7 @@ This is the latest UK Odoo localisation necessary to run Odoo accounting for UK 
     - InfoLogic UK counties listing
     - a few other adaptations""",
     'author': 'SmartMode LTD',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/united_kingdom.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations/united_kingdom.html',
     'depends': [
         'account',
         'base_iban',

--- a/addons/l10n_us/__manifest__.py
+++ b/addons/l10n_us/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'United States - Localizations',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations.html',
     'icon': '/account/static/description/l10n.png',
     'countries': ['us'],
     'version': '1.1',

--- a/addons/l10n_us_account/__manifest__.py
+++ b/addons/l10n_us_account/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     'name': 'United States - Accounting',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations.html',
     'icon': '/account/static/description/l10n.png',
     'countries': ['us'],
     'version': '1.0',

--- a/addons/l10n_uy/__manifest__.py
+++ b/addons/l10n_uy/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Uruguay - Accounting',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/uruguay.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations/uruguay.html',
     'icon': '/account/static/description/l10n.png',
     'countries': ['uy'],
     'version': '0.1',

--- a/addons/l10n_ve/__manifest__.py
+++ b/addons/l10n_ve/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Venezuela - Accounting',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations.html',
     'icon': '/account/static/description/l10n.png',
     'countries': ['ve'],
     'author': 'Odoo S.A., Vauxoo',

--- a/addons/l10n_vn/__manifest__.py
+++ b/addons/l10n_vn/__manifest__.py
@@ -5,7 +5,7 @@
     'countries': ['vn'],
     'version': '2.0.3',
     'author': 'General Solutions',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/vietnam.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations/vietnam.html',
     'category': 'Accounting/Localizations/Account Charts',
     'description': """
 This is the module to manage the accounting chart, bank information for Vietnam in Odoo.

--- a/addons/l10n_vn_edi_viettel/__manifest__.py
+++ b/addons/l10n_vn_edi_viettel/__manifest__.py
@@ -5,7 +5,7 @@
     "version": "1.0",
     'countries': ['vn'],
     "category": "Accounting/Localizations/EDI",
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/vietnam.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations/vietnam.html',
     "depends": [
         "l10n_vn",
     ],

--- a/addons/l10n_za/__manifest__.py
+++ b/addons/l10n_za/__manifest__.py
@@ -11,7 +11,7 @@ This is the latest basic South African localisation necessary to run Odoo in ZA:
     - a generic chart of accounts
     - SARS VAT Ready Structure""",
     'author': 'Paradigm Digital (https://www.paradigmdigital.co.za)',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/fiscal_localizations.html',
     'depends': [
         'account',
         'base_vat',

--- a/addons/mail/views/res_config_settings_views.xml
+++ b/addons/mail/views/res_config_settings_views.xml
@@ -69,7 +69,7 @@
                         </setting>
                         <setting string="Custom ICE Server with Twilio"
                                  help="Set up your own server for small group calls using peer-to-peer connections"
-                                 documentation="https://www.odoo.com/documentation/18.0/applications/productivity/discuss/ice_servers.html">
+                                 documentation="https://www.odoo.com/documentation/19.0/applications/productivity/discuss/ice_servers.html">
                             <field name="use_twilio_rtc_servers"/>
                             <div class="content-group" invisible="not use_twilio_rtc_servers">
                                 <div class="row mt16" id="mail_twilio_sid">
@@ -96,7 +96,7 @@
                             </div>
                         </setting>
                         <setting string="Custom ICE Servers" help="Use your own servers for calls to manage heavy traffic and ensure reliability if Twilio is unavailable"
-                                 documentation="https://www.odoo.com/documentation/18.0/applications/productivity/discuss/ice_servers.html#define-a-list-of-custom-ice-servers">
+                                 documentation="https://www.odoo.com/documentation/19.0/applications/productivity/discuss/ice_servers.html#define-a-list-of-custom-ice-servers">
                                  <div class="content-group">
                                         <button type="action" name="%(mail.action_ice_servers)d" string="Configure ICE Servers" icon="oi-arrow-right" class="btn-link"/>
                                  </div>

--- a/addons/mail/views/res_config_settings_views.xml
+++ b/addons/mail/views/res_config_settings_views.xml
@@ -69,7 +69,7 @@
                         </setting>
                         <setting string="Custom ICE Server with Twilio"
                                  help="Set up your own server for small group calls using peer-to-peer connections"
-                                 documentation="https://www.odoo.com/documentation/19.0/applications/productivity/discuss/ice_servers.html">
+                                 documentation="https://www.odoo.com/documentation/latest/applications/productivity/discuss/ice_servers.html">
                             <field name="use_twilio_rtc_servers"/>
                             <div class="content-group" invisible="not use_twilio_rtc_servers">
                                 <div class="row mt16" id="mail_twilio_sid">
@@ -96,7 +96,7 @@
                             </div>
                         </setting>
                         <setting string="Custom ICE Servers" help="Use your own servers for calls to manage heavy traffic and ensure reliability if Twilio is unavailable"
-                                 documentation="https://www.odoo.com/documentation/19.0/applications/productivity/discuss/ice_servers.html#define-a-list-of-custom-ice-servers">
+                                 documentation="https://www.odoo.com/documentation/latest/applications/productivity/discuss/ice_servers.html#define-a-list-of-custom-ice-servers">
                                  <div class="content-group">
                                         <button type="action" name="%(mail.action_ice_servers)d" string="Configure ICE Servers" icon="oi-arrow-right" class="btn-link"/>
                                  </div>

--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -504,7 +504,7 @@
             <section t-if="debug and allow_api_keys">
                 <h4>
                 Developer API Keys
-                    <a href="https://www.odoo.com/documentation/master/developer/misc/api/external_api.html#api-keys" target="_blank">
+                    <a href="https://www.odoo.com/documentation/latest/developer/reference/external_api.html#api-key" target="_blank">
                         <i title="Documentation" class="fa fa-fw o_button_icon fa-info-circle"></i>
                     </a>
                 </h4>

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -631,7 +631,7 @@ class ProductTemplate(models.Model):
                     %s
                 </p>
                 <p>
-                    <a class="oe_link" href="https://www.odoo.com/documentation/18.0/_downloads/c2c6ce32294dfddffcfefcf2775f7a09/pdfquotebuilderexamples.zip">
+                    <a class="oe_link" href="https://www.odoo.com/documentation/19.0/_downloads/c2c6ce32294dfddffcfefcf2775f7a09/pdfquotebuilderexamples.zip">
                     %s
                     </a>
                 </p>

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -631,7 +631,7 @@ class ProductTemplate(models.Model):
                     %s
                 </p>
                 <p>
-                    <a class="oe_link" href="https://www.odoo.com/documentation/19.0/_downloads/c2c6ce32294dfddffcfefcf2775f7a09/pdfquotebuilderexamples.zip">
+                    <a class="oe_link" href="https://www.odoo.com/documentation/latest/_downloads/c2c6ce32294dfddffcfefcf2775f7a09/pdfquotebuilderexamples.zip">
                     %s
                     </a>
                 </p>

--- a/addons/rpc/controllers/__init__.py
+++ b/addons/rpc/controllers/__init__.py
@@ -8,7 +8,7 @@ The /xmlrpc, /xmlrpc/2 and /jsonrpc endpoints are deprecated in Odoo 19 \
 and scheduled for removal in Odoo 20. Please report the problem to the \
 client making the request.
 Mute this logger: --log-handler %s:ERROR
-https://www.odoo.com/documentation/19.0/developer/reference/external_api.html#migrating-from-xml-rpc-json-rpc"""
+https://www.odoo.com/documentation/latest/developer/reference/external_api.html#migrating-from-xml-rpc-json-rpc"""
 
 
 def _check_request():

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -1059,7 +1059,7 @@
             <a
                 role="button"
                 class="btn btn-secondary"
-                href="https://www.odoo.com/documentation/19.0/_downloads/312a470653db882b08ad72eb30cb4088/sample_quotation.pdf"
+                href="https://www.odoo.com/documentation/latest/_downloads/312a470653db882b08ad72eb30cb4088/sample_quotation.pdf"
                 target="_blank"
             >
                 Check a sample. It's clean!
@@ -1096,7 +1096,7 @@
             <a
                 role="button"
                 class="btn btn-secondary"
-                href="https://www.odoo.com/documentation/19.0/_downloads/312a470653db882b08ad72eb30cb4088/sample_quotation.pdf"
+                href="https://www.odoo.com/documentation/latest/_downloads/312a470653db882b08ad72eb30cb4088/sample_quotation.pdf"
                 target="_blank"
             >
                 Check a sample. It's clean!

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -1059,7 +1059,7 @@
             <a
                 role="button"
                 class="btn btn-secondary"
-                href="https://www.odoo.com/documentation/18.0/_downloads/312a470653db882b08ad72eb30cb4088/sample_quotation.pdf"
+                href="https://www.odoo.com/documentation/19.0/_downloads/312a470653db882b08ad72eb30cb4088/sample_quotation.pdf"
                 target="_blank"
             >
                 Check a sample. It's clean!
@@ -1096,7 +1096,7 @@
             <a
                 role="button"
                 class="btn btn-secondary"
-                href="https://www.odoo.com/documentation/18.0/_downloads/312a470653db882b08ad72eb30cb4088/sample_quotation.pdf"
+                href="https://www.odoo.com/documentation/19.0/_downloads/312a470653db882b08ad72eb30cb4088/sample_quotation.pdf"
                 target="_blank"
             >
                 Check a sample. It's clean!

--- a/addons/sale/wizard/res_config_settings_views.xml
+++ b/addons/sale/wizard/res_config_settings_views.xml
@@ -163,7 +163,7 @@
                         </setting>
                         <setting id="ups">
                             <div class="o_form_label">UPS Connector</div>
-                                <a href="https://www.odoo.com/documentation/19.0/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
+                                <a href="https://www.odoo.com/documentation/latest/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
                                 <div class="text-muted">
                                     Compute shipping costs and ship with UPS<br/>
                                     <strong>(please go to Home>Apps to install)</strong>
@@ -171,7 +171,7 @@
                         </setting>
                         <setting id="shipping_costs_dhl">
                             <div class="o_form_label">DHL Connector</div>
-                                <a href="https://www.odoo.com/documentation/19.0/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
+                                <a href="https://www.odoo.com/documentation/latest/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
                                 <div class="text-muted">
                                     Compute shipping costs and ship with DHL<br/>
                                     <strong>(please go to Home>Apps to install)</strong>
@@ -179,7 +179,7 @@
                         </setting>
                         <setting id="shipping_costs_fedex">
                             <div class="o_form_label">FedEx Connector</div>
-                                <a href="https://www.odoo.com/documentation/19.0/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
+                                <a href="https://www.odoo.com/documentation/latest/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
                                 <div class="text-muted">
                                     Compute shipping costs and ship with FedEx<br/>
                                     <strong>(please go to Home>Apps to install)</strong>
@@ -187,7 +187,7 @@
                         </setting>
                         <setting id="shipping_costs_usps">
                             <div class="o_form_label">USPS Connector</div>
-                                <a href="https://www.odoo.com/documentation/19.0/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
+                                <a href="https://www.odoo.com/documentation/latest/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
                                 <div class="text-muted">
                                     Compute shipping costs and ship with USPS<br/>
                                     <strong>(please go to Home>Apps to install)</strong>

--- a/addons/sale/wizard/res_config_settings_views.xml
+++ b/addons/sale/wizard/res_config_settings_views.xml
@@ -163,7 +163,7 @@
                         </setting>
                         <setting id="ups">
                             <div class="o_form_label">UPS Connector</div>
-                                <a href="https://www.odoo.com/documentation/17.0/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
+                                <a href="https://www.odoo.com/documentation/19.0/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
                                 <div class="text-muted">
                                     Compute shipping costs and ship with UPS<br/>
                                     <strong>(please go to Home>Apps to install)</strong>
@@ -171,7 +171,7 @@
                         </setting>
                         <setting id="shipping_costs_dhl">
                             <div class="o_form_label">DHL Connector</div>
-                                <a href="https://www.odoo.com/documentation/17.0/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
+                                <a href="https://www.odoo.com/documentation/19.0/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
                                 <div class="text-muted">
                                     Compute shipping costs and ship with DHL<br/>
                                     <strong>(please go to Home>Apps to install)</strong>
@@ -179,7 +179,7 @@
                         </setting>
                         <setting id="shipping_costs_fedex">
                             <div class="o_form_label">FedEx Connector</div>
-                                <a href="https://www.odoo.com/documentation/17.0/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
+                                <a href="https://www.odoo.com/documentation/19.0/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
                                 <div class="text-muted">
                                     Compute shipping costs and ship with FedEx<br/>
                                     <strong>(please go to Home>Apps to install)</strong>
@@ -187,7 +187,7 @@
                         </setting>
                         <setting id="shipping_costs_usps">
                             <div class="o_form_label">USPS Connector</div>
-                                <a href="https://www.odoo.com/documentation/17.0/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
+                                <a href="https://www.odoo.com/documentation/19.0/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
                                 <div class="text-muted">
                                     Compute shipping costs and ship with USPS<br/>
                                     <strong>(please go to Home>Apps to install)</strong>

--- a/addons/sms_twilio/wizard/sms_twilio_account_manage_views.xml
+++ b/addons/sms_twilio/wizard/sms_twilio_account_manage_views.xml
@@ -14,7 +14,7 @@
                             required="1"/>
                         <a target="_blank" class="btn btn-link ms-1 w-25"
                             role="button"
-                            href="https://www.odoo.com/documentation/19.0/applications/marketing/sms_marketing/twilio.html">
+                            href="https://www.odoo.com/documentation/latest/applications/marketing/sms_marketing/twilio.html">
                             Need help ?
                             <i class="fa fa-external-link" aria-hidden="true"/>
                         </a>

--- a/addons/sms_twilio/wizard/sms_twilio_account_manage_views.xml
+++ b/addons/sms_twilio/wizard/sms_twilio_account_manage_views.xml
@@ -14,7 +14,7 @@
                             required="1"/>
                         <a target="_blank" class="btn btn-link ms-1 w-25"
                             role="button"
-                            href="https://www.odoo.com/documentation/17.0/applications/marketing/sms_marketing/twilio.html">
+                            href="https://www.odoo.com/documentation/19.0/applications/marketing/sms_marketing/twilio.html">
                             Need help ?
                             <i class="fa fa-external-link" aria-hidden="true"/>
                         </a>

--- a/addons/stock/views/res_config_settings_views.xml
+++ b/addons/stock/views/res_config_settings_views.xml
@@ -81,7 +81,7 @@
                         <block title="Shipping Connectors" name="shipping_connectors_setting_container">
                             <setting id="compute_shipping_costs_ups" help="Compute shipping costs and ship with UPS">
                                 <div class="o_form_label">UPS Connector</div>
-                                <a href="https://www.odoo.com/documentation/17.0/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
+                                <a href="https://www.odoo.com/documentation/19.0/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
                                 <div class="text-muted">
                                     Compute shipping costs and ship with UPS<br/>
                                     <strong>(please go to Home>Apps to install)</strong>
@@ -89,7 +89,7 @@
                             </setting>
                             <setting id="compute_shipping_costs_dhl" help=" Compute shipping costs and ship with DHL">
                                 <div class="o_form_label">DHL Connector</div>
-                                <a href="https://www.odoo.com/documentation/17.0/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
+                                <a href="https://www.odoo.com/documentation/19.0/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
                                 <div class="text-muted">
                                     Compute shipping costs and ship with DHL<br/>
                                     <strong>(please go to Home>Apps to install)</strong>
@@ -97,7 +97,7 @@
                             </setting>
                             <setting id="compute_shipping_costs_fedex" help="Compute shipping costs and ship with FedEx">
                                 <div class="o_form_label">FedEx Connector</div>
-                                <a href="https://www.odoo.com/documentation/17.0/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
+                                <a href="https://www.odoo.com/documentation/19.0/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
                                 <div class="text-muted">
                                     Compute shipping costs and ship with FedEx<br/>
                                     <strong>(please go to Home>Apps to install)</strong>
@@ -105,7 +105,7 @@
                             </setting>
                             <setting id="compute_shipping_costs_usps" help="Compute shipping costs and ship with USPS">
                                 <div class="o_form_label">USPS Connector</div>
-                                <a href="https://www.odoo.com/documentation/17.0/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
+                                <a href="https://www.odoo.com/documentation/19.0/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
                                 <div class="text-muted">
                                     Compute shipping costs and ship with USPS<br/>
                                     <strong>(please go to Home>Apps to install)</strong>

--- a/addons/stock/views/res_config_settings_views.xml
+++ b/addons/stock/views/res_config_settings_views.xml
@@ -81,7 +81,7 @@
                         <block title="Shipping Connectors" name="shipping_connectors_setting_container">
                             <setting id="compute_shipping_costs_ups" help="Compute shipping costs and ship with UPS">
                                 <div class="o_form_label">UPS Connector</div>
-                                <a href="https://www.odoo.com/documentation/19.0/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
+                                <a href="https://www.odoo.com/documentation/latest/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
                                 <div class="text-muted">
                                     Compute shipping costs and ship with UPS<br/>
                                     <strong>(please go to Home>Apps to install)</strong>
@@ -89,7 +89,7 @@
                             </setting>
                             <setting id="compute_shipping_costs_dhl" help=" Compute shipping costs and ship with DHL">
                                 <div class="o_form_label">DHL Connector</div>
-                                <a href="https://www.odoo.com/documentation/19.0/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
+                                <a href="https://www.odoo.com/documentation/latest/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
                                 <div class="text-muted">
                                     Compute shipping costs and ship with DHL<br/>
                                     <strong>(please go to Home>Apps to install)</strong>
@@ -97,7 +97,7 @@
                             </setting>
                             <setting id="compute_shipping_costs_fedex" help="Compute shipping costs and ship with FedEx">
                                 <div class="o_form_label">FedEx Connector</div>
-                                <a href="https://www.odoo.com/documentation/19.0/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
+                                <a href="https://www.odoo.com/documentation/latest/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
                                 <div class="text-muted">
                                     Compute shipping costs and ship with FedEx<br/>
                                     <strong>(please go to Home>Apps to install)</strong>
@@ -105,7 +105,7 @@
                             </setting>
                             <setting id="compute_shipping_costs_usps" help="Compute shipping costs and ship with USPS">
                                 <div class="o_form_label">USPS Connector</div>
-                                <a href="https://www.odoo.com/documentation/19.0/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
+                                <a href="https://www.odoo.com/documentation/latest/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
                                 <div class="text-muted">
                                     Compute shipping costs and ship with USPS<br/>
                                     <strong>(please go to Home>Apps to install)</strong>

--- a/addons/web_unsplash/static/src/unsplash_credentials/unsplash_credentials.xml
+++ b/addons/web_unsplash/static/src/unsplash_credentials/unsplash_credentials.xml
@@ -1,7 +1,7 @@
 <templates id="template" xml:space="preserve">
     <t t-name="web_unsplash.UnsplashCredentials">
         <div class="d-flex align-items-center flex-wrap">
-            <a href="https://www.odoo.com/documentation/master/applications/websites/website/optimize/unsplash.html#generate-an-unsplash-access-key"
+            <a href="https://www.odoo.com/documentation/latest/applications/websites/website/optimize/unsplash.html#generate-an-unsplash-access-key"
                class="me-1" target="_blank">Get an Access key</a>
             and paste it here:
             <input type="text"
@@ -12,7 +12,7 @@
                    t-on-input="() => this.state.hasKeyError = false"
                    t-att-class="{ 'is-invalid': state.hasKeyError }"/>
             and paste
-            <a href="https://www.odoo.com/documentation/master/applications/websites/website/optimize/unsplash.html#generate-an-unsplash-application-id"
+            <a href="https://www.odoo.com/documentation/latest/applications/websites/website/optimize/unsplash.html#generate-an-unsplash-application-id"
                class="mx-1" target="_blank">Application ID</a>
             here:
             <input type="text"

--- a/addons/website_links/views/website_links_template.xml
+++ b/addons/website_links/views/website_links_template.xml
@@ -67,7 +67,7 @@
                         <div class="offset-md-1 col-md-4 d-none d-md-block">
                             <p class="text-muted text-justify">Share this page with a <strong>short link</strong> that includes <strong>analytics trackers</strong>.</p>
                             <p class="text-muted text-justify">Those trackers can be used in Google Analytics to track clicks and visitors, or in Odoo reports to track opportunities and related revenues.</p>
-                            <a target="_blank" href="https://www.odoo.com/documentation/18.0/applications/websites/website/reporting/link_tracker.html">Read More</a>
+                            <a target="_blank" href="https://www.odoo.com/documentation/19.0/applications/websites/website/reporting/link_tracker.html">Read More</a>
                         </div>
                     </div>
 

--- a/addons/website_links/views/website_links_template.xml
+++ b/addons/website_links/views/website_links_template.xml
@@ -67,7 +67,7 @@
                         <div class="offset-md-1 col-md-4 d-none d-md-block">
                             <p class="text-muted text-justify">Share this page with a <strong>short link</strong> that includes <strong>analytics trackers</strong>.</p>
                             <p class="text-muted text-justify">Those trackers can be used in Google Analytics to track clicks and visitors, or in Odoo reports to track opportunities and related revenues.</p>
-                            <a target="_blank" href="https://www.odoo.com/documentation/19.0/applications/websites/website/reporting/link_tracker.html">Read More</a>
+                            <a target="_blank" href="https://www.odoo.com/documentation/latest/applications/websites/website/reporting/link_tracker.html">Read More</a>
                         </div>
                     </div>
 

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -1263,7 +1263,7 @@ class ResUsers(models.Model):
                     "and *might* be a proxy. If your Odoo is behind a proxy, "
                     "it may be mis-configured. Check that you are running "
                     "Odoo in Proxy Mode and that the proxy is properly configured, see "
-                    "https://www.odoo.com/documentation/master/administration/install/deploy.html#https for details.",
+                    "https://www.odoo.com/documentation/latest/administration/install/deploy.html#https for details.",
                     source
                 )
             raise AccessDenied(_("Too many login failures, please wait a bit before trying again."))

--- a/ruff.toml
+++ b/ruff.toml
@@ -77,7 +77,7 @@ ignore = [
 ]
 
 [lint.isort]
-# https://www.odoo.com/documentation/19.0/contributing/development/coding_guidelines.html#imports
+# https://www.odoo.com/documentation/master/contributing/development/coding_guidelines.html#imports
 section-order = ["future", "standard-library", "third-party", "first-party", "local-folder"]
 known-first-party = ["odoo"]
 known-local-folder = ["odoo.addons"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -77,7 +77,7 @@ ignore = [
 ]
 
 [lint.isort]
-# https://www.odoo.com/documentation/18.0/contributing/development/coding_guidelines.html#imports
+# https://www.odoo.com/documentation/19.0/contributing/development/coding_guidelines.html#imports
 section-order = ["future", "standard-library", "third-party", "first-party", "local-folder"]
 known-first-party = ["odoo"]
 known-local-folder = ["odoo.addons"]


### PR DESCRIPTION
Before this commit, many of the url is pointing to 18.0.

After this commit, the url will point to 19.0 documentation link.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr