### PR TITLE
[FIX] html_builder: fix UI navigation order in add snippet dialog

### DIFF
--- a/addons/html_builder/static/src/snippets/snippet_viewer.js
+++ b/addons/html_builder/static/src/snippets/snippet_viewer.js
@@ -1,5 +1,6 @@
 import { Component, markup, useRef } from "@odoo/owl";
 import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
+import { localization } from "@web/core/l10n/localization";
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 import { InputConfirmationDialog } from "./input_confirmation_dialog";
@@ -19,6 +20,7 @@ export class SnippetViewer extends Component {
     setup() {
         this.dialog = useService("dialog");
         this.content = useRef("content");
+        this.backendDirection = localization.direction;
     }
 
     getRenameBtnLabel(snippetName) {

--- a/addons/html_builder/static/src/snippets/snippet_viewer.xml
+++ b/addons/html_builder/static/src/snippets/snippet_viewer.xml
@@ -3,7 +3,10 @@
 
 
 <t t-name="html_builder.SnippetViewer">
-    <div t-ref="content" class="row g-0 o_snippets_preview_row" t-att-dir="this.props.frontendDirection">
+    <div t-ref="content"
+         class="row g-0 o_snippets_preview_row"
+         t-att-class="{ 'flex-row-reverse': props.frontendDirection !== backendDirection }"
+         t-att-dir="props.frontendDirection">
         <div class="col-lg-6" t-foreach="this.getSnippetColumns()" t-as="snippetsColumn" t-key="snippetsColumn_index">
             <t t-foreach="snippetsColumn" t-as="snippet" t-key="snippet.id">
                 <div t-on-click="() => this.onClick(snippet)"


### PR DESCRIPTION
After the accessibility improvement in [9ae02d8], snippets previews within the add snippet dialog are tabable. It reveals an issue with the order of the columns depending on the interface language: when the backend language and the frontend language are not read in the same direction (RTL / LTR), the frontend language is taken to display the previews (see [f9c77de]). This is the right approach to show the snippets themselves, but the order of the columns should be done according to the backend language, which is the one that gives the instructions for the overall UI.

To reproduce:
- Set the admin's language to arabic
- Clear the cache and refresh your page
- Edit and open the add snippet dialog
- Navigate with Tab => The 1st focused snippet is in the wrong column compared with the rest of the UI.

[9ae02d8]: https://github.com/odoo/odoo/commit/9ae02d80894d4043e49d8e2cad068f8018e6f113
[f9c77de]: https://github.com/odoo/odoo/commit/f9c77de84aa6ea705e5d3f129328fb2199103b9a

task-5109547