### PR TITLE
[FIX] website_sale: enhance product image quality

### DIFF
--- a/addons/website_sale/static/src/website_builder/product_page_option_plugin.js
+++ b/addons/website_sale/static/src/website_builder/product_page_option_plugin.js
@@ -276,7 +276,7 @@ export class BaseProductPageAction extends BuilderAction {
                     {
                         name: webpName,
                         description: size === originalSize ? "" : `resize: ${size}`,
-                        datas: canvas.toDataURL("image/webp", 0.75).split(",")[1],
+                        datas: canvas.toDataURL("image/webp", 1).split(",")[1],
                         res_id: referenceId,
                         res_model: "ir.attachment",
                         mimetype: "image/webp",
@@ -295,7 +295,7 @@ export class BaseProductPageAction extends BuilderAction {
                     {
                         name: attachment.name,
                         description: `format: ${format}`,
-                        datas: canvas.toDataURL(mimetype, 0.75).split(",")[1],
+                        datas: canvas.toDataURL(mimetype, 1).split(",")[1],
                         res_id: resizedId,
                         res_model: "ir.attachment",
                         mimetype: mimetype,


### PR DESCRIPTION
Product image quality was set to 75% not good enough in some cases.
So it increased to 100% to keep the original quality of the image.

opw-5094063



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
