### PR TITLE
[IMP] mail: message reaction 'Add reaction' also uses quick reaction

### DIFF
--- a/addons/im_livechat/static/tests/embed/message_actions.test.js
+++ b/addons/im_livechat/static/tests/embed/message_actions.test.js
@@ -35,7 +35,7 @@ test("Only two quick actions are shown", async () => {
     await click(".o-mail-QuickReactionMenu button", { text: "😅" });
     await contains(".o-mail-MessageReaction", { text: "😅" });
     await contains(".o-mail-Message-actions i", { count: 3 });
-    await contains("[title='Add a Reaction']");
+    await contains(".o-mail-Message-actions [title='Add a Reaction']");
     await contains("[title='Edit']");
     await contains("[title='Expand']");
     await click("[title='Expand']");

--- a/addons/mail/static/src/core/common/message_reactions.js
+++ b/addons/mail/static/src/core/common/message_reactions.js
@@ -1,6 +1,8 @@
 import { Component, useRef } from "@odoo/owl";
 
+import { useMessageActions } from "@mail/core/common/message_actions";
 import { MessageReactionList } from "@mail/core/common/message_reaction_list";
+import { QuickReactionMenu } from "@mail/core/common/quick_reaction_menu";
 import { useService } from "@web/core/utils/hooks";
 import { useEmojiPicker } from "@web/core/emoji_picker/emoji_picker";
 import { isMobileOS } from "@web/core/browser/feature_detection";
@@ -8,7 +10,7 @@ import { isMobileOS } from "@web/core/browser/feature_detection";
 export class MessageReactions extends Component {
     static props = ["message", "openReactionMenu"];
     static template = "mail.MessageReactions";
-    static components = { MessageReactionList };
+    static components = { MessageReactionList, QuickReactionMenu };
 
     setup() {
         super.setup();
@@ -16,6 +18,7 @@ export class MessageReactions extends Component {
         this.ui = useService("ui");
         this.addRef = useRef("add");
         this.isMobileOS = isMobileOS();
+        this.messageActions = useMessageActions({ message: () => this.props.message });
         this.emojiPicker = useEmojiPicker(this.addRef, {
             onSelect: (emoji) => {
                 const reaction = this.props.message.reactions.find(

--- a/addons/mail/static/src/core/common/message_reactions.xml
+++ b/addons/mail/static/src/core/common/message_reactions.xml
@@ -10,7 +10,7 @@
         <t t-foreach="props.message.reactions" t-as="reaction" t-key="reaction.content">
             <MessageReactionList message="this.props.message" openReactionMenu="this.props.openReactionMenu" reaction="reaction"/>
         </t>
-        <button t-if="props.message.canAddReaction()" class="o-mail-MessageReactions-add btn bg-inherit d-flex px-1 py-0 border-0 rounded-0 mb-1 align-items-center fs-5 opacity-25 opacity-100-hover" t-att-class="{ 'o-mobile': isMobileOS }" title="Add Reaction" t-ref="add"><i class="oi fa-fw oi-smile-add"/></button>
+        <QuickReactionMenu t-if="props.message.canAddReaction()" action="messageActions.actions.find(action => action.id === 'reaction')" classNames="{ 'p-1 mb-1 opacity-25 opacity-100-hover': true }" message="props.message"/>
     </div>
 </t>
 </templates>

--- a/addons/mail/static/src/core/common/quick_reaction_menu.js
+++ b/addons/mail/static/src/core/common/quick_reaction_menu.js
@@ -102,9 +102,14 @@ export class QuickReactionMenu extends Component {
     }
 
     get attClass() {
-        const invisible = !this.props.messageActive && !this.dropdown.isOpen && !this.picker.isOpen;
+        const invisible =
+            typeof this.props.messageActive === "boolean" &&
+            !this.props.messageActive &&
+            !this.dropdown.isOpen &&
+            !this.picker.isOpen;
         return {
             ...this.props.classNames,
+            "o-open": this.dropdown.isOpen,
             invisible,
             visible: !invisible,
         };

--- a/addons/mail/static/src/core/common/quick_reaction_menu.scss
+++ b/addons/mail/static/src/core/common/quick_reaction_menu.scss
@@ -3,6 +3,10 @@
     transform: rotate(45deg);
 }
 
+.o-mail-QuickReactionMenu-toggler.o-open {
+    opacity: 100% !important;
+}
+
 //==========================================================
 // Menu slide in effect
 //==========================================================

--- a/addons/mail/static/src/core/common/quick_reaction_menu.xml
+++ b/addons/mail/static/src/core/common/quick_reaction_menu.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.QuickReactionMenu">
-        <Dropdown state="dropdown" manual="true" menuClass="`o-mail-QuickReactionMenu-popover shadow-none`" position="'top-middle'" navigationOptions="navigationOptions">
-            <button class="btn border-0 p-0 o-inline" t-att-class="attClass" t-att-title="props.action.name" t-att-aria-label="props.action.name" t-on-click="onClick">
+        <Dropdown state="dropdown" manual="true" menuClass="`o-mail-QuickReactionMenu-popover shadow-none`" position="'top-middle'" navigationOptions="navigationOptions" bottomSheet="false">
+            <button class="btn border-0 p-0 o-inline o-mail-QuickReactionMenu-toggler" t-att-class="attClass" t-att-title="props.action.name" t-att-aria-label="props.action.name" t-on-click="onClick">
                 <i t-att-class="props.action.icon"/>
             </button>
             <t t-set-slot="content">

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -18,7 +18,7 @@ import {
 } from "@mail/../tests/mail_test_helpers";
 import { LONG_PRESS_DELAY } from "@mail/utils/common/hooks";
 import { describe, expect, test } from "@odoo/hoot";
-import { animationFrame, leave, pointerDown, press, queryFirst } from "@odoo/hoot-dom";
+import { animationFrame, leave, pointerDown, press, queryFirst, waitFor } from "@odoo/hoot-dom";
 import { advanceTime, mockDate, mockTouch, mockUserAgent, tick } from "@odoo/hoot-mock";
 import {
     asyncStep,
@@ -776,10 +776,9 @@ test("Can quickly add a reaction", async () => {
     await click("[title='Add a Reaction']");
     await click(".o-mail-QuickReactionMenu button", { text: "😅" });
     await contains(".o-mail-MessageReaction", { text: "😅1" });
-    await hover(".o-mail-MessageReactions");
-    await click("button[title='Add Reaction']");
-    await click(".o-Emoji", { text: "😏" });
-    await contains(".o-mail-MessageReaction", { text: "😏1" });
+    await click(".o-mail-MessageReactions button[title='Add a Reaction']");
+    await click(".o-mail-QuickReactionMenu button", { text: "🤣" });
+    await contains(".o-mail-MessageReaction", { text: "🤣1" });
 });
 
 test("Reaction summary", async () => {
@@ -810,9 +809,12 @@ test("Reaction summary", async () => {
         const userId = pyEnv["res.users"].create({ partner_id });
         pyEnv["res.partner"].create({ name, user_ids: [Command.link(userId)] });
         await withUser(userId, async () => {
-            await click("[title='Add a Reaction']");
+            await click(".o-mail-Message-actions [title='Add a Reaction']");
             await click(".o-mail-QuickReactionMenu button", { text: "😅" });
-            await contains(".o-mail-MessageReaction", { text: `😅${idx + 1}` });
+            await waitFor(`.o-mail-MessageReaction:contains(/^😅 ${idx + 1}$/)`, {
+                exact: true,
+                timeout: 3000,
+            });
             await hover(".o-mail-MessageReaction");
             await contains(".o-mail-MessageReactionList-preview", {
                 text: `${expectedSummaries[idx]}`,
@@ -836,10 +838,10 @@ test("Select already reacted emoji from quick reaction removes the reaction on m
     });
     await start();
     await openDiscuss(channelId);
-    await click("[title='Add a Reaction']");
+    await click(".o-mail-Message-actions [title='Add a Reaction']");
     await click(".o-mail-QuickReactionMenu button", { text: "😅" });
     await contains(".o-mail-MessageReaction", { text: "😅1" });
-    await click("[title='Add a Reaction']");
+    await click(".o-mail-Message-actions [title='Add a Reaction']");
     await click(".o-mail-QuickReactionMenu button", { text: "😅" });
     await contains(".o-mail-MessageReaction", { count: 0 });
 });

--- a/addons/website_slides/static/tests/tours/slides_course_reviews.js
+++ b/addons/website_slides/static/tests/tours/slides_course_reviews.js
@@ -80,7 +80,7 @@ registry.category("web_tour.tours").add("course_reviews", {
         },
         {
             trigger:
-                "#chatterRoot:shadow .o-mail-Message .o-mail-MessageReactions-add:not(:visible)",
+                "#chatterRoot:shadow .o-mail-Message .o-mail-MessageReactions:not([title='Add a Reaction'])",
         },
         {
             trigger: "#chatterRoot:shadow .o-mail-Message .o-mail-MessageReaction",


### PR DESCRIPTION
Before this commit, message action "Add reaction" and the quick button to add a reaction next to existing reactions on a message differ:
- one opens the quick reaction menu, aka the 5 frequently used emoji and "+" button for emoji picker
- one opens immediately the emoji picker

The quick reaction menu is the preferred UX. The "Add reaction" button next to existing reactions was not adapted, which this commit is changing.

Before
<img width="317" height="416" alt="Screenshot 2025-09-17 at 16 39 09" src="https://github.com/user-attachments/assets/29143518-b835-4a79-ace9-c686514e4c5b" />

After
<img width="288" height="175" alt="Screenshot 2025-09-17 at 16 38 55" src="https://github.com/user-attachments/assets/64d6d321-32fb-4430-b510-9b97df78e2f5" />
