### PR TITLE
[FIX] mail: keep composer focused after jump to present on desktop

### DIFF
--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -78,6 +78,7 @@ export class Thread extends Component {
         });
         this.lastJumpPresent = this.props.jumpPresent;
         this.orm = useService("orm");
+        this.ui = useService("ui");
         /** @type {ReturnType<import('@mail/utils/common/hooks').useMessageHighlight>|null} */
         this.messageHighlight = this.env.messageHighlight
             ? useState(this.env.messageHighlight)
@@ -546,6 +547,9 @@ export class Thread extends Component {
         this.props.thread.scrollTop = "bottom";
         this.state.showJumpPresent = false;
         this.scrollingToHighlight = false;
+        if (!this.ui.isSmall) {
+            this.props.thread.composer.autofocus++;
+        }
     }
 
     async onClickUnreadMessagesBanner() {

--- a/addons/mail/static/tests/discuss_app/jump_to_present.test.js
+++ b/addons/mail/static/tests/discuss_app/jump_to_present.test.js
@@ -260,3 +260,24 @@ test("show jump to present banner after scrolling up 10 messages", async () => {
     await scroll(".o-mail-Thread", queryFirst(".o-mail-Thread").scrollTop - 5 * messageHeight);
     await contains("[title='Jump to Present']");
 });
+
+test("focus composer after jump to present", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    pyEnv["mail.message"].create(
+        [...Array(40).keys()].map((i) => ({
+            body: `<p>Non Empty Message ${i}</p>`,
+            message_type: "comment",
+            model: "discuss.channel",
+            res_id: channelId,
+        }))
+    );
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Message", { count: 30 });
+    await contains(".o-mail-Composer.o-focused");
+    queryFirst(".o-mail-Composer-input").blur();
+    await contains(".o-mail-Composer.o-focused", { count: 0 });
+    await click("[title='Jump to Present']");
+    await contains(".o-mail-Composer.o-focused");
+});


### PR DESCRIPTION
**Current behavior before PR:**
clicking "Jump to Present" caused the composer to lose focus, forcing users to manually focus the input before typing.

**Desired behavior after PR is merged:**
The composer automatically regains focus on desktop after clicking "Jump to Present".

task-[5035977](https://www.odoo.com/odoo/project/1519/tasks/5035977)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
