### PR TITLE
[FIX] website_blog: fix blog tag color update

### DIFF
--- a/addons/website_blog/models/website_blog.py
+++ b/addons/website_blog/models/website_blog.py
@@ -149,6 +149,19 @@ class BlogTag(models.Model):
         ('name_uniq', 'unique (name)', "Tag name already exists!"),
     ]
 
+    def write(self, *args, **kwargs):
+        # When the tags configuration related to blog posts is changed, force
+        # the posts to be marked as updated (we will assume here that the tags
+        # own attributes are not changed everyday so this is acceptable). This
+        # allows to handle a t-cache problem in stable (blog tags not being
+        # updated if their color is changed for example). In 19.0, the t-cache
+        # system is gone so this will be removed and perf IMP done other ways.
+        # TODO remove in 19.0
+        res = super().write(*args, **kwargs)
+        for record in self:
+            record.post_ids.write({})
+        return res
+
 
 class BlogPost(models.Model):
     _name = "blog.post"


### PR DESCRIPTION
Steps to reproduce:
- Go to the /blog page
- See that some posts use some tags
- Go to Configuration > Tags
- Change the color of an existing tag
- Go back to the /blog page => The color of the tag is not updated for existing posts using it.

This is a t-cache issue, which unfortunately is difficult to fix in stable (as it would require modifying multiple nodes in qweb).

As a workaround, and knowing that the t-cache system was fully removed in 19.0 at [1], this fixes the bug with a hack: on tag update, make a dummy update to the related blog posts already using it. Tag updates should be quite rare anyway.

[1]: https://github.com/odoo/odoo/commit/1cf06a5688e6aa80175d5a28a83b639d0eb925a7

task-4045724
