### PR TITLE
[IMP] iot_drivers: add mac address to device info

### DIFF
--- a/addons/iot_drivers/controllers/homepage.py
+++ b/addons/iot_drivers/controllers/homepage.py
@@ -171,6 +171,7 @@ class IotBoxOwlHomePage(http.Controller):
             'hostname': helpers.get_hostname(),
             'ip': helpers.get_ip(),
             'identifier': helpers.get_identifier(),
+            'mac_address': helpers.get_mac_address(),
             'devices': grouped_devices,
             'server_status': odoo_server_url,
             'pairing_code': connection_manager.pairing_code,

--- a/addons/iot_drivers/static/src/app/Homepage.js
+++ b/addons/iot_drivers/static/src/app/Homepage.js
@@ -150,6 +150,7 @@ export class Homepage extends Component {
             </SingleData>
             <SingleData t-if="store.advanced" name="'IP address'" value="state.data.ip" icon="'fa-globe'" />
             <SingleData t-if="store.advanced" name="'Identifier'" value="state.data.identifier" icon="'fa-address-card'" />
+            <SingleData t-if="store.advanced" name="'Mac Address'" value="state.data.mac_address" icon="'fa-address-book'" />
             <SingleData t-if="store.isLinux" name="'Internet Status'" value="networkStatus" icon="'fa-wifi'">
                 <t t-set-slot="button">
                     <WifiDialog />

--- a/addons/iot_drivers/tools/helpers.py
+++ b/addons/iot_drivers/tools/helpers.py
@@ -8,6 +8,7 @@ from importlib import util
 import inspect
 import io
 import logging
+import netifaces
 from pathlib import Path
 import platform
 import re
@@ -225,6 +226,15 @@ def get_identifier():
         return False
 
     return p.stdout.decode().strip() or False
+
+
+def get_mac_address():
+    interfaces = netifaces.interfaces()
+    for interface in interfaces:
+        if netifaces.ifaddresses(interface).get(netifaces.AF_INET):
+            addr = netifaces.ifaddresses(interface).get(netifaces.AF_LINK)[0]['addr']
+            if addr != '00:00:00:00:00:00':
+                return addr
 
 
 def get_path_nginx():


### PR DESCRIPTION
This PR adds the MAC address to the device info returned by the IoT Box. It is displayed on the IoT Box Homepage.
This helps to fix ip addresses of the IoT Boxes during the installations.