### PR TITLE
[IMP] l10n_tr_nilvera_{einvoice|edispatch}: concatenate street and st…

### DIFF
--- a/addons/l10n_tr_nilvera_edispatch/templates/l10n_tr_nilvera_edispatch.xml
+++ b/addons/l10n_tr_nilvera_edispatch/templates/l10n_tr_nilvera_edispatch.xml
@@ -21,7 +21,7 @@
             </cac:PartyName>
         </t>
         <cac:PostalAddress>
-            <cbc:StreetName t-out="partner.street"/>
+            <cbc:StreetName t-out="' '.join(s for s in [partner.street, partner.street2] if s)"/>
             <cbc:CitySubdivisionName t-out="partner.city"/>
             <cbc:CityName t-out="partner.state_id.name"/>
             <cbc:PostalZone t-out="partner.country_id.code == 'TR' and partner.zip or partner.l10n_tr_nilvera_edispatch_customs_zip"/>

--- a/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
@@ -169,9 +169,8 @@ class AccountEdiXmlUblTr(models.AbstractModel):
         state = partner['state' if model == 'res.bank' else 'state_id']
 
         return {
-            'cbc:StreetName': {'_text': partner.street},
+            'cbc:StreetName': {'_text': ' '.join(s for s in [partner.street, partner.street2] if s)},
             'cbc:CitySubdivisionName': {'_text': partner.city},
-            'cbc:AdditionalStreetName': {'_text': partner.street2},
             'cbc:CityName': {'_text': state.name},
             'cbc:PostalZone': {'_text': partner.zip},
             'cac:Country': {

--- a/addons/l10n_tr_nilvera_einvoice/models/account_move_send.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_move_send.py
@@ -87,15 +87,6 @@ class AccountMoveSend(models.AbstractModel):
                 )),
             }
 
-        # Alert if partner has Street 2 filled, which is not allowed
-        if tr_partners_with_street2 := tr_nilvera_moves.filtered(lambda m: (m.partner_id.street2)).partner_id:
-            alerts["tr_partners_with_street2"] = {
-                'level': 'danger',
-                "message": _("The following partner(s) must have Street 2 empty"),
-                "action_text": _("View Partner(s)"),
-                "action": tr_partners_with_street2._get_records_action(name=_("Check Street 2 on Partner(s)")),
-            }
-
         # Alert if partner does not use UBL TR e-invoice format or has not checked Nilvera status
         if tr_partners_invalid_edi_or_status := tr_nilvera_moves.filtered(
             lambda m: (


### PR DESCRIPTION
…reet2 in UBL

We are concatenating the values of `street` and `street2` fields on `res.partner` because nilvera expects only <cbc:StreetName> for the fully qualified street name. The previously enforced validation that forced `street2` to be left empty is also removed to match the change.

task-5002986

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
