### PR TITLE
[IMP] l10n_in_*: streamline HSN warnings; truncate product description in EDI and Ewaybill

### DIFF
--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -679,9 +679,13 @@ class AccountMove(models.Model):
     @api.model
     def _l10n_in_extract_digits(self, string):
         if not string:
-            return string
+            return ""
         matches = re.findall(r"\d+", string)
         return "".join(matches)
+
+    @api.model
+    def _l10n_in_is_service_hsn(self, hsn_code):
+        return self._l10n_in_extract_digits(hsn_code).startswith('99')
 
     @api.model
     def _l10n_in_round_value(self, amount, precision_digits=2):

--- a/addons/l10n_in_edi/i18n/l10n_in_edi.pot
+++ b/addons/l10n_in_edi/i18n/l10n_in_edi.pot
@@ -128,7 +128,7 @@ msgstr ""
 #. module: l10n_in_edi
 #. odoo-python
 #: code:addons/l10n_in_edi/models/account_move_line.py:0
-msgid "Check Invoice Lines"
+msgid "Check Invoice Line(s)"
 msgstr ""
 
 #. module: l10n_in_edi
@@ -565,7 +565,7 @@ msgstr ""
 #. module: l10n_in_edi
 #. odoo-python
 #: code:addons/l10n_in_edi/models/account_move_line.py:0
-msgid "View Invoice Lines"
+msgid "View Invoice Line(s)"
 msgstr ""
 
 #. module: l10n_in_edi

