### PR TITLE
[IMP] hr_attendance: improve presence state logic and tooltips

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -880,7 +880,9 @@ class HrEmployee(models.Model):
             if employee.company_id.sudo().hr_presence_control_login:
                 # sudo: res.users - can access presence of accessible user
                 presence_status = employee.user_id.sudo().presence_ids.status or "offline"
-                if presence_status == "online":
+                if not employee.sudo().is_in_contract:
+                    state = "out_of_working_hour"
+                elif presence_status == "online":
                     state = 'present'
                 elif presence_status == "offline" and employee.id in working_now_list:
                     state = 'absent'

--- a/addons/hr_attendance/models/hr_employee.py
+++ b/addons/hr_attendance/models/hr_employee.py
@@ -242,11 +242,16 @@ class HrEmployee(models.Model):
                                                             and e.hr_presence_state == "out_of_working_hour")
         working_now_list = employee_to_check_working._get_employee_working_now()
         for employee in employees:
-            if employee.attendance_state == "checked_out" and employee.hr_presence_state == "out_of_working_hour" and \
-                    employee.id in working_now_list:
+            if employee.attendance_state == "checked_in" or not employee.user_id:
+                if not employee.user_id and not employee.is_in_contract:
+                    employee.hr_presence_state = "out_of_working_hour"
+                else:
+                    employee.hr_presence_state = "present"
+            elif employee.attendance_state == "checked_out" and \
+                 employee.hr_presence_state == "out_of_working_hour" and \
+                 employee.id in working_now_list and \
+                 employee.is_in_contract:
                 employee.hr_presence_state = "absent"
-            elif employee.attendance_state == "checked_in":
-                employee.hr_presence_state = "present"
 
     def _compute_presence_icon(self):
         res = super()._compute_presence_icon()

--- a/addons/hr_attendance/static/src/components/hr_presence_status/hr_attendance_presence_status.js
+++ b/addons/hr_attendance/static/src/components/hr_presence_status/hr_attendance_presence_status.js
@@ -1,0 +1,25 @@
+import { hrPresenceStatus, HrPresenceStatus } from "@hr/components/hr_presence_status/hr_presence_status";
+import { patch } from "@web/core/utils/patch";
+import { _t } from "@web/core/l10n/translation";
+
+patch(HrPresenceStatus.prototype, {
+    get label() {
+        if (this.value === 'presence_present') {
+            const hasUser = this.props.record.data.user_id;
+            if (!hasUser) {
+                return _t("Present (untracked)");
+            }
+        } else if (this.value === 'presence_out_of_working_hour') {
+            return _t("Off-Hours");
+        }
+        
+        return super.label;
+    }
+});
+
+Object.assign(hrPresenceStatus, {
+    fieldDependencies: [
+        ...hrPresenceStatus.fieldDependencies,
+        { name: "user_id", type: "many2one" },
+    ],
+});


### PR DESCRIPTION
- Fix presence state for employees without users to show as 'present' instead of 'absent'
- Fix presence state for employees not in contract to show as 'out_of_working_hour'
- Add custom tooltips: "Present (untracked)" for employees without users
- Add "Off-Hours" tooltip for out of working hours state, Not in contract and not a user -> Off-Hours too

task-5082763