### PR TITLE
[FIX] hr_work_entry: require Working Hours for Working Schedule source

### DIFF
--- a/addons/hr_work_entry/models/hr_version.py
+++ b/addons/hr_work_entry/models/hr_version.py
@@ -36,10 +36,10 @@ class HrVersion(models.Model):
         groups="hr.group_hr_manager",
     )
 
-    @api.depends('work_entry_source', 'resource_calendar_id')
+    @api.depends('work_entry_source', 'resource_calendar_id', 'employee_id')
     def _compute_work_entry_source_calendar_invalid(self):
         for version in self:
-            version.work_entry_source_calendar_invalid = version.work_entry_source == 'calendar' and not version.resource_calendar_id
+            version.work_entry_source_calendar_invalid = version.work_entry_source == 'calendar' and not version.resource_calendar_id and version.employee_id
 
     @ormcache()
     def _get_default_work_entry_type_id(self):

--- a/addons/hr_work_entry/views/hr_employee_views.xml
+++ b/addons/hr_work_entry/views/hr_employee_views.xml
@@ -20,6 +20,12 @@
             <separator name="schedule" position="after">
                 <field name="work_entry_source" invisible="1"/>
             </separator>
+            <xpath expr="//page[@name='payroll_information']//group[@name='payroll_group']//field[@name='resource_calendar_id']" position='attributes'>
+                <attribute name="required">
+                    work_entry_source_calendar_invalid == True
+                </attribute>
+                <attribute name="placeholder">e.g. Half-Time, 40h/week, Flexible 20h, ...</attribute>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
#### Steps to Reproduce
1. Go to Employees.
2. Select an employee with Work Entry Source = "Working Schedule".
3. Clear the "Working Hours" field.
4. Try to save.

#### Issue
A traceback occurs because work entries are recomputed with no working schedule set. The UI does not prevent saving without a schedule.

#### Fix
Made `resource_calendar_id` required conditionally in the inherited `hr.employee` form view and added a placeholder.

task-5068798
