### PR TITLE
[IMP] sale_project: custom milestone percentage from project template

### DIFF
--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -401,7 +401,7 @@
                                         <div role="menuitem">
                                             <a name="action_view_tasks" type="object">Tasks</a>
                                         </div>
-                                        <div role="menuitem" groups="project.group_project_milestone" t-if="record.allow_milestones.raw_value and !record.is_template.raw_value">
+                                        <div role="menuitem" groups="project.group_project_milestone" t-if="record.allow_milestones.raw_value">
                                             <a name="action_get_list_view" type="object">Milestones</a>
                                         </div>
                                     </div>

--- a/addons/sale_project/models/project_milestone.py
+++ b/addons/sale_project/models/project_milestone.py
@@ -30,7 +30,8 @@ class ProjectMilestone(models.Model):
     sale_line_id = fields.Many2one('sale.order.line', 'Sales Order Item', default=_default_sale_line_id, help='Sales Order Item that will be updated once the milestone is reached.',
         index='btree_not_null',
         domain="[('order_partner_id', '=?', project_partner_id), ('qty_delivered_method', '=', 'milestones')]")
-    quantity_percentage = fields.Float('Quantity (%)', compute="_compute_quantity_percentage", store=True, help='Percentage of the ordered quantity that will automatically be delivered once the milestone is reached.')
+    quantity_percentage = fields.Float('Quantity (%)', compute="_compute_quantity_percentage", copy=True, store=True, help='Percentage of the ordered quantity that will automatically be delivered once the milestone is reached.')
+    is_project_template = fields.Boolean(related='project_id.is_template', export_string_translation=False)
 
     sale_line_display_name = fields.Char("Sale Line Display Name", related='sale_line_id.display_name', export_string_translation=False)
     product_uom_id = fields.Many2one(related="sale_line_id.product_uom_id", export_string_translation=False)
@@ -38,8 +39,10 @@ class ProjectMilestone(models.Model):
 
     @api.depends('sale_line_id.product_uom_qty', 'product_uom_qty')
     def _compute_quantity_percentage(self):
-        for milestone in self:
-            milestone.quantity_percentage = milestone.sale_line_id.product_uom_qty and milestone.product_uom_qty / milestone.sale_line_id.product_uom_qty
+        changed = any(milestone.quantity_percentage != 0.0 for milestone in self)
+        if not changed:
+            for milestone in self:
+                milestone.quantity_percentage = milestone.sale_line_id.product_uom_qty and milestone.product_uom_qty / milestone.sale_line_id.product_uom_qty
 
     @api.depends('sale_line_id', 'quantity_percentage')
     def _compute_product_uom_qty(self):

--- a/addons/sale_project/tests/test_so_line_milestones.py
+++ b/addons/sale_project/tests/test_so_line_milestones.py
@@ -161,7 +161,10 @@ class TestSoLineMilestones(TestSaleCommon):
         self.milestone1.quantity_percentage = 1.0
         self.assertEqual(self.milestone1.quantity_percentage / self.milestone1.product_uom_qty, ratio, "The ratio should be the same as before")
         self.milestone1.product_uom_qty = 25
-        self.assertEqual(self.milestone1.quantity_percentage / self.milestone1.product_uom_qty, ratio, "The ratio should be the same as before")
+        self.assertNotEqual(self.milestone1.quantity_percentage / self.milestone1.product_uom_qty, ratio, "The ratio shouldn't be the same as before, the quantity shouldn't change")
+        self.milestone1.quantity_percentage = 0
+        self.milestone1.product_uom_qty = self.milestone1.sale_line_id.product_uom_qty
+        self.assertEqual(self.milestone1.quantity_percentage, self.milestone1.product_uom_qty / self.milestone1.sale_line_id.product_uom_qty, "The quantity percentage should be evenly distributed when the quantity is set to 0 initially")
 
     def test_create_milestone_on_project_set_on_sales_order(self):
         """

--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -336,7 +336,7 @@
                 <field name="sale_line_id" options="{'no_open': True}" placeholder="Non-billable" readonly="1" groups="!sales_team.group_sale_salesman"/>
                 <field name="sale_line_id" options="{'no_create': True}" placeholder="Non-billable" groups="sales_team.group_sale_salesman"/>
                 <field name="quantity_percentage" string="Quantity (%)" widget="percentage" groups="!sales_team.group_sale_salesman"/>
-                <field name="quantity_percentage" string="Quantity (%)" widget="percentage" readonly="0" groups="sales_team.group_sale_salesman"/>
+                <field name="quantity_percentage" string="Quantity (%)" widget="percentage" readonly="not is_project_template" groups="sales_team.group_sale_salesman"/>
                 <field name="product_uom_qty" optional="hide" groups="!sales_team.group_sale_salesman" readonly="1"/>
                 <field name="product_uom_qty" optional="hide" groups="sales_team.group_sale_salesman"/>
             </xpath>


### PR DESCRIPTION
- ability to add a custom milestone percentage in project templates
- keep the even distribution if no customization is set to the milestone quantity
- Make the milestones page accessible in the project template page to edit them
- Adjust the test so it can check the new quality calculation

---

Task-4102768
