### PR TITLE
[FIX] l10n_my*: more precise tests

### DIFF
--- a/addons/l10n_my_edi/tests/test_file_generation.py
+++ b/addons/l10n_my_edi/tests/test_file_generation.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from freezegun import freeze_time
 from lxml import etree
 
+from odoo.fields import Command
 from odoo.tests import Form, tagged
 from odoo.tools import file_open
 
@@ -341,6 +342,7 @@ class L10nMyEDITestFileGeneration(AccountTestInvoicingCommon):
                 'product_uom_qty': 1,
                 'price_unit': 100,
                 'currency_id': self.other_currency.id,
+                'tax_ids': [Command.set(self.company_data['default_tax_sale'].ids)],
             })],
         }).sudo(False)
         sale_order.action_confirm()

--- a/addons/l10n_my_edi/tests/test_submissions.py
+++ b/addons/l10n_my_edi/tests/test_submissions.py
@@ -256,7 +256,10 @@ class L10nMyEDITestNewSubmission(TestAccountMoveSendCommon):
                 'move_type': 'out_invoice',
                 'partner_id': self.partner_a.id,
                 'invoice_line_ids': [
-                    Command.create({'product_id': self.product_a.id}),
+                    Command.create({
+                        'product_id': self.product_a.id,
+                        'tax_ids': [Command.set(self.company_data['default_tax_sale'].ids)],
+                    }),
                 ],
             })
 
@@ -332,7 +335,10 @@ class L10nMyEDITestNewSubmission(TestAccountMoveSendCommon):
                 'move_type': 'out_invoice',
                 'partner_id': self.partner_a.id,
                 'invoice_line_ids': [
-                    Command.create({'product_id': self.product_a.id}),
+                    Command.create({
+                        'product_id': self.product_a.id,
+                        'tax_ids': [Command.set(self.company_data['default_tax_sale'].ids)],
+                    }),
                 ],
             })
 


### PR DESCRIPTION
follow-up on https://github.com/odoo/odoo/pull/227111 The fixes helped improve the stability of the tests, but a few using different ways of setting up their invoices (or SO) went through without the change.

This adds the fixed tax to these as well, so that they should no longer fail if a side effect changes the default tax/product tax.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
