### PR TITLE
[IMP] website: synchronize theme colors in highlight picker

### DIFF
--- a/addons/website/static/src/builder/plugins/highlight/highlight_configurator.js
+++ b/addons/website/static/src/builder/plugins/highlight/highlight_configurator.js
@@ -85,7 +85,7 @@ export class HighlightConfigurator extends Component {
             ColorPicker,
             {
                 state: { selectedColor: this.state.color, defaultTab: "solid" },
-                colorPrefix: "",
+                colorPrefix: "hb-cp-",
                 getUsedCustomColors: this.props.getUsedCustomColors,
                 enabledTabs: ["solid", "custom"],
                 applyColor: this.selectHighlightColor.bind(this),
@@ -96,6 +96,7 @@ export class HighlightConfigurator extends Component {
                     ),
                 applyColorResetPreview: this.props.revertHighlightStyle,
                 className: "d-contents",
+                themeColorPrefix: "hb-cp-",
             },
             "Select a color",
             true
@@ -109,10 +110,10 @@ export class HighlightConfigurator extends Component {
 
     selectHighlightColor(color) {
         this.props.componentStack.pop();
-        this.props.applyHighlightStyle(
-            "--text-highlight-color",
-            normalizeColor(color, getHtmlStyle(document))
-        );
+        const highlightColor = color.startsWith("hb-cp-")
+            ? `var(--${color.replace("hb-cp-", "")})`
+            : normalizeColor(color, getHtmlStyle(document));
+        this.props.applyHighlightStyle("--text-highlight-color", highlightColor);
     }
 
     deleteHighlight() {

--- a/addons/website/static/tests/builder/website_builder/highlight.test.js
+++ b/addons/website/static/tests/builder/website_builder/highlight.test.js
@@ -56,7 +56,7 @@ test("Can set a color to a highlight", async () => {
     await animationFrame();
     await click("#colorButton");
     await animationFrame();
-    await click("button[style='background-color: var(--o-color-2)']");
+    await click("button[style='background-color: var(--hb-cp-o-color-2)']");
     await animationFrame();
     const color = getComputedStyle(document.documentElement).getPropertyValue("--o-color-2");
     expect("span.o_text_highlight_freehand_2").toHaveStyle({


### PR DESCRIPTION
Before this commit:
1. The colors in the _highlight_ color picker were not properly synchronized with the _theme_ colors.
2. The _theme_ colors were copied as raw values instead of using _CSS_ variables, which caused them to fall out of sync.

After this commit:
1. The _solid_ tab theme colors of _highlight_ color picker now stay in sync with _theme_ colors, even when they are updated.
2. Used CSS variables `var(--o-color-x)` instead of copying _theme_ color values.

task-5079081
