### PR TITLE
[FIX] mail, hr_holidays: consistent style for 'back on X' text

### DIFF
--- a/addons/hr_holidays/static/src/avatar_card_popover_patch.xml
+++ b/addons/hr_holidays/static/src/avatar_card_popover_patch.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-inherit="mail.AvatarCardPopover" t-inherit-mode="extension">
         <xpath expr="//span[hasclass('o-mail-avatar-card-name')]" position="after">
-            <span t-if="partner?.outOfOfficeDateEndText" class="text-warning me-1 small fw-bold" t-esc="partner.outOfOfficeDateEndText"/>
+            <span t-if="partner?.outOfOfficeDateEndText" class="text-warning me-1 smaller fw-bold opacity-75" t-esc="partner.outOfOfficeDateEndText"/>
         </xpath>
     </t>
 </templates>

--- a/addons/hr_holidays/static/src/core/common/composer_patch.xml
+++ b/addons/hr_holidays/static/src/core/common/composer_patch.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-inherit="mail.Composer.suggestionPartner" t-inherit-mode="extension">
         <xpath expr="//span[@t-if='partner.email']" position="before">
-            <span t-if="partner.outOfOfficeDateEndText" class="text-warning me-1 small fw-bold" t-esc="partner.outOfOfficeDateEndText"/>
+            <span t-if="partner.outOfOfficeDateEndText" class="text-warning me-1 smaller fw-bold opacity-75" t-esc="partner.outOfOfficeDateEndText"/>
         </xpath>
     </t>
 </templates>

--- a/addons/hr_holidays/static/src/discuss/core/common/channel_member_list_patch.xml
+++ b/addons/hr_holidays/static/src/discuss/core/common/channel_member_list_patch.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-inherit="discuss.channel_member" t-inherit-mode="extension">
         <xpath expr="//*[@t-ref='displayName']" position="inside">
-            <span t-if="member.partner_id?.outOfOfficeDateEndText" class="text-warning small ms-2 text-truncate fw-bold">
+            <span t-if="member.partner_id?.outOfOfficeDateEndText" class="text-warning smaller ms-2 text-truncate fw-bold opacity-75">
                 <t t-esc="member.partner_id.outOfOfficeDateEndText"/>
             </span>
         </xpath>

--- a/addons/hr_holidays/static/src/discuss/core/public_web/discuss_command_palette_patch.xml
+++ b/addons/hr_holidays/static/src/discuss/core/public_web/discuss_command_palette_patch.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-inherit="mail.DiscussCommand" t-inherit-mode="extension">
         <xpath expr="//span[hasclass('o-mail-DiscussCommand-nameContainer')]" position="inside">
-            <span t-if="props.persona?.outOfOfficeDateEndText" class="text-warning small ms-2 fw-bold" t-out="props.persona.outOfOfficeDateEndText"/>
+            <span t-if="props.persona?.outOfOfficeDateEndText" class="text-warning smaller ms-2 fw-bold opacity-75" t-out="props.persona.outOfOfficeDateEndText"/>
         </xpath>
     </t>
 </templates>

--- a/addons/hr_holidays/static/src/discuss/core/public_web/discuss_sidebar_categories_patch.xml
+++ b/addons/hr_holidays/static/src/discuss/core/public_web/discuss_sidebar_categories_patch.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-inherit="mail.DiscussSidebarChannel.main" t-inherit-mode="extension">
         <xpath expr="//span[hasclass('o-mail-DiscussSidebarChannel-itemName')]" position="inside">
-            <div t-if="thread.correspondent?.partner_id?.outOfOfficeDateEndText" class="text-warning small" t-out="thread.correspondent.persona.outOfOfficeDateEndText"/>
+            <div t-if="thread.correspondent?.partner_id?.outOfOfficeDateEndText" class="text-warning smaller" t-out="thread.correspondent.persona.outOfOfficeDateEndText"/>
         </xpath>
     </t>
 </templates>

--- a/addons/hr_holidays/static/src/thread_patch.xml
+++ b/addons/hr_holidays/static/src/thread_patch.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-inherit="mail.Thread" t-inherit-mode="extension">
         <xpath expr="//*[hasclass('o-mail-Thread')]" position="before">
-            <div t-if="props.thread.model === 'discuss.channel' and props.thread.correspondent?.partner_id?.outOfOfficeDateEndText" class="alert alert-primary mb-0 smaller fw-bolder o-rounded-bubble mx-1 o-mt-0_5 py-1 shadow-sm" t-esc="props.thread.correspondent.partner_id.outOfOfficeDateEndText" role="alert"/>
+            <div t-if="props.thread.model === 'discuss.channel' and props.thread.correspondent?.partner_id?.outOfOfficeDateEndText" class="alert alert-primary mb-0 smaller fw-bolder rounded-0 py-1 shadow-sm" t-esc="props.thread.correspondent.partner_id.outOfOfficeDateEndText" role="alert"/>
         </xpath>
     </t>
 </templates>

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.xml
@@ -40,7 +40,7 @@
                 <img class="w-100 h-100 rounded-3 object-fit-cover" t-att-src="member.avatarUrl"/>
                 <ImStatus member="member" className="'position-absolute top-100 start-100 translate-middle mt-n1 ' + (member.isTyping ? 'ms-n2' : 'ms-n1')" size="'md'"/>
             </div>
-            <div t-ref="displayName" class="d-flex overflow-hidden flex-column">
+            <div t-ref="displayName" class="d-flex overflow-hidden flex-column lh-sm">
                 <span class="ms-2 text-truncate text-muted fw-bold" t-esc="member.name" t-att-title="member.name"/>
             </div>
             <span class="ms-auto">

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -159,7 +159,7 @@
                     <img class="w-100 h-100 rounded-2 object-fit-cover" t-att-class="threadAvatarAttClass" t-att-src="thread.avatarUrl" alt="Thread Image"/>
                     <ThreadIcon t-if="thread.channel_type?.includes('chat') or (thread.channel_type === 'channel' and !thread.group_public_id)" thread="thread" size="'small'" className="'o-mail-DiscussSidebarChannel-threadIcon position-absolute top-100 start-100 translate-middle mt-n1 ms-n1 d-flex align-items-center justify-content-center rounded-circle bg-inherit'"/>
                 </div>
-                <span t-if="!store.discuss.isSidebarCompact" class="o-mail-DiscussSidebarChannel-itemName mx-2 text-truncate text-start lh-base opacity-trigger-hove flex-grow-1" t-att-class="itemNameAttClass">
+                <span t-if="!store.discuss.isSidebarCompact" class="o-mail-DiscussSidebarChannel-itemName mx-2 text-truncate text-start lh-sm opacity-trigger-hove flex-grow-1" t-att-class="itemNameAttClass">
                     <t t-esc="thread.displayName"/>
                 </span>
             </div>


### PR DESCRIPTION
- size and color of "Back on X" text when someone is on leave was inconsistent on UI.
- discuss sidebar item and member list with "Back on X" had too much height `lh-base` => `lh-sm`.
- floating text "Back on X" above conversation had old style of alert instead of newer one that is not rounded nor has margin.

Before
<img width="1917" height="722" alt="Screenshot 2025-09-23 at 18 18 22" src="https://github.com/user-attachments/assets/ffa12430-1ff6-4271-9b11-c818b262888d" />

After
<img width="1918" height="724" alt="Screenshot 2025-09-23 at 18 17 02" src="https://github.com/user-attachments/assets/bbf9c529-b1ae-4340-897d-69a121408189" />

