### PR TITLE
[FIX] website_sale: prevent data loss when creating new ribbon

### DIFF
--- a/addons/website_sale/static/src/website_builder/product_ribbon_options_plugin.js
+++ b/addons/website_sale/static/src/website_builder/product_ribbon_options_plugin.js
@@ -55,6 +55,22 @@ class ProductsRibbonOptionPlugin extends Plugin {
     getCount() {
         return this.count;
     }
+    /**
+     * Get the server ID for a ribbon.
+     *
+     * Resolves the ID from `originalRibbons` or `ribbonsObject`. Falls back to
+     * the provided `ribbonId` if no mapped server ID is found.
+     *
+     * @param {number} ribbonId
+     * @returns {number}
+     */
+    getServerId(ribbonId) {
+        return (
+            this.originalRibbons?.[ribbonId]?.serverId ??
+            this.ribbonsObject?.[ribbonId]?.serverId ??
+            ribbonId
+        );
+    }
 
     async loadInfo() {
         if (!this.ribbons) {
@@ -118,36 +134,21 @@ class ProductsRibbonOptionPlugin extends Plugin {
         });
 
         const createdRibbonProms = [];
-        let createdRibbonIds;
         if (created.length > 0) {
             createdRibbonProms.push(
                 this.services.orm.create(
                     'product.ribbon',
-                    created.map((ribbon) => {
-                        ribbon = Object.assign({}, ribbon);
-                        this.originalRibbons[ribbon.id] = ribbon;
-                        delete ribbon.id;
-                        return ribbon;
-                    })
-                ).then((ids) => (createdRibbonIds = ids))
+                    created.map(({ id, serverId, ...ribbon }) => ribbon)
+                ).then((ids) => {
+                    // Map each created ribbon's local ID to its server ID
+                    created.forEach((ribbon, index) => {
+                        ribbon.serverId = ids[index];
+                        this.originalRibbons[ribbon.id] = Object.assign({}, ribbon);
+                    });
+                })
             );
         }
         await Promise.all(createdRibbonProms);
-
-        const localToServer = Object.assign(
-            this.ribbonsObject,
-            Object.fromEntries(
-                created.map((ribbon, index) => [
-                    ribbon.id,
-                    { ...this.ribbonsObject[ribbon.id], id: createdRibbonIds[index] },
-                ])
-            ),
-            {
-                false: {
-                    id: "",
-                },
-            }
-        );
 
         const proms = [];
         for (const ribbon of modified) {
@@ -158,13 +159,14 @@ class ProductsRibbonOptionPlugin extends Plugin {
                 position: ribbon.position,
                 style: ribbon.style,
             };
-            const serverId = localToServer[ribbon.id]?.id || ribbon.id;
+            const serverId = this.getServerId(ribbon.id);
             proms.push(this.services.orm.write('product.ribbon', [serverId], ribbonData));
-            this.originalRibbons[ribbon.id] = Object.assign({}, ribbon);
+            this.originalRibbons[ribbon.id] = { ...ribbon, serverId };
         }
 
         if (deletedIds.length > 0) {
-            proms.push(this.services.orm.unlink('product.ribbon', deletedIds));
+            const serverIds = deletedIds.map((id) => this.getServerId(id));
+            proms.push(this.services.orm.unlink("product.ribbon", serverIds));
         }
 
         await Promise.all(proms);
@@ -180,18 +182,17 @@ class ProductsRibbonOptionPlugin extends Plugin {
         // reduce RPCs
         const ribbonTemplates = {};
         for (const [templateId, ribbonId] of Object.entries(finalTemplateRibbons)) {
-            const rid = ribbonTemplates[ribbonId] ||= [];
-            rid.push(parseInt(templateId));
+            const serverRibbonId = this.getServerId(ribbonId);
+            const templates = (ribbonTemplates[serverRibbonId] ||= []);
+            templates.push(parseInt(templateId));
         }
 
         const promises = [];
-        for (const ribbonId in ribbonTemplates) {
-            const templateIds = ribbonTemplates[ribbonId];
-            const parsedId = parseInt(ribbonId);
-            const validRibbonId = currentIds.includes(parsedId) ? ribbonId : false;
+        for (const [ribbonIdStr, templateIds] of Object.entries(ribbonTemplates)) {
+            const ribbonId = parseInt(ribbonIdStr) || false;
             promises.push(
                 this.services.orm.write('product.template', templateIds, {
-                    website_ribbon_id: localToServer[validRibbonId]?.id || false,
+                    website_ribbon_id: ribbonId,
                 })
             );
         }
@@ -203,7 +204,7 @@ class ProductsRibbonOptionPlugin extends Plugin {
      * Deletes a ribbon.
      *
      */
-    deleteRibbon(editingElement) {
+    async deleteRibbon(editingElement) {
         const ribbonId = parseInt(editingElement.querySelector('.o_ribbons')?.dataset.ribbonId);
         if (this.ribbonsObject[ribbonId]) {
             const ribbonIndex = this.ribbons.findIndex(ribbon => ribbon.id === ribbonId);
@@ -238,13 +239,13 @@ class ProductsRibbonOptionPlugin extends Plugin {
                 templateId = templateElement ? parseInt(templateElement.getAttribute('data-oe-id')) : null;
             }
             if (templateId && !isNaN(templateId)) {
-                this.productTemplatesRibbons.push({
+                this.addProductTemplatesRibbons({
                     templateId: templateId,
                     ribbonId: false,
                 });
             }
         });
-        this._saveRibbons();
+        await this._saveRibbons();
     }
     getProductTemplateID() {
         return this.productTemplateID;
@@ -252,8 +253,24 @@ class ProductsRibbonOptionPlugin extends Plugin {
     setProductTemplateID(id) {
         this.productTemplateID = id
     }
-    addProductTemplatesRibbons(value) {
-        this.productTemplatesRibbons.push(value);
+    /**
+     * Add or update a product template's ribbon assignment.
+     * Ensures each template has only one ribbon entry.
+     *
+     * @param {Object} params
+     * @param {number} params.templateId - Product template ID
+     * @param {number|string|false} params.ribbonId - Ribbon ID to assign
+     */
+    addProductTemplatesRibbons({ templateId, ribbonId }) {
+        // Ensure one entry per template
+        const index = this.productTemplatesRibbons.findIndex(
+            (entry) => entry.templateId === templateId
+        );
+        if (index !== -1) {
+            this.productTemplatesRibbons[index].ribbonId = ribbonId;
+        } else {
+            this.productTemplatesRibbons.push({ templateId, ribbonId });
+        }
     }
     getRibbonsObject() {
         return this.ribbonsObject;
@@ -325,18 +342,19 @@ class CreateRibbonAction extends BuilderAction {
         this.ribbonOptions = this.dependencies.productsRibbonOptionPlugin
     }
     apply({ editingElement }) {
-        const productTemplateId = editingElement
-            .querySelector('[data-oe-model="product.template"]')
-            .getAttribute('data-oe-id')
-        this.ribbonOptions.setProductTemplateID(parseInt(
-            productTemplateId
-        ));
+        const productTemplateId = parseInt(
+            editingElement
+                .querySelector('[data-oe-model="product.template"]')
+                .getAttribute('data-oe-id')
+        );
+        this.ribbonOptions.setProductTemplateID(productTemplateId);
         const ribbonId = Date.now();
         this.ribbonOptions.addProductTemplatesRibbons({
             templateId: productTemplateId,
             ribbonId: ribbonId,
         });
         const ribbon = reactive({
+            serverId: null,
             id: ribbonId,
             name: 'Ribbon Name',
             bg_color: '',
@@ -374,7 +392,7 @@ class ModifyRibbonAction extends BuilderAction {
         }
         return this.ribbonOptions.getRibbonsObject()[ribbonId][params.mainParam] === value;
     }
-    apply({ editingElement, params, value }) {
+    async apply({ editingElement, params, value }) {
         const isPreviewMode = this.dependencies.history.getIsPreviewing();
         const ribbonEl = editingElement.querySelector('.o_ribbons')
         const setting = params.mainParam;
@@ -382,7 +400,11 @@ class ModifyRibbonAction extends BuilderAction {
         const previousRibbon = this.ribbonOptions.getRibbonsObject()[ribbonId];
         this.ribbonOptions.setRibbonObject(ribbonId, {...previousRibbon, [setting]: value});
         this.ribbonOptions.setRibbon(ribbonId, {...previousRibbon, [setting]: value});
-        const res = this.ribbonOptions._setRibbon(ribbonEl, {...previousRibbon, [setting]: value}, !isPreviewMode);
+        const res = await this.ribbonOptions._setRibbon(
+            ribbonEl,
+            { ...previousRibbon, [setting]: value },
+            !isPreviewMode
+        );
         if(isPreviewMode){
             this.ribbonOptions.setRibbonObject(ribbonId, previousRibbon)
             this.ribbonOptions.setRibbon(ribbonId, previousRibbon)

--- a/addons/website_sale/static/tests/tours/website_sale_shop_editor_tour.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_editor_tour.js
@@ -1,8 +1,10 @@
 import {
+    changeBackgroundColor,
+    changeOption,
     clickOnEditAndWaitEditMode,
     clickOnSave,
     registerWebsitePreviewTour,
-} from '@website/js/tours/tour_utils';
+} from "@website/js/tours/tour_utils";
 
 registerWebsitePreviewTour("shop_editor", {
     url: "/shop",
@@ -96,3 +98,49 @@ registerWebsitePreviewTour("shop_editor_no_alternative_products_visibility_tour"
         trigger: ':iframe .s_dynamic_snippet_products:not(:visible)',
     }
 ]);
+
+registerWebsitePreviewTour(
+    "shop_editor_create_and_set_product_ribbon",
+    {
+        url: "/shop",
+        edition: true,
+    },
+    () => [
+        {
+            content: "Click on first product",
+            trigger: ":iframe .oe_product:first",
+            run: "click",
+        },
+        changeOption("Product", "createRibbon"),
+        {
+            trigger: "[data-action-id='modifyRibbon'] input",
+            run: "edit New Ribbon",
+        },
+        changeBackgroundColor(),
+        {
+            content: "Select the color #FF9C00",
+            trigger: ".popover button[data-color='#FF9C00']",
+            run: "click",
+        },
+        {
+            content: "Check the ribbon name appears in the dropdown title",
+            trigger: "[data-container-title='Product'] .o-hb-select-toggle:contains(New Ribbon)",
+        },
+        {
+            content: "Check the background color preview displays correctly in the dropdown",
+            trigger:
+                "[data-action-id='setRibbon'] div:contains(New Ribbon) .o_wsale_color_preview[style='background-color: #FF9C00; border: ;']",
+        },
+        {
+            content: "Check the font color preview displays correctly in the dropdown",
+            trigger:
+                "[data-action-id='setRibbon'] div:contains(New Ribbon) .o_wsale_color_preview[style='background-color: purple !important; border: ;']",
+        },
+        ...clickOnSave(),
+        {
+            content: "Check that the ribbon was properly saved",
+            trigger:
+                ":iframe .oe_product:first .o_ribbons:contains('New Ribbon')[style='color: purple; background-color:#FF9C00']",
+        },
+    ]
+);

--- a/addons/website_sale/tests/test_customize.py
+++ b/addons/website_sale/tests/test_customize.py
@@ -419,3 +419,6 @@ class TestCustomize(HttpCaseWithUserDemo, HttpCaseWithUserPortal, TestProductCon
         product_no_alternative.set_sequence_top()
         product_with_alternative.set_sequence_top()
         self.start_tour('/', 'shop_editor_no_alternative_products_visibility_tour', login="admin")
+
+    def test_13_shop_editor_create_and_set_product_ribbon(self):
+        self.start_tour("/", 'shop_editor_create_and_set_product_ribbon', login="admin")


### PR DESCRIPTION
When creating a new ribbon and immediately changing its options, the 
title and colors would unexpectedly reset to None.

This happened because the ribbon was not fully saved in the database 
before we tried to update its settings, causing the changes to be lost.

Now we wait for the ribbon to be properly created and assigned its 
database identifier before applying any updates. A mapping system tracks 
the relationship between temporary and final identifiers to ensure 
changes are always applied to the correct ribbon.

task-5503716