### PR TITLE
[FIX] project: fix project template demo data issues

### DIFF
--- a/addons/hr_timesheet/views/project_task_views.xml
+++ b/addons/hr_timesheet/views/project_task_views.xml
@@ -31,7 +31,7 @@
                     </div>
                 </xpath>
                 <xpath expr="//t[@name='warning_section']" position="inside">
-                    <div class="alert alert-warning text-center mb-2" role="alert" invisible="analytic_account_active or not allow_timesheets or is_template" groups="hr_timesheet.group_hr_timesheet_user">
+                    <div class="alert alert-warning text-center mb-2" role="alert" invisible="analytic_account_active or not allow_timesheets or is_template or has_project_template" groups="hr_timesheet.group_hr_timesheet_user">
                         You cannot log timesheets on this project since it is linked to an inactive analytic account.<br/> Please change this account, or reactivate the current one to timesheet on the project.
                     </div>
                 </xpath>
@@ -40,7 +40,7 @@
                     <t groups="hr_timesheet.group_hr_timesheet_user">
                         <field name="analytic_account_active" invisible="1"/>
                     </t>
-                    <page string="Timesheets" name="page_timesheets" id="timesheets_tab" invisible="not allow_timesheets or has_template_ancestor or (not id and context.get('hide_timesheet_ids'))" groups="hr_timesheet.group_hr_timesheet_user">
+                    <page string="Timesheets" name="page_timesheets" id="timesheets_tab" invisible="not allow_timesheets or has_template_ancestor or has_project_template or (not id and context.get('hide_timesheet_ids'))" groups="hr_timesheet.group_hr_timesheet_user">
                     <field name="timesheet_ids" mode="list,kanban" readonly="not analytic_account_active" context="{'default_project_id': project_id, 'default_name': '', 'form_view_ref': 'hr_timesheet.timesheet_view_form_user'}">
                         <list editable="top" string="Timesheet Activities" decoration-muted="readonly_timesheet == True">
                             <field name="readonly_timesheet" column_invisible="True"/>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -429,7 +429,7 @@
                                 class="o_task_user_field"
                                 options="{'no_open': True}"
                                 widget="many2many_avatar_user"/>
-                            <field name="role_ids" invisible="not (is_template and has_project_template)" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}" placeholder="Assign at project creation"/>
+                            <field name="role_ids" invisible="not (is_template or has_project_template)" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}" placeholder="Assign at project creation"/>
                         </group>
                         <group>
                             <field name="active" invisible="1"/>


### PR DESCRIPTION
**Steps to reproduce:**
 1. Open a task in project template.

**Issue:**
 1) The 'Project Roles' field is missing in project template tasks.
 2) The 'Timesheets' tab is still visible, even though timesheets should not be
    available on project templates. 3) A confusing warning about inactive analytic accounts is shown on project template tasks.

**Current behaviour:**
- role_ids field is hidden on templates.
- Timesheets tab is shown on templates.
- Warning message about inactive analytic account is shown on templates.

**Expected behaviour:**
- role_ids field should be visible on templates.
- Timesheets tab should be hidden on templates.
- Warning message about inactive analytic accounts should not be shown on templates.

**Fix:**
1) Updated the invisible condition to correctly show `role_ids` on project
   templates.
2) Updated the invisible condition hide the 'Timesheets' tab for
   project templates.
3) Updated the invisible condition  to disabled the analytic account warning on
   project templates.

**task-5079828**