### PR TITLE
[FIX] sale_project: fix quantity(%) of milestones from the project dashboard

### DIFF
--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -330,8 +330,8 @@
                 <field name="allow_billable" column_invisible="True"/>
                 <field name="sale_line_id" options="{'no_open': True}" placeholder="Non-billable" readonly="1" groups="!sales_team.group_sale_salesman"/>
                 <field name="sale_line_id" options="{'no_create': True}" placeholder="Non-billable" groups="sales_team.group_sale_salesman"/>
-                <field name="quantity_percentage" string="Quantity (%)" widget="percentage" groups="!sales_team.group_sale_salesman"/>
-                <field name="quantity_percentage" string="Quantity (%)" widget="percentage" readonly="0" groups="sales_team.group_sale_salesman"/>
+                <field name="quantity_percentage" string="Quantity (%)" widget="percentage" readonly="not sale_line_id" groups="!sales_team.group_sale_salesman"/>
+                <field name="quantity_percentage" string="Quantity (%)" widget="percentage" readonly="not sale_line_id" groups="sales_team.group_sale_salesman"/>
                 <field name="product_uom_qty" optional="hide" groups="!sales_team.group_sale_salesman" readonly="1"/>
                 <field name="product_uom_qty" optional="hide" groups="sales_team.group_sale_salesman"/>
             </xpath>


### PR DESCRIPTION
**Steps to Reproduce:**
- Install sale_project.
- Go to the project dashboard.
- Click on Edit milestones.

**Isuue:**
When a sales order line exists, the quantity percentage can be updated. When no sales order line exists, the quantity percentage cannot be updated.

**Fix:**
Make the field readonly when no sales order line is linked.

task-5068312





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
