### PR TITLE
[FIX] website_sale_collect: set default pickup location

### DIFF
--- a/addons/website_sale/static/src/js/checkout.js
+++ b/addons/website_sale/static/src/js/checkout.js
@@ -434,6 +434,7 @@ publicWidget.registry.WebsiteSaleCheckout = publicWidget.Widget.extend({
             if (checkedRadio) {
                 await this._updateDeliveryMethod(checkedRadio);
                 this._enableMainButton();
+                await this._showPickupLocation(checkedRadio);
             }
         }
         // Asynchronously fetch delivery rates to mitigate delays from third-party APIs

--- a/addons/website_sale_collect/static/src/tests/tours/buy_with_click_and_collect.js
+++ b/addons/website_sale_collect/static/src/tests/tours/buy_with_click_and_collect.js
@@ -2,67 +2,79 @@ import {registry} from '@web/core/registry';
 import {clickOnElement} from '@website/js/tours/tour_utils';
 import * as tourUtils from '@website_sale/js/tours/tour_utils';
 
+const addToCartAndPay = () => [
+    clickOnElement('Add to cart', '#add_to_cart'),
+    tourUtils.goToCart({quantity: 1}),
+    tourUtils.goToCheckout(),
+    {
+        content: "Fill delivery address form",
+        trigger: 'select[name="country_id"]',
+        run: 'selectByLabel Belgium',
+    },
+    {
+        trigger: 'input[name="name"]',
+        run: 'edit Name',
+    },
+    {
+        trigger: 'input[name="phone"]',
+        run: 'edit 99999999',
+    },
+    {
+        trigger: 'input[name="email"]',
+        run: 'edit test@odoo.com',
+    },
+    {
+        trigger: 'input[name="street"]',
+        run: 'edit Test Street',
+    },
+    {
+        trigger: 'input[name="city"]',
+        run: 'edit Test City',
+    },
+    {
+        trigger: 'input[name="zip"]',
+        run: 'edit 10000',
+    },
+    {
+        content: "Click on confirm button",
+        trigger: '[name="website_sale_main_button"]',
+        run: 'click',
+    },
+    {
+        content: "Ensure in store delivery method is selected.",
+        trigger: 'input[name="o_delivery_radio"][data-delivery-type="in_store"]:checked',
+    },
+    {
+        content: "Check the pickup address is set.",
+        trigger: 'b[name="o_pickup_location_name"]:contains("Shop 1")',
+    },
+    tourUtils.confirmOrder(),
+    {
+        content: "Select `Pay on site`  payment method",
+        trigger: 'input[name="o_payment_radio"][data-payment-method-code="pay_on_site"]',
+        run: 'click',
+    },
+    ...tourUtils.pay({ expectUnloadPage: true, waitFinalizeYourPayment: true }),
+    {
+        content: "Check payment status confirmation window",
+        trigger: '.oe_website_sale_tx_status[data-order-tracking-info]',
+    },
+];
+
 registry.category('web_tour.tours').add('website_sale_collect_buy_product', {
     url: '/shop',
     steps: () => [
         ...tourUtils.searchProduct("Test CAC Product", { select: true }),
         clickOnElement("Open Location selector", '[name="click_and_collect_availability"]'),
         clickOnElement("Choose location", '#submit_location_large'),
-        clickOnElement('Add to cart', '#add_to_cart'),
-        tourUtils.goToCart({quantity: 1}),
-        tourUtils.goToCheckout(),
-        {
-            content: "Fill delivery address form",
-            trigger: 'select[name="country_id"]',
-            run: 'selectByLabel Belgium',
-        },
-        {
-            trigger: 'input[name="name"]',
-            run: 'edit Name',
-        },
-        {
-            trigger: 'input[name="phone"]',
-            run: 'edit 99999999',
-        },
-        {
-            trigger: 'input[name="email"]',
-            run: 'edit test@odoo.com',
-        },
-        {
-            trigger: 'input[name="street"]',
-            run: 'edit Test Street',
-        },
-        {
-            trigger: 'input[name="city"]',
-            run: 'edit Test City',
-        },
-        {
-            trigger: 'input[name="zip"]',
-            run: 'edit 10000',
-        },
-        {
-            content: "Click on confirm button",
-            trigger: '[name="website_sale_main_button"]',
-            run: 'click',
-        },
-        {
-            content: "Ensure in store delivery method is selected.",
-            trigger: 'input[name="o_delivery_radio"][data-delivery-type="in_store"]:checked',
-        },
-        {
-            content: "Check the pickup address is set.",
-            trigger: 'b[name="o_pickup_location_name"]:contains("Shop 1")',
-        },
-        tourUtils.confirmOrder(),
-        {
-            content: "Select `Pay on site`  payment method",
-            trigger: 'input[name="o_payment_radio"][data-payment-method-code="pay_on_site"]',
-            run: 'click',
-        },
-        ...tourUtils.pay({ expectUnloadPage: true, waitFinalizeYourPayment: true }),
-        {
-            content: "Check payment status confirmation window",
-            trigger: '.oe_website_sale_tx_status[data-order-tracking-info]',
-        },
+        ...addToCartAndPay(),
+    ],
+});
+
+registry.category('web_tour.tours').add('website_sale_collect_buy_product_default_location_pick_up_in_store', {
+    url: '/shop',
+    steps: () => [
+        ...tourUtils.searchProduct("Test CAC Product", { select: true }),
+        ...addToCartAndPay(),
     ],
 });

--- a/addons/website_sale_collect/tests/test_click_and_collect_flow.py
+++ b/addons/website_sale_collect/tests/test_click_and_collect_flow.py
@@ -9,20 +9,37 @@ from odoo.addons.website_sale_collect.tests.common import ClickAndCollectCommon
 @tagged('post_install', '-at_install')
 class TestClickAndCollectFlow(HttpCase, ClickAndCollectCommon):
 
-    def test_buy_with_click_and_collect_as_public_user(self):
-        self.storable_product.name = "Test CAC Product"
-        self.provider.write(
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.storable_product.name = "Test CAC Product"
+        cls.provider.write(
             {
                 'state': 'enabled',
                 'is_published': True,
             }
         )
-        self.in_store_dm.warehouse_ids[0].partner_id = self.env['res.partner'].create(
+        cls.in_store_dm.warehouse_ids[0].partner_id = cls.env['res.partner'].create(
             {
-                **self.dummy_partner_address_values,
+                **cls.dummy_partner_address_values,
                 'name': "Shop 1",
                 'partner_latitude': 1.0,
                 'partner_longitude': 2.0,
             }
         )
+
+    def test_buy_with_click_and_collect_as_public_user(self):
+        """
+        Test the basic flow of buying with click and collect as a public user with more than
+        one delivery method available
+        """
         self.start_tour('/', 'website_sale_collect_buy_product')
+
+    def test_default_location_is_set_for_pick_up_in_store(self):
+        """
+        Verify that when `Pick Up In Store` is the only active delivery method with the only wh,
+        the checkout flow automatically sets the default store location.
+        """
+        self.env['delivery.carrier'].search([]).active = False
+        self.in_store_dm.active = True
+        self.start_tour('/', 'website_sale_collect_buy_product_default_location_pick_up_in_store')


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

This commit fixes the issue where the pickup location does not get set even though it is present on the checkout page. This happens when the user directly adds an item to cart without specifying the pick up location before adding to cart. This results in the location not being set but at the checkout page, the default pick up location appears as one of the warehouses given the way the default pickup location is set when loading the checkout page values.

This makes the user think that the pickup location is set, but when they try to go to the pay page, an error is thrown saying the pick up location was not specified. This commit sets the pickup location data in such a case.

[This commit] refactored the way in which the default location would be set on the checkout page but did not take into account the possbility that the customer might not select the pickup location when they are adding to cart, thus only rendering the value at the checkout page but not actually setting it.

Refactored the test cases to avoid the redundancy in the setup process.

Steps to reproduce on runbot:
1. Set the pick up in store as the default delivery method by updating the sequence
2. Go the shop on the website and add any item to cart which has stock in the specified pickup location, but don't select the pickup location here
3. Go to the cart and click checkout
4. The default pickup location will be set here
5. Click on Confirm
6. An error will appear saying the location was not set

opw-4954187

[This commit]: https://github.com/odoo/odoo/commit/1d3942c75e59ac9538d112df43b4e39f2462fee4

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
