### PR TITLE
[FIX] website: prevent animation option from resetting

### DIFF
--- a/addons/website/static/src/builder/plugins/options/animate_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/animate_option_plugin.js
@@ -296,11 +296,12 @@ export class AnimateOptionPlugin extends Plugin {
     getAnimatedText() {
         const selection = this.dependencies.selection.getSelectionData().editableSelection;
         const ancestor = closestElement(selection.commonAncestorContainer, ".o_animated_text");
-        if (
-            ancestor &&
-            (selection.isCollapsed || selection.textContent() === ancestor.textContent)
-        ) {
-            return ancestor;
+        if (ancestor) {
+            const selectionText = selection.textContent().replace(/\s+/g, " ").trim();
+            const ancestorText = ancestor.innerText.replace(/\s+/g, " ").trim();
+            if (selection.isCollapsed || selectionText === ancestorText) {
+                return ancestor;
+            }
         }
     }
     isAnimatedTextActive() {


### PR DESCRIPTION
Steps to reproduce:

case 1:

1. Select all text in the footer.
2. Apply an animation (e.g. slide).
3. Re-select the same text (e.g. by triple-clicking or drag-selecting).
4. Observe that the animation option resets unexpectedly.

Case 2:
1. Select all text in a paragraph.
2. Apply a text highlight.
3. Re-select the same text (e.g. by triple-clicking or drag-selecting).
4. Apply an animation (e.g. on scroll).
5. Re-select the same text again.
6. Observe that the animation option resets unexpectedly.

Cause:
The previous comparison between `selection.textContent()` and
`ancestor.innerText` did not account for differences in whitespace and
formatting, leading to false mismatches even when the selected and
ancestor text appeared identical.

Fix:
Normalized both the selection and ancestor text by collapsing multiple
whitespace characters and trimming leading/trailing spaces before
comparison. This ensures that visually identical text is treated as
equal, maintaining the animation option state when re-selecting the
same text.

