### PR TITLE
[FIX] crm, web: prevent error when clicking Export All action

### DIFF
--- a/addons/crm/static/tests/tours/crm_forecast_tour.js
+++ b/addons/crm/static/tests/tours/crm_forecast_tour.js
@@ -20,6 +20,14 @@ registry.category("web_tour.tours").add('crm_forecast', {
         content: 'Open Forecast menu',
         run: 'click',
     }, {
+        trigger: `.fa-cog`,
+        content: "Click on the Gear icon",
+        run: "click",
+    }, {
+        trigger: ".dropdown-item:contains('Export All')",
+        content: "Click on Export All",
+        run: "click",
+    }, {
         trigger: '.o_column_quick_create:contains(Add next month)',
         content: 'Wait page loading',
     }, {

--- a/addons/web/controllers/export.py
+++ b/addons/web/controllers/export.py
@@ -90,6 +90,8 @@ class GroupsTreeNode:
         return aggregate_func((child.aggregated_values.get(field_name) for child in self.children.values()))
 
     def _get_avg_aggregate(self, field_name, data):
+        if not self.count:
+            return 0  # this is required for kanban forecast views with no data in some stages
         aggregate_func = OPERATOR_MAPPING.get('sum')
         if self.data:
             return aggregate_func(data) / self.count


### PR DESCRIPTION
Currently an error occurs when we try to export CRM forecast.

**Steps to replicate:**
- Go to CRM > Reports > Forecast.
- Click on the gear menu and click `Export All`.

**Error:**
`ZeroDivisionError: division by zero`

**Cause:**
- The error due to a modification in the List and Kanban views, which are now merged into the DynamicList.
- This change resulted in the `Export All` option appearing in the CRM Forecast kanban view and forecast views can have empty stages.
- The issue occurs at line [1] where `self.count` becomes zero for stages without records, leading to the error.

**Solution:**
- This commit solves the issue by returning default value 0 when data is empty.

[1]: https://github.com/odoo/odoo/blob/6be0e8ad57c531fb88dc33e126df884430f1ab21/addons/web/controllers/export.py#L97

sentry-6720460271
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
