### PR TITLE
[IMP] mrp: add 'copy existing operations' button in bom operations tab

### DIFF
--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -135,9 +135,12 @@
                                         </div>
                                     </div>
                                 </div>
-                                <div class="d-flex justify-content-center" invisible="operation_ids.length != 0">
+                                <div class="d-flex justify-content-center gap-1" invisible="operation_ids.length != 0">
                                     <button name="action_open_operation_form" type="object" class="btn btn-primary">
                                         <span class="o_stat_text">Add Operation</span>
+                                    </button>
+                                    <button name="action_copy_existing_operations" type="object" invisible="not show_copy_operations_button">
+                                        <span class="o_stat_text">Copy Existing Operations</span>
                                     </button>
                                 </div>
                         </page>


### PR DESCRIPTION
Purpose:
===================
In the BoM form view, if no operations are defined, the user currently has only one option, to add a new operation using the `Add Operation` button. However, if the user wants to reuse existing operations, there is no option to copy them, which makes the process inconvenient and inefficient.

With This Commit:
===================
This commit adds a button to `Copy Existing Operations` when at least one operation exists to copy to remedy this. It follows the same behavior as the existing button when an operation is already assigned to the BoM.

TaskId-5079261