### PR TITLE
[FIX] stock: prevent error when clicking ‘View Diagram’

### DIFF
--- a/addons/stock/wizard/stock_rules_report.py
+++ b/addons/stock/wizard/stock_rules_report.py
@@ -33,6 +33,8 @@ class StockRulesReport(models.TransientModel):
         if 'warehouse_ids' in fields:
             company = product_tmpl_id.company_id or self.env.company
             warehouse_id = self.env['stock.warehouse'].search(self.env['stock.warehouse']._check_company_domain(company), limit=1).id
+            if not warehouse_id:
+                self.env['stock.warehouse']._warehouse_redirect_warning()
             res['warehouse_ids'] = [(6, 0, [warehouse_id])]
         return res
 


### PR DESCRIPTION
Currently, if a user creates a new company without configuring its warehouse, clicking 'View Diagram' raises an error.

**Steps to Reproduce:**
1) Install sale_stock module.(with Demo Data)
2) Navigate to Inventory>Configuration>Warehouses and create a new Warehouse. 
3) Create a new company and switch to that company. 
4) Navigate to Inventory>Products>Products
5) Open any product and click on 'View Diagram' in the 'inventory tab'.

**Error:**
`AttributeError: 'bool' object has no attribute 'origin'`

**Root Cause:**
On following above steps, `default_get` method is called. At [1], it attempts to fetch the ID of the warehouse. Because Odoo does not create a default warehouse for a newly created company, the value received by `res` at [2] looks like `[(6, 0, ['False'])]` which causes an error during further computation.

**Fix:**
Raise a `Redirect Warehouse Warning` when clicking 'View Diagram' if no warehouse is found.

[1]- https://github.com/odoo/odoo/blob/a729578afb7fed79aac2d622aae4da4c0917f8e5/addons/stock/wizard/stock_rules_report.py#L35

[2]- https://github.com/odoo/odoo/blob/a729578afb7fed79aac2d622aae4da4c0917f8e5/addons/stock/wizard/stock_rules_report.py#L36



**Note**: not adding a test case, as the issue is not reproducible in test mode as default warehouse is created for a company in the test mode
https://github.com/odoo/odoo/blob/de264d99c22283390d18beb7c7c62c29824f72b3/addons/stock/models/res_company.py#L197-L198

sentry-6575082178
