### PR TITLE
[FIX] stock_delivery: put only the selected SML in the pack

### DIFF
--- a/addons/stock_delivery/models/stock_picking.py
+++ b/addons/stock_delivery/models/stock_picking.py
@@ -106,7 +106,9 @@ class StockPicking(models.Model):
                 if len(move_line_ids.carrier_id) > 1 or any(not ml.carrier_id for ml in move_line_ids):
                     # avoid (duplicate) costs for products
                     raise UserError(_("You cannot pack products into the same package when they have different carriers (i.e. check that all of their transfers have a carrier assigned and are using the same carrier)."))
-                return self._set_delivery_package_type(batch_pack=len(move_line_ids.picking_id) > 1)
+                return self.with_context(
+                    default_move_line_ids=move_line_ids.ids
+                )._set_delivery_package_type(batch_pack=len(move_line_ids.picking_id) > 1)
         else:
             return res
 

--- a/addons/stock_delivery/wizard/choose_delivery_package.py
+++ b/addons/stock_delivery/wizard/choose_delivery_package.py
@@ -42,7 +42,8 @@ class ChooseDeliveryPackage(models.TransientModel):
             return {'warning': warning_mess}
 
     def action_put_in_pack(self):
-        move_line_ids = self.picking_id._package_move_lines(batch_pack=self.env.context.get("batch_pack"))
+        move_line_ids = self.env["stock.move.line"].browse(self.env.context.get("default_move_line_ids"))\
+            or self.picking_id._package_move_lines(batch_pack=self.env.context.get("batch_pack"))
         delivery_package = self.picking_id._put_in_pack(move_line_ids)
         # write shipping weight and package type on 'stock_quant_package' if needed
         if self.delivery_package_type_id:


### PR DESCRIPTION
Steps to reproduce the bug:
- Create two storable products, e.g., “P1” and “P2”.
- Create a delivery:
    - Add one unit of each product.
    - Add any carrier (e.g., DHL).
    - Mark the picking as "To Do".
    - Set the quantity to 1.

- The move lines are created.
- Click on the Moves smart button.
- Select any move line (ML).
- Click Put in Pack.
- A wizard is triggered.
- Select any pack.

Problem:
The pack is applied to both move lines instead of only the selected one.

opw-5104034