### PR TITLE
[FIX] im_livechat: auto popup livechat delay

### DIFF
--- a/addons/im_livechat/static/src/embed/common/autopopup_service.js
+++ b/addons/im_livechat/static/src/embed/common/autopopup_service.js
@@ -18,13 +18,15 @@ export class AutopopupService {
         this.livechatService = livechatService;
         this.ui = ui;
 
-        browser.setTimeout(async () => {
-            await Promise.all([storeService.isReady, storeService.chatHub.initPromise]);
-            if (this.allowAutoPopup) {
-                expirableStorage.setItem(AutopopupService.STORAGE_KEY, true);
-                livechatService.open();
-            }
-        }, storeService.livechat_rule?.auto_popup_timer * 1000);
+        storeService.isReady.then(() => { 
+            browser.setTimeout(async () => {
+                await storeService.chatHub.initPromise;
+                if (this.allowAutoPopup) {
+                    expirableStorage.setItem(AutopopupService.STORAGE_KEY, true);
+                    livechatService.open();
+                }
+            }, storeService.livechat_rule?.auto_popup_timer * 1000);
+        });
     }
 
     get allowAutoPopup() {


### PR DESCRIPTION
### Issue:

The livechat delay doesn't work as expected.

#### To reproduce:
1- Create a livechat channel
2- In channel rules, set these rules:
   - Live Chat Button: Open automatically
   - Enable ChatBot: Always
   - Open automatically: 20
  
3- In widget tab, you can find channel URL, open it.
4- We expect it opens after 20s but it opens immediately

### Cause:

This issue is caused during refactoring: https://github.com/odoo/odoo/commit/6d903ccd0ad48fc8f58094b45f01656b1d47acfe https://github.com/odoo/odoo/blob/6d903ccd0ad48fc8f58094b45f01656b1d47acfe/addons/im_livechat/static/src/embed/common/autopopup_service.js#L21-L27 Here storeService promise is not ready yet but we are trying to use `storeService.livechat_rule?.auto_popup_timer` which is `Nan`, as a result the timeout will be 0, opening it without delay.

opw-4988003
