### PR TITLE
[FIX] website_sale_collect: fix stock check when multiple order lines

### DIFF
--- a/addons/website_sale_collect/models/sale_order.py
+++ b/addons/website_sale_collect/models/sale_order.py
@@ -138,22 +138,29 @@ class SaleOrder(models.Model):
     def _get_insufficient_stock_data(self, wh_id):
         """Return the mapping of order lines with insufficient stock in the given warehouse to their
         maximum available quantity in the line's UoM.
+        If there are multiple order lines for the same product, consider the sum of their
+        quantities.
 
         :param int wh_id: The warehouse in which to check the stock, as a `stock.warehouse` id.
         :return: The mapping of order lines to their maximum available quantity.
         :rtype: dict
         """
         insufficient_stock_data = {}
-        for ol in self.order_line.filtered('is_storable'):
-            product = ol.product_id
+        for product, ols in self.order_line.grouped('product_id').items():
+            if not product.is_storable:
+                continue
             free_qty = product.with_context(warehouse_id=wh_id).free_qty
-            free_qty_in_uom = product.uom_id._compute_quantity(free_qty, ol.product_uom_id)
-            if ol.product_uom_qty > free_qty_in_uom:
-                insufficient_stock_data[ol] = max(free_qty_in_uom, 0)
-                ol.shop_warning = self.env._(
-                    "%(available_qty)s/%(cart_qty)s available at this location",
-                    available_qty=int(free_qty_in_uom), cart_qty=int(ol.product_uom_qty),
-                )
+            for ol in ols:
+                free_qty_in_uom = max(
+                    int(product.uom_id._compute_quantity(free_qty, ol.product_uom_id)), 0
+                )  # Round down as only integer quantities can be sold.
+                if ol.product_uom_qty > free_qty_in_uom:
+                    insufficient_stock_data[ol] = free_qty_in_uom
+                    ol.shop_warning = self.env._(
+                        "%(available_qty)s/%(line_qty)s available at this location",
+                        available_qty=free_qty_in_uom, line_qty=int(ol.product_uom_qty),
+                    )
+                free_qty -= ol.product_uom_id._compute_quantity(free_qty_in_uom, product.uom_id)
         return insufficient_stock_data
 
     def _verify_updated_quantity(self, order_line, product_id, new_qty, uom_id, **kwargs):

--- a/addons/website_sale_collect/tests/test_sale_order.py
+++ b/addons/website_sale_collect/tests/test_sale_order.py
@@ -119,6 +119,37 @@ class TestSaleOrder(ClickAndCollectCommon):
         insufficient_stock_data = cart._get_insufficient_stock_data(self.warehouse.id)
         self.assertEqual(insufficient_stock_data[cart.order_line], 10)
 
+    def test_insufficient_stock_with_mixed_uom_order_lines(self):
+        """Test that the insufficient stock is correctly computed when the order lines
+        use different UoMs."""
+        pack_of_6_id = self.ref('uom.product_uom_pack_6')
+        # 1 pack of 6 + 5 units = 11 units in the cart
+        cart = self._create_in_store_delivery_order(
+            order_line=[
+                Command.create(
+                    {
+                        'product_id': self.storable_product.id,
+                        'product_uom_qty': 1.0,
+                        'product_uom_id': pack_of_6_id,
+                    }
+                ),
+                Command.create(
+                    {
+                        'product_id': self.storable_product.id,
+                        'product_uom_qty': 5.0,
+                        'product_uom_id': self.storable_product.uom_id.id,
+                    }
+                ),
+            ]
+        )
+        # 10 units available, 11 requested, so 1 unit short
+        insufficient_stock_data = cart._get_insufficient_stock_data(self.warehouse.id)
+        ol_unit = cart.order_line.filtered(
+            lambda l: l.product_uom_id == self.storable_product.uom_id
+        )
+        # only 4 units are available for the second order line instead of 5
+        self.assertEqual(insufficient_stock_data[ol_unit], 4)
+
     def test_out_of_stock_product_is_unavailable(self):
         cart = self._create_in_store_delivery_order(
             order_line=[

--- a/addons/website_sale_collect/views/delivery_form_templates.xml
+++ b/addons/website_sale_collect/views/delivery_form_templates.xml
@@ -30,7 +30,12 @@
                         t-value="order_line.product_id.product_template_attribute_value_ids._get_combination_name()"
                     />
                     <div class="fw-bold">
-                        <t t-out="order_line.product_id.name"/> <t t-if="attrib_names" t-out="' - ' + attrib_names"/>
+                        <t t-out="order_line.product_id.name"/>
+                        <t t-if="attrib_names" t-out="' - ' + attrib_names"/>
+                        <t
+                            t-if="order_line.product_id.product_tmpl_id._has_multiple_uoms()"
+                            t-out="' (' + order_line.product_uom_id.name + ')'"
+                        />
                     </div>
                     <div t-out="order_line._get_shop_warning()"/>
                     <div name="o_wsale_unavailable_line_button_container" class="mt-2 mt-md-1">


### PR DESCRIPTION
Steps to reproduce:
1. Enable Pickup in Store in eCommerce.
2. Create a product with multiple UoMs (e.g., Unit, Pack of Six).
3. Add the product to the cart using different UoMs in separate lines.
4. Select a store with insufficient total stock but enough for individual lines.
5. Proceed to checkout → No warning is shown.

After this commit, all order lines will be taken into account when checking available stock.

opw-5108294

