### PR TITLE
[FIX] account_peppol: Hide Peppol status column on bills

### DIFF
--- a/addons/account_peppol/views/account_move_views.xml
+++ b/addons/account_peppol/views/account_move_views.xml
@@ -61,7 +61,7 @@
         <field name="inherit_id" ref="account.view_in_invoice_tree"/>
         <field name="arch" type="xml">
             <field name="state" position="before">
-                <field name="peppol_move_state" invisible="1"/>
+                <field name="peppol_move_state" column_invisible="1"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
Was supposed to be fixed in related commit but done incorrectly.

Related: https://github.com/odoo/odoo/commit/d5a2a802c911994294bdd9ef739232e54fb7358e#diff-85bbebe496014ea47e573d3c54aa4b37ba32991e51f06e20e5a40d632602b5afR64

opw-livechat-886115213
