### PR TITLE
[IMP] pos_restaurant: show ticket code for demo orders instead of `false`

### DIFF
--- a/addons/point_of_sale/data/orders_demo.xml
+++ b/addons/point_of_sale/data/orders_demo.xml
@@ -26,6 +26,7 @@
             <field name="amount_tax">0.0</field>
             <field name="amount_paid">4.81</field>
             <field name="amount_return">0.0</field>
+            <field name="ticket_code">sv34t</field>
         </record>
 
         <record id="pos_closed_orderline_1_1_1" model="pos.order.line" forcecreate="False">
@@ -60,6 +61,7 @@
             <field name="amount_tax">0.0</field>
             <field name="amount_paid">6.78</field>
             <field name="amount_return">0.0</field>
+            <field name="ticket_code">lm34t</field>
         </record>
 
         <record id="pos_closed_orderline_1_2_1" model="pos.order.line" forcecreate="False">
@@ -113,6 +115,7 @@
             <field name="amount_tax">0.0</field>
             <field name="amount_paid">9.90</field>
             <field name="amount_return">0.0</field>
+            <field name="ticket_code">cv36m</field>
         </record>
 
         <record id="pos_closed_orderline_2_1_1" model="pos.order.line" forcecreate="False">
@@ -149,6 +152,7 @@
             <field name="amount_tax">0.0</field>
             <field name="amount_paid">8.36</field>
             <field name="amount_return">0.0</field>
+            <field name="ticket_code">cv44t</field>
         </record>
 
         <record id="pos_closed_orderline_2_2_1" model="pos.order.line" forcecreate="False">

--- a/addons/pos_restaurant/data/scenarios/restaurant_demo_session.xml
+++ b/addons/pos_restaurant/data/scenarios/restaurant_demo_session.xml
@@ -31,6 +31,7 @@
             <field name="amount_tax">0.0</field>
             <field name="amount_paid">14.0</field>
             <field name="amount_return">0.0</field>
+            <field name="ticket_code">cs24t</field>
             <field name="preset_id" eval="ref('pos_takein_preset', raise_if_not_found=False)"/>
         </record>
 
@@ -66,6 +67,7 @@
             <field name="amount_tax">0.0</field>
             <field name="amount_paid">7.0</field>
             <field name="amount_return">0.0</field>
+            <field name="ticket_code">bg3yt</field>
             <field name="preset_id" eval="ref('pos_takein_preset', raise_if_not_found=False)"/>
         </record>
 
@@ -107,6 +109,7 @@
             <field name="amount_tax">0.0</field>
             <field name="amount_paid">6.7</field>
             <field name="amount_return">0.0</field>
+            <field name="ticket_code">kq9ty</field>
             <field name="preset_id" eval="ref('pos_takein_preset', raise_if_not_found=False)"/>
         </record>
 
@@ -142,6 +145,7 @@
             <field name="amount_tax">0.0</field>
             <field name="amount_paid">28.0</field>
             <field name="amount_return">0.0</field>
+            <field name="ticket_code">ij0ty</field>
             <field name="preset_id" eval="ref('pos_takein_preset', raise_if_not_found=False)"/>
         </record>
 
@@ -187,6 +191,7 @@
             <field name="partner_id" ref="customer_1" />
             <field name="table_id" ref="table_01" />
             <field name="customer_count">8</field>
+            <field name="ticket_code">pp3ss</field>
             <field name="preset_id" eval="ref('pos_takein_preset', raise_if_not_found=False)"/>
         </record>
 
@@ -221,6 +226,7 @@
             <field name="partner_id" ref="customer_1" />
             <field name="table_id" ref="table_02" />
             <field name="customer_count">3</field>
+            <field name="ticket_code">lm5sr</field>
             <field name="preset_id" eval="ref('pos_takein_preset', raise_if_not_found=False)"/>
         </record>
 
@@ -255,6 +261,7 @@
             <field name="partner_id" ref="customer_1" />
             <field name="table_id" ref="table_04" />
             <field name="customer_count">5</field>
+            <field name="ticket_code">qrs2t</field>
             <field name="preset_id" eval="ref('pos_takein_preset', raise_if_not_found=False)"/>
         </record>
 
@@ -289,6 +296,7 @@
             <field name="partner_id" ref="customer_1" />
             <field name="table_id" ref="table_06" />
             <field name="customer_count">1</field>
+            <field name="ticket_code">cv34t</field>
             <field name="preset_id" eval="ref('pos_takein_preset', raise_if_not_found=False)"/>
         </record>
 


### PR DESCRIPTION
Before this commit:
- When validating draft orders created in the restaurant configuration with demo data, the receipt shows the ticket code as `false`.
- For all demo paid orders also ticket code shows false.

After this commit:
- Instead of false, the ticket code will be shown

task-5103925