### PR TITLE
[FIX] web_editor: fix traceback on theme color change

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -4528,8 +4528,9 @@ const SnippetOptionWidget = publicWidget.Widget.extend({
                 return;
             }
 
-            // Call widget option methods and update $target
-            await this._select(previewMode, widget);
+            // Invoke widget option methods to update $target, handling any silent errors
+            // (e.g., when changing theme color and saving before the update is applied).
+            await this._select(previewMode, widget).catch(() => {});
 
             // If it is not preview mode, the user selected the option for good
             // (so record the action)

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -4530,7 +4530,7 @@ const SnippetOptionWidget = publicWidget.Widget.extend({
 
             // Invoke widget option methods to update $target, handling any silent errors
             // (e.g., when changing theme color and saving before the update is applied).
-            await this._select(previewMode, widget).catch(() => {});
+            await this._select(previewMode, widget);
 
             // If it is not preview mode, the user selected the option for good
             // (so record the action)

--- a/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
+++ b/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
@@ -753,7 +753,7 @@ export class WysiwygAdapterComponent extends Wysiwyg {
         // TODO we should investigate if this is normal the websiteRootInstance
         // is being accessed while being dead following a wysiwyg adapter event.
         if (!websiteRootInstance) {
-            if (eventData.onFailure) {
+            if (eventData.onFailure && !eventData.onSuccess) {
                 return eventData.onFailure();
             }
             return false;


### PR DESCRIPTION
This PR resolves a traceback that occurred when changing the theme
color from the color palette and pressing the save button. This was due
to an unhandled promise rejection.

task-3919146
