### PR TITLE
[IMP] tools: add merge attribute for view inheritance

### DIFF
--- a/doc/cla/individual/mohandgesm.md
+++ b/doc/cla/individual/mohandgesm.md
@@ -1,0 +1,11 @@
+Sudan, 2025-09-21
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Mohand-GesmElkhalig mohandgesm8420@gmail.com https://github.com/mohandgesm

--- a/odoo/tools/template_inheritance.py
+++ b/odoo/tools/template_inheritance.py
@@ -229,7 +229,7 @@ def apply_inheritance_specs(source, specs_tree, inherit_branding=False, pre_loca
                     unknown = [
                         key
                         for key in child.attrib
-                        if key not in ('name', 'add', 'remove', 'separator', 'merge') 
+                        if key not in ('name', 'add', 'remove', 'separator', 'merge')
                         and not key.startswith('data-oe-')
                     ]
                     if unknown:
@@ -290,8 +290,7 @@ def apply_inheritance_specs(source, specs_tree, inherit_branding=False, pre_loca
                                 (v for v in values if v and v not in to_remove),
                                 to_add
                             ))
-                            
-                    if child.get('merge'):
+                    elif child.get('merge'):
                         merge_from: str = node.attrib.get(attribute)
                         merge_to: str = child.get('merge', '')
 

--- a/odoo/tools/template_inheritance.py
+++ b/odoo/tools/template_inheritance.py
@@ -292,22 +292,22 @@ def apply_inheritance_specs(source, specs_tree, inherit_branding=False, pre_loca
                             ))
                             
                     if child.get('merge'):
-                        merge_from :str = node.attrib.get(attribute)
-                        merge_to :str = child.get('merge', '')
-                            
-                        if merge_from: # check if merge_form exists first
-                            if "domain" == attribute or "options" == attribute: 
-                                # example 
+                        merge_from: str = node.attrib.get(attribute)
+                        merge_to: str = child.get('merge', '')
+
+                        if merge_from:  # check if merge_from exists first
+                            if attribute == "domain" or attribute == "options":
+                                # example
                                 # merge_from=[('is_vender','=',1)] merge_to =[('is_customer','=',1)] results = [('is_vender','=',1),('is_customer','=',1)]
                                 # removing the last merge_from '] or }' and first merge_to '[ or {' and combine them with ','
                                 value = f"{merge_from[:-1]},{merge_to[1:]}"
-                                
-                                #in case merge_to set to "[] or {}" nothing will happen, it will be valid expression
-                                
-                            else :#other type must be of type string (class,readonly,invisible,required,...ect)
-                                value =  f"{merge_from} {merge_to}"
-                        
-                        else: # if merge_from do not exist then just assign it to value
+
+                                # in case merge_to set to "[] or {}" nothing will happen, it will be valid expression
+
+                            else:  # other type must be of type string (class,readonly,invisible,required,...ect)
+                                value = f"{merge_from} {merge_to}"
+
+                        else:  # if merge_from do not exist then just assign it to value
                             value = merge_to
                     else:
                         value = child.text or ''

