### PR TITLE
[IMP] website_sale: global GMC feature group

### DIFF
--- a/addons/website_sale/controllers/product_feed.py
+++ b/addons/website_sale/controllers/product_feed.py
@@ -22,7 +22,7 @@ class ProductFeed(Controller):
         This method generates an XML feed containing information about eCommerce products.
         The feed is configured via the `product.feed` model, allowing customization such as:
         - Localization by specifying a language or pricelist (currency).
-        - Filtering products by category or categories.
+        - Filtering products by categories.
 
         Notes:
         - The feed is only accessible through a valid `access_token`.
@@ -35,7 +35,7 @@ class ProductFeed(Controller):
         :return: The XML feed compressed using GZIP.
         :rtype: bytes
         """
-        if not request.website.enabled_gmc_src:
+        if not request.env['res.groups']._is_feature_enabled('website_sale.group_product_feed'):
             raise NotFound()
 
         feed_sudo = self._find_and_check_feed_access(feed_id, access_token)

--- a/addons/website_sale/models/res_config_settings.py
+++ b/addons/website_sale/models/res_config_settings.py
@@ -24,8 +24,6 @@ class ResConfigSettings(models.TransientModel):
         string="Google Merchant Center",
         implied_group='website_sale.group_product_feed',
         group='base.group_user',
-        related='website_id.enabled_gmc_src',
-        readonly=False,
     )
 
     # Modules

--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -247,8 +247,6 @@ class Website(models.Model):
 
     prevent_zero_price_sale = fields.Boolean(string="Hide 'Add To Cart' when price = 0")
 
-    enabled_gmc_src = fields.Boolean(string="Google Merchant Center")
-
     currency_id = fields.Many2one(
         string="Default Currency",
         comodel_name='res.currency',

--- a/addons/website_sale/tests/common_gmc.py
+++ b/addons/website_sale/tests/common_gmc.py
@@ -15,7 +15,7 @@ class WebsiteSaleGMCCommon(ProductVariantsCommon, WebsiteSaleCommon):
     def setUpClass(cls):
         super().setUpClass()
         cls.ProductFeedController = ProductFeed()
-        cls.website.enabled_gmc_src = True
+        cls.env['res.config.settings'].create({'group_gmc_feed': True}).execute()
 
         cls.gmc_feed = cls.env['product.feed'].create({
             'name': "GMC",

--- a/addons/website_sale/tests/test_website_sale_gmc.py
+++ b/addons/website_sale/tests/test_website_sale_gmc.py
@@ -20,7 +20,7 @@ class TestWebsiteSaleGMC(WebsiteSaleGMCCommon, HttpCase):
         self.assertEqual(200, response.status_code)
 
     def test_gmc_xml_not_found_if_gmc_setting_disabled(self):
-        self.website.enabled_gmc_src = False
+        self.env['res.config.settings'].create({'group_gmc_feed': False}).execute()
 
         response = self.url_open(self.gmc_feed.url)
 


### PR DESCRIPTION
During the reintroduction of GMC in [^1], a new feature group was added to control the visibility of the product feed menu. This allowed the creation of feeds for any website, even if the feature was not enabled for that website. However, it was later deemed unnecessary to keep a feature flag per website.

This commit removes the website-specific flag, leaving only the group-based feature control.

See also:
- https://github.com/odoo/upgrade/pull/8468

[^1]: https://github.com/odoo/odoo/pull/224889
