### PR TITLE
 [IMP] loyalty: prevent setting expiration date in the past

### DIFF
--- a/addons/loyalty/models/loyalty_card.py
+++ b/addons/loyalty/models/loyalty_card.py
@@ -53,6 +53,12 @@ class LoyaltyCard(models.Model):
         "UNIQUE(code)", "A coupon/loyalty card must have a unique code."
     )
 
+    @api.constrains("expiration_date")
+    def _check_expiration_date(self):
+        for card in self:
+            if card.expiration_date and card.expiration_date < fields.Date.context_today(card):
+                raise ValidationError(self.env._("The expiry date cannot be in the past. Please select a valid date."))
+
     @api.constrains("code")
     def _contrains_code(self):
         """Prevent a coupon from having the same code a program."""

--- a/addons/loyalty/tests/test_loyalty.py
+++ b/addons/loyalty/tests/test_loyalty.py
@@ -1,11 +1,12 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from datetime import timedelta
 from unittest.mock import patch
 
 from psycopg2 import IntegrityError
 
 from odoo.exceptions import UserError, ValidationError
-from odoo.fields import Command
+from odoo import Command, fields
 from odoo.tests import Form, TransactionCase, tagged
 from odoo.tools import mute_logger
 
@@ -320,3 +321,15 @@ class TestLoyalty(TransactionCase):
         # attempt to unarchive both programs together
         with self.assertRaises(ValidationError):
             (program1 + program2).action_unarchive()
+
+    def test_card_write_with_past_expiration_date(self):
+        """A loyalty card should not allow an expiry date in the past"""
+        partner = self.env["res.partner"].create({"name": "Test Partner"})
+        card = self.env["loyalty.card"].create({
+            "program_id": self.program.id,
+            "partner_id": partner.id,
+            "points": 10,
+        })
+        past_date = fields.Date.today() - timedelta(days=1)
+        with self.assertRaises(ValidationError):
+            card.write({"expiration_date": past_date})

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -2,6 +2,7 @@
 
 from datetime import date, timedelta
 from unittest.mock import patch
+from freezegun import freeze_time
 
 from odoo import Command
 from odoo.tests import tagged
@@ -1592,12 +1593,13 @@ class TestUi(TestPointOfSaleHttpCommon):
         # Create test partners
         partner_aaa = self.env['res.partner'].create({'name': 'AAAA'})
         #Create an eWallet for partner_aaa
-        self.env['loyalty.card'].create({
-            'partner_id': partner_aaa.id,
-            'program_id': ewallet_program.id,
-            'points': 50,
-            'expiration_date': date(2020, 1, 1),
-        })
+        with freeze_time('2020-1-1'):
+            self.env['loyalty.card'].create({
+                'partner_id': partner_aaa.id,
+                'program_id': ewallet_program.id,
+                'points': 50,
+                'expiration_date': date.today(),
+            })
         self.main_pos_config.open_ui()
         self.start_pos_tour("ExpiredEWalletProgramTour")
 
@@ -3259,12 +3261,13 @@ class TestUi(TestPointOfSaleHttpCommon):
                 'issued': 60.0,
             })]
         })
-        gift_card_expired = self.env['loyalty.card'].create({
-            'program_id': gift_card_program.id,
-            'code': 'gift_card_expired',
-            'points': 60.0,
-            'expiration_date': date.today() - timedelta(days=1),
-        })
+        with freeze_time(date.today() - timedelta(days=1)):
+            gift_card_expired = self.env['loyalty.card'].create({
+                'program_id': gift_card_program.id,
+                'code': 'gift_card_expired',
+                'points': 60.0,
+                'expiration_date': date.today(),
+            })
         gift_card_sold = self.env['loyalty.card'].create({
             'program_id': gift_card_program.id,
             'source_pos_order_id': example_order_3.id,

--- a/addons/sale_loyalty/tests/test_loyalty.py
+++ b/addons/sale_loyalty/tests/test_loyalty.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from datetime import date
 from freezegun import freeze_time
 
 from odoo.exceptions import ValidationError
@@ -1421,7 +1422,8 @@ class TestLoyalty(TestSaleCouponCommon):
 
     @freeze_time("2026-01-10")
     def test_expired_ewallet_is_not_claimable(self):
-        self.ewallet.expiration_date = "2026-01-01"
+        with freeze_time("2026-01-01"):
+            self.ewallet.expiration_date = date.today()
         sale_order = self._create_so(order_line=[Command.create({"product_id": self.product_a.id})])
         sale_order.action_open_reward_wizard()
         sale_order._update_programs_and_rewards()

--- a/addons/sale_loyalty/tests/test_unlink_reward.py
+++ b/addons/sale_loyalty/tests/test_unlink_reward.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import timedelta
+from freezegun import freeze_time
 
 from odoo.fields import Command, Date
 from odoo.tests.common import tagged
@@ -67,6 +68,7 @@ class TestUnlinkReward(TestSaleCouponCommon):
         coupon = coupon_program.coupon_ids
         self._apply_promo_code(order, coupon.code)
         self.assertTrue(order.order_line.coupon_id)
-        coupon.expiration_date = Date.today() - timedelta(days=1)
+        with freeze_time(Date.today() - timedelta(days=1)):
+            coupon.expiration_date = Date.today()
         order._update_programs_and_rewards()
         self.assertFalse(order.order_line.coupon_id)


### PR DESCRIPTION
Before this commit, it was possible to create or update loyalty cards
with an expiration date in the past, potentially leading to invalid or
unusable coupons.

After this commit, a ValidationError is raised when attempting to set
expiration_date to a past date, ensuring data integrity for loyalty cards.

task-5075177
