### PR TITLE
[FIX] delivery: modify cash-on-delivery payment button on mobile

### DIFF
--- a/addons/delivery/static/src/js/payment_form.js
+++ b/addons/delivery/static/src/js/payment_form.js
@@ -7,7 +7,8 @@ PaymentForm.include({
      * @override
      */
     async start() {
-        this.submitButton = document.querySelector('[adapt-label-for-cod="True"]');
+        this.submitButtons = document.querySelectorAll('[adapt-label-for-cod="True"]');
+        this.submitButton = this.submitButtons[0];
         this.submitButtonDefaultLabel = this.submitButton.textContent;
         await this._super(...arguments);
     },
@@ -21,12 +22,11 @@ PaymentForm.include({
      * @return {void}
      */
      async _expandInlineForm(radio) {
+         let label = this.submitButtonDefaultLabel;
          if (radio.dataset.paymentMethodCode === 'cash_on_delivery') {
-             this.submitButton.textContent = _t("Place order");
+             label = _t("Place order");
          }
-         else {
-             this.submitButton.textContent = this.submitButtonDefaultLabel;
-         }
+         this.submitButtons.forEach((btn) => btn.textContent = label);
          return await this._super(...arguments);
      }
 


### PR DESCRIPTION
Versions
--------
- saas-18.4

No longer an issue in later versions due to the `_isPayLaterMethod` hook introduced in 7be832ce00be

Steps
-----
1. Active cash-on-delivery on a published delivery method;
2. activate & publish the cash-on-delivery payment method;
3. add a deliverable item to your cart;
4. go to checkout > delivery > payment;
5. select the cash-on-delivery payment method;
6. activate mobile view.

Issue
-----
The payment button's label changes from "Place order" to "Pay now".

Cause
-----
Commit 260f3fc4397bf added a seperate cart summary for mobile, which duplicates the payment button. The `_expendInlineForm` override which modifies the button's label only modifies the first payment button.

Solution
--------
Select all cash-on-delivery buttons to modify their labels.

opw-5061516
