### PR TITLE
[FIX] hr_work_entry_holidays: fix test case error

### DIFF
--- a/addons/hr_work_entry_holidays/tests/test_work_entry.py
+++ b/addons/hr_work_entry_holidays/tests/test_work_entry.py
@@ -241,7 +241,6 @@ class TestWorkeEntryHolidaysWorkEntry(TestWorkEntryHolidaysBase):
             'state': 'open',
             'wage': 1000,
             'resource_calendar_id': self.calendar_40h.id,
-            'work_entry_source': 'attendance',
             'date_generated_from': datetime(2023, 2, 1, 0, 0),
             'date_generated_to': datetime(2023, 2, 28, 23, 59),
         })


### PR DESCRIPTION
**Steps to reproduce:**

1. Install Payroll and Time Off modules.
2. Run the `test_leave_validation_with_multiple_work_entry_types` test

**Issue -**

A ValueError is raised:
`raise ValueError('Wrong value for %s: %r' % (self, value)) ValueError: Wrong value for hr.contract.work_entry_source: 'attendance'`

**Runbot error** - https://runbot.odoo.com/odoo/runbot.build.error/232697

**Cause-**

- The field `work_entry_source` is a selection field. The value 'attendance' is added by the 
`hr_work_entry_contract_attendance` module, but it is being used in
 `hr_work_entry_holidays`.
- If `hr_work_entry_holidays` is install without `hr_work_entry_contract_attendance`
 the value 'attendance' is invalid, causing the error.

**Solution:**
-The `test_leave_validation_with_multiple_work_entry_types` test case was originally written for this issue,
-PR- https://github.com/odoo/odoo/pull/224254
but it is not important to use this field.
-So, remove the use of this value in the test case, since it is not mandatory to reproduce the issue.
