### PR TITLE
[FIX] website_sale_collect: fix when a combination is not possible

### DIFF
--- a/addons/website_sale_collect/static/src/js/click_and_collect_availability/click_and_collect_availability.js
+++ b/addons/website_sale_collect/static/src/js/click_and_collect_availability/click_and_collect_availability.js
@@ -56,6 +56,9 @@ export class ClickAndCollectAvailability extends Component {
      * @return {void}
      */
     async openLocationSelector() {
+        if (!this.state.active) { // Combination is not possible.
+            return; // Do not open the location selector.
+        }
         const { zip_code, id } = this.state.selectedLocationData;
         this.dialog.add(LocationSelectorDialog, {
             isProductPage: true,

--- a/addons/website_sale_collect/static/src/js/click_and_collect_availability/click_and_collect_availability.xml
+++ b/addons/website_sale_collect/static/src/js/click_and_collect_availability/click_and_collect_availability.xml
@@ -6,7 +6,6 @@
             <div
                 name="click_and_collect_availability"
                 t-on-click="openLocationSelector"
-                t-att-class="{'disabled': !this.state.active}"
             >
                 <h6>
                     <i class="fa fa-fw fa-map-marker text-muted"/>
@@ -17,7 +16,7 @@
                     <t t-else="">Click and Collect</t>
                 </h6>
                 <div class="d-flex gap-5">
-                    <t t-if="this.state.inStoreStockData.in_stock">
+                    <t t-if="this.state.inStoreStockData?.in_stock">
                         <div
                             t-if="this.state.inStoreStockData.show_quantity &amp;&amp; this.state.selectedLocationData.id"
                             class="text-muted"


### PR DESCRIPTION
Steps to reproduce:
1. Configure 'pick up in store' delivery method
2. Open the page of the product with an impossible combination (e.g. Customizable desk)
3. Edit the url to have attribute values of the impossible combination (2,5)

There is a traceback as there is no `inStoreStockData`. After fixing it, the widget was still clickable, but as there was no product, there was another traceback since the data was not present. After this commit, the location selector is prevented from being opened when the combitation is not possible.
