### PR TITLE
[IMP] stock*: track current user in chatter for manual replenishment

### DIFF
--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -113,8 +113,10 @@ class StockRule(models.Model):
 
         for company_id in new_productions_values_by_company:
             productions_vals_list = new_productions_values_by_company[company_id]['values']
-            # create the MO as SUPERUSER because the current user may not have the rights to do it (mto product launched by a sale for example)
-            productions = self.env['mrp.production'].with_user(SUPERUSER_ID).sudo().with_company(company_id).create(productions_vals_list)
+            # Create the MO using the current logged-in user if the replenishment is triggered manually.
+            # Otherwise, fallback to SUPERUSER_ID (e.g., MO generated from sales orders).
+            user_id = (self.env.context.get('manual_replenishment') and self.env.uid) or SUPERUSER_ID
+            productions = self.env['mrp.production'].with_user(user_id).sudo().with_company(company_id).create(productions_vals_list)
             for mo in productions:
                 if self._should_auto_confirm_procurement_mo(mo):
                     mo.action_confirm()

--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -108,9 +108,10 @@ class StockRule(models.Model):
                     vals = rules[0]._prepare_purchase_order(company_id, origins, positive_values)
                     # The company_id is the same for all procurements since
                     # _make_po_get_domain add the company in the domain.
-                    # We use SUPERUSER_ID since we don't want the current user to be follower of the PO.
-                    # Indeed, the current user may be a user without access to Purchase, or even be a portal user.
-                    po = self.env['purchase.order'].with_company(company_id).with_user(SUPERUSER_ID).create(vals)
+                    # Create the PO using the current logged-in user if the replenishment is triggered manually.
+                    # Otherwise, fallback to SUPERUSER_ID (e.g., PO generated from sales orders).
+                    user_id = (self.env.context.get('manual_replenishment') and self.env.uid) or SUPERUSER_ID
+                    po = self.env['purchase.order'].with_company(company_id).with_user(user_id).sudo().create(vals)
             else:
                 reference_ids = set()
                 for procurement in procurements:

--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -344,7 +344,7 @@ class StockWarehouseOrderpoint(models.Model):
             for orderpoint in self:
                 orderpoint.qty_to_order = orderpoint._get_multiple_rounded_qty(orderpoint.product_max_qty - orderpoint.qty_forecast)
         try:
-            self._procure_orderpoint_confirm(company_id=self.env.company)
+            self.with_context(manual_replenishment=True)._procure_orderpoint_confirm(company_id=self.env.company)
         except UserError as e:
             if len(self) != 1:
                 raise e

--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -355,7 +355,7 @@ class StockWarehouseOrderpoint(models.Model):
         for orderpoint in self:
             orderpoint.qty_to_order = orderpoint.qty_to_order_manual or orderpoint.qty_to_order_to_max
         try:
-            self._procure_orderpoint_confirm(company_id=self.env.company)
+            self.with_context(manual_replenishment=True)._procure_orderpoint_confirm(company_id=self.env.company)
         except UserError as e:
             if len(self) != 1:
                 raise e

--- a/addons/stock/wizard/product_replenish.py
+++ b/addons/stock/wizard/product_replenish.py
@@ -90,7 +90,7 @@ class ProductReplenish(models.TransientModel):
     def launch_replenishment(self):
         try:
             now = self.env.cr.now()
-            self.env['stock.rule'].with_context(clean_context(self.env.context)).run([
+            self.env['stock.rule'].with_context(clean_context(self.env.context), manual_replenishment=True).run([
                 self.env['stock.rule'].Procurement(
                     self.product_id,
                     self.quantity,

--- a/addons/stock/wizard/product_replenish.py
+++ b/addons/stock/wizard/product_replenish.py
@@ -89,7 +89,7 @@ class ProductReplenish(models.TransientModel):
     def launch_replenishment(self):
         try:
             now = self.env.cr.now()
-            self.env['stock.rule'].with_context(clean_context(self.env.context)).run([
+            self.env['stock.rule'].with_context(clean_context(self.env.context), manual_replenishment=True).run([
                 self.env['stock.rule'].Procurement(
                     self.product_id,
                     self.quantity,


### PR DESCRIPTION
*=mrp,purchase_stock

Purpose:
=================
When a user replenishes a product by clicking the `Replenish button` in the product’s forecasted quantity view or orders from the `Replenishment menu`, a `Purchase Order / Manufacturing Order` is created based on the selected route. Currently, the chatter logs show `OdooBot` as the creator of the record. This makes it unclear, as all replenishment records show OdooBot as the creator, preventing users from distinguishing manually placed replenishment from those automatically generated by OdooBot. Recording the actual user (logged-in user) in the chatter who triggered a manual replenishment improves accountability and provides clear visibility, making it easier to audit.

With This Commit:
=================
When a user triggers a manual replenishment, the system sets the creator of the record to the `current user` for manual replenishment, or otherwise to `OdooBot` for auto-generated replenishments. This ensures the chatter correctly shows who actually created the record. This makes it easier to track who placed manual replenishments and improves accountability.

Enterprise PR : https://github.com/odoo/enterprise/pull/95464
TaskID–4893809