### PR TITLE
[FIX] website_sale: check view active

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2129,7 +2129,7 @@
                                         </div>
                                     </div>
                                     <t
-                                        t-if="not is_fullwidth_content"
+                                        t-if="not is_fullwidth_content and is_view_active('website_sale.product_terms_and_conditions')"
                                         t-call="website_sale.product_terms_and_conditions"
                                     />
                                 </div>
@@ -2139,7 +2139,7 @@
                                 >
                                     <div class="o_wsale_product_sticky_col position-sticky">
                                         <t t-call="website_sale.cta_wrapper"/>
-                                        <t t-call="website_sale.product_terms_and_conditions"/>
+                                        <t t-if="is_view_active('website_sale.product_terms_and_conditions')" t-call="website_sale.product_terms_and_conditions"/>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
**Description**

- following this commit: odoo/odoo@bbb2d98d9ab97ce729d59b9858b63daccf5434e2 terms and conditions was explicitly called with t-call, which ignores whether the view is active or not. This caused the block to remain visible even when toggled off in the website editor.

The fix ensures that the call to `website_sale.product_terms_and_conditions` is wrapped in `is_view_active(...)`, so the snippet is only rendered when enabled.

**Steps to reproduce before the fix:**
1. Go to website → open any product in edit mode.
2. Toggle off the Terms & Conditions option.
3. The block still shows up.

**After the fix:** toggling off correctly hides the block.

opw-5096452

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
