### PR TITLE
[FIX] html_builder: aligned "x" button in Add to Cart snippet option

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/select_many2x.scss
+++ b/addons/html_builder/static/src/core/building_blocks/select_many2x.scss
@@ -6,6 +6,7 @@
     // To be improved by removing the unwanted classes and share relevant
     // rules across the BuilderSelect AND SelectMany2X components.
 
+    display: grid;
     border: 0 !important; // Override backend's `border`class
     width: 100% !important; // Override backend's `w-auto`class
 
@@ -18,6 +19,7 @@
     }
 
     .o_select_menu_toggler {
+        min-width: 0; // allow shrinking
         &, &.btn-light.bg-light {
             --border-color: #{$o-we-bg-light};
             --btn-padding-x: #{map-get($spacers , 2)};


### PR DESCRIPTION
Steps to reproduce:
1. Install `eCommerce`.
2. Add a product with a name longer than 20 characters.
3. Drop the "Add to Cart" snippet.
4. In the Choose Record option, select that product.
5. The "x" button to the right of the product name overflows beyond the screen.

Issue:
When the product name is too long in the Add to Cart snippet options (many2x field), the "x" button overflows outside the
visible area.

Reason:
The many2x dropdown field was not allowed to shrink, so its content pushed the "x" button out of view.

Fix:
Applied `display: grid` to structure the content properly. Moreover, added `min-width: 0` to allow the many2x dropdown field to shrink when the content is too long, ensuring the "x" button stays aligned within the visible area.
