### PR TITLE
[FIX] product: fix product search in po to be case insensitive

### DIFF
--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -546,9 +546,9 @@ class ProductProduct(models.Model):
             positive_operators = ['=', 'ilike', '=ilike', 'like', '=like']
             product_ids = []
             if operator in positive_operators:
-                product_ids = list(self._search([('default_code', '=', name)] + domain, limit=limit, order=order))
+                product_ids = list(self._search([('default_code', 'ilike', name)] + domain, limit=limit, order=order))
                 if not product_ids:
-                    product_ids = list(self._search([('barcode', '=', name)] + domain, limit=limit, order=order))
+                    product_ids = list(self._search([('barcode', 'like', name)] + domain, limit=limit, order=order))
             if not product_ids and operator not in expression.NEGATIVE_TERM_OPERATORS:
                 # Do not merge the 2 next lines into one single search, SQL search performance would be abysmal
                 # on a database with thousands of matching products, due to the huge merge+unique needed for the


### PR DESCRIPTION
This commit fixes the issue where products search in PO line was case sensitive.

Before this commit:
Search on `product.product` (which is used in PO lines) was case sensitive if the search term matches exactly the `default_code` or `barcode` because it used exact equal `=` in the search matching.

After this commit:
Search on `product.product` is now case insensitive when matching with `default_code` (using `ilike`) and case sensitive when matching with `barcode` (using `like`).

Task-5080161