### PR TITLE
[FIX] point_of_sale: product_screen when opening pos

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -208,13 +208,17 @@ export class PosStore extends WithLazyGetterTrap {
         this.navigate(page, params);
     }
 
-    get defaultPage() {
+    get productScreenPage() {
         return {
             page: "ProductScreen",
             params: {
                 orderUuid: this.openOrder.uuid,
             },
         };
+    }
+
+    get defaultPage() {
+        return this.productScreenPage;
     }
 
     get firstPage() {
@@ -231,7 +235,7 @@ export class PosStore extends WithLazyGetterTrap {
             this.resetCashier();
         }
 
-        return !this.cashier ? { page: "LoginScreen", params: {} } : this.defaultPage;
+        return !this.cashier ? { page: "LoginScreen", params: {} } : this.productScreenPage;
     }
 
     get idleTimeout() {

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -26,9 +26,10 @@ class TestPointOfSaleHttpCommon(AccountTestInvoicingHttpCommon):
     def _get_main_company(cls):
         return cls.company_data['company']
 
-    def _get_url(self, pos_config=None):
+    def _get_url(self, pos_config=None, url_extension=None):
         pos_config = pos_config or self.main_pos_config
-        return f"/pos/ui/{pos_config.id}"
+        url_extension = url_extension or ''
+        return f"/pos/ui/{pos_config.id}{url_extension}"
 
     def get_method_additional_tags(self, test_method):
         additional_tags = super().get_method_additional_tags(test_method)
@@ -38,7 +39,7 @@ class TestPointOfSaleHttpCommon(AccountTestInvoicingHttpCommon):
         return additional_tags
 
     def start_pos_tour(self, tour_name, login="pos_user", **kwargs):
-        self.start_tour(self._get_url(pos_config=kwargs.get('pos_config')), tour_name, login=login, **kwargs)
+        self.start_tour(self._get_url(pos_config=kwargs.get('pos_config'), url_extension=kwargs.get('url_extension')), tour_name, login=login, **kwargs)
 
     @contextmanager
     def with_new_session(self, config=None, user=None):

--- a/addons/pos_hr/static/src/app/utils/select_cashier_mixin.js
+++ b/addons/pos_hr/static/src/app/utils/select_cashier_mixin.js
@@ -124,20 +124,19 @@ export function useCashierSelector({ exclusive, onScan } = { onScan: () => {}, e
 
         const currentScreen = pos.router.state.current;
         if (currentScreen === "LoginScreen" && login && employee) {
-            const isRestaurant = pos.config.module_pos_restaurant;
             const selectedScreen =
                 pos.previousScreen && pos.previousScreen !== "LoginScreen"
                     ? pos.previousScreen
-                    : isRestaurant
-                    ? "FloorScreen"
                     : "ProductScreen";
-            const props = {
-                orderUuid: pos.selectedOrderUuid,
-            };
-            if (selectedScreen === "FloorScreen") {
-                delete props.orderUuid;
+
+            if (selectedScreen === "ProductScreen" && !pos.getOrder()) {
+                pos.addNewOrder();
             }
-            pos.navigate(selectedScreen, props);
+
+            pos.navigate(
+                selectedScreen,
+                selectedScreen === "ProductScreen" ? { orderUuid: pos.selectedOrderUuid } : {}
+            );
         }
 
         return employee;

--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -18,17 +18,6 @@ patch(PosStore.prototype, {
         this.tableSelectorState = false;
         await super.setup(...arguments);
     },
-    get firstPage() {
-        const screen = super.firstPage;
-
-        if (!this.config.module_pos_restaurant) {
-            return screen;
-        }
-
-        return screen.page === "LoginScreen"
-            ? { page: "LoginScreen", params: {} }
-            : this.defaultPage;
-    },
     get openOrder() {
         if (this.config.module_pos_restaurant) {
             return (

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -1171,3 +1171,7 @@ registry.category("web_tour.tours").add("test_name_preset_skip_screen", {
             ReceiptScreen.clickNextOrder(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("testProductScreenWhenOpeningPos", {
+    steps: () => [Dialog.confirm("Open Register"), ProductScreen.isShown()].flat(),
+});

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -815,3 +815,7 @@ class TestFrontend(TestFrontendCommon):
         })
         self.pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('test_name_preset_skip_screen')
+
+    def test_product_screen_when_opening_pos(self):
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('testProductScreenWhenOpeningPos', url_extension="?from_backend=True")


### PR DESCRIPTION
This commit ensures that when a point_of_sale (in restaurant mode) session is opened, the user is taken directly to the ProductScreen instead of the FloorScreen.

Task-5101142

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
