### PR TITLE
[IMP] link_tracker: generate QR codes for link trackers

### DIFF
--- a/addons/link_tracker/models/link_tracker.py
+++ b/addons/link_tracker/models/link_tracker.py
@@ -260,6 +260,16 @@ class LinkTracker(models.Model):
     def _convert_links_text(self, body, vals, blacklist=None):
         raise NotImplementedError('Moved on mail.render.mixin')
 
+    def action_download_qrcode(self):
+        self.ensure_one()
+        url = urls.url_quote_plus(self.short_url)
+
+        return {
+            "type": "ir.actions.act_url",
+            "url": f"/report/barcode/QR/{url}?width=500&height=500&download=1",
+            "target": "self",
+        }
+
     def action_view_statistics(self):
         action = self.env['ir.actions.act_window']._for_xml_id('link_tracker.link_tracker_click_action_statistics')
         action['domain'] = [('link_id', '=', self.id)]

--- a/addons/link_tracker/views/link_tracker_views.xml
+++ b/addons/link_tracker/views/link_tracker_views.xml
@@ -26,6 +26,10 @@
             <field name="model">link.tracker</field>
             <field name="arch" type="xml">
                 <form string="Website Link" duplicate="0">
+                    <header>
+                        <button name="action_download_qrcode" type="object" string="Download QR Code" class="btn-secondary"
+                            invisible="not id"/>
+                    </header>
                     <sheet>
                         <div class="oe_button_box" name="button_box">
                             <button type="object" icon="fa-sign-out" name="action_visit_page"
@@ -41,10 +45,11 @@
                         </div>
                         <div class="oe_title mw-100">
                             <label for="code" string="Link Tracker"/>
-                            <h2 class="d-flex flex-wrap fw-normal">
+                            <h2 invisible="not id" class="d-flex flex-wrap fw-normal">
                                 <field name="short_url_host" nolabel="1" readonly="1" class="text-break w-auto me-1"/>
-                                <field name="code" nolabel="1" readonly="not code" invisible="not code" class="o_input w-100 w-sm-50 w-lg-25"/>
+                                <field name="code" nolabel="1" readonly="not id" required="id" class="o_input w-100 w-sm-50 w-lg-25"/>
                             </h2>
+                            <h2 invisible="id" class="fw-normal">New Link Tracker</h2>
                         </div>
                         <group>
                             <group name="link" string="Link">

--- a/addons/web/controllers/report.py
+++ b/addons/web/controllers/report.py
@@ -77,6 +77,8 @@ class ReportController(http.Controller):
                      Masks allow adding elements on top of the generated image,
                      such as the Swiss cross in the center of QR-bill codes.
         :param barLevel: QR code Error Correction Levels. Default is 'L'.
