### PR TITLE
[IMP] web,*: replace tagslist by t-foreach

### DIFF
--- a/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.js
+++ b/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.js
@@ -11,7 +11,7 @@ import { _t } from "@web/core/l10n/translation";
 import { useRecordObserver } from "@web/model/relational_model/utils";
 
 import { standardFieldProps } from "@web/views/fields/standard_field_props";
-import { TagsList } from "@web/core/tags_list/tags_list";
+import { BadgeTag } from "@web/core/tags_list/badge_tag";
 import { useOpenMany2XRecord } from "@web/views/fields/relational_utils";
 import { formatPercentage } from "@web/views/fields/formatters";
 
@@ -29,7 +29,7 @@ import {
 export class AnalyticDistribution extends Component {
     static template = "analytic.AnalyticDistribution";
     static components = {
-        TagsList,
+        BadgeTag,
         Record,
         Field,
     }
@@ -217,7 +217,7 @@ export class AnalyticDistribution extends Component {
             return {
                 id: accs[0].planId,
                 text: accs.reduce((p, n) => p + (p.length ? " | " : "") + (this.planIsComplete(n.total) ? n.accName : `${formatPercentage(n.total)} ${n.accName}`) , ""),
-                colorIndex: accs[0].planColor,
+                color: accs[0].planColor,
                 onClick: (ev) => this.tagClicked(ev),
             };
         });

--- a/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.xml
+++ b/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.xml
@@ -3,7 +3,9 @@
 
     <t t-name="analytic.AnalyticDistribution">
         <div class="o_field_tags d-inline-flex flex-wrap mw-100" t-att-class="{'o_tags_input o_input': !props.readonly}" t-ref="analyticDistribution" t-on-keydown="onWidgetKeydown">
-            <TagsList tags="planSummaryTags()"/>
+            <t t-foreach="planSummaryTags()" t-as="tag" t-key="tag.id">
+                <BadgeTag color="tag.color" text="tag.text" onClick="tag.onClick"/>
+            </t>
             <div t-if="!props.readonly" class="o_input_dropdown d-inline-flex w-100" tabindex="0" t-ref="mainElement" t-on-focus="onMainElementFocus" t-on-click="onMainElementFocus">
                 <span class="analytic_distribution_placeholder"><t t-if="!state.formattedData.length" t-esc="props.placeholder"/></span>
                 <span class="o_dropdown_button" />

--- a/addons/im_livechat/static/src/core/web/livechat_channel_info_list.js
+++ b/addons/im_livechat/static/src/core/web/livechat_channel_info_list.js
@@ -10,11 +10,11 @@ import { rpc } from "@web/core/network/rpc";
 import { useService } from "@web/core/utils/hooks";
 import { url } from "@web/core/utils/urls";
 import { startUrl } from "@web/core/browser/router";
-import { TagsList } from "@web/core/tags_list/tags_list";
+import { BadgeTag } from "@web/core/tags_list/badge_tag";
 import { usePopover } from "@web/core/popover/popover_hook";
 
 export class LivechatChannelInfoList extends Component {
-    static components = { ActionPanel, TagsList, TranscriptSender };
+    static components = { ActionPanel, BadgeTag, TranscriptSender };
     static template = "im_livechat.LivechatChannelInfoList";
     static props = ["thread"];
 
@@ -47,8 +47,7 @@ export class LivechatChannelInfoList extends Component {
         return this.props.thread.livechat_conversation_tag_ids.map((tag) => ({
             id: tag.id,
             text: tag.name,
-            colorIndex: tag.color,
-            className: "me-1 mb-1",
+            color: tag.color,
         }));
     }
 
@@ -62,8 +61,6 @@ export class LivechatChannelInfoList extends Component {
         return this.props.thread.livechat_expertise_ids.map((expertise) => ({
             id: expertise.id,
             text: expertise.name,
-            colorIndex: 0,
-            className: "me-1 mb-1",
         }));
     }
 

--- a/addons/im_livechat/static/src/core/web/livechat_channel_info_list.xml
+++ b/addons/im_livechat/static/src/core/web/livechat_channel_info_list.xml
@@ -30,7 +30,9 @@
                     <button class="btn btn-link text-dark opacity-75 opacity-100-hover p-0 ms-1" t-on-click="onClickEditTags"><i class="oi oi-plus"/></button>
                 </h6>
                 <div t-if="conversationTags.length" class="d-flex flex-wrap flex-grow-1 gap-1">
-                    <TagsList displayText="true" tags="conversationTags"/>
+                    <t t-foreach="conversationTags" t-as="tag" t-key="tag.id">
+                        <BadgeTag cssClass="'me-1 mb-1'" color="tag.color" text="tag.text"/>
+                    </t>
                     <button t-if="this.store.has_access_livechat" class="btn btn-sm btn-link text-dark opacity-75 opacity-100 lh-1" t-on-click="onClickEditTags"><i class="fa fa-pencil"/></button>
                 </div>
             </div>
@@ -46,7 +48,9 @@
             <div t-if="expertiseTags.length" class="d-flex flex-column bg-inherit gap-1">
                 <h6 class="pt-3 mb-1">Expertise</h6>
                 <div class="d-flex flex-wrap gap-1">
-                    <TagsList displayText="true" tags="expertiseTags"/>
+                    <t t-foreach="expertiseTags" t-as="tag" t-key="tag.id">
+                        <BadgeTag cssClass="'me-1 mb-1'" text="tag.text"/>
+                    </t>
                 </div>
             </div>
             <t t-name="extra_infos"/>

--- a/addons/mail/static/src/views/web/fields/properties_field/property_value.js
+++ b/addons/mail/static/src/views/web/fields/properties_field/property_value.js
@@ -1,6 +1,5 @@
 import { useOpenChat } from "@mail/core/web/open_chat_hook";
 
-import { TagsList } from "@web/core/tags_list/tags_list";
 import { patch } from "@web/core/utils/patch";
 import { PropertyValue } from "@web/views/fields/properties/property_value";
 
@@ -18,36 +17,24 @@ patch(PropertyValue.prototype, {
         }
     },
 
+    get propertyValue() {
+        const value = super.propertyValue;
+        if (this.props.type === "many2many") {
+            return value.map((tag) => {
+                if (this.openChat && this.props.comodel === "res.users") {
+                    tag.props.onAvatarClick = () => {
+                        this.openChat(tag.id);
+                    };
+                }
+                return tag;
+            });
+        }
+        return value;
+    },
+
     _onAvatarClicked() {
         if (this.openChat && this.showAvatar && this.props.comodel === "res.users") {
             this.openChat(this.props.value.id);
         }
     },
 });
