### PR TITLE
[ADD] tools: add merge attribute for view inheritance

### DIFF
--- a/odoo/tools/template_inheritance.py
+++ b/odoo/tools/template_inheritance.py
@@ -225,11 +225,12 @@ def apply_inheritance_specs(source, specs_tree, inherit_branding=False, pre_loca
                     # The element should only have attributes:
                     # - name (mandatory),
                     # - add, remove, separator
+                    # - megre
                     # - any attribute that starts with data-oe-*
                     unknown = [
                         key
                         for key in child.attrib
-                        if key not in ('name', 'add', 'remove', 'separator')
+                        if key not in ('name', 'add', 'remove', 'separator','merge') 
                         and not key.startswith('data-oe-')
                     ]
                     if unknown:
@@ -290,6 +291,21 @@ def apply_inheritance_specs(source, specs_tree, inherit_branding=False, pre_loca
                                 (v for v in values if v and v not in to_remove),
                                 to_add
                             ))
+                            
+                    if child.get('merge'):
+                        merge_from :str = node.attrib.get(attribute)
+                        merge_to :str = child.get('merge', '')
+                        
+                        if "domain" == attribute or "options" == attribute: 
+                            # example 
+                            # merge_from=[('is_vender','=',1)] merge_to =[('is_customer','=',1)] results = [('is_vender','=',1),('is_customer','=',1)]
+                            # removing the last merge_from '] or }' and first merge_to '[ or {' and combine them with ','
+                            value = f"{merge_from[:-1]},{merge_to[1:]}"
+                            
+                            #in case merge_to set to "[] or {}" nothing will happen, it will be valid expression
+                            
+                        else :#other type must be of type string (class,readonly,invisible,required,...ect)
+                            value =  f"{merge_from} {merge_to}"
                     else:
                         value = child.text or ''
 


### PR DESCRIPTION
This commit introduces a new `merge` attribute to the `<attribute>` tag, allowing developers to safely merge existing dictionary-based or list-based attributes in XML view inheritance.

Problem:
Currently, when a developer needs to extend an attribute like `options` or `domain` in an inherited view, they must completely redefine the attribute, which can lead to unintended overwrites of properties set in the base view. For example, to add a new option, one must copy all existing options, which is tedious and brittle.

Solution:
The new `merge` attribute provides a declarative way to extend these attributes. When specified on an `<attribute>` tag, it intelligently merges its value with the existing attribute value on the target node. For dictionary-based attributes like `options`, it performs a dictionary update. For list-based attributes like `domain`, it extends the list.

Usage Example:
Given an existing field with a base `options` attribute: `<field name="supplier_id" options="{'no_open': 1, 'no_create': 1}"/>`

A developer can now extend this in an inherited view without overwriting: `<attribute name="options" merge="{'list_view_ref':'cm_product.cm_product_supplierinfo_tree_view'}"/>`

The result will be a combined `options` attribute: `options="{'no_open': 1, 'no_create': 1, 'list_view_ref': 'cm_product.cm_product_supplierinfo_tree_view'}"`

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
