### PR TITLE
[FIX] l10n_fr_account: do not export lines without account_id

### DIFF
--- a/addons/l10n_fr_account/tests/test_fec_export.py
+++ b/addons/l10n_fr_account/tests/test_fec_export.py
@@ -6,7 +6,16 @@ from odoo.tests.common import tagged
 class TestFECExport(AccountTestInvoicingCommon):
     def test_fec_export(self):
         self.init_invoice("out_invoice", self.partner_a, "2019-01-01", amounts=[1000, 2000], post=True)
-        self.init_invoice("out_invoice", self.partner_a, "2020-01-01", amounts=[1000, 2000], post=True)
+        inv = self.init_invoice("out_invoice", self.partner_a, "2020-01-01", amounts=[1000, 2000])
+        inv.write({
+            "line_ids": [
+                Command.create({
+                    "name": "Note",
+                    "display_type": "line_note",
+                })
+            ]
+        })
+        inv.action_post()
         # Create a new FEC export
         fec_export = self.env['l10n_fr.fec.export.wizard'].create({
             'date_from': '2020-01-01',

--- a/addons/l10n_fr_account/wizard/account_fr_fec_export_wizard.py
+++ b/addons/l10n_fr_account/wizard/account_fr_fec_export_wizard.py
@@ -263,7 +263,7 @@ class FecExportWizard(models.TransientModel):
             limit=query_limit + 1,
             order='date, move_name, id',
         )
-        account_alias = query.left_join('account_move_line', 'account_id', 'account_account', 'id', 'account_id')
+        account_alias = query.join('account_move_line', 'account_id', 'account_account', 'id', 'account_id')
         aa_code = self.env['account.account']._field_to_sql(account_alias, 'code', query)
 
         aj_name = self.env['account.journal']._field_to_sql('account_move_line__journal_id', 'name')


### PR DESCRIPTION
Step to reproduce:
- for l10n_fr Localization
- Create a customer invoice and add a note or Add a section .
- Go to accounting > reporting > FEC
- Export FEC (don't exclude 0 lines)

Obseravtion:
- The journal items with note and section will be included in the FEC

Cause:
- for Fec report, we consider move_line which do not have account_id linked to it, due to left_join, hence lines with  display_type line_note or line_section are included

Fix:
- use `join` instead of `left_join`
- **v17.0, when the behaviour was as expected**

https://github.com/odoo/odoo/blob/3d3898b442379d7416da0ee7e363b6587c725218/addons/l10n_fr_fec/wizard/account_fr_fec.py#L194-L196

opw-5079457


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
