### PR TITLE
[FIX] html_editor: perma-inline -t-inline items

### DIFF
--- a/addons/html_editor/static/src/others/qweb_plugin.js
+++ b/addons/html_editor/static/src/others/qweb_plugin.js
@@ -56,7 +56,6 @@ export class QWebPlugin extends Plugin {
             if (
                 [
                     "data-oe-t-group",
-                    "data-oe-t-inline",
                     "data-oe-t-selectable",
                     "data-oe-t-group-active",
                 ].includes(mutationRecord.attributeName)
@@ -242,11 +241,10 @@ export class QWebPlugin extends Plugin {
 
     clearDataAttributes(root) {
         for (const node of root.querySelectorAll(
-            "[data-oe-t-group], [data-oe-t-inline], [data-oe-t-selectable], [data-oe-t-group-active]"
+            "[data-oe-t-group], [data-oe-t-selectable], [data-oe-t-group-active]"
         )) {
             node.removeAttribute("data-oe-t-group-active");
             node.removeAttribute("data-oe-t-group");
-            node.removeAttribute("data-oe-t-inline");
             node.removeAttribute("data-oe-t-selectable");
         }
     }

--- a/addons/html_editor/static/tests/insert/paragraph_break.test.js
+++ b/addons/html_editor/static/tests/insert/paragraph_break.test.js
@@ -104,9 +104,9 @@ describe("Selection collapsed", () => {
                 stepFunction: splitBlock,
                 contentAfter: unformat(`
                     <h1 t-if="true">
-                        <t t-out="Hello"></t>
+                        <t t-out="Hello" data-oe-t-inline="true"></t>
                         <br>
-                        []<t t-out="World"></t>
+                        []<t t-out="World" data-oe-t-inline="true"></t>
                     </h1>
                 `),
                 config: { Plugins: [...MAIN_PLUGINS, QWebPlugin] },

--- a/addons/html_editor/static/tests/qweb.test.js
+++ b/addons/html_editor/static/tests/qweb.test.js
@@ -33,7 +33,7 @@ describe("qweb picker", () => {
         );
 
         dispatchClean(editor);
-        expect(getContent(el)).toBe(`<div><t t-if="test">yes</t><t t-else="">no</t></div>`);
+        expect(getContent(el)).toBe(`<div><t t-if="test" data-oe-t-inline="true">yes</t><t t-else="" data-oe-t-inline="true">no</t></div>`);
     });
 
     test("plugin's dom markers are not savable", async () => {
@@ -301,9 +301,9 @@ test("cleaning removes content editable", async () => {
 
     expect(editor.getContent()).toBe(`
         <div>
-            <t t-field="test">Hello</t>
-            <t t-out="test">Hello</t>
-            <t t-esc="test">Hello</t>
-            <t t-raw="test">Hello</t>
+            <t t-field="test" data-oe-t-inline="true">Hello</t>
+            <t t-out="test" data-oe-t-inline="true">Hello</t>
+            <t t-esc="test" data-oe-t-inline="true">Hello</t>
+            <t t-raw="test" data-oe-t-inline="true">Hello</t>
         </div>`);
 });

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -62,7 +62,7 @@ safe_attrs = defs.safe_attrs | frozenset(
      'data-oe-model', 'data-oe-id', 'data-oe-field', 'data-oe-type', 'data-oe-expression', 'data-oe-translation-source-sha', 'data-oe-nodeid',
      'data-last-history-steps', 'data-oe-protected', 'data-embedded', 'data-embedded-editable', 'data-embedded-props', 'data-oe-version',
      'data-oe-transient-content', 'data-behavior-props', 'data-prop-name', 'data-width', 'data-height', 'data-scale-x', 'data-scale-y', 'data-x', 'data-y',  # legacy editor
-     'data-oe-role', 'data-oe-aria-label',
+     'data-oe-role', 'data-oe-aria-label', 'data-oe-t-inline',
      'data-publish', 'data-id', 'data-res_id', 'data-interval', 'data-member_id', 'data-scroll-background-ratio', 'data-view-id',
      'data-class', 'data-mimetype', 'data-original-src', 'data-original-id', 'data-gl-filter', 'data-quality', 'data-resize-width',
      'data-shape', 'data-shape-colors', 'data-file-name', 'data-original-mimetype',


### PR DESCRIPTION
In editable fields, the Html Editor currently adds the data-oe-t-inline
attribute to items that are identified as needing to be displayed inline

However, this attribute is removed on save. As a result, if the editable
body ever "locks" (for example: a mailing that is sent no longer allows
users to edit its body), then the inline property appears to be lost:
an inline dynamic attribute suddenly looks like it's on its own line.

Steps to reproduce:

- Create a mailing
- Add a dynamic attribute in the middle of a line
- Send the mailing
- You will see a carriage return directly before and after the dynamic
    attribute

Fix:

- When a data-oe-t-inline is added to an element, the d-inline class is
also added

task-4852246