### PR TITLE
[IMP] pos_event: add PoS Orders smart button on event form

### DIFF
--- a/addons/pos_event/models/event_event.py
+++ b/addons/pos_event/models/event_event.py
@@ -6,6 +6,25 @@ class EventEvent(models.Model):
     _inherit = ['event.event', 'pos.load.mixin']
 
     image_1024 = fields.Image("PoS Image", max_width=1024, max_height=1024)
+    pos_price_total = fields.Monetary('PoS Total (Tax Included)', compute='_compute_pos_price_total', groups='point_of_sale.group_pos_user')
+
+    @api.depends('company_id.currency_id', 'registration_ids.pos_order_line_id.price_subtotal_incl',
+                 'registration_ids.pos_order_line_id.currency_id', 'registration_ids.pos_order_line_id.order_id.state')
+    def _compute_pos_price_total(self):
+        """ Compute the total amount (tax included) of paid/posted PoS orders linked to the event. """
+        totals = {event.id: 0.0 for event in self}
+        event_subtotals = self.env['pos.order.line']._read_group(
+            [('event_ticket_id.event_id', 'in', self.ids), ('order_id.state', 'in', ['paid', 'done'])],
+            ['event_ticket_id.event_id', 'currency_id'],
+            ['price_subtotal_incl:sum'],
+        )
+
+        for event, currency_id, sum_subtotal in event_subtotals:
+            company = event.company_id or self.env.company
+            totals[event.id] += event.currency_id._convert(sum_subtotal, currency_id, company)
+
+        for event in self:
+            event.pos_price_total = totals.get(event.id, 0.0)
 
     @api.model
     def _load_pos_data_domain(self, data, config):
@@ -27,3 +46,9 @@ class EventEvent(models.Model):
             for slot_id, ticket_id in slot_ticket_ids
         ]
         return self._get_seats_availability(slot_tickets)
+
+    def action_view_linked_pos_orders(self):
+        """ Redirects to the Paid/Posted PoS Orders linked to the current event records. """
+        pos_order_action = self.env["ir.actions.actions"]._for_xml_id("point_of_sale.action_pos_pos_form")
+        pos_order_action['domain'] = [('state', 'in', ['paid', 'done']), ('lines.event_ticket_id.event_id', 'in', self.ids)]
+        return pos_order_action

--- a/addons/pos_event/views/event_event_views.xml
+++ b/addons/pos_event/views/event_event_views.xml
@@ -8,6 +8,20 @@
             <xpath expr="//div[hasclass('oe_title')]" position="before">
                 <field name="image_1024" widget="image" class="oe_avatar me-4"/>
             </xpath>
+            <xpath expr="//button[@name='%(event.act_event_registration_from_event)d']" position="after">
+                <field name="currency_id" invisible="1"/> <!-- To use currency in the button -->
+                <button name="action_view_linked_pos_orders"
+                        type="object" class="oe_stat_button" icon="fa-shopping-basket"
+                        groups="point_of_sale.group_pos_user"
+                        help="Total sales for this event from PoS">
+                    <div class="o_field_widget o_stat_info">
+                        <span class="o_stat_value">
+                            <field name="pos_price_total"/>
+                        </span>
+                        <span class="o_stat_text">PoS Sales</span>
+                    </div>
+                </button>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
In this commit:
---------------
- Added a new smart button on the event form view.
- The button provides quick access to PoS orders related to the event, making it easier to track ticket sales from PoS.

task-5038033
