### PR TITLE
[FIX] account: drag & drop button and dropzone of cards to adapt theme

### DIFF
--- a/addons/account/static/src/components/bill_guide/bill_guide.scss
+++ b/addons/account/static/src/components/bill_guide/bill_guide.scss
@@ -21,5 +21,4 @@
 .account_drag_drop_btn {
     border-style: dashed !important;
     border-color: $o-brand-primary;
-    background-color: #F2EDF0;
 }

--- a/addons/account/static/src/components/upload_drop_zone/upload_drop_zone.scss
+++ b/addons/account/static/src/components/upload_drop_zone/upload_drop_zone.scss
@@ -2,7 +2,6 @@
     width: calc(100% + 2px);
     height: calc(100% + 2px);
     position: absolute;
-    background-color: grey;
     z-index: 3;
     left: -1px;
     top: -1px;

--- a/addons/account/static/src/views/account_dashboard_kanban/account_dashboard_kanban.scss
+++ b/addons/account/static/src/views/account_dashboard_kanban/account_dashboard_kanban.scss
@@ -4,7 +4,6 @@
         border: 1px dashed $border-color;
         &.drag_to_card {
             border-color: $o-brand-primary;
-            background-color: #F2EDF0;
         }
     }
 }


### PR DESCRIPTION
Current behavior before PR:
- Drag & drop buttons and upload drop zones of dashboard cards had hardcoded
backgrounds (#F2EDF0 / grey), which did not adapt to dark mode.

Desired behavior after PR is merged:
- Removed hardcoded background colors from drag & drop button and upload drop
zone cards on dashboard and updated their background to adapt in light & dark 
modes.

Changes implemented:
- Removed hardcoded background color (`#F2EDF0`) from `account_drag_drop_btn` &
`drag_to_card` CSS classes.
- Removed overriding background-color property from `o_drop_area` CSS class.
- Updated background-color of `o_drop_area` in `o_account_dashboard_kanban_view`
CSS class to `o-view-background-color`.




task-5092460

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

