### PR TITLE
[FIX] account: Ref rounding of tax_details for better handling of price-included

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -1205,6 +1205,7 @@ class AccountTax(models.Model):
                     'group': batching_results['group_per_tax'].get(tax_data['tax'].id) or self.env['account.tax'],
                     'batch': batching_results['batch_per_tax'][tax_data['tax'].id],
                     'tax_amount': tax_data['tax_amount'],
+                    'price_include': tax_data['price_include'],
                     'base_amount': tax_data['base'],
                     'is_reverse_charge': tax_data.get('is_reverse_charge', False),
                 }
@@ -1358,6 +1359,8 @@ class AccountTax(models.Model):
 
             # For all computation that are inferring a base amount in order to reach a total you know in advance, you have to force some
             # base/tax amounts for the computation (E.g. down payment, combo products, global discounts etc).
+            'manual_total_excluded_currency': load('manual_total_excluded_currency', None, from_base_line=True),
+            'manual_total_excluded': load('manual_total_excluded', None, from_base_line=True),
             'manual_tax_amounts': load('manual_tax_amounts', None, from_base_line=True),
 
             # Add a function allowing to filter out some taxes during the evaluation. Those taxes can't be removed from the base_line
@@ -1556,6 +1559,285 @@ class AccountTax(models.Model):
         return amounts_to_distribute
 
     @api.model
+    def _round_tax_details_tax_amounts(self, base_lines, company, mode='mixed'):
+        """ Dispatch the delta in term of tax amounts across the tax details when dealing with the 'round_globally' method.
+        Suppose 2 lines:
+        - quantity=12.12, price_unit=12.12, tax=23%
+        - quantity=12.12, price_unit=12.12, tax=23%
+        The tax of each line is computed as round(12.12 * 12.12 * 0.23) = 33.79
+        The expected tax amount of the whole document is round(12.12 * 12.12 * 0.23 * 2) = 67.57
+        The delta in term of tax amount is 67.57 - 33.79 - 33.79 = -0.01
+
+        [!] Mirror of the same method in account_tax.js.
+        PLZ KEEP BOTH METHODS CONSISTENT WITH EACH OTHERS.
+
+        :param base_lines:          A list of base lines generated using the '_prepare_base_line_for_taxes_computation' method.
+        :param company:             The company owning the base lines.
+        :param mode:                The mode to round taxes:
+            * excluded:                 Round base and tax independently.
+            * included:                 Round base + tax, then subtract the tax and round the base according the remaining amount.
+            * mixed:                    Round 'excluded' or 'included' depending if the tax is price-included or not.
+        """
+        def grouping_function(base_line, tax_data):
+            if not tax_data:
+                return
+            return {
+                'tax': tax_data['tax'],
+                'currency': base_line['currency_id'],
+                'is_refund': base_line['is_refund'],
+                'is_reverse_charge': tax_data['is_reverse_charge'],
+                'price_include': tax_data['price_include'],
+            }
+
+        base_lines_aggregated_values = self._aggregate_base_lines_tax_details(base_lines, grouping_function)
+        values_per_grouping_key = self._aggregate_base_lines_aggregated_values(base_lines_aggregated_values)
+        for grouping_key, values in values_per_grouping_key.items():
+            if not grouping_key:
+                continue
+
+            price_include = grouping_key['price_include']
+            currency = grouping_key['currency']
+            for delta_currency_indicator, delta_currency in (
+                ('_currency', currency),
+                ('', company.currency_id),
+            ):
+                # Tax amount.
+                raw_total_tax_amount = values[f'target_tax_amount{delta_currency_indicator}']
+                rounded_raw_total_tax_amount = delta_currency.round(raw_total_tax_amount)
+                total_tax_amount = values[f'tax_amount{delta_currency_indicator}']
+                delta_total_tax_amount = rounded_raw_total_tax_amount - total_tax_amount
+
+                if raw_total_tax_amount:
+                    target_factors = [
+                        {
+                            'factor': tax_data[f'raw_tax_amount{delta_currency_indicator}'],
+                            'tax_data': tax_data,
+                        }
+                        for _base_line, taxes_data in values['base_line_x_taxes_data']
+                        for tax_data in taxes_data
+                    ]
+                    amounts_to_distribute = self._distribute_delta_amount_smoothly(
+                        precision_digits=delta_currency.decimal_places,
+                        delta_amount=delta_total_tax_amount,
+                        target_factors=target_factors,
+                    )
+                    for target_factor, amount_to_distribute in zip(target_factors, amounts_to_distribute):
+                        tax_data = target_factor['tax_data']
+                        tax_data[f'tax_amount{delta_currency_indicator}'] += amount_to_distribute
+
+                # Base amount.
+                raw_total_base_amount = values[f'target_base_amount{delta_currency_indicator}']
+                if (mode == 'mixed' and price_include) or mode == 'included':
+                    raw_total_amount = raw_total_base_amount + raw_total_tax_amount
+                    rounded_raw_total_amount = delta_currency.round(raw_total_amount)
+                    total_amount = values[f'base_amount{delta_currency_indicator}'] + total_tax_amount + delta_total_tax_amount
+                    delta_total_base_amount = rounded_raw_total_amount - total_amount
+                elif (mode == 'mixed' and not price_include) or mode == 'excluded':
+                    rounded_raw_total_base_amount = delta_currency.round(raw_total_base_amount)
+                    total_base_amount = values[f'base_amount{delta_currency_indicator}']
+                    delta_total_base_amount = rounded_raw_total_base_amount - total_base_amount
+
+                if raw_total_base_amount:
+                    target_factors = [
+                        {
+                            'factor': tax_data[f'raw_base_amount{delta_currency_indicator}'],
+                            'tax_data': tax_data,
+                        }
+                        for _base_line, taxes_data in values['base_line_x_taxes_data']
+                        for tax_data in taxes_data
+                    ]
+                    amounts_to_distribute = self._distribute_delta_amount_smoothly(
+                        precision_digits=delta_currency.decimal_places,
+                        delta_amount=delta_total_base_amount,
+                        target_factors=target_factors,
+                    )
+                    for target_factor, amount_to_distribute in zip(target_factors, amounts_to_distribute):
+                        tax_data = target_factor['tax_data']
+                        tax_data[f'base_amount{delta_currency_indicator}'] += amount_to_distribute
+
+    @api.model
+    def _round_tax_details_base_lines(self, base_lines, company, mode='mixed'):
+        """ Additional global rounding depending on if the taxes are included or excluded in price.
+
+        This method does not modify the rounding in `taxes_data`, rather it computes an adjustment
+        for `tax_details['total_excluded{_currency}']` and stores it as `tax_details['delta_total_excluded{_currency}']`.
+
+        Suppose all taxes are price-included.
+        Suppose two price-included taxes of 10%.
+        Suppose a line having price_unit=100.0.
+        The tax amount is computed as 100.0 / 1.2 * 0.1 = 8.333333333
+        The base amount is computed as 100.0 - (2 * 8.333333333) = 83.333333334
+        Without doing anything, we end up with a base of 83.33 and 2 * 8.33 as tax amounts.
+        83.33 + 8.33 + 8.33 = 99.99.
+        However, since all tax are price-included, we expect a base amount of 83.34 to reach the
+        original 100.0.
+
+        Manage price-excluded taxes.
+        Suppose 2 lines, both having quantity=12.12, price_unit=12.12, tax=23%
+        The base amount of each line is computed as round(12.12 * 12.12) = 146.89
+        The expected base amount of the whole document is round(12.12 * 12.12 * 2) = 293.79
+        The delta in term of base amount is 293.79 - 146.89 - 146.89 = 0.01
+
+        [!] Mirror of the same method in account_tax.js.
+        PLZ KEEP BOTH METHODS CONSISTENT WITH EACH OTHERS.
+
+        :param base_lines:          A list of base lines generated using the '_prepare_base_line_for_taxes_computation' method.
+        :param company:             The company owning the base lines.
+        :param mode:                The mode to round taxes:
+            * excluded:                 Round base and tax independently.
+            * included:                 Round base + tax, then subtract the tax and round the base according the remaining amount.
+            * mixed:                    Round 'excluded' or 'included' depending if the tax is price-included or not.
+        """
+        def grouping_function(base_line, tax_data):
+            return {
+                'currency': base_line['currency_id'],
+                'is_refund': base_line['is_refund'],
+            }
+
+        base_lines_aggregated_values = self._aggregate_base_lines_tax_details(base_lines, grouping_function)
+        values_per_grouping_key = self._aggregate_base_lines_aggregated_values(base_lines_aggregated_values)
+        for grouping_key, values in values_per_grouping_key.items():
+            current_mode = mode
+            if mode == 'mixed':
+                current_mode = 'included'
+                for base_line, taxes_data in values['base_line_x_taxes_data']:
+                    if any(not tax_data['price_include'] for tax_data in taxes_data):
+                        current_mode = 'excluded'
+                        break
+
+            currency = grouping_key['currency']
+            for delta_currency_indicator, delta_currency in (
+                ('_currency', currency),
+                ('', company.currency_id),
+            ):
+                if current_mode == 'excluded':
+                    # Price-excluded rounding.
+                    raw_total_excluded = values[f'target_total_excluded{delta_currency_indicator}']
+                    if not raw_total_excluded:
+                        continue
+
+                    rounded_raw_total_excluded = delta_currency.round(raw_total_excluded)
+                    total_excluded = values[f'total_excluded{delta_currency_indicator}']
+                    delta_total_excluded = rounded_raw_total_excluded - total_excluded
+                    target_factors = [
+                        {
+                            'factor': base_line['tax_details'][f'raw_total_excluded{delta_currency_indicator}'],
+                            'base_line': base_line,
+                        }
+                        for base_line, _taxes_data in values['base_line_x_taxes_data']
+                    ]
+                else:
+                    # Price-included rounding.
+                    raw_total_included = (
+                        values[f'target_total_excluded{delta_currency_indicator}']
+                        + values[f'target_tax_amount{delta_currency_indicator}']
+                    )
+                    if not raw_total_included:
+                        continue
+
+                    rounded_raw_total_included = delta_currency.round(raw_total_included)
+                    total_included = (
+                        values[f'total_excluded{delta_currency_indicator}']
+                        + values[f'tax_amount{delta_currency_indicator}']
+                    )
+                    delta_total_excluded = rounded_raw_total_included - total_included
+                    target_factors = [
+                        {
+                            'factor': base_line['tax_details'][f'raw_total_included{delta_currency_indicator}'],
+                            'base_line': base_line,
+                        }
+                        for base_line, _taxes_data in values['base_line_x_taxes_data']
+                    ]
+
+                amounts_to_distribute = self._distribute_delta_amount_smoothly(
+                    precision_digits=delta_currency.decimal_places,
+                    delta_amount=delta_total_excluded,
+                    target_factors=target_factors,
+                )
+                for target_factor, amount_to_distribute in zip(target_factors, amounts_to_distribute):
+                    base_line = target_factor['base_line']
+                    base_line['tax_details'][f'delta_total_excluded{delta_currency_indicator}'] += amount_to_distribute
+
+    @api.model
+    def _round_tax_details_tax_amounts_from_tax_lines(self, base_lines, company, tax_lines):
+        """ If tax lines are provided, the totals will be aggregated according them.
+        At this point, everything is rounded and won't change anymore.
+
+        [!] Only added python-side.
+
+        :param base_lines:          A list of base lines generated using the '_prepare_base_line_for_taxes_computation' method.
+        :param company:             The company owning the base lines.
+        :param tax_lines:           A optional list of base lines generated using the '_prepare_tax_line_for_taxes_computation'
+                                    method. If specified, the tax amounts will be computed based on those existing tax lines.
+                                    It's used to keep the manual tax amounts set by the user.
+        """
+        if not tax_lines:
+            return
+
+        total_per_tax_line_key = defaultdict(lambda: {
+            'currency': None,
+            'tax_amount_currency': 0.0,
+            'tax_amount': 0.0,
+        })
+        for tax_line in tax_lines:
+            tax_rep = tax_line['tax_repartition_line_id']
+            sign = tax_line['sign']
+            tax = tax_rep.tax_id
+            currency = tax_line['currency_id']
+            tax_line_key = (tax.id, currency.id, tax_rep.document_type == 'refund')
+            total_per_tax_line_key[tax_line_key]['currency'] = currency
+            total_per_tax_line_key[tax_line_key]['tax_amount_currency'] += sign * tax_line['amount_currency']
+            total_per_tax_line_key[tax_line_key]['tax_amount'] += sign * tax_line['balance']
+
+        def grouping_function(base_line, tax_data):
+            if not tax_data:
+                return
+            return {
+                'tax': tax_data['tax'],
+                'currency': base_line['currency_id'],
+                'is_refund': base_line['is_refund'],
+            }
+
+        base_lines_aggregated_values = self._aggregate_base_lines_tax_details(base_lines, grouping_function)
+        values_per_grouping_key = self._aggregate_base_lines_aggregated_values(base_lines_aggregated_values)
+        for grouping_key, values in values_per_grouping_key.items():
+            if not grouping_key:
+                continue
+
+            currency = grouping_key['currency']
+            tax_line_key = (grouping_key['tax'].id, currency.id, grouping_key['is_refund'])
+            if tax_line_key not in total_per_tax_line_key:
+                continue
+
+            for delta_currency_indicator, delta_currency in (
+                ('_currency', currency),
+                ('', company.currency_id),
+            ):
+                current_total_tax_amount = values[f'tax_amount{delta_currency_indicator}']
+                if not current_total_tax_amount:
+                    continue
+
+                target_total_tax_amount = total_per_tax_line_key[tax_line_key][f'tax_amount{delta_currency_indicator}']
+                delta_total_tax_amount = target_total_tax_amount - current_total_tax_amount
+
+                target_factors = [
+                    {
+                        'factor': tax_data[f'tax_amount{delta_currency_indicator}'],
+                        'tax_data': tax_data,
+                    }
+                    for _base_line, taxes_data in values['base_line_x_taxes_data']
+                    for tax_data in taxes_data
+                ]
+                amounts_to_distribute = self._distribute_delta_amount_smoothly(
+                    precision_digits=delta_currency.decimal_places,
+                    delta_amount=delta_total_tax_amount,
+                    target_factors=target_factors,
+                )
+                for target_factor, amount_to_distribute in zip(target_factors, amounts_to_distribute):
+                    tax_data = target_factor['tax_data']
+                    tax_data[f'tax_amount{delta_currency_indicator}'] += amount_to_distribute
+
+    @api.model
     def _round_base_lines_tax_details(self, base_lines, company, tax_lines=None):
         """ Round the 'tax_details' added to base_lines with the '_add_accounting_data_to_base_line_tax_details'.
         This method performs all the rounding and take care of rounding issues that could appear when using the
@@ -1614,352 +1896,56 @@ class AccountTax(models.Model):
                                     method. If specified, the tax amounts will be computed based on those existing tax lines.
                                     It's used to keep the manual tax amounts set by the user.
         """
-        total_per_tax = defaultdict(lambda: {
-            'base_amount_currency': 0.0,
-            'base_amount': 0.0,
-            'raw_base_amount_currency': 0.0,
-            'raw_base_amount': 0.0,
-            'tax_amount_currency': 0.0,
-            'tax_amount': 0.0,
-            'raw_tax_amount_currency': 0.0,
-            'raw_tax_amount': 0.0,
-            'raw_total_amount_currency': 0.0,
-            'raw_total_amount': 0.0,
-            'base_lines': [],
-        })
-        total_per_base = defaultdict(lambda: {
-            'base_amount_currency': 0.0,
-            'base_amount': 0.0,
-            'raw_base_amount_currency': 0.0,
-            'raw_base_amount': 0.0,
-            'tax_amount_currency': 0.0,
-            'tax_amount': 0.0,
-            'raw_total_amount_currency': 0.0,
-            'raw_total_amount': 0.0,
-            'base_lines': [],
-        })
-        map_total_per_tax_key_x_for_tax_line_key = defaultdict(set)
-        country_code = company.account_fiscal_country_id.code
-
+        # Raw rounding.
         for base_line in base_lines:
-            currency = base_line['currency_id']
             tax_details = base_line['tax_details']
-            tax_details['total_excluded_currency'] = currency.round(tax_details['raw_total_excluded_currency'])
-            tax_details['total_excluded'] = company.currency_id.round(tax_details['raw_total_excluded'])
-            tax_details['delta_total_excluded_currency'] = 0.0
-            tax_details['delta_total_excluded'] = 0.0
-            tax_details['total_included_currency'] = currency.round(tax_details['raw_total_included_currency'])
-            tax_details['total_included'] = company.currency_id.round(tax_details['raw_total_included'])
-            taxes_data = tax_details['taxes_data']
 
-            # If there are taxes on it, account the amounts from taxes_data.
-            for index, tax_data in enumerate(taxes_data):
-                tax = tax_data['tax']
+            for suffix, currency in (('_currency', base_line['currency_id']), ('', company.currency_id)):
+                total_excluded_field = f'total_excluded{suffix}'
+                tax_details[total_excluded_field] = currency.round(tax_details[f'raw_{total_excluded_field}'])
 
-                tax_data['tax_amount_currency'] = currency.round(tax_data['raw_tax_amount_currency'])
-                tax_data['tax_amount'] = company.currency_id.round(tax_data['raw_tax_amount'])
-                tax_data['base_amount_currency'] = currency.round(tax_data['raw_base_amount_currency'])
-                tax_data['base_amount'] = company.currency_id.round(tax_data['raw_base_amount'])
+                for tax_data in tax_details['taxes_data']:
+                    for prefix in ('base', 'tax'):
+                        field = f'{prefix}_amount{suffix}'
+                        tax_data[field] = currency.round(tax_data[f'raw_{field}'])
 
-                tax_rounding_key = (tax, currency, base_line['is_refund'], tax_data['is_reverse_charge'])
-                tax_line_key = (tax, currency, base_line['is_refund'])
-                map_total_per_tax_key_x_for_tax_line_key[tax_line_key].add(tax_rounding_key)
-                tax_amounts = total_per_tax[tax_rounding_key]
-                tax_amounts['tax_amount_currency'] += tax_data['tax_amount_currency']
-                tax_amounts['raw_tax_amount_currency'] += tax_data['raw_tax_amount_currency']
-                tax_amounts['tax_amount'] += tax_data['tax_amount']
-                tax_amounts['raw_tax_amount'] += tax_data['raw_tax_amount']
-                tax_amounts['base_amount_currency'] += tax_data['base_amount_currency']
-                tax_amounts['raw_base_amount_currency'] += tax_data['raw_base_amount_currency']
-                tax_amounts['base_amount'] += tax_data['base_amount']
-                tax_amounts['raw_base_amount'] += tax_data['raw_base_amount']
-                tax_amounts['raw_total_amount_currency'] += tax_data['raw_base_amount_currency'] + tax_data['raw_tax_amount_currency']
-                tax_amounts['raw_total_amount'] += tax_data['raw_base_amount'] + tax_data['raw_tax_amount']
-                if not base_line['special_type']:
-                    tax_amounts['base_lines'].append(base_line)
+        # Apply 'manual_tax_amounts'.
+        for base_line in base_lines:
+            manual_tax_amounts = base_line['manual_tax_amounts']
+            rate = base_line['rate']
+            tax_details = base_line['tax_details']
 
-                base_rounding_key = (currency, base_line['is_refund'])
-                base_amounts = total_per_base[base_rounding_key]
-                base_amounts['tax_amount_currency'] += tax_data['tax_amount_currency']
-                base_amounts['tax_amount'] += tax_data['tax_amount']
-                base_amounts['raw_total_amount_currency'] += tax_data['raw_tax_amount_currency']
-                base_amounts['raw_total_amount'] += tax_data['raw_tax_amount']
-                if index == 0:
-                    base_amounts['base_amount_currency'] += tax_data['base_amount_currency']
-                    base_amounts['raw_base_amount_currency'] += tax_data['raw_base_amount_currency']
-                    base_amounts['base_amount'] += tax_data['base_amount']
-                    base_amounts['raw_base_amount'] += tax_data['raw_base_amount']
-                    base_amounts['raw_total_amount_currency'] += tax_data['raw_base_amount_currency']
-                    base_amounts['raw_total_amount'] += tax_data['raw_base_amount']
-                    if not base_line['special_type']:
-                        base_amounts['base_lines'].append(base_line)
+            for suffix, currency in (('_currency', base_line['currency_id']), ('', company.currency_id)):
+                total_field = f'total_excluded{suffix}'
+                manual_field = f'manual_{total_field}'
+                if base_line[manual_field] is not None:
+                    tax_details[total_field] = base_line[manual_field]
 
