### PR TITLE
[FIX] appointment: add resource filtering to calendar

### DIFF
--- a/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_model.js
+++ b/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_model.js
@@ -103,6 +103,7 @@ export class AttendeeCalendarModel extends CalendarModel {
      */
     async updateAttendeeData(data) {
         const attendeeFilters = data.filterSections.partner_ids;
+        const resourceFilters = data.filterSections.resource_ids;
         let isEveryoneFilterActive = false;
         let attendeeIds = [];
         const eventIds = Object.keys(data.records).map((id) => Number.parseInt(id));
@@ -158,6 +159,24 @@ export class AttendeeCalendarModel extends CalendarModel {
                     record._recordId = recordId;
                     newRecords[recordId] = record;
                     duplicatedRecords++;
+                }
+                if (resourceFilters && !(event.id in newRecords)) {
+                    const activeResourceIds = new Set(
+                        resourceFilters.filters
+                            .filter((filter) => filter.type !== "all" && filter.value && filter.active)
+                            .map((filter) => filter.value)
+                    );
+                    const resources = eventData.resource_ids || [];
+                    for (const resource of resources) {
+                        if (!activeResourceIds.has(resource)) {
+                            continue;
+                        }
+                        const record = { ...event };
+                        record.colorIndex = resource;
+                        const recordId = record.id;
+                        record._recordId = recordId;
+                        newRecords[recordId] = record;
+                    }
                 }
             }
             data.records = newRecords;


### PR DESCRIPTION
**Steps to reproduce:**
- Install Appointment app
- Create a new resource
- Create an appointment type with the new resource
- Create an appointment for this type
- Go to the Calendar app or to Appointments > Schedule > Resources Bookings
- Click on the calendar view
- The new appointment can't be found

**Issue:**
As "Everybody's Calendar" option was removed, there is currently no way to display the appointments on resources in the calendar view.

**Fix:**
Added a `calendar.resource.filters` model and its flow to the calendar view.

It was also necessary to revert the parallel fetching of filters in https://github.com/odoo/odoo/commit/aa5f2d5dc3b7c64217cea57535b04261e801c4d2 to ensure the order of filters remains constant.

related: https://github.com/odoo/odoo/commit/08ceb41a47de5ee1a0758eb0ebba3a3c6964a2f9

opw-4964405

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
