### PR TITLE
[FIX] mail: prevent traceback when pressing up in empty message composer

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -490,7 +490,7 @@ export class Composer extends Component {
         const composer = toRaw(this.props.composer);
         switch (ev.key) {
             case "ArrowUp":
-                if (!this.env.inChatter && composer.text === "") {
+                if (!this.env.inChatter && composer.text === "" && composer.thread) {
                     const messageToEdit = composer.thread.lastEditableMessageOfSelf;
                     if (messageToEdit) {
                         messageToEdit.enterEditMode(this.props.composer.thread);

--- a/addons/mail/static/tests/composer/composer.test.js
+++ b/addons/mail/static/tests/composer/composer.test.js
@@ -566,23 +566,34 @@ test.tags("focus required");
 test("quick edit last self-message from UP arrow", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "general" });
-    pyEnv["mail.message"].create({
-        author_id: serverState.partnerId,
-        body: "Test",
-        attachment_ids: [],
-        message_type: "comment",
-        model: "discuss.channel",
-        res_id: channelId,
-    });
+    pyEnv["mail.message"].create([
+        {
+            author_id: serverState.partnerId,
+            body: "Test-1",
+            attachment_ids: [],
+            message_type: "comment",
+            model: "discuss.channel",
+            res_id: channelId,
+        },
+        {
+            author_id: serverState.partnerId,
+            body: "Test-2",
+            attachment_ids: [],
+            message_type: "comment",
+            model: "discuss.channel",
+            res_id: channelId,
+        },
+    ]);
     await start();
     await openDiscuss(channelId);
-    await contains(".o-mail-Message-content", { text: "Test" });
+    await contains(".o-mail-Message-content", { text: "Test-1" });
+    await contains(".o-mail-Message-content", { text: "Test-2" });
     await contains(".o-mail-Message .o-mail-Composer", { count: 0 });
     triggerHotkey("ArrowUp");
-    await contains(".o-mail-Message .o-mail-Composer");
+    await contains(".o-mail-Message .o-mail-Composer-input", { value: "Test-2" });
     triggerHotkey("Escape");
     await contains(".o-mail-Message .o-mail-Composer", { count: 0 });
-    await contains(".o-mail-Composer-input:focus");
+    await contains(".o-mail-Composer.o-focused");
     // non-empty composer should not trigger quick edit
     await insertText(".o-mail-Composer-input", "Shrek");
     triggerHotkey("ArrowUp");
@@ -591,6 +602,15 @@ test("quick edit last self-message from UP arrow", async () => {
     await tick();
     await tick();
     await contains(".o-mail-Message .o-mail-Composer", { count: 0 });
+    // ArrowUp for quick edit last stays on last edit message, does not jump to older messages.
+    await insertText(".o-mail-Composer-input", "", { replace: true });
+    triggerHotkey("ArrowUp");
+    await insertText(".o-mail-Message .o-mail-Composer-input", "", { replace: true });
+    triggerHotkey("ArrowUp");
+    await contains(".o-mail-Message .o-mail-Composer-input", { value: "" });
+    await insertText(".o-mail-Message .o-mail-Composer-input", "edited message", { replace: true });
+    triggerHotkey("Enter");
+    await contains(".o-mail-Message-content", { text: "edited message (edited)" });
 });
 
 test("Select composer suggestion via Enter does not send the message", async () => {


### PR DESCRIPTION
**Description of the issue this PR addresses:**
------------------------------------------------

Pressing the ArrowUp key in the editing composer when it is empty while editing 
a message with only an attachment caused a JavaScript traceback. This happened 
because the composer was not associated with a thread, and the code tried to 
access `composer.thread.lastEditableMessageOfSelf`.

**Current behavior before PR:**
---------------------------------

- Pressing ArrowUp in the empty editing composer triggers a TypeError  
- The error occurs when editing a message that only has an attachment  
- The composer does not have a thread reference  

**Desired behavior after PR is merged:**
-----------------------------------------

- Pressing ArrowUp in this scenario safely checks if a thread exists  
- No TypeError occurs, and the composer remains stable  

**Task:** 5068553

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
