### PR TITLE
[IMP] mail, *: allow users to post to readonly chatter

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -72,6 +72,7 @@ class CalendarEvent(models.Model):
     _description = "Calendar Event"
     _order = "start desc"
     _inherit = ["mail.thread"]
+    _mail_post_access = 'read'
     _systray_view = 'calendar'
 
     DISCUSS_ROUTE = 'calendar/join_videocall'

--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -15,6 +15,7 @@ class ResPartner(models.Model):
     _name = 'res.partner'
     _inherit = ['res.partner', 'mail.activity.mixin', 'mail.thread.blacklist']
     _mail_flat_thread = False
+    _mail_post_access = 'read'
 
     # override to add and order tracking
     name = fields.Char(tracking=1)

--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -24,6 +24,7 @@ class PurchaseOrder(models.Model):
     _description = "Purchase Order"
     _rec_names_search = ['name', 'partner_ref']
     _order = 'priority desc, id desc'
+    _mail_post_access = 'read'
 
     @api.depends('order_line.price_subtotal', 'company_id', 'currency_id')
     def _amount_all(self):

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -37,6 +37,7 @@ class SaleOrder(models.Model):
     _description = "Sales Order"
     _order = 'date_order desc, id desc'
     _check_company_auto = True
+    _mail_post_access = 'read'
 
     _date_order_conditional_required = models.Constraint(
         "CHECK((state = 'sale' AND date_order IS NOT NULL) OR state != 'sale')",

--- a/addons/sales_team/models/crm_team.py
+++ b/addons/sales_team/models/crm_team.py
@@ -10,6 +10,7 @@ class CrmTeam(models.Model):
     _description = "Sales Team"
     _order = "sequence ASC, create_date DESC, id DESC"
     _check_company_auto = True
+    _mail_post_access = 'read'
 
     def _get_default_color(self):
         return random.randint(1, 11)


### PR DESCRIPTION
also modified: calendar, purchase, sale, sales_team

This commit allows users to post on a record's chatter
even if they only have read access to that record,
for the following models:

- CalendarEvent
- ResPartner (contacts)
- PurchaseOrder
- SaleOrder
- CrmTeam (sales teams)

task-3969547
