### PR TITLE
[FIX] im_livechat: hide rating percentage from stat button

### DIFF
--- a/addons/im_livechat/views/im_livechat_channel_views.xml
+++ b/addons/im_livechat/views/im_livechat_channel_views.xml
@@ -80,7 +80,7 @@
                                         <span class="o_stat_value"><field name="nbr_channel"/></span>
                                         <span class="o_stat_text">Sessions</span>
                                     </div>
-                                    <div class="o_stat_info flex-row-reverse align-items-baseline gap-1 me-1">
+                                    <div class="o_stat_info flex-row-reverse align-items-baseline gap-1 me-1" invisible="rating_count == 0">
                                         <span class="o_stat_value"><field name="rating_percentage_satisfaction"/>%</span>
                                         <span class="o_stat_text">Happy</span>
                                     </div>


### PR DESCRIPTION
**Steps to reproduce:**

- Install website_livechat
- Initiate a conversation from the visitor's side
- Close the conversation without providing a rating
- Log in as 'Admin'
- Go to Live Chat
- Open the form view of the default channel

**Current behavior before PR:**

The stat button displays the `rating_percentage_satisfaction` field as -1, which is a fallback value used when there are no ratings.

**Desired behavior after PR is merged:**

The `rating_percentage_satisfaction` field is only displayed when we have received at least 1 valid rating.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
