### PR TITLE
[FIX] spreadsheet: group by many2one_reference

### DIFF
--- a/addons/spreadsheet/static/src/pivot/pivot_to_function_values.js
+++ b/addons/spreadsheet/static/src/pivot/pivot_to_function_values.js
@@ -41,6 +41,7 @@ function _toNumber(value) {
 pivotToFunctionValueRegistry
     .add("text", _toString)
     .add("selection", _toString)
+    .add("reference", _toString)
     .add("char", _toString)
     .add("integer", _toNumber)
     .add("monetary", _toNumber)

--- a/addons/spreadsheet/static/src/pivot/pivot_to_function_values.js
+++ b/addons/spreadsheet/static/src/pivot/pivot_to_function_values.js
@@ -45,6 +45,7 @@ pivotToFunctionValueRegistry
     .add("integer", _toNumber)
     .add("monetary", _toNumber)
     .add("many2one", _toNumber)
+    .add("many2one_reference", _toNumber)
     .add("many2many", _toNumber)
     .add("float", _toNumber)
     .add("date", _toDate)

--- a/addons/spreadsheet/static/src/pivot/pivot_values_normalizers.js
+++ b/addons/spreadsheet/static/src/pivot/pivot_values_normalizers.js
@@ -12,6 +12,7 @@ const { toString, toNumber } = helpers;
 pivotNormalizationValueRegistry
     .add("text", (value) => toString(value))
     .add("selection", (value) => toString(value))
+    .add("many2one_reference", (value) => toNumber(value, DEFAULT_LOCALE))
     .add("monetary", (value) => toNumber(value, DEFAULT_LOCALE))
     .add("many2one", (value) => toNumber(value, DEFAULT_LOCALE))
     .add("many2many", (value) => toNumber(value, DEFAULT_LOCALE))

--- a/addons/spreadsheet/static/src/pivot/pivot_values_normalizers.js
+++ b/addons/spreadsheet/static/src/pivot/pivot_values_normalizers.js
@@ -11,6 +11,7 @@ const { toString, toNumber } = helpers;
 
 pivotNormalizationValueRegistry
     .add("text", (value) => toString(value))
+    .add("reference", (value) => toString(value))
     .add("selection", (value) => toString(value))
     .add("many2one_reference", (value) => toNumber(value, DEFAULT_LOCALE))
     .add("monetary", (value) => toNumber(value, DEFAULT_LOCALE))

--- a/addons/spreadsheet/static/tests/pivots/model/pivot_plugin.test.js
+++ b/addons/spreadsheet/static/tests/pivots/model/pivot_plugin.test.js
@@ -1101,6 +1101,77 @@ test("Can group by many2one_reference field ", async () => {
     expect(getCellValue(model, "B5")).toBe(13);
 });
 
+test("Can group by reference field ", async () => {
+    onRpc("partner", "read_group", ({ kwargs }) => {
+        // The mock server doesn't support well reference.
+        // It is fixed in master/saas-19.1, but for now we have to mock the correct output ourselves.
+        if (kwargs.groupby?.includes("ref")) {
+            return [
+                {
+                    ref: "partner,2",
+                    __domain: [["ref", "=", "partner,2"]],
+                    __count: 1,
+                    probability_avg_id: 11,
+                },
+                {
+                    ref: "partner,3",
+                    __domain: [["ref", "=", "partner,3"]],
+                    __count: 1,
+                    probability_avg_id: 12,
+                },
+                {
+                    ref: false,
+                    __domain: [["ref", "=", false]],
+                    __count: 1,
+                    probability_avg_id: 13,
+                },
+            ];
+        }
+    });
+    Partner._fields = {
+        ...Partner._fields,
+        ref: fields.Reference({
+            selection: [["partner", "Partner"]],
+        }),
+    };
+    Partner._records = [
+        {
+            id: 1,
+            ref: "partner,2",
+            probability: 11,
+        },
+        {
+            id: 2,
+            ref: "partner,3",
+            probability: 12,
+        },
+        {
+            id: 3,
+            probability: 13,
+        },
+    ];
+    const { model } = await createSpreadsheetWithPivot({
+        arch: /* xml */ `
+            <pivot>
+                <field name="ref" type="row"/>
+                <field name="probability" type="measure"/>
+            </pivot>`,
+    });
+    expect(getCellFormula(model, "A3")).toBe('=PIVOT.HEADER(1,"ref","partner,2")');
+    expect(getCellFormula(model, "A4")).toBe('=PIVOT.HEADER(1,"ref","partner,3")');
+    expect(getCellFormula(model, "A5")).toBe('=PIVOT.HEADER(1,"ref",FALSE)');
+    expect(getCellFormula(model, "B3")).toBe('=PIVOT.VALUE(1,"probability:avg","ref","partner,2")');
+    expect(getCellFormula(model, "B4")).toBe('=PIVOT.VALUE(1,"probability:avg","ref","partner,3")');
+    expect(getCellFormula(model, "B5")).toBe('=PIVOT.VALUE(1,"probability:avg","ref",FALSE)');
+
+    expect(getCellValue(model, "A3")).toBe("partner,2");
+    expect(getCellValue(model, "A4")).toBe("partner,3");
+    expect(getCellValue(model, "A5")).toBe("None");
+    expect(getCellValue(model, "B3")).toBe(11);
+    expect(getCellValue(model, "B4")).toBe(12);
+    expect(getCellValue(model, "B5")).toBe(13);
+});
+
 test("PIVOT.HEADER grouped by date field without value", async function () {
     const { model, pivotId } = await createSpreadsheetWithPivot({
         arch: /* xml */ `

--- a/addons/spreadsheet/static/tests/pivots/model/pivot_plugin.test.js
+++ b/addons/spreadsheet/static/tests/pivots/model/pivot_plugin.test.js
@@ -6,6 +6,7 @@ import {
     getBasicServerData,
 } from "@spreadsheet/../tests/helpers/data";
 import {
+    fields,
     makeServerError,
     onRpc,
     patchTranslations,
@@ -1023,6 +1024,81 @@ test("Can group by many2many field ", async () => {
     expect(getCellValue(model, "C3")).toBe(15);
     expect(getCellValue(model, "C4")).toBe("");
     expect(getCellValue(model, "C5")).toBe("");
+});
+
+test("Can group by many2one_reference field ", async () => {
+    onRpc("partner", "read_group", ({ kwargs }) => {
+        // The mock server doesn't support well many2one_reference.
+        // It is fixed in master/saas-19.1, but for now we have to mock the correct output ourselves.
+        if (kwargs.groupby?.includes("res_id")) {
+            return [
+                {
+                    res_id: 2,
+                    __domain: [["res_id", "=", 2]],
+                    __count: 1,
+                    probability_avg_id: 11,
+                },
+                {
+                    res_id: 3,
+                    __domain: [["res_id", "=", 3]],
+                    __count: 1,
+                    probability_avg_id: 12,
+                },
+                {
+                    res_id: false,
+                    __domain: [["res_id", "=", false]],
+                    __count: 1,
+                    probability_avg_id: 13,
+                },
+            ];
+        }
+    });
+    Partner._fields = {
+        ...Partner._fields,
+        res_id: fields.Many2oneReference({
+            model_field: "res_model",
+            relation: "",
+        }),
+        res_model: fields.Char(),
+    };
+    Partner._records = [
+        {
+            id: 1,
+            res_id: 2,
+            res_model: "partner",
+            probability: 11,
+        },
+        {
+            id: 2,
+            res_id: 3,
+            res_model: "partner",
+            probability: 12,
+        },
+        {
+            id: 3,
+            probability: 13,
+        },
+    ];
+    const { model } = await createSpreadsheetWithPivot({
+        arch: /* xml */ `
+            <pivot>
+                <field name="res_id" type="row"/>
+                <field name="probability" type="measure"/>
+            </pivot>`,
+    });
+    expect(getCellFormula(model, "A3")).toBe('=PIVOT.HEADER(1,"res_id",2)');
+    expect(getCellFormula(model, "A4")).toBe('=PIVOT.HEADER(1,"res_id",3)');
+    expect(getCellFormula(model, "A5")).toBe('=PIVOT.HEADER(1,"res_id",FALSE)');
+    expect(getCellFormula(model, "B3")).toBe('=PIVOT.VALUE(1,"probability:avg","res_id",2)');
+    expect(getCellFormula(model, "B4")).toBe('=PIVOT.VALUE(1,"probability:avg","res_id",3)');
+    expect(getCellFormula(model, "B5")).toBe('=PIVOT.VALUE(1,"probability:avg","res_id",FALSE)');
+
+    expect(getCellValue(model, "A3")).toBe(2);
+    expect(getCellValue(model, "A4")).toBe(3);
+    expect(getCellValue(model, "A5")).toBe("None");
+    expect(getCellValue(model, "B3")).toBe(11);
+    expect(getCellValue(model, "B4")).toBe(12);
+    expect(getCellValue(model, "B5")).toBe(13);
 });
 
 test("PIVOT.HEADER grouped by date field without value", async function () {


### PR DESCRIPTION
This is a feedback from a partner at OXP, he wants to know the number
of activities (late or not) linked to some Lead -> activities grouped by
res_id.

But grouping a pivot by a many2one_reference is currently not supported.

This commit adds the support.

Note that carelessly grouping by a many2one_reference mixes records linked to
different models (same id, but different model).
To avoid mixin apples and oranges, you have to either groupby model, *then*
by res_id, or add the model to the domain.

Task: 5102923


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
