### PR TITLE
[IMP] l10n_in: remove TDS deduction type from TDS entry wizard

### DIFF
--- a/addons/l10n_in/wizard/l10n_in_withhold_wizard.xml
+++ b/addons/l10n_in/wizard/l10n_in_withhold_wizard.xml
@@ -31,7 +31,7 @@
                                        decoration-success="tds_deduction == 'lower'"
                                        decoration-danger="tds_deduction == 'higher'"
                                        decoration-warning="tds_deduction == 'no'"
-                                       invisible="tds_deduction == 'normal'"
+                                       invisible="tds_deduction == 'normal' or l10n_in_tds_tax_type == 'tds_sale'"
                                 />
                             </div>
                             <field name="amount" widget="monetary" options="{'currency_field': 'currency_id'}"/>


### PR DESCRIPTION
Before this PR:
- TDS deduction type is visible in the TDS entry wizard for all document types.

After this PR:
- TDS deduction type is not visible in the TDS entry wizard for 'sale' type documents.