### PR TITLE
[IMP] point_of_sale: extract cancel logic into a dedicated method

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/closing_popup/closing_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/closing_popup/closing_popup.js
@@ -305,9 +305,7 @@ export class ClosePosPopup extends Component {
             },
             cancel: async () => {
                 if (!response.redirect) {
-                    const ordersDraft = this.pos.models["pos.order"].filter((o) => !o.finalized);
-                    await this.pos.deleteOrders(ordersDraft, response.open_order_ids);
-                    this.closeSession();
+                    await this.cancelOrders(response);
                 }
             },
             dismiss: async () => {},
@@ -316,6 +314,11 @@ export class ClosePosPopup extends Component {
         if (response.redirect) {
             this.pos.router.close();
         }
+    }
+    async cancelOrders(response) {
+        const ordersDraft = this.pos.models["pos.order"].filter((o) => !o.finalized);
+        await this.pos.deleteOrders(ordersDraft, response.open_order_ids);
+        this.closeSession();
     }
     getMovesTotalAmount() {
         const amounts = this.props.default_cash_details.moves.map((move) => move.amount);


### PR DESCRIPTION
In this commit:
===============
- Extract the order cancellation logic during session closing into a new
  method `cancelOrders`.
- This makes it possible to override the method in other modules if needed.

Task: 4966693
Related Enterprise PR: https://github.com/odoo/enterprise/pull/95074