### PR TITLE
[FIX] google_calendar: add context key to all reset writes

### DIFF
--- a/addons/google_calendar/wizard/reset_account.py
+++ b/addons/google_calendar/wizard/reset_account.py
@@ -59,7 +59,7 @@ class ResetGoogleAccount(models.TransientModel):
 
         # Write the next sync update attribute on the existing events.
         if self.delete_policy not in ('delete_odoo', 'delete_both'):
-            events.write(next_sync_update)
+            events.with_context(skip_event_permission=True).write(next_sync_update)
 
         self.user_id.res_users_settings_id._set_google_auth_tokens(False, False, 0)
         self.user_id.write({


### PR DESCRIPTION
This commit adds the last context key "skip_event_permission" to the remaining writes done to `calendar.event` records at the reset of google_calendar account, created at odoo/odoo#227991. By adding it, we'll no longer face any possibility of triggering a ValidationError during account resets of google_calendar.

task-5103918