### PR TITLE
[FIX] web: add Set.difference polyfill for public users

### DIFF
--- a/addons/web/__manifest__.py
+++ b/addons/web/__manifest__.py
@@ -153,6 +153,7 @@ This module provides the core of the Odoo Web Client.
             'web/static/src/polyfills/object.js',
             'web/static/src/polyfills/array.js',
             'web/static/src/module_loader.js',
+            'web/static/src/polyfills/set.js',
             'web/static/src/session.js',
             'web/static/src/core/browser/cookie.js',
             'web/static/src/core/utils/ui.js',
@@ -452,6 +453,7 @@ This module provides the core of the Odoo Web Client.
             ('include', 'web.assets_backend'),
             ('include', 'web.assets_backend_lazy'),
 
+            'web/static/src/polyfills/set.js',
             'web/static/src/public/**/*.js',
             'web/static/src/public/**/*.xml',
             'web/static/tests/public/**/*.xml',

--- a/addons/web/static/src/polyfills/set.js
+++ b/addons/web/static/src/polyfills/set.js
@@ -1,0 +1,15 @@
+export const difference = function (s) {
+    if (!(s instanceof Set)) {
+        throw new Error("argument must be a Set");
+    }
+    return new Set([...this].filter((e) => !s.has(e)));
+};
+
+// Safari < 17 (09/2023) doesn't support Set.difference, but this version is
+// quite recent enough for **public** users
+if (!Set.prototype.difference) {
+    Object.defineProperty(Set.prototype, "difference", {
+        enumerable: false,
+        value: difference,
+    });
+}

--- a/addons/web/static/tests/polyfills/set.test.js
+++ b/addons/web/static/tests/polyfills/set.test.js
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "@odoo/hoot";
+
+import { difference } from "@web/polyfills/set";
+
+describe.current.tags("headless");
+
+test("set difference", () => {
+    function test(s1, s2) {
+        let result;
+        try {
+            result = s1.difference(s2);
+        } catch {
+            expect(() => difference.call(s1, s2)).toThrow();
+            return;
+        }
+        expect(difference.call(s1, s2)).toEqual(result);
+    }
+    test(new Set([1, 2, 3]), new Set([])); // [1, 2, 3]
+    test(new Set([1, 2, 3]), new Set([1])); // [2, 3]
+    test(new Set([1, 2, 3]), new Set([1, 2, 3])); // []
+    test(new Set([1, 2, 3]), new Set([1, 2, 3, 5])); // []
+    test(new Set([1, 2, 3]), new Set([5, 6])); // []
+    test(new Set([]), new Set([1, 2, 3, 5])); // []
+
+    test(new Set([])); // throws
+    test(new Set([]), []); // throws
+    test(new Set([]), {}); // throws
+    test(new Set([]), 2); // throws
+    test(new Set([1])); // throws
+    test(new Set([1]), []); // throws
+    test(new Set([1]), {}); // throws
+    test(new Set([1]), 2); // throws
+});


### PR DESCRIPTION
Safari < 17 (09/2023) doesn't support Set.difference. This function is used in our indexeddb wrapper, which runs also in the frontend, even for public (non logged-in) users, to fetch and cache translations. As a consequence, those people have a crash at each page launch. Safari 17 being recent enough for public users, we add a polyfill (for frontend only).

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
