### PR TITLE
[IMP] *: crud options become attrs

### DIFF
--- a/addons/account/views/product_views.xml
+++ b/addons/account/views/product_views.xml
@@ -21,7 +21,7 @@
                 <div name="tax_info" class="o_row">
                     <field name="taxes_id" widget="many2many_tags"
                         context="{'search_default_sale': 1}"
-                        options="{'create': false, 'create_edit': false}"/>
+                        create="False"/>
                     <field name="tax_string"/>
                 </div>
             </field>

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -466,7 +466,7 @@
                                         readonly="1"
                                         column_invisible="not parent.show_lot_ids or parent.state == 'draft'"
                                         invisible="not show_details_visible"
-                                        options="{'create': [('parent.use_create_components_lots', '!=', False)]}"
+                                        create="parent.use_create_components_lots"
                                         context="{'default_product_id': product_id}"
                                         domain="[('product_id','=',product_id)]"/>
                                     <button name="action_show_details" type="object" title="Show Details" string="Details" context="{'default_product_uom_qty': 0}" invisible="not show_details_visible or has_tracking == 'none'"/>
@@ -477,13 +477,13 @@
                         <page string="Work Orders" name="operations" groups="mrp.group_mrp_routings">
                             <field name="workorder_ids"
                                 context="{'list_view_ref': 'mrp.mrp_production_workorder_tree_editable_view_mo_form', 'from_manufacturing_order': True}"
-                                options="{'create': [('id', '!=', False), ('state', '!=', 'done')]}"
+                                create="id != False and state != 'done'"
                                 />
                         </page>
                         <page string="By-Products" name="finished_products" groups="mrp.group_mrp_byproducts">
                             <field name="move_byproduct_ids"
                                 context="{'default_date': date_finished, 'default_date_deadline': date_deadline, 'default_warehouse_id': warehouse_id, 'default_location_id': production_location_id, 'default_location_dest_id': location_dest_id, 'default_state': 'draft', 'default_production_id': id, 'default_picking_type_id': picking_type_id, 'default_company_id': company_id, 'form_view_ref': 'mrp.view_mrp_stock_move_operations'}"
-                                readonly="state == 'cancel' or (state == 'done' and is_locked)" options="{'delete': [('state', '=', 'draft')]}">
+                                readonly="state == 'cancel' or (state == 'done' and is_locked)" delete="state == 'draft'">
                                 <list default_order="sequence, id" decoration-muted="state in ['done', 'cancel']" editable="bottom">
                                     <control>
                                         <create string="Add a line"/>
@@ -522,7 +522,7 @@
                                         readonly="1"
                                         column_invisible="not parent.show_lot_ids or parent.state == 'draft'"
                                         invisible="not show_details_visible"
-                                        options="{'create': [('parent.use_create_components_lots', '!=', False)]}"
+                                        create="parent.use_create_components_lots"
                                         context="{'default_product_id': product_id}"
                                         domain="[('product_id','=',product_id)]"/>
                                     <button name="action_show_details" type="object" title="Show Details" icon="fa-list" invisible="has_tracking == 'none' or not show_details_visible"/>

--- a/addons/point_of_sale/views/product_view.xml
+++ b/addons/point_of_sale/views/product_view.xml
@@ -208,7 +208,7 @@
                             <div name="tax_info" class="o_row">
                                 <field name="taxes_id" widget="many2many_tags"
                                     context="{'search_default_sale': 1}"
-                                    options="{'create': false, 'create_edit': false}"/>
+                                    create="False"/>
                                 <field name="tax_string"/>
                             </div>
                             <field name="pos_categ_ids" string="POS Category" class="oe_inline" widget="many2many_tags"/>

--- a/addons/pos_loyalty/views/loyalty_program_views.xml
+++ b/addons/pos_loyalty/views/loyalty_program_views.xml
@@ -22,7 +22,7 @@
                 </span>
             </xpath>
             <xpath expr="//div[@id='o_loyalty_program_availabilities']" position="after">
-                <field name="pos_config_ids" string="Point of Sale" widget="many2many_tags" invisible="not pos_ok" options="{'create': False}" placeholder="All PoS"/>
+                <field name="pos_config_ids" string="Point of Sale" widget="many2many_tags" invisible="not pos_ok" create="False" placeholder="All PoS"/>
             </xpath>
         </field>
     </record>

