### PR TITLE
[FIX] google_calendar: reset validation error

### DIFF
--- a/addons/google_calendar/models/calendar.py
+++ b/addons/google_calendar/models/calendar.py
@@ -99,13 +99,18 @@ class Meeting(models.Model):
         return res
 
     def _check_modify_event_permission(self, values):
-        # Check if event modification attempt by attendee is valid to avoid duplicate events creation.
-        for event in self:
-            # Edge case: when restarting the synchronization, guests can write 'need_sync=True' on events.
-            google_sync_restart = values.get('need_sync') and len(values)
-            if not google_sync_restart and (event.guests_readonly and self.env.user.id != event.user_id.id):
-                raise ValidationError(_("The following event can only be updated by the organizer "
-                                        "according to the event permissions set on Google Calendar."))
+        """ Check if event modification attempt by attendee is valid to avoid duplicate events creation. """
+        # Edge case: when restarting the synchronization, guests can write 'need_sync=True' on events.
+        google_sync_restart = values.get('need_sync') and len(values)
+        # Edge case 2: when resetting an account, we must be able to erase the event's google_id.
+        skip_event_permission = self.env.context.get('skip_event_permission', False)
+        if google_sync_restart or skip_event_permission:
+            return
+        if any(event.guests_readonly and self.env.user.id != event.user_id.id for event in self):
+            raise ValidationError(
+                _("The following event can only be updated by the organizer "
+                "according to the event permissions set on Google Calendar.")
+            )
 
     def _skip_send_mail_status_update(self):
         """If a google calendar is not syncing with the user, don't send a mail."""

--- a/addons/google_calendar/wizard/reset_account.py
+++ b/addons/google_calendar/wizard/reset_account.py
@@ -42,8 +42,9 @@ class ResetGoogleAccount(models.TransientModel):
         # Delete events according to the selected policy. If the deletion is only in
         # Google, we won't keep track of the 'google_id' field for events and recurrences.
         if self.delete_policy in ('delete_odoo', 'delete_both', 'delete_google'):
-            events.google_id = False
-            recurrences.google_id = False
+            # Flag need_sync as False in order to skip the write permission when resetting.
+            events.with_context(skip_event_permission=True).google_id = False
+            recurrences.with_context(skip_event_permission=True).google_id = False
             if self.delete_policy != 'delete_google':
                 events.unlink()
 


### PR DESCRIPTION
Before this commit, when resetting the Odoo Calendar of an user, it would trigger a ValidationError for updating events that the current user wasn't able to update, even though it was not an updated per se, but just a deletion of it in Odoo.

After this commit, we no longer trigger that ValidationError during resets of Odoo Calendars, fixing the error.

task-5103918