### PR TITLE
[FIX] account,sale: display portal "back to edit mode" banner

### DIFF
--- a/addons/account/views/account_portal_templates.xml
+++ b/addons/account/views/account_portal_templates.xml
@@ -136,13 +136,15 @@
     </template>
 
     <template id="portal_invoice_page" name="Invoice/Bill" inherit_id="portal.portal_sidebar" primary="True">
-        <xpath expr="//div[hasclass('o_portal_sidebar')]" position="inside">
+        <t t-call="portal.portal_layout" position="inside">
             <t t-set="o_portal_fullwidth_alert" groups="sales_team.group_sale_salesman,account.group_account_invoice,account.group_account_readonly">
                 <t t-call="portal.portal_back_in_edit_mode">
                     <t t-set="backend_url" t-value="'/odoo/action-account.action_move_out_invoice_type/%s' % invoice.id"/>
                 </t>
             </t>
+        </t>
 
+        <xpath expr="//div[hasclass('o_portal_sidebar')]" position="inside">
             <div class="row o_portal_invoice_sidebar">
                 <!-- Sidebar -->
                 <t t-call="portal.portal_record_sidebar">

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -122,12 +122,14 @@
 
     <!-- Complete page of the sale_order -->
     <template id="sale_order_portal_template" name="Sales Order" inherit_id="portal.portal_sidebar" primary="True">
-        <xpath expr="//div[hasclass('o_portal_sidebar')]" position="inside">
+        <t t-call="portal.portal_layout" position="inside">
             <t t-set="o_portal_fullwidth_alert" groups="sales_team.group_sale_salesman">
                 <!-- Uses backend_url provided in rendering values -->
                 <t t-call="portal.portal_back_in_edit_mode"/>
             </t>
+        </t>
 
+        <xpath expr="//div[hasclass('o_portal_sidebar')]" position="inside">
             <div
                 class="row o_portal_sale_sidebar"
                 t-att-data-order-amount-total="sale_order.amount_total"


### PR DESCRIPTION
## Versions
19.0+

## Issue
The blue banner ("This is a preview of the customer portal. → Back to edit mode") does not appear when previewing a Sale Order or Invoice from the backend.

## Steps to reproduce
Open a SO:
- Click the "Preview" button;
- The portal preview page opens, but the top blue banner to return to the backend is missing.

## Cause
This regression appeared after the QWeb refactor (https://github.com/odoo/odoo/commit/eb6e88a25050fff2bd09317739dd51ba451450df) which changed how template variables propagate:
- `t-call` is now parametric, variables defined inside a `t-call` no longer affect the outer scope;
- The inner content of a `t-call` only sees variables defined before the call;
- Lazy XML evaluation means `t-set` values defined after the layout call are not yet in scope during rendering.

Previously, `o_portal_fullwidth_alert` was set **after** the layout was called, so the variable was invisible when the alert banner was rendered.

opw-5096001