### PR TITLE
[IMP] hr: make new contract button invisible if no contract

### DIFF
--- a/addons/hr/static/src/components/button_new_contract/button_new_contract.xml
+++ b/addons/hr/static/src/components/button_new_contract/button_new_contract.xml
@@ -3,7 +3,7 @@
     <t t-name="hr.ButtonNewContract">
         <span class="w-100 d-flex justify-content-end">
             <button class="btn btn-link p-0 o_field_widget text-end w-auto" t-on-click="onClickNewContractBtn"
-                    t-ref="datetime-picker-target-new-contract">New Contract</button>
+                    t-ref="datetime-picker-target-new-contract" t-if="props.record.data.contract_date_start">New Contract</button>
         </span>
     </t>
 </template>


### PR DESCRIPTION
The button new contract should only be displayed if a contract_date_start is already set. Otherwise, the user should only directly set the start of the contract.

Task: 5094909