### PR TITLE
[FIX] l10n_gcc_*,l10n_sa: fixing post l10n_gcc report refactor bugs

### DIFF
--- a/addons/l10n_ae/views/report_invoice_templates.xml
+++ b/addons/l10n_ae/views/report_invoice_templates.xml
@@ -23,42 +23,40 @@
         <td name="td_taxes" position="after">
             <t t-if="display_taxes">
                 <td name="td_vat_amount" class="text-end">
-                    <span t-if="not line.collapse_prices" name="td_vat_amount_span" t-field="line.l10n_gcc_invoice_tax_amount"/>
+                    <span t-if="not hide_prices" name="td_vat_amount_span" t-field="line.l10n_gcc_invoice_tax_amount"/>
                 </td>
             </t>
         </td>
         <td name="td_subtotal" position="after">
             <t t-if="o.currency_id != o.company_currency_id">
                 <td name="td_subtotal_curr" class="text-end">
-                    <span name="td_subtotal_curr_excl_span" class="text-nowrap" t-if="o.company_price_include == 'tax_excluded' and not line.collapse_prices"
-                          t-out="line.currency_id._convert(line.price_subtotal, o.company_currency_id, o.company_id, o.invoice_date or datetime.date.today())"
+                    <span name="td_subtotal_curr_excl_span" class="text-nowrap" t-if="o.company_price_include == 'tax_excluded' and not hide_prices"
+                          t-out="line.price_subtotal * 1 / o.invoice_currency_rate"
                           t-options="{'widget': 'monetary', 'display_currency': o.company_currency_id}"/>
-                    <span name="td_subtotal_curr_incl_span" class="text-nowrap" t-if="o.company_price_include == 'tax_included' and not line.collapse_prices"
-                          t-out="line.currency_id._convert(line.price_total, o.company_currency_id, o.company_id, o.invoice_date or datetime.date.today())"
+                    <span name="td_subtotal_curr_incl_span" class="text-nowrap" t-if="o.company_price_include == 'tax_included' and not hide_prices"
+                          t-out="line.price_total * 1 / o.invoice_currency_rate"
                           t-options="{'widget': 'monetary', 'display_currency': o.company_currency_id}"/>
                 </td>
             </t>
         </td>
         <td name="td_subtotal_grouped" position="before">
             <td name="td_vat_amount_grouped" t-attf-class="text-end">
-                <span t-if="not line.collapse_prices" t-out="grouped_line['l10n_gcc_invoice_tax_amount']"  t-options='{"widget": "monetary", "display_currency": o.currency_id}' class="text-nowrap">4.05</span>
+                <span t-if="(grouped_line.get('display_type') in ('line_section', 'line_subsection') or hide_details)" t-out="grouped_line['l10n_gcc_invoice_tax_amount']"  t-options='{"widget": "monetary", "display_currency": o.currency_id}' class="text-nowrap">4.05</span>
             </td>
         </td>
         <td name="td_subtotal_grouped" position="after">
             <td name="th_subtotal_curr_grouped" class="text-end" t-if="o.currency_id != o.company_currency_id">
-                <span t-if="not line.collapse_prices and o.company_price_include == 'tax_excluded'" class="text-nowrap" t-out="line.currency_id._convert(grouped_line['price_subtotal'], o.company_currency_id, o.company_id, o.invoice_date or datetime.date.today())" t-options='{"widget": "monetary", "display_currency": o.company_currency_id}'>27.00</span>
-                <span t-if="not line.collapse_prices and o.company_price_include == 'tax_included'" class="text-nowrap" t-out="line.currency_id._convert(grouped_line['price_total'], o.company_currency_id, o.company_id, o.invoice_date or datetime.date.today())" t-options='{"widget": "monetary", "display_currency": o.company_currency_id}'>27.00</span>
+                <span t-if="(grouped_line.get('display_type') in ('line_section', 'line_subsection') or hide_details) and o.company_price_include == 'tax_excluded'" class="text-nowrap" t-out="grouped_line['price_subtotal'] * 1 / o.invoice_currency_rate" t-options='{"widget": "monetary", "display_currency": o.company_currency_id}'>27.00</span>
+                <span t-if="(grouped_line.get('display_type') in ('line_section', 'line_subsection') or hide_details) and o.company_price_include == 'tax_included'" class="text-nowrap" t-out="grouped_line['price_total'] * 1 / o.invoice_currency_rate" t-options='{"widget": "monetary", "display_currency": o.company_currency_id}'>27.00</span>
             </td>
         </td>
