### PR TITLE
[FIX] privacy_lookup: handle invalid email in lookup

### DIFF
--- a/addons/privacy_lookup/tests/test_privacy_wizard.py
+++ b/addons/privacy_lookup/tests/test_privacy_wizard.py
@@ -1,6 +1,7 @@
 # # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo.exceptions import UserError
 from odoo.tests.common import TransactionCase, tagged
 
 
@@ -147,3 +148,12 @@ class TestPrivacyWizard(TransactionCase):
         wizard.line_ids[1]._onchange_is_active()
         wizard.execution_details
         self.assertEqual(1, self.env['privacy.log'].search_count([('anonymized_email', '=', 'r*****.t**@gmail.com')]))
+
+    def test_wizard_lookup_with_invalid_email(self):
+        # lookup with an invalid email should raise UserError
+        wizard = self.env['privacy.lookup.wizard'].create({
+            'email': 'demo',
+            'name': self.partner.name,
+        })
+        with self.assertRaises(UserError, msg='Invalid email address "%s"' % wizard.email):
+            wizard.action_lookup()

--- a/addons/privacy_lookup/wizard/privacy_lookup_wizard.py
+++ b/addons/privacy_lookup/wizard/privacy_lookup_wizard.py
@@ -47,6 +47,8 @@ class PrivacyLookupWizard(models.TransientModel):
         name = self.name.strip()
         email = f"%{self.email.strip()}%"
         email_normalized = tools.email_normalize(self.email.strip())
+        if not email_normalized:
+            raise UserError(_('Invalid email address “%s”', self.email))
 
         # Step 1: Retrieve users/partners liked to email address or name
         query = SQL("""


### PR DESCRIPTION
Currently, an error occurs when running a privacy lookup on a contact with an invalid email address.

**Steps to reproduce:**
- Install CRM modules.
- Create a new contact with an invalid email address (missing @ - e.g; `demo`).
- In the contact form, click the gear icon and select "**Privacy Lookup**".
- Click on "**Lookup**" button.

**Error:**
```
UndefinedFunction
operator does not exist: character varying = boolean
LINE 55:                 WHERE email_normalized = false
                                                ^
HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
```

**Cause:**
Here, Execution of the query fails because `email_normalized` is set to a Boolean value, which is being computed at [1]. And method `tools.email_normalize` returns `False` for invalid email inputs - [2].

**Fix:**
This commit raises an error if the email address is invalid before executing the query. 
A similar case is already handled in the mail blacklisting module. ([Ref](https://github.com/odoo/odoo/blob/c7f86c3250c59130ae0b95c6847050d3a6fc7a6d/addons/mail/models/mail_blacklist.py#L29-L31)): 

[1] - https://github.com/odoo/odoo/blob/e6c0e963c5379ba7ad8da00ba4ea6c2bb259d95c/addons/privacy_lookup/wizard/privacy_lookup_wizard.py#L49
[2] - https://github.com/odoo/odoo/blob/a729578afb7fed79aac2d622aae4da4c0917f8e5/odoo/tools/mail.py#L734-L735

sentry-6881416673