--- a/odoo/tools/template_inheritance.py
+++ b/odoo/tools/template_inheritance.py
@@ -229,7 +229,7 @@ def apply_inheritance_specs(source, specs_tree, inherit_branding=False, pre_loca
                     unknown = [
                         key
                         for key in child.attrib
-                        if key not in ('name', 'add', 'remove', 'separator','merge') 
+                        if key not in ('name', 'add', 'remove', 'separator', 'merge') 
                         and not key.startswith('data-oe-')
                     ]
                     if unknown:

--- a/odoo/tools/template_inheritance.py
+++ b/odoo/tools/template_inheritance.py
@@ -294,17 +294,21 @@ def apply_inheritance_specs(source, specs_tree, inherit_branding=False, pre_loca
                     if child.get('merge'):
                         merge_from :str = node.attrib.get(attribute)
                         merge_to :str = child.get('merge', '')
+                            
+                        if merge_from: # check if merge_form exists first
+                            if "domain" == attribute or "options" == attribute: 
+                                # example 
+                                # merge_from=[('is_vender','=',1)] merge_to =[('is_customer','=',1)] results = [('is_vender','=',1),('is_customer','=',1)]
+                                # removing the last merge_from '] or }' and first merge_to '[ or {' and combine them with ','
+                                value = f"{merge_from[:-1]},{merge_to[1:]}"
+                                
+                                #in case merge_to set to "[] or {}" nothing will happen, it will be valid expression
+                                
+                            else :#other type must be of type string (class,readonly,invisible,required,...ect)
+                                value =  f"{merge_from} {merge_to}"
                         
-                        if "domain" == attribute or "options" == attribute: 
-                            # example 
-                            # merge_from=[('is_vender','=',1)] merge_to =[('is_customer','=',1)] results = [('is_vender','=',1),('is_customer','=',1)]
-                            # removing the last merge_from '] or }' and first merge_to '[ or {' and combine them with ','
-                            value = f"{merge_from[:-1]},{merge_to[1:]}"
-                            
-                            #in case merge_to set to "[] or {}" nothing will happen, it will be valid expression
-                            
-                        else :#other type must be of type string (class,readonly,invisible,required,...ect)
-                            value =  f"{merge_from} {merge_to}"
+                        else: # if merge_from do not exist then just assign it to value
+                            value = merge_to
                     else:
                         value = child.text or ''
 

--- a/odoo/tools/template_inheritance.py
+++ b/odoo/tools/template_inheritance.py
@@ -224,12 +224,12 @@ def apply_inheritance_specs(source, specs_tree, inherit_branding=False, pre_loca
                 for child in spec.getiterator('attribute'):
                     # The element should only have attributes:
                     # - name (mandatory),
-                    # - add, remove, separator
+                    # - add, remove, separator, megre
                     # - any attribute that starts with data-oe-*
                     unknown = [
                         key
                         for key in child.attrib
-                        if key not in ('name', 'add', 'remove', 'separator')
+                        if key not in ('name', 'add', 'remove', 'separator','merge') 
                         and not key.startswith('data-oe-')
                     ]
                     if unknown:
@@ -290,6 +290,21 @@ def apply_inheritance_specs(source, specs_tree, inherit_branding=False, pre_loca
                                 (v for v in values if v and v not in to_remove),
                                 to_add
                             ))
+                            
+                    if child.get('merge'):
+                        merge_from :str = node.attrib.get(attribute)
+                        merge_to :str = child.get('merge', '')
+                        
+                        if "domain" == attribute or "options" == attribute: 
+                            # example 
+                            # merge_from=[('is_vender','=',1)] merge_to =[('is_customer','=',1)] results = [('is_vender','=',1),('is_customer','=',1)]
+                            # removing the last merge_from '] or }' and first merge_to '[ or {' and combine them with ','
+                            value = f"{merge_from[:-1]},{merge_to[1:]}"
+                            
+                            #in case merge_to set to "[] or {}" nothing will happen, it will be valid expression
+                            
+                        else :#other type must be of type string (class,readonly,invisible,required,...ect)
+                            value =  f"{merge_from} {merge_to}"
                     else:
                         value = child.text or ''
 

--- a/odoo/tools/template_inheritance.py
+++ b/odoo/tools/template_inheritance.py
@@ -224,7 +224,7 @@ def apply_inheritance_specs(source, specs_tree, inherit_branding=False, pre_loca
                 for child in spec.getiterator('attribute'):
                     # The element should only have attributes:
                     # - name (mandatory),
-                    # - add, remove, separator, megre
+                    # - add, remove, separator, merge
                     # - any attribute that starts with data-oe-*
                     unknown = [
                         key


### PR DESCRIPTION
This commit introduces a new `merge` attribute to the `<attribute>` tag, allowing developers to safely merge existing dictionary-based or list-based attributes in XML view inheritance.

Problem:
Currently, when a developer needs to extend an attribute like `options` or `domain` in an inherited view, they must completely redefine the attribute, which can lead to unintended overwrites of properties set in the base view. For example, to add a new option, one must copy all existing options, which is tedious and brittle.

Solution:
The new `merge` attribute provides a declarative way to extend these attributes. When specified on an `<attribute>` tag, it intelligently merges its value with the existing attribute value on the target node. For dictionary-based attributes like `options`, it performs a dictionary update. For list-based attributes like `domain`, it extends the list.

Usage Example:
Given an existing field with a base `options` attribute: `<field name="supplier_id" options="{'no_open': 1, 'no_create': 1}"/>`

A developer can now extend this in an inherited view without overwriting: `<attribute name="options" merge="{'list_view_ref':'cm_product.cm_product_supplierinfo_tree_view'}"/>`

The result will be a combined `options` attribute: `options="{'no_open': 1, 'no_create': 1, 'list_view_ref': 'cm_product.cm_product_supplierinfo_tree_view'}"`

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
