### PR TITLE
[FIX] survey: Reset scoring_success_min to 0 when scoring_type changes to no_scoring to prevent failure emails 

### DIFF
--- a/addons/survey/models/survey_survey.py
+++ b/addons/survey/models/survey_survey.py
@@ -122,7 +122,7 @@ class Survey(models.Model):
         ('scoring_with_answers_after_page', 'Scoring with answers after each page'),
         ('scoring_with_answers', 'Scoring with answers at the end'),
         ('scoring_without_answers', 'Scoring without answers')],
-        string='Scoring', required=True, store=True, readonly=False, compute='_compute_scoring_type', precompute=True)
+        string='Scoring', required=True, store=True, readonly=False, compute='_compute_scoring_type', inverse='_inverse_scoring_type', precompute=True)
     scoring_success_min = fields.Float('Required Score (%)', default=80.0)
     scoring_max_obtainable = fields.Float('Maximum obtainable score', compute='_compute_scoring_max_obtainable')
     # attendees context: attempts and time limitation
@@ -354,6 +354,10 @@ class Survey(models.Model):
                 survey.scoring_type = 'scoring_without_answers'
             elif not survey.scoring_type:
                 survey.scoring_type = 'no_scoring'
+
+    @api.onchange('scoring_type')
+    def _inverse_scoring_type(self):
+        self.filtered(lambda r: r.scoring_type == 'no_scoring').scoring_success_min = 0
 
     @api.onchange('survey_type')
     def _onchange_survey_type(self):


### PR DESCRIPTION
Currently, when updating an exam’s scoring_type to no_scoring, the system retains the old value of scoring_success_min. This may trigger the failure email logic even though the exam is not supposed to be scored, causing users to incorrectly receive a “failed” notification.

The field scoring_success_min still retains its old value in the database but is hidden on the UI.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
