### PR TITLE
[IMP] sale: allow manual closing and reopening of sales orders

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -78,6 +78,11 @@ class SaleOrder(models.Model):
         default=False,
         copy=False,
         tracking=True)
+    invoicing_closed = fields.Boolean(
+        string="Manually Closed For Invoicing",
+        help="If enabled, the order is considered fully invoiced regardless of lines.",
+        copy=False,
+    )
     has_archived_products = fields.Boolean(compute="_compute_has_archived_products")
 
     client_order_ref = fields.Char(string="Customer Reference", copy=False)
@@ -619,7 +624,7 @@ class SaleOrder(models.Model):
             ('move_id', operator, value),
         ])]
 
-    @api.depends('state', 'order_line.invoice_status')
+    @api.depends('state', 'order_line.invoice_status', 'invoicing_closed')
     def _compute_invoice_status(self):
         """
         Compute the invoice status of a SO. Possible statuses:
@@ -631,17 +636,20 @@ class SaleOrder(models.Model):
         """
         confirmed_orders = self.filtered(lambda so: so.state == 'sale')
         (self - confirmed_orders).invoice_status = 'no'
-        if not confirmed_orders:
+        closed_orders = confirmed_orders.filtered('invoicing_closed')
+        closed_orders.invoice_status = 'invoiced'
+        orders_to_compute = confirmed_orders - closed_orders
+        if not orders_to_compute:
             return
         lines_domain = [('is_downpayment', '=', False), ('display_type', '=', False)]
         line_invoice_status_all = [
             (order.id, invoice_status)
             for order, invoice_status in self.env['sale.order.line']._read_group(
-                lines_domain + [('order_id', 'in', confirmed_orders.ids)],
+                lines_domain + [('order_id', 'in', orders_to_compute.ids)],
                 ['order_id', 'invoice_status']
             )
         ]
-        for order in confirmed_orders:
+        for order in orders_to_compute:
             line_invoice_status = [d[1] for d in line_invoice_status_all if d[0] == order.id]
             if order.state != 'sale':
                 order.invoice_status = 'no'
@@ -1306,6 +1314,30 @@ class SaleOrder(models.Model):
             remaining_time = self.env['ir.cron']._commit_progress(processed=1)
             if not remaining_time:
                 break
+
+    def action_close_invoicing(self):
+        """Mark sales orders as manually closed for invoicing."""
+        draft_orders = self.filtered(lambda o: o.state != 'sale')
+        if draft_orders:
+            orders_name = ', '.join(draft_orders.mapped('name'))
+            raise UserError(
+                self.env._("Cannot close %(orders_name)s: must be in 'Sales Order' state.",
+                orders_name=orders_name,
+            )
+        )
+        orders_to_close = self.filtered(lambda o: not o.invoicing_closed)
+        self.invoicing_closed = True
+        orders_to_close._message_log_batch(
+            bodies={order.id: _("Invoicing closed") for order in orders_to_close}
+        )
+
+    def action_reopen_order(self):
+        """Reopen invoicing for manually closed sales orders."""
+        orders_to_reopen = self.filtered('invoicing_closed')
+        orders_to_reopen.invoicing_closed = False
+        orders_to_reopen._message_log_batch(
+            bodies={order.id: _("Invoicing reopened") for order in orders_to_reopen}
+        )
 
     def action_lock(self):
         self.locked = True

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -164,12 +164,16 @@
                     decoration-primary="state == 'sent'"
                     widget="badge"
                     optional="hide"/>
-                <field name="invoice_status"
-                    decoration-success="invoice_status == 'invoiced'"
+                <field
+                    name="invoice_status"
+                    decoration-success="invoice_status == 'invoiced' and not invoicing_closed"
                     decoration-info="invoice_status == 'to invoice'"
-                    decoration-warning="invoice_status == 'upselling'"
+                    decoration-warning="
+                        (invoice_status == 'invoiced' and invoicing_closed)
+                        or invoice_status == 'upselling'"
                     widget="badge"
-                    optional="show"/>
+                    optional="show"
+                />
                 <field name="client_order_ref" optional="hide"/>
                 <field name="validity_date" optional="hide"/>
             </list>
@@ -400,6 +404,14 @@
                         invisible="locked or state != 'sale'"
                         groups="sales_team.group_sale_manager"/>
                 </t>
+                <button
+                    string="Reopen Invoicing"
+                    name="action_reopen_order"
+                    type="object"
+                    class="btn-primary"
+                    invisible="not invoicing_closed or state != 'sale'"
+                    groups="sales_team.group_sale_manager"
+                />
                 <field name="state" widget="statusbar" statusbar_visible="draft,sent,sale"/>
             </header>
             <div class="alert alert-warning" role="alert" invisible="not sale_warning_text">
@@ -1264,6 +1276,15 @@
             if records:
                 action = records.with_context(hide_default_template=True).action_quotation_send()
         </field>
+    </record>
+
+    <record id="model_sale_order_action_close_invoicing" model="ir.actions.server">
+        <field name="name">Close Invoicing</field>
+        <field name="model_id" ref="sale.model_sale_order"/>
+        <field name="binding_model_id" ref="sale.model_sale_order"/>
+        <field name="binding_view_types">form,list</field>
+        <field name="state">code</field>
+        <field name="code">records.action_close_invoicing()</field>
     </record>
 
     <record id="mail_followers_edit_action_from_sale" model="ir.actions.act_window">


### PR DESCRIPTION
Before this commit:
- Confirmed sales orders (state = sale) in status to invoice or upselling
  could not be marked as fully invoiced without reconciling all lines.
- Users had no way to mark such orders as fully invoiced manually.

After this commit:
- Introduced a boolean field `is_manually_closed` to explicitly mark confirmed
  orders as closed.
- Added server actions:
  • To mark the order as manually closed.
  • To reopen a previously closed order.
- Each action automatically posts a chatter log entry for traceability.
task-5027819

- See Also:
    Enterprise PR: https://github.com/odoo/enterprise/pull/98747

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
