### PR TITLE
[FIX] pos_restaurant: traceback on cancel order with default preset with identification

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -491,7 +491,9 @@ export class PosStore extends WithLazyGetterTrap {
         return orderIsDeleted;
     }
     async afterOrderDeletion() {
-        this.setOrder(this.getOpenOrders().at(-1) || this.addNewOrder());
+        if (!this.config.module_pos_restaurant) {
+            this.setOrder(this.getOpenOrders().at(-1) || this.addNewOrder());
+        }
     }
 
     async deleteOrders(orders, serverIds = [], ignoreChange = false) {

--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -3,7 +3,6 @@ import { PosStore } from "@point_of_sale/app/services/pos_store";
 import { ConnectionLostError } from "@web/core/network/rpc";
 import { _t } from "@web/core/l10n/translation";
 import { EditOrderNamePopup } from "@pos_restaurant/app/popup/edit_order_name_popup/edit_order_name_popup";
-import { ProductScreen } from "@point_of_sale/app/screens/product_screen/product_screen";
 import { NumberPopup } from "@point_of_sale/app/components/popups/number_popup/number_popup";
 import { SelectionPopup } from "@point_of_sale/app/components/popups/selection_popup/selection_popup";
 import { makeAwaitable } from "@point_of_sale/app/utils/make_awaitable_dialog";
@@ -334,15 +333,18 @@ patch(PosStore.prototype, {
 
         return false;
     },
-    async onDeleteOrder(order) {
-        const orderIsDeleted = await super.onDeleteOrder(...arguments);
+    removeOrder(order) {
+        const wasCurrentOrder = this.selectedOrderUuid === order?.uuid;
+        const orderRemoved = super.removeOrder(...arguments);
         if (
-            orderIsDeleted &&
+            orderRemoved &&
+            wasCurrentOrder &&
             this.config.module_pos_restaurant &&
             this.mainScreen.component.name !== "TicketScreen"
         ) {
             this.showScreen("FloorScreen");
         }
+        return orderRemoved;
     },
     async closingSessionNotification(data) {
         await super.closingSessionNotification(...arguments);
@@ -418,18 +420,6 @@ patch(PosStore.prototype, {
     },
     get selectedTable() {
         return this.getOrder()?.table_id;
-    },
-    showScreen(screenName, props = {}, newOrder = false) {
-        const order = this.getOrder();
-        if (
-            this.config.module_pos_restaurant &&
-            this.mainScreen.component === ProductScreen &&
-            order &&
-            !order.isBooked
-        ) {
-            this.removeOrder(order);
-        }
-        return super.showScreen(...arguments);
     },
     closeScreen() {
         if (this.config.module_pos_restaurant && !this.getOrder()) {

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -508,27 +508,49 @@ registry.category("web_tour.tours").add("test_multiple_preparation_printer_diffe
             Dialog.confirm(),
         ].flat(),
 });
+registry.category("web_tour.tours").add("test_preset_delivery_restaurant", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            FloorScreen.clickTable("2"),
+            ProductScreen.clickCustomer("Partner Full"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola", true),
+            ProductScreen.clickControlButton("Cancel Order"),
+            Dialog.cancel(),
+            ProductScreen.isShown(),
+            ProductScreen.clickControlButton("Cancel Order"),
+            Dialog.confirm(),
+            FloorScreen.hasTable("2"),
+        ].flat(),
+});
 
 registry.category("web_tour.tours").add("test_preset_timing_restaurant", {
     steps: () =>
         [
             Chrome.startPoS(),
-            Dialog.confirm("Open Register"),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola", true),
+            ProductScreen.clickControlButton("Cancel Order"),
+            Dialog.cancel(),
+            ProductScreen.clickControlButton("Cancel Order"),
+            Dialog.confirm(),
+            FloorScreen.isShown(),
             FloorScreen.clickNewOrder(),
-            ProductScreen.clickDisplayedProduct("Coca-Cola"),
-            ProductScreen.selectPreset("Eat in", "Takeaway"),
             TextInputPopup.inputText("John"),
             Dialog.confirm(),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
             Chrome.clickPresetTimingSlot(),
             Chrome.selectPresetTimingSlotHour("15:00"),
             Chrome.presetTimingSlotIs("15:00"),
             Chrome.clickPlanButton(),
             FloorScreen.clickTable("4"),
+            ProductScreen.selectPreset("Takeaway", "Eat in"),
             ProductScreen.clickDisplayedProduct("Coca-Cola"),
             Chrome.clickOrders(),
             TicketScreen.nthRowContains(1, "John"),
             TicketScreen.nthRowContains(1, "Takeaway", false),
-            TicketScreen.nthRowContains(2, "002"),
+            TicketScreen.nthRowContains(2, "004"),
             TicketScreen.nthRowContains(2, "Eat in", false),
         ].flat(),
 });

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -553,11 +553,22 @@ class TestFrontend(TestFrontendCommon):
             'name': 'Takeaway',
             'identification': 'name',
         })
+        self.preset_delivery = self.env['pos.preset'].create({
+            'name': 'Delivery',
+            'identification': 'address',
+        })
         self.main_pos_config.write({
             'use_presets': True,
-            'default_preset_id': self.preset_eat_in.id,
-            'available_preset_ids': [(6, 0, [self.preset_takeaway.id])],
+            'default_preset_id': self.preset_delivery.id,
+            'available_preset_ids': [(6, 0, [
+                self.preset_takeaway.id,
+                self.preset_eat_in.id,
+                self.preset_delivery.id,
+            ])],
         })
+        self.start_pos_tour('test_preset_delivery_restaurant')
+        self.main_pos_config.write({'default_preset_id': self.preset_takeaway.id})
+
         resource_calendar = self.env['resource.calendar'].create({
             'name': 'Takeaway',
             'attendance_ids': [(0, 0, {
@@ -573,6 +584,7 @@ class TestFrontend(TestFrontendCommon):
             'resource_calendar_id': resource_calendar
         })
         self.start_pos_tour('test_preset_timing_restaurant')
+        self.main_pos_config.write({'default_preset_id': self.preset_eat_in.id})
         # remove time slot for this preset
         self.preset_takeaway.resource_calendar_id = False
         self.start_pos_tour('test_preset_timing_restaurant_dialog')


### PR DESCRIPTION
### step to reproduce:
- Set default preset to "Takeout or Delivery" in restaurant config.
- Open restaurant .
- Open any table and add a product.
- Cancel the order using the action button.

### issue:
- A popup appears asking to select a partner/floating order name, followed by a traceback.

### cause:
- Traceback occures as next screen is loaded after order deletion.

### fix:
- Redirect to the default screen before deleting the order.
- Ensure that no new order is created when the next screen is the floor screen.

task: 5092951
