### PR TITLE
[FIX] l10n_es_edi_tbai_pos: retry previous chain head

### DIFF
--- a/addons/l10n_es_edi_tbai_pos/models/pos_order.py
+++ b/addons/l10n_es_edi_tbai_pos/models/pos_order.py
@@ -84,7 +84,17 @@ class PosOrder(models.Model):
         res = super().action_pos_order_paid()
 
         if self.l10n_es_tbai_is_required and not self.to_invoice:
-            self._l10n_es_tbai_post()
+            error = self._l10n_es_tbai_post()
+
+            if error:
+                chain_head_doc = self.company_id._get_l10n_es_tbai_last_chained_document()
+                chain_head_order = self.search([('l10n_es_tbai_post_document_id', '=', chain_head_doc.id)])
+
+                if chain_head_doc and chain_head_order and chain_head_order != self and chain_head_doc.state != 'accepted':
+                    chain_head_order._l10n_es_tbai_post()
+                    if self.env['account.move.send']._can_commit():
+                        self.env.cr.commit()
+                    self._l10n_es_tbai_post()
 
         return res
 


### PR DESCRIPTION
Currently, the post failure of a single pos order can easily cause a backlog of more unposted orders since new orders will not be posted until the chain head is posted.

Steps to reproduce
-----
1. Validate a pos order and have the TicketBAI post fail
2. Validate another pos order
3. The post for the second order is never attempted

Cause
-----
`_check_can_post()` ensures that new orders are not posted if the chain head was not posted successfully. During normal operation, it is common for many new orders to be paid before the user has a chance to manually retry the chain head post in the backend, causing a backlog of unposted orders.

Solution
-----
During `action_pos_order_paid()` retry the chain head post if is not sent.

opw-4669823