### PR TITLE
[FIX] l10n_gcc_invoice: fix description alignment issue on arabic invoice report

### DIFF
--- a/addons/l10n_gcc_invoice/views/report_invoice.xml
+++ b/addons/l10n_gcc_invoice/views/report_invoice.xml
@@ -282,7 +282,7 @@
                                         <span t-field="line.quantity" class="text-nowrap"/>
                                         <span t-field="line.product_uom_id" groups="uom.group_uom"/>
                                     </td>
-                                    <td name="account_invoice_line_name">
+                                    <td class="text-end" name="account_invoice_line_name">
                                         <t t-if="line.product_id">
                                             <t t-set="english_name" t-value="line.with_context(lang='en_US').product_id.display_name"/>
                                             <t t-set="arabic_name" t-value="line.with_context(lang=o.env['res.lang']._get_code('ar_001')).product_id.display_name"/>


### PR DESCRIPTION
**Steps to reproduce:**
1. Install l10n_gcc_invoice.
2. Add and Switch to a Saudi Arabia company.
3. Select boxed layout (or keep any layout).
4. Create and print an invoice.

**Issue:**
- The description column is misaligned in the Arabic invoice report. According to Saudi localization, it should 
  be aligned to the left for better readability. The current alignment makes Arabic text inconvenient to read.

**Cause:**
- Other columns (e.g., quantity, taxes) already use the `text-end` class, but the description column has 
  no alignment class, causing inconsistent layout and misalignment.

**Solution:**
- Added the `text-end` class to the description column to ensure proper alignment and consistent readability
  in Arabic invoice reports.
  
**Before FIX:**
<img width="831" height="329" alt="image" src="https://github.com/user-attachments/assets/857f9f7f-d930-4c73-b2fa-eacd7a153ea3" />

   **After FIX**
<img width="788" height="354" alt="image" src="https://github.com/user-attachments/assets/929acdb1-bb13-4e1e-829c-8fdbe18334a4" />


**opw-5087770**

