### PR TITLE
[FIX] website_sale_comparison: show `Comparator` button correctly on mobile

### DIFF
--- a/addons/website_sale_comparison/static/src/js/website_sale_comparison.js
+++ b/addons/website_sale_comparison/static/src/js/website_sale_comparison.js
@@ -172,7 +172,7 @@ var ProductComparison = publicWidget.Widget.extend(VariantMixin, {
     },
     _addNewProductsImpl: function (product_id) {
         var self = this;
-        $('.o_product_feature_panel').addClass('d-md-block');
+        $('.o_product_feature_panel').addClass('d-block');
         if (!_.contains(self.comparelist_product_ids, product_id)) {
             self.comparelist_product_ids.push(product_id);
             if (_.has(self.product_data, product_id)){
@@ -233,14 +233,14 @@ var ProductComparison = publicWidget.Widget.extend(VariantMixin, {
      */
     _updateComparelistView: function () {
         this.$('.o_product_circle').text(this.comparelist_product_ids.length);
-        this.$('.o_comparelist_button').removeClass('d-md-block');
+        this.$('.o_comparelist_button').addClass('d-none');
         if (_.isEmpty(this.comparelist_product_ids)) {
-            $('.o_product_feature_panel').removeClass('d-md-block');
+            $('.o_product_feature_panel').addClass('d-none').removeClass('d-block');
         } else {
-            $('.o_product_feature_panel').addClass('d-md-block');
-            this.$('.o_comparelist_products').addClass('d-md-block');
+            $('.o_product_feature_panel').removeClass('d-none').addClass('d-block');
+            this.$('.o_comparelist_products').addClass('d-block');
             if (this.comparelist_product_ids.length >=2) {
-                this.$('.o_comparelist_button').addClass('d-md-block');
+                this.$('.o_comparelist_button').removeClass('d-none').addClass('d-block');
                 this.$('.o_comparelist_button a').attr('href',
                     '/shop/compare?products=' + encodeURIComponent(this.comparelist_product_ids));
             }

--- a/addons/website_sale_comparison/static/src/xml/comparison.xml
+++ b/addons/website_sale_comparison/static/src/xml/comparison.xml
@@ -16,8 +16,15 @@
                             </div>
                         </div>
                     </div>
-                    <div class="o_comparelist_button" style='display:none'>
-                        <a role="button" class="btn btn-primary d-block" href="#"><i class="fa fa-exchange me-2"/>Compare</a>
+                    <div class="o_comparelist_button">
+                        <a
+                            role="button"
+                            class="btn btn-primary d-block"
+                            href="#"
+                        >
+                            <i class="fa fa-exchange me-2"/>
+                            Compare
+                        </a>
                     </div>
                 </span>
             </span>

--- a/addons/website_sale_comparison/views/website_sale_comparison_template.xml
+++ b/addons/website_sale_comparison/views/website_sale_comparison_template.xml
@@ -5,7 +5,18 @@
         <xpath expr="//div[hasclass('o_wsale_product_btn')]" position="inside">
             <t t-set="categories" t-value="product.valid_product_template_attribute_line_ids._prepare_categories_for_display()"/>
             <t t-set="product_variant_id" t-value="product._get_first_possible_variant_id()"/>
-            <button t-if="product_variant_id and categories" type="button" role="button" class="d-none d-md-inline-block btn btn-outline-primary bg-white o_add_compare" title="Compare" aria-label="Compare" t-att-data-product-product-id="product_variant_id" data-action="o_comparelist"><span class="fa fa-exchange"></span></button>
+            <button
+                t-if="product_variant_id and categories"
+                type="button"
+                role="button"
+                class="btn btn-outline-primary bg-white o_add_compare"
+                title="Compare"
+                aria-label="Compare"
+                t-att-data-product-product-id="product_variant_id"
+                data-action="o_comparelist"
+            >
+                <span class="fa fa-exchange"></span>
+            </button>
         </xpath>
     </template>
 
@@ -16,7 +27,7 @@
             <button t-if="product_variant_id and categories"
                 type="button"
                 role="button"
-                class="d-none d-md-block btn btn-link px-0 o_add_compare_dyn"
+                class="btn btn-link px-0 o_add_compare_dyn"
                 aria-label="Compare"
                 t-att-data-product-product-id="product_variant_id"
                 data-action="o_comparelist">


### PR DESCRIPTION
Description:
This commit removes desktop-only visibility classes and ensures that show/hide is handled consistently with `d-none`/`d-block` across all views.

Steps to Reproduce on versions 16+:
1. Enable the `Product Comparison Tool` button from Website.
2. Open any product grid or product page.
3. Switch between desktop and mobile view.

Before the Merge:
- The `Compare` button was not visible  in mobile view. The underlying cause was the use of Bootstrap classes restricted to desktop (`d-md-block`, `d-md-inline-block`)and inconsistent toggling in JS.
- Buttons appeared in desktop view but hidden in mobile view.

After the Merge:
-`Compare` button are visible and usable in mobile view as well.
- The bottom  `Compare` panel also visible in mobile view. 

opw-5091746

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
