### PR TITLE
[FIX] point_of_sale: customer name and address shown twice on receipt header

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.js
@@ -15,6 +15,7 @@ export class ReceiptHeader extends Component {
     }
 
     get partnerAddress() {
+        // TODO : REMOVE ME IN MASTER
         return this.order.partner_id.pos_contact_address
             .split("\n")
             .filter((line) => line.trim() !== "")

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml
@@ -42,10 +42,5 @@
                 <t t-out="order.preset_id.name"/>: <t t-out="order.presetDateTime"/>
             </span>
         </div>
-        <div t-if="order.preset_id?.identification === 'address'" t-attf-class="{{ order?.presetDateTime ? '' : 'pt-2'}}">
-            <div class="text-break">
-                <span class="fw-bolder" t-out="order.partner_id.name"/> (<span t-out="partnerAddress"/>)
-            </div>
-        </div>
     </t>
 </templates>


### PR DESCRIPTION
Steps to reproduce:
- Open the restaurant configuration.
- Select the preset as Delivery and choose a customer with an address.
- Validate the order and print the receipt. 

Issue:
- The customer’s name and address appear twice on the receipt.

Fix:
- Removed the duplicate name and address from the receipt header.

task-5097764
