### PR TITLE
[FIX] l10n_cz: accounting date and sequence number for demo moves

### DIFF
--- a/addons/l10n_cz/models/template_cz.py
+++ b/addons/l10n_cz/models/template_cz.py
@@ -1,5 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from odoo import models
+from odoo import api, models
 from odoo.addons.account.models.chart_template import template
 
 
@@ -38,3 +38,29 @@ class AccountChartTemplate(models.AbstractModel):
                 'account_purchase_tax_id': 'l10n_cz_21_receipt_domestic_supplies',
             },
         }
+
+    @api.model
+    def _get_demo_data_move(self, company=False):
+        data = super()._get_demo_data_move(company)
+        if company and company.account_fiscal_country_id.code == 'CZ':
+            for key in (
+                'demo_invoice_1',
+                'demo_invoice_2',
+                'demo_invoice_3',
+                'demo_invoice_followup',
+                'demo_invoice_5',
+                'demo_invoice_equipment_purchase',
+                'demo_move_auto_reconcile_1',
+                'demo_move_auto_reconcile_2',
+                'demo_move_auto_reconcile_3',
+                'demo_move_auto_reconcile_4',
+                'demo_move_auto_reconcile_5',
+                'demo_move_auto_reconcile_6',
+                'demo_move_auto_reconcile_7',
+                'demo_move_auto_reconcile_8',
+                'demo_move_auto_reconcile_9',
+            ):
+                vals = data[key]
+                if invoice_date := vals.get('invoice_date'):
+                    vals['taxable_supply_date'] = invoice_date
+        return data


### PR DESCRIPTION
## [FIX] l10n_cz: prevent error with misaligned accounting date and sequence number of demo moves

#### Description of the issue/feature this PR addresses:
Editing CZ Company address while having demo data throws Validation Error

#### Current behavior before PR:
When trying to change address of CZ Company while l10n_cz with demo data is present an error popup is displayed and it's not possible to to save the changes. Steps to reproduce:
 - Install l10n_cz with demo data
 - Open CZ Company in form view
 - Change address (e.g. change city Praha -> Brno)
 - Click Save

#### Desired behavior after PR is merged:
The address changes are saved without any error.

#### Solution:
This change adds `taxable_supply_date` date values for CZ demo moves that are compatible with `invoice_date` values to make sure that accounting date values are the same on each recomputatation and do not lead to new sequence numbers that are not aligned with the previous ones which would cause errors being raised by sequence mixin.

Related to: #226152







---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
