### PR TITLE
[IMP] mail: improve call preview and call invitation

### DIFF
--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -198,7 +198,7 @@ export class Store extends BaseStore {
 
     shouldSimulateDarkTheme(ctx) {
         return (
-            ctx?.env?.inDiscussCallView &&
+            (ctx?.env?.inDiscussCallView || ctx?.env?.inCallInvitation) &&
             this.isOdooWhiteTheme &&
             !ctx?.env.inMeetingSideActions &&
             !ctx?.env.inDiscussActionPanel

--- a/addons/mail/static/src/discuss/call/common/call_actions.js
+++ b/addons/mail/static/src/discuss/call/common/call_actions.js
@@ -26,7 +26,7 @@ export function registerCallAction(id, definition) {
     callActionsRegistry.add(id, definition);
 }
 
-registerCallAction("mute", {
+export const muteAction = {
     condition: ({ store, thread }) => thread?.eq(store.rtc?.channel),
     name: ({ store }) => (store.rtc.selfSession.isMute ? _t("Unmute") : _t("Mute")),
     isActive: ({ store }) =>
@@ -47,7 +47,8 @@ registerCallAction("mute", {
         }
         return tags;
     },
-});
+};
+registerCallAction("mute", muteAction);
 registerCallAction("deafen", {
     condition: ({ store, thread }) => thread?.eq(store.rtc?.channel),
     name: ({ store }) => (store.rtc.selfSession.is_deaf ? _t("Undeafen") : _t("Deafen")),
@@ -60,7 +61,7 @@ registerCallAction("deafen", {
     sequenceGroup: 100,
     tags: ({ action }) => (action.isActive ? ACTION_TAGS.DANGER : undefined),
 });
-registerCallAction("camera-on", {
+export const cameraOnAction = {
     condition: ({ store, thread }) => thread?.eq(store.rtc?.channel),
     disabledCondition: ({ store }) => store.rtc?.isRemote,
     name: ({ store }) =>
@@ -85,8 +86,9 @@ registerCallAction("camera-on", {
         }
         return tags;
     },
-});
-registerCallAction("switch-camera", {
+};
+registerCallAction("camera-on", cameraOnAction);
+export const switchCameraAction = {
     condition: ({ store, thread }) =>
         thread?.eq(store.rtc?.channel) && isMobileOS() && store.rtc.selfSession?.is_camera_on,
     name: _t("Switch Camera"),
@@ -95,7 +97,8 @@ registerCallAction("switch-camera", {
     onSelected: ({ store }) => store.rtc.toggleCameraFacingMode(),
     sequence: 40,
     sequenceGroup: 100,
-});
+};
+registerCallAction("switch-camera", switchCameraAction);
 registerCallAction("raise-hand", {
     condition: ({ store, thread }) => thread?.eq(store.rtc?.channel),
     name: ({ store }) => (store.rtc.selfSession.raisingHand ? _t("Lower Hand") : _t("Raise Hand")),
@@ -133,7 +136,7 @@ registerCallAction("auto-focus", {
     sequence: 50,
     sequenceGroup: 200,
 });
-registerCallAction("blur-background", {
+export const blurBackgroundAction = {
     condition: ({ store, thread }) =>
         !isBrowserSafari() &&
         thread?.eq(store.rtc?.channel) &&
@@ -145,7 +148,8 @@ registerCallAction("blur-background", {
     onSelected: ({ store }) => (store.settings.useBlur = !store.settings.useBlur),
     sequence: 60,
     sequenceGroup: 200,
-});
+};
+registerCallAction("blur-background", blurBackgroundAction);
 registerCallAction("fullscreen", {
     condition: ({ store, thread }) => thread?.eq(store.rtc?.channel),
     name: ({ store }) => (store.rtc.state.isFullscreen ? _t("Exit Fullscreen") : _t("Fullscreen")),
@@ -183,7 +187,7 @@ registerCallAction("picture-in-picture", {
     sequence: 70,
     tags: ACTION_TAGS.CALL_LAYOUT,
 });
-registerCallAction("accept-with-camera", {
+export const acceptWithCamera = {
     condition: ({ thread }) =>
         thread?.self_member_id?.rtc_inviting_session_id?.is_camera_on &&
         typeof thread?.useCameraByDefault !== "boolean",
@@ -194,7 +198,8 @@ registerCallAction("accept-with-camera", {
     sequence: 100,
     sequenceGroup: 300,
     tags: [ACTION_TAGS.JOIN_LEAVE_CALL, ACTION_TAGS.SUCCESS],
-});
+};
+registerCallAction("accept-with-camera", acceptWithCamera);
 registerCallAction("join-back", {
     btnClass: "text-nowrap pe-2 rounded-pill",
     condition: ({ store, thread }) =>
@@ -223,7 +228,7 @@ registerCallAction("join-with-camera", {
     sequenceGroup: 300,
     tags: [ACTION_TAGS.JOIN_LEAVE_CALL, ACTION_TAGS.SUCCESS],
 });
-registerCallAction("join", {
+export const joinAction = {
     condition: ({ store, thread }) =>
         !thread?.eq(store.rtc?.channel) && typeof thread?.useCameraByDefault !== "boolean",
     disabledCondition: ({ store }) => store.rtc?.state.hasPendingRequest,
@@ -233,8 +238,9 @@ registerCallAction("join", {
     sequence: 130,
     sequenceGroup: 300,
     tags: [ACTION_TAGS.JOIN_LEAVE_CALL, ACTION_TAGS.SUCCESS],
-});
-registerCallAction("reject", {
+};
+registerCallAction("join", joinAction);
+export const rejectAction = {
     btnClass: ({ thread }) =>
         typeof thread?.useCameraByDefault === "boolean" ? "pe-2 rounded-pill" : undefined,
     condition: ({ thread }) => thread?.self_member_id?.rtc_inviting_session_id,
@@ -254,7 +260,8 @@ registerCallAction("reject", {
     sequence: 140,
     sequenceGroup: 300,
     tags: [ACTION_TAGS.JOIN_LEAVE_CALL, ACTION_TAGS.DANGER],
-});
+};
+registerCallAction("reject", rejectAction);
 registerCallAction("disconnect", {
     condition: ({ store, thread }) =>
         thread?.eq(store.rtc?.channel) && !thread?.self_member_id?.rtc_inviting_session_id,

--- a/addons/mail/static/src/discuss/call/common/call_invitation.dark.scss
+++ b/addons/mail/static/src/discuss/call/common/call_invitation.dark.scss
@@ -1,0 +1,3 @@
+.o-discuss-CallInvitation {
+    background-color: $meeting-view-bg;
+}

--- a/addons/mail/static/src/discuss/call/common/call_invitation.js
+++ b/addons/mail/static/src/discuss/call/common/call_invitation.js
@@ -1,78 +1,138 @@
-import { Component, onWillUnmount, useRef, useState, useSubEnv } from "@odoo/owl";
-
+import { Action, ACTION_TAGS } from "@mail/core/common/action";
 import { ActionList } from "@mail/core/common/action_list";
+import {
+    acceptWithCamera,
+    CallAction,
+    joinAction,
+    rejectAction,
+} from "@mail/discuss/call/common/call_actions";
+import { CallPreview } from "@mail/discuss/call/common/call_preview";
+
+import { Component, useState, useSubEnv } from "@odoo/owl";
+
+import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
-import { useCallActions } from "@mail/discuss/call/common/call_actions";
 
 export class CallInvitation extends Component {
     static props = ["thread"];
     static template = "discuss.CallInvitation";
-    static components = { ActionList };
+    static components = { ActionList, CallPreview };
 
     setup() {
         super.setup();
         this.rtc = useService("discuss.rtc");
+        this.store = useService("mail.store");
         this.ui = useService("ui");
-        this.state = useState({ videoStream: null });
-        this.videoRef = useRef("video");
-        this.callActions = useCallActions({ thread: () => this.props.thread });
+        this.state = useState({
+            activateCamera: 0,
+            activateMicrophone: 0,
+            showCameraPreview: false,
+            hasCamera: false,
+            hasMicrophone: this.rtc.microphonePermission === "granted",
+        });
         useSubEnv({ inCallInvitation: true });
-        onWillUnmount(() => {
-            if (!this.state.videoStream) {
-                return;
-            }
-            this.stopTracksOnMediaStream(this.state.videoStream);
+    }
+
+    joinCall() {
+        this.rtc.toggleCall(this.props.thread, {
+            audio: this.state.hasMicrophone,
+            camera: this.state.hasCamera,
         });
     }
 
-    async onClickAccept(ev, { camera = false } = {}) {
-        this.props.thread.open({ focus: true });
-        if (this.rtc.state.hasPendingRequest) {
-            return;
-        }
-        await this.rtc.toggleCall(this.props.thread, { camera });
+    get acceptOrRejectActions() {
+        const joinUpdated = {
+            ...joinAction,
+            btnClass: joinAction.btnClass + " o-me-0_5",
+            onSelected: () => this.joinCall(),
+        };
+        const acceptWithCameraUpdated = {
+            ...acceptWithCamera,
+            btnClass: acceptWithCamera.btnClass + " o-me-0_5",
+            onSelected: () => {
+                this.state.hasCamera = true;
+                this.joinCall();
+            },
+            condition: true,
+        };
+        return [
+            new CallAction({
+                id: "accept-with-camera",
+                definition: acceptWithCameraUpdated,
+                owner: this,
+                store: this.store,
+                thread: this.props.thread,
+            }),
+            new CallAction({
+                id: "join",
+                definition: joinUpdated,
+                owner: this,
+                store: this.store,
+                thread: this.props.thread,
+            }),
+            new CallAction({
+                id: "reject",
+                definition: rejectAction,
+                owner: this,
+                store: this.store,
+                thread: this.props.thread,
+            }),
+        ];
     }
 
-    onClickAvatar(ev) {
-        this.props.thread.open({ focus: true });
+    get otherActions() {
+        return [
+            new Action({
+                id: "toggle-camera-preview",
+                definition: {
+                    name: () =>
+                        this.state.showCameraPreview
+                            ? _t("Hide camera preview")
+                            : _t("Show camera preview"),
+                    icon: () =>
+                        this.state.showCameraPreview ? "fa fa-chevron-up" : "fa fa-chevron-down",
+                    onSelected: () => {
+                        this.state.showCameraPreview = !this.state.showCameraPreview;
+                        if (this.rtc.cameraPermission !== "denied") {
+                            this.state.activateCamera++;
+                        }
+                        if (this.state.hasMicrophone) {
+                            this.state.activateMicrophone++;
+                        }
+                    },
+                    tags: () => [ACTION_TAGS.CALL_LAYOUT],
+                },
+                store: this.store,
+            }),
+        ];
     }
 
-    get hasRtcSupport() {
-        return Boolean(
-            navigator.mediaDevices && navigator.mediaDevices.getUserMedia && window.MediaStream
-        );
+    get avatarTitle() {
+        const channelName = this.props.thread.displayName;
+        if (this.props.thread.channel_type === "chat") {
+            return _t("View chat with %(channel_name)s", { channel_name: channelName });
+        }
+        return _t("View the %(channel_name)s channel", { channel_name: channelName });
     }
 
-    onClickPreviewCamera() {
-        this.enableVideo();
+    get inviter() {
+        return this.props.thread.self_member_id?.rtc_inviting_session_id?.channel_member_id;
     }
 
-    async enableVideo() {
-        if (!this.hasRtcSupport) {
-            return;
+    get incomingCallText() {
+        if (this.props.thread.channel_type === "chat" || !this.inviter) {
+            return _t("Incoming call");
         }
-        try {
-            this.state.videoStream = await navigator.mediaDevices.getUserMedia({ video: true });
-            this.videoRef.el.srcObject = this.state.videoStream;
-        } catch {
-            // TODO: display popup asking the user to re-enable their camera
-        }
+        return _t("Incoming call from %(inviter)s", { inviter: this.inviter.name });
     }
 
-    /** @param {MediaStream} mediaStream */
-    stopTracksOnMediaStream(mediaStream) {
-        if (!mediaStream) {
-            return;
+    /** @param {{ microphone?: boolean, camera?: boolean }} settings */
+    onCallSettingsChanged(settings) {
+        if (settings.microphone !== undefined) {
+            this.state.hasMicrophone = settings.microphone;
         }
-        for (const track of mediaStream.getTracks()) {
-            track.stop();
+        if (settings.camera !== undefined) {
+            this.state.hasCamera = settings.camera;
         }
-    }
-
-    onClickRefuse(ev) {
-        if (this.rtc.state.hasPendingRequest) {
-            return;
-        }
-        this.rtc.leaveCall(this.props.thread);
     }
 }

--- a/addons/mail/static/src/discuss/call/common/call_invitation.scss
+++ b/addons/mail/static/src/discuss/call/common/call_invitation.scss
@@ -1,24 +1,32 @@
+$expand-curve: cubic-bezier(0.22, 1, 0.36, 1);
+
 .o-discuss-CallInvitation {
-    background-color: #000;
+    background-color: var(--o-discuss-Call-bgColor, #{$dark});
     color: #fff;
-    border-color: $gray-300 !important;
+    width: MIN(400px, 92vw);
+    transition: width 0.45s $expand-curve;
 
-    &.o-cameraPreview {
-        aspect-ratio: 16 / 9;
-        width: Min(720px, 92vw);
+    &.o-chat {
+    width: MIN(350px, 92vw);
     }
 
-    button {
-        aspect-ratio: 1;
+    &.o-preview-open {
+        width: MIN(500px, 92vw);
     }
+}
 
-    img {
-        aspect-ratio: 1;
-        width: 75px;
-        border: 3px solid gray;
-    }
+.o-mail-CallInvitation-avatar {
+    width: 40px;
+    height: 40px;
+    --pulse-spread-radius: 0.6rem;
+    animation: pulse 1s cubic-bezier(0.4, 0, 0.6, 1) infinite alternate;
+}
 
-    &.o-cameraPreview img {
-        width: 50px;
+.o-discuss-CallInvitation-cameraPreview {
+    max-height: 0;
+
+    &.o-opened {
+        transition: max-height 0.45s $expand-curve;
+        max-height: 500px;
     }
 }

--- a/addons/mail/static/src/discuss/call/common/call_invitation.xml
+++ b/addons/mail/static/src/discuss/call/common/call_invitation.xml
@@ -2,38 +2,30 @@
 <templates xml:space="preserve">
 
     <t t-name="discuss.CallInvitation">
-        <div class="o-discuss-CallInvitation d-flex flex-column m-2 rounded-3 border align-items-center position-relative" t-attf-class="{{ className }}" t-ref="root" t-att-class="{
-            'o-cameraPreview': state.videoStream,
-        }">
-            <div class="position-relative d-flex justify-content-center position-absolute h-100 w-100 rounded-3">
-                <video class="shadow rounded h-100 w-100 object-fit-cover rounded-3" autoplay="" t-ref="video"/>
-            </div>
-            <div t-if="props.thread.self_member_id?.rtc_inviting_session_id" class="o-discuss-CallInvitation-correspondent d-flex justify-content-around align-items-center text-nowrap px-3 mb-2 z-1" t-att-class="{
-                'align-self-start mt-3': state.videoStream,
-                'flex-column mt-4': !state.videoStream,
-            }">
-                <img class="o-discuss-CallInvitation-avatar mb-2 rounded-circle cursor-pointer object-fit-cover"
-                    t-att-src="props.thread.self_member_id?.rtc_inviting_session_id?.channel_member_id.avatarUrl"
-                    t-on-click="onClickAvatar"
-                    alt="Avatar"/>
-                <div class="d-flex pb-2 flex-column" t-att-class="{
-                    'justify-content-start ps-2': state.videoStream,
-                    'justify-content-center': !state.videoStream,
-                }">
-                    <span class="w-100 fw-bolder text-truncate overflow-hidden" t-att-class="{ 'text-center': !state.videoStream }" t-esc="props.thread.self_member_id?.rtc_inviting_session_id.channel_member_id.name"/>
-                    <span class="opacity-75 smaller">
-                        <t t-if="props.thread.self_member_id?.rtc_inviting_session_id?.is_camera_on">Incoming Video Call...</t>
-                        <t t-else="">Incoming Call...</t>
-                    </span>
+        <div class="o-discuss-CallInvitation align-self-center o-rounded-bubble overflow-hidden shadow-sm" t-att-class="{'o-preview-open': state.showCameraPreview, 'o-chat': props.thread.channel_type === 'chat', 'border border-light': !store.isOdooWhiteTheme}">
+            <div class="d-flex flex-colum d-flex flex-column">
+                <div class="o-discuss-CallInvitation-main" t-ref="root">
+                    <div class="ms-1 position-relative d-flex justify-content-between p-2">
+                        <div class="d-flex align-items-center" style="min-width: 0;">
+                            <div class="o-mail-CallInvitation-avatar flex-shrink-0 cursor-pointer d-flex align-items-center justify-content-center rounded-circle overflow-hidden" t-att-class="{'bg-primary': !inviter}" t-on-click="() => props.thread.open()" t-att-title="avatarTitle">
+                                <img t-if="inviter" class="object-fit-cover h-100 w-100" t-att-src="inviter.avatarUrl" alt="Avatar"/>
+                                <i t-else="" class="fa fa-phone"/>
+                            </div>
+                            <div class="ms-2 me-3 flex-grow-1 overflow-hidden">
+                                <p class="o-discuss-CallInvitation-channelName m-0 fw-bold small text-truncate" t-esc="props.thread.displayName"/>
+                                <p class="o-discuss-CallInvitation-description m-0 fst-italic smaller text-truncate pe-1" t-esc="incomingCallText"/>
+                            </div>
+                        </div>
+                        <div class="d-flex align-items-center flex-shrink-0">
+                            <ActionList actions="acceptOrRejectActions" inline="true" hasBtnBg="true"/>
+                            <ActionList actions="otherActions" inline="true"/>
+                        </div>
+                    </div>
+                    <div class="o-discuss-CallInvitation-cameraPreview" t-att-class="{'o-opened': state.showCameraPreview}">
+                        <CallPreview activateCamera="state.activateCamera" activateMicrophone="state.activateMicrophone" onSettingsChanged="(settings) => this.onCallSettingsChanged(settings)"/>
+                    </div>
                 </div>
-            </div>
-            <div class="d-flex justify-content-center align-items-center w-100 px-3 mt-auto gap-2 z-1" t-att-class="{ 'pb-3': state.videoStream }">
-                <ActionList actions="callActions.actions" inline="true" hasBtnBg="true"/>
-            </div>
-            <div t-if="!state.videoStream" class="py-3 z-1">
-                <span class="fw-bold smaller px-3 opacity-50 opacity-75-hover cursor-pointer" t-on-click="onClickPreviewCamera">Preview my camera</span>
             </div>
         </div>
     </t>
-
 </templates>

--- a/addons/mail/static/src/discuss/call/common/call_preview.js
+++ b/addons/mail/static/src/discuss/call/common/call_preview.js
@@ -1,0 +1,284 @@
+import { Action, ACTION_TAGS } from "@mail/core/common/action";
+import { ActionList } from "@mail/core/common/action_list";
+import {
+    blurBackgroundAction,
+    cameraOnAction,
+    muteAction,
+} from "@mail/discuss/call/common/call_actions";
+import { CallPermissionDialog } from "@mail/discuss/call/common/call_permission_dialog";
+import { closeStream, onChange } from "@mail/utils/common/misc";
+
+import { Component, onWillDestroy, status, useEffect, useRef, useState } from "@odoo/owl";
+
+import { _t } from "@web/core/l10n/translation";
+import { useService } from "@web/core/utils/hooks";
+
+/**
+ * @typedef {Object} Props
+ * @property {Number} [activateCamera]
+ * @property {Number} [activateMicrophone]
+ * @property {({ microphone?: boolean, camera?: boolean }) => void} [onSettingsChanged]
+ * @extends {Component<Props, Env>}
+ */
+export class CallPreview extends Component {
+    static template = "mail.CallPreview";
+    static props = ["activateCamera?", "activateMicrophone?", "onSettingsChanged?"];
+    static components = { ActionList };
+
+    setup() {
+        this.dialog = useService("dialog");
+        this.rtc = useService("discuss.rtc");
+        this.store = useService("mail.store");
+        this.state = useState({ audioStream: null, blurManager: null, videoStream: null });
+        this.audioRef = useRef("audio");
+        this.videoRef = useRef("video");
+        useEffect(
+            (videoEl, audioEl, audioStream, videoStream, blurStream) => {
+                if (audioEl && !audioEl.srcObject && audioStream) {
+                    audioEl.srcObject = audioStream;
+                }
+                if (videoEl && !videoEl.srcObject && videoStream) {
+                    videoEl.srcObject = blurStream ?? videoStream;
+                }
+            },
+            () => [
+                this.videoRef.el,
+                this.audioRef.el,
+                this.state.audioStream,
+                this.state.videoStream,
+                this.state.blurManager?.stream,
+            ]
+        );
+        if (this.hasRtcSupport) {
+            onChange(this.rtc, "microphonePermission", () => {
+                if (this.rtc.microphonePermission !== "granted") {
+                    this.disableMicrophone();
+                }
+            });
+            onChange(this.rtc, "cameraPermission", () => {
+                if (this.rtc.cameraPermission !== "granted") {
+                    this.disableCamera();
+                }
+            });
+            onChange(this.store.settings, "audioInputDeviceId", () => {
+                if (this.state.audioStream) {
+                    closeStream(this.state.audioStream);
+                    this.enableMicrophone();
+                }
+            });
+            onChange(this.store.settings, "cameraInputDeviceId", () => {
+                if (this.state.videoStream) {
+                    closeStream(this.state.videoStream);
+                    this.enableCamera();
+                }
+            });
+            onChange(this.store.settings, "audioOutputDeviceId", (deviceId) => {
+                this.audioRef.el?.setSinkId?.(deviceId).catch(() => {});
+            });
+            onWillDestroy(() => {
+                closeStream(this.state.audioStream);
+                closeStream(this.state.videoStream);
+            });
+            useEffect(
+                (activateCamera) => {
+                    if (activateCamera > 0 && !this.state.videoStream) {
+                        this.enableCamera();
+                    }
+                },
+                () => [this.props.activateCamera]
+            );
+            useEffect(
+                (activateMicrophone) => {
+                    if (activateMicrophone > 0 && !this.state.audioStream) {
+                        this.enableMicrophone();
+                    }
+                },
+                () => [this.props.activateMicrophone]
+            );
+        }
+    }
+
+    get hasRtcSupport() {
+        return Boolean(
+            navigator.mediaDevices && navigator.mediaDevices.getUserMedia && window.MediaStream
+        );
+    }
+
+    get actions() {
+        const cameraOnActionUpdated = {
+            ...cameraOnAction,
+            name: () => (this.state.videoStream ? _t("Stop camera") : _t("Turn camera on")),
+            isActive: () => this.state.videoStream,
+            onSelected: () => this.toggleCamera(),
+            tags: (...args) => {
+                const tags = cameraOnAction.tags?.(...args) ?? [];
+                if (!args[0].action.isActive) {
+                    tags.push(ACTION_TAGS.DANGER);
+                }
+                return tags;
+            },
+        };
+        const muteActionUpdated = {
+            ...muteAction,
+            isActive: () => !this.state.audioStream,
+            name: ({ action }) => (action.isActive ? _t("Unmute") : _t("Mute")),
+            onSelected: () => this.toggleMic(),
+        };
+        const blurActionUpdated = {
+            ...blurBackgroundAction,
+            isActive: () => this.state.blurManager,
+            disabledCondition: () => !this.state.videoStream,
+            onSelected: () => this.toggleBlur(),
+            tags: ({ action }) => (action.isActive ? [ACTION_TAGS.SUCCESS] : []),
+        };
+        return [
+            new Action({
+                id: "toggle-microphone",
+                owner: this,
+                definition: muteActionUpdated,
+                store: this.store,
+            }),
+            new Action({
+                id: "toggle-camera",
+                owner: this,
+                definition: cameraOnActionUpdated,
+                store: this.store,
+            }),
+            new Action({
+                id: "toggle-blur",
+                owner: this,
+                definition: blurActionUpdated,
+                store: this.store,
+            }),
+        ];
+    }
+
+    async enableMicrophone() {
+        if (
+            this.rtc.microphonePermission !== "granted" &&
+            !(await this.rtc.askForBrowserPermission({ audio: true }))
+        ) {
+            return;
+        }
+        this.state.audioStream = await navigator.mediaDevices.getUserMedia({
+            audio: this.store.settings.audioConstraints,
+        });
+        if (status(this) === "destroyed") {
+            closeStream(this.state.audioStream);
+            return;
+        }
+        if (this.audioRef.el) {
+            this.audioRef.el.srcObject = this.state.audioStream;
+        }
+        this.props.onSettingsChanged?.({ microphone: true });
+    }
+
+    disableMicrophone() {
+        closeStream(this.state.audioStream);
+        this.state.audioStream = null;
+        if (this.audioRef.el) {
+            this.audioRef.el.srcObject = null;
+        }
+        this.props.onSettingsChanged?.({ microphone: false });
+    }
+
+    async toggleMic() {
+        if (this.state.audioStream) {
+            this.disableMicrophone();
+            return;
+        }
+        if (this.rtc.microphonePermission === "prompt") {
+            this.dialog.add(CallPermissionDialog, {
+                media: "microphone",
+                useMicrophone: () => this.enableMicrophone(),
+                useCamera: () => this.enableCamera(),
+            });
+            return;
+        }
+        await this.enableMicrophone();
+    }
+
+    async enableCamera() {
+        if (
+            this.rtc.cameraPermission !== "granted" &&
+            !(await this.rtc.askForBrowserPermission({ video: true }))
+        ) {
+            return;
+        }
+        this.state.videoStream = await navigator.mediaDevices.getUserMedia({
+            video: this.store.settings.cameraConstraints,
+        });
+        if (!this.videoRef.el) {
+            return;
+        }
+        if (status(this) === "destroyed") {
+            closeStream(this.state.videoStream);
+            return;
+        }
+        if (this.videoRef.el) {
+            this.videoRef.el.srcObject = this.state.videoStream;
+        }
+        this.props.onSettingsChanged?.({ camera: true });
+        if (this.store.settings.useBlur) {
+            await this.enableBlur();
+        }
+    }
+
+    disableCamera() {
+        closeStream(this.state.videoStream);
+        this.state.videoStream = null;
+        this.state.blurManager?.close();
+        this.state.blurManager = undefined;
+        if (this.videoRef.el) {
+            this.videoRef.el.srcObject = null;
+        }
+        this.props.onSettingsChanged?.({ camera: false });
+    }
+
+    async toggleCamera() {
+        if (this.state.videoStream) {
+            this.disableCamera();
+            return;
+        }
+        if (this.rtc.cameraPermission === "prompt") {
+            this.dialog.add(CallPermissionDialog, {
+                media: "camera",
+                useMicrophone: () => this.enableMicrophone(),
+                useCamera: () => this.enableCamera(),
+            });
+            return;
+        }
+        await this.enableCamera();
+    }
+
+    async enableBlur() {
+        this.store.settings.useBlur = true;
+        if (!this.videoRef.el) {
+            return;
+        }
+        try {
+            this.state.blurManager = await this.rtc.applyBlurEffect(this.state.videoStream);
+            this.videoRef.el.srcObject = this.state.blurManager.stream;
+        } catch (_e) {
+            this.notification.add(_e.message, { type: "warning" });
+            this.disableBlur();
+        }
+    }
+
+    disableBlur() {
+        this.store.settings.useBlur = false;
+        if (this.videoRef.el) {
+            this.videoRef.el.srcObject = this.state.videoStream;
+        }
+        this.state.blurManager?.close();
+        this.state.blurManager = undefined;
+    }
+
+    toggleBlur() {
+        if (this.state.blurManager) {
+            this.disableBlur();
+            return;
+        }
+        this.enableBlur();
+    }
+}

--- a/addons/mail/static/src/discuss/call/common/call_preview.xml
+++ b/addons/mail/static/src/discuss/call/common/call_preview.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="mail.CallPreview">
+        <div class="o-mail-CallPreview ratio ratio-16x9">
+            <div class="bg-dark">
+                <video class="object-fit-cover h-100 w-100" autoplay="" style="background-color: rgba(0, 0, 0, 0.5);" t-ref="video"/>
+                <div class="position-absolute bottom-0 mb-3 w-100 d-flex justify-content-center">
+                    <ActionList actions="actions" inline="true" hasBtnBg="true"/>
+                </div>
+            </div>
+            <audio autoplay="" t-ref="audio"/>
+        </div>
+    </t>
+</templates>

--- a/addons/mail/static/src/discuss/call/common/channel_member_patch.js
+++ b/addons/mail/static/src/discuss/call/common/channel_member_patch.js
@@ -4,6 +4,7 @@ import { fields } from "@mail/core/common/record";
 import { browser } from "@web/core/browser/browser";
 import { patch } from "@web/core/utils/patch";
 
+ChannelMember.CANCEL_CALL_INVITE_DELAY = 30000;
 /** @type {import("models").ChannelMember} */
 const ChannelMemberPatch = {
     setup() {
@@ -18,7 +19,7 @@ const ChannelMemberPatch = {
                 this.store.ringingThreads.add(this.channel_id);
                 this.channel_id.cancelRtcInvitationTimeout = browser.setTimeout(() => {
                     this.store.env.services["discuss.rtc"].leaveCall(this.channel_id);
-                }, 30000);
+                }, ChannelMember.CANCEL_CALL_INVITE_DELAY);
             },
             /** @this {import("models").ChannelMember} */
             onDelete() {

--- a/addons/mail/static/src/discuss/call/common/meeting.scss
+++ b/addons/mail/static/src/discuss/call/common/meeting.scss
@@ -1,5 +1,6 @@
+$meeting-view-bg: #111827;
 .o-mail-Meeting {
-    background-color: #111827;
+    background-color: $meeting-view-bg;
 }
 
 .o-overlay-item:has(.o-mail-Meeting) {

--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -395,14 +395,6 @@ export class Rtc extends Record {
             isFullscreen: false,
         });
         this.blurManager = undefined;
-        browser.navigator.permissions?.query({ name: "microphone" }).then((status) => {
-            this.microphonePermission = status.state;
-            status.onchange = () => (this.microphonePermission = status.state);
-        });
-        browser.navigator.permissions?.query({ name: "camera" }).then((status) => {
-            this.cameraPermission = status.state;
-            status.onchange = () => (this.cameraPermission = status.state);
-        });
     }
 
     start() {
@@ -2362,6 +2354,14 @@ export const rtcService = {
                     rtc.state.screenTrack.enabled = true;
                 }
             }
+        });
+        browser.navigator.permissions?.query({ name: "microphone" }).then((status) => {
+            rtc.microphonePermission = status.state;
+            status.onchange = () => (rtc.microphonePermission = status.state);
+        });
+        browser.navigator.permissions?.query({ name: "camera" }).then((status) => {
+            rtc.cameraPermission = status.state;
+            status.onchange = () => (rtc.cameraPermission = status.state);
         });
         rtc.p2pService = services["discuss.p2p"];
         rtc.p2pService.acceptOffer = async (id, sequence) => {

--- a/addons/mail/static/src/discuss/core/public/welcome_page.js
+++ b/addons/mail/static/src/discuss/core/public/welcome_page.js
@@ -1,58 +1,28 @@
-import { Component, useEffect, useRef, useState } from "@odoo/owl";
-
+import { CallPreview } from "@mail/discuss/call/common/call_preview";
 import { DeviceSelect } from "@mail/discuss/call/common/device_select";
+
+import { Component, useState } from "@odoo/owl";
+
 import { browser } from "@web/core/browser/browser";
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
-import { CallPermissionDialog } from "@mail/discuss/call/common/call_permission_dialog";
 
 export class WelcomePage extends Component {
     static props = ["proceed?"];
     static template = "mail.WelcomePage";
-    static components = { DeviceSelect };
-
-    /** @type {BlurManager} */
-    blurManager;
+    static components = { CallPreview, DeviceSelect };
 
     setup() {
         super.setup();
         this.isClosed = false;
-        this.dialog = useService("dialog");
         this.store = useService("mail.store");
         this.ui = useService("ui");
-        this.notification = useService("notification");
         this.rtc = useService("discuss.rtc");
         this.state = useState({
             userName: this.store.self.name || _t("Guest"),
-            audioStream: null,
-            videoStream: null,
+            hasMicrophone: undefined,
+            hasCamera: undefined,
         });
-        this.audioRef = useRef("audio");
-        this.videoRef = useRef("video");
-        useEffect(
-            () => {
-                if (this.state.audioStream) {
-                    this.stopTracksOnMediaStream(this.state.audioStream);
-                    this.enableMicrophone();
-                }
-            },
-            () => [this.store.settings.audioInputDeviceId]
-        );
-        useEffect(
-            () => {
-                if (this.state.videoStream) {
-                    this.stopTracksOnMediaStream(this.state.videoStream);
-                    this.enableVideo();
-                }
-            },
-            () => [this.store.settings.cameraInputDeviceId]
-        );
-        useEffect(
-            (deviceId) => {
-                this.audioRef.el?.setSinkId?.(deviceId).catch(() => {});
-            },
-            () => [this.store.settings.audioOutputDeviceId]
-        );
     }
 
     onKeydownInput(ev) {
@@ -65,136 +35,12 @@ export class WelcomePage extends Component {
         if (!this.store.self_partner) {
             this.store.self_guest?.updateGuestName(this.state.userName.trim());
         }
-        browser.localStorage.setItem("discuss_call_preview_join_mute", !this.state.audioStream);
+        browser.localStorage.setItem("discuss_call_preview_join_mute", !this.state.hasMicrophone);
         browser.localStorage.setItem(
             "discuss_call_preview_join_video",
-            Boolean(this.state.videoStream)
+            Boolean(this.state.hasCamera)
         );
-        this.stopTracksOnMediaStream(this.state.audioStream);
-        this.stopTracksOnMediaStream(this.state.videoStream);
-        this.blurManager?.close();
-        this.blurManager = undefined;
-        this.isClosed = true;
         this.props.proceed?.();
-    }
-
-    get hasRtcSupport() {
-        return Boolean(
-            navigator.mediaDevices && navigator.mediaDevices.getUserMedia && window.MediaStream
-        );
-    }
-
-    get blurButtonTitle() {
-        return this.store.settings.useBlur ? _t("Remove Blur Background") : _t("Blur Background");
-    }
-
-    async enableMicrophone() {
-        if (!this.hasRtcSupport || !(await this.rtc.askForBrowserPermission({ audio: true }))) {
-            return;
-        }
-        this.state.audioStream = await navigator.mediaDevices.getUserMedia({
-            audio: this.store.settings.audioConstraints,
-        });
-        this.audioRef.el.srcObject = this.state.audioStream;
-        if (this.isClosed) {
-            this.stopTracksOnMediaStream(this.state.audioStream);
-        }
-    }
-
-    disableMicrophone() {
-        this.audioRef.el.srcObject = null;
-        this.stopTracksOnMediaStream(this.state.audioStream);
-        this.state.audioStream = null;
-    }
-
-    async enableVideo() {
-        if (!this.hasRtcSupport || !(await this.rtc.askForBrowserPermission({ video: true }))) {
-            return;
-        }
-        this.state.videoStream = await navigator.mediaDevices.getUserMedia({
-            video: this.store.settings.cameraConstraints,
-        });
-        await this.applyBlurConditionally();
-        if (this.isClosed) {
-            this.stopTracksOnMediaStream(this.state.videoStream);
-        }
-    }
-
-    async onClickBlur() {
-        this.store.settings.useBlur = !this.store.settings.useBlur;
-        await this.applyBlurConditionally();
-    }
-
-    async applyBlurConditionally() {
-        if (!this.state.videoStream) {
-            return;
-        }
-        if (!this.store.settings.useBlur) {
-            this.videoRef.el.srcObject = this.state.videoStream;
-            return;
-        }
-        this.blurManager?.close();
-        this.blurManager = undefined;
-        try {
-            this.blurManager = await this.rtc.applyBlurEffect(this.state.videoStream);
-            this.videoRef.el.srcObject = this.blurManager.stream;
-        } catch (_e) {
-            this.notification.add(_e.message, { type: "warning" });
-            this.store.settings.useBlur = false;
-            this.videoRef.el.srcObject = this.state.videoStream;
-        }
-    }
-
-    disableVideo() {
-        this.videoRef.el.srcObject = null;
-        this.stopTracksOnMediaStream(this.state.videoStream);
-        this.state.videoStream = null;
-        this.blurManager?.close();
-        this.blurManager = undefined;
-    }
-
-    /**
-     * @param {MediaStream} mediaStream
-     */
-    stopTracksOnMediaStream(mediaStream) {
-        if (!mediaStream) {
-            return;
-        }
-        for (const track of mediaStream.getTracks()) {
-            track.stop();
-        }
-    }
-
-    async onClickMic() {
-        if (this.state.audioStream) {
-            this.disableMicrophone();
-            return;
-        }
-        if (this.rtc.microphonePermission === "prompt") {
-            this.dialog.add(CallPermissionDialog, {
-                media: "microphone",
-                useMicrophone: () => this.enableMicrophone(),
-                useCamera: () => this.enableVideo(),
-            });
-            return;
-        }
-        await this.enableMicrophone();
-    }
-
-    async onClickVideo() {
-        if (this.state.videoStream) {
-            this.disableVideo();
-            return;
-        }
-        if (this.rtc.cameraPermission === "prompt") {
-            this.dialog.add(CallPermissionDialog, {
-                media: "camera",
-                useMicrophone: () => this.enableMicrophone(),
-                useCamera: () => this.enableVideo(),
-            });
-            return;
-        }
-        await this.enableVideo();
     }
 
     getLoggedInAsText() {
@@ -203,5 +49,15 @@ export class WelcomePage extends Component {
 
     get noActiveParticipants() {
         return !this.store.discuss.thread.rtc_session_ids.length;
+    }
+
+    /** @param {{ microphone?: boolean, camera?: boolean }} settings */
+    onCallSettingsChanged(settings) {
+        if (settings.microphone !== undefined) {
+            this.state.hasMicrophone = settings.microphone;
+        }
+        if (settings.camera !== undefined) {
+            this.state.hasCamera = settings.camera;
+        }
     }
 }

--- a/addons/mail/static/src/discuss/core/public/welcome_page.xml
+++ b/addons/mail/static/src/discuss/core/public/welcome_page.xml
@@ -10,34 +10,8 @@
         </h1>
         <h2 class="m-3 m-md-5" t-esc="store.companyName"/>
         <div class="w-100 d-flex justify-content-center gap-5" t-att-class="{'flex-column': ui.isSmall}">
-            <div t-if="showCallPreview" class="w-100 align-self-center" style="max-width: 640px;">
-                <div class="position-relative d-flex flex-column align-items-center" t-ref="root">
-                    <video class="shadow rounded-3 bg-dark object-fit-contain" t-attf-height="{{ui.isSmall ? 240 : 360}}" width="100%" autoplay="" t-ref="video"/>
-                    <p t-if="hasRtcSupport and !state.videoStream" class="position-absolute bottom-50 text-light">
-                        Camera is off
-                    </p>
-                    <p t-if="!hasRtcSupport" class="position-absolute bottom-50 text-light">
-                        Your browser does not support videoconference
-                    </p>
-                    <div class="position-absolute d-flex gap-3 mb-3 bottom-0">
-                        <button class="btn fa-stack p-0 rounded-circle fs-2 shadow" t-attf-class="{{ state.audioStream ? 'btn-dark' : 'btn-danger' }}" t-on-click="onClickMic">
-                            <i class="fa" t-attf-class="{{ state.audioStream ? 'fa-microphone' : 'fa-microphone-slash' }}"/>
-                            <span t-if="rtc.microphonePermission !== 'granted'" class="position-absolute text-dark fw-bolder mt-1 start-100 translate-middle p-1 badge rounded-circle bg-warning">
-                                <i class="fa fa-exclamation-triangle"/>
-                            </span>
-                        </button>
-                        <button class="btn fa-stack p-0 rounded-circle fs-2 shadow" t-attf-class="{{ state.videoStream ? 'btn-dark' : 'btn-danger' }}" t-on-click="onClickVideo">
-                            <i class="fa fa-camera"/>
-                            <span t-if="rtc.cameraPermission !== 'granted'" class="position-absolute text-dark fw-bolder mt-1 start-100 translate-middle p-1 badge rounded-circle bg-warning">
-                                <i class="fa fa-exclamation-triangle"/>
-                            </span>
-                        </button>
-                        <button t-if="state.videoStream" class="btn fa-stack p-0 rounded-circle fs-2 shadow" t-attf-class="{{ store.settings.useBlur ? 'btn-secondary' : 'btn-dark' }}" t-on-click="onClickBlur" t-att-title="blurButtonTitle">
-                            <i class="fa fa-photo" t-att-class="{ 'opacity-50': !store.settings.useBlur }"/>
-                        </button>
-                    </div>
-                    <audio autoplay="" t-ref="audio"/>
-                </div>
+            <div t-if="showCallPreview" class="w-100 rounded-3 overflow-hidden" style="max-width: 640px;">
+                <CallPreview onSettingsChanged="(settings) => this.onCallSettingsChanged(settings)"/>
                 <div class="d-flex flex-column flex-md-row gap-2 text-muted mt-3">
                     <div class="w-100 text-uppercase">
                         <i class="fa fa-microphone"></i> Microphone

--- a/addons/mail/static/tests/tours/discuss_call_invitation_tour.js
+++ b/addons/mail/static/tests/tours/discuss_call_invitation_tour.js
@@ -1,0 +1,59 @@
+import { ChannelMember } from "@mail/discuss/core/common/channel_member_model";
+
+import { registry } from "@web/core/registry";
+import { patchWithCleanup } from "@web/../tests/helpers/utils";
+
+registry.category("web_tour.tours").add("discuss_call_invitation.js", {
+    steps: () => {
+        // Call invitation is cancelled after 30s. Increase this delay for the test.
+        patchWithCleanup(ChannelMember, { CANCEL_CALL_INVITE_DELAY: 1e6 });
+        return [
+            { trigger: ".o-discuss-CallInvitation" },
+            {
+                trigger:
+                    ".o-mail-CallInvitation-avatar[title='View the bob (base.group_user) and john (base.group_user) channel']",
+            },
+            {
+                trigger:
+                    ".o-discuss-CallInvitation-channelName:contains('bob (base.group_user) and john (base.group_user)')",
+            },
+            {
+                trigger:
+                    ".o-discuss-CallInvitation-description:contains('Incoming call from bob (base.group_user)')",
+            },
+            {
+                trigger: ".o-discuss-CallInvitation-cameraPreview:not(:visible)",
+            },
+            {
+                trigger: ".o-discuss-CallInvitation button[title='Join Call']",
+            },
+            {
+                trigger: ".o-discuss-CallInvitation button[title='Reject']",
+            },
+            {
+                trigger: ".o-discuss-CallInvitation button[title='Show camera preview']",
+                run: "click",
+            },
+            {
+                trigger: ".o-discuss-CallInvitation-cameraPreview",
+            },
+            {
+                trigger: ".o-discuss-CallInvitation-cameraPreview button[title='Turn camera on']",
+            },
+            {
+                trigger: ".o-discuss-CallInvitation-cameraPreview button[title='Unmute']",
+            },
+            {
+                trigger:
+                    ".o-discuss-CallInvitation-cameraPreview button[title='Blur Background']:disabled",
+            },
+            {
+                trigger: ".o-discuss-CallInvitation button[title='Hide camera preview']",
+                run: "click",
+            },
+            {
+                trigger: ".o-discuss-CallInvitation-cameraPreview:not(:visible)",
+            },
+        ];
+    },
+});

--- a/addons/web/static/src/scss/animation.scss
+++ b/addons/web/static/src/scss/animation.scss
@@ -41,5 +41,5 @@
 // pulse effect
 @keyframes pulse {
     from { box-shadow: 0 0 0 0 var(--pulse-color-from, #{$primary}); }
-    to { box-shadow: 0 0 0 2em var(--pulse-color-to, #{rgba(#FFF, 0)}); }
+    to { box-shadow: 0 0 0 var(--pulse-spread-radius, 2em) var(--pulse-color-to, #{rgba(#FFF, 0)}); }
 }


### PR DESCRIPTION
Backport of https://github.com/odoo/odoo/pull/227998

The welcome page and the call invitation both provide a way to preview the camera before entering a call.

However, they have several issues:
- The call invitation does not provide a way to configure call settings.
- Both views are missing the blur setting.
- Each handles audio/video streams separately, which increases maintenance costs and leads to incomplete flows (e.g. missing warnings when permissions are denied).
- Neither relies on the call actions: the logic is duplicated and must be updated every time the call view is improved.

In addition, the call invitation takes up a lot of space and does not provide useful information such as the channel the user was invited to.

This commit improves both views by factoring out the setup logic into its own component, which is also responsible for handling video and audio streams.

At the same time, it reworks the call invitation to take up less space, allow configuring the call, and display additional information such as who is calling and on which channel.

task-5090396