--- a/addons/project/views/project_sharing_project_task_views.xml
+++ b/addons/project/views/project_sharing_project_task_views.xml
@@ -243,7 +243,7 @@
                             </field>
                         </page>
                         <page name="task_dependencies" string="Blocked By" invisible="not allow_task_dependencies">
-                            <field name="depend_on_ids" widget="depend_on_ids_one2many" nolabel="1" options="{'link': false}" readonly="1"
+                            <field name="depend_on_ids" widget="depend_on_ids_one2many" nolabel="1" link="False" readonly="1"
                                 context="{
                                     'depend_on_count': depend_on_count,
                                     'list_view_ref': 'project.open_view_blocked_by_list_view',

--- a/addons/sale_pdf_quote_builder/views/sale_order_template_views.xml
+++ b/addons/sale_pdf_quote_builder/views/sale_order_template_views.xml
@@ -14,7 +14,7 @@
                         widget="quotation_document_many2many"
                         class="w-100"
                         nolabel="1"
-                        options="{'create': False}"
+                        create="False"
                         context="{
                             'kanban_view_ref': 'sale_pdf_quote_builder.quotation_document_kanban',
                             'hide_template_ids': True,

--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -125,7 +125,7 @@
                     invisible="not allow_billable or not partner_id or is_template">
                     <field name="sale_line_id"
                         groups="!sales_team.group_sale_salesman"
-                        options="{'no_create': True, 'no_edit': True, 'delete': False, 'no_open': True}"/>
+                        options="{'no_create': True, 'no_edit': True, 'no_open': True}"/>
                     <field name="sale_line_id"
                         groups="sales_team.group_sale_salesman"
                         options="{'no_create': True}"

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -312,7 +312,7 @@
                                         groups="stock.group_production_lot"
                                         invisible="not show_details_visible or has_tracking == 'none'"
                                         optional="hide"
-                                        options="{'create': [('parent.use_create_lots', '=', True)]}"
+                                        create="parent.use_create_lots == True"
                                         context="{'default_company_id': company_id, 'default_product_id': product_id, 'active_picking_id': parent.id}"
                                         domain="[('product_id','=',product_id)]"
                                     />

