### PR TITLE
[FIX] website: website_meta_og_img without domain


### DIFF
--- a/addons/website/static/src/components/dialog/seo.js
+++ b/addons/website/static/src/components/dialog/seo.js
@@ -100,9 +100,10 @@ class ImageSelector extends Component {
             useMediaLibrary: true,
             save: image => {
                 let existingImage;
+                const src = image.getAttribute('src');
                 this.state.images = this.state.images.map(img => {
                     img.active = false;
-                    if (img.src === image.src) {
+                    if (img.src === src) {
                         existingImage = img;
                         img.active = true;
                     }
@@ -110,12 +111,12 @@ class ImageSelector extends Component {
                 });
                 if (!existingImage) {
                     this.state.images.push({
-                        src: image.src,
+                        src: src,
                         active: true,
                         custom: true,
                     });
                 }
-                this.seoContext.metaImage = image.src;
+                this.seoContext.metaImage = src;
             },
         });
     }


### PR DESCRIPTION
Scenario:

- in 19.0 add a website_meta_og_img (Website > Editor > Site > Optimize
  SEO > Cover Image)
- set a domain on the website
- go to the page with the cover image

Result: an error 500 with this traceback error:

```py
 File "addons/website/models/mixins.py", line 92, in get_website_meta
     opengraph_meta['og:image'] = url_join(root_url, self.env['ir.http']
     ._url_for(self.website_meta_og_img or opengraph_meta['og:image']))
 File "odoo/tools/urls.py", line 59, in urljoin
     raise ValueError("Extra URL must use same scheme and host as base,
     and begin with base path")
```

Cause: since 19.0 977e62d91f3e8235e251e9d21b08f53db1856c6b werkzeug
url_join is replaced by odoo urljoin, which requires that the path that
is appended has no host, or the same host. Since the current code saves
the scheme and host of the website_meta_og_img, if the URL is different
than the saved one (because of domain or another reason), we get an
error.

Fix: save a relative URL instead of an absolute one.

opw-5101875
opw-5102079
opw-5105258
opw-5107443
opw-5111474
opw-5112343
opw-5113844
opw-5114544

__Note:__ I rebased on 17.0 since the code has not changed since then, the problem just become visible because of the urljoin change.

__Note:__ I created a upgrade PR to fix the issue for migrated database https://github.com/odoo/upgrade/pull/8494