-            # If not, just account the base amounts.
-            if not taxes_data:
-                tax_rounding_key = (None, currency, base_line['is_refund'], False)
-                tax_amounts = total_per_tax[tax_rounding_key]
-                tax_amounts['base_amount_currency'] += tax_details['total_excluded_currency']
-                tax_amounts['raw_base_amount_currency'] += tax_details['raw_total_excluded_currency']
-                tax_amounts['base_amount'] += tax_details['total_excluded']
-                tax_amounts['raw_base_amount'] += tax_details['raw_total_excluded']
-                tax_amounts['raw_total_amount_currency'] += tax_details['raw_total_excluded_currency']
-                tax_amounts['raw_total_amount'] += tax_details['raw_total_excluded']
-                if not base_line['special_type']:
-                    tax_amounts['base_lines'].append(base_line)
+                for tax_data in tax_details['taxes_data']:
+                    tax = tax_data['tax']
+                    reverse_charge_sign = -1 if tax_data['is_reverse_charge'] else 1
+                    current_manual_tax_amounts = manual_tax_amounts and manual_tax_amounts.get(str(tax.id)) or {}
+                    for prefix, factor in (('base', 1), ('tax', reverse_charge_sign)):
+                        field = f'{prefix}_amount{suffix}'
+                        if field in current_manual_tax_amounts:
+                            tax_data[field] = currency.round(factor * current_manual_tax_amounts[field])
+                            if suffix == '_currency' and rate:
+                                tax_data[f'{prefix}_amount'] = company.currency_id.round(tax_data[field] / rate)
 
-                base_rounding_key = (currency, base_line['is_refund'])
-                base_amounts = total_per_base[base_rounding_key]
-                base_amounts['base_amount_currency'] += tax_details['total_excluded_currency']
-                base_amounts['raw_base_amount_currency'] += tax_details['raw_total_excluded_currency']
-                base_amounts['base_amount'] += tax_details['total_excluded']
-                base_amounts['raw_base_amount'] += tax_details['raw_total_excluded']
-                base_amounts['raw_total_amount_currency'] += tax_details['raw_total_excluded_currency']
-                base_amounts['raw_total_amount'] += tax_details['raw_total_excluded']
-                if not base_line['special_type']:
-                    base_amounts['base_lines'].append(base_line)
+        # Compute 'total_included' & add 'delta_total_excluded'.
+        for base_line in base_lines:
+            tax_details = base_line['tax_details']
 
-        # Round 'total_per_tax'.
-        for (_tax, currency, _is_refund, _is_reverse_charge), tax_amounts in total_per_tax.items():
-            tax_amounts['raw_tax_amount_currency'] = currency.round(tax_amounts['raw_tax_amount_currency'])
-            tax_amounts['raw_tax_amount'] = company.currency_id.round(tax_amounts['raw_tax_amount'])
-            tax_amounts['raw_base_amount_currency'] = currency.round(tax_amounts['raw_base_amount_currency'])
-            tax_amounts['raw_base_amount'] = company.currency_id.round(tax_amounts['raw_base_amount'])
-            tax_amounts['raw_total_amount_currency'] = currency.round(tax_amounts['raw_total_amount_currency'])
-            tax_amounts['raw_total_amount'] = company.currency_id.round(tax_amounts['raw_total_amount'])
+            for suffix in ('_currency', ''):
+                tax_details[f'delta_total_excluded{suffix}'] = 0.0
+                tax_details[f'total_included{suffix}'] = tax_details[f'total_excluded{suffix}']
 
-        # Round 'total_per_base'.
-        for (currency, _is_refund), base_amounts in total_per_base.items():
-            base_amounts['raw_base_amount_currency'] = currency.round(base_amounts['raw_base_amount_currency'])
-            base_amounts['raw_base_amount'] = company.currency_id.round(base_amounts['raw_base_amount'])
-            base_amounts['raw_total_amount_currency'] = currency.round(base_amounts['raw_total_amount_currency'])
-            base_amounts['raw_total_amount'] = company.currency_id.round(base_amounts['raw_total_amount'])
+                for tax_data in tax_details['taxes_data']:
+                    tax_details[f'total_included{suffix}'] += tax_data[f'tax_amount{suffix}']
 
-        # If tax lines are provided, the totals will be aggregated according them.
-        # Note: there is no managment of custom tax lines js-side.
-        if tax_lines:
-            # Aggregate the tax lines all together under the 'tax_line_key'.
-            # Since the 'rounding_key' is not similar as 'tax_line_key' because we are not able to recover all
-            # the key from an accounting tax lines, we have to map both and dispatch somehow the delta in term of
-            # base and tax amounts.
-            total_per_tax_line_key = defaultdict(lambda: {
-                'tax_amount_currency': 0.0,
-                'tax_amount': 0.0,
-            })
-            for tax_line in tax_lines:
-                tax_rep = tax_line['tax_repartition_line_id']
-                sign = tax_line['sign']
-                tax = tax_rep.tax_id
-                currency = tax_line['currency_id']
-                tax_line_key = (tax, currency, tax_rep.document_type == 'refund')
-                total_per_tax_line_key[tax_line_key]['tax_amount_currency'] += sign * tax_line['amount_currency']
-                total_per_tax_line_key[tax_line_key]['tax_amount'] += sign * tax_line['balance']
-
-            # Reflect the difference to 'total_per_tax'.
-            for tax_line_key, tax_line_amounts in total_per_tax_line_key.items():
-                raw_tax_amount_currency = 0.0
-                raw_tax_amount = 0.0
-                rounding_keys = map_total_per_tax_key_x_for_tax_line_key[tax_line_key]
-                if not rounding_keys:
-                    continue
-
-                for tax_rounding_key in rounding_keys:
-                    raw_tax_amount_currency += total_per_tax[tax_rounding_key]['raw_tax_amount_currency']
-                    raw_tax_amount += total_per_tax[tax_rounding_key]['raw_tax_amount']
-                delta_raw_tax_amount_currency = tax_line_amounts['tax_amount_currency'] - raw_tax_amount_currency
-                delta_raw_tax_amount = tax_line_amounts['tax_amount'] - raw_tax_amount
-                biggest_total_per_tax = max(
-                    [
-                        total_per_tax[rounding_key]
-                        for rounding_key in rounding_keys
-                    ],
-                    key=lambda total_per_tax_amounts: total_per_tax_amounts['raw_tax_amount_currency'],
-                )
-                biggest_total_per_tax['raw_tax_amount_currency'] += delta_raw_tax_amount_currency
-                biggest_total_per_tax['raw_tax_amount'] += delta_raw_tax_amount
-
-                # Suppose a vendor bill of 123.0 with 23% tax.
-                # Your total amounts are 123.0 for the base, 28.29 for the tax and a total of 151.29.
-                # If the tax line says a tax amount of 28.30, we want the total to be 151.30.
-                # So we have to increase the total too since the Portugal computation is based on it.
-                if country_code == 'PT' and delta_raw_tax_amount_currency:
-                    total_per_tax[tax_rounding_key]['raw_total_amount_currency'] += delta_raw_tax_amount_currency
-                    total_per_tax[tax_rounding_key]['raw_total_amount'] += delta_raw_tax_amount
-
-                    base_rounding_key = (tax_line_key[1], tax_rep.document_type == 'refund')
-                    total_per_base[base_rounding_key]['raw_total_amount_currency'] += delta_raw_tax_amount_currency
-                    total_per_base[base_rounding_key]['raw_total_amount'] += delta_raw_tax_amount
-
-        # Dispatch the delta in term of tax amounts across the tax details when dealing with the 'round_globally' method.
-        # Suppose 2 lines:
-        # - quantity=12.12, price_unit=12.12, tax=23%
-        # - quantity=12.12, price_unit=12.12, tax=23%
-        # The tax of each line is computed as round(12.12 * 12.12 * 0.23) = 33.79
-        # The expected tax amount of the whole document is round(12.12 * 12.12 * 0.23 * 2) = 67.57
-        # The delta in term of tax amount is 67.57 - 33.79 - 33.79 = -0.01
-        for (tax, currency, _is_refund, is_reverse_charge), tax_amounts in total_per_tax.items():
-            if not tax_amounts['base_lines']:
-                continue
-
-            tax_amounts['sorted_base_line_x_tax_data'] = [
-                (
-                    base_line,
-                    next(
-                        (
-                            (index, tax_data)
-                            for index, tax_data in enumerate(base_line['tax_details']['taxes_data'])
-                            if tax_data['tax'] == tax and tax_data['is_reverse_charge'] == is_reverse_charge
-                        ),
-                        None,
-                    )
-                )
-                for base_line in sorted(
-                    tax_amounts['base_lines'],
-                    key=lambda base_line: -base_line['tax_details']['total_included_currency'],
-                )
-            ]
-            tax_amounts['total_included_currency'] = sum(
-                abs(base_line['tax_details']['total_included_currency'])
-                for base_line in tax_amounts['base_lines']
-            )
-            if not tax or not tax_amounts['total_included_currency']:
-                continue
-
-            for delta_field, delta_currency in (
-                ('tax_amount_currency', currency),
-                ('tax_amount', company.currency_id),
-            ):
-                delta_amount = tax_amounts[f'raw_{delta_field}'] - tax_amounts[delta_field]
-                target_factors = [
-                    {
-                        'factor': base_line['tax_details']['total_included_currency'],
-                        'base_line': base_line,
-                        'index_tax_data': index_tax_data,
-                    }
-                    for base_line, index_tax_data in tax_amounts['sorted_base_line_x_tax_data']
-                    if index_tax_data
-                ]
-                amounts_to_distribute = self._distribute_delta_amount_smoothly(
-                    precision_digits=delta_currency.decimal_places,
-                    delta_amount=delta_amount,
-                    target_factors=target_factors,
-                )
-                for target_factor, amount_to_distribute in zip(target_factors, amounts_to_distribute):
-                    base_line = target_factor['base_line']
-                    index, tax_data = target_factor['index_tax_data']
-
-                    tax_data[delta_field] += amount_to_distribute
-                    tax_amounts[delta_field] += amount_to_distribute
-
-                    if index == 0:
-                        base_rounding_key = (currency, base_line['is_refund'])
-                        base_amounts = total_per_base[base_rounding_key]
-                        base_amounts[delta_field] += amount_to_distribute
-
-        # Dispatch the delta of base amounts across the base lines.
-        # Suppose 2 lines:
-        # - quantity=12.12, price_unit=12.12, tax=23%
-        # - quantity=12.12, price_unit=12.12, tax=23%
-        # The base amount of each line is computed as round(12.12 * 12.12) = 146.89
-        # The expected base amount of the whole document is round(12.12 * 12.12 * 2) = 293.79
-        # The delta in term of base amount is 293.79 - 146.89 - 146.89 = 0.01
-        for (tax, currency, _is_refund, _is_reverse_charge), tax_amounts in total_per_tax.items():
-            if not tax_amounts.get('sorted_base_line_x_tax_data') or not tax_amounts.get('total_included_currency'):
-                continue
-
-            for delta_currency_indicator, delta_currency in (
-                ('_currency', currency),
-                ('', company.currency_id),
-            ):
-                if country_code == 'PT':
-                    delta_amount = (
-                        tax_amounts[f'raw_total_amount{delta_currency_indicator}']
-                        - tax_amounts[f'base_amount{delta_currency_indicator}']
-                        - tax_amounts[f'tax_amount{delta_currency_indicator}']
-                    )
-                else:
-                    delta_amount = tax_amounts[f'raw_base_amount{delta_currency_indicator}'] - tax_amounts[f'base_amount{delta_currency_indicator}']
-
-                target_factors = [
-                    {
-                        'factor': base_line['tax_details']['total_included_currency'],
-                        'base_line': base_line,
-                        'index_tax_data': index_tax_data,
-                    }
-                    for base_line, index_tax_data in tax_amounts['sorted_base_line_x_tax_data']
-                ]
-                amounts_to_distribute = self._distribute_delta_amount_smoothly(
-                    precision_digits=delta_currency.decimal_places,
-                    delta_amount=delta_amount,
-                    target_factors=target_factors,
-                )
-                for target_factor, amount_to_distribute in zip(target_factors, amounts_to_distribute):
-                    base_line = target_factor['base_line']
-                    tax_details = base_line['tax_details']
-                    index_tax_data = target_factor['index_tax_data']
-                    if index_tax_data:
-                        _index, tax_data = index_tax_data
-                        tax_data[f'base_amount{delta_currency_indicator}'] += amount_to_distribute
-                    else:
-                        tax_details[f'delta_total_excluded{delta_currency_indicator}'] += amount_to_distribute
-
-                        base_rounding_key = (currency, base_line['is_refund'])
-                        base_amounts = total_per_base[base_rounding_key]
-                        base_amounts[f'base_amount{delta_currency_indicator}'] += amount_to_distribute
-
-        # Dispatch the delta of base amounts accross the base lines.
-        # Suppose 2 lines:
-        # - quantity=12.12, price_unit=12.12, tax=23%
-        # - quantity=12.12, price_unit=12.12, tax=13%
-        # The base amount of each line is computed as round(12.12 * 12.12) = 146.89
-        # The expected base amount of the whole document is round(12.12 * 12.12 * 2) = 293.79
-        # Currently, the base amount has already been rounded per tax. So the tax details for the whole document is currently:
-        # 23%: base = 146.89, tax = 33.79
-        # 13%: base = 146.89, tax = 19.1
-        # However, for the whole document, there is a delta in term of base amount: 293.79 - 146.89 - 146.89 = 0.01
-        # This delta won't be there in any base but still has to be accounted.
-        for (currency, _is_refund), base_amounts in total_per_base.items():
-            if not base_amounts['base_lines']:
-                continue
-
-            if country_code == 'PT':
-                delta_base_amount_currency = (
-                    base_amounts['raw_total_amount_currency']
-                    - base_amounts['base_amount_currency']
-                    - base_amounts['tax_amount_currency']
-                )
-                delta_base_amount = (
-                    base_amounts['raw_total_amount']
-                    - base_amounts['base_amount']
-                    - base_amounts['tax_amount']
-                )
-            else:
-                delta_base_amount_currency = base_amounts['raw_base_amount_currency'] - base_amounts['base_amount_currency']
-                delta_base_amount = base_amounts['raw_base_amount'] - base_amounts['base_amount']
-
-            if currency.is_zero(delta_base_amount_currency) and company.currency_id.is_zero(delta_base_amount):
-                continue
-
-            # Dispatch the base delta evenly on the base lines, starting from the biggest line.
-            factors = [{'factor': 1.0}] * len(base_amounts['base_lines'])
-            base_lines_sorted = sorted(
-                base_amounts['base_lines'],
-                key=lambda base_line: base_line['tax_details']['total_included_currency'],
-                reverse=True,
-            )
-            for delta_currency_indicator, currency, delta_amount in (
-                ('_currency', currency, delta_base_amount_currency),
-                ('', company.currency_id, delta_base_amount),
-            ):
-                amounts_to_distribute = self._distribute_delta_amount_smoothly(
-                    currency.decimal_places,
-                    delta_amount,
-                    factors,
-                )
-                for base_line, amount_to_distribute in zip(
-                    base_lines_sorted,
-                    amounts_to_distribute,
-                ):
-                    base_line['tax_details'][f'delta_total_excluded{delta_currency_indicator}'] += amount_to_distribute
+        self._round_tax_details_tax_amounts(base_lines, company)
+        self._round_tax_details_base_lines(base_lines, company)
+        self._round_tax_details_tax_amounts_from_tax_lines(base_lines, company, tax_lines)
 
     @api.model
     def _prepare_base_line_grouping_key(self, base_line):
@@ -2210,66 +2196,100 @@ class AccountTax(models.Model):
         :return: A mapping <grouping_key, amounts> where:
             grouping_key                is the grouping_key returned by the 'grouping_function' or 'None'.
             amounts                     is a dictionary containing:
-                base_amount_currency:       The base amount of this grouping key expressed in foreign currency.
-                base_amount:                The base amount of this grouping key expressed in local currency.
-                raw_base_amount_currency:   The base amount of this grouping key expressed in foreign currency before any rounding.
-                raw_base_amount:            The base amount of this grouping key expressed in local currency before any rounding.
-                tax_amount_currency:        The tax amount of this grouping key expressed in foreign currency.
-                tax_amount:                 The tax amount of this grouping key expressed in local currency.
-                raw_tax_amount_currency:    The tax amount of this grouping key expressed in foreign currency before any rounding.
-                raw_tax_amount:             The tax amount of this grouping key expressed in local currency before any rounding.
-                total_excluded_currency:    The delta base amount for the base line involved in this grouping key expressed
-                                            in foreign currency.
-                total_excluded:             The delta base amount for the base line involved in this grouping key expressed
-                                            in local currency.
-                taxes_data:                 The subset of base_line['tax_details']['taxes_data'] aggregated under this grouping_key.
+                base_amount_currency:           The base amount of this grouping key expressed in foreign currency.
+                base_amount:                    The base amount of this grouping key expressed in local currency.
+                raw_base_amount_currency:       The base amount of this grouping key expressed in foreign currency before any rounding.
+                raw_base_amount:                The base amount of this grouping key expressed in local currency before any rounding.
+                target_base_amount_currency:    The same as 'raw_base_amount_currency' but considering the manual amounts.
+                target_base_amount:             The same as 'raw_base_amount' but considering the manual amounts.
+                tax_amount_currency:            The tax amount of this grouping key expressed in foreign currency.
+                tax_amount:                     The tax amount of this grouping key expressed in local currency.
+                raw_tax_amount_currency:        The tax amount of this grouping key expressed in foreign currency before any rounding.
+                raw_tax_amount:                 The tax amount of this grouping key expressed in local currency before any rounding.
+                target_tax_amount_currency:     The same as 'raw_tax_amount_currency' but considering the manual amounts.
+                target_tax_amount:              The same as 'raw_tax_amount' but considering the manual amounts.
+                total_excluded_currency:        The delta base amount for the base line involved in this grouping key expressed
+                                                in foreign currency.
+                total_excluded:                 The delta base amount for the base line involved in this grouping key expressed
+                                                in local currency.
+                raw_total_excluded_currency:    The delta base amount for the base line involved in this grouping key expressed
+                                                in foreign currency before any rounding.
+                raw_total_excluded:             The delta base amount for the base line involved in this grouping key expressed
+                                                in local currency before any rounding.
+                target_total_excluded_currency: The same as 'raw_total_excluded_currency' but considering the manual amounts.
+                target_total_excluded:          The same as 'raw_total_excluded' but considering the manual amounts.
+                taxes_data:                     The subset of base_line['tax_details']['taxes_data'] aggregated under this grouping_key.
         """
-        values_per_grouping_key = defaultdict(lambda: {
-            'base_amount_currency': 0.0,
-            'base_amount': 0.0,
-            'raw_base_amount_currency': 0.0,
-            'raw_base_amount': 0.0,
-            'tax_amount_currency': 0.0,
-            'tax_amount': 0.0,
-            'raw_tax_amount_currency': 0.0,
-            'raw_tax_amount': 0.0,
-            'total_excluded_currency': 0.0,
-            'total_excluded': 0.0,
-            'taxes_data': [],
-        })
-
+        values_per_grouping_key = {}
         tax_details = base_line['tax_details']
         taxes_data = tax_details['taxes_data']
+        manual_tax_amounts = base_line['manual_tax_amounts']
+
         # If there are no taxes, we pass None to the grouping function.
         for tax_data in (taxes_data or [None]):
+            current_manual_tax_amounts = manual_tax_amounts and tax_data and manual_tax_amounts.get(str(tax_data['tax'].id)) or {}
+
             grouping_key = grouping_function(base_line, tax_data)
             if isinstance(grouping_key, dict):
                 grouping_key = frozendict(grouping_key)
-            already_accounted = grouping_key in values_per_grouping_key
-            values = values_per_grouping_key[grouping_key]
-            values['grouping_key'] = grouping_key
 
             # Base amount.
-            if not already_accounted:
-                values['total_excluded_currency'] += tax_details['total_excluded_currency'] + tax_details['delta_total_excluded_currency']
-                values['total_excluded'] += tax_details['total_excluded'] + tax_details['delta_total_excluded']
-                if tax_data:
-                    values['base_amount_currency'] += tax_data['base_amount_currency']
-                    values['base_amount'] += tax_data['base_amount']
-                    values['raw_base_amount_currency'] += tax_data['raw_base_amount_currency']
-                    values['raw_base_amount'] += tax_data['raw_base_amount']
-                else:
-                    values['base_amount_currency'] += tax_details['total_excluded_currency'] + tax_details['delta_total_excluded_currency']
-                    values['base_amount'] += tax_details['total_excluded'] + tax_details['delta_total_excluded']
-                    values['raw_base_amount_currency'] += tax_details['raw_total_excluded_currency']
-                    values['raw_base_amount'] += tax_details['raw_total_excluded']
+            if grouping_key not in values_per_grouping_key:
+                values = values_per_grouping_key[grouping_key] = {
+                    'grouping_key': grouping_key,
+                    'taxes_data': [],
+                }
+                for suffix in ('_currency', ''):
+                    excluded_rounded_field = f'total_excluded{suffix}'
+                    excluded_delta_field = f'delta_{excluded_rounded_field}'
+                    excluded_raw_field = f'raw_{excluded_rounded_field}'
+                    excluded_target_field = f'target_{excluded_rounded_field}'
+                    excluded_manual_field = f'manual_{excluded_rounded_field}'
+                    excluded_rounded_amount = tax_details[excluded_rounded_field] + tax_details[excluded_delta_field]
+                    excluded_raw_amount = tax_details[excluded_raw_field]
+                    values[excluded_rounded_field] = excluded_rounded_amount
+                    values[excluded_raw_field] = excluded_raw_amount
+                    if base_line[excluded_manual_field] is not None:
+                        excluded_target_amount = excluded_rounded_amount
+                    else:
+                        excluded_target_amount = excluded_raw_amount
+                    values[excluded_target_field] = excluded_target_amount
+
+                    tax_base_rounded_field = f'base_amount{suffix}'
+                    tax_base_raw_field = f'raw_{tax_base_rounded_field}'
+                    tax_base_target_field = f'target_{tax_base_rounded_field}'
+                    if tax_data:
+                        values[tax_base_rounded_field] = tax_data[tax_base_rounded_field]
+                        values[tax_base_raw_field] = tax_data[tax_base_raw_field]
+                        if tax_base_rounded_field in current_manual_tax_amounts:
+                            values[tax_base_target_field] = tax_data[tax_base_rounded_field]
+                        else:
+                            values[tax_base_target_field] = tax_data[tax_base_raw_field]
+                    else:
+                        values[tax_base_rounded_field] = excluded_rounded_amount
+                        values[tax_base_raw_field] = excluded_raw_amount
+                        values[tax_base_target_field] = excluded_target_amount
+
+                    tax_tax_rounded_field = f'tax_amount{suffix}'
+                    tax_tax_raw_field = f'raw_{tax_tax_rounded_field}'
+                    tax_tax_target_field = f'target_{tax_tax_rounded_field}'
+                    values[tax_tax_rounded_field] = 0.0
+                    values[tax_tax_raw_field] = 0.0
+                    values[tax_tax_target_field] = 0.0
 
             # Tax amount.
             if tax_data:
-                values['tax_amount_currency'] += tax_data['tax_amount_currency']
-                values['tax_amount'] += tax_data['tax_amount']
-                values['raw_tax_amount_currency'] += tax_data['raw_tax_amount_currency']
-                values['raw_tax_amount'] += tax_data['raw_tax_amount']
+                values = values_per_grouping_key[grouping_key]
+                for suffix in ('_currency', ''):
+                    tax_tax_rounded_field = f'tax_amount{suffix}'
+                    tax_tax_raw_field = f'raw_{tax_tax_rounded_field}'
+                    tax_tax_target_field = f'target_{tax_tax_rounded_field}'
+                    values[tax_tax_rounded_field] += tax_data[tax_tax_rounded_field]
+                    values[tax_tax_raw_field] += tax_data[tax_tax_raw_field]
+                    if tax_tax_rounded_field in current_manual_tax_amounts:
+                        values[tax_tax_target_field] += tax_data[tax_tax_rounded_field]
+                    else:
+                        values[tax_tax_target_field] += tax_data[tax_tax_raw_field]
                 values['taxes_data'].append(tax_data)
 
         return values_per_grouping_key
@@ -2319,23 +2339,16 @@ class AccountTax(models.Model):
                 base_line_x_taxes_data:     A list of tuple <base_line, taxes_data> that associates for each base_line the
                                             subset of base_line['tax_details']['taxes_data'] aggregated under this grouping_key.
         """
