### PR TITLE
[FIX] stock_account: revaluate fifo product correct cost

### DIFF
--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -1959,6 +1959,23 @@ class TestStockValuation(TestStockValuationBase):
         self._make_in_move(product, 1, unit_cost=77)
         self.assertEqual(product.standard_price, 77)
 
+    def test_fifo_manual_revaluation_after_manual_standard_price(self):
+        self.product1.categ_id.property_cost_method = 'fifo'
+        self._make_in_move(self.product1, 1, unit_cost=200)
+        self._make_in_move(self.product1, 1, unit_cost=300)
+        self.assertEqual(self.product1.standard_price, 250)
+
+        self.product1.standard_price = 300
+
+        Form(self.env['stock.valuation.layer.revaluation'].with_context({
+            'default_product_id': self.product1.id,
+            'default_company_id': self.env.company.id,
+            'default_account_id': self.stock_valuation_account,
+            'default_added_value': 200.0,
+        })).save().action_validate_revaluation()
+
+        self.assertEqual(self.product1.standard_price, 350)
+
     def test_create_done_move(self):
         """Stock Move created directly in Done state must impact de valuation."""
         self.product1.categ_id.property_cost_method = 'average'


### PR DESCRIPTION
**Steps to reproduce:**
- create a storable product with fifo category
- update the cost to 200
- click on the on hand smart button and add a quant of 1 quantity
- update the cost to 300
- click on the on hand smart button and update the quantity to 2
- the value should be 500, which makes a 250 value per product
- open Inventory/valuation and search your product
- group by product, select your product and click on "+" icon to open 
the revaluation widget
- add 200 (so +100 per unit)
- go back to the product form

**Current behavior:**
the cost is now at 400

**Expected behavior:**
the cost should be at 350 (250 + 100)
If we change the standard_price we should change it in accordance 
with the valuation

**Cause of the issue:**
In action_validate_revaluation, during the update of the standard_price, 
the current standard_price (set by the user and disconnected from the
valuation) is used in the computation.
https://github.com/odoo/odoo/blob/5118f7cb80744f901d7028dc75c29aba9591b83b/addons/stock_account/wizard/stock_valuation_layer_revaluation.py#L127

opw-5028848