### PR TITLE
[IMP] mail: hotkey 'f' to quickly search messages in discuss app

### DIFF
--- a/addons/mail/static/src/core/common/thread_actions.js
+++ b/addons/mail/static/src/core/common/thread_actions.js
@@ -72,6 +72,7 @@ registerThreadAction("search-messages", {
         ["discuss.channel", "mail.box"].includes(thread?.model) &&
         (!owner.props.chatWindow || owner.props.chatWindow.isOpen) &&
         !owner.isDiscussSidebarChannelActions,
+    hotkey: "f",
     panelOuterClass: "o-mail-SearchMessagesPanel bg-inherit",
     icon: "oi oi-fw oi-search",
     name: ({ action }) => (action.isActive ? _t("Close Search") : _t("Search Messages")),

--- a/addons/mail/static/tests/discuss/search_messages_panel.test.js
+++ b/addons/mail/static/tests/discuss/search_messages_panel.test.js
@@ -11,6 +11,7 @@ import {
     triggerHotkey,
 } from "@mail/../tests/mail_test_helpers";
 import { describe, expect, test } from "@odoo/hoot";
+import { press } from "@odoo/hoot-dom";
 import { tick } from "@odoo/hoot-mock";
 import { serverState } from "@web/../tests/web_test_helpers";
 
@@ -36,6 +37,24 @@ test("Should open the search panel when search button is clicked", async () => {
     await contains(".o-mail-SearchMessagesPanel");
     await contains(".o_searchview");
     await contains(".o_searchview_input");
+});
+
+test("Should open the search panel with hotkey 'f'", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    pyEnv["mail.message"].create({
+        author_id: serverState.partnerId,
+        body: "This is a message",
+        attachment_ids: [],
+        message_type: "comment",
+        model: "discuss.channel",
+        res_id: channelId,
+    });
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Message");
+    await press("alt+f");
+    await contains(".o-mail-SearchMessagesPanel");
 });
 
 test("Search a message", async () => {


### PR DESCRIPTION
This commit adds hotkey `F` in discuss app in desktop to quickly open the search panel of the active conversation.