### PR TITLE
[FIX] mail: hide translate action when message body is empty

### DIFF
--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -111,6 +111,15 @@ export class Message extends Record {
             return Boolean(div.querySelector("a:not([data-oe-model])"));
         },
     });
+    hasMailNotificationSummary = Record.attr(false, {
+        compute() {
+            return Boolean(
+                createDocumentFragmentFromContent(this.body).querySelector(
+                    '[summary="o_mail_notification"]'
+                )
+            );
+        },
+    });
     /** @type {number|string} */
     id;
     /** @type {boolean} */
@@ -335,6 +344,8 @@ export class Message extends Record {
 
     isTranslatable(thread) {
         return (
+            !this.isBodyEmpty &&
+            !this.hasMailNotificationSummary &&
             this.store.hasMessageTranslationFeature &&
             !["discuss.channel", "mail.box"].includes(thread?.model)
         );


### PR DESCRIPTION
**Current behavior before PR:**

The translate action was shown on all messages, including those with an empty
body such as tracking updates or messages containing only attachments.
Clicking the translate action on these messages had no effect.

**Desired behavior after PR is merged:**

The translate action is hidden for messages with an empty body.
Only messages containing text display the translate option.

**Task-5106303**


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
