### PR TITLE
[FIX] account: different record name on sending invoice

### DIFF
--- a/addons/account/wizard/account_move_send.py
+++ b/addons/account/wizard/account_move_send.py
@@ -481,6 +481,7 @@ class AccountMoveSend(models.TransientModel):
 
         new_message = move\
             .with_context(
+                active_test=False,
                 no_document=True,
                 no_new_invoice=True,
                 mail_notify_author=author_id in partner_ids,


### PR DESCRIPTION
Steps to Reproduce:
-------------------------
1. Create a user (e.g., Test 1) with an email
2. Create an invoice with Test 1 as the salesperson and confirm it
3. Click Send and send the mail.
4. Archive the Test 1 user
5. Go to Customers and copy any customer’s email
6. Update the email on Test 1’s partner record
7. Go to the same previously created invoice and repeat step 3

Observation:
-------------------------
In the chatter, the displayed sender name and image change. They no longer correspond to Test 1’s partner, even though the salesperson is still the same.

Issue:
-------------------------
In the following code:
https://github.com/odoo/odoo/blob/3a1ec3bad5d4884952e09ed4eaabccf10cebbddf/addons/account/models/account_move_send.py#L451-L467

the `active_test` context is missing. Because of this, the partner search method in ORM skips archived users
https://github.com/odoo/odoo/blob/3a1ec3bad5d4884952e09ed4eaabccf10cebbddf/addons/mail/models/mail_thread.py#L1942-L1951

Solution:
-------------------------
Set `active_test=False` in the context so that archived user's partner records are also considered when determining the sender.

opw-5067129
