### PR TITLE
[FIX] account: clean up of section and subsection feature

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -7022,13 +7022,10 @@ class AccountMove(models.Model):
         def show_line(line):
             return (
                 line.display_type == 'line_section'
-                or (not (
-                    line.parent_id.collapse_composition
-                    or line.parent_id.parent_id.collapse_composition
-                ) and not (
-                    line.parent_id.collapse_prices
-                    or line.parent_id.parent_id.collapse_prices
-                ))
+                or (
+                    not any([line.parent_id.collapse_composition, line.parent_id.parent_id.collapse_composition]) and
+                    not any([line.parent_id.collapse_prices, line.parent_id.parent_id.collapse_prices])
+                )
             )
 
         return self.invoice_line_ids.filtered(show_line).sorted('sequence')

--- a/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.js
+++ b/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.js
@@ -134,7 +134,12 @@ export class SectionAndNoteListRenderer extends ListRenderer {
     }
 
     async toggleCollapse(record, fieldName) {
-        const changes = { [fieldName]: !record.data[fieldName] };
+        // We don't want to have 'collapse_prices' & 'collapse_composition' set to True at the same time
+        const reverseFieldName = fieldName === 'collapse_prices' ? 'collapse_composition' : 'collapse_prices';
+        const changes = {
+            [fieldName]: !record.data[fieldName],
+            [reverseFieldName]: false,
+        };
         await record.update(changes);
     }
 

--- a/addons/account/tests/__init__.py
+++ b/addons/account/tests/__init__.py
@@ -49,6 +49,7 @@ from . import test_payment_term
 from . import test_account_payment_items
 from . import test_account_payment_register
 from . import test_account_report
+from . import test_account_section_and_subsection
 from . import test_tour
 from . import test_early_payment_discount
 from . import test_ir_actions_report

--- a/addons/account/tests/test_account_section_and_subsection.py
+++ b/addons/account/tests/test_account_section_and_subsection.py
@@ -1,0 +1,93 @@
+from odoo import Command
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install')
+class TestAccountSectionAndSubsection(AccountTestInvoicingCommon):
+
+    def test_get_child_lines_with_one_taxes(self):
+        move = self.init_invoice('out_invoice')
+        move.invoice_line_ids = [
+            Command.create({
+                'name': "Section 1",
+                'display_type': 'line_section',
+                'collapse_prices': True,
+            }),
+            Command.create({
+                'product_id': self.product_a.id,
+                'price_unit': 100,
+                'tax_ids': self.tax_sale_a.ids,
+            }),
+            Command.create({
+                'name': "Subsection 1.1",
+                'display_type': 'line_subsection',
+                'collapse_composition': True,
+            }),
+            Command.create({
+                'product_id': self.product_a.id,
+                'price_unit': 200,
+                'tax_ids': self.tax_sale_a.ids,
+            }),
+            Command.create({
+                'product_id': self.product_b.id,
+                'price_unit': 100,
+                'tax_ids': self.tax_sale_a.ids,
+            }),
+        ]
+        section_lines = move.invoice_line_ids[0]._get_child_lines()
+        expected_values = [
+            {'display_type': 'line_section', 'name': 'Section 1', 'price_subtotal': 400.0, 'taxes': ['15%']},
+            {'display_type': 'product', 'name': 'product_a', 'price_subtotal': 100.0, 'taxes': []},
+            {'display_type': 'product', 'name': 'Subsection 1.1', 'price_subtotal': 300.0, 'taxes': []},
+        ]
+        for expected_value, line_value in zip(expected_values, section_lines):
+            for key, value in expected_value.items():
+                self.assertEqual(line_value[key], value)
+
+    def test_get_child_lines_with_multiple_taxes(self):
+        move = self.init_invoice('out_invoice')
+        move.invoice_line_ids = [
+            Command.create({
+                'name': "Section 1",
+                'display_type': 'line_section',
+                'collapse_prices': True,
+            }),
+            Command.create({
+                'product_id': self.product_a.id,
+                'price_unit': 100,
+                'tax_ids': self.tax_sale_a.ids,
+            }),
+            Command.create({
+                'product_id': self.product_a.id,
+                'price_unit': 100,
+                'tax_ids': self.tax_sale_b.ids,
+            }),
+            Command.create({
+                'name': "Subsection 1.1",
+                'display_type': 'line_subsection',
+                'collapse_composition': True,
+            }),
+            Command.create({
+                'product_id': self.product_b.id,
+                'price_unit': 200,
+                'tax_ids': self.tax_sale_a.ids,
+            }),
+            Command.create({
+                'product_id': self.product_b.id,
+                'price_unit': 200,
+                'tax_ids': self.tax_sale_b.ids,
+            }),
+        ]
+        section_lines = move.invoice_line_ids[0]._get_child_lines()
+        expected_values = [
+            {'display_type': 'line_section', 'name': 'Section 1', 'price_subtotal': 300.0, 'taxes': ['15%']},
+            {'display_type': 'product', 'name': 'product_a', 'price_subtotal': 100.0, 'taxes': []},
+            {'display_type': 'product', 'name': 'Subsection 1.1', 'price_subtotal': 200.0, 'taxes': []},
+            {'display_type': 'line_section', 'name': 'Section 1', 'price_subtotal': 300.0, 'taxes': ['15% (copy)']},
+            {'display_type': 'product', 'name': 'product_a', 'price_subtotal': 100.0, 'taxes': []},
+            {'display_type': 'product', 'name': 'Subsection 1.1', 'price_subtotal': 200.0, 'taxes': []},
+        ]
+        for expected_value, line_value in zip(expected_values, section_lines):
+            for key, value in expected_value.items():
+                self.assertEqual(line_value[key], value)

