### PR TITLE
[FIX] html_editor: prevent pasting in contenteditable=false

### DIFF
--- a/addons/html_editor/static/src/core/clipboard_plugin.js
+++ b/addons/html_editor/static/src/core/clipboard_plugin.js
@@ -174,7 +174,10 @@ export class ClipboardPlugin extends Plugin {
      */
     onPaste(ev) {
         let selection = this.dependencies.selection.getEditableSelection();
-        if (!selection.anchorNode.isConnected) {
+        if (
+            !selection.anchorNode.isConnected ||
+            !closestElement(selection.anchorNode).isContentEditable
+        ) {
             return;
         }
         ev.preventDefault();

--- a/addons/html_editor/static/tests/paste.test.js
+++ b/addons/html_editor/static/tests/paste.test.js
@@ -391,6 +391,15 @@ describe("Simple text", () => {
             });
         });
     });
+    test("should not paste a text when in contenteditable=false", async () => {
+        await testEditor({
+            contentBefore: '<div contenteditable="false">a[b]c</div>',
+            stepFunction: async (editor) => {
+                pasteText(editor, "xyz");
+            },
+            contentAfter: '<div contenteditable="false">a[b]c</div>',
+        });
+    });
 });
 
 describe("Simple html span", () => {


### PR DESCRIPTION
When the selection is on text inside an element which is not `contenteditable` and is a inside the editable root, the user could paste text that would get inserted.

This commit prevents that by ignoring `paste` events when selection is in a `contenteditable=false`.

Steps to reproduce:
- On `form/help-1`, open website builder
- Select the text of "Help" title
- Paste text
- Bug: text is inserted

task-5109671
