### PR TITLE
[FIX] hr_timesheet: show allocated hours on tasks even if equals to 0

### DIFF
--- a/addons/hr_timesheet/views/project_task_views.xml
+++ b/addons/hr_timesheet/views/project_task_views.xml
@@ -161,7 +161,7 @@
                 <field name="date_deadline" position="before">
                     <field name="progress" column_invisible="True"/>
                     <field name="effective_hours" column_invisible="True"/>
-                    <field name="allocated_hours" widget="timesheet_uom_no_toggle" sum="Total Allocated Time" invisible="allocated_hours == 0" optional="hide" column_invisible="not context.get('allow_timesheets', True)"/>
+                    <field name="allocated_hours" widget="timesheet_uom_no_toggle" sum="Total Allocated Time" optional="hide" column_invisible="not context.get('allow_timesheets', True)"/>
                     <field name="effective_hours" widget="timesheet_uom" sum="Effective Hours" optional="show" invisible="effective_hours == 0" column_invisible="not context.get('allow_timesheets', True)"/>
                     <field name="subtask_effective_hours" widget="timesheet_uom" sum="Sub-Tasks Total Effective Hours" optional="hide" column_invisible="not context.get('allow_timesheets', True)"/>
                     <field name="total_hours_spent" widget="timesheet_uom" sum="Total Hours" optional="hide" column_invisible="not context.get('allow_timesheets', True)"/>


### PR DESCRIPTION
Before this commit, when the user would like to edit the allocated hours field of multiple tasks inside the list view, he cannot when the allocated hours is equal to 0. The reason is because the cell is hidden once the value is equal to 0.

This commit makes that field is always editable in the list view of tasks even if the value is 0.

task-5093288