-        default_float_fields = {
-            'base_amount_currency',
-            'base_amount',
-            'raw_base_amount_currency',
-            'raw_base_amount',
-            'tax_amount_currency',
-            'tax_amount',
-            'raw_tax_amount_currency',
-            'raw_tax_amount',
-            'total_excluded_currency',
-            'total_excluded',
-        }
+        default_float_fields = set()
+        for prefix in ('', 'raw_', 'target_'):
+            for suffix in ('_currency', ''):
+                for field in ('base_amount', 'tax_amount', 'total_excluded'):
+                    default_float_fields.add(f'{prefix}{field}{suffix}')
+
         values_per_grouping_key = defaultdict(lambda: {
             **dict.fromkeys(default_float_fields, 0.0),
             'base_line_x_taxes_data': [],
         })
-
         for base_line, aggregated_values in base_lines_aggregated_values:
             for grouping_key, values in aggregated_values.items():
                 agg_values = values_per_grouping_key[grouping_key]
@@ -2343,7 +2356,6 @@ class AccountTax(models.Model):
                     agg_values[field] += values[field]
                 agg_values['grouping_key'] = grouping_key
                 agg_values['base_line_x_taxes_data'].append((base_line, values['taxes_data']))
-
         return values_per_grouping_key
 
     # -------------------------------------------------------------------------
@@ -2465,17 +2477,28 @@ class AccountTax(models.Model):
                     involved_taxes |= tax_data['tax']
 
             # Compute the display base amounts.
-            display_base_amount = values['base_amount']
-            display_base_amount_currency = values['base_amount_currency']
             if set(involved_taxes.mapped('amount_type')) == {'fixed'}:
                 display_base_amount = None
                 display_base_amount_currency = None
             elif set(involved_taxes.mapped('amount_type')) == {'division'} and all(involved_taxes.mapped('price_include')):
+                display_base_amount = 0.0
+                display_base_amount_currency = 0.0
                 for base_line, _taxes_data in values['base_line_x_taxes_data']:
-                    for tax_data in base_line['tax_details']['taxes_data']:
-                        if tax_data['tax'].amount_type == 'division':
-                            display_base_amount_currency += tax_data['tax_amount_currency']
-                            display_base_amount += tax_data['tax_amount']
+                    tax_details = base_line['tax_details']
+                    display_base_amount += (
+                        tax_details['total_excluded']
+                        + tax_details['delta_total_excluded']
+                    )
+                    display_base_amount_currency += (
+                        tax_details['total_excluded_currency']
+                        + tax_details['delta_total_excluded_currency']
+                    )
+                    for tax_data in tax_details['taxes_data']:
+                        display_base_amount_currency += tax_data['tax_amount_currency']
+                        display_base_amount += tax_data['tax_amount']
+            else:
+                display_base_amount = values['base_amount']
+                display_base_amount_currency = values['base_amount_currency']
 
             if display_base_amount_currency is not None:
                 encountered_base_amounts.add(float_repr(display_base_amount_currency, currency.decimal_places))

--- a/addons/account/static/src/helpers/account_tax.js
+++ b/addons/account/static/src/helpers/account_tax.js
@@ -456,14 +456,21 @@ export const accountTaxHelpers = {
         return {
             total_excluded: total_excluded,
             total_included: total_included,
-            taxes_data: taxes_data_list.map(tax_data => Object.assign({}, {
-                tax: tax_data.tax,
-                group: batching_results.group_per_tax[tax_data.tax.id],
-                batch: batching_results.batch_per_tax[tax_data.tax.id],
-                tax_amount: tax_data.tax_amount,
-                base_amount: tax_data.base,
-                is_reverse_charge: tax_data.is_reverse_charge || false
-            })),
+            taxes_data: taxes_data_list.map((tax_data) =>
+                Object.assign(
+                    {},
+                    {
+                        tax: tax_data.tax,
+                        taxes: tax_data.taxes,
+                        group: batching_results.group_per_tax[tax_data.tax.id],
+                        batch: batching_results.batch_per_tax[tax_data.tax.id],
+                        tax_amount: tax_data.tax_amount,
+                        price_include: tax_data.price_include,
+                        base_amount: tax_data.base,
+                        is_reverse_charge: tax_data.is_reverse_charge || false,
+                    }
+                )
+            ),
         };
     },
 
@@ -555,6 +562,8 @@ export const accountTaxHelpers = {
             special_mode: load('special_mode', null),
             special_type: load('special_type', null),
             rate: load("rate", 1.0),
+            manual_total_excluded_currency: load("manual_total_excluded_currency", null),
+            manual_total_excluded: load("manual_total_excluded", null),
             manual_tax_amounts: load("manual_tax_amounts", null),
             filter_tax_function: load("filter_tax_function", null),
         }
