### PR TITLE
[FIX] mail: meeting view hides dialogs

### DIFF
--- a/addons/mail/static/src/discuss/call/common/meeting.scss
+++ b/addons/mail/static/src/discuss/call/common/meeting.scss
@@ -1,3 +1,10 @@
 .o-mail-Meeting {
     background-color: #111827;
 }
+
+.o-overlay-item:has(.o-mail-Meeting) {
+    // When both the meeting view and another overlay are open (e.g. message delete dialog,
+    // call permission, etc.), only the last one opened is visible because they share the same
+    // stacking context and z-index. This fix ensure dialogs and other overlays are on top.
+    z-index: $zindex-modal - 1;
+}


### PR DESCRIPTION
The meeting view allows focusing on an ongoing call, removing
any distraction with a full screen call view. To do so, the
overlay service is used, and the call view takes the whole
screen.

However, other components, such as confirmation dialogs also
use the overlay service. As a result, dialogs are sometimes
hidden behind the meeting view.

This commit ensures the meeting view won't hide other overlays
by reducing it's z-index.

Steps to reproduce:
- Reset your mic/camera permission.
- Start a meeting.
- The call permission dialog is hidden by the meeting view.

task-5095114