### PR TITLE
[FIX] spreadsheet: styling for filters in mobile bottom sheet

### DIFF
--- a/addons/spreadsheet/static/src/global_filters/components/date_filter_value/date_filter_value.scss
+++ b/addons/spreadsheet/static/src/global_filters/components/date_filter_value/date_filter_value.scss
@@ -1,5 +1,7 @@
 .o-date-filter-dropdown:hover .btn-previous,
-.o-date-filter-dropdown:hover .btn-next {
+.o-date-filter-dropdown:hover .btn-next,
+.o-date-filter-dropdown.selected .btn-previous,
+.o-date-filter-dropdown.selected .btn-next {
     color: $o-gray-600;
 }
 
@@ -42,4 +44,9 @@
     &:focus, &:hover {
         outline: none;
     }
+}
+
+.o_bottom_sheet .o-date-filter-dropdown  :last-child {
+    /* Make space for the check icon of the active item */
+    margin-right: 12px;
 }


### PR DESCRIPTION
In mobile, the dropdown to edit a date filter value is now displayed in a bottom sheet. There was some minor issues in the styling:

- the check icon for active item wasinside another icon
- the arrow next/previous were grayed out since ":hover" doesn't really exist on mobile

Task: [5092756](https://www.odoo.com/odoo/2328/tasks/5092756)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
