### PR TITLE
[IMP] point_of_sale: display variant colors names on hover

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/product_configurator_popup/product_configurator_popup.scss
+++ b/addons/point_of_sale/static/src/app/components/popups/product_configurator_popup/product_configurator_popup.scss
@@ -27,3 +27,6 @@ option.ptav-not-available {
     opacity: 1;
     color: #ccc;
 }
+.price-extra-cell {
+    width: max-content;
+}

--- a/addons/point_of_sale/static/src/app/components/popups/product_configurator_popup/product_configurator_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/product_configurator_popup/product_configurator_popup.xml
@@ -96,7 +96,7 @@
                     <span class="d-flex flex-row justify-content-center align-items-center">
                         <label t-attf-class="configurator_color rounded-circle border position-relative {{ value.id == props.selected.id ? 'active border-3' : 'border-3 border-secondary' }}"
                             t-att-class="{'ptav-not-available' : value.excluded}"
-                            t-attf-style="{{ img_style or color_style }}" t-att-data-color="value.name">
+                            t-attf-style="{{ img_style or color_style }}" t-att-data-color="value.name" t-att-title="value.name">
                             <input 
                                 type="radio"
                                 t-att-checked="value.id === props.selected.id"


### PR DESCRIPTION
In this commit:
---------------
- We will display variant names when hovering over them from edit product popup on UI for color variants.

task: 5095570