### PR TITLE
[IMP] l10n_mx: Change demo company.

### DIFF
--- a/addons/l10n_mx/demo/demo_company.xml
+++ b/addons/l10n_mx/demo/demo_company.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="base.partner_demo_company_mx" model="res.partner" forcecreate="1">
-        <field name="name">ESCUELA KEMPER URGATE</field>
-        <field name="vat">EKU9003173C9</field>
-        <field name="street">Campobasso Norte 3206 - 9000</field>
-        <field name="street2">Fraccionamiento Montecarlo</field>
-        <field name="zip">20914</field>
-        <field name="city">Jesús María</field>
-        <field name="state_id" ref="base.state_mx_ags"/>
+        <field name="name">My MX Company</field>
+        <field name="vat">IVD920810GU2</field>
+        <field name="street">Av. Francisco I. Madero Ote 313</field>
+        <field name="zip">58000</field>
+        <field name="city">Centro Histórico</field>
+        <field name="state_id" ref="base.state_mx_mich"/>
         <field name="country_id" ref="base.mx"/>
         <field name="phone">+52 222 123 4567</field>
         <field name="email">info@company.mxexample.com</field>
@@ -16,8 +15,16 @@
     </record>
 
     <record id="base.demo_company_mx" model="res.company" forcecreate="1">
-        <field name="name">ESCUELA KEMPER URGATE</field>
+        <field name="name">My MX Company</field>
         <field name="partner_id" ref="base.partner_demo_company_mx"/>
+    </record>
+
+    <record id="base.demo_bank_mx" model="res.partner.bank" forcecreate="1">
+        <field name="acc_number">0134567890</field>
+        <field name="partner_id" ref="base.partner_demo_company_mx"/>
+        <field name="company_id" ref="base.demo_company_mx"/>
+        <field name="bank_id" ref="l10n_mx.acc_bank_014_SANTANDER"/>
+        <field name="allow_out_payment" eval="True"/>
     </record>
 
     <function model="res.company" name="_onchange_country_id">


### PR DESCRIPTION
The SAT has a list of ‘demo’ companies to enable invoicing demo operations through Electronic Data Interchange (EDI). Currently, in Odoo, the default demo company is Kemper School. However, with the release of payroll stamping in version 19, this company is no longer useful, as it cannot stamp payroll. So, instead of adding another company, we modified the Kemper School data to change it to another company that can stamp payroll and all other existing documents.

The demo company data was changed.

Task-id: 5083590