### PR TITLE
[FIX] hr_holidays: fix time off summary card display

### DIFF
--- a/addons/hr_holidays/static/src/leave_stats/leave_stats.xml
+++ b/addons/hr_holidays/static/src/leave_stats/leave_stats.xml
@@ -17,19 +17,19 @@
             </div>
             <div class="d-flex flex-column mb-1">
                 <div t-foreach="state.leaves" t-as="leave" t-key="leave.id" class="d-flex mb-2 gap-1">
-                    <span class="col-4 fw-bold" t-esc="leave.holiday_status_id[1]"/>
-                    <div t-if="leave.leave_type_request_unit == 'hour'" class="d-flex gap-2 col-6">
+                    <span class="col-3 fw-bold" t-esc="leave.holiday_status_id[1]"/>
+                    <div t-if="leave.leave_type_request_unit == 'hour'" class="d-flex gap-2 col-6 flex-wrap">
                         <span t-esc="leave.date_from"/>
                         <span t-esc="leave.hour_from" class="fst-italic"/>
                         <i class="fa fa-long-arrow-right my-1" aria-label="Arrow icon" title="Arrow"/>
                         <span t-esc="leave.hour_to" class="fst-italic"/>
                     </div>
-                    <div t-else="" class="col-5 d-flex gap-2 flex-wrap">
+                    <div t-else="" class="col-6 d-flex gap-2 flex-wrap">
                         <span t-esc="leave.date_from"/>
                         <i class="fa fa-long-arrow-right my-1" aria-label="Arrow icon" title="Arrow"/>
                         <span t-esc="leave.date_to"/>
                     </div>
-                    <div class="col-3 text-center">
+                    <div class="col-3 flex-wrap">
                     (
                         <span t-if="leave.leave_type_request_unit == 'hour'"><t t-esc="leave.number_of_hours"/> hours</span>
                         <span t-else=""><t t-esc="leave.number_of_days"/> days</span>
@@ -49,25 +49,25 @@
             <div class="d-flex flex-column mb-1">
                 <div t-foreach="state.departmentLeaves" t-as="leave" t-key="leave.id" class="d-flex flex-column mb-2">
                     <div class=" d-flex my-1 gap-1">
-                        <div class="col-4 d-flex">
+                        <div class="col-3 d-flex">
                             <KanbanMany2OneAvatarEmployeeField
                                 record="{'data' : {'employee_id': leave.employee_id}, 'fields': this.props.record.fields}"
                                 name="'employee_id'" relation="'hr.employee.public'"
                             />
                             <span t-esc="leave.employee_id[1]" class="mx-1 fw-bold"/>
                         </div>
-                        <div t-if="leave.leave_type_request_unit == 'hour'" class="d-flex gap-2 col-6">
+                        <div t-if="leave.leave_type_request_unit == 'hour'" class="d-flex gap-2 col-6 flex-wrap">
                             <span t-esc="leave.date_from"/>
                             <span t-esc="leave.hour_from" class="fst-italic"/>
                             <i class="fa fa-long-arrow-right my-1" aria-label="Arrow icon" title="Arrow"/>
                             <span t-esc="leave.hour_to" class="fst-italic"/>
                         </div>
-                        <div t-else="" class="col-5 d-flex gap-2 flex-wrap">
+                        <div t-else="" class="col-6 d-flex gap-2 flex-wrap">
                             <span t-esc="leave.date_from"/>
                             <i class="fa fa-long-arrow-right my-1" aria-label="Arrow icon" title="Arrow"/>
                             <span t-esc="leave.date_to"/>
                         </div>
-                        <div class="col-3 text-center">
+                        <div class="col-3 flex-wrap">
                             (
                             <span t-if="leave.leave_type_request_unit == 'hour'"><t t-esc="leave.number_of_hours"/> hours</span>
                             <span t-else=""><t t-esc="leave.number_of_days"/> days</span>

--- a/addons/hr_holidays/static/src/scss/time_off.scss
+++ b/addons/hr_holidays/static/src/scss/time_off.scss
@@ -118,7 +118,7 @@
             }
         }
         @media only screen and (min-width:768px){
-            .o_kanban_record {
+            .o_kanban_record:not(.o_kanban_ghost) {
                 width: 100%;
                 min-height: 6.5rem;
                 margin: 0px;

--- a/addons/hr_holidays/static/src/views/kanban/kanban_renderer.xml
+++ b/addons/hr_holidays/static/src/views/kanban/kanban_renderer.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="hr_holidays.KanbanRenderer">
-        <div class="o_timeoff_calendar d-flex flex-column">
-            <TimeOffDashboard t-if="showDashboard" employeeId="employeeId"/>
+        <div class="d-flex flex-column h-100 overflow-hidden">
+            <div class="o_timeoff_calendar">
+                <TimeOffDashboard t-if="showDashboard" employeeId="employeeId"/>
+            </div>
             <t t-call="web.KanbanRenderer"/>
         </div>
     </t>


### PR DESCRIPTION
On a time off request, there is a summary on the side. Problem: if we have time off in hours, the display is not adapted and the text is too long.

This commit fixes the issue to display the hours correctly.

task-5092855

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
