### PR TITLE
[FIX] web: remove date param for currency_rates fetch

### DIFF
--- a/addons/web/static/src/core/currency.js
+++ b/addons/web/static/src/core/currency.js
@@ -1,5 +1,4 @@
 import { reactive } from "@odoo/owl";
-import { serializeDate } from "@web/core/l10n/dates";
 import { rpc } from "@web/core/network/rpc";
 import { user } from "@web/core/user";
 import { formatFloat, humanNumber } from "@web/core/utils/numbers";
@@ -27,7 +26,6 @@ export async function getCurrencyRates() {
     const context = {
         ...user.context,
         to_currency: user.activeCompany.currency_id,
-        date: serializeDate(luxon.DateTime.now()),
     };
     const params = {
         model,


### PR DESCRIPTION
The date parameter used for currency_rates fetches is removed since it is always computed server-side by default.

This prevents unnecessary growth of the disk cache, which previously added at least one new entry every day.
