### PR TITLE
[IMP] html_editor: preview on radial gradient type

### DIFF
--- a/addons/html_editor/static/src/main/font/color_picker_gradient_tab.xml
+++ b/addons/html_editor/static/src/main/font/color_picker_gradient_tab.xml
@@ -24,6 +24,8 @@
             setOnCloseCallback.bind="props.setOnCloseCallback"
             setOperationCallbacks.bind="props.setOperationCallbacks"
             selectedGradient="getCurrentGradientColor()"
+            onColorPointerOver.bind="props.onColorPointerOver"
+            onColorPointerOut.bind="props.onColorPointerOut"
             noTransparency="props.noTransparency"/>
     </div>
 </t>

--- a/addons/html_editor/static/src/main/font/gradient_picker/gradient_picker.js
+++ b/addons/html_editor/static/src/main/font/gradient_picker/gradient_picker.js
@@ -17,6 +17,8 @@ export class GradientPicker extends Component {
         setOperationCallbacks: { type: Function, optional: true },
         selectedGradient: { type: String, optional: true },
         noTransparency: { type: Boolean, optional: true },
+        onColorPointerOver: { type: Function, optional: true },
+        onColorPointerOut: { type: Function, optional: true },
     };
 
     setup() {
@@ -125,6 +127,13 @@ export class GradientPicker extends Component {
     onSizeChange(size) {
         this.state.size = size;
         this.onColorGradientChange();
+    }
+
+    getRadialGradient(size) {
+        const gradientColors = this.colors
+            .map((color) => `${color.hex} ${color.percentage}%`)
+            .join(", ");
+        return `radial-gradient(circle ${size} at ${this.positions.x}% ${this.positions.y}%, ${gradientColors})`;
     }
 
     onColorPercentageChange(colorIndex, ev) {

--- a/addons/html_editor/static/src/main/font/gradient_picker/gradient_picker.xml
+++ b/addons/html_editor/static/src/main/font/gradient_picker/gradient_picker.xml
@@ -34,8 +34,8 @@
             </div>
             <div t-else="" class="d-flex flex-column gap-1 mb-1">
                 Size
-                <div class="d-flex align-items-center justify-content-between">
-                    <button t-on-click="() => this.onSizeChange('closest-side')" t-attf-class="btn btn-light p-0 {{ this.state.size === 'closest-side' ? `active` : ''}}" title="Extend to the closest side">
+                <div class="d-flex align-items-center justify-content-between" t-on-mouseover="props.onColorPointerOver" t-on-mouseout="props.onColorPointerOut">
+                    <button t-on-click="() => this.onSizeChange('closest-side')" t-att-data-color="getRadialGradient('closest-side')" t-attf-class="btn btn-light p-0 {{ this.state.size === 'closest-side' ? `active` : ''}}" title="Extend to the closest side">
                         <svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 16 20" fill="none">
                             <rect x="1.5" y="3.5" width="13" height="13" stroke="#AAAAAD"></rect>
                             <path d="M3 4H9V8C9 8.55228 8.55228 9 8 9H4C3.44772 9 3 8.55228 3 8V4Z" fill="#8C8C92"></path>
@@ -44,7 +44,7 @@
                             <rect x="2" y="3" width="12" height="1" fill="white"></rect>
                         </svg>
                     </button>
-                    <button t-on-click="() => this.onSizeChange('closest-corner')" t-attf-class="btn btn-light p-0 {{ this.state.size === 'closest-corner' ? `active` : ''}}" title="Extend to the closest corner">
+                    <button t-on-click="() => this.onSizeChange('closest-corner')" t-att-data-color="getRadialGradient('closest-corner')" t-attf-class="btn btn-light p-0 {{ this.state.size === 'closest-corner' ? `active` : ''}}" title="Extend to the closest corner">
                         <svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 16 20" fill="none">
                             <rect x="1.5" y="3.5" width="13" height="13" stroke="#AAAAAD"></rect>
                             <path d="M2 4H9V7C9 9.20914 7.20914 11 5 11H2V4Z" fill="#8C8C92"></path>
@@ -54,7 +54,7 @@
                             <rect x="1" y="11" width="8" height="1" transform="rotate(-90 1 11)" fill="white"></rect>
                         </svg>
                     </button>
-                    <button t-on-click="() => this.onSizeChange('farthest-side')" t-attf-class="btn btn-light p-0 {{ this.state.size === 'farthest-side' ? `active` : ''}}" title="Extend to the farthest side">
+                    <button t-on-click="() => this.onSizeChange('farthest-side')" t-att-data-color="getRadialGradient('farthest-side')" t-attf-class="btn btn-light p-0 {{ this.state.size === 'farthest-side' ? `active` : ''}}" title="Extend to the farthest side">
                         <svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 16 20" fill="none">
                             <rect x="1.5" y="3.5" width="13" height="13" stroke="#AAAAAD"></rect>
                             <path d="M7 12C10.3137 12 14 10.2091 14 8C14 5.79086 10.3137 4 7 4C3.68629 4 2 5.79086 2 8C2 10.2091 3.68629 12 7 12Z" fill="#8C8C92"></path>
@@ -63,7 +63,7 @@
                             <rect x="14" y="4" width="1" height="12" fill="white"></rect>
                         </svg>
                     </button>
-                    <button t-on-click="() => this.onSizeChange('farthest-corner')" t-attf-class="btn btn-light p-0 {{ this.state.size === 'farthest-corner' ? `active` : ''}}" title="Extend to the farthest corner">
+                    <button t-on-click="() => this.onSizeChange('farthest-corner')" t-att-data-color="getRadialGradient('farthest-corner')" t-attf-class="btn btn-light p-0 {{ this.state.size === 'farthest-corner' ? `active` : ''}}" title="Extend to the farthest corner">
                         <svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 16 20" fill="none">
                             <rect x="1.5" y="3.5" width="13" height="13" stroke="#AAAAAD"></rect>
                             <path d="M2 4H14V10C14 13.3137 11.3137 16 8 16H2V4Z" fill="#8C8C92"></path>

--- a/addons/html_editor/static/tests/color_selector.test.js
+++ b/addons/html_editor/static/tests/color_selector.test.js
@@ -616,6 +616,62 @@ test("should be able to select farthest-corner option in radial gradient", async
     expect("button[title='Extend to the farthest corner']").toHaveClass("active");
 });
 
+test.tags("desktop");
+test("should be able to show preview when hovering radial type button", async () => {
+    const gradientBefore = `radial-gradient(circle closest-side at 25% 25%, rgb(223, 124, 196) 0%, rgb(108, 53, 130) 100%)`;
+    const gradientAfter = `radial-gradient(circle farthest-side at 25% 25%, rgb(223, 124, 196) 0%, rgb(108, 53, 130) 100%)`;
+
+    const { el } = await setupEditor(
+        `<p>a<font style="background-image: ${gradientBefore};">[bcd]</font>e</p>`
+    );
+    await expandToolbar();
+    await click(".o-we-toolbar .o-select-color-background");
+    await animationFrame();
+    expect(".btn:contains('Gradient')").toHaveCount(1);
+    await click(".btn:contains('Gradient')");
+    await animationFrame();
+    await click("button[title='Define a custom gradient']");
+    await animationFrame();
+    expect("button:contains('Radial')").toHaveCount(1);
+    await click(".btn:contains('Radial')");
+    await animationFrame();
+    expect("button[title='Extend to the farthest corner']").toHaveCount(1);
+
+    const gradientButton = queryOne(".o_custom_gradient_button");
+
+    // Hover for preview
+    await hover("button[title='Extend to the farthest side']");
+    await animationFrame();
+    expect(gradientButton.style.backgroundImage).toBe(gradientAfter);
+    expect(getContent(el)).toBe(
+        `<p>a<font style="background-image: ${gradientAfter};">[bcd]</font>e</p>`
+    );
+    expect("button[title='Extend to the farthest side']").toHaveClass("active");
+
+    // Hover out
+    await hover(".o-we-toolbar .o-select-color-foreground");
+    await animationFrame();
+    expect(gradientButton.style.backgroundImage).toBe(gradientBefore);
+    expect(getContent(el)).toBe(
+        `<p>a<font style="background-image: ${gradientBefore};">[bcd]</font>e</p>`
+    );
+    expect("button[title='Extend to the farthest side']").not.toHaveClass("active");
+
+    // Hover again, click and hover out
+    await hover("button[title='Extend to the farthest side']");
+    await animationFrame();
+    await click("button[title='Extend to the farthest side']");
+    await animationFrame();
+    await hover(".o-we-toolbar .o-select-color-foreground");
+    await animationFrame();
+
+    expect(gradientButton.style.backgroundImage).toBe(gradientAfter);
+    expect(getContent(el)).toBe(
+        `<p>a<font style="background-image: ${gradientAfter};">[bcd]</font>e</p>`
+    );
+    expect("button[title='Extend to the farthest side']").toHaveClass("active");
+});
+
 test("solid tab color navigation using keys", async () => {
     const { el } = await setupEditor("<p>[test]</p>");
     await expandToolbar();

--- a/addons/web/static/src/core/color_picker/color_picker.js
+++ b/addons/web/static/src/core/color_picker/color_picker.js
@@ -190,14 +190,16 @@ export class ColorPicker extends Component {
     }
 
     onColorHover(ev) {
-        if (!this.isColorButton(this.getTarget(ev))) {
+        const target = this.getTarget(ev);
+        if (!this.isColorButton(target) || target.contains(ev.relatedTarget)) {
             return;
         }
         this.onColorPreview(ev);
     }
 
     onColorHoverOut(ev) {
-        if (!this.isColorButton(this.getTarget(ev))) {
+        const target = this.getTarget(ev);
+        if (!this.isColorButton(target) || target.contains(ev.relatedTarget)) {
             return;
         }
         this.applyColorResetPreview();

--- a/addons/web/static/tests/core/color_picker.test.js
+++ b/addons/web/static/tests/core/color_picker.test.js
@@ -1,5 +1,5 @@
 import { test, expect } from "@odoo/hoot";
-import { press, click, animationFrame, queryOne } from "@odoo/hoot-dom";
+import { press, click, animationFrame, queryOne, hover } from "@odoo/hoot-dom";
 import { Component, xml } from "@odoo/owl";
 import { defineStyle, mountWithCleanup } from "@web/../tests/web_test_helpers";
 import { ColorPicker, DEFAULT_COLORS } from "@web/core/color_picker/color_picker";
@@ -143,6 +143,60 @@ test("keyboard navigation", async () => {
     expect(
         ".o_font_color_selector .o_color_section .o_color_button[data-color]:last-of-type"
     ).toBeFocused();
+});
+
+class AdditionalTab extends Component {
+    static template = xml`
+        <div class="container" t-on-mouseover="props.onColorPointerOver" t-on-mouseout="props.onColorPointerOut">
+            <button class="o_color_picker_button btn p-1 m-1" data-color="#FFFF00" style="background-color: #ffff00; width: auto">
+                <div>Hover me</div>
+            </button>
+        </div>
+    `;
+    static props = ["*"];
+}
+
+test.tags("desktop");
+test("should trigger color preview callbacks only once when hovering button having nested elements", async () => {
+    registry.category("color_picker_tabs").add("web.test", {
+        id: "test",
+        name: "Test",
+        component: AdditionalTab,
+    });
+    let pointerHoverCounter = 0;
+    let pointerOutCounter = 0;
+    await mountWithCleanup(ColorPicker, {
+        props: {
+            state: {
+                selectedColor: "#B5D6A5",
+                defaultTab: "test",
+            },
+            getUsedCustomColors: () => [],
+            applyColor() {},
+            applyColorPreview() {
+                pointerHoverCounter++;
+            },
+            applyColorResetPreview() {
+                pointerOutCounter++;
+            },
+            colorPrefix: "",
+            enabledTabs: ["solid", "custom", "test"],
+        },
+    });
+    expect(".o_font_color_selector").toHaveCount(1);
+    expect("button.test-tab").toHaveClass("active");
+
+    // Hover in
+    await hover("div.container");
+    await hover("button[data-color='#FFFF00']");
+    await hover("button[data-color='#FFFF00'] div");
+
+    // Hover out
+    await hover("button[data-color='#FFFF00']");
+    await hover("div.container");
+
+    expect(pointerHoverCounter).toBe(1);
+    expect(pointerOutCounter).toBe(1);
 });
 
 test("colorpicker inside the builder are linked to the builder theme colors", async () => {


### PR DESCRIPTION
Currently, when user wants to apply custom radial gradient type (text or bg), there is no preview. This PR ensures that user is able to see the preview when hovering the gradient radial type.

task-5095842




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
