### PR TITLE
[FIX] pos_sale: avoid psycopg2 error in test_draft_pos_order_linked_sale_order

### DIFF
--- a/addons/pos_sale/static/tests/tours/pos_sale_tour.js
+++ b/addons/pos_sale/static/tests/tours/pos_sale_tour.js
@@ -368,7 +368,6 @@ registry.category("web_tour.tours").add("PosSettleOrder5", {
             Dialog.confirm("Open Register"),
             PosSale.settleNthOrder(1),
             ProductScreen.selectedOrderlineHas("Product A", "1.00"),
-            Chrome.clickMenuOption("Backend", { expectUnloadPage: true }),
         ].flat(),
 });
 


### PR DESCRIPTION
Before this commit:
=================
The `test_draft_pos_order_linked_sale_order` test fails intermittently with a 
`psycopg2.ProgrammingError: no results to fetch`. This failure occurs when the 
browser tour navigates back to the backend.

After this commit:
=====================
The problematic navigation step is removed from the `PosSettleOrder5` tour, 
stabilizing the test and preventing the runbot error.

Cause:
========
The `Chrome.clickMenuOption("Backend", { expectUnloadPage: true })` step 
forces an immediate database flush (`self.cr.flush()`) during the test's 
authentication phase.

This forced flush happens when the records are in an intermediate state (after 
loading the Sale Order but before payment/validation). This specific 
intermediate state, combined with the subsequent recomputation of computed 
fields (like `qty_delivered` through `sale_mrp` and `sale_margin`), exposes an 
underlying bug in Odoo's ORM cursor management, leading to the 
`psycopg2.ProgrammingError`.

Since the backend navigation is not necessary for the test's assertion logic, 
removing this step prevents the premature flush and resolves the failure.

Runbot Error: 226521
Task: 4974084
