### PR TITLE
[FIX] hr_recruitment: Talent open applications button

### DIFF
--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -334,6 +334,7 @@ class HrApplicant(models.Model):
                 Domain("email_normalized", "in", [email for email in self.mapped("email_normalized") if email]),
                 Domain("partner_phone_sanitized", "in", [phone for phone in self.mapped("partner_phone_sanitized") if phone]),
                 Domain("linkedin_profile", "in", [linkedin_profile for linkedin_profile in self.mapped("linkedin_profile") if linkedin_profile]),
+                Domain("pool_applicant_id", "in", [pool_applicant.id for pool_applicant in self.mapped("pool_applicant_id") if pool_applicant]),
             ])
         ])
         if ignore_talent:


### PR DESCRIPTION
`_get_similar_applicants_domain` used in `action_open_applications` did not return the same domain used in `_compute_application_count`.

Fixed by complementing the domain within `_get_similar_applicants_domain` used in the action to include applications with the same associated `pool_applicant_id` as the current applicant/talent.

Task-5092128
