### PR TITLE
[FIX] base: fix dependency error on distros without ID_LIKE assignment

### DIFF
--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -353,7 +353,7 @@ class IrModuleModule(models.Model):
             install_package = None
             if platform.system() == 'Linux':
                 distro = platform.freedesktop_os_release()
-                id_likes = {distro['ID'], *distro.get('ID_LIKE').split()}
+                id_likes = {distro['ID'], *distro.get('ID_LIKE', '').split()}
                 if 'debian' in id_likes or 'ubuntu' in id_likes:
                     if package := manifest['external_dependencies'].get('apt', {}).get(e.dependency):
                         install_package = f'apt install {package}'


### PR DESCRIPTION
Steps to replicate:
- Try installing odoo without some external dependency on a linux distro that does not assign ID_LIKE os-release variable.

Error:
- AttributeError: 'NoneType' object has no attribute 'split'

Cause:
- Default value None does not work here as it does not have a split() method.

Solution:
- Default is now empty string instead of None.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
