### PR TITLE
[IMP] mail: show linked thread preview below message 

### DIFF
--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -135,6 +135,7 @@ export class Message extends Component {
         useChildSubEnv({
             message: this.props.message,
             alignedRight: this.isAlignedRight,
+            inMessage: true,
         });
         onMounted(() => {
             if (this.shadowBody.el) {

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -140,6 +140,7 @@
                             <t t-if="message.bubbleColor and (!message.hasTextContent or env.inChatWindow) and !(props.asCard and isMobileOS)" t-call="mail.Message.actions"/>
                         </div>
                         <MessageReactions message="message" openReactionMenu="openReactionMenu" t-if="message.reactions.length"/>
+                        <t name="after-reactions"/>
                     </div>
                 </div>
             </div>

--- a/addons/mail/static/src/core/public_web/notification_item.xml
+++ b/addons/mail/static/src/core/public_web/notification_item.xml
@@ -14,7 +14,7 @@
             'o-active': props.isActive,
         }">
             <div class="o-mail-NotificationItem-avatarContainer position-relative bg-inherit flex-shrink-0 align-self-start" t-att-class="{ 'o-small': ui.isSmall }">
-                <img class="o_avatar w-100 h-100" t-att-class="{ 'rounded-3': ui.isSmall, 'rounded': !ui.isSmall }" alt="Notification Item Image" t-att-src="props.iconSrc"/>
+                <img t-if="props.iconSrc" class="o_avatar w-100 h-100" t-att-class="{ 'rounded-3': ui.isSmall, 'rounded': !ui.isSmall }" alt="Notification Item Image" t-att-src="props.iconSrc"/>
                 <t t-slot="icon"/>
             </div>
             <div class="d-flex flex-column flex-grow-1 align-self-start overflow-auto o-scrollbar-thin" t-att-class="{ 'o-ps-1_5': ui.isSmall, 'ps-1': !ui.isSmall }">

--- a/addons/mail/static/src/discuss/core/public_web/message_patch.js
+++ b/addons/mail/static/src/discuss/core/public_web/message_patch.js
@@ -1,0 +1,4 @@
+import { Message } from "@mail/core/common/message";
+import { SubChannelPreview } from "@mail/discuss/core/public_web/sub_channel_preview";
+
+Object.assign(Message.components, { SubChannelPreview });

--- a/addons/mail/static/src/discuss/core/public_web/message_patch.xml
+++ b/addons/mail/static/src/discuss/core/public_web/message_patch.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-inherit="mail.Message" t-inherit-mode="extension">
+        <xpath expr="//*[@name='after-reactions']" position="after">
+            <SubChannelPreview t-if="message.linkedSubChannel?.notEq(props.thread)" class="'mt-1 mx-4'" thread="message.linkedSubChannel" onClick="() => this.message.linkedSubChannel.open()"/>
+        </xpath>
+    </t>
+</templates>

--- a/addons/mail/static/src/discuss/core/public_web/sub_channel_list.js
+++ b/addons/mail/static/src/discuss/core/public_web/sub_channel_list.js
@@ -1,14 +1,12 @@
 import { NotificationItem } from "@mail/core/public_web/notification_item";
 import { ActionPanel } from "@mail/discuss/core/common/action_panel";
-import { isToday } from "@mail/utils/common/dates";
+import { SubChannelPreview } from "@mail/discuss/core/public_web/sub_channel_preview";
 import { useSequential, useVisible } from "@mail/utils/common/hooks";
 import { Component, useEffect, useRef, useState } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
 import { rpc } from "@web/core/network/rpc";
 import { useAutofocus, useService } from "@web/core/utils/hooks";
 import { fuzzyLookup } from "@web/core/utils/search";
-
-const { DateTime } = luxon;
 
 /**
  * @typedef {Object} Props
@@ -18,7 +16,7 @@ const { DateTime } = luxon;
  */
 export class SubChannelList extends Component {
     static template = "mail.SubChannelList";
-    static components = { ActionPanel, NotificationItem };
+    static components = { ActionPanel, NotificationItem, SubChannelPreview };
 
     static props = ["thread", "close?"];
 
@@ -71,13 +69,6 @@ export class SubChannelList extends Component {
         this.state.searching = false;
         this.state.loading = false;
         this.state.subChannels = this.props.thread.sub_channel_ids;
-    }
-
-    dateText(message) {
-        if (isToday(message.datetime)) {
-            return message.datetime?.toLocaleString(DateTime.TIME_SIMPLE);
-        }
-        return message.datetime?.toLocaleString(DateTime.DATE_MED);
     }
 
     onKeydownSearch(ev) {

--- a/addons/mail/static/src/discuss/core/public_web/sub_channel_list.xml
+++ b/addons/mail/static/src/discuss/core/public_web/sub_channel_list.xml
@@ -26,22 +26,7 @@
                     </p>
                 </div>
                 <div class="d-flex flex-column flex-grow-1 gap-2">
-                    <t t-foreach="state.subChannels" t-as="thread" t-key="thread.localId">
-                        <t t-set="message" t-value="thread.newestPersistentOfAllMessage ?? thread.from_message_id"/>
-                        <button class="o-mail-SubChannelList-thread btn btn-light-subtle d-flex flex-column border border-secondary mx-1 px-2 py-1 rounded-2" t-on-click="() => this.onClickSubThread(thread)">
-                            <div class="d-flex w-100">
-                                <span class="o-fw-600 text-truncate small" t-esc="thread.displayName"/>
-                                <span class="flex-grow-1"/>
-                                <span t-if="message" class="text-muted smaller flex-shrink-0" t-esc="dateText(message)"/>
-                            </div>
-                            <div class="o-mail-SubChannelList-threadLastMessage text-start text-muted fw-normal smaller overflow-hidden ms-2">
-                                <t t-if="message" t-call="mail.message_preview_prefix">
-                                    <t t-set="message" t-value="message"/>
-                                </t>
-                                <t t-out="message?.inlineBody"/>
-                            </div>
-                        </button>
-                    </t>
+                    <SubChannelPreview t-foreach="state.subChannels" t-as="thread" t-key="thread.localId" thread="thread" onClick="() => this.onClickSubThread(thread)"/>
                     <span class="pt-1" t-ref="load-more"/>
                 </div>
             </div>

--- a/addons/mail/static/src/discuss/core/public_web/sub_channel_preview.js
+++ b/addons/mail/static/src/discuss/core/public_web/sub_channel_preview.js
@@ -1,0 +1,24 @@
+import { isToday } from "@mail/utils/common/dates";
+import { Component } from "@odoo/owl";
+
+const { DateTime } = luxon;
+
+export class SubChannelPreview extends Component {
+    static template = "mail.SubChannelPreview";
+    static props = ["class?", "onClick?", "thread"];
+
+    dateText(message) {
+        if (isToday(message.datetime)) {
+            return message.datetime?.toLocaleString(DateTime.TIME_SIMPLE);
+        }
+        return message.datetime?.toLocaleString(DateTime.DATE_MED);
+    }
+
+    get thread() {
+        return this.props.thread;
+    }
+
+    onClick() {
+        this.props.onClick?.();
+    }
+}

--- a/addons/mail/static/src/discuss/core/public_web/sub_channel_preview.scss
+++ b/addons/mail/static/src/discuss/core/public_web/sub_channel_preview.scss
@@ -1,4 +1,4 @@
-.o-mail-SubChannelList-thread {
+.o-mail-SubChannelPreview {
     background-color: mix($gray-100, $gray-200);
 
     &:hover {
@@ -6,7 +6,7 @@
     }
 }
 
-.o-mail-SubChannelList-threadLastMessage {
+.o-mail-SubChannelPreview-lastMessage {
     display: -webkit-box;
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;

--- a/addons/mail/static/src/discuss/core/public_web/sub_channel_preview.xml
+++ b/addons/mail/static/src/discuss/core/public_web/sub_channel_preview.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="mail.SubChannelPreview">
+        <t t-set="message" t-value="thread.newestPersistentOfAllMessage ?? thread.from_message_id"/>
+        <button class="o-mail-SubChannelPreview btn btn-light-subtle d-flex border border-secondary mx-1 px-2 py-1 rounded-2 align-items-center" t-attf-class="{{ props.class }}" t-on-click="onClick">
+            <div class="d-flex flex-column">
+                <div class="d-flex w-100">
+                    <span class="o-fw-600 text-truncate small" t-esc="thread.displayName"/>
+                    <span class="flex-grow-1"/>
+                    <span t-if="message" class="text-muted smaller flex-shrink-0" t-esc="dateText(message)"/>
+                </div>
+                <div class="o-mail-SubChannelPreview-lastMessage text-start text-muted fw-normal smaller overflow-hidden ms-2">
+                    <t t-if="message" t-call="mail.message_preview_prefix">
+                        <t t-set="message" t-value="message"/>
+                    </t>
+                    <t t-out="message?.inlineBody"/>
+                </div>
+            </div>
+            <i t-if="env.inMessage" class="oi oi-chevron-right ms-2 opacity-50"/>
+        </button>
+    </t>
+</templates>

--- a/addons/mail/static/tests/discuss/core/public_web/sub_channels.test.js
+++ b/addons/mail/static/tests/discuss/core/public_web/sub_channels.test.js
@@ -31,7 +31,7 @@ test("navigate to sub channel", async () => {
     await click(".o-mail-DiscussSidebarChannel", { name: "General" });
     await contains(".o-mail-DiscussContent-threadName", { value: "General" });
     await click("button[title='Threads']");
-    await click(".o-mail-SubChannelList-thread", { text: "New Thread" });
+    await click(".o-mail-SubChannelPreview", { text: "New Thread" });
     await contains(".o-mail-DiscussContent-threadName", { value: "New Thread" });
     // Should access sub-thread when clicking on the notification.
     await click(".o-mail-DiscussSidebarChannel", { name: "General" });
@@ -79,9 +79,13 @@ test("create sub thread from existing message", async () => {
     await click(".o-mail-DiscussSidebarChannel", { name: "General" });
     await click(".o-mail-Message-actions [title='Expand']");
     await contains(".o-dropdown-item:contains('Create Thread')", { count: 0 });
-    await click(".o-dropdown-item:contains('View Thread')");
+    await contains(".o-mail-SubChannelPreview:contains('Selling a training session and')");
+    await click(".o-mail-SubChannelPreview:contains('Selling a training session and')");
     await contains(".o-mail-DiscussContent-threadName", {
         value: "Selling a training session and",
+    });
+    await contains(".o-mail-SubChannelPreview:contains('Selling a training session and')", {
+        count: 0,
     });
 });
 

--- a/addons/mail/static/tests/tours/discuss_sub_channel_search_tour.js
+++ b/addons/mail/static/tests/tours/discuss_sub_channel_search_tour.js
@@ -12,10 +12,10 @@ registry.category("web_tour.tours").add("test_discuss_sub_channel_search", {
             async run() {
                 // 30 newest sub channels are loaded initially.
                 for (let i = 99; i > 69; i--) {
-                    await contains(".o-mail-SubChannelList-thread", {
+                    await contains(".o-mail-SubChannelPreview", {
                         text: `Sub Channel ${i}`,
                     });
-                    await contains(".o-mail-SubChannelList-thread", { count: 30 });
+                    await contains(".o-mail-SubChannelPreview", { count: 30 });
                 }
             },
         },
@@ -29,9 +29,9 @@ registry.category("web_tour.tours").add("test_discuss_sub_channel_search", {
             run: "click",
         },
         {
-            trigger: ".o-mail-SubChannelList-thread:contains(Sub Channel 10)",
+            trigger: ".o-mail-SubChannelPreview:contains(Sub Channel 10)",
             async run() {
-                await contains(".o-mail-SubChannelList-thread", { count: 1 });
+                await contains(".o-mail-SubChannelPreview", { count: 1 });
             },
         },
         {
@@ -39,27 +39,27 @@ registry.category("web_tour.tours").add("test_discuss_sub_channel_search", {
             run: "clear",
         },
         {
-            trigger: ".o-mail-SubChannelList-thread:contains(Sub Channel 99)",
+            trigger: ".o-mail-SubChannelPreview:contains(Sub Channel 99)",
             async run() {
-                await contains(".o-mail-SubChannelList-thread", { count: 31 });
+                await contains(".o-mail-SubChannelPreview", { count: 31 });
                 // Already fetched sub channels are shown in addition to the one
                 // that was fetched during the search.
                 for (let i = 99; i > 69; i--) {
-                    await contains(".o-mail-SubChannelList-thread", {
+                    await contains(".o-mail-SubChannelPreview", {
                         text: `Sub Channel ${i}`,
                     });
                 }
-                await contains(".o-mail-SubChannelList-thread", { text: `Sub Channel 10` });
+                await contains(".o-mail-SubChannelPreview", { text: `Sub Channel 10` });
                 // Ensure lazy loading is still working after a search.
                 await scroll(".o-mail-ActionPanel:has(.o-mail-SubChannelList)", "bottom");
             },
         },
         {
-            trigger: ".o-mail-SubChannelList-thread:contains(Sub Channel 40)",
+            trigger: ".o-mail-SubChannelPreview:contains(Sub Channel 40)",
             async run() {
-                await contains(".o-mail-SubChannelList-thread", { count: 61 });
+                await contains(".o-mail-SubChannelPreview", { count: 61 });
                 for (let i = 99; i > 39; i--) {
-                    await contains(".o-mail-SubChannelList-thread", {
+                    await contains(".o-mail-SubChannelPreview", {
                         text: `Sub Channel ${i}`,
                     });
                 }
@@ -67,11 +67,11 @@ registry.category("web_tour.tours").add("test_discuss_sub_channel_search", {
             },
         },
         {
-            trigger: ".o-mail-SubChannelList-thread:contains(Sub Channel 11)",
+            trigger: ".o-mail-SubChannelPreview:contains(Sub Channel 11)",
             async run() {
-                await contains(".o-mail-SubChannelList-thread", { count: 90 });
+                await contains(".o-mail-SubChannelPreview", { count: 90 });
                 for (let i = 99; i > 9; i--) {
-                    await contains(".o-mail-SubChannelList-thread", {
+                    await contains(".o-mail-SubChannelPreview", {
                         text: `Sub Channel ${i}`,
                     });
                 }
@@ -79,11 +79,11 @@ registry.category("web_tour.tours").add("test_discuss_sub_channel_search", {
             },
         },
         {
-            trigger: ".o-mail-SubChannelList-thread:contains(Sub Channel 0)",
+            trigger: ".o-mail-SubChannelPreview:contains(Sub Channel 0)",
             async run() {
-                await contains(".o-mail-SubChannelList-thread", { count: 100 });
+                await contains(".o-mail-SubChannelPreview", { count: 100 });
                 for (let i = 99; i > 0; i--) {
-                    await contains(".o-mail-SubChannelList-thread", {
+                    await contains(".o-mail-SubChannelPreview", {
                         text: `Sub Channel ${i}`,
                     });
                 }


### PR DESCRIPTION
Before this commit, when a thread was created from a message, the message lack visual to tell a thread is linked to it.

This commit adds a preview of thread at the bottom of message when this is linked to a thread. Click on preview opens the linked thread.

Task-4656448

<img width="862" height="366" alt="Screenshot 2025-09-18 at 22 35 34" src="https://github.com/user-attachments/assets/2bcabcea-d7c5-4916-afc7-a2e56ea32a29" />