@@ -672,412 +681,320 @@ export const accountTaxHelpers = {
      * [!] Mirror of the same method in account_tax.py.
      * PLZ KEEP BOTH METHODS CONSISTENT WITH EACH OTHERS.
      */
-    round_base_lines_tax_details(base_lines, company) {
-        const total_per_tax = {};
-        const total_per_base = {};
-        const country_code = company.account_fiscal_country_id.code;
-
-        for (const base_line of base_lines) {
-            const currency = base_line.currency_id;
-            const tax_details = base_line.tax_details;
-            tax_details.total_excluded_currency = roundPrecision(
-                tax_details.raw_total_excluded_currency,
-                currency.rounding
-            );
-            tax_details.total_excluded = roundPrecision(
-                tax_details.raw_total_excluded,
-                company.currency_id.rounding
-            );
-            tax_details.delta_total_excluded_currency = 0.0;
-            tax_details.delta_total_excluded = 0.0;
-            tax_details.total_included_currency = roundPrecision(
-                tax_details.raw_total_included_currency,
-                currency.rounding
-            );
-            tax_details.total_included = roundPrecision(
-                tax_details.raw_total_included,
-                company.currency_id.rounding
-            );
-            const taxes_data = tax_details.taxes_data;
-
-            // If there are taxes on it, account the amounts from taxes_data.
-            let index = 0;
-            for (const tax_data of taxes_data) {
-                const tax = tax_data.tax;
-                tax_data.tax_amount_currency = roundPrecision(
-                    tax_data.raw_tax_amount_currency,
-                    currency.rounding
-                );
-                tax_data.tax_amount = roundPrecision(
-                    tax_data.raw_tax_amount,
-                    company.currency_id.rounding
-                );
-                tax_data.base_amount_currency = roundPrecision(
-                    tax_data.raw_base_amount_currency,
-                    currency.rounding
-                );
-                tax_data.base_amount = roundPrecision(
-                    tax_data.raw_base_amount,
-                    company.currency_id.rounding
-                );
-
-                const tax_rounding_key = [tax.id, currency.id, base_line.is_refund, tax_data.is_reverse_charge];
-                if (!(tax_rounding_key in total_per_tax)) {
-                    total_per_tax[tax_rounding_key] = {
-                        tax: tax,
-                        is_reverse_charge: tax_data.is_reverse_charge,
-                        currency: currency,
-                        base_amount_currency: 0.0,
-                        base_amount: 0.0,
-                        raw_base_amount_currency: 0.0,
-                        raw_base_amount: 0.0,
-                        tax_amount_currency: 0.0,
-                        tax_amount: 0.0,
-                        raw_tax_amount_currency: 0.0,
-                        raw_tax_amount: 0.0,
-                        raw_total_amount_currency: 0.0,
-                        raw_total_amount: 0.0,
-                        base_lines: [],
-                    };
-                }
-
-                const tax_amounts = total_per_tax[tax_rounding_key];
-                tax_amounts.tax_amount_currency += tax_data.tax_amount_currency;
-                tax_amounts.raw_tax_amount_currency += tax_data.raw_tax_amount_currency;
-                tax_amounts.tax_amount += tax_data.tax_amount;
-                tax_amounts.raw_tax_amount += tax_data.raw_tax_amount;
-                tax_amounts.base_amount_currency += tax_data.base_amount_currency;
-                tax_amounts.raw_base_amount_currency += tax_data.raw_base_amount_currency;
-                tax_amounts.base_amount += tax_data.base_amount;
-                tax_amounts.raw_base_amount += tax_data.raw_base_amount;
-                tax_amounts.raw_total_amount_currency += tax_data.raw_base_amount_currency + tax_data.raw_tax_amount_currency;
-                tax_amounts.raw_total_amount += tax_data.raw_base_amount + tax_data.raw_tax_amount;
-                if (!base_line.special_type) {
-                    tax_amounts.base_lines.push(base_line);
-                }
-
-                const base_rounding_key = [currency.id, base_line.is_refund];
-                if (!(base_rounding_key in total_per_base)) {
-                    total_per_base[base_rounding_key] = {
-                        currency: currency,
-                        tax_amount_currency: 0.0,
-                        tax_amount: 0.0,
-                        base_amount_currency: 0.0,
-                        base_amount: 0.0,
-                        raw_base_amount_currency: 0.0,
-                        raw_base_amount: 0.0,
-                        raw_total_amount_currency: 0.0,
-                        raw_total_amount: 0.0,
-                        base_lines: [],
-                    };
-                }
-                const base_amounts = total_per_base[base_rounding_key];
-                base_amounts.tax_amount_currency += tax_data.tax_amount_currency;
-                base_amounts.tax_amount += tax_data.tax_amount;
-                base_amounts.raw_total_amount_currency += tax_data.raw_tax_amount_currency;
-                base_amounts.raw_total_amount += tax_data.raw_tax_amount;
-                if (index === 0) {
-                    base_amounts.base_amount_currency += tax_data.base_amount_currency;
-                    base_amounts.raw_base_amount_currency += tax_data.raw_base_amount_currency;
-                    base_amounts.base_amount += tax_data.base_amount;
-                    base_amounts.raw_base_amount += tax_data.raw_base_amount;
-                    base_amounts.raw_total_amount_currency += tax_data.raw_base_amount_currency;
-                    base_amounts.raw_total_amount += tax_data.raw_base_amount;
-                    if (!base_line.special_type) {
-                        base_amounts.base_lines.push(base_line);
-                    }
-                }
-
-                index++;
+    round_tax_details_tax_amounts(base_lines, company, { mode = "mixed" } = {}) {
+        function grouping_function(base_line, tax_data) {
+            if (!tax_data) {
+                return;
             }
-
-            // If not, just account the base amounts.
-            if(!taxes_data.length){
-                const tax_rounding_key = [null, currency.id, base_line.is_refund, false];
-                if (!(tax_rounding_key in total_per_tax)) {
-                    total_per_tax[tax_rounding_key] = {
-                        tax: null,
-                        currency: currency,
-                        base_amount_currency: 0.0,
-                        base_amount: 0.0,
-                        raw_base_amount_currency: 0.0,
-                        raw_base_amount: 0.0,
-                        tax_amount_currency: 0.0,
-                        tax_amount: 0.0,
-                        raw_tax_amount_currency: 0.0,
-                        raw_tax_amount: 0.0,
-                        raw_total_amount_currency: 0.0,
-                        raw_total_amount: 0.0,
-                        base_lines: []
-                    };
-                }
-                const tax_amounts = total_per_tax[tax_rounding_key];
-                tax_amounts.base_amount_currency += tax_details.total_excluded_currency;
-                tax_amounts.raw_base_amount_currency += tax_details.raw_total_excluded_currency;
-                tax_amounts.base_amount += tax_details.total_excluded;
-                tax_amounts.raw_base_amount += tax_details.raw_total_excluded;
-                tax_amounts.raw_total_amount_currency += tax_details.raw_total_excluded_currency;
-                tax_amounts.raw_total_amount += tax_details.raw_total_excluded;
-                if(!base_line.special_type){
-                    tax_amounts.base_lines.push(base_line);
-                }
-
-                const base_rounding_key = [currency.id, base_line.is_refund];
-                if (!(base_rounding_key in total_per_base)) {
-                    total_per_base[base_rounding_key] = {
-                        currency: currency,
-                        tax_amount_currency: 0.0,
-                        tax_amount: 0.0,
-                        base_amount_currency: 0.0,
-                        base_amount: 0.0,
-                        raw_base_amount_currency: 0.0,
-                        raw_base_amount: 0.0,
-                        raw_total_amount_currency: 0.0,
-                        raw_total_amount: 0.0,
-                        base_lines: []
-                    };
-                }
-                const base_amounts = total_per_base[base_rounding_key];
-                base_amounts.base_amount_currency += tax_details.total_excluded_currency;
-                base_amounts.raw_base_amount_currency += tax_details.raw_total_excluded_currency;
-                base_amounts.base_amount += tax_details.total_excluded;
-                base_amounts.raw_base_amount += tax_details.raw_total_excluded;
-                base_amounts.raw_total_amount_currency += tax_details.raw_total_excluded_currency;
-                base_amounts.raw_total_amount += tax_details.raw_total_excluded;
-                if(!base_line.special_type){
-                    base_amounts.base_lines.push(base_line);
-                }
-            }
+            const common_grouping_key = {
+                is_refund: base_line.is_refund,
+                is_reverse_charge: tax_data.is_reverse_charge,
+                price_include: tax_data.price_include,
+            };
+            return {
+                grouping_key: {
+                    ...common_grouping_key,
+                    tax: tax_data.tax.id,
+                    currency: base_line.currency_id.id,
+                },
+                raw_grouping_key: {
+                    ...common_grouping_key,
+                    tax: tax_data.tax,
+                    currency: base_line.currency_id,
+                },
+            };
         }
 
-        // Round 'total_per_tax'.
-        for (const tax_amounts of Object.values(total_per_tax)) {
-            tax_amounts.raw_tax_amount_currency = roundPrecision(
-                tax_amounts.raw_tax_amount_currency,
-                tax_amounts.currency.rounding
-            );
-            tax_amounts.raw_tax_amount = roundPrecision(
-                tax_amounts.raw_tax_amount,
-                company.currency_id.rounding
-            );
-            tax_amounts.raw_base_amount_currency = roundPrecision(
-                tax_amounts.raw_base_amount_currency,
-                tax_amounts.currency.rounding
-            );
-            tax_amounts.raw_base_amount = roundPrecision(
-                tax_amounts.raw_base_amount,
-                company.currency_id.rounding
-            );
-            tax_amounts.raw_total_amount_currency = roundPrecision(
-                tax_amounts.raw_total_amount_currency,
-                tax_amounts.currency.rounding
-            );
-            tax_amounts.raw_total_amount = roundPrecision(
-                tax_amounts.raw_total_amount,
-                company.currency_id.rounding
-            );
-        }
-
-        // Round 'total_per_base'.
-        for (const base_amounts of Object.values(total_per_base)) {
-            base_amounts.raw_base_amount_currency = roundPrecision(
-                base_amounts.raw_base_amount_currency,
-                base_amounts.currency.rounding
-            );
-            base_amounts.raw_base_amount = roundPrecision(
-                base_amounts.raw_base_amount,
-                company.currency_id.rounding
-            );
-            base_amounts.raw_total_amount_currency = roundPrecision(
-                base_amounts.raw_total_amount_currency,
-                base_amounts.currency.rounding
-            );
-            base_amounts.raw_total_amount = roundPrecision(
-                base_amounts.raw_total_amount,
-                company.currency_id.rounding
-            );
-        }
-
-        // Dispatch the delta in term of tax amounts across the tax details when dealing with the 'round_globally' method.
-        // Suppose 2 lines:
-        // - quantity=12.12, price_unit=12.12, tax=23%
-        // - quantity=12.12, price_unit=12.12, tax=23%
-        // The tax of each line is computed as round(12.12 * 12.12 * 0.23) = 33.79
-        // The expected tax amount of the whole document is round(12.12 * 12.12 * 0.23 * 2) = 67.57
-        // The delta in term of tax amount is 67.57 - 33.79 - 33.79 = -0.01
-        for (const tax_amounts of Object.values(total_per_tax)) {
-            const is_reverse_charge = tax_amounts.is_reverse_charge;
-            const currency = tax_amounts.currency;
-            const tax = tax_amounts.tax;
-            if (!tax_amounts.base_lines.length) {
+        const base_lines_aggregated_values = this.aggregate_base_lines_tax_details(
+            base_lines,
+            grouping_function
+        );
+        const values_per_grouping_key = this.aggregate_base_lines_aggregated_values(
+            base_lines_aggregated_values
+        );
+        for (const values of Object.values(values_per_grouping_key)) {
+            const grouping_key = values.grouping_key;
+            if (!grouping_key) {
                 continue;
             }
 
-            tax_amounts.sorted_base_line_x_tax_data = tax_amounts.base_lines
-                .sort((a, b) => b.tax_details.total_included_currency - a.tax_details.total_included_currency)
-                .map(base_line => [
-                    base_line,
-                    base_line.tax_details.taxes_data.map((tax_data, index) => [index, tax_data]).find(
-                        ([index, tax_data]) => tax_data.tax.id === tax.id && tax_data.is_reverse_charge === is_reverse_charge
-                    ) || null
-                ]);
-
-            tax_amounts.total_included_currency = tax_amounts.base_lines.reduce(
-                (sum, base_line) => sum + Math.abs(base_line.tax_details.total_included_currency),
-                0
-            );
-
-            if (!tax || !tax_amounts.total_included_currency) {
-                continue;
-            }
-
-            for (const [delta_field, delta_currency] of [
-                ["tax_amount_currency", currency],
-                ["tax_amount", company.currency_id],
-            ]) {
-                const delta_amount = tax_amounts[`raw_${delta_field}`] - tax_amounts[delta_field];
-                const target_factors = tax_amounts.sorted_base_line_x_tax_data
-                    .filter(([base_line, index_tax_data]) => index_tax_data)
-                    .map(([base_line, index_tax_data]) => ({
-                        factor: base_line.tax_details.total_included_currency,
-                        base_line: base_line,
-                        index_tax_data: index_tax_data,
-                    }));
-                const amounts_to_distribute = this.distribute_delta_amount_smoothly(
-                    delta_currency.decimal_places,
-                    delta_amount,
-                    target_factors
-                );
-                for (let i = 0; i < target_factors.length; i++) {
-                    const target_factor = target_factors[i];
-                    const amount_to_distribute = amounts_to_distribute[i];
-
-                    const base_line = target_factor.base_line;
-                    const [index, tax_data] = target_factor.index_tax_data;
-                    tax_data[delta_field] += amount_to_distribute;
-                    tax_amounts[delta_field] += amount_to_distribute;
-
-                    if (index === 0) {
-                        const base_rounding_key = [currency.id, base_line.is_refund];
-                        const base_amounts = total_per_base[base_rounding_key];
-                        base_amounts[delta_field] += amount_to_distribute;
-                    }
-                }
-            }
-        }
-
-        // Dispatch the delta of base amounts accross the base lines.
-        // Suppose 2 lines:
-        // - quantity=12.12, price_unit=12.12, tax=23%
-        // - quantity=12.12, price_unit=12.12, tax=23%
-        // The base amount of each line is computed as round(12.12 * 12.12) = 146.89
-        // The expected base amount of the whole document is round(12.12 * 12.12 * 2) = 293.79
-        // The delta in term of base amount is 293.79 - 146.89 - 146.89 = 0.01
-        for (const tax_amounts of Object.values(total_per_tax)) {
-            const currency = tax_amounts.currency;
-            if (!tax_amounts.sorted_base_line_x_tax_data || !tax_amounts.total_included_currency) {
-                continue;
-            }
-
+            const price_include = grouping_key.price_include;
+            const currency = grouping_key.currency;
             for (const [delta_currency_indicator, delta_currency] of [
                 ["_currency", currency],
                 ["", company.currency_id],
             ]) {
-                let delta_amount;
-                if (country_code === "PT") {
-                    delta_amount =
-                        tax_amounts[`raw_total_amount${delta_currency_indicator}`] -
-                        tax_amounts[`base_amount${delta_currency_indicator}`] -
-                        tax_amounts[`tax_amount${delta_currency_indicator}`];
-                } else {
-                    delta_amount =
-                        tax_amounts[`raw_base_amount${delta_currency_indicator}`] -
-                        tax_amounts[`base_amount${delta_currency_indicator}`];
+                // Tax amount
+                const raw_total_tax_amount = values[`target_tax_amount${delta_currency_indicator}`];
+                const rounded_raw_total_tax_amount = roundPrecision(
+                    raw_total_tax_amount,
+                    delta_currency.rounding
+                );
+                const total_tax_amount = values[`tax_amount${delta_currency_indicator}`];
+                const delta_total_tax_amount = rounded_raw_total_tax_amount - total_tax_amount;
+
+                if (raw_total_tax_amount) {
+                    const target_factors = values.base_line_x_taxes_data.flatMap(
+                        ([_, taxes_data]) =>
+                            taxes_data.map((tax_data) => ({
+                                factor: tax_data[`raw_tax_amount${delta_currency_indicator}`],
+                                tax_data: tax_data,
+                            }))
+                    );
+
+                    const amounts_to_distribute = this.distribute_delta_amount_smoothly(
+                        delta_currency.decimal_places,
+                        delta_total_tax_amount,
+                        target_factors
+                    );
+
+                    for (let i = 0; i < target_factors.length; i++) {
+                        const tax_data = target_factors[i].tax_data;
+                        const amount_to_distribute = amounts_to_distribute[i];
+                        tax_data[`tax_amount${delta_currency_indicator}`] += amount_to_distribute;
+                    }
                 }
 
-                const target_factors = tax_amounts.sorted_base_line_x_tax_data.map(
-                    ([base_line, index_tax_data]) => ({
-                        factor: base_line.tax_details.total_included_currency,
+                // Base amount
+                const raw_total_base_amount =
+                    values[`target_base_amount${delta_currency_indicator}`];
+                let delta_total_base_amount = 0.0;
+
+                if ((mode === "mixed" && price_include) || mode === "included") {
+                    const raw_total_amount = raw_total_base_amount + raw_total_tax_amount;
+                    const rounded_raw_total_amount = roundPrecision(
+                        raw_total_amount,
+                        delta_currency.rounding
+                    );
+                    const total_amount =
+                        values[`base_amount${delta_currency_indicator}`] +
+                        total_tax_amount +
+                        delta_total_tax_amount;
+                    delta_total_base_amount = rounded_raw_total_amount - total_amount;
+                } else if ((mode === "mixed" && !price_include) || mode === "excluded") {
+                    const rounded_raw_total_base_amount = roundPrecision(
+                        raw_total_base_amount,
+                        delta_currency.rounding
+                    );
+                    const total_base_amount = values[`base_amount${delta_currency_indicator}`];
+                    delta_total_base_amount = rounded_raw_total_base_amount - total_base_amount;
+                }
+
+                if (raw_total_base_amount) {
+                    const target_factors = values.base_line_x_taxes_data.flatMap(
+                        ([_, taxes_data]) =>
+                            taxes_data.map((tax_data) => ({
+                                factor: tax_data[`raw_base_amount${delta_currency_indicator}`],
+                                tax_data: tax_data,
+                            }))
+                    );
+
+                    const amounts_to_distribute = this.distribute_delta_amount_smoothly(
+                        delta_currency.decimal_places,
+                        delta_total_base_amount,
+                        target_factors
+                    );
+
+                    for (let i = 0; i < target_factors.length; i++) {
+                        const tax_data = target_factors[i].tax_data;
+                        const amount_to_distribute = amounts_to_distribute[i];
+                        tax_data[`base_amount${delta_currency_indicator}`] += amount_to_distribute;
+                    }
+                }
+            }
+        }
+    },
+
+    /**
+     * [!] Mirror of the same method in account_tax.py.
+     * PLZ KEEP BOTH METHODS CONSISTENT WITH EACH OTHERS.
+     */
+    round_tax_details_base_lines(base_lines, company, { mode = "mixed" } = {}) {
+        function grouping_function(base_line, tax_data) {
+            return {
+                grouping_key: {
+                    is_refund: base_line.is_refund,
+                    currency: base_line.currency_id.id,
+                },
+                raw_grouping_key: {
+                    is_refund: base_line.is_refund,
+                    currency: base_line.currency_id,
+                },
+            };
+        }
+
+        const base_lines_aggregated_values = this.aggregate_base_lines_tax_details(
+            base_lines,
+            grouping_function
+        );
+        const values_per_grouping_key = this.aggregate_base_lines_aggregated_values(
+            base_lines_aggregated_values
+        );
+        for (const values of Object.values(values_per_grouping_key)) {
+            const grouping_key = values.grouping_key;
+            let current_mode = mode;
+            if (current_mode === "mixed") {
+                current_mode = "included";
+                for (const base_line_taxes_data of values.base_line_x_taxes_data) {
+                    const taxes_data = base_line_taxes_data[1];
+                    if (taxes_data.some((tax_data) => !tax_data.price_include)) {
+                        current_mode = "excluded";
+                        break;
+                    }
+                }
+            }
+
+            const currency = grouping_key.currency;
+            for (const [delta_currency_indicator, delta_currency] of [
+                ["_currency", currency],
+                ["", company.currency_id],
+            ]) {
+                let delta_total_excluded = 0.0;
+                let target_factors = [];
+                if (current_mode === "excluded") {
+                    // Price-excluded rounding.
+                    const raw_total_excluded =
+                        values[`target_total_excluded${delta_currency_indicator}`];
+                    if (!raw_total_excluded) {
+                        continue;
+                    }
+
+                    const rounded_raw_total_excluded = roundPrecision(
+                        raw_total_excluded,
+                        delta_currency.rounding
+                    );
+                    const total_excluded = values[`total_excluded${delta_currency_indicator}`];
+                    delta_total_excluded = rounded_raw_total_excluded - total_excluded;
+                    target_factors = values.base_line_x_taxes_data.map(([base_line]) => ({
+                        factor: base_line.tax_details[`raw_total_excluded${delta_currency_indicator}`],
                         base_line: base_line,
-                        index_tax_data: index_tax_data,
-                    })
-                );
+                    }));
+                } else {
+                    // Price-included rounding.
+                    const raw_total_included =
+                        values[`target_total_excluded${delta_currency_indicator}`] +
+                        values[`target_tax_amount${delta_currency_indicator}`];
+                    if (!raw_total_included) {
+                        continue;
+                    }
+                    const rounded_raw_total_included = roundPrecision(
+                        raw_total_included,
+                        delta_currency.rounding
+                    );
+                    const total_included =
+                        values[`total_excluded${delta_currency_indicator}`] +
+                        values[`tax_amount${delta_currency_indicator}`];
+                    delta_total_excluded = rounded_raw_total_included - total_included;
+                    target_factors = values.base_line_x_taxes_data.map(([base_line]) => ({
+                        factor: base_line.tax_details[`raw_total_included${delta_currency_indicator}`],
+                        base_line: base_line,
+                    }));
+                }
+
                 const amounts_to_distribute = this.distribute_delta_amount_smoothly(
                     delta_currency.decimal_places,
-                    delta_amount,
+                    delta_total_excluded,
                     target_factors
                 );
                 for (let i = 0; i < target_factors.length; i++) {
-                    const target_factor = target_factors[i];
+                    const base_line = target_factors[i].base_line;
                     const amount_to_distribute = amounts_to_distribute[i];
+                    base_line.tax_details[`delta_total_excluded${delta_currency_indicator}`] +=
+                        amount_to_distribute;
+                }
+            }
+        }
+    },
 
-                    const base_line = target_factor.base_line;
-                    const tax_details = base_line.tax_details;
-                    const index_tax_data = target_factor.index_tax_data;
-                    if (index_tax_data) {
-                        const tax_data = index_tax_data[1];
-                        tax_data[`base_amount${delta_currency_indicator}`] += amount_to_distribute;
-                    } else {
-                        tax_details[`delta_total_excluded${delta_currency_indicator}`] += amount_to_distribute;
+    /**
+     * [!] Mirror of the same method in account_tax.py.
+     * PLZ KEEP BOTH METHODS CONSISTENT WITH EACH OTHERS.
+     */
+    round_base_lines_tax_details(base_lines, company) {
+        // Raw rounding.
+        for (const base_line of base_lines) {
+            const tax_details = base_line.tax_details;
 
-                        const base_rounding_key = [currency.id, base_line.is_refund];
-                        const base_amounts = total_per_base[base_rounding_key];
-                        base_amounts[`base_amount${delta_currency_indicator}`] += amount_to_distribute;
+            for (const [suffix, currency] of [
+                ["_currency", base_line.currency_id],
+                ["", company.currency_id],
+            ]) {
+                const total_excluded_field = `total_excluded${suffix}`;
+                tax_details[total_excluded_field] = roundPrecision(
+                    tax_details[`raw_${total_excluded_field}`],
+                    currency.rounding
+                );
+
+                for (const tax_data of tax_details.taxes_data) {
+                    for (const prefix of ["base", "tax"]) {
+                        const field = `${prefix}_amount${suffix}`;
+                        tax_data[field] = roundPrecision(
+                            tax_data[`raw_${field}`],
+                            currency.rounding
+                        );
                     }
                 }
             }
         }
 
-        // Dispatch the delta of base amounts accross the base lines.
-        // Suppose 2 lines:
-        // - quantity=12.12, price_unit=12.12, tax=23%
-        // - quantity=12.12, price_unit=12.12, tax=13%
-        // The base amount of each line is computed as round(12.12 * 12.12) = 146.89
-        // The expected base amount of the whole document is round(12.12 * 12.12 * 2) = 293.79
-        // Currently, the base amount has already been rounded per tax. So the tax details for the whole document is currently:
-        // 23%: base = 146.89, tax = 33.79
-        // 13%: base = 146.89, tax = 19.1
-        // However, for the whole document, there is a delta in term of base amount: 293.79 - 146.89 - 146.89 = 0.01
-        // This delta won't be there in any base but still has to be accounted.
-        for (const base_amounts of Object.values(total_per_base)) {
-            if (!base_amounts.base_lines.length) {
-                continue;
-            }
+        // Apply 'manual_tax_amounts'.
+        for (const base_line of base_lines) {
+            const manual_tax_amounts = base_line.manual_tax_amounts;
+            const rate = base_line.rate;
+            const tax_details = base_line.tax_details;
 
-            let delta_base_amount_currency;
-            let delta_base_amount;
-            if (country_code === "PT") {
-                delta_base_amount_currency = base_amounts.raw_total_amount_currency - base_amounts.base_amount_currency - base_amounts.tax_amount_currency;
-                delta_base_amount = base_amounts.raw_total_amount - base_amounts.base_amount - base_amounts.tax_amount;
-            } else {
-                delta_base_amount_currency = base_amounts.raw_base_amount_currency - base_amounts.base_amount_currency;
-                delta_base_amount = base_amounts.raw_base_amount - base_amounts.base_amount;
-            }
-
-            if (floatIsZero(delta_base_amount_currency, base_amounts.currency.decimal_places) && floatIsZero(delta_base_amount, company.currency_id.decimal_places)) {
-                continue;
-            }
-
-            // Dispatch the base delta evenly on the base lines, starting from the biggest line.
-            const factors = Array(base_amounts.base_lines.length).fill({ factor: 1.0 });
-            const base_lines_sorted = base_amounts.base_lines.sort((a, b) => 
-                a.tax_details.total_included_currency - b.tax_details.total_included_currency
-            );
-            for (const [delta_currency_indicator, delta_currency, delta_amount] of [
-                ["_currency", base_amounts.currency, delta_base_amount_currency],
-                ["", company.currency_id, delta_base_amount],
+            for (const [suffix, currency] of [
+                ["_currency", base_line.currency_id],
+                ["", company.currency_id],
             ]) {
-                const amounts_to_distribute = this.distribute_delta_amount_smoothly(
-                    delta_currency.decimal_places,
-                    delta_amount,
-                    factors,
-                );
+                const total_field = `total_excluded${suffix}`;
+                const manual_field = `manual_${total_field}`;
+                if (base_line[manual_field] !== null) {
+                    tax_details[total_field] = base_line[manual_field];
+                }
 
-                for (const [i, base_line] of base_lines_sorted.entries()) {
-                    base_line.tax_details[`delta_total_excluded${delta_currency_indicator}`] += amounts_to_distribute[i];
+                for (const tax_data of tax_details.taxes_data) {
+                    const tax = tax_data.tax;
+                    const reverse_charge_sign = tax_data.is_reverse_charge ? -1 : 1;
+                    const current_manual_tax_amounts =
+                        (manual_tax_amounts && manual_tax_amounts[String(tax.id)]) || {};
+
+                    for (const [prefix, factor] of [
+                        ["base", 1],
+                        ["tax", reverse_charge_sign],
+                    ]) {
+                        const field = `${prefix}_amount${suffix}`;
+                        if (field in current_manual_tax_amounts) {
+                            tax_data[field] = roundPrecision(
+                                factor * current_manual_tax_amounts[field],
+                                currency.rounding
+                            );
+                            if (suffix === "_currency" && rate) {
+                                tax_data[`${prefix}_amount`] = roundPrecision(
+                                    tax_data[field] / rate,
+                                    company.currency_id.rounding
+                                );
+                            }
+                        }
+                    }
                 }
             }
         }
+
+        // Compute 'total_included' & add 'delta_total_excluded'.
+        for (const base_line of base_lines) {
+            const tax_details = base_line.tax_details;
+            for (const suffix of ["_currency", ""]) {
+                tax_details[`delta_total_excluded${suffix}`] = 0.0;
+                tax_details[`total_included${suffix}`] = tax_details[`total_excluded${suffix}`];
+                for (const tax_data of tax_details.taxes_data) {
+                    tax_details[`total_included${suffix}`] += tax_data[`tax_amount${suffix}`];
+                }
+            }
+        }
+
+        this.round_tax_details_tax_amounts(base_lines, company);
+        this.round_tax_details_base_lines(base_lines, company);
     },
 
     // -------------------------------------------------------------------------
@@ -1160,8 +1077,8 @@ export const accountTaxHelpers = {
             });
 
             // Compute the display base amounts.
-            let display_base_amount = values.base_amount;
-            let display_base_amount_currency = values.base_amount_currency;
+            let display_base_amount;
+            let display_base_amount_currency;
             if (involved_amount_types.size === 1 && involved_amount_types.has("fixed")) {
                 display_base_amount = null;
                 display_base_amount_currency = null;
@@ -1171,14 +1088,23 @@ export const accountTaxHelpers = {
                 && involved_price_include.size === 1
                 && involved_price_include.has(true)
             ) {
+                display_base_amount = 0.0;
+                display_base_amount_currency = 0.0;
                 values.base_line_x_taxes_data.forEach(([base_line, _taxes_data]) => {
-                    base_line.tax_details.taxes_data.forEach(tax_data => {
-                        if (tax_data.tax.amount_type === 'division') {
-                            display_base_amount_currency += tax_data.tax_amount_currency;
-                            display_base_amount += tax_data.tax_amount;
-                        }
-                    });
+                    const tax_details = base_line.tax_details;
+                    display_base_amount +=
+                        tax_details.total_excluded + tax_details.delta_total_excluded;
+                    display_base_amount_currency +=
+                        tax_details.total_excluded_currency +
+                        tax_details.delta_total_excluded_currency;
+                    for (const tax_data of tax_details.taxes_data) {
+                        display_base_amount_currency += tax_data.tax_amount_currency;
+                        display_base_amount += tax_data.tax_amount;
+                    }
                 });
+            } else {
+                display_base_amount = values.base_amount;
+                display_base_amount_currency = values.base_amount_currency;
             }
 
             if (display_base_amount_currency !== null) {
@@ -1324,9 +1250,15 @@ export const accountTaxHelpers = {
         const values_per_grouping_key = {};
         const tax_details = base_line.tax_details;
         const taxes_data = tax_details.taxes_data;
+        const manual_tax_amounts = base_line.manual_tax_amounts;
 
         // If there are no taxes, we pass an empty object to the grouping function.
-        for (const tax_data of (taxes_data.length !== 0 ? taxes_data : [null])) {
+        for (const tax_data of taxes_data.length !== 0 ? taxes_data : [null]) {
+            const current_manual_tax_amounts =
+                tax_data && manual_tax_amounts
+                    ? manual_tax_amounts[tax_data.tax.id.toString()] || {}
+                    : {};
+
             const generated_grouping_key = grouping_function(base_line, tax_data);
             let raw_grouping_key = generated_grouping_key;
             let grouping_key = generated_grouping_key;
@@ -1340,48 +1272,89 @@ export const accountTaxHelpers = {
             }
 
             // Handle dictionary-like keys (converted to string in JS)
-            if (typeof grouping_key === 'object') {
-                grouping_key = JSON.stringify(raw_grouping_key);
+            if (typeof grouping_key === "object") {
+                grouping_key = JSON.stringify(grouping_key);
             }
 
-            // Base amount
-            if(!(grouping_key in values_per_grouping_key)){
-                values_per_grouping_key[grouping_key] = {
-                    tax_amount_currency: 0.0,
-                    tax_amount: 0.0,
-                    raw_tax_amount_currency: 0.0,
-                    raw_tax_amount: 0.0,
-                    total_excluded_currency: tax_details.total_excluded_currency + tax_details.delta_total_excluded_currency,
-                    total_excluded: tax_details.total_excluded + tax_details.delta_total_excluded,
+            // Base amount.
+            if (!(grouping_key in values_per_grouping_key)) {
+                const values = {
+                    grouping_key: raw_grouping_key,
                     taxes_data: [],
-                    grouping_key: raw_grouping_key
                 };
-                const values = values_per_grouping_key[grouping_key];
+                values_per_grouping_key[grouping_key] = values;
 
-                if (tax_data) {
-                    values.base_amount_currency = tax_data.base_amount_currency;
-                    values.base_amount = tax_data.base_amount;
-                    values.raw_base_amount_currency = tax_data.raw_base_amount_currency;
-                    values.raw_base_amount = tax_data.raw_base_amount;
-                } else {
-                    values.base_amount_currency = tax_details.total_excluded_currency + tax_details.delta_total_excluded_currency;
-                    values.base_amount = tax_details.total_excluded + tax_details.delta_total_excluded;
-                    values.raw_base_amount_currency = tax_details.raw_total_excluded_currency;
-                    values.raw_base_amount = tax_details.raw_total_excluded;
+                for (const suffix of ["_currency", ""]) {
+                    const excluded_rounded_field = `total_excluded${suffix}`;
+                    const excluded_delta_field = `delta_${excluded_rounded_field}`;
+                    const excluded_raw_field = `raw_${excluded_rounded_field}`;
+                    const excluded_target_field = `target_${excluded_rounded_field}`;
+                    const excluded_manual_field = `manual_${excluded_rounded_field}`;
+
+                    const excluded_rounded_amount =
+                        tax_details[excluded_rounded_field] + tax_details[excluded_delta_field];
+                    const excluded_raw_amount = tax_details[excluded_raw_field];
+
+                    values[excluded_rounded_field] = excluded_rounded_amount;
+                    values[excluded_raw_field] = excluded_raw_amount;
+
+                    let excluded_target_amount;
+                    if (base_line[excluded_manual_field] !== null) {
+                        excluded_target_amount = excluded_rounded_amount;
+                    } else {
+                        excluded_target_amount = excluded_raw_amount;
+                    }
+                    values[excluded_target_field] = excluded_target_amount;
+
+                    const tax_base_rounded_field = `base_amount${suffix}`;
+                    const tax_base_raw_field = `raw_${tax_base_rounded_field}`;
+                    const tax_base_target_field = `target_${tax_base_rounded_field}`;
+
+                    if (tax_data) {
+                        values[tax_base_rounded_field] = tax_data[tax_base_rounded_field];
+                        values[tax_base_raw_field] = tax_data[tax_base_raw_field];
+
+                        if (tax_base_rounded_field in current_manual_tax_amounts) {
+                            values[tax_base_target_field] = tax_data[tax_base_rounded_field];
+                        } else {
+                            values[tax_base_target_field] = tax_data[tax_base_raw_field];
+                        }
+                    } else {
+                        values[tax_base_rounded_field] = excluded_rounded_amount;
+                        values[tax_base_raw_field] = excluded_raw_amount;
+                        values[tax_base_target_field] = excluded_target_amount;
+                    }
+
+                    const tax_tax_rounded_field = `tax_amount${suffix}`;
+                    const tax_tax_raw_field = `raw_${tax_tax_rounded_field}`;
+                    const tax_tax_target_field = `target_${tax_tax_rounded_field}`;
+
+                    values[tax_tax_rounded_field] = 0.0;
+                    values[tax_tax_raw_field] = 0.0;
+                    values[tax_tax_target_field] = 0.0;
                 }
             }
-            const values = values_per_grouping_key[grouping_key];
 
-            // Tax amount
+            // Tax amount.
             if (tax_data) {
-                values.tax_amount_currency += tax_data.tax_amount_currency;
-                values.tax_amount += tax_data.tax_amount;
-                values.raw_tax_amount_currency += tax_data.raw_tax_amount_currency;
-                values.raw_tax_amount += tax_data.raw_tax_amount;
+                const values = values_per_grouping_key[grouping_key];
+                for (const suffix of ["_currency", ""]) {
+                    const tax_tax_rounded_field = `tax_amount${suffix}`;
+                    const tax_tax_raw_field = `raw_${tax_tax_rounded_field}`;
+                    const tax_tax_target_field = `target_${tax_tax_rounded_field}`;
+
+                    values[tax_tax_rounded_field] += tax_data[tax_tax_rounded_field];
+                    values[tax_tax_raw_field] += tax_data[tax_tax_raw_field];
+
+                    if (tax_tax_rounded_field in current_manual_tax_amounts) {
+                        values[tax_tax_target_field] += tax_data[tax_tax_rounded_field];
+                    } else {
+                        values[tax_tax_target_field] += tax_data[tax_tax_raw_field];
+                    }
+                }
                 values.taxes_data.push(tax_data);
             }
         }
-
         return values_per_grouping_key;
     },
 
@@ -1398,18 +1371,15 @@ export const accountTaxHelpers = {
      * PLZ KEEP BOTH METHODS CONSISTENT WITH EACH OTHERS.
      */
     aggregate_base_lines_aggregated_values(base_lines_aggregated_values) {
-        const default_float_fields = new Set([
-            'base_amount_currency',
-            'base_amount',
-            'raw_base_amount_currency',
-            'raw_base_amount',
-            'tax_amount_currency',
-            'tax_amount',
-            'raw_tax_amount_currency',
-            'raw_tax_amount',
-            'total_excluded_currency',
-            'total_excluded'
-        ]);
+        const default_float_fields = new Set();
+        for (const prefix of ["", "raw_", "target_"]) {
+            for (const suffix of ["_currency", ""]) {
+                for (const field of ["base_amount", "tax_amount", "total_excluded"]) {
+                    default_float_fields.add(`${prefix}${field}${suffix}`);
+                }
+            }
+        }
+
         const values_per_grouping_key = {};
         for (const [base_line, aggregated_values] of base_lines_aggregated_values) {
             for (const [raw_grouping_key, values] of Object.entries(aggregated_values)) {
@@ -1431,8 +1401,6 @@ export const accountTaxHelpers = {
                 agg_values.base_line_x_taxes_data.push([base_line, values.taxes_data]);
             }
         }
-
         return values_per_grouping_key;
     },
-
 };

--- a/addons/account/tests/test_taxes_base_lines_tax_details.py
+++ b/addons/account/tests/test_taxes_base_lines_tax_details.py
@@ -12,38 +12,56 @@ class TestTaxesBaseLinesTaxDetails(TestTaxCommon):
         tax_21 = self.percent_tax(21.0)
         document = self.populate_document(self.init_document(
             lines=[
-                {'quantity': 1, 'price_unit': 10.04, 'discount': 10, 'tax_ids': tax_21},
+                {'price_unit': 10.04, 'discount': 10, 'tax_ids': tax_21},
             ] + [
-                {'quantity': 1, 'price_unit': 1.04, 'discount': 10, 'tax_ids': tax_21},
+                {'price_unit': 1.04, 'discount': 10, 'tax_ids': tax_21},
             ] * 10,
         ))
+
+        line_1_expected_values = {
+            'total_excluded': 9.04,
+            'total_excluded_currency': 9.04,
+            'total_included': 10.94,
+            'total_included_currency': 10.94,
+            'delta_total_excluded': 0.0,
+            'delta_total_excluded_currency': 0.0,
+            'taxes_data': [
+                {
+                    'tax_id': tax_21.id,
+                    'tax_amount': 1.88,
+                    'tax_amount_currency': 1.88,
+                    'base_amount': 9.02,
+                    'base_amount_currency': 9.02,
+                }
+            ],
+        }
+        line_2_expected_values = {
+            'total_excluded': 0.94,
+            'total_excluded_currency': 0.94,
+            'total_included': 1.14,
+            'total_included_currency': 1.14,
+            'delta_total_excluded': 0.0,
+            'delta_total_excluded_currency': 0.0,
+            'taxes_data': [
+                {
+                    'tax_id': tax_21.id,
+                    'tax_amount': 0.2,
+                    'tax_amount_currency': 0.2,
+                    'base_amount': 0.94,
+                    'base_amount_currency': 0.94,
+                }
+            ],
+        }
 
         expected_values = {
             'base_lines_tax_details': [
                 {
-                    'total_excluded': 9.04,
-                    'total_excluded_currency': 9.04,
-                    'total_included': 10.93,
-                    'total_included_currency': 10.93,
-                    'delta_total_excluded': -0.01,
-                    'delta_total_excluded_currency': -0.01,
-                    'taxes_data': [
-                        {
-                            'tax_id': tax_21.id,
-                            'tax_amount': 1.88,
-                            'tax_amount_currency': 1.88,
-                            'base_amount': 9.02,
-                            'base_amount_currency': 9.02,
-                        }
-                    ],
+                    **line_1_expected_values,
+                    'delta_total_excluded': -0.02,
+                    'delta_total_excluded_currency': -0.02,
                 },
-            ]
-            + 2 * [
                 {
-                    'total_excluded': 0.94,
-                    'total_excluded_currency': 0.94,
-                    'total_included': 1.13,
-                    'total_included_currency': 1.13,
+                    **line_2_expected_values,
                     'delta_total_excluded': -0.01,
                     'delta_total_excluded_currency': -0.01,
                     'taxes_data': [
@@ -56,45 +74,29 @@ class TestTaxesBaseLinesTaxDetails(TestTaxCommon):
                         }
                     ],
                 },
-            ]
-            + [
                 {
-                    'total_excluded': 0.94,
-                    'total_excluded_currency': 0.94,
-                    'total_included': 1.13,
-                    'total_included_currency': 1.13,
+                    **line_2_expected_values,
                     'delta_total_excluded': -0.01,
                     'delta_total_excluded_currency': -0.01,
                     'taxes_data': [
                         {
                             'tax_id': tax_21.id,
-                            'tax_amount': 0.2,
-                            'tax_amount_currency': 0.2,
-                            'base_amount': 0.94,
-                            'base_amount_currency': 0.94,
+                            'tax_amount': 0.19,
+                            'tax_amount_currency': 0.19,
+                            'base_amount': 0.9299999999999999,
+                            'base_amount_currency': 0.9299999999999999,
                         }
                     ],
                 },
+                line_2_expected_values,
+                line_2_expected_values,
+                line_2_expected_values,
+                line_2_expected_values,
+                line_2_expected_values,
+                line_2_expected_values,
+                line_2_expected_values,
+                line_2_expected_values,
             ]
-            + 7 * [
-                {
-                    'total_excluded': 0.94,
-                    'total_excluded_currency': 0.94,
-                    'total_included': 1.13,
-                    'total_included_currency': 1.13,
-                    'delta_total_excluded': 0.0,
-                    'delta_total_excluded_currency': 0.0,
-                    'taxes_data': [
-                        {
-                            'tax_id': tax_21.id,
-                            'tax_amount': 0.2,
-                            'tax_amount_currency': 0.2,
-                            'base_amount': 0.94,
-                            'base_amount_currency': 0.94,
-                        }
-                    ],
-                },
-            ],
         }
 
         self.assert_base_lines_tax_details(document, expected_values)

--- a/addons/account/tests/test_taxes_tax_totals_summary.py
+++ b/addons/account/tests/test_taxes_tax_totals_summary.py
@@ -261,7 +261,7 @@ class TestTaxesTaxTotalsSummary(TestTaxCommon):
                 yield 5, self.populate_document(document_params), expected_values
             with self.with_tax_calculation_rounding_method('round_globally'):
                 expected_values = {
-                    'same_tax_base': True,
+                    'same_tax_base': False,
                     'currency_id': self.foreign_currency.id,
                     'company_currency_id': self.currency.id,
                     'base_amount_currency': 31.77,
@@ -280,11 +280,11 @@ class TestTaxesTaxTotalsSummary(TestTaxCommon):
                             'tax_groups': [
                                 {
                                     'id': self.tax_groups[0].id,
-                                    'base_amount_currency': 31.77,
+                                    'base_amount_currency': 31.76,
                                     'base_amount': 6.35,
                                     'tax_amount_currency': 4.89,
                                     'tax_amount': 0.97,
-                                    'display_base_amount_currency': 31.77,
+                                    'display_base_amount_currency': 31.76,
                                     'display_base_amount': 6.35,
                                 },
                             ],
@@ -365,20 +365,20 @@ class TestTaxesTaxTotalsSummary(TestTaxCommon):
                             'tax_groups': [
                                 {
                                     'id': self.tax_groups[0].id,
-                                    'base_amount_currency': 31.77,
+                                    'base_amount_currency': 31.76,
                                     'base_amount': 6.35,
                                     'tax_amount_currency': 1.91,
                                     'tax_amount': 0.38,
-                                    'display_base_amount_currency': 31.77,
+                                    'display_base_amount_currency': 31.76,
                                     'display_base_amount': 6.35,
                                 },
                                 {
                                     'id': self.tax_groups[1].id,
-                                    'base_amount_currency': 31.77,
+                                    'base_amount_currency': 31.76,
                                     'base_amount': 6.35,
                                     'tax_amount_currency': 1.91,
                                     'tax_amount': 0.38,
-                                    'display_base_amount_currency': 31.77,
+                                    'display_base_amount_currency': 31.76,
                                     'display_base_amount': 6.35,
                                 },
                                 {
@@ -847,107 +847,6 @@ class TestTaxesTaxTotalsSummary(TestTaxCommon):
                 }
                 yield 8, self.populate_document(document_params), expected_values
 
-        # Extreme case to push the computation of the display_base_amount to its limit.
-        # Note: tax6 is the only one in a separated tax group.
-        tax6 = self.fixed_tax(1, include_base_amount=True, sequence=0, tax_group_id=self.tax_groups[7].id)
-        tax7 = self.division_tax(20, price_include_override='tax_included')
-        tax8 = self.division_tax(20, price_include_override='tax_included')
-        taxes += tax7 + tax8
-
-        document_params = self.init_document(
-            lines=[
-                {'price_unit': 47.0, 'tax_ids': tax6 + tax1 + tax2 + tax3 + tax4 + tax5},
-                {'price_unit': 48.0, 'tax_ids': tax7 + tax8},
-            ],
-            currency=self.foreign_currency,
-            rate=3.0,
-        )
-        with self.same_tax_group(taxes):
-            with self.with_tax_calculation_rounding_method('round_per_line'):
-                expected_values = {
-                    'same_tax_base': False,
-                    'currency_id': self.foreign_currency.id,
-                    'company_currency_id': self.currency.id,
-                    'base_amount_currency': 60.13,
-                    'base_amount': 20.04,
-                    'tax_amount_currency': 35.87,
-                    'tax_amount': 11.95,
-                    'total_amount_currency': 96.0,
-                    'total_amount': 31.99,
-                    'subtotals': [
-                        {
-                            'name': "Untaxed Amount",
-                            'base_amount_currency': 60.13,
-                            'base_amount': 20.04,
-                            'tax_amount_currency': 35.87,
-                            'tax_amount': 11.95,
-                            'tax_groups': [
-                                {
-                                    'id': self.tax_groups[0].id,
-                                    'base_amount_currency': 61.13,
-                                    'base_amount': 20.38,
-                                    'tax_amount_currency': 34.87,
-                                    'tax_amount': 11.62,
-                                    'display_base_amount_currency': 96.0,
-                                    'display_base_amount': 32.0,
-                                },
-                                {
-                                    'id': self.tax_groups[7].id,
-                                    'base_amount_currency': 31.33,
-                                    'base_amount': 10.44,
-                                    'tax_amount_currency': 1.0,
-                                    'tax_amount': 0.33,
-                                    'display_base_amount_currency': None,
-                                    'display_base_amount': None,
-                                },
-                            ],
-                        },
-                    ],
-                }
-                yield 9, self.populate_document(document_params), expected_values
-            with self.with_tax_calculation_rounding_method('round_globally'):
-                expected_values = {
-                    'same_tax_base': False,
-                    'currency_id': self.foreign_currency.id,
-                    'company_currency_id': self.currency.id,
-                    'base_amount_currency': 60.13,
-                    'base_amount': 20.04,
-                    'tax_amount_currency': 35.87,
-                    'tax_amount': 11.95,
-                    'total_amount_currency': 96.0,
-                    'total_amount': 31.99,
-                    'subtotals': [
-                        {
-                            'name': "Untaxed Amount",
-                            'base_amount_currency': 60.13,
-                            'base_amount': 20.04,
-                            'tax_amount_currency': 35.87,
-                            'tax_amount': 11.95,
-                            'tax_groups': [
-                                {
-                                    'id': self.tax_groups[0].id,
-                                    'base_amount_currency': 61.13,
-                                    'base_amount': 20.38,
-                                    'tax_amount_currency': 34.87,
-                                    'tax_amount': 11.62,
-                                    'display_base_amount_currency': 96.0,
-                                    'display_base_amount': 32.0,
-                                },
-                                {
-                                    'id': self.tax_groups[7].id,
-                                    'base_amount_currency': 31.33,
-                                    'base_amount': 10.44,
-                                    'tax_amount_currency': 1.0,
-                                    'tax_amount': 0.33,
-                                    'display_base_amount_currency': None,
-                                    'display_base_amount': None,
-                                },
-                            ],
-                        },
-                    ],
-                }
-                yield 10, self.populate_document(document_params), expected_values
-
     def test_taxes_l10n_br_generic_helpers(self):
         for test_index, document, expected_values in self._test_taxes_l10n_br():
             with self.subTest(test_index=test_index):
@@ -1374,753 +1273,6 @@ class TestTaxesTaxTotalsSummary(TestTaxCommon):
                 invoice = self.convert_document_to_invoice(document)
                 self.assert_invoice_tax_totals_summary(invoice, expected_values)
 
-    def _test_taxes_l10n_pt(self):
-        """ !!!! THOSE TESTS ARE THERE TO CERTIFY THE USE OF ODOO INVOICING IN PORTUGAL.
-        Therefore, they have to stay like this to stay compliant.
-        """
-        self.env.company.tax_calculation_rounding_method = 'round_globally'
-        self.change_company_country(self.env.company, self.env.ref('base.pt'))
-        self.env['decimal.precision'].search([('name', '=', "Product Price")]).digits = 6
-        tax_0 = self.percent_tax(0, tax_group_id=self.tax_groups[0].id)
-        tax_6 = self.percent_tax(6, tax_group_id=self.tax_groups[1].id)
-        tax_13 = self.percent_tax(13, tax_group_id=self.tax_groups[2].id)
-        tax_23 = self.percent_tax(23, tax_group_id=self.tax_groups[3].id)
-
-        document = self.populate_document(self.init_document(
-            lines=[
-                {'quantity': 12.12, 'price_unit': 12.12},
-                {'quantity': 12.12, 'price_unit': 12.12},
-            ],
-        ))
-        expected_values = {
-            'same_tax_base': True,
-            'currency_id': self.currency.id,
-            'base_amount_currency': 293.79,
-            'tax_amount_currency': 0.0,
-            'total_amount_currency': 293.79,
-            'subtotals': [
-                {
-                    'name': "Untaxed Amount",
-                    'base_amount_currency': 293.79,
-                    'tax_amount_currency': 0.0,
-                    'tax_groups': [],
-                },
-            ],
-        }
-        yield 1, document, expected_values
-
-        document = self.populate_document(self.init_document(
-            lines=[
-                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_13},
-                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_13},
-            ],
-        ))
-        expected_values = {
-            'same_tax_base': True,
-            'currency_id': self.currency.id,
-            'base_amount_currency': 293.79,
-            'tax_amount_currency': 38.19,
-            'total_amount_currency': 331.98,
-            'subtotals': [
-                {
-                    'name': "Untaxed Amount",
-                    'base_amount_currency': 293.79,
-                    'tax_amount_currency': 38.19,
-                    'tax_groups': [
-                        {
-                            'id': self.tax_groups[2].id,
-                            'base_amount_currency': 293.79,
-                            'tax_amount_currency': 38.19,
-                            'display_base_amount_currency': 293.79,
-                        },
-                    ],
-                },
-            ],
-        }
-        yield 2, document, expected_values
-
-        document = self.populate_document(self.init_document(
-            lines=[
-                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_13},
-                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_23},
-            ],
-        ))
-        expected_values = {
-            'same_tax_base': False,
-            'currency_id': self.currency.id,
-            'base_amount_currency': 293.78,
-            'tax_amount_currency': 52.89,
-            'total_amount_currency': 346.67,
-            'subtotals': [
-                {
-                    'name': "Untaxed Amount",
-                    'base_amount_currency': 293.78,
-                    'tax_amount_currency': 52.89,
-                    'tax_groups': [
-                        {
-                            'id': self.tax_groups[2].id,
-                            'base_amount_currency': 146.89,
-                            'tax_amount_currency': 19.1,
-                            'display_base_amount_currency': 146.89,
-                        },
-                        {
-                            'id': self.tax_groups[3].id,
-                            'base_amount_currency': 146.89,
-                            'tax_amount_currency': 33.79,
-                            'display_base_amount_currency': 146.89,
-                        },
-                    ],
-                },
-            ],
-        }
-        yield 3, document, expected_values
-
-        document = self.populate_document(self.init_document(
-            lines=[
-                {'quantity': 1.0, 'price_unit': 0.5, 'tax_ids': tax_23},
-                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_23},
-            ],
-        ))
-        expected_values = {
-            'same_tax_base': True,
-            'currency_id': self.currency.id,
-            'base_amount_currency': 147.40,
-            'tax_amount_currency': 33.9,
-            'total_amount_currency': 181.30,
-            'subtotals': [
-                {
-                    'name': "Untaxed Amount",
-                    'base_amount_currency': 147.40,
-                    'tax_amount_currency': 33.9,
-                    'tax_groups': [
-                        {
-                            'id': self.tax_groups[3].id,
-                            'base_amount_currency': 147.40,
-                            'tax_amount_currency': 33.9,
-                            'display_base_amount_currency': 147.40,
-                        },
-                    ],
-                },
-            ],
-        }
-        yield 4, document, expected_values
-
-        document = self.populate_document(self.init_document(
-            lines=[
-                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_0},
-                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_0},
-                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_6},
-                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_6},
-                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_13},
-                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_13},
-                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_23},
-                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_23},
-            ],
-        ))
-        expected_values = {
-            'same_tax_base': False,
-            'currency_id': self.currency.id,
-            'base_amount_currency': 1175.16,
-            'tax_amount_currency': 123.39,
-            'total_amount_currency': 1298.55,
-            'subtotals': [
-                {
-                    'name': "Untaxed Amount",
-                    'base_amount_currency': 1175.16,
-                    'tax_amount_currency': 123.39,
-                    'tax_groups': [
-                        {
-                            'id': self.tax_groups[0].id,
-                            'base_amount_currency': 293.79,
-                            'tax_amount_currency': 0.0,
-                            'display_base_amount_currency': 293.79,
-                        },
-                        {
-                            'id': self.tax_groups[1].id,
-                            'base_amount_currency': 293.79,
-                            'tax_amount_currency': 17.63,
-                            'display_base_amount_currency': 293.79,
-                        },
-                        {
-                            'id': self.tax_groups[2].id,
-                            'base_amount_currency': 293.79,
-                            'tax_amount_currency': 38.19,
-                            'display_base_amount_currency': 293.79,
-                        },
-                        {
-                            'id': self.tax_groups[3].id,
-                            'base_amount_currency': 293.79,
-                            'tax_amount_currency': 67.57,
-                            'display_base_amount_currency': 293.79,
-                        },
-                    ],
-                },
-            ],
-        }
-        yield 5, document, expected_values
-
-        document = self.populate_document(self.init_document(
-            lines=[
-                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_23},
-                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_23},
-                {'quantity': 1, 'price_unit': 0.5, 'tax_ids': tax_23},
-            ],
-        ))
-        expected_values = {
-            'same_tax_base': True,
-            'currency_id': self.currency.id,
-            'base_amount_currency': 294.29,
-            'tax_amount_currency': 67.69,
-            'total_amount_currency': 361.98,
-            'subtotals': [
-                {
-                    'name': "Untaxed Amount",
-                    'base_amount_currency': 294.29,
-                    'tax_amount_currency': 67.69,
-                    'tax_groups': [
-                        {
-                            'id': self.tax_groups[3].id,
-                            'base_amount_currency': 294.29,
-                            'tax_amount_currency': 67.69,
-                            'display_base_amount_currency': 294.29,
-                        },
-                    ],
-                },
-            ],
-        }
-        yield 6, document, expected_values
-
-        document = self.populate_document(self.init_document(
-            lines=[
-                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_0},
-                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_6},
-                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_13},
-                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_13},
-                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_23},
-                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_23},
-            ],
-        ))
-        expected_values = {
-            'same_tax_base': False,
-            'currency_id': self.currency.id,
-            'base_amount_currency': 881.37,
-            'tax_amount_currency': 114.57,
-            'total_amount_currency': 995.94,
-            'subtotals': [
-                {
-                    'name': "Untaxed Amount",
-                    'base_amount_currency': 881.37,
-                    'tax_amount_currency': 114.57,
-                    'tax_groups': [
-                        {
-                            'id': self.tax_groups[0].id,
-                            'base_amount_currency': 146.89,
-                            'tax_amount_currency': 0.0,
-                            'display_base_amount_currency': 146.89,
-                        },
-                        {
-                            'id': self.tax_groups[1].id,
-                            'base_amount_currency': 146.90,
-                            'tax_amount_currency': 8.81,
-                            'display_base_amount_currency': 146.90,
-                        },
-                        {
-                            'id': self.tax_groups[2].id,
-                            'base_amount_currency': 293.79,
-                            'tax_amount_currency': 38.19,
-                            'display_base_amount_currency': 293.79,
-                        },
-                        {
-                            'id': self.tax_groups[3].id,
-                            'base_amount_currency': 293.79,
-                            'tax_amount_currency': 67.57,
-                            'display_base_amount_currency': 293.79,
-                        },
-                    ],
-                },
-            ],
-        }
-        yield 7, document, expected_values
-
-        document = self.populate_document(self.init_document(
-            lines=[
-                {'quantity': 5.55, 'price_unit': 1.09, 'tax_ids': tax_23},
-                {'quantity': 5.5, 'price_unit': 1.09, 'tax_ids': tax_23},
-            ],
-        ))
-        expected_values = {
-            'same_tax_base': True,
-            'currency_id': self.currency.id,
-            'base_amount_currency': 12.04,
-            'tax_amount_currency': 2.77,
-            'total_amount_currency': 14.81,
-            'subtotals': [
-                {
-                    'name': "Untaxed Amount",
-                    'base_amount_currency': 12.04,
-                    'tax_amount_currency': 2.77,
-                    'tax_groups': [
-                        {
-                            'id': self.tax_groups[3].id,
-                            'base_amount_currency': 12.04,
-                            'tax_amount_currency': 2.77,
-                            'display_base_amount_currency': 12.04,
-                        },
-                    ],
-                },
-            ],
-        }
-        yield 8, document, expected_values
-
-        document = self.populate_document(self.init_document(
-            lines=[
-                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_0},
-                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_0},
-                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_6},
-                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_6},
-                {'quantity': 13.13, 'price_unit': 12.12, 'tax_ids': tax_13},
-                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_13},
-                {'quantity': 13.13, 'price_unit': 12.12, 'tax_ids': tax_23},
-                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_23},
-            ],
-        ))
-        expected_values = {
-            'same_tax_base': False,
-            'currency_id': self.currency.id,
-            'base_amount_currency': 1199.64,
-            'tax_amount_currency': 127.80,
-            'total_amount_currency': 1327.44,
-            'subtotals': [
-                {
-                    'name': "Untaxed Amount",
-                    'base_amount_currency': 1199.64,
-                    'tax_amount_currency': 127.80,
-                    'tax_groups': [
-                        {
-                            'id': self.tax_groups[0].id,
-                            'base_amount_currency': 293.79,
-                            'tax_amount_currency': 0.0,
-                            'display_base_amount_currency': 293.79,
-                        },
-                        {
-                            'id': self.tax_groups[1].id,
-                            'base_amount_currency': 293.79,
-                            'tax_amount_currency': 17.63,
-                            'display_base_amount_currency': 293.79,
-                        },
-                        {
-                            'id': self.tax_groups[2].id,
-                            'base_amount_currency': 306.03,
-                            'tax_amount_currency': 39.78,
-                            'display_base_amount_currency': 306.03,
-                        },
-                        {
-                            'id': self.tax_groups[3].id,
-                            'base_amount_currency': 306.03,
-                            'tax_amount_currency': 70.39,
-                            'display_base_amount_currency': 306.03,
-                        },
-                    ],
-                },
-            ],
-        }
-        yield 9, document, expected_values
-
-        document = self.populate_document(self.init_document(
-            lines=[
-                {'quantity': 501.0, 'price_unit': 3.0, 'tax_ids': tax_6},
-            ],
-        ))
-        expected_values = {
-            'same_tax_base': True,
-            'currency_id': self.currency.id,
-            'base_amount_currency': 1503.0,
-            'tax_amount_currency': 90.18,
-            'total_amount_currency': 1593.18,
-            'subtotals': [
-                {
-                    'name': "Untaxed Amount",
-                    'base_amount_currency': 1503.0,
-                    'tax_amount_currency': 90.18,
-                    'tax_groups': [
-                        {
-                            'id': self.tax_groups[1].id,
-                            'base_amount_currency': 1503.0,
-                            'tax_amount_currency': 90.18,
-                            'display_base_amount_currency': 1503.0,
-                        },
-                    ],
-                },
-            ],
-        }
-        yield 10, document, expected_values
-
-        document = self.populate_document(self.init_document(
-            lines=[
-                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_23},
-            ],
-        ))
-        expected_values = {
-            'same_tax_base': True,
-            'currency_id': self.currency.id,
-            'base_amount_currency': 146.89,
-            'tax_amount_currency': 33.79,
-            'total_amount_currency': 180.68,
-            'subtotals': [
-                {
-                    'name': "Untaxed Amount",
-                    'base_amount_currency': 146.89,
-                    'tax_amount_currency': 33.79,
-                    'tax_groups': [
-                        {
-                            'id': self.tax_groups[3].id,
-                            'base_amount_currency': 146.89,
-                            'tax_amount_currency': 33.79,
-                            'display_base_amount_currency': 146.89,
-                        },
-                    ],
-                },
-            ],
-        }
-        yield 11, document, expected_values
-
-        document = self.populate_document(self.init_document(
-            lines=[
-                {'quantity': 50.0, 'price_unit': 2.0, 'tax_ids': tax_13},
-                {'quantity': 100.0, 'price_unit': 1.0, 'tax_ids': tax_23},
-            ],
-        ))
-        expected_values = {
-            'same_tax_base': False,
-            'currency_id': self.currency.id,
-            'base_amount_currency': 200.0,
-            'tax_amount_currency': 36.0,
-            'total_amount_currency': 236.0,
-            'subtotals': [
-                {
-                    'name': "Untaxed Amount",
-                    'base_amount_currency': 200.0,
-                    'tax_amount_currency': 36.0,
-                    'tax_groups': [
-                        {
-                            'id': self.tax_groups[2].id,
-                            'base_amount_currency': 100.0,
-                            'tax_amount_currency': 13.0,
-                            'display_base_amount_currency': 100.0,
-                        },
-                        {
-                            'id': self.tax_groups[3].id,
-                            'base_amount_currency': 100.0,
-                            'tax_amount_currency': 23.0,
-                            'display_base_amount_currency': 100.0,
-                        },
-                    ],
-                },
-            ],
-        }
-        yield 12, document, expected_values
-
-        document = self.populate_document(self.init_document(
-            lines=[
-                {'quantity': 1.0, 'price_unit': 1.0, 'tax_ids': tax_0},
-                {'quantity': 1.0, 'price_unit': 4.0, 'tax_ids': tax_0},
-                {'quantity': 10.0, 'price_unit': 3.0, 'tax_ids': tax_6},
-                {'quantity': 1.0, 'price_unit': 2.0, 'tax_ids': tax_13},
-                {'quantity': 1.0, 'price_unit': 1.0, 'tax_ids': tax_23},
-            ],
-        ))
-        expected_values = {
-            'same_tax_base': False,
-            'currency_id': self.currency.id,
-            'base_amount_currency': 38.0,
-            'tax_amount_currency': 2.29,
-            'total_amount_currency': 40.29,
-            'subtotals': [
-                {
-                    'name': "Untaxed Amount",
-                    'base_amount_currency': 38.0,
-                    'tax_amount_currency': 2.29,
-                    'tax_groups': [
-                        {
-                            'id': self.tax_groups[0].id,
-                            'base_amount_currency': 5.0,
-                            'tax_amount_currency': 0.0,
-                            'display_base_amount_currency': 5.0,
-                        },
-                        {
-                            'id': self.tax_groups[1].id,
-                            'base_amount_currency': 30.0,
-                            'tax_amount_currency': 1.8,
-                            'display_base_amount_currency': 30.0,
-                        },
-                        {
-                            'id': self.tax_groups[2].id,
-                            'base_amount_currency': 2.0,
-                            'tax_amount_currency': 0.26,
-                            'display_base_amount_currency': 2.0,
-                        },
-                        {
-                            'id': self.tax_groups[3].id,
-                            'base_amount_currency': 1.0,
-                            'tax_amount_currency': 0.23,
-                            'display_base_amount_currency': 1.0,
-                        },
-                    ],
-                },
-            ],
-        }
-        yield 13, document, expected_values
-
-        document = self.populate_document(self.init_document(
-            lines=[
-                {'quantity': 50.0, 'price_unit': 1.09, 'tax_ids': tax_23},
-            ],
-        ))
-        expected_values = {
-            'same_tax_base': True,
-            'currency_id': self.currency.id,
-            'base_amount_currency': 54.5,
-            'tax_amount_currency': 12.54,
-            'total_amount_currency': 67.04,
-            'subtotals': [
-                {
-                    'name': "Untaxed Amount",
-                    'base_amount_currency': 54.5,
-                    'tax_amount_currency': 12.54,
-                    'tax_groups': [
-                        {
-                            'id': self.tax_groups[3].id,
-                            'base_amount_currency': 54.5,
-                            'tax_amount_currency': 12.54,
-                            'display_base_amount_currency': 54.5,
-                        },
-                    ],
-                },
-            ],
-        }
-        yield 14, document, expected_values
-
-        document = self.populate_document(self.init_document(
-            lines=[
-                {'quantity': 100.0, 'price_unit': 0.55, 'discount': 8.8, 'tax_ids': tax_23},
-                {'quantity': 10.0, 'price_unit': 2.0, 'tax_ids': tax_23},
-                {'quantity': 1.0, 'price_unit': -7.016, 'tax_ids': tax_23},
-            ],
-        ))
-        expected_values = {
-            'same_tax_base': True,
-            'currency_id': self.currency.id,
-            'base_amount_currency': 63.15,
-            'tax_amount_currency': 14.52,
-            'total_amount_currency': 77.67,
-            'subtotals': [
-                {
-                    'name': "Untaxed Amount",
-                    'base_amount_currency': 63.15,
-                    'tax_amount_currency': 14.52,
-                    'tax_groups': [
-                        {
-                            'id': self.tax_groups[3].id,
-                            'base_amount_currency': 63.15,
-                            'tax_amount_currency': 14.52,
-                            'display_base_amount_currency': 63.15,
-                        },
-                    ],
-                },
-            ],
-        }
-        yield 15, document, expected_values
-
-        document = self.populate_document(self.init_document(
-            lines=[
-                {'quantity': 12.12, 'price_unit': 12.12, 'discount': 6.6, 'tax_ids': tax_13},
-                {'quantity': 12.12, 'price_unit': 12.12, 'discount': 6.6, 'tax_ids': tax_13},
-                {'quantity': 12.12, 'price_unit': 12.12, 'discount': 8.8, 'tax_ids': tax_23},
-                {'quantity': 12.12, 'price_unit': 12.12, 'discount': 8.8, 'tax_ids': tax_23},
-            ],
-        ))
-        expected_values = {
-            'same_tax_base': False,
-            'currency_id': self.currency.id,
-            'base_amount_currency': 542.33,
-            'tax_amount_currency': 97.30,
-            'total_amount_currency': 639.63,
-            'subtotals': [
-                {
-                    'name': "Untaxed Amount",
-                    'base_amount_currency': 542.33,
-                    'tax_amount_currency': 97.30,
-                    'tax_groups': [
-                        {
-                            'id': self.tax_groups[2].id,
-                            'base_amount_currency': 274.4,
-                            'tax_amount_currency': 35.67,
-                            'display_base_amount_currency': 274.4,
-                        },
-                        {
-                            'id': self.tax_groups[3].id,
-                            'base_amount_currency': 267.93,
-                            'tax_amount_currency': 61.63,
-                            'display_base_amount_currency': 267.93,
-                        },
-                    ],
-                },
-            ],
-        }
-        yield 16, document, expected_values
-
-        document = self.populate_document(self.init_document(
-            lines=[
-                {'quantity': 13.13, 'price_unit': 13.13, 'tax_ids': tax_13},
-                {'quantity': 1.0, 'price_unit': 0.5, 'tax_ids': tax_13},
-                {'quantity': 1.0, 'price_unit': 0.5, 'tax_ids': tax_23},
-            ],
-        ))
-        expected_values = {
-            'same_tax_base': False,
-            'currency_id': self.currency.id,
-            'base_amount_currency': 173.39,
-            'tax_amount_currency': 22.6,
-            'total_amount_currency': 195.99,
-            'subtotals': [
-                {
-                    'name': "Untaxed Amount",
-                    'base_amount_currency': 173.39,
-                    'tax_amount_currency': 22.6,
-                    'tax_groups': [
-                        {
-                            'id': self.tax_groups[2].id,
-                            'base_amount_currency': 172.89,
-                            'tax_amount_currency': 22.48,
-                            'display_base_amount_currency': 172.89,
-                        },
-                        {
-                            'id': self.tax_groups[3].id,
-                            'base_amount_currency': 0.5,
-                            'tax_amount_currency': 0.12,
-                            'display_base_amount_currency': 0.5,
-                        },
-                    ],
-                },
-            ],
-        }
-        yield 17, document, expected_values
-
-        document = self.populate_document(self.init_document(
-            lines=[
-                {'quantity': 1.0, 'price_unit': 0.5, 'tax_ids': tax_13},
-                {'quantity': 1.0, 'price_unit': 0.5, 'tax_ids': tax_23},
-            ],
-        ))
-        expected_values = {
-            'same_tax_base': False,
-            'currency_id': self.currency.id,
-            'base_amount_currency': 0.99,
-            'tax_amount_currency': 0.19,
-            'total_amount_currency': 1.18,
-            'subtotals': [
-                {
-                    'name': "Untaxed Amount",
-                    'base_amount_currency': 0.99,
-                    'tax_amount_currency': 0.19,
-                    'tax_groups': [
-                        {
-                            'id': self.tax_groups[2].id,
-                            'base_amount_currency': 0.5,
-                            'tax_amount_currency': 0.07,
-                            'display_base_amount_currency': 0.5,
-                        },
-                        {
-                            'id': self.tax_groups[3].id,
-                            'base_amount_currency': 0.5,
-                            'tax_amount_currency': 0.12,
-                            'display_base_amount_currency': 0.5,
-                        },
-                    ],
-                },
-            ],
-        }
-        yield 18, document, expected_values
-
-    def test_taxes_l10n_pt_generic_helpers(self):
-        for test_index, document, expected_values in self._test_taxes_l10n_pt():
-            with self.subTest(test_index=test_index):
-                self.assert_tax_totals_summary(document, expected_values)
-        self._run_js_tests()
-
-    def test_taxes_l10n_pt_invoices(self):
-        for test_index, document, expected_values in self._test_taxes_l10n_pt():
-            with self.subTest(test_index=test_index):
-                invoice = self.convert_document_to_invoice(document)
-                self.assert_invoice_tax_totals_summary(invoice, expected_values)
-
-    def test_taxes_l10n_pt_vendor_bill_manual_tax_amount(self):
-        self.env.company.tax_calculation_rounding_method = 'round_globally'
-        self.change_company_country(self.env.company, self.env.ref('base.pt'))
-        tax_23 = self.percent_tax(23)
-
-        invoice = self.env['account.move'].create({
-            'move_type': 'in_invoice',
-            'invoice_date': '2020-01-01',
-            'invoice_line_ids': [
-                Command.create({
-                    'product_id': self.product_a.id,
-                    'price_unit': 123.0,
-                    'tax_ids': [Command.set(tax_23.ids)],
-                })
-            ],
-        })
-        expected_values = {
-            'same_tax_base': True,
-            'currency_id': self.currency.id,
-            'base_amount_currency': 123.0,
-            'tax_amount_currency': 28.29,
-            'total_amount_currency': 151.29,
-            'subtotals': [
-                {
-                    'name': "Untaxed Amount",
-                    'base_amount_currency': 123.0,
-                    'tax_amount_currency': 28.29,
-                    'tax_groups': [
-                        {
-                            'id': self.tax_groups[0].id,
-                            'base_amount_currency': 123.0,
-                            'tax_amount_currency': 28.29,
-                            'display_base_amount_currency': 123.0,
-                        },
-                    ],
-                },
-            ],
-        }
-        self._assert_tax_totals_summary(invoice.tax_totals, expected_values)
-
-        # Manual edition of the tax amount.
-        tax_line = invoice.line_ids.filtered('tax_repartition_line_id')
-        invoice.line_ids = [Command.update(tax_line.id, {'amount_currency': 28.30})]
-        expected_values = {
-            'same_tax_base': True,
-            'currency_id': self.currency.id,
-            'base_amount_currency': 123.0,
-            'tax_amount_currency': 28.30,
-            'total_amount_currency': 151.30,
-            'subtotals': [
-                {
-                    'name': "Untaxed Amount",
-                    'base_amount_currency': 123.0,
-                    'tax_amount_currency': 28.30,
-                    'tax_groups': [
-                        {
-                            'id': self.tax_groups[0].id,
-                            'base_amount_currency': 123.0,
-                            'tax_amount_currency': 28.30,
-                            'display_base_amount_currency': 123.0,
-                        },
-                    ],
-                },
-            ],
-        }
-        self._assert_tax_totals_summary(invoice.tax_totals, expected_values)
-
     def _test_reverse_charge_taxes_1(self):
         tax = self.percent_tax(
             21.0,
@@ -2220,6 +1372,90 @@ class TestTaxesTaxTotalsSummary(TestTaxCommon):
     def test_reverse_charge_taxes_2_invoices(self):
         for document, expected_values in self._test_reverse_charge_taxes_2():
             invoice = self.convert_document_to_invoice(document)
+            self.assert_invoice_tax_totals_summary(invoice, expected_values)
+
+    def _test_random_case_tax_included(self):
+        self.env.company.tax_calculation_rounding_method = 'round_globally'
+        tax = self.percent_tax(20.0, price_include_override='tax_included')
+        document_params = self.init_document(lines=[
+            {'price_unit': 24.99, 'tax_ids': tax},
+        ])
+        expected_values = {
+            'same_tax_base': True,
+            'currency_id': self.currency.id,
+            'base_amount_currency': 20.82,
+            'tax_amount_currency': 4.17,
+            'total_amount_currency': 24.99,
+            'subtotals': [
+                {
+                    'name': "Untaxed Amount",
+                    'base_amount_currency': 20.82,
+                    'tax_amount_currency': 4.17,
+                    'tax_groups': [
+                        {
+                            'id': self.tax_groups[0].id,
+                            'base_amount_currency': 20.82,
+                            'tax_amount_currency': 4.17,
+                            'display_base_amount_currency': 20.82,
+                        },
+                    ],
+                },
+            ],
+        }
+        yield 1, self.populate_document(document_params), expected_values
+
+        tax_1 = self.percent_tax(10.0, price_include_override='tax_included', tax_group_id=self.tax_groups[0].id)
+        tax_2 = self.percent_tax(10.0, price_include_override='tax_included', tax_group_id=self.tax_groups[1].id)
+        taxes = tax_1 + tax_2
+        document_params = self.init_document(lines=[
+            {'price_unit': 24.99, 'tax_ids': tax},
+        ])
+        yield 2, self.populate_document(document_params), expected_values
+
+        document_params = self.init_document(lines=[
+            {'price_unit': 100.0, 'tax_ids': taxes},
+            {'price_unit': -90.0, 'tax_ids': taxes},
+        ])
+        expected_values = {
+            'same_tax_base': True,
+            'currency_id': self.currency.id,
+            'base_amount_currency': 8.34,
+            'tax_amount_currency': 1.66,
+            'total_amount_currency': 10.0,
+            'subtotals': [
+                {
+                    'name': "Untaxed Amount",
+                    'base_amount_currency': 8.34,
+                    'tax_amount_currency': 1.66,
+                    'tax_groups': [
+                        {
+                            'id': self.tax_groups[0].id,
+                            'base_amount_currency': 8.34,
+                            'tax_amount_currency': 0.83,
+                            'display_base_amount_currency': 8.34,
+                        },
+                        {
+                            'id': self.tax_groups[1].id,
+                            'base_amount_currency': 8.34,
+                            'tax_amount_currency': 0.83,
+                            'display_base_amount_currency': 8.34,
+                        },
+                    ],
+                },
+            ],
+        }
+        yield 3, self.populate_document(document_params), expected_values
+
+    def test_random_case_tax_included_generic_helpers(self):
+        for test_index, document, expected_values in self._test_random_case_tax_included():
+            with self.subTest(test_index=test_index):
+                self.assert_tax_totals_summary(document, expected_values)
+        self._run_js_tests()
+
+    def test_random_case_tax_included_invoices(self):
+        for test_index, document, expected_values in self._test_random_case_tax_included():
+            with self.subTest(test_index=test_index):
+                invoice = self.convert_document_to_invoice(document)
             self.assert_invoice_tax_totals_summary(invoice, expected_values)
 
     def _test_cash_rounding(self):

--- a/addons/account_edi_ubl_cii/tests/test_files/bis3/test_dispatch_base_lines_delta.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/bis3/test_dispatch_base_lines_delta.xml
@@ -125,7 +125,7 @@
   <cac:InvoiceLine>
     <cbc:ID>1</cbc:ID>
     <cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
-    <cbc:LineExtensionAmount currencyID="EUR">9.03</cbc:LineExtensionAmount>
+    <cbc:LineExtensionAmount currencyID="EUR">9.02</cbc:LineExtensionAmount>
     <cac:AllowanceCharge>
       <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
       <cbc:AllowanceChargeReasonCode>95</cbc:AllowanceChargeReasonCode>
@@ -197,7 +197,7 @@
   <cac:InvoiceLine>
     <cbc:ID>4</cbc:ID>
     <cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
-    <cbc:LineExtensionAmount currencyID="EUR">0.93</cbc:LineExtensionAmount>
+    <cbc:LineExtensionAmount currencyID="EUR">0.94</cbc:LineExtensionAmount>
     <cac:AllowanceCharge>
       <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
       <cbc:AllowanceChargeReasonCode>95</cbc:AllowanceChargeReasonCode>

--- a/addons/l10n_mx/__manifest__.py
+++ b/addons/l10n_mx/__manifest__.py
@@ -43,6 +43,14 @@ With this module you will have:
     'demo': [
         'demo/demo_company.xml',
     ],
+    'assets': {
+        'web.assets_backend': [
+            'l10n_mx/static/src/helpers/*.js',
+        ],
+        'web.assets_frontend': [
+            'l10n_mx/static/src/helpers/*.js',
+        ],
+    },
     'license': 'LGPL-3',
     'post_init_hook': '_enable_group_uom_post_init',
 }

