### PR TITLE
[IMP] hr_holidays: enable leave calendar mobility

### DIFF
--- a/addons/hr_holidays/static/src/views/calendar/calendar_model.js
+++ b/addons/hr_holidays/static/src/views/calendar/calendar_model.js
@@ -6,6 +6,7 @@ import {
     serializeDateTime,
 } from "@web/core/l10n/dates";
 import { Cache } from "@web/core/utils/cache";
+import { parseFloatTime } from "@web/views/fields/parsers";
 const { DateTime } = luxon;
 
 export class TimeOffCalendarModel extends CalendarModel {
@@ -21,6 +22,45 @@ export class TimeOffCalendarModel extends CalendarModel {
             (data) => this.fetchMandatoryDays(data),
             (data) => `${serializeDateTime(data.range.start)},${serializeDateTime(data.range.end)}`
         );
+    }
+
+    async buildLeaveRawRecord(partialRecord, options = {}) {
+        const rawRecord = super.buildRawRecord(partialRecord, options);
+        const leaveRecord = this.data.records[partialRecord.id]?.rawRecord;
+        if (leaveRecord) {
+            const [employee] = await this.orm.searchRead(
+                "hr.employee",
+                [["id", "=", leaveRecord.employee_id[0]]],
+                ["tz"]
+            );
+            const tz = employee?.tz || leaveRecord.tz || this.env.user.tz || "UTC";
+            const dateFrom = deserializeDateTime(rawRecord.date_from, { tz })
+            const dateTo = deserializeDateTime(rawRecord.date_to, { tz });
+            rawRecord.request_date_from = serializeDate(dateFrom);
+            rawRecord.request_date_to = serializeDate(dateTo);
+            if (leaveRecord.work_entry_type_request_unit == 'hour') {
+                rawRecord.request_hour_from = parseFloatTime(dateFrom.toFormat("HH:mm"));
+                rawRecord.request_hour_to = parseFloatTime(dateTo.toFormat("HH:mm"));
+            }
+        }
+        return rawRecord;
+    }
+
+    /**
+     * @override
+    */
+   async updateRecord(record, options = {}) {
+       const rawRecord = await this.buildLeaveRawRecord(record, options);
+       delete rawRecord.name;
+       delete rawRecord.date_from;
+       delete rawRecord.date_to;
+        try {
+            await this.orm.write(this.meta.resModel, [record.id], rawRecord, {
+                context: this.meta.context,
+            });
+        } finally {
+            await this.load();
+        }
     }
 
     /**
@@ -129,7 +169,7 @@ export class TimeOffCalendarModel extends CalendarModel {
         if (!this.employeeId) {
             context["short_name"] = 1;
         }
-        const fieldNamesToAdd = resModel === "hr.leave" ? ["work_entry_type_request_unit", "request_date_from_period", "request_date_to_period"] : [];
+        const fieldNamesToAdd = resModel === "hr.leave" ? ["work_entry_type_request_unit", "request_date_from_period", "request_date_to_period", "employee_id", "tz"] : [];
         return this.orm.searchRead(resModel, this.computeDomain(data), [...fieldNames, ...fieldNamesToAdd], { context });
     }
 

--- a/addons/hr_holidays/static/src/views/calendar/common/calendar_common_renderer.js
+++ b/addons/hr_holidays/static/src/views/calendar/common/calendar_common_renderer.js
@@ -18,6 +18,21 @@ export class TimeOffCalendarCommonRenderer extends CalendarCommonRenderer {
         });
     }
 
+    /**
+     * @override
+     */
+    convertRecordToEvent(record) {
+        const isConfirmed = record.rawRecord?.state === 'confirm';
+        const editable = isConfirmed;
+        const durationEditable = isConfirmed && (record.rawRecord.work_entry_type_request_unit === 'hour' || false);
+
+        return {
+            ...super.convertRecordToEvent(record),
+            editable,
+            durationEditable,
+        };
+    }
+
     getDayCellClassNames(info) {
         return [...super.getDayCellClassNames(info), ...this.mandatoryDays(info)];
     }

--- a/addons/hr_holidays/static/tests/tours/time_off_request_calendar_view.js
+++ b/addons/hr_holidays/static/tests/tours/time_off_request_calendar_view.js
@@ -21,3 +21,137 @@ registry.category("web_tour.tours").add("time_off_request_calendar_view", {
         },
     ],
 });
