### PR TITLE
[FIX] iot_drivers: fixes for 19.0

### DIFF
--- a/addons/iot_box_image/configuration/odoo.conf
+++ b/addons/iot_box_image/configuration/odoo.conf
@@ -8,3 +8,4 @@ limit_time_real = 1200
 max_cron_threads = 0
 server_wide_modules=iot_drivers,web
 list_db = False
+http_interface = 0.0.0.0

--- a/addons/iot_box_image/overwrite_before_init/etc/systemd/system/odoo.service
+++ b/addons/iot_box_image/overwrite_before_init/etc/systemd/system/odoo.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Odoo IoT Box service
-After=cups.socket network-online.target NetworkManager.service
+After=cups.socket network-online.target NetworkManager.service rc-local.service
 Wants=network-online.target
 StartLimitIntervalSec=0 # infinetely wait for Odoo to start
 

--- a/addons/iot_drivers/static/src/app/components/SingleData.js
+++ b/addons/iot_drivers/static/src/app/components/SingleData.js
@@ -21,7 +21,7 @@ export class SingleData extends Component {
             /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[-;:&=+$,\w]+@)?[A-Za-z0-9.-]+|(?:www.|[-;:&=+$,\w]+@)[A-Za-z0-9.-]+)((?:\/[+~%/.\w-_]*)?\??(?:[-+=&;%@.\w_]*)#?(?:[\w]*))?)/;
 
         const regex = new RegExp(expression);
-        if (this.props.value.match(regex)) {
+        if (this.props.value?.match(regex)) {
             return true;
         } else {
             return false;

--- a/addons/iot_drivers/tools/upgrade.py
+++ b/addons/iot_drivers/tools/upgrade.py
@@ -144,7 +144,7 @@ def checkout(branch, remote=None):
     _logger.warning("Checking out %s/%s", remote, branch)
     git('remote', 'set-branches', remote, branch)
     git('fetch', remote, branch, '--depth=1', '--prune')  # refs/remotes to avoid 'unknown revision'
-    git('reset', f'{remote}/{branch}', '--hard')
+    git('reset', 'FETCH_HEAD', '--hard')
 
     _logger.info("Cleaning the working directory")
     git('clean', '-dfx')


### PR DESCRIPTION
This PR is made of 3 small commits:

- `[FIX] iot_drivers: fix blank homepage after checkout`
  Due to the `odoo.service` starting before the `rc.local` file has finished updating the Odoo code, you can end up with the old Python code running but the updated JS code loading in the browser. This can lead to a blank screen as a traceback occurs trying to read the MAC address.
  
  We fix this in two ways:
  - A quick fix, which is just making the JS code robust to the missing value to avoid crashing.
  - A proper fix that will require a new image, as it modifies the `odoo.service` file to add `rc-local.service` as a dependency. This means Odoo will not start until `rc.local` has finished executing.


- `[FIX] iot_box_image: set http_interface explicitly`
  From Odoo 19.0, a warning is logged when your `http_interface` config
  setting is not explicitly set. From Odoo 20.0, the default value will
  change from `0.0.0.0` to `127.0.0.1`, which would break the IoT box as
  it would only listen to localhost requests.
  
  To fix this we explicitly set the `http_interface` value to `0.0.0.0` in
  `odoo.conf` so that the IoT box will listen to all requests.


- `[FIX] iot_drivers: use FETCH_HEAD when checking out`
  The current 25.07 IoT box image cannot checkout to 19.0 databases due to
  an issue where the `git reset origin/19.0 --hard` command fails. In the
  other places where we use `git reset` in the IoT box this was fixed by
  using `FETCH_HEAD` (an alias for the last branch that was fetched).
  
  In this commit we apply the same fix to the `upgrade.py` checkout.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
