### PR TITLE
[FIX] pos_sale: set discount for lot product in pos

### DIFF
--- a/addons/pos_sale/static/src/overrides/models/pos_store.js
+++ b/addons/pos_sale/static/src/overrides/models/pos_store.js
@@ -176,6 +176,7 @@ patch(PosStore.prototype, {
                         ...newLineValues,
                     });
                     splitted_line.set_quantity(converted_line.lot_qty_by_name[lot] || 0, true);
+                    splitted_line.set_discount(line.discount);
                     splitted_line.setPackLotLines({
                         modifiedPackLotLines: [],
                         newPackLotLines: [{ lot_name: lot }],


### PR DESCRIPTION
When creating a sale order for a product, confirming it, Then, when paying for the order in the POS, the discount line is not available.

Steps to reproduce:
-------------------
* Create a product tracked by lot
* Create a sale order for that same product and set the discount
* Confirm the sale order
* Pay the order in the POS
> Observation: The discount line is not appearing.

Why the fix:
------------
The customer applies the discount for the product, but it's not appearing in the POS. So I just added the discount line


**Before Fix**
<img width="485" height="202" alt="before_fix" src="https://github.com/user-attachments/assets/5c559569-8f89-4bfd-8fe8-5415b1236406" />

**After Fix**
<img width="485" height="221" alt="after_fix" src="https://github.com/user-attachments/assets/e6aa7ea6-5ff9-4d66-ae56-d18ea25e2878" />




opw-5084170
