### PR TITLE
[IMP] l10n_ar: include code 110 as document type for credit notes

### DIFF
--- a/addons/l10n_ar/models/account_journal.py
+++ b/addons/l10n_ar/models/account_journal.py
@@ -107,7 +107,7 @@ class AccountJournal(models.Model):
         receipt_m_code = ['54']
         receipt_codes = ['4', '9', '15']
         expo_codes = ['19', '20', '21']
-        zeta_codes = ['80', '83']
+        zeta_codes = ['80', '83', '110']
         lsg_codes = ['331']
         no_pos_docs = [
             '23', '24', '25', '26', '27', '28', '33', '43', '45', '46', '48', '58', '60', '61', '150', '151', '157',


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
This PR adds the AFIP document type 110 - CREDIT NOTE TICKET, which is required for the Argentinian localization

**Current behavior before PR:**
When users in Argentina tried to create a credit note for a ticket, the corresponding document type was not available as an option.

**Desired behavior after PR is merged:**
After this change, users can now select "110 - CREDIT NOTE TICKET" to issue the document correctly.

[HERE](https://app.screencastify.com/watch/fVBWwSD6DAcodKO57qUZ) is a video replicating the issue
1) In localization Argentina, check document types and see that 110 CREDIT NOTE TICKET exists
2) Create a new journal as shown in the video
3) Create an invoice selecting that journal, and (83) TICKET as Document Type
4) Confirm the invoice and try to create a credit note. See that (110) CREDIT NOTE TICKET does not appear as an option

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
