### PR TITLE
[FIX] purchase_stock: allow suggest for non-admin users

### DIFF
--- a/addons/purchase_stock/wizard/purchase_order_suggest.py
+++ b/addons/purchase_stock/wizard/purchase_order_suggest.py
@@ -201,4 +201,4 @@ class PurchaseOrderSuggest(models.TransientModel):
         cid = self.env.company.id
         condition = f'partner_id={self.partner_id.id}'
         for field in ['based_on', 'number_of_days', 'percent_factor']:
-            self.env['ir.default'].set('purchase.order.suggest', field, self[field], company_id=cid, condition=condition)
+            self.env['ir.default'].set('purchase.order.suggest', field, self[field], user_id=True, company_id=cid, condition=condition)


### PR DESCRIPTION
**Issue:**

Non-admin users get an AccessError as follows

```doesn't have 'create' access to: - Default Values, Based on (Purchase Order Suggest) (ir.default: 45)... ```

when using the Purchase Order Suggest wizard.

**Cause:**

The `ir_default_user_rule` record rule restricts non-admin users to only create/modify ir.default records where
  `user_id = user.id`

However,  in  `_save_values_for_vendor` method:

https://github.com/odoo/odoo/blob/6b8a8196c63275eead6709bb20002df0be12a059/addons/purchase_stock/wizard/purchase_order_suggest.py#L199-L204

 `ir.default.set()`  is called without setting the `user_id` parameter, which defaults to an attempt to create a global default: what only admins can do.

**Steps to reproduce:**

- create a non-admin user with purchase user permissions.
- log  in as that user and create a Purchase Order
- add products to the catalog and click "Suggest.
- configure suggest parameters and click "Compute" (Note: compute is only enabled when estimated_price > 0)

An AccessError occurs

opw-5076647