### PR TITLE
[IMP] stock: enhance visibility of lock/unlock button in picking form

### DIFF
--- a/addons/stock/static/src/fields/stock_picking_locked_statusbar_field.js
+++ b/addons/stock/static/src/fields/stock_picking_locked_statusbar_field.js
@@ -1,0 +1,25 @@
+import { _t } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+import { statusBarField, StatusBarField } from "@web/views/fields/statusbar/statusbar_field";
+
+export class StockPickingLockedStatusBarField extends StatusBarField {
+    static template = "stock.PickingLockedStatusBarField";
+
+    get isLocked() {
+        return this.props.record.data.is_locked;
+    }
+
+    get currentItem() {
+        return this.getAllItems().find((item) => item.isSelected);
+    }
+}
+
+export const stockPickingLockedStatusBarField = {
+    ...statusBarField,
+    component: StockPickingLockedStatusBarField,
+    displayName: _t("Status bar with lock/unlock indicator for Pickings"),
+    supportedTypes: ["selection"],
+    additionalClasses: ["o_field_statusbar"],
+};
+
+registry.category("fields").add("stock_picking_locked_statusbar", stockPickingLockedStatusBarField);

--- a/addons/stock/static/src/fields/stock_picking_locked_statusbar_field.xml
+++ b/addons/stock/static/src/fields/stock_picking_locked_statusbar_field.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <!-- Display a "lock/unlock" icon for the picking in the done and cancelled states -->
+    <t t-name="stock.PickingLockedStatusBarField.ItemLabel">
+        <span t-esc="item.label"/>
+        <t t-if="['done', 'cancel'].includes(item.value) and item.isSelected">
+            <i t-attf-class="fa fa-fw ms-1 #{isLocked ? 'fa-lock text-success' : 'fa-unlock text-warning'}"/>
+        </t>
+    </t>
+
+    <t t-name="stock.PickingLockedStatusBarField" t-inherit="web.StatusBarField" t-inherit-mode="primary">
+        <xpath expr="//button[@t-esc='item.label']" position="inside">
+            <t t-call="stock.PickingLockedStatusBarField.ItemLabel"/>
+        </xpath>
+        <xpath expr="//button[@t-esc='item.label']" position="attributes">
+            <attribute name="t-esc"/>
+        </xpath>
+
+        <!-- For Mobile view -->
+        <xpath expr="//t[@t-out='getCurrentLabel()']" position="replace">
+            <t t-set="item" t-value="currentItem"/>
+            <t t-call="stock.PickingLockedStatusBarField.ItemLabel"/>
+        </xpath>
+    </t>
+</templates>

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -126,9 +126,11 @@
                     <button name="do_print_picking" string="Print" groups="stock.group_stock_user" type="object" invisible="state != 'assigned'" data-hotkey="o"/>
                     <button name="%(action_report_delivery)d" string="Print" invisible="state != 'done'" type="action" groups="base.group_user" data-hotkey="o"/>
                     <button name="%(act_stock_return_picking)d" string="Return" invisible="state != 'done'" type="action" groups="base.group_user" data-hotkey="k"/>
-                    <field name="state" widget="statusbar" invisible="picking_type_code != 'incoming'" statusbar_visible="draft,assigned,done"/>
-                    <field name="state" widget="statusbar" invisible="picking_type_code == 'incoming'" statusbar_visible="draft,confirmed,assigned,done"/>
+                    <field name="state" widget="stock_picking_locked_statusbar" invisible="picking_type_code != 'incoming'" statusbar_visible="draft,assigned,done"/>
+                    <field name="state" widget="stock_picking_locked_statusbar" invisible="picking_type_code == 'incoming'" statusbar_visible="draft,confirmed,assigned,done"/>
                     <button name="action_cancel" invisible="state not in ('assigned', 'confirmed', 'draft', 'waiting')" string="Cancel" groups="base.group_user" type="object" confirm="Are you sure you want to cancel this transfer?" data-hotkey="x"/>
+                    <button name="action_toggle_is_locked" string="Lock" groups="stock.group_stock_manager" type="object" invisible="is_locked or state == 'cancel'" class="btn btn-primary"/>
+                    <button name="action_toggle_is_locked" string="Unlock" groups="stock.group_stock_manager" type="object" invisible="not is_locked or state not in ('done', 'cancel')"/>
                 </header>
                 <div class="alert alert-info" role="alert" invisible="not picking_warning_text">
                     <field name="picking_warning_text" class="fw-bold"/>
@@ -484,18 +486,6 @@
             if records:
                 action = records.action_open_label_type()
             </field>
-        </record>
-
-        <record id="action_toggle_is_locked" model="ir.actions.server">
-            <field name="name">Lock/Unlock</field>
-            <field name="model_id" ref="stock.model_stock_picking"/>
-            <field name="binding_model_id" ref="stock.model_stock_picking"/>
-            <field name="binding_view_types">form</field>
-            <field name="state">code</field>
-            <field name="group_ids" eval="[Command.link(ref('stock.group_stock_manager'))]"/>
-            <field name="code">
-            if records:
-                records.action_toggle_is_locked()</field>
         </record>
 
         <record id="action_scrap" model="ir.actions.server">


### PR DESCRIPTION
- Currently, stock managers can only lock or unlock a stock picking through the Actions menu in the form view, which makes it hard to quickly find and use. Additionally, the lock/unlock status is not displayed on the form itself, leaving users unaware of the current state of the picking. This can be confusing, as users may repeatedly open the Actions menu to lock or unlock the picking.

These changes add `Lock` and `Unlock` buttons directly in the header of the stock picking form view (visible only to stock managers when the picking is in Done or Cancelled state), remove the old Actions menu option. Also add a `Lock/Unlock` icon inside the status bar for pickings in Done or Cancelled state, making it easier and faster for stock managers to lock or unlock pickings while providing clear visibility of the current state.

TaskId-5016551