### PR TITLE
[FIX] event: ignore exclusion list when sending event registration mails

### DIFF
--- a/addons/event/models/event_mail_registration.py
+++ b/addons/event/models/event_mail_registration.py
@@ -40,7 +40,9 @@ class EventMailRegistration(models.Model):
             lambda r: r.scheduler_id.notification_type == "mail"
         )
         for scheduler, reg_mails in todo.grouped('scheduler_id').items():
-            scheduler._send_mail(reg_mails.registration_id)
+            # exclusion_list should not be applied as registering to an event is implicitly
+            # subscribing to the emails relevant to the event such as the email containing the ticket
+            scheduler.with_context(default_use_exclusion_list=False)._send_mail(reg_mails.registration_id)
         todo.mail_sent = True
         return todo
 


### PR DESCRIPTION
**Steps to reproduce:**
- Install Events & Contacts apps
- Open Contacts
- Create a contact "BLACKLIST", email: `blacklist@example.com`
- Create a contact "GOOD", email: `good@example.com`
- Open Settings > Technical > Discuss > Email Blacklist
- Create a record with email: `blacklist@example.com`
- Open Events
- Create an event
- Go to the event attendees
- Create attendees for both contacts
- Open Settings > Technical > Email > Emails
- Both email are listed but the blacklisted one is cancelled

**Issue:**
The composer created in `EventMailScheduler._send_mail` is using `_process_mail_values_state` to find the list of blacklisted records and applies it to filter the mail recipients, which prevents the event mailing from being processed correctly.

**Fix:**
`use_exclusion_list` is set to `false` on the composer to bypass its exclusion process.

opw-5046491
