### PR TITLE
[IMP] pos_restaurant: new table number based on the max existing on floor screen

### DIFF
--- a/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_screen.js
+++ b/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_screen.js
@@ -619,25 +619,10 @@ export class FloorScreen extends Component {
         this.pos.restoreOrdersToOriginalTable(mainOrder, table);
     }
     _getNewTableNumber() {
-        let firstNum = 1;
-        const tablesNumber = [
-            ...new Set(
-                this.activeTables
-                    .map((table) => table.table_number)
-                    .sort(function (a, b) {
-                        return a - b;
-                    })
-            ),
-        ];
-
-        for (let i = 0; i < tablesNumber.length; i++) {
-            if (tablesNumber[i] == firstNum) {
-                firstNum += 1;
-            } else {
-                break;
-            }
+        if (!this.activeTables?.length) {
+            return 1;
         }
-        return firstNum;
+        return Math.max(...this.activeTables.map((t) => t.table_number)) + 1;
     }
     get activeFloor() {
         return this.state.selectedFloorId

--- a/addons/pos_restaurant/static/tests/tours/floor_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/floor_screen_tour.js
@@ -61,7 +61,7 @@ registry.category("web_tour.tours").add("FloorScreenTour", {
                 trigger: `.edit-buttons i[aria-label="Add Table"]`,
                 run: "click",
             },
-            FloorScreen.selectedTableIs("1"),
+            FloorScreen.selectedTableIs("6"),
             FloorScreen.clickEditButton("Rename"),
 
             NumberPopup.enterValue("100"),
@@ -92,8 +92,8 @@ registry.category("web_tour.tours").add("FloorScreenTour", {
             FloorScreen.ctrlClickTable("3"),
             FloorScreen.selectedTableIs("3"),
             FloorScreen.clickEditButton("Clone"),
-            FloorScreen.selectedTableIs("2"),
             FloorScreen.selectedTableIs("4"),
+            FloorScreen.selectedTableIs("5"),
 
             //test delete multiple tables
             FloorScreen.clickEditButton("Delete"),

--- a/addons/pos_restaurant/static/tests/unit/components/floor_screen.test.js
+++ b/addons/pos_restaurant/static/tests/unit/components/floor_screen.test.js
@@ -89,7 +89,7 @@ describe("floor_screen.js", () => {
         const table = await screen._createTableHelper(null);
         expect(Boolean(table)).toBe(true);
         expect(table.floor_id.id).toBe(floor.id);
-        expect(table.table_number).toBe(4);
+        expect(table.table_number).toBe(5);
         expect(table.height).toBe(table.width);
         expect(table.position_v >= 0).toBe(true);
         expect(table.position_h >= 10).toBe(true);
@@ -97,11 +97,11 @@ describe("floor_screen.js", () => {
 
     test("_getNewTableNumber", async () => {
         const store = await setupPosEnv();
-        const floor = store.models["restaurant.floor"].getFirst();
+        const floor = store.models["restaurant.floor"].getFirst(); // Main Floor (tables 1,2,4)
         const screen = await mountWithCleanup(FloorScreen, {});
         screen.selectFloor(floor);
         const newNumber = screen._getNewTableNumber();
-        expect(newNumber).toBe(4);
+        expect(newNumber).toBe(5); // max(1,2,4) + 1 = 5
     });
 
     test("duplicateTable", async () => {

--- a/addons/pos_restaurant/static/tests/unit/data/restaurant_table.data.js
+++ b/addons/pos_restaurant/static/tests/unit/data/restaurant_table.data.js
@@ -52,7 +52,7 @@ export class RestaurantTable extends models.ServerModel {
         },
         {
             id: 4,
-            table_number: 3,
+            table_number: 4,
             width: 165,
             height: 100,
             position_h: 762,


### PR DESCRIPTION
Before this commit:
-------------
- When adding a new table in the floor screen, the system reused missing number.
- For example, if table 2 was deleted, the next added table would again be
  number 2.
- Logic: find the minimum missing number starting from 1.

After this commit:
--------------------
- A new table in the floor screen always gets the next number after the biggest
  existing one.
- For example, with tables [1, 3, 4], the next table becomes 5 (not 2).

Task-5056800