### PR TITLE
[FIX] mrp: preserve product sequence when adding from catalog

### DIFF
--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -538,6 +538,7 @@ class MrpBom(models.Model):
             command = Command.create({
                 'product_qty': quantity,
                 'product_id': product_id,
+                'sequence': (self[child_field][-1:].sequence or 1) + 1,
             })
             self.write({child_field: [command]})
 

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -3069,7 +3069,7 @@ class MrpProduction(models.Model):
             else:
                 entity.unlink()
         elif quantity > 0:
-            new_line_vals = self._get_new_catalog_line_values(product_id, quantity, **kwargs)
+            new_line_vals = self._get_new_catalog_line_values(product_id, quantity, child_field=child_field, **kwargs)
             command = Command.create(new_line_vals)
             self.write({child_field: [command]})
             new_line = self[child_field].filtered(lambda mv: mv.product_id.id == product_id)[-1:]
@@ -3081,9 +3081,11 @@ class MrpProduction(models.Model):
         line.product_uom_qty = quantity
 
     def _get_new_catalog_line_values(self, product_id, quantity, **kwargs):
+        child_field = kwargs.get('child_field')
         return {
             'product_id': product_id,
             'product_uom_qty': quantity,
+            'sequence': (self[child_field][-1:].sequence or 1) + 1,
         }
 
     def _is_display_stock_in_catalog(self):

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -413,7 +413,7 @@
                                 context="{'default_date': date_start, 'default_date_deadline': date_start, 'default_location_id': location_src_id, 'default_location_dest_id': production_location_id, 'default_warehouse_id': warehouse_id, 'default_state': 'draft', 'default_raw_material_production_id': id, 'default_picking_type_id': picking_type_id, 'default_company_id': company_id, 'form_view_ref': 'mrp.view_mrp_stock_move_operations', 'active_mo_id': id}"
 
                                 readonly="state == 'cancel' or (state == 'done' and is_locked)">
-                                <list default_order="sequence" editable="bottom">
+                                <list editable="bottom">
                                     <control>
                                         <create string="Add a line"/>
                                         <button name="action_add_from_catalog_raw" string="Catalog" type="object" class="px-4 btn-link" context="{'order_id': parent.id}"/>


### PR DESCRIPTION
Before this commit:
-------------------------
When adding products to a Manufacturing Order (MO) or Bill of Materials (BOM)
Via the catalog, the newly added products did not follow the order in which they
were selected. Instead, they could appear in the middle or even at the top of
the existing lines. This inconsistent behavior made it difficult for users to
track the intended sequence of products, adding unnecessary complexity in
planning.

Steps to reproduce:
-------------------------
1. Install the 'mrp' module.
2. Create or open an existing BOM or MO.
3. Click on Catalog and add random products.
4. Return to the form view → the product sequence is disrupted.

After this commit:
-----------------------
- Products added from the catalog to an MO or BOM now retain the order in which
  they were selected. A proper sequence number is assigned to each new line,
  ensuring that the sequence remains consistent with user input.
- This ensures a cleaner and more intuitive view, making it easier for users to
  Follow the creation process.

Task Id: 4737887