### PR TITLE
[FIX] html_editor: prevent removal of unremovable link element with link popover

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -698,7 +698,9 @@ export class LinkPlugin extends Plugin {
                         { anchorNode, anchorOffset },
                         { normalize: false }
                     );
-                    link.remove();
+                    if (!this.isUnremovable(link)){
+                        link.remove();
+                    }
                 } else if (cursors) {
                     cursors.restore();
                 } else {

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -86,6 +86,32 @@ describe("should open a popover", () => {
         expect(".o_we_edit_link").toHaveCount(1);
         expect(".o_we_remove_link").toHaveCount(0);
     });
+
+    test("unremovable button should not be removed when label and link are removed", async () => {
+        await setupEditor('<p><a href="http://test.com/" class=" oe_unremovable btn btn-fill-primary">link2[]</a></p>');
+        await waitFor(".o-we-linkpopover");
+        await click(".o_we_edit_link");
+        await animationFrame();
+        expect(".o_we_label_link").toHaveValue("link2");
+        expect(".o_we_href_input_link").toHaveValue("http://test.com/");
+        await contains(".o_we_label_link").edit("  ");
+        await contains(".o_we_href_input_link").edit("  ");
+        expect(".oe_unremovable").toHaveCount(1);
+    });
+
+    test("button should  be removed when label and link are removed for removable class", async () => {
+        await setupEditor('<p><a href="http://test.com/" class="btn btn-fill-primary">link2[]</a></p>');
+        await waitFor(".o-we-linkpopover");
+        await click(".o_we_edit_link");
+        await animationFrame();
+        expect(".o_we_label_link").toHaveValue("link2");
+        expect(".o_we_href_input_link").toHaveValue("http://test.com/");
+        expect("a").toHaveCount(1);
+        await contains(".o_we_label_link").edit("  ");
+        await contains(".o_we_href_input_link").edit("  ");
+        expect("a").toHaveCount(0);
+    });
+
     test("link popover should not repositioned when clicking in the input field", async () => {
         await setupEditor("<p>this is a <a>li[]nk</a></p>");
         await waitFor(".o_we_href_input_link");


### PR DESCRIPTION
Currently, an error occurs when the user edits the `Contact Us` button and removes both the label and the link.

**Steps to replicate:**
* Install `website`
* website > edit > Click on contact us > Edit Link
* replace all the fields by adding one space ' ' and apply > Save.

**Error:**
`ValueError: Element '<xpath expr='//a[hasclass('oe_unremovable')]'>' cannot be located in parent view.`

**Root cause:**
* When the user edits the `Contact Us` button and clears all the fields, then clicks `Apply` line [1] removes the button. But the button is meant to be unremovable, so this breaks the website.

**Solution:**
* Add a check before removal to verify whether the link element is removable and only remove it if it is removable.

[1]:
https://github.com/odoo/odoo/blob/674280cd86088a6cc3bd5c10dd56ece65bf5e517/addons/html_editor/static/src/main/link/link_plugin.js#L701

sentry-6639000902