### PR TITLE
[IMP] hw_posbox_homepage: add route and UI for sending IoT devices to server

### DIFF
--- a/addons/hw_posbox_homepage/controllers/homepage.py
+++ b/addons/hw_posbox_homepage/controllers/homepage.py
@@ -13,7 +13,7 @@ import time
 from pathlib import Path
 from odoo import http
 from odoo.addons.hw_drivers.tools import helpers
-from odoo.addons.hw_drivers.main import iot_devices
+from odoo.addons.hw_drivers.main import iot_devices, manager
 from odoo.addons.web.controllers.home import Home
 from odoo.addons.hw_drivers.connection_manager import connection_manager
 from odoo.tools.misc import file_path
@@ -249,6 +249,16 @@ class IotBoxOwlHomePage(Home):
         return json.dumps({
             'status': 'success',
             'message': 'IoT Handlers cleared successfully',
+        })
+
+    @http.route('/hw_posbox_homepage/send_iot_devices', auth="none", type="http", cors='*')
+    def send_iot_devices(self):
+        """Manually send the list of all connected IoT devices to the connected Odoo database"""
+        manager.send_alldevices()
+
+        return json.dumps({
+            'status': 'success',
+            'message': 'IoT devices sent to Odoo database',
         })
 
     # ---------------------------------------------------------- #

--- a/addons/hw_posbox_homepage/static/src/app/components/dialog/DeviceDialog.js
+++ b/addons/hw_posbox_homepage/static/src/app/components/dialog/DeviceDialog.js
@@ -41,6 +41,16 @@ export class DeviceDialog extends Component {
         }, {});
     }
 
+    async sendIoTDevices() {
+        try {
+            await this.store.rpc({
+                url: "/hw_posbox_homepage/send_iot_devices",
+            });
+        } catch {
+            console.warn("Error while sending IoT devices to server");
+        }
+    }
+
     static template = xml`
         <BootstrapDialog identifier="'device-list'" btnName="'Show'" isLarge="true">
             <t t-set-slot="header">
@@ -74,6 +84,7 @@ export class DeviceDialog extends Component {
                 </div>
             </t>
             <t t-set-slot="footer">
+                <button t-if="this.store.advanced" class="btn btn-info btn-sm" t-on-click="sendIoTDevices">Send to Server</button>
                 <button type="button" class="btn btn-primary btn-sm" data-bs-dismiss="modal">Close</button>
             </t>
         </BootstrapDialog>


### PR DESCRIPTION
In the context of the labodoo, database without IoT box are reseted which force to restart the IoT service to re-setup the IoT in the database. This does take some time and ressources that is not neccesary in this context as we would only need to retieve the IoT devices information.

This PR propose the idea of having a dedicated route that would directly call the `send_alldevices` method which call `/iot/setup` route which will update the devices.

I do think it can also be convenient in the context of the support in the case somehow a device was not synced (can likely happen if the odoo server was down when it was detected) or if the iot box record was removed from the odoo database and need to be recreated

Preview:
<img width="344" height="512" alt="image" src="https://github.com/user-attachments/assets/1b6c94b5-3f79-4d51-8e0e-f6a83f31bf46" />


task-5101536