### PR TITLE
[IMP] spreadsheet: add fiscal year date filter

### DIFF
--- a/addons/spreadsheet/static/src/chart/plugins/odoo_chart_feature_plugin.js
+++ b/addons/spreadsheet/static/src/chart/plugins/odoo_chart_feature_plugin.js
@@ -21,8 +21,12 @@ export class OdooChartFeaturePlugin extends OdooUIPlugin {
                         const { fieldName, granularity } =
                             this.getters.getChartGranularity(chartId);
                         const fieldMatching = this.getters.getChartFieldMatch(chartId)[filterId];
-                        const bestGranularity = getBestGranularity(cmd.value, fieldMatching);
-                        const validGranularities = getValidGranularities(cmd.value);
+                        const bestGranularity = getBestGranularity(
+                            cmd.value,
+                            fieldMatching,
+                            this.getters
+                        );
+                        const validGranularities = getValidGranularities(cmd.value, this.getters);
                         if (
                             fieldMatching?.chain === fieldName &&
                             !validGranularities.includes(this.overwrittenGranularities[chartId]) &&
@@ -70,7 +74,7 @@ export class OdooChartFeaturePlugin extends OdooUIPlugin {
         if (matching?.type === "datetime") {
             all.unshift({ value: "hour", label: _t("Hours") });
         }
-        const validGranularities = getValidGranularities(currentFilterValue);
+        const validGranularities = getValidGranularities(currentFilterValue, this.getters);
         return all.filter(
             ({ value }) => validGranularities.includes(value) || value === granularity
         );

--- a/addons/spreadsheet/static/src/global_filters/components/date_filter_dropdown/date_filter_dropdown.js
+++ b/addons/spreadsheet/static/src/global_filters/components/date_filter_dropdown/date_filter_dropdown.js
@@ -74,9 +74,10 @@ export class DateFilterDropdown extends Component {
     }
 
     get dateOptions() {
-        const filterTypes = getDateGlobalFilterTypes().filter(
-            (type) => !globalFilterDateRegistry.get(type).canOnlyBeDefault
-        );
+        const filterTypes = getDateGlobalFilterTypes().filter((type) => {
+            const item = globalFilterDateRegistry.get(type);
+            return !item.canOnlyBeDefault && !item.shouldBeHidden?.(this.props.model.getters);
+        });
         const options = filterTypes.map((type, i) => {
             const item = globalFilterDateRegistry.get(type);
             const nextItem = filterTypes[i + 1] && globalFilterDateRegistry.get(filterTypes[i + 1]);

--- a/addons/spreadsheet/static/src/global_filters/components/date_filter_dropdown/date_filter_dropdown.js
+++ b/addons/spreadsheet/static/src/global_filters/components/date_filter_dropdown/date_filter_dropdown.js
@@ -4,89 +4,13 @@ import {
     getDateRange,
     getNextDateFilterValue,
     getPreviousDateFilterValue,
-    RELATIVE_PERIODS,
+    globalFilterDateRegistry,
+    getDateGlobalFilterTypes,
 } from "@spreadsheet/global_filters/helpers";
 import { DateTimeInput } from "@web/core/datetime/datetime_input";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { _t } from "@web/core/l10n/translation";
 const { DateTime } = luxon;
-
-const DATE_OPTIONS = [
-    {
-        id: "today",
-        type: "relative",
-        label: RELATIVE_PERIODS["today"],
-    },
-    {
-        id: "yesterday",
-        type: "relative",
-        label: RELATIVE_PERIODS["yesterday"],
-        separator: true,
-    },
-    {
-        id: "last_7_days",
-        type: "relative",
-        label: RELATIVE_PERIODS["last_7_days"],
-    },
-    {
-        id: "last_30_days",
-        type: "relative",
-        label: RELATIVE_PERIODS["last_30_days"],
-    },
-    {
-        id: "last_90_days",
-        type: "relative",
-        label: RELATIVE_PERIODS["last_90_days"],
-        separator: true,
-    },
-    {
-        id: "month_to_date",
-        type: "relative",
-        label: RELATIVE_PERIODS["month_to_date"],
-    },
-    {
-        id: "last_month",
-        type: "relative",
-        label: RELATIVE_PERIODS["last_month"],
-    },
-    {
-        id: "month",
-        type: "month",
-        label: _t("Month"),
-    },
-    {
-        id: "quarter",
-        type: "quarter",
-        label: _t("Quarter"),
-        separator: true,
-    },
-    {
-        id: "year_to_date",
-        type: "relative",
-        label: RELATIVE_PERIODS["year_to_date"],
-    },
-    {
-        id: "last_12_months",
-        type: "relative",
-        label: RELATIVE_PERIODS["last_12_months"],
-    },
-    {
-        id: "year",
-        type: "year",
-        label: _t("Year"),
-        separator: true,
-    },
-    {
-        id: undefined,
-        type: undefined,
-        label: _t("All time"),
-    },
-    {
-        id: "range",
-        type: "range",
-        label: _t("Custom Range"),
-    },
-];
 
 /**
  * This component is used to select a date filter value.
@@ -112,12 +36,16 @@ export class DateFilterDropdown extends Component {
      */
     _computeDefaultSelectedValues() {
         const now = DateTime.local();
-        this.selectedValues = {
-            month: { month: now.month, year: now.year, type: "month" },
-            quarter: { quarter: Math.ceil(now.month / 3), year: now.year, type: "quarter" },
-            year: { year: now.year, type: "year" },
-            range: { from: "", to: "", type: "range" },
-        };
+        const fixedPeriodsTypes = getDateGlobalFilterTypes().filter(
+            (type) => globalFilterDateRegistry.get(type).isFixedPeriod
+        );
+
+        this.selectedValues = {};
+        for (const type of fixedPeriodsTypes) {
+            this.selectedValues[type] = globalFilterDateRegistry
+                .get(type)
+                .getCurrentFixedPeriod(now);
+        }
     }
 
     /**
@@ -126,31 +54,11 @@ export class DateFilterDropdown extends Component {
      */
     _applyCurrentValueToSelectedValues(value) {
         this._setRangeToCurrentValue(value);
-        switch (value?.type) {
-            case "month":
-                this.selectedValues.month = {
-                    type: "month",
-                    month: value.month,
-                    year: value.year,
-                };
-                break;
-            case "quarter":
-                this.selectedValues.quarter = {
-                    type: "quarter",
-                    quarter: value.quarter,
-                    year: value.year,
-                };
-                break;
-            case "year":
-                this.selectedValues.year = { type: "year", year: value.year };
-                break;
-            case "range":
-                this.selectedValues.range = {
-                    type: "range",
-                    from: value.from,
-                    to: value.to,
-                };
-                break;
+        if (value?.type) {
+            const filterType = value.type === "relative" ? value.period : value.type;
+            if (this.isFixedPeriod(filterType)) {
+                this.selectedValues[value.type] = { ...value };
+            }
         }
     }
 
@@ -165,37 +73,42 @@ export class DateFilterDropdown extends Component {
     }
 
     get dateOptions() {
-        return DATE_OPTIONS;
-    }
+        const filterTypes = getDateGlobalFilterTypes().filter(
+            (type) => !globalFilterDateRegistry.get(type).canOnlyBeDefault
+        );
+        const options = filterTypes.map((type, i) => {
+            const item = globalFilterDateRegistry.get(type);
+            const nextItem = filterTypes[i + 1] && globalFilterDateRegistry.get(filterTypes[i + 1]);
+            return {
+                type,
+                label: item.label,
+                separator: nextItem && nextItem.category !== item.category,
+            };
+        });
 
-    isMonthQuarterYear(value) {
-        return ["month", "quarter", "year"].includes(value?.type);
+        const rangeIndex = options.findIndex((option) => option.type === "range");
+        if (rangeIndex !== -1) {
+            options.splice(rangeIndex, 0, { type: undefined, label: _t("All time") });
+        }
+        return options;
     }
 
     isSelected(value) {
         if (!this.props.value) {
-            return value.id === undefined;
+            return value.type === undefined;
         }
         if (this.props.value.type === "relative") {
-            return this.props.value.period === value.id;
+            return this.props.value.period === value.type;
         }
         return this.props.value.type === value.type;
     }
 
     update(value) {
+        if (value.type && !this.isFixedPeriod(value.type)) {
+            this.props.update({ type: "relative", period: value.type });
+            return;
+        }
         switch (value.type) {
-            case "relative":
-                this.props.update({ type: "relative", period: value.id });
-                break;
-            case "month":
-                this.props.update(this.selectedValues.month);
-                break;
-            case "quarter":
-                this.props.update(this.selectedValues.quarter);
-                break;
-            case "year":
-                this.props.update(this.selectedValues.year);
-                break;
             case "range": {
                 const { from, to } = this.selectedValues.range;
                 if (from && to) {
@@ -208,8 +121,12 @@ export class DateFilterDropdown extends Component {
                 this.props.update(this.selectedValues.range);
                 break;
             }
-            default:
+            case undefined:
                 this.props.update(undefined);
+                break;
+            default:
+                this.props.update(this.selectedValues[value.type]);
+                break;
         }
     }
 
@@ -244,5 +161,12 @@ export class DateFilterDropdown extends Component {
 
     selectNext(type) {
         this.selectedValues[type] = getNextDateFilterValue(this.selectedValues[type]);
+    }
+
+    isFixedPeriod(type) {
+        if (!type) {
+            return false;
+        }
+        return globalFilterDateRegistry.get(type).isFixedPeriod;
     }
 }

--- a/addons/spreadsheet/static/src/global_filters/components/date_filter_dropdown/date_filter_dropdown.js
+++ b/addons/spreadsheet/static/src/global_filters/components/date_filter_dropdown/date_filter_dropdown.js
@@ -23,6 +23,7 @@ export class DateFilterDropdown extends Component {
     static props = {
         value: { type: Object, optional: true },
         update: Function,
+        model: Object,
     };
 
     setup() {
@@ -63,8 +64,8 @@ export class DateFilterDropdown extends Component {
     }
 
     _setRangeToCurrentValue(value) {
-        const { from, to } = getDateRange(value);
         const now = DateTime.local();
+        const { from, to } = getDateRange(value, 0, now, this.props.model.getters);
         this.selectedValues.range = {
             type: "range",
             from: from ? from.toISODate() : now.startOf("month").toISODate(),
@@ -152,7 +153,7 @@ export class DateFilterDropdown extends Component {
     }
 
     getDescription(type) {
-        return dateFilterValueToString(this.selectedValues[type]);
+        return dateFilterValueToString(this.selectedValues[type], this.props.model.getters);
     }
 
     selectPrevious(type) {

--- a/addons/spreadsheet/static/src/global_filters/components/date_filter_dropdown/date_filter_dropdown.xml
+++ b/addons/spreadsheet/static/src/global_filters/components/date_filter_dropdown/date_filter_dropdown.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <templates>
     <t t-name="spreadsheet.DateFilterDropdown">
-        <t t-foreach="dateOptions" t-as="option" t-key="option.id">
+        <t t-foreach="dateOptions" t-as="option" t-key="option.type">
             <DropdownItem tag="'div'"
                             class="{ 'selected': isSelected(option), 'd-flex justify-content-between o-date-filter-dropdown': true }"
                             closingMode="'none'"
-                            attrs="{ 'data-id': option.id }"
+                            attrs="{ 'data-id': option.type }"
                             onSelected="() => this.update(option)">
 
                 <div class="o-date-option-label" t-esc="option.label"/>
@@ -16,7 +16,7 @@
                         <DateTimeInput type="'date'" value="dateTo()" onChange="(dateTo) => this.setDateTo(dateTo)" />
                     </div>
                 </t>
-                <t t-elif="isMonthQuarterYear(option)">
+                <t t-elif="isFixedPeriod(option.type)">
                     <div class="d-flex justify-content-between">
                         <button class="btn-previous fa fa-caret-left" t-on-click="() => this.selectPrevious(option.type)" />
                         <input class="o_input" type="text" t-att-value="getDescription(option.type)" readonly="true"/>

--- a/addons/spreadsheet/static/src/global_filters/components/date_filter_value/date_filter_value.js
+++ b/addons/spreadsheet/static/src/global_filters/components/date_filter_value/date_filter_value.js
@@ -15,6 +15,7 @@ export class DateFilterValue extends Component {
     static props = {
         value: { type: Object, optional: true },
         update: Function,
+        model: Object,
     };
 
     setup() {
@@ -26,6 +27,6 @@ export class DateFilterValue extends Component {
     }
 
     get inputValue() {
-        return dateFilterValueToString(this.props.value);
+        return dateFilterValueToString(this.props.value, this.props.model.getters);
     }
 }

--- a/addons/spreadsheet/static/src/global_filters/components/date_filter_value/date_filter_value.xml
+++ b/addons/spreadsheet/static/src/global_filters/components/date_filter_value/date_filter_value.xml
@@ -12,6 +12,7 @@
                 <DateFilterDropdown
                     value="props.value"
                     update.bind="props.update"
+                    model="props.model"
                 />
             </t>
         </Dropdown>

--- a/addons/spreadsheet/static/src/global_filters/components/default_date_value/default_date_value.js
+++ b/addons/spreadsheet/static/src/global_filters/components/default_date_value/default_date_value.js
@@ -27,9 +27,10 @@ export class DefaultDateValue extends Component {
     }
 
     get dateOptions() {
-        const filterTypes = getDateGlobalFilterTypes().filter(
-            (type) => !globalFilterDateRegistry.get(type).isFixedPeriod
-        );
+        const filterTypes = getDateGlobalFilterTypes().filter((type) => {
+            const item = globalFilterDateRegistry.get(type);
+            return !item.isFixedPeriod && !item.shouldBeHidden?.(this.env.model.getters);
+        });
         const options = filterTypes.map((type, i) => {
             const item = globalFilterDateRegistry.get(type);
             const nextItem = filterTypes[i + 1] && globalFilterDateRegistry.get(filterTypes[i + 1]);

--- a/addons/spreadsheet/static/src/global_filters/components/default_date_value/default_date_value.js
+++ b/addons/spreadsheet/static/src/global_filters/components/default_date_value/default_date_value.js
@@ -1,67 +1,11 @@
 import { Component } from "@odoo/owl";
-import { RELATIVE_PERIODS } from "@spreadsheet/global_filters/helpers";
+import {
+    globalFilterDateRegistry,
+    getDateGlobalFilterTypes,
+} from "@spreadsheet/global_filters/helpers";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { _t } from "@web/core/l10n/translation";
-
-const DATE_OPTIONS = [
-    {
-        id: "today",
-        label: RELATIVE_PERIODS["today"],
-    },
-    {
-        id: "yesterday",
-        label: RELATIVE_PERIODS["yesterday"],
-        separator: true,
-    },
-    {
-        id: "last_7_days",
-        label: RELATIVE_PERIODS["last_7_days"],
-    },
-    {
-        id: "last_30_days",
-        label: RELATIVE_PERIODS["last_30_days"],
-    },
-    {
-        id: "last_90_days",
-        label: RELATIVE_PERIODS["last_90_days"],
-        separator: true,
-    },
-    {
-        id: "month_to_date",
-        label: RELATIVE_PERIODS["month_to_date"],
-    },
-    {
-        id: "last_month",
-        label: RELATIVE_PERIODS["last_month"],
-    },
-    {
-        id: "this_month",
-        label: _t("Current Month"),
-    },
-    {
-        id: "this_quarter",
-        label: _t("Current Quarter"),
-        separator: true,
-    },
-    {
-        id: "year_to_date",
-        label: RELATIVE_PERIODS["year_to_date"],
-    },
-    {
-        id: "last_12_months",
-        label: RELATIVE_PERIODS["last_12_months"],
-    },
-    {
-        id: "this_year",
-        label: _t("Current Year"),
-        separator: true,
-    },
-    {
-        id: undefined,
-        label: _t("All time"),
-    },
-];
 
 /**
  * This component is used to select a default value for a date filter.
@@ -83,6 +27,20 @@ export class DefaultDateValue extends Component {
     }
 
     get dateOptions() {
-        return DATE_OPTIONS;
+        const filterTypes = getDateGlobalFilterTypes().filter(
+            (type) => !globalFilterDateRegistry.get(type).isFixedPeriod
+        );
+        const options = filterTypes.map((type, i) => {
+            const item = globalFilterDateRegistry.get(type);
+            const nextItem = filterTypes[i + 1] && globalFilterDateRegistry.get(filterTypes[i + 1]);
+            return {
+                id: type,
+                label: item.label,
+                separator: nextItem && nextItem.category !== item.category,
+            };
+        });
+        options.at(-1).separator = true;
+        options.push({ id: undefined, label: _t("All time") });
+        return options;
     }
 }

--- a/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.xml
+++ b/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.xml
@@ -20,7 +20,8 @@
             </div>
             <div t-elif="filter.type === 'date'" class="w-100">
                 <DateFilterValue value="filterValue"
-                                 update.bind="(value) => this.onDateInput(filter.id, value)"/>
+                                 update.bind="(value) => this.onDateInput(filter.id, value)"
+                                 model="props.model"/>
             </div>
             <div t-elif="filter.type === 'numeric'" class="w-100 d-flex align-items-center"
                  t-att-class="filterValue?.operator === 'between' ? 'justify-content-between' : ''">

--- a/addons/spreadsheet/static/src/global_filters/helpers.js
+++ b/addons/spreadsheet/static/src/global_filters/helpers.js
@@ -12,6 +12,7 @@ import { deepEqual } from "@web/core/utils/objects";
 import { formatList } from "@web/core/l10n/utils";
 
 export const globalFieldMatchingRegistry = new Registry();
+export const globalFilterDateRegistry = new Registry();
 
 const { DateTime, Interval } = luxon;
 
@@ -23,18 +24,6 @@ const { DateTime, Interval } = luxon;
  * @typedef {import("@spreadsheet").RelativeDateValue} RelativeDateValue
  * @typedef {import("@spreadsheet").DateRangeValue} DateRangeValue
  */
-
-export const RELATIVE_PERIODS = {
-    today: _t("Today"),
-    yesterday: _t("Yesterday"),
-    last_7_days: _t("Last 7 Days"),
-    last_30_days: _t("Last 30 Days"),
-    last_90_days: _t("Last 90 Days"),
-    month_to_date: _t("Month to Date"),
-    last_month: _t("Last Month"),
-    last_12_months: _t("Last 12 Months"),
-    year_to_date: _t("Year to Date"),
-};
 
 /**
  * @param {DateValue} dateFilterValue
@@ -81,46 +70,39 @@ export function getValidGranularities(dateFilterValue) {
     }
 }
 
+export function getDateGlobalFilterRegistryItem(value) {
+    const registryKey = value.type === "relative" ? value.period : value.type;
+    return globalFilterDateRegistry.get(registryKey);
+}
+
+export function getDateGlobalFilterValueFromDefault(value) {
+    if (!value || typeof value !== "string") {
+        return undefined;
+    }
+    const now = DateTime.local();
+    const registryItem = globalFilterDateRegistry.get(value);
+    return registryItem.canOnlyBeDefault
+        ? registryItem.getDefaultValue(now)
+        : { type: "relative", period: value };
+}
+
+export function getDateGlobalFilterTypes() {
+    return globalFilterDateRegistry
+        .getKeys()
+        .sort(
+            (a, b) =>
+                globalFilterDateRegistry.get(a).sequence - globalFilterDateRegistry.get(b).sequence
+        );
+}
+
 /**
  * Compute the display name of a date filter value.
  */
 export function dateFilterValueToString(value) {
-    switch (value?.type) {
-        case "relative":
-            return RELATIVE_PERIODS[value.period];
-        case "month": {
-            const month = DateTime.local().set({
-                year: value.year,
-                month: value.month,
-            });
-            return month.toFormat("LLLL yyyy");
-        }
-        case "quarter": {
-            return _t("Q%(quarter)s %(year)s", {
-                quarter: value.quarter,
-                year: value.year,
-            });
-        }
-        case "year":
-            return String(value.year);
-        case "range":
-            if (value.from && value.to) {
-                const interval = Interval.fromDateTimes(
-                    DateTime.fromISO(value.from).startOf("day"),
-                    DateTime.fromISO(value.to).endOf("day")
-                );
-                return interval.toLocaleString(DateTime.DATE_FULL);
-            } else if (value.from) {
-                return _t("Since %(from)s", {
-                    from: DateTime.fromISO(value.from).toLocaleString(DateTime.DATE_FULL),
-                });
-            } else if (value.to) {
-                return _t("Until %(to)s", {
-                    to: DateTime.fromISO(value.to).toLocaleString(DateTime.DATE_FULL),
-                });
-            }
+    if (!value || !value.type) {
+        return _t("All time");
     }
-    return _t("All time");
+    return getDateGlobalFilterRegistryItem(value).getValueString(value);
 }
 
 /**
@@ -390,10 +372,7 @@ function isSetValueValid(value) {
  * @returns {boolean}
  */
 function isDateFilterDefaultValueValid(value) {
-    return (
-        Object.keys(RELATIVE_PERIODS).includes(value) ||
-        ["this_month", "this_quarter", "this_year"].includes(value)
-    );
+    return globalFilterDateRegistry.contains(value);
 }
 
 /**
@@ -406,32 +385,11 @@ function isDateFilterDefaultValueValid(value) {
  * @returns {boolean}
  */
 function isDateFilterValueValid(value) {
-    switch (value.type) {
-        case "relative":
-            return Object.keys(RELATIVE_PERIODS).includes(value.period);
-        case "month":
-            return (
-                typeof value.year === "number" &&
-                typeof value.month === "number" &&
-                value.month >= 1 &&
-                value.month <= 12
-            );
-        case "quarter":
-            return (
-                typeof value.year === "number" &&
-                typeof value.quarter === "number" &&
-                value.quarter >= 1 &&
-                value.quarter <= 4
-            );
-        case "year":
-            return typeof value.year === "number";
-        case "range":
-            return (
-                (value.from === undefined || typeof value.from === "string") &&
-                (value.to === undefined || typeof value.to === "string")
-            );
+    try {
+        return getDateGlobalFilterRegistryItem(value).isValueValid(value);
+    } catch {
+        return false;
     }
-    return false;
 }
 
 /**
@@ -448,29 +406,226 @@ export function checkFilterFieldMatching(fieldMatchings) {
     return CommandResult.Success;
 }
 
+globalFilterDateRegistry
+    .add("today", {
+        sequence: 10,
+        label: _t("Today"),
+        getDateRange: (now, value, offset) => getRelativeDateFromTo(now, offset, "today"),
+        getNextDateFilterValue: () => getNextValueForRelativeDatePeriod("today"),
+        getPreviousDateFilterValue: () => getPreviousValueForRelativeDatePeriod("today"),
+        isValueValid: (value) => true,
+        getValueString: (value) => _t("Today"),
+        isFixedPeriod: false,
+        category: "day",
+    })
+    .add("yesterday", {
+        sequence: 20,
+        label: _t("Yesterday"),
+        getDateRange: (now, value, offset) => getRelativeDateFromTo(now, offset, "yesterday"),
+        getNextDateFilterValue: () => getNextValueForRelativeDatePeriod("yesterday"),
+        getPreviousDateFilterValue: () => getPreviousValueForRelativeDatePeriod("yesterday"),
+        isValueValid: (value) => true,
+        getValueString: (value) => _t("Yesterday"),
+        isFixedPeriod: false,
+        category: "day",
+    })
+    .add("last_7_days", {
+        sequence: 30,
+        label: _t("Last 7 Days"),
+        getDateRange: (now, value, offset) => getRelativeDateFromTo(now, offset, "last_7_days"),
+        getNextDateFilterValue: () => getNextValueForRelativeDatePeriod("last_7_days"),
+        getPreviousDateFilterValue: () => getPreviousValueForRelativeDatePeriod("last_7_days"),
+        isValueValid: (value) => true,
+        getValueString: (value) => _t("Last 7 Days"),
+        isFixedPeriod: false,
+        category: "last_period",
+    })
+    .add("last_30_days", {
+        sequence: 40,
+        label: _t("Last 30 Days"),
+        getDateRange: (now, value, offset) => getRelativeDateFromTo(now, offset, "last_30_days"),
+        getNextDateFilterValue: () => getNextValueForRelativeDatePeriod("last_30_days"),
+        getPreviousDateFilterValue: () => getPreviousValueForRelativeDatePeriod("last_30_days"),
+        isValueValid: (value) => true,
+        getValueString: (value) => _t("Last 30 Days"),
+        isFixedPeriod: false,
+        category: "last_period",
+    })
+    .add("last_90_days", {
+        sequence: 50,
+        label: _t("Last 90 Days"),
+        getDateRange: (now, value, offset) => getRelativeDateFromTo(now, offset, "last_90_days"),
+        getNextDateFilterValue: () => getNextValueForRelativeDatePeriod("last_90_days"),
+        getPreviousDateFilterValue: () => getPreviousValueForRelativeDatePeriod("last_90_days"),
+        isValueValid: (value) => true,
+        getValueString: (value) => _t("Last 90 Days"),
+        isFixedPeriod: false,
+        category: "last_period",
+    })
+    .add("month_to_date", {
+        sequence: 60,
+        label: _t("Month to Date"),
+        getDateRange: (now, value, offset) => getRelativeDateFromTo(now, offset, "month_to_date"),
+        getNextDateFilterValue: () => getNextValueForRelativeDatePeriod("month_to_date"),
+        getPreviousDateFilterValue: () => getPreviousValueForRelativeDatePeriod("month_to_date"),
+        isValueValid: (value) => true,
+        getValueString: (value) => _t("Month to Date"),
+        isFixedPeriod: false,
+        category: "month",
+    })
+    .add("last_month", {
+        sequence: 70,
+        label: _t("Last Month"),
+        getDateRange: (now, value, offset) => getRelativeDateFromTo(now, offset, "last_month"),
+        getNextDateFilterValue: () => getNextValueForRelativeDatePeriod("last_month"),
+        getPreviousDateFilterValue: () => getPreviousValueForRelativeDatePeriod("last_month"),
+        isValueValid: (value) => true,
+        getValueString: (value) => _t("Last Month"),
+        isFixedPeriod: false,
+        category: "month",
+    })
+    .add("this_month", {
+        sequence: 80,
+        label: _t("Current Month"),
+        canOnlyBeDefault: true,
+        getDefaultValue: (now) => ({ type: "month", year: now.year, month: now.month }),
+        category: "month",
+    })
+    .add("month", {
+        sequence: 90,
+        label: _t("Month"),
+        getDateRange: (now, value, offset) => getFixedPeriodFromTo(now, offset, value),
+        getNextDateFilterValue: (value) => getNextFixedDateFilterValue(value),
+        getPreviousDateFilterValue: (value) => getPreviousFixedDateFilterValue(value),
+        isValueValid: (value) =>
+            typeof value.year === "number" &&
+            typeof value.month === "number" &&
+            value.month >= 1 &&
+            value.month <= 12,
+        getValueString: (value) =>
+            DateTime.local().set({ year: value.year, month: value.month }).toFormat("LLLL yyyy"),
+        isFixedPeriod: true,
+        getCurrentFixedPeriod: (now) => ({ type: "month", year: now.year, month: now.month }),
+        category: "month",
+    })
+    .add("this_quarter", {
+        sequence: 100,
+        label: _t("Current Quarter"),
+        canOnlyBeDefault: true,
+        getDefaultValue: (now) => ({
+            type: "quarter",
+            year: now.year,
+            quarter: Math.floor((now.month - 1) / 3) + 1,
+        }),
+        category: "month",
+    })
+    .add("quarter", {
+        sequence: 110,
+        label: _t("Quarter"),
+        getDateRange: (now, value, offset) => getFixedPeriodFromTo(now, offset, value),
+        getNextDateFilterValue: (value) => getNextFixedDateFilterValue(value),
+        getPreviousDateFilterValue: (value) => getPreviousFixedDateFilterValue(value),
+        isValueValid: (value) =>
+            typeof value.year === "number" &&
+            typeof value.quarter === "number" &&
+            value.quarter >= 1 &&
+            value.quarter <= 4,
+        getValueString: (value) =>
+            _t("Q%(quarter)s %(year)s", { quarter: value.quarter, year: value.year }),
+        isFixedPeriod: true,
+        getCurrentFixedPeriod: (now) => ({
+            type: "quarter",
+            year: now.year,
+            quarter: Math.floor((now.month - 1) / 3) + 1,
+        }),
+        category: "month",
+    })
+    .add("year_to_date", {
+        sequence: 120,
+        label: _t("Year to Date"),
+        getDateRange: (now, value, offset) => getRelativeDateFromTo(now, offset, "year_to_date"),
+        getNextDateFilterValue: () => getNextValueForRelativeDatePeriod("year_to_date"),
+        getPreviousDateFilterValue: () => getPreviousValueForRelativeDatePeriod("year_to_date"),
+        isValueValid: (value) => true,
+        getValueString: (value) => _t("Year to Date"),
+        isFixedPeriod: false,
+        category: "year",
+    })
+    .add("last_12_months", {
+        sequence: 130,
+        label: _t("Last 12 Months"),
+        getDateRange: (now, value, offset) => getRelativeDateFromTo(now, offset, "last_12_months"),
+        getNextDateFilterValue: () => getNextValueForRelativeDatePeriod("last_12_months"),
+        getPreviousDateFilterValue: () => getPreviousValueForRelativeDatePeriod("last_12_months"),
+        isValueValid: (value) => true,
+        getValueString: (value) => _t("Last 12 Months"),
+        isFixedPeriod: false,
+        category: "year",
+    })
+    .add("this_year", {
+        sequence: 140,
+        label: _t("Current Year"),
+        canOnlyBeDefault: true,
+        getDefaultValue: (now) => ({ type: "year", year: now.year }),
+        category: "year",
+    })
+    .add("year", {
+        sequence: 150,
+        label: _t("Year"),
+        getDateRange: (now, value, offset) => getFixedPeriodFromTo(now, offset, value),
+        getNextDateFilterValue: (value) => getNextFixedDateFilterValue(value),
+        getPreviousDateFilterValue: (value) => getPreviousFixedDateFilterValue(value),
+        isValueValid: (value) => typeof value.year === "number",
+        getValueString: (value) => String(value.year),
+        isFixedPeriod: true,
+        getCurrentFixedPeriod: (now) => ({ type: "year", year: now.year }),
+        category: "year",
+    })
+    .add("range", {
+        sequence: 160,
+        label: _t("Custom Range"),
+        getDateRange: (now, value, offset) => ({
+            from: value.from && DateTime.fromISO(value.from).startOf("day"),
+            to: value.to && DateTime.fromISO(value.to).endOf("day"),
+        }),
+        getNextDateFilterValue: (value) => getNextRangeDateFilterValue(value),
+        getPreviousDateFilterValue: (value) => getPreviousRangeDateFilterValue(value),
+        isValueValid: (value) =>
+            (value.from === undefined || typeof value.from === "string") &&
+            (value.to === undefined || typeof value.to === "string"),
+        getValueString: (value) => {
+            if (value.from && value.to) {
+                const interval = Interval.fromDateTimes(
+                    DateTime.fromISO(value.from).startOf("day"),
+                    DateTime.fromISO(value.to).endOf("day")
+                );
+                return interval.toLocaleString(DateTime.DATE_FULL);
+            } else if (value.from) {
+                return _t("Since %(from)s", {
+                    from: DateTime.fromISO(value.from).toLocaleString(DateTime.DATE_FULL),
+                });
+            } else if (value.to) {
+                return _t("Until %(to)s", {
+                    to: DateTime.fromISO(value.to).toLocaleString(DateTime.DATE_FULL),
+                });
+            }
+            return _t("All time");
+        },
+        isFixedPeriod: true,
+        getCurrentFixedPeriod: () => ({ from: "", to: "", type: "range" }),
+        category: "misc",
+    });
+
 /**
  * The from-to date range from a date filter value.
  *
  * @returns {{ from?: DateTime, to?: DateTime }}
  */
-export function getDateRange(value, offset = 0) {
+export function getDateRange(value, offset = 0, now = DateTime.local()) {
     if (!value) {
         return {};
     }
-    const now = DateTime.local();
-    switch (value.type) {
-        case "month":
-        case "quarter":
-        case "year":
-            return getFixedPeriodFromTo(now, offset, value);
-        case "relative":
-            return getRelativeDateFromTo(now, offset, value.period);
-        case "range":
-            return {
-                from: value.from && DateTime.fromISO(value.from).startOf("day"),
-                to: value.to && DateTime.fromISO(value.to).endOf("day"),
-            };
-    }
+    return getDateGlobalFilterRegistryItem(value).getDateRange(now, value, offset);
 }
 
 function getFixedPeriodFromTo(now, offset, value) {
@@ -512,7 +667,7 @@ function getFixedPeriodFromTo(now, offset, value) {
     };
 }
 
-export function getRelativeDateFromTo(now, offset, period) {
+function getRelativeDateFromTo(now, offset, period) {
     const startOfNextDay = now.plus({ days: 1 }).startOf("day");
     let to = now.endOf("day");
     let from = to;
@@ -577,13 +732,7 @@ export function getRelativeDateFromTo(now, offset, period) {
     return { from, to };
 }
 
-/**
- * Compute the next date filter value.
- *
- * @param {DateValue | undefined} value
- * @returns {DateValue | undefined}
- */
-export function getNextDateFilterValue(value) {
+function getNextFixedDateFilterValue(value) {
     switch (value?.type) {
         case "quarter":
             return {
@@ -602,15 +751,24 @@ export function getNextDateFilterValue(value) {
                 type: "year",
                 year: value.year + 1,
             };
-        case "relative":
-            return getNextRelativeDateFilterValue(value);
-        case "range":
-            return getNextRangeDateFilterValue(value);
     }
     return undefined;
 }
 
-export function getPreviousDateFilterValue(value) {
+/**
+ * Compute the next date filter value.
+ *
+ * @param {DateValue | undefined} value
+ * @returns {DateValue | undefined}
+ */
+export function getNextDateFilterValue(value) {
+    if (!value) {
+        return undefined;
+    }
+    return getDateGlobalFilterRegistryItem(value).getNextDateFilterValue(value);
+}
+
+function getPreviousFixedDateFilterValue(value) {
     switch (value?.type) {
         case "quarter":
             return {
@@ -629,28 +787,31 @@ export function getPreviousDateFilterValue(value) {
                 type: "year",
                 year: value.year - 1,
             };
-        case "relative":
-            return getPreviousRelativeDateFilterValue(value);
-        case "range":
-            return getPreviousRangeDateFilterValue(value);
     }
     return undefined;
 }
 
+export function getPreviousDateFilterValue(value) {
+    if (!value) {
+        return undefined;
+    }
+    return getDateGlobalFilterRegistryItem(value).getPreviousDateFilterValue(value);
+}
+
 /**
- * Compute the next relative date filter value.
+ * Compute the next value for the given relative period.
  *
- * @param {RelativeDateValue} value
- * @returns {RelativeDateValue}
+ * @param {RelativeDateValue.period} period
+ * @returns {DateValue}
  */
-function getNextRelativeDateFilterValue(value) {
-    switch (value.period) {
+function getNextValueForRelativeDatePeriod(period) {
+    switch (period) {
         case "today":
         case "yesterday":
         case "last_7_days":
         case "last_30_days":
         case "last_90_days": {
-            const { from, to } = getRelativeDateFromTo(DateTime.local(), 1, value.period);
+            const { from, to } = getRelativeDateFromTo(DateTime.local(), 1, period);
             return {
                 type: "range",
                 from: from.toISODate(),
@@ -658,7 +819,7 @@ function getNextRelativeDateFilterValue(value) {
             };
         }
         case "last_12_months": {
-            const { from, to } = getRelativeDateFromTo(DateTime.local(), 1, value.period);
+            const { from, to } = getRelativeDateFromTo(DateTime.local(), 1, period);
             return {
                 type: "range",
                 from: from.startOf("month").toISODate(),
@@ -691,19 +852,19 @@ function getNextRelativeDateFilterValue(value) {
 }
 
 /**
- * Compute the previous relative date filter value.
+ * Compute the previous value for the given relative period.
  *
- * @param {RelativeDateValue} value
- * @returns {RelativeDateValue}
+ * @param {RelativeDateValue.period} period
+ * @returns {DateValue}
  */
-function getPreviousRelativeDateFilterValue(value) {
-    switch (value.period) {
+function getPreviousValueForRelativeDatePeriod(period) {
+    switch (period) {
         case "today":
         case "yesterday":
         case "last_7_days":
         case "last_30_days":
         case "last_90_days": {
-            const { from, to } = getRelativeDateFromTo(DateTime.local(), -1, value.period);
+            const { from, to } = getRelativeDateFromTo(DateTime.local(), -1, period);
             return {
                 type: "range",
                 from: from.toISODate(),
@@ -711,7 +872,7 @@ function getPreviousRelativeDateFilterValue(value) {
             };
         }
         case "last_12_months": {
-            const { from, to } = getRelativeDateFromTo(DateTime.local(), -1, value.period);
+            const { from, to } = getRelativeDateFromTo(DateTime.local(), -1, period);
             return {
                 type: "range",
                 from: from.startOf("month").toISODate(),
@@ -750,7 +911,7 @@ function getPreviousRelativeDateFilterValue(value) {
  * @param {DateRangeValue} value
  * @returns {DateRangeValue}
  */
-export function getNextRangeDateFilterValue(value) {
+function getNextRangeDateFilterValue(value) {
     if (!value.from && !value.to) {
         return value;
     }
@@ -770,7 +931,7 @@ export function getNextRangeDateFilterValue(value) {
  * @param {DateRangeValue} value
  * @returns {DateRangeValue}
  */
-export function getPreviousRangeDateFilterValue(value) {
+function getPreviousRangeDateFilterValue(value) {
     if (!value.from && !value.to) {
         return value;
     }

--- a/addons/spreadsheet/static/src/global_filters/plugins/global_filters_core_view_plugin.js
+++ b/addons/spreadsheet/static/src/global_filters/plugins/global_filters_core_view_plugin.js
@@ -26,6 +26,7 @@ import { OdooCoreViewPlugin } from "@spreadsheet/plugins";
 import { getItemId } from "../../helpers/model";
 import { serializeDate } from "@web/core/l10n/dates";
 import { getFilterCellValue, getFilterValueDomain } from "../helpers";
+const { DateTime } = luxon;
 
 const { UuidGenerator, createEmptyExcelSheet, createEmptySheet, toXC, toNumber } = helpers;
 const uuidGenerator = new UuidGenerator();
@@ -297,7 +298,8 @@ export class GlobalFiltersCoreViewPlugin extends OdooCoreViewPlugin {
     }
 
     _getDateFilterDisplayValue(filter) {
-        const { from, to } = getDateRange(this.getGlobalFilterValue(filter.id));
+        const value = this.getGlobalFilterValue(filter.id);
+        const { from, to } = getDateRange(value, 0, DateTime.local(), this.getters);
         const locale = this.getters.getLocale();
         const _from = {
             value: from ? toNumber(serializeDate(from), locale) : "",
@@ -339,7 +341,12 @@ export class GlobalFiltersCoreViewPlugin extends OdooCoreViewPlugin {
         const field = fieldMatching.chain;
         const type = /** @type {"date" | "datetime"} */ (fieldMatching.type);
         const offset = fieldMatching.offset || 0;
-        const { from, to } = getDateRange(this.getGlobalFilterValue(filter.id), offset);
+        const { from, to } = getDateRange(
+            this.getGlobalFilterValue(filter.id),
+            offset,
+            DateTime.local(),
+            this.getters
+        );
         return getDateDomain(from, to, field, type);
     }
 

--- a/addons/spreadsheet/static/src/global_filters/plugins/global_filters_core_view_plugin.js
+++ b/addons/spreadsheet/static/src/global_filters/plugins/global_filters_core_view_plugin.js
@@ -20,13 +20,12 @@ import {
     checkFilterValueIsValid,
     getDateDomain,
     getDateRange,
+    getDateGlobalFilterValueFromDefault,
 } from "@spreadsheet/global_filters/helpers";
 import { OdooCoreViewPlugin } from "@spreadsheet/plugins";
 import { getItemId } from "../../helpers/model";
 import { serializeDate } from "@web/core/l10n/dates";
 import { getFilterCellValue, getFilterValueDomain } from "../helpers";
-
-const { DateTime } = luxon;
 
 const { UuidGenerator, createEmptyExcelSheet, createEmptySheet, toXC, toNumber } = helpers;
 const uuidGenerator = new UuidGenerator();
@@ -320,33 +319,7 @@ export class GlobalFiltersCoreViewPlugin extends OdooCoreViewPlugin {
      * @returns {DateValue|undefined}
      */
     _getDateValueFromDefaultValue(defaultValue) {
-        const year = DateTime.local().year;
-        switch (defaultValue) {
-            case "this_year":
-                return { type: "year", year };
-            case "this_month": {
-                const month = DateTime.local().month;
-                return { type: "month", year, month };
-            }
-            case "this_quarter": {
-                const quarter = Math.floor(new Date().getMonth() / 3) + 1;
-                return { type: "quarter", year, quarter };
-            }
-            case "today":
-            case "yesterday":
-            case "last_7_days":
-            case "last_30_days":
-            case "last_90_days":
-            case "month_to_date":
-            case "last_month":
-            case "last_12_months":
-            case "year_to_date":
-                return {
-                    type: "relative",
-                    period: defaultValue,
-                };
-        }
-        return undefined;
+        return getDateGlobalFilterValueFromDefault(defaultValue);
     }
 
     /**

--- a/addons/spreadsheet/static/tests/global_filters/date_filter_value.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/date_filter_value.test.js
@@ -3,6 +3,7 @@ import { mockDate } from "@odoo/hoot-mock";
 import { makeMockEnv, contains, mountWithCleanup } from "@web/../tests/web_test_helpers";
 import { defineSpreadsheetModels } from "@spreadsheet/../tests/helpers/data";
 import { DateFilterValue } from "@spreadsheet/global_filters/components/date_filter_value/date_filter_value";
+import { Model } from "@odoo/o-spreadsheet";
 
 describe.current.tags("desktop");
 defineSpreadsheetModels();
@@ -18,7 +19,7 @@ beforeEach(() => {
  * @param {{ model: Model, filter: object}} props
  */
 async function mountDateFilterValue(env, props) {
-    await mountWithCleanup(DateFilterValue, { props, env });
+    await mountWithCleanup(DateFilterValue, { props: { model: new Model(), ...props }, env });
 }
 
 test("basic date filter value", async function () {

--- a/addons/spreadsheet/static/tests/global_filters/global_filter_helper.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/global_filter_helper.test.js
@@ -3,12 +3,12 @@ import { describe, expect, test, beforeEach } from "@odoo/hoot";
 import { mockDate } from "@odoo/hoot-mock";
 import {
     getDateDomain,
-    getRelativeDateFromTo,
+    getDateRange,
     dateFilterValueToString,
     getNextDateFilterValue,
     getPreviousDateFilterValue,
     getFacetInfo,
-    RELATIVE_PERIODS,
+    globalFilterDateRegistry,
 } from "@spreadsheet/global_filters/helpers";
 import {
     getDateDomainDurationInDays,
@@ -32,7 +32,7 @@ beforeEach(() => {
 });
 
 function getRelativeDateDomain(now, offset, period, fieldName, fieldType) {
-    const { from, to } = getRelativeDateFromTo(now, offset, period);
+    const { from, to } = getDateRange({ type: "relative", period }, offset, now);
     return getDateDomain(from, to, fieldName, fieldType);
 }
 
@@ -230,11 +230,6 @@ test("dateFilterValueToString > range", function () {
 test("dateFilterValueToString > all time", function () {
     expect(valueToString({ type: undefined })).toBe("All time");
     expect(valueToString({})).toBe("All time");
-});
-
-test("dateFilterValueToString > invalid value", function () {
-    expect(valueToString({ type: "invalid" })).toBe("All time");
-    expect(valueToString(undefined)).toBe("All time");
 });
 
 describe("getNextDateFilterValue", () => {
@@ -502,13 +497,24 @@ test("getFacetInfo for date values", async () => {
         id: "1",
     };
     const env = {};
-    for (const [period, label] of Object.entries(RELATIVE_PERIODS)) {
+    const relativeFilterTypes = [
+        "today",
+        "yesterday",
+        "last_7_days",
+        "last_30_days",
+        "last_90_days",
+        "month_to_date",
+        "last_month",
+        "year_to_date",
+        "last_12_months",
+    ];
+    for (const period of relativeFilterTypes) {
         expect(await getFacetInfo(env, filter, { type: "relative", period })).toEqual({
             title: "Date Filter",
             id: "1",
             separator: "or",
             operator: "",
-            values: [label],
+            values: [globalFilterDateRegistry.get(period).label.toString()],
         });
     }
     expect(

--- a/addons/spreadsheet/static/tests/global_filters/global_filters_core_view.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/global_filters_core_view.test.js
@@ -7,7 +7,6 @@ import {
     addGlobalFilterWithoutReload,
     setGlobalFilterValueWithoutReload,
 } from "@spreadsheet/../tests/helpers/commands";
-import { RELATIVE_PERIODS } from "@spreadsheet/global_filters/helpers";
 
 describe.current.tags("headless");
 defineSpreadsheetModels();
@@ -260,7 +259,18 @@ test("Value of date filter", () => {
     });
     expect(result.isSuccessful).toBe(true);
 
-    for (const period of Object.keys(RELATIVE_PERIODS)) {
+    const relativeFilterTypes = [
+        "today",
+        "yesterday",
+        "last_7_days",
+        "last_30_days",
+        "last_90_days",
+        "month_to_date",
+        "last_month",
+        "year_to_date",
+        "last_12_months",
+    ];
+    for (const period of relativeFilterTypes) {
         result = setGlobalFilterValueWithoutReload(model, {
             id: "1",
             value: { type: "relative", period },

--- a/addons/spreadsheet/static/tests/global_filters/global_filters_model.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/global_filters_model.test.js
@@ -57,7 +57,6 @@ import { toRangeData } from "@spreadsheet/../tests/helpers/zones";
 import { GlobalFiltersCoreViewPlugin } from "@spreadsheet/global_filters/plugins/global_filters_core_view_plugin";
 import { waitForDataLoaded } from "@spreadsheet/helpers/model";
 import { PivotUIGlobalFilterPlugin } from "@spreadsheet/pivot/index";
-import { RELATIVE_PERIODS } from "@spreadsheet/global_filters/helpers";
 
 describe.current.tags("headless");
 defineSpreadsheetModels();
@@ -3241,7 +3240,15 @@ test("Default value of date filter", () => {
     expect(result.reasons).toEqual(["InvalidValueTypeCombination"]);
 
     for (const value of [
-        ...Object.keys(RELATIVE_PERIODS),
+        "today",
+        "yesterday",
+        "last_7_days",
+        "last_30_days",
+        "last_90_days",
+        "month_to_date",
+        "last_month",
+        "year_to_date",
+        "last_12_months",
         "this_year",
         "this_month",
         "this_quarter",

--- a/addons/spreadsheet_account/__manifest__.py
+++ b/addons/spreadsheet_account/__manifest__.py
@@ -8,7 +8,7 @@
     'description': 'Spreadsheet Accounting formulas',
     'depends': ['spreadsheet', 'account'],
     'installable': True,
-    'auto_install': True,
+    'auto_install': ['account'],
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
     'assets': {

--- a/addons/spreadsheet_account/models/__init__.py
+++ b/addons/spreadsheet_account/models/__init__.py
@@ -1,2 +1,3 @@
 from . import account
 from . import res_company
+from . import spreadsheet_mixin

--- a/addons/spreadsheet_account/models/spreadsheet_mixin.py
+++ b/addons/spreadsheet_account/models/spreadsheet_mixin.py
@@ -1,0 +1,25 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+
+from odoo import fields, models
+from odoo.tools import date_utils
+
+
+class SpreadsheetMixin(models.AbstractModel):
+    _name = "spreadsheet.mixin"
+    _inherit = "spreadsheet.mixin"
+
+    def _get_spreadsheet_metadata(self, access_token=None):
+        metadata = super()._get_spreadsheet_metadata(access_token=access_token)
+        company = self.env.company
+        start, end = date_utils.get_fiscal_year(
+            fields.Date.context_today(self),
+            day=company.fiscalyear_last_day,
+            month=int(company.fiscalyear_last_month),
+        )
+
+        return {
+            **metadata,
+            "current_fiscal_year_start": fields.Date.to_string(start),
+            "current_fiscal_year_end": fields.Date.to_string(end),
+        }

--- a/addons/spreadsheet_account/static/src/fiscal_year_global_filter.js
+++ b/addons/spreadsheet_account/static/src/fiscal_year_global_filter.js
@@ -8,6 +8,7 @@ globalFilterDateRegistry
         canOnlyBeDefault: true,
         getDefaultValue: (now) => ({ type: "fiscal_year", offset: 0 }),
         category: "fiscal_year",
+        shouldBeHidden: (getters) => isFiscalYearSameAsStandardYear(getters),
     })
     .add("fiscal_year", {
         sequence: 156,
@@ -29,6 +30,7 @@ globalFilterDateRegistry
         isFixedPeriod: true,
         getCurrentFixedPeriod: (now) => ({ type: "fiscal_year", offset: 0 }),
         category: "fiscal_year",
+        shouldBeHidden: (getters) => isFiscalYearSameAsStandardYear(getters),
     });
 
 function getFiscalYearFromTo(offset, getters) {
@@ -42,4 +44,15 @@ function getFiscalYearFromTo(offset, getters) {
 function getFiscalYearDisplayString(value, getters) {
     const { from, to } = getFiscalYearFromTo(value.offset || 0, getters);
     return from.year === to.year ? String(from.year) : String(from.year) + "-" + String(to.year);
+}
+
+function isFiscalYearSameAsStandardYear(getters) {
+    const fiscalYearStart = getters.getCurrentFiscalYearStart();
+    const fiscalYearEnd = getters.getCurrentFiscalYearEnd();
+    return (
+        fiscalYearStart.month === 1 &&
+        fiscalYearStart.day === 1 &&
+        fiscalYearEnd.month === 12 &&
+        fiscalYearEnd.day === 31
+    );
 }

--- a/addons/spreadsheet_account/static/src/fiscal_year_global_filter.js
+++ b/addons/spreadsheet_account/static/src/fiscal_year_global_filter.js
@@ -1,0 +1,45 @@
+import { globalFilterDateRegistry } from "@spreadsheet/global_filters/helpers";
+import { _t } from "@web/core/l10n/translation";
+
+globalFilterDateRegistry
+    .add("this_fiscal_year", {
+        sequence: 155,
+        label: _t("Current Fiscal Year"),
+        canOnlyBeDefault: true,
+        getDefaultValue: (now) => ({ type: "fiscal_year", offset: 0 }),
+        category: "fiscal_year",
+    })
+    .add("fiscal_year", {
+        sequence: 156,
+        label: _t("Fiscal Year"),
+        getDateRange: (now, value, dataSourceOffset, getters) => {
+            const offset = (value?.offset ?? 0) + dataSourceOffset;
+            return getFiscalYearFromTo(offset, getters);
+        },
+        getNextDateFilterValue: (value) => ({
+            type: "fiscal_year",
+            offset: value.offset + 1,
+        }),
+        getPreviousDateFilterValue: (value) => ({
+            type: "fiscal_year",
+            offset: value.offset - 1,
+        }),
+        isValueValid: (value) => Number.isInteger(value.offset),
+        getValueString: (value, getters) => getFiscalYearDisplayString(value, getters),
+        isFixedPeriod: true,
+        getCurrentFixedPeriod: (now) => ({ type: "fiscal_year", offset: 0 }),
+        category: "fiscal_year",
+    });
+
+function getFiscalYearFromTo(offset, getters) {
+    const currentFiscalYearStart = getters.getCurrentFiscalYearStart();
+    const currentFiscalYearEnd = getters.getCurrentFiscalYearEnd();
+    const start = currentFiscalYearStart.plus({ years: offset }).startOf("day");
+    const end = currentFiscalYearEnd.plus({ years: offset }).endOf("day");
+    return { from: start, to: end };
+}
+
+function getFiscalYearDisplayString(value, getters) {
+    const { from, to } = getFiscalYearFromTo(value.offset || 0, getters);
+    return from.year === to.year ? String(from.year) : String(from.year) + "-" + String(to.year);
+}

--- a/addons/spreadsheet_account/static/src/plugins/accounting_plugin.js
+++ b/addons/spreadsheet_account/static/src/plugins/accounting_plugin.js
@@ -20,9 +20,13 @@ export class AccountingPlugin extends OdooUIPlugin {
         "getAccountResidual",
         "getAccountPartnerData",
         "getAccountTagData",
+        "getCurrentFiscalYearStart",
+        "getCurrentFiscalYearEnd",
     ]);
     constructor(config) {
         super(config);
+        this.currentFiscalYearStart = config.custom.currentFiscalYearStart;
+        this.currentFiscalYearEnd = config.custom.currentFiscalYearEnd;
         /** @type {import("@spreadsheet/data_sources/server_data").ServerData} */
         this._serverData = config.custom.odooDataProvider?.serverData;
     }
@@ -84,6 +88,14 @@ export class AccountingPlugin extends OdooUIPlugin {
      */
     getFiscalEndDate(date, companyId) {
         return this._fetchCompanyData(date, companyId).end;
+    }
+
+    getCurrentFiscalYearStart() {
+        return this.currentFiscalYearStart;
+    }
+
+    getCurrentFiscalYearEnd() {
+        return this.currentFiscalYearEnd;
     }
 
     /**
@@ -165,7 +177,9 @@ export class AccountingPlugin extends OdooUIPlugin {
             camelToSnakeObject({ codes, dateRange, companyId, includeUnposted })
         );
         if (result === false) {
-            throw new EvaluationError(_t("The residual amount for given accounts could not be computed."));
+            throw new EvaluationError(
+                _t("The residual amount for given accounts could not be computed.")
+            );
         }
         return result.amount_residual;
     }
@@ -228,7 +242,9 @@ export class AccountingPlugin extends OdooUIPlugin {
             camelToSnakeObject({ accountTagIds, dateRange, companyId, includeUnposted })
         );
         if (result === false) {
-            throw new EvaluationError(_t("The balance for given account tag could not be computed."));
+            throw new EvaluationError(
+                _t("The balance for given account tag could not be computed.")
+            );
         }
         return result.balance;
     }

--- a/addons/spreadsheet_account/static/tests/model/fiscal_year_global_filter.test.js
+++ b/addons/spreadsheet_account/static/tests/model/fiscal_year_global_filter.test.js
@@ -1,0 +1,76 @@
+/** @ts-check */
+import { describe, expect, test } from "@odoo/hoot";
+import { Model } from "@odoo/o-spreadsheet";
+import {
+    dateFilterValueToString,
+    getDateRange,
+    getNextDateFilterValue,
+    getPreviousDateFilterValue,
+} from "@spreadsheet/global_filters/helpers";
+
+const { DateTime } = luxon;
+
+describe.current.tags("headless");
+
+const modelConfig = {
+    custom: {
+        currentFiscalYearStart: DateTime.fromISO("2022-07-01"),
+        currentFiscalYearEnd: DateTime.fromISO("2023-06-30"),
+    },
+};
+
+test("fiscal_year global filter", () => {
+    const model = new Model({}, modelConfig);
+    const now = DateTime.fromISO("2022-10-16");
+    const filterValue = { type: "fiscal_year", offset: 0 };
+
+    let { from, to } = getDateRange(filterValue, 0, now, model.getters);
+    expect(from.toISODate()).toBe("2022-07-01");
+    expect(to.toISODate()).toBe("2023-06-30");
+    expect(dateFilterValueToString(filterValue, model.getters)).toBe("2022-2023");
+
+    const nextValue = getNextDateFilterValue(filterValue);
+    expect(nextValue).toEqual({ type: "fiscal_year", offset: 1 });
+    ({ from, to } = getDateRange(nextValue, 0, now, model.getters));
+    expect(from.toISODate()).toBe("2023-07-01");
+    expect(to.toISODate()).toBe("2024-06-30");
+    expect(dateFilterValueToString(nextValue, model.getters)).toBe("2023-2024");
+
+    const previousValue = getPreviousDateFilterValue(filterValue);
+    expect(previousValue).toEqual({ type: "fiscal_year", offset: -1 });
+    ({ from, to } = getDateRange(previousValue, 0, now, model.getters));
+    expect(from.toISODate()).toBe("2021-07-01");
+    expect(to.toISODate()).toBe("2022-06-30");
+    expect(dateFilterValueToString(previousValue, model.getters)).toBe("2021-2022");
+});
+
+test("Data source offset is applied to fiscal_year global filter", () => {
+    const model = new Model({}, modelConfig);
+    const now = DateTime.fromISO("2022-10-16");
+    const filterValue = { type: "fiscal_year", offset: 1 };
+    let dataSourceOffset = 2;
+
+    let { from, to } = getDateRange(filterValue, dataSourceOffset, now, model.getters);
+    expect(from.toISODate()).toBe("2025-07-01"); // 2022 + 1 + 2
+    expect(to.toISODate()).toBe("2026-06-30");
+
+    dataSourceOffset = -1;
+    ({ from, to } = getDateRange(filterValue, dataSourceOffset, now, model.getters));
+    expect(from.toISODate()).toBe("2022-07-01"); // 2022 + 1 - 1
+    expect(to.toISODate()).toBe("2023-06-30");
+});
+
+test("this_fiscal_year global filter", () => {
+    const spreadsheetData = {
+        globalFilters: [
+            {
+                id: "1",
+                type: "date",
+                label: "This Fiscal Year",
+                defaultValue: "this_fiscal_year",
+            },
+        ],
+    };
+    const model = new Model(spreadsheetData, modelConfig);
+    expect(model.getters.getGlobalFilterValue("1")).toEqual({ type: "fiscal_year", offset: 0 });
+});

--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_date_filter/dashboard_date_filter.js
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_date_filter/dashboard_date_filter.js
@@ -19,10 +19,11 @@ export class DashboardDateFilter extends Component {
     static props = {
         value: { type: Object, optional: true },
         update: Function,
+        model: Object,
     };
 
     get inputValue() {
-        return dateFilterValueToString(this.props.value);
+        return dateFilterValueToString(this.props.value, this.props.model.getters);
     }
 
     selectPrevious() {

--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_date_filter/dashboard_date_filter.xml
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_date_filter/dashboard_date_filter.xml
@@ -10,6 +10,7 @@
                 <DateFilterDropdown
                     value="props.value"
                     update="props.update"
+                    model="props.model"
                 />
             </t>
         </Dropdown>

--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_search_bar/dashboard_search_bar.js
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_search_bar/dashboard_search_bar.js
@@ -187,7 +187,7 @@ export class DashboardSearchBar extends Component {
 
     async getFacetFor(filter) {
         const filterValue = this.props.model.getters.getGlobalFilterValue(filter.id);
-        return getFacetInfo(this.env, filter, filterValue);
+        return getFacetInfo(this.env, filter, filterValue, this.props.model.getters);
     }
 
     getItems(globalFilter, trimmedQuery) {

--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_search_bar/dashboard_search_bar.xml
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_search_bar/dashboard_search_bar.xml
@@ -62,7 +62,8 @@
             </div>
             <div class="o_sp_date_filter_button d-flex" t-if="firstDateFilter">
                 <DashboardDateFilter value="firstDateFilterValue"
-                                update.bind="updateFirstDateFilter" />
+                                update.bind="updateFirstDateFilter"
+                                model="this.props.model"/>
             </div>
         </div>
     </t>

--- a/addons/spreadsheet_dashboard/static/tests/dashboard/dashboard_date_filter.test.js
+++ b/addons/spreadsheet_dashboard/static/tests/dashboard/dashboard_date_filter.test.js
@@ -2,6 +2,7 @@ import { describe, expect, test } from "@odoo/hoot";
 import { makeMockEnv, contains, mountWithCleanup } from "@web/../tests/web_test_helpers";
 import { defineSpreadsheetModels } from "@spreadsheet/../tests/helpers/data";
 import { DashboardDateFilter } from "@spreadsheet_dashboard/bundle/dashboard_action/dashboard_date_filter/dashboard_date_filter";
+import { Model } from "@odoo/o-spreadsheet";
 
 describe.current.tags("desktop");
 defineSpreadsheetModels();
@@ -11,7 +12,8 @@ defineSpreadsheetModels();
  * @param {{ model: Model, filter: object}} props
  */
 async function mountDashboardFilterValue(env, props) {
-    await mountWithCleanup(DashboardDateFilter, { props, env });
+    const model = new Model();
+    await mountWithCleanup(DashboardDateFilter, { props: { model, ...props }, env });
 }
 
 test("Can display the input as a button", async function () {

--- a/addons/spreadsheet_dashboard_account/__manifest__.py
+++ b/addons/spreadsheet_dashboard_account/__manifest__.py
@@ -6,12 +6,20 @@
     'category': 'Productivity/Dashboard',
     'summary': 'Spreadsheet',
     'description': 'Spreadsheet',
-    'depends': ['spreadsheet_dashboard', 'account'],
+    'depends': ['spreadsheet_dashboard', 'spreadsheet_account'],
     'data': [
         "data/dashboards.xml",
     ],
     'installable': True,
-    'auto_install': ['account'],
+    'auto_install': ['spreadsheet_account'],
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
+    "assets": {
+        "spreadsheet.o_spreadsheet": [
+            "spreadsheet_dashboard_account/static/src/bundle/**/*.js",
+        ],
+        'web.assets_unit_tests': [
+            "spreadsheet_dashboard_account/static/tests/**/*",
+        ],
+    },
 }

--- a/addons/spreadsheet_dashboard_account/static/src/bundle/account_dashboard_loader.js
+++ b/addons/spreadsheet_dashboard_account/static/src/bundle/account_dashboard_loader.js
@@ -1,0 +1,15 @@
+import { DashboardLoader } from "@spreadsheet_dashboard/bundle/dashboard_action/dashboard_loader_service";
+import { patch } from "@web/core/utils/patch";
+const { DateTime } = luxon;
+
+patch(DashboardLoader.prototype, {
+    getModelConfig(serverResult) {
+        const config = super.getModelConfig(serverResult);
+        config.custom = {
+            ...config.custom,
+            currentFiscalYearStart: DateTime.fromISO(serverResult.current_fiscal_year_start),
+            currentFiscalYearEnd: DateTime.fromISO(serverResult.current_fiscal_year_end),
+        };
+        return config;
+    },
+});

--- a/addons/spreadsheet_dashboard_account/static/tests/fiscal_year_filter_dashboard.test.js
+++ b/addons/spreadsheet_dashboard_account/static/tests/fiscal_year_filter_dashboard.test.js
@@ -16,16 +16,21 @@ const THIS_FISCAL_YEAR_FILTER = {
     defaultValue: "this_fiscal_year",
 };
 
+let fiscalYearStart = "2025-07-01";
+let fiscalYearEnd = "2026-06-30";
+
 let spreadsheetData;
 beforeEach(() => {
     spreadsheetData = undefined;
+    fiscalYearStart = "2025-07-01";
+    fiscalYearEnd = "2026-06-30";
     onRpc(
         "/spreadsheet/dashboard/data/1",
         () => ({
             snapshot: spreadsheetData,
             revisions: [],
-            current_fiscal_year_start: "2025-07-01",
-            current_fiscal_year_end: "2026-06-30",
+            current_fiscal_year_start: fiscalYearStart,
+            current_fiscal_year_end: fiscalYearEnd,
         }),
         { pure: true }
     );
@@ -72,4 +77,15 @@ test("Can navigate in a fiscal year global filter in the dropdown", async functi
     expect(".o-dropdown-item[data-id='fiscal_year']").toHaveClass("selected");
     expect(getCustomRangeValue()).toEqual(["07/01/2026", "06/30/2027"]);
     expect(model.getters.getGlobalFilterValue("1")).toEqual({ type: "fiscal_year", offset: 1 });
+});
+
+test("Fiscal year filter is hidden in dropdown if the fiscal year the same as the normal year", async function () {
+    fiscalYearStart = "2025-01-01";
+    fiscalYearEnd = "2025-12-31";
+    spreadsheetData = { globalFilters: [THIS_FISCAL_YEAR_FILTER] };
+    SpreadsheetDashboard._records[0].spreadsheet_data = JSON.stringify(spreadsheetData);
+    await createSpreadsheetDashboard({});
+    await contains(".o-date-filter-value").click();
+
+    expect(".o-dropdown-item[data-id='fiscal_year']").toHaveCount(0);
 });

--- a/addons/spreadsheet_dashboard_account/static/tests/fiscal_year_filter_dashboard.test.js
+++ b/addons/spreadsheet_dashboard_account/static/tests/fiscal_year_filter_dashboard.test.js
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, getFixture, test } from "@odoo/hoot";
+import { createSpreadsheetDashboard } from "@spreadsheet_dashboard/../tests/helpers/dashboard_action";
+import {
+    defineSpreadsheetDashboardModels,
+    SpreadsheetDashboard,
+} from "@spreadsheet_dashboard/../tests/helpers/data";
+import { contains, onRpc } from "@web/../tests/web_test_helpers";
+
+describe.current.tags("desktop");
+defineSpreadsheetDashboardModels();
+
+const THIS_FISCAL_YEAR_FILTER = {
+    id: "1",
+    type: "date",
+    label: "This Fiscal Year",
+    defaultValue: "this_fiscal_year",
+};
+
+let spreadsheetData;
+beforeEach(() => {
+    spreadsheetData = undefined;
+    onRpc(
+        "/spreadsheet/dashboard/data/1",
+        () => ({
+            snapshot: spreadsheetData,
+            revisions: [],
+            current_fiscal_year_start: "2025-07-01",
+            current_fiscal_year_end: "2026-06-30",
+        }),
+        { pure: true }
+    );
+});
+
+test("Can navigate in a fiscal year global filter", async function () {
+    spreadsheetData = { globalFilters: [THIS_FISCAL_YEAR_FILTER] };
+    SpreadsheetDashboard._records[0].spreadsheet_data = JSON.stringify(spreadsheetData);
+    const { model } = await createSpreadsheetDashboard({});
+
+    expect(".o-date-filter-value").toHaveText("2025-2026");
+    expect(model.getters.getGlobalFilterValue("1")).toEqual({ type: "fiscal_year", offset: 0 });
+
+    await contains(".btn-previous-date").click();
+    expect(".o-date-filter-value").toHaveText("2024-2025");
+    expect(model.getters.getGlobalFilterValue("1")).toEqual({ type: "fiscal_year", offset: -1 });
+
+    await contains(".btn-next-date").click();
+    expect(".o-date-filter-value").toHaveText("2025-2026");
+    expect(model.getters.getGlobalFilterValue("1")).toEqual({ type: "fiscal_year", offset: 0 });
+
+    await contains(".btn-next-date").click();
+    expect(".o-date-filter-value").toHaveText("2026-2027");
+    expect(model.getters.getGlobalFilterValue("1")).toEqual({ type: "fiscal_year", offset: 1 });
+});
+
+test("Can navigate in a fiscal year global filter in the dropdown", async function () {
+    spreadsheetData = { globalFilters: [THIS_FISCAL_YEAR_FILTER] };
+    SpreadsheetDashboard._records[0].spreadsheet_data = JSON.stringify(spreadsheetData);
+    const { model } = await createSpreadsheetDashboard({});
+    const fixture = getFixture();
+
+    function getCustomRangeValue() {
+        const inputs = fixture.querySelectorAll(".o-dropdown-item[data-id='range'] input");
+        return [...inputs].map((input) => input.value);
+    }
+
+    await contains(".o-date-filter-value").click();
+
+    expect(".o-dropdown-item[data-id='fiscal_year']").toHaveClass("selected");
+    expect(getCustomRangeValue()).toEqual(["07/01/2025", "06/30/2026"]);
+
+    await contains(".o-dropdown-item[data-id='fiscal_year'] .btn-next").click();
+    expect(".o-dropdown-item[data-id='fiscal_year']").toHaveClass("selected");
+    expect(getCustomRangeValue()).toEqual(["07/01/2026", "06/30/2027"]);
+    expect(model.getters.getGlobalFilterValue("1")).toEqual({ type: "fiscal_year", offset: 1 });
+});


### PR DESCRIPTION
### [IMP] spreadsheet_*: add fiscal year global filter

This commit adds the fiscal year global filter, that can be used to
filter the data source based on the given fiscal year.

### [REF] spreadshet: make date global filter extensibles

This commit refactors the date global filters and add them to a registry
to make them extensible, and easier to understand since all the logic
is in the same place now.

Task: [4942255](https://www.odoo.com/odoo/2328/tasks/4942255)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
