### PR TITLE
[IMP] base, web: Retrieve the last rate update of currency

### DIFF
--- a/addons/account/models/res_currency.py
+++ b/addons/account/models/res_currency.py
@@ -109,7 +109,7 @@ class ResCurrency(models.Model):
 
         last_date_to = None
         for period_key, date_from, date_to in date_periods:
-            main_company_unit_factor = main_company.currency_id._get_rates(main_company, date_to)[main_company.currency_id.id]
+            main_company_unit_factor, _ = main_company.currency_id._get_rates(main_company, date_to)[main_company.currency_id.id]
 
             if use_cta_rates:
                 table_builders += [

--- a/addons/sale/tests/test_sale_report.py
+++ b/addons/sale/tests/test_sale_report.py
@@ -61,11 +61,6 @@ class TestSaleReportCurrencyRate(SaleCommon):
 
         self.assertEqual(self.product.currency_id, usd)
 
-        # Needed to get conversion rates between companies.
-        currency_rates = (companies + self.env.company).mapped('currency_id')._get_rates(
-            self.env.company, today
-        )
-
         sale_orders = self.env['sale.order']
         expected_reported_amount = 0  # The total amount of all sale orders in the report.
         qty = 0  # to add variety to the data
@@ -111,9 +106,7 @@ class TestSaleReportCurrencyRate(SaleCommon):
 
                     # The amount in the report is converted first to the currency of the company and
                     # then to the currency of the current company (self.env.company).
-                    current_company_rate = currency_rates[self.env.company.currency_id.id]
-                    so_company_rate = currency_rates[company.currency_id.id]
-                    conversion_rate = (current_company_rate / so_company_rate)
+                    conversion_rate = company.currency_id.with_context(date=today).rate
                     expected_reported_amount += (
                         order.amount_total / order.currency_rate * conversion_rate
                     )

--- a/addons/web/static/src/core/currency.js
+++ b/addons/web/static/src/core/currency.js
@@ -1,4 +1,5 @@
 import { reactive } from "@odoo/owl";
+import { parseDate } from "@web/core/l10n/dates";
 import { rpc } from "@web/core/network/rpc";
 import { user } from "@web/core/user";
 import { formatFloat, humanNumber } from "@web/core/utils/numbers";
@@ -17,7 +18,15 @@ export async function getCurrencyRates() {
     const rates = reactive({});
 
     function recordsToRates(records) {
-        return Object.fromEntries(records.map((r) => [r.id, r.inverse_rate]));
+        return Object.fromEntries(
+            records.map((r) => [
+                r.id,
+                {
+                    rate: r.inverse_rate,
+                    date: parseDate(r.rate_date),
+                },
+            ])
+        );
     }
 
     const model = "res.currency";
@@ -30,7 +39,7 @@ export async function getCurrencyRates() {
     const params = {
         model,
         method,
-        args: [Object.keys(currencies).map(Number), ["inverse_rate"]],
+        args: [Object.keys(currencies).map(Number), ["inverse_rate", "rate_date"]],
         kwargs: { context },
     };
     const records = await rpc(url, params, {

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -739,7 +739,7 @@ export class ListRenderer extends Component {
                                             : values[i][currencyField][0];
                                 }
                                 if (currency !== currencyId) {
-                                    fieldValues[i] *= this.state.currencyRates[currency];
+                                    fieldValues[i] *= this.state.currencyRates[currency].rate;
                                 }
                             }
                         }

--- a/addons/web/static/src/views/view_components/multi_currency_popover.js
+++ b/addons/web/static/src/views/view_components/multi_currency_popover.js
@@ -1,5 +1,6 @@
 import { Component, onWillStart, useExternalListener, useState } from "@odoo/owl";
 import { getCurrency, getCurrencyRates } from "@web/core/currency";
+import { toLocaleDateString } from "@web/core/l10n/dates";
 import { user } from "@web/core/user";
 import { useService } from "@web/core/utils/hooks";
 import { formatMonetary } from "../fields/formatters";
@@ -33,8 +34,9 @@ export class MultiCurrencyPopover extends Component {
                 currencies.push({
                     ...getCurrency(currencyId),
                     id: currencyId,
-                    rate: this.state.rates[currencyId],
-                    value: this.props.value / this.state.rates[currencyId],
+                    rate: this.state.rates[currencyId].rate,
+                    date: toLocaleDateString(this.state.rates[currencyId].date),
+                    value: this.props.value / this.state.rates[currencyId].rate,
                 });
             }
             return currencies;

--- a/addons/web/static/src/views/view_components/multi_currency_popover.xml
+++ b/addons/web/static/src/views/view_components/multi_currency_popover.xml
@@ -6,7 +6,7 @@
             <div class="popover-body">
                 <t t-foreach="currencies" t-as="currency" t-key="currency.id">
                     <div>
-                        <t t-out="formatedValue(currency.value, currency.id)"/> at <t t-out="formatedValue(currency.rate, defaultCurrency)"/>
+                        <t t-out="formatedValue(currency.value, currency.id)"/> at <t t-out="formatedValue(currency.rate, defaultCurrency)"/> on <t t-out="currency.date"/>
                     </div>
                 </t>
             </div>

--- a/addons/web/static/tests/views/kanban/kanban_column_progressbar.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_column_progressbar.test.js
@@ -173,10 +173,25 @@ class Currency extends models.Model {
         ],
     });
     inverse_rate = fields.Float();
+    rate_date = fields.Date();
 
     _records = [
-        { id: 1, name: "USD", symbol: "$", position: "before", inverse_rate: 1 },
-        { id: 2, name: "EUR", symbol: "€", position: "after", inverse_rate: 0.5 },
+        {
+            id: 1,
+            name: "USD",
+            symbol: "$",
+            position: "before",
+            inverse_rate: 1,
+            rate_date: "2017-01-08",
+        },
+        {
+            id: 2,
+            name: "EUR",
+            symbol: "€",
+            position: "after",
+            inverse_rate: 0.5,
+            rate_date: "2019-06-13",
+        },
     ];
 }
 
