### PR TITLE
[FIX] website_sale: fix nested category list alignment

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -436,7 +436,7 @@
                             id="products_grid_before"
                             class="d-none d-lg-block position-sticky align-self-start col clearfix"
                         >
-                            <div class="o_wsale_products_grid_before_rail vh-100 ms-n2 pt-2 px-lg-2 pb-lg-5 ps-2 overflow-y-scroll">
+                            <div class="o_wsale_products_grid_before_rail vh-100 ms-n5 pt-2 px-lg-2 pb-lg-5 ps-2 overflow-y-scroll">
                                 <t
                                     t-set="is_sidebar_collapsible"
                                     t-value="is_view_active('website_sale.products_categories_list_collapsible')"


### PR DESCRIPTION
__Issue:__
The nested `<li>` in product categories had a width greater than its parent `<ul>`, causing the parent to expand in height before the child.

__Fix:__
Increased the negative margin on the parent container from `ms-n2` → `ms-n5` to align the widths. This fixes the visual layout now that the product aside column is flexible `col` instead of fixed `col-3`.

- opw-5075226
