### PR TITLE
[FIX] stock: use reordering rule multiple no rounding error

### DIFF
--- a/addons/purchase_stock/tests/test_reordering_rule.py
+++ b/addons/purchase_stock/tests/test_reordering_rule.py
@@ -1556,3 +1556,41 @@ class TestReorderingRule(TransactionCase):
         self.assertRecordValues(purchase_order_line, [
             {'product_uom_qty': 100, 'move_dest_ids': [delivery.move_ids.id, delivery.backorder_ids.move_ids.id]}
         ])
+
+    def test_reordering_rule_replenishment_multiple_repeating_decimal(self):
+        warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.user.id)], limit=1)
+        stock_location = warehouse.lot_stock_id
+        out_type = warehouse.out_type_id
+        customer_location = self.env.ref('stock.stock_location_customers')
+        pack_2 = self.env['uom.uom'].create({
+            'name': 'Product Serial 1 Packaging',
+            'relative_factor': 2,
+            'relative_uom_id': self.env.ref('uom.product_uom_unit').id,
+        })
+        pack_6 = self.env.ref('uom.product_uom_pack_6')
+        self.product_01.uom_id = pack_6
+        self.product_01.uom_ids = pack_2
+        self.env['stock.warehouse.orderpoint'].create({
+            'product_id': self.product_01.id,
+            'product_min_qty': 0,
+            'product_max_qty': 0,
+            'replenishment_uom_id': pack_2.id,
+        })
+
+        delivery = self.env['stock.picking'].create({
+            'picking_type_id': out_type.id,
+            'location_id': stock_location.id,
+            'location_dest_id': customer_location.id,
+            'move_ids': [(0, 0, {
+                'name': self.product_01.name,
+                'product_id': self.product_01.id,
+                'product_uom_qty': 1,
+                'product_uom': pack_6.id,
+                'location_id': stock_location.id,
+                'location_dest_id': customer_location.id,
+            })]
+        })
+        delivery.action_confirm()
+
+        pol = self.env['purchase.order.line'].search([('product_id', '=', self.product_01.id)])
+        self.assertEqual(pol.product_uom_qty, 1.0)


### PR DESCRIPTION
**Steps to reproduce:**
- enable "units of measure & packagings" settings
- navigate to "units and packagings" and create a new one called 
"pack of 2"
- set a quantity of 2 and the reference unit as "units"
- create a new storable product
- next to "sale price" change the unit to "pack of 6"
- in the sales tab add "pack of 2" in the packagings
- in the purchase tab add a vendor
- click on the reordering rule smart button and create a new one
- set the min and max to 0 and set the replenishment multiple to 
"pack of 2" (you might have to make this column visible using the filters)
- create and confirm a quotation for 1 pack of 6

**Current behavior:**
a new Purchase Order is created for a quantity of 1.02

**Expected behavior:**
it should be a quantity of 1

**Cause of the issue:**
qty_multiple is rounded (in _compute_quantity) before the computation
of remainder.
https://github.com/odoo/odoo/blob/7a0a246016d50ae80e49f3502a97e82d414ab0b0/addons/stock/models/stock_orderpoint.py#L373-L376
In cases of repeating decimal numbers (like 0.3333333 in our example),
this leads to the remainder not being 0 even though it should be 0.

opw-5040144
