### PR TITLE
[FIX] point_of_sale: empty receipt after fast validation

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
@@ -32,8 +32,12 @@ export class ReceiptScreen extends Component {
             phone: partner?.phone || "",
         });
         this.sendReceipt = useTrackedAsync(this._sendReceiptToCustomer.bind(this));
-        this.doFullPrint = useTrackedAsync(() => this.pos.printReceipt());
-        this.doBasicPrint = useTrackedAsync(() => this.pos.printReceipt({ basic: true }));
+        this.doFullPrint = useTrackedAsync(() =>
+            this.pos.printReceipt({ order: this.currentOrder })
+        );
+        this.doBasicPrint = useTrackedAsync(() =>
+            this.pos.printReceipt({ order: this.currentOrder, basic: true })
+        );
     }
     actionSendReceiptOnEmail() {
         this.sendReceipt.call({

--- a/addons/pos_event/static/src/app/screens/receipt_screen/receipt_screen.js
+++ b/addons/pos_event/static/src/app/screens/receipt_screen/receipt_screen.js
@@ -14,13 +14,13 @@ patch(ReceiptScreen.prototype, {
         this.doPrintEventBadge = useTrackedAsync(() => this.printEventBadge());
     },
     async printEventFull() {
-        const registrations = this.pos.getOrder().eventRegistrations.map((reg) => reg.id);
+        const registrations = this.currentOrder.eventRegistrations.map((reg) => reg.id);
         await this.report.doAction("event.action_report_event_registration_full_page_ticket", [
             registrations,
         ]);
     },
     async printEventBadge() {
-        const registrations = this.pos.getOrder().eventRegistrations.map((reg) => reg.id);
+        const registrations = this.currentOrder.eventRegistrations.map((reg) => reg.id);
         await this.report.doAction("event.action_report_event_registration_badge", [registrations]);
 
         // Update the status to "attended" if we print the attendee badge


### PR DESCRIPTION
Steps to reproduce:
- Enable a one-click payment method.
- Create and validate an order using fast validation.
- On the receipt screen, print the order receipt.

Issue:
- The printed receipt is empty (no order details).
- In restaurant mode, a traceback occurs when printing the receipt.
- In retail mode, an unwanted new order is created.

Fix:
- Prevent the creation of a new floating order during fast order validation.

Task-5093060

Related: https://github.com/odoo/enterprise/pull/96695