### PR TITLE
[16.0][FIX] account: fix Due Date is not calculated correctly

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -991,7 +991,7 @@ class AccountMove(models.Model):
 
             invoice.payment_state = new_pmt_state
 
-    @api.depends('invoice_payment_term_id', 'invoice_date', 'currency_id', 'amount_total_in_currency_signed', 'invoice_date_due')
+    @api.depends('invoice_payment_term_id', 'invoice_date', 'currency_id', 'amount_total_in_currency_signed', 'invoice_date_due', 'invoice_line_ids')
     def _compute_needed_terms(self):
         for invoice in self:
             is_draft = invoice.id != invoice._origin.id


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The due date of invoice is always today.
I have confirmed that the issue exists in versions 16.0, 17.0, and 18.0.

Steps to reproduce:

- Create an invoice by entering the invoice date, setting the payment terms, and adding the invoice lines.
- Save the invoice.

Current behavior before PR:
The due date of invoice is always today.

Desired behavior after PR is merged:
The due date of invoice will be calculated correctly depends on it's payment term.


https://github.com/user-attachments/assets/c175d0c0-e1c7-4d4e-bc0e-775ef6582a73

@qrtl QT5606