-        <xpath expr="//t[@t-elif=&quot;line.display_type in ('line_section', 'line_subsection')&quot;]//span[@t-out='section_subtotal']/.." position="before">
-            <td colspan="1" class="text-end o_price_total">
-                <span t-out="line._l10n_gcc_get_section_tax_amount()" class="text-nowrap" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
-            </td>
+        <xpath expr="//span[@t-out='section_subtotal']/.." position="attributes">
+            <attribute name="colspan">2</attribute>
         </xpath>
         <xpath expr="//t[@t-elif=&quot;line.display_type in ('line_section', 'line_subsection')&quot;]//span[@t-out='section_subtotal']/.." position="after">
             <td colspan="1" class="text-end o_price_total" t-if="o.currency_id != o.company_currency_id">
                 <span class="text-nowrap"
-                      t-out="line.currency_id._convert(section_subtotal, o.company_currency_id, o.company_id, o.invoice_date or datetime.date.today())"
+                      t-out="section_subtotal * 1 / o.invoice_currency_rate"
                       t-options='{"widget": "monetary", "display_currency": o.company_currency_id}'/>
             </td>
         </xpath>

--- a/addons/l10n_gcc_invoice/models/account_move.py
+++ b/addons/l10n_gcc_invoice/models/account_move.py
@@ -92,10 +92,10 @@ class AccountMoveLine(models.Model):
             else:
                 line.l10n_gcc_line_name = line.name
 
-    def get_lines_grouped_by_section(self):
+    def _get_child_lines(self):
         # EXTENDS account
         self.ensure_one()
-        res = super().get_lines_grouped_by_section()
+        res = super()._get_child_lines()
 
         for line in res:
             line['l10n_gcc_invoice_tax_amount'] = line['price_total'] - line['price_subtotal']

--- a/addons/l10n_gcc_pos/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
+++ b/addons/l10n_gcc_pos/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
@@ -10,16 +10,16 @@
                 <div class="pos-receipt-header">
                     <t t-if="!show_simplified_title">
                         <t t-if="order.config_id.l10n_gcc_dual_language_receipt">
-                            <span id="title_en" t-translation="off">Tax Invoice</span>
+                            <span id="title_en" t-translation="off">Tax Invoice</span> / 
                             <span id="title_ar" t-translation="off">الفاتورة الضريبية</span>
                         </t>
                         <t t-else="">
-                            <span name="title_simplified">Simplified Tax Invoice</span>
+                            <span name="title">Tax Invoice</span>
                         </t>
                     </t>
                     <t t-else="">
                         <t t-if="order.config_id.l10n_gcc_dual_language_receipt">
-                            <span name="title_simplified_en" t-translation="off">Simplified Tax Invoice</span>
+                            <span name="title_simplified_en" t-translation="off">Simplified Tax Invoice</span> / 
                             <span name="title_simplified_ar" t-translation="off">فاتورة ضريبية مبسطة</span>
                         </t>
                         <t t-else="">

--- a/addons/l10n_sa/views/report_invoice.xml
+++ b/addons/l10n_sa/views/report_invoice.xml
@@ -4,7 +4,7 @@
         <!-- Header & Footer -->
          <t name="l10n_gcc_settings" position="inside">
             <t t-set="additional_footer_text" t-value="o.get_l10n_sa_confirmation_datetime_sa_tz()"/>
-            <t t-if="o.company_id.country_id.code == 'SA' and not o._l10n_sa_is_legal() " t-set="custom_header_sa">
+            <t t-if="o.company_id.country_id.code == 'SA' and o.is_sale_document() and not o._l10n_sa_is_legal() " t-set="custom_header_sa">
                 <div class="fw-bold text-center mt-2">
                     <h5>THIS IS NOT A LEGAL DOCUMENT</h5>
                     <h5>هذا المستند ليس مستنداً قانونياً</h5>
@@ -134,13 +134,13 @@
         </td>
         <t name="account_invoice_line_accountable" position="inside">
             <td name="td_vat_amount" class="text-end">
-                <span t-if="not line.collapse_prices" class="text-nowrap" t-field="line.l10n_gcc_invoice_tax_amount" t-options="{'widget': 'monetary', 'display_currency': o.currency_id}">4.05</span>
+                <span class="text-nowrap" t-field="line.l10n_gcc_invoice_tax_amount" t-options="{'widget': 'monetary', 'display_currency': o.currency_id}">4.05</span>
             </td>
             <td name="td_vat_excl" class="text-end o_price_total">
