### PR TITLE
[FIX] stock, mrp, purchase_stock, *: fix forecast date and report lines

### DIFF
--- a/addons/mrp/report/stock_forecasted.py
+++ b/addons/mrp/report/stock_forecasted.py
@@ -57,3 +57,15 @@ class StockForecasted(models.AbstractModel):
             'name': move[m2o].name,
             'id': move[m2o].id
         }
+
+    def _reconcile_with_reserved_stock(self, lines, ins, reserved_move, reserved_out, demand_out, out, read):
+        if reserved_out > 0 and reserved_move.production_id:
+            demand_out = max(demand_out - reserved_out, 0)
+            in_transit = bool(reserved_move.move_orig_ids)
+            # set the move_in to WH IN move for MOs and delete the move_in after to prevent duplicate line creation
+            for index, in_ in enumerate(ins):
+                lines.append(self._prepare_report_line(reserved_out, move_in=in_['move'], move_out=out, reserved_move=in_['move'], in_transit=in_transit, read=read))
+                del ins[index]
+                return demand_out
+        else:
+            return super()._reconcile_with_reserved_stock(lines, ins, reserved_move, reserved_out, demand_out, out, read)

--- a/addons/stock/static/src/stock_forecasted/forecasted_details.xml
+++ b/addons/stock/static/src/stock_forecasted/forecasted_details.xml
@@ -25,13 +25,7 @@
                 </tr>
                 <tr t-foreach="props.docs.lines" t-as="line" t-key="line_index" t-attf-class="#{line.is_matched and 'o_grid_match table-info'}">
                     <td t-attf-class="#{line.is_late and 'o_grid_warning table-danger'}">
-                        <a t-if="line.document_in"
-                            href="#"
-                            t-on-click.prevent="() => this.props.openView(line.document_in._name, 'form', line.document_in.id)"
-                            t-out="line.document_in.name"
-                            class="fw-bold"/>
-
-                        <t t-elif="line.reservation">
+                        <t t-if="line.reservation">
                             <a t-out="line.reservation.name" href="#" class="fw-bold"
                                t-on-click.prevent="() => this.props.openView(line.reservation._name, 'form', line.reservation.id)"
                                 /> reserved
@@ -42,6 +36,13 @@
                                 Unreserve
                             </button>
                         </t>
+
+                        <a t-elif="line.document_in"
+                            href="#"
+                            t-on-click.prevent="() => this.props.openView(line.document_in._name, 'form', line.document_in.id)"
+                            t-out="line.document_in.name"
+                            class="fw-bold"/>
+
                         <t t-elif="line.in_transit">
                             <t t-if="line.move_out">
                                 <span>Stock In Transit</span>


### PR DESCRIPTION
*: sale_mrp, sale_purchase_stock

Issue:
Product availability and forecasted lines are not correct when handling multi-warehouse, multi-step deliveries; specifically for manufactured and purchased products with future delivery dates. Product availability for final delivery is "Available" when it should be "Exp."
The forecasted lines show the reserved move as the MO, when it should be the interwarehouse transfer.

This behavior occurs from 17.0 onward, due to [this](https://github.com/odoo/odoo/commit/57d8590) refactor of `_get_forecast_availability_outgoing()` and [this](https://github.com/odoo/odoo/commit/2dad4a5) refactor of StockForecasted.

Assuming we have two warehouses, WH1 and WH2, where WH2 is supplied from WH1, `_get_out_move_reserved_data()` calculates the reserved out quantity, reserved move, and move state. For manufactured/purchased products:
* The products will be reserved from the WH1 MO. WH2 delivery will not recognize the interwarehouse transfer as its in move.
* The forecasted date for the WH2 delivery becomes "Available" when it should match the WH1 transfer date.
* The finished products should be reserved from WH2, which will be transfered from WH1.

This commit refactors `_get_report_lines()` in StockForecasted to encapsulate the reserved stock logic for easier inheriting. It also adjusts the forecast report view to account for case where both reserved move and in move are set.
* We add a check to see if the reserved move has a `production_id` (MRP) or `purchase_line_id` (purchase)
* If true, append the correct in move and reserved move to the forecast line.

Before this commit: 
Product Availability is not consistent (WH2/OUT is "Available" when should match WH1/OUT).

<img width="1915" height="356" alt="image" src="https://github.com/user-attachments/assets/bef9cc3c-b98c-4385-a1bb-aaa4b1e00d71" />

Forecasted report shows the "MO" move as the reserved move.
<img width="1899" height="326" alt="image" src="https://github.com/user-attachments/assets/05a75426-9811-435c-8dad-25a405e8ef2d" />


After this commit:
Multi-warehouse deliveries will have the correct in moves and reserved moves and will reflect correctly in the forecast report.
The products availability will also be consistent, showing "Exp mm/dd/yyyy" for each delivery.

<img width="1910" height="388" alt="image" src="https://github.com/user-attachments/assets/3ee9059e-3202-4409-8dc7-b25222b8f817" />

Forecasted report shows the "IN" move as the reserved move.
<img width="1912" height="294" alt="image" src="https://github.com/user-attachments/assets/e4e4418d-0de7-43fa-8b5a-9267e6a91b15" />


Steps to Reproduce:
* Enable multi-step routes
* Create two warehouses (WH1 and WH2)
  * Both 3-step delivery only
  * WH2 -> resupply from WH1
* WH2 routes:
  * MTO unarchived
  * WH2: Supply product from WH1 -> check "Sales Order Line"
* Create product with routes "Manufacture" and "MTO" + BOM
  * "Buy" and "MTO" for purchases
* Create SO with product
  * show "Route" on SO line
  * set "Route" to "WH2: Supply product from WH1"
* On "Other Info" tab, set:
    * Warehouse -> WH2
    * Shipping Policy -> As Soon as Possible
    * Delivery Date -> +10 days from current date
* Confirm SO
  * 7 delivery orders and 1 MO (or 1 PO) should be made
* For Purchase Only: Confirm the PO
* Go to Delivery Orders
  * show "Product Availability" on the lines
* Products availability for WH2 delivery will be "Available", WH1 delivery will be "Exp mm/dd/yyyy"
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
