### PR TITLE
[FIX] im_livechat: message translation for agent when not member

### DIFF
--- a/addons/im_livechat/static/src/core/common/message_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/message_model_patch.js
@@ -14,7 +14,7 @@ const messagePatch = {
             super.isTranslatable(thread) ||
             (this.store.hasMessageTranslationFeature &&
                 thread?.channel_type === "livechat" &&
-                thread?.selfMember?.persona?.isInternalUser)
+                this.store.self?.isInternalUser)
         );
     },
 };

--- a/addons/im_livechat/static/tests/translation.test.js
+++ b/addons/im_livechat/static/tests/translation.test.js
@@ -6,14 +6,35 @@ import { defineLivechatModels } from "./livechat_test_helpers";
 describe.current.tags("desktop");
 defineLivechatModels();
 
-test("message translation in livechat", async () => {
+test("message translation in livechat (agent is member)", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({
         anonymous_name: "Visitor",
         channel_type: "livechat",
         channel_member_ids: [
             Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ partner_id: serverState.publicPartnerId }),
+            Command.create({ guest_id: pyEnv["mail.guest"].create({ name: "Mario" }) }),
+        ],
+    });
+    pyEnv["mail.message"].create({
+        body: "Mai mettere l'ananas sulla pizza!",
+        model: "discuss.channel",
+        res_id: channelId,
+    });
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Message");
+    await click("[title='Expand']");
+    await contains("[title='Translate']");
+});
+
+test("message translation in livechat (agent is not member)", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        anonymous_name: "Visitor",
+        channel_type: "livechat",
+        channel_member_ids: [
+            Command.create({ guest_id: pyEnv["mail.guest"].create({ name: "Mario" }) }),
         ],
     });
     pyEnv["mail.message"].create({


### PR DESCRIPTION
Before this commit, when an agent that is not member of livechat but is peeking the conversation, the agent could not translate the message.

This happens because the translation feature is limited to internal users, but this was determined based on the self member relational field. This works when the agent is a member but when not a member this was arbitrarily disabling the feature.

This commit fixes the issue by looking at whether the user is internal or not, based on self persona independently on whether the agent is member or not of the conversation.

Task-5111383