### PR TITLE
[FIX] html_editor: styles not applied on list markers

### DIFF
--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -232,9 +232,9 @@ export class DomPlugin extends Plugin {
             }
         }
 
+        const textNode = this.document.createTextNode("");
         if (startNode.nodeType === Node.ELEMENT_NODE) {
             if (selection.anchorOffset === 0) {
-                const textNode = this.document.createTextNode("");
                 if (isSelfClosingElement(startNode)) {
                     startNode.parentNode.insertBefore(textNode, startNode);
                 } else {
@@ -374,6 +374,8 @@ export class DomPlugin extends Plugin {
             }
             currentNode = nodeToInsert;
         }
+        // Remove the empty text node created earlier
+        textNode.remove();
         allInsertedNodes.push(...lastInsertedNodes);
         let insertedNodesParents = getConnectedParents(allInsertedNodes);
         for (const parent of insertedNodesParents) {

--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -422,14 +422,12 @@ export class ListPlugin extends Plugin {
         }
         const newTag = newMode === "CL" ? "UL" : newMode;
         const newList = this.dependencies.dom.setTagName(list, newTag);
-        // Clear list style (@todo @phoenix - why??)
+        // Remove any previously set list-style so that when changing the list
+        // type, the new list can show its correct default marker style.
         newList.style.removeProperty("list-style");
         for (const li of newList.children) {
             if (li.style.listStyle !== "none") {
                 li.style.listStyle = null;
-                if (!li.style.all) {
-                    li.removeAttribute("style");
-                }
             }
         }
         removeClass(newList, "o_checklist");

--- a/addons/html_editor/static/tests/list/toggle_cl.test.js
+++ b/addons/html_editor/static/tests/list/toggle_cl.test.js
@@ -325,6 +325,24 @@ describe("Range collapsed", () => {
                     '<ul class="o_checklist"><li style="font-size: 18px; list-style-position: inside;"><b><font style="color: rgb(255, 0, 0);">a</font></b><i><font style="color: rgb(255, 0, 0);">a</font></i></li></ul>',
             });
         });
+
+        test("should convert an ordered list to a checklist without removing inline styles", async () => {
+            await testEditor({
+                contentBefore: '<ol><li style="color: rgb(0, 128, 0);">a</li></ol>',
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<ul class="o_checklist"><li style="color: rgb(0, 128, 0);">a</li></ul>',
+            });
+        });
+
+        test("should convert an unordered list to a checklist without removing inline styles", async () => {
+            await testEditor({
+                contentBefore: '<ul><li style="color: rgb(0, 128, 0);">a</li></ul>',
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<ul class="o_checklist"><li style="color: rgb(0, 128, 0);">a</li></ul>',
+            });
+        });
     });
     describe("Remove", () => {
         test("should turn an empty list into a paragraph", async () => {

--- a/addons/html_editor/static/tests/list/toggle_cl.test.js
+++ b/addons/html_editor/static/tests/list/toggle_cl.test.js
@@ -271,6 +271,60 @@ describe("Range collapsed", () => {
                 contentAfter: '<ul class="o_checklist text-uppercase" dir="rtl"><li>a[]b</li></ul>',
             });
         });
+
+        test("should apply both color and size styles on list item", async () => {
+            await testEditor({
+                contentBefore:
+                    '<p><span style="font-size: 18px; list-style-position: inside;"><font style="color: rgb(255, 0, 0);">[abc]</font></span></p>',
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<ul class="o_checklist"><li style="color: rgb(255, 0, 0); font-size: 18px; list-style-position: inside;">[abc]</li></ul>',
+            });
+            await testEditor({
+                contentBefore:
+                    '<p><b><i><span style="font-size: 18px; list-style-position: inside;"><font style="color: rgb(255, 0, 0);">[abc]</font></span></i></b></p>',
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<ul class="o_checklist"><li style="color: rgb(255, 0, 0); font-size: 18px; list-style-position: inside;"><b><i>[abc]</i></b></li></ul>',
+            });
+        });
+
+        test("should not apply color and size styles on list item", async () => {
+            await testEditor({
+                contentBefore:
+                    '<p><span style="font-size: 18px; list-style-position: inside;"><font style="color: rgb(255, 0, 0);">a</font></span>b</p>',
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<ul class="o_checklist"><li><span style="font-size: 18px; list-style-position: inside;"><font style="color: rgb(255, 0, 0);">a</font></span>b</li></ul>',
+            });
+            await testEditor({
+                contentBefore:
+                    '<p><b><span style="font-size: 18px; list-style-position: inside;"><font style="color: rgb(255, 0, 0);">a</font></span></b><i><span style="font-size: 18px; list-style-position: inside;"><font style="color: rgb(255, 0, 0);">a</font></span></i></p>',
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<ul class="o_checklist"><li><b><span style="font-size: 18px; list-style-position: inside;"><font style="color: rgb(255, 0, 0);">a</font></span></b><i><span style="font-size: 18px; list-style-position: inside;"><font style="color: rgb(255, 0, 0);">a</font></span></i></li></ul>',
+            });
+        });
+
+        test("should only apply color style on list item", async () => {
+            await testEditor({
+                contentBefore:
+                    '<p><font style="color: rgb(255, 0, 0);"><b><span style="font-size: 18px; list-style-position: inside;">a</span></b><i><span style="font-size: 18px; list-style-position: inside;">a</span></i></font></p>',
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<ul class="o_checklist"><li style="color: rgb(255, 0, 0);"><b><span style="font-size: 18px; list-style-position: inside;">a</span></b><i><span style="font-size: 18px; list-style-position: inside;">a</span></i></li></ul>',
+            });
+        });
+
+        test("should only apply size style on list item", async () => {
+            await testEditor({
+                contentBefore:
+                    '<p><span style="font-size: 18px; list-style-position: inside;"><b><font style="color: rgb(255, 0, 0);">a</font></b><i><font style="color: rgb(255, 0, 0);">a</font></i></span></p>',
+                stepFunction: toggleCheckList,
+                contentAfter:
+                    '<ul class="o_checklist"><li style="font-size: 18px; list-style-position: inside;"><b><font style="color: rgb(255, 0, 0);">a</font></b><i><font style="color: rgb(255, 0, 0);">a</font></i></li></ul>',
+            });
+        });
     });
     describe("Remove", () => {
         test("should turn an empty list into a paragraph", async () => {

--- a/addons/html_editor/static/tests/list/toggle_ol.test.js
+++ b/addons/html_editor/static/tests/list/toggle_ol.test.js
@@ -150,6 +150,53 @@ describe("Range collapsed", () => {
                 contentAfter: '<ol dir="rtl" class="text-uppercase"><li>a[]b</li></ol>',
             });
         });
+
+        test("should apply both color and size styles on list item", async () => {
+            await testEditor({
+                contentBefore:
+                    '<p><span style="font-size: 18px; list-style-position: inside;"><font style="color: rgb(255, 0, 0);">[abc]</font></span></p>',
+                stepFunction: toggleOrderedList,
+                contentAfter:
+                    '<ol><li style="color: rgb(255, 0, 0); font-size: 18px; list-style-position: inside;">[abc]</li></ol>',
+            });
+            await testEditor({
+                contentBefore:
+                    '<p><b><i><span style="font-size: 18px; list-style-position: inside;"><font style="color: rgb(255, 0, 0);">[abc]</font></span></i></b></p>',
+                stepFunction: toggleOrderedList,
+                contentAfter:
+                    '<ol><li style="color: rgb(255, 0, 0); font-size: 18px; list-style-position: inside;"><b><i>[abc]</i></b></li></ol>',
+            });
+        });
+
+        test("should not apply color and size styles on list item", async () => {
+            await testEditor({
+                contentBefore:
+                    '<p><span style="font-size: 18px;"><font style="color: rgb(0, 128, 0);">a</font></span>b</p>',
+                stepFunction: toggleOrderedList,
+                contentAfter:
+                    '<ol><li><span style="font-size: 18px;"><font style="color: rgb(0, 128, 0);">a</font></span>b</li></ol>',
+            });
+        });
+
+        test("should only apply color style on list item", async () => {
+            await testEditor({
+                contentBefore:
+                    '<p><font style="color: rgb(0, 128, 0);"><b><span style="font-size: 18px;">a</span></b><i><span style="font-size: 18px;">a</span></i></font></p>',
+                stepFunction: toggleOrderedList,
+                contentAfter:
+                    '<ol><li style="color: rgb(0, 128, 0);"><b><span style="font-size: 18px;">a</span></b><i><span style="font-size: 18px;">a</span></i></li></ol>',
+            });
+        });
+
+        test("should only apply size style on list item", async () => {
+            await testEditor({
+                contentBefore:
+                    '<p><span style="font-size: 18px;"><b><font style="color: rgb(0, 128, 0);">a</font></b><i><font style="color: rgb(0, 128, 0);">a</font></i></span></p>',
+                stepFunction: toggleOrderedList,
+                contentAfter:
+                    '<ol><li style="font-size: 18px; list-style-position: inside;"><b><font style="color: rgb(0, 128, 0);">a</font></b><i><font style="color: rgb(0, 128, 0);">a</font></i></li></ol>',
+            });
+        });
     });
     describe("Remove", () => {
         test("should turn an empty list into a paragraph", async () => {

--- a/addons/html_editor/static/tests/list/toggle_ol.test.js
+++ b/addons/html_editor/static/tests/list/toggle_ol.test.js
@@ -197,6 +197,23 @@ describe("Range collapsed", () => {
                     '<ol><li style="font-size: 18px; list-style-position: inside;"><b><font style="color: rgb(0, 128, 0);">a</font></b><i><font style="color: rgb(0, 128, 0);">a</font></i></li></ol>',
             });
         });
+
+        test("should convert an unordered list to an ordered list without removing inline styles", async () => {
+            await testEditor({
+                contentBefore: '<ul><li style="color: rgb(0, 128, 0);">a</li></ul>',
+                stepFunction: toggleOrderedList,
+                contentAfter: '<ol><li style="color: rgb(0, 128, 0);">a</li></ol>',
+            });
+        });
+
+        test("should convert a checklist to an ordered list without removing inline styles", async () => {
+            await testEditor({
+                contentBefore:
+                    '<ul class="o_checklist"><li style="color: rgb(0, 128, 0);">a</li></ul>',
+                stepFunction: toggleOrderedList,
+                contentAfter: '<ol><li style="color: rgb(0, 128, 0);">a</li></ol>',
+            });
+        });
     });
     describe("Remove", () => {
         test("should turn an empty list into a paragraph", async () => {

--- a/addons/html_editor/static/tests/list/toggle_ul.test.js
+++ b/addons/html_editor/static/tests/list/toggle_ul.test.js
@@ -204,6 +204,23 @@ describe("Range collapsed", () => {
                     '<ul><li style="font-size: 18px; list-style-position: inside;"><b><font style="color: rgb(255, 0, 0);">a</font></b><i><font style="color: rgb(255, 0, 0);">a</font></i></li></ul>',
             });
         });
+
+        test("should convert an ordered list to an unordered list without removing inline styles", async () => {
+            await testEditor({
+                contentBefore: '<ol><li style="color: rgb(0, 128, 0);">a</li></ol>',
+                stepFunction: toggleUnorderedList,
+                contentAfter: '<ul><li style="color: rgb(0, 128, 0);">a</li></ul>',
+            });
+        });
+
+        test("should convert a checklist to an unordered list without removing inline styles", async () => {
+            await testEditor({
+                contentBefore:
+                    '<ul class="o_checklist"><li style="color: rgb(0, 128, 0);">a</li></ul>',
+                stepFunction: toggleUnorderedList,
+                contentAfter: '<ul><li style="color: rgb(0, 128, 0);">a</li></ul>',
+            });
+        });
     });
     describe("Remove", () => {
         test("should turn an empty list into a paragraph", async () => {

--- a/addons/html_editor/static/tests/list/toggle_ul.test.js
+++ b/addons/html_editor/static/tests/list/toggle_ul.test.js
@@ -157,6 +157,53 @@ describe("Range collapsed", () => {
                 contentAfter: '<ul dir="rtl" class="text-uppercase"><li>a[]b</li></ul>',
             });
         });
+
+        test("should apply both color and size styles on list item", async () => {
+            await testEditor({
+                contentBefore:
+                    '<p><span style="font-size: 18px; list-style-position: inside;"><font style="color: rgb(255, 0, 0);">[abc]</font></span></p>',
+                stepFunction: toggleUnorderedList,
+                contentAfter:
+                    '<ul><li style="color: rgb(255, 0, 0); font-size: 18px; list-style-position: inside;">[abc]</li></ul>',
+            });
+            await testEditor({
+                contentBefore:
+                    '<p><b><i><span style="font-size: 18px; list-style-position: inside;"><font style="color: rgb(255, 0, 0);">[abc]</font></span></i></b></p>',
+                stepFunction: toggleUnorderedList,
+                contentAfter:
+                    '<ul><li style="color: rgb(255, 0, 0); font-size: 18px; list-style-position: inside;"><b><i>[abc]</i></b></li></ul>',
+            });
+        });
+
+        test("should not apply color and size styles on list item", async () => {
+            await testEditor({
+                contentBefore:
+                    '<p><span style="font-size: 18px;"><font style="color: rgb(255, 0, 0);">a</font></span>b</p>',
+                stepFunction: toggleUnorderedList,
+                contentAfter:
+                    '<ul><li><span style="font-size: 18px;"><font style="color: rgb(255, 0, 0);">a</font></span>b</li></ul>',
+            });
+        });
+
+        test("should only apply color style on list item", async () => {
+            await testEditor({
+                contentBefore:
+                    '<p><font style="color: rgb(255, 0, 0);"><b><span style="font-size: 18px;">a</span></b><i><span style="font-size: 18px;">a</span></i></font></p>',
+                stepFunction: toggleUnorderedList,
+                contentAfter:
+                    '<ul><li style="color: rgb(255, 0, 0);"><b><span style="font-size: 18px;">a</span></b><i><span style="font-size: 18px;">a</span></i></li></ul>',
+            });
+        });
+
+        test("should only apply size style on list item", async () => {
+            await testEditor({
+                contentBefore:
+                    '<p><span style="font-size: 18px;"><b><font style="color: rgb(255, 0, 0);">a</font></b><i><font style="color: rgb(255, 0, 0);">a</font></i></span></p>',
+                stepFunction: toggleUnorderedList,
+                contentAfter:
+                    '<ul><li style="font-size: 18px; list-style-position: inside;"><b><font style="color: rgb(255, 0, 0);">a</font></b><i><font style="color: rgb(255, 0, 0);">a</font></i></li></ul>',
+            });
+        });
     });
     describe("Remove", () => {
         test("should turn an empty list into a paragraph", async () => {

--- a/addons/html_editor/static/tests/paste.test.js
+++ b/addons/html_editor/static/tests/paste.test.js
@@ -3320,9 +3320,9 @@ describe("images", () => {
             // select xxx in "<p>ab[xxx]cd</p>""
             const p = editor.editable.querySelector("p");
             const selection = {
-                anchorNode: p.childNodes[1],
+                anchorNode: p.childNodes[0],
                 anchorOffset: 2,
-                focusNode: p.childNodes[1],
+                focusNode: p.childNodes[0],
                 focusOffset: 5,
             };
             setSelection(selection);
@@ -3516,9 +3516,9 @@ describe("youtube video", () => {
             // select xxx in "<p>ab[xxx]cd</p>"
             const p = editor.editable.querySelector("p");
             const selection = {
-                anchorNode: p.childNodes[1],
+                anchorNode: p.childNodes[0],
                 anchorOffset: 2,
-                focusNode: p.childNodes[1],
+                focusNode: p.childNodes[0],
                 focusOffset: 5,
             };
             setSelection(selection);


### PR DESCRIPTION
**Current behavior before PR:**

- When applying a color or size style to the entire text and then converting it into a list, the style was reflected on the list marker.
- However, if multiple styles (e.g., both color and size, or color and bold) were applied, only one style or sometimes none was reflected on the marker.

**Desired behavior after PR is merged:**

- When text with color, size, or both styles is converted into a list, The list markers now consistently reflect those styles.

task-5097649