### PR TITLE
[PERF] orm: domain operations optimization

### DIFF
--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -1335,6 +1335,9 @@ def _optimize_any_domain(condition, model):
         # id ANY domain  <=>  domain
         # id NOT ANY domain  <=>  ~domain
         return domain if condition.operator in ('any', 'any!') else ~domain
+    if value is domain:
+        # avoid recreating the same condition
+        return condition
     return DomainCondition(condition.field_expr, condition.operator, domain)
 
 
@@ -1355,6 +1358,9 @@ def _optimize_any_domain_at_level(level: OptimizationLevel, condition, model):
     # if the domain is True, we keep it as is
     if domain.is_false():
         return _FALSE_DOMAIN if condition.operator in ('any', 'any!') else _TRUE_DOMAIN
+    if domain is condition.value:
+        # avoid recreating the same condition
+        return condition
     return DomainCondition(condition.field_expr, condition.operator, domain)
 
 

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -800,10 +800,7 @@ class DomainCondition(Domain):
         """Validate `self` and return it if correct, otherwise raise an exception."""
         if not isinstance(self.field_expr, str) or not self.field_expr:
             self._raise("Empty field name", error=TypeError)
-        operator = self.operator.lower()
-        if operator != self.operator:
-            warnings.warn(f"Deprecated since 19.0, the domain condition {(self.field_expr, self.operator, self.value)!r} should have a lower-case operator", DeprecationWarning)
-            return DomainCondition(self.field_expr, operator, self.value).checked()
+        operator = self.operator
         if operator not in CONDITION_OPERATORS:
             self._raise("Invalid operator")
         # check already the consistency for domain manipulation

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -921,11 +921,14 @@ class DomainCondition(Domain):
         """
         assert level == self._opt_level + 1, f"Trying to skip optimization level after {self._opt_level}"
 
-        # optimize path
-        field, property_name = self.__get_field(model)
-        if property_name and field.relational:
-            sub_domain = DomainCondition(property_name, self.operator, self.value)
-            return DomainCondition(field.name, 'any', sub_domain)
+        if level == OptimizationLevel.BASIC:
+            # optimize path
+            field, property_name = self.__get_field(model)
+            if property_name and field.relational:
+                sub_domain = DomainCondition(property_name, self.operator, self.value)
+                return DomainCondition(field.name, 'any', sub_domain)
+        else:
+            field = self._field(model)
 
         if level == OptimizationLevel.FULL:
             # resolve inherited fields

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -1287,6 +1287,9 @@ def _operator_equal_as_in(condition, _):
 def _optimize_in_set(condition, _model):
     """Make sure the value is an OrderedSet or use 'any' operator"""
     value = condition.value
+    if isinstance(value, OrderedSet) and value:
+        # very common case, just skip creation of a new Domain instance
+        return condition
     if isinstance(value, ANY_TYPES):
         operator = 'any' if condition.operator == 'in' else 'not any'
         return DomainCondition(condition.field_expr, operator, value)

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -656,6 +656,10 @@ class DomainNary(Domain):
                 children = merge(cls, children, model)
                 if len(children) < size:
                     break
+            else:
+                # if no change, skip creation of a new object
+                if len(self.children) == len(children) and all(map(operator.is_, self.children, children)):
+                    return self
         return self.apply(children)
 
     def _to_sql(self, model: BaseModel, alias: str, query: Query) -> SQL:

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -180,6 +180,11 @@ class OptimizationLevel(enum.IntEnum):
     DYNAMIC_VALUES = enum.auto()
     FULL = enum.auto()
 
+    @functools.cached_property
+    def next_level(self):
+        assert self is not OptimizationLevel.FULL, "FULL level is the last one"
+        return OptimizationLevel(int(self) + 1)
+
 
 MAX_OPTIMIZE_ITERATIONS = 1000
 
@@ -450,7 +455,7 @@ class Domain:
         while domain._opt_level < level:
             if (count := count + 1) > MAX_OPTIMIZE_ITERATIONS:
                 raise RecursionError("Domain.optimize: too many loops")
-            next_level = OptimizationLevel(domain._opt_level + 1)
+            next_level = domain._opt_level.next_level
             previous, domain = domain, domain._optimize_step(model, next_level)
             # set the optimization level if necessary (unlike DomainBool, for instance)
             if domain == previous and domain._opt_level < next_level:
@@ -923,7 +928,7 @@ class DomainCondition(Domain):
         - Run optimizations.
         - Check the output.
         """
