### PR TITLE
[FIX] project: fix role/user mapping for task template

### DIFF
--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -1300,10 +1300,11 @@ class ProjectProject(models.Model):
         project.message_post(body=self.env._("Project created from template %(name)s.", name=self.name))
 
         # Tasks dispatching using project roles
-        project.task_ids.role_ids = False
         if role_to_users_mapping and (mapping := role_to_users_mapping.filtered(lambda entry: entry.user_ids)):
-            for template_task, new_task in zip(self.task_ids, project.task_ids):
+            for new_task in project.task_ids:
                 for entry in mapping:
-                    if entry.role_id in template_task.role_ids:
+                    if entry.role_id in new_task.role_ids:
                         new_task.user_ids |= entry.user_ids
+
+        project.task_ids.role_ids = False
         return project

--- a/addons/project/tests/test_project_template.py
+++ b/addons/project/tests/test_project_template.py
@@ -78,6 +78,11 @@ class TestProjectTemplates(TestProjectCommon):
                 Command.create({
                     'name': 'Task 3',
                     'role_ids': [role2.id, role5.id],
+                    'child_ids': [Command.create({
+                        'name': 'Sub Task 1',
+                    }), Command.create({
+                        'name': 'Sub Task 2',
+                    })],
                 }),
                 Command.create({
                     'name': 'Task 4',


### PR DESCRIPTION
Before this commit, when we created a project from a template with task with subtask, the mapping of the role/user was not correctly applied. This lead to inconsistent data at the project creation such as setting users on the child tasks randomly instead of correctly setting it on the parent task

Source of the issue:
We wrongly assumed that the task order of the project copied was the same as the original project and thus used the original project task's list in order to set the user on the copied tasks.

Solution:
Keep the role_ids on the copied tasks and use that data to set the correct user using the wizard mapping. The role_ids are set to False once the data are correctly set.

task-5094321