### PR TITLE
[FIX] hr_work_entry: No work entry type

### DIFF
--- a/addons/hr_work_entry/__manifest__.py
+++ b/addons/hr_work_entry/__manifest__.py
@@ -25,7 +25,10 @@
     ],
     'assets': {
         'web.assets_backend': [
-            'hr_work_entry/static/**/*',
+            'hr_work_entry/static/src/**/*',
+        ],
+        'web.assets_unit_tests': [
+            'hr_work_entry/static/tests/**/*',
         ],
     },
     'author': 'Odoo S.A.',

--- a/addons/hr_work_entry/models/hr_work_entry.py
+++ b/addons/hr_work_entry/models/hr_work_entry.py
@@ -282,8 +282,8 @@ class HrWorkEntry(models.Model):
             stop = stop or max(self.mapped('date'), default=False)
             if not skip and start and stop:
                 domain = (
-                    Domain('date', '<', stop)
-                    & Domain('date', '>', start)
+                    Domain('date', '<=', stop)
+                    & Domain('date', '>=', start)
                     & Domain('state', 'not in', ('validated', 'cancelled'))
                 )
                 if employee_ids:

--- a/addons/hr_work_entry/static/src/components/work_entry_type_field/work_entry_type_field.js
+++ b/addons/hr_work_entry/static/src/components/work_entry_type_field/work_entry_type_field.js
@@ -19,6 +19,9 @@ export class WorkEntryType extends Component {
 }
 
 function extractData(record) {
+    if (!record) {
+        return null;
+    }
     let name;
     if ("display_name" in record) {
         name = record.display_name;

--- a/addons/hr_work_entry/static/src/components/work_entry_type_field/work_entry_type_field.xml
+++ b/addons/hr_work_entry/static/src/components/work_entry_type_field/work_entry_type_field.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
     <t t-name="hr_work_entry.Many2OneWorkEntryTypeField">
         <div class="d-flex align-items-center gap-1">
-            <t t-if="value !== false">
+            <t t-if="m2oProps.value !== false">
                 <WorkEntryType data="state.data"/>
             </t>
             <Many2One t-props="m2oProps" cssClass="'w-100'">

--- a/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_calendar_model.js
+++ b/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_calendar_model.js
@@ -44,7 +44,7 @@ export class WorkEntryCalendarModel extends CalendarModel {
         if (userFavoritesWorkEntriesIds.length) {
             this.userFavoritesWorkEntries = await this.orm.read(
                 "hr.work.entry.type",
-                userFavoritesWorkEntriesIds.map((r) => r.work_entry_type_id[0]),
+                userFavoritesWorkEntriesIds.map((r) => r.work_entry_type_id?.[0]).filter(Boolean),
                 ["display_name", "display_code", "color"]
             );
             this.userFavoritesWorkEntries = this.userFavoritesWorkEntries.sort((a, b) =>

--- a/addons/hr_work_entry/static/tests/hr_work_entry_test_helpers.js
+++ b/addons/hr_work_entry/static/tests/hr_work_entry_test_helpers.js
@@ -1,0 +1,16 @@
+import { defineModels } from "@web/../tests/web_test_helpers";
+import { hrModels } from "@hr/../tests/hr_test_helpers";
+import { HrEmployee } from "@hr_work_entry/../tests/mock_server/mock_models/hr_employee";
+import { HrWorkEntryType } from "@hr_work_entry/../tests/mock_server/mock_models/hr_work_entry_type";
+import { HrWorkEntry } from "@hr_work_entry/../tests/mock_server/mock_models/hr_work_entry";
+
+export function defineHrWorkEntryModels() {
+    return defineModels(hrWorkEntryModels);
+}
+
+export const hrWorkEntryModels = {
+    ...hrModels,
+    HrEmployee,
+    HrWorkEntry,
+    HrWorkEntryType,
+};

--- a/addons/hr_work_entry/static/tests/mock_server/mock_models/hr_employee.js
+++ b/addons/hr_work_entry/static/tests/mock_server/mock_models/hr_employee.js
@@ -1,0 +1,12 @@
+import { models } from "@web/../tests/web_test_helpers";
+
+export class HrEmployee extends models.ServerModel {
+    _name = "hr.employee";
+
+    _records = [
+        { id: 100, name: "Richard" },
+        { id: 200, name: "Alice" },
+    ];
+
+    async generate_work_entries(employeeIds, startDate, endDate) {}
+}

--- a/addons/hr_work_entry/static/tests/mock_server/mock_models/hr_work_entry.js
+++ b/addons/hr_work_entry/static/tests/mock_server/mock_models/hr_work_entry.js
@@ -1,0 +1,30 @@
+import { models } from "@web/../tests/web_test_helpers";
+
+export class HrWorkEntry extends models.ServerModel {
+    _name = "hr.work.entry";
+
+    _views = {
+        "form,multi_create_form": `
+            <form>
+                <field name="employee_id" invisible="1"/>
+            </form>
+        `,
+        calendar: `
+            <calendar
+                date_start="date"
+                date_stop="date" 
+                mode="month"
+                scales="month"
+                month_overflow="0"
+                quick_create="0"
+                color="color"
+                event_limit="9"
+                show_date_picker="0"
+                multi_create_view="multi_create_form"
+                js_class="work_entries_calendar">
+            </calendar>
+        `,
+    };
+
+    action_split(workEntryIds, vals) {}
+}

--- a/addons/hr_work_entry/static/tests/mock_server/mock_models/hr_work_entry_type.js
+++ b/addons/hr_work_entry/static/tests/mock_server/mock_models/hr_work_entry_type.js
@@ -1,0 +1,26 @@
+import { models } from "@web/../tests/web_test_helpers";
+
+export class HrWorkEntryType extends models.ServerModel {
+    _name = "hr.work.entry.type";
+
+    _records = [
+        {
+            id: 1,
+            name: "Test Work Entry Type",
+            color: 1,
+            display_code: "WT1",
+        },
+        {
+            id: 2,
+            name: "WET no color",
+            color: false,
+            display_code: "WT2",
+        },
+        {
+            id: 3,
+            name: "WET no display code",
+            color: 1,
+            display_code: false,
+        },
+    ];
+}

--- a/addons/hr_work_entry/static/tests/work_entry_calendar_view.test.js
+++ b/addons/hr_work_entry/static/tests/work_entry_calendar_view.test.js
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, test } from "@odoo/hoot";
+import { animationFrame, mockDate } from "@odoo/hoot-mock";
+import { findComponent, makeMockServer, mountView } from "@web/../tests/web_test_helpers";
+import { defineHrWorkEntryModels } from "@hr_work_entry/../tests/hr_work_entry_test_helpers";
+import { WorkEntryCalendarController } from "@hr_work_entry/views/work_entry_calendar/work_entry_calendar_controller";
+const { DateTime } = luxon;
+
+describe.current.tags("desktop");
+defineHrWorkEntryModels();
+
+beforeEach(() => {
+    mockDate("2025-01-01 12:00:00", +0);
+});
+
+function getCalendarController(view) {
+    return findComponent(view, (c) => c instanceof WorkEntryCalendarController);
+}
+
+test("Test work entry calendar without work entry type", async () => {
+    const { env } = await makeMockServer();
+    env["hr.work.entry"].create([
+        {
+            name: "Test Work Entry 0",
+            employee_id: 100,
+            work_entry_type_id: false,
+            date: "2025-01-01",
+            duration: 120,
+        },
+    ]);
+    const calendar = await mountView({
+        type: "calendar",
+        resModel: "hr.work.entry",
+    });
+    expect(".o_calendar_renderer").toBeDisplayed({
+        message:
+            "Calendar view should be displayed even with work entries with false work entry type",
+    });
+    const controller = getCalendarController(calendar);
+    const data = {
+        name: "Test New Work Entry",
+        employee_id: 100,
+        work_entry_type_id: false,
+    };
+    await controller.model.multiCreateRecords(
+        {
+            record: {
+                getChanges: () => data,
+            },
+        },
+        [DateTime.fromISO("2025-01-02")]
+    );
+    await animationFrame();
+    expect(".fc-event").toHaveCount(2, {
+        message: "2 work entries should be displayed in the calendar view",
+    });
+});

--- a/addons/hr_work_entry/tests/test_hr_work_entry.py
+++ b/addons/hr_work_entry/tests/test_hr_work_entry.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import date
+
 from odoo.tests.common import TransactionCase
 
 
@@ -45,4 +46,34 @@ class TestHrWorkEntry(TransactionCase):
         self.assertEqual(
             work_entry.company_id, self.employee_b.company_id,
             "Work entry should use the employee's company not the current user's company.",
+        )
+
+    def test_work_entry_conflict_no_we_type(self):
+        """Test that work entry conflicts with no work entry type."""
+        work_entry = self.env['hr.work.entry'].create({
+            'name': 'Test Work Entry',
+            'work_entry_type_id': False,
+            'employee_id': self.employee_b.id,
+            'date': date(2024, 1, 1),
+            'duration': 8,
+        })
+        self.assertEqual(
+            work_entry.state, 'conflict',
+            "Work entry should conflict with no work entry type.",
+        )
+        work_entry = self.env['hr.work.entry'].create({
+            'name': 'Test Work Entry',
+            'work_entry_type_id': self.work_entry_type.id,
+            'employee_id': self.employee_b.id,
+            'date': date(2024, 1, 1),
+            'duration': 8,
+        })
+        self.assertEqual(
+            work_entry.state, 'draft',
+            "Work entry should not conflict with a work entry type.",
+        )
+        work_entry.write({'work_entry_type_id': False})
+        self.assertEqual(
+            work_entry.state, 'conflict',
+            "Work entry should conflict with no work entry type.",
         )


### PR DESCRIPTION
If the user creates a work entry without a work entry type, it will fetch "false" id work entry type. It raises a traceback

task-5078885