### PR TITLE
[FIX] im_livechat: prevent some thread actions for live chat visitors

### DIFF
--- a/addons/im_livechat/controllers/__init__.py
+++ b/addons/im_livechat/controllers/__init__.py
@@ -4,6 +4,7 @@
 from . import attachment
 from . import chatbot
 from . import main
+from . import rtc
 from . import thread
 from . import webclient
 from . import cors

--- a/addons/im_livechat/controllers/rtc.py
+++ b/addons/im_livechat/controllers/rtc.py
@@ -1,0 +1,20 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from werkzeug.exceptions import NotFound
+
+from odoo.http import route, request
+from odoo.addons.mail.controllers.discuss.rtc import RtcController
+from odoo.addons.mail.models.discuss.mail_guest import add_guest_to_context
+
+
+class LivechatRtcController(RtcController):
+    @route()
+    @add_guest_to_context
+    def channel_call_join(self, channel_id, check_rtc_session_ids=None, camera=False):
+        if request.env.user.is_public and request.env["discuss.channel"].search([
+            ("id", "=", channel_id),
+            ("channel_type", "=", "livechat"),
+            ("rtc_session_ids", "=", False),
+        ]):
+            raise NotFound()
+        return super().channel_call_join(channel_id, check_rtc_session_ids, camera)

--- a/addons/im_livechat/static/src/core/common/thread_actions.js
+++ b/addons/im_livechat/static/src/core/common/thread_actions.js
@@ -1,0 +1,17 @@
+import { patch } from "@web/core/utils/patch";
+
+import { threadActionsInternal } from "@mail/core/common/thread_actions";
+
+patch(threadActionsInternal, {
+    condition(component, id, action) {
+        const visitorActions = ["fold-chat-window", "close", "restart", "settings"];
+        if (
+            component.thread?.channel_type === "livechat" &&
+            !component.store.self.isInternalUser &&
+            !visitorActions.includes(id)
+        ) {
+            return false;
+        }
+        return super.condition(component, id, action);
+    },
+});

--- a/addons/im_livechat/static/src/embed/common/disabled_features.js
+++ b/addons/im_livechat/static/src/embed/common/disabled_features.js
@@ -1,4 +1,3 @@
-import { threadActionsRegistry } from "@mail/core/common/thread_actions";
 import { Thread } from "@mail/core/common/thread_model";
 
 import { patch } from "@web/core/utils/patch";
@@ -10,16 +9,4 @@ patch(Thread.prototype, {
     get hasAttachmentPanel() {
         return this.channel_type !== "livechat" && super.hasAttachmentPanel;
     },
-});
-
-const allowedThreadActions = new Set(["fold-chat-window", "close", "restart", "settings"]);
-for (const [actionName] of threadActionsRegistry.getEntries()) {
-    if (!allowedThreadActions.has(actionName)) {
-        threadActionsRegistry.remove(actionName);
-    }
-}
-threadActionsRegistry.addEventListener("UPDATE", ({ detail: { operation, key } }) => {
-    if (operation === "add" && !allowedThreadActions.has(key)) {
-        threadActionsRegistry.remove(key);
-    }
 });

--- a/addons/im_livechat/tests/__init__.py
+++ b/addons/im_livechat/tests/__init__.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import chatbot_common
+from . import test_call
 from . import test_chatbot_form_ui
 from . import test_chatbot_internals
 from . import test_digest

--- a/addons/im_livechat/tests/test_call.py
+++ b/addons/im_livechat/tests/test_call.py
@@ -1,0 +1,27 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests.common import tagged, HttpCase, JsonRpcException
+
+
+@tagged("post_install", "-at_install")
+class TestCall(HttpCase):
+    def test_visitor_cannot_start_call(self):
+        self.authenticate(None, None)
+        operator = self.env["res.users"].create({"name": "Operator", "login": "operator"})
+        self.env["bus.presence"].create({"user_id": operator.id, "status": "online"})
+        livechat_channel = self.env["im_livechat.channel"].create(
+            {"name": "Test Livechat Channel", "user_ids": [operator.id]}
+        )
+        data = self.make_jsonrpc_request(
+            "/im_livechat/get_session",
+            {
+                "anonymous_name": "Visitor",
+                "channel_id": livechat_channel.id,
+                "persisted": True,
+            },
+        )
+        with self.assertRaises(JsonRpcException, msg="werkzeug.exceptions.NotFound"):
+            self.make_jsonrpc_request(
+                "/mail/rtc/channel/join_call",
+                {"channel_id": data["discuss.channel"][0]["id"]},
+            )

--- a/addons/mail/static/src/core/common/thread_actions.js
+++ b/addons/mail/static/src/core/common/thread_actions.js
@@ -108,10 +108,7 @@ function transformAction(component, id, action) {
         },
         /** Condition to display this action. */
         get condition() {
-            if (action.condition === undefined) {
-                return true;
-            }
-            return action.condition(component);
+            return threadActionsInternal.condition(component, id, action);
         },
         /** Condition to disable the button of this action (but still display it). */
         get disabledCondition() {
@@ -207,6 +204,15 @@ function transformAction(component, id, action) {
         toggle: action.toggle,
     };
 }
+
+export const threadActionsInternal = {
+    condition(component, id, action) {
+        if (action.condition === undefined) {
+            return true;
+        }
+        return action.condition(component);
+    },
+};
 
 export function useThreadActions() {
     const component = useComponent();


### PR DESCRIPTION
This commit removes the possibility for live chat visitors to start a call and invite guests.

task-4849019