### PR TITLE
[FIX] mail: open form view when clicking on a channel from kanban view

### DIFF
--- a/addons/mail/views/discuss_channel_views.xml
+++ b/addons/mail/views/discuss_channel_views.xml
@@ -136,7 +136,7 @@
         <record id="mail.discuss_channel_action" model="ir.actions.act_window">
             <field name="name">Channels</field>
             <field name="res_model">discuss.channel</field>
-            <field name="view_mode">kanban</field>
+            <field name="view_mode">kanban,form</field>
             <field name="domain" eval="[(('channel_type', '=', 'channel'))]" />
             <field name="search_view_id" ref="discuss_channel_view_search" />
         </record>


### PR DESCRIPTION
**Steps to reproduce:**
Open 'Discuss'
Click on 'Channel' in the menu to display channels in kanban view 
Click on any channel

**Cause**:
The action 'mail.discuss_channel_action' did not include form view in view_mode.

**Effect**:
Clicking on a kanban card does not display the form view.

**Fix**:
Open the form view of a channel when clicking on a kanban card.

Task-5076555

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
