### PR TITLE
[FIX] web: correctly hide the time when using show_time false

### DIFF
--- a/addons/web/static/src/core/datetime/datetimepicker_service.js
+++ b/addons/web/static/src/core/datetime/datetimepicker_service.js
@@ -278,6 +278,7 @@ export const datetimePickerService = {
                     const options = { tz: pickerProps.tz, format: hookParams.format };
                     if (operation === "format") {
                         options.showSeconds = hookParams.showSeconds ?? true;
+                        options.showTime = hookParams.showTime ?? true;
                         options.condensed = hookParams.condensed || false;
                     }
                     try {

--- a/addons/web/static/src/core/l10n/dates.js
+++ b/addons/web/static/src/core/l10n/dates.js
@@ -389,10 +389,14 @@ export function formatDateTime(value, options = {}) {
     }
     let format = options.format;
     if (!format) {
-        if (options.showSeconds === false) {
-            format = `${localization.dateFormat} ${localization.shortTimeFormat}`;
+        if (options.showTime === false) {
+            format = `${localization.dateFormat}`;
         } else {
-            format = localization.dateTimeFormat;
+            if (options.showSeconds === false) {
+                format = `${localization.dateFormat} ${localization.shortTimeFormat}`;
+            } else {
+                format = localization.dateTimeFormat;
+            }
         }
         if (options.condensed) {
             format = getCondensedFormat(format);

--- a/addons/web/static/src/views/fields/datetime/datetime_field.js
+++ b/addons/web/static/src/views/fields/datetime/datetime_field.js
@@ -125,6 +125,7 @@ export class DateTimeField extends Component {
         const dateTimePicker = useDateTimePicker({
             target: "root",
             showSeconds: this.props.showSeconds,
+            showTime: this.props.showTime,
             condensed: this.props.condensed,
             get pickerProps() {
                 return getPickerProps();

--- a/addons/web/static/tests/views/fields/datetime_field.test.js
+++ b/addons/web/static/tests/views/fields/datetime_field.test.js
@@ -582,7 +582,6 @@ test("datetime field in list with show_time option", async () => {
         arch: `
             <list editable="bottom">
                 <field name="datetime" options="{'show_time': false}"/>
-                <field name="datetime" />
             </list>
         `,
     });
@@ -591,9 +590,6 @@ test("datetime field in list with show_time option", async () => {
 
     expect(dates[0]).toHaveText("02/08/2017", {
         message: "for date field only date should be visible with date widget",
-    });
-    expect(dates[1]).toHaveText("02/08/2017 12:00:00", {
-        message: "for datetime field only date should be visible with date widget",
     });
     await click(dates[0]);
     await animationFrame();


### PR DESCRIPTION
### Before this PR
 show_time didn't affect the datetime field. With this PR, the time is correctly hidden if show_time is false


### After this PR
show_time will hide the time in datetime field




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
