### PR TITLE
[FIX] payment_stripe: handle special currency decimal cases

### DIFF
--- a/addons/payment_stripe/const.py
+++ b/addons/payment_stripe/const.py
@@ -136,3 +136,13 @@ COUNTRY_MAPPING = {
     'YT': 'FR',  # Mayotte
     'MF': 'FR',  # Saint-Martin
 }
+
+# Stripe-specific mapping of currency codes in ISO 4217 format to the number of decimals.
+# Only currencies for which Stripe does not follow the ISO 4217 norm are listed here.
+CURRENCY_DECIMALS = {
+    # https://docs.stripe.com/currencies#special-cases
+    'ISK': 2,
+    'UGX': 2,
+    # https://docs.stripe.com/currencies#zero-decimal
+    'MGA': 0,
+}

--- a/addons/payment_stripe/controllers/main.py
+++ b/addons/payment_stripe/controllers/main.py
@@ -15,7 +15,7 @@ from odoo.tools import file_open, mute_logger
 
 from odoo.addons.payment import utils as payment_utils
 from odoo.addons.payment_stripe import utils as stripe_utils
-from odoo.addons.payment_stripe.const import HANDLED_WEBHOOK_EVENTS
+from odoo.addons.payment_stripe.const import CURRENCY_DECIMALS, HANDLED_WEBHOOK_EVENTS
 
 _logger = logging.getLogger(__name__)
 
@@ -184,7 +184,9 @@ class StripeController(http.Controller):
         """
         amount_to_refund = refund_object['amount']
         converted_amount = payment_utils.to_major_currency_units(
-            amount_to_refund, source_tx_sudo.currency_id
+            amount_to_refund,
+            source_tx_sudo.currency_id,
+            arbitrary_decimal_number=CURRENCY_DECIMALS.get(source_tx_sudo.currency_id.name),
         )
         return source_tx_sudo._create_child_transaction(converted_amount, is_refund=True)
 

--- a/addons/payment_stripe/models/payment_provider.py
+++ b/addons/payment_stripe/models/payment_provider.py
@@ -483,7 +483,11 @@ class PaymentProvider(models.Model):
         inline_form_values = {
             'publishable_key': self._stripe_get_publishable_key(),
             'currency_name': currency_name,
-            'minor_amount': amount and payment_utils.to_minor_currency_units(amount, currency),
+            'minor_amount': amount and payment_utils.to_minor_currency_units(
+                amount,
+                currency,
+                arbitrary_decimal_number=const.CURRENCY_DECIMALS.get(currency.name),
+            ),
             'capture_method': 'manual' if self.capture_manually else 'automatic',
             'billing_details': {
                 'name': partner.name or '',

--- a/addons/payment_stripe/models/payment_transaction.py
+++ b/addons/payment_stripe/models/payment_transaction.py
@@ -158,7 +158,11 @@ class PaymentTransaction(models.Model):
         ppm_code = self.payment_method_id.primary_payment_method_id.code
         payment_method_type = ppm_code or self.payment_method_code
         payment_intent_payload = {
-            'amount': payment_utils.to_minor_currency_units(self.amount, self.currency_id),
+            'amount': payment_utils.to_minor_currency_units(
+                self.amount,
+                self.currency_id,
+                arbitrary_decimal_number=const.CURRENCY_DECIMALS.get(self.currency_id.name),
+            ),
             'currency': self.currency_id.name.lower(),
             'description': self.reference,
             'capture_method': 'manual' if self.provider_id.capture_manually else 'automatic',
@@ -222,7 +226,9 @@ class PaymentTransaction(models.Model):
             f'{OPTION_PATH_PREFIX}[reference]': self.reference,
             f'{OPTION_PATH_PREFIX}[amount_type]': 'maximum',
             f'{OPTION_PATH_PREFIX}[amount]': payment_utils.to_minor_currency_units(
-                mandate_values.get('amount', 15000), self.currency_id
+                mandate_values.get('amount', 15000),
+                self.currency_id,
+                arbitrary_decimal_number=const.CURRENCY_DECIMALS.get(self.currency_id.name),
             ),  # Use the specified amount, if any, or define the maximum amount of 15.000 INR.
             f'{OPTION_PATH_PREFIX}[start_date]': int(round(
                 (mandate_values.get('start_datetime') or fields.Datetime.now()).timestamp()
@@ -267,6 +273,7 @@ class PaymentTransaction(models.Model):
                 'amount': payment_utils.to_minor_currency_units(
                     -refund_tx.amount,  # Refund transactions' amount is negative, inverse it.
                     refund_tx.currency_id,
+                    arbitrary_decimal_number=const.CURRENCY_DECIMALS.get(refund_tx.currency_id.name)
                 ),
             }
         )


### PR DESCRIPTION
Steps:
- Activate the 'UGX' currency.
- Make a sale order with amount 100 with 'UGX' currency
- Try to pay that order (100 USh) using card

Issue:
- stripe throws the following error - 

> 'The Checkout Session's total amount must convert to at least 50 cents. 1.00 USh converts to approximately €0.00.'

- Hence 100 USh sent was identified as 1 USh by stripe. This confirms issue with decimals and currency mapping.

Cause:
- 'UGX' is zero-decimal currency but stripe identify it as two-decimal.

Fix:
- Update mapping for such special currency cases for stripe that don't follow general rules

opw-5075707
