### PR TITLE
[FIX] point_of_sale: stop event propagation when selecting orderline

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.js
@@ -45,6 +45,7 @@ export class OrderSummary extends Component {
     }
 
     clickLine(ev, orderline) {
+        ev.stopPropagation();
         if (ev.detail === 2) {
             clearTimeout(this.singleClick);
             return;

--- a/addons/point_of_sale/static/tests/tours/utils/numpad_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/numpad_util.js
@@ -19,3 +19,8 @@ export const isActive = (buttonValue) => ({
     content: `check if --${buttonValue}-- mode is activated`,
     trigger: `${buttonTriger(buttonValue)}.active`,
 });
+
+export const isVisible = () => ({
+    content: "check if numpad is visible",
+    trigger: "div.numpad:visible",
+});

--- a/addons/pos_loyalty/static/tests/tours/e_wallet_program_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/e_wallet_program_tour.js
@@ -4,6 +4,10 @@ import * as TicketScreen from "@point_of_sale/../tests/tours/utils/ticket_screen
 import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
 import * as Chrome from "@point_of_sale/../tests/tours/utils/chrome_util";
 import * as PartnerList from "@point_of_sale/../tests/tours/utils/partner_list_util";
+import * as Numpad from "@point_of_sale/../tests/tours/utils/numpad_util";
+import * as Order from "@point_of_sale/../tests/tours/utils/generic_components/order_widget_util";
+import { negateStep } from "@point_of_sale/../tests/tours/utils/common";
+import { delay } from "@web/core/utils/concurrency";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("EWalletProgramTour1", {
@@ -27,6 +31,47 @@ registry.category("web_tour.tours").add("EWalletProgramTour1", {
             ProductScreen.addOrderline("Top-up eWallet", "1", "10"),
             PosLoyalty.orderTotalIs("10.00"),
             PosLoyalty.finalizeOrder("Cash", "10"),
+
+            // Check numpad visibility when clicking on eWallet orderline
+            ProductScreen.addOrderline("Whiteboard Pen"),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("AAAAAAA"),
+            PosLoyalty.eWalletButtonState({
+                highlighted: true,
+                text: getEWalletText("Pay"),
+                click: true,
+            }),
+            PosLoyalty.orderTotalIs("0.00"),
+            ...ProductScreen.clickLine("eWallet"),
+            // Added a small wait because the clickLine function uses a 300ms timeout
+            {
+                content: "Wait 300ms after clicking orderline",
+                trigger: "body",
+                async run() {
+                    await delay(300);
+                },
+            },
+            Numpad.isVisible(),
+            ...Order.hasLine({
+                withClass: ".selected",
+                run: "click",
+                productName: "eWallet",
+                quantity: "1.0",
+            }),
+            {
+                content: "Wait 300ms after clicking orderline",
+                trigger: "body",
+                async run() {
+                    await delay(300);
+                },
+            },
+            negateStep(Numpad.isVisible()),
+            {
+                content: "Click Current Balance line in orderline",
+                trigger: ".orderline li:contains(Current Balance:)",
+                run: "click",
+            },
+            Numpad.isVisible(),
         ].flat(),
 });
 

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -556,6 +556,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             'limit_categories': True,
             'iface_available_categ_ids': [(6, 0, [pos_category.id])],
         })
+        self.whiteboard_pen.write({'pos_categ_ids': [(6, 0, [pos_category.id])]})
         self.main_pos_config.open_ui()
 
         LoyaltyProgram = self.env['loyalty.program']
@@ -584,7 +585,6 @@ class TestUi(TestPointOfSaleHttpCommon):
         ewallet_bbb = self.env['loyalty.card'].search([('partner_id', '=', partner_bbb.id), ('program_id', '=', ewallet_program.id)])
         self.assertEqual(len(ewallet_bbb), 1)
         self.assertAlmostEqual(ewallet_bbb.points, 10, places=2)
-        self.whiteboard_pen.write({'pos_categ_ids': [(6, 0, [pos_category.id])]})
         self.desk_pad.write({'pos_categ_ids': [(6, 0, [pos_category.id])]})
         # Run the tour consume ewallets.
         self.start_pos_tour("EWalletProgramTour2")


### PR DESCRIPTION
Steps to reproduce:
===================
- Click on an orderline
- Then click on a detail inside it (e.g., eWallet Balance line)
- The numpad first opens and then closes right away

Issue:
======
- Clicking on a detail inside the orderline makes the numpad open and
  close at the same time
- This makes it impossible to use the numpad properly

Cause:
======
- The click from the child element also reaches the main orderline click
- Because of this, the numpad gets two clicks (open and close)

Fix:
====
- Added `stopPropagation` in the click handler to block event bubbling
- Now the numpad only reacts once and stays open as expected

Task: 5000327