### PR TITLE
[FIX] pos_online_* : avoid duplicate background on payment page

### DIFF
--- a/addons/pos_online_payment_self_order/static/src/app/pages/payment_page/payment_page.xml
+++ b/addons/pos_online_payment_self_order/static/src/app/pages/payment_page/payment_page.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
     <t t-name="pos_online_payment_self_order.PaymentPage" t-inherit="pos_self_order.PaymentPage" t-inherit-mode="extension">
         <xpath expr="//div[hasclass('payment-state-container')]" position="after">
-            <div t-if="this.selectedPaymentIsOnline and !state.selection and selfOrder.config.self_ordering_mode === 'kiosk'" class="o_self_payment_screen d-flex justify-content-center align-items-center flex-column h-100 px-3 text-center o_self_fade" t-attf-style="background-image:#{selfOrder.kioskBackgroundImageUrl};background-size: cover; background-position: center;">
+            <div t-if="this.selectedPaymentIsOnline and !state.selection and selfOrder.config.self_ordering_mode === 'kiosk'" class="o_self_payment_screen d-flex justify-content-center align-items-center flex-column h-100 px-3 text-center o_self_fade">
                 <h1 class="fw-bolder mb-4">Scan the QR code to pay</h1>
                 <div class="qr-code d-inline-flex flex-column border rounded-4 p-0 bg-view mb-3">
                     <img t-att-src="state.qrImage" />


### PR DESCRIPTION
pos_online_* = pos_online_payment_self_order

This commit ensures that only one background is displayed on the kiosk online payment page. The background is correctly displayed in 'pos_self_order.PaymentPage', and it should not be displayed again in the “Scan the QR code to pay” subcomponent.


<img width="688" height="485" alt="Screenshot 2025-09-24 at 13 49 00" src="https://github.com/user-attachments/assets/e521ffce-82db-4900-828a-5d086fa9b4ac" />


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
