### PR TITLE
[FIX] sale_gelato: prevent duplicate Gelato order creation

### DIFF
--- a/addons/sale_gelato/utils.py
+++ b/addons/sale_gelato/utils.py
@@ -30,6 +30,10 @@ def make_request(api_key, subdomain, version, endpoint, payload=None, method='PO
     try:
         if method == 'GET':
             response = requests.get(url=url, params=payload, headers=headers, timeout=10)
+        elif method == 'PATCH':
+            response = requests.patch(url=url, json=payload, headers=headers, timeout=10)
+        elif method == 'DELETE':
+            response = requests.delete(url=url, params=payload, headers=headers, timeout=10)
         else:
             response = requests.post(url=url, json=payload, headers=headers, timeout=10)
         response_content = response.json()


### PR DESCRIPTION
In case on a concurrent update happen in the same transaction as the sale order confirmation (was observed during payment transaction post-processing), we may currently create duplicate Gelato orders on each retry.

This commit avoid duplicate order creation by splitting the Gelato order creation in two steps:

- during the sale order confirmation we create a 'draft' order on Gelato
- on post-commit/post-rollback we either try to confirm or delete the Gelato draft order.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