--- a/addons/l10n_in_edi/models/account_move.py
+++ b/addons/l10n_in_edi/models/account_move.py
@@ -468,7 +468,7 @@ class AccountMove(models.Model):
         in_round = self._l10n_in_round_value
         line_details = {
             'SlNo': str(index),
-            'IsServc': line.product_id.type == 'service' and 'Y' or 'N',
+            'IsServc': self._l10n_in_is_service_hsn(line.l10n_in_hsn_code) and 'Y' or 'N',
             'HsnCd': self._l10n_in_extract_digits(line.l10n_in_hsn_code),
             'Qty': in_round(quantity or 0.0, 3),
             'Unit': (

--- a/addons/l10n_in_edi/models/account_move.py
+++ b/addons/l10n_in_edi/models/account_move.py
@@ -504,7 +504,7 @@ class AccountMove(models.Model):
             'TotItemVal': in_round((sign * line.balance) + line_tax_details.get('tax_amount', 0.00)),
         }
         if line.name:
-            line_details['PrdDesc'] = line.name.replace("\n", "")
+            line_details['PrdDesc'] = line.name.replace("\n", "")[:300]
         return line_details
 
     def _l10n_in_edi_generate_invoice_json_managing_negative_lines(self, json_payload):

--- a/addons/l10n_in_edi/models/account_move_line.py
+++ b/addons/l10n_in_edi/models/account_move_line.py
@@ -39,15 +39,16 @@ class AccountMoveLine(models.Model):
 
         return {
             f"l10n_in_edi_{error_code}": {
+                'level': 'danger' if error_code == 'invalid_hsn' else 'warning',
                 'message': error_messages[error_code],
-                'action_text': _("View Invoice Lines"),
+                'action_text': _("View Invoice Line(s)"),
                 # The context are set in view_move_line_tree_hsn_l10n_in
                 # Please make sure to change, if any change in error codes
                 'action': lines.with_context(**{
                     error_code: True,
                     'send_and_print': True
                 })._get_records_action(
-                    name=_("Check Invoice Lines"),
+                    name=_("Check Invoice Line(s)"),
                     domain=[('id', 'in', lines.ids)],
                     views=[(
                         self.env.ref('l10n_in.view_move_line_tree_hsn_l10n_in').id,

--- a/addons/l10n_in_ewaybill/i18n/l10n_in_ewaybill.pot
+++ b/addons/l10n_in_ewaybill/i18n/l10n_in_ewaybill.pot
@@ -420,6 +420,12 @@ msgid "Cess value should not be negative"
 msgstr ""
 
 #. module: l10n_in_ewaybill
+#. odoo-python
+#: code:addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py:0
+msgid "Check Invoice Line(s)"
+msgstr ""
+
+#. module: l10n_in_ewaybill
 #: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill.report_ewaybill
 msgid "Combination of 2 and 3"
 msgstr ""
@@ -2977,6 +2983,12 @@ msgstr ""
 #. module: l10n_in_ewaybill
 #: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill.res_config_settings_view_form_inherit_l10n_in_edi_ewaybill
 msgid "Verify Username and Password"
+msgstr ""
+
+#. module: l10n_in_ewaybill
+#. odoo-python
+#: code:addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py:0
+msgid "View Invoice Line(s)"
 msgstr ""
 
 #. module: l10n_in_ewaybill

--- a/addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py
@@ -385,16 +385,20 @@ class L10nInEwaybill(models.Model):
     def _check_lines(self):
         error_message = []
         invoice_lines = self.account_move_id.invoice_line_ids
+        AccountMove = self.env['account.move']
         if not any(l.product_id for l in invoice_lines):
             error_message.append(_("Ensure that at least one line item includes a product."))
             return error_message
-        if all(l.product_id.type == 'service' for l in invoice_lines if l.product_id):
+        if all(
+            AccountMove._l10n_in_is_service_hsn(l.l10n_in_hsn_code)
+            for l in invoice_lines if l.product_id
+        ):
             error_message.append(_("You need at least one product having 'Product Type' as stockable or consumable."))
             return error_message
         for line in invoice_lines:
             if (
                 line.display_type == 'product'
-                and line.product_id.type != 'service'
+                and not AccountMove._l10n_in_is_service_hsn(line.l10n_in_hsn_code)
                 and (hsn_error_message := line._l10n_in_check_invalid_hsn_code())
             ):
                 error_message.append(hsn_error_message)

--- a/addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py
@@ -570,9 +570,9 @@ class L10nInEwaybill(models.Model):
         round_value = self.env['account.move']._l10n_in_round_value
         tax_details_by_code = self.env['account.move']._get_l10n_in_tax_details_by_line_code(tax_details.get('tax_details', {}))
         line_details = {
-            'productName': line.product_id.name,
+            'productName': line.product_id.name[:100] if line.product_id else "",
             'hsnCode': extract_digits(line.l10n_in_hsn_code),
-            'productDesc': line.name,
+            'productDesc': line.name[:100] if line.name else "",
             'quantity': line.quantity,
             'qtyUnit': line.product_uom_id.l10n_in_code and line.product_uom_id.l10n_in_code.split('-')[0] or 'OTH',
             'taxableAmount': round_value(line.balance * sign),

--- a/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py
@@ -220,9 +220,9 @@ class L10nInEwaybill(models.Model):
             AccountMove = self.env['account.move']
             product = line.product_id
             line_details = {
-                'productName': product.name,
+                'productName': product.name[:100],
                 'hsnCode': AccountMove._l10n_in_extract_digits(product.l10n_in_hsn_code),
-                'productDesc': product.name,
+                'productDesc': line.description_picking[:100] if line.description_picking else "",
                 'quantity': line.quantity,
                 'qtyUnit': (
                     line.product_uom.l10n_in_code

--- a/addons/l10n_in_ewaybill_stock/views/l10n_in_ewaybill_views.xml
+++ b/addons/l10n_in_ewaybill_stock/views/l10n_in_ewaybill_views.xml
@@ -54,6 +54,7 @@
                                 <list editable="bottom" create="0" delete="0">
                                     <field name="company_currency_id" column_invisible="1"/> <!-- To display the currency symbol  -->
                                     <field name="product_id" readonly="1"/>
+                                    <field name="description_picking" string="Description" help="Max 100-character description is allowed" readonly="1"/>
                                     <field name="quantity" string="Quantity" readonly="1"/>
                                     <field name="ewaybill_price_unit" string="Unit Price"/>
                                     <field name="ewaybill_tax_ids" widget="many2many_tax_tags"/>


### PR DESCRIPTION
**[IMP] l10n_in_*: streamline HSN warnings**

- With this PR, we remove the warning about mismatches between HSN code and product type. From now on, the product type will be derived directly from the HSN code: if the HSN starts with '99', it will be considered a 'service'; otherwise, it will be treated as 'goods'. This simplifies the user experience by reducing unnecessary warnings. This will also cover cases where the product is service but the HSN is of goods for e.g. Job Work, Discount Line etc.
- Additionally, invalid/missing HSN on invoice line will now raise a blocking warning.


**[IMP] l10n_in_*: truncate product descriptions for e-invoicing**
- Product descriptions in invoice lines must comply with character limits for e-invoicing and e-waybill:

  - E-invoicing: maximum 300 characters
  - E-waybill: maximum 100 characters for both product names and descriptions

- Descriptions exceeding these limits are automatically truncated in the generated JSON. A user alert is displayed during sending to notify about any truncation.

**task**-5061450

Enterprise PR - https://github.com/odoo/enterprise/pull/95108