### PR TITLE
[FIX] point_of_sale: load only paid orders from related PoS configs

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1380,16 +1380,13 @@ class PosOrder(models.Model):
     @api.model
     def search_paid_order_ids(self, config_id, domain, limit, offset):
         """Search for 'paid' orders that satisfy the given domain, limit and offset."""
-        default_domain = [('state', '!=', 'draft'), ('state', '!=', 'cancel')]
-        if domain == []:
-            real_domain = AND([[['config_id', '=', config_id]], default_domain])
-        else:
-            real_domain = AND([domain, default_domain])
+        pos_config = self.env['pos.config'].browse(config_id)
+        default_domain = [('state', '!=', 'draft'), ('state', '!=', 'cancel'), ('config_id', 'in', [config_id] + pos_config.trusted_config_ids.ids)]
+        real_domain = AND([domain, default_domain])
         orders = self.search(real_domain, limit=limit, offset=offset, order='create_date desc')
         # We clean here the orders that does not have the same currency.
         # As we cannot use currency_id in the domain (because it is not a stored field),
         # we must do it after the search.
-        pos_config = self.env['pos.config'].browse(config_id)
         orders = orders.filtered(lambda order: order.currency_id == pos_config.currency_id)
         orderlines = self.env['pos.order.line'].search(['|', ('refunded_orderline_id.order_id', 'in', orders.ids), ('order_id', 'in', orders.ids)])
 


### PR DESCRIPTION
Before this commit, when searching paid orders in the PoS UI, orders from other configs could appear even if they were not part of the trusted configs or the same PoS config.

This commit ensures that only orders related to the current PoS configuration (or its trusted configs) are loaded and displayed.

opw-5083747

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
