### PR TITLE
[FIX] html_builder: removed useless scroll area in contact form option

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_list.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_list.xml
@@ -6,7 +6,7 @@
         <div class="w-100 p-2 py-0">
             <t t-if="state.value?.length > 2">
                 <div class="o_we_table_wrapper">
-                    <table t-ref="table">
+                    <table t-ref="table" class="position-relative">
                         <t t-foreach="formatRawValue(state.value)" t-as="item" t-key="item._id">
                             <tr class="o_row_draggable" t-att-data-id="item._id">
                                 <td t-if="props.sortable" class="o_handle_cell">


### PR DESCRIPTION
Steps to Reproduce:
1. Install `eCommerce`.
2. Go to "Contact Us" page and enter the edit mode.
3. Set the form action to "Create a Customer".
4. Add a field of type _Country or State_.
5. Scroll down (a blank scroll area appears).

Issue:
When the Country or State field is added to the contact form (Create a Customer), a large unnecessary blank scroll area is
displayed.

Reason:
The table inside the option list stretched its content vertically (default behavior), which caused the blank scroll area.

Fix:
Prevent the table from stretching by applying `position: relative` to it. This ensures that table rows (option list items) are positioned relatively and no extra scroll space is created.
