### PR TITLE
[FIX] point_of_sale: fetch invoice from self invoicing

### DIFF
--- a/addons/point_of_sale/controllers/main.py
+++ b/addons/point_of_sale/controllers/main.py
@@ -134,8 +134,8 @@ class PosController(PortalAccount):
 
             if errors:
                 errors['generic'] = _("Please fill all the required fields.")
-            elif len(form_values['pos_reference']) < 14:
-                errors['pos_reference'] = _("The Ticket Number should be at least 14 characters long.")
+            elif len(form_values['pos_reference']) < 12:
+                errors['pos_reference'] = _("The Ticket Number should be at least 12 characters long.")
             else:
                 date_order = datetime(*[int(i) for i in form_values['date_order'].split('-')])
                 order = request.env['pos.order'].sudo().search([

--- a/addons/point_of_sale/tests/test_pos_controller.py
+++ b/addons/point_of_sale/tests/test_pos_controller.py
@@ -63,6 +63,7 @@ class TestPoSController(TestPointOfSaleHttpCommon):
         self.url_open(f'/pos/ticket/validate?access_token={self.pos_order.access_token}', data=get_invoice_data)
         self.assertEqual(self.env['res.partner'].sudo().search_count([('name', '=', 'AAA Partner')]), 1)
         self.assertTrue(self.pos_order.is_invoiced, "The pos order should have an invoice")
+        self.assertTrue(len(self.pos_order.pos_reference) >= 12, "The pos reference should not be less than 12 characters")
 
     def test_qr_code_receipt_user_connected(self):
         """This test make sure that when the user is already connected he correctly gets redirected to the invoice."""


### PR DESCRIPTION
Before this commit:
- Fetching an invoice through self-invoicing caused an error: `Ticket Number should be at least 14 characters long`.

After this commit:
- With the revamp of the POS sequence, the new sequence format has been adapted, resolving the issue.

task-5092989
