### PR TITLE
[FIX] pos_*: display order on prep display after payment confirmation

### DIFF
--- a/addons/pos_online_payment/controllers/payment_portal.py
+++ b/addons/pos_online_payment/controllers/payment_portal.py
@@ -289,9 +289,13 @@ class PaymentPortal(payment_portal.PaymentPortal):
         tx_sudo._process_pos_online_payment()
 
         rendering_context['state'] = 'success'
+        self._on_payment_successful(pos_order_sudo)
         if exit_route:
             return request.redirect(exit_route)
         return self._render_pay_confirmation(rendering_context)
 
     def _render_pay_confirmation(self, rendering_context):
         return request.render('pos_online_payment.pay_confirmation', rendering_context)
+
+    def _on_payment_successful(self, pos_order):
+        return

--- a/addons/pos_online_payment/tests/online_payment_common.py
+++ b/addons/pos_online_payment/tests/online_payment_common.py
@@ -25,10 +25,10 @@ class OnlinePaymentCommon(PaymentHttpCommon):
         url = self._build_url(uri)
         return self.make_jsonrpc_request(url, route_values)
 
-    def _fake_open_pos_order_pay_confirmation_page(self, pos_order_id, access_token, tx_id):
-        self._fake_http_get_request(PaymentPortal._get_landing_route(pos_order_id, access_token, tx_id=tx_id))
+    def _fake_open_pos_order_pay_confirmation_page(self, pos_order_id, access_token, tx_id, exit_route=None):
+        self._fake_http_get_request(PaymentPortal._get_landing_route(pos_order_id, access_token, tx_id=tx_id, exit_route=exit_route))
 
-    def _fake_online_payment(self, pos_order_id, access_token, expected_payment_provider_id):
+    def _fake_online_payment(self, pos_order_id, access_token, expected_payment_provider_id, exit_route=None):
         payment_context = self._fake_open_pos_order_pay_page(pos_order_id, access_token)
 
         # Code inspired by addons/payment/tests/test_flows.py
@@ -53,4 +53,4 @@ class OnlinePaymentCommon(PaymentHttpCommon):
             processing_values = self._fake_request_pos_order_pay_transaction_page(pos_order_id, route_values)
         tx_sudo = self._get_tx(processing_values['reference'])
         tx_sudo._set_done()
-        self._fake_open_pos_order_pay_confirmation_page(pos_order_id, access_token, tx_sudo.id)
+        self._fake_open_pos_order_pay_confirmation_page(pos_order_id, access_token, tx_sudo.id, exit_route=exit_route)

--- a/addons/pos_online_payment_self_order/models/pos_config.py
+++ b/addons/pos_online_payment_self_order/models/pos_config.py
@@ -21,3 +21,9 @@ class PosConfig(models.Model):
         payment_methods = self._get_self_ordering_payment_methods_data(self.self_order_online_payment_method_id)
         res['pos_payment_methods'] += payment_methods
         return res
+
+    def has_valid_self_payment_method(self):
+        res = super().has_valid_self_payment_method()
+        if self.self_ordering_mode == 'mobile':
+            return res or bool(self.self_order_online_payment_method_id)
+        return res or any(pm.is_online_payment for pm in self.payment_method_ids)

--- a/addons/pos_online_payment_self_order/tests/test_self_order_mobile.py
+++ b/addons/pos_online_payment_self_order/tests/test_self_order_mobile.py
@@ -23,6 +23,12 @@ class TestSelfOrderMobile(SelfOrderCommonTest, OnlinePaymentCommon):
             'is_online_payment': True,
             'online_payment_provider_ids': [Command.set([cls.payment_provider.id])],
         })
