### PR TITLE
[FIX] point_of_sale: correct refund order flow

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -576,7 +576,7 @@ export class TicketScreen extends Component {
                 !this.pos.isProductQtyZero(refund.qty) &&
                 refund.line.order_id.uuid === order.uuid &&
                 (partner ? refund.line.order_id.partner_id?.id === partner.id : true) &&
-                !refund.destination_order_id
+                !refund.destination_order
         );
     }
 

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
@@ -137,7 +137,7 @@
                                     <span> Refunded</span>
                                 </li>
                                 <li t-if="!pos.isProductQtyZero(toRefundDetail?.qty)" class="info to-refund-highlight refund-note mt-1 fw-bold text-primary">
-                                    <t t-set="_destinationOrderUid" t-value="toRefundDetail.destination_order_uuid"/>
+                                    <t t-set="_destinationOrderUid" t-value="toRefundDetail.destination_order?.uuid"/>
                                     <t t-set="refundQty" t-value="env.utils.formatProductQty(toRefundDetail.qty)"/>
                                     <t t-if="_destinationOrderUid">
                                         Refunding <t t-esc="refundQty" /> in

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -428,12 +428,25 @@ export class PosStore extends Reactive {
                 return false;
             }
         }
+        const refundedOrderLines = order.lines
+            .filter((line) => line.refunded_orderline_id?.order_id)
+            .map((line) => ({
+                order: line.refunded_orderline_id.order_id,
+                uuid: line.refunded_orderline_id.uuid,
+            }));
+
         const orderIsDeleted = await this.deleteOrders([order]);
-        if (orderIsDeleted) {
-            order.uiState.displayed = false;
-            this.afterOrderDeletion();
+        if (!orderIsDeleted) {
+            return false;
         }
-        return orderIsDeleted;
+        order.uiState.displayed = false;
+        // Delete refunded lines linked to the current order
+        for (const refundedLine of refundedOrderLines) {
+            delete refundedLine.order?.uiState?.lineToRefund[refundedLine.uuid];
+        }
+
+        this.afterOrderDeletion();
+        return true;
     }
     afterOrderDeletion() {
         this.set_order(this.get_open_orders().at(-1) || this.createNewOrder());

--- a/addons/point_of_sale/static/tests/tours/ticket_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/ticket_screen_tour.js
@@ -239,6 +239,53 @@ registry.category("web_tour.tours").add("RefundFewQuantities", {
         ].flat(),
 });
 
+registry.category("web_tour.tours").add("test_order_refund_flow", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.addOrderline("Desk Pad", "2", "3"),
+            ProductScreen.addOrderline("Letter Tray", "3", "2"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+            ReceiptScreen.clickNextOrder(),
+            // First refund order
+            ProductScreen.clickRefund(),
+            TicketScreen.selectOrder("-0001"),
+            ProductScreen.clickNumpad("1"),
+            TicketScreen.toRefundTextContains("To Refund: 1.00"),
+            TicketScreen.confirmRefund(),
+            { ...ProductScreen.back(), isActive: ["mobile"] },
+            ProductScreen.isShown(),
+            inLeftSide([...Order.hasLine("Desk Pad", "-1")]),
+            // Second refund order
+            Chrome.createFloatingOrder(),
+            ProductScreen.clickRefund(),
+            TicketScreen.selectOrder("-0001"),
+            TicketScreen.toRefundTextContains("Refunding"),
+            inLeftSide([...ProductScreen.clickLine("Letter Tray", "3.0")]),
+            ProductScreen.clickNumpad("1"),
+            TicketScreen.toRefundTextContains("To Refund: 1.00"),
+            TicketScreen.confirmRefund(),
+            { ...ProductScreen.back(), isActive: ["mobile"] },
+            ProductScreen.isShown(),
+            // Verify refund order has only one line
+            inLeftSide([...Order.hasLine("Letter Tray", "-1")]),
+            ProductScreen.totalAmountIs("-2.20"),
+            // Delete both refunding orders
+            Chrome.clickMenuOption("Orders"),
+            TicketScreen.deleteOrder("-0002"),
+            Dialog.confirm(),
+            TicketScreen.deleteOrder("-0003"),
+            Dialog.confirm(),
+            TicketScreen.selectFilter("Paid"),
+            TicketScreen.selectOrder("-0001"),
+            TicketScreen.noLinesToRefund(),
+        ].flat(),
+});
+
 registry.category("web_tour.tours").add("LotTour", {
     steps: () =>
         [

--- a/addons/point_of_sale/static/tests/tours/utils/ticket_screen_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/ticket_screen_util.js
@@ -178,6 +178,12 @@ export function refundedNoteContains(text) {
         trigger: `.ticket-screen .refund-note:contains("${text}")`,
     });
 }
+export function noLinesToRefund() {
+    return inLeftSide({
+        content: "No lines are marked for to refund or refunding",
+        trigger: ".ticket-screen:not(:has(.to-refund-highlight))",
+    });
+}
 export function tipContains(amount) {
     return [
         {

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1455,6 +1455,10 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'RefundFewQuantities', login="pos_user")
 
+    def test_order_refund_flow(self):
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_order_refund_flow')
+
     def test_product_combo_price(self):
         """ Check that the combo has the expected price """
         self.desk_organizer.write({"lst_price": 7})


### PR DESCRIPTION
Steps to reproduce:
- In POS, select a paid order in the ticket screen with multiple lines.
- Select the first line, choose a quantity to refund, and click Refund.
- Return to the ticket screen, select the same paid order again.
- Select another line and quantity, and click Refund.

Issue:
- In the second refund, all order lines were being refunded, even though only one line was selected.
- After deleting a refund order, the ticket screen still showed messages like "Refunding x quantities in xyz order."

Fix:
- Only the selected lines are refunded.
- Deleting a refund order restores the state of the linked order correctly.

Task-5095578
