### PR TITLE
[IMP] base: improve error handling in instances of attachment collision

### DIFF
--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -127,7 +127,8 @@ class IrAttachment(models.Model):
 
         # prevent sha-1 collision
         if os.path.isfile(full_path) and not self._same_content(bin_data, full_path):
-            raise UserError(_("The attachment collides with an existing file."))
+            _logger.error('SHA1 collision for file %s', full_path)
+            raise UserError(_('The attachment collides with an existing file located at %s. Please contact your administrator.', full_path))
         return fname, full_path
 
     @api.model


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In the event of attachment collision, the system just throws its hands up and says that it cannot proceed. I like it when I can determine where an issue is coming from so that I can solve it.

Current behavior before PR:
Odoo throws 'The attachment collides with an existing file.' as a `WARNING` in the logs and theoretically to the user.

Desired behavior after PR is merged:
The system gets an actual `ERROR` type message in the logs, along with a descriptive source of the issue.

Potentially we can also change the type of error we are throwing from `UserError`.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
