### PR TITLE
[IMP] product: add a reverse smart button from variant to template

### DIFF
--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -556,6 +556,16 @@ class ProductProduct(models.Model):
         action['context'] = {'default_product_ids': self.ids}
         return action
 
+    def action_open_product_template(self):
+        self.ensure_one()
+        return {
+            "name": "Product Template",
+            "type": "ir.actions.act_window",
+            "res_model": "product.template",
+            "view_mode": "form",
+            "res_id": self.product_tmpl_id.id,
+        }
+
     def open_pricelist_rules(self):
         self.ensure_one()
         domain = ['|',

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -236,7 +236,14 @@
                         <button string="Print Labels" type="object" name="action_open_label_layout"/>
                     </header>
                     <sheet>
-                        <div class="oe_button_box" name="button_box"/>
+                        <div class="oe_button_box" name="button_box">
+                            <button name="action_open_product_template"
+                                    type="object"
+                                    icon="fa-cube"
+                                    class="oe_stat_button">
+                                <span t-out="'Template'"/>
+                            </button>
+                        </div>
                         <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                         <field name="active" invisible="1"/>
                         <field name="id" invisible="1"/>


### PR DESCRIPTION
This feature can make transition between variants and their template easy and quick.