### PR TITLE
[FIX] mail: fix 2 'Add a reaction' assertion error in HOOT test

### DIFF
--- a/addons/mail/static/tests/quick_reaction_menu/quick_reaction_menu.test.js
+++ b/addons/mail/static/tests/quick_reaction_menu/quick_reaction_menu.test.js
@@ -24,7 +24,7 @@ test("can toggle reaction from quick reaction menu", async () => {
     await click("[title='Add a Reaction']");
     await click(".o-mail-QuickReactionMenu button", { text: "👍" });
     await contains(".o-mail-MessageReaction", { text: "👍1" });
-    await click("[title='Add a Reaction']");
+    await click(".o-mail-Message-actions [title='Add a Reaction']");
     await click(".o-mail-QuickReactionMenu button", { text: "👍" });
     await contains(".o-mail-MessageReaction", { text: "👍1", count: 0 });
 });
@@ -59,7 +59,7 @@ test("show default emojis when no frequent emojis are available", async () => {
     }
     await click(".o-mail-QuickReactionMenu [title='Toggle Emoji Picker']");
     await click(".o-Emoji", { text: "🤢" });
-    await click("[title='Add a Reaction']");
+    await click(".o-mail-Message-actions [title='Add a Reaction']");
     await contains(".o-mail-QuickReactionMenu-emoji", {
         text: QuickReactionMenu.DEFAULT_EMOJIS.at(-1),
         count: 0,


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/227728

PR above improved quick add a reaction to use quick reaction menu too, similarly to "Add a reaction" in the message actions.

By doing so, the 2 buttons to add a reaction have been adapted to use same label "Add a reaction", one was just "Add reaction".

Some HOOT tests were asserting presence of the "Add a reaction" button, but with the change there are sometimes 2 such buttons, one being the message action and the other is the quick add reaction. Tests were adapted but not all of them: when they expect to click on "Add a reaction" on a message with at least one reaction, it should clarify whether the "Add a reaction" is the one in message action or the one in quick add a reaction, otherwise the HOOT test fails due to attempting to click on the 2 buttons at once.

This commit fixes with more specific selector, that the "Add a reaction" to click is the one from message actions.