### PR TITLE
[FIX] point_of_sale: prevent tb when no payment line is selected in tipscreen

### DIFF
--- a/addons/pos_restaurant/static/src/app/tip_screen/tip_screen.js
+++ b/addons/pos_restaurant/static/src/app/tip_screen/tip_screen.js
@@ -109,10 +109,10 @@ export class TipScreen extends Component {
     }
     async printTipReceipt() {
         const order = this.currentOrder;
-        const receipts = [
-            order.get_selected_paymentline().ticket,
-            order.get_selected_paymentline().cashier_receipt,
-        ];
+        const selectedPaymentLine = order.get_selected_paymentline() || order.payment_ids[0];
+        const receipts = [selectedPaymentLine?.ticket, selectedPaymentLine?.cashier_receipt].filter(
+            Boolean
+        );
         for (let i = 0; i < receipts.length; i++) {
             await this.printer.print(
                 TipReceipt,

--- a/addons/pos_restaurant/static/tests/tours/tip_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/tip_screen_tour.js
@@ -27,6 +27,7 @@ registry.category("web_tour.tours").add("PosResTipScreenTour", {
             ProductScreen.totalAmountIs("2.0"),
             ProductScreen.clickPayButton(),
             PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickPaymentMethod("Bank"),
             PaymentScreen.clickValidate(),
             TipScreen.isShown(),
             Chrome.clickPlanButton(),


### PR DESCRIPTION
Steps:
---
- Enable Tips and "Add tip after payment" in restaurant.
- Open a session and add any product(s).
- Go to payment and add two card lines (first with full amount, second with 0).
- Click on "Close Tab".

Issue:
---
- After redirecting to the Tip Screen, a traceback appears.

Cause:
---
- Clicking "Close Tab" clears all 0-amount payment lines. This can leave no selected payment line, but the Tip Screen still tries to access it.

Fix:
---
- Use the selected payment line if available, otherwise fallback to the first payment line.

task-5095825

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
