### PR TITLE
[FIX] l10n_*_pos: include added fields in PoS session notifications

### DIFF
--- a/addons/l10n_es_edi_tbai_pos/models/pos_session.py
+++ b/addons/l10n_es_edi_tbai_pos/models/pos_session.py
@@ -4,9 +4,7 @@ from odoo import models
 class PosSession(models.Model):
     _inherit = 'pos.session'
 
-    def _load_pos_data(self, models_to_load):
-        data = super()._load_pos_data(models_to_load)
-
+    def _post_read_pos_data(self, data):
         tbai_refund_reason_field = self.env['ir.model.fields']._get('account.move', 'l10n_es_tbai_refund_reason')
         data[0]['_tbai_refund_reasons'] = [
             {'value': refund_reason.value, 'name': refund_reason.name}
@@ -14,4 +12,4 @@ class PosSession(models.Model):
             if refund_reason.value != 'R5'  # R5 is for simplified invoice
         ]
 
-        return data
+        return super()._post_read_pos_data(data)

--- a/addons/l10n_es_edi_verifactu_pos/models/pos_session.py
+++ b/addons/l10n_es_edi_verifactu_pos/models/pos_session.py
@@ -4,13 +4,11 @@ from odoo import models
 class PosSession(models.Model):
     _inherit = 'pos.session'
 
-    def _load_pos_data(self, models_to_load):
-        data = super()._load_pos_data(models_to_load)
-
+    def _post_read_pos_data(self, data):
         verifactu_refund_reason_field = self.env['ir.model.fields']._get('pos.order', 'l10n_es_edi_verifactu_refund_reason')
         data[0]['_verifactu_refund_reasons'] = [
             {'value': refund_reason.value, 'name': refund_reason.name}
             for refund_reason in verifactu_refund_reason_field.selection_ids
         ]
 
-        return data
+        return super()._post_read_pos_data(data)


### PR DESCRIPTION
Before this commit, the special fields were added to the PoS session in the `_load_pos_data` function. However, they were not included when sending synchronization notifications to other devices. As a result, in multi-device setups, these fields would be removed after a WebSocket notification.

related: https://github.com/odoo/enterprise/pull/95455
opw-5073848

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
