### PR TITLE
[FIX] html_editor: phrasing content should not be unwrapped in PRE

### DIFF
--- a/addons/html_editor/static/src/main/font/font_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_plugin.js
@@ -2,7 +2,11 @@ import { Plugin } from "@html_editor/plugin";
 import { isBlock, closestBlock } from "@html_editor/utils/blocks";
 import { fillEmpty, unwrapContents } from "@html_editor/utils/dom";
 import { leftLeafOnlyNotBlockPath } from "@html_editor/utils/dom_state";
-import { isRedundantElement, isVisibleTextNode } from "@html_editor/utils/dom_info";
+import {
+    isPhrasingContent,
+    isRedundantElement,
+    isVisibleTextNode,
+} from "@html_editor/utils/dom_info";
 import {
     closestElement,
     createDOMPathGenerator,
@@ -542,7 +546,7 @@ export class FontPlugin extends Plugin {
                 linebreak = this.document.createTextNode("\n");
                 node.append(linebreak);
             }
-            if (node.nodeType === Node.ELEMENT_NODE) {
+            if (!isPhrasingContent(node)) {
                 unwrapContents(node);
             }
             for (const child of children) {

--- a/addons/html_editor/static/tests/insert/html.test.js
+++ b/addons/html_editor/static/tests/insert/html.test.js
@@ -5,6 +5,7 @@ import { setupEditor, testEditor } from "../_helpers/editor";
 import { unformat } from "../_helpers/format";
 import { getContent } from "../_helpers/selection";
 import { dispatchClean } from "../_helpers/dispatch";
+import { execCommand } from "../_helpers/userCommands";
 
 function span(text) {
     const span = document.createElement("span");
@@ -106,6 +107,17 @@ describe("collapsed selection", () => {
                 editor.shared.history.addStep();
             },
             contentAfter: "<pre>abcdef[]<br>ghi</pre>",
+        });
+    });
+
+    test("should be able to insert phrasing content inside pre", async () => {
+        await testEditor({
+            contentBefore: "<pre>abc[]</pre>",
+            stepFunction: async (editor) => {
+                execCommand(editor, "toggleLinkTools");
+                editor.shared.history.addStep();
+            },
+            contentAfterEdit: `<pre>abc\ufeff<a class="o_link_in_selection">\ufeff[]</a>\ufeff</pre>`,
         });
     });
 

--- a/addons/html_editor/static/tests/paste.test.js
+++ b/addons/html_editor/static/tests/paste.test.js
@@ -2599,7 +2599,7 @@ describe("pasting within pre", () => {
             contentAfter: "<pre>xabc\ndef\nghi[]y</pre>",
         });
     });
-    test("should paste as plain text within pre", async () => {
+    test("should paste only phrasing content within pre", async () => {
         await testEditor({
             contentBefore: "<pre>[]<br></pre>",
             stepFunction: async (editor) => {
@@ -2608,7 +2608,7 @@ describe("pasting within pre", () => {
                     '<div class="o-paragraph">a<strong>bcd</strong><font style="color: rgb(255, 0, 0);">efg</font><font style="background-color: rgba(255, 156, 0, 0.6);">hij</font><span class="display-3-fs">klm</span>no</div>'
                 );
             },
-            contentAfter: "<pre>abcdefghijklmno[]</pre>",
+            contentAfter: "<pre>a<strong>bcd</strong>efghijklmno[]</pre>",
         });
     });
     test("should paste lists within pre as plain text and keep the list style and indentation", async () => {


### PR DESCRIPTION
In this previous [task], insertion in `pre` elements was filtered to prevent non-phrasing content from being inserted (as it is invalid per the html specification). Invalid elements were targeted using the wrong condition, resulting in an issue where any `ELEMENT_NODE` phrasing content inserted through `DomPlugin:insert` (such as links, images) caused an error if empty and was unwrapped if not.

[task]: https://github.com/odoo/odoo/commit/216e9ebf02e8350b82ec676586d8bcaa2a446615

task-4984152
