### PR TITLE
[FIX] hr_homeworking: change work location filter name

### DIFF
--- a/addons/hr_homeworking/views/hr_employee_views.xml
+++ b/addons/hr_homeworking/views/hr_employee_views.xml
@@ -7,7 +7,7 @@
         <field name="arch" type="xml">
             <xpath expr="//filter[@name='group_department']" position="after">
                 <separator/>
-                <filter name="_search_today_location" string="Work location" domain="[]" context="{'group_by':'today_location_name'}"/>
+                <filter name="_search_today_location" string="Today Work location" domain="[]" context="{'group_by':'today_location_name'}"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Before Commit:
In the employee views, the group-by filter was labeled 'Work Location', which was misleading. It suggested that the grouping was based on the `work_location_id` field, but in reality, it was grouping by today’s work location.

After Commit:
The group-by filter label has been updated to 'Today Work Location' to accurately reflect its actual functionality.


opw-5073966



I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
