### PR TITLE
[REF] html_editor, *: rename color picker's color prefix prop

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
@@ -138,7 +138,7 @@ export class BuilderColorPicker extends Component {
                 getUsedCustomColors:
                     this.props.getUsedCustomColors || this.getUsedCustomColors.bind(this),
                 colorPrefix: "color-prefix-",
-                themeColorPrefix: "hb-cp-",
+                cssVarColorPrefix: "hb-cp-",
                 noTransparency: this.props.noTransparency,
                 enabledTabs: this.props.enabledTabs,
                 grayscales: this.props.grayscales,

--- a/addons/html_builder/static/src/core/color_ui_plugin.js
+++ b/addons/html_builder/static/src/core/color_ui_plugin.js
@@ -7,8 +7,8 @@ export class ColorUIPlugin extends EditorColorUIPlugin {
     }
 
     getPropsForColorSelector(type) {
-        const props = {...super.getPropsForColorSelector(type)};
-        props.themeColorPrefix = "hb-cp-";
+        const props = { ...super.getPropsForColorSelector(type) };
+        props.cssVarColorPrefix = "hb-cp-";
         return props;
     }
 }

--- a/addons/html_editor/static/src/main/font/color_selector.js
+++ b/addons/html_editor/static/src/main/font/color_selector.js
@@ -25,11 +25,11 @@ export class ColorSelector extends Component {
         getTargetedElements: Function,
         colorPrefix: { type: String },
         enabledTabs: { type: Array, optional: true },
-        themeColorPrefix: { type: String, optional: true },
+        cssVarColorPrefix: { type: String, optional: true },
         onClose: Function,
     };
     static defaultProps = {
-        themeColorPrefix: "",
+        cssVarColorPrefix: "",
         enabledTabs: ["solid", "gradient", "custom"],
     };
 
