### PR TITLE
[IMP] stock: removed operations link from inventory dashboard

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -124,7 +124,6 @@ class StockPickingType(models.Model):
     count_picking_waiting = fields.Integer(compute='_compute_picking_count')
     count_picking_late = fields.Integer(compute='_compute_picking_count')
     count_picking_backorders = fields.Integer(compute='_compute_picking_count')
-    count_move_ready = fields.Integer(compute='_compute_move_count')
     hide_reservation_method = fields.Boolean(compute='_compute_hide_reservation_method')
     barcode = fields.Char('Barcode', copy=False)
     company_id = fields.Many2one(
@@ -267,15 +266,6 @@ class StockPickingType(models.Model):
             count = {picking_type.id: count for picking_type, count in data}
             for record in self:
                 record[field_name] = count.get(record.id, 0)
-
-    def _compute_move_count(self):
-        data = self.env['stock.move']._read_group(
-            [('state', '=', 'assigned'), ('picking_type_id', 'in', self.ids)],
-            ['picking_type_id'], ['__count']
-        )
-        count = {picking_type.id: count for picking_type, count in data}
-        for record in self:
-            record['count_move_ready'] = count.get(record.id, 0)
 
     @api.depends('warehouse_id')
     def _compute_display_name(self):
@@ -467,9 +457,6 @@ class StockPickingType(models.Model):
         if self.code == 'internal':
             return self._get_action('stock.action_picking_tree_internal')
         return self._get_action('stock.stock_picking_action_picking_type')
-
-    def get_action_picking_type_ready_moves(self):
-        return self._get_action('stock.action_get_picking_type_ready_moves')
 
     def _get_aggregated_records_by_date(self):
         """

--- a/addons/stock/views/stock_picking_type_views.xml
+++ b/addons/stock/views/stock_picking_type_views.xml
@@ -181,7 +181,6 @@
             <kanban highlight_color="color" class="o_stock_kanban" js_class="stock_dashboard_kanban" records_draggable="0" create="0" group_create="false" can_open="0">
                 <field name="color"/>
                 <field name="code" readonly="1"/>
-                <field name="count_move_ready"/>
                 <field name="show_picking_type" invisible="1"/>
                 <templates>
                     <t t-name="menu" t-if="!selection_mode">
@@ -269,15 +268,6 @@
                                             <div class="row">
                                                 <span class="col-6">Back Orders</span>
                                                 <field class="col-2 text-end" name="count_picking_backorders"/>
-                                            </div>
-                                        </a>
-                                    </div>
-
-                                    <div t-if="record.count_move_ready.raw_value > 0" class="row">
-                                        <a class="col-8 offset-4 pe-0 text-truncate" name="get_action_picking_type_ready_moves" type="object">
-                                            <div class="row">
-                                                <span class="col-6">Operations</span>
-                                                <field class="col-2 text-end" name="count_move_ready"/>
                                             </div>
                                         </a>
                                     </div>

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -595,15 +595,6 @@
             <field name="context">{'contact_display': 'partner_address', 'search_default_backorder': 1}</field>
         </record>
 
-        <record id="action_get_picking_type_ready_moves" model="ir.actions.act_window">
-            <field name="name">Ready Moves</field>
-            <field name="res_model">stock.move</field>
-            <field name="view_id" ref="view_move_tree"/>
-            <field name="search_view_id" ref="view_move_search"/>
-            <field name="domain">[('picking_type_id', '=', active_id)]</field>
-            <field name="context">{'search_default_ready': 1}</field>
-        </record>
-
         <template id="help_message_template" name="Help Message" groups="base.group_user">
             <p name="top_help_message" class="o_view_nocontent_smiling_face o_view_nocontent_stock">
                 <t name="receipt_message">


### PR DESCRIPTION
The inventory dashboard previously included a link of operations which will open
a list of moves. This link had become obsolete and misleading. Users could
mistakenly believe that the list was still relevant, which caused confusion
in daily warehouse operations.

This commit removes the link of operations from the dashboard to ensure users
only see relevant and actionable options. By cleaning up outdated navigation,
the interface becomes clearer.

Task - 5025930