### PR TITLE
[FIX] website_sale: adapt overlay of showcase product design

### DIFF
--- a/addons/website_sale/static/src/scss/product_tile.scss
+++ b/addons/website_sale/static/src/scss/product_tile.scss
@@ -744,9 +744,9 @@
     --o-wsale-card-offset-x: 3%;
     --o-wsale-card-overlay: "";
     --o-wsale-card-overlay-background: linear-gradient(-120deg,
-        rgba(var(--o-wsale-card-cc-bg-rgb), .35),
-        rgba(var(--o-wsale-card-cc-bg-rgb), .35),
-        rgba(var(--o-wsale-card-cc-bg-rgb), .46)
+        rgba(var(--o-wsale-card-cc-bg-rgb), .55),
+        rgba(var(--o-wsale-card-cc-bg-rgb), .55),
+        rgba(var(--o-wsale-card-cc-bg-rgb), .66)
     );
 
     // o_label equivalent


### PR DESCRIPTION
This commit adjusts the overlay of the Showcase product design, as it was too light and not visible enough, even when set to its maximum value.

task-5090301


| Before | After |
|--------|--------|
| <img width="1387" height="793" alt="Capture d’écran 2025-09-17 à 15 27 49" src="https://github.com/user-attachments/assets/616e635b-d7ae-4d9a-b6a6-6807e7b68b4d" /> |  <img width="1370" height="788" alt="Capture d’écran 2025-09-17 à 15 29 05" src="https://github.com/user-attachments/assets/094e00c2-6658-4d8b-a57d-a909ade08ca4" /> |


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
