### PR TITLE
[FIX] mail: Hide unpin button for guest 

### DIFF
--- a/addons/mail/static/src/core/common/message_card_list.js
+++ b/addons/mail/static/src/core/common/message_card_list.js
@@ -35,6 +35,7 @@ export class MessageCardList extends Component {
 
     setup() {
         super.setup();
+        this.store = useService("mail.store");
         this.ui = useService("ui");
         useSubEnv({ messageCard: true });
         useVisible("load-more", (isVisible) => {
@@ -42,6 +43,10 @@ export class MessageCardList extends Component {
                 this.props.onLoadMoreVisible?.();
             }
         });
+    }
+    
+    isGuestUser() {
+        return this.store.self?.Model?.name === 'MailGuest';
     }
 
     /**

--- a/addons/mail/static/src/core/common/message_card_list.xml
+++ b/addons/mail/static/src/core/common/message_card_list.xml
@@ -6,7 +6,7 @@
                 <div class="card-body ps-0 py-2 rounded-3">
                     <div class="position-absolute top-0 end-0 z-1 mx-2 my-1 d-flex align-items-center">
                         <a role="button" class="o-mail-MessageCard-jump rounded bg-400 badge opacity-0" t-att-class="{ 'opacity-100 py-1 px-2': ui.isSmall }" t-on-click="() => this.onClickJump(message)">Jump</a>
-                        <button t-if="props.mode === 'pin'" class="btn btn-link text-reset ms-2 p-0 opacity-25 opacity-100-hover" t-att-class="{ 'fs-5': ui.isSmall }" title="Unpin" t-on-click="message.unpin">
+                        <button t-if="props.mode === 'pin' and !this.isGuestUser()" class="btn btn-link text-reset ms-2 p-0 opacity-25 opacity-100-hover" t-att-class="{ 'fs-5': ui.isSmall }" title="Unpin" t-on-click="message.unpin">
                             <i class="oi oi-close"/>
                         </button>
                     </div>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
----------------------------------------------
Currently, guest users in PinnedMessagesPanel can see the unpin button on pinned messages,
but the server correctly rejects their unpin requests. This creates confusion
and a poor user experience where external users see functionality that doesn't
work for them.

**Current behavior before PR:**
----------------------------------------------
- Guest users see the unpin button on pinned messages
- Clicking the unpin button results in server rejection
- UI shows functionality that guest users cannot actually use

**Desired behavior after PR is merged:**
----------------------------------------------
- Guest users cannot see the unpin button on pinned messages
- Internal users continue to have full pin/unpin functionality
- UI accurately reflects user permissions and capabilities
- Better user experience with appropriate access control

Task-5033295

----------------------------------------------
I confirm I have signed the CLA and read the PR guidelines at https://www.odoo.com/submit-pr