### PR TITLE
Re-adapt auto hidden menu on content change

### DIFF
--- a/addons/website/static/src/interactions/dropdown.edit.js
+++ b/addons/website/static/src/interactions/dropdown.edit.js
@@ -8,6 +8,19 @@ export class DropdownEdit extends Interaction {
             // We want dropdown menus not to close when clicking inside them in
             // edit mode.
             "t-att-data-bs-auto-close": () => "outside",
+            "t-on-hidden.bs.dropdown": () => {
+                const selection = this.el.ownerDocument.getSelection();
+                if (
+                    this.el.parentElement
+                        ?.querySelector(".dropdown-menu")
+                        ?.contains(selection.anchorNode)
+                ) {
+                    // If the selection is in a closed dropdown, we remove it so
+                    // that overlays appearing around the selection go away
+                    // (like toolbar, or link tools)
+                    selection.empty();
+                }
+            },
         },
     };
 }

--- a/addons/website/static/src/js/content/auto_hide_menu.js
+++ b/addons/website/static/src/js/content/auto_hide_menu.js
@@ -89,7 +89,12 @@ async function autoHideMenu(el, options) {
         }
     };
 
-    window.addEventListener('resize', throttleAdapt);
+    const observer = new ResizeObserver(throttleAdapt);
+    for (const child of el.parentElement.children) {
+        observer.observe(child);
+    }
+    observer.observe(el.parentElement);
+    observer.observe(navbar);
 
     function _restore() {
         if (!extraItemsToggle) {


### PR DESCRIPTION
> [VBAL] Supported payment methods inner content (in the header): You can adjust the height, but this moves the elements on the right outside of the screen (can be fixed by zooming/unzooming on the screen but not user friendly): https://drive.google.com/file/d/1J0Vp050kDzx_jnPVfWyHxy6GpQ6GvpBX/view?usp=drive_link


### [FIX] website: re-adapt extra menu on size changes of menu and navbar

When the size available or needed for the the top menu changes (for
other reasons than a window resize), the menus were not auto-hidden.
They were auto-hidden only if the window changes size.

If the user is editing the website and increase the width of some
element in the header, it may overflow. The overflow disappears only
once the user changes the size of the window (which causes some menu to
be hidden again).

This commit fixes that by replacing the listener for a window `resize`
event by a `ResizeObserver` that observe the sizes of the navbar, the
menu and the menu's siblings.

Steps to reproduce:
- Open website builder
- Add text in the header until it gets too large
- Bug: the last menu is not moved to the dropdown to make more space
  available

task-4367641

### [FIX] website: move selection with menu when auto-hiding menus

When some menu are moved to be hidden in the dropdown, if the selection
is inside a moved menu, it was lost.

This commit fixes that by opening the dropdown and moving the selection
if it is in a menu moved to the dropdown

Steps to reproduce:
- Open website builder
- Add text in the label of a menu until it is moved to the dropdown
- Bug: the selection is lost, keep writing does not write anywhere

task-4367641

### [FIX] website: remove selection in dropdown when it closes

When the user has the selection inside a dropdown that closes, the
selection was kept. If the toolbar was shown on the selection, then used
to stays floating where the selection used to be.

This commits listen for the closing of the dropdown to remove the
selection if it was in the dropdown.

Steps to reproduce:
- Open website builder
- Click on the user's name to open the dropdown
- Select some text in the dropdown (the toolbar should appear)
- Press "esc" (the dropdown should close)
- Bug: the toolbar is left hanging where the selection used to be

task-4367641