### PR TITLE
[IMP] html_editor: gradient picker improvements

### DIFF
--- a/addons/html_editor/static/src/img/gradient-closest-corner.svg
+++ b/addons/html_editor/static/src/img/gradient-closest-corner.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="35" height="35" viewBox="0 0 20 20" fill="none">
+    <clipPath id="clip-rect">
+        <rect x="2" y="2" width="16" height="16"/>
+    </clipPath>
+    <g clip-path="url(#clip-rect)">
+        <circle cx="4" cy="6" r="4.4" fill="#333"/>
+        <circle cx="4" cy="6" r="3.3" fill="#666"/>
+        <circle cx="4" cy="6" r="2.2" fill="#999"/>
+        <circle cx="4" cy="6" r="1.1" fill="#CCC"/>
+    </g>
+    <rect x="2" y="2" width="16" height="16" stroke="#999"></rect>
+</svg>

--- a/addons/html_editor/static/src/img/gradient-closest-side.svg
+++ b/addons/html_editor/static/src/img/gradient-closest-side.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="35" height="35" viewBox="0 0 20 20" fill="none">
+    <clipPath id="clip-rect">
+        <rect x="2" y="2" width="16" height="16"/>
+    </clipPath>
+    <g clip-path="url(#clip-rect)">
+        <circle cx="4" cy="6" r="2" fill="#333"/>
+        <circle cx="4" cy="6" r="1.5" fill="#666"/>
+        <circle cx="4" cy="6" r="1" fill="#999"/>
+        <circle cx="4" cy="6" r="0.5" fill="#CCC"/>
+    </g>
+    <rect x="2" y="2" width="16" height="16" stroke="#999"></rect>
+</svg>

--- a/addons/html_editor/static/src/img/gradient-farthest-corner.svg
+++ b/addons/html_editor/static/src/img/gradient-farthest-corner.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="35" height="35" viewBox="0 0 20 20" fill="none">
+    <clipPath id="clip-rect">
+        <rect x="2" y="2" width="16" height="16"/>
+    </clipPath>
+    <g clip-path="url(#clip-rect)">
+        <circle cx="4" cy="6" r="18" fill="#333"/>
+        <circle cx="4" cy="6" r="13.5" fill="#666"/>
+        <circle cx="4" cy="6" r="9" fill="#999"/>
+        <circle cx="4" cy="6" r="4.5" fill="#CCC"/>
+    </g>
+    <rect x="2" y="2" width="16" height="16" stroke="#999"></rect>
+</svg>

--- a/addons/html_editor/static/src/img/gradient-farthest-side.svg
+++ b/addons/html_editor/static/src/img/gradient-farthest-side.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="35" height="35" viewBox="0 0 20 20" fill="none">
+    <clipPath id="clip-rect">
+        <rect x="2" y="2" width="16" height="16"/>
+    </clipPath>
+    <g clip-path="url(#clip-rect)">
+        <circle cx="4" cy="6" r="14" fill="#333"/>
+        <circle cx="4" cy="6" r="10.5" fill="#666"/>
+        <circle cx="4" cy="6" r="7" fill="#999"/>
+        <circle cx="4" cy="6" r="3.5" fill="#CCC"/>
+    </g>
+    <rect x="2" y="2" width="16" height="16" stroke="#999"></rect>
+</svg>

--- a/addons/html_editor/static/src/main/font/color_picker_gradient_tab.scss
+++ b/addons/html_editor/static/src/main/font/color_picker_gradient_tab.scss
@@ -79,6 +79,10 @@
             box-shadow: 0 0 0 1px var(--bg, $white), 0 0 0 3px var(--o-color-picker-active-color, $o-enterprise-action-color);
         }
     }
+
+    input[type=checkbox] {
+        border: 1px solid #999;
+    }
 }
 
 .custom-gradient-configurator + .o_colorpicker_widget {
@@ -86,13 +90,11 @@
 }
 
 .gradient-color-bin {
-    position: relative;
-    margin: 0 12px;
+    margin: 0 4px 8px 4px;
     height: 22px;
     > a.btn {
-        padding: 0 2px 2px;
-        margin-top: 0;
-        margin-left: -12px;
-        position: absolute;
+        padding: 0;
+        width: 20px;
+        transform: translateX(-50%);
     }
 }

