### PR TITLE
[FIX] hr: fix a bug when trying to edit properties of certain demo jobs

### DIFF
--- a/addons/hr/data/hr_demo.xml
+++ b/addons/hr/data/hr_demo.xml
@@ -111,7 +111,6 @@ Knowledge of UML-like modeling
 Good language skills, other than English (Dutch and French preferred, others welcome)
             </field>
             <field name="contract_type_id" ref="contract_type_permanent"/>
-            <field name="company_id" eval="False"></field>
         </record>
 
         <record id="job_consultant" model="hr.job">
@@ -123,7 +122,6 @@ Good language skills, other than English (Dutch and French preferred, others wel
                 driving business growth. Strong analytical skills and a proven track record in delivering results are
                 essential.
             </field>
-            <field name="company_id" eval="False"></field>
         </record>
 
         <record id="job_developer" model="hr.job">
@@ -136,7 +134,6 @@ Good language skills, other than English (Dutch and French preferred, others wel
                 Someone who can snap out of coding and perform analysis or meet clients to explain the technical
                 possibilities that can meet their needs.
             </field>
-            <field name="company_id" eval="False"></field>
         </record>
 
         <record id="job_hrm" model="hr.job">
@@ -152,7 +149,6 @@ Good language skills, other than English (Dutch and French preferred, others wel
                 aligning the workforce with the organization's goals and objectives.
             </field>
             <field name="contract_type_id" ref="contract_type_permanent"/>
-            <field name="company_id" eval="False"></field>
         </record>
 
         <record id="job_marketing" model="hr.job">


### PR DESCRIPTION
Steps to reproduce:
- Go to the Recruitment app
- Open the configuration panel for the demo offer for CTO, Consultant, Experienced Developer or Human Resources Manager
- Click on the cogwheel
- Select "Edit properties"
- A warning appears and you can't edit properties

Reason:
The definition of the job demo data sets the "company_id" field to False, which causes an error when you try to edit the properties.

How it was fixed:
By removing the explicit value of False for the field "company_id", it will auto assign the field to the current company and allow the properties to be edited correctly.

Task ID: 5093032