### PR TITLE
[FIX] sale_mrp: Fix test to allow invoicing kits pre-delivery

### DIFF
--- a/addons/sale_mrp/tests/test_sale_mrp_anglo_saxon_valuation.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_anglo_saxon_valuation.py
@@ -634,6 +634,7 @@ class TestSaleMRPAngloSaxonValuation(ValuationReconciliationTestCommon):
         compo01 = self._create_product(name="Compo 01", is_storable=True, standard_price=10)
         compo02 = self._create_product(name="Compo 02", is_storable=True, standard_price=20)
         kit = self._create_product(name="Kit", is_storable=True, standard_price=30)
+        (compo01 + compo02 + kit).write({'invoice_policy': 'order'})
         warehouse = self.company_data['default_warehouse']
         self.env['stock.quant']._update_available_quantity(compo01, warehouse.lot_stock_id, 1.0)
         self.env['stock.quant']._update_available_quantity(compo02, warehouse.lot_stock_id, 2.0)


### PR DESCRIPTION
This change updates the test_sell_kit_invoice_before_delivery test to ensure that kit components and the kit product itself use an invoicing policy of Ordered Quantities rather than the default Delivered Quantities.

build_error-232796
