### PR TITLE
[IMP] web,calendar: improve some filter behavior

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_arch_parser.js
+++ b/addons/web/static/src/views/calendar/calendar_arch_parser.js
@@ -93,7 +93,7 @@ export class CalendarArchParser {
                                 context: fieldInfo.context || "{}",
                                 fieldName,
                                 filterFieldName: null,
-                                label: field.string,
+                                label: null,
                                 resModel: field.relation,
                                 writeFieldName: null,
                                 writeResModel: null,
@@ -103,6 +103,7 @@ export class CalendarArchParser {
                             filterInfo.colorFieldName =
                                 (node.hasAttribute("filters") && node.getAttribute("color")) ||
                                 null;
+                            filterInfo.label = node.getAttribute("string") || field.string;
                             filterInfo.filterFieldName = node.getAttribute("filter_field") || null;
                             filterInfo.writeFieldName = node.getAttribute("write_field") || null;
                             filterInfo.writeResModel = node.getAttribute("write_model") || null;

--- a/addons/web/static/src/views/calendar/calendar_filter_section/calendar_filter_section.xml
+++ b/addons/web/static/src/views/calendar/calendar_filter_section/calendar_filter_section.xml
@@ -3,7 +3,8 @@
 
     <t t-name="web.CalendarFilterSection">
         <div t-if="section.filters.length gt 0 or section.canAddFilter"
-             class="o_calendar_filter d-flex flex-column gap-1 mt-3 mb-2"
+             class="o_calendar_filter d-flex flex-column gap-1 mt-3"
+             t-attf-class="{{ state.collapsed ? 'mb-2' : 'mb-4' }}"
              t-att-data-name="section.fieldName"
         >
             <t t-if="section.label">


### PR DESCRIPTION
[IMP] web: keep calendar filters order
In some undeterminist cases, the filter sections order is messed up.
Making sure that, when loading the filters, the sections are inserted
in the same order as their promises are resolved.

[IMP] calendar: prevent attendee filters record deletion
Prevent the "updateAttendeeData" method from unintentionally
removing records if their "partner_ids" isn't matching the
active attendee filters.

Task-5072004
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
