### PR TITLE
[FIX] hr_attendance: auto-checkout on different date

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -707,7 +707,7 @@ class HrAttendance(models.Model):
     def _cron_auto_check_out(self):
         def check_in_tz(attendance):
             """Returns check-in time in calendar's timezone."""
-            return attendance.check_in.astimezone(pytz.timezone(attendance.employee_id.resource_calendar_id.tz or 'UTC'))
+            return attendance.check_in.astimezone(pytz.timezone(attendance.employee_id._get_tz()))
 
         to_verify = self.env['hr.attendance'].search(
             [('check_out', '=', False),
@@ -718,9 +718,10 @@ class HrAttendance(models.Model):
         if not to_verify:
             return
 
+        to_verify_min_date = min(to_verify.mapped('check_in')).replace(hour=0, minute=0, second=0)
         previous_attendances = self.env['hr.attendance'].search([
                     ('employee_id', 'in', to_verify.mapped('employee_id').ids),
-                    ('check_in', '>', (fields.Datetime.now() - relativedelta(days=1)).replace(hour=0, minute=0, second=0)),
+                    ('check_in', '>', to_verify_min_date),
                     ('check_out', '!=', False)
         ])
 
@@ -734,20 +735,32 @@ class HrAttendance(models.Model):
             max_tol = company.auto_check_out_tolerance
             to_verify_company = to_verify.filtered(lambda a: a.employee_id.company_id.id == company.id)
 
-            # Attendances where Last open attendance time + previously worked time on that day + tolerance greater than the attendances hours (including lunch) in his calendar
-            to_check_out = to_verify_company.filtered(lambda a: (fields.Datetime.now() - a.check_in).seconds / 3600 + mapped_previous_duration[a.employee_id][check_in_tz(a).date()] - max_tol >
-                                                                (sum(a.employee_id.resource_calendar_id.attendance_ids.filtered(lambda att: att.dayofweek == str(check_in_tz(a).weekday()) and (not att.two_weeks_calendar or att.week_type == str(att.get_week_type(check_in_tz(a).date())))).mapped(lambda at: at.hour_to - at.hour_from))))
-            body = _('This attendance was automatically checked out because the employee exceeded the allowed time for their scheduled work hours.')
+            for att in to_verify_company:
 
-            for att in to_check_out:
-                expected_worked_hours = sum(att.employee_id.resource_calendar_id.attendance_ids.filtered(lambda a: a.dayofweek == str(check_in_tz(att).weekday()) and (not a.two_weeks_calendar or a.week_type == str(a.get_week_type(check_in_tz(att).date())))).mapped("duration_hours"))
-                att.check_out = fields.Datetime.now()
-                excess_hours = att.worked_hours - (expected_worked_hours + max_tol - mapped_previous_duration[att.employee_id][check_in_tz(att).date()])
-                att.write({
-                    "check_out": max(att.check_out - relativedelta(hours=excess_hours), att.check_in + relativedelta(seconds=1)),
-                    "out_mode": "auto_check_out"
-                })
-                att.message_post(body=body)
+                employee_timezone = pytz.timezone(att.employee_id._get_tz())
+                check_in_datetime = check_in_tz(att)
+                now_datetime = fields.Datetime.now().astimezone(employee_timezone)
+                current_attendance_duration = (now_datetime - check_in_datetime).total_seconds() / 3600
+                previous_attendances_duration = mapped_previous_duration[att.employee_id][check_in_datetime.date()]
+
+                expected_worked_hours = sum(
+                    att.employee_id.resource_calendar_id.attendance_ids.filtered(
+                        lambda a: a.dayofweek == str(check_in_datetime.weekday())
+                            and (not a.two_weeks_calendar or a.week_type == str(a.get_week_type(check_in_datetime.date())))
+                    ).mapped("duration_hours")
+                )
+
+                # Attendances where Last open attendance time + previously worked time on that day + tolerance greater than the attendances hours (including lunch) in his calendar
+                if (current_attendance_duration + previous_attendances_duration - max_tol) > expected_worked_hours:
+                    att.check_out = att.check_in.replace(hour=23, minute=59, second=59)
+                    excess_hours = att.worked_hours - (expected_worked_hours + max_tol - previous_attendances_duration)
+                    att.write({
+                        "check_out": max(att.check_out - relativedelta(hours=excess_hours), att.check_in + relativedelta(seconds=1)),
+                        "out_mode": "auto_check_out"
+                    })
+                    att.message_post(
+                        body=_('This attendance was automatically checked out because the employee exceeded the allowed time for their scheduled work hours.')
+                    )
 
     def _cron_absence_detection(self):
         """

--- a/addons/hr_attendance/tests/test_hr_attendance_overtime.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_overtime.py
@@ -444,6 +444,37 @@ class TestHrAttendanceOvertime(TransactionCase):
         # Employee with flexible working schedule should not be checked out
         self.assertEqual(attendance_flexible_pending.check_out, False)
 
+    @freeze_time("2024-02-1 23:00:00")
+    def test_auto_check_out_more_one_day_delta(self):
+        """ Test that the checkout is correct if the delta between the check in and now is > 24 hours"""
+        self.company.write({
+            'auto_check_out': True,
+            'auto_check_out_tolerance': 1
+        })
+
+        attendance_utc_pending = self.env['hr.attendance'].create({
+            'employee_id': self.employee.id,
+            'check_in': datetime(2024, 1, 30, 8, 0)
+        })
+
+        self.assertEqual(attendance_utc_pending.check_out, False)
+        self.env['hr.attendance']._cron_auto_check_out()
+        self.assertEqual(attendance_utc_pending.check_out, datetime(2024, 1, 30, 18, 0))
+
+    @freeze_time("2024-02-05 23:00:00")
+    def test_auto_checkout_past_day(self):
+        self.company.write({
+            'auto_check_out': True,
+            'auto_check_out_tolerance': 1,
+        })
+        attendance_utc_pending_7th_day = self.env['hr.attendance'].create({
+            'employee_id': self.employee.id,
+            'check_in': datetime(2024, 2, 1, 14, 0),
+        })
+        self.assertEqual(attendance_utc_pending_7th_day.check_out, False)
+        self.env['hr.attendance']._cron_auto_check_out()
+        self.assertEqual(attendance_utc_pending_7th_day.check_out, datetime(2024, 2, 1, 23, 0))
+
     @freeze_time("2024-02-2 20:00:00")
     def test_auto_check_out_calendar_tz(self):
         """Check expected working hours and previously worked hours are from the correct day when


### PR DESCRIPTION
Problem: the auto-checkout feature was basing the computation on the fact that the unclosed attendance was starting today. However, it might not always be the case, for example if the server is shutdown for more than 24 hours after checking in.

Steps to reproduce:
- Activate the auto-checkout feature
- Create an open-ended attendance for two days ago
- Run the cron
- Result: the attendance is not closed.

This commit solves the issue by taking into account the days delta between today and the check-in date.

task-5082359

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
