### PR TITLE
[FIX] point_of_sale: show optional product popup when scanning barcode

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -242,6 +242,7 @@ export class ProductScreen extends Component {
             product.needToConfigure()
         );
         this.numberBuffer.reset();
+        this.showOptionalProductPopupIfNeeded(product);
     }
     async _getPartnerByBarcode(code) {
         let partner = this.pos.models["res.partner"].getBy("barcode", code.code);
@@ -289,6 +290,7 @@ export class ProductScreen extends Component {
             { code: lotBarcode }
         );
         this.numberBuffer.reset();
+        this.showOptionalProductPopupIfNeeded(product);
     }
     displayAllControlPopup() {
         this.dialog.add(ControlButtonsPopup);
@@ -390,8 +392,11 @@ export class ProductScreen extends Component {
                 options["presetVariant"] = searchedProduct[0];
             }
         }
-        const line = await this.pos.addLineToCurrentOrder({ product_tmpl_id: product }, options);
-        if (line?.product_id?.product_tmpl_id?.pos_optional_product_ids?.length) {
+        await this.pos.addLineToCurrentOrder({ product_tmpl_id: product }, options);
+        this.showOptionalProductPopupIfNeeded(product);
+    }
+    showOptionalProductPopupIfNeeded(product) {
+        if (product.pos_optional_product_ids?.length) {
             this.dialog.add(OptionalProductPopup, {
                 productTemplate: product,
             });

--- a/addons/point_of_sale/static/tests/pos/tours/optional_product_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/optional_product_tour.js
@@ -3,6 +3,7 @@ import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
 import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
 import * as OptionalProduct from "@point_of_sale/../tests/pos/tours/utils/optional_product_util";
 import { registry } from "@web/core/registry";
+import { scan_barcode } from "@point_of_sale/../tests/generic_helpers/utils";
 
 registry.category("web_tour.tours").add("test_optional_product", {
     steps: () =>
@@ -32,6 +33,19 @@ registry.category("web_tour.tours").add("test_optional_product", {
                 "Configurable Chair",
                 "5.0",
                 "50.0",
+                "Blue, Metal, wool"
+            ),
+
+            // Scan a product with optional products
+            scan_barcode("lettertray"),
+            Dialog.is({ title: "Optional Products" }),
+            // Add an optional product
+            OptionalProduct.addOptionalProduct("Configurable Chair", 2, true),
+            // Verify the configurable product is added with correct attributes and quantity
+            ProductScreen.selectedOrderlineHas(
+                "Configurable Chair",
+                "7.0",
+                "70.0",
                 "Blue, Metal, wool"
             ),
 

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -667,9 +667,10 @@ class TestUi(TestPointOfSaleHttpCommon):
             Command.set([ self.small_shelf.id ])
         ]})
 
-        self.letter_tray.write({'pos_optional_product_ids': [
-            Command.set([ self.configurable_chair.id ])
-        ]})
+        self.letter_tray.write({
+            'pos_optional_product_ids': [Command.set([self.configurable_chair.id])],
+            'barcode': 'lettertray'
+        })
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('test_optional_product')


### PR DESCRIPTION
Before this commit, the optional product popup was only displayed when adding a product by clicking on it. When the product was added through barcode scanning, the popup did not appear.

This commit ensures that the optional product popup is consistently shown both when clicking on a product and when scanning its barcode.

opw-5089175

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
