### PR TITLE
[FIX] mail: discuss call isTalking no transparent in dark theme

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_menu.dark.scss
+++ b/addons/mail/static/src/discuss/call/common/call_menu.dark.scss
@@ -1,0 +1,3 @@
+.o-discuss-CallMenu-buttonContent {
+    --discuss-talkingColor: #{darken($o-enterprise-action-color, 5%)};
+}

--- a/addons/mail/static/src/discuss/call/common/call_menu.scss
+++ b/addons/mail/static/src/discuss/call/common/call_menu.scss
@@ -3,7 +3,7 @@
     @include o-mail-call-bordered(.7);
 
     &.o-is-talking {
-        box-shadow: inset 0 0 0 2px var(--discuss-talkingColor, $o-discuss-talkingColor);
+        box-shadow: inset 0 0 0 1px var(--discuss-talkingColor, $o-discuss-talkingColor);
     }
 
     &.o-isOdooCommunity {

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.dark.scss
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.dark.scss
@@ -1,4 +1,4 @@
 .o-discuss-CallParticipantCard {
     --o-discuss-CallParticipantCard-avatarBgColor: #{$gray-200};
-    --discuss-talkingColor: #{rgba(darken($o-enterprise-action-color, 5%), .75)};
+    --discuss-talkingColor: #{darken($o-enterprise-action-color, 5%)};
 }


### PR DESCRIPTION
Before this commit, the outline color when someone is talking in a discuss call had some transparency in dark theme. This is not great because this makes it hard to see it, especially when it fuses with the content below like camera or screen-sharing stream.

This commit removes the transparency in dark theme isTalking outline color, matching the lack of transparency like in white theme.

Also this commit reduces the effect of the isTalking in the systray call menu: this was too distracting especially in dark theme. The color wasn't also matching in dark theme, which this commit fixes.

Before
<img width="1920" height="962" alt="before" src="https://github.com/user-attachments/assets/f78a2eac-58af-4dd7-869d-4f80c529b93d" />


After
<img width="1920" height="966" alt="after" src="https://github.com/user-attachments/assets/6daf94a7-35fe-440a-a3c0-2b608f5595e3" />

