### PR TITLE
[FIX] mail: channel thread list should take whole width

### DIFF
--- a/addons/mail/static/src/discuss/core/public_web/sub_channel_preview.xml
+++ b/addons/mail/static/src/discuss/core/public_web/sub_channel_preview.xml
@@ -3,7 +3,7 @@
     <t t-name="mail.SubChannelPreview">
         <t t-set="message" t-value="thread.newestPersistentOfAllMessage ?? thread.from_message_id"/>
         <button class="o-mail-SubChannelPreview btn btn-light-subtle d-flex border border-secondary mx-1 px-2 py-1 rounded-2 align-items-center" t-attf-class="{{ props.class }}" t-on-click="onClick">
-            <div class="d-flex flex-column">
+            <div class="d-flex flex-column w-100">
                 <div class="d-flex w-100">
                     <span class="o-fw-600 text-truncate small" t-esc="thread.displayName"/>
                     <span class="flex-grow-1"/>


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/227734

PR above made an improvement to display thread preview below message that initiated these threads.

This PR introduced a style regression in thread list: some thread previews in the thread list in the "Threads" action panel were not taking the whole width, which this commit fixes.

Before
<img width="483" height="302" alt="Screenshot 2025-09-20 at 12 48 02" src="https://github.com/user-attachments/assets/daaec1cc-d57b-414a-aa47-b9db9d720596" />

After
<img width="483" height="303" alt="Screenshot 2025-09-20 at 12 48 13" src="https://github.com/user-attachments/assets/285c2d2d-d79b-4db6-b808-e046cb152e73" />

