### PR TITLE
[FIX] mail: recompute activity related record name

### DIFF
--- a/addons/mail/models/mail_activity_mixin.py
+++ b/addons/mail/models/mail_activity_mixin.py
@@ -250,9 +250,9 @@ class MailActivityMixin(models.AbstractModel):
 
             If so force the recompute of the res_name of the linked activities, if any.
             """
-            res_id_display_name_by_model = self.env.cr.precommit.data.pop('mail_activity_mixin_write_original_display_names', {})
+            display_name_by_model = self.env.cr.precommit.data.pop('mail_activity_mixin_write_original_display_names', {})
             to_recompute_activities_sudo = self.env['mail.activity'].sudo()
-            for model, display_name_by_res_id in res_id_display_name_by_model.items():
+            for model, display_name_by_res_id in display_name_by_model.items():
                 records_sudo = self.env[model].browse(list(display_name_by_res_id.keys())).sudo().exists()
                 modified_records = self.browse([
                     res_id for res_id, new_display_name in zip(records_sudo.ids, records_sudo.mapped('display_name'))
@@ -262,9 +262,14 @@ class MailActivityMixin(models.AbstractModel):
             to_recompute_activities_sudo._compute_res_name()
 
         # add the original display_name when the records were first encountered to be checked later.
-        precommit_data = self.env.cr.precommit.data.setdefault('mail_activity_mixin_write_original_display_names', {})
-        precommit_data[self._name] = dict(zip(self.ids, self.mapped('display_name'))) | precommit_data.setdefault(self._name, {})
-        self.env.cr.precommit.add(update_activity_res_name)
+        observed_field_names = ([self._rec_name] + [
+            field_name.split('.')[0]
+            for field_name in self._fields[self._rec_name].get_depends(self)[0]
+        ]) if self._rec_name else []
+        if any(field_name for field_name in observed_field_names if field_name in vals):
+            precommit_data = self.env.cr.precommit.data.setdefault('mail_activity_mixin_write_original_display_names', {})
+            precommit_data[self._name] = dict(zip(self.ids, self.mapped(self._rec_name))) | precommit_data.setdefault(self._name, {})
+            self.env.cr.precommit.add(update_activity_res_name)
 
         return super().write(vals)
 

--- a/addons/test_mail/models/test_mail_models.py
+++ b/addons/test_mail/models/test_mail_models.py
@@ -196,11 +196,17 @@ class MailTestActivity(models.Model):
     _name = 'mail.test.activity'
     _inherit = ['mail.thread', 'mail.activity.mixin']
 
-    name = fields.Char()
+    name = fields.Char(compute='_compute_name', readonly=False, store=True)
     date = fields.Date()
     email_from = fields.Char()
     active = fields.Boolean(default=True)
     company_id = fields.Many2one('res.company')
+    container_id = fields.Many2one('mail.test.container')
+
+    @api.depends('container_id.name', 'email_from')
+    def _compute_name(self):
+        for activity_record in self:
+            activity_record.name = f'{activity_record.container_id.name}: activity test for {activity_record.email_from}'
 
     def action_start(self, action_summary):
         return self.activity_schedule(

--- a/addons/test_mail/tests/test_mail_activity.py
+++ b/addons/test_mail/tests/test_mail_activity.py
@@ -825,6 +825,18 @@ class TestActivityMixin(TestActivityCommon):
             self.assertFalse(record, "Should not find record if the only late activity is done")
 
     @users('employee')
+    def test_record_renamed(self):
+        """Check that MailActivity.res_name is updated with its related record display_name when it changes."""
+        test_record = self.test_record.with_user(self.env.user)
+        my_activity = test_record.activity_schedule(summary='My Activity', user_id=self.env.uid)
+        admin_activity = test_record.activity_schedule(summary='Admin Activity', user_id=self.user_admin.id)
+        activities = my_activity + admin_activity
+        self.assertEqual(activities.mapped('res_name'), ['Test', 'Test'])
+        test_record.name = 'Renamed Test Record'
+        test_record.env.cr.precommit.run()
+        self.assertEqual(activities.mapped('res_name'), ['Renamed Test Record', 'Renamed Test Record'])
+
+    @users('employee')
     def test_record_unlink(self):
         test_record = self.test_record.with_user(self.env.user)
         act1 = test_record.activity_schedule(summary='Active')

--- a/addons/test_mail/tests/test_mail_activity.py
+++ b/addons/test_mail/tests/test_mail_activity.py
@@ -827,14 +827,32 @@ class TestActivityMixin(TestActivityCommon):
     @users('employee')
     def test_record_renamed(self):
         """Check that MailActivity.res_name is updated with its related record display_name when it changes."""
+        container = self.env['mail.test.container'].create({'name': 'Container'})
         test_record = self.test_record.with_user(self.env.user)
         my_activity = test_record.activity_schedule(summary='My Activity', user_id=self.env.uid)
         admin_activity = test_record.activity_schedule(summary='Admin Activity', user_id=self.user_admin.id)
         activities = my_activity + admin_activity
-        self.assertEqual(activities.mapped('res_name'), ['Test', 'Test'])
-        test_record.name = 'Renamed Test Record'
-        test_record.env.cr.precommit.run()
-        self.assertEqual(activities.mapped('res_name'), ['Renamed Test Record', 'Renamed Test Record'])
+        self.assertEqual(activities.mapped('res_name'), ['Test'] * 2)
+        # change name directly
+        with self.assertQueryCount(5):
+            test_record.name = 'Renamed Test Record'
+            test_record.env.cr.precommit.run()
+        self.assertEqual(activities.mapped('res_name'), ['Renamed Test Record'] * 2)
+        # change company -> rename record
+        with self.assertQueryCount(3):
+            test_record.container_id = container
+            test_record.env.cr.precommit.run()
+        self.assertEqual(activities.mapped('res_name'), ['Container: activity test for False'] * 2)
+        # change company name -> cannot be detected easily, not updated
+        with self.assertQueryCount(5):
+            test_record.container_id.name = 'New Container Name'
+            test_record.env.cr.precommit.run()
+        self.assertEqual(activities.mapped('res_name'), ['Container: activity test for False'] * 2)
+        # change completely unrelated field
+        with self.assertQueryCount(1):
+            test_record.date = self.env.cr.now()
+            test_record.env.cr.precommit.run()
+        self.assertEqual(activities.mapped('res_name'), ['Container: activity test for False'] * 2)
 
     @users('employee')
     def test_record_unlink(self):


### PR DESCRIPTION
res_name is a field used to show the name of the related record when browsing activities in list view for example. However this name is based on the display_name of a record which can only be indirectly referenced (due to the refered table being dynamic). As such we cannot set a compute dependency for it to update automatically, and have to resort to resort to updating the name from the related record directly. Fortunately only activity.mixin models are really relevant so this search + write will only be necessary when renaming such records. Note that this also means if the name is somehow recomputed, we do not update the activity as there is no way to hook gracefully into the compute mechanism. Only explicit writes will work.

task-4988342
