### PR TITLE
[IMP] website_slides: remove href=#

### DIFF
--- a/addons/website_sale_slides/views/website_slides_templates.xml
+++ b/addons/website_sale_slides/views/website_slides_templates.xml
@@ -145,13 +145,13 @@
             </small>
             <small t-else="" class="text-center mb-2">
                 There are some
-                <a href="#" class="o_wslides_js_prerequisite_course"
+                <button class="o_wslides_js_prerequisite_course border-0 bg-transparent btn-link p-0 text-primary"
                    t-att-data-channels="json.dumps([
                       {'course_id': course.id, 'course_name': course.name}
                       for course in channel.prerequisite_channel_ids]
                    )">
                     prerequisite courses.
-                </a>
+                </button>
             </small>
         </t>
         <t t-if="invite_preview">

--- a/addons/website_slides/static/src/js/public/components/slide_upload_dialog/slide_upload_dialog_select.xml
+++ b/addons/website_slides/static/src/js/public/components/slide_upload_dialog/slide_upload_dialog_select.xml
@@ -30,23 +30,22 @@
     </t>
 
     <t t-name="website_slides.SlideCategoryIcon" owl="1">
-        <a
-            href="#"
+        <button
             t-on-click="() => props.onClickSlideCategoryIcon(props.slideCategory)"
             t-att-data-slide-category="props.slideCategory"
-            class="content-type d-flex flex-column align-items-center mb-4 btn rounded border text-600 p-3"
+            class="content-type d-flex flex-column align-items-center mb-4 btn rounded border text-600 p-3 w-100 btn link-body-emphasis"
         >
             <i t-attf-class="fa #{props.categoryData.icon} mb-2 fa-3x"/>
             <t t-out="props.categoryData.label"/>
-        </a>
+        </button>
     </t>
 
     <t t-name="website_slides.ModuleToInstallIcon" owl="1">
-        <a class="w-100 text-center mb-4 btn rounded border text-600 p-3"
-            href="#" t-on-click="() => props.onClickInstallModuleIcon(props.moduleId)"
+        <button class="w-100 text-center mb-4 btn rounded border text-600 p-3"
+            t-on-click="() => props.onClickInstallModuleIcon(props.moduleId)"
             t-att-title="props.title"
             t-att-data-module-id="props.moduleId">
             <i class="fa fa-trophy"/> <t t-out="props.motivational"/><span class="text-primary"> Install the <t t-out="props.title"/> app.</span>
-        </a>
+        </button>
     </t>
 </templates>

