### PR TITLE
[FIX] l10n_vn: Preserve user data when updating taxes in migration

### DIFF
--- a/addons/l10n_vn/migrations/2.0.3/end-migrate_update_taxes.py
+++ b/addons/l10n_vn/migrations/2.0.3/end-migrate_update_taxes.py
@@ -4,4 +4,10 @@ from odoo import api, SUPERUSER_ID
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
     for company in env['res.company'].search([('chart_template', '=', 'vn')], order="parent_path"):
-        env['account.chart.template'].try_loading('vn', company)
+        ChartTemplate = env['account.chart.template'].with_company(company)
+        data = {
+            'account.tax.group': ChartTemplate._get_account_tax_group(company.chart_template),
+            'account.tax': ChartTemplate._get_account_tax(company.chart_template)
+        }
+        ChartTemplate._pre_reload_data(company, {}, data)
+        ChartTemplate._load_data(data)


### PR DESCRIPTION
Problem
The previous implementation used try_loading() which would reload the entire chart template, potentially overwriting user-customized configurations settings.

Solution
Replaced try_loading() with a more targeted approach usin _load_data for account.tax.group and account.tax

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
