### PR TITLE
[FIX] web: notification with markup and title

### DIFF
--- a/addons/web/static/src/core/notifications/notification.xml
+++ b/addons/web/static/src/core/notifications/notification.xml
@@ -7,9 +7,11 @@
             <div class="w-100 py-2 ps-3 pe-5 border border-start-0 rounded-end text-break">
                 <button type="button" class="o_notification_close btn-close position-absolute top-0 end-0 mt-2 me-2" aria-label="Close" t-on-click="close"/>
                 <div class="o_notification_body d-flex align-items-center">
-                    <!-- TODO-IPB: at the end, title has to be removed, but the change is too important to do all in once now -->
-                    <span t-if="props.title" class="me-auto o_notification_content w-100" t-out="props.title + '. ' + props.message"/>
-                    <span t-else="" class="me-auto o_notification_content w-100" t-out="props.message"/>
+                    <span class="me-auto o_notification_content w-100">
+                        <!-- TODO-IPB: at the end, title has to be removed, but the change is too important to do all in once now -->
+                        <t t-if="props.title"><t t-out="props.title"/>. </t>
+                        <t t-out="props.message"/>
+                    </span>
                     <div t-if="props.buttons.length" class="o_notification_buttons justify-content-end w-50">
                         <button t-foreach="props.buttons" t-as="button" type="button" t-key="button_index" t-attf-class="btn btn-link" t-on-click="button.onClick">
                             <t t-if="button.icon">

--- a/addons/web/static/tests/core/notifications/notifications.test.js
+++ b/addons/web/static/tests/core/notifications/notifications.test.js
@@ -54,6 +54,23 @@ test("can display a notification with markup content", async () => {
     expect(".o_notification_content").toHaveInnerHTML("<b>I'm a <i>markup</i> notification</b>");
 });
 
+test("can display a notification with title and markup content", async () => {
+    await makeMockEnv();
+    const { Component: NotificationContainer, props } = registry
+        .category("main_components")
+        .get("NotificationContainer");
+    await mountWithCleanup(NotificationContainer, { props, noMainContainer: true });
+    getService("notification").add(markup`<b>I'm a <i>markup</i> notification</b>`, {
+        title: "I'm a title",
+    });
+    await animationFrame();
+    expect(".o_notification").toHaveCount(1);
+    expect(".o_notification_content").toHaveInnerHTML(
+        "I'm a title. <b>I'm a <i>markup</i> notification</b>"
+    );
+    expect(".o_notification_content").toHaveText("I'm a title. I'm a markup notification");
+});
+
 test("can display a notification of type danger", async () => {
     await makeMockEnv();
     const { Component: NotificationContainer, props } = registry


### PR DESCRIPTION
This commit fixes the notification's rendering issue when both message
and title are provided. Before, the message's HTML was escaped even if
marked as safe with `markup`.

Steps to reproduce:
- Open CRM app
- Open a lead
- Click on "Enrich" button
=> a notification appears "Not enough credits" but the button's html is
   not properly rendered (escaped).

task-5088945