### PR TITLE
[FIX] website_sale_stock: prevent traceback when quantity snippet is removed

### DIFF
--- a/addons/website_sale_stock/static/src/js/variant_mixin.js
+++ b/addons/website_sale_stock/static/src/js/variant_mixin.js
@@ -33,7 +33,7 @@ VariantMixin._onChangeCombinationStock = async function (ev, parent, combination
     }
 
     const addQtyInput = parent.querySelector('input[name="add_qty"]');
-    let qty = addQtyInput.value;
+    const qty = parseFloat(addQtyInput?.value) || 1;
     const ctaWrapper = parent.querySelector('#o_wsale_cta_wrapper');
     ctaWrapper.classList.replace('d-none', 'd-flex');
     ctaWrapper.classList.remove('out_of_stock');
@@ -41,25 +41,25 @@ VariantMixin._onChangeCombinationStock = async function (ev, parent, combination
     if (!combination.allow_out_of_stock_order) {
         const unavailableQty = await this.waitFor(VariantMixin._getUnavailableQty(combination));
         combination.free_qty -= unavailableQty;
-        addQtyInput.dataset.max = combination.free_qty || 1;
         if (combination.free_qty < 0) {
             combination.free_qty = 0;
         }
-        if (qty > combination.free_qty) {
-            qty = combination.free_qty || 1;
-            addQtyInput.value = qty;
+        if (addQtyInput) {
+            addQtyInput.dataset.max = combination.free_qty || 1;
+            if (qty > combination.free_qty) {
+                addQtyInput.value = addQtyInput.dataset.max;
+            }
         }
         if (combination.free_qty < 1) {
             ctaWrapper.classList.replace('d-flex', 'd-none');
             ctaWrapper.classList.add('out_of_stock');
         }
-    }
-
-    if (has_max_combo_quantity) {
-        addQtyInput.dataset.max = combination.max_combo_quantity || 1;
-        if (qty > combination.max_combo_quantity) {
-            qty = combination.max_combo_quantity || 1;
-            addQtyInput.value = qty;
+    } else if (has_max_combo_quantity) {
+        if (addQtyInput) {
+            addQtyInput.dataset.max = combination.max_combo_quantity || 1;
+            if (qty > combination.max_combo_quantity) {
+                addQtyInput.value = addQtyInput.dataset.max;
+            }
         }
         if (combination.max_combo_quantity < 1) {
             ctaWrapper.classList.replace('d-flex', 'd-none');


### PR DESCRIPTION
steps to reproduce:
-------------------
1. Install website_sale_stock
2. Go to Website > Shop > Product (with inventory tracking enabled)
3. Click on Edit and remove the "Quantity" snippet
4. Save the changes

issue:
------
```
TypeError: Cannot read properties of null (reading 'value')
```
cause:
------
The code:
https://github.com/odoo/odoo/blob/2bd0b503e0b30a7a5e19736f7bdf89700ef1d3c6/addons/website_sale_stock/static/src/js/variant_mixin.js#L35-L36 unconditionally accessed `addQtyInput.value`
This raises an error when the "Quantity" snippet has been removed, since `addQtyInput` is null.

Reference PR: https://github.com/odoo/odoo/pull/223917

**NOTE**: During the conversion of website_sale public widgets to interactions,
the jQuery was replaced with an HTML element.
For e.g,
```python3
$addQtyInput ==> addQtyInput
```

Unlike jQuery objects, native elements can be null, but the code
still assumes its presence in several places,
https://github.com/odoo/odoo/blob/bdc888e78283f25067eb8cf5b79d4c30ad4b3469/addons/website_sale_stock/static/src/js/variant_mixin.js#L36
https://github.com/odoo/odoo/blob/bdc888e78283f25067eb8cf5b79d4c30ad4b3469/addons/website_sale_stock/static/src/js/variant_mixin.js#L43
https://github.com/odoo/odoo/blob/bdc888e78283f25067eb8cf5b79d4c30ad4b3469/addons/website_sale_stock/static/src/js/variant_mixin.js#L58

This leads to errors when the "Quantity" snippet is removed.

solution:
---------
Check if `addQtyInput` exists before accessing its value.

Co-Authored by loti@odoo.com

opw-5095486

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
