### PR TITLE
[FIX] web: prevent color picker from scrolling horizontally

### DIFF
--- a/addons/web/static/src/core/color_picker/color_picker.xml
+++ b/addons/web/static/src/core/color_picker/color_picker.xml
@@ -2,15 +2,15 @@
 <t t-name="web.ColorPicker">
     <div t-attf-class="o_font_color_selector user-select-none {{this.props.className}}"
         t-on-pointerdown.stop="() => {}" data-prevent-closing-overlay="true" t-ref="root">
-        <div class="mb-1 pt-2 d-flex">
+        <div class="px-1 mb-1 pt-2 d-flex">
             <t t-foreach="this.tabs" t-as="tab" t-key="tab.id">
-                <button t-attf-class="btn btn-sm ms-1 text-truncate btn-tab #{tab.id}-tab #{ isDarkTheme ? 'btn-secondary' : 'btn-light'} #{state.activeTab === tab.id ? 'active' : ''}"
+                <button t-attf-class="btn btn-sm text-truncate btn-tab #{tab.id}-tab #{ isDarkTheme ? 'btn-secondary' : 'btn-light'} #{state.activeTab === tab.id ? 'active' : ''}"
                     t-on-click="() => this.setTab(tab.id)">
                     <t t-out="tab.name" />
                 </button>
             </t>
             <div class="flex-grow-1" />
-            <button t-attf-class="btn btn-sm fa fa-trash me-1 #{ isDarkTheme ? 'btn-secondary' : 'btn-light'}"
+            <button t-attf-class="btn btn-sm fa fa-trash #{ isDarkTheme ? 'btn-secondary' : 'btn-light'}"
                     title="Reset"
                     t-on-click="onColorApply"
                     t-on-mouseover="onColorHover"


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

- Due to a recent [refactor](https://github.com/odoo/odoo/commit/edc9d5bb9582db704ed02051ee4adb3801ddfaa9#diff-f2da6e6a1009564765335a3006ab73d76120e094d3554786c9acbe15b79f9fe0R7), the margin start (`ms-1`) was applied to all tabs of the color picker instead of only the first one, and `me-1` to the last one. Because color picker has fixed width, this change introduced scrollbar.

Desired behavior after PR is merged:

- Added `px-1` to the parent element so that the color picker remains fixed and does not scroll horizontally.

task-5103832

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr