### PR TITLE
[FIX] website: link menu items with/without leading slash in URL

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -665,7 +665,11 @@ class Website(Home):
         # If that URL is also a menu, we update it accordingly.
         # NB: we don't want to slugify on menu creation as it could redirect
         # towards files (with spaces, apostrophes, etc.).
-        menu = request.env['website.menu'].search([('url', '=', '/' + path), ('page_id', '=', False)])
+        # Here we search for URLs with or without leading slash to prevent
+        # mismatch issue in DB when URL is created without leading slash.
+        menu = request.env['website.menu'].search(
+            [('url', 'in', ['/' + path, path]), ('page_id', '=', False)], limit=1
+        )
         if menu:
             menu.page_id = page['page_id']
 

--- a/addons/website/static/src/components/dialog/edit_menu.xml
+++ b/addons/website/static/src/components/dialog/edit_menu.xml
@@ -17,6 +17,9 @@
             <div class="col-md-9">
                 <input id="url_input" t-ref="url-input" type="text" t-model="url.input.value" class="form-control" t-att-class="{ 'is-invalid': url.input.hasError }"/>
                 <small class="form-text">Hint: Type '/' to search an existing page and '#' to link to an anchor.</small>
+                <small class="text-warning d-block" t-att-class="{'invisible': !url.input.value?.includes(' ')}">
+                    Spaces are not allowed in URL.
+                </small>
             </div>
         </div>
     </WebsiteDialog>

--- a/addons/website/static/tests/tours/edit_menus.js
+++ b/addons/website/static/tests/tours/edit_menus.js
@@ -75,7 +75,22 @@ wTourUtils.registerWebsitePreviewTour('edit_menus', {
         content: "It didn't save without a url. Fill url input.",
         trigger: '.modal-dialog .o_website_dialog input:eq(1)',
         extra_trigger: '.modal-dialog .o_website_dialog input.is-invalid',
-        run: 'text #',
+        run: "text invalid url",
+    },
+    {
+        content: "Check that warning is shown when URL contains spaces",
+        trigger: ".modal-dialog .o_website_dialog small.text-warning",
+        run: () => {}, // It's a check.
+    },
+    {
+        content: "Clear the URL and enter valid one",
+        trigger: ".modal-dialog .o_website_dialog input:eq(1)",
+        run: "text #",
+    },
+    {
+        content: "Verify warning is hidden when URL has no spaces",
+        trigger: ".modal-dialog .o_website_dialog small.text-warning.invisible",
+        run: () => {}, // It's a check.
     },
     {
         content: "Confirm the new menu entry",


### PR DESCRIPTION
Issue:
-------
When a menu item was created without a leading slash (e.g., "Red
Carpet") and a new page was created from its 404 page, but the page
wasn't linked to that menu item. Only menu items with a leading slash
were linked correctly, since the controller didn't check for URLs without 
one, causing the menu to remain unlinked and display a 404 error.

Steps to reproduce:
------
1. Add a menu item with a URL without a leading slash 
  (e.g., "Red Carpet").
2. Click the menu item > lands on a `404` (expected).
3. Click `Create Page` > page is created & saved.
4. Click the menu item again > still `404` (bug).

Fix:
----
Menu items with or without a leading slash are correctly linked with
their corresponding pages. The URL lookup now considers both formats
(with and without a leading slash), ensuring consistent linking and
preventing 404s. Additionally, the menu editor now shows a warning when
the URL contains spaces (Note: this is just a warning to guide users -
if they want, they can still create a URL with a space).

task-[5095646](https://www.odoo.com/odoo/project/974/tasks/5095646)