### PR TITLE
[FIX] html_editor: remove fully-selected link on paste only if removable

### DIFF
--- a/addons/html_editor/static/tests/paste.test.js
+++ b/addons/html_editor/static/tests/paste.test.js
@@ -3051,6 +3051,28 @@ describe("link", () => {
             });
         });
 
+        test("should paste plain text content inside a link if all of its contents is selected but link is inside non-editable (not collapsed)", async () => {
+            await testEditor({
+                contentBefore:
+                    '<p contenteditable="false">a<a href="#" contenteditable="true">[xyz]</a>d</p>',
+                stepFunction: async (editor) => {
+                    pasteText(editor, "bc");
+                },
+                contentAfter:
+                    '<p contenteditable="false">a<a href="#" contenteditable="true">bc[]</a>d</p>',
+            });
+        });
+
+        test("should paste plain text content inside a link if all of its contents is selected but link is unremovable (not collapsed)", async () => {
+            await testEditor({
+                contentBefore: '<p>a<a href="#" class="oe_unremovable">[xyz]</a>d</p>',
+                stepFunction: async (editor) => {
+                    pasteText(editor, "bc");
+                },
+                contentAfter: '<p>a<a href="#" class="oe_unremovable">bc[]</a>d</p>',
+            });
+        });
+
         test("should paste and transform plain text content over a link if all of its contents is selected (not collapsed)", async () => {
             await testEditor({
                 contentBefore: '<p><a href="#">[xyz]</a></p>',


### PR DESCRIPTION
When the label of a link is fully selected and the user pastes some
text, the link is removed. It was removed even if the link was in a
`contenteditable=false` or was unremovable.

This commit only attempts to remove the link element after checking
these conditions. It also only selects the link in the `before_paste`
handler, and lets the normal paste logic remove it.

Steps to reproduce (after 18.4, where it was noticed):
- Copy some simple text
- Open website builder
- Select completely the label of a menu in the header
- Paste
- Bug: the menu item is removed, and replaced with simple text

Steps to reproduce (in 18.0 and later):
- Open "To-Do" app
- Add a link in the middle of a line of text
- With inspector, edit html to put `contenteditable="false"` on the
  container of the line, and `contenteditable="true"` on the link
- Select completely the label of the link in the document
- Paste some text
- Bug: the link is removed, and the clipboard content is inserted after
  the non editable element

task-5110141