### PR TITLE
[FIX] web: look at all columns to find the currency

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -767,7 +767,7 @@ export class ListRenderer extends Component {
     }
 
     getFieldCurrencies(fieldName) {
-        const column = this.columns.find((c) => c.name === fieldName);
+        const column = this.allColumns.find((c) => c.name === fieldName);
         const currencyField = this.getCurrencyField(column);
         let values;
         if (this.props.list.selection.length) {


### PR DESCRIPTION
`getFieldCurrencies` is called in the `aggregates` getter, while iterating on `allColumns`, trying to find the argument found from `allColumns` in `columns`, which is a subset of it. It was leading to an undefined attribute error.

