### PR TITLE
[FIX] website_blog: prevent horizontal scrollbar on long blog titles

### DIFF
--- a/addons/website_blog/static/src/scss/website_blog.scss
+++ b/addons/website_blog/static/src/scss/website_blog.scss
@@ -102,6 +102,10 @@ $o-wblog-loader-size: 50px;
         }
     }
 
+    .o_blog_post_title{
+        word-break: break-all;
+    }
+
     // Blog Post Page
     // ==============================================
     #o_wblog_post_content {
@@ -197,6 +201,7 @@ $o-wblog-loader-size: 50px;
     // ==============================================
     .o_wblog_post_title {
         #o_wblog_post_name {
+            word-break: break-all;
             font-weight: $display-font-weight;
             line-height: $display-line-height;
             // Default font-size.


### PR DESCRIPTION
Long blog post titles caused the page to overflow horizontally, displaying an unnecessary scrollbar.

This fix ensures long titles wrap correctly, avoiding horizontal scrolling while keeping the text intact.

 | Before  | After |
   | ------------- | ------------- |
   | <img width="1631" height="422" alt="image" src="https://github.com/user-attachments/assets/8faa6e22-ac7a-4b59-9b54-f674978dc931" /> | <img width="1633" height="420" alt="image" src="https://github.com/user-attachments/assets/66a2de39-95e2-4871-827e-4965e571ed33" /> |
   | <img width="882" height="394" alt="image" src="https://github.com/user-attachments/assets/b807245f-0d84-47b6-a65b-ce0005037c50" /> | <img width="888" height="385" alt="image" src="https://github.com/user-attachments/assets/3c35cd12-08f2-4775-9c4d-d9d6e4555f00" /> |





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
