### PR TITLE
[FIX] account_fleet: prevent tax report error with multiple vehicles on invoices

### DIFF
--- a/addons/account_fleet/models/account_move.py
+++ b/addons/account_fleet/models/account_move.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models, _
+from odoo import api, fields, models, _
+from odoo.tools import SQL
 
 
 class AccountMove(models.Model):
@@ -59,3 +60,12 @@ class AccountMoveLine(models.Model):
     def unlink(self):
         self.sudo().vehicle_log_service_ids.with_context(ignore_linked_bill_constraint=True).unlink()
         return super().unlink()
+
+    @api.model
+    def _get_extra_query_base_tax_line_mapping(self) -> SQL:
+        """Override to add vehicle_id matching condition for tax details query.
+        This ensures that tax lines are only matched with base lines that have the same vehicle_id,
+        preventing tax lines from being incorrectly merged when different vehicles are used.
+        """
+        query = super()._get_extra_query_base_tax_line_mapping()
+        return SQL("%s AND COALESCE(base_line.vehicle_id, 0) = COALESCE(account_move_line.vehicle_id, 0)", query)

--- a/addons/account_fleet/tests/test_account_fleet.py
+++ b/addons/account_fleet/tests/test_account_fleet.py
@@ -1,12 +1,13 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from freezegun import freeze_time
-from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo import Command
+from odoo.addons.account.tests.test_account_move_line_tax_details import TestAccountTaxDetailsReport
 from odoo.tests import tagged
 
 
 @tagged('post_install', '-at_install')
-class TestAccountFleet(AccountTestInvoicingCommon):
+class TestAccountFleet(TestAccountTaxDetailsReport):
 
     @freeze_time('2021-09-15')
     def test_transfer_wizard_vehicle_info_propagation(self):
@@ -44,3 +45,57 @@ class TestAccountFleet(AccountTestInvoicingCommon):
         result_action = wizard.do_action()
         transfer_moves = self.env['account.move'].search(result_action['domain'])
         self.assertEqual(transfer_moves.line_ids.filtered(lambda l: l.account_id == expense_account).vehicle_id, car_1, "Vehicle info is missing")
+
+    def test_tax_report_with_vehicle_split_repartition(self):
+        """Test tax report with split repartition lines across different vehicles."""
+        ChartTemplate = self.env['account.chart.template']
+        brand = self.env["fleet.vehicle.model.brand"].create({"name": "Audi"})
+        model = self.env["fleet.vehicle.model"].create({"brand_id": brand.id, "name": "A3"})
+        cars = self.env["fleet.vehicle"].create([
+            {"model_id": model.id, "plan_to_change_car": False},
+            {"model_id": model.id, "plan_to_change_car": False},
+        ])
+
+        expense_account = ChartTemplate.ref('expense')
+        asset_account = ChartTemplate.ref('current_assets')
+
+        tax = self.env['account.tax'].create({
+            'name': 'Split Tax',
+            'amount': 10,
+            'invoice_repartition_line_ids': [
+                Command.create({'repartition_type': 'base', 'factor_percent': 100}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 50, 'account_id': expense_account.id}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 50, 'account_id': asset_account.id}),
+            ],
+            'refund_repartition_line_ids': [
+                Command.create({'repartition_type': 'base', 'factor_percent': 100}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 50, 'account_id': expense_account.id}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 50, 'account_id': asset_account.id}),
+            ],
+        })
+
+        bill = self.init_invoice('in_invoice', invoice_date='2025-10-16', post=False)
+        bill.write({
+            'invoice_line_ids': [
+                Command.create({
+                    'product_id': self.product_a.id,
+                    'account_id': expense_account.id,
+                    'price_unit': 100,
+                    'tax_ids': [Command.set(tax.ids)],
+                    'vehicle_id': cars[0].id
+                }),
+                Command.create({
+                    'product_id': self.product_a.id,
+                    'account_id': expense_account.id,
+                    'price_unit': 100,
+                    'tax_ids': [Command.set(tax.ids)],
+                    'vehicle_id': cars[1].id
+                }),
+            ]
+        })
+        bill.action_post()
+
+        tax_details = self._get_tax_details()
+        self.assertEqual(len(tax_details), 2)
+        for line in tax_details:
+            self.assertEqual(line['tax_amount'], 5)

--- a/addons/hr_expense/models/account_move_line.py
+++ b/addons/hr_expense/models/account_move_line.py
@@ -27,4 +27,5 @@ class AccountMoveLine(models.Model):
         super(AccountMoveLine, self - expenses)._compute_totals()
 
     def _get_extra_query_base_tax_line_mapping(self) -> SQL:
-        return SQL(' AND (base_line.expense_id IS NULL OR account_move_line.expense_id = base_line.expense_id)')
+        query = super()._get_extra_query_base_tax_line_mapping()
+        return SQL('%s AND (base_line.expense_id IS NULL OR account_move_line.expense_id = base_line.expense_id)', query)


### PR DESCRIPTION
**Steps to reproduce:**
1. Install the *Fleet* and `accounting` modules.
2. Create a new purchase tax.
3. Configure the tax with a 50% repartition line for an `600000 expense` account and a 50% repartition line for a `101000 current asset` account for both income and refund.
4. Create a vendor bill with two product lines, each having a different vehicle assigned with the newly created tax in both lines.
5. Check the *Tax Report*(account>tax), including the date of this vendor bill.

**Observed behavior:**
* Tax lines linked to the current asset account are merged.
* Tax lines linked to the expense account remain separate (since `vehicle_id` is set on the `account.move.line`).
* This mismatch triggers an error in the tax report.

**Root cause:**
The tax details query does not account for the `vehicle_id` field when matching tax lines with base lines. As a result, tax lines are incorrectly merged across different vehicles.

**Solution:**
Override `_get_extra_query_base_tax_line_mapping` to include the `vehicle_id` in the matching condition, ensuring tax lines are only paired with base lines having the same `vehicle_id`. This prevents incorrect merging and resolves the report error.

opw-5013757
