### PR TITLE
[FIX] im_livechat: restrict triggering_answer_ids to current chatbot script

### DIFF
--- a/addons/im_livechat/models/chatbot_script_answer.py
+++ b/addons/im_livechat/models/chatbot_script_answer.py
@@ -38,22 +38,11 @@ class ChatbotScriptAnswer(models.Model):
 
     @api.model
     def _search_display_name(self, operator, value):
-        """
-        Search the records whose name or step message are matching the ``name`` pattern.
-        The chatbot_script_id is also passed to the context through the custom widget
-        ('chatbot_triggering_answers_widget') This allows to only see the question_answer
-        from the same chatbot you're configuring.
-        """
-        domain = []
+        """Search the records whose name or step message are matching the ``name`` pattern."""
         if value and operator == 'ilike':
             # search on both name OR step's message (combined with passed args)
-            domain = ['|', ('name', operator, value), ('script_step_id.message', operator, value)]
-
-        force_domain_chatbot_script_id = self.env.context.get('force_domain_chatbot_script_id')
-        if force_domain_chatbot_script_id:
-            domain = expression.AND([domain, [('chatbot_script_id', '=', force_domain_chatbot_script_id)]])
-
-        return domain
+            return ['|', ('name', operator, value), ('script_step_id.message', operator, value)]
+        return super()._search_display_name(operator, value)
 
     def _to_store_defaults(self):
         return ["name", "redirect_link"]

--- a/addons/im_livechat/models/chatbot_script_step.py
+++ b/addons/im_livechat/models/chatbot_script_step.py
@@ -36,7 +36,7 @@ class ChatbotScriptStep(models.Model):
         'chatbot.script.answer', 'script_step_id',
         copy=True, string='Answers')
     triggering_answer_ids = fields.Many2many(
-        'chatbot.script.answer', domain="[('script_step_id.sequence', '<', sequence)]",
+        'chatbot.script.answer', domain="[('script_step_id.sequence', '<', sequence), ('script_step_id.chatbot_script_id', '=', chatbot_script_id)]",
         compute='_compute_triggering_answer_ids', readonly=False, store=True,
         copy=False,  # copied manually, see chatbot.script#copy
         string='Only If', help='Show this step only if all of these answers have been selected.')


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
In the `triggering_answer_ids` searchable dropdown, when no value is entered, the `_search_display_name` method of `chatbot_script_answer` is not called. Instead, the ORM falls back to the field’s default domain and returns all `chatbot.script.answer` records, including those from other scripts. When a value is entered, `_search_display_name` is triggered and the results are filtered correctly.

This behavior changed after PR #201587, where the `operator_optimization` step started executing before `determine_domain`. Since `determine_domain` is the step that triggers `_search_display_name`, it no longer gets called when the domain `('name', 'ilike', '')` is stripped by `operator_optimization`. Therefore, filtering only works when a non-empty filter value is provided.

**Current behavior before PR:**
All `chatbot.script.answer` records are shown in the `triggering_answer_ids` dropdown when no search value is entered, even if they don’t belong to the current chatbot script.

**Desired behavior after PR is merged:**
The `triggering_answer_ids` dropdown only shows answers belonging to the current chatbot script, regardless of whether a search value is entered.

task-[4968490](https://www.odoo.com/odoo/project/1519/tasks/4968490)