### PR TITLE
[FIX] html_editor: prevent unformatted typing at link edges

### DIFF
--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -178,7 +178,7 @@ export class FormatPlugin extends Plugin {
     hasSelectionFormat(format, targetedNodes = this.dependencies.selection.getTargetedNodes()) {
         const targetedTextNodes = targetedNodes.filter(isTextNode);
         const isFormatted = formatsSpecs[format].isFormatted;
-        return targetedTextNodes.some((n) => isFormatted(n, this.editable));
+        return targetedTextNodes.some((n) => isFormatted(n, { editable: this.editable }));
     }
     /**
      * Return true if the current selection on the editable appears as the given
@@ -199,7 +199,8 @@ export class FormatPlugin extends Plugin {
         );
         const isFormatted = formatsSpecs[format].isFormatted;
         return (
-            targetedTextNodes.length && targetedTextNodes.every((node) => isFormatted(node, this.editable))
+            targetedTextNodes.length &&
+            targetedTextNodes.every((node) => isFormatted(node, { editable: this.editable }))
         );
     }
 

--- a/addons/html_editor/static/src/main/link/link.scss
+++ b/addons/html_editor/static/src/main/link/link.scss
@@ -14,4 +14,14 @@
     [contenteditable=false] .btn {
         cursor: pointer;
     }
+
+    // Unset the font size and family applied by `.btn` 
+    // if inside `FONT_SIZE_CLASSES`.
+    span[class$="-fs"],
+    span.small {
+        .btn:not(:has(span[class$="-fs"], span.small)) {
+            font-family: unset;
+            font-size: unset;
+        }
+    }
 }

--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -18,7 +18,6 @@ import { rpc } from "@web/core/network/rpc";
 import { memoize } from "@web/core/utils/functions";
 import { withSequence } from "@html_editor/utils/resource";
 import { isBlock, closestBlock } from "@html_editor/utils/blocks";
-import { FONT_SIZE_CLASSES } from "@html_editor/utils/formatting";
 
 /**
  * @typedef {import("@html_editor/core/selection_plugin").EditorSelection} EditorSelection
@@ -612,26 +611,7 @@ export class LinkPlugin extends Plugin {
 
             const link = this.document.createElement("a");
             if (!selection.isCollapsed) {
-                let content;
-                const fontSizeWrapper = closestElement(
-                    selection.commonAncestorContainer,
-                    (el) =>
-                        el.tagName === "SPAN" &&
-                        (FONT_SIZE_CLASSES.some((cls) => el.classList.contains(cls)) ||
-                            el.style?.fontSize)
-                );
-                // Split selection to include font-size <span>
-                // inside <a> to preserve styling.
-                if (fontSizeWrapper) {
-                    this.dependencies.split.splitSelection();
-                    const selectedNodes = this.dependencies.selection.getSelectedNodes();
-                    content = this.dependencies.split.splitAroundUntil(
-                        selectedNodes,
-                        fontSizeWrapper
-                    );
-                } else {
-                    content = this.dependencies.selection.extractContent(selection);
-                }
+                const content = this.dependencies.selection.extractContent(selection);
                 link.append(content);
                 link.normalize();
             }

--- a/addons/html_editor/static/src/utils/formatting.js
+++ b/addons/html_editor/static/src/utils/formatting.js
@@ -93,10 +93,13 @@ export const formatsSpecs = {
         removeStyle: (node) => removeStyle(node, "font-size"),
     },
     setFontSizeClassName: {
-        isFormatted: (node) =>
+        isFormatted: (node, props) =>
             !!findNode(
                 closestPath(node),
-                (el) => FONT_SIZE_CLASSES.find((cls) => el.classList?.contains(cls)),
+                (el) =>
+                    props?.className
+                        ? el.classList?.contains(props.className)
+                        : FONT_SIZE_CLASSES.some((className) => el.classList?.contains(className)),
                 isBlock
             ),
         hasStyle: (node, props) => FONT_SIZE_CLASSES.find((cls) => node.classList.contains(cls)),
@@ -104,10 +107,13 @@ export const formatsSpecs = {
             node.style.removeProperty("font-size");
             node.classList.add(props.className);
         },
-        removeStyle: (node) => removeClass(node, ...FONT_SIZE_CLASSES, ...TEXT_STYLE_CLASSES),
+        removeStyle: (node) => {
+            removeStyle(node, "font-size");
+            removeClass(node, ...FONT_SIZE_CLASSES, ...TEXT_STYLE_CLASSES);
+        },
     },
     switchDirection: {
-        isFormatted: isDirectionSwitched,
+        isFormatted: (node, props) => isDirectionSwitched(node, props.editable),
     },
 };
 

--- a/addons/html_editor/static/tests/link/button.test.js
+++ b/addons/html_editor/static/tests/link/button.test.js
@@ -1,9 +1,10 @@
 import { describe, expect, test } from "@odoo/hoot";
-import { setupEditor } from "../_helpers/editor";
+import { setupEditor, testEditor } from "../_helpers/editor";
 import { cleanLinkArtifacts, unformat } from "../_helpers/format";
-import { waitForNone } from "@odoo/hoot-dom";
+import { animationFrame, click, select, waitFor, waitForNone } from "@odoo/hoot-dom";
 import { getContent, simulateDoubleClickSelect } from "../_helpers/selection";
 import { insertText } from "../_helpers/user_actions";
+import { contains } from "@web/../tests/web_test_helpers";
 
 describe("button style", () => {
     test("editable button should have cursor text", async () => {
@@ -28,6 +29,64 @@ describe("button style", () => {
         );
         const button = el.querySelector(".o_embedded_toolbar button");
         expect(button).toHaveStyle({ cursor: "pointer" });
+    });
+
+    test("Button styling should not override inner font size", async () => {
+        const { el } = await setupEditor(
+            unformat(`
+                <div>
+                    <span class="display-1-fs">a[b]c</span>
+                </div>
+            `)
+        );
+        await waitFor(".o-we-toolbar");
+        await click("button[name='link']");
+        await animationFrame();
+        await click('select[name="link_type"]');
+        await animationFrame();
+        await select("primary");
+        await animationFrame();
+        await contains(".o-we-linkpopover input.o_we_href_input_link").edit("#");
+
+        // Ensure `.display-1-fs` overrides the `.btn`'s default font size.
+        const link = el.querySelector("a.btn");
+        const span = el.querySelector("span.display-1-fs");
+        expect(getComputedStyle(link).fontSize).toBe(getComputedStyle(span).fontSize);
+
+        expect(el).toHaveInnerHTML(
+            unformat(`
+                <div class="o-paragraph">
+                    <span class="display-1-fs">a\ufeff<a class="btn btn-fill-primary" href="#">\ufeffb\ufeff</a>\ufeffc</span>
+                </div>
+            `)
+        );
+    });
+
+    test("Should be able to change button style", async () => {
+        await testEditor({
+            contentBefore: unformat(`
+                <div class="o-paragraph">
+                    <span class="display-1-fs">a<a class="btn btn-fill-primary" href="#">[b]</a>c</span>
+                </div>
+            `),
+            stepFunction: (editor) => {
+                editor.shared.format.formatSelection("setFontSizeClassName", {
+                    formatProps: { className: "h1-fs" },
+                    applyStyle: true,
+                });
+            },
+            contentAfter: unformat(`
+                <div>
+                    <span class="display-1-fs">
+                        a
+                        <a class="btn btn-fill-primary" href="#">
+                            <span class="h1-fs">[b]</span>
+                        </a>
+                        c
+                    </span>
+                </div>
+            `),
+        });
     });
 });
 

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -15,7 +15,7 @@ import { animationFrame, tick } from "@odoo/hoot-mock";
 import { markup } from "@odoo/owl";
 import { contains, onRpc, patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { setupEditor } from "../_helpers/editor";
-import { cleanLinkArtifacts, unformat } from "../_helpers/format";
+import { cleanLinkArtifacts } from "../_helpers/format";
 import { getContent, setContent, setSelection } from "../_helpers/selection";
 import { insertLineBreak, insertText, splitBlock, undo } from "../_helpers/user_actions";
 import { execCommand } from "../_helpers/userCommands";
@@ -525,63 +525,6 @@ describe("Link creation", () => {
             undo(editor);
             expect(cleanLinkArtifacts(getContent(el))).toBe(
                 `<p>[<a href="https://www.test.com">Hello</a> my friend]</p>`
-            );
-        });
-        test("should wrap selected text with link and preserve styles", async () => {
-            const { el } = await setupEditor(
-                `<p><span style="font-size: 48px;"><strong>s[trong</strong><u>underlin]e</u></span></p>`
-            );
-            await waitFor(".o-we-toolbar");
-            await click(".o-we-toolbar .fa-link");
-            await expectElementCount(".o-we-linkpopover", 1);
-            expect(".o_we_href_input_link").toBeFocused();
-            await fill("http://test.com");
-            await click('select[name="link_type"');
-            await select("primary");
-            await click(".o_we_apply_link");
-            await animationFrame();
-            expect(cleanLinkArtifacts(getContent(el))).toBe(
-                unformat(`
-                    <p>
-                        <span style="font-size: 48px;"><strong>s</strong></span>
-                        <a class="btn btn-fill-primary" href="http://test.com">
-                            <span style="font-size: 48px;"><strong>trong</strong><u>underlin[]</u></span>
-                        </a>
-                        <span style="font-size: 48px;"><u>e</u></span>
-                    </p>
-                `)
-            );
-        });
-        test("should apply link over split text nodes while preserving styles", async () => {
-            const { el } = await setupEditor(`<p><span class="display-1-fs"></span></p>`);
-
-            const fontSizeSpan = queryOne("span.display-1-fs");
-            fontSizeSpan.appendChild(document.createTextNode("te"));
-            fontSizeSpan.appendChild(document.createTextNode("st"));
-            setSelection({
-                anchorNode: fontSizeSpan.firstChild,
-                anchorOffset: 1,
-                focusNode: fontSizeSpan.lastChild,
-                focusOffset: 1,
-            });
-
-            await waitFor(".o-we-toolbar");
-            await click(".o-we-toolbar .fa-link");
-            await expectElementCount(".o-we-linkpopover", 1);
-            expect(".o_we_href_input_link").toBeFocused();
-            await fill("http://test.com");
-            await click(".o_we_apply_link");
-            await animationFrame();
-            expect(cleanLinkArtifacts(getContent(el))).toBe(
-                unformat(`
-                    <p>
-                        <span class="display-1-fs">t</span>
-                        <a href="http://test.com">
-                            <span class="display-1-fs">es[]</span>
-                        </a>
-                        <span class="display-1-fs">t</span>
-                    </p>
-                `)
             );
         });
     });


### PR DESCRIPTION
Problem:
If we add a link on a slice of formatted text we end up being able
to type unformatted content at the link edges.

Cause:
After https://github.com/odoo/odoo/commit/3bcbd6f34facb9c88290dbd6496cc5103665a0a2
the `span` can be split and `feff`s are placed around the link,
precisely between the link and the `span`. This allows writing
unformatted content at the caret when placed between them.

Solution:
Ensure that the link is created inside the `span`. Also prevent the
formatting applied by `.btn` when the link is inside a `span`.

Steps to reproduce:
1. Add "abc".
2. Format all the text: set font size 48 (or whatever).
3. Select "b".
4. Create a link on "b" only.
5. Put caret before "a".
6. Press Arrow left.
7. Type any character.
→ The character is not formatted as the link content.

task-5092298
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
