### PR TITLE
[FIX] website: reCaptcha line alignment issue

### DIFF
--- a/addons/website/static/src/snippets/s_website_form/001.scss
+++ b/addons/website/static/src/snippets/s_website_form/001.scss
@@ -53,7 +53,7 @@
         display: none;
     }
 
-    .s_website_form_submit, .s_website_form_recaptcha {
+    .s_website_form_submit {
         .s_website_form_label {
             float: left;
             height: 1px;


### PR DESCRIPTION
Steps to Reproduce:
1. Go to _Settings_ and search for reCAPTCHA.
2. Add the required keys.
3. Go to _Website_ and enter edit mode.
4. Drop any _Contact Form_ snippet.
5. Make the labels to top.
6. Enable the _Show reCAPTCHA_ option.
7. Notice an unnecessary blank space before the privacy policy line.

Issue:
The reCAPTCHA line created unnecessary blank space when aligned to the left.

Reason:
The line was placed inside the form block, which reserves space for a label. Since reCAPTCHA has no label, an empty placeholder space appeared.

Fix:
Hide the unused label by setting its visibility to `none` for the reCAPTCHA line, removing the extra blank space.

Before:
<img width="1464" height="406" alt="image" src="https://github.com/user-attachments/assets/b5fc0fc2-104d-4a3e-a6c9-fab34992ee0d" />

After:
<img width="936" height="772" alt="image" src="https://github.com/user-attachments/assets/8d721d90-b7fa-45a5-8d0c-a750ec504a12" />


task-4756289