### PR TITLE
[IMP] purchase: enable mass mailing option in list and kanban views

### DIFF
--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -947,4 +947,16 @@ if isinstance(res, dict):
         <field name="binding_model_id" ref="purchase.model_purchase_order"/>
         <field name="binding_view_types">list,kanban</field>
     </record>
+
+    <record id="action_purchase_order_mass_mail" model="ir.actions.act_window">
+        <field name="name">Send by mail</field>
+        <field name="res_model">mail.compose.message</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+        <field name="context">{
+            'default_composition_mode': 'mass_mail',
+        }</field>
+        <field name="binding_model_id" ref="purchase.model_purchase_order"/>
+        <field name="binding_view_types">list,kanban</field>
+    </record>
 </odoo>


### PR DESCRIPTION
Purpose:
================
Currently, when users create multiple `alternative RFQs`, manage many RFQs, or need to communicate with vendors, whether by sending RFQs, reminders, or purchase orders, they must open each record individually to send an email. This repetitive process is time-consuming, slows down the purchasing workflow, and becomes particularly inefficient when handling large volumes of orders or numerous vendors. Moreover, the absence of a direct mass email action in the list or kanban views increases manual effort, adds unnecessary steps, and reduces overall productivity.

With This Commit:
================
- Added a mass mailing action `Send by mail` in both list and kanban views, allowing users to select multiple purchase orders or RFQs and send templated or generic emails to vendors in one action. This opens the email wizard, where users can compose a message or select a template before sending. This enables efficient communication with multiple vendors simultaneously, whether sending RFQs, reminders, or PO updates, without having to open each record individually.
- This improvement streamlines communication, reduces repetitive manual work, and significantly enhances efficiency when handling large volumes of orders.

Task-4977286