### PR TITLE
[FIX] purchase_stock: make Buy route selectable on products for tests

### DIFF
--- a/addons/purchase_stock/tests/test_reordering_rule.py
+++ b/addons/purchase_stock/tests/test_reordering_rule.py
@@ -25,8 +25,8 @@ class TestReorderingRule(TransactionCase):
         cls.partner = cls.env['res.partner'].create({
             'name': 'Smith'
         })
-        cls.env.user.group_ids += cls.env.ref('uom.group_uom')
-
+        cls.buy_route = cls.env.ref('purchase_stock.route_warehouse0_buy')
+        cls.buy_route.product_selectable = True
         # create product and set the vendor
         product_form = Form(cls.env['product.product'])
         product_form.name = 'Product A'
@@ -35,7 +35,7 @@ class TestReorderingRule(TransactionCase):
         with product_form.seller_ids.new() as seller:
             seller.partner_id = cls.partner
             seller.product_uom_id = product_form.uom_id
-        product_form.route_ids.add(cls.env.ref('purchase_stock.route_warehouse0_buy'))
+        product_form.route_ids.add(cls.buy_route)
         cls.product_01 = product_form.save()
 
     def test_reordering_rule_1(self):


### PR DESCRIPTION
The setup class `TestReorderingRule` fails with `AssertionError: field 'route_ids' is not visible`.

This happens because the  `route_ids` field on the product form is only visible when `has_available_route_ids` is `True`, which requires at least one route to be `product_selectable`.

After recent changes here: https://github.com/odoo/odoo/pull/223685, the Buy route (`purchase_stock.route_warehouse0_buy`) is no longer product-selectable, causing the field to be hidden and the test to break.

This commit re-enables `product_selectable` on the Buy route in tests to make sure `route_ids` is visible and the reordering rule tests run successfully.

I also removed `cls.env.user.group_ids += cls.env.ref('uom.group_uom')` it was a duplicated line, from two different fixes.
 
[RB-232574](https://runbot.odoo.com/odoo/error/232574)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
