### PR TITLE
[IMP] l10n_be_hr_payroll: Refactor Group Insurance Export to standard views

### DIFF
--- a/addons/hr/__manifest__.py
+++ b/addons/hr/__manifest__.py
@@ -47,6 +47,7 @@
         'views/res_users.xml',
         'views/hr_templates.xml',
         'data/hr_data.xml',
+        'views/hr_export_mixin_views.xml',
     ],
     'demo': [
         'data/hr_demo.xml'

--- a/addons/hr/models/__init__.py
+++ b/addons/hr/models/__init__.py
@@ -25,3 +25,4 @@ from . import resource
 from . import resource_calendar
 from . import resource_calendar_leaves
 from . import ir_ui_menu
+from . import hr_export_mixin

--- a/addons/hr/models/hr_export_mixin.py
+++ b/addons/hr/models/hr_export_mixin.py
@@ -1,0 +1,106 @@
+from base64 import b64encode
+from dateutil.relativedelta import relativedelta
+
+from odoo import api, fields, models
+from odoo.exceptions import UserError
+from odoo.fields import Domain
+
+
+class HrExportMixin(models.AbstractModel):
+    _name = 'hr.export.mixin'
+    _description = 'HR Export Mixin'
+
+    @api.model
+    def _country_restriction(self):
+        return False
+
+    @api.model
+    def default_get(self, fields):
+        country_restriction = self._country_restriction()
+        if country_restriction and country_restriction not in self.env.companies.mapped('country_id.code'):
+            raise UserError(self.env._(
+                'You must be logged in a %(country_code)s company to use this feature',
+                country_code=country_restriction
+            ))
+        return super().default_get(fields)
+
+    def _get_company_domain(self):
+        domain = Domain('id', 'in', self.env.companies.ids)
+        if restriction := self._country_restriction():
+            domain &= Domain('country_id.code', '=', restriction)
+        return domain
+
+    period_start = fields.Date('Period Start', compute='_compute_period_dates', store=True, readonly=False)
+    period_stop = fields.Date('Period Stop', compute='_compute_period_dates', store=True, readonly=False)
+    export_file = fields.Binary('Export File', readonly=True)
+    export_filename = fields.Char('Export Filename', readonly=True)
+    company_id = fields.Many2one(
+        'res.company', domain=lambda self: self._get_company_domain(),
+        default=lambda self: self.env.company, required=True)
+    eligible_employee_line_ids = fields.One2many(
+        'hr.export.employee.mixin', 'export_id',
+        string='Eligible Employees')
+    eligible_employee_count = fields.Integer(
+        '#Employees', compute='_compute_eligible_employee_count')
+    creation_date = fields.Date(
+        string="Creation Date",
+        compute="_compute_creation_date",
+        store=False,
+    )
+    create_uid = fields.Many2one('res.users', index=True)
+
+    @api.depends('eligible_employee_line_ids')
+    def _compute_eligible_employee_count(self):
+        for export in self:
+            export.eligible_employee_count = len(export.eligible_employee_line_ids)
+
+    def _compute_period_dates(self):
+        for export in self:
+            export.period_start = fields.Date.today().replace(day=1)
+            export.period_stop = export.period_start + relativedelta(months=1, days=-1)
+
+    def _compute_creation_date(self):
+        for rec in self:
+            rec.creation_date = rec.create_date.date() if rec.create_date else False
+
+    def action_export_file(self):
+        self.ensure_one()
+        self._check_before_export()
+        file_content = self._generate_export_file()
+        filename = self._generate_export_filename()
+        self.write({
+            "export_file": b64encode(file_content),
+            "export_filename": filename,
+        })
+
+    def _check_before_export(self):
+        return True
+
+    def _generate_export_file(self):
+        raise NotImplementedError()
+
+    def _generate_export_filename(self):
+        raise NotImplementedError()
+
+    def action_open_employees(self):
+        self.ensure_one()
+        return {
+            'name': self.env._("Eligible Employees"),
+            'type': "ir.actions.act_window",
+            'res_model': self.eligible_employee_line_ids._name,
+            'view_mode': "list",
+            'domain': [('id', 'in', self.eligible_employee_line_ids.ids)],
+            'context': dict(self.env.context, default_export_id=self.id),
+        }
+
+    def action_populate(self):
+        raise NotImplementedError()
+
+
+class HrExportEmployeeMixin(models.AbstractModel):
+    _name = 'hr.export.employee.mixin'
+    _description = 'HR Export Employee'
+
+    export_id = fields.Many2one('hr.export.mixin', required=True, index=True, ondelete='cascade')
+    company_id = fields.Many2one(related='export_id.company_id', store=True, readonly=True)
+    employee_id = fields.Many2one('hr.employee', required=True, ondelete='cascade', check_company=True)

--- a/addons/hr/views/hr_export_mixin_views.xml
+++ b/addons/hr/views/hr_export_mixin_views.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="hr_export_mixin_form_view" model="ir.ui.view">
+        <field name="name">hr.export.mixin.form</field>
+        <field name="model">hr.export.mixin</field>
+        <field name="arch" type="xml">
+            <form string="HR Export">
+                <header>
+                    <button name="action_populate"
+                            type="object"
+                            string="Populate"
+                            class="btn-primary"
+                            data-hotkey="p"
+                            invisible="eligible_employee_count"/>
+                    <button name="action_export_file"
+                            type="object"
+                            string="Generate Export File"
+                            class="btn-primary"
+                            data-hotkey="z"
+                            invisible="export_file or not eligible_employee_count"/>
+                    <button name="action_populate"
+                            type="object"
+                            string="Populate"
+                            data-hotkey="p"
+                            invisible="not eligible_employee_count"/>
+                    <button name="action_export_file"
+                            type="object"
+                            string="Generate Export File"
+                            data-hotkey="z"
+                            invisible="not export_file or not eligible_employee_count"/>
+                </header>
+                <sheet>
+                    <div class="oe_button_box" name="button_box">
+                        <button name="action_open_employees"
+                                type="object"
+                                class="oe_stat_button"
+                                icon="fa-users">
+                            <div class="o_field_widget o_stat_info">
+                                <span class="o_stat_value"><field name="eligible_employee_count"/></span>
+                                <span class="o_stat_text">Eligible Employees</span>
+                            </div>
+                        </button>
+                    </div>
+                    <group name="export_group">
+                        <field name="export_filename" readonly="1" invisible="1"/>
+                        <field name="export_file" readonly="1" filename="export_filename" invisible="not export_file"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="hr_export_mixin_list_view" model="ir.ui.view">
+        <field name="name">hr.export.mixin.list</field>
+        <field name="model">hr.export.mixin</field>
+        <field name="arch" type="xml">
+            <list string="Export Employee">
+                <field name="create_uid" widget="many2one_avatar_user"/>
+                <field name="creation_date" />
+                <field name="period_start"/>
+                <field name="period_stop"/>
+                <field name="export_filename" column_invisible="True"/> <!-- needed for the widget -->
+                <field name="export_file" widget="binary" filename="export_filename"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="hr_export_employee_mixin_list_view" model="ir.ui.view">
+        <field name="name">hr.export.employee.list</field>
+        <field name="model">hr.export.employee.mixin</field>
+        <field name="arch" type="xml">
+            <list string="Eligible Employees" type="object" editable="top">
+                <field name="export_id" column_invisible="1"/>
+                <field name="employee_id" widget="many2one_avatar_employee"/>
+            </list>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
In this PR we:
- Converted the Group Insurance Export from a wizard-based flow into standard list and form views.
- Extracted common fields and views from both Group Insurance Export and HR Work Entry Export mixin into a new hr.export.mixin
- Updated Group Insurance Export and HR Work Entry Export to inherit from hr.export.mixin and override their views.
- Related task: 5010866.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
