### PR TITLE
[FIX] website: get scroll from document element

### DIFF
--- a/addons/website/static/src/js/content/snippets.animation.js
+++ b/addons/website/static/src/js/content/snippets.animation.js
@@ -1676,8 +1676,8 @@ registry.WebsiteAnimate = publicWidget.Widget.extend({
                 // case specifically instead of a generic solution using
                 // elementFromPoint as it is a rare case and the implementation
                 // would have been too complicated for such a small use case.
-                const actualScroll = wrapEl.scrollTop + this.windowsHeight;
-                const totalScrollHeight = wrapEl.scrollHeight;
+                const actualScroll = document.scrollingElement.scrollTop + this.windowsHeight;
+                const totalScrollHeight = document.scrollingElement.scrollHeight;
                 const heightFromFooter = this._getElementOffsetTop(el, footerEl);
                 visible = actualScroll >=
                     totalScrollHeight - heightFromFooter - elHeight + elOffset;

--- a/addons/website/static/src/snippets/s_faq_horizontal/options.js
+++ b/addons/website/static/src/snippets/s_faq_horizontal/options.js
@@ -5,17 +5,16 @@ options.registry.faqHorizontalMultipleItems = options.registry.MultipleItems.ext
         // Find the iframe and its #wrapwrap
         const iframe = document.querySelector('.o_iframe');
         const iframeDocument = iframe.contentDocument || iframe.contentWindow.document;
-        const wrapwrap = iframeDocument.getElementById('wrapwrap');
+        const scrollingEl = iframeDocument.scrollingElement;
 
         const topics = this.$target[0].getElementsByClassName('s_faq_horizontal_entry');
         const newTopic = topics[topics.length - 1];
         const newTopicRect = newTopic.getBoundingClientRect();
-        const wrapwrapRect = wrapwrap.getBoundingClientRect();
 
-        const scrollTop = wrapwrap.scrollTop;
-        const centerY = (newTopicRect.top - wrapwrapRect.top) + scrollTop - (wrapwrap.clientHeight / 2) + (newTopicRect.height / 2);
+        const scrollTop = scrollingEl.scrollTop;
+        const centerY = newTopicRect.top + scrollTop - (scrollingEl.clientHeight / 2) + (newTopicRect.height / 2);
 
-        wrapwrap.scrollTo({
+        scrollingEl.scrollTo({
             top: centerY,
             behavior: 'smooth'
         });

--- a/addons/website/static/tests/tours/snippet_faq_horizontal.js
+++ b/addons/website/static/tests/tours/snippet_faq_horizontal.js
@@ -1,0 +1,34 @@
+import {
+    checkIfVisibleOnScreen,
+    clickOnSnippet,
+    insertSnippet,
+    registerWebsitePreviewTour,
+} from "@website/js/tours/tour_utils";
+
+registerWebsitePreviewTour(
+    "snippet_faq_horizontal",
+    {
+        url: "/",
+        edition: true,
+    },
+    () => [
+        ...insertSnippet({ id: "s_faq_horizontal", name: "Topics List", groupName: "Text" }),
+        ...clickOnSnippet({ id: "s_faq_horizontal", name: "Topics List" }),
+        {
+            content: "Wait for Add New button to appear and mock scrollTo",
+            trigger: "we-button:has(div:contains('Add New'))",
+            async run() {
+                const iframeScrollingEl = document.querySelector(".o_iframe").contentDocument.scrollingElement;
+                // Mock scrollTo to bypass the animation delay
+                iframeScrollingEl.scrollTo = ({ top }) => {
+                    iframeScrollingEl.scrollTop = top;
+                };
+            },
+        }, {
+            content: "Click on Add New",
+            trigger: "we-button:has(div:contains('Add New'))",
+            run: "click",
+        },
+        checkIfVisibleOnScreen(":iframe .s_faq_horizontal_entry:nth-child(4)"),
+    ],
+);

--- a/addons/website/static/tests/tours/snippets_animation.js
+++ b/addons/website/static/tests/tours/snippets_animation.js
@@ -1,0 +1,47 @@
+import {
+    clickOnSave,
+    insertSnippet,
+    registerWebsitePreviewTour,
+} from "@website/js/tours/tour_utils";
+
+registerWebsitePreviewTour(
+    "footer_slideout_and_animation",
+    {
+        url: "/",
+        edition: true,
+    },
+    () => [
+        // Insert a big snippet to make the footer slideout below
+        ...insertSnippet({ id: "s_faq_horizontal", name: "Topics List", groupName: "Text" }),
+        {
+            content: "Click on a footer column",
+            trigger: ":iframe #footer .container > .row > div:contains('Useful Links')",
+            run: "click",
+        },
+        {
+            content: "Set Column Animation to On Appearance",
+            trigger:
+                ".snippet-option-WebsiteAnimate [data-animation-mode=onAppearance]:not(:visible)",
+            run: "click",
+        },
+        {
+            content: "Set Slideout effect to Slide Hover",
+            trigger:
+                ".snippet-option-WebsiteLevelColor [data-customize-website-variable=\"'slideout_slide_hover'\"]:not(:visible)",
+            run: "click",
+        },
+        ...clickOnSave(),
+        {
+            content: "Scroll to footer",
+            trigger: ":iframe #footer",
+            run() {
+                const iframeScrollingEl = document.querySelector(".o_iframe").contentDocument.scrollingElement;
+                iframeScrollingEl.scrollTo({ top: iframeScrollingEl.scrollHeight });
+            },
+        },
+        {
+            content: "The footer column should appear",
+            trigger: ":iframe #footer .container > .row > div:contains('Useful Links'):visible",
+        },
+    ],
+);

--- a/addons/website/tests/test_snippets.py
+++ b/addons/website/tests/test_snippets.py
@@ -148,3 +148,6 @@ class TestSnippets(HttpCase):
 
     def test_footer_slideout_and_animation(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'footer_slideout_and_animation', login='admin')
+
+    def test_snippet_faq_horizontal(self):
+        self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_faq_horizontal', login='admin')

--- a/addons/website/tests/test_snippets.py
+++ b/addons/website/tests/test_snippets.py
@@ -145,3 +145,6 @@ class TestSnippets(HttpCase):
 
     def test_snippet_popup_open_on_top(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_popup_open_on_top', login='admin')
+
+    def test_footer_slideout_and_animation(self):
+        self.start_tour(self.env['website'].get_client_action_url('/'), 'footer_slideout_and_animation', login='admin')


### PR DESCRIPTION
[FIX] website: get scroll from document element for footer animation

__Current behavior before commit:__
Since [this PR], the scrolling is not done on `#wrapwrap` anymore.
Now when an animation is set on an element inside the footer it
will not appear if a slideout effect is set on it.

__Description of the fix:__
Get `scrollTop` and `scrollHeight` from the document element instead of
`#wrapwrap` and add a test tour.

__Steps to reproduce:__
1. Open the Website builder.
2. Click on a column in the footer.
3. Set an "On Appearance" Animation on it.
4. Set the footer Slideout Effect to "Slide Hover".
5. Add some content on the page so that it's needed to scroll for the
footer to be visible.
6. Save.
7. Scroll to the footer.
=> The column doesn't appear.

[this PR]: https://github.com/odoo/odoo/pull/98429

---

[FIX] website: scroll on new entry in faq horizontal

__Current behavior before commit:__
Since [this PR][1], the scrolling is not done on `#wrapwrap` anymore.
Now when adding a new entry to the snippet faq horizontal, the page
doesn't scroll automatically to the new entry.

This behavior has actually never worked because [the PR that introduced
faq horizontal][2] was merged just after [the PR that moved the
scrolling to the document element][1]. 

__Description of the fix:__
Get `scrollTop` and `scrollHeight` from the document element instead of
`#wrapwrap` and add a test tour.

__Steps to reproduce:__
1. Open the Website builder.
2. Drag a Text block
3. Choose the FAQ horizontal snippet
4. Click on "Add New"
=> The page doesn't scroll to the new entry.

[1]: https://github.com/odoo/odoo/pull/98429
[2]: https://github.com/odoo/odoo/pull/176438