### PR TITLE
[FIX] calendar: consider email_from field of template

### DIFF
--- a/addons/calendar/models/calendar_attendee.py
+++ b/addons/calendar/models/calendar_attendee.py
@@ -175,8 +175,11 @@ class Attendee(models.Model):
                     'subject',
                     attendee.ids,
                     compute_lang=True)[attendee.id]
+                email_from = mail_template._render_field(
+                    'email_from',
+                    attendee.ids)[attendee.id]
                 mail_messages += attendee.event_id.with_context(no_document=True).sudo().message_notify(
-                    email_from=attendee.event_id.user_id.email_formatted or self.env.user.email_formatted,
+                    email_from=email_from or None,  # use None to trigger fallback sender
                     author_id=attendee.event_id.user_id.partner_id.id or self.env.user.partner_id.id,
                     body=body,
                     subject=subject,


### PR DESCRIPTION
Problem:
The `email_from` field of the mail template is not considered while sending calendar invites.

Steps to reproduce:
- Log in as admin and install `calendar`.
- Open the email template named `Calendar: Meeting Invitation`.
- Change the `email_from` to `"ABC" <abc@example.com>`.
- Create an event with the admin as the organizer.
- Add Marc demo as an attendee.
- Check the invitation email: the email to Marc demo is sent by the admin instead of ABC

Solution:
The `email_from` field of the mail template is rendered and passed to `message_notify`. If the rendered value is empty, `None` is passed so that `_message_compute_author` computes a fallback using the `author_id`’s email (i.e. calendar event organizer or current user), ensuring the email is always sent with a valid sender.

Task-5082075