--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -194,11 +194,11 @@
                                     </t>
                                     <t t-elif="is_subsection">
                                         <t t-set="current_subsection" t-value="line"/>
-                                        <t t-set="line_padding" t-value="2"/>
+                                        <t t-set="line_padding" t-value="3"/>
                                     </t>
                                     <t t-else="">
                                         <t t-set="line_padding"
-                                           t-value="3 if current_subsection else (2 if current_section else 0)"
+                                           t-value="4 if current_subsection else (3 if current_section else 0)"
                                         />
                                     </t>
                                     <t t-set="padding_class" t-value="line_padding and ('px-' + str(line_padding)) or ''"/>
@@ -211,7 +211,7 @@
                                             'fw-bold o_line_subsection' if is_subsection else
                                             'fst-italic o_line_note' if is_note
                                             else ''">
-                                            <t t-set="line_colspan" t-value="line.get_column_to_exclude_for_colspan_calculation(line.tax_ids)"/>
+                                            <t t-set="line_colspan" t-value="3 + (1 if display_discount else 0) + (1 if display_taxes and not line.tax_ids else 0)"/>
                                             <t t-if="is_product" name="account_invoice_line_accountable">
                                                 <td name="account_invoice_line_name" t-att-class="padding_class">
                                                     <span t-if="line.name" t-field="line.name" t-options="{'widget': 'text'}">Bacon Burger</span>
@@ -244,7 +244,7 @@
                                                 <t t-set="section_subtotal" t-value="line.get_section_subtotal()"/>
                                                 <!-- For desktop -->
                                                 <td name="line_name_td"
-                                                    t-att-colspan="(1 if is_product else 6 if display_discount else 5) - line_colspan"
+                                                    t-att-colspan="(1 if is_product else line_colspan)"
                                                     t-attf-class="{{'d-none d-md-table-cell' if report_type == 'html' else ''}} {{padding_class}}">
                                                     <span t-if="line.name" t-field="line.name" t-options="{'widget': 'text'}">A section title</span>
                                                 </td>
@@ -264,8 +264,7 @@
                                         </tr>
                                     </t>
                                     <t t-else="">
-                                        <t t-if="hide_details" t-set="grouped_lines" t-value="line._get_child_lines()"/>
-                                        <t t-if="hide_prices" t-set="grouped_lines" t-value="line._get_child_lines(False)"/>
+                                        <t t-set="grouped_lines" t-value="line._get_child_lines()"/>
                                         <t t-foreach="grouped_lines" t-as="grouped_line">
                                             <t t-if="grouped_line['display_type'] == 'product'">
                                                 <t t-set="line_colspan" t-value="1"/>
@@ -274,14 +273,18 @@
                                                 <t t-set="line_colspan" t-value="3 + (1 if display_discount else 0) + (1 if display_taxes and not grouped_line.get('taxes') else 0)"/>
                                             </t>
                                             <t t-if="hide_prices">
