### PR TITLE
[FIX] website_sale: enable zoom-out on product image in product page

### DIFF
--- a/addons/website_sale/static/src/js/components/website_sale_image_viewer.js
+++ b/addons/website_sale/static/src/js/components/website_sale_image_viewer.js
@@ -126,7 +126,11 @@ export class ProductImageViewer extends Dialog {
         if (ev.target.tagName === "IMG") {
             // Only zoom if the image did not move
             if (this.dragStartPos.clientX === ev.clientX && this.dragStartPos.clientY === ev.clientY) {
-                this.zoomIn(ZOOM_STEP * 3);
+                if (this.state.imageScale <= 1) {
+                    this.zoomIn(ZOOM_STEP * 3);
+                } else {
+                    this.zoomOut(this.state.imageScale - 1);
+                }
             }
         }
         if (ev.target.classList.contains('o_wsale_image_viewer_void') && !this.isDragging) {

--- a/addons/website_sale/static/src/scss/website_sale_frontend.scss
+++ b/addons/website_sale/static/src/scss/website_sale_frontend.scss
@@ -18,6 +18,10 @@
 
         img {
             cursor: zoom-in;
+
+            &.zoomed-in {
+                cursor: zoom-out;
+            }
         }
     }
 

--- a/addons/website_sale/static/src/xml/website_sale_image_viewer.xml
+++ b/addons/website_sale/static/src/xml/website_sale_image_viewer.xml
@@ -17,6 +17,7 @@
                             <img
                                 alt="Viewer"
                                 class="mw-100 mh-100 transition-base"
+                                t-att-class="{ 'zoomed-in': state.imageScale > 1 }"
                                 draggable="false"
                                 t-att-src="selectedImage.src"
                                 t-att-style="imageStyle"


### PR DESCRIPTION
Step to reproduce:
1. Install 'website_sale'
2. Create a product with an image
3. Open its page on the website via smart button
4. Click on the product image

**Issue:**
- After zooming in on the image with mouse click,
there is no option to zoom out with mouse click.

**Solution:**
- Implement a toggle mechanism:
  - First click on the image zooms in
  - Second click zooms out

opw-5104526