### PR TITLE
[FIX] web: adapt color picker in bottom sheet

### DIFF
--- a/addons/web/static/src/core/bottom_sheet/bottom_sheet.scss
+++ b/addons/web/static/src/core/bottom_sheet/bottom_sheet.scss
@@ -312,7 +312,13 @@
         }
     }
     .row.o_kanban_card_manage_settings:last-child {
-        flex-direction: column;
+        &:has(:not(.o_field_boolean_favorite)) {
+            flex-direction: column-reverse;
+
+            .o_field_kanban_color_picker {
+                padding: map-get($spacers, 3);
+            }
+        }
 
         div[class*="col-"] + div[class*="col-"] {
             border-left: none;


### PR DESCRIPTION
This commit correctly repositions the color picker in the project bottom sheet.

task-5087158

Requires:
- https://github.com/odoo/enterprise/pull/95001


| Before | After |
|--------|--------|
| <img width="402" height="691" alt="Capture d’écran 2025-09-17 à 10 15 42" src="https://github.com/user-attachments/assets/1eb10eb1-68d5-4271-957a-647fcfc14910" /> | <img width="415" height="693" alt="Capture d’écran 2025-09-17 à 10 15 59" src="https://github.com/user-attachments/assets/0c52f84e-9873-4d6a-8317-79c46b043c84" /> |



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
