### PR TITLE
[IMP] mail, web_unsplash: improve check on attachment upload

### DIFF
--- a/addons/html_editor/controllers/main.py
+++ b/addons/html_editor/controllers/main.py
@@ -314,6 +314,16 @@ class HTML_Editor(Controller):
             # the token, so we need to generate it using sudo
             if not attachment_data['public']:
                 attachment.sudo().generate_access_token()
+
+            if request.env.user.share:
+                max_portal_file_size = int(request.env["ir.config_parameter"].sudo().get_int(
+                    "html_editor.max_portal_file_size",
+                    100_000_000,
+                ))
+                if not (attachment.mimetype or '').startswith('image/'):
+                    raise AccessError(request.env._("Non-internal users can only upload image."))
+                if attachment.file_size >= max_portal_file_size:
+                    raise AccessError(request.env._("Non-internal users can't upload large files."))
         else:
             attachment = get_existing_attachment(IrAttachment, attachment_data) \
                 or IrAttachment.create(attachment_data)

--- a/addons/web_unsplash/models/ir_attachment.py
+++ b/addons/web_unsplash/models/ir_attachment.py
@@ -1,11 +1,17 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models
+from odoo import api, models
+from odoo.exceptions import ValidationError
 
 
 class IrAttachment(models.Model):
     _inherit = "ir.attachment"
+
+    @api.constrains("url", "mimetype")
+    def _check_unsplash(self):
+        if any(a.url and a.url.startswith("/unsplash/") and not (a.mimetype or "").startswith("image/") for a in self):
+            raise ValidationError(self.env._("Unsplash attachments must be images."))
 
     def _can_bypass_rights_on_media_dialog(self, **attachment_data):
         # We need to allow and sudo the case of an "url + file" attachment,

--- a/addons/web_unsplash/tests/__init__.py
+++ b/addons/web_unsplash/tests/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_unsplash

--- a/addons/web_unsplash/tests/test_unsplash.py
+++ b/addons/web_unsplash/tests/test_unsplash.py
@@ -1,0 +1,24 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import common
+from odoo.exceptions import ValidationError
+
+
+class TestUnsplash(common.TransactionCase):
+    def test_constraint(self):
+        self.env["ir.attachment"].create(
+            {
+                "name": "attachment",
+                "url": "/unsplash/xyz",
+                "datas": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+            },
+        )
+
+        with self.assertRaises(ValidationError):
+            self.env["ir.attachment"].create(
+                {
+                    "name": "attachment",
+                    "url": "/unsplash/xyz",
+                    "datas": "dGVzdA==",
+                },
+            )


### PR DESCRIPTION
Purpose
=======
Unsplash bypass a feature that when you go to an URL that doesn't have
a route, then it will read from `ir.attachment` an attachment of type
binary with an URL. This is not a security issue, because we can't
control the URL, but there's no reason to allow type that are not
images.

Add tests about access when uploading attachment for a message.

Task-4687269