### PR TITLE
[FIX] snailmail_account: error when move linked to Snailmail Letter is deleted

### DIFF
--- a/addons/snailmail_account/models/__init__.py
+++ b/addons/snailmail_account/models/__init__.py
@@ -1,2 +1,3 @@
+from . import account_move
 from . import account_move_send
 from . import res_partner

--- a/addons/snailmail_account/models/account_move.py
+++ b/addons/snailmail_account/models/account_move.py
@@ -1,0 +1,13 @@
+from odoo import api, models
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    @api.ondelete(at_uninstall=False)
+    def unlink_snailmail_letters(self):
+        snailmail_letters = self.env['snailmail.letter'].search([
+            ('model', '=', 'account.move'),
+            ('res_id', 'in', self.ids),
+        ])
+        snailmail_letters.unlink()


### PR DESCRIPTION
When an account move linked to a snailmail letter is deleted,
the cron ``Snailmail: process letters queue`` crashes with a traceback.

Steps to reproduce the error:

- Create a new invoice > Confirm > Send > Select ``By post`` > Send
- Reset to Draft > Delete the invoice
- Run the cron ``Snailmail: process letters queue``

Traceback:
```
MissingError
Record does not exist or has been deleted.
(Record: account.move(1,), User: 1)
```

Solution:
Ensure that when a move is deleted, its related Snailmail letters are also deleted.

sentry-6883768061

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