--- a/addons/l10n_mx/models/account_tax.py
+++ b/addons/l10n_mx/models/account_tax.py
@@ -32,3 +32,19 @@ class AccountTax(models.Model):
     def _compute_l10n_mx_tax_type(self):
         for tax in self:
             tax.l10n_mx_tax_type = 'iva' if tax.country_id.code == 'MX' else False
+
+    @api.model
+    def _round_tax_details_tax_amounts(self, base_lines, company, mode='mixed'):
+        # EXTENDS 'account'
+        country_code = company.account_fiscal_country_id.code
+        if country_code == 'MX':
+            mode = 'excluded'
+        super()._round_tax_details_tax_amounts(base_lines, company, mode=mode)
+
+    @api.model
+    def _round_tax_details_base_lines(self, base_lines, company, mode='mixed'):
+        # EXTENDS 'account'
+        country_code = company.account_fiscal_country_id.code
+        if country_code == 'MX':
+            mode = 'excluded'
+        super()._round_tax_details_base_lines(base_lines, company, mode=mode)

--- a/addons/l10n_mx/static/src/helpers/account_tax.js
+++ b/addons/l10n_mx/static/src/helpers/account_tax.js
@@ -1,0 +1,27 @@
+import { patch } from "@web/core/utils/patch";
+
+import { accountTaxHelpers } from "@account/helpers/account_tax";
+
+// -------------------------------------------------------------------------
+// HELPERS IN BOTH PYTHON/JAVASCRIPT (account_tax.js / account_tax.py)
+// -------------------------------------------------------------------------
+
+patch(accountTaxHelpers, {
+    // EXTENDS 'account'
+    round_tax_details_tax_amounts(base_lines, company, { mode = "mixed" } = {}) {
+        const country_code = company.account_fiscal_country_id.code;
+        if (country_code === "MX") {
+            mode = "excluded";
+        }
+        return super.round_tax_details_tax_amounts(base_lines, company, { mode: mode });
+    },
+
+    // EXTENDS 'account'
+    round_tax_details_base_lines(base_lines, company, { mode = "mixed" } = {}) {
+        const country_code = company.account_fiscal_country_id.code;
+        if (country_code === "MX") {
+            mode = "excluded";
+        }
+        return super.round_tax_details_base_lines(base_lines, company, { mode: mode });
+    },
+});

