### PR TITLE
[FIX] point_of_sale: correct shipping date handling as date instead of datetime

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -6,7 +6,7 @@ import { roundCurrency } from "@point_of_sale/app/models/utils/currency";
 import { computeComboItems } from "./utils/compute_combo_items";
 import { accountTaxHelpers } from "@account/helpers/account_tax";
 import { localization } from "@web/core/l10n/localization";
-import { formatDate, deserializeDate, serializeDateTime } from "@web/core/l10n/dates";
+import { formatDate, serializeDateTime } from "@web/core/l10n/dates";
 
 const formatCurrency = registry.subRegistries.formatters.content.monetary[1];
 const { DateTime } = luxon;
@@ -896,11 +896,7 @@ export class PosOrder extends Base {
     /* ---- Ship later --- */
     //FIXME remove this
     setShippingDate(shippingDate) {
-        if (shippingDate) {
-            this.shipping_date = serializeDateTime(deserializeDate(shippingDate), { zone: "utc" });
-        } else {
-            this.shipping_date = shippingDate;
-        }
+        this.shipping_date = shippingDate;
     }
     //FIXME remove this
     getShippingDate() {

--- a/addons/point_of_sale/static/src/app/models/related_models/index.js
+++ b/addons/point_of_sale/static/src/app/models/related_models/index.js
@@ -10,6 +10,7 @@ import {
     STORE_SYMBOL,
     mapObj,
     convertDateTimeToRaw,
+    convertDateToRaw,
     BACKREF_PREFIX,
     PARENT_X2MANY_TYPES,
     SERIALIZED_UI_STATE_PROP,
@@ -277,7 +278,9 @@ export function createRelatedModels(modelDefs, modelClasses = {}, opts = {}) {
                     }
                 } else {
                     rawData[fieldName] = DATE_TIME_TYPE.has(field.type)
-                        ? convertDateTimeToRaw(value)
+                        ? field.type === "datetime"
+                            ? convertDateTimeToRaw(value)
+                            : convertDateToRaw(value)
                         : value;
                 }
             }
@@ -430,7 +433,10 @@ export function createRelatedModels(modelDefs, modelClasses = {}, opts = {}) {
                     const oldValue = record[RAW_SYMBOL][name];
                     let newValue = vals[name];
                     if (DATE_TIME_TYPE.has(field.type)) {
-                        newValue = convertDateTimeToRaw(newValue);
+                        newValue =
+                            field.type === "datetime"
+                                ? convertDateTimeToRaw(newValue)
+                                : convertDateToRaw(newValue);
                     }
                     if (newValue !== oldValue) {
                         record[RAW_SYMBOL][name] = newValue;

--- a/addons/point_of_sale/static/src/app/models/related_models/model_classes.js
+++ b/addons/point_of_sale/static/src/app/models/related_models/model_classes.js
@@ -4,6 +4,7 @@ import {
     X2MANY_TYPES,
     RAW_SYMBOL,
     convertRawToDateTime,
+    convertRawToDate,
     STORE_SYMBOL,
 } from "./utils";
 import { Base } from "./base";
@@ -47,15 +48,16 @@ export function processModelClasses(modelDefs, modelClasses = {}) {
             }
             const isRelationNotInModelDef = field.relation && !modelNames.has(field.relation);
             if (!RELATION_TYPES.has(field.type) || isRelationNotInModelDef) {
-                const isDateTime = DATE_TIME_TYPE.has(field.type);
-                if (!isDateTime) {
+                if (!DATE_TIME_TYPE.has(field.type)) {
                     excludedLazyGetters.push(fieldName);
                 }
                 Object.defineProperty(ModelRecordClass.prototype, fieldName, {
                     get: function () {
                         const value = this[RAW_SYMBOL][fieldName];
-                        if (isDateTime) {
-                            return convertRawToDateTime(this, value, field);
+                        if (DATE_TIME_TYPE.has(field.type)) {
+                            return field.type === "datetime"
+                                ? convertRawToDateTime(this, value, field)
+                                : convertRawToDate(this, value, field);
                         } else if (isRelationNotInModelDef && value instanceof Set) {
                             return unmodifiableArray(
                                 [...value],

--- a/addons/point_of_sale/static/src/app/models/related_models/serialization.js
+++ b/addons/point_of_sale/static/src/app/models/related_models/serialization.js
@@ -1,4 +1,4 @@
-import { serializeDateTime } from "@web/core/l10n/dates";
+import { serializeDateTime, serializeDate } from "@web/core/l10n/dates";
 import { X2MANY_TYPES, DATE_TIME_TYPE } from "./utils";
 
 const deepSerialization = (
@@ -158,7 +158,10 @@ const deepSerialization = (
             continue;
         }
         if (DATE_TIME_TYPE.has(field.type) && typeof record[fieldName] === "object") {
-            result[fieldName] = serializeDateTime(record[fieldName]);
+            result[fieldName] =
+                field.type === "datetime"
+                    ? serializeDateTime(record[fieldName])
+                    : serializeDate(record[fieldName]);
             continue;
         }
         if (fieldName === "id") {

--- a/addons/point_of_sale/static/src/app/models/related_models/utils.js
+++ b/addons/point_of_sale/static/src/app/models/related_models/utils.js
@@ -1,4 +1,9 @@
-import { deserializeDateTime, serializeDateTime } from "@web/core/l10n/dates";
+import {
+    deserializeDateTime,
+    serializeDateTime,
+    deserializeDate,
+    serializeDate,
+} from "@web/core/l10n/dates";
 export const RELATION_TYPES = new Set(["many2many", "many2one", "one2many"]);
 export const DATE_TIME_TYPE = new Set(["date", "datetime"]);
 export const X2MANY_TYPES = new Set(["many2many", "one2many"]);
@@ -51,6 +56,28 @@ export function convertDateTimeToRaw(value) {
     // Verify if is already a valid date object
     if (typeof value !== "string") {
         return serializeDateTime(value);
+    }
+    return value;
+}
+
+export function convertRawToDate(model, value, prop) {
+    if (!value) {
+        return undefined;
+    }
+    const date = deserializeDate(value);
+    if (!date.isValid) {
+        throw new Error(`Invalid date: ${value} for model ${model.model} in field ${prop}`);
+    }
+    return date;
+}
+
+export function convertDateToRaw(value) {
+    if (!value) {
+        return undefined;
+    }
+    // Verify if is already a valid date object
+    if (typeof value !== "string") {
+        return serializeDate(value);
     }
     return value;
 }

--- a/addons/point_of_sale/static/tests/unit/models/pos_order.test.js
+++ b/addons/point_of_sale/static/tests/unit/models/pos_order.test.js
@@ -206,4 +206,17 @@ describe("pos.order", () => {
         order.preset_time = "2025-08-11 14:00:00";
         expect(order.presetRequirementsFilled).toBe(true);
     });
+
+    test("setShippingDate and getShippingDate with Luxon", async () => {
+        const store = await setupPosEnv();
+        const order = store.addNewOrder();
+
+        const testDate = "2019-03-11";
+        order.setShippingDate(testDate);
+
+        expect(order.shipping_date.toISODate()).toBe(testDate);
+        expect(typeof order.getShippingDate()).toBe("string");
+        order.setShippingDate(null);
+        expect(order.getShippingDate()).toBeEmpty();
+    });
 });

--- a/addons/point_of_sale/static/tests/unit/related_models/utils.test.js
+++ b/addons/point_of_sale/static/tests/unit/related_models/utils.test.js
@@ -1,0 +1,26 @@
+import { test, describe, expect } from "@odoo/hoot";
+import { convertRawToDate, convertDateToRaw } from "@point_of_sale/app/models/related_models/utils";
+const { DateTime } = luxon;
+
+describe("Date conversion utilities", () => {
+    const mockModel = { model: "test.model" };
+
+    test("convertRawToDate", () => {
+        const rawDate = "2023-12-25";
+        const result = convertRawToDate(mockModel, rawDate, "date_field");
+        expect(result).toBeInstanceOf(DateTime);
+        expect(result.isValid).toBe(true);
+        expect(convertRawToDate(mockModel, null, "date_field")).toBe(undefined);
+        expect(convertRawToDate(mockModel, undefined, "date_field")).toBe(undefined);
+        expect(() => convertRawToDate(mockModel, "invalid", "date_field")).toThrow();
+    });
+
+    test("convertDateToRaw", () => {
+        const dateTime = DateTime.fromISO("2023-12-25");
+        const result = convertDateToRaw(dateTime);
+        expect(result).toBe("2023-12-25"); // directly check the string value
+        expect(convertDateToRaw(null)).toBe(undefined);
+        expect(convertDateToRaw(undefined)).toBe(undefined);
+        expect(convertDateToRaw("2023-12-25")).toBe("2023-12-25"); // should return the same string
+    });
+});


### PR DESCRIPTION
PURPOSE: 
----------------
- Fix incorrect handling of shipping date in POS . It was treated as a datetime, which led to timezone shifts and wrong dates in      receipts.

STEPS TO REPRODUCE:
-------------------
  1. Open point of sale
  2. In Configuration → Settings, enable Allow Ship Later for a POS shop.
  3. Open a POS session, add a product, proceed to payment, and select Ship Later.
  4. Validate the order.

ISSUE:
--------------------
  - The receipt shows the wrong shipping date.

CAUSE:
---------------------
  - shipping_date was serialized using serializeDateTime, forcing a UTC conversion.
  - Related models only supported datetime type, so date fields were mishandled.

FIX:
--------------------
  - Introduced proper date handling (convertRawToDate, convertDateToRaw).
  - Updated serialization/deserialization to handle both `date` and `datetime`.
  - Changed ShippingDate to use serializeDate instead of  serializeDateTime.

Task-5055738