### PR TITLE
[FIX] l10n_my_edi: myinvois cleanup fixes

### DIFF
--- a/addons/l10n_my_edi/models/account_tax.py
+++ b/addons/l10n_my_edi/models/account_tax.py
@@ -40,7 +40,7 @@ class AccountTax(models.Model):
             if tax.country_id.code != 'MY':
                 tax.l10n_my_tax_type = False
             else:
-                if tax.amount == 0:
+                if tax.amount == 0 and tax.tax_scope:
                     tax.l10n_my_tax_type = 'E'
                 elif tax.tax_scope == 'consu':
                     tax.l10n_my_tax_type = '01'


### PR DESCRIPTION
### PURPOSE

 - While clicking on the 'Send To MyInvoice' button, the current Error shows HTML tags.
 - Improve Malaysian Tax Type computation.
 - There is a traceback when there is no tax selected on any of the lines of the invoice, and we click on the Send To MyInvoice button.

### SPECIFICATION

 - Fixing the Display message shown inside UserError.
 - Change the computation of tax,
    - If the tax amount is 0 and the tax scope is set, the tax type will be set to `Exempt` (Based on the default tax data provided)
 - Fix traceback when submitting to MyInvois occurs when no tax is selected in the invoice.
 - Additionally, we handle flow when there is no tax on the product and submit to MyInvois.
   - If the case is of a Consolidated Invoice in POS, there will be no UserError to notify the User to set taxes (coz we do that in batch), and by default the tax will be set to 'Not Applicable'.
   - If the user tries to send a separate invoice and the tax is not set, then there will be a UserError that notifies the user that they must set tax on the invoice line.

task-5086207