### PR TITLE
[FIX] barcodes: enforce minimum barcode length

### DIFF
--- a/addons/barcodes/static/src/barcode_service.js
+++ b/addons/barcodes/static/src/barcode_service.js
@@ -4,6 +4,7 @@ import { isBrowserChrome, isMobileOS } from "@web/core/browser/feature_detection
 import { registry } from "@web/core/registry";
 import { session } from "@web/session";
 import { EventBus, whenReady } from "@odoo/owl";
+import { _t } from "@web/core/l10n/translation";
 
 function isEditable(element) {
     return element.matches('input,textarea,[contenteditable="true"]');
@@ -30,8 +31,8 @@ export const barcodeService = {
     cleanBarcode: function(barcode) {
         return barcode.replace(/Alt|Shift|Control/g, '');
     },
-
-    start() {
+    dependencies: ["notification"],
+    start(_env, { notification }) {
         const bus = new EventBus();
         let timeout = null;
 
@@ -58,6 +59,8 @@ export const barcodeService = {
                     ev.preventDefault();
                 }
                 handleBarcode(str, currentTarget);
+            } else {
+                notification.add(_t("Barcode must be at least 3 characters: %s", str), { type: "danger" });
             }
             if (barcodeInput) {
                 barcodeInput.value = "";


### PR DESCRIPTION
When scanning a barcode shorter than 3 characters, the system previously failed silently, leaving users without feedback and unclear whether the scan was processed.

This fix adds a notification to inform the user that barcodes must be at least 3 characters long.

Steps to reproduce (17.0+):
Scan a barcode shorter than 3 characters.

Expected result:
A notification is displayed indicating that the scanned barcode is invalid.

Actual result:
The scan is ignored silently with no feedback to the user

opw-5041723

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
