### PR TITLE
[FIX] test_sale_purchase_edi_ubl: fix test case issue

### DIFF
--- a/addons/test_sale_purchase_edi_ubl/tests/test_order_ubl_bis3.py
+++ b/addons/test_sale_purchase_edi_ubl/tests/test_order_ubl_bis3.py
@@ -5,10 +5,11 @@ from odoo.fields import Command
 from odoo.tests import tagged
 
 from odoo.addons.account_edi_ubl_cii.tests.test_ubl_cii import TestAccountEdiUblCii
+from odoo.addons.sale.tests.common import SaleCommon
 
 
 @tagged('post_install', '-at_install')
-class TestOrderEdiUbl(TestAccountEdiUblCii):
+class TestOrderEdiUbl(TestAccountEdiUblCii, SaleCommon):
 
     @classmethod
     def get_default_groups(cls):
@@ -18,6 +19,11 @@ class TestOrderEdiUbl(TestAccountEdiUblCii):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+
+        # Need to enable pricelist and discount to compute discount price.
+        cls._enable_pricelists()
+        # `_enable_discount()` will not work because we need this group to enable on superuser
+        cls.env['res.config.settings'].create({'group_discount_per_so_line': True}).execute()
 
         # Seller company: it should import PO and export SO
         supplier_company_data = cls.setup_other_company(name='Gestral Inc.', vat='US9357841')


### PR DESCRIPTION
This commit fix runbot issue cause by PR https://github.com/odoo/odoo/pull/226859 to compute discount depending on pricelist.

Cause:
- In subscription discount and pricelist are default enable that allow discount to compute properly and set it to 0 but when only sale is installed test was breaking because non of the condition was enabled require to compute discount properly.

Fix:
- Enabled discount and pricelist feature in testcase to compute discount properly

runbot-232685