### PR TITLE
[IMP] hr_attendance: adding overtime ruleset data

### DIFF
--- a/addons/hr_attendance/__manifest__.py
+++ b/addons/hr_attendance/__manifest__.py
@@ -17,6 +17,8 @@ actions(Check in/Check out) performed by them.
     'website': 'https://www.odoo.com/app/employees',
     'depends': ['hr', 'barcodes', 'base_geolocalize'],
     'data': [
+        'data/hr_attendance_overtime_ruleset.xml',
+        'data/hr_attendance_overtime_rule.xml',
         'data/hr_attendance_data.xml',
         'security/hr_attendance_security.xml',
         'security/ir.model.access.csv',

--- a/addons/hr_attendance/data/hr_attendance_overtime_rule.xml
+++ b/addons/hr_attendance/data/hr_attendance_overtime_rule.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="hr_attendance_overtime_employee_schedule_rule" model="hr.attendance.overtime.rule">
+            <field name="name">Employee Schedule Rule</field>
+            <field name="base_off">quantity</field>
+            <field name="timing_type">schedule</field>
+            <field name="expected_hours_from_contract" eval="True"/>
+            <field name="paid" eval="True"/>
+            <field name="ruleset_id" ref="hr_attendance_default_ruleset"/>
+        </record>
+
+        <record id="hr_attendance_overtime_non_working_days_rule" model="hr.attendance.overtime.rule">
+            <field name="name">Non Working Days Rule</field>
+            <field name="base_off">timing</field>
+            <field name="timing_type">non_work_days</field>
+            <field name="paid" eval="True"/>
+            <field name="timing_start" eval="0.0"/>
+            <field name="timing_stop" eval="24.0"/>
+            <field name="ruleset_id" ref="hr_attendance_default_ruleset"/>
+        </record>
+    </data>
+</odoo>

--- a/addons/hr_attendance/data/hr_attendance_overtime_ruleset.xml
+++ b/addons/hr_attendance/data/hr_attendance_overtime_ruleset.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="hr_attendance_default_ruleset" model="hr.attendance.overtime.ruleset">
+            <field name="name">Ruleset Default</field>
+            <field name="country_id" model="res.company" eval="obj(ref('base.main_company')).country_id"/>
+            <field name="company_id" ref="base.main_company"/>
+            <field name="rate_combination_mode">max</field>
+        </record>
+    </data>
+</odoo>

--- a/addons/hr_attendance/models/hr_version.py
+++ b/addons/hr_attendance/models/hr_version.py
@@ -17,7 +17,8 @@ class HrVersion(models.Model):
     ruleset_id = fields.Many2one(
          "hr.attendance.overtime.ruleset",
          domain=_domain_current_countries,
-         groups="hr.group_hr_manager"
+         groups="hr.group_hr_manager",
+         default=lambda self: self.env.ref("hr_attendance.hr_attendance_default_ruleset", raise_if_not_found=False),
     )
 
     @api.model


### PR DESCRIPTION
## PR Purpose

Adding a default ruleset with 2 rules in order to create overtime (as it's impossible to create one without overtime ruleset).

Those data are the same as the data added in the upgrade/migrations/hr_attendance/saas~18.5.2.0 post-migrate script.

[Task#5082628](https://www.odoo.com/odoo/tasks/5082628)
[Enterprise#95296](https://github.com/odoo/enterprise/pull/95296)

Signed-off by thha
