### PR TITLE
[FIX] point_of_sale: ensure syncing of last changes

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -368,6 +368,7 @@ export class PosOrder extends Base {
         this.last_order_preparation_change.metadata = {
             serverDate: serializeDateTime(DateTime.now()),
         };
+        this.setDirty();
     }
 
     hasSkippedChanges() {


### PR DESCRIPTION
Before this commit, if an order had no changes and no preparation display was active, adding items to the order in the restaurant PoS and then returning to the tables would sync the order to the server and mark it as not dirty. As a result, reopening the order and clicking the order button to send it to the preparation display or printer would not sync the updated changes. This caused inconsistencies and errors.

Steps to reproduce:
1. Open a table, place an order, and send it to the kitchen printer
2. Add more products but instead of placing the order, go back
3. Re-enter the table, place the order, and send it
4. When placing another order, the error "Order Outdated" appears

This commit fixes the syncing logic to ensure that last changes are properly synced, avoiding the "Order Outdated" error.

opw-5097566

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