+
+function simulateDragAndDrop(sourceElement, targetElement, options = {}) {
+    const { top = true, offsetX = 1, offsetY = 1 } = options;
+
+    const sourceRect = sourceElement.getBoundingClientRect();
+    const targetRect = targetElement.getBoundingClientRect();
+    const startX = sourceRect.left + (sourceRect.width / 2);
+    const startY = top ? sourceRect.top : sourceRect.bottom;
+    const endX = targetRect.left + (offsetX || 1);
+    const endY = targetRect.top + (offsetY || 1);
+
+    sourceElement.dispatchEvent(new MouseEvent('mousedown', {
+        bubbles: true,
+        clientX: startX,
+        clientY: startY,
+    }));
+
+    targetElement.dispatchEvent(new MouseEvent('mousemove', {
+        bubbles: true,
+        clientX: endX,
+        clientY: endY,
+    }));
+
+    targetElement.dispatchEvent(new MouseEvent('mouseup', {
+        bubbles: true,
+        clientX: endX,
+        clientY: endY,
+    }));
+}
+
+registry.category("web_tour.tours").add("timeoff_calendar_move_leave_to_next_day_tour", {
+    steps: () => [
+        stepUtils.showAppsMenuItem(),
+        {
+            content: "Open Time Off app",
+            trigger: '.o_app[data-menu-xmlid="hr_holidays.menu_hr_holidays_root"]',
+            run: "click",
+        },
+        {
+            content: "Open dropdown to change view",
+            trigger: ".o-dropdown:contains('Year')",
+            run: "click",
+        },
+        {
+            content: "Select Week view",
+            trigger: '.o-dropdown-item:contains("Week")',
+            run: "click",
+        },
+        {
+            content: "Wait a bit to ensure the view is loaded",
+            trigger: ".fc-day-sun .fc-event .fc-event-main",
+        },
+        {
+            content: "Drag Sunday Leave to Monday",
+            trigger: ".fc-day-sun .fc-event",
+            run: function () {
+                const sundayEvent = document.querySelector('.fc-day-sun .fc-event');
+                const mondayTarget = document.querySelector('.fc-day-mon .fc-daygrid-day-events');
+                simulateDragAndDrop(sundayEvent, mondayTarget);
+            }
+        },
+        {
+            content: "Drag Tuesday Leave to Wednesday",
+            trigger: ".fc-day-tue .fc-event",
+            run: function () {
+                const tuesdayEvent = document.querySelector('.fc-day-tue .fc-event');
+                const wednesdayTarget = document.querySelector('.fc-day-wed .fc-daygrid-day-events');
+                simulateDragAndDrop(tuesdayEvent, wednesdayTarget);
+            }
+        },
+        {
+            content: "Drag Thursday Leave to Friday",
+            trigger: ".fc-day-thu .fc-event",
+            run: async function () {
+                const thursdayEvent = document.querySelector('.fc-day-thu .fc-event');
+                const fridayTarget = document.querySelector('.fc-day-fri .fc-daygrid-day-events');
+                simulateDragAndDrop(thursdayEvent, fridayTarget);
+            }
+        },
+        {
+            content: "Wait a bit to ensure changes are saved",
+            trigger: "body",
+            run: async function () {
+                await new Promise(resolve => setTimeout(resolve, 500));
+            }
+        },
+    ]
+});
+
+registry.category("web_tour.tours").add("timeoff_calendar_resize_leave_duration_tour", {
+    steps: () => [
+        stepUtils.showAppsMenuItem(),
+        {
+            content: "Open Time Off app",
+            trigger: '.o_app[data-menu-xmlid="hr_holidays.menu_hr_holidays_root"]',
+            run: "click",
+        },
+        {
+            content: "Open dropdown to change view",
+            trigger: ".o-dropdown:contains('Year')",
+            run: "click",
+        },
+        {
+            content: "Select Week view",
+            trigger: '.o-dropdown-item:contains("Week")',
+            run: "click",
+        },
+        {
+            content: "Wait a bit to ensure the view is loaded",
+            trigger: ".fc-day-sun .fc-event .fc-event-main",
+        },
+        {
+            content: "Resize Sunday Leave to end at 14:00",
+            trigger: '.fc-day-sun .fc-timegrid-event',
+            run: async function() {
+                const resizer = this.anchor.querySelector(`.fc-day-sun .fc-event-resizer-end`);
+                Object.assign(resizer.style, {
+                    display: "block",
+                    height: "5px",
+                    bottom: "0",
+                });
+                const target = document.querySelector('.fc-timegrid-slot.fc-timegrid-slot-lane[data-time="14:00:00"]');
+                simulateDragAndDrop(resizer, target, { top: false, offsetY: -1 });
+            }
+        },
+        {
+            content: "Wait a bit to ensure changes are saved",
+            trigger: "body",
+            run: async function () {
+                await new Promise(resolve => setTimeout(resolve, 500));
+            }
+        },
+    ]
+});