@@ -68,7 +68,7 @@ export class ColorSelector extends Component {
                 getUsedCustomColors: this.props.getUsedCustomColors,
                 colorPrefix: this.props.colorPrefix,
                 enabledTabs: this.props.enabledTabs,
-                themeColorPrefix: this.props.themeColorPrefix,
+                cssVarColorPrefix: this.props.cssVarColorPrefix,
             },
             {
                 env: this.__owl__.childEnv,

--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -192,7 +192,7 @@ export class LinkPopover extends Component {
                                 : ["solid", "custom"],
                         getUsedCustomColors: () => [],
                         colorPrefix: "",
-                        themeColorPrefix: "hb-cp-",
+                        cssVarColorPrefix: "hb-cp-",
                         applyColor: (colorValue) => {
                             this[colorStateRef].selectedColor = colorValue;
                             this[resetValueRef] = colorValue;

--- a/addons/web/static/src/core/color_picker/color_picker.js
+++ b/addons/web/static/src/core/color_picker/color_picker.js
@@ -53,7 +53,7 @@ export class ColorPicker extends Component {
         setOperationCallbacks: { type: Function, optional: true },
         enabledTabs: { type: Array, optional: true },
         colorPrefix: { type: String },
-        themeColorPrefix: { type: String, optional: true },
+        cssVarColorPrefix: { type: String, optional: true },
         defaultOpacity: { type: Number, optional: true },
         grayscales: { type: Object, optional: true },
         noTransparency: { type: Boolean, optional: true },
@@ -64,7 +64,7 @@ export class ColorPicker extends Component {
         close: () => {},
         defaultOpacity: 100,
         enabledTabs: ["solid", "custom"],
-        themeColorPrefix: "",
+        cssVarColorPrefix: "",
         setOnCloseCallback: () => {},
     };
 

--- a/addons/web/static/src/core/color_picker/color_picker.xml
+++ b/addons/web/static/src/core/color_picker/color_picker.xml
@@ -37,7 +37,7 @@
             noTransparency: this.props.noTransparency,
             defaultThemeColorVars: this.DEFAULT_THEME_COLOR_VARS,
             defaultColorSet: this.defaultColorSet,
-            themeColorPrefix: this.props.themeColorPrefix,
+            cssVarColorPrefix: this.props.cssVarColorPrefix,
             defaultColors: this.DEFAULT_COLORS,
             getUsedCustomColors: this.props.getUsedCustomColors,
             grayscales: this.grayscales,

--- a/addons/web/static/src/core/color_picker/tabs/color_picker_custom_tab.js
+++ b/addons/web/static/src/core/color_picker/tabs/color_picker_custom_tab.js
@@ -22,7 +22,7 @@ class ColorPickerCustomTab extends Component {
         defaultColorSet: { type: String | Boolean, optional: true },
         defaultOpacity: { type: Number, optional: true },
         grayscales: { type: Object, optional: true },
-        themeColorPrefix: { type: String, optional: true },
+        cssVarColorPrefix: { type: String, optional: true },
         noTransparency: { type: Boolean, optional: true },
         setOnCloseCallback: { type: Function, optional: true },
         setOperationCallbacks: { type: Function, optional: true },

--- a/addons/web/static/src/core/color_picker/tabs/color_picker_custom_tab.xml
+++ b/addons/web/static/src/core/color_picker/tabs/color_picker_custom_tab.xml
@@ -3,7 +3,7 @@
     <div class="d-flex flex-column align-items-start p-2 pb-0" t-on-keydown="props.colorPickerNavigation">
         <div class="o_colorpicker_section" t-on-click="props.onColorClick"
             t-on-mouseover="props.onColorPointerOver" t-on-mouseout="props.onColorPointerOut"
-t-on-focusin="props.onFocusin" t-on-focusout="props.onColorPointerOut">
+            t-on-focusin="props.onFocusin" t-on-focusout="props.onColorPointerOut">
             <t t-foreach="usedCustomColors" t-as="color" t-key="color_index">
                 <button t-if="color.toLowerCase() !== props.currentCustomColor?.toLowerCase()"
                     class="o_color_button o_color_picker_button btn p-0" t-att-data-color="color"
@@ -28,7 +28,7 @@ t-on-focusin="props.onFocusin" t-on-focusout="props.onColorPointerOut">
                 <t t-foreach="grayscaleColors" t-as="color" t-key="color">
                     <button t-att-data-color="color" class="o_color_button o_color_picker_button btn p-0"
                         t-att-class="{'selected': color === props.defaultColorSet and !props.currentColorPreview}"
-                        t-attf-style="background-color: var(--{{props.themeColorPrefix+color}})"/>
+                        t-attf-style="background-color: var(--{{props.cssVarColorPrefix+color}})"/>
                 </t>
             </div>
         </t>

--- a/addons/web/static/src/core/color_picker/tabs/color_picker_solid_tab.js
+++ b/addons/web/static/src/core/color_picker/tabs/color_picker_solid_tab.js
@@ -13,7 +13,7 @@ class ColorPickerSolidTab extends Component {
         onFocusout: Function,
         currentCustomColor: { type: String, optional: true },
         defaultColorSet: { type: String | Boolean, optional: true },
-        themeColorPrefix: { type: String, optional: true },
+        cssVarColorPrefix: { type: String, optional: true },
         defaultColors: Array,
         defaultThemeColorVars: Array,
         "*": { optional: true },

--- a/addons/web/static/src/core/color_picker/tabs/color_picker_solid_tab.xml
+++ b/addons/web/static/src/core/color_picker/tabs/color_picker_solid_tab.xml
@@ -7,7 +7,7 @@
         <div class="o_colorpicker_section">
             <t t-foreach="props.defaultThemeColorVars" t-as="color" t-key="color">
                 <button t-att-data-color="color" t-att-class="{'selected': color === props.defaultColorSet}"
-                    t-att-style="`background-color: var(--${props.themeColorPrefix + color})` + (color_index === 3 ? '; grid-column: 5' : '')"
+                    t-att-style="`background-color: var(--${props.cssVarColorPrefix + color})` + (color_index === 3 ? '; grid-column: 5' : '')"
                     class="btn p-0 o_color_button o_color_picker_button"/>
             </t>
         </div>

--- a/addons/web/static/tests/core/color_picker.test.js
+++ b/addons/web/static/tests/core/color_picker.test.js
@@ -157,7 +157,7 @@ test("colorpicker inside the builder are linked to the builder theme colors", as
             applyColorPreview() {},
             applyColorResetPreview() {},
             colorPrefix: "",
-            themeColorPrefix: "xyz-",
+            cssVarColorPrefix: "xyz-",
         },
     });
     const getButtonColor = (sel) => getComputedStyle(queryOne(sel)).backgroundColor;
@@ -195,7 +195,7 @@ test("colorpicker outside the builder are not linked to the builder theme colors
             applyColorPreview() {},
             applyColorResetPreview() {},
             colorPrefix: "",
-            themeColorPrefix: "",
+            cssVarColorPrefix: "",
         },
     });
     const getButtonColor = (sel) => getComputedStyle(queryOne(sel)).backgroundColor;


### PR DESCRIPTION
*: html_builder, web.
When this prop was added in this [commit], it was named
themeColorPrefix, which does not reflect its purpose properly. It could
mistakenly be taken as a prop for the theme tab of the color picker,
when actually it's a prefix CSS variable names used to display colors
correctly.

[commit]: https://github.com/odoo/odoo/commit/62bdb31587f2586d6d45f53d264e193028b3c860