### PR TITLE
[IMP] account: show outstanding credits/debits on draft invoices

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -801,22 +801,22 @@
                     <!-- Invoice outstanding credits -->
                     <div groups="account.group_account_invoice,account.group_account_readonly"
                          class="alert alert-info" role="alert"
-                         invisible="state != 'posted' or move_type not in ('out_invoice', 'out_receipt') or not invoice_has_outstanding or payment_state not in ('not_paid', 'partial')">
+                         invisible="move_type not in ('out_invoice', 'out_receipt') or not invoice_has_outstanding or payment_state not in ('not_paid', 'partial')">
                         You have <bold><a class="alert-link" href="#outstanding" role="button">outstanding credits</a></bold> listed below for this customer.
                     </div>
                     <div groups="account.group_account_invoice,account.group_account_readonly"
                          class="alert alert-info" role="alert"
-                         invisible="state != 'posted' or move_type not in ('in_invoice', 'in_receipt') or not invoice_has_outstanding or payment_state not in ('not_paid', 'partial')">
+                         invisible="move_type not in ('in_invoice', 'in_receipt') or not invoice_has_outstanding or payment_state not in ('not_paid', 'partial')">
                         You have <bold><a class="alert-link" href="#outstanding" role="button">outstanding debits</a></bold> listed below for this vendor.
                     </div>
                     <div groups="account.group_account_invoice,account.group_account_readonly"
                          class="alert alert-info" role="alert"
-                         invisible="state != 'posted' or move_type != 'out_refund' or not invoice_has_outstanding or payment_state not in ('not_paid', 'partial')">
+                         invisible="move_type != 'out_refund' or not invoice_has_outstanding or payment_state not in ('not_paid', 'partial')">
                         You have <bold><a class="alert-link" href="#outstanding" role="button">outstanding debits</a></bold> listed below for this customer.
                     </div>
                     <div groups="account.group_account_invoice,account.group_account_readonly"
                          class="alert alert-info" role="alert"
-                         invisible="state != 'posted' or move_type != 'in_refund' or not invoice_has_outstanding or payment_state not in ('not_paid', 'partial')">
+                         invisible="move_type != 'in_refund' or not invoice_has_outstanding or payment_state not in ('not_paid', 'partial')">
                         You have <bold><a class="alert-link" href="#outstanding" role="button">outstanding credits</a></bold> listed below for this vendor.
                     </div>
                     <!-- Currency consistency -->
@@ -1321,7 +1321,7 @@
                                         </group>
                                         <group
                                             class="oe_subtotal_footer px-4"
-                                            invisible="state != 'posted' or not invoice_has_outstanding"
+                                            invisible="not invoice_has_outstanding"
                                             groups="account.group_account_invoice,account.group_account_readonly">
                                             <field name="invoice_outstanding_credits_debits_widget"
                                                 class="oe_invoice_outstanding_credits_debits py-3"


### PR DESCRIPTION
This commit implements the display of outstanding credits/debits on draft invoices.

Previously, these were only visible on posted invoices, showing a warning  at the top and the outstanding lines at the bottom of the form. However, since draft invoices can now be reconciled directly from a bank statement, users also need to see the outstanding credits/debits at the draft stage.

With this change, outstanding credits/debits are shown consistently on both draft and posted invoices.

task-5106833