### PR TITLE
[IMP] mail: move can_react back to thread_model

### DIFF
--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -76,6 +76,7 @@ export class Thread extends Record {
          */
         sort: (a1, a2) => (a1.id < a2.id ? 1 : -1),
     });
+    can_react = true;
     chat_window = fields.One("ChatWindow", {
         inverse: "thread",
     });

--- a/addons/mail/static/src/discuss/core/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_model_patch.js
@@ -60,7 +60,6 @@ patch(Thread, threadStaticPatch);
 const threadPatch = {
     setup() {
         super.setup();
-        this.can_react = true;
         this.channel_member_ids = fields.Many("discuss.channel.member", {
             inverse: "channel_id",
             onDelete: (r) => r.delete(),


### PR DESCRIPTION
Reactions are not limited to discuss_channel threads. Previous PR (https://github.com/odoo/odoo/pull/226274/) moved it to discuss folder. This PR reverts this change.
