### PR TITLE
[FIX] html_builder, *: fix non-deterministic crash on editor reload

### DIFF
--- a/addons/html_builder/static/src/core/utils.js
+++ b/addons/html_builder/static/src/core/utils.js
@@ -239,6 +239,9 @@ export function useSelectableComponent(id, { onItemChange } = {}) {
     });
 
     function refreshCurrentItem() {
+        if (env.editor.isDestroyed) {
+            return;
+        }
         let currentItem;
         let itemPriority = 0;
         for (const selectableItem of selectableItems) {


### PR DESCRIPTION
*: website_sale

__Current behavior before commit:__
Some builder actions (e.g `ProductPageImageLayoutAction`) reload the
editor after being applied. If another button in the builder is pressed
rapidly, `refreshCurrentItem` might be called after the editor is
destroyed leading to the following error in [`isApplied`]:

`TypeError: Cannot read properties of undefined (reading 'getAction')`.

The "Product page options" test fails in rare occasion due to this
issue.

__Description of the fix:__
- Add a safety guard to make sure the editor is not destroyed before
calling `refreshCurrentItem`.
- Add some checks at the end of the test in order for the crash to
appear consistently (if the fix is not applied).
- Make the test more robust (some code is backported from
[this commit]).

[this commit]: https://github.com/odoo/odoo/commit/670b1daa2254d76
[`isApplied`]: https://github.com/odoo/odoo/blob/f258b263136f606f7896/addons/html_builder/static/src/core/utils.js#L939

Runbot error: https://runbot.odoo.com/odoo/runbot.build.error/232649