### PR TITLE
[FIX] mass_mailing: inline placeholder elements

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
@@ -643,6 +643,30 @@ export class MassMailingHtmlField extends HtmlField {
             this.props.record.data[this.props.name] = this.props.record.data.body_html;
         }
         await super._setupReadonlyIframe();
+
+        const iframeTarget = this.sandboxedPreview
+            ? this.iframeRef.el.contentDocument.documentElement
+            : this.iframeRef.el.contentDocument.querySelector("#iframe_target");
+        this._fixInlineDynamicPlaceholders(iframeTarget);
+    }
+    _fixInlineDynamicPlaceholders(iframe) {
+        // Add data-oe-t-inline attribute to t elements whose contents are inline
+        const checkAllInline = (el) =>
+            [...el.children].every((child) => {
+                if (child.tagName === "T") {
+                    return checkAllInline(child);
+                } else {
+                    return (
+                        child.nodeType !== Node.ELEMENT_NODE ||
+                        iframe.contentWindow.getComputedStyle(child).display === "inline"
+                    );
+                }
+            });
+        for (const tElement of iframe.querySelectorAll("t")) {
+            if (checkAllInline(tElement)) {
+                tElement.setAttribute("data-oe-t-inline", "true");
+            }
+        }
     }
     async _lazyloadWysiwyg() {
         await super._lazyloadWysiwyg(...arguments);


### PR DESCRIPTION
In editable fields, the Web Editor currently adds the data-oe-t-inline
attribute to items that are identified as needing to be displayed inline

However, this attribute is added by the editor and removed on save.

As a result, if the previously-editable field is ever set to readonly
(for example: a mailing that is sent no longer allows users to edit its
body), then the inline property appears to be lost: an inline dynamic
attribute suddenly looks like it's on its own line.

Steps to reproduce:

- Create a mailing
- Add a dynamic attribute in the middle of a line
- Send the mailing
- You will see a carriage return directly before and after the dynamic
  attribute

Fix:
The mass_mailing html field now applies the current inlining logic to
readonly HTML.

task-4852246