@@ -1151,7 +1166,14 @@ test("progress bar recompute after filter selection (aggregates)", async () => {
 });
 
 test("progress bar with monetary aggregate and multi currencies", async () => {
-    const aed = { id: 3, name: "AED", symbol: "AED", position: "after", inverse_rate: 0.25 };
+    const aed = {
+        id: 3,
+        name: "AED",
+        symbol: "AED",
+        position: "after",
+        inverse_rate: 0.25,
+        rate_date: "2017-03-17",
+    };
     serverState.currencies = serverState.currencies.concat([aed]);
     Currency._records.push(aed);
     Partner._records.push({ id: 99, foo: "bar", salary: 300, currency_id: 3, product_id: 3 });
@@ -1178,7 +1200,9 @@ test("progress bar with monetary aggregate and multi currencies", async () => {
 
     await toggleMultiCurrencyPopover(".o_kanban_counter:first .o_animated_number sup");
     expect(".o_multi_currency_popover").toHaveCount(1);
-    expect(".o_multi_currency_popover").toHaveText("8,100.00 € at $ 0.50\n16,200.00 AED at $ 0.25");
+    expect(".o_multi_currency_popover").toHaveText(
+        "8,100.00 € at $ 0.50 on Jun 13\n16,200.00 AED at $ 0.25 on Mar 17, 2017"
+    );
 });
 
 test("progress bar with monetary aggregate and multi currencies: quick create record", async () => {

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -190,10 +190,25 @@ class Currency extends models.Model {
         ],
     });
     inverse_rate = fields.Float();
+    rate_date = fields.Date();
 
     _records = [
-        { id: 1, name: "USD", symbol: "$", position: "before", inverse_rate: 1 },
-        { id: 2, name: "EUR", symbol: "€", position: "after", inverse_rate: 0.5 },
+        {
+            id: 1,
+            name: "USD",
+            symbol: "$",
+            position: "before",
+            inverse_rate: 1,
+            rate_date: "2017-01-08",
+        },
+        {
+            id: 2,
+            name: "EUR",
+            symbol: "€",
+            position: "after",
+            inverse_rate: 0.5,
+            rate_date: "2019-06-13",
+        },
     ];
 }
 
@@ -4667,7 +4682,7 @@ test(`monetary aggregates in grouped list`, async () => {
     expect(`.o_list_footer .o_list_number span:first`).toHaveText("$ 1,400.00?");
     await toggleMultiCurrencyPopover(".o_list_footer .o_list_number span:first sup");
     expect(".o_multi_currency_popover").toHaveCount(1);
-    expect(".o_multi_currency_popover").toHaveText("2,800.00 € at $ 0.50");
+    expect(".o_multi_currency_popover").toHaveText("2,800.00 € at $ 0.50 on Jun 13");
 });
 
 test(`monetary aggregates in grouped list (!= currencies in same group)`, async () => {
@@ -4923,7 +4938,7 @@ test(`aggregates monetary (different currencies)`, async () => {
     expect(`tfoot`).toHaveText("$ 1,400.00?");
     await toggleMultiCurrencyPopover("tfoot span sup");
     expect(".o_multi_currency_popover").toHaveCount(1);
-    expect(".o_multi_currency_popover").toHaveText("2,800.00 € at $ 0.50");
+    expect(".o_multi_currency_popover").toHaveText("2,800.00 € at $ 0.50 on Jun 13");
 });
 
 test(`aggregates monetary (currency field not in view)`, async () => {

--- a/addons/web/static/tests/views/pivot_view.test.js
+++ b/addons/web/static/tests/views/pivot_view.test.js
@@ -183,10 +183,25 @@ class Currency extends models.Model {
         ],
     });
     inverse_rate = fields.Float();
+    rate_date = fields.Date();
 
     _records = [
-        { id: 1, name: "USD", symbol: "$", position: "before", inverse_rate: 1 },
-        { id: 2, name: "EUR", symbol: "€", position: "after", inverse_rate: 0.5 },
+        {
+            id: 1,
+            name: "USD",
+            symbol: "$",
+            position: "before",
+            inverse_rate: 1,
+            rate_date: "2017-01-08",
+        },
+        {
+            id: 2,
+            name: "EUR",
+            symbol: "€",
+            position: "after",
+            inverse_rate: 0.5,
+            rate_date: "2019-06-13",
+        },
     ];
 }
 
@@ -3984,7 +3999,7 @@ test("pivot view with monetary with multiple currencies", async () => {
     // multi currencies popover
     await toggleMultiCurrencyPopover(".o_pivot table tbody tr:first .o_value sup");
     expect(".o_multi_currency_popover").toHaveCount(1);
-    expect(".o_multi_currency_popover").toHaveText("2,800.00 € at $ 0.50");
+    expect(".o_multi_currency_popover").toHaveText("2,800.00 € at $ 0.50 on Jun 13");
 
     // test sorting
     await contains("th.o_pivot_measure_row").click();

--- a/odoo/addons/base/views/res_currency_views.xml
+++ b/odoo/addons/base/views/res_currency_views.xml
@@ -87,7 +87,7 @@
                     <field name="name"/>
                     <field name="symbol"/>
                     <field name="full_name" string="Name" optional="show"/>
-                    <field name="date" string="Last Update"/>
+                    <field name="rate_date"/>
                     <field name="rate" digits="[12,6]"/>
                     <field name="inverse_rate" digits="[12,6]" optional="hide"/>
                     <field name="active" widget="boolean_toggle"/>
@@ -117,7 +117,7 @@
                                 <div class="row">
                                     <div class="col-12">
                                         <div><field name="rate_string"/></div>
-                                        <t t-if="record.date.raw_value"><div>Last update: <field name="date"/></div></t>
+                                        <t t-if="record.rate_date.raw_value"><div>Last update: <field name="rate_date"/></div></t>
                                     </div>
                                 </div>
                         </t>

--- a/odoo/addons/test_read_group/tests/test_formatted_read_group.py
+++ b/odoo/addons/test_read_group/tests/test_formatted_read_group.py
@@ -2143,18 +2143,33 @@ class TestFormattedReadGroupMonetary(common.TransactionCase):
             FROM
                 "test_read_group_aggregate_monetary"
                 LEFT JOIN (
-                    SELECT DISTINCT ON ("res_currency_rate"."currency_id")
-                        "res_currency_rate"."currency_id",
-                        "res_currency_rate"."rate"
-                    FROM "res_currency_rate"
-                    WHERE "res_currency_rate"."company_id" IS NULL OR "res_currency_rate"."company_id" = %s
-                    ORDER BY
-                        "res_currency_rate"."currency_id",
-                        "res_currency_rate"."company_id",
-                        CASE WHEN "res_currency_rate"."name" <= %s THEN "res_currency_rate"."name" END DESC,
-                        CASE WHEN "res_currency_rate"."name" > %s THEN "res_currency_rate"."name" END ASC
+                    SELECT
+                        "res_currency"."id",
+                        COALESCE("before_rate"."rate", "after_rate"."rate", 1.0) AS "rate",
+                        COALESCE("before_rate"."name", "after_rate"."name") AS "name"
+                    FROM
+                        "res_currency"
+                        LEFT JOIN LATERAL (
+                            SELECT "res_currency_rate"."rate", "res_currency_rate"."name"
+                            FROM "res_currency_rate"
+                            WHERE (
+                                ("res_currency_rate"."company_id" IN %s OR "res_currency_rate"."company_id" IS NULL)
+                                AND "res_currency_rate"."name" <= %s
+                            ) AND "res_currency_rate"."currency_id" = "res_currency"."id"
+                            ORDER BY "res_currency_rate"."company_id", "res_currency_rate"."name" DESC
+                            LIMIT %s
+                        ) AS "before_rate" ON (TRUE)
+                        LEFT JOIN LATERAL (
+                            SELECT "res_currency_rate"."rate", "res_currency_rate"."name"
+                            FROM "res_currency_rate"
+                            WHERE (
+                                "res_currency_rate"."company_id" IN %s OR "res_currency_rate"."company_id" IS NULL
+                            ) AND "res_currency_rate"."currency_id" = "res_currency"."id"
+                            ORDER BY "res_currency_rate"."company_id", "res_currency_rate"."name" ASC
+                            LIMIT %s
+                        ) AS "after_rate" ON (TRUE)
                 ) AS "test_read_group_aggregate_monetary__currency_id__rates" ON (
-                    "test_read_group_aggregate_monetary"."currency_id" = "test_read_group_aggregate_monetary__currency_id__rates"."currency_id"
+                    "test_read_group_aggregate_monetary"."currency_id" = "test_read_group_aggregate_monetary__currency_id__rates"."id"
                 )
         """]):
             self.assertEqual(
@@ -2237,18 +2252,33 @@ class TestFormattedReadGroupMonetary(common.TransactionCase):
             FROM
                 "test_read_group_aggregate_monetary"
                 LEFT JOIN (
-                    SELECT DISTINCT ON ("res_currency_rate"."currency_id")
-                        "res_currency_rate"."currency_id",
-                        "res_currency_rate"."rate"
-                    FROM "res_currency_rate"
-                    WHERE "res_currency_rate"."company_id" IS NULL OR "res_currency_rate"."company_id" = %s
-                    ORDER BY
-                        "res_currency_rate"."currency_id",
-                        "res_currency_rate"."company_id",
-                        CASE WHEN "res_currency_rate"."name" <= %s THEN "res_currency_rate"."name" END DESC,
-                        CASE WHEN "res_currency_rate"."name" > %s THEN "res_currency_rate"."name" END ASC
+                    SELECT
+                        "res_currency"."id",
+                        COALESCE("before_rate"."rate", "after_rate"."rate", 1.0) AS "rate",
+                        COALESCE("before_rate"."name", "after_rate"."name") AS "name"
+                    FROM
+                        "res_currency"
+                        LEFT JOIN LATERAL (
+                            SELECT "res_currency_rate"."rate", "res_currency_rate"."name"
+                            FROM "res_currency_rate"
+                            WHERE (
+                                ("res_currency_rate"."company_id" IN %s OR "res_currency_rate"."company_id" IS NULL)
+                                AND "res_currency_rate"."name" <= %s
+                            ) AND "res_currency_rate"."currency_id" = "res_currency"."id"
+                            ORDER BY "res_currency_rate"."company_id", "res_currency_rate"."name" DESC
+                            LIMIT %s
+                        ) AS "before_rate" ON (TRUE)
+                        LEFT JOIN LATERAL (
+                            SELECT "res_currency_rate"."rate", "res_currency_rate"."name"
+                            FROM "res_currency_rate"
+                            WHERE (
+                                "res_currency_rate"."company_id" IN %s OR "res_currency_rate"."company_id" IS NULL
+                            ) AND "res_currency_rate"."currency_id" = "res_currency"."id"
+                            ORDER BY "res_currency_rate"."company_id", "res_currency_rate"."name" ASC
+                            LIMIT %s
+                        ) AS "after_rate" ON (TRUE)
                 ) AS "test_read_group_aggregate_monetary__currency_id__rates" ON (
-                    "test_read_group_aggregate_monetary"."currency_id" = "test_read_group_aggregate_monetary__currency_id__rates"."currency_id"
+                    "test_read_group_aggregate_monetary"."currency_id" = "test_read_group_aggregate_monetary__currency_id__rates"."id"
                 )
         """]):
             self.assertEqual(

--- a/odoo/orm/query.py
+++ b/odoo/orm/query.py
@@ -20,6 +20,7 @@ def _sql_from_table(alias: str, table: SQL) -> SQL:
 _SQL_JOINS = {
     "JOIN": SQL("JOIN"),
     "LEFT JOIN": SQL("LEFT JOIN"),
+    "LEFT JOIN LATERAL": SQL("LEFT JOIN LATERAL"),
 }
 
 


### PR DESCRIPTION
The multi-currency popover now displays the last updated date alongside the rates.

To compute this rate date, we've modified `_compute_current_rate` and `_get_rates` to calculate this information at the same time as the current rate.

We also took the opportunity to refactor `_get_rates` and use the exact same query to generate the SQL for the `sum_currency` aggregator. Furthermore, extra focus has been placed on the performance of this query (or subquery in the case of sum_currency): 
- We modified the `_unique_name_per_day` index by changing the order of fields, as we want this index to be used for the ordering of the second `LEFT LATERAL JOIN`. Also, this unique index now becomes `NULLS NOT DISTINCT` (which makes more sense and are available in PG16).
- We also created the same unique index but with the order of `name` reversed at the end for the first `LEFT LATERAL JOIN`. Both these changes make the `_get_rates` query much faster than before and allow us to retrieve the rate date as well.

Performance improvements
------------------------
With a database containing 8 active currencies, 2 companies, and 10 years of daily currency rates (including no-company rates): 
Before: 
- The old query of `_get_rates` (all currencies): +- 16 ms 
- The old subquery done for the `sum_currency` aggregator: +- 20 ms 
Now, for both cases: less than 1 ms. Also tested with other data distributions (more companies/currencies); results were similar and drastically in favor of the new indexes.

Note that pushing the order of 'name' to the end of the index shouldn't impact other queries using `res_currency_rate` because 'name' is already indexed alone and all queries on `res_currency_rate` use these 3 fields anyway.

task-5109447

https://github.com/odoo/enterprise/pull/96738
https://github.com/odoo/upgrade/pull/8593
