### PR TITLE
[FIX] web: avoid page number wrapping on external layout folder

### DIFF
--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -609,7 +609,7 @@
                 <div class="flex-grow-1 me-2 text-start" t-field="company.report_footer"/>
                 <div class="text-end text-muted">
                     <div t-if="report_type == 'pdf' and display_name_in_footer" t-out="o.name">(document name)</div>
-                    <div t-if="report_type == 'pdf'">Page <span class="page"/> / <span class="topage"/></div>
+                    <div t-if="report_type == 'pdf'" class="text-nowrap">Page <span class="page"/> / <span class="topage"/></div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
The folder layout is using the same footer than the `external_layout_standard` but when using Montserrat, the page number wraps in 2 lines on the folder layout.

It's missing a `text-nowrap` class.

task-4942402



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
