### PR TITLE
[FIX] l10n_ro_edi: Fix 'error' traceback for synchronization messages

### DIFF
--- a/addons/l10n_ro_efactura_synchronize/tests/test_xml_ubl_ro.py
+++ b/addons/l10n_ro_efactura_synchronize/tests/test_xml_ubl_ro.py
@@ -58,6 +58,9 @@ def _patch_request_ciusro_download_answer(company, key_download, session):
                 'attachment_raw': file_open("l10n_ro_efactura_synchronize/tests/test_files/from_odoo/ciusro_in_invoice.xml").read(),
             },
         },
+        '3029027563': {
+            'error': "There has been an connection error when downloading the message content",
+        }
     }
     return answer_data.get(key_download, {})
 
@@ -90,6 +93,15 @@ def _patch_request_ciusro_synchronize_invoices(self, company, session, nb_days=1
             'tip': 'FACTURA TRIMISA',
             'id': '3029027562',
             'answer': _patch_request_ciusro_download_answer(company, '3029027562', None),
+        },
+        {
+            'data_creare': '202503272020',
+            'cif': company.vat,
+            'id_solicitare': '5019882654',
+            'detalii': f"Factura cu id_incarcare=5019882654 emisa de cif_emitent={company.vat} pentru cif_beneficiar=RO1234567897",
+            'tip': 'FACTURA TRIMISA',
+            'id': '3029027563',
+            'answer': _patch_request_ciusro_download_answer(company, '3029027563', None),
         },
     ]
     sent_invoices_refused_messages = [
@@ -204,6 +216,24 @@ class TestUBLROSynchronize(TestUBLROCommon):
 
         self.assertEqual(invoice.l10n_ro_edi_state, 'invoice_sent')
         self.assertEqual(len(invoice.l10n_ro_edi_document_ids), 1)
+
+    def test_ciusro_synchronize_invoices_validation_error(self):
+        ''' Test that a sent invoice status is not updated and the error message logged when there is a communication error.
+        '''
+        # Create an invoice that will match the success response returned by the server
+        invoice = self.create_move('out_invoice', send=False)
+        invoice.name = 'INV/2017/00003'  # Skip 00001 and 00002 to avoid the validation due to similar invoice name
+        self.env['l10n_ro_edi.document'].create({
+            'key_loading': '5019882654',
+            'invoice_id': invoice.id,
+            'state': 'invoice_sending',
+        })
+        self.assertEqual(invoice.l10n_ro_edi_state, 'invoice_sending')
+
+        self.env['account.move']._l10n_ro_edi_fetch_invoices()
+
+        self.assertEqual(len(invoice.l10n_ro_edi_document_ids), 1)
+        self.assertEqual(invoice.l10n_ro_edi_document_ids.state, 'invoice_sending_failed')
 
     def test_ciusro_synchronize_invoices_validation_without_index(self):
         """ Test that a sent invoice status is validated although the invoice did not receive its index.


### PR DESCRIPTION
Problem
---------
Currently, the 'error' message (in case of communication error) is stored in the 'answer' dict. However, the code verify for the 'error' key in the message dict itself.

Solution
---------
When checking if the 'error' key is present, check in the 'answer' dict rather than the message dict

The code is
```message = {**data, 'answer': {**data, 'error': ""}}```

The verifications were
```'error' in message ?```

and now they are
```'error' in message['answer'] ?```

opw-5046567

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
