### PR TITLE
[FIX] stock: fix to stock past quantities calc

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -373,7 +373,7 @@ class ProductProduct(models.Model):
         if self.env.context.get('strict'):
             loc_domain = Domain('location_id', 'in', locations.ids)
             dest_loc_domain = Domain('location_dest_id', 'in', locations.ids)
-            dest_loc_domain_out = Domain('location_dest_id', 'in', locations.ids)
+            dest_loc_domain_out = ~Domain('location_dest_id', 'in', locations.ids)
         elif locations:
             paths_domain = Domain.OR(Domain('parent_path', '=like', loc.parent_path + '%') for loc in locations)
             loc_domain = Domain('location_id', 'any', paths_domain)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- Basic calculations of past quantities with context "strict" miss all "out" stock moves due to the poor domain.



Current behavior before PR:

Getting a stock quantity in a "strict" context returned a malformed out domain

domain_move_in:
    ['&', ('location_dest_id', 'in', [879]), ('location_id', 'not in', [879])]
correct - source location is not stock and destination is stock

domain_move_out :
    ['&', ('location_id', 'in', [879]), ('location_dest_id', 'in', [879])]
incorrect - both source and destination are the same



Desired behavior after PR is merged:

The domain is correct:

domain_move_in :
    ['&', ('location_dest_id', 'in', [879]), ('location_id', 'not in', [879])]
still correct

domain_move_out :
    ['&', ('location_id', 'in', [879]), ('location_dest_id', 'not in', [879])]
destination is now "not" stock



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
