### PR TITLE
[FIX] mass_mailing: retry failed emails in batches

### DIFF
--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -664,12 +664,20 @@ class MassMailing(models.Model):
         self.write({'state': 'draft', 'schedule_date': False, 'schedule_type': 'now', 'next_departure': False})
 
     def action_retry_failed(self):
-        failed_mails = self.env['mail.mail'].sudo().search([
+        """ Remove all failed emails and their traces, and try sending them again."""
+        # Use batching to prevent cache overfill in unlink()
+        batch_size = 1000
+        failed_emails = self.env['mail.mail'].sudo().with_context(prefetch_fields=False).search([
             ('mailing_id', 'in', self.ids),
             ('state', '=', 'exception')
-        ])
-        failed_mails.mapped('mailing_trace_ids').unlink()
-        failed_mails.unlink()
+        ], limit=batch_size)
+        while failed_emails:
+            failed_emails.mapped('mailing_trace_ids').unlink()
+            failed_emails.unlink()
+            failed_emails = failed_emails.search([
+                ('mailing_id', 'in', self.ids),
+                ('state', '=', 'exception')
+            ], limit=batch_size)
         self.action_put_in_queue()
 
     def action_view_traces_scheduled(self):


### PR DESCRIPTION
Steps to reproduce the issue:
1. Have 100s of thousands of recipients on a campaign
2. Disconnect your outgoing server and send
3. Reconnect the mailing server and retry sending.

Current behavior before PR:
A `MemoryError` is raised due to the large number of emails processed to `unlink()`

Desired behavior after PR is merged:
 Larger-scale clients would be able to resend 100s of thousands of
emails if they fail

opw-5091567