+        # Needed to test online payments through the portal
+        cls.env['account.payment.method'].sudo().create({
+            'name': 'Dummy method',
+            'code': 'none',
+            'payment_type': 'inbound'
+        })
 
     def test_online_payment_self_pay_after_meal_table(self):
         """

--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -435,3 +435,13 @@ class PosConfig(models.Model):
             'redirect_url': url_form,
             'zip_archive': base64.b64encode(zip_buffer.read()).decode('utf-8'),
         }
+
+    def _supported_kiosk_payment_terminal(self):
+        return ['adyen', 'razorpay', 'stripe', 'pine_labs']
+
+    def has_valid_self_payment_method(self):
+        """ Checks if the POS config has a valid payment method (terminal or online). """
+        self.ensure_one()
+        if self.self_ordering_mode == 'mobile':
+            return False
+        return any(pm.use_payment_terminal in self._supported_kiosk_payment_terminal() for pm in self.payment_method_ids)

--- a/addons/pos_self_order/models/pos_order.py
+++ b/addons/pos_self_order/models/pos_order.py
@@ -59,3 +59,15 @@ class PosOrder(models.Model):
         for config in config_ids:
             config.notify_synchronisation(config.current_session_id.id, self.env.context.get('login_number', 0))
             config._notify('ORDER_STATE_CHANGED', {})
+
+    def _send_payment_result(self, payment_result):
+        self.ensure_one()
+        self.config_id._notify('PAYMENT_STATUS', {
+            'payment_result': payment_result,
+            'data': {
+                'pos.order': self.read(self._load_pos_self_data_fields(self.config_id.id), load=False),
+                'pos.order.line': self.lines.read(self._load_pos_self_data_fields(self.config_id.id), load=False),
+            }
+        })
+        if payment_result == 'Success':
+            self._send_order()

--- a/addons/pos_self_order_adyen/controllers/main.py
+++ b/addons/pos_self_order_adyen/controllers/main.py
@@ -43,14 +43,8 @@ class PosSelfAdyenController(PosAdyenController):
                 'pos_order_id': order.id
             })
             order.action_pos_order_paid()
-            order._send_order()
 
         if order.config_id.self_ordering_mode == 'kiosk':
-            order.config_id._notify('PAYMENT_STATUS', {
-                'payment_result': payment_result,
-                'data': {
-                    'pos.order': order.read(order._load_pos_self_data_fields(order.config_id.id), load=False),
-                    'pos.order.line': order.lines.read(order._load_pos_self_data_fields(order.config_id.id), load=False),
-                }
-            })
+            order._send_payment_result(payment_result)
+
         return request.make_json_response('[accepted]') # https://docs.adyen.com/point-of-sale/design-your-integration/choose-your-architecture/cloud/#guarantee

--- a/addons/pos_self_order_razorpay/controllers/orders.py
+++ b/addons/pos_self_order_razorpay/controllers/orders.py
@@ -61,10 +61,4 @@ class PosSelfOrderControllerRazorpay(PosSelfOrderController):
         return razorpay_cancel_response
 
     def call_bus_service(self, order, payment_result):
-        order.config_id._notify('PAYMENT_STATUS', {
-            'payment_result': payment_result,
-            'data': {
-                'pos.order': order.read(order._load_pos_self_data_fields(order.config_id.id), load=False),
-                'pos.order.line': order.lines.read(order._load_pos_self_data_fields(order.config_id.id), load=False),
-            }
-        })
+        order._send_payment_result(payment_result)

--- a/addons/pos_self_order_stripe/controllers/orders.py
+++ b/addons/pos_self_order_stripe/controllers/orders.py
@@ -44,18 +44,6 @@ class PosSelfOrderControllerStripe(PosSelfOrderController):
             order.action_pos_order_paid()
 
             if order.config_id.self_ordering_mode == 'kiosk':
-                order.config_id._notify('PAYMENT_STATUS', {
-                    'payment_result': 'Success',
-                    'data': {
-                        'pos.order': order.read(order._load_pos_self_data_fields(order.config_id.id), load=False),
-                        'pos.order.line': order.lines.read(order._load_pos_self_data_fields(order.config_id.id), load=False),
-                    }
-                })
+                order._send_payment_result('Success')
         else:
-            order.config_id._notify('PAYMENT_STATUS', {
-                'payment_result': 'fail',
-                'data': {
-                    'pos.order': order.read(order._load_pos_self_data_fields(order.config_id.id), load=False),
-                    'pos.order.line': order.lines.read(order._load_pos_self_data_fields(order.config_id.id), load=False),
-                }
-            })
+            order._send_payment_result('fail')


### PR DESCRIPTION
pos_*=  pos_online_payment, pos_online_payment_self_order, pos_self_order

Before this commit, if an online payment method was assigned to a self or a kiosk, the order was displayed on the preparation display before the payment was confirmed.

After this commit, the order is no longer displayed on the preparation display until the payment confirmation.

Enterprise PR: https://github.com/odoo/enterprise/pull/95312

Backport of https://github.com/odoo/odoo/pull/213493, with additional logic to ensure the order is correctly sent to the preparation display even if an exit route is used in the payment portal




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
