### PR TITLE
[FIX] mail: prevent traceback when clicking Add GIFs from More Actions

### DIFF
--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -153,7 +153,7 @@
 </t>
 
 <t t-name="mail.Composer.moreActions">
-    <div class="o-mail-Composer-bg" t-attf-class="{{ actionsContainerClass }}">
+    <div class="o-mail-Composer-bg" t-attf-class="{{ actionsContainerClass }}" t-ref="more-actions">
         <div class="o-mail-Composer-mainActions d-flex flex-grow-1 align-items-baseline">
             <t t-set="moreName">More Actions</t>
             <ActionList inline="true" actions="[{

--- a/addons/mail/static/tests/gif_picker/gif_picker.test.js
+++ b/addons/mail/static/tests/gif_picker/gif_picker.test.js
@@ -102,12 +102,23 @@ test("composer should display a GIF button", async () => {
     await contains("button[title='Add GIFs']");
 });
 
-test("Composer GIF button should open the GIF picker", async () => {
+test("Composer GIF button should open the GIF picker (discuss app)", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "" });
     await start();
     await openDiscuss(channelId);
     await click("button[title='Add GIFs']");
+    await contains(".o-discuss-GifPicker");
+});
+
+test("Composer GIF button should open the GIF picker (chat window)", async () => {
+    const pyEnv = await startServer();
+    pyEnv["discuss.channel"].create({ name: "General" });
+    await start();
+    await click(".o_menu_systray i[aria-label='Messages']");
+    await click(".o-mail-NotificationItem:contains('General')");
+    await click(".o-mail-ChatWindow .o-mail-Composer [title='More Actions']");
+    await click(".o-dropdown-item:contains('Add GIFs')");
     await contains(".o-discuss-GifPicker");
 });
 


### PR DESCRIPTION
**Description of the issue this PR addresses:**

Traceback on clicking `Add GIFs` from more actions

**Steps to reproduce:**
- Open a Chat Window and click on `+` More Actions.
- Select the Add GIFs option.

**Desired behavior after PR is merged:**

This PR ensures that the Add GIFs option is accessible from More Actions. 
If no API key is configured, the picker now opens the popover as expected 
instead of crashing.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
