### PR TITLE
[FIX] mail: hide volume slider when user is not in a call

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_context_menu.xml
+++ b/addons/mail/static/src/discuss/call/common/call_context_menu.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="discuss.CallContextMenu">
-        <div class="d-flex flex-column p-3">
+        <div class="o-discuss-CallContextMenu d-flex flex-column p-3">
             <input t-if="!isSelf" type="range" min="0.0" max="1" step="0.01" t-att-value="volume" t-on-change="onChangeVolume" class="form-range"/>
             <t t-if="env.debug and !isSelf and rtc.state.connectionType === rtcConnectionTypes.P2P">
                 <hr class="w-100 border-top"/>

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.js
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.js
@@ -57,13 +57,10 @@ export class CallParticipantCard extends Component {
     }
 
     get isContextMenuAvailable() {
-        if (!this.rtcSession) {
-            return false;
-        }
-        if (this.env.debug) {
-            return true;
-        }
-        return !this.rtcSession?.eq(this.rtc.state.selfSession);
+        return (
+            this.isOfActiveCall &&
+            (this.rtcSession.notEq(this.rtc.state.selfSession) || this.env.debug)
+        );
     }
 
     get rtcSession() {

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.xml
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.xml
@@ -65,7 +65,7 @@
                 </div>
 
                 <!-- context menu -->
-                <i t-if="isContextMenuAvailable" class="position-absolute bottom-0 start-50" t-ref="contextMenuAnchor"/>
+                <i t-if="isContextMenuAvailable" class="o-discuss-CallParticipantCard-contextMenuAnchor position-absolute bottom-0 start-50" t-ref="contextMenuAnchor"/>
             </t>
         </div>
     </t>

--- a/addons/mail/static/tests/discuss/call/call_tests.js
+++ b/addons/mail/static/tests/discuss/call/call_tests.js
@@ -273,3 +273,33 @@ QUnit.test("should also invite to the call when inviting to the channel", async 
     await click("[title='Invite to Channel']:enabled");
     await contains(".o-discuss-CallParticipantCard.o-isInvitation");
 });
+
+QUnit.test("should not show context menu on participant card when not in a call", async () => {
+    mockGetMedia();
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "General",
+    });
+    pyEnv["discuss.channel.rtc.session"].create([
+        {
+            channel_member_id: pyEnv["discuss.channel.member"].create({
+                channel_id: channelId,
+                partner_id: pyEnv["res.partner"].create({ name: "Awesome Partner" }),
+            }),
+            channel_id: channelId,
+        },
+    ]);
+    const { openDiscuss } = await start();
+    openDiscuss(channelId);
+    await contains(".o-discuss-CallParticipantCard[title='Awesome Partner']");
+    await contains(
+        ".o-discuss-CallParticipantCard[title='Awesome Partner'] .o-discuss-CallParticipantCard-contextMenuAnchor",
+        { count: 0 }
+    );
+    await click("[title='Join Call']");
+    await contains(
+        ".o-discuss-CallParticipantCard[title='Awesome Partner'] .o-discuss-CallParticipantCard-contextMenuAnchor"
+    );
+    await triggerEvents(".o-discuss-CallParticipantCard[title='Awesome Partner']", ["contextmenu"]);
+    await contains(".o-discuss-CallContextMenu");
+});

--- a/addons/mail/static/tests/helpers/mock_server/controllers/discuss.js
+++ b/addons/mail/static/tests/helpers/mock_server/controllers/discuss.js
@@ -168,6 +168,9 @@ patch(MockServer.prototype, {
         if (route === "/mail/rtc/channel/leave_call") {
             return this._mockRouteMailRtcChannelLeaveCall(args.channel_id);
         }
+        if (route === "/mail/rtc/session/notify_call_members") {
+            return true;
+        }
         if (route === "/mail/rtc/session/update_and_broadcast") {
             return this._mockRouteMailRtcSessionUpdateAndBroadcast(args.session_id, args.values);
         }


### PR DESCRIPTION
Before this PR, the volume slider for call participants was visible even when the user was not part of the call.

This PR fixes the behavior by ensuring the volume slider is only available when the user is in the call.

task-[5092826](https://www.odoo.com/odoo/project/1519/tasks/5092826)