### PR TITLE
[FIX] pos_self_order: make slots with max capacity unavailable

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -5,7 +5,13 @@ import { markRaw, reactive } from "@odoo/owl";
 import { renderToElement } from "@web/core/utils/render";
 import { registry } from "@web/core/registry";
 import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
-import { deduceUrl, random5Chars, uuidv4, Counter } from "@point_of_sale/utils";
+import {
+    deduceUrl,
+    random5Chars,
+    uuidv4,
+    Counter,
+    orderUsageUTCtoLocalUtil,
+} from "@point_of_sale/utils";
 import { HWPrinter } from "@point_of_sale/app/utils/printer/hw_printer";
 import { ConnectionAbortedError, ConnectionLostError, RPCError } from "@web/core/network/rpc";
 import { OrderReceipt } from "@point_of_sale/app/screens/receipt_screen/receipt/order_receipt";
@@ -37,7 +43,7 @@ import { unaccent } from "@web/core/utils/strings";
 import { WithLazyGetterTrap } from "@point_of_sale/lazy_getter";
 import { debounce } from "@web/core/utils/timing";
 import DevicesSynchronisation from "../utils/devices_synchronisation";
-import { deserializeDateTime, formatDate } from "@web/core/l10n/dates";
+import { formatDate } from "@web/core/l10n/dates";
 import { openProxyCustomerDisplay } from "@point_of_sale/customer_display/utils";
 import { ProductInfoPopup } from "@point_of_sale/app/components/popups/product_info_popup/product_info_popup";
 import { PresetSlotsPopup } from "@point_of_sale/app/components/popups/preset_slots_popup/preset_slots_popup";
