### PR TITLE
[FIX] account: merge wizard colspan

### DIFF
--- a/addons/account/wizard/account_merge_wizard_views.xml
+++ b/addons/account/wizard/account_merge_wizard_views.xml
@@ -10,6 +10,7 @@
                     <group>
                         <field name="is_group_by_name"/>
                         <field name="wizard_line_ids"
+                               colspan="4"
                                nolabel="1"
                                widget="account_merge_wizard_lines_one2many">
                             <list editable="bottom" create="0" delete="0">


### PR DESCRIPTION
Use the full width of the wizard to display the list view. It was even worse because the width of the view was being reduced in multiple renders with a few frames per second.

