### PR TITLE
[FIX] base: Handle write error when merging pdfs using pypdf2

### DIFF
--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -679,7 +679,10 @@ class IrActionsReport(models.Model):
                 raise UserError(_("Odoo is unable to merge the generated PDFs."))
         result_stream = io.BytesIO()
         streams.append(result_stream)
-        writer.write(result_stream)
+        try:
+            writer.write(result_stream)
+        except (PdfReadError, TypeError, NotImplementedError, ValueError) as e:
+            raise UserError(_("Odoo is unable to write the merged PDF due to the following error: %s", e)) from e
         return result_stream
 
     def _render_qweb_pdf_prepare_streams(self, report_ref, data, res_ids=None):


### PR DESCRIPTION
**Issue description:**
In the `_merge_pdfs` method, error handling was only implemented for the PDF reader. Errors occurring during the writer process (e.g., parsing errors caused by special characters like "ü") were not caught, which resulted in a traceback.
**Solution:**
Adding error handling for the writer step, by just wrapping the PdfReadError error in a UserError.

**Steps to reproduce:**
1. Have multiple PDF invoices with special characters (e.g., "ü").
2. Import two or more of them as vendor bills and confirm them.
3. From the vendor bills list, select two or more, then download, then "original bill".
4. The merge operation fails with a traceback.

Note: Downloading a single bill works as the `_merge_pdfs` method is not called.

opw-4991601

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