+        :param download: Accepted values: 0 (default) or 1. 1 will make the browser download the code as a
+        PNG image.
         ref: https://hg.reportlab.com/hg-public/reportlab/file/830157489e00/src/reportlab/graphics/barcode/qr.py#l101
         """
         try:
@@ -84,10 +86,15 @@ class ReportController(http.Controller):
         except (ValueError, AttributeError):
             raise werkzeug.exceptions.HTTPException(description='Cannot convert into barcode.')
 
-        return request.make_response(barcode, headers=[
+        headers = [
             ('Content-Type', 'image/png'),
             ('Cache-Control', f'public, max-age={http.STATIC_CACHE_LONG}, immutable'),
-        ])
+        ]
+
+        if int(kwargs.get('download', '0')):
+            headers.append(('Content-Disposition', f'attachment; filename={barcode_type}.png'))
+
+        return request.make_response(barcode, headers)
 
     @http.route(['/report/download'], type='http', auth="user")
     # pylint: disable=unused-argument

--- a/addons/website_links/static/src/interactions/website_links.js
+++ b/addons/website_links/static/src/interactions/website_links.js
@@ -145,10 +145,12 @@ class WebsiteLinks extends Interaction {
         } else {
             // Link generated, clean the form and show the link
             const link = result[0];
-
             this.el.querySelector("#generated_tracked_link").classList.remove("d-none");
             this.el.querySelector("#btn_shorten_url").classList.add("d-none");
             this.el.querySelector(".copy-to-clipboard").dataset.clipboardText = link.short_url;
+            this.el.querySelector(".download-qr-code").href = `/report/barcode/QR/${encodeURIComponent(
+                link.short_url
+            )}?width=500&height=500&download=1`;
             this.el.querySelector("#short-url-host").textContent = link.short_url_host;
             this.el.querySelector("#o_website_links_code").textContent = link.code;
 

--- a/addons/website_links/static/src/interactions/website_links_code_editor.js
+++ b/addons/website_links/static/src/interactions/website_links_code_editor.js
@@ -12,6 +12,9 @@ class WebsiteLinksCodeEditor extends Interaction {
             "t-on-click.prevent": this.onCopyToClipboardClick,
             "t-att-class": () => ({ "d-none": this.editing }),
         },
+        ".download-qr-code": {
+            "t-att-class": () => ({ "d-none": this.editing }),
+        },
         ".o_website_links_edit_code": {
             "t-on-click": this.onEditCodeClick,
             "t-att-class": () => ({ "d-none": this.editing }),
@@ -73,6 +76,14 @@ class WebsiteLinksCodeEditor extends Interaction {
         this.codeEl.replaceChildren(newCode);
         const host = this.el.querySelector("#short-url-host").textContent;
         this.copyButtonEl.dataset.clipboardText = `${host}${newCode}`;
+
+        const downloadQRButton = this.el.querySelector(".download-qr-code");
+        if (downloadQRButton) {
+            downloadQRButton.href = `/report/barcode/QR/${encodeURIComponent(
+                `${host}${newCode}`
+            )}?width=500&height=500&download=1`;
+        }
+
         this.editing = false;
         this.error = false;
     }

--- a/addons/website_links/views/website_links_graphs.xml
+++ b/addons/website_links/views/website_links_graphs.xml
@@ -38,6 +38,9 @@
                                     </span>
                                     <a t-attf-class="#{'' if can_create_link_tracker_code else 'd-none'} o_website_links_edit_code o_translate_inline" aria-label="Edit code" title="Edit code"><span class="fa fa-pencil gray"></span></a>
                                     <a class="copy-to-clipboard btn btn-sm btn-primary o_translate_inline" t-att-data-clipboard-text="short_url"><i class="fa fa-copy me-2"/>Copy</a>
+                                    <a class="download-qr-code btn btn-sm btn-primary o_translate_inline" t-attf-href="/report/barcode/QR/#{quote_plus(short_url)}?width=500&amp;height=500&amp;download=1">
+                                        <i class="fa fa-qrcode align-middle me-2"/>Download QR Code
+                                    </a>
                                 </p>
                                 <p class='o_website_links_code_error' style='color:red;font-weight:bold'></p>
                             </div>

--- a/addons/website_links/views/website_links_template.xml
+++ b/addons/website_links/views/website_links_template.xml
@@ -55,6 +55,7 @@
                                         </span>
                                         <a t-attf-class="#{'' if can_create_link_tracker_code else 'd-none'} o_website_links_edit_code o_translate_inline" aria-label="Edit code" title="Edit code"><i class="fa fa-pencil gray"/></a>
                                         <a class="copy-to-clipboard btn btn-success text-nowrap o_translate_inline"><i class="fa fa-copy me-2"/>Copy</a>
+                                        <a class="download-qr-code btn btn-info text-nowrap o_translate_inline"><i class="fa fa-qrcode align-middle me-2"/>Download QR Code</a>
                                     </p>
                                 </div>
                                 <div class="offset-md-3 col-md-9 px-2">


### PR DESCRIPTION
This commit adds the generation of QR codes for the link trackers. 
The QR code will be displayed in the form view of the link tracker. 
Below it will be the download button to download the QR code in the `PNG` format.

Task-5106566
