### PR TITLE
[IMP] account: Use a variable that is filled in to call a function.

### DIFF
--- a/addons/account/models/account_move_send.py
+++ b/addons/account/models/account_move_send.py
@@ -153,11 +153,11 @@ class AccountMoveSend(models.AbstractModel):
         if mail_template.email_to:
             email_to = self._get_mail_default_field_value_from_template(mail_template, mail_lang, move, 'email_to')
             for mail_data in tools.email_split(email_to):
-                partners |= partners.find_or_create(mail_data)
+                partners |= self.env['res.partner'].with_company(move.company_id).find_or_create(mail_data)
         if mail_template.email_cc:
             email_cc = self._get_mail_default_field_value_from_template(mail_template, mail_lang, move, 'email_cc')
             for mail_data in tools.email_split(email_cc):
-                partners |= partners.find_or_create(mail_data)
+                partners |= self.env['res.partner'].with_company(move.company_id).find_or_create(mail_data)
         if mail_template.partner_to:
             partner_to = self._get_mail_default_field_value_from_template(mail_template, mail_lang, move, 'partner_to')
             partner_ids = mail_template._parse_partner_to(partner_to)

--- a/doc/cla/corporate/studio73.md
+++ b/doc/cla/corporate/studio73.md
@@ -21,3 +21,4 @@ Carlos Reyes carlos@studio73.es https://github.com/reyes4711-s73
 Miguel Gandia miguel@studio73.es https://github.com/miguel-s73
 Roger Amorós roger@studio73.es https://github.com/rabbitjon-s73
 Guillermo Llinares guillermo@studio73.es https://github.com/willerr-mo-s73
+David López david.lopez@studio73.es https://github.com/david-s73


### PR DESCRIPTION
[IMP] account: Use a variable that is filled in to call a function.

- The function is modified so that the “parents” variable does not call the “find_or_create” function, since a variable is being used that is filled in each pass of the ‘for’ loop with “res.partner”. Therefore, when “find_or_create” is called, self may have more than one “partner,” so the solution we have implemented is to change the ‘partner’ variable when the function is called and replace it with “self.env[‘res.partner’]”.


https://github.com/odoo/odoo/blob/18.0/addons/account/models/account_move_send.py#L156
