### PR TITLE
[IMP] fleet: prevent duplicate license plates

### DIFF
--- a/addons/fleet/models/fleet_vehicle.py
+++ b/addons/fleet/models/fleet_vehicle.py
@@ -145,6 +145,11 @@ class FleetVehicle(models.Model):
     range_unit = fields.Selection([('km', 'km'), ('mi', 'mi')],
         compute='_compute_range_unit', store=True, readonly=False, default="km", required=True)
 
+    _unique_license_plate = models.Constraint(
+        'UNIQUE(license_plate)',
+        'The license plate must be unique',
+    )
+
     @api.depends('log_services')
     def _compute_service_activity(self):
         for vehicle in self:

--- a/addons/fleet/tests/__init__.py
+++ b/addons/fleet/tests/__init__.py
@@ -3,3 +3,4 @@
 
 from . import test_access_rights
 from . import test_overdue
+from . import test_unique_license_plate

--- a/addons/fleet/tests/test_unique_license_plate.py
+++ b/addons/fleet/tests/test_unique_license_plate.py
@@ -1,0 +1,60 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo.tests import tagged, common
+from odoo.tools import mute_logger
+from psycopg2 import IntegrityError
+
+
+@tagged('at_install', '-post_install')
+class TestUniqueLicensePlate(common.TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.car_brand = cls.env["fleet.vehicle.model.brand"].create({
+            "name": "Toyota",
+        })
+        cls.car_model = cls.env["fleet.vehicle.model"].create({
+            "brand_id": cls.car_brand.id,
+            "name": "Corolla",
+        })
+
+    def test_unique_license_plate_constraint(self):
+        """Test that license plates must be unique across all vehicles"""
+        vehicle1 = self.env["fleet.vehicle"].create({
+            "model_id": self.car_model.id,
+            "license_plate": "ABC-123",
+        })
+        self.assertTrue(vehicle1.id)
+        with mute_logger('odoo.sql_db'), self.assertRaises(IntegrityError):
+            self.env["fleet.vehicle"].create({
+                "model_id": self.car_model.id,
+                "license_plate": "ABC-123",
+            })
+
+    def test_unique_license_plate_allows_different_plates(self):
+        """Test that vehicles with different license plates can be created"""
+        vehicle1 = self.env["fleet.vehicle"].create({
+            "model_id": self.car_model.id,
+            "license_plate": "ABC-123",
+        })
+        vehicle2 = self.env["fleet.vehicle"].create({
+            "model_id": self.car_model.id,
+            "license_plate": "XYZ-789",
+        })
+        self.assertTrue(vehicle1.id)
+        self.assertTrue(vehicle2.id)
+        self.assertNotEqual(vehicle1.license_plate, vehicle2.license_plate)
+
+    def test_unique_license_plate_allows_none(self):
+        """Test that multiple vehicles can have no license plate (NULL values)"""
+        vehicle1 = self.env["fleet.vehicle"].create({
+            "model_id": self.car_model.id,
+            "license_plate": False,
+        })
+        vehicle2 = self.env["fleet.vehicle"].create({
+            "model_id": self.car_model.id,
+            "license_plate": False,
+        })
+        self.assertTrue(vehicle1.id)
+        self.assertTrue(vehicle2.id)
+        self.assertFalse(vehicle1.license_plate)
+        self.assertFalse(vehicle2.license_plate)


### PR DESCRIPTION
Before:
- The license_plate field in the fleet.vehicle model allowed duplicate values.
- Multiple vehicles could be registered with the same license plate,
causing data inconsistencies and confusion in fleet management.

After:
- A unique SQL constraint has been added to the license_plate field.
- The system now prevents saving multiple vehicles with the same license plate,
ensuring data integrity.

Task-5071264