--- a/addons/website_slides/static/src/js/tours/slides_tour.js
+++ b/addons/website_slides/static/src/js/tours/slides_tour.js
@@ -45,12 +45,12 @@ registerWebsitePreviewTour('slides_tour', {
     tooltipPosition: 'bottom',
     run: "click",
 }, {
-    trigger: '.o_iframe:iframe a.btn-primary.o_wslides_js_slide_upload',
+    trigger: '.o_iframe:iframe button.btn-primary.o_wslides_js_slide_upload',
     content: markup(_t("Your first section is created, now it's time to add lessons to your course. Click on <b>Add Content</b> to upload a document, create an article or link a video.")),
     tooltipPosition: 'bottom',
     run: "click",
 }, {
-    trigger: ':iframe a[data-slide-category="document"]',
+    trigger: ':iframe button[data-slide-category="document"]',
     content: markup(_t("First, let's add a <b>Document</b>. It has to be a .pdf file.")),
     tooltipPosition: 'bottom',
     run: "click",

--- a/addons/website_slides/static/src/scss/slides_slide_fullscreen.scss
+++ b/addons/website_slides/static/src/scss/slides_slide_fullscreen.scss
@@ -8,7 +8,7 @@
         background-image: linear-gradient(-6deg, $o-wslides-color-dark1, $o-wslides-color-dark2);
         height: 50px;
 
-        > div > a {
+        > div > a, button {
             background-color: rgba($o-wslides-color-dark3, 0.5);
             @include o-hover-text-color(rgba(white, 0.8), white);
             text-decoration: none!important;
@@ -68,7 +68,7 @@
             }
         }
 
-        a {
+        a, button {
             text-decoration: none !important;
             @include o-hover-text-color(rgba(white, 0.8), white);
         }
@@ -85,7 +85,7 @@
                 box-shadow: inset 2px 0 0 map-get($theme-colors, 'primary');
                 background-color: rgba($o-wslides-color-dark3, 0.5);
 
-                &, a {
+                &, a, button {
                     color: white;
                 }
             }

--- a/addons/website_slides/static/src/scss/website_slides.scss
+++ b/addons/website_slides/static/src/scss/website_slides.scss
@@ -679,7 +679,8 @@ li.o_wslides_fs_sidebar_list_item.active {
     .oe_slides_panel_footer span[role="button"],
     .oe_slides_panel_footer a,
     .oe_slides_share_bar span[role="button"],
-    .oe_slides_share_bar a {
+    .oe_slides_share_bar a,
+    .oe_slides_share_bar button {
         cursor: pointer;
         user-select: none;
         @include o-hover-text-color(rgba(white, 0.7), white);

--- a/addons/website_slides/static/src/xml/slide_quiz.xml
+++ b/addons/website_slides/static/src/xml/slide_quiz.xml
@@ -12,7 +12,7 @@
                     </div>
                     <div class="list-group">
                         <t t-foreach="question.answer_ids" t-as="answer" t-key="answer_index">
-                            <a t-att-data-answer-id="answer.id" href="#"
+                            <button t-att-data-answer-id="answer.id"
                                 t-att-data-text="answer.text_value"
                                 t-attf-class="o_wslides_quiz_answer list-group-item d-flex align-items-center list-group-item-action #{slide.completed  &amp;&amp; answer.is_correct ? 'list-group-item-success' : '' }">
 
@@ -26,7 +26,7 @@
                                     <i t-att-class="'fa fa-check-circle text-success' + (slide.completed &amp;&amp; answer.is_correct ? '' :  ' d-none')"></i>
                                 </label>
                                 <span t-out="answer.text_value"/>
-                            </a>
+                            </button>
                             <t t-if="slide.completed and answer.is_correct" t-set="correct_answer_comment" t-value="answer.comment"/>
                         </t>
                         <div t-attf-class="o_wslides_quiz_answer_info list-group-item list-group-item-info #{correct_answer_comment ? '' : 'd-none'}">
@@ -58,7 +58,7 @@
                                 </a>
                                 to enroll.
                             </span>
-                            <a t-else="" href="#" class="fw-bold o_wslides_js_channel_enroll"
+                            <button t-else="" class="fw-bold o_wslides_js_channel_enroll btn btn-link p-0"
                                t-att-data-channel-id="channel.id">
                                 <span t-if="channel.requestedAccess" class="text-success">
                                     Responsible already contacted.
@@ -66,7 +66,7 @@
                                 <span t-else="">
                                     Contact the responsible to enroll.
                                 </span>
-                            </a>
+                            </button>
                         </b>
                         <span class="my-0 h4">
                             <span title="Succeed and gain karma" aria-label="Succeed and gain karma" class="badge bg-warning fw-bold ms-3">

--- a/addons/website_slides/static/tests/tours/slides_course_member.js
+++ b/addons/website_slides/static/tests/tours/slides_course_member.js
@@ -33,7 +33,7 @@ registry.category("web_tour.tours").add("course_member", {
             run: "click",
         },
         {
-            trigger: 'a:contains("Join this Course")',
+            trigger: 'button:contains("Join this Course")',
             run: "click",
             expectUnloadPage: true,
         },
@@ -119,11 +119,11 @@ registry.category("web_tour.tours").add("course_member", {
             run: "click",
         },
         {
-            trigger: ".o_wslides_js_lesson_quiz_question:first .list-group a:first",
+            trigger: ".o_wslides_js_lesson_quiz_question:first .list-group button:first",
             run: "click",
         },
         {
-            trigger: ".o_wslides_js_lesson_quiz_question:last .list-group a:first",
+            trigger: ".o_wslides_js_lesson_quiz_question:last .list-group button:first",
             run: "click",
         },
         {

--- a/addons/website_slides/static/tests/tours/slides_course_member_invited_logged.js
+++ b/addons/website_slides/static/tests/tours/slides_course_member_invited_logged.js
@@ -16,7 +16,7 @@ registry.category("web_tour.tours").add("invite_check_channel_preview_as_logged"
             },
         },
         {
-            trigger: 'a:contains("Join this Course")',
+            trigger: 'button:contains("Join this Course")',
             run: "click",
             expectUnloadPage: true,
         },

--- a/addons/website_slides/static/tests/tours/slides_course_member_invited_public.js
+++ b/addons/website_slides/static/tests/tours/slides_course_member_invited_public.js
@@ -44,7 +44,7 @@ registry.category("web_tour.tours").add("invite_check_channel_preview_as_public"
             run: "click",
         },
         {
-            trigger: 'a:contains("Join this Course")',
+            trigger: 'button:contains("Join this Course")',
             run: "click",
             expectUnloadPage: true,
         },

--- a/addons/website_slides/static/tests/tours/slides_course_review_modification.js
+++ b/addons/website_slides/static/tests/tours/slides_course_review_modification.js
@@ -9,7 +9,7 @@ registry.category("web_tour.tours").add("course_review_modification", {
             expectUnloadPage: true,
         },
         {
-            trigger: 'a:contains("Join this Course")',
+            trigger: 'button:contains("Join this Course")',
             run: "click",
             expectUnloadPage: true,
         },

--- a/addons/website_slides/static/tests/tours/slides_tour_tools.js
+++ b/addons/website_slides/static/tests/tours/slides_tour_tools.js
@@ -16,7 +16,7 @@ var addSection = function (sectionName, backend = false) {
 	return [
 {
     content: 'eLearning: click on Add Section',
-    trigger: prefix + 'a.o_wslides_js_slide_section_add',
+    trigger: prefix + 'button.o_wslides_js_slide_section_add',
     run: "click",
 }, {
     content: 'eLearning: set section name',
@@ -35,7 +35,7 @@ var addSection = function (sectionName, backend = false) {
 
 const addContentToSection = (prefix, sectionName) => ({
     content: `eLearning: click on add content for section ${sectionName}`,
-    trigger: `${prefix} div.o_wslides_slide_list_category_header:contains(${sectionName}) a:contains(Add Content)`,
+    trigger: `${prefix} div.o_wslides_slide_list_category_header:contains(${sectionName}) button:contains(Add Content)`,
     run: "click",
 });
 
@@ -62,7 +62,7 @@ var addVideoToSection = function (sectionName, saveAsDraft, backend = false) {
         addContentToSection(prefix, sectionName),
         {
             content: "eLearning: click on video",
-            trigger: prefix + "a[data-slide-category=video]",
+            trigger: prefix + "button[data-slide-category=video]",
             run: "click",
         },
         {
@@ -112,7 +112,7 @@ var addArticleToSection = function (sectionName, pageName, backend) {
         addContentToSection(prefix, sectionName),
         {
 	content: 'eLearning: click on article',
-	trigger: prefix + 'a[data-slide-category=article]',
+	trigger: prefix + 'button[data-slide-category=article]',
     run: "click",
 }, {
 	content: 'eLearning: fill article title',
@@ -163,7 +163,7 @@ const addImageToSection = (sectionName, pageName, backend) => {
         addContentToSection(prefix, sectionName),
         {
     content: 'eLearning: click on image',
-    trigger: `${prefix}a[data-slide-category=infographic]`,
+    trigger: `${prefix}button[data-slide-category=infographic]`,
     run: "click",
 }, {
     content: 'eLearning: choose upload from device',
@@ -225,7 +225,7 @@ const addPdfToSection = function (sectionName, pageName, backend) {
         addContentToSection(prefix, sectionName),
         {
     content: 'eLearning: click on document',
-    trigger: `${prefix}a[data-slide-category=document]`,
+    trigger: `${prefix}button[data-slide-category=document]`,
     run: "click",
 }, {
     content: 'eLearning: choose upload from device',

--- a/addons/website_slides/views/website_slides_templates_course.xml
+++ b/addons/website_slides/views/website_slides_templates_course.xml
@@ -58,7 +58,7 @@
                 <div class="col d-md-none py-1">
                     <div class="btn-group w-100 position-relative" role="group" aria-label="Mobile sub-nav">
                         <div class="btn-group w-100">
-                            <a class="btn bg-black-25 text-white dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Nav</a>
+                            <button class="btn bg-black-25 text-white dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Nav</button>
 
                             <div class="dropdown-menu">
                                 <a class="dropdown-item" href="/slides">Home</a>
@@ -88,7 +88,7 @@
                         </div>
 
                         <div class="btn-group ms-1 position-static">
-                            <a class="btn bg-black-25 text-white dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="Search"><i class="fa fa-search"></i></a>
+                            <button class="btn bg-black-25 text-white dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="Search"><i class="fa fa-search"></i></button>
                             <div class="dropdown-menu dropdown-menu-end w-100" style="right: 10px;">
                                 <t t-call="website.website_search_box_input">
                                     <t t-set="_classes" t-valuef="px-3"/>
@@ -212,6 +212,7 @@
                                                 <span t-attf-class="badge o_wslides_channel_tag #{'o_color_'+str(channel_tag.color)}" t-out="channel_tag.name"/>
                                             </t>
                                         </t>
+                                        <!-- TODO -->
                                         <a t-if="channel.can_upload"
                                             class="o_wslides_js_channel_tag_add badge text-bg-primary fw-normal m-1 o_not_editable"
                                             role="button"
@@ -299,19 +300,19 @@
                             <a t-if="len(channel.prerequisite_channel_ids) == 1"
                                 t-attf-href="/slides/{{channel.prerequisite_channel_ids[0].id}}"
                                 t-out="channel.prerequisite_channel_ids[0].name"/>
-                            <a t-else="" href="#" class="o_wslides_js_prerequisite_course"
+                            <button t-else="" class="o_wslides_js_prerequisite_course border-0 bg-transparent btn-link p-0 text-primary"
                                 t-att-data-channels="json.dumps(
                                     [{'course_id': course.id, 'course_name': course.name}
                                     for course in channel.prerequisite_channel_ids]
                                 )">
                                 courses
-                            </a>
+                            </button>
                             to unlock
                         </small>
                         <small>
                             or
-                            <a role="button" class="o_wslides_js_course_join_link"
-                                title="Start Course" aria-label="Start Course" href="#"
+                            <button class="o_wslides_js_course_join_link border-0 bg-transparent btn-link p-0 text-primary"
+                                title="Start Course" aria-label="Start Course"
                                 t-att-data-channel-id="channel.id"
                                 t-att-data-channel-enroll="channel.enroll"
                                 t-att-data-invite-hash="invite_hash"
@@ -321,13 +322,13 @@
                                 t-att-data-is-partner-without-user="is_partner_without_user">
                                 <t t-if="channel.channel_type == 'documentation'">start</t>
                                 <t t-else="">join</t>
-                            </a> anyway
+                            </button> anyway
                         </small>
                     </div>
                 </div>
             </div>
-            <a t-else="" role="button" class="btn btn-primary o_wslides_js_course_join_link"
-               title="Start Course" aria-label="Start Course" href="#"
+            <button t-else="" class="btn btn-primary o_wslides_js_course_join_link"
+               title="Start Course" aria-label="Start Course"
                t-att-data-channel-id="channel.id"
                t-att-data-channel-enroll="channel.enroll"
                t-att-data-invite-hash="invite_hash"
@@ -339,7 +340,7 @@
                     <t t-if="channel.channel_type == 'documentation'">Start this Course</t>
                     <t t-else="">Join this Course</t>
                 </span>
-            </a>
+            </button>
         </t>
         <div t-elif="not invite_preview and channel.enroll == 'invite' and not channel.is_member and not channel.is_member_invited" class="text-center">
             <div t-if="channel.prerequisite_channel_ids and not channel.prerequisite_user_has_completed" class="text-center">
@@ -354,20 +355,20 @@
                             <a t-if="len(channel.prerequisite_channel_ids) == 1"
                                 t-attf-href="/slides/{{channel.prerequisite_channel_ids[0].id}}"
                                 t-out="channel.prerequisite_channel_ids[0].name"/>
-                            <a t-else="" href="#" class="o_wslides_js_prerequisite_course"
+                            <button t-else="" class="o_wslides_js_prerequisite_course border-0 bg-transparent btn-link p-0 text-primary"
                                 t-att-data-channels="json.dumps(
                                     [{'course_id': course.id, 'course_name': course.name}
                                     for course in channel.prerequisite_channel_ids]
                                 )">
                                 courses
-                            </a>
+                            </button>
                             to unlock
                         </small>
                         <small t-if="is_public_user">
                             or <a t-att-href="'/web/login?redirect=/slides/%s' % (slug(channel))">sign in</a> to request access
                         </small>
                         <small t-else="">
-                            or <a href="#" class="o_wslides_js_channel_enroll" t-att-data-channel-id="channel.id">request</a> direct access
+                            or <button class="o_wslides_js_channel_enroll border-0 bg-transparent btn-link p-0 text-primary" t-att-data-channel-id="channel.id">request</button> direct access
                         </small>
                     </div>
                 </div>
@@ -446,14 +447,12 @@
                         </div>
                         <t t-if="category_id">
                             <div class="d-flex o_not_editable">
-                                <a  t-if="channel.can_publish"
-                                    class="o_text_link text-danger o_wslides_js_category_delete px-3 py-2"
-                                    role="button"
+                                <button t-if="channel.can_publish"
+                                    class="o_text_link text-danger o_wslides_js_category_delete px-3 py-2 border-0 bg-transparent"
                                     aria-label="Delete Category"
-                                    href="#"
                                     t-att-data-category-id="category_id">
                                     <i class="fa fa-trash"/>
-                                </a>
+                                </button>
                             </div>
                             <div class="d-flex ms-2 o_not_editable">
                                 <span t-field="category['category'].total_slides"/><span class="ms-1">Lessons</span>
@@ -461,18 +460,16 @@
                                 <span class="ms-1" t-field="category['category'].completion_time" t-options="{'widget': 'duration', 'format' : 'short', 'unit': 'hour', 'round': 'minute'}"/>
                             </div>
                             <div class="d-flex border-start ms-2 o_not_editable">
-                                <a  t-if="channel.can_upload"
-                                    class="o_text_link o_wslides_js_slide_upload px-3 py-2"
-                                    role="button"
+                                <button t-if="channel.can_upload"
+                                    class="o_text_link o_wslides_js_slide_upload px-3 py-2 border-0 bg-transparent"
                                     aria-label="Add Content"
-                                    href="#"
                                     t-att-data-modules-to-install="modules_to_install"
                                     t-att-data-channel-id="channel.id"
                                     t-att-data-category-id="category_id"
                                     t-att-data-can-upload="channel.can_upload"
                                     t-att-data-can-publish="channel.can_publish">
                                     <i class="fa fa-plus me-1"/> <span class="d-none d-md-inline-block">Add Content</span>
-                                </a>
+                                </button>
                             </div>
                         </t>
                     </div>
@@ -489,18 +486,15 @@
             </t>
         </ul>
         <div t-if="channel.can_upload" class="o_wslides_content_actions o_not_editable btn-group">
-            <a  class="o_wslides_js_slide_upload me-1 border btn btn-primary"
-                role="button"
+            <button class="o_wslides_js_slide_upload me-1 border btn btn-primary"
                 aria-label="Add Content"
-                href="#"
                 t-att-data-open-modal="enable_slide_upload"
                 t-att-data-modules-to-install="modules_to_install"
                 t-att-data-channel-id="channel.id"
                 t-att-data-can-upload="channel.can_upload"
-                t-att-data-can-publish="channel.can_publish"><i class="fa fa-plus me-1"/><span>Add Content</span></a>
-            <a class="o_wslides_js_slide_section_add border btn btn-light bg-white" t-attf-channel_id="#{channel.id}"
-                href="#" role="button"
-                groups="website_slides.group_website_slides_officer"><i class="fa fa-folder-o me-1"/><span>Add Section</span></a>
+                t-att-data-can-publish="channel.can_publish"><i class="fa fa-plus me-1"/><span>Add Content</span></button>
+            <button class="o_wslides_js_slide_section_add border btn btn-light bg-white" t-attf-channel_id="#{channel.id}"
+                groups="website_slides.group_website_slides_officer"><i class="fa fa-folder-o me-1"/><span>Add Section</span></button>
         </div>
         <t t-if="not channel.slide_ids and channel.can_publish" t-call="website_slides.course_slides_list_sample"/>
         <t t-elif="slide_count == 0 and not channel.can_publish" t-call="website_slides.course_slides_list_placeholder"/>
@@ -608,6 +602,7 @@
             <a name="o_wslides_list_slide_add_quizz" t-if="channel.can_upload and not slide.question_ids" t-attf-href="/slides/slide/#{slug(slide)}?quiz_quick_create" aria-label="Add quiz">
                 <span class="badge text-bg-primary badge-hide fw-normal m-1">Add Quiz</span>
             </a>
+            <!-- TODO -->
             <a t-if="channel.can_upload" href="#" name="o_wslides_slide_toggle_is_preview" aria-label="Preview">
                 <span t-att-data-slide-id="slide.id" t-attf-class="o_wslides_js_slide_toggle_is_preview badge #{'text-bg-success' if slide.is_preview else 'text-bg-primary badge-hide'} fw-normal m-1"><span>Preview</span></span>
             </a>
@@ -633,7 +628,7 @@
             <span t-if="channel.can_publish" class="d-none d-md-flex">
                 <a t-if="slide.slide_category == 'article'" class="mx-2 o_text_link text-primary o_not_editable" target="_blank" t-attf-href="/slides/slide/#{slug(slide)}?enable_editor=1" title="Edit"><span class="fa fa-pencil"/></a>
                 <a t-else="" class="mx-2 o_text_link text-primary o_not_editable" target="_blank" t-attf-href="/odoo/slide.slide/{{slide.id}}" title="Edit in backend"><span class="fa fa-pencil"/></a>
-                <a href="#" t-att-data-slide-id="slide.id" class="o_text_link text-danger mx-2 o_wslides_js_slide_archive o_not_editable" title="Delete"><span class="fa fa-trash"/></a>
+                <button t-att-data-slide-id="slide.id" class="o_text_link text-danger mx-2 o_wslides_js_slide_archive o_not_editable border-0 bg-transparent" title="Delete"><span class="fa fa-trash"/></button>
             </span>
         </div>
     </li>
@@ -674,7 +669,7 @@
         <div class="container">
             <div class="row">
                 <nav class="navbar navbar-expand-lg navbar-light bg-transparent col">
-                    <a class="navbar-brand d-lg-none" href="#">Filter &amp; order</a>
+                    <button class="navbar-brand d-lg-none border-0 bg-transparent">Filter &amp; order</button>
 
                     <div class="ms-auto d-lg-none" t-if="search_slide_category or search">
                         <a t-att-href="'/slides/%s' % (slug(channel))" class="btn btn-info me-3">
@@ -717,15 +712,15 @@
                         <div class="col-12 d-flex align-items-start">
                             <ul class="navbar-nav me-auto">
                                 <li class="nav-item dropdown ms-lg-auto">
-                                    <a class="nav-link dropdown-toggle dropdown-toggle align-items-center d-flex" type="button" id="slidesChannelDropdownSort"
-                                       data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" href="#">
+                                    <button class="nav-link dropdown-toggle dropdown-toggle align-items-center d-flex" type="button" id="slidesChannelDropdownSort"
+                                       data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                         <b>Order by</b>
                                         <span class="d-none d-xl-inline">:
                                             <t t-if="sorting == 'most_voted'">Most Voted</t>
                                             <t t-elif="sorting == 'most_viewed'">Most Viewed</t>
                                             <t t-else="">Newest</t>
                                         </span>
-                                    </a>
+                                    </button>
                                     <div class="dropdown-menu" aria-labelledby="slidesChannelDropdownSort" role="menu">
                                         <h6 class="dropdown-header">Sort by</h6>
                                         <a role="menuitem" t-att-href="'/slides/%s?%s' % (slug(channel), keep_query('slide_category', sorting='latest'))"
@@ -767,6 +762,7 @@
                         <span t-attf-class="badge o_wslides_channel_tag #{'o_color_'+str(channel_tag.color)}" t-out="channel_tag.name"/>
                     </t>
                 </t>
+                <!-- TODO -->
                 <a t-if="channel.can_upload"
                     class="o_wslides_js_channel_tag_add badge text-bg-primary fw-normal m-1"
                     role="button"
@@ -779,20 +775,18 @@
             </div>
 
             <div t-if="channel.can_upload" class="text-end pb-2 col-auto">
-                <a class="btn btn-primary py-1 o_wslides_js_slide_upload"
-                    title="Upload Document" role="button"
-                    href="#"
+                <button class="btn btn-primary py-1 o_wslides_js_slide_upload"
+                    title="Upload Document"
                     t-att-data-channel-id="channel.id"
                     t-att-data-can-upload="channel.can_upload"
                     t-att-data-can-publish="channel.can_publish">
                     <i class="fa fa-cloud-upload me-1"/>Add Content
-                </a>
-                <a class="btn btn-secondary py-1 o_wslides_js_slide_section_add"
-                    title="Add Section" role="button"
-                    href="#"
+                </button>
+                <button class="btn btn-secondary py-1 o_wslides_js_slide_section_add"
+                    title="Add Section"
                     t-att-channel_id="channel.id">
                     <i class="fa fa-folder-o me-1"/>Add a section
-                </a>
+                </button>
             </div>
         </div>
     </div>

--- a/addons/website_slides/views/website_slides_templates_homepage.xml
+++ b/addons/website_slides/views/website_slides_templates_homepage.xml
@@ -244,16 +244,15 @@
                     <input type="hidden" name="prevent_redirect" value="True"/>
                 </t>
                 <!-- Mobile Search button -->
-                <a
+                <button
                     class="btn o_not_editable d-md-none btn-light"
                     data-bs-target="#o_wslides_search_modal"
                     data-bs-toggle="modal"
                     role="button"
                     title="Search Courses"
-                    href="#"
                 >
                     <i class="oi oi-search" role="img"/>
-                </a>
+                </button>
                 <!-- Mobile Filter button -->
                 <button class="o_not_editable btn btn-light position-relative d-lg-none"
                     data-bs-toggle="offcanvas"

--- a/addons/website_slides/views/website_slides_templates_lesson.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson.xml
@@ -511,7 +511,7 @@
         </div>
         <div class="list-group">
             <t t-foreach="question['answer_ids']" t-as="answer">
-                <a t-att-data-answer-id="answer['id']" href="#"
+                <button t-att-data-answer-id="answer['id']"
                     t-att-data-text="answer['text_value']" t-att-data-is-correct="answer['is_correct']" t-att-data-comment="answer['comment']"
                     t-att-class="'o_wslides_quiz_answer list-group-item list-group-item-action d-flex align-items-center %s' % ('list-group-item-success' if slide_completed and answer['is_correct'] else '')">
                     <label class="my-0 d-flex align-items-center justify-content-center me-2">
@@ -525,7 +525,7 @@
                         <i t-att-class="'fa fa-check-circle text-success %s' % ('d-none' if not (slide_completed and answer['is_correct']) else '')"></i>
                     </label>
                     <span t-out="answer['text_value']"/>
-                </a>
+                </button>
                 <t t-if="slide_completed and answer['is_correct']" t-set="correct_answer_comment" t-value="answer['comment']"/>
             </t>
             <div t-attf-class="o_wslides_quiz_answer_info list-group-item list-group-item-info #{'' if correct_answer_comment else 'd-none'}">

--- a/addons/website_slides/views/website_slides_templates_lesson_embed.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson_embed.xml
@@ -27,10 +27,10 @@
                                         </div>
                                     </div>
                                     <div class="col flex-grow-0 d-flex text-nowrap small">
-                                        <a class="oe_slide_js_embed_option_link" href="#" data-bs-toggle="modal" t-attf-data-bs-target="#slideShareModal_{{slide.id}}">
+                                        <button class="oe_slide_js_embed_option_link btn btn-link p-0" data-bs-toggle="modal" t-attf-data-bs-target="#slideShareModal_{{slide.id}}">
                                             <i class="fa fa-share-alt" aria-label="Share" title="Share"/>
                                             Share
-                                        </a>
+                                        </button>
                                     </div>
                                 </div>
                             </div>

--- a/addons/website_slides/views/website_slides_templates_lesson_fullscreen.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson_fullscreen.xml
@@ -15,9 +15,9 @@
 
             <div class="o_wslides_slide_fs_header d-flex flex-shrink-0 text-white">
                 <div class="d-flex">
-                    <a class="o_wslides_fs_toggle_sidebar d-flex align-items-center px-3" href="#" title="Lessons">
+                    <button class="o_wslides_fs_toggle_sidebar d-flex align-items-center px-3 border-0" title="Lessons">
                         <i class="fa fa-bars"/><span class="d-none d-md-inline-block ms-1">Lessons</span>
-                    </a>
+                    </button>
                     <a class="o_wslides_fs_review d-flex align-items-center" title="Reviews" t-if="slide.channel_id.allow_comment">
                         <t t-call="portal_rating.rating_stars_static_popup_composer">
                             <t t-set="rating_avg" t-value="rating_avg"/>
@@ -41,10 +41,10 @@
                     </a>
                 </div>
                 <div class="d-flex ms-auto">
-                    <a class="o_wslides_share d-flex align-items-center px-3" href="#" title="Share">
+                    <button class="o_wslides_share d-flex align-items-center px-3 border-0" title="Share">
                         <i class="fa fa-share-alt"/>
                         <span class="d-none d-md-inline-block ms-2">Share</span>
-                    </a>
+                    </button>
                     <a class="d-flex align-items-center px-3 o_wslides_fs_exit_fullscreen" t-attf-href="/slides/slide/#{slug(slide)}" title="Exit Fullscreen">
                         <i class="fa fa-sign-out"/><span class="d-none d-md-inline-block ms-1">Exit Fullscreen</span>
                     </a>
@@ -88,7 +88,7 @@
                             </t>
                         </ul>
                     </div>
-                    <a href="#" class="o_wslides_fs_toggle_sidebar d-md-none bg-black-50"/>
+                    <button class="o_wslides_fs_toggle_sidebar d-md-none bg-black-50"/>
                 </div>
             </div>
         </div>
@@ -136,6 +136,7 @@
                     t-att-data-website-share-url="slide.website_share_url"
                     t-att-data-email-sharing="bool(slide.channel_id.share_slide_template_id)">
                     <div class="ms-2 o_wslides_sidebar_content overflow-hidden">
+                        <!-- TODO complex to convert in button  -->
                         <a t-if="can_access" class="d-block" href="#">
                             <div class="d-flex">
                                 <t t-if="is_member" t-call="website_slides.slide_sidebar_done_button"/>
@@ -186,9 +187,9 @@
                                 t-att-data-is-member-or-invited="is_member_or_invited"
                                 t-att-data-session-answers="session_answers"
                                 t-att-data-website-share-url="slide.website_share_url">
-                                <a t-if="can_access" class="o_wslides_fs_slide_quiz o_wslides_fs_slide_name" href="#" t-att-index="i">
+                                <button t-if="can_access" class="o_wslides_fs_slide_quiz o_wslides_fs_slide_name border-0 bg-transparent" t-att-index="i">
                                     <i class="fa fa-flag-checkered text-warning"/>Quiz
-                                </a>
+                                </button>
                                 <span t-else="" class="text-600">
                                     <i class="fa fa-flag-checkered text-warning"/>Quiz
                                 </span>

--- a/addons/website_slides/views/website_slides_templates_utils.xml
+++ b/addons/website_slides/views/website_slides_templates_utils.xml
@@ -133,8 +133,8 @@
 </template>
 
 <template id="join_course_link" name="Join Course Link">
-    <a class="o_wslides_js_course_join_link" href="#" t-att-data-channel-enroll="slide.channel_id.enroll"
-       t-att-data-channel-id="slide.channel_id.id">Join this Course</a><t t-if="for_resources"> to access resources</t>
+    <button class="o_wslides_js_course_join_link border-0 bg-transparent" t-att-data-channel-enroll="slide.channel_id.enroll"
+       t-att-data-channel-id="slide.channel_id.id">Join this Course</button><t t-if="for_resources"> to access resources</t>
 </template>
 
 <!-- Python equivalent of the JS template "website.slides.sidebar.done.button" -->


### PR DESCRIPTION
We use `href=#` to activate <a> elements, but the default behavior of clicking this link is prevented. However, this creates an inconsistency for middle-click and Ctrl+Click, as these events are not prevented by default.

This commit removes `href=#` and replaces it with the appropriate element or class to activate the `<a>` elements correctly.

task-4380519



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
