### PR TITLE
[IMP] link_tracker: encode '...' in redirect url

### DIFF
--- a/addons/link_tracker/models/link_tracker.py
+++ b/addons/link_tracker/models/link_tracker.py
@@ -110,7 +110,12 @@ class LinkTracker(models.Model):
                     attr = attr.name
                 if attr:
                     query[key] = attr
-            tracker.redirected_url = parsed.replace(query=urls.url_encode(query)).to_url()
+
+            query = urls.url_encode(query)
+            # '...' is detected as malicious by some nginx
+            # configuration, encoding it solve the issue
+            query = query.replace('...', '%2E%2E%2E')
+            tracker.redirected_url = parsed.replace(query=query).to_url()
 
     @api.model
     @api.depends('url')

--- a/addons/link_tracker/tests/test_link_tracker.py
+++ b/addons/link_tracker/tests/test_link_tracker.py
@@ -180,3 +180,19 @@ class TestLinkTracker(common.TransactionCase, MockLinkTracker):
         self.assertRaises(UserError, self.env['link.tracker'].create, {'url': '?debug=1'})
         self.assertRaises(UserError, self.env['link.tracker'].create, {'url': '#'})
         self.assertRaises(UserError, self.env['link.tracker'].create, {'url': '#model=project.task&id=3603607'})
+
+    def test_url_encoding(self):
+        """Test that the redirect URL is properly encoded."""
+        campaign = self.env['utm.campaign'].create({'name': 'campai.gn...'})
+        source = self.env['utm.source'].create({'name': 'source...'})
+        medium = self.env['utm.medium'].create({'name': 'medium'})
+        link = self.env['link.tracker'].create({
+            'url': 'http://example.com',
+            'title': 'Odoo',
+            'campaign_id': campaign.id,
+            'source_id': source.id,
+            'medium_id': medium.id,
+        })
+        self.assertIn('utm_campaign=campai.gn%2E%2E%2E', link.redirected_url)
+        self.assertIn('utm_source=source%2E%2E%2E', link.redirected_url)
+        self.assertIn('utm_medium=medium', link.redirected_url)


### PR DESCRIPTION
Purpose
=======
It has been reported that some nginx configuration detect '...' as malicious. When testing, encoding the '...' solve the issue, and so we force the encoding for the redirection URL.

Task-4920533