### PR TITLE
[FIX] web: filter group_by field to keep active only

### DIFF
--- a/addons/web/static/src/core/orm_service.js
+++ b/addons/web/static/src/core/orm_service.js
@@ -240,10 +240,24 @@ export class ORM {
         validateArray("domain", domain);
         validatePrimitiveList("fields", "string", fields);
         validatePrimitiveList("groupby", "string", groupby);
+        const extendedDomain = [...domain];
+        const { is_relational, ...realKwargs } = kwargs;
+        if (is_relational) {
+            groupby.forEach(field => {
+                const activeField = field + ".active";
+                if (!extendedDomain.find(d => d[0] === activeField)) {
+                    extendedDomain.push(
+                        '|',
+                        [field, '=', false],
+                        [activeField, '=', true]
+                    );
+                }
+            });
+        }
         return this.call(model, "web_read_group", [], {
-            ...kwargs,
+            ...realKwargs,
             groupby,
-            domain,
+            domain: extendedDomain,
             fields,
         });
     }

--- a/addons/web/static/src/model/relational_model/relational_model.js
+++ b/addons/web/static/src/model/relational_model/relational_model.js
@@ -701,6 +701,7 @@ export class RelationalModel extends Model {
     }
 
     async _webReadGroup(config, firstGroupByName, orderBy) {
+        const type = config.fields[config.groupBy[0]]?.type;
         return this.orm.webReadGroup(
             config.resModel,
             config.domain,
@@ -712,6 +713,7 @@ export class RelationalModel extends Model {
                 offset: config.offset,
                 limit: config.limit,
                 context: config.context,
+                is_relational: ["many2one", "one2many", "many2many"].includes(type),
             }
         );
     }

--- a/addons/web/static/tests/views/kanban/kanban_view_tests.js
+++ b/addons/web/static/tests/views/kanban/kanban_view_tests.js
@@ -15124,4 +15124,62 @@ QUnit.module("Views", (hooks) => {
         assert.hasClass(target.querySelector(".o_content"), "o_view_sample_data");
         assert.isNotVisible(target.querySelector(".o_cp_pager"));
     });
+
+//     QUnit.test("webReadGroup method with archived field", async (assert) => {
+//         assert.expect(4); // Won't work due to the mockServer way of applying domains
+//         serverData.models.category.fields.active = {
+//             string: "Active",
+//             type: "char",
+//             default: true,
+//         };
+
+//         debugger;
+
+//         // patchWithCleanup(KanbanRenderer.prototype, {
+//         //     _webReadGroup() {
+//         //         debugger;
+//         //         super._webReadGroup(...arguments);
+//         //         // assert.step("_webReadGroup");
+//         //         debugger;
+//         //     },
+//         // });
+
+//         serverData.models.category.records[0].active = false;
+//         serverData.models.category.records[1].active = true;
+
+//         const kanban = await makeView({
+//             type: "kanban",
+//             resModel: "partner",
+//             serverData,
+//             arch: `
+//                 <kanban class="o_kanban_test">
+//                     <field name="foo"/>
+//                     <templates>
+//                         <t t-name="kanban-box">
+//                             <div>
+//                                 <field name="foo"/>
+//                             </div>
+//                         </t>
+//                     </templates>
+//                 </kanban>`,
+//             groupBy: ["category_ids"],
+//             async mockRPC(route, args) {
+//                 if (args.method === "web_read_group") {
+//                     // assert.step("web_read_group");
+//                     debugger;
+//                 }
+//             },
+//         });
+
+//         assert.containsN(target, ".o_kanban_group", 3);
+
+//         debugger;
+//         serverData.models.category.records[0].active = false;
+//         // serverData.models.category.records[1].active = true;
+
+//         await reload(kanban, { groupBy: ["category_ids"] });
+
+//         assert.containsN(target, ".o_kanban_group", 2);
+
+//     });
 });


### PR DESCRIPTION
**Steps to reproduce:**
- Create a new tag
- Add it to a contact
- Archieve the new tag
- Groupo the contacts by tags
- The archived tag is still present as a column of the group_by results

**Issue:**
When a user performs a group by on a view with
`webReadGroup`, if a record of the field used for
grouping is archived, it still appears in the search results.
This is caused by the field used not being filtered by its `active` status.

**Fix:**
Add a custom domain filter for the field of the group_by which can be overwritten.
The filter allow unset value for the field and restrict the rest to records with active = true.

opw-5032604

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