--- a/addons/web/static/src/core/domain.js
+++ b/addons/web/static/src/core/domain.js
@@ -149,6 +149,7 @@ export class Domain {
     /**
      * Check if the set of records represented by a domain contains a record
      * Warning: smart dates (see parseSmartDateInput) are not handled here.
+     * Similarly, some operators like any, child_of are not handled correctly.
      *
      * @param {Object} record
      * @returns {boolean}

--- a/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
+++ b/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
@@ -47,7 +47,7 @@ export class Many2ManyTagsField extends Component {
         canQuickCreate: { type: Boolean, optional: true },
         canCreateEdit: { type: Boolean, optional: true },
         colorField: { type: String, optional: true },
-        createDomain: { type: [Array, Boolean], optional: true },
+        createExpression: { type: String, optional: true },
         domain: { type: [Array, Function], optional: true },
         context: { type: Object, optional: true },
         placeholder: { type: String, optional: true },
@@ -87,7 +87,7 @@ export class Many2ManyTagsField extends Component {
         this.activeActions = useActiveActions({
             fieldType: "many2many",
             crudOptions: {
-                create: this.props.canCreate && this.props.createDomain,
+                create: this.props.canCreate && this.props.createExpression,
                 createEdit: this.props.canCreateEdit,
                 onDelete: removeRecord,
                 edit: this.props.record.isInEdition,
@@ -268,7 +268,7 @@ export const many2ManyTagsField = {
             canCreate,
             canQuickCreate: canCreate && !noQuickCreate,
             canCreateEdit: canCreate && !noCreateEdit,
-            createDomain: options.create,
+            createExpression: attrs.create,
             context: dynamicInfo.context,
             domain: dynamicInfo.domain,
             placeholder,

--- a/addons/web/static/src/views/fields/relational_utils.js
+++ b/addons/web/static/src/views/fields/relational_utils.js
@@ -1,7 +1,6 @@
 import { AutoComplete } from "@web/core/autocomplete/autocomplete";
 import { makeContext } from "@web/core/context";
 import { Dialog } from "@web/core/dialog/dialog";
-import { Domain } from "@web/core/domain";
 import { _t } from "@web/core/l10n/translation";
 import { RPCError } from "@web/core/network/rpc";
 import { evaluateBooleanExpr } from "@web/core/py_js/py";
@@ -126,7 +125,7 @@ export function useActiveActions({
         let evalFn = () => true;
         if (!isNull(crudOptions[actionName])) {
             const action = crudOptions[actionName];
-            evalFn = (evalContext) => Boolean(action && new Domain(action).contains(evalContext));
+            evalFn = (evalContext) => Boolean(action && evaluateBooleanExpr(action, evalContext));
         }
 
         if (actionName in subViewActiveActions) {

--- a/addons/web/static/src/views/fields/x2many/x2many_field.js
+++ b/addons/web/static/src/views/fields/x2many/x2many_field.js
@@ -1,9 +1,12 @@
 import { makeContext } from "@web/core/context";
 import { _t } from "@web/core/l10n/translation";
+import { x2ManyCommands } from "@web/core/orm_service";
 import { Pager } from "@web/core/pager/pager";
 import { evaluateBooleanExpr } from "@web/core/py_js/py";
 import { registry } from "@web/core/registry";
+import { symmetricalDifference } from "@web/core/utils/arrays";
 import { useService } from "@web/core/utils/hooks";
+import { pick } from "@web/core/utils/objects";
 import { getFieldDomain } from "@web/model/relational_model/utils";
 import {
     useActiveActions,
@@ -18,8 +21,6 @@ import { KanbanRenderer } from "@web/views/kanban/kanban_renderer";
 import { ListRenderer } from "@web/views/list/list_renderer";
 import { computeViewClassName } from "@web/views/utils";
 import { ViewButton } from "@web/views/view_button/view_button";
-import { symmetricalDifference } from "@web/core/utils/arrays";
-import { x2ManyCommands } from "@web/core/orm_service";
 
 import { Component } from "@odoo/owl";
 
@@ -325,15 +326,12 @@ export const x2ManyField = {
     displayName: _t("Relational table"),
     supportedTypes: ["one2many", "many2many"],
     useSubView: true,
-    extractProps: (
-        { attrs, relatedFields, viewMode, views, widget, options, string },
-        dynamicInfo
-    ) => {
+    extractProps: ({ attrs, relatedFields, viewMode, views, widget, string }, dynamicInfo) => {
         const props = {
             addLabel: attrs["add-label"],
             context: dynamicInfo.context,
             domain: dynamicInfo.domain,
-            crudOptions: options,
+            crudOptions: pick(attrs, "create", "delete", "link", "unlink", "write"),
             string,
         };
         if (viewMode) {

--- a/addons/web/static/tests/views/fields/many2many_field.test.js
+++ b/addons/web/static/tests/views/fields/many2many_field.test.js
@@ -438,7 +438,7 @@ test("many2many kanban: create action disabled", async () => {
     expect(".modal .modal-footer .btn-primary").toHaveCount(1);
 });
 
-test("many2many kanban: conditional create/delete actions", async () => {
+test("many2many kanban: conditional create/delete attrs", async () => {
     PartnerType._views = {
         form: '<form><field name="name"/></form>',
         list: '<list><field name="name"/></list>',
@@ -451,7 +451,7 @@ test("many2many kanban: conditional create/delete actions", async () => {
         arch: `
             <form>
                 <field name="color"/>
-                <field name="timmy" options="{'create': [('color', '=', 'red')], 'delete': [('color', '=', 'red')]}">
+                <field name="timmy" create="color == 'red'" delete="color == 'red'">
                     <kanban>
                         <templates>
                             <t t-name="card">
@@ -894,7 +894,7 @@ test("fieldmany2many list comodel not writable", async () => {
     await clickSave();
 });
 
-test("many2many list: conditional create/delete actions", async () => {
+test("many2many list: conditional create/delete attrs", async () => {
     Partner._records[0].timmy = [1, 2];
 
     PartnerType._views = {
@@ -907,7 +907,7 @@ test("many2many list: conditional create/delete actions", async () => {
         arch: `
             <form>
                 <field name="color"/>
-                <field name="timmy" options="{'create': [('color', '=', 'red')], 'delete': [('color', '=', 'red')]}">
+                <field name="timmy" create="color == 'red'" delete="color == 'red'">
                     <list>
                         <field name="name"/>
                     </list>
@@ -940,7 +940,7 @@ test("many2many list: conditional create/delete actions", async () => {
     expect(".modal .modal-footer button").toHaveCount(2);
 });
 
-test("many2many field with link/unlink options (list)", async () => {
+test("many2many field with link/unlink attrs (list)", async () => {
     Partner._records[0].timmy = [1, 2];
     PartnerType._views = {
         list: '<list><field name="name"/></list>',
@@ -952,7 +952,7 @@ test("many2many field with link/unlink options (list)", async () => {
         arch: `
             <form>
                 <field name="color"/>
-                <field name="timmy" options="{'link': [('color', '=', 'red')], 'unlink': [('color', '=', 'red')]}">
+                <field name="timmy" link="color =='red'" unlink="color == 'red'">
                     <list>
                         <field name="name"/>
                     </list>
@@ -978,7 +978,7 @@ test("many2many field with link/unlink options (list)", async () => {
     expect(".o_list_record_remove").toHaveCount(0);
 });
 
-test('many2many field with link/unlink options (list, create="0")', async () => {
+test('many2many field with link/unlink attrs (list, create="0")', async () => {
     Partner._records[0].timmy = [1, 2];
     PartnerType._views = {
         list: '<list><field name="name"/></list>',
@@ -990,7 +990,7 @@ test('many2many field with link/unlink options (list, create="0")', async () => 
         arch: `
             <form>
                 <field name="color"/>
-                <field name="timmy" options="{'link': [('color', '=', 'red')], 'unlink': [('color', '=', 'red')]}">
+                <field name="timmy" link="color == 'red'" unlink="color == 'red'">
                     <list create="0">
                         <field name="name"/>
                     </list>
@@ -1016,7 +1016,7 @@ test('many2many field with link/unlink options (list, create="0")', async () => 
     expect(".o_list_record_remove").toHaveCount(0);
 });
 
-test("many2many field with link option (kanban)", async () => {
+test("many2many field with link attr (kanban)", async () => {
     Partner._records[0].timmy = [1, 2];
 
     PartnerType._views = {
@@ -1029,7 +1029,7 @@ test("many2many field with link option (kanban)", async () => {
         arch: `
             <form>
                 <field name="color"/>
-                <field name="timmy" options="{'link': [('color', '=', 'red')]}">
+                <field name="timmy" link="color == 'red'">
                     <kanban>
                         <templates>
                             <t t-name="card">
@@ -1057,7 +1057,7 @@ test("many2many field with link option (kanban)", async () => {
     expect(".o-kanban-button-new").toHaveCount(0);
 });
 
-test('many2many field with link option (kanban, create="0")', async () => {
+test('many2many field with link attr (kanban, create="0")', async () => {
     Partner._records[0].timmy = [1, 2];
     PartnerType._views = {
         list: '<list><field name="name"/></list>',
@@ -1069,7 +1069,7 @@ test('many2many field with link option (kanban, create="0")', async () => {
         arch: `
             <form>
                 <field name="color"/>
-                <field name="timmy" options="{'link': [('color', '=', 'red')]}">
+                <field name="timmy" link="color == 'red'">
                     <kanban create="0">
                         <templates>
                             <t t-name="card">

--- a/addons/web/static/tests/views/fields/many2many_tags_field.test.js
+++ b/addons/web/static/tests/views/fields/many2many_tags_field.test.js
@@ -1224,7 +1224,7 @@ test("Many2ManyTagsField: Save&New in many2many_tags with default_ keys in conte
 });
 
 test.tags("desktop");
-test("Many2ManyTagsField: conditional create/delete actions on desktop", async () => {
+test("Many2ManyTagsField: conditional create/delete attrs on desktop", async () => {
     Turtle._records[0].partner_ids = [2];
     for (let id = 101; id <= 110; id++) {
         Partner._records.push({ id, name: "Partner" + id });
@@ -1241,7 +1241,7 @@ test("Many2ManyTagsField: conditional create/delete actions on desktop", async (
             <form>
                 <field name="name"/>
                 <field name="turtle_bar"/>
-                <field name="partner_ids" options="{'create': [('turtle_bar', '=', True)], 'delete': [('turtle_bar', '=', True)]}" widget="many2many_tags"/>
+                <field name="partner_ids" create="turtle_bar == True" delete="turtle_bar == True" widget="many2many_tags"/>
             </form>`,
         resId: 1,
     });
@@ -1457,7 +1457,7 @@ test("Many2ManyTagsField supports 'create' props to be a Boolean on mobile", asy
     await mountView({
         type: "form",
         resModel: "partner",
-        arch: `<form><field name="timmy" widget="many2many_tags" placeholder="Placeholder" options="{'create': False }"/></form>`,
+        arch: `<form><field name="timmy" widget="many2many_tags" placeholder="Placeholder" create="False"/></form>`,
     });
 
     await contains(".o_field_many2many_tags input").click();

--- a/addons/web/static/tests/views/fields/one2many_field.test.js
+++ b/addons/web/static/tests/views/fields/one2many_field.test.js
@@ -3339,7 +3339,7 @@ test("one2many list: cannot open record in editable=bottom and edit=false list",
     expect(".modal-dialog").toHaveCount(0);
 });
 
-test("one2many list: conditional create/delete actions", async () => {
+test("one2many list: conditional create/delete attrs", async () => {
     Partner._records[0].p = [2, 4];
     await mountView({
         type: "form",
@@ -3347,7 +3347,7 @@ test("one2many list: conditional create/delete actions", async () => {
         arch: `
             <form>
                 <field name="bar"/>
-                <field name="p" options="{'create': [('bar', '=', True)], 'delete': [('bar', '=', True)]}">
+                <field name="p" create="bar == True" delete="bar == True">
                     <list>
                         <field name="name"/>
                     </list>
@@ -3617,7 +3617,7 @@ test("one2many kanban: create action disabled", async () => {
     expect(".o_field_x2many_kanban .delete_icon").toHaveCount(1);
 });
 
-test("one2many kanban: conditional create/delete actions", async () => {
+test("one2many kanban: conditional create/delete attrs", async () => {
     Partner._records[0].p = [2, 4];
 
     await mountView({
@@ -3626,7 +3626,7 @@ test("one2many kanban: conditional create/delete actions", async () => {
         arch: `
             <form>
                 <field name="bar"/>
-                <field name="p" options="{'create': [('bar', '=', True)], 'delete': [('bar', '=', True)]}">
+                <field name="p" create="bar == True" delete="bar == True">
                     <kanban>
                         <templates>
                             <t t-name="card">
@@ -3672,7 +3672,7 @@ test("one2many kanban: conditional write action", async () => {
         arch: `
             <form>
                 <field name="bar"/>
-                <field name="p" options="{'write': [('bar', '=', True)]}">
+                <field name="p" write="bar == True">
                     <kanban>
                         <templates>
                             <t t-name="card">

--- a/addons/web_tour/static/src/widgets/tour_start.js
+++ b/addons/web_tour/static/src/widgets/tour_start.js
@@ -40,8 +40,8 @@ export class TourStartWidget extends CharField {
 export const tourStartWidgetField = {
     ...charField,
     component: TourStartWidget,
-    extractProps: ({ options }) => ({
-        link: options.link,
+    extractProps: ({ viewType }) => ({
+        link: viewType === "list",
     }),
 };
 

--- a/addons/web_tour/views/tour_views.xml
+++ b/addons/web_tour/views/tour_views.xml
@@ -51,7 +51,7 @@
                 <field name="url"/>
                 <field name="custom"/>
                 <field name="rainbow_man_message" column_invisible="1"/> <!-- Invisible to get the data in JS -->
-                <field name="name" widget="tour_start_widget" options="{'link': true}" string=""/>
+                <field name="name" widget="tour_start_widget" string=""/>
             </list>
         </field>
     </record>


### PR DESCRIPTION
Crud options like create, unlink,... for x2many are currently domains. Here we refactor the code so that they should become expressions like it was done for the attrs invisible, required,... in https://github.com/odoo/odoo/pull/104741.
In that way, we gain some uniformity and also no longer have to rely on the method contains of the class Domain.
We have updated some archs and also remove some useless options.

Task ID: 5188852