### PR TITLE
[FIX] l10n_gcc_invoice: prevent error when no country is set on company

### DIFF
--- a/addons/l10n_gcc_invoice/models/res_company.py
+++ b/addons/l10n_gcc_invoice/models/res_company.py
@@ -10,4 +10,4 @@ class ResCompany(models.Model):
     @api.depends('partner_id.country_id.country_group_ids.code')
     def _compute_l10n_gcc_country_is_gcc(self):
         for record in self:
-            record.l10n_gcc_country_is_gcc = 'GCC' in record.country_id.country_group_codes
+            record.l10n_gcc_country_is_gcc = record.country_id and 'GCC' in record.country_id.country_group_codes


### PR DESCRIPTION
Steps to reproduce:-
- Install `l10n_gcc_invoice` module.
- Go to Companies and open current Company.
- Remove Country from company Address.
- Click on General Settings.

Error :-
Pastebin: https://pastebin.com/xWqVDWjB
```
File /home/odoo/odoo18/odoo/community/addons/l10n_gcc_invoice/models/res_company.py, line 13, in _compute_l10n_gcc_country_is_gcc
    record.l10n_gcc_country_is_gcc = 'GCC' in record.country_id.country_group_codes
TypeError: argument of type 'bool' is not iterable
```

Root cause: At [1], `record.country_id.country_group_codes` is considered as iterable, but when no country is set on company it evaluates to False.

Solution: First check for `country_id` before checking `country_group_codes`.

[1]: https://github.com/odoo/odoo/blob/45fcd9716fe8cabd4db2ddbdf54caa8f69d5a013/addons/l10n_gcc_invoice/models/res_company.py#L13