### PR TITLE
[FIX] point_of_sale: Adapt pos_reference length

### DIFF
--- a/addons/point_of_sale/controllers/main.py
+++ b/addons/point_of_sale/controllers/main.py
@@ -134,8 +134,8 @@ class PosController(PortalAccount):
 
             if errors:
                 errors['generic'] = _("Please fill all the required fields.")
-            elif len(form_values['pos_reference']) < 14:
-                errors['pos_reference'] = _("The Ticket Number should be at least 14 characters long.")
+            elif len(form_values['pos_reference']) < 12:
+                errors['pos_reference'] = _("The Ticket Number should be at least 12 characters long.")
             else:
                 date_order = datetime(*[int(i) for i in form_values['date_order'].split('-')])
                 order = request.env['pos.order'].sudo().search([


### PR DESCRIPTION
This commit (https://github.com/odoo/odoo/commit/2ead34e974f55dadf791ff6b2924edbf43442b34) introduced a revamp of sequence management in POS. However this part of the code was still taking into account the old format which would then trigger an error when accessing /pos/ticket to try to view a POS ticket.
