### PR TITLE
[FIX] resource: fix `_search_work_time_rate` method

### DIFF
--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -268,8 +268,16 @@ class ResourceCalendar(models.Model):
         else:
             return NotImplemented
 
-        calendar_ids = self.env['resource.calendar']._search(Domain('work_time', operator, value))
-        return [('id', 'in', calendar_ids)]
+        calendar_ids = self.env['resource.calendar'].search([])
+        if operator == 'in':
+            calender = calendar_ids.filtered(lambda m: m.work_time_rate in value)
+        elif operator == 'not in':
+            calender = calendar_ids.filtered(lambda m: m.work_time_rate not in value)
+        elif operator == '<':
+            calender = calendar_ids.filtered(lambda m: m.work_time_rate < value)
+        elif operator == '>':
+            calender = calendar_ids.filtered(lambda m: m.work_time_rate > value)
+        return [('id', 'in', calender.ids)]
 
     # --------------------------------------------------
     # Overrides


### PR DESCRIPTION
The `_search_work_time_rate` implimination was missed up on refactor at odoo/odoo#219608

runbot error: 231181

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
