### PR TITLE
[FIX] website: misreferenced cookie bar button IDs 

### DIFF
--- a/addons/website/static/src/interactions/cookies/cookies_bar.js
+++ b/addons/website/static/src/interactions/cookies/cookies_bar.js
@@ -63,7 +63,7 @@ export class CookiesBar extends Popup {
      * @param {MouseEvent} ev
      */
     onAcceptClick(ev) {
-        const isFullConsent = ev.target.id === "cookies-consent-all";
+        const isFullConsent = ev.currentTarget.id === "cookies-consent-all";
         this.cookieValue = `{"required": true, "optional": ${isFullConsent}, "ts": ${Date.now()}}`;
         if (isFullConsent) {
             document.dispatchEvent(new Event("optionalCookiesAccepted"));


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Nested tags/containers inside the cookie bar buttons/links cause mis-referenced IDs.  This resulted in empty strings to be passed instead of 'cookies-consent-all' or 'cookies-consent-essential'

Current behavior before PR:
The original line does not consistently pick up the parent element's ID on the 'I Agree' button. When you click directl;y on the text, it reads the inner <font> tag (which has no ID). Clicking on the surrounding area does return 'cookies-consent-all'

Desired behavior after PR is merged:

By changing it to the line --> const isFullConsent = ev.currentTarget.id === 'cookies-consent-all'; --> you ensure the ID is always taken from the element the listener in bound to.

opw-5051677


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
