### PR TITLE
[FIX] web: removed horizontal scrolling from many2x dropdown

### DIFF
--- a/addons/web/static/src/core/select_menu/select_menu.xml
+++ b/addons/web/static/src/core/select_menu/select_menu.xml
@@ -88,12 +88,12 @@
         <DropdownItem
             t-if="!choice.isGroup"
             onSelected="() => this.onItemSelected(choice.value)"
-            class="getItemClass(choice) + ' d-flex align-items-center'"
+            class="getItemClass(choice) + ' text-wrap'"
             attrs="{ 'data-choice-index': choice_index }"
         >
             <t t-if="props.slots and props.slots.choice" t-slot="choice" data="choice"/>
             <t t-else="">
-                <div class="text-wrap" t-esc="choice.label || choice.value" />
+                <div t-esc="choice.label || choice.value" />
             </t>
         </DropdownItem>
     </t>


### PR DESCRIPTION
Steps to Reproduce:
1. Install `eCommerce`.
2. Add a product with a name longer than 30 characters.
3. Drop the _Add to Cart_ snippet.
4. In Choose record option, search for the product.
5. Hover over the product name and try to scroll horizontally.

Issue:
The product name does not wrap, causing horizontal scrolling. Additionally, the hover background is applied only to the visible viewport area, breaking visual consistency.

Cause:
The dropdown items had `d-flex`, which makes them flex containers. By default, flex containers prevent text from wrapping and force content to stay on a single line, which caused horizontal overflow.

Fix:
Removed the `d-flex` class from the _DropdownItem_ and added `text-wrap` to allow product names to wrap onto multiple lines. This eliminates horizontal scrolling and ensures the hover background covers the entire item. Additionally, removed the `align-items-center` class from _DropdownItem_ and `text-wrap` from the child div, as they were unnecessary.

Behaviour in 18.4:
<img width="1042" height="441" alt="image" src="https://github.com/user-attachments/assets/377047d0-0ea0-4ad8-8f6c-7a62ebf56398" />
