### PR TITLE
[IMP] web, mail: improve states of systray items

### DIFF
--- a/addons/auth_passkey/static/tests/passkeys_delete.js
+++ b/addons/auth_passkey/static/tests/passkeys_delete.js
@@ -5,7 +5,7 @@ registry.category("web_tour.tours").add('passkeys_tour_delete', {
     steps: () => [
         {
             content: 'Open user account menu',
-            trigger: '.o_user_menu .dropdown-toggle',
+            trigger: '.o_user_menu',
             run: 'click',
         }, {
             content: "Open preferences / profile screen",
@@ -49,7 +49,7 @@ registry.category("web_tour.tours").add('passkeys_tour_delete', {
             run: "click",
         }, {
             content: 'Open user account menu',
-            trigger: '.o_user_menu .dropdown-toggle',
+            trigger: '.o_user_menu',
             run: 'click',
         }, {
             content: "Open preferences / profile screen",

--- a/addons/auth_passkey/static/tests/passkeys_login.js
+++ b/addons/auth_passkey/static/tests/passkeys_login.js
@@ -36,7 +36,7 @@ registry.category("web_tour.tours").add('passkeys_tour_login', {
             expectUnloadPage: true,
         }, {
             content: 'Check if we are logged in',
-            trigger: '.o_user_menu .dropdown-toggle',
+            trigger: '.o_user_menu',
         },
     ]
 })

--- a/addons/auth_passkey/static/tests/passkeys_registration.js
+++ b/addons/auth_passkey/static/tests/passkeys_registration.js
@@ -9,7 +9,7 @@ registry.category("web_tour.tours").add('passkeys_tour_registration', {
     steps: () => [
         {
             content: 'Open user account menu',
-            trigger: '.o_user_menu .dropdown-toggle',
+            trigger: '.o_user_menu',
             run: 'click',
         }, {
             content: "Open preferences / profile screen",
@@ -84,7 +84,7 @@ registry.category("web_tour.tours").add('passkeys_tour_registration', {
             run: "click",
         }, {
             content: 'Open user account menu',
-            trigger: '.o_user_menu .dropdown-toggle',
+            trigger: '.o_user_menu',
             run: 'click',
         }, {
             content: "Return startRegistration to original state",

--- a/addons/auth_passkey/static/tests/passkeys_verify.js
+++ b/addons/auth_passkey/static/tests/passkeys_verify.js
@@ -9,7 +9,7 @@ registry.category("web_tour.tours").add('passkeys_tour_verify', {
     steps: () => [
         {
             content: 'Open user account menu',
-            trigger: '.o_user_menu .dropdown-toggle',
+            trigger: '.o_user_menu',
             run: 'click',
         }, {
             content: "Open preferences / profile screen",

--- a/addons/auth_totp/static/tests/apikeys_flow.js
+++ b/addons/auth_totp/static/tests/apikeys_flow.js
@@ -3,7 +3,7 @@ import { registry } from "@web/core/registry";
 
 const openUserPreferenceSecurity = () => [{
     content: 'Open user account menu',
-    trigger: '.o_user_menu .dropdown-toggle',
+    trigger: '.o_user_menu',
     run: 'click',
 }, {
     content: "Open preferences / profile screen",
@@ -71,7 +71,7 @@ registry.category("web_tour.tours").add('apikeys_tour_teardown', {
     url: '/odoo?debug=1', // Needed as API key part is now only displayed in debug mode
     steps: () => [{
     content: 'Open preferences',
-    trigger: '.o_user_menu .dropdown-toggle',
+    trigger: '.o_user_menu',
     run: "click",
 }, {
     trigger: '[data-menu=preferences]',
@@ -98,7 +98,7 @@ registry.category("web_tour.tours").add('apikeys_tour_teardown', {
 },
 {
     content: 'Re-open preferences again',
-    trigger: '.o_user_menu .dropdown-toggle',
+    trigger: '.o_user_menu',
     run: "click",
 }, {
     trigger: '[data-menu=preferences]',

--- a/addons/auth_totp/static/tests/totp_flow.js
+++ b/addons/auth_totp/static/tests/totp_flow.js
@@ -21,7 +21,7 @@ function openRoot() {
 function openUserPreferencesAtSecurityTab() {
     return [{
         content: 'Open user account menu',
-        trigger: '.o_user_menu .dropdown-toggle',
+        trigger: '.o_user_menu',
         run: 'click',
     }, {
         content: "Open My Preferences",
@@ -199,7 +199,7 @@ registry.category("web_tour.tours").add('totp_login_enabled', {
     expectUnloadPage: true,
 }, {
     content: "check we're logged in",
-    trigger: ".o_user_menu .dropdown-toggle",
+    trigger: ".o_user_menu",
 }]});
 
 registry.category("web_tour.tours").add('totp_login_device', {
@@ -264,7 +264,7 @@ registry.category("web_tour.tours").add('totp_login_device', {
 },
 {
     content: "check we're logged in",
-    trigger: ".o_user_menu .dropdown-toggle",
+    trigger: ".o_user_menu",
     run: 'click',
 }, {
     content: "click the Log out button",
@@ -290,7 +290,7 @@ registry.category("web_tour.tours").add('totp_login_device', {
     expectUnloadPage: true,
 },  {
     content: "check we're logged in without 2FA",
-    trigger: ".o_user_menu .dropdown-toggle",
+    trigger: ".o_user_menu",
 },
 // now go and disable two-factor authentication would be annoying to do in a separate tour
 // because we'd need to login & totp again as HttpCase.authenticate can't

--- a/addons/hr/static/tests/tours/hr_employee_flow.js
+++ b/addons/hr/static/tests/tours/hr_employee_flow.js
@@ -17,7 +17,7 @@ registry.category("web_tour.tours").add("hr_employee_tour", {
         },
         {
             content: "Open user account menu",
-            trigger: ".o_user_menu .dropdown-toggle",
+            trigger: ".o_user_menu",
             run: "click",
         },
         {

--- a/addons/hr_holidays/static/src/tours/hr_leave_type_tour.js
+++ b/addons/hr_holidays/static/src/tours/hr_leave_type_tour.js
@@ -122,7 +122,7 @@ registry.category("web_tour.tours").add("hr_leave_type_tour", {
                 "Make sure that the leave is approved by checking that the cancel button appears",
         },
         {
-            trigger: ".o_switch_company_menu button",
+            trigger: ".o_switch_company_menu",
             content: "Open the companies selection menu",
             tooltipPosition: "bottom",
             run: "click",

--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -357,13 +357,6 @@ a.o-discuss-mention {
     --border-color: #{$o-gray-300} !important; // cancel custom border color of dropdown
 }
 
-.o-mail-DiscussSystray-class {
-    margin-top: - $o-navbar-padding-v; // cancel navbar padding
-    margin-bottom: - $o-navbar-padding-v; // cancel navbar padding
-    display: flex;
-    align-items: center;
-}
-
 .o-mail-systrayFullscreenDropdownMenu {
     top: $o-navbar-height !important;
     height: calc(100% - #{$o-navbar-height}); // no bottom-0 otherwise performance issue

--- a/addons/mail/static/src/core/web/messaging_menu_patch.xml
+++ b/addons/mail/static/src/core/web/messaging_menu_patch.xml
@@ -2,17 +2,15 @@
 <templates xml:space="preserve">
     <t t-inherit="mail.MessagingMenu" t-inherit-mode="extension">
         <xpath expr="//*[@t-name='mail.MessagingMenu']" position="inside">
-            <div t-if="!env.inDiscussApp" t-att-class="discussSystray.class">
-                <Dropdown state="dropdown" beforeOpen.bind="beforeOpen" position="'bottom-end'" menuClass="discussSystray.menuClass" bottomSheet="false">
-                    <button class="bg-transparent">
-                        <i class="fa fa-lg fa-comments" role="img" aria-label="Messages" t-on-click="() => store.discuss.activeTab = ui.isSmall and store.discuss.activeTab === 'notification' ? 'notification' : store.discuss.activeTab"></i>
-                        <span t-if="counter" class="o-mail-MessagingMenu-counter badge rounded-pill"><t t-esc="counter"/></span>
-                    </button>
-                    <t t-set-slot="content">
-                        <t t-call="mail.MessagingMenu.content"/>
-                    </t>
-                </Dropdown>
-            </div>
+            <Dropdown t-if="!env.inDiscussApp" state="dropdown" beforeOpen.bind="beforeOpen" position="'bottom-end'" menuClass="discussSystray.menuClass" bottomSheet="false">
+                <button t-att-class="discussSystray.class">
+                    <i class="fa fa-lg fa-comments" role="img" aria-label="Messages" t-on-click="() => store.discuss.activeTab = ui.isSmall and store.discuss.activeTab === 'notification' ? 'notification' : store.discuss.activeTab"></i>
+                    <span t-if="counter" class="o-mail-MessagingMenu-counter badge rounded-pill"><t t-esc="counter"/></span>
+                </button>
+                <t t-set-slot="content">
+                    <t t-call="mail.MessagingMenu.content"/>
+                </t>
+            </Dropdown>
         </xpath>
     </t>
 

--- a/addons/mail/static/src/discuss/core/web/user_menu_patch.xml
+++ b/addons/mail/static/src/discuss/core/web/user_menu_patch.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">  
     <t t-inherit="web.UserMenu" t-inherit-mode="extension">
         <xpath expr="//img[hasclass('o_user_avatar')]" position="replace">
-            <div class="position-relative d-flex flex-shrink-0 bg-inherit">
+            <div class="position-relative d-flex flex-shrink-0">
                 <t>$0</t>
                 <ImStatus className="'o-web-UserMenu-imStatus position-absolute'" persona="store.self" size="'md'"/>
             </div>

--- a/addons/mail/static/tests/tours/user_modify_own_profile_tour.js
+++ b/addons/mail/static/tests/tours/user_modify_own_profile_tour.js
@@ -8,7 +8,7 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/user_modify_own
     steps: () => [
         {
             content: "Open user account menu",
-            trigger: ".o_user_menu button",
+            trigger: ".o_user_menu",
             run: "click",
         },
         {

--- a/addons/web/static/src/webclient/burger_menu/burger_menu.xml
+++ b/addons/web/static/src/webclient/burger_menu/burger_menu.xml
@@ -3,33 +3,32 @@
 
 <!-- Owl Templates -->
 
-<div t-name="web.BurgerMenu" class="d-flex">
-    <button
-        class="o_mobile_menu_toggle o_nav_entry o-no-caret d-md-none border-0 pe-3"
-        title="Toggle menu" aria-label="Toggle menu"
-        t-on-click="_openBurger">
-        <img class="o_burger_menu_avatar o_image_24_cover rounded" t-att-src="'/web/image?model=res.users&amp;field=avatar_128&amp;id=' + user.userId" alt="Menu"/>
-    </button>
+<t t-name="web.BurgerMenu">
+  <button
+    class="o_mobile_menu_toggle o_nav_entry o-no-caret d-md-none border-0 pe-3"
+    title="Toggle menu" aria-label="Toggle menu"
+    t-on-click="_openBurger">
+    <img class="o_burger_menu_avatar o_image_24_cover rounded" t-att-src="'/web/image?model=res.users&amp;field=avatar_128&amp;id=' + user.userId" alt="Menu"/>
+  </button>
 
-    <t t-portal="'body'">
-      <Transition name="'o-burger-slide'" visible="state.isBurgerOpened" leaveDuration="200" t-slot-scope="transition">
-        <div class="o_burger_menu position-fixed top-0 bottom-0 start-100 d-flex flex-column flex-nowrap" t-att-class="transition.className" t-on-touchstart.stop="_onSwipeStart" t-on-touchend.stop="_onSwipeEnd">
-          <div class="o_sidebar_topbar d-flex align-items-center justify-content-between flex-shrink-0 py-0 fs-4">
-              <small class="d-flex align-items-center justify-content-between ms-2">
-                  <img class="o_burger_menu_avatar o_image_24_cover rounded" t-att-src="'/web/image?model=res.users&amp;field=avatar_128&amp;id=' + user.userId" alt="Menu"/>
-                  <span class="o_burger_menu_username px-2"><t t-esc="user.name"/></span>
-              </small>
-              <button class="o_sidebar_close oi oi-close btn d-flex align-items-center h-100 bg-transparent border-0 fs-2 text-reset" aria-label="Close menu" title="Close menu" t-on-click.stop="_closeBurger"/>
-          </div>
-          <nav class="o_burger_menu_content flex-grow-1 flex-shrink-1 overflow-auto o_burger_menu_app">
-
-            <MobileSwitchCompanyMenu t-if="user.allowedCompanies.length > 1" />
-            <BurgerUserMenu onMenuClicked.bind="_closeBurger"/>
-          </nav>
+  <t t-portal="'body'">
+    <Transition name="'o-burger-slide'" visible="state.isBurgerOpened" leaveDuration="200" t-slot-scope="transition">
+      <div class="o_burger_menu position-fixed top-0 bottom-0 start-100 d-flex flex-column flex-nowrap" t-att-class="transition.className" t-on-touchstart.stop="_onSwipeStart" t-on-touchend.stop="_onSwipeEnd">
+        <div class="o_sidebar_topbar d-flex align-items-center justify-content-between flex-shrink-0 py-0 fs-4">
+            <small class="d-flex align-items-center justify-content-between ms-2">
+              <img class="o_burger_menu_avatar o_image_24_cover rounded" t-att-src="'/web/image?model=res.users&amp;field=avatar_128&amp;id=' + user.userId" alt="Menu"/>
+              <span class="o_burger_menu_username px-2"><t t-esc="user.name"/></span>
+            </small>
+            <button class="o_sidebar_close oi oi-close btn d-flex align-items-center h-100 bg-transparent border-0 fs-2 text-reset" aria-label="Close menu" title="Close menu" t-on-click.stop="_closeBurger"/>
         </div>
-      </Transition>
-      <div t-if="state.isBurgerOpened" class="modal-backdrop show d-block d-md-none" t-on-click.stop="_closeBurger" t-on-touchstart.stop="_onSwipeStart" t-on-touchend.stop="_onSwipeEnd" />
-    </t>
-</div>
+        <nav class="o_burger_menu_content flex-grow-1 flex-shrink-1 overflow-auto o_burger_menu_app">
+          <MobileSwitchCompanyMenu t-if="user.allowedCompanies.length > 1" />
+          <BurgerUserMenu onMenuClicked.bind="_closeBurger"/>
+        </nav>
+      </div>
+    </Transition>
+    <div t-if="state.isBurgerOpened" class="modal-backdrop show d-block d-md-none" t-on-click.stop="_closeBurger" t-on-touchstart.stop="_onSwipeStart" t-on-touchend.stop="_onSwipeEnd" />
+  </t>
+</t>
 
 </templates>

--- a/addons/web/static/src/webclient/navbar/navbar.scss
+++ b/addons/web/static/src/webclient/navbar/navbar.scss
@@ -10,7 +10,6 @@
     height: var(--o-navbar-height);
     padding-top: $o-navbar-padding-v;
     padding-bottom: $o-navbar-padding-v;
-    border-bottom: $o-navbar-border-bottom;
     background: $o-navbar-background;
     font-size: $o-navbar-font-size;
 
@@ -150,8 +149,12 @@
         border-color: transparent;
     }
 
-    .o_menu_sections {
-        .o_nav_entry, .dropdown-toggle {
+    .o_menu_sections, .o_menu_systray:where(:not(.o_home_menu_background .o_menu_systray)) {
+        .dropdown-toggle:disabled {
+            --NavBar-entry-color--hover: var(--NavBar-entry-color, #{$o-navbar-entry-color});
+        }
+
+        .o_nav_entry, .dropdown-toggle:not(:disabled) {
             background: var(--NavBar-entry-backgroundColor, #{$o-navbar-background});
             border: $border-width solid transparent;
 

--- a/addons/web/static/src/webclient/navbar/navbar.variables.scss
+++ b/addons/web/static/src/webclient/navbar/navbar.variables.scss
@@ -5,10 +5,9 @@ $o-navbar-padding-v: 0px !default;
 $o-navbar-font-size: $o-font-size-base !default;
 
 $o-navbar-background: $o-brand-odoo !default;
-$o-navbar-border-bottom: 1px solid darken($o-brand-odoo, 10%) !default;
 
 $o-navbar-entry-margin-h: 0 !default;
-$o-navbar-entry-padding-h: .63em !default;
+$o-navbar-entry-padding-h: $o-spacer * .5 !default;
 $o-navbar-entry-border-radius: 0 !default;
 $o-navbar-entry-color: rgba($o-white, .9) !default;
 $o-navbar-entry-color--hover: $o-white !default;
@@ -36,8 +35,8 @@ $o-navbar-badge-text-shadow: 1px 1px 0 rgba($o-black, .3) !default;
     display: flex;
     align-items: center;
     width: auto;
-    height: calc(var(--o-navbar-height) - #{$o-navbar-padding-v * 2});
-    border-radius: $o-navbar-entry-border-radius;
+    height: var(--Navbar-entry-height, calc(var(--o-navbar-height) - #{$o-navbar-padding-v} * 2));
+    border-radius: var(--NavBar-entry-borderRadius, #{$o-navbar-entry-border-radius});
     user-select: none;
     background-color: inherit;
     font-size: $o-navbar-entry-font-size;
@@ -49,7 +48,7 @@ $o-navbar-badge-text-shadow: 1px 1px 0 rgba($o-black, .3) !default;
 }
 
 %-main-navbar-entry-spacing {
-    margin: 0;
+    margin: var(--Navbar-entry-margin, 0);
     margin-left: var(--NavBar-entry-margin-left, #{$o-navbar-entry-margin-h});
     margin-right: var(--NavBar-entry-margin-right, #{$o-navbar-entry-margin-h});
     padding: 0;

--- a/addons/web/static/src/webclient/switch_company_menu/switch_company_menu.xml
+++ b/addons/web/static/src/webclient/switch_company_menu/switch_company_menu.xml
@@ -2,28 +2,26 @@
 <templates xml:space="preserve">
 
 <t t-name="web.SwitchCompanyMenu">
-    <div class="o_switch_company_menu d-none d-md-block">
-        <DropdownGroup group="'web-navbar-group'">
-            <Dropdown
-                position="'bottom-end'"
-                menuRef="containerRef"
-                state="this.dropdown"
-                onStateChanged.bind="handleDropdownChange"
-                navigationOptions="navigationOptions"
-                menuClass="'o_switch_company_menu_dropdown'"
-                disabled="isSingleCompany"
-            >
-                <button data-hotkey="shift+u" t-att-disabled="isSingleCompany" t-att-title="user.activeCompany.name">
-                    <i class="fa fa-building d-lg-none"/>
-                    <span class="oe_topbar_name d-none d-lg-block text-truncate" t-esc="user.activeCompany.name"/>
-                </button>
+    <DropdownGroup group="'web-navbar-group'">
+        <Dropdown
+            position="'bottom-end'"
+            menuRef="containerRef"
+            state="this.dropdown"
+            onStateChanged.bind="handleDropdownChange"
+            navigationOptions="navigationOptions"
+            menuClass="'o_switch_company_menu_dropdown'"
+            disabled="isSingleCompany"
+        >
+            <button data-hotkey="shift+u" t-att-disabled="isSingleCompany" t-att-title="user.activeCompany.name" class="o_switch_company_menu d-none d-md-flex">
+                <i class="fa fa-building d-lg-none"/>
+                <span class="oe_topbar_name d-none d-lg-block text-truncate" t-esc="user.activeCompany.name"/>
+            </button>
 
-                <t t-set-slot="content">
-                    <t t-call="web.SwitchCompanyMenu.Items"/>
-                </t>
-            </Dropdown>
-        </DropdownGroup>
-    </div>
+            <t t-set-slot="content">
+                <t t-call="web.SwitchCompanyMenu.Items"/>
+            </t>
+        </Dropdown>
+    </DropdownGroup>
 </t>
 
 <t t-name="web.SwitchCompanyMenu.Items">

--- a/addons/web/static/src/webclient/user_menu/user_menu.scss
+++ b/addons/web/static/src/webclient/user_menu/user_menu.scss
@@ -1,5 +1,5 @@
-.o_user_menu .dropdown-toggle {
-    --NavBar-entry-padding-right: #{$o-horizontal-padding};
+.o_user_menu {
+    --NavBar-entry-margin-right: calc(#{$spacer} - var(--NavBar-entry-padding-right));
 
     .o_user_avatar {
         height: calc(var(--o-navbar-height) - 20px);

--- a/addons/web/static/src/webclient/user_menu/user_menu.xml
+++ b/addons/web/static/src/webclient/user_menu/user_menu.xml
@@ -2,45 +2,43 @@
 <templates xml:space="preserve">
 
     <t t-name="web.UserMenu">
-        <div class="o_user_menu d-none d-md-block pe-0 bg-inherit">
-            <DropdownGroup group="'web-navbar-group'">
-                <Dropdown>
-                    <button class="py-1 py-lg-0">
-                        <img class="o_avatar o_user_avatar rounded" t-att-src="source" alt="User"/>
-                        <small class="oe_topbar_name d-none ms-2 text-start smaller lh-1 text-truncate"  t-att-class="{'d-lg-inline-block' : env.debug}" style="max-width: 200px">
-                            <t t-esc="userName"/>
-                            <mark class="d-block font-monospace text-truncate">
-                                <i class="fa fa-database oi-small me-1"/><t t-esc="dbName"/>
-                            </mark>
-                        </small>
-                    </button>
-                    <t t-set-slot="content">
-                        <t t-foreach="getElements()" t-as="element" t-key="element_index">
-                            <t t-if="!element.hide">
-                                <t t-if="element.type === 'component'" t-component="element.contentComponent"/>
-                                <DropdownItem
-                                    t-if="element.type == 'item' || element.type == 'switch'"
-                                    attrs="{ href: element.href, 'data-menu': element.id }"
-                                    onSelected="element.callback"
+        <DropdownGroup group="'web-navbar-group'">
+            <Dropdown>
+                <button class="o_user_menu d-none d-md-flex py-1 py-lg-0">
+                    <img class="o_avatar o_user_avatar rounded" t-att-src="source" alt="User"/>
+                    <small class="oe_topbar_name d-none ms-2 text-start smaller lh-1 text-truncate"  t-att-class="{'d-lg-inline-block' : env.debug}" style="max-width: 200px">
+                        <t t-esc="userName"/>
+                        <mark class="d-block font-monospace text-truncate">
+                            <i class="fa fa-database oi-small me-1"/><t t-esc="dbName"/>
+                        </mark>
+                    </small>
+                </button>
+                <t t-set-slot="content">
+                    <t t-foreach="getElements()" t-as="element" t-key="element_index">
+                        <t t-if="!element.hide">
+                            <t t-if="element.type === 'component'" t-component="element.contentComponent"/>
+                            <DropdownItem
+                                t-if="element.type == 'item' || element.type == 'switch'"
+                                attrs="{ href: element.href, 'data-menu': element.id }"
+                                onSelected="element.callback"
+                            >
+                            <div class="d-flex justify-content-between p-0 w-100">
+                                <t t-out="element.description"/>
+                                <CheckBox
+                                    t-if="element.type == 'switch'"
+                                    value="element.isChecked"
+                                    className="'form-switch ms-2'"
+                                    onChange="element.callback"
                                 >
-                                <div class="d-flex justify-content-between p-0 w-100">
-                                    <t t-out="element.description"/>
-                                    <CheckBox
-                                        t-if="element.type == 'switch'"
-                                        value="element.isChecked"
-                                        className="'form-switch ms-2'"
-                                        onChange="element.callback"
-                                    >
-                                    </CheckBox>
-                                </div>
-                                </DropdownItem>
-                                <div t-if="element.type == 'separator'" role="separator" class="dropdown-divider"/>
-                            </t>
+                                </CheckBox>
+                            </div>
+                            </DropdownItem>
+                            <div t-if="element.type == 'separator'" role="separator" class="dropdown-divider"/>
                         </t>
                     </t>
-                </Dropdown>
-            </DropdownGroup>
-        </div>
+                </t>
+            </Dropdown>
+        </DropdownGroup>
     </t>
 
 </templates>

--- a/addons/web/static/tests/tours/user_switch_tour.js
+++ b/addons/web/static/tests/tours/user_switch_tour.js
@@ -20,7 +20,7 @@ function logout() {
         },
         {
             content: "check we're logged in",
-            trigger: ".o_user_menu .dropdown-toggle",
+            trigger: ".o_user_menu",
             run: "click",
         },
         {

--- a/addons/web/static/tests/webclient/switch_company_menu.test.js
+++ b/addons/web/static/tests/webclient/switch_company_menu.test.js
@@ -52,8 +52,8 @@ beforeEach(() => {
 test("basic rendering", async () => {
     await createSwitchCompanyMenu();
 
-    expect("div.o_switch_company_menu").toHaveCount(1);
-    expect("div.o_switch_company_menu").toHaveText("Hermit");
+    expect("button.o_switch_company_menu").toHaveCount(1);
+    expect("button.o_switch_company_menu").toHaveText("Hermit");
 
     await openCompanyMenu();
 

--- a/addons/website/static/src/client_actions/website_preview/publish_website_systray_item.js
+++ b/addons/website/static/src/client_actions/website_preview/publish_website_systray_item.js
@@ -12,8 +12,8 @@ const websiteSystrayRegistry = registry.category("website_systray");
 export class PublishSystrayItem extends Component {
     static template = xml`
         <div t-on-click="publishContent" class="o_menu_systray_item o_website_publish_container d-flex ms-auto" t-att-data-processing="state.processing and 1">
-            <a href="#" class="d-flex align-items-center mx-1 px-2 px-md-0" data-hotkey="p">
-                <span class="o_nav_entry d-none d-md-block mx-0 pe-1" t-esc="this.label"/>
+            <a href="#" class="o_nav_entry d-flex align-items-center mx-1" data-hotkey="p">
+                <span class="d-none d-md-block mx-0 pe-1" t-esc="this.label"/>
                 <CheckBox value="state.published" className="'form-switch d-flex justify-content-center m-0 pe-none'"/>
             </a>
         </div>`;

--- a/addons/website/static/src/components/navbar/navbar.scss
+++ b/addons/website/static/src/components/navbar/navbar.scss
@@ -4,13 +4,12 @@
     --NavBar-separator-margin-v: 10px; // equal to $o-navbar-padding-v in web_enterprise
     --border-color: #{darken($primary, 10%)};
 
+    .o_nav_entry,
+    .o_menu_systray_item > a,
+    .o_menu_systray_item > button,
     .o_user_menu {
-        margin: -$o-navbar-padding-v 0;
-        border-right: $border-width solid var(--border-color);
-        padding: $o-navbar-padding-v 0;
-    }
+        --NavBar-entry-borderColor-active: transparent;
 
-    .o_nav_entry, .o_menu_systray_item > a, .o_menu_systray_item > button {
         height: auto;
         margin-top: -$o-navbar-padding-v;
         margin-bottom: -$o-navbar-padding-v;

--- a/odoo/addons/test_main_flows/static/tests/tours/switch_company_access_error_tour.js
+++ b/odoo/addons/test_main_flows/static/tests/tours/switch_company_access_error_tour.js
@@ -22,7 +22,7 @@ registry.category("web_tour.tours").add("test_company_switch_access_error", {
             trigger: ".o_form_view .o_last_breadcrumb_item:contains(p2)",
         },
         {
-            trigger: ".o_switch_company_menu button",
+            trigger: ".o_switch_company_menu",
             run: "click",
         },
         {

--- a/odoo/addons/test_main_flows/static/tests/tours/test_company_access_error_redirect_tour.js
+++ b/odoo/addons/test_main_flows/static/tests/tours/test_company_access_error_redirect_tour.js
@@ -17,7 +17,7 @@ registry.category("web_tour.tours").add("test_company_access_error_redirect", {
             trigger: ".o_form_view .o_last_breadcrumb_item:contains(p2)",
         },
         {
-            trigger: ".o_switch_company_menu button",
+            trigger: ".o_switch_company_menu",
             run: "click",
         },
         {


### PR DESCRIPTION
*: auth_passkey, auth_totp, hr, hr_holidays, website, test_main_flows

This PR improves the different button states within the `.o_menu_systray element`

- requires https://github.com/odoo/enterprise/pull/95339

| Master | This PR |
|--------|--------|
| <img width="404" height="49" alt="image" src="https://github.com/user-attachments/assets/f8033712-44c0-45fa-9fd0-6ab7dfee4fbd" /> | <img width="389" height="47" alt="image" src="https://github.com/user-attachments/assets/8bea49a8-63bf-488e-9c2a-8ba0df0df10b" /> | 
---------

Currently, these buttons are either:

- `<button>` elements with only the .btn class, which does not provide a complete set of CSS properties.

- `.dropdown-toggle` elements with an inherited background-color, which ends up being the transparent background set on the `<nav>` element.

This commit harmonizes these approaches into a single one, aligned with the implementation used in .o_menu_sections. This increases consistency and also improves the accessibility of these items.

task-5098241

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
