### PR TITLE
[FIX] mail: cannot mark notification as read from messaging menu

### DIFF
--- a/addons/mail/static/src/core/public_web/notification_item.js
+++ b/addons/mail/static/src/core/public_web/notification_item.js
@@ -55,7 +55,7 @@ export class NotificationItem extends Component {
     }
 
     onClick(ev) {
-        this.props.onClick(ev.target === this.markAsReadRef.el);
+        this.props.onClick(this.markAsReadRef.el?.contains(ev.target));
     }
 
     webkitLineClamp(maxLine) {


### PR DESCRIPTION
Steps to reproduce:
* Open the messaging menu from the systray with an unread notification.
* Hover on a notification item.
* Click on the `mark as read` button (check icon).
The notification is not marked as read. Instead, the related record is opened.

In [1] UI changes introduced to avoid flickering in the messaging menu modified the structure of the `mark as read` button. Because the click handler only checked if the clicked element exactly matched the button reference, clicks on the inner icon were ignored and triggered the record opening instead.

This commit adjusts the button so that clicks are correctly detected even when they occur on the icon.

[1]: https://github.com/odoo/odoo/pull/226531



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
