### PR TITLE
[FIX] point_of_sale: make partner name field editable in PoS

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -183,6 +183,7 @@
             ('remove', 'web/static/src/webclient/actions/reports/layout_assets/**/*'),
             ('remove', 'web/static/src/webclient/actions/**/*css'),
             'web/static/src/webclient/company_service.js',
+            'partner_autocomplete/static/src/**/*',
         ],
         'point_of_sale.base_tests': [
             "web/static/lib/hoot-dom/**/*",

--- a/addons/point_of_sale/static/src/app/missing_fields.js
+++ b/addons/point_of_sale/static/src/app/missing_fields.js
@@ -11,8 +11,6 @@ class DefaultField extends Component {
 registry.category("fields").add("list.many2one_avatar_user", { component: DefaultField });
 registry.category("fields").add("list.list_activity", { component: DefaultField });
 registry.category("fields").add("x2many_buttons", { component: DefaultField });
-registry.category("fields").add("field_partner_autocomplete", { component: DefaultField });
-registry.category("fields").add("res_partner_many2one", { component: DefaultField });
 registry.category("fields").add("many2one_avatar_user", { component: DefaultField });
 registry.category("fields").add("auto_save_res_partner", { component: DefaultField });
 registry.category("fields").add("website_redirect_button", { component: DefaultField });

--- a/addons/point_of_sale/static/tests/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_screen_tour.js
@@ -722,3 +722,24 @@ registry.category("web_tour.tours").add("test_pos_ui_round_globally", {
             Chrome.endTour(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_pos_partner_name_editable", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCreateCustomerButton(),
+            ProductScreen.clickPartnerTab("Sales"),
+            {
+                content: "Add a name to the new customer",
+                trigger: 'div[name="name"] input[type="text"][id^="name_"]',
+                run: function (trigger) {
+                    const input = document.querySelector(
+                        'div[name="name"] input[type="text"][id^="name_"]'
+                    );
+                    input.value = "Test Partner Name";
+                },
+            },
+        ].flat(),
+});

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -2147,6 +2147,11 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_default_pricelist_when_creating_partner', login="pos_user")
 
+    def test_pos_partner_name_editable(self):
+        """ Test to check that customer name is editable in POS """
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_pos_partner_name_editable', login="pos_user")
+
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):
     browser_size = '375x667'


### PR DESCRIPTION
Before this commit, the partner name field in the PoS partner popup was rendered as a non-editable div when the field_partner_autocomplete widget was missing in the PoS JS environment. This caused users to be unable to type a name for new customers.

The original workaround registered a DefaultField for field_partner_autocomplete, which suppressed the missing widget warning but broke editability.

opw-5111958

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
