### PR TITLE
[FIX] web: keep handles visible in list edit mode

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -2218,7 +2218,6 @@ export class ListRenderer extends Component {
      * @param {HTMLElement} [params.previous]
      */
     async sortDrop(dataRowId, dataGroupId, { element, previous }) {
-        await this.props.list.leaveEditMode();
         element.classList.remove("o_row_draggable");
         const refId = previous ? previous.dataset.id : null;
         try {
@@ -2237,6 +2236,7 @@ export class ListRenderer extends Component {
             await this.resequencePromise;
         } finally {
             element.classList.add("o_row_draggable");
+            await this.props.list.leaveEditMode();
         }
     }
 

--- a/addons/web/static/src/views/list/list_renderer.scss
+++ b/addons/web/static/src/views/list/list_renderer.scss
@@ -408,7 +408,7 @@
                     margin: 0;
                     width: 100%;
                 }
-                button.o_input { 
+                button.o_input {
                     width: auto !important;
                 }
                 &.o_field_text {
@@ -452,9 +452,6 @@
                 }
                 .o_field_input_buttons, .btn.o_field_translate {
                     visibility: visible;
-                }
-                > .o_row_handle {
-                    visibility: hidden; // hide sequence when editing
                 }
             }
         }

--- a/addons/web/static/tests/views/fields/one2many_field.test.js
+++ b/addons/web/static/tests/views/fields/one2many_field.test.js
@@ -1440,7 +1440,10 @@ test("onchange for embedded one2many with handle widget (more records)", async (
     await contains('.o_list_renderer div[name="turtle_foo"] input').edit("blurp");
 
     // Drag and drop the third line in second position
-    await contains("tbody tr:eq(2) .o_handle_cell").dragAndDrop("tbody tr:eq(1)");
+    // TODO JUM: PRHOOT the events
+    const { drop, moveTo } = await contains("tbody tr:eq(2) .o_handle_cell").drag();
+    await moveTo(`tbody tr:eq(1)`);
+    await drop(document.body);
 
     // need to unselect row...
     expect(queryAllTexts(".o_data_cell.o_list_char")).toEqual(["blurp", "kawa", "blip"]);
@@ -8489,7 +8492,10 @@ test("one2many with sequence field and text field", async () => {
 
     expect(".ui-sortable-handle").toHaveCount(3);
 
-    await contains("tbody tr:eq(1) .o_handle_cell").dragAndDrop("tbody tr:eq(0)");
+    // TODO JUM: PRHOOT the events
+    const { drop, moveTo } = await contains("tbody tr:eq(1) .o_handle_cell").drag();
+    await moveTo("tbody tr:eq(0)");
+    await drop(document.body);
 
     // empty line has been discarded on the drag and drop)
     expect(queryAllTexts(".o_data_cell.o_list_char")).toEqual([inputText2, inputText1]);

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -10439,10 +10439,12 @@ test(`resequence list lines when discardable lines are present`, async () => {
     await contains(`.o_field_x2many_list_row_add a`).click();
     await animationFrame();
     // Drag and drop second line before first one (with 1 draft and invalid line)
-    await contains(`tbody.ui-sortable tr:nth-child(1) .o_handle_cell`).dragAndDrop(
-        `tbody.ui-sortable tr:nth-child(2)`
-    );
-    expect.verifySteps(["onchange"]);
+    // TODO JUM: PRHOOT the events
+    const { drop, moveTo } = await contains(
+        `tbody.ui-sortable tr:nth-child(1) .o_handle_cell`
+    ).drag();
+    await moveTo(`tbody.ui-sortable tr:nth-child(2)`);
+    await drop(document.body);
     expect(`[name="foo"] input`).toHaveValue("1");
 
     // Add a second line

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -10324,8 +10324,13 @@ test(`editable list with handle widget`, async () => {
         message: "default fourth record should have amount 0",
     });
 
+    await contains(`tbody tr:eq(1) div[name='amount']`).click();
+    await contains(`tbody tr:eq(1) div[name='amount'] input`).edit(600, { confirm: false });
     // Drag and drop the fourth line in second position
-    await contains(`tbody tr:eq(3) .o_handle_cell`).dragAndDrop(queryFirst(`tbody tr:eq(1)`));
+    // TODO JUM: PRHOOT the events
+    const { drop, moveTo } = await contains(`tbody tr:eq(3) .o_handle_cell`).drag();
+    await moveTo(`tbody tr:eq(1)`);
+    await drop(document.body);
     expect.verifySteps([["web_resequence", [4, 2, 3], "int_field", 1]]);
     expect(`tbody tr:eq(0) td:last`).toHaveText("1,200", {
         message: "new first record should have amount 1,200",
@@ -10333,7 +10338,7 @@ test(`editable list with handle widget`, async () => {
     expect(`tbody tr:eq(1) td:last`).toHaveText("0", {
         message: "new second record should have amount 0",
     });
-    expect(`tbody tr:eq(2) td:last`).toHaveText("500", {
+    expect(`tbody tr:eq(2) td:last`).toHaveText("600", {
         message: "new third record should have amount 500",
     });
     expect(`tbody tr:eq(3) td:last`).toHaveText("300", {


### PR DESCRIPTION
When editing a list row, handle fields were invisible but still interactable, leading to confusing behavior. They are now kept fully visible during edition.

Additionally, the explicit leaveEditMode call on drop has been put further in the method, since it could cause a flicker to occur with the save otherwise.


task-5079713