### PR TITLE
 [FIX] l10n_ar: allow printing with lang other than l10n_ar

### DIFF
--- a/addons/l10n_ar/views/report_invoice.xml
+++ b/addons/l10n_ar/views/report_invoice.xml
@@ -260,7 +260,7 @@
          http://biblioteca.afip.gob.ar/dcp/LEY_C_027440_2018_05_09 article 5.f -->
         <xpath expr="//div[@id='total']/div/table" position="after">
             <t t-if="o.l10n_latam_document_type_id.code in ['201', '202', '203', '206', '207', '208', '211', '212', '213']">
-                <strong>Son: </strong><span t-out="o.currency_id.with_context(lang='es_AR').amount_to_text(o.amount_total)"/>
+                <strong>Son: </strong><span t-out="o.currency_id.amount_to_text(o.amount_total)"/>
             </t>
         </xpath>
 


### PR DESCRIPTION
#The issue:
- With l10n_ar company
- Make sure that the language es_AR is not installed.
- Create an invoice where the Document type (l10n_latam_document_type_id) code is in 201, 202, 203, 206, 207, 208, 211, 212 or 213
- Try to print the invoice, the following error occurs:

odoo.addons.base.models.ir_qweb.QWebException: Error while render the template
UserError: Invalid language code: es_AR

In the report_invoice template used in l10n_ar, if the document type is 201, 202, 203, 206, 207, 208, 211, 212, or 213, the amount in letters is mandatory. Currently, the template is hard-coded to use es_AR. As a result, if the customer does not have the es_AR language installed, the invoice cannot be printed, even if another Spanish language is available.

opw-5079885



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
