### PR TITLE
[REF] base: Unify recursion checks and improve error message

### DIFF
--- a/addons/hr/models/hr_department.py
+++ b/addons/hr/models/hr_department.py
@@ -4,7 +4,6 @@ import ast
 import re
 
 from odoo import api, fields, models, _
-from odoo.exceptions import ValidationError
 from odoo.fields import Domain
 
 
@@ -111,11 +110,6 @@ class HrDepartment(models.Model):
         plans_count = {department.id: count for department, count in plans_data}
         for department in self:
             department.plans_count = plans_count.get(department.id, 0) + plans_count.get(False, 0)
-
-    @api.constrains('parent_id')
-    def _check_parent_id(self):
-        if self._has_cycle():
-            raise ValidationError(_('You cannot create recursive departments.'))
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/product/models/product_category.py
+++ b/addons/product/models/product_category.py
@@ -2,7 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, _
-from odoo.exceptions import ValidationError
 
 
 class ProductCategory(models.Model):
@@ -42,11 +41,6 @@ class ProductCategory(models.Model):
             for sub_categ_id in categ.search([('id', 'child_of', categ.ids)]).ids:
                 product_count += group_data.get(sub_categ_id, 0)
             categ.product_count = product_count
-
-    @api.constrains('parent_id')
-    def _check_category_recursion(self):
-        if self._has_cycle():
-            raise ValidationError(_('You cannot create recursive categories.'))
 
     @api.model
     def name_create(self, name):

--- a/addons/website_sale/models/product_public_category.py
+++ b/addons/website_sale/models/product_public_category.py
@@ -115,13 +115,6 @@ class ProductPublicCategory(models.Model):
                 or any(category.mapped('child_id.has_published_products'))
             )
 
-    # === CONSTRAINT METHODS === #
-
-    @api.constrains('parent_id')
-    def check_parent_id(self):
-        if self._has_cycle():
-            raise ValueError(self.env._("Error! You cannot create recursive categories."))
-
     # === SEARCH METHODS === #
 
     @api.model

--- a/odoo/addons/base/models/ir_ui_menu.py
+++ b/odoo/addons/base/models/ir_ui_menu.py
@@ -65,11 +65,6 @@ class IrUiMenu(models.Model):
         except FileNotFoundError:
             return False
 
-    @api.constrains('parent_id')
-    def _check_parent_id(self):
-        if self._has_cycle():
-            raise ValidationError(self.env._('Error! You cannot create recursive menus.'))
-
     @api.model
     @tools.ormcache('frozenset(self.env.user._get_group_ids())', 'debug')
     def _visible_menu_ids(self, debug=False):

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -153,11 +153,6 @@ class ResPartnerCategory(models.Model):
     parent_path = fields.Char(index=True)
     partner_ids: ResPartner = fields.Many2many('res.partner', column1='category_id', column2='partner_id', string='Partners', copy=False)
 
-    @api.constrains('parent_id')
-    def _check_parent_id(self):
-        if self._has_cycle():
-            raise ValidationError(_('You can not create recursive tags.'))
-
     @api.depends('parent_id')
     def _compute_display_name(self):
         """ Return the categories' display name, including their direct

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -4377,7 +4377,13 @@ class BaseModel(metaclass=MetaModel):
             if prefix:
                 parent_ids = {int(label) for label in prefix.split('/')[:-1]}
                 if not parent_ids.isdisjoint(records._ids):
-                    raise UserError(_("Recursion Detected."))
+                    ir_model = self.env['ir.model']._get(self._name)
+                    raise UserError(_(
+                        "You are creating a loop in your '%s' records. "
+                        "A record cannot be a child of itself or one of its own sub-items. "
+                        "Please select a different parent.",
+                        ir_model.name,
+                    ))
 
             # update parent_path of all records and their descendants
             updated = dict(self.env.execute_query(SQL(


### PR DESCRIPTION
The ORM's `_parent_store` mechanism already prevents recursive loops by raising a `ValidationError` early on.

This commit removes now-redundant (since
https://github.com/odoo/odoo/pull/35659) Python constraints across various models that were performing the same check.

Additionally, the generic ORM error message for recursion has been made more user-friendly to improve the user experience.

