### PR TITLE
[FIX] pos_online_payment: send online payment order to kitchen

### DIFF
--- a/addons/pos_online_payment/controllers/payment_portal.py
+++ b/addons/pos_online_payment/controllers/payment_portal.py
@@ -289,9 +289,14 @@ class PaymentPortal(payment_portal.PaymentPortal):
         tx_sudo._process_pos_online_payment()
 
         rendering_context['state'] = 'success'
+        self._on_payment_successful(pos_order_sudo)
+
         if exit_route:
             return request.redirect(exit_route)
         return self._render_pay_confirmation(rendering_context)
+
+    def _on_payment_successful(self, pos_order):
+        return
 
     def _render_pay_confirmation(self, rendering_context):
         return request.render('pos_online_payment.pay_confirmation', rendering_context)


### PR DESCRIPTION
Currently, when using online payment with the kiosk. The order is marked as paid in the backedn but never redirected to the kitchen.

Steps to reproduce:
-------------------
* Create an online payment method (use demo for example)
* Change the kiosk settings to use those it
* Change the settings of the preparation display to use the kiosk
* Open preparation display
* Open kiosk, make on order, and select the online payment method
* Scan QR code and pay
> You are redirected to the confirmation page saying that the order
is being prepared while not sent to the preparation display

Why the fix:
------------
The following commit is forwarded. It had been stopped before 18.2 since orders were sent to the kitchen before being paid. That behavior was changed again in the next version thus the fix needs to be forwarded as well.
https://github.com/odoo/odoo/commit/6d8ec9948f1d0924ca92e2a9492b9882ae3338c0

opw-5096094