### PR TITLE
[FIX] html_editor,web_editor: fix non-deterministic test timeout

### DIFF
--- a/addons/html_editor/static/tests/list/delete_backward.test.js
+++ b/addons/html_editor/static/tests/list/delete_backward.test.js
@@ -1815,7 +1815,7 @@ describe("Selection collapsed", () => {
             });
         });
         describe("Checklist to unordered", () => {
-            test("should merge an checklist list into an unordered list", async () => {
+            test("should merge an checklist list into an unordered list (1)", async () => {
                 await testEditor({
                     contentBefore: '<ul><li>a</li></ul><ul class="o_checklist"><li>[]b</li></ul>',
                     stepFunction: async (editor) => {
@@ -1825,6 +1825,8 @@ describe("Selection collapsed", () => {
                     },
                     contentAfter: "<ul><li>a[]b</li></ul>",
                 });
+            });
+            test("should merge an checklist list into an unordered list (2)", async () => {
                 await testEditor({
                     contentBefore:
                         '<ul><li>a</li></ul><ul class="o_checklist"><li><p>[]b</p></li></ul>',
@@ -1835,6 +1837,8 @@ describe("Selection collapsed", () => {
                     },
                     contentAfter: "<ul><li>a[]b</li></ul>",
                 });
+            });
+            test("should merge an checklist list into an unordered list (3)", async () => {
                 await testEditor({
                     contentBefore:
                         '<ul><li><p>a</p></li></ul><ul class="o_checklist"><li>[]b</li></ul>',
@@ -1845,6 +1849,8 @@ describe("Selection collapsed", () => {
                     },
                     contentAfter: "<ul><li><p>a[]b</p></li></ul>",
                 });
+            });
+            test("should merge an checklist list into an unordered list (4)", async () => {
                 await testEditor({
                     contentBefore:
                         '<ul><li><p>a</p></li></ul><ul class="o_checklist"><li><p>[]b</p></li></ul>',

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/list.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/list.test.js
@@ -5240,7 +5240,7 @@ describe('List', () => {
                         });
                     });
                     describe('Checklist to unordered', () => {
-                        it('should merge an checklist list into an unordered list', async () => {
+                        it('should merge an checklist list into an unordered list (1)', async () => {
                             await testEditor(BasicEditor, {
                                 contentBefore:
                                     '<ul><li>a</li></ul><ul class="o_checklist"><li>[]b</li></ul>',
@@ -5250,6 +5250,8 @@ describe('List', () => {
                                 },
                                 contentAfter: '<ul><li>a[]b</li></ul>',
                             });
+                        });
+                        it("should merge an checklist list into an unordered list (2)", async () => {
                             await testEditor(BasicEditor, {
                                 contentBefore:
                                     '<ul><li>a</li></ul><ul class="o_checklist"><li><p>[]b</p></li></ul>',
@@ -5259,6 +5261,8 @@ describe('List', () => {
                                 },
                                 contentAfter: '<ul><li>a[]b</li></ul>',
                             });
+                        });
+                        it("should merge an checklist list into an unordered list (3)", async () => {
                             await testEditor(BasicEditor, {
                                 contentBefore:
                                     '<ul><li><p>a</p></li></ul><ul class="o_checklist"><li>[]b</li></ul>',
@@ -5268,6 +5272,8 @@ describe('List', () => {
                                 },
                                 contentAfter: '<ul><li>a[]b</li></ul>',
                             });
+                        });
+                        it("should merge an checklist list into an unordered list (4)", async () => {
                             await testEditor(BasicEditor, {
                                 contentBefore:
                                     '<ul><li><p>a</p></li></ul><ul class="o_checklist"><li><p>[]b</p></li></ul>',


### PR DESCRIPTION
Grouping multiple `testEditor` in a single `it` is bad practice because the timeout of `it` is then shared between the different `testEditor` calls rather than each having their own separate timers.

Technically, only the web_edior tests ever timed out, but I split the html_editor ones as well for good measure.

runbot-231687