--- a/addons/l10n_pt/__manifest__.py
+++ b/addons/l10n_pt/__manifest__.py
@@ -20,5 +20,13 @@
     'demo': [
         'demo/demo_company.xml',
     ],
+    'assets': {
+        'web.assets_backend': [
+            'l10n_pt/static/src/helpers/*.js',
+        ],
+        'web.assets_frontend': [
+            'l10n_pt/static/src/helpers/*.js',
+        ],
+    },
     'license': 'LGPL-3',
 }

--- a/addons/l10n_pt/models/__init__.py
+++ b/addons/l10n_pt/models/__init__.py
@@ -1,3 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
 from . import template_pt
 from . import account_account
+from . import account_tax

--- a/addons/l10n_pt/models/account_tax.py
+++ b/addons/l10n_pt/models/account_tax.py
@@ -1,0 +1,21 @@
+from odoo import api, models
+
+
+class AccountTax(models.Model):
+    _inherit = 'account.tax'
+
+    @api.model
+    def _round_tax_details_tax_amounts(self, base_lines, company, mode='mixed'):
+        # EXTENDS 'account'
+        country_code = company.account_fiscal_country_id.code
+        if country_code == 'PT':
+            mode = 'included'
+        super()._round_tax_details_tax_amounts(base_lines, company, mode=mode)
+
+    @api.model
+    def _round_tax_details_base_lines(self, base_lines, company, mode='mixed'):
+        # EXTENDS 'account'
+        country_code = company.account_fiscal_country_id.code
+        if country_code == 'PT':
+            mode = 'included'
+        super()._round_tax_details_base_lines(base_lines, company, mode=mode)