@@ -2245,13 +2251,7 @@ export class PosStore extends WithLazyGetterTrap {
         }
     }
     orderUsageUTCtoLocal(data) {
-        const result = {};
-        for (const [datetime, usage] of Object.entries(data)) {
-            const dt = deserializeDateTime(datetime);
-            const formattedDt = dt.toFormat("yyyy-MM-dd HH:mm:ss");
-            result[formattedDt] = usage;
-        }
-        return result;
+        return orderUsageUTCtoLocalUtil(data);
     }
     async syncPresetSlotAvaibility(preset) {
         try {

--- a/addons/point_of_sale/static/src/utils.js
+++ b/addons/point_of_sale/static/src/utils.js
@@ -1,5 +1,6 @@
 import { session } from "@web/session";
 import { getDataURLFromFile } from "@web/core/utils/urls";
+import { deserializeDateTime } from "@web/core/l10n/dates";
 /*
  * comes from o_spreadsheet.js
  * https://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript
@@ -179,4 +180,14 @@ export async function getImageDataUrl(imageUrl) {
     const res = await fetch(imageUrl);
     const blob = await res.blob();
     return await getDataURLFromFile(blob);
+}
+
+export function orderUsageUTCtoLocalUtil(data) {
+    const result = {};
+    for (const [datetime, usage] of Object.entries(data)) {
+        const dt = deserializeDateTime(datetime);
+        const formattedDt = dt.toFormat("yyyy-MM-dd HH:mm:ss");
+        result[formattedDt] = usage;
+    }
+    return result;
 }

--- a/addons/pos_self_order/static/src/app/components/preset_info_popup/preset_info_popup.xml
+++ b/addons/pos_self_order/static/src/app/components/preset_info_popup/preset_info_popup.xml
@@ -16,6 +16,7 @@
                         <option t-att-value="slot[0]" t-esc="formatDate(slot[0])" disabled="1" />
                         <option t-foreach="Object.values(slot[1])"
                             t-as="s" t-key="s_index"
+                            t-if="!s.isFull"
                             t-att-value="s.datetime.toFormat('yyyy-MM-dd HH:mm:ss')"
                             t-esc="s.datetime.toFormat('HH:mm')" />
                     </t>

--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -13,7 +13,12 @@ import { HWPrinter } from "@point_of_sale/app/utils/printer/hw_printer";
 import { renderToElement } from "@web/core/utils/render";
 import { TimeoutPopup } from "@pos_self_order/app/components/timeout_popup/timeout_popup";
 import { UnavailableProductsDialog } from "@pos_self_order/app/components/unavailable_product_dialog/unavailable_product_dialog";
-import { constructFullProductName, deduceUrl, random5Chars } from "@point_of_sale/utils";
+import {
+    constructFullProductName,
+    deduceUrl,
+    random5Chars,
+    orderUsageUTCtoLocalUtil,
+} from "@point_of_sale/utils";
 import { getOrderLineValues } from "./card_utils";
 import {
     getTaxesAfterFiscalPosition,
@@ -196,8 +201,8 @@ export class SelfOrder extends Reactive {
                 access_token: this.access_token,
                 preset_id: this.currentOrder?.preset_id?.id,
             });
-
-            preset.computeAvailabilities(presetAvailabilities);
+            const localUsage = orderUsageUTCtoLocalUtil(presetAvailabilities.usage_utc);
+            preset.computeAvailabilities(localUsage);
         } catch {
             console.info("Offline mode, cannot update the slot avaibility");
         }

--- a/addons/pos_self_order/static/tests/tours/self_order_preset_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_preset_tour.js
@@ -80,3 +80,25 @@ registry.category("web_tour.tours").add("self_order_preset_slot_tour", {
         Utils.clickBtn("Ok"),
     ],
 });
+
+registry.category("web_tour.tours").add("test_slot_limit_orders", {
+    steps: () => [
+        Utils.checkIsNoBtn("My Order"),
+        Utils.clickBtn("Order Now"),
+        LandingPage.selectLocation("Takeaway"),
+        ProductPage.clickProduct("Free"),
+        Utils.clickBtn("Checkout"),
+        Utils.clickBtn("Order"),
+        // Will always pick the first available: 00:00
+        CartPage.selectRandomValueInInput(".slot-select"),
+        CartPage.fillInput("Name", "Dr Dre"),
+        Utils.clickBtn("Continue"),
+        Utils.clickBtn("Ok"),
+        Utils.clickBtn("Order Now"),
+        LandingPage.selectLocation("Takeaway"),
+        ProductPage.clickProduct("Free"),
+        Utils.clickBtn("Checkout"),
+        Utils.clickBtn("Order"),
+        CartPage.checkSlotUnavailable("00:00"),
+    ],
+});

--- a/addons/pos_self_order/static/tests/tours/utils/cart_page_util.js
+++ b/addons/pos_self_order/static/tests/tours/utils/cart_page_util.js
@@ -137,3 +137,17 @@ export function cancelOrder() {
         },
     ];
 }
+
+export function checkSlotUnavailable(slotValue) {
+    return {
+        content: `Check that the first available slot is not ${slotValue}`,
+        trigger: ".slot-select",
+        run: () => {
+            const select = document.querySelector(".slot-select");
+            // select[0] and select[1] are header values
+            if (select[2].innerText === slotValue) {
+                throw new Error(`${slotValue} should not be available`);
+            }
+        },
+    };
+}

--- a/addons/pos_self_order/tests/test_self_order_preset.py
+++ b/addons/pos_self_order/tests/test_self_order_preset.py
@@ -79,3 +79,29 @@ class TestSelfOrderPreset(SelfOrderCommonTest):
         last_order = self.env["pos.order"].search([], limit=1, order="id desc")
         self.assertEqual(last_order.floating_order_name, 'Dr Dre')
         self.assertNotEqual(last_order.preset_time, False)
+
+    def test_slot_limit_orders(self):
+        """
+        Tests that when a slot reached it's limit capacity, it is not shown
+        in the selector anymore.
+        """
+        resource_calendar = self.env['resource.calendar'].create({
+            'name': 'Takeaway',
+            'attendance_ids': [(0, 0, {
+                'name': 'Takeaway',
+                'dayofweek': str(day),
+                'hour_from': 0,
+                'hour_to': 24,
+                'day_period': 'morning',
+            }) for day in range(0, 6)],
+        })
+        self.preset_takeaway.write({
+            'use_timing': True,
+            'resource_calendar_id': resource_calendar,
+            'slots_per_interval': 1,
+            'interval_time': 20,
+        })
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.pos_config.current_session_id.set_opening_control(0, "")
+        self_route = self.pos_config._get_self_order_route()
+        self.start_tour(self_route, "test_slot_limit_orders")


### PR DESCRIPTION
**Steps to reproduce:**
- Have a preset that requires time slots
- Make the slots_per_interval 1 and the interval_time long enough
- Go to the self order, make a purchase and select a slot
- Make another purchase
- The slot we chose before is still showing and available

**Why the fix:**
Once the capacity of a time slot has been reached, we should not allow customer to chose it.
This behavior occured for 2 reasons:
- In the xml file where we declare this select, we did not take the fact that a slot could be full into account, leading to it always being showed. This is now done using the isFull attribute, like it is done in the regular PoS.
- This same isFull was not correctly set, as there was a mismatch in slots timezone and format. When we retrieved them from the server, they were in UTC timezone, but the current slot we were working with was in the locale timezone. It is now converted to UTC to check if we already hit max capacity. Before this, selecting a timezone was actually selecting the one that was two hours earlier (for Belgium).

With this commit, the values that reached max capacity will not be displayed on the select for the time slots anymore.

opw-5092888