### PR TITLE
[FIX] stock,sale_stock: prioritize SOL routes over product routes

### DIFF
--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -126,6 +126,8 @@ class StockMove(models.Model):
         # to pass sale_line_id fom SO to MO in mto
         if self.sale_line_id:
             res['sale_line_id'] = self.sale_line_id.id
+            if self.sale_line_id.route_ids:
+                res['route_ids'] |= self.sale_line_id.route_ids
         return res
 
 

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1661,7 +1661,7 @@ Please change the quantity done or the rounding precision in your settings.""",
 
         product_id = self.product_id.with_context(lang=self._get_lang())
         dates_info = {'date_planned': self._get_mto_procurement_date()}
-        route = []
+        route = self.env['stock.route']
         if self.location_id.warehouse_id and self.location_id.warehouse_id.lot_stock_id.parent_path in self.location_id.parent_path:
             dates_info = self.product_id._get_dates_info(self.date, self.location_id, route_ids=self.route_ids)
         warehouse = self.warehouse_id or self.picking_type_id.warehouse_id


### PR DESCRIPTION
Issue before this commit:
=========================
When a product has routes defined both on the product itself and on the Sale Order Line (SOL), the system ignored the SOL routes and only considered the product routes.

Steps to Reproduce:
=========================
- Install sale_mrp and purchase modules.
- Create a product with Buy and Manufacture routes.
- Create a Sale Order for that product and define Buy + MTO on the SOL.
- Confirm the Sale Order. → An MO was created instead of a PO, even though the SOL specified Buy.

Cause of the issue:
=========================
Due to this [PR](https://github.com/odoo/odoo/pull/212679) The system only considered product-level routes and ignored routes explicitly set on the SOL. At this [line](https://github.com/odoo/odoo/blob/master/addons/stock/models/stock_move.py#L1665)

 ```
      if not self.location_id.warehouse_id:
         warehouse = self.env['stock.warehouse']
         route = self.route_ids or self.move_line_ids.result_package_id.package_type_id.route_ids
```

The presence of `warehouse` caused the condition `not self.location_id.warehouse_id`
to evaluate as False. As a result, the SOL routes were never applied.

With This Commit:
=========================
- The system now considers the routes defined on the Sale Order Line
  and gives them priority over product routes.
- This ensures that SOL routes are applied first, restoring the expected behaviour.

