### PR TITLE
[REF] website_livechat: remove visitor history store repr

### DIFF
--- a/addons/website_livechat/models/discuss_channel.py
+++ b/addons/website_livechat/models/discuss_channel.py
@@ -34,9 +34,9 @@ class DiscussChannel(models.Model):
                     Store.One("country_id", ["code"]),
                     "display_name",
                     Store.One("lang_id", ["name"]),
-                    "page_visit_history",
                     Store.One("partner_id", [Store.One("country_id", ["code"])]),
                     Store.One("website_id", ["name"]),
+                    *self.livechat_visitor_id._get_store_visitor_history_fields(),
                 ],
                 predicate=lambda channel: channel.channel_type == "livechat"
                 and self.livechat_visitor_id.has_access("read"),

--- a/addons/website_livechat/models/website_visitor.py
+++ b/addons/website_livechat/models/website_visitor.py
@@ -117,13 +117,11 @@ class WebsiteVisitor(models.Model):
                 guest_livechats.country_id = visitor_sudo.country_id
         return visitor_id, upsert
 
-    def _field_store_repr(self, field_name):
-        if field_name == "page_visit_history":
+    def _get_store_visitor_history_fields(self):
+        return [
             # sudo: website.track - reading the history of accessible visitor is acceptable
-            return [
-                Store.Attr("page_visit_history", lambda visitor: visitor.sudo()._get_visitor_history()),
-            ]
-        return [field_name]
+            Store.Attr("page_visit_history", lambda visitor: visitor.sudo()._get_visitor_history()),
+        ]
 
     def _get_visitor_history(self):
         self.ensure_one()


### PR DESCRIPTION
This commit moves the `page_visit_history` fields from the deprecated `_field_store_repr` to a dedicated method.

task-4855080