### PR TITLE
[FIX] stock_account: lot cost calc not correct

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -299,7 +299,12 @@ class ProductProduct(models.Model):
                 avco_value = avco_total_value / quantity if quantity else 0
             if move.is_out or move.is_dropship:
                 out_qty = move._get_valued_qty()
-                avco_total_value -= out_qty * avco_value
+                out_value = out_qty * avco_value
+                if lot:
+                    lot_qty = move._get_valued_qty(lot)
+                    out_value = out_value * lot_qty / out_qty
+                    out_qty = lot_qty
+                avco_total_value -= out_value
                 quantity -= out_qty
 
         return avco_value, avco_total_value


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

If "out" moves have more than one lot (i.e. two move lines for one move), then the lot cost calculations go way askew.


Current behavior before PR:

Lot cost calculations work by taking a subset of a stock move value, up to the quantity of just that lot.

When recalcing lot cost, for "in moves" the value correctly uses a "portion" of the cost from the move.

But for "out moves", it does not - assuming the FULL move is for a single lot.  If multiple lots or serial numbers are on a single move, then it should apportion that too.



Desired behavior after PR is merged:

The out moves check the move lines for those for the specific lot, and only include a portion of the out in the calculation.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
