### PR TITLE
[FIX] spreadsheet_dashboard: fix star icon on mobile

### DIFF
--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.scss
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.scss
@@ -115,18 +115,12 @@
 
     .o_dashboard_star {
         margin: auto 0;
-        @include o-hover-text-color($gray-400, $o-main-favorite-color);
-
-        &:hover:before {
-            content: "\f005";
+        cursor: pointer;
+        &.fa-star-o {
+            @include o-hover-text-color($o-main-color-muted, $o-main-favorite-color);
         }
-
-        &.favorite_button_enabled {
-            @include o-hover-text-color($o-main-favorite-color, $gray-400);
-
-            &:hover:before {
-                content: "\f006";
-            }
+        &.fa-star {
+            color: $o-main-favorite-color;
         }
     }
 }

--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.xml
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.xml
@@ -24,7 +24,7 @@
                     t-if="state.activeDashboard"
                     title="Toggle favorite"
                     t-on-click="toggleFavorite"
-                    t-attf-class="o_dashboard_star fa fa-lg fa-star{{!state.activeDashboard.isFavorite ? '-o' : ' favorite_button_enabled'}}"
+                    t-attf-class="o_dashboard_star fa fa-lg fa-star{{!state.activeDashboard.isFavorite ? '-o' : ''}}"
                 />
             </t>
         </ControlPanel>

--- a/addons/spreadsheet_dashboard/static/tests/dashboard/dashboard_action.test.js
+++ b/addons/spreadsheet_dashboard/static/tests/dashboard/dashboard_action.test.js
@@ -334,7 +334,7 @@ test("Should toggle favorite status of a dashboard when the 'Favorite' icon is c
     await createSpreadsheetDashboard();
     expect(".o_search_panel_section").toHaveCount(2);
     await contains(".o_dashboard_star").click();
-    expect(".o_dashboard_star").toHaveClass("fa-star favorite_button_enabled", {
+    expect(".o_dashboard_star").toHaveClass("fa-star", {
         message: "The star should be filled",
     });
     expect(".o_search_panel_section").toHaveCount(3);
@@ -343,7 +343,7 @@ test("Should toggle favorite status of a dashboard when the 'Favorite' icon is c
         "FAVORITES"
     );
     await contains(".o_dashboard_star").click();
-    expect(".o_dashboard_star").not.toHaveClass("fa-star favorite_button_enabled", {
+    expect(".o_dashboard_star").not.toHaveClass("fa-star", {
         message: "The star should not be filled",
     });
     expect.verifySteps(["action_toggle_favorite"]);


### PR DESCRIPTION
The star icon on mobile would have a strange behaviour. After clicking it, the star would not change between filler/not filled until clicking elsewhere.

It turns out that on mobile, after a click the hover rule is applied. And our hover rule would modify the icon to be the opposite of what it should be.

This commit changes the CSS to use the same css as `BooleanFavoriteField` to stay consistent with the rest of Odoo.

Task: [5092945](https://www.odoo.com/odoo/2328/tasks/5092945)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
