### PR TITLE
[FIX] website: make icon of the share snippet editable

### DIFF
--- a/addons/website/static/src/builder/plugins/options/social_media_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/social_media_option_plugin.js
@@ -145,6 +145,7 @@ class SocialMediaOptionPlugin extends Plugin {
         save_handlers: this.saveRecordedSocialMedia.bind(this),
         extra_contenteditable_handlers: this.extraContentEditableHandlers.bind(this),
         force_not_editable_selector: [".s_share"],
+        force_editable_selector: [".s_share a > i", ".s_share .s_share_title"],
     };
 
     extraContentEditableHandlers(filteredContentEditableEls) {
@@ -152,7 +153,7 @@ class SocialMediaOptionPlugin extends Plugin {
         // grep: SOCIAL_MEDIA_TITLE_CONTENTEDITABLE
         return filteredContentEditableEls.flatMap((filteredContentEditableEl) => [
             ...filteredContentEditableEl.querySelectorAll(
-                ".s_social_media a > i, .s_social_media .s_social_media_title, .s_share a > i, .s_share .s_share_title"
+                ".s_social_media a > i, .s_social_media .s_social_media_title"
             ),
         ]);
     }

--- a/addons/website/static/tests/builder/website_builder/social_media.test.js
+++ b/addons/website/static/tests/builder/website_builder/social_media.test.js
@@ -1,5 +1,11 @@
 import { expect, test } from "@odoo/hoot";
-import { defineWebsiteModels, setupWebsiteBuilder } from "../website_helpers";
+import {
+    defineWebsiteModels,
+    getDragHelper,
+    setupWebsiteBuilder,
+    setupWebsiteBuilderWithSnippet,
+    waitForEndOfOperation,
+} from "../website_helpers";
 import { contains, onRpc } from "@web/../tests/web_test_helpers";
 import { click, queryOne } from "@odoo/hoot-dom";
 
@@ -191,4 +197,21 @@ test("share snippet should not be editable (except title) nor user-selectable", 
     expect(queryOne(":iframe .s_share").isContentEditable).toBe(false);
     expect(queryOne(":iframe .s_share_title").isContentEditable).toBe(true);
     expect(":iframe .s_share").toHaveStyle({ "user-select": "none" });
+});
+
+test("Edit share icon", async () => {
+    const dragAndDropSnippet = async (dataSnippet) => {
+        const dragUtils = await contains(
+            `.o-snippets-menu #snippet_content .o_snippet_thumbnail[data-snippet='${dataSnippet}']`
+        ).drag();
+        await dragUtils.moveTo(":iframe .s_text_image .oe_drop_zone");
+        await dragUtils.drop(getDragHelper());
+        await waitForEndOfOperation();
+    };
+    await setupWebsiteBuilderWithSnippet("s_text_image", { loadIframeBundles: true });
+    // Add a dummy snippet so that the page is dirty
+    await dragAndDropSnippet("s_inline_text");
+    await dragAndDropSnippet("s_share");
+    await contains(":iframe .s_share a i").dblclick();
+    expect(".modal-content").toBeDisplayed();
 });


### PR DESCRIPTION
Steps to reproduce:
- Add an "Image-Text" snippet on the page.
- Drop the "Share" snippet below the image.
- Double click on an icon to change it.

-> Problem: the icon can not be changed

Note: in the above steps to reproduce, an important think is that the "Share" snippet is not the first snippet that is dropped.

The problem is that the icons and the title of the snippet were added in the `extra_contenteditable_handlers` resource. The handler of this resource takes the elements of `force_editable_selector` that are inside the `root` (that is the column of the snippet if the "Share" snippet is the second dropped snippet) and checks for other elements. Because they are no elements remaining after checking for elements of the `force_editable_selector` resource, the system does not correctly add the `contenteditable` attribute on those elements.

task-5107669
