### PR TITLE
[FIX] sale: prevent JS steps failing in case field shown before `product_id`

### DIFF
--- a/addons/sale/static/src/js/tours/product_configurator_tour_utils.js
+++ b/addons/sale/static/src/js/tours/product_configurator_tour_utils.js
@@ -98,6 +98,11 @@ function selectAttribute(productName, attributeName, attributeValue, attributeTy
                 run: 'click',
             };
         case 'multi':
+            return {
+                content: content,
+                trigger: `${ptalSelector}:has(label:contains(/^${attributeValue}$/)) input[type="checkbox"]`,
+                run: "click",
+            };
         case 'pills':
         case 'radio':
             return {


### PR DESCRIPTION

To reproduce:

1. Manually modify the SO view `view_order_form` notebook SO lines list view to make visible any column before `product_id` For example:
https://github.com/odoo/odoo/blob/18.0/addons/sale/views/sale_order_views.xml#L521 making the field `display_type` visible
2. Run the tests of `sale` module

=> `sale` module tests will fail on test `test_sale_combo_configurator_preconfigure_unconfigurable_ptals`

```
FAILED: [18/22] Tour sale_combo_configurator_preconfigure_unconfigurable_ptals → Step Verify that configurable ptals are now configured (trigger:
        .sale-combo-configurator-dialog
        .combo-item-grid
        .product-card:has(.card-title:contains("Test product"))
    :contains("Attribute B: B")).
Element (
        .sale-combo-configurator-dialog
        .combo-item-grid
        .product-card:has(.card-title:contains("Test product"))
    :contains("Attribute B: B")) has not been found.
TIMEOUT step failed to complete within 10000 ms.
```
see runbot build fail at:
https://runbot.odoo.com/runbot/build/89552334

The issue happen as - for some dark magic JS/XML reason - adding the field before product_id make fail the step to click the checkbox using the span.

Fix was suggested by PIPU to solve/workaround the issue

In practice, this issue was discovered accidentally with a customisation which was willing to add a custom field at the start of the list

opw-5068699