### PR TITLE
[FIX] website: fail inde palette in theme tab

### DIFF
--- a/addons/website/static/tests/builder/theme_tab/palette.test.js
+++ b/addons/website/static/tests/builder/theme_tab/palette.test.js
@@ -38,8 +38,10 @@ test("theme tab: warning on palette change", async () => {
     await contains(`[data-action-value="'default-light-1'"] .o-color-palette-pill span`).click();
     expect(".o_dialog").toHaveCount(1);
     await contains(".o_dialog .btn-primary").click();
+    await def;
     expect.verifySteps([
         `/website/static/src/scss/options/user_values.scss {"color-palettes-name":"'default-light-1'"}`,
+        "asset reload",
     ]);
 });
 
@@ -64,8 +66,10 @@ test("theme tab: no warning on palette change", async () => {
         ".o_theme_tab [data-src='/website/static/src/img/snippets_options/palette.svg']"
     ).click();
     await contains(`[data-action-value="'default-light-1'"] .o-color-palette-pill span`).click();
+    await def;
     expect(".o_dialog").toHaveCount(0);
     expect.verifySteps([
         `/website/static/src/scss/options/user_values.scss {"color-palettes-name":"'default-light-1'"}`,
+        "asset reload",
     ]);
 });


### PR DESCRIPTION
The goal of this commit is to fix an undetermined bug in the theme tab palette tests. Sometimes, ‘reload assets’ occurred before the end of the test. We will therefore wait to go through ‘reload assets’ before the end of the test in order to make it deterministic.

Error: https://runbot.odoo.com/odoo/error/232650

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
