### PR TITLE
[IMP] web: do not wait for specialData to render

### DIFF
--- a/addons/calendar/static/src/views/fields/many2many_attendee.js
+++ b/addons/calendar/static/src/views/fields/many2many_attendee.js
@@ -33,7 +33,7 @@ export class Many2ManyAttendee extends Many2ManyTagsAvatarField {
     }
 
     get tags() {
-        const partnerIds = this.specialData.data;
+        const partnerIds = this.specialData.data || [];
         const noEmailPartnerIds = this.props.record.data.invalid_email_partner_ids
             ? this.props.record.data.invalid_email_partner_ids.records
             : [];

--- a/addons/web/static/src/views/fields/badge_selection/badge_selection_field.js
+++ b/addons/web/static/src/views/fields/badge_selection/badge_selection_field.js
@@ -32,7 +32,13 @@ export class BadgeSelectionField extends Component {
     get options() {
         switch (this.type) {
             case "many2one":
-                return this.specialData.data;
+                if (this.specialData.data) {
+                    return this.specialData.data;
+                }
+                if (this.props.record.data[this.props.name]) {
+                    return [Object.values(this.props.record.data[this.props.name])];
+                }
+                return [];
             case "selection":
                 return this.props.record.fields[this.props.name].selection;
             default:

--- a/addons/web/static/src/views/fields/many2many_checkboxes/many2many_checkboxes_field.js
+++ b/addons/web/static/src/views/fields/many2many_checkboxes/many2many_checkboxes_field.js
@@ -36,7 +36,16 @@ export class Many2ManyCheckboxesField extends Component {
     }
 
     get items() {
-        return this.specialData.data;
+        if (this.specialData.data) {
+            return this.specialData.data;
+        }
+        if (this.props.record.data[this.props.name].currentIds.length) {
+            return this.props.record.data[this.props.name].records.map((r) => [
+                r.resId,
+                r.data.display_name,
+            ]);
+        }
+        return [];
     }
 
     isSelected(item) {
@@ -78,6 +87,7 @@ export const many2ManyCheckboxesField = {
     component: Many2ManyCheckboxesField,
     displayName: _t("Checkboxes"),
     supportedTypes: ["many2many"],
+    relatedFields: () => [{ name: "display_name", type: "char" }],
     isEmpty: () => false,
     extractProps(fieldInfo, dynamicInfo) {
         return {

--- a/addons/web/static/src/views/fields/radio/radio_field.js
+++ b/addons/web/static/src/views/fields/radio/radio_field.js
@@ -40,7 +40,13 @@ export class RadioField extends Component {
             case "selection":
                 return this.props.record.fields[this.props.name].selection;
             case "many2one": {
-                return this.specialData.data;
+                if (this.specialData.data) {
+                    return this.specialData.data;
+                }
+                if (this.props.record.data[this.props.name]) {
+                    return [Object.values(this.props.record.data[this.props.name])];
+                }
+                return [];
             }
             default:
                 return [];

--- a/addons/web/static/src/views/fields/relational_utils.js
+++ b/addons/web/static/src/views/fields/relational_utils.js
@@ -177,14 +177,18 @@ export function useSpecialData(loadFn) {
     };
 
     /** @type {{ data: Record<string, T> }} */
-    const result = useState({ data: {} });
+    const result = useState({ data: undefined });
     useRecordObserver(async (record, props) => {
-        result.data = await loadFn(ormWithCache, { ...props, record });
+        loadFn(ormWithCache, { ...props, record }).then((res) => {
+            result.data = res;
+        });
     });
     onWillUpdateProps(async (props) => {
         // useRecordObserver callback is not called when the record doesn't change
         if (props.record.id === component.props.record.id) {
-            result.data = await loadFn(ormWithCache, props);
+            loadFn(ormWithCache, props).then((res) => {
+                result.data = res;
+            });
         }
     });
     return result;
@@ -465,7 +469,9 @@ export class Many2XAutocomplete extends Component {
     }
 
     addStartTypingSuggestion({ request, records }) {
-        return records !== null ? request.length === 0 && !this.activeActions.createEdit : !this.props.value;
+        return records !== null
+            ? request.length === 0 && !this.activeActions.createEdit
+            : !this.props.value;
     }
 
     buildCreateSuggestion(request) {

--- a/addons/web/static/src/views/fields/selection/selection_field.js
+++ b/addons/web/static/src/views/fields/selection/selection_field.js
@@ -43,7 +43,13 @@ export class SelectionField extends Component {
     get options() {
         switch (this.type) {
             case "many2one":
-                return [...this.specialData.data];
+                if (this.specialData.data) {
+                    return [...this.specialData.data];
+                }
+                if (this.props.record.data[this.props.name]) {
+                    return [Object.values(this.props.record.data[this.props.name])];
+                }
+                return [];
             case "selection":
                 return this.props.record.fields[this.props.name].selection.filter(
                     (option) => option[0] !== false && option[1] !== ""

--- a/addons/web/static/src/views/fields/statusbar/statusbar_field.js
+++ b/addons/web/static/src/views/fields/statusbar/statusbar_field.js
@@ -1,5 +1,4 @@
 import { Component, onWillRender, useEffect, useExternalListener, useRef } from "@odoo/owl";
-import { browser } from "@web/core/browser/browser";
 import { useCommand } from "@web/core/commands/command_hook";
 import { Domain } from "@web/core/domain";
 import { Dropdown } from "@web/core/dropdown/dropdown";
@@ -72,7 +71,6 @@ export class StatusBarField extends Component {
             status = "adjusting";
             this.adjustVisibleItems();
             this.render();
-            browser.requestAnimationFrame(() => (status = "idle"));
         };
 
         useEffect(
@@ -84,6 +82,8 @@ export class StatusBarField extends Component {
             if (status !== "adjusting") {
                 Object.assign(this.items, this.getSortedItems());
                 status = "shouldAdjust";
+            } else {
+                status = "idle";
             }
         });
 
@@ -253,12 +253,21 @@ export class StatusBarField extends Component {
         const currentValue = record.data[name];
         if (this.field.type === "many2one") {
             // Many2one
-            return this.specialData.data.map((option) => ({
-                value: option.id,
-                label: option.display_name,
-                isFolded: option[foldField],
-                isSelected: Boolean(currentValue && option.id === currentValue.id),
-            }));
+            return (
+                this.specialData.data?.map((option) => ({
+                    value: option.id,
+                    label: option.display_name,
+                    isFolded: option[foldField],
+                    isSelected: Boolean(currentValue && option.id === currentValue.id),
+                })) || [
+                    {
+                        value: currentValue.id,
+                        label: currentValue.display_name,
+                        isFolded: false,
+                        isSelected: true,
+                    },
+                ]
+            );
         } else {
             // Selection
             let { selection } = this.field;

--- a/addons/web/static/tests/views/fields/badge_selection_field.test.js
+++ b/addons/web/static/tests/views/fields/badge_selection_field.test.js
@@ -1,4 +1,5 @@
 import { expect, test } from "@odoo/hoot";
+import { animationFrame, Deferred, queryAllTexts } from "@odoo/hoot-dom";
 import {
     clickSave,
     contains,
@@ -71,6 +72,36 @@ test("BadgeSelectionField widget on a many2one in a new record", async () => {
 
     await clickSave();
     expect.verifySteps(["saved product_id: 37"]);
+});
+
+test("[Lazy] BadgeSelectionField widget on a many2one", async () => {
+    const def = new Deferred();
+    onRpc("name_search", async () => {
+        await def;
+    });
+    await mountView({
+        resModel: "res.partner",
+        resId: 2,
+        type: "form",
+        arch: `<form><field name="product_id" widget="selection_badge"/></form>`,
+    });
+
+    expect(`div.o_field_selection_badge`).toHaveCount(1, {
+        message: "should have rendered outer div",
+    });
+    expect(`span.o_selection_badge`).toHaveCount(1, { message: "should have 2 possible choices" });
+    expect(queryAllTexts(`span.o_selection_badge`)).toEqual(["xphone"]);
+    expect(`span.active`).toHaveCount(1, { message: "none of the input should be checked" });
+
+    def.resolve();
+    await animationFrame();
+
+    expect(`div.o_field_selection_badge`).toHaveCount(1, {
+        message: "should have rendered outer div",
+    });
+    expect(`span.o_selection_badge`).toHaveCount(2, { message: "should have 2 possible choices" });
+    expect(queryAllTexts(`span.o_selection_badge`)).toEqual(["xphone", "xpad"]);
+    expect(`span.active`).toHaveCount(1, { message: "none of the input should be checked" });
 });
 
 test("BadgeSelectionField widget on a selection in a new record", async () => {
@@ -181,7 +212,6 @@ test("BadgeSelectionField widget in list with the color_field option", async () 
             </list>
         `,
     });
-
 
     // Ensure that the correct o_badge_color is used.
     expect(`.o_field_selection_badge[name="product_id"] .o_badge_color_6`).toHaveCount(1);

--- a/addons/web/static/tests/views/fields/radio_field.test.js
+++ b/addons/web/static/tests/views/fields/radio_field.test.js
@@ -1,5 +1,5 @@
 import { expect, test } from "@odoo/hoot";
-import { check, click, queryRect } from "@odoo/hoot-dom";
+import { check, click, Deferred, queryRect } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import {
     clickSave,
@@ -67,6 +67,33 @@ test("radio field on a many2one in a new record", async () => {
     expect("input.o_radio_input").toHaveCount(2);
     expect(".o_field_radio:first").toHaveText("xphone\nxpad");
     expect("input.o_radio_input:checked").toHaveCount(0);
+});
+
+test("[lazy] radio field on a many2one", async () => {
+    Partner._records[0].product_id = 37;
+    const def = new Deferred();
+    onRpc("web_search_read", async () => {
+        await def;
+    });
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: /* xml */ `<form><field name="product_id" widget="radio"/></form>`,
+    });
+
+    expect("div.o_radio_item").toHaveCount(1);
+    expect("input.o_radio_input").toHaveCount(1);
+    expect(".o_field_radio:first").toHaveText("xphone");
+    expect("input.o_radio_input:checked").toHaveCount(1);
+
+    def.resolve();
+    await animationFrame();
+
+    expect("div.o_radio_item").toHaveCount(2);
+    expect("input.o_radio_input").toHaveCount(2);
+    expect(".o_field_radio:first").toHaveText("xphone\nxpad");
+    expect("input.o_radio_input:checked").toHaveCount(1);
 });
 
 test("required radio field on a many2one", async () => {

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -12322,12 +12322,15 @@ test(`field with special data`, async () => {
 test(`field with special data (with persistent Cache)`, async () => {
     class MyWidget extends Component {
         static props = ["*"];
-        static template = xml`<div class="my_widget">MyWidget <t t-esc="specialData.data.test"/></div>`;
+        static template = xml`<div class="my_widget">MyWidget <t t-esc="test"/></div>`;
         setup() {
             this.specialData = useSpecialData((orm, props) => {
                 const { record } = props;
                 return orm.call("my.model", "get_special_data", [record.data.int_field]);
             });
+        }
+        get test() {
+            return this.specialData.data?.test || "";
         }
     }
     widgetsRegistry.add("my_widget", { component: MyWidget });


### PR DESCRIPTION
This commit modifies specialData and all its uses, enabling the web client to be rendered without waiting for the RPCs to finish.

part-of-task-id 4893295
