### PR TITLE
[IMP] point_of_sale: electronic_payment force done button

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_lines/payment_lines.xml
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_lines/payment_lines.xml
@@ -58,8 +58,13 @@
                                     <div class="electronic_status">
                                         Waiting for card
                                     </div>
-                                    <div class="button send_payment_cancel" title="Cancel Payment Request" t-on-click="() => this.props.sendPaymentCancel(line)">
-                                        Cancel
+                                    <div>
+                                        <div class="button send_force_done" title="Force Done" t-on-click="() => this.props.sendForceDone(line)">
+                                            Force done
+                                        </div>
+                                        <div class="button send_payment_cancel" title="Cancel Payment Request" t-on-click="() => this.props.sendPaymentCancel(line)">
+                                            Cancel
+                                        </div>
                                     </div>
                                 </t>
                                 <t t-elif="['waiting', 'waitingCancel', 'waitingCapture'].includes(line.payment_status)">


### PR DESCRIPTION
Current behavior before PR:
If we faced an issue with a terminal payment while the `line.payment_status` being "waitingCard", only possible option for the user would be to "Cancel" the payment and try again or choose another payment method. This is an issue for the cases where the payment went through on the terminal but Odoo didn't update the status for some reason.

Desired behavior after PR is merged:
We add the possibility to "Force done" while the status is "waitingCard" to avoid blocking the user in such situations and have a possible fallback.

opw-4978772

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
