### PR TITLE
[IMP] hr_attendance: adding overtime ruleset data

### DIFF
--- a/addons/hr_attendance/__manifest__.py
+++ b/addons/hr_attendance/__manifest__.py
@@ -17,8 +17,11 @@ actions(Check in/Check out) performed by them.
     'website': 'https://www.odoo.com/app/employees',
     'depends': ['hr', 'barcodes', 'base_geolocalize'],
     'data': [
+        'data/hr_attendance_overtime_ruleset_data.xml',
+        'data/hr_attendance_overtime_rule_data.xml',
         'data/hr_attendance_data.xml',
         'security/hr_attendance_security.xml',
+        'security/hr_attendance_overtime_ruleset_security.xml',
         'security/ir.model.access.csv',
         'views/hr_attendance_view.xml',
         'views/hr_department_view.xml',

--- a/addons/hr_attendance/data/hr_attendance_overtime_rule_data.xml
+++ b/addons/hr_attendance/data/hr_attendance_overtime_rule_data.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="hr_attendance_overtime_employee_schedule_rule" model="hr.attendance.overtime.rule">
+            <field name="name">Employee Schedule Rule</field>
+            <field name="base_off">quantity</field>
+            <field name="timing_type">schedule</field>
+            <field name="expected_hours_from_contract" eval="True"/>
+            <field name="paid" eval="True"/>
+            <field name="ruleset_id" ref="hr_attendance_default_ruleset"/>
+        </record>
+
+        <record id="hr_attendance_overtime_non_working_days_rule" model="hr.attendance.overtime.rule">
+            <field name="name">Non Working Days Rule</field>
+            <field name="base_off">timing</field>
+            <field name="timing_type">non_work_days</field>
+            <field name="paid" eval="True"/>
+            <field name="timing_start" eval="0.0"/>
+            <field name="timing_stop" eval="24.0"/>
+            <field name="ruleset_id" ref="hr_attendance_default_ruleset"/>
+        </record>
+    </data>
+</odoo>

--- a/addons/hr_attendance/data/hr_attendance_overtime_ruleset_data.xml
+++ b/addons/hr_attendance/data/hr_attendance_overtime_ruleset_data.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="hr_attendance_default_ruleset" model="hr.attendance.overtime.ruleset">
+            <field name="name">Default Ruleset</field>
+            <field name="country_id" eval="False"/>
+            <field name="company_id" eval="False"/>
+            <field name="rate_combination_mode">max</field>
+        </record>
+    </data>
+</odoo>

--- a/addons/hr_attendance/models/hr_attendance_overtime_rule.py
+++ b/addons/hr_attendance/models/hr_attendance_overtime_rule.py
@@ -183,8 +183,8 @@ class HrAttendanceOvertimeRule(models.Model):
         end_dt = max(attendances.mapped('check_out'))
 
         if self.timing_type in ['work_days', 'non_work_days']:
-
-            unusual_days = self.company_id.resource_calendar_id._get_unusual_days(start_dt, end_dt)
+            company = self.company_id or employee.company_id
+            unusual_days = company.resource_calendar_id._get_unusual_days(start_dt, end_dt)
 
             attendance_intervals = []
             for date, day_attendances in attendances.filtered(

--- a/addons/hr_attendance/models/hr_version.py
+++ b/addons/hr_attendance/models/hr_version.py
@@ -19,6 +19,7 @@ class HrVersion(models.Model):
          domain=_domain_current_countries,
          groups="hr.group_hr_manager",
          tracking=True,
+         default=lambda self: self.env.ref('hr_attendance.hr_attendance_default_ruleset', raise_if_not_found=False),
     )
 
     @api.model

--- a/addons/hr_attendance/security/hr_attendance_overtime_ruleset_security.xml
+++ b/addons/hr_attendance/security/hr_attendance_overtime_ruleset_security.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+
+    <record id="hr_attendance_overtime_ruleset_rule" model="ir.rule">
+        <field name="name">Attendance Overtime Ruleset</field>
+        <field name="model_id" ref="model_hr_attendance_overtime_ruleset"/>
+        <field name="global" eval="True"/>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+    </record>
+
+    <record id="hr_attendance_overtime_ruleset_rule_group_hr_attendance_manager" model="ir.rule">
+        <field name="name">Attendance Overtime Ruleset</field>
+        <field name="model_id" ref="model_hr_attendance_overtime_ruleset"/>
+        <field name="global" eval="[Command.link(ref('hr_attendance.group_hr_attendance_manager'))]"/>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_unlink" eval="True"/>
+    </record>
+
+</odoo>

--- a/addons/hr_attendance/tests/test_hr_attendance_constraints.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_constraints.py
@@ -13,7 +13,7 @@ class TestHrAttendance(TransactionCase):
     def setUpClass(cls):
         super(TestHrAttendance, cls).setUpClass()
         cls.attendance = cls.env['hr.attendance']
-        cls.test_employee = cls.env['hr.employee'].create({'name': "Jacky"})
+        cls.test_employee = cls.env['hr.employee'].create({'name': "Jacky", 'ruleset_id': False})
         # demo data contains set up for cls.test_employee
         cls.open_attendance = cls.attendance.create({
             'employee_id': cls.test_employee.id,

--- a/addons/hr_attendance/tests/test_hr_attendance_process.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_process.py
@@ -22,6 +22,7 @@ class TestHrAttendance(TransactionCase):
             'name': "François Russie",
             'user_id': cls.user.id,
             'pin': '1234',
+            'ruleset_id': False,
         })
         cls.employee_kiosk = cls.env['hr.employee'].create({
             'name': "Machiavel",


### PR DESCRIPTION
## PR Purpose
It's impossible to create an attendance for an employee without a ruleset.
To solve this problem, this PR adds a default ruleset with 2 rules: one for
overtime, and another one for non working days.

Those data are the same as the data added in the
upgrade/migrations/hr_attendance/saas~18.5.2.0 post-migrate script.

[Task#5082628](https://www.odoo.com/odoo/all-tasks/5082628)
[Enterprise#95421](https://github.com/odoo/enterprise/pull/95421)
[Upgrade#8684](https://github.com/odoo/upgrade/pull/8684)