### PR TITLE
[FIX] point_of_sale: same padding left pad

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/action_pad.scss
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/action_pad.scss
@@ -1,0 +1,3 @@
+.remove-if-empty:empty {
+    display: none !important;
+}

--- a/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/action_pad.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/action_pad.xml
@@ -20,21 +20,18 @@
                 </t>
             </div>
             <t t-if="props.showActionButton">
-                <div class="mw-100 container validation" t-att-class="{'p-0': !showFastPaymentMethods}">
-                    <div class="gap-2" t-attf-class="{{showFastPaymentMethods ? 'row' : 'd-flex'}}">
-                        <BackButton t-if="pos.showBackButton() and !pos.config.module_pos_restaurant" class="{'col-3': showFastPaymentMethods}" onClick="() => pos.onClickBackButton()"/>
-                        <button class="pay pay-order-button button btn btn-primary btn-lg py-3 d-flex align-items-center justify-content-center flex-fill"
-                            t-att-class="{'col-3': showFastPaymentMethods}" t-on-click="props.actionToTrigger" t-out="props.actionName" />
-                        <t t-if="showFastPaymentMethods" t-foreach="this.pos.config.fast_payment_method_ids" t-as="paymentMethod" t-key="paymentMethod.id">
-                            <button class="fast-pay-button col-3 button btn btn-secondary btn-lg py-3 d-flex align-items-center justify-content-center flex-fill"
-                                t-on-click="() => props.fastValidate(paymentMethod)"
-                                t-out="paymentMethod.name"
-                            />
-                        </t>
-                    </div>
+                <div class="mw-100 container validation gap-2 remove-if-empty" t-att-class="{'p-0': !showFastPaymentMethods}" t-attf-class="{{showFastPaymentMethods ? 'row' : 'd-flex'}}">
+                    <BackButton t-if="pos.showBackButton() and !pos.config.module_pos_restaurant" class="{'col-3': showFastPaymentMethods}" onClick="() => pos.onClickBackButton()"/>
+                    <button class="pay pay-order-button button btn btn-primary btn-lg py-3 d-flex align-items-center justify-content-center flex-fill"
+                        t-att-class="{'col-3': showFastPaymentMethods}" t-on-click="props.actionToTrigger" t-out="props.actionName" />
+                    <t t-if="showFastPaymentMethods" t-foreach="this.pos.config.fast_payment_method_ids" t-as="paymentMethod" t-key="paymentMethod.id">
+                        <button class="fast-pay-button col-3 button btn btn-secondary btn-lg py-3 d-flex align-items-center justify-content-center flex-fill"
+                            t-on-click="() => props.fastValidate(paymentMethod)"
+                            t-out="paymentMethod.name"
+                        />
+                    </t>
                 </div>
             </t>
         </div>
     </t>
-
 </templates>

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml
@@ -3,7 +3,7 @@
     <t t-name="point_of_sale.ProductScreen">
         <div class="product-screen d-flex h-100">
             <div t-att-class="{'flex-grow-1 w-100 mw-100': ui.isSmall, 'd-none': ui.isSmall and pos.mobile_pane !== 'left'}"
-                class="leftpane d-flex flex-column pb-2 border-end bg-view">
+                class="leftpane d-flex flex-column pb-1 border-end bg-view">
                 <OrderSummary />
                 <div class="pads px-2">
                     <div class="control-buttons d-flex justify-content-between gap-2 w-100 py-2">


### PR DESCRIPTION
For the main buttons of the product screen and the payment screen, we put the same padding so that the layout is more consistent.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