--- a/addons/hr_holidays/tests/test_holidays_calendar.py
+++ b/addons/hr_holidays/tests/test_holidays_calendar.py
@@ -102,3 +102,82 @@ class TestHolidaysCalendar(HttpCase, TestHrHolidaysCommon):
         self.assertEqual(leave_half.meeting_id.allday, False)
         self.assertEqual(leave_half.meeting_id.start, leave_half.date_from)
         self.assertEqual(leave_half.meeting_id.stop, leave_half.date_to)
+
+    @users('bastien')
+    def test_timeoff_calendar_resize_leave_duration(self):
+        """Test resizing a leave to adjust its duration in the calendar view."""
+        self.employee_hrmanager.tz = 'UTC'
+        self.env.user.tz = 'UTC'
+        hours_leave_type = self.env['hr.work.entry.type'].create(
+            {'name': 'Hours Leave', 'requires_allocation': False, 'request_unit': 'hour', 'code': 'HOUR100'},
+        )
+        today = date.today()
+        sunday = today - timedelta(days=(today.weekday() + 1) % 7)
+        hourly_leave = self.env['hr.leave'].create(
+            {
+                'name': 'Hourly Leave',
+                'employee_id': self.employee_hrmanager.id,
+                'work_entry_type_id': hours_leave_type.id,
+                'request_date_from': sunday,
+                'request_date_to': sunday,
+                'request_hour_from': 8,
+                'request_hour_to': 12,
+            },
+        )
+
+        # Resize the leave to end at 14:00
+        self.start_tour('/odoo', 'timeoff_calendar_resize_leave_duration_tour', login='bastien')
+
+        assert hourly_leave.request_date_from == sunday
+        assert hourly_leave.request_date_to == sunday
+        assert hourly_leave.request_hour_from == 8
+        assert hourly_leave.request_hour_to == 14
+
+    @users('bastien')
+    def test_timeoff_calendar_move_leave_to_next_day(self):
+        """Test dragging and dropping leaves to reschedule them in the calendar view."""
+        self.employee_hrmanager.tz = 'UTC'
+        self.env.user.tz = 'UTC'
+        leave_type = self.env['hr.work.entry.type'].create(
+            {'name': 'Full Day Leave', 'requires_allocation': False, 'request_unit': 'day', 'code': 'DAY100'},
+        )
+        today = date.today()
+        sunday = today - timedelta(days=(today.weekday() + 1) % 7)
+        tuesday = sunday + timedelta(days=2)
+        thursday = sunday + timedelta(days=4)
+
+        confirmed_leave, approved_leave, refused_leave = self.env['hr.leave'].create([
+            {
+                'name': 'Sunday Leave',
+                'employee_id': self.employee_hrmanager.id,
+                'work_entry_type_id': leave_type.id,
+                'request_date_from': sunday,
+                'request_date_to': sunday,
+            },
+            {
+                'name': 'Tuesday Leave',
+                'employee_id': self.employee_hrmanager.id,
+                'work_entry_type_id': leave_type.id,
+                'request_date_from': tuesday,
+                'request_date_to': tuesday,
+            },
+            {
+                'name': 'Thursday Leave',
+                'employee_id': self.employee_hrmanager.id,
+                'work_entry_type_id': leave_type.id,
+                'request_date_from': thursday,
+                'request_date_to': thursday,
+            },
+        ])
+        approved_leave.action_approve()
+        refused_leave.action_refuse()
+
+        # Moving all leaves to the next day
+        self.start_tour('/odoo', 'timeoff_calendar_move_leave_to_next_day_tour', login='bastien')
+
+        assert confirmed_leave.request_date_from == sunday + timedelta(days=1)
+        assert confirmed_leave.request_date_to == sunday + timedelta(days=1)
+        assert approved_leave.request_date_from == tuesday
+        assert approved_leave.request_date_to == tuesday
+        assert refused_leave.request_date_from == thursday
+        assert refused_leave.request_date_to == thursday


### PR DESCRIPTION
with this commit we can adjust time off directly from the calendar
by drag/drop to move or resize events in Day/Week/Month view.

- Full-day & half-day: only date change allowed
- Hourly leaves: date change + resize supported

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
