### PR TITLE
[FIX] purchase_stock: purchase catalog loading twice

### DIFF
--- a/addons/purchase_stock/static/src/product_catalog/kanban_controller.js
+++ b/addons/purchase_stock/static/src/product_catalog/kanban_controller.js
@@ -1,5 +1,5 @@
 import { ProductCatalogKanbanController } from "@product/product_catalog/kanban_controller";
-import { onWillStart, useState, useSubEnv, useEffect } from "@odoo/owl";
+import { onWillStart, useState, useSubEnv } from "@odoo/owl";
 import { useDebounced } from "@web/core/utils/timing";
 import { useBus } from "@web/core/utils/hooks";
 
@@ -25,6 +25,9 @@ export class PurchaseSuggestCatalogKanbanController extends ProductCatalogKanban
 
         onWillStart(async () => {
             this._baseContext = { ...this.model.config.context }; // For resetting when suggest is off
+            if (this.state.suggestToggle.isOn) {
+                this._debouncedKanbanRecompute();
+            }
         });
 
         /* Pass context to backend and reload front-end with computed values
@@ -48,18 +51,6 @@ export class PurchaseSuggestCatalogKanbanController extends ProductCatalogKanban
             }
         }, 300); // Enough to type eg. 110 in percent input without rendering 3 times
 
-        useEffect(
-            () => {
-                this._debouncedKanbanRecompute();
-            },
-            () => [
-                this.state.basedOn,
-                this.state.numberOfDays,
-                this.state.percentFactor,
-                this.state.suggestToggle.isOn,
-            ]
-        );
-
         /* Recompute Kanban on filter changes (incl. sidebar category filters)
          * The "update" triggers a refresh, which can happen before debounce on slow
          * internet --> pass suggest context to searchModel in case it refreshes first */
@@ -82,6 +73,7 @@ export class PurchaseSuggestCatalogKanbanController extends ProductCatalogKanban
         useSubEnv({
             suggest: this.state,
             addAllProducts: onAddAll,
+            debouncedKanbanRecompute: this._debouncedKanbanRecompute,
         });
     }
 

--- a/addons/purchase_stock/static/src/product_catalog/search/search_panel.js
+++ b/addons/purchase_stock/static/src/product_catalog/search/search_panel.js
@@ -24,6 +24,7 @@ export class PurchaseSuggestCatalogSearchPanel extends AccountProductCatalogSear
         super.setup();
         this.suggest = useState(useEnv().suggest);
         this.addAllProducts = useEnv().addAllProducts;
+        this.debouncedKanbanRecompute = useEnv().debouncedKanbanRecompute;
         this.displaySuggest = useEnv().suggest.poState === "draft";
         this.tooltipTitle = _t(
             "Get recommendations of products to purchase at %(vendorName)s based on stock on hand, incoming quantities, " +
@@ -37,12 +38,14 @@ export class PurchaseSuggestCatalogSearchPanel extends AccountProductCatalogSear
         const boundedVal = clamp(value, 0, 999); // 999 because input is 3 digits wide
         this.suggest.numberOfDays = boundedVal;
         ev.target.value = boundedVal;
+        this.debouncedKanbanRecompute();
     }
     onPercentFactorInput(ev) {
         const value = parseInt(ev.target.value, 10) || 0;
         const boundedVal = clamp(value, 0, 999); // 999 because input is 3 digits wide
         this.suggest.percentFactor = boundedVal;
         ev.target.value = boundedVal;
+        this.debouncedKanbanRecompute();
     }
     async onSuggestToggle() {
         this.suggest.suggestToggle.isOn = !this.suggest.suggestToggle.isOn;
@@ -50,6 +53,7 @@ export class PurchaseSuggestCatalogSearchPanel extends AccountProductCatalogSear
             "purchase_stock.suggest_toggle_state",
             JSON.stringify({ isOn: this.suggest.suggestToggle.isOn })
         );
+        this.debouncedKanbanRecompute();
     }
     get estimatedSuggestPrice() {
         const { currencyId, digits } = this.suggest;
@@ -65,6 +69,7 @@ export class PurchaseSuggestCatalogSearchPanel extends AccountProductCatalogSear
             },
             onChange: (val) => {
                 this.suggest.basedOn = val;
+                this.debouncedKanbanRecompute();
             },
         };
     }


### PR DESCRIPTION
Removes double web_search_read on product catalog, which was bad UX and causing tour non determinism.

BEFORE: useEffect is trigger on first mount (as well as state changes), causing double load on catalog open
(even with suggest OFF)

NOW: Remove useEffect removes double load on catalog open if suggest is OFF 
(other double load issues on filter changes being worked on here odoo/odoo#225721 with other approach).

task#4783508


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
