### PR TITLE
[FIX] stock: Correct forecasted quantity with expiration date

### DIFF
--- a/addons/sale_stock_product_expiry/__manifest__.py
+++ b/addons/sale_stock_product_expiry/__manifest__.py
@@ -9,6 +9,9 @@
     'license': 'LGPL-3',
     'author': 'Odoo S.A.',
     'assets': {
+        'web.assets_tests': [
+            'sale_stock_product_expiry/static/tests/tours/*.js',
+        ],
         'web.assets_backend': [
             'sale_stock_product_expiry/static/src/**/*',
         ],

--- a/addons/sale_stock_product_expiry/static/tests/tours/perishable_qty_at_date_tour.js
+++ b/addons/sale_stock_product_expiry/static/tests/tours/perishable_qty_at_date_tour.js
@@ -1,0 +1,20 @@
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("test_forecast_widget_perishable_qty_at_date", {
+    steps: () => [
+        {
+            trigger: "div.o_widget_qty_at_date_widget:first() > a",
+            run: "click",
+        },
+        {
+            trigger: "div.o_popover tr:has(td:nth-child(1)>strong:contains('Fresh Forecasted Stock')):has(td:nth-child(1)>small:contains('10/06/2025')):has(td:nth-child(2)>b:contains('200'))",
+        },
+        {
+            trigger: "div.o_widget_qty_at_date_widget:last() > a",
+            run: "click",
+        },
+        {
+            trigger: "div.o_popover tr:has(td:nth-child(1)>strong:contains('Fresh Forecasted Stock')):has(td:nth-child(1)>small:contains('10/11/2025')):has(td:nth-child(2)>b:contains('100'))",
+        },
+    ],
+});

--- a/addons/sale_stock_product_expiry/tests/__init__.py
+++ b/addons/sale_stock_product_expiry/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_perishable_qty_at_date

--- a/addons/sale_stock_product_expiry/tests/test_perishable_qty_at_date.py
+++ b/addons/sale_stock_product_expiry/tests/test_perishable_qty_at_date.py
@@ -1,0 +1,49 @@
+from freezegun import freeze_time
+from odoo import Command
+from odoo.addons.stock.tests.common import TestStockCommon
+from odoo.tests import HttpCase, tagged
+
+
+@tagged('post_install', '-at_install')
+class TestPerishableQtyAtDate(TestStockCommon, HttpCase):
+
+    @freeze_time("2025-10-01")
+    def test_forecast_widget_perishable_qty_at_date(self):
+        product_exp = self.env['product.product'].create([{
+            'name': f'Perishable Product {i}',
+            'is_storable': True,
+            'tracking': 'lot',
+            'use_expiration_date': True,
+            'expiration_time': 7,
+            'removal_time': 1,
+            'use_time': 2,
+            'alert_time': 3,
+            'sale_delay': i * 5,
+        } for i in (1, 2)])
+
+        partner = self.env['res.partner'].create({'name': 'Buyer'})
+
+        # Create 3 lots with different expiration dates for each product_exp
+        lot_records = self.env['stock.lot'].create([{
+            'name': f'LOT{i:03d}',
+            'product_id': p.id,
+            'expiration_date': f'2025-10-{i * 5:02d}',
+        } for p in product_exp for i in range(1, 4)])
+
+        # Add stock to each lot
+        for lot in lot_records:
+            self.env['stock.quant']._update_available_quantity(lot.product_id, self.stock_location, 100, lot_id=lot)
+
+        # update customer lead time, and create SO
+        sale_order = self.env['sale.order'].create({
+            'partner_id': partner.id,
+            'order_line': [Command.create({
+                'product_id': product_exp[i].id,
+                'product_uom_qty': 50,
+                'price_unit': 100,
+            }) for i in range(2)],
+        })
+        self.assertEqual(sale_order.order_line[0].virtual_available_at_date, 200)
+        self.assertEqual(sale_order.order_line[1].virtual_available_at_date, 100)
+        url = f"odoo/sales/{sale_order.id}"
+        self.start_tour(url, 'test_forecast_widget_perishable_qty_at_date', login='admin')

--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -205,7 +205,8 @@ class ProductProduct(models.Model):
         quants_res = {product.id: (quantity, reserved_quantity) for product, quantity, reserved_quantity in Quant._read_group(domain_quant, ['product_id'], ['quantity:sum', 'reserved_quantity:sum'])}
         expired_unreserved_quants_res = {}
         if self.env.context.get('with_expiration'):
-            domain_quant += [('removal_date', '<=', self.env.context['with_expiration'])]
+            max_date = self.env.context['to_date'] if self.env.context.get('to_date') else self.env.context['with_expiration']
+            domain_quant += [('removal_date', '<=', max_date)]
             expired_unreserved_quants_res = {product.id: quantity - reserved_quantity for product, quantity, reserved_quantity in Quant._read_group(domain_quant, ['product_id'], ['quantity:sum', 'reserved_quantity:sum'])}
         moves_in_res_past = defaultdict(float)
         moves_out_res_past = defaultdict(float)


### PR DESCRIPTION
When computing the forecasted quantity of a product with expiration for a specific date in the forecast widget. We should take into account the quants that will be expired before that date. Not only the ones that are already expired.

Task: 5077677

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