-
-/**
- * Allow to open the chatter of the user when we click on the avatar of a Many2many
- * property (like we do for many2many_avatar_user widget).
- */
-export class Many2manyPropertiesTagsList extends TagsList {
-    static template = "mail.Many2manyPropertiesTagsList";
-
-    setup() {
-        super.setup();
-        if (this.env.services["mail.store"]) {
-            this.openChat = useOpenChat("res.users");
-        }
-    }
-
-    _onAvatarClicked(tagIndex) {
-        const tag = this.props.tags[tagIndex];
-        if (this.openChat && tag.comodel === "res.users") {
-            this.openChat(tag.id);
-        }
-    }
-}
-
-PropertyValue.components = {
-    ...PropertyValue.components,
-    TagsList: Many2manyPropertiesTagsList,
-};

--- a/addons/mail/static/src/views/web/fields/properties_field/property_value.xml
+++ b/addons/mail/static/src/views/web/fields/properties_field/property_value.xml
@@ -7,12 +7,4 @@
             <attribute name="t-att-comodel">props.comodel</attribute>
         </xpath>
     </t>
-    <!-- Many2many -->
-    <t t-name="mail.Many2manyPropertiesTagsList" t-inherit="web.TagsList"
-        t-inherit-mode="primary">
-        <img position="attributes">
-            <attribute name="t-on-click.prevent.stop">() => this._onAvatarClicked(tag_index)</attribute>
-            <attribute name="t-att-comodel">tag.comodel</attribute>
-        </img>
-    </t>
 </templates>

--- a/addons/point_of_sale/static/src/app/components/order_display/order_display.js
+++ b/addons/point_of_sale/static/src/app/components/order_display/order_display.js
@@ -3,12 +3,12 @@ import { CenteredIcon } from "@point_of_sale/app/components/centered_icon/center
 import { Orderline } from "@point_of_sale/app/components/orderline/orderline";
 import { formatCurrency } from "@web/core/currency";
 import { _t } from "@web/core/l10n/translation";
