### PR TITLE
[FIX] html_editor: fix non-deterministic test failure

### DIFF
--- a/addons/html_editor/static/tests/icon.test.js
+++ b/addons/html_editor/static/tests/icon.test.js
@@ -231,11 +231,11 @@ test("Should be able to undo after adding spin effect to an icon", async () => {
     await click("button[name='icon_spin']");
     await animationFrame();
     expect("span.fa-glass.fa-spin").toHaveCount(1);
-    expect(".btn-group[name='icon_spin'] button").toHaveClass("active");
+    await expectElementCount(".btn-group[name='icon_spin'] button.active", 1);
     undo(editor);
     await animationFrame();
     expect("span.fa-glass.fa-spin").toHaveCount(0);
-    expect(".btn-group[name='icon_spin']").not.toHaveClass("active");
+    await expectElementCount(".btn-group[name='icon_spin'].active", 0);
     expect("span.fa-glass").toHaveCount(1);
     expect("span.fa-glass.fa-spin").toHaveCount(0);
 });


### PR DESCRIPTION
The editor toolbar is affected by [1] and therefore needs to be properly awaited for. This test was missed by [2], probably because it did not explicitly waited for the toolbar itself.

runbot-231692

[1]: https://github.com/odoo/odoo/pull/211426/commits/54da715df84789f9a1acc0cfc91be41dcdbab140
[2]: https://github.com/odoo/odoo/pull/213090
