### PR TITLE
[FIX] l10n_tr_nilvera: fix server error message

### DIFF
--- a/addons/l10n_tr_nilvera/lib/nilvera_client.py
+++ b/addons/l10n_tr_nilvera/lib/nilvera_client.py
@@ -71,7 +71,7 @@ class NilveraClient:
         if response.status_code in {401, 403}:
             raise UserError("Oops, seems like you're unauthorised to do this. Try another API key with more rights or contact Nilvera.")
         elif 403 < response.status_code < 600:
-            raise UserError("Odoo could not perform this action at the moment, try again later.\n%s - %s" % (response.reason, response.code))
+            raise UserError("Odoo could not perform this action at the moment, try again later.\n%s - %s" % (response.reason, response.status_code))
 
         try:
             return response.json()


### PR DESCRIPTION
The http response object doesn't have a `code` attribute, this commit fixes this typo which has already been fixed in 19.0 as a part of #222869

task-5050516

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
