### PR TITLE
[FIX] l10n_mx: Change columns positions in diot

### DIFF
--- a/addons/l10n_mx/data/account_report_diot.xml
+++ b/addons/l10n_mx/data/account_report_diot.xml
@@ -122,14 +122,14 @@
                     <field name="expression_label">withheld</field>
                     <field name="sequence">30</field>
                 </record>
-                <record id="diot_report_exempt" model="account.report.column">
-                    <field name="name">Exempt</field>
-                    <field name="expression_label">exempt</field>
-                    <field name="sequence">31</field>
-                </record>
                 <record id="diot_report_exempt_imp" model="account.report.column">
                     <field name="name">Exempt Imports</field>
                     <field name="expression_label">exempt_imp</field>
+                    <field name="sequence">31</field>
+                </record>
+                <record id="diot_report_exempt" model="account.report.column">
+                    <field name="name">Exempt</field>
+                    <field name="expression_label">exempt</field>
                     <field name="sequence">32</field>
                 </record>
                 <record id="diot_report_paid_0" model="account.report.column">


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The description of the columns “exempt imports” and “exempt” is somewhat ambiguous, so when developing the diot, there was a small error in the order of the columns. The values are calculated correctly, but columns 49 and 50 were inadvertently swapped.

Current behavior before PR:
“exempt” is column 49
“exempt imports” is column 50


Desired behavior after PR is merged:
“exempt” is column 50
“exempt imports” is column 49

Task-id: 5096808
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
