### PR TITLE
[FIX] point_of_sale: local cascade deletion not removing child records

### DIFF
--- a/addons/point_of_sale/static/src/app/services/data_service.js
+++ b/addons/point_of_sale/static/src/app/services/data_service.js
@@ -880,10 +880,7 @@ export class PosData extends Reactive {
         const relationsToDelete = Object.values(this.relations[recordModel])
             .filter((rel) => this.opts.cascadeDeleteModels.includes(rel.relation))
             .map((rel) => rel.name);
-        const recordsToDelete = Object.entries(record)
-            .filter(([idx, values]) => relationsToDelete.includes(idx) && values)
-            .map(([idx, values]) => values)
-            .flat();
+        const recordsToDelete = relationsToDelete.flatMap((relation) => record[relation]);
 
         // Delete all children records before main record
         this.indexedDB.delete(recordModel, [record.uuid]);

--- a/addons/point_of_sale/static/tests/unit/services/data_service.test.js
+++ b/addons/point_of_sale/static/tests/unit/services/data_service.test.js
@@ -1,0 +1,19 @@
+import { test, expect, describe } from "@odoo/hoot";
+import { getFilledOrder, setupPosEnv } from "../utils";
+import { definePosModels } from "../data/generate_model_definitions";
+
+definePosModels();
+
+describe("data_service", () => {
+    test("localDeleteCascade", async () => {
+        const store = await setupPosEnv();
+        const data = store.data;
+        const order = await getFilledOrder(store);
+
+        expect(store.models["pos.order"].length).toBe(1);
+        expect(store.models["pos.order.line"].length).toBe(2);
+        data.localDeleteCascade(order);
+        expect(store.models["pos.order"].length).toBe(0);
+        expect(store.models["pos.order.line"].length).toBe(0);
+    });
+});

--- a/addons/pos_restaurant/static/tests/unit/services/pos_service.test.js
+++ b/addons/pos_restaurant/static/tests/unit/services/pos_service.test.js
@@ -230,17 +230,18 @@ describe("restaurant pos_store.js", () => {
             let id = 1;
             let lineId = 1;
             const createOrderForTable = async () => {
+                const orderId = `${id++}_string`;
                 const lines = [
                     {
                         id: `${lineId++}_string`,
-                        order_id: 31,
+                        order_id: orderId,
                         product_id: 5,
                         qty: 1,
                         write_date: date,
                     },
                     {
                         id: `${lineId++}_string`,
-                        order_id: 31,
+                        order_id: orderId,
                         product_id: 6,
                         qty: 1,
                         write_date: date,
@@ -248,7 +249,7 @@ describe("restaurant pos_store.js", () => {
                 ];
                 const order = [
                     {
-                        id: `${id++}_string`,
+                        id: orderId,
                         lines: lines.map((line) => line.id),
                         write_date: date,
                         table_id: table.id,


### PR DESCRIPTION
Issue:
Deleting an order did not remove its related order lines from local records.

Cause:
Because of the use of `lazyGetter`, model fields were defined as getters
instead of object keys. This caused `Object.entries` to skip some fields,
preventing cascade deletion from including child records.

Fix:
Updated the logic for computing `recordsToDelete` to correctly handle cascade
deletion and ensure child records are properly removed.

Task-5095578
