### PR TITLE
[IMP] account: remove advance setting from the bank journal settings

### DIFF
--- a/addons/account/views/account_journal_views.xml
+++ b/addons/account/views/account_journal_views.xml
@@ -153,7 +153,7 @@
                                     <field name="selected_payment_method_codes" invisible="1"/>
                                     <group name="outgoing_payment" />
                             </page>
-                            <page name="advanced_settings" string="Advanced Settings">
+                            <page name="advanced_settings" string="Advanced Settings" invisible="type in ['bank', 'cash']">
                                 <group>
                                     <group string="Automation" groups="account.group_account_manager">
                                         <field name="restrict_mode_hash_table" groups="account.group_account_readonly" invisible="type not in ['sale', 'purchase', 'general']"


### PR DESCRIPTION
Current behavior before PR:
- The `Advanced Settings` tab was visible for bank journals.
- Bank journals no longer use any options from the Advanced Settings tab, so it is irrelevant.


Desired behavior after PR is merged:
- The `Advanced Settings` tab is hidden when the journal type is bank.

Changes implemented:
- Added the invisible attribute on the Advanced Settings page to hide it when type of the journal is 'bank'.


task-5107381

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
