### PR TITLE
[IMP] account: make kpi.provider report unreconciled bank statements

### DIFF
--- a/addons/account/models/kpi_provider.py
+++ b/addons/account/models/kpi_provider.py
@@ -1,4 +1,5 @@
 from odoo import api, models
+from odoo.osv import expression
 
 
 class KpiProvider(models.AbstractModel):
@@ -6,10 +7,15 @@ class KpiProvider(models.AbstractModel):
 
     @api.model
     def get_account_kpi_summary(self):
-        grouped_moves_to_report = self.env['account.move']._read_group([
-            '|', ('state', '=', 'draft'),
-            '&', ('state', '=', 'posted'), ('to_check', '=', True),
-        ], ['journal_id'], ['journal_id'])
+        grouped_moves_to_report = self.env['account.move']._read_group(
+            expression.OR([
+                [('state', '=', 'draft')],
+                [('state', '=', 'posted'), ('to_check', '=', True)],
+                [('state', '=', 'posted'), ('journal_id.type', '=', 'bank'), ('statement_line_id.is_reconciled', '=', False)],
+            ]),
+            ['journal_id'],
+            ['journal_id'],
+        )
 
         FieldsSelection = self.env['ir.model.fields.selection'].with_context(lang=self.env.user.lang)
         journal_type_names = {x.value: x.name for x in FieldsSelection.search([

--- a/addons/account/tests/test_kpi_provider.py
+++ b/addons/account/tests/test_kpi_provider.py
@@ -10,7 +10,10 @@ class TestKpiProvider(TransactionCase):
         super().setUpClass()
 
         # Clean things for the test
-        cls.env['account.move'].search([('state', '=', 'draft')]).unlink()
+        cls.env['account.move'].search([
+            '|', ('state', '=', 'draft'),
+            ('statement_line_id.is_reconciled', '=', False),
+        ])._unlink_or_reverse()
 
     def test_empty_kpi_summary(self):
         # Ensure that nothing gets reported when there is nothing to report
@@ -71,4 +74,42 @@ class TestKpiProvider(TransactionCase):
         ])
 
         move.button_set_checked()
+        self.assertCountEqual(self.env['kpi.provider'].get_account_kpi_summary(), [])
+
+    def test_kpi_summary_reports_unreconciled_bank_statements(self):
+        company_id = self.ref('base.main_company')
+        account_id = self.env['account.account'].search([('company_id', '=', company_id), ('account_type', '=', 'income')], limit=1).id
+        move = self.env['account.move'].create({
+            'company_id': company_id,
+            'line_ids': [Command.create({'account_id': account_id, 'quantity': 15, 'price_unit': 10})],
+            'partner_id': self.env.user.partner_id.id,
+            'move_type': 'out_invoice',
+        })
+        move.action_post()
+
+        journal_id = self.env['account.journal'].create({
+            'name': 'Bank',
+            'type': 'bank',
+        })
+        bank_statement = self.env['account.bank.statement'].create({
+            'name': 'test_statement',
+            'line_ids': [Command.create({
+                'date': '2025-09-15',
+                'payment_ref': 'line_1',
+                'journal_id': journal_id.id,
+                'amount': move.amount_total,
+            })],
+        })
+
+        self.assertEqual(bank_statement.line_ids.move_id.state, 'posted')
+        self.assertFalse(bank_statement.line_ids.is_reconciled)
+        self.assertCountEqual(self.env['kpi.provider'].get_account_kpi_summary(), [
+            {'id': 'account_journal_type.bank', 'name': 'Bank', 'type': 'integer', 'value': 1},
+        ])
+
+        move_line = move.line_ids.filtered(lambda line: line.account_type == 'asset_receivable')
+        _st_liquidity_lines, st_suspense_lines, _st_other_lines = bank_statement.line_ids._seek_for_lines()
+        st_suspense_lines.account_id = move_line.account_id
+        (move_line + st_suspense_lines).reconcile()
+        self.assertTrue(bank_statement.line_ids.is_reconciled)
         self.assertCountEqual(self.env['kpi.provider'].get_account_kpi_summary(), [])

--- a/addons/account/tests/test_kpi_provider.py
+++ b/addons/account/tests/test_kpi_provider.py
@@ -5,17 +5,18 @@ from odoo.tests import tagged, TransactionCase
 @tagged('post_install', '-at_install')
 class TestKpiProvider(TransactionCase):
 
-    def test_kpi_summary(self):
-        """
-        - Ensure that nothing is reported when there is nothing to report
-        - All <account.move> in draft or to_check should be reported
-        - Posting one <account.move> should reduce the number reported
-        - Posting all <account.move> of a journal_type should remove that journal_type from the reporting
-        """
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
         # Clean things for the test
-        self.env['account.move'].search([('state', '=', 'draft')]).unlink()
+        cls.env['account.move'].search([('state', '=', 'draft')]).unlink()
+
+    def test_empty_kpi_summary(self):
+        # Ensure that nothing gets reported when there is nothing to report
         self.assertCountEqual(self.env['kpi.provider'].get_account_kpi_summary(), [])
 
+    def test_kpi_summary(self):
         company_id = self.ref('base.main_company')
         account_id = self.env['account.account'].search([('company_id', '=', company_id)], limit=1)
         base_move = {
@@ -23,7 +24,7 @@ class TestKpiProvider(TransactionCase):
             'line_ids': [Command.create({'account_id': account_id.id, 'quantity': 15, 'price_unit': 10})],
             'partner_id': self.env.user.partner_id.id,
         }
-        all_moves = self.env['account.move'].create(
+        self.env['account.move'].create(
             [{**base_move, 'move_type': 'entry'}] * 2 +
             [{**base_move, 'move_type': 'out_invoice'}] * 3 +
             [{**base_move, 'move_type': 'out_refund'}] * 4 +
@@ -38,28 +39,36 @@ class TestKpiProvider(TransactionCase):
             {'id': 'account_journal_type.purchase', 'name': 'Purchase', 'type': 'integer', 'value': 5 + 6 + 8},
         ])
 
-        all_moves[0].action_post()
+    def test_kpi_summary_doesnt_report_posted_moves(self):
+        company_id = self.ref('base.main_company')
+        account_id = self.env['account.account'].search([('company_id', '=', company_id)], limit=1).id
+        move = self.env['account.move'].create({
+            'company_id': company_id,
+            'line_ids': [Command.create({'account_id': account_id, 'quantity': 15, 'price_unit': 10})],
+            'partner_id': self.env.user.partner_id.id,
+            'move_type': 'out_invoice',
+        })
         self.assertCountEqual(self.env['kpi.provider'].get_account_kpi_summary(), [
-            {'id': 'account_journal_type.general', 'name': 'Miscellaneous', 'type': 'integer', 'value': 1},
-            {'id': 'account_journal_type.sale', 'name': 'Sales', 'type': 'integer', 'value': 14},
-            {'id': 'account_journal_type.purchase', 'name': 'Purchase', 'type': 'integer', 'value': 19},
+            {'id': 'account_journal_type.sale', 'name': 'Sales', 'type': 'integer', 'value': 1},
         ])
 
-        all_moves[1].action_post()
+        move.action_post()
+        self.assertCountEqual(self.env['kpi.provider'].get_account_kpi_summary(), [])
+
+    def test_kpi_summary_reports_posted_but_to_check_moves(self):
+        company_id = self.ref('base.main_company')
+        account_id = self.env['account.account'].search([('company_id', '=', company_id)], limit=1).id
+        move = self.env['account.move'].create({
+            'company_id': company_id,
+            'line_ids': [Command.create({'account_id': account_id, 'quantity': 15, 'price_unit': 10})],
+            'partner_id': self.env.user.partner_id.id,
+            'move_type': 'out_invoice',
+        })
+        move.action_post()
+        move.to_check = True
         self.assertCountEqual(self.env['kpi.provider'].get_account_kpi_summary(), [
-            {'id': 'account_journal_type.sale', 'name': 'Sales', 'type': 'integer', 'value': 14},
-            {'id': 'account_journal_type.purchase', 'name': 'Purchase', 'type': 'integer', 'value': 19},
+            {'id': 'account_journal_type.sale', 'name': 'Sales', 'type': 'integer', 'value': 1},
         ])
 
-        all_moves[2].action_post()
-        all_moves[2].to_check = True
-        self.assertCountEqual(self.env['kpi.provider'].get_account_kpi_summary(), [
-            {'id': 'account_journal_type.sale', 'name': 'Sales', 'type': 'integer', 'value': 14},
-            {'id': 'account_journal_type.purchase', 'name': 'Purchase', 'type': 'integer', 'value': 19},
-        ])
-
-        all_moves[2].button_set_checked()
-        self.assertCountEqual(self.env['kpi.provider'].get_account_kpi_summary(), [
-            {'id': 'account_journal_type.sale', 'name': 'Sales', 'type': 'integer', 'value': 13},
-            {'id': 'account_journal_type.purchase', 'name': 'Purchase', 'type': 'integer', 'value': 19},
-        ])
+        move.button_set_checked()
+        self.assertCountEqual(self.env['kpi.provider'].get_account_kpi_summary(), [])


### PR DESCRIPTION
### [REF] account: reorganize kpi.provider tests

The account test_kpi_provider was already getting complicated, and this commit aims to simplify it by breaking it into smaller tests that show more clearly what is expected.

Task-id: 5062431

### [IMP] account: make kpi.provider report unreconciled bank statements

The `kpi.provider:get_account_kpi_summary` method should include posted moves of a bank journal that are related to an unreconciled bank statement.

Task-id: 5062431