### PR TITLE
[FIX] 19.0 Error client side - table.difference is not set on mobile browsers

### DIFF
--- a/addons/web/static/src/core/utils/indexed_db.js
+++ b/addons/web/static/src/core/utils/indexed_db.js
@@ -132,13 +132,13 @@ export class IndexedDB {
             request.onupgradeneeded = (event) => {
                 const db = event.target.result;
                 const dbTables = new Set(db.objectStoreNames);
-                const newTables = this._tables.difference(dbTables);
+const newTables = new Set([...this._tables].filter(x => !dbTables.has(x)));
                 newTables.forEach((table) => db.createObjectStore(table));
             };
             request.onsuccess = (event) => {
                 const db = event.target.result;
                 const dbTables = new Set(db.objectStoreNames);
-                const newTables = this._tables.difference(dbTables);
+const newTables = new Set([...this._tables].filter(x => !dbTables.has(x)));
                 if (newTables.size !== 0) {
                     db.close();
                     const version = db.version + 1;

--- a/doc/cla/individual/smr-77.md
+++ b/doc/cla/individual/smr-77.md
@@ -1,0 +1,10 @@
+France, 2025-09-17
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+Nicolas nico.ortolland@protonmail.com https://github.com/Smr-77


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Error occurred only on mobile device on v19.0 community installation with new created database.
On the same device and browser no error on v18.0 but always this error on v19.0

Error:
———————
UncaughtPromiseError > TypeError

Uncaught Promise > this._tables.difference is not a function. (In 'this._tables.difference(dbTables)', 'this._tables.difference' is undefined)

Occured on mydomain.fr on 2025-09-17 19:05:42 GMT

TypeError: this._tables.difference is not a function. (In 'this._tables.difference(dbTables)', 'this._tables.difference' is undefined)
    @https://mydomain.fr/web/assets/debug/web.assets_web.js:48443:58 (https://mydomain.fr/web/assets/debug/web.assets_web.js:48443)
 ———————

Analyze:
——
Original: Using .difference()

const newTables = this._tables.difference(dbTables);

- This syntax assumes that _tables is a Set and that the difference method exists.
- However, native JavaScript has never defined Set.prototype.difference in the ECMAScript specification.
- In some environments (e.g., Node.js with a polyfill, or certain experimental JS engines), it might exist, but Safari does not have this method, which causes the error.


FIX: Using filter and new Set()

const newTables = new Set([...this._tables].filter(x => !dbTables.has(x)));

- Here, we convert _tables to an array, filter out elements that are not in dbTables, and then create a new Set.
- Everything is standard ECMAScript, so it works in all modern browsers, including Safari on iOS

Fix:
Use standardized JS function supported by all browsers in indexed_db.js

Test:
All is fine, no more error on client side

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
