### PR TITLE
[FIX] l10n_ar: handle invalid document number format in invoice processing

### DIFF
--- a/addons/l10n_ar/i18n/es_419.po
+++ b/addons/l10n_ar/i18n/es_419.po
@@ -220,6 +220,12 @@ msgstr ""
 "Nota: Es posible que tenga que volver a vincular sus impuestos existentes a este nuevo grupo de impuestos."
 
 #. module: l10n_ar
+#. odoo-python
+#: code:addons/l10n_ar/models/account_move.py:0
+msgid "The associated receipt number does not appear to be in the Argentine format: %s"
+msgstr "El número del comprobante asociado no parece tener el formato argentino: %s"
+
+#. module: l10n_ar
 #: model:l10n_latam.document.type,name:l10n_ar.dc_ac_dis_cf
 msgid "ACCOUNTING ADJUSTMENTS THAT DECREASE THE TAX CREDIT"
 msgstr "AJUSTES CONTABLES QUE DISMINUYEN EL CRÉDITO FISCAL"

--- a/addons/l10n_ar/models/account_move.py
+++ b/addons/l10n_ar/models/account_move.py
@@ -18,7 +18,10 @@ class AccountMove(models.Model):
         if document_type_code in ['66', '67']:
             pos = invoice_number = '0'
         else:
-            pos, invoice_number = document_number.split('-')
+            try:
+                pos, invoice_number = document_number.split('-')
+            except ValueError:
+                raise UserError(_("The associated receipt number does not appear to be in the Argentine format: %s ", document_number))
         return {'invoice_number': int(invoice_number), 'point_of_sale': int(pos)}
 
     l10n_ar_afip_responsibility_type_id = fields.Many2one(


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This pull request improves error handling in the `_l10n_ar_get_document_number_parts` method in `account_move.py`. The main change is to provide a user-friendly error message when the document number does not match the expected Argentine format.

Error handling improvement:

* Added a `try/except` block to catch `ValueError` when splitting the `document_number`, raising a `UserError` with a localized message if the format is incorrect.

Current behavior before PR:
If the user tries to reverse a document that does not match the argentinean format, a traceback an error such as the following is generated:
`File "/home/odoo/src/enterprise/l10n_ar_edi/models/account_move.py", line 588, in _get_related_invoice_datawskey[afip_ws]['number']: self._l10n_ar_get_document_number_parts(File "/home/odoo/src/repositories/ingadhoc-odoo-argentina/l10n_ar_ux/models/account_move.py", line 101, in _l10n_ar_get_document_number_partsreturn super()._l10n_ar_get_document_number_parts(document_number, document_type_code)File "/home/odoo/src/odoo/addons/l10n_ar/models/account_move.py", line 21, in _l10n_ar_get_document_number_partspos, invoice_number = document_number.split('-')ValueError: not enough values to unpack (expected 2, got 1)​as`

Desired behavior after PR is merged:
An `UserError` is raised. 
<img width="1553" height="419" alt="image" src="https://github.com/user-attachments/assets/b47dc205-6997-4117-a768-d6241d33b158" />





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
