### PR TITLE
[FIX] mrp: increase MO quantity after decrease

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1287,6 +1287,8 @@ class MrpProduction(models.Model):
                 continue
 
             new_qty = float_round((self.qty_producing - self.qty_produced) * move.unit_factor, precision_rounding=move.product_uom.rounding)
+            if move in self.move_raw_ids and float_compare(new_qty, move.quantity, precision_rounding=move.product_uom.rounding) > 0:
+                move._action_assign(new_qty - move.quantity)
             move._set_quantity_done(new_qty)
             if (not move.manual_consumption or pick_manual_consumption_moves) \
                     and move.quantity \


### PR DESCRIPTION
**Problem:**
When you increase the quantity of a MO with a comp tracked by lot, the new 
stock move line created doesn't have a lot even if there is a quant available 
with a lot and on hand quantities.

**Steps to reproduce:**
- set Manufacture as 1 step in your warehouse
- create a product (the comp product) tracked by lot and set an on hand quantity
of 10 with a lot on the quant
- create another product (the final product) tracked by quantity, create a bom for this 
product with the comp product as the component with a quantity of 1
- create a MO for a quantity of 10 of the final product and confirm
- change the quantity on the MO to 5 and save
- change the quantity on the MO to 7 and save

**Current behavior:**
If you click on the 3 horizontal lines at the end of the component line you will 
notice that a new stock move line was create with a quantity of 2 and no lot.
If you go back to the form of the comp product and click on the "on hand" smart
button you will see that a new quant has been created for the reservation of the 
additional two unit generated in the last step

**Expected behavior:**
there is available quantity in a quant with a lot so the move line should be created 
with a lot and reserve quantity from this quant.

**Cause of the issue:**
when we update the quantity on the MO
_set_quantity_producing calls _set_quantity_done on the move
with the new quantity
https://github.com/odoo/odoo/blob/73af26879b353cc17b2bed6ae5f0823a67f668ab/addons/mrp/models/mrp_production.py#L1290
Inside _set_quantity_done_prepare_vals, if it's an increase of quantity
the values of a new move line (with the additional quantity
and no lot) will be added to res, resulting in the creation of this line without lot
https://github.com/odoo/odoo/blob/73af26879b353cc17b2bed6ae5f0823a67f668ab/addons/stock/models/stock_move.py#L2275-L2279

**fix**
Instead of increasing, we assign the move and then decrease to 
the new quantity resulting in a single move line with the correct lot 
and quantity

opw-5083977