### PR TITLE
[FIX] point_of_sale: prevent crash when cancelling customer account popup

### DIFF
--- a/addons/point_of_sale/static/src/app/utils/order_payment_validation.js
+++ b/addons/point_of_sale/static/src/app/utils/order_payment_validation.js
@@ -109,7 +109,9 @@ export default class OrderPaymentValidation {
         if ((await this.askBeforeValidation()) === false) {
             return false;
         }
-        await this._askForCustomerIfRequired();
+        if ((await this._askForCustomerIfRequired()) === false) {
+            return false;
+        }
         this.pos.numberBuffer.capture();
         if (!this.checkCashRoundingHasBeenWellApplied()) {
             return false;

--- a/addons/point_of_sale/static/tests/pos/tours/chrome_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/chrome_tour.js
@@ -187,6 +187,15 @@ registry.category("web_tour.tours").add("test_reload_page_before_payment_with_cu
             PaymentScreen.clickValidate(),
             ReceiptScreen.clickNextOrder(),
             ProductScreen.isShown(),
+            ProductScreen.clickDisplayedProduct("Desk Organizer", true, "1.0"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Customer Account"),
+            PaymentScreen.clickValidate(),
+            Dialog.cancel(),
+            PaymentScreen.clickValidate(),
+            Dialog.confirm("Ok"),
+            PaymentScreen.clickCustomer("Partner Test 1"),
+            PaymentScreen.clickValidate(),
         ].flat(),
 });
 


### PR DESCRIPTION
Steps to reproduce:
===================
- Open POS and add a product to the cart
- Go to the Payment screen
- Select `Customer Account` as the payment method and Validate Order
- The `Customer Required` popup appears
- Click `Cancel` on the popup

Issue:
======
- POS still continues with the order validation process
- This leads to a traceback since the order data is incomplete

Cause:
======
- The `_askForCustomerIfRequired()` always returned a value that allowed
validation to continue
- As a result, validation continued even after clicking Cancel

Fix:
====
- `validateOrder()` now checks the return value and aborts validation
  if the user cancels the popup

Task: 5094722