### PR TITLE
[FIX] web: fix positioning when container in iframe

### DIFF
--- a/addons/web/static/src/core/position/utils.js
+++ b/addons/web/static/src/core/position/utils.js
@@ -139,6 +139,8 @@ function computePosition(popper, target, { container, flip, margin, position, sh
     const iframeBox = iframe?.getBoundingClientRect() ?? { top: 0, left: 0 };
 
     const containerIsHTMLNode = container === container.ownerDocument.firstElementChild;
+    const containerIsInIframe =
+        shouldAccountForIFrame && target.ownerDocument === container.ownerDocument;
 
     // Compute positioning data
     const directionsData = {
@@ -166,16 +168,19 @@ function computePosition(popper, target, { container, flip, margin, position, sh
         const variantPrefix = vertical ? "v" : "h";
         const directionValue = directionsData[d];
         let variantValue = variantsData[variantPrefix + v];
+        const [leftCompensation, topCompensation] = containerIsInIframe
+            ? [iframeBox.left, iframeBox.top]
+            : [0, 0];
 
         const [directionSize, variantSize] = vertical
             ? [popBox.height, popBox.width]
             : [popBox.width, popBox.height];
         let [directionMin, directionMax] = vertical
-            ? [contBox.top, contBox.bottom]
-            : [contBox.left, contBox.right];
+            ? [contBox.top + topCompensation, contBox.bottom + topCompensation]
+            : [contBox.left + leftCompensation, contBox.right + leftCompensation];
         let [variantMin, variantMax] = vertical
-            ? [contBox.left, contBox.right]
-            : [contBox.top, contBox.bottom];
+            ? [contBox.left + leftCompensation, contBox.right + leftCompensation]
+            : [contBox.top + topCompensation, contBox.bottom + topCompensation];
 
         if (containerIsHTMLNode) {
             if (vertical) {


### PR DESCRIPTION
This commit fixes an issue with containers inside iframes that renders the position computation for the popper incorrect.

The problematic situation arises when the popper needs to be positioned near an element inside an iframe and the base container used for the computation is inside the same iframe.
This case happens in the mass_mailing builder when in the mobile preview as the iframe is centered in the viewport and the element that enables the scrolling when overflowed is also inside the iframe.

When in this case, the min and max values for the variant and the direction are computed on a container that is really smaller than the viewport. Meaning that when this happens the popper is positioned on the left of the iframe, which is completely incorrect.

To fix this issue, when we detect that we are indeed in the problematic situation, we add the left and top values of the iframeBox to direction{Min/Max} and variant{Min/Max}. This way the variantOffset is computed based on the position of the container adjusted to the iframe.

before:
<img width="3021" height="1549" alt="image" src="https://github.com/user-attachments/assets/f6c6f3b7-cdd1-4699-97ab-732ef3ec5ff1" />

after:
<img width="3099" height="1502" alt="image" src="https://github.com/user-attachments/assets/00c06936-de4d-48a0-b4f7-19cab3fc821d" />


task-5109138

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
