### PR TITLE
[FIX] website_sale: fix nested category list width in product aside

### DIFF
--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -1258,6 +1258,10 @@ a.no-decoration {
 }
 
 // Hide chevrons for collapsed categories
+#categories_recursive li {
+    width: 100% !important;
+}
+
 .o_categories_recursive_button:after {
     display: none;
 }


### PR DESCRIPTION
__Issue:__
In the product categories sidebar (`#products_grid_before`), nested
`<li>` elements could become wider than their parent `<ul>` when the
category names were long (e.g., "Untersuchungshandschuhe"). This caused
the parent <ul> to expand in height before the child and broke the
visual layout.

__Fix:__

Force `<li>` elements inside the `#categories_recursive` list to respect
their parent width by applying `width: 100%` This keeps the sidebar
layout consistent even with long category names.

- opw-5075226

