### PR TITLE
[IMP] mail: hide signature/reply images

### DIFF
--- a/addons/im_livechat/static/tests/embed/livechat_service.test.js
+++ b/addons/im_livechat/static/tests/embed/livechat_service.test.js
@@ -133,7 +133,11 @@ test("Only necessary requests are made when creating a new chat", async () => {
                     },
                     thread_id: threadId,
                     thread_model: "discuss.channel",
-                    context: { ...userContext(), temporary_id: 0.8200000000000001 },
+                    context: {
+                        ...userContext(),
+                        hide_quote_attachments: true,
+                        temporary_id: 0.8200000000000001,
+                    },
                 })}`,
             ],
         }

--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -115,6 +115,7 @@ For more specific needs, you may also assign custom-defined actions
         'views/res_users_settings_views.xml',
         'views/mail_template_views.xml',
         'views/ir_actions_server_views.xml',
+        'views/ir_attachment_views.xml',
         'views/ir_model_views.xml',
         'views/res_partner_views.xml',
         'views/mail_blacklist_views.xml',

--- a/addons/mail/controllers/thread.py
+++ b/addons/mail/controllers/thread.py
@@ -59,8 +59,10 @@ class ThreadController(http.Controller):
     # ------------------------------------------------------------
 
     @http.route("/mail/thread/messages", methods=["POST"], type="jsonrpc", auth="user")
-    def mail_thread_messages(self, thread_model, thread_id, fetch_params=None):
+    def mail_thread_messages(self, thread_model, thread_id, fetch_params=None, context=None):
         thread = self._get_thread_with_access(thread_model, thread_id, mode="read")
+        if context:
+            request.update_context(**context)
         res = request.env["mail.message"]._message_fetch(domain=None, thread=thread, **(fetch_params or {}))
         messages = res.pop("messages")
         if not request.env.user._is_public():

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -353,6 +353,7 @@ export class Store extends BaseStore {
     _fetchStoreDataRpc(fetchParams) {
         const context = {
             ...user.context,
+            hide_quote_attachments: true,
             allowed_company_ids: user.allowedCompanies.map((c) => c.id),
         };
         return rpc(

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -381,7 +381,11 @@ export class Thread extends Record {
     }
 
     get rpcParams() {
-        return {};
+        return {
+            context: {
+                hide_quote_attachments: true,
+            },
+        };
     }
 
     async checkReadAccess() {

--- a/addons/mail/static/tests/chatter/web/chatter.test.js
+++ b/addons/mail/static/tests/chatter/web/chatter.test.js
@@ -56,7 +56,7 @@ test("simple chatter on a record", async () => {
             [
                 "mail.thread",
                 {
-                    access_params: {},
+                    access_params: { context: { hide_quote_attachments: true } },
                     request_list: [
                         "activities",
                         "attachments",
@@ -73,7 +73,7 @@ test("simple chatter on a record", async () => {
         {
             ignoreOrder: true,
             stepsAfter: [
-                `/mail/thread/messages - {"thread_id":${partnerId},"thread_model":"res.partner","fetch_params":{"limit":30}}`,
+                `/mail/thread/messages - {"thread_id":${partnerId},"thread_model":"res.partner","context":{"hide_quote_attachments":true},"fetch_params":{"limit":30}}`,
             ],
         }
     );

--- a/addons/mail/views/ir_attachment_views.xml
+++ b/addons/mail/views/ir_attachment_views.xml
@@ -1,0 +1,14 @@
+<odoo>
+    <data>
+        <record id="ir_attachment_view_search_inherit_mail" model="ir.ui.view">
+            <field name="name">ir.attachment.search.inherit.mail</field>
+            <field name="model">ir.attachment</field>
+            <field name="inherit_id" ref="base.view_attachment_search"/>
+            <field name="arch" type="xml">
+                <xpath expr="//filter[@name='binary_filter']" position="after">
+                    <filter name="quote_attachments" string="Quote Attachments" domain="[('quote_attachment', '=', True)]"/>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/addons/test_mail/data/test_mail_data.py
+++ b/addons/test_mail/data/test_mail_data.py
@@ -680,6 +680,102 @@ AAAAACwAAAAAAgACAAAEA3DJFQA7
 --001a11416b9e9b229a05272b7052--
 """
 
+MAIL_MULTIPART_IMAGE_WITH_SIGNATURE = """X-Original-To: raoul@example.com
+Delivered-To: micheline@example.com
+Received: by mail1.example.com (Postfix, from userid 99999)
+    id 9DFB7BF509; Thu, 17 Dec 2015 15:22:56 +0100 (CET)
+X-Spam-Checker-Version: SpamAssassin 3.4.0 (2014-02-07) on mail1.example.com
+X-Spam-Level: *
+X-Spam-Status: No, score=1.1 required=5.0 tests=FREEMAIL_FROM,
+    HTML_IMAGE_ONLY_08,HTML_MESSAGE,RCVD_IN_DNSWL_LOW,RCVD_IN_MSPIKE_H3,
+    RCVD_IN_MSPIKE_WL,T_DKIM_INVALID autolearn=no autolearn_force=no version=3.4.0
+Received: from mail-lf0-f44.example.com (mail-lf0-f44.example.com [209.85.215.44])
+    by mail1.example.com (Postfix) with ESMTPS id 1D80DBF509
+    for <micheline@example.com>; Thu, 17 Dec 2015 15:22:56 +0100 (CET)
+Authentication-Results: mail1.example.com; dkim=pass
+    reason="2048-bit key; unprotected key"
+    header.d=example.com header.i=@example.com header.b=kUkTIIlt;
+    dkim-adsp=pass; dkim-atps=neutral
+Received: by mail-lf0-f44.example.com with SMTP id z124so47959461lfa.3
+        for <micheline@example.com>; Thu, 17 Dec 2015 06:22:56 -0800 (PST)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=example.com; s=20120113;
+        h=mime-version:date:message-id:subject:from:to:content-type;
+        bh=GdrEuMrz6vxo/Z/F+mJVho/1wSe6hbxLx2SsP8tihzw=;
+        b=kUkTIIlt6fe4dftKHPNBkdHU2rO052o684R0e2bqH7roGUQFb78scYE+kqX0wo1zlk
+         zhKPVBR1TqTsYlqcHu+D3aUzai7L/Q5m40sSGn7uYGkZJ6m1TwrWNqVIgTZibarqvy94
+         NWhrjjK9gqd8segQdSjCgTipNSZME4bJCzPyBg/D5mqe07FPBJBGoF9SmIzEBhYeqLj1
+         GrXjb/D8J11aOyzmVvyt+bT+oeLUJI8E7qO5g2eQkMncyu+TyIXaRofOOBA14NhQ+0nS
+         w5O9rzzqkKuJEG4U2TJ2Vi2nl2tHJW2QPfTtFgcCzGxQ0+5n88OVlbGTLnhEIJ/SYpem
+         O5EA==
+MIME-Version: 1.0
+X-Received: by 10.25.167.197 with SMTP id q188mr22222517lfe.129.1450362175493;
+ Thu, 17 Dec 2015 06:22:55 -0800 (PST)
+Received: by 10.25.209.145 with HTTP; Thu, 17 Dec 2015 06:22:55 -0800 (PST)
+Date: Thu, 17 Dec 2015 15:22:55 +0100
+Message-ID: <CAP76m_UB=aLqWEFccnq86AhkpwRB3aZoGL9vMffX7co3YEro_A@mail.gmail.com>
+Subject: {subject}
+From: =?UTF-8?Q?Thibault_Delavall=C3=A9e?= <raoul@example.com>
+To: {to}
+Content-Type: multipart/related; boundary=001a11416b9e9b229a05272b7052
+
+--001a11416b9e9b229a05272b7052
+Content-Type: multipart/alternative; boundary=001a11416b9e9b229805272b7051
+
+--001a11416b9e9b229805272b7051
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+
+<div dir=3D"ltr">
+<div>Seconde image, rosa=C3=A7=C3=A9e.</div>
+<div><img src=3D"cid:ii_2_expected" alt=3D"Inline image 2" width=3D"2" height=3D"2"></div>
+<div><br></div>
+<div>J&#39;espere que tout se passera bien.</div>
+-- <br>
+<div class=3D"gmail_signature">
+Thibault Delavallee
+<div><br></div>
+<div>Seconde image, rosa=C3=A7=C3=A9e.</div>
+<div><img src=3D"cid:ii_2_expected" alt=3D"Inline image 2" width=3D"2" height=3D"2"></div>
+<div><br></div>
+<div>Troisieme image, verte!=C2=B5</div>
+<div><img src=3D"cid:ii_3_not_expected" alt=3D"Inline image 3" width=3D"10" height=3D"10"><br></div>
+<div><br></div>
+</div>
+
+</div>
+
+--001a11416b9e9b229805272b7051--
+--001a11416b9e9b229a05272b7052
+Content-Type: image/gif; name="=?UTF-8?B?ZW1iZWRkZWQtYXR0YWNobWVudC0xLWJvZHlBbmRTaWduYXR1cmU==?="
+Content-Disposition: inline; filename="=?UTF-8?B?ZW1iZWRkZWQtYXR0YWNobWVudC0xLWJvZHlBbmRTaWduYXR1cmU==?="
+Content-Transfer-Encoding: base64
+Content-ID: <ii_1_expected>
+X-Attachment-Id: ii_1_expected
+
+R0lGODdhAgACALMAAAAAAP///wAAAP//AP8AAP+AAAD/AAAAAAAA//8A/wAAAAAAAAAAAAAAAAAA
+AAAAACwAAAAAAgACAAAEA7DIEgA7
+--001a11416b9e9b229a05272b7052
+Content-Type: image/gif; name="=?UTF-8?B?ZW1iZWRkZWQtYXR0YWNobWVudC0zLXNpZ25hdHVyZQ==?="
+Content-Disposition: inline; filename="=?UTF-8?B?ZW1iZWRkZWQtYXR0YWNobWVudC0zLXNpZ25hdHVyZQ==?="
+Content-Transfer-Encoding: base64
+Content-ID: <ii_3_not_expected>
+X-Attachment-Id: ii_3_not_expected
+
+R0lGODlhCgAKALMAAAAAAIAAAACAAICAAAAAgIAAgACAgMDAwICAgP8AAAD/AP//AAAA//8A/wD/
+/////ywAAAAACgAKAAAEClDJSau9OOvNe44AOw==
+--001a11416b9e9b229a05272b7052
+Content-Type: image/gif; name="=?UTF-8?B?ZW1iZWRkZWQtYXR0YWNobWVudC0yLWF0dGFjaGVk==?="
+Content-Disposition: inline; filename="=?UTF-8?B?ZW1iZWRkZWQtYXR0YWNobWVudC0yLWF0dGFjaGVk==?="
+Content-Transfer-Encoding: base64
+Content-ID: <ii_2_expected>
+X-Attachment-Id: ii_2_expected
+
+R0lGODdhAgACALMAAAAAAP///wAAAP//AP8AAP+AAAD/AAAAAAAA//8A/wAAAP+AgAAAAAAAAAAA
+AAAAACwAAAAAAgACAAAEA3DJFQA7
+--001a11416b9e9b229a05272b7052--
+"""
+
 MAIL_EML_ATTACHMENT = """Subject: {subject}
 From: {email_from}
 To: {to}


### PR DESCRIPTION
Emails are often sent with a signature. Sometimes, that signature has
an embedded image inside it.
Email threads may also have embedded images getting
passed around from email to email, from reply to reply.
As each image is effectively a separate attachment, it is always
displayed for every message reply that has it. Additionally,
these attachments show up in image and aggregate searches, causing a
significant amount of clutter.

Fix:
When attachment images are referenced only in quoted sections of emails,
they are marked as "quote attachments" before being saved to DB.

This way, they are only visible when users click on "read more" icons
in messages with quotes, but not in aggregates and searches unless
specifically called upon.

task-4707320