-        assert level == self._opt_level + 1, f"Trying to skip optimization level after {self._opt_level}"
+        assert level is self._opt_level.next_level, f"Trying to skip optimization level after {self._opt_level}"
 
         if level == OptimizationLevel.BASIC:
             # optimize path

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -304,9 +304,10 @@ class Domain:
         return DomainOr.apply(Domain(item) for item in items)
 
     def __setattr__(self, name, value):
-        if hasattr(self, name):
-            raise TypeError("Domain objects are immutable")
-        return super().__setattr__(name, value)
+        raise TypeError("Domain objects are immutable")
+
+    def __delattr__(self, name):
+        raise TypeError("Domain objects are immutable")
 
     def __and__(self, other):
         """Domain & Domain"""
@@ -477,8 +478,8 @@ class DomainBool(Domain):
     def __new__(cls, value: bool):
         """Create a constant domain."""
         self = object.__new__(cls)
-        self.value = value
-        self._opt_level = OptimizationLevel.FULL
+        object.__setattr__(self, 'value', value)
+        object.__setattr__(self, '_opt_level', OptimizationLevel.FULL)
         return self
 
     def __eq__(self, other):
@@ -531,8 +532,8 @@ class DomainNot(Domain):
     def __new__(cls, child: Domain):
         """Create a domain which is the inverse of the child."""
         self = object.__new__(cls)
-        self.child = child
-        self._opt_level = OptimizationLevel.NONE
+        object.__setattr__(self, 'child', child)
+        object.__setattr__(self, '_opt_level', OptimizationLevel.NONE)
         return self
 
     def __invert__(self):
@@ -579,8 +580,8 @@ class DomainNary(Domain):
         """Create the n-ary domain with at least 2 conditions."""
         assert len(children) >= 2
         self = object.__new__(cls)
-        self.children = children
-        self._opt_level = OptimizationLevel.NONE
+        object.__setattr__(self, 'children', children)
+        object.__setattr__(self, '_opt_level', OptimizationLevel.NONE)
         return self
 
     @classmethod
@@ -727,6 +728,9 @@ class DomainCustom(Domain):
     """Domain condition that generates directly SQL and possibly a ``filtered`` predicate."""
     __slots__ = ('_filtered', '_sql')
 
+    _filtered: Callable[[BaseModel], bool] | None
+    _sql: Callable[[BaseModel, str, Query], SQL]
+
     def __new__(
         cls,
         sql: Callable[[BaseModel, str, Query], SQL],
@@ -740,9 +744,9 @@ class DomainCustom(Domain):
                           when filtering (``Model.filtered``)
         """
         self = object.__new__(cls)
-        self._sql = sql
-        self._filtered = filtered
-        self._opt_level = OptimizationLevel.FULL
+        object.__setattr__(self, '_sql', sql)
+        object.__setattr__(self, '_filtered', filtered)
+        object.__setattr__(self, '_opt_level', OptimizationLevel.FULL)
         return self
 
     def _as_predicate(self, records):
@@ -789,11 +793,11 @@ class DomainCondition(Domain):
         :param value: A value for the comparison
         """
         self = object.__new__(cls)
-        self.field_expr = field_expr
-        self.operator = operator
-        self.value = value
-        self._field_instance = None
-        self._opt_level = OptimizationLevel.NONE
+        object.__setattr__(self, 'field_expr', field_expr)
+        object.__setattr__(self, 'operator', operator)
+        object.__setattr__(self, 'value', value)
+        object.__setattr__(self, '_field_instance', None)
+        object.__setattr__(self, '_opt_level', OptimizationLevel.NONE)
         return self
 
     def checked(self) -> DomainCondition:

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -573,9 +573,9 @@ class DomainNary(Domain):
     ZERO: DomainBool = _FALSE_DOMAIN  # default for lint checks
 
     __slots__ = ('children',)
-    children: list[Domain]
+    children: tuple[Domain, ...]
 
-    def __new__(cls, children: list[Domain]):
+    def __new__(cls, children: tuple[Domain, ...]):
         """Create the n-ary domain with at least 2 conditions."""
         assert len(children) >= 2
         self = object.__new__(cls)
@@ -589,7 +589,7 @@ class DomainNary(Domain):
         children = cls._flatten(items)
         if len(children) == 1:
             return children[0]
-        return cls(children)
+        return cls(tuple(children))
 
     @classmethod
     def _flatten(cls, children: Iterable[Domain]) -> list[Domain]:
@@ -598,7 +598,7 @@ class DomainNary(Domain):
         and subdomains of the same class are flattened into the list.
         The returned list is never empty.
         """
-        result = []
+        result: list[Domain] = []
         for child in children:
             if isinstance(child, DomainBool):
                 if child != cls.ZERO:
@@ -622,7 +622,7 @@ class DomainNary(Domain):
         )
 
     def __hash__(self):
-        return hash(self.OPERATOR) ^ hash(tuple(self.children))
+        return hash(self.OPERATOR) ^ hash(self.children)
 
     @classproperty
     def INVERSE(cls) -> type[DomainNary]:
@@ -630,10 +630,10 @@ class DomainNary(Domain):
         raise NotImplementedError
 
     def __invert__(self):
-        return self.INVERSE([~child for child in self.children])
+        return self.INVERSE(tuple(~child for child in self.children))
 
     def _negate(self, model):
-        return self.INVERSE([child._negate(model) for child in self.children])
+        return self.INVERSE(tuple(child._negate(model) for child in self.children))
 
     def iter_conditions(self):
         for child in self.children:
@@ -927,6 +927,7 @@ class DomainCondition(Domain):
             # inherits implies both Field.delegate=True and Field.bypass_search_access=True
             # so no additional permissions will be added by the 'any' operator below
             if field.inherited:
+                assert field.related
                 parent_fname = field.related.split('.')[0]
                 parent_domain = DomainCondition(self.field_expr, self.operator, self.value)
                 return DomainCondition(parent_fname, 'any', parent_domain)
@@ -1872,7 +1873,7 @@ def _optimize_merge_any(cls, conditions, model):
     if len(merge_conditions) < 2:
         return conditions
     base = merge_conditions[0]
-    sub_domain = cls([c.value for c in merge_conditions])
+    sub_domain = cls(tuple(c.value for c in merge_conditions))
     return [DomainCondition(base.field_expr, base.operator, sub_domain), *other_conditions]
 
 
@@ -1894,7 +1895,7 @@ def _optimize_merge_not_any(cls, conditions, model):
     if len(merge_conditions) < 2:
         return conditions
     base = merge_conditions[0]
-    sub_domain = cls.INVERSE([c.value for c in merge_conditions])
+    sub_domain = cls.INVERSE(tuple(c.value for c in merge_conditions))
     return [DomainCondition(base.field_expr, base.operator, sub_domain), *other_conditions]
 
 

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -1934,8 +1934,19 @@ def _optimize_same_conditions(cls, conditions, model):
     Quick optimization for some conditions, just compare if we have the same
     condition twice.
     """
+    # check if we need to create a new list (this is usually not the case)
+    prev = None
+    for condition in conditions:
+        if prev == condition:
+            break
+        prev = condition
+    else:
+        return conditions
+
+    # avoid any function calls, and use the stack semantics for prev comparison
+    prev = None
     return [
-        b
-        for a, b in itertools.pairwise(itertools.chain([None], conditions))
-        if a != b
+        condition
+        for condition in conditions
+        if prev != (prev := condition)
     ]


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Various optimizations

```
model = env['res.partner']
model_user = model.with_user(5)
simple_domain = Domain('id', '=', 8)
normal_domain = simple_domain | Domain('name', '=', 'test')
optimized_domain = normal_domain.optimize_full(model)

time       %change    operation
0.000010    0.020  Domain(simple_domain)
0.000110   -0.530  Domain('id', '>', 5)
0.000111   -0.524  Domain('id', '=', 5)
0.000151   -0.459  Domain([('id', '=', 5)])
0.000373   -0.530  simple_domain.optimize(model)
0.000510   -0.459  simple_domain.optimize_full(model)
0.001568   -0.473  normal_domain.optimize(model)
0.002468   -0.486  normal_domain.optimize_full(model)
0.004011   -0.404  model._search(simple_domain)
0.006973   -0.405  model._search(normal_domain)
0.004025   -0.350  model._search(optimized_domain)
0.011301   -0.394  model_user._search(simple_domain)
0.014113   -0.413  model_user._search(normal_domain)
0.012895   -0.392  model_user._search(simple_domain & Domain('name', '=', 999))
0.002968   -0.411  model_user._search(simple_domain & Domain('id', '=', 999))
0.031529   -0.271  model._search(Domain('category_id', 'ilike', 'a'))
0.015952   -0.423  model._search(Domain('category_id', 'any', [('display_name', '=', 'hello')]))
```



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
