### PR TITLE
 [FIX] html_editor: avoid traceback when changing list type

### DIFF
--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -247,6 +247,10 @@ export class ListPlugin extends Plugin {
         // Apply changes.
         if (listsToSwitch.size || nonListBlocks.size) {
             for (const list of listsToSwitch) {
+                // Clean before preserving cursors otherwise the saved cursors
+                // might reference a node that will be removed when setTagName
+                // eventually calls clean of its own.
+                this.dispatchTo("clean_handlers", list);
                 const cursors = this.dependencies.selection.preserveSelection();
                 const newList = this.switchListMode(list, mode);
                 cursors.remapNode(list, newList).restore();

--- a/addons/html_editor/static/tests/list/toggle_misc.test.js
+++ b/addons/html_editor/static/tests/list/toggle_misc.test.js
@@ -10,6 +10,11 @@ describe("Mixed", () => {
             stepFunction: toggleUnorderedList,
             contentAfter: "<ul><li>a[b]c</li></ul>",
         });
+        await testEditor({
+            contentBefore: '<ol><li><a href="http://test.com">[test]</a></li></ol>',
+            stepFunction: toggleUnorderedList,
+            contentAfter: '<ul><li><a href="http://test.com">[test]</a></li></ul>',
+        });
     });
 
     test("should turn an unordered list into an ordered list", async () => {
@@ -17,6 +22,11 @@ describe("Mixed", () => {
             contentBefore: "<ul><li>a[b]c</li></ul>",
             stepFunction: toggleOrderedList,
             contentAfter: "<ol><li>a[b]c</li></ol>",
+        });
+        await testEditor({
+            contentBefore: '<ul><li><a href="http://test.com">[test]</a></li></ul>',
+            stepFunction: toggleOrderedList,
+            contentAfter: '<ol><li><a href="http://test.com">[test]</a></li></ol>',
         });
     });
 
@@ -377,6 +387,12 @@ describe("Mixed", () => {
             contentBefore: "<ul><li>a[b]c</li></ul>",
             stepFunction: toggleCheckList,
             contentAfter: '<ul class="o_checklist"><li>a[b]c</li></ul>',
+        });
+        await testEditor({
+            contentBefore: '<ul><li><a href="http://test.com">[test]</a></li></ul>',
+            stepFunction: toggleCheckList,
+            contentAfter:
+                '<ul class="o_checklist"><li><a href="http://test.com">[test]</a></li></ul>',
         });
     });
 


### PR DESCRIPTION
Steps to Reproduce:

1. Go to To-Do
2. Create a link
3. Select all using Ctrl + A
4. Switch to order list and then unordered list.
5. Traceback occurs

Description of the issue:

- This issue occurs because a feff (zero-width no-break space) character is present inside the link. When the link is inside a list and the list type is changed, the `removeFEFF` method is triggered. `removeFEFF` removes the feff characters, but the selection is preserved based on positions from when those feffs were still present inside the link. As a result, after the list type is changed, restoring the selection causes a traceback.

Solution:

- Triggered `clean_handlers` before preserving the selection. This ensures feff characters are removed from the link before the selection is preserved, preventing invalid selection offsets and avoiding the traceback.

task-5095561