--- a/addons/l10n_pt/models/template_pt.py
+++ b/addons/l10n_pt/models/template_pt.py
@@ -26,6 +26,7 @@ class AccountChartTemplate(models.AbstractModel):
                 'account_default_pos_receivable_account_id': 'chart_2117',
                 'income_currency_exchange_account_id': 'chart_7861',
                 'expense_currency_exchange_account_id': 'chart_6863',
+                'tax_calculation_rounding_method': 'round_globally',
                 'account_journal_early_pay_discount_loss_account_id': 'chart_682',
                 'account_journal_early_pay_discount_gain_account_id': 'chart_728',
                 'account_sale_tax_id': 'iva_pt_sale_normal',

--- a/addons/l10n_pt/static/src/helpers/account_tax.js
+++ b/addons/l10n_pt/static/src/helpers/account_tax.js
@@ -1,0 +1,27 @@
+import { patch } from "@web/core/utils/patch";
+
+import { accountTaxHelpers } from "@account/helpers/account_tax";
+
+// -------------------------------------------------------------------------
+// HELPERS IN BOTH PYTHON/JAVASCRIPT (account_tax.js / account_tax.py)
+// -------------------------------------------------------------------------
+
+patch(accountTaxHelpers, {
+    // EXTENDS 'account'
+    round_tax_details_tax_amounts(base_lines, company, { mode = "mixed" } = {}) {
+        const country_code = company.account_fiscal_country_id.code;
+        if (country_code === "PT") {
+            mode = "included";
+        }
+        return super.round_tax_details_tax_amounts(base_lines, company, { mode: mode });
+    },
+
+    // EXTENDS 'account'
+    round_tax_details_base_lines(base_lines, company, { mode = "mixed" } = {}) {
+        const country_code = company.account_fiscal_country_id.code;
+        if (country_code === "PT") {
+            mode = "included";
+        }
+        return super.round_tax_details_base_lines(base_lines, company, { mode: mode });
+    },
+});

--- a/addons/l10n_pt/tests/__init__.py
+++ b/addons/l10n_pt/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_taxes_tax_totals_summary

