### PR TITLE
[FIX] hr_recruitment: removing ai widget

### DIFF
--- a/addons/hr_recruitment/wizard/applicant_refuse_reason_views.xml
+++ b/addons/hr_recruitment/wizard/applicant_refuse_reason_views.xml
@@ -49,7 +49,6 @@
                         <div class="d-flex" invisible="not send_mail">
                             <div invisible="not can_edit_body">
                                 <field name="template_id" widget="mail_composer_template_selector"/>
-                                <field name="body" widget="mail_composer_chatgpt"/>
                             </div>
                             <field name="scheduled_date" widget="text_scheduled_date"/>
                         </div>


### PR DESCRIPTION
The ai widget was moved to a new bridge module.

Task-5079755