### PR TITLE
[FIX] mail: add padding around search bar

### DIFF
--- a/addons/mail/static/src/core/public_web/discuss_search.scss
+++ b/addons/mail/static/src/core/public_web/discuss_search.scss
@@ -14,3 +14,7 @@
         }
     }
 }
+
+.o-mail-DiscussSearch {
+    padding-top: var(--DiscussSearch-padding-top, #{map-get($spacers, 1)});
+}

--- a/addons/mail/static/src/discuss/core/public_web/discuss_search.dark.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_search.dark.scss
@@ -1,3 +1,7 @@
 .o-mail-DiscussSearch-inputContainer {
     --border-opacity: 0;
 }
+
+.o-mail-DiscussSearch {
+    --DiscussSearch-padding-top: #{map-get($spacers, 1)};
+}


### PR DESCRIPTION
Before this commit, the search bar was too close to the header bar, now padding has been added.

Enterprise: https://github.com/odoo/enterprise/pull/95004
task-5092001

| Before | After |
|--------|--------|
| <img width="440" height="673" alt="Screenshot 2025-09-17 at 11 19 41" src="https://github.com/user-attachments/assets/226c48ff-a6cf-4e13-9f91-7b2fcfa8f92f" /> | <img width="440" height="673" alt="Screenshot 2025-09-17 at 11 19 31" src="https://github.com/user-attachments/assets/2b0b8034-6dff-4717-92fc-322b69a5c2ca" /> | 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
