### PR TITLE
[FIX] html_builder: snippet modal’s dark mode background

### DIFF
--- a/addons/web_editor/static/src/js/editor/add_snippet_dialog.js
+++ b/addons/web_editor/static/src/js/editor/add_snippet_dialog.js
@@ -9,6 +9,7 @@ import {
     Component,
     onMounted,
 } from "@odoo/owl";
+import { cookie } from "@web/core/browser/cookie";
 import { localization } from "@web/core/l10n/localization";
 
 export class RenameCustomSnippetDialog extends Component {
@@ -74,6 +75,7 @@ export class AddSnippetDialog extends Component {
             }
             this.iframeDocument.documentElement.classList.add("o_add_snippets_preview");
             this.iframeDocument.body.style.setProperty("direction", localization.direction);
+            this.insertColorScheme();
             await this.insertStyle().then(() => {
                 this.iframeRef.el.classList.add("show");
             });
@@ -391,6 +393,21 @@ export class AddSnippetDialog extends Component {
             this.iframeDocument.body.style.setProperty("--body-bg", mainBgColor);
         }
         await Promise.all(linkPromises);
+    }
+
+    /**
+     * Retrieves the color-scheme cookie and injects it into the iframe's
+     * <head> and add a custom class. This is necessary to allow the dark mode
+     * to be handled correctly across browsers.
+     */
+    insertColorScheme() {
+        const colorScheme = cookie.get("color_scheme") || "light";
+        const metaElement = document.createElement("meta");
+        const iframeDocument = this.iframeRef.el.contentDocument;
+        metaElement.setAttribute("name", "color-scheme");
+        metaElement.content = colorScheme;
+        iframeDocument.head.appendChild(metaElement);
+        iframeDocument.body.parentElement.classList.add("o_add_snippets_preview--" + colorScheme);
     }
 
     _onSnippetPreviewClick(ev) {

--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -3060,4 +3060,10 @@ we-select.o_grid we-toggler {
             }
         }
     }
+
+    &.o_add_snippets_preview--dark {
+        .o_snippets_preview_row .o_custom_snippet_wrap .o_custom_snippet_edit > * {
+            color: $white;
+        }
+    }
 }


### PR DESCRIPTION
This commit aims to fix two issues with the snippet modal in dark mode:
1. Streamline the background color accross browsers. Chrome takes into account the classes on the iframe for the background color but Firefox and Safari don't.
2. The text below the custom snippets is always black, regardless of the color scheme selected.

These 2 issues are fixed by using the color-scheme cookie value inside the snippet modal's iframe, adding as a meta tag and a custom class.

task-5095262

| Browser(s) | Before | After |
|--------|--------|--------|
| Firefox/Safari | <img width="1192" height="847" alt="image" src="https://github.com/user-attachments/assets/f38f4944-3379-4300-8ec7-78a73dcce7f1" /> | <img width="1174" height="828" alt="image" src="https://github.com/user-attachments/assets/06e93051-737e-4abe-b937-79ce9a4e0a33" /> |
| Chrome | <img width="1171" height="828" alt="image" src="https://github.com/user-attachments/assets/c5f1fcb4-eb55-4a26-83f5-e2c3c65ad0dd" /> | <img width="1174" height="833" alt="image" src="https://github.com/user-attachments/assets/c4066e4d-876c-455c-92eb-1ab0e115500c" /> | 



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
