### PR TITLE
[FIX]Update cash_move_popup.js for translate

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/cash_move_popup/cash_move_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/cash_move_popup/cash_move_popup.js
@@ -79,7 +79,7 @@ export class CashMovePopup extends Component {
 
         this.props.close();
         this.notification.add(
-            _t("Successfully made a cash %s of %s.", type, formattedAmount),
+            _t("Successfully made a cash %s of %s.", translatedType, formattedAmount),
             3000
         );
     }


### PR DESCRIPTION
Makes changes for translation

Description of the issue/feature this PR addresses: Error variable code for translation

Current behavior before PR: The original variable is used

Desired behavior after PR is merged: The translated variable is used




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
