### PR TITLE
Update form_controller.js

### DIFF
--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -128,7 +128,7 @@ export class FormController extends Component {
         this.archInfo = this.props.archInfo;
         const { create, edit } = this.archInfo.activeActions;
         this.canCreate = create && !this.props.preventCreate;
-        this.canEdit = edit && !this.props.preventEdit;
+        this.canEdit = (edit || !this.props.resId) && !this.props.preventEdit;
         this.duplicateId = false;
 
         this.display = { ...this.props.display };


### PR DESCRIPTION
Fix Form Button Visibility for New Records When Using edit="0" in View

Problem Description:
When using edit="0" in a form view definition, the Save/Discard buttons were not appearing for new records (creation mode), even though they should be visible and functional during record creation.

Root Cause:
The issue was in the FormController where the canEdit logic was incorrectly relying solely on the edit parameter. For new records (resId is false), the form should always be in edit mode regardless of the edit="0" setting in the view

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
