### PR TITLE
[WIP] mail,test_mail: add versioning mixin to avoid race conditions

### DIFF
--- a/addons/mail/models/discuss/__init__.py
+++ b/addons/mail/models/discuss/__init__.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import versioning_mixin
 # mail
 from . import mail_message
 

--- a/addons/mail/models/discuss/mail_message.py
+++ b/addons/mail/models/discuss/mail_message.py
@@ -5,7 +5,7 @@ from odoo.addons.mail.tools.discuss import Store
 
 
 class MailMessage(models.Model):
-    _inherit = "mail.message"
+    _inherit = ["mail.message", "mail.versioning.mixin"]
 
     call_history_ids = fields.One2many("discuss.call.history", "start_call_message_id")
     channel_id = fields.Many2one("discuss.channel", compute="_compute_channel_id")

--- a/addons/mail/models/discuss/versioning_mixin.py
+++ b/addons/mail/models/discuss/versioning_mixin.py
@@ -1,0 +1,27 @@
+from odoo import models, fields
+
+class VersioningMixin(models.AbstractModel):
+    _name = "mail.versioning.mixin"
+    _description = "Mixin to add versioning to a model"
+
+    version = fields.Integer(string="Version", default=1)
+
+    def create(self, vals_list):
+        if not isinstance(vals_list, list):
+            if "version" in vals_list:
+                raise ValueError("Direct modification of 'version' field is not allowed.")
+            vals_list["version"] = 1
+        else:
+            for vals in vals_list:
+                if "version" in vals:
+                    raise ValueError("Direct modification of 'version' field is not allowed.")
+                vals["version"] = 1
+        return super().create(vals_list)
+
+    def write(self, vals):
+        self.ensure_one()
+        if "version" in vals:
+            raise ValueError("Direct modification of 'version' field is not allowed.")
+        vals["version"] = self.version + 1
+        res = super().write(vals)
+        return res

--- a/addons/mail/static/src/model/record_internal.js
+++ b/addons/mail/static/src/model/record_internal.js
@@ -59,6 +59,8 @@ export class RecordInternal {
     fieldsComputeProxy2 = new Map();
     uses = new RecordUses();
     updatingAttrs = new Map();
+    versionByField = new Map();
+    overrideByField = new Map();
     proxyUsed = new Map();
     /** @type {string} */
     localId;

--- a/addons/mail/tools/discuss.py
+++ b/addons/mail/tools/discuss.py
@@ -252,6 +252,8 @@ class Store:
             fields = [Store.Attr(key, value) for key, value in fields.items()]
         if not isinstance(fields, list):
             fields = [fields]
+        if "version" in records._fields and "version" not in fields:
+            fields.append("version")
         if hasattr(records, "_field_store_repr"):
             return [f for field in fields for f in records._field_store_repr(field)]
         return fields

--- a/addons/test_mail/models/__init__.py
+++ b/addons/test_mail/models/__init__.py
@@ -5,3 +5,4 @@ from . import test_mail_corner_case_models
 from . import test_mail_feature_models
 from . import test_mail_models
 from . import test_mail_thread_models
+from . import test_mail_versioning_models

--- a/addons/test_mail/models/test_mail_versioning_models.py
+++ b/addons/test_mail/models/test_mail_versioning_models.py
@@ -1,0 +1,14 @@
+from odoo import models, fields
+
+class Foo(models.Model):
+    _name = "foo.model"
+    _inherit = ["mail.versioning.mixin"]
+
+    name = fields.Char()
+
+class Bar(models.Model):
+    _name = "bar.model"
+    _inherit = ["mail.versioning.mixin"]
+
+    name = fields.Char()
+    foo_id = fields.Many2one("foo.model")

--- a/addons/test_mail/tests/__init__.py
+++ b/addons/test_mail/tests/__init__.py
@@ -30,3 +30,4 @@ from . import test_mail_template_preview
 from . import test_message_post
 from . import test_message_track
 from . import test_performance
+from . import test_versioning

--- a/addons/test_mail/tests/test_versioning.py
+++ b/addons/test_mail/tests/test_versioning.py
@@ -1,0 +1,60 @@
+from odoo.tests.common import TransactionCase
+from odoo.addons.mail.tools.discuss import Store
+
+
+class TestVersioningModelsMixin(TransactionCase):
+    def test_basic_versioning_model(self):
+        foo = self.env['foo.model'].create({
+            'name': 'Test Foo',
+        })
+        self.assertEqual(foo.version, 1)
+        foo.write({'name': 'Updated Test Foo'})
+        self.assertEqual(foo.version, 2)
+
+    def test_versioning_with_relational_field(self):
+        foo = self.env["foo.model"].create(
+            [
+                {
+                    "name": "Test Foo",
+                },
+                {
+                    "name": "Another Test Foo",
+                },
+            ]
+        )
+        bar = self.env['bar.model'].create({
+            'name': 'Test Bar',
+            'foo_id': foo[0].id,
+        })
+        self.assertEqual(bar.version, 1)
+        bar.write({'name': 'Updated Test Bar'})
+        self.assertEqual(bar.version, 2)
+        foo[0].name = "Modified Foo"
+        self.assertEqual(foo[0].version, 2)
+        self.assertEqual(foo[1].version, 1)
+        self.assertEqual(bar.version, 2)
+        bar.foo_id = foo[1]
+        self.assertEqual(bar.version, 3)
+        self.assertEqual(foo[1].version, 1)
+
+    def test_versioning_in_store(self):
+        foo = self.env['foo.model'].create({
+            'name': 'Test Foo',
+        })
+        store = Store()
+        store.add(foo, [])
+        store_data = store.get_result()
+        foo_data = next(filter(lambda r: r["id"] == foo.id, store_data['foo.model']))
+        self.assertEqual(foo_data['version'], 1)
+
+    def test_versioning_in_store_with_fields(self):
+        foo = self.env['foo.model'].create({
+            'name': 'Test Foo',
+        })
+        foo.name = "Changed Name"
+        store = Store()
+        store.add(foo, ['name'])
+        store_data = store.get_result()
+        foo_data = next(filter(lambda r: r["id"] == foo.id, store_data['foo.model']))
+        self.assertEqual(foo_data['version'], 2)
+        self.assertEqual(foo_data['name'], "Changed Name")


### PR DESCRIPTION
This commit tries to handle race conditions arising from using bus notifications and rpc calls. Since using the store in all of those, we can add a version field that allows us to filter old updates.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
