### PR TITLE
[FIX] website_sale: make GMC feature flag global

### DIFF
--- a/addons/website_sale/models/res_config_settings.py
+++ b/addons/website_sale/models/res_config_settings.py
@@ -122,6 +122,13 @@ class ResConfigSettings(models.TransientModel):
             ):
                 website._populate_product_feeds()
 
+            # Due to an earlier oversight, the GMC feature flag was implemented as website-specific,
+            # even though a group-based feature flag is global. This has been corrected in future
+            # versions, but fixing it here would require a model change, which cannot be backported.
+            # This line serves as a workaround to ensure that all websites share the same setting,
+            # providing consistent behavior across versions.
+            self.env['website'].sudo().search_fetch([], []).enabled_gmc_src = self.group_gmc_feed
+
     # === ACTION METHODS === #
 
     def action_view_delivery_provider_modules(self):

--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -247,7 +247,12 @@ class Website(models.Model):
 
     prevent_zero_price_sale = fields.Boolean(string="Hide 'Add To Cart' when price = 0")
 
-    enabled_gmc_src = fields.Boolean(string="Google Merchant Center")
+    enabled_gmc_src = fields.Boolean(
+        string="Google Merchant Center",
+        default=lambda self: self.env['res.groups']._is_feature_enabled(
+            'website_sale.group_product_feed',
+        ),
+    )
 
     currency_id = fields.Many2one(
         string="Default Currency",


### PR DESCRIPTION
In a more recent version (see [^1]), it was decided to entirely remove the website-specific feature flag and instead rely on a group-based feature flag. Unfortunately, this change only affected newer versions of Odoo, specifically 19.1. To ensure consistent behavior across v19, this commit introduces a workaround to ensure all websites always share the same configuration regarding GMC.

See also https://github.com/odoo/upgrade/pull/8468#discussion_r2374582760 for the initial discussion.

[^1]: https://github.com/odoo/odoo/pull/227629
