### PR TITLE
[IMP] iot_box_image: redirect DB selector to 502 page

### DIFF
--- a/addons/iot_box_image/overwrite_after_init/etc/nginx/conf.d/iot.conf
+++ b/addons/iot_box_image/overwrite_after_init/etc/nginx/conf.d/iot.conf
@@ -18,6 +18,13 @@ server {
         proxy_pass http://127.0.0.1:8069;
     }
 
+    # If the iot_drivers module fails to start, the user will be sent to the
+    # database selector. Instead of this we will show them the 502 error page
+    # (IoT box is down) as it is more appropriate.
+    location /web/database/selector {
+        return 301 /502.html;
+    }
+
     error_page 502 /502.html;
     location /502.html {
         root /var/www/html;


### PR DESCRIPTION
Before this commit, if the IoT box enters a state where Odoo can start but the `iot_drivers` module fails to load, the user would be redirected to the database selector instead of the IoT homepage.

This commit adds an nginx redirect to instead send the user to the 502 error page, stating that the IoT box is down and with links to see the log files. This page is more representative of the situation and more helpful for the user.

task-5111009

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