-                <span t-if="not line.collapse_prices" class="text-nowrap" t-field="line.price_subtotal">27.00</span>
+                <span class="text-nowrap" t-field="line.price_subtotal">27.00</span>
             </td>
             <td name="td_vat_incl" class="text-end o_price_total">
-                <span t-if="not line.collapse_prices" class="text-nowrap" t-field="line.price_total">31.05</span>
+                <span class="text-nowrap" t-field="line.price_total">31.05</span>
             </td>
         </t>
         <xpath expr="//td[@name='td_price_unit']/span" position="attributes">
@@ -148,20 +148,26 @@
         </xpath>
         <td name="td_subtotal_grouped" position="before">
             <td name="td_vat_amount_grouped" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
-                <span t-if="not line.collapse_prices" t-out="grouped_line['l10n_gcc_invoice_tax_amount']"  t-options='{"widget": "monetary", "display_currency": o.currency_id}' class="text-nowrap">4.05</span>
+                <span t-if="(grouped_line.get('display_type') in ('line_section', 'line_subsection') or hide_details)" t-out="grouped_line['l10n_gcc_invoice_tax_amount']"  t-options='{"widget": "monetary", "display_currency": o.currency_id}' class="text-nowrap">4.05</span>
+            </td>
+        </td>
+        <td name="td_subtotal_grouped" position="attributes">
+            <attribute name="class" separator=" " add="d-none"/>
+        </td>
+        <td name="td_subtotal_grouped" position="after">
+            <td name="td_vat_incl_grouped" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
+                <span t-if="(grouped_line.get('display_type') in ('line_section', 'line_subsection') or hide_details)" class="text-nowrap" t-out="grouped_line['price_total']" t-options='{"widget": "monetary", "display_currency": o.currency_id}'>27.00</span>
             </td>
         </td>
         <td name="td_subtotal_grouped" position="after">
-            <td name="td_vat_amount_grouped" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
-                <span t-if="not line.collapse_prices" t-out="grouped_line['price_total']"  t-options='{"widget": "monetary", "display_currency": o.currency_id}' class="text-nowrap">4.05</span>
+            <td name="td_vat_excl_grouped" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
+                <span t-if="(grouped_line.get('display_type') in ('line_section', 'line_subsection') or hide_details)" class="text-nowrap" t-out="grouped_line['price_subtotal']" t-options='{"widget": "monetary", "display_currency": o.currency_id}'>27.00</span>
             </td>
         </td>
-        <xpath expr="//t[@t-elif=&quot;line.display_type in ('line_section', 'line_subsection')&quot;]//span[@t-out='section_subtotal']/.." position="before">
-            <td colspan="1" class="text-end o_price_total">
-                <span t-out="line._l10n_gcc_get_section_tax_amount()" class="text-nowrap" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
-            </td>
+        <xpath expr="//span[@t-out='section_subtotal']/.." position="attributes">
+            <attribute name="colspan">2</attribute>
         </xpath>
-        <xpath expr="//t[@t-elif=&quot;line.display_type in ('line_section', 'line_subsection')&quot;]//span[@t-out='section_subtotal']/.." position="after">
+        <xpath expr="//span[@t-out='section_subtotal']/.." position="after">
             <td colspan="1" class="text-end o_price_total">
                 <span t-out="line._l10n_gcc_get_section_total()" class="text-nowrap" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
             </td>

--- a/addons/l10n_sa/views/report_templates_views.xml
+++ b/addons/l10n_sa/views/report_templates_views.xml
@@ -47,6 +47,9 @@
         <xpath expr="//span[hasclass('page')]/.." position="before">
             <t t-call="l10n_sa.l10n_sa_additional_footer"/>
         </xpath>
+        <t t-set="header_shape_height" position="after">
+            <t t-set="header_shape_height" t-if="o and o._name == 'account.move' and o.country_code == 'SA'">215</t>
+        </t>
     </template>
     <template id="l10n_sa_external_layout_wave" inherit_id="web.external_layout_wave">
         <!-- support for custom header -->


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
after the merge https://github.com/odoo/odoo/pull/220167 there were some bugs due to the new section features that were also merged in 19.0
this commits fixes certain tracebacks that occured when sections were used in the invoice pdf report.
it also fixes certain formatting issues due to different layouts or due to changes made in the standard report.

Current behavior before PR:
certain tracebacks/unwanted formatting changes occur when you try to print any report that inherits l10n_gcc_invoice and you have sections in the invoice.

Desired behavior after PR is merged:
the changes done in the account invoice report are accounted for in the ae & sa reports.

task-5069610



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
