### PR TITLE
[FIX] point_of_sale: avoid showing 'change' on draft bill print

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -261,7 +261,7 @@ export class PosOrder extends Base {
             label_discounts: _t("Discounts"),
             show_rounding: !floatIsZero(order_rounding, this.currency.decimal_places),
             order_rounding: order_rounding,
-            show_change: !floatIsZero(order_change, this.currency.decimal_places),
+            show_change: !floatIsZero(order_change, this.currency.decimal_places) && this.finalized,
             order_change: order_change,
             paymentlines,
             amount_total: this.get_total_with_tax(),


### PR DESCRIPTION
steps to reproduce:
------------------
1. Install pos_restaurant
2. Go to Settings of the Restaurant and activate Early Receipt Printing
3. Go to dashboard > open restaurant > create an order
4. Click on Actions > Bill > Print

issue:
------
The "CHANGE" line appears on the bill print even without a payment transaction.

cause of the issue:
--------------------
The condition:
https://github.com/odoo/odoo/blob/76757158c0ce4a29883c3c52c3378218ea755a8f/addons/point_of_sale/static/src/app/models/pos_order.js#L264 is responsible to display of "CHANGE" regardless of the order state, leading to incorrect printing while the order is still in DRAFT state.

solution:
---------
Add a check to ensure the order is not in DRAFT state before printing the bill.

**NOTE:** The issue no longer exists in later versions, as it was [resolved](https://github.com/odoo/odoo/commit/e11a3489a78334ad5d3395fd405b870fa1aa218b#diff-5f6173b111795dcdfe25b1fb26d55d27e1ce9c334eabe838d413fc35c5084d1aR1034-R1036) in commit e11a348.

<details>
    <summary>Click here to see:</summary>
    Before fix:
    <img src="https://github.com/user-attachments/assets/4acd2322-ecae-4ff8-8421-234a9d00af86"/>
    After fix:
   <img src="https://github.com/user-attachments/assets/02edc28b-b1c1-40aa-b478-7a3419f2e736"/>
</details>

opw-5078803

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
