### PR TITLE
[FIX] point_of_sale: prevent internal reference being added after edit

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1887,7 +1887,9 @@ export class PosStore extends Reactive {
                 props: {
                     resId: product?.id,
                     onSave: (record) => {
-                        this.data.read("product.product", [record.evalContext.id]);
+                        this.data.read("product.product", [record.evalContext.id], [], {
+                            context: { display_default_code: false },
+                        });
                         this.action.doAction({
                             type: "ir.actions.act_window_close",
                         });

--- a/addons/point_of_sale/static/tests/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_screen_tour.js
@@ -722,3 +722,16 @@ registry.category("web_tour.tours").add("test_pos_ui_round_globally", {
             Chrome.endTour(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_edit_product_ref_not_in_name", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+
+            ProductScreen.clickInfoProduct("Test Product Ref"),
+            Dialog.confirm("Edit", ".btn-secondary"),
+            Dialog.confirm(),
+            ProductScreen.productIsDisplayed("[TESTPRODREF] Test Product Ref").map(negateStep),
+        ].flat(),
+});

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -2147,6 +2147,17 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_default_pricelist_when_creating_partner', login="pos_user")
 
+    def test_edit_product_ref_not_in_name(self):
+        self.env['product.product'].create({
+            'name': 'Test Product Ref',
+            'default_code': 'TESTPRODREF',
+            'list_price': 100,
+            'taxes_id': False,
+            'available_in_pos': True,
+        })
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_edit_product_ref_not_in_name', login="pos_user")
+
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):
     browser_size = '375x667'


### PR DESCRIPTION
Before this commit, editing a product in the PoS (even without making changes) would update the product name in the UI. The internal reference was automatically prefixed to the product name, and this formatting persisted through to the receipt.

With this commit, saving a product without modifications will no longer alter the product name displayed in the PoS.

Steps to reproduce:

 1. Open any PoS
 2. Choose any product
 3. Click the (i) icon to view the product information
 4. Click Edit (no need to change anything)
 5. Click Save

opw-5073848

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