-                                                <t t-set="line_padding"
-                                                   t-value="3 if current_subsection and grouped_line['display_type'] != 'line_subsection' and grouped_line.get('original_display_type') != 'line_subsection' else
-                                                            2 if current_section and grouped_line['display_type'] != 'line_section' and grouped_line.get('original_display_type') != 'line_section' else
-                                                            0"/>
-                                                <t t-set="padding_class" t-value="line_padding and ('px-' + str(line_padding)) or ''"/>
+                                                <t t-if="grouped_line['display_type'] == 'line_section'">
+                                                    <t t-set="current_section" t-value="grouped_line"/>
+                                                    <t t-set="current_subsection" t-value="None"/>
+                                                </t>
                                                 <t t-if="grouped_line['display_type'] == 'line_subsection'">
                                                     <t t-set="current_subsection" t-value="grouped_line"/>
                                                 </t>
+                                                <t t-set="line_padding"
+                                                   t-value="4 if current_subsection and grouped_line['display_type'] != 'line_subsection' else
+                                                            3 if current_section and grouped_line['display_type'] != 'line_section' else
+                                                            0"/>
+                                                <t t-set="padding_class" t-value="line_padding and ('px-' + str(line_padding)) or ''"/>
                                             </t>
                                             <tr t-att-class="
                                                 'fw-bolder o_line_section' if grouped_line.get('display_type') == 'line_section' and not hide_details else

--- a/addons/l10n_ar/models/account_move_line.py
+++ b/addons/l10n_ar/models/account_move_line.py
@@ -43,9 +43,6 @@ class AccountMoveLine(models.Model):
             'price_net': price_net,
         }
 
+    # TODO: deprecated, remove in master
     def get_column_to_exclude_for_colspan_calculation(self, taxes=None):
-        # OVERRIDE OF ACCOUNT
-        if self.move_id.company_id.country_code == 'AR':
-            return 0 if self.display_type == 'product' else 2
-
         return super().get_column_to_exclude_for_colspan_calculation(taxes)

--- a/addons/l10n_ar/views/report_invoice.xml
+++ b/addons/l10n_ar/views/report_invoice.xml
@@ -139,6 +139,12 @@
         <t t-set="section_subtotal" t-value="line.get_section_subtotal()" position="attributes">
             <attribute name="t-value">line.get_section_subtotal() + l10n_ar_values['price_subtotal']</attribute>
         </t>
+        <t t-set="line_colspan" t-value="3 + (1 if display_discount else 0) + (1 if display_taxes and not line.tax_ids else 0)" position="attributes">
+            <attribute name="t-value">3 + (1 if display_discount else 0) + (1 if not line.tax_ids and not o._l10n_ar_include_vat() else 0)</attribute>
+        </t>
+        <t t-set="line_colspan" t-value="3 + (1 if display_discount else 0) + (1 if display_taxes and not grouped_line.get('taxes') else 0)" position="attributes">
+            <attribute name="t-value">3 + (1 if display_discount else 0) + (1 if display_taxes and not grouped_line.get('taxes') and o._l10n_ar_include_vat() else 0)</attribute>
+        </t>
         <!-- label amount for subtotal column on b2b and b2c -->
         <xpath expr="//th[@name='th_subtotal']/span" position="replace">
             <span>Amount</span>
@@ -164,7 +170,7 @@
         </xpath>
 
         <xpath expr="//span[@id='line_tax_ids']/.." position="attributes">
-            <attribute name="t-if">not o._l10n_ar_include_vat()</attribute>
+            <attribute name="t-if">not hide_prices and not o._l10n_ar_include_vat()</attribute>
         </xpath>
         <xpath expr="//span[@id='grouped_line_tax_ids']/.." position="attributes">
             <attribute name="t-if">not o._l10n_ar_include_vat()</attribute>


### PR DESCRIPTION
Few fixes for section and subsection feature.

1. Simplify the colspan calculation by removing the get_column_to_exclude_for_colspan_calculation
    Python method and performing all calculations in XML. This change makes it simpler to override
    the behavior.
2. Add padding to make the PDF indentation more readable. The px-3 class was not enough on some
    layouts, such as 'bubble' and 'boxed'.
3. Remove the possibility of having a section appear under both the "Hide Prices" and "Composition"
    options. It doesn't make sense to enable both simultaneously, as the user should choose to either
    hide the prices or the composition. A PDF with both options enabled is unreadable.
4. Technical refactor of the `_get_child_lines` method. This method is a bit messy and hard
    to read. This commit adds a bit of clarity in this method to be more readable in the future.
5. Fix a computation issue in `_get_child_lines`. While iterating on move lines of a hide prices section, we were using the section total amount on each line, which is wrong in case we have subsections. For subsections, we need to recompute the amount to only include the subsection lines.

no-task
