### PR TITLE
[FIX] pos_loyalty: ignore order discount on specific products

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/models/loyalty.js
+++ b/addons/pos_loyalty/static/src/overrides/models/loyalty.js
@@ -1215,7 +1215,8 @@ patch(Order.prototype, {
                             applicableProducts.has(product)
                         ) &&
                         lineReward.reward_type === 'discount' &&
-                        lineReward.discount_mode != 'percent'
+                        lineReward.discount_mode != 'percent' &&
+                        !lineReward.all_discount_product_ids.has(line.get_product().id)
                     )
                 ) {
                     linesToDiscount.push(line);

--- a/addons/pos_loyalty/static/tests/tours/PosLoyaltyTour.js
+++ b/addons/pos_loyalty/static/tests/tours/PosLoyaltyTour.js
@@ -551,3 +551,24 @@ registry.category("web_tour.tours").add("PosRewardProductScanGS1", {
             PosLoyalty.finalizeOrder("Cash", "575.00"),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_specific_discount_dont_apply_on_others", {
+    test: true,
+    url: "/pos/web",
+    steps: () =>
+        [
+            ProductScreen.confirmOpeningPopup(),
+            ProductScreen.clickHomeCategory(),
+
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("AAA Partner"),
+            ProductScreen.clickDisplayedProduct("Desk Organizer"),
+            PosLoyalty.clickRewardButton(),
+            SelectionPopup.clickItem("$ 10 per order on your order"),
+            ProductScreen.clickDisplayedProduct("Magnetic Board"),
+            PosLoyalty.orderTotalIs("80.00"),
+            PosLoyalty.enterCode("free"),
+            PosLoyalty.hasRewardLine("$ 50 per order on Magnetic Board", "-50.00"),
+            PosLoyalty.orderTotalIs('30.00'),
+        ].flat(),
+});


### PR DESCRIPTION
**Steps to reproduce:**
- Have two products, A (150$) and B (50$)
- Make a loyalty program for A, 10$ reduction on the order when bought
- Make another one for B, 100% reduction on B when bought. Make it a coupon with a code
- Open the PoS, click on A, then B, then enter the coupon code

**Problem:**
After those steps, the reward for buying be should be 100% of B, meaning 50$, but it is only 40$.

**Why the fix:**
This happens because the reward line for A was taken into account when computing B's reward value.
Meaning that the original 50$ was taking the -10$
into account, thus making it 40$.

We now check if the current product is in all_discount_product_ids, and do not go through the next step if it is. This attribute represents all the products that the current reward applies to. 
So this means that if the current product is in the products the reward applies to, we do not add it to the lines to discount.
With this condition, we prevent a reward from discounting a product it already applies to again.

With this fix, we exclude the reward lines that target one of the products the reward targets. This ensures that any line directly associated with a discounted product are not considered.

opw-4970441