### PR TITLE
[FIX] mass_mailing: fix html_editor test helpers not present in single app

### DIFF
--- a/addons/mass_mailing/__manifest__.py
+++ b/addons/mass_mailing/__manifest__.py
@@ -155,7 +155,6 @@
             'mass_mailing/static/src/js/tours/**/*',
         ],
         'web.assets_tests': [
-            'html_editor/static/tests/_helpers/selection.js',
             'mass_mailing/static/tests/tours/**/*',
         ],
         'web.assets_unit_tests': [

--- a/addons/mass_mailing/static/tests/tours/mailing_editor_theme.js
+++ b/addons/mass_mailing/static/tests/tours/mailing_editor_theme.js
@@ -1,7 +1,7 @@
 import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 import { boundariesIn } from "@html_editor/utils/position";
-import { setSelection } from "@html_editor/../tests/_helpers/selection";
+import { setSelection } from "@html_editor/../tests/tours/helpers/editor";
 
 registry.category("web_tour.tours").add('mailing_editor_theme', {
     url: '/odoo',


### PR DESCRIPTION
The full editor helpers require hoot to be loaded and it's not loaded in the assets bundle used for mailing_editor_theme.js. There is a more lightweight file that exists solely to expose `setSelection` which does not require hoot.

runbot-232630