### PR TITLE
[FIX] pos_discount: traceback while processing draft order on ticket screen

### DIFF
--- a/addons/pos_discount/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/pos_discount/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -28,7 +28,7 @@ patch(TicketScreen.prototype, {
         const orderline = this.getSelectedOrder().lines.find(
             (line) => line.id == selectedOrderlineId
         );
-        if (orderline.product_id.id === this.pos.config.discount_product_id?.id) {
+        if (orderline && orderline.product_id.id === this.pos.config.discount_product_id?.id) {
             return this.dialog.add(AlertDialog, {
                 title: _t("Error"),
                 body: _t("You cannot edit a discount line."),

--- a/addons/pos_discount/static/tests/tours/test_pos_global_discount_flow.js
+++ b/addons/pos_discount/static/tests/tours/test_pos_global_discount_flow.js
@@ -1,0 +1,66 @@
+import * as ProductScreen from "@point_of_sale/../tests/pos/tours/utils/product_screen_util";
+import * as ReceiptScreen from "@point_of_sale/../tests/pos/tours/utils/receipt_screen_util";
+import * as PaymentScreen from "@point_of_sale/../tests/pos/tours/utils/payment_screen_util";
+import * as TicketScreen from "@point_of_sale/../tests/pos/tours/utils/ticket_screen_util";
+import * as Order from "@point_of_sale/../tests/generic_helpers/order_widget_util";
+import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
+import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("test_pos_global_discount_sell_and_refund", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.addOrderline("Desk Pad", "1", "3"),
+            Chrome.clickOrders(),
+            Order.hasLine({
+                withoutClass: ".selected",
+                run: "click",
+                productName: "Desk Pad",
+                quantity: "1",
+            }),
+            // Check that the draft order's order line is not selected and not causing issues while
+            // comparing the line to the discount line
+            {
+                content: "Manually trigger keyup event",
+                trigger: ".ticket-screen",
+                run: function () {
+                    window.dispatchEvent(new KeyboardEvent("keyup", { key: "9" }));
+                },
+            },
+            TicketScreen.loadSelectedOrder(),
+            ProductScreen.clickControlButton("Discount"),
+            {
+                content: `click discount numpad button: 5`,
+                trigger: `.o_dialog div.numpad button:contains(5)`,
+                run: "click",
+            },
+            Dialog.confirm(),
+            ProductScreen.selectedOrderlineHas("discount", 1, "-0.15"),
+            ProductScreen.totalAmountIs("2.85"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+            ReceiptScreen.clickNextOrder(),
+            ...ProductScreen.clickRefund(),
+            TicketScreen.selectOrder("001"),
+            ProductScreen.clickNumpad("1"),
+            TicketScreen.toRefundTextContains("To Refund: 1"),
+            ProductScreen.clickLine("discount"),
+            ProductScreen.clickNumpad("1"),
+            Dialog.confirm(),
+            TicketScreen.confirmRefund(),
+            PaymentScreen.isShown(),
+            PaymentScreen.clickBack(),
+            ProductScreen.clickLine("discount"),
+            ProductScreen.clickNumpad("1"),
+            Dialog.is({ title: "quantity update not allowed" }),
+            Dialog.confirm(),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+        ].flat(),
+});

--- a/addons/pos_discount/tests/test_taxes_global_discount.py
+++ b/addons/pos_discount/tests/test_taxes_global_discount.py
@@ -103,3 +103,19 @@ class TestTaxesGlobalDiscountPOS(TestTaxCommonPOS, TestTaxesGlobalDiscount):
         self.assert_pos_orders_and_invoices('test_taxes_l10n_be_pos_global_discount_round_globally_price_included', [
             round_globally_included_tests[0],
         ])
+
+    def test_pos_global_discount_sell_and_refund(self):
+        self.main_pos_config.open_ui()
+        self.start_pos_tour('test_pos_global_discount_sell_and_refund')
+        orders = self.main_pos_config.current_session_id.order_ids
+        self.assertEqual(len(orders), 2)
+        refund_order = orders[0]
+        self.assertAlmostEqual(refund_order.amount_total, -2.85)
+        self.assertEqual(len(refund_order.lines), 2)
+        self.assertEqual(refund_order.lines[1].product_id.id, self.main_pos_config.discount_product_id.id)
+        self.assertAlmostEqual(refund_order.lines[1].price_subtotal_incl, 0.15)
+        pos_order = orders[1]
+        self.assertAlmostEqual(pos_order.amount_total, 2.85)
+        self.assertEqual(len(pos_order.lines), 2)
+        self.assertEqual(pos_order.lines[1].product_id.id, self.main_pos_config.discount_product_id.id)
+        self.assertAlmostEqual(pos_order.lines[1].price_subtotal_incl, -0.15)


### PR DESCRIPTION
Steps:
----------
- Install pos_discount.
- Open a PoS config with a global discount configured.
- Add a product to the order.
- Open the ticket screen, select an order line, and press any key on the keyboard.

Issue:
----------
- A traceback is raised for accessing product_id from an undefined order line.

Cause:
----------
- The system tries to compare the selected order line's product with the global discount product, but draft order lines cannot be selected on the ticket screen.

Fix:
----------
- Compare only if the selected line is available.

task-5095765
