### PR TITLE
[FIX] hr_recruitment: wrong recipient address after applicant email change

### DIFF
--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -939,6 +939,18 @@ class HrApplicant(models.Model):
             })
         return email_keys_to_values
 
+    def _message_add_default_recipients(self):
+        # Not using partner_id as recipent because partner.email may not reflect changes in the applicant form."""
+        results = super()._message_add_default_recipients()
+        res = {}
+        for record in self:
+            res[record.id] = {
+                'email_cc_lst': results[record.id]['email_cc_lst'],
+                'email_to_lst': results[record.id]['email_to_lst'],
+                'partners': self.env['res.partner'],
+            }
+        return res
+
     @api.depends('partner_name')
     @api.depends_context('show_partner_name')
     def _compute_display_name(self):

--- a/addons/hr_recruitment/tests/test_recruitment.py
+++ b/addons/hr_recruitment/tests/test_recruitment.py
@@ -408,3 +408,19 @@ class TestRecruitment(TransactionCase):
 
         res = A1.action_open_applications()
         self.assertEqual(len(res['domain'][0][2]), 3, "The list view should display 3 applications")
+
+    def test_applicant_email_update_excludes_old_address(self):
+        """
+        Ensure that when an applicant's email is updated, only the new email address
+        is suggested for communications, and the old email address is no longer
+        included in the suggested recipients.
+        """
+        applicant_1 = self.env['hr.applicant'].create({
+            'partner_name': 'Applicant 1',
+            'email_from': 'test_applicant@example.com'
+        })
+        applicant_1.email_from = 'test_applicant_new@example.com'
+        recipients = applicant_1._message_get_suggested_recipients()
+        emails = [r['email'] for r in recipients]
+        assert 'test_applicant@example.com' not in emails
+        assert 'test_applicant_new@example.com' in emails


### PR DESCRIPTION
### Issue:

In this bug, when an applicant's email is changed, the old email is also still used in communications.

#### To reproduce:
1- Create a job position and then create an applicant for the position with an email address.
2- Change email from the applicant form.
3- Use the chatter to send an email.
4- As seen, both old email and new email address are used as
   recipient addresses.

### Cause:

This is arose because of https://github.com/odoo/odoo/commit/db5cfc54a1af7b4cd47be859935c7691fcbd100a in which, the `partner_id.email` is not changed if the email exists. It's because changing email might cause side effects on other module using the same partner.
As a result, after the change, there is a mismatch between `applicant.email_from` and `applicant.partner_id.email`. Then `_message_add_default_recipients` will return both emails as recipients.

### Fix:

As said in the commit causing the issue, it is not suggested to change `partner_id.email`. To avoid that, we can override
_message_add_default_recipients so it doesn't use partner_id as as recipient as it might not reflect changes in applicant.

opw-5066694

