### PR TITLE
[FIX] sale_mrp: handle duplicate date in sale order portal view

### DIFF
--- a/addons/sale_mrp/views/sale_portal_templates.xml
+++ b/addons/sale_mrp/views/sale_portal_templates.xml
@@ -20,10 +20,6 @@
                                     <span class="text-muted"
                                         t-field="mo.date_finished"
                                         t-options="{'date_only': True}"/>
-                                    <span t-if="mo.state in ['draft', 'confirmed', 'progress', 'to_close']"
-                                        class="text-muted"
-                                        t-field="mo.date_finished"
-                                        t-options="{'date_only': True}"/>
                                 </div>
                             </div>
                             <span t-if="mo.state in ['to_close', 'done']"


### PR DESCRIPTION
**Steps to reproduce:**

1.Install `website_sale` and `sale_mrp`.
2.In settings, enable `multi-route` and `unarchive` the Replenish MTO route.
3.Create a product with routes -> `Replenish MTO` and `Manufacturing` then publish it  on the website.
4.Buy the product from the website and make the payment. 
5.Go to My Account → Your Orders → Open your sale order. 
6.In the Manufacturing section, the date appears twice.

**Issue-**
<img width="604" height="186" alt="image" src="https://github.com/user-attachments/assets/e4164564-8555-4005-8282-20e6f5de7e55" />

- Date found twice in Portal View of sale order

**Cause-**
https://github.com/odoo/odoo/blob/097c04156517bd97a2789bde22ffd0c69c0bf6bf/addons/sale_mrp/views/sale_portal_templates.xml#L18-L27

- Here using same field two time one it with condition and other is without condition so in some case when condition satisfied then same field are coming twice

**Solution-**

- Remove Conditional field because no meaning of using same field inside and outside of the condition

**opw - 5096009**