### PR TITLE
[FIX] web: support many2many filters in calendar arch

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_model.js
+++ b/addons/web/static/src/views/calendar/calendar_model.js
@@ -13,7 +13,7 @@ import { Model } from "@web/model/model";
 import { extractFieldsFromArchInfo } from "@web/model/relational_model/utils";
 import { browser } from "@web/core/browser/browser";
 import { makeContext } from "@web/core/context";
-import { groupBy } from "@web/core/utils/arrays";
+import { groupBy, intersection } from "@web/core/utils/arrays";
 import { Cache } from "@web/core/utils/cache";
 import { formatFloat } from "@web/core/utils/numbers";
 import { useDebounced } from "@web/core/utils/timing";
@@ -442,28 +442,27 @@ export class CalendarModel extends Model {
         Object.assign(data.filterSections, dynamicSections);
 
         // Remove records that don't match dynamic filters
-        for (const [recordId, record] of Object.entries(data.records)) {
-            for (const [fieldName, filterInfo] of Object.entries(dynamicSections)) {
-                const field = this.meta.fields[fieldName];
-                if (!field) {
-                    continue;
+        for (const [fieldName, filterInfo] of Object.entries(dynamicSections)) {
+            const field = this.meta.fields[fieldName];
+            if (!field) {
+                continue;
+            }
+            const inactiveFilters = filterInfo.filters.filter((f) => !f.active);
+            if (!inactiveFilters.length) {
+                continue;
+            }
+            for (const [recordId, record] of Object.entries(data.records)) {
+                const rawValue = record.rawRecord[fieldName];
+                let remove = false;
+                if (["many2many", "one2many"].includes(field.type)) {
+                    const inactiveFilterVals = inactiveFilters.map((filter) => filter.value);
+                    remove = intersection(rawValue, inactiveFilterVals).length === rawValue.length;
+                } else {
+                    const recordValue = Array.isArray(rawValue) ? rawValue[0] : rawValue;
+                    remove = inactiveFilters.some((filter) => filter.value === recordValue);
                 }
-                const isX2Many = ["many2many", "one2many"].includes(field.type);
-                for (const filter of filterInfo.filters) {
-                    if (filter.active) {
-                        continue;
-                    }
-                    const rawValue = record.rawRecord[fieldName];
-                    let match = false;
-                    if (isX2Many) {
-                        match = Array.isArray(rawValue) && rawValue.includes(filter.value);
-                    } else {
-                        const recordValue = Array.isArray(rawValue) ? rawValue[0] : rawValue;
-                        match = filter.value === recordValue;
-                    }
-                    if (match) {
-                        delete data.records[recordId];
-                    }
+                if (remove) {
+                    delete data.records[recordId];
                 }
             }
         }

--- a/addons/web/static/tests/views/calendar/calendar_view.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_view.test.js
@@ -2144,15 +2144,15 @@ test(`set filter with many2many field on desktop`, async () => {
     });
     expect(`.o_calendar_filter_item`).toHaveCount(5);
     expect(`.o_event[data-event-id="1"] .fc-event-main`).toHaveCount(1);
-    expect(`.o_event[data-event-id="3"] .fc-event-main`).toHaveCount(1);
+    expect(`.o_event[data-event-id="5"] .fc-event-main`).toHaveCount(1);
 
     await toggleSectionFilter("attendee_ids");
     expect(`.o_event[data-event-id="1"] .fc-event-main`).toHaveCount(0);
-    expect(`.o_event[data-event-id="3"] .fc-event-main`).toHaveCount(0);
+    expect(`.o_event[data-event-id="5"] .fc-event-main`).toHaveCount(0);
 
     await toggleFilter("attendee_ids", "1");
-    expect(`.o_event[data-event-id="1"] .fc-event-main`).toHaveCount(0);
-    expect(`.o_event[data-event-id="3"] .fc-event-main`).toHaveCount(1);
+    expect(`.o_event[data-event-id="1"] .fc-event-main`).toHaveCount(1);
+    expect(`.o_event[data-event-id="5"] .fc-event-main`).toHaveCount(0);
 });
 
 test.tags("mobile");
@@ -2176,15 +2176,15 @@ test(`set filter with many2many field on mobile`, async () => {
     expect(`.o_calendar_filter_item`).toHaveCount(5);
     await contains(`.o_filter`).click();
     expect(`.o_event[data-event-id="1"] .fc-event-main`).toHaveCount(1);
-    expect(`.o_event[data-event-id="3"] .fc-event-main`).toHaveCount(1);
+    expect(`.o_event[data-event-id="5"] .fc-event-main`).toHaveCount(1);
 
     await toggleSectionFilter("attendee_ids");
     expect(`.o_event[data-event-id="1"] .fc-event-main`).toHaveCount(0);
-    expect(`.o_event[data-event-id="3"] .fc-event-main`).toHaveCount(0);
+    expect(`.o_event[data-event-id="5"] .fc-event-main`).toHaveCount(0);
 
     await toggleFilter("attendee_ids", "1");
-    expect(`.o_event[data-event-id="1"] .fc-event-main`).toHaveCount(0);
-    expect(`.o_event[data-event-id="3"] .fc-event-main`).toHaveCount(1);
+    expect(`.o_event[data-event-id="1"] .fc-event-main`).toHaveCount(1);
+    expect(`.o_event[data-event-id="5"] .fc-event-main`).toHaveCount(0);
 });
 
 test.tags("desktop");
@@ -2206,15 +2206,15 @@ test(`set filter with one2many field on desktop`, async () => {
     });
     expect(`.o_calendar_filter_item`).toHaveCount(5);
     expect(`.o_event[data-event-id="1"] .fc-event-main`).toHaveCount(1);
-    expect(`.o_event[data-event-id="3"] .fc-event-main`).toHaveCount(1);
+    expect(`.o_event[data-event-id="5"] .fc-event-main`).toHaveCount(1);
 
     await toggleSectionFilter("attendee_ids");
     expect(`.o_event[data-event-id="1"] .fc-event-main`).toHaveCount(0);
-    expect(`.o_event[data-event-id="3"] .fc-event-main`).toHaveCount(0);
+    expect(`.o_event[data-event-id="5"] .fc-event-main`).toHaveCount(0);
 
     await toggleFilter("attendee_ids", "1");
-    expect(`.o_event[data-event-id="1"] .fc-event-main`).toHaveCount(0);
-    expect(`.o_event[data-event-id="3"] .fc-event-main`).toHaveCount(1);
+    expect(`.o_event[data-event-id="1"] .fc-event-main`).toHaveCount(1);
+    expect(`.o_event[data-event-id="5"] .fc-event-main`).toHaveCount(0);
 });
 
 test.tags("mobile");
@@ -2238,15 +2238,15 @@ test(`set filter with one2many field on mobile`, async () => {
     expect(`.o_calendar_filter_item`).toHaveCount(5);
     await contains(`.o_filter`).click();
     expect(`.o_event[data-event-id="1"] .fc-event-main`).toHaveCount(1);
-    expect(`.o_event[data-event-id="3"] .fc-event-main`).toHaveCount(1);
+    expect(`.o_event[data-event-id="5"] .fc-event-main`).toHaveCount(1);
 
     await toggleSectionFilter("attendee_ids");
     expect(`.o_event[data-event-id="1"] .fc-event-main`).toHaveCount(0);
-    expect(`.o_event[data-event-id="3"] .fc-event-main`).toHaveCount(0);
+    expect(`.o_event[data-event-id="5"] .fc-event-main`).toHaveCount(0);
 
     await toggleFilter("attendee_ids", "1");
-    expect(`.o_event[data-event-id="1"] .fc-event-main`).toHaveCount(0);
-    expect(`.o_event[data-event-id="3"] .fc-event-main`).toHaveCount(1);
+    expect(`.o_event[data-event-id="1"] .fc-event-main`).toHaveCount(1);
+    expect(`.o_event[data-event-id="5"] .fc-event-main`).toHaveCount(0);
 });
 
 test(`open form view`, async () => {


### PR DESCRIPTION
This commit add support for Many2many filters in the calendar arch. This PR follows the PR #215790

Example:
Add `<field name="user_ids" filters="1" invisible="1"/>` in the calendar arch with:

Tasks:
- T1 assigned to A
- T2 assigned to A and B
- T3 assigned to B and C

Giving:
- A => show T1 and T2
- B => show T2 and T3
- A and B => show T1, T2 and T3

task-5005992


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
