### PR TITLE
[FIX] sale: invoiced amount filter sections/notes

### DIFF
--- a/addons/sale/models/account_move.py
+++ b/addons/sale/models/account_move.py
@@ -155,7 +155,9 @@ class AccountMove(models.Model):
         """
         order_amount = 0
         for invoice in self:
-            prices = sum(invoice.line_ids.filtered(lambda x: order in x.sale_line_ids.order_id).mapped('price_total'))
+            prices = sum(invoice.line_ids.filtered(
+                lambda x: x.display_type not in ('line_note', 'line_section') and order in x.sale_line_ids.order_id
+            ).mapped('price_total'))
             order_amount += invoice.currency_id._convert(
                 prices * -invoice.direction_sign,
                 order.currency_id,


### PR DESCRIPTION
When computing the invoiced amount for a SO, ignore the invoice's lines of `display_type` equal to `line_note` and `line_section`
This matches the accounting features which always ignore such lines.

**Current behavior before PR**
Method `_get_sale_order_invoiced_amount` includes display lines.

**Desired behavior after PR is merged**
Method `_get_sale_order_invoiced_amount` ignores display lines.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
