### PR TITLE
[FIX] calendar: prevent crash on Google Calendar sync due to invalid timezone

### DIFF
--- a/addons/calendar/models/calendar_recurrence.py
+++ b/addons/calendar/models/calendar_recurrence.py
@@ -510,7 +510,10 @@ class RecurrenceRule(models.Model):
         return ((start, start + event_duration) for start in starts)
 
     def _get_timezone(self):
-        return pytz.timezone(self.event_tz or self.env.context.get('tz') or 'UTC')
+        try:
+            return pytz.timezone(self.event_tz or self.env.context.get('tz') or 'UTC')
+        except pytz.UnknownTimeZoneError:
+            return pytz.timezone('UTC')
 
     def _get_occurrences(self, dtstart):
         """


### PR DESCRIPTION
- When users attempt to sync Google Calendar with Odoo, a crash occurs if the event’s timezone is invalid.
- In Sentry, we have observed multiple occurrences of this issue.

**Error: -**
`UnknownTimeZoneError: 'GMT+05:30'`

**Cause: -**
- At [1], we call `pytz.timezone` and if `self.event_tz` contains an invalid timezone string, `pytz` raises a time zone error, causing the sync to fail.

**Solution: -**
- Wrap the `pytz.timezone` call in a `try/except`.
- First, attempt with `self.event_tz or self.env.context.get('tz') or 'UTC'`.
- If that fails due to an invalid timezone, gracefully fall back to `UTC`.

[1]
https://github.com/odoo/odoo/blob/9805d09dff64de835de0c764da8c6e213d6b88aa/addons/calendar/models/calendar_recurrence.py#L513

**sentry-6738882905**

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