--- a/addons/html_editor/static/src/main/font/gradient_picker/gradient_picker.scss
+++ b/addons/html_editor/static/src/main/font/gradient_picker/gradient_picker.scss
@@ -1,5 +1,5 @@
 .gradient-angle-knob {
-    --radius: 15px;
+    --radius: 10px;
     --thumb-size: calc(var(--radius) * 0.5);
 
     width: calc(var(--radius) * 2);
@@ -11,6 +11,14 @@
     &:active {
       cursor: grabbing;
     }
+}
+
+.color-percentage {
+    color: white !important;
+    text-shadow: 0 0 3px black;
+    width: 30px;
+    top: -20px;
+    margin: 0 4px;
 }
 
 .gradient-angle-thumb {
@@ -25,15 +33,24 @@
 
 .o_color_gradient_input {
     font-size: 11px;
+    display: flex;
+    align-items: center;
 
-    input {
+    * {
         font-family: monospace !important;
         font-size: 12px;
-        width: 5ch !important;
         padding: 0 2px !important;
         background-color: transparent;
         border: 1px solid !important;
         text-align: center;
         opacity: 0.7;
+    }
+    input {
+        width: 5ch !important;
+        border-right: none !important;
+    }
+    span {
+        width: 30px !important;
+        border-left: none !important;
     }
 }

--- a/addons/html_editor/static/src/main/font/gradient_picker/gradient_picker.xml
+++ b/addons/html_editor/static/src/main/font/gradient_picker/gradient_picker.xml
@@ -2,109 +2,111 @@
     <t t-name="html_editor.GradientPicker">
         <div class="d-flex flex-column">
 
-            <div class="align-items-center d-flex justify-content-between my-2 o_type_row">
+            <div class="align-items-center d-flex justify-content-between my-3 o_type_row">
                 Type
                 <span class="d-flex justify-content-between">
                     <button t-attf-class="btn btn-sm btn-light {{ this.state.type === 'linear' ? 'active' : ''}}" t-on-click="() => this.selectType('linear')"> Linear </button>
                     <button t-attf-class="btn btn-sm btn-light {{ this.state.type === 'radial' ? 'active' : ''}}" t-on-click="() => this.selectType('radial')"> Radial </button>
+                    <button t-attf-class="btn btn-sm btn-light {{ this.state.type === 'conic' ? 'active' : ''}}" t-on-click="() => this.selectType('conic')"> Conic </button>
                 </span>
             </div>
 
-            <div t-if="this.state.type === 'linear'" class="d-flex align-items-center justify-content-between mb-1">
-                Angle
-                <span class="d-flex justify-content-between align-items-center">
-                    <div class="d-flex justify-content-center align-items-center my-auto me-2 position-relative gradient-angle-knob"
-                        t-ref="gradientAngleKnob"
-                        t-attf-style="--angle: #{this.state.angle}deg;"
-                        t-on-mousedown="onKnobMouseDown">
-                        <div class="position-absolute gradient-angle-thumb"></div>
+            <div t-if="this.state.type === 'radial'">
+                <div class="d-flex flex-column gap-1 mb-1 me-n1">
+                    <div class="d-flex align-items-center justify-content-between" t-on-mouseover="props.onColorPointerOver" t-on-mouseout="props.onColorPointerOut">
+                        <div style="margin-right: auto;">
+                            Size
+                        </div>
+                        <button t-on-click="() => this.onSizeChange('closest-side')" t-att-data-color="getRadialGradient('closest-side')" t-attf-class="btn btn-light p-0 {{ this.state.size === 'closest-side' ? `active` : ''}}" title="Extend to the closest side">
+                            <img src="/html_editor/static/src/img/gradient-closest-side.svg"/>
+                        </button>
+                        <button t-on-click="() => this.onSizeChange('closest-corner')" t-att-data-color="getRadialGradient('closest-corner')" t-attf-class="btn btn-light p-0 {{ this.state.size === 'closest-corner' ? `active` : ''}}" title="Extend to the closest corner">
+                            <img src="/html_editor/static/src/img/gradient-closest-corner.svg"/>
+                        </button>
+                        <button t-on-click="() => this.onSizeChange('farthest-side')" t-att-data-color="getRadialGradient('farthest-side')" t-attf-class="btn btn-light p-0 {{ this.state.size === 'farthest-side' ? `active` : ''}}" title="Extend to the farthest side">
+                            <img src="/html_editor/static/src/img/gradient-farthest-side.svg"/>
+                        </button>
+                        <button t-on-click="() => this.onSizeChange('farthest-corner')" t-att-data-color="getRadialGradient('farthest-corner')" t-attf-class="btn btn-light p-0 {{ this.state.size === 'farthest-corner' ? `active`: ''}}" title="Extend to the farthest corner">
+                            <img src="/html_editor/static/src/img/gradient-farthest-corner.svg"/>
+                        </button>
                     </div>
-                    <div class="o_color_gradient_input d-flex align-items-center">
-                        <input
-                            name="angle"
-                            type="number"
-                            min="0"
-                            max="360"
-                            t-att-value="this.state.angle"
-                            t-on-change="onAngleChange"
-                        />
-                        <label class="flex-grow-0 ms-1 mb-0">deg</label>
-                    </div>
-                </span>
+                </div>
             </div>
-            <div t-else="" class="d-flex flex-column gap-1 mb-1">
-                Size
-                <div class="d-flex align-items-center justify-content-between" t-on-mouseover="props.onColorPointerOver" t-on-mouseout="props.onColorPointerOut">
-                    <button t-on-click="() => this.onSizeChange('closest-side')" t-att-data-color="getRadialGradient('closest-side')" t-attf-class="btn btn-light p-0 {{ this.state.size === 'closest-side' ? `active` : ''}}" title="Extend to the closest side">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 16 20" fill="none">
-                            <rect x="1.5" y="3.5" width="13" height="13" stroke="#AAAAAD"></rect>
-                            <path d="M3 4H9V8C9 8.55228 8.55228 9 8 9H4C3.44772 9 3 8.55228 3 8V4Z" fill="#8C8C92"></path>
-                            <path d="M6 11C7.65685 11 9 9.65685 9 8C9 6.34315 7.65685 5 6 5C4.34315 5 3 6.34315 3 8C3 9.65685 4.34315 11 6 11Z" fill="#74747B"></path>
-                            <path d="M6 10C7.10457 10 8 9.10457 8 8C8 6.89543 7.10457 6 6 6C4.89543 6 4 6.89543 4 8C4 9.10457 4.89543 10 6 10Z" fill="white"></path>
-                            <rect x="2" y="3" width="12" height="1" fill="white"></rect>
-                        </svg>
-                    </button>
-                    <button t-on-click="() => this.onSizeChange('closest-corner')" t-att-data-color="getRadialGradient('closest-corner')" t-attf-class="btn btn-light p-0 {{ this.state.size === 'closest-corner' ? `active` : ''}}" title="Extend to the closest corner">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 16 20" fill="none">
-                            <rect x="1.5" y="3.5" width="13" height="13" stroke="#AAAAAD"></rect>
-                            <path d="M2 4H9V7C9 9.20914 7.20914 11 5 11H2V4Z" fill="#8C8C92"></path>
-                            <path d="M6 11C7.65685 11 9 9.65685 9 8C9 6.34315 7.65685 5 6 5C4.34315 5 3 6.34315 3 8C3 9.65685 4.34315 11 6 11Z" fill="#74747B"></path>
-                            <path d="M6 10C7.10457 10 8 9.10457 8 8C8 6.89543 7.10457 6 6 6C4.89543 6 4 6.89543 4 8C4 9.10457 4.89543 10 6 10Z" fill="white"></path>
-                            <rect x="1" y="3" width="8" height="1" fill="white"></rect>
-                            <rect x="1" y="11" width="8" height="1" transform="rotate(-90 1 11)" fill="white"></rect>
-                        </svg>
-                    </button>
-                    <button t-on-click="() => this.onSizeChange('farthest-side')" t-att-data-color="getRadialGradient('farthest-side')" t-attf-class="btn btn-light p-0 {{ this.state.size === 'farthest-side' ? `active` : ''}}" title="Extend to the farthest side">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 16 20" fill="none">
-                            <rect x="1.5" y="3.5" width="13" height="13" stroke="#AAAAAD"></rect>
-                            <path d="M7 12C10.3137 12 14 10.2091 14 8C14 5.79086 10.3137 4 7 4C3.68629 4 2 5.79086 2 8C2 10.2091 3.68629 12 7 12Z" fill="#8C8C92"></path>
-                            <path d="M6 11C7.65685 11 9 9.65685 9 8C9 6.34315 7.65685 5 6 5C4.34315 5 3 6.34315 3 8C3 9.65685 4.34315 11 6 11Z" fill="#74747B"></path>
-                            <path d="M6 10C7.10457 10 8 9.10457 8 8C8 6.89543 7.10457 6 6 6C4.89543 6 4 6.89543 4 8C4 9.10457 4.89543 10 6 10Z" fill="white"></path>
-                            <rect x="14" y="4" width="1" height="12" fill="white"></rect>
-                        </svg>
-                    </button>
-                    <button t-on-click="() => this.onSizeChange('farthest-corner')" t-att-data-color="getRadialGradient('farthest-corner')" t-attf-class="btn btn-light p-0 {{ this.state.size === 'farthest-corner' ? `active` : ''}}" title="Extend to the farthest corner">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 16 20" fill="none">
-                            <rect x="1.5" y="3.5" width="13" height="13" stroke="#AAAAAD"></rect>
-                            <path d="M2 4H14V10C14 13.3137 11.3137 16 8 16H2V4Z" fill="#8C8C92"></path>
-                            <path d="M6 11C7.65685 11 9 9.65685 9 8C9 6.34315 7.65685 5 6 5C4.34315 5 3 6.34315 3 8C3 9.65685 4.34315 11 6 11Z" fill="#74747B"></path>
-                            <path d="M6 10C7.10457 10 8 9.10457 8 8C8 6.89543 7.10457 6 6 6C4.89543 6 4 6.89543 4 8C4 9.10457 4.89543 10 6 10Z" fill="white"></path>
-                            <rect x="15" y="17" width="7" height="0.999999" transform="rotate(-180 15 17)" fill="white"></rect>
-                            <rect x="15" y="10" width="7" height="1" transform="rotate(90 15 10)" fill="white"></rect>
-                        </svg>
-                    </button>
-                </div>
-                <div class="d-flex align-items-center justify-content-between">
-                    Position X
-                    <span class="o_color_gradient_input">
-                        <input
-                            name="positionX"
-                            type="number"
-                            min="0"
-                            max="100"
-                            t-att-value="this.positions['x']"
-                            t-on-change="(ev) => this.onPositionChange('x', ev)"
-                        />
+            <div t-if="this.state.type === 'linear' or this.state.type === 'conic'">
+                <div class="d-flex align-items-center justify-content-between mb-1">
+                    Angle
+                    <span class="d-flex justify-content-between align-items-center">
+                        <div class="d-flex justify-content-center align-items-center my-auto me-2 position-relative gradient-angle-knob"
+                            t-ref="gradientAngleKnob"
+                            t-attf-style="--angle: #{this.state.angle - 90}deg;"
+                            t-on-mousedown="onKnobMouseDown">
+                            <div class="position-absolute gradient-angle-thumb"></div>
+                        </div>
+                        <div class="o_color_gradient_input d-flex align-items-center">
+                            <input
+                                name="angle"
+                                type="number"
+                                min="-360"
+                                max="360"
+                                t-att-value="this.state.angle"
+                                t-on-change="onAngleChange"
+                            />
+                            <span>deg</span>
+                        </div>
                     </span>
                 </div>
-                <div class="d-flex align-items-center justify-content-between">
-                    Position Y
-                    <span class="o_color_gradient_input">
-                        <input
-                            name="positionY"
-                            type="number"
-                            min="0"
-                            max="100"
-                            t-att-value="this.positions['y']"
-                            t-on-change="(ev) => this.onPositionChange('y', ev)"
-                        />
-                    </span>
+            </div>
+            <div t-if="this.state.type === 'radial' or this.state.type === 'conic'">
+                <div class="d-flex flex-column gap-1 mb-1">
+                    <div class="d-flex align-items-center justify-content-between">
+                        Position X
+                        <div class="d-flex">
+                            <span class="o_color_gradient_input">
+                                <input
+                                    name="positionX"
+                                    type="number"
+                                    min="-100"
+                                    max="200"
+                                    t-att-value="this.positions['x']"
+                                    t-on-change="(ev) => this.onPositionChange('x', ev)"
+                                />
+                                <span>%</span>
+                            </span>
+                        </div>
+                    </div>
+                    <div class="d-flex align-items-center justify-content-between">
+                        Position Y
+                        <div class="d-flex">
+                            <span class="o_color_gradient_input">
+                                <input
+                                    name="positionY"
+                                    type="number"
+                                    min="-100"
+                                    max="200"
+                                    t-att-value="this.positions['y']"
+                                    t-on-change="(ev) => this.onPositionChange('y', ev)"
+                                />
+                                <span>%</span>
+                            </span>
+                            
+                        </div>
+                    </div>
                 </div>
             </div>
 
-            <div class="custom-gradient-configurator">
-                 <div class="gradient-checkers"></div>
-                <div class="gradient-preview" t-attf-style="background-image: #{this.cssGradients.preview};"
+
+
+            <div class="custom-gradient-configurator mt-3">
+                <div class="mb-1 d-flex justify-content-between align-items-center">
+                    Colors
+                    <div class="d-flex align-items-center">
+                        Repeating
+                        <CheckBox className="'d-flex align-items-center justify-content-center o_field_boolean o_boolean_toggle form-switch'" onChange="this.onToggleRepeatingBound" value="this.state.repeating"/> 
+                    </div>
+                </div>
+                <div class="gradient-checkers"></div>
+                <div class="gradient-preview" 
+                     t-attf-style="background-image: #{this.cssGradients.preview};"
                      t-on-click="this.onGradientPreviewClick" >
                 </div>
                 <style><t t-out="this.cssGradients.sliderThumbStyle" /></style>
@@ -113,15 +115,22 @@
                         <input type="range" min="0" max="100" t-att-value="color.percentage"
                                t-att-class="{'active': this.state.currentColorIndex === color_index}"
                                t-attf-name="custom gradient percentage color #{color_index+1}"
-                               t-on-click="() => this.state.currentColorIndex = color_index"
-                               t-on-change="(ev) => this.onColorPercentageChange(color_index, ev)" />
+                               t-on-change="(ev) => this.onColorPercentageChange(color_index, ev)" 
+                               t-on-pointerdown="() => this.state.currentColorIndex = color_index"
+                        />
                     </div>
+                    <div class="position-relative text-white fw-bolder color-percentage pe-none d-flex justify-content-center" 
+                         t-out="this.colors[this.state.currentColorIndex].percentage" 
+                         t-attf-style="left: calc(#{this.colors[this.state.currentColorIndex].percentage}% - #{15 + 0.08*this.colors[this.state.currentColorIndex].percentage}px);"
+                    />
                 </div>
-                <div class="gradient-color-bin">
+                <div class="gradient-color-bin position-relative">
                     <t t-if="this.colors.length > 2">
                         <a t-on-click="() => this.removeColor(this.state.currentColorIndex)"
                            t-attf-style="left: #{this.colors[this.state.currentColorIndex].percentage}%"
-                           type="button" class="btn btn-sm btn-light"><i class="fa fa-fw fa-trash" role="img"/></a>
+                           type="button" class="btn btn-sm btn-light position-absolute">
+                           <i class="fa fa-fw fa-trash" role="img"/>
+                        </a>
                     </t>
                 </div>
             </div>

--- a/addons/html_editor/static/tests/color_selector.test.js
+++ b/addons/html_editor/static/tests/color_selector.test.js
@@ -646,7 +646,7 @@ test("should be able to show preview when hovering radial type button", async ()
     expect(getContent(el)).toBe(
         `<p>a<font style="background-image: ${gradientAfter};">[bcd]</font>e</p>`
     );
-    expect("button[title='Extend to the farthest side']").toHaveClass("active");
+    expect("button[title='Extend to the farthest side']").not.toHaveClass("active");
 
     // Hover out
     await hover(".o-we-toolbar .o-select-color-foreground");


### PR DESCRIPTION
Here is a list of all the updates done in this commit:

New:
- Add the "conic" gradient type
- Add the "repeating" gradient modifier
- Add the percentage above the active slider to help user fine tune their gradients.

Update:
- Enable the gradient center to be positioned outside of the screen, which is useful when creating radial or conic gradients, in order to hide the gradient center.
- Enable negative angle values (e.g. -90° instead of 270°)
- Update the svg for radial gradient size option to be closer to the result (concentric circles).
- Reduce the size of the angle knob to fit inside a row
- Reduce the size of the svg elements to fit better in a row
- Fix the position of the fa-trash, which was shifted toward the center

task-5159041