### PR TITLE
[FIX] mail: skip change event for mobile call permissions

### DIFF
--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -16,7 +16,7 @@ import { debounce } from "@web/core/utils/timing";
 import { loadBundle, loadJS } from "@web/core/assets";
 import { memoize } from "@web/core/utils/functions";
 import { url } from "@web/core/utils/urls";
-import { isMobileOS } from "@web/core/browser/feature_detection";
+import { isBrowserSafari, isMobileOS } from "@web/core/browser/feature_detection";
 import { CallAction } from "./call_actions";
 
 let sequence = 1;
@@ -832,6 +832,14 @@ export class Rtc extends Record {
                 audio: audio ? this.store.settings.audioConstraints : false,
                 video: video ? this.store.settings.cameraConstraints : false,
             });
+            if (isBrowserSafari() || isMobileOS()) {
+                if (audio) {
+                    this.microphonePermission = "granted";
+                }
+                if (video) {
+                    this.cameraPermission = "granted";
+                }
+            }
             closeStream(stream);
         } catch {
             this.showMediaUnavailableWarning({ microphone: audio, camera: video });


### PR DESCRIPTION
Before this commit, it was practically impossible to enable the microphone and camera on some User Agents.
The User Agents affected include Safari Desktop/Mobile, Firefox Mobile and Chrome Mobile.
On those platforms the `change` event of PermissionStatus is never fired, breaking the flow of the new permissions flow introduced in [1].

Steps to reproduce:
1. Open Discuss on one of the listed user agents.
2. Start a call
3. Unmute to prompt microphone permissions -> observe being unable to give permissions

This commit fixes the issue by manually setting the permission status of voice and video on the affected user agents.

[1] https://github.com/odoo/odoo/pull/226552

task-5090302