### PR TITLE
[FIX]  base: fails to update fully upgraded modules

### DIFF
--- a/doc/cla/individual/tharcisse.md
+++ b/doc/cla/individual/tharcisse.md
@@ -1,0 +1,9 @@
+Kenya, 2025-09-07
+
+I hereby agree to the terms of the Odoo Individual Contributor License Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Tharcisse Mukundayi mukundayi@gmail.com https://github.com/tharcisse

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -455,7 +455,7 @@ actual arch.
 
                     # During an upgrade, we can only use the views that have been
                     # fully upgraded already.
-                    if self.pool._init and sibling_primary_views:
+                    if self.pool._init and sibling_primary_views and self.pool._init_modules:
                         query = sibling_primary_views._get_filter_xmlid_query()
                         sql = SQL(query, res_ids=tuple(sibling_primary_views.ids), modules=tuple(self.pool._init_modules))
                         loaded_view_ids = {id_ for id_, in self.env.execute_query(sql)}


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
--update=all fails because self.pool._init_modules is empty

Current behavior before PR:
when runnig  with --update=all  odoo fails  to load some views because the corresponding module is not found

Desired behavior after PR is merged:
--update=all should upgrade all existing views

[Runbot error](https://runbot.odoo.com/odoo/runbot.build.error/231527)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr