### PR TITLE
[FIX] website_sale: product carrousal strikethrough price issue

### DIFF
--- a/addons/website_sale/data/product_snippet_template_data.xml
+++ b/addons/website_sale/data/product_snippet_template_data.xml
@@ -129,6 +129,7 @@
                       name="product_price"
                       t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"/>
                 <del
+                    t-if="data.get('has_discounted_price')"
                     aria-label="Original price"
                     t-attf-class="text-muted me-1 mb-0"
                     style="white-space: nowrap;"

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -605,7 +605,7 @@ class ProductTemplate(models.Model):
                 currency=currency,
             )
 
-        has_discounted_price = price_before_discount > pricelist_price
+        has_discounted_price = currency.compare_amounts(price_before_discount, pricelist_price) == 1
         combination_info = {
             'list_price': max(pricelist_price, price_before_discount),
             'price': pricelist_price,


### PR DESCRIPTION
- Removed the unnecessary strikethrough on product prices when no discount 
  is applied. Previously, the strikethrough was always shown by default. 
  Now it only appears when the discount conditions are applied.
 - In this commit-https://github.com/odoo/odoo/pull/227270 it is fixed in 19.0

opw-5090228

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