-import { TagsList } from "@web/core/tags_list/tags_list";
+import { BadgeTag } from "@web/core/tags_list/badge_tag";
 
 // This methods is service-less, see PoS knowledges for more information
 export class OrderDisplay extends Component {
     static template = "point_of_sale.OrderDisplay";
-    static components = { CenteredIcon, Orderline, TagsList };
+    static components = { CenteredIcon, Orderline, BadgeTag };
     static props = {
         order: Object,
         slots: Object,

--- a/addons/point_of_sale/static/src/app/components/order_display/order_display.xml
+++ b/addons/point_of_sale/static/src/app/components/order_display/order_display.xml
@@ -21,10 +21,12 @@
                             </div>
                         </div>
                     </div>
-                    <div t-if="order.internal_note and props.mode !== 'receipt'" 
-                        class="internal-note-container d-flex flex-wrap gap-2" 
+                    <div t-if="order.internal_note and props.mode !== 'receipt'"
+                        class="internal-note-container d-flex flex-wrap gap-2"
                         t-attf-class="{{this.props.mode === 'receipt' ? 'py-2' : 'p-2'}}">
-                        <TagsList tags="getInternalNotes()"/>
+                        <t t-foreach="getInternalNotes()" t-as="note" t-key="note.id or note_index">
+                            <BadgeTag color="note.colorIndex" text="note.text"/>
+                        </t>
                     </div>
                 </div>
                 <t t-set="taxTotals" t-value="order.taxTotals" />

--- a/addons/point_of_sale/static/src/app/components/orderline/orderline.js
+++ b/addons/point_of_sale/static/src/app/components/orderline/orderline.js
@@ -1,9 +1,9 @@
 import { Component } from "@odoo/owl";
 import { formatCurrency } from "@web/core/currency";
-import { TagsList } from "@web/core/tags_list/tags_list";
+import { BadgeTag } from "@web/core/tags_list/badge_tag";
 
 export class Orderline extends Component {
-    static components = { TagsList };
+    static components = { BadgeTag };
     static template = "point_of_sale.Orderline";
     static props = {
         line: Object,

--- a/addons/point_of_sale/static/src/app/components/orderline/orderline.xml
+++ b/addons/point_of_sale/static/src/app/components/orderline/orderline.xml
@@ -55,7 +55,9 @@
                         <t t-esc="line.customer_note" />
                     </li>
                     <div t-if="this.props.mode === 'display' and line.note" class="internal-note-container d-flex gap-2 flex-wrap">
-                        <TagsList tags="getInternalNotes()" />
+                        <t t-foreach="getInternalNotes()" t-as="note" t-key="note.id or note_index">
+                            <BadgeTag color="note.colorIndex" text="note.text"/>
+                        </t>
                     </div>
                     <li t-if="line.product_id.tracking !== 'none'" class="row flex-wrap w-100 m-0">
                         <div class="col-auto" t-attf-class="{{ props.mode == 'receipt' ? 'p-0' : 'px-1' }}">

--- a/addons/point_of_sale/static/src/customer_display/customer_display.js
+++ b/addons/point_of_sale/static/src/customer_display/customer_display.js
@@ -5,12 +5,12 @@ import { MainComponentsContainer } from "@web/core/main_components_container";
 import { session } from "@web/session";
 import { useService } from "@web/core/utils/hooks";
 import { mountComponent } from "@web/env";
-import { TagsList } from "@web/core/tags_list/tags_list";
+import { BadgeTag } from "@web/core/tags_list/badge_tag";
 import { CustomerFacingQR } from "./customer_facing_qr";
 
 export class CustomerDisplay extends Component {
     static template = "point_of_sale.CustomerDisplay";
-    static components = { OdooLogo, MainComponentsContainer, TagsList };
+    static components = { OdooLogo, MainComponentsContainer, BadgeTag };
     static props = [];
 
     setup() {

--- a/addons/point_of_sale/static/src/customer_display/customer_display.xml
+++ b/addons/point_of_sale/static/src/customer_display/customer_display.xml
@@ -41,7 +41,9 @@
                                         <t t-esc="line.customerNote" />
                                     </li>
                                     <div class="internal-note-container d-flex gap-2 p-2">
-                                        <TagsList tags="getInternalNotes()"/>
+                                        <t t-foreach="getInternalNotes()" t-as="note" t-key="note.id or note_index">
+                                            <BadgeTag color="note.colorIndex" text="note.text"/>
+                                        </t>
                                     </div>
                                     <li t-foreach="line.packLotLines or []" t-as="lot" t-key="lot_index" t-esc="lot" />
                                     <t t-slot="default" />

--- a/addons/spreadsheet/static/src/global_filters/components/filter_text_value/filter_text_value.js
+++ b/addons/spreadsheet/static/src/global_filters/components/filter_text_value/filter_text_value.js
@@ -3,13 +3,13 @@
 import { Component, useEffect } from "@odoo/owl";
 import { useChildRef } from "@web/core/utils/hooks";
 
-import { TagsList } from "@web/core/tags_list/tags_list";
+import { BadgeTag } from "@web/core/tags_list/badge_tag";
 import { AutoComplete } from "@web/core/autocomplete/autocomplete";
 
 export class TextFilterValue extends Component {
     static template = "spreadsheet.TextFilterValue";
     static components = {
-        TagsList,
+        BadgeTag,
         AutoComplete,
     };
     static props = {

--- a/addons/spreadsheet/static/src/global_filters/components/filter_text_value/filter_text_value.xml
+++ b/addons/spreadsheet/static/src/global_filters/components/filter_text_value/filter_text_value.xml
@@ -2,7 +2,9 @@
 <templates>
     <t t-name="spreadsheet.TextFilterValue">
         <div class="o_input o-global-filter-text-value d-flex flex-wrap gap-1">
-            <TagsList tags="tags"/>
+            <t t-foreach="this.tags" t-as="tag" t-key="tag.id">
+                <BadgeTag text="tag.text" onDelete="tag.onDelete"/>
+            </t>
             <AutoComplete
                 sources="sources"
                 input="inputRef"

--- a/addons/spreadsheet/static/src/global_filters/components/selection_filter_value/selection_filter_value.js
+++ b/addons/spreadsheet/static/src/global_filters/components/selection_filter_value/selection_filter_value.js
@@ -3,13 +3,13 @@
 import { Component, onWillStart, onWillUpdateProps, useEffect } from "@odoo/owl";
 import { useChildRef, useService } from "@web/core/utils/hooks";
 
-import { TagsList } from "@web/core/tags_list/tags_list";
+import { BadgeTag } from "@web/core/tags_list/badge_tag";
 import { AutoComplete } from "@web/core/autocomplete/autocomplete";
 
 export class SelectionFilterValue extends Component {
     static template = "spreadsheet.SelectionFilterValue";
     static components = {
-        TagsList,
+        BadgeTag,
         AutoComplete,
     };
     static props = {

--- a/addons/spreadsheet/static/src/global_filters/components/selection_filter_value/selection_filter_value.xml
+++ b/addons/spreadsheet/static/src/global_filters/components/selection_filter_value/selection_filter_value.xml
@@ -2,7 +2,9 @@
 <templates>
     <t t-name="spreadsheet.SelectionFilterValue">
         <div class="o_input o-global-filter-selection-value d-flex flex-wrap gap-1">
-            <TagsList tags="tags"/>
+            <t t-foreach="this.tags" t-as="tag" t-key="tag.id">
+                <BadgeTag text="tag.text" onDelete="tag.onDelete"/>
+            </t>
             <AutoComplete input="inputRef" sources="sources"/>
         </div>
     </t>

--- a/addons/web/static/src/core/record_selectors/multi_record_selector.js
+++ b/addons/web/static/src/core/record_selectors/multi_record_selector.js
@@ -1,6 +1,7 @@
 import { Component, onWillStart, onWillUpdateProps } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
-import { TagsList } from "@web/core/tags_list/tags_list";
+import { AvatarTag } from "@web/core/tags_list/avatar_tag";
+import { BadgeTag } from "@web/core/tags_list/badge_tag";
 import { isId } from "@web/core/tree_editor/utils";
 import { useService } from "@web/core/utils/hooks";
 import { imageUrl } from "@web/core/utils/urls";
@@ -17,7 +18,7 @@ export class MultiRecordSelector extends Component {
         fieldString: { type: String, optional: true },
         placeholder: { type: String, optional: true },
     };
-    static components = { RecordAutocomplete, TagsList };
+    static components = { AvatarTag, BadgeTag, RecordAutocomplete };
     static template = "web.MultiRecordSelector";
 
     setup() {
@@ -66,6 +67,7 @@ export class MultiRecordSelector extends Component {
                     ? displayNames[id]
                     : _t("Inaccessible/missing record ID: %s", id);
             return {
+                id,
                 text,
                 onDelete: () => {
                     this.deleteTag(index);

--- a/addons/web/static/src/core/record_selectors/multi_record_selector.xml
+++ b/addons/web/static/src/core/record_selectors/multi_record_selector.xml
@@ -3,7 +3,14 @@
 
     <t t-name="web.MultiRecordSelector" >
         <div class="o_input d-flex flex-wrap gap-1 o_multi_record_selector" t-ref="multiRecordSelector">
-            <TagsList tags="tags"/>
+            <t t-foreach="this.tags" t-as="tag" t-key="tag.id">
+                <t t-if="tag.img">
+                    <AvatarTag imageUrl="tag.img" onDelete="tag.onDelete" text="tag.text"/>
+                </t>
+                <t t-else="">
+                    <BadgeTag onDelete="tag.onDelete" text="tag.text"/>
+                </t>
+            </t>
             <RecordAutocomplete
                 resModel="props.resModel"
                 value="''"

--- a/addons/web/static/src/core/select_menu/select_menu.js
+++ b/addons/web/static/src/core/select_menu/select_menu.js
@@ -2,7 +2,7 @@ import { Component, onWillUpdateProps, useEffect, useRef, useState } from "@odoo
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
-import { TagsList } from "@web/core/tags_list/tags_list";
+import { BadgeTag } from "@web/core/tags_list/badge_tag";
 import { mergeClasses } from "@web/core/utils/classname";
 import { useChildRef } from "@web/core/utils/hooks";
 import { scrollTo } from "@web/core/utils/scrolling";
@@ -14,11 +14,19 @@ let selectMenuId = 0;
 
 export const DEBOUNCED_DELAY = 250;
 
+class SelectMenuTagsList extends Component {
+    static template = "web.SelectMenuTagsList";
+    static components = { BadgeTag };
+    static props = {
+        tags: { type: Array },
+    };
+}
+
 export class SelectMenu extends Component {
     static template = "web.SelectMenu";
     static choiceItemTemplate = "web.SelectMenu.ChoiceItem";
 
-    static components = { Dropdown, DropdownItem, TagsList };
+    static components = { Dropdown, DropdownItem, TagsList: SelectMenuTagsList };
 
     static defaultProps = {
         value: undefined,

--- a/addons/web/static/src/core/select_menu/select_menu.xml
+++ b/addons/web/static/src/core/select_menu/select_menu.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates>
+    <t t-name="web.SelectMenuTagsList">
+        <t t-foreach="this.props.tags" t-as="tag" t-key="tag.id">
+            <BadgeTag onDelete="tag.onDelete" text="tag.text"/>
+        </t>
+    </t>
+
     <t t-name="web.SelectMenu.search">
         <input
             type="text"

--- a/addons/web/static/src/core/tags_list/avatar_tag.js
+++ b/addons/web/static/src/core/tags_list/avatar_tag.js
@@ -1,0 +1,31 @@
+import { Component } from "@odoo/owl";
+import { useForwardRefToParent } from "@web/core/utils/hooks";
+
+export class AvatarTag extends Component {
+    static template = "web.AvatarTag";
+    static props = {
+        cssClass: { type: [String, Object], optional: true },
+        imageUrl: { type: String },
+        onAvatarClick: { type: Function, optional: true },
+        onDelete: { type: Function, optional: true },
+        ref: { type: Object, optional: true },
+        slots: { optional: true },
+        text: { type: String, optional: true },
+        tooltip: { type: String, optional: true },
+    };
+
+    setup() {
+        useForwardRefToParent("ref");
+    }
+
+    /**
+     * @param {MouseEvent} ev
+     */
+    onAvatarClick(ev) {
+        if (this.props.onAvatarClick) {
+            ev.stopPropagation();
+            ev.preventDefault();
+            this.props.onAvatarClick(ev.target);
+        }
+    }
+}

--- a/addons/web/static/src/core/tags_list/avatar_tag.xml
+++ b/addons/web/static/src/core/tags_list/avatar_tag.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="web.AvatarTag">
+        <span class="o_tag position-relative d-inline-flex align-items-center user-select-none mw-100 o_avatar opacity-trigger-hover" tabindex="-1" t-att-class="this.props.cssClass" t-att-data-tooltip="this.props.tooltip or this.props.text" t-att-aria-label="this.props.tooltip or this.props.text" t-ref="ref">
+            <t t-if="this.props.onDelete">
+                <span class="o_avatar_backdrop position-absolute top-0 end-0 bottom-0 start-0 ms-n2 mt-n1 mb-n1 bg-view rounded border shadow opacity-0 opacity-100-hover"/>
+            </t>
+            <img class="o_avatar o_m2m_avatar position-relative rounded" t-att-src="this.props.imageUrl" t-on-click="this.onAvatarClick"/>
+            <t t-slot="default">
+                <t t-if="this.props.text">
+                    <div class="o_tag_badge_text position-relative ms-1" t-out="this.props.text"/>
+                </t>
+            </t>
+            <t t-if="this.props.onDelete">
+                <a class="o_delete d-flex align-items-center opacity-100-hover btn btn-link position-relative py-0 px-1 text-danger opacity-0" href="#" tabindex="-1" aria-label="Delete" data-tooltip="Delete" t-on-click.stop.prevent="() => this.props.onDelete()">
+                    <i class="oi oi-close align-text-center"/>
+                </a>
+            </t>
+        </span>
+    </t>
+
+</templates>

--- a/addons/web/static/src/core/tags_list/badge_tag.js
+++ b/addons/web/static/src/core/tags_list/badge_tag.js
@@ -1,0 +1,32 @@
+import { Component } from "@odoo/owl";
+import { mergeClasses } from "@web/core/utils/classname";
+import { useForwardRefToParent } from "@web/core/utils/hooks";
+
+export class BadgeTag extends Component {
+    static template = "web.BadgeTag";
+    static props = {
+        color: { type: Number, optional: true },
+        cssClass: { type: [String, Object], optional: true },
+        onClick: { type: Function, optional: true },
+        onDelete: { type: Function, optional: true },
+        ref: { optional: true },
+        slots: { optional: true },
+        text: { type: String, optional: true },
+        tooltip: { type: String, optional: true },
+    };
+    static defaultProps = {
+        color: 0,
+    };
+
+    get cssClass() {
+        return mergeClasses(
+            `o_badge badge rounded-pill lh-1 o_tag_color_${this.props.color}`,
+            { "cursor-pointer": this.props.onClick },
+            this.props.cssClass
+        );
+    }
+
+    setup() {
+        useForwardRefToParent("ref");
+    }
+}

--- a/addons/web/static/src/core/tags_list/badge_tag.xml
+++ b/addons/web/static/src/core/tags_list/badge_tag.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="web.BadgeTag">
+        <span class="o_tag position-relative d-inline-flex align-items-center user-select-none mw-100 o_badge badge rounded-pill lh-1" tabindex="-1" t-att-class="this.cssClass" t-att-data-color="this.props.color" t-att-data-tooltip="this.props.tooltip or this.props.text" t-att-aria-label="this.props.tooltip or this.props.text" t-on-click="(ev) => this.props.onClick?.(ev)" t-ref="ref">
+            <t t-slot="default">
+                <div class="o_tag_badge_text o_badge_text" t-out="this.props.text"/>
+            </t>
+            <t t-if="this.props.onDelete">
+                <a class="o_delete d-flex align-items-center opacity-100-hover ps-1 opacity-75" href="#" tabindex="-1" aria-label="Delete" data-tooltip="Delete" t-on-click.stop.prevent="() => this.props.onDelete()">
+                    <i class="oi oi-close align-text-center"/>
+                </a>
+            </t>
+        </span>
+    </t>
+
+</templates>

--- a/addons/web/static/src/core/tree_editor/tree_editor_autocomplete.js
+++ b/addons/web/static/src/core/tree_editor/tree_editor_autocomplete.js
@@ -39,8 +39,9 @@ export class DomainSelectorAutocomplete extends MultiRecordSelector {
         return props.resIds.map((val, index) => {
             const { text, colorIndex } = getFormat(val, displayNames);
             return {
+                id: val,
                 text,
-                colorIndex,
+                color: colorIndex,
                 onDelete: () => {
                     this.props.update([
                         ...this.props.resIds.slice(0, index),

--- a/addons/web/static/src/core/tree_editor/tree_editor_components.js
+++ b/addons/web/static/src/core/tree_editor/tree_editor_components.js
@@ -1,5 +1,5 @@
 import { Component } from "@odoo/owl";
-import { TagsList } from "@web/core/tags_list/tags_list";
+import { BadgeTag } from "@web/core/tags_list/badge_tag";
 import { _t } from "@web/core/l10n/translation";
 
 export class Input extends Component {
@@ -61,7 +61,7 @@ export class InRange extends Component {
 }
 
 export class List extends Component {
-    static components = { TagsList };
+    static components = { BadgeTag };
     static props = ["value", "update", "editorInfo"];
     static template = "web.TreeEditor.List";
 
@@ -69,7 +69,7 @@ export class List extends Component {
         const { isSupported, stringify } = this.props.editorInfo;
         return this.props.value.map((val, index) => ({
             text: stringify(val),
-            colorIndex: isSupported(val) ? 0 : 2,
+            color: isSupported(val) ? 0 : 2,
             onDelete: () => {
                 this.props.update([
                     ...this.props.value.slice(0, index),

--- a/addons/web/static/src/core/tree_editor/tree_editor_components.xml
+++ b/addons/web/static/src/core/tree_editor/tree_editor_components.xml
@@ -53,7 +53,9 @@
 
     <t t-name="web.TreeEditor.List">
         <div class="o_input d-flex flex-wrap gap-1">
-            <TagsList tags="tags"/>
+            <t t-foreach="tags" t-as="tag" t-key="tag_index">
+                <BadgeTag t-props="tag"/>
+            </t>
             <div class="flex-grow-1">
                 <t t-call="web.TreeEditor.Editor">
                     <t t-set="info" t-value="props.editorInfo" />

--- a/addons/web/static/src/views/fields/properties/property_tags.js
+++ b/addons/web/static/src/views/fields/properties/property_tags.js
@@ -4,7 +4,7 @@ import { _t } from "@web/core/l10n/translation";
 import { usePopover } from "@web/core/popover/popover_hook";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
-import { TagsList } from "@web/core/tags_list/tags_list";
+import { BadgeTag } from "@web/core/tags_list/badge_tag";
 import { standardFieldProps } from "@web/views/fields/standard_field_props";
 import { useTagNavigation } from "@web/core/record_selectors/tag_navigation_hook";
 
@@ -27,7 +27,7 @@ export class PropertyTags extends Component {
     static template = "web.PropertyTags";
     static components = {
         AutoComplete,
-        TagsList,
+        BadgeTag,
         ColorList,
         Popover: PropertyTagsColorListPopover,
     };
@@ -70,7 +70,7 @@ export class PropertyTags extends Component {
     }
 
     /**
-     * Return the list containing tags values and actions for the TagsList component.
+     * Return the list containing tags values and actions for the BadgeTag component.
      *
      * @returns {array}
      */
@@ -97,10 +97,9 @@ export class PropertyTags extends Component {
             return {
                 id: tagId,
                 text: tagLabel,
-                className: this.props.canChangeTags ? "" : "pe-none",
-                colorIndex: tagColorIndex || 0,
+                color: tagColorIndex || 0,
                 onClick: (event) => this.onTagClick(event, tagId, tagColorIndex),
-                onDelete: canDeleteTag && (() => this.onTagDelete(tagId)),
+                onDelete: canDeleteTag ? (() => this.onTagDelete(tagId)) : undefined,
             };
         });
     }

--- a/addons/web/static/src/views/fields/properties/property_tags.xml
+++ b/addons/web/static/src/views/fields/properties/property_tags.xml
@@ -2,9 +2,10 @@
 <templates xml:space="preserve">
     <t t-name="web.PropertyTags">
         <!-- Copy many2many tags style without duplicating all the CSS -->
-        <div t-attf-class="o_field_property_tag o_field_widget o_field_many2many_tags d-flex {{props.readonly ? 'readonly' : ''}}"
-            t-ref="propertyTags">
-            <TagsList tags="tagListItems"/>
+        <div t-attf-class="o_field_property_tag o_field_widget o_field_many2many_tags d-flex {{props.readonly ? 'readonly' : ''}}" t-ref="propertyTags">
+            <t t-foreach="tagListItems" t-as="tag" t-key="tag.id">
+                <BadgeTag color="tag.color" text="tag.text" onDelete="tag.onDelete" onClick="tag.onClick"/>
+            </t>
             <div
                 t-if="!props.readonly"
                 class="o_field_property_dropdown_menu o_input_dropdown">

--- a/addons/web/static/src/views/fields/properties/property_value.xml
+++ b/addons/web/static/src/views/fields/properties/property_value.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
+    <t t-name="web.PropertyValueTag">
+        <t t-if="this.props.imageUrl">
+            <AvatarTag imageUrl="this.props.imageUrl" onAvatarClick="this.props.onAvatarClick" onDelete="this.props.onDelete" text="this.props.text" t-on-click="(ev) => this.props.onClick?.(ev)"/>
+        </t>
+        <t t-else="">
+            <BadgeTag onClick="this.props.onClick" onDelete="this.props.onDelete" text="this.props.text"/>
+        </t>
+    </t>
+
     <t t-name="web.PropertyValue">
         <t t-if="props.readonly and !['boolean', 'many2one', 'many2many', 'tags', 'html'].includes(props.type)">
             <span t-if="displayValue" t-out="displayValue"/>
@@ -136,7 +145,9 @@
                 <div t-if="props.comodel" class="o_field_property_many2many_value d-flex flex-wrap flex-row gap-1 ms-0 pe-1 w-100 "
                     t-attf-class="o_field_widget o_field_many2many_tags {{showAvatar ? 'avatar' : ''}} {{props.readonly ? 'readonly' : ''}}">
                     <!-- Copy many2many tags style without duplicating all CSS -->
-                    <TagsList tags="propertyValue"/>
+                    <t t-foreach="propertyValue" t-as="tag" t-key="tag.id">
+                        <PropertyValueTag t-props="tag.props"/>
+                    </t>
                     <Many2XAutocomplete
                         t-if="!props.readonly"
                         t-key="props.id + '_' + props.comodel + '_' + props.string"

--- a/addons/web/static/src/views/list/list_confirmation_dialog.js
+++ b/addons/web/static/src/views/list/list_confirmation_dialog.js
@@ -1,7 +1,7 @@
 import { Dialog } from "@web/core/dialog/dialog";
 import { _t } from "@web/core/l10n/translation";
 import { useAutofocus } from "@web/core/utils/hooks";
-import { TagsList } from "@web/core/tags_list/tags_list";
+import { BadgeTag } from "@web/core/tags_list/badge_tag";
 import { Operation } from "@web/model/relational_model/operation";
 import { Field, fieldVisualFeedback } from "@web/views/fields/field";
 
@@ -9,7 +9,7 @@ import { Component } from "@odoo/owl";
 
 export class ListConfirmationDialog extends Component {
     static template = "web.ListView.ConfirmationModal";
-    static components = { Dialog, Field, TagsList };
+    static components = { BadgeTag, Dialog, Field };
     static props = {
         close: Function,
         title: {
@@ -75,9 +75,8 @@ export class ListConfirmationDialog extends Component {
         const colorField = field.fieldNode.options?.color_field;
         return records.map((record) => ({
             id: record.id,
-            resId: record.resId,
             text: record.data.display_name,
-            colorIndex: colorField ? record.data[colorField] : undefined,
+            color: colorField ? record.data[colorField] : undefined,
         }));
     }
 

--- a/addons/web/static/src/views/list/list_confirmation_dialog.xml
+++ b/addons/web/static/src/views/list/list_confirmation_dialog.xml
@@ -25,14 +25,19 @@
                                         <td><span>Add</span>: </td>
                                         <td>
                                             <div class="o_field_many2many_tags">
-                                            <TagsList tags="getTagProps(props.changes[field.name].add, field)"/>                                            </div>
+                                                <t t-foreach="getTagProps(props.changes[field.name].add, field)" t-as="tag" t-key="tag.id">
+                                                    <BadgeTag color="tag.color" text="tag.text"/>
+                                                </t>
+                                            </div>
                                         </td>
                                     </tr>
                                     <tr t-if="props.changes[field.name].remove.length">
                                         <td><span>Remove</span>: </td>
                                         <td>
                                             <div class="o_field_many2many_tags">
-                                                <TagsList tags="getTagProps(props.changes[field.name].remove, field)"/>
+                                                <t t-foreach="getTagProps(props.changes[field.name].remove, field)" t-as="tag" t-key="tag.id">
+                                                    <BadgeTag color="tag.color" text="tag.text"/>
+                                                </t>
                                             </div>
                                         </td>
                                     </tr>


### PR DESCRIPTION
* analytic,hr_skills,im_livechat,mail,point_of_sale,spreadsheet

This commit introduces two new components BadgeTag and AvatarTag
and replaces the use of component TagsList by t-foreach and tag
component.TagsList will soon not render tags anymore. This commit is a
first pass to reduce the diff and make the transition smoother.

task-4660360