### PR TITLE
[FIX] hr: no forcreate employee_admin

### DIFF
--- a/addons/hr/data/hr_data.xml
+++ b/addons/hr/data/hr_data.xml
@@ -17,7 +17,7 @@
             <field name="type">private</field>
         </record>
 
-        <record id="employee_admin" model="hr.employee">
+        <record id="employee_admin" model="hr.employee" forcecreate="0">
             <field name="name" eval="obj(ref('base.partner_admin')).name" model="res.partner"/>
             <field name="department_id" ref="dep_administration"/>
             <field name="user_id" ref="base.user_admin"/>


### PR DESCRIPTION
The `employee_admin` is a default admin option. Later when clients set up their work flow they set up their own admin employee. This record is not present, and it doesn't make sense recreate it with every update.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
