### PR TITLE
[FIX] hr_attendance: gaurd the unusual_days keys access

### DIFF
--- a/addons/hr_attendance/models/hr_attendance_overtime_rule.py
+++ b/addons/hr_attendance/models/hr_attendance_overtime_rule.py
@@ -188,7 +188,7 @@ class HrAttendanceOvertimeRule(models.Model):
 
             attendance_intervals = []
             for date, day_attendances in attendances.filtered(
-                lambda att: unusual_days[att.date.strftime('%Y-%m-%d')] == (self.timing_type == 'non_work_days')
+                lambda att: unusual_days.get(att.date.strftime('%Y-%m-%d'), None) == (self.timing_type == 'non_work_days')
             ).grouped('date').items():
                 tz = timezone(version_map[employee][date]._get_tz())
                 time_start = self._get_local_time_start(date, tz)


### PR DESCRIPTION
add extra guard for access unusual_days dict using `.get(key, None)` instead of normal `dict[key]`

Task: 5107868



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
