### PR TITLE
[FIX] html_builder: ensure custom text in gradient picker is visible

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.scss
+++ b/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.scss
@@ -3,6 +3,16 @@
     --popover-border-color: #{$o-we-bg-darker};
 }
 
+.o_custom_gradient_button {
+    &, &:hover, &:focus {
+        color: #000000;
+    }
+
+    &[style*="background-image"] {
+        color: $o-we-item-clickable-color;
+    }
+}
+
 .o-hb-colorpicker {
     --o-color-picker-active-color: var(--o-hb-select-item-active-color, #{$o-we-sidebar-content-field-toggle-active-bg});
 


### PR DESCRIPTION
Steps to Reproduce:
1. Go to `Website` and enter edit mode.
2. Drop any `text` snippet.
3. Select the text.
4. Open color picker from the toolbar and switch to `gradient` tab.

Issue:
The custom text in the gradient tab of the color picker was not clearly visible in dark mode.

Reason:
The background is already light, and in dark mode the text color was also light. This resulted in insufficient contrast, making the text hard to read.

Fix:
Set the text color to black when button has no background image. In case of button containing style of background-image, the text color will be same as earlier.

| Before | After |
|-----------------------------|---------------------------------|
| <img width="483" height="274" alt="image" src="https://github.com/user-attachments/assets/911c53f2-bb0e-4d70-9fb2-078ac17388c1" /> | <img width="473" height="326" alt="image" src="https://github.com/user-attachments/assets/c976fb49-6c10-47c0-b559-6a58cfcbcdc2" /> |