--- a/addons/l10n_pt/tests/test_taxes_tax_totals_summary.py
+++ b/addons/l10n_pt/tests/test_taxes_tax_totals_summary.py
@@ -1,0 +1,786 @@
+from odoo import Command
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.addons.account.tests.test_taxes_tax_totals_summary import TestTaxesTaxTotalsSummary
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install', 'post_install_l10n')
+class TestTaxesTaxTotalsSummaryL10nPt(TestTaxesTaxTotalsSummary):
+
+    @classmethod
+    @AccountTestInvoicingCommon.setup_country('pt')
+    def setUpClass(cls):
+        super().setUpClass()
+
+    def _test_taxes_l10n_pt(self):
+        """ !!!! THOSE TESTS ARE THERE TO CERTIFY THE USE OF ODOO INVOICING IN PORTUGAL.
+        Therefore, they have to stay like this to stay compliant.
+        """
+        self.env['decimal.precision'].search([('name', '=', "Product Price")]).digits = 6
+        tax_0 = self.percent_tax(0, tax_group_id=self.tax_groups[0].id)
+        tax_6 = self.percent_tax(6, tax_group_id=self.tax_groups[1].id)
+        tax_13 = self.percent_tax(13, tax_group_id=self.tax_groups[2].id)
+        tax_23 = self.percent_tax(23, tax_group_id=self.tax_groups[3].id)
+
+        document = self.populate_document(self.init_document(
+            lines=[
+                {'quantity': 12.12, 'price_unit': 12.12},
+                {'quantity': 12.12, 'price_unit': 12.12},
+            ],
+        ))
+        expected_values = {
+            'same_tax_base': True,
+            'currency_id': self.currency.id,
+            'base_amount_currency': 293.79,
+            'tax_amount_currency': 0.0,
+            'total_amount_currency': 293.79,
+            'subtotals': [
+                {
+                    'name': "Untaxed Amount",
+                    'base_amount_currency': 293.79,
+                    'tax_amount_currency': 0.0,
+                    'tax_groups': [],
+                },
+            ],
+        }
+        yield 1, document, expected_values
+
+        document = self.populate_document(self.init_document(
+            lines=[
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_13},
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_13},
+            ],
+        ))
+        expected_values = {
+            'same_tax_base': True,
+            'currency_id': self.currency.id,
+            'base_amount_currency': 293.79,
+            'tax_amount_currency': 38.19,
+            'total_amount_currency': 331.98,
+            'subtotals': [
+                {
+                    'name': "Untaxed Amount",
+                    'base_amount_currency': 293.79,
+                    'tax_amount_currency': 38.19,
+                    'tax_groups': [
+                        {
+                            'id': self.tax_groups[2].id,
+                            'base_amount_currency': 293.79,
+                            'tax_amount_currency': 38.19,
+                            'display_base_amount_currency': 293.79,
+                        },
+                    ],
+                },
+            ],
+        }
+        yield 2, document, expected_values
+
+        document = self.populate_document(self.init_document(
+            lines=[
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_13},
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_23},
+            ],
+        ))
+        expected_values = {
+            'same_tax_base': False,
+            'currency_id': self.currency.id,
+            'base_amount_currency': 293.78,
+            'tax_amount_currency': 52.89,
+            'total_amount_currency': 346.67,
+            'subtotals': [
+                {
+                    'name': "Untaxed Amount",
+                    'base_amount_currency': 293.78,
+                    'tax_amount_currency': 52.89,
+                    'tax_groups': [
+                        {
+                            'id': self.tax_groups[2].id,
+                            'base_amount_currency': 146.89,
+                            'tax_amount_currency': 19.1,
+                            'display_base_amount_currency': 146.89,
+                        },
+                        {
+                            'id': self.tax_groups[3].id,
+                            'base_amount_currency': 146.89,
+                            'tax_amount_currency': 33.79,
+                            'display_base_amount_currency': 146.89,
+                        },
+                    ],
+                },
+            ],
+        }
+        yield 3, document, expected_values
+
+        document = self.populate_document(self.init_document(
+            lines=[
+                {'quantity': 1.0, 'price_unit': 0.5, 'tax_ids': tax_23},
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_23},
+            ],
+        ))
+        expected_values = {
+            'same_tax_base': True,
+            'currency_id': self.currency.id,
+            'base_amount_currency': 147.40,
+            'tax_amount_currency': 33.9,
+            'total_amount_currency': 181.30,
+            'subtotals': [
+                {
+                    'name': "Untaxed Amount",
+                    'base_amount_currency': 147.40,
+                    'tax_amount_currency': 33.9,
+                    'tax_groups': [
+                        {
+                            'id': self.tax_groups[3].id,
+                            'base_amount_currency': 147.40,
+                            'tax_amount_currency': 33.9,
+                            'display_base_amount_currency': 147.40,
+                        },
+                    ],
+                },
+            ],
+        }
+        yield 4, document, expected_values
+
+        document = self.populate_document(self.init_document(
+            lines=[
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_0},
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_0},
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_6},
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_6},
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_13},
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_13},
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_23},
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_23},
+            ],
+        ))
+        expected_values = {
+            'same_tax_base': False,
+            'currency_id': self.currency.id,
+            'base_amount_currency': 1175.16,
+            'tax_amount_currency': 123.39,
+            'total_amount_currency': 1298.55,
+            'subtotals': [
+                {
+                    'name': "Untaxed Amount",
+                    'base_amount_currency': 1175.16,
+                    'tax_amount_currency': 123.39,
+                    'tax_groups': [
+                        {
+                            'id': self.tax_groups[0].id,
+                            'base_amount_currency': 293.79,
+                            'tax_amount_currency': 0.0,
+                            'display_base_amount_currency': 293.79,
+                        },
+                        {
+                            'id': self.tax_groups[1].id,
+                            'base_amount_currency': 293.79,
+                            'tax_amount_currency': 17.63,
+                            'display_base_amount_currency': 293.79,
+                        },
+                        {
+                            'id': self.tax_groups[2].id,
+                            'base_amount_currency': 293.79,
+                            'tax_amount_currency': 38.19,
+                            'display_base_amount_currency': 293.79,
+                        },
+                        {
+                            'id': self.tax_groups[3].id,
+                            'base_amount_currency': 293.79,
+                            'tax_amount_currency': 67.57,
+                            'display_base_amount_currency': 293.79,
+                        },
+                    ],
+                },
+            ],
+        }
+        yield 5, document, expected_values
+
+        document = self.populate_document(self.init_document(
+            lines=[
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_23},
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_23},
+                {'quantity': 1, 'price_unit': 0.5, 'tax_ids': tax_23},
+            ],
+        ))
+        expected_values = {
+            'same_tax_base': True,
+            'currency_id': self.currency.id,
+            'base_amount_currency': 294.29,
+            'tax_amount_currency': 67.69,
+            'total_amount_currency': 361.98,
+            'subtotals': [
+                {
+                    'name': "Untaxed Amount",
+                    'base_amount_currency': 294.29,
+                    'tax_amount_currency': 67.69,
+                    'tax_groups': [
+                        {
+                            'id': self.tax_groups[3].id,
+                            'base_amount_currency': 294.29,
+                            'tax_amount_currency': 67.69,
+                            'display_base_amount_currency': 294.29,
+                        },
+                    ],
+                },
+            ],
+        }
+        yield 6, document, expected_values
+
+        document = self.populate_document(self.init_document(
+            lines=[
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_0},
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_6},
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_13},
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_13},
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_23},
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_23},
+            ],
+        ))
+        expected_values = {
+            'same_tax_base': False,
+            'currency_id': self.currency.id,
+            'base_amount_currency': 881.37,
+            'tax_amount_currency': 114.57,
+            'total_amount_currency': 995.94,
+            'subtotals': [
+                {
+                    'name': "Untaxed Amount",
+                    'base_amount_currency': 881.37,
+                    'tax_amount_currency': 114.57,
+                    'tax_groups': [
+                        {
+                            'id': self.tax_groups[0].id,
+                            'base_amount_currency': 146.89,
+                            'tax_amount_currency': 0.0,
+                            'display_base_amount_currency': 146.89,
+                        },
+                        {
+                            'id': self.tax_groups[1].id,
+                            'base_amount_currency': 146.90,
+                            'tax_amount_currency': 8.81,
+                            'display_base_amount_currency': 146.90,
+                        },
+                        {
+                            'id': self.tax_groups[2].id,
+                            'base_amount_currency': 293.79,
+                            'tax_amount_currency': 38.19,
+                            'display_base_amount_currency': 293.79,
+                        },
+                        {
+                            'id': self.tax_groups[3].id,
+                            'base_amount_currency': 293.79,
+                            'tax_amount_currency': 67.57,
+                            'display_base_amount_currency': 293.79,
+                        },
+                    ],
+                },
+            ],
+        }
+        yield 7, document, expected_values
+
+        document = self.populate_document(self.init_document(
+            lines=[
+                {'quantity': 5.55, 'price_unit': 1.09, 'tax_ids': tax_23},
+                {'quantity': 5.5, 'price_unit': 1.09, 'tax_ids': tax_23},
+            ],
+        ))
+        expected_values = {
+            'same_tax_base': True,
+            'currency_id': self.currency.id,
+            'base_amount_currency': 12.04,
+            'tax_amount_currency': 2.77,
+            'total_amount_currency': 14.81,
+            'subtotals': [
+                {
+                    'name': "Untaxed Amount",
+                    'base_amount_currency': 12.04,
+                    'tax_amount_currency': 2.77,
+                    'tax_groups': [
+                        {
+                            'id': self.tax_groups[3].id,
+                            'base_amount_currency': 12.04,
+                            'tax_amount_currency': 2.77,
+                            'display_base_amount_currency': 12.04,
+                        },
+                    ],
+                },
+            ],
+        }
+        yield 8, document, expected_values
+
+        document = self.populate_document(self.init_document(
+            lines=[
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_0},
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_0},
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_6},
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_6},
+                {'quantity': 13.13, 'price_unit': 12.12, 'tax_ids': tax_13},
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_13},
+                {'quantity': 13.13, 'price_unit': 12.12, 'tax_ids': tax_23},
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_23},
+            ],
+        ))
+        expected_values = {
+            'same_tax_base': False,
+            'currency_id': self.currency.id,
+            'base_amount_currency': 1199.64,
+            'tax_amount_currency': 127.80,
+            'total_amount_currency': 1327.44,
+            'subtotals': [
+                {
+                    'name': "Untaxed Amount",
+                    'base_amount_currency': 1199.64,
+                    'tax_amount_currency': 127.80,
+                    'tax_groups': [
+                        {
+                            'id': self.tax_groups[0].id,
+                            'base_amount_currency': 293.79,
+                            'tax_amount_currency': 0.0,
+                            'display_base_amount_currency': 293.79,
+                        },
+                        {
+                            'id': self.tax_groups[1].id,
+                            'base_amount_currency': 293.79,
+                            'tax_amount_currency': 17.63,
+                            'display_base_amount_currency': 293.79,
+                        },
+                        {
+                            'id': self.tax_groups[2].id,
+                            'base_amount_currency': 306.03,
+                            'tax_amount_currency': 39.78,
+                            'display_base_amount_currency': 306.03,
+                        },
+                        {
+                            'id': self.tax_groups[3].id,
+                            'base_amount_currency': 306.03,
+                            'tax_amount_currency': 70.39,
+                            'display_base_amount_currency': 306.03,
+                        },
+                    ],
+                },
+            ],
+        }
+        yield 9, document, expected_values
+
+        document = self.populate_document(self.init_document(
+            lines=[
+                {'quantity': 501.0, 'price_unit': 3.0, 'tax_ids': tax_6},
+            ],
+        ))
+        expected_values = {
+            'same_tax_base': True,
+            'currency_id': self.currency.id,
+            'base_amount_currency': 1503.0,
+            'tax_amount_currency': 90.18,
+            'total_amount_currency': 1593.18,
+            'subtotals': [
+                {
+                    'name': "Untaxed Amount",
+                    'base_amount_currency': 1503.0,
+                    'tax_amount_currency': 90.18,
+                    'tax_groups': [
+                        {
+                            'id': self.tax_groups[1].id,
+                            'base_amount_currency': 1503.0,
+                            'tax_amount_currency': 90.18,
+                            'display_base_amount_currency': 1503.0,
+                        },
+                    ],
+                },
+            ],
+        }
+        yield 10, document, expected_values
+
+        document = self.populate_document(self.init_document(
+            lines=[
+                {'quantity': 12.12, 'price_unit': 12.12, 'tax_ids': tax_23},
+            ],
+        ))
+        expected_values = {
+            'same_tax_base': True,
+            'currency_id': self.currency.id,
+            'base_amount_currency': 146.89,
+            'tax_amount_currency': 33.79,
+            'total_amount_currency': 180.68,
+            'subtotals': [
+                {
+                    'name': "Untaxed Amount",
+                    'base_amount_currency': 146.89,
+                    'tax_amount_currency': 33.79,
+                    'tax_groups': [
+                        {
+                            'id': self.tax_groups[3].id,
+                            'base_amount_currency': 146.89,
+                            'tax_amount_currency': 33.79,
+                            'display_base_amount_currency': 146.89,
+                        },
+                    ],
+                },
+            ],
+        }
+        yield 11, document, expected_values
+
+        document = self.populate_document(self.init_document(
+            lines=[
+                {'quantity': 50.0, 'price_unit': 2.0, 'tax_ids': tax_13},
+                {'quantity': 100.0, 'price_unit': 1.0, 'tax_ids': tax_23},
+            ],
+        ))
+        expected_values = {
+            'same_tax_base': False,
+            'currency_id': self.currency.id,
+            'base_amount_currency': 200.0,
+            'tax_amount_currency': 36.0,
+            'total_amount_currency': 236.0,
+            'subtotals': [
+                {
+                    'name': "Untaxed Amount",
+                    'base_amount_currency': 200.0,
+                    'tax_amount_currency': 36.0,
+                    'tax_groups': [
+                        {
+                            'id': self.tax_groups[2].id,
+                            'base_amount_currency': 100.0,
+                            'tax_amount_currency': 13.0,
+                            'display_base_amount_currency': 100.0,
+                        },
+                        {
+                            'id': self.tax_groups[3].id,
+                            'base_amount_currency': 100.0,
+                            'tax_amount_currency': 23.0,
+                            'display_base_amount_currency': 100.0,
+                        },
+                    ],
+                },
+            ],
+        }
+        yield 12, document, expected_values
+
+        document = self.populate_document(self.init_document(
+            lines=[
+                {'quantity': 1.0, 'price_unit': 1.0, 'tax_ids': tax_0},
+                {'quantity': 1.0, 'price_unit': 4.0, 'tax_ids': tax_0},
+                {'quantity': 10.0, 'price_unit': 3.0, 'tax_ids': tax_6},
+                {'quantity': 1.0, 'price_unit': 2.0, 'tax_ids': tax_13},
+                {'quantity': 1.0, 'price_unit': 1.0, 'tax_ids': tax_23},
+            ],
+        ))
+        expected_values = {
+            'same_tax_base': False,
+            'currency_id': self.currency.id,
+            'base_amount_currency': 38.0,
+            'tax_amount_currency': 2.29,
+            'total_amount_currency': 40.29,
+            'subtotals': [
+                {
+                    'name': "Untaxed Amount",
+                    'base_amount_currency': 38.0,
+                    'tax_amount_currency': 2.29,
+                    'tax_groups': [
+                        {
+                            'id': self.tax_groups[0].id,
+                            'base_amount_currency': 5.0,
+                            'tax_amount_currency': 0.0,
+                            'display_base_amount_currency': 5.0,
+                        },
+                        {
+                            'id': self.tax_groups[1].id,
+                            'base_amount_currency': 30.0,
+                            'tax_amount_currency': 1.8,
+                            'display_base_amount_currency': 30.0,
+                        },
+                        {
+                            'id': self.tax_groups[2].id,
+                            'base_amount_currency': 2.0,
+                            'tax_amount_currency': 0.26,
+                            'display_base_amount_currency': 2.0,
+                        },
+                        {
+                            'id': self.tax_groups[3].id,
+                            'base_amount_currency': 1.0,
+                            'tax_amount_currency': 0.23,
+                            'display_base_amount_currency': 1.0,
+                        },
+                    ],
+                },
+            ],
+        }
+        yield 13, document, expected_values
+
+        document = self.populate_document(self.init_document(
+            lines=[
+                {'quantity': 50.0, 'price_unit': 1.09, 'tax_ids': tax_23},
+            ],
+        ))
+        expected_values = {
+            'same_tax_base': True,
+            'currency_id': self.currency.id,
+            'base_amount_currency': 54.5,
+            'tax_amount_currency': 12.54,
+            'total_amount_currency': 67.04,
+            'subtotals': [
+                {
+                    'name': "Untaxed Amount",
+                    'base_amount_currency': 54.5,
+                    'tax_amount_currency': 12.54,
+                    'tax_groups': [
+                        {
+                            'id': self.tax_groups[3].id,
+                            'base_amount_currency': 54.5,
+                            'tax_amount_currency': 12.54,
+                            'display_base_amount_currency': 54.5,
+                        },
+                    ],
+                },
+            ],
+        }
+        yield 14, document, expected_values
+
+        document = self.populate_document(self.init_document(
+            lines=[
+                {'quantity': 100.0, 'price_unit': 0.55, 'discount': 8.8, 'tax_ids': tax_23},
+                {'quantity': 10.0, 'price_unit': 2.0, 'tax_ids': tax_23},
+                {'quantity': 1.0, 'price_unit': -7.016, 'tax_ids': tax_23},
+            ],
+        ))
+        expected_values = {
+            'same_tax_base': True,
+            'currency_id': self.currency.id,
+            'base_amount_currency': 63.15,
+            'tax_amount_currency': 14.52,
+            'total_amount_currency': 77.67,
+            'subtotals': [
+                {
+                    'name': "Untaxed Amount",
+                    'base_amount_currency': 63.15,
+                    'tax_amount_currency': 14.52,
+                    'tax_groups': [
+                        {
+                            'id': self.tax_groups[3].id,
+                            'base_amount_currency': 63.15,
+                            'tax_amount_currency': 14.52,
+                            'display_base_amount_currency': 63.15,
+                        },
+                    ],
+                },
+            ],
+        }
+        yield 15, document, expected_values
+
+        document = self.populate_document(self.init_document(
+            lines=[
+                {'quantity': 12.12, 'price_unit': 12.12, 'discount': 6.6, 'tax_ids': tax_13},
+                {'quantity': 12.12, 'price_unit': 12.12, 'discount': 6.6, 'tax_ids': tax_13},
+                {'quantity': 12.12, 'price_unit': 12.12, 'discount': 8.8, 'tax_ids': tax_23},
+                {'quantity': 12.12, 'price_unit': 12.12, 'discount': 8.8, 'tax_ids': tax_23},
+            ],
+        ))
+        expected_values = {
+            'same_tax_base': False,
+            'currency_id': self.currency.id,
+            'base_amount_currency': 542.33,
+            'tax_amount_currency': 97.30,
+            'total_amount_currency': 639.63,
+            'subtotals': [
+                {
+                    'name': "Untaxed Amount",
+                    'base_amount_currency': 542.33,
+                    'tax_amount_currency': 97.30,
+                    'tax_groups': [
+                        {
+                            'id': self.tax_groups[2].id,
+                            'base_amount_currency': 274.4,
+                            'tax_amount_currency': 35.67,
+                            'display_base_amount_currency': 274.4,
+                        },
+                        {
+                            'id': self.tax_groups[3].id,
+                            'base_amount_currency': 267.93,
+                            'tax_amount_currency': 61.63,
+                            'display_base_amount_currency': 267.93,
+                        },
+                    ],
+                },
+            ],
+        }
+        yield 16, document, expected_values
+
+        document = self.populate_document(self.init_document(
+            lines=[
+                {'quantity': 13.13, 'price_unit': 13.13, 'tax_ids': tax_13},
+                {'quantity': 1.0, 'price_unit': 0.5, 'tax_ids': tax_13},
+                {'quantity': 1.0, 'price_unit': 0.5, 'tax_ids': tax_23},
+            ],
+        ))
+        expected_values = {
+            'same_tax_base': False,
+            'currency_id': self.currency.id,
+            'base_amount_currency': 173.39,
+            'tax_amount_currency': 22.6,
+            'total_amount_currency': 195.99,
+            'subtotals': [
+                {
+                    'name': "Untaxed Amount",
+                    'base_amount_currency': 173.39,
+                    'tax_amount_currency': 22.6,
+                    'tax_groups': [
+                        {
+                            'id': self.tax_groups[2].id,
+                            'base_amount_currency': 172.89,
+                            'tax_amount_currency': 22.48,
+                            'display_base_amount_currency': 172.89,
+                        },
+                        {
+                            'id': self.tax_groups[3].id,
+                            'base_amount_currency': 0.5,
+                            'tax_amount_currency': 0.12,
+                            'display_base_amount_currency': 0.5,
+                        },
+                    ],
+                },
+            ],
+        }
+        yield 17, document, expected_values
+
+        document = self.populate_document(self.init_document(
+            lines=[
+                {'quantity': 1.0, 'price_unit': 0.5, 'tax_ids': tax_13},
+                {'quantity': 1.0, 'price_unit': 0.5, 'tax_ids': tax_23},
+            ],
+        ))
+        expected_values = {
+            'same_tax_base': False,
+            'currency_id': self.currency.id,
+            'base_amount_currency': 0.99,
+            'tax_amount_currency': 0.19,
+            'total_amount_currency': 1.18,
+            'subtotals': [
+                {
+                    'name': "Untaxed Amount",
+                    'base_amount_currency': 0.99,
+                    'tax_amount_currency': 0.19,
+                    'tax_groups': [
+                        {
+                            'id': self.tax_groups[2].id,
+                            'base_amount_currency': 0.5,
+                            'tax_amount_currency': 0.07,
+                            'display_base_amount_currency': 0.5,
+                        },
+                        {
+                            'id': self.tax_groups[3].id,
+                            'base_amount_currency': 0.5,
+                            'tax_amount_currency': 0.12,
+                            'display_base_amount_currency': 0.5,
+                        },
+                    ],
+                },
+            ],
+        }
+        yield 18, document, expected_values
+
+        document = self.populate_document(self.init_document(
+            lines=[
+                {'quantity': 100.0, 'price_unit': 0.55, 'discount': 17.92, 'tax_ids': tax_23},
+                {'quantity': 10.0, 'price_unit': 2.0, 'discount': 10.0, 'tax_ids': tax_23},
+            ],
+        ))
+        expected_values = {
+            'same_tax_base': True,
+            'currency_id': self.currency.id,
+            'base_amount_currency': 63.15,
+            'tax_amount_currency': 14.52,
+            'total_amount_currency': 77.67,
+            'subtotals': [
+                {
+                    'name': "Untaxed Amount",
+                    'base_amount_currency': 63.15,
+                    'tax_amount_currency': 14.52,
+                    'tax_groups': [
+                        {
+                            'id': self.tax_groups[3].id,
+                            'base_amount_currency': 63.15,
+                            'tax_amount_currency': 14.52,
+                            'display_base_amount_currency': 63.15,
+                        },
+                    ],
+                },
+            ],
+        }
+        yield 19, document, expected_values
+
+    def test_taxes_l10n_pt_generic_helpers(self):
+        for test_index, document, expected_values in self._test_taxes_l10n_pt():
+            with self.subTest(test_index=test_index):
+                self.assert_tax_totals_summary(document, expected_values)
+        self._run_js_tests()
+
+    def test_taxes_l10n_pt_invoices(self):
+        for test_index, document, expected_values in self._test_taxes_l10n_pt():
+            with self.subTest(test_index=test_index):
+                invoice = self.convert_document_to_invoice(document)
+                self.assert_invoice_tax_totals_summary(invoice, expected_values)
+
+    def test_taxes_l10n_pt_vendor_bill_manual_tax_amount(self):
+        tax_23 = self.percent_tax(23)
+
+        invoice = self.env['account.move'].create({
+            'move_type': 'in_invoice',
+            'invoice_date': '2020-01-01',
+            'invoice_line_ids': [
+                Command.create({
+                    'product_id': self.product_a.id,
+                    'price_unit': 123.0,
+                    'tax_ids': [Command.set(tax_23.ids)],
+                })
+            ],
+        })
+        expected_values = {
+            'same_tax_base': True,
+            'currency_id': self.currency.id,
+            'base_amount_currency': 123.0,
+            'tax_amount_currency': 28.29,
+            'total_amount_currency': 151.29,
+            'subtotals': [
+                {
+                    'name': "Untaxed Amount",
+                    'base_amount_currency': 123.0,
+                    'tax_amount_currency': 28.29,
+                    'tax_groups': [
+                        {
+                            'id': self.tax_groups[0].id,
+                            'base_amount_currency': 123.0,
+                            'tax_amount_currency': 28.29,
+                            'display_base_amount_currency': 123.0,
+                        },
+                    ],
+                },
+            ],
+        }
+        self._assert_tax_totals_summary(invoice.tax_totals, expected_values)
+
+        # Manual edition of the tax amount.
+        tax_line = invoice.line_ids.filtered('tax_repartition_line_id')
+        invoice.line_ids = [Command.update(tax_line.id, {'amount_currency': 28.30})]
+        expected_values = {
+            'same_tax_base': True,
+            'currency_id': self.currency.id,
+            'base_amount_currency': 123.0,
+            'tax_amount_currency': 28.30,
+            'total_amount_currency': 151.30,
+            'subtotals': [
+                {
+                    'name': "Untaxed Amount",
+                    'base_amount_currency': 123.0,
+                    'tax_amount_currency': 28.30,
+                    'tax_groups': [
+                        {
+                            'id': self.tax_groups[0].id,
+                            'base_amount_currency': 123.0,
+                            'tax_amount_currency': 28.30,
+                            'display_base_amount_currency': 123.0,
+                        },
+                    ],
+                },
+            ],
+        }
+        self._assert_tax_totals_summary(invoice.tax_totals, expected_values)

--- a/addons/sale/tests/test_taxes_tax_totals_summary.py
+++ b/addons/sale/tests/test_taxes_tax_totals_summary.py
@@ -31,12 +31,6 @@ class TestTaxesTaxTotalsSummarySale(TestTaxCommonSale, TestTaxesTaxTotalsSummary
                 sale_order = self.convert_document_to_sale_order(document)
                 self.assert_sale_order_tax_totals_summary(sale_order, expected_values)
 
-    def test_taxes_l10n_pt_sale_orders(self):
-        for test_index, document, expected_values in self._test_taxes_l10n_pt():
-            with self.subTest(test_index=test_index):
-                sale_order = self.convert_document_to_sale_order(document)
-                self.assert_sale_order_tax_totals_summary(sale_order, expected_values)
-
     def test_reverse_charge_taxes_1_generic_helpers(self):
         for document, expected_values in self._test_reverse_charge_taxes_1():
             sale_order = self.convert_document_to_sale_order(document)


### PR DESCRIPTION
== Fix bug price-included ==
Suppose a line of 24.99 with a 20% tax price-included.
base: 24.99 / 1.2 = 20.825
tax: 20.825 * 0.2 = 4.165
If we round both, we get 20.83 + 4.17 = 25.0 != 24.99

== Split and simplify round_base_line_tax_details ==
Easier implementation of this method to be easier to understand and
easier to be customized (see PT override). Also, we now use the
aggregate methods to aggregate the amounts instead of doing that by hand.

opw-4505888

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
