### PR TITLE
[FIX] point_of_sale: Fix the lru_cache function usage error

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -331,7 +331,7 @@ class PosOrder(models.Model):
 
     @api.depends('date_order', 'company_id', 'currency_id', 'company_id.currency_id')
     def _compute_currency_rate(self):
-        @lru_cache
+        @lru_cache()
         def get_rate(from_currency, to_currency, company, date):
             return self.env['res.currency']._get_conversion_rate(
                 from_currency=from_currency,

--- a/addons/pos_sale/models/pos_order.py
+++ b/addons/pos_sale/models/pos_order.py
@@ -25,7 +25,7 @@ class PosOrder(models.Model):
 
     @api.depends('pricelist_id.currency_id', 'date_order', 'company_id')
     def _compute_currency_rate(self):
-        @lru_cache
+        @lru_cache()
         def get_rate(from_currency, to_currency, company, date):
             return self.env['res.currency']._get_conversion_rate(
                 from_currency=from_currency,


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
This PR fixes a TypeError caused by incorrect usage of the @lru_cache decorator in a Python 3.6 environment. The root issue is that the @lru_cache decorator (from Python's functools module) requires explicit invocation with valid parameters (per its syntax rules in Python 3.6), but the current code uses it without parentheses or arguments—violating its usage constraints and triggering a type error.

**Current behavior before PR:**
In the current codebase, the @lru_cache decorator is applied directly as:
```
    def _compute_currency_rate(self):
        @lru_cache
        def get_rate(from_currency, to_currency, company, date):
```
An error occurred: “TypeError: Expected maxsize to be an integer or None”

**Desired behavior after PR is merged:**
No Error

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
