### PR TITLE
[IMP] hr_skills: Make resume section consider contract dates

### DIFF
--- a/addons/hr_skills/models/hr_employee.py
+++ b/addons/hr_skills/models/hr_employee.py
@@ -2,6 +2,7 @@
 
 from collections import defaultdict
 
+from datetime import date
 from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models
@@ -155,31 +156,48 @@ class HrEmployee(models.Model):
             raise AccessError(self.env._("You cannot access the resume of this employee."))
         res = []
         employee_versions = self.env['hr.employee'].sudo().browse(res_id).version_ids
-        if len(employee_versions) == 1 and employee_versions[0].job_title:
-            return [{
-                'id': employee_versions[0].id,
-                'job_title': employee_versions[0].job_title,
-                'date_start': employee_versions[0].date_start,
-                'date_end': False,
-            }]
-        current_date_start = employee_versions[0].date_start
+        interval_date_start = False
         for i in range(len(employee_versions) - 1):
             current_version = employee_versions[i]
             next_version = employee_versions[i + 1]
-            if current_version.job_title != next_version.job_title and current_version.job_title:
+            current_date_start = max(current_version.date_version, current_version.contract_date_start or date.min)
+            current_date_end = min(next_version.date_version + relativedelta(days=-1), current_version.contract_date_end or date.max)
+            if not current_version.job_title:
+                if interval_date_start:
+                    previous_version = employee_versions[i - 1]
+                    res.append({
+                        'id': previous_version.id,
+                        'job_title': previous_version.job_title,
+                        'date_start': interval_date_start,
+                        'date_end': current_date_start + relativedelta(days=-1),
+                    })
+                    interval_date_start = False
+            elif current_version.job_title != next_version.job_title or current_date_end + relativedelta(days=1) != next_version.date_version:
                 res.append({
                     'id': current_version.id,
                     'job_title': current_version.job_title,
-                    'date_start': current_date_start,
-                    'date_end': next_version.date_start - relativedelta(days=1),
+                    'date_start': interval_date_start or current_date_start,
+                    'date_end': current_date_end,
                 })
-                current_date_start = next_version.date_start
-            if i == len(employee_versions) - 2 and next_version.job_title:
-                # Last version, add it to the result
-                res.append({
-                    'id': next_version.id,
-                    'job_title': next_version.job_title,
-                    'date_start': current_date_start,
-                    'date_end': False,
-                })
+                interval_date_start = False
+            else:
+                interval_date_start = interval_date_start or current_date_start
+
+        last_version = employee_versions[-1]
+        if last_version.job_title:
+            current_date_start = max(last_version.date_version, last_version.contract_date_start or date.min)
+            res.append({
+                'id': last_version.id,
+                'job_title': last_version.job_title,
+                'date_start': interval_date_start or current_date_start,
+                'date_end': last_version.contract_date_end or False,
+            })
+        elif interval_date_start:
+            previous_version = employee_versions[-2]
+            res.append({
+                'id': previous_version.id,
+                'job_title': previous_version.job_title,
+                'date_start': interval_date_start,
+                'date_end': current_date_start + relativedelta(days=-1),
+            })
         return res[::-1]


### PR DESCRIPTION
Previously, the resume section showed dates depending on the starting dates of version, neglecting the cases when a contract might end and the next version starting later in time. This PR fixes that by taking into account the contract dates of each version.

Task-5102961

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
