### PR TITLE
[IMP] mail,*: auto scroll to message for portal chatter

### DIFF
--- a/addons/mail/static/src/chatter/web_portal/chatter.js
+++ b/addons/mail/static/src/chatter/web_portal/chatter.js
@@ -1,5 +1,6 @@
 import { Composer } from "@mail/core/common/composer";
 import { Thread } from "@mail/core/common/thread";
+import { useMessageScrolling } from "@mail/utils/common/hooks";
 
 import {
     Component,
@@ -33,6 +34,7 @@ export class Chatter extends Component {
             aside: false,
             disabled: !this.props.threadId,
         });
+        this.messageHighlight = useMessageScrolling();
         this.rootRef = useRef("root");
         this.onScrollDebounced = useThrottleForAnimation(this.onScroll);
         useChildSubEnv(this.childSubEnv);
@@ -60,7 +62,10 @@ export class Chatter extends Component {
     }
 
     get childSubEnv() {
-        return { inChatter: this.state };
+        return {
+            inChatter: this.state,
+            messageHighlight: this.messageHighlight,
+        };
     }
 
     get onCloseFullComposerRequestList() {
@@ -72,7 +77,14 @@ export class Chatter extends Component {
     }
 
     changeThread(threadModel, threadId) {
-        this.state.thread = this.store.Thread.insert({ model: threadModel, id: threadId });
+        const data = {
+            model: threadModel,
+            id: threadId,
+        };
+        if (this.highlightMessage) {
+            data.highlightMessage = this.highlightMessage;
+        }
+        this.state.thread = this.store.Thread.insert(data);
         if (threadId === false) {
             if (this.state.thread.messages.length === 0) {
                 this.state.thread.messages.push({

--- a/addons/portal/static/src/chatter/frontend/chatter_patch.js
+++ b/addons/portal/static/src/chatter/frontend/chatter_patch.js
@@ -1,14 +1,16 @@
 import { Chatter } from "@mail/chatter/web_portal/chatter";
 
+import { router } from "@web/core/browser/router";
 import { patch } from "@web/core/utils/patch";
 import { useRef, onWillPatch, useEffect } from "@odoo/owl";
 
 patch(Chatter.prototype, {
     setup() {
+        this.highlightMessage = router.current.highlight_message_id;
         super.setup(...arguments);
         this.topRef = useRef("top");
         onWillPatch(() => {
-            // Keep the composer position under the page header on scrolling 
+            // Keep the composer position under the page header on scrolling
             // unless the header is on the side.
             const headerEl = document.querySelector("#wrapwrap header");
             if (!this.props.twoColumns && headerEl && !headerEl.matches(".o_header_sidebar")) {

--- a/addons/test_mail_full/controllers/portal.py
+++ b/addons/test_mail_full/controllers/portal.py
@@ -35,3 +35,8 @@ class PortalTest(http.Controller):
     @http.route('/test_portal/public_type/<int:res_id>', type='http', auth='public', methods=['GET'])
     def test_public_record_view(self, res_id):
         return request.make_response(f'Testing public controller for {res_id}')
+
+    @http.route("/my/test_portal_no_partner/<int:res_id>", type="http", auth="public", website=True)
+    def test_no_partner_portal_record_page(self, res_id, **kwargs):
+        record = request.env["mail.test.portal.no.partner"]._get_thread_with_access(res_id, **kwargs)
+        return request.render("test_mail_full.test_portal_template", {"object": record})

--- a/addons/test_mail_full/static/tests/tours/portal_message_highlight_tour.js
+++ b/addons/test_mail_full/static/tests/tours/portal_message_highlight_tour.js
@@ -1,0 +1,12 @@
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("portal_message_highlight_tour", {
+    steps: () => [
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Message:contains(Test Message)",
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-highlighted:contains(Test Message)"
+        },
+    ],
+});

--- a/addons/test_mail_full/tests/test_ui.py
+++ b/addons/test_mail_full/tests/test_ui.py
@@ -3,6 +3,7 @@
 from urllib.parse import urlencode
 
 from odoo import tests
+from odoo.addons.mail.tests.common import mail_new_test_user
 from odoo.addons.test_mail_full.tests.test_portal import TestPortal
 
 
@@ -74,4 +75,29 @@ class TestUIPortal(TestPortal):
         self.start_tour(
             f"/my/test_portal_rating_records/{record_rating.id}?token={record_rating._portal_ensure_token()}",
             "portal_rating_tour",
+        )
+
+    def test_message_highlight(self):
+        self.record_portal_no_partner = self.env['mail.test.portal.no.partner'].create({
+            'name': 'Test Portal Record',
+        })
+        self.record_portal_message = self.env["mail.message"].create(
+            {
+                "author_id": self.user_employee.partner_id.id,
+                "body": "Test Message",
+                "model": self.record_portal_no_partner._name,
+                "res_id": self.record_portal_no_partner.id,
+                "subtype_id": self.ref("mail.mt_comment"),
+            }
+        )
+        self.user_portal = mail_new_test_user(
+            self.env,
+            groups='base.group_portal',
+            login='user_portal',
+        )
+        self.record_portal_no_partner.message_subscribe(partner_ids=[self.user_portal.partner_id.id])
+        self.start_tour(
+            f"/mail/message/{self.record_portal_message.id}",
+            "portal_message_highlight_tour",
+            login=self.user_portal.login,
         )


### PR DESCRIPTION
*= portal, test_mail_full

**Current behavior before PR:**

Opening a copied message link does not automatically scroll to the message for portal users, it only opens the record.

**Desired behavior after PR is merged:**

Opening the copied link now automatically scrolls to the specific message within the record instead of just opening the record.

**task-id**:4518058

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
