### PR TITLE
[IMP] project_timesheet_holidays: disable timesheet creation from work type leave

### DIFF
--- a/addons/project_timesheet_holidays/models/hr_holidays.py
+++ b/addons/project_timesheet_holidays/models/hr_holidays.py
@@ -83,7 +83,7 @@ class Holidays(models.Model):
     def _timesheet_create_lines(self):
         vals_list = []
         for leave in self:
-            if not leave.employee_id:
+            if not leave.employee_id or leave.holiday_status_id.time_type == 'other':
                 continue
             work_hours_data = leave.employee_id.list_work_time_per_day(
                 leave.date_from,


### PR DESCRIPTION
When a leave using a work leave type is approved, now it should not create a timesheet.

task-5097482

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
