### PR TITLE
[FIX] website_sale: show all published product tags

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -425,7 +425,12 @@ class WebsiteSale(payment_portal.PaymentPortal):
         if filter_by_tags_enabled and search_product:
             all_tags = ProductTag.search(
                 expression.AND([
-                    [('product_ids.is_published', '=', True), ('visible_on_ecommerce', '=', True)],
+                    [
+                        ('visible_on_ecommerce', '=', True),
+                        '|',
+                        ('product_template_ids.is_published', '=', True),
+                        ('product_product_ids.is_published', '=', True),
+                    ],
                     website_domain
                 ])
             )

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -734,7 +734,11 @@ class ProductTemplate(models.Model):
         if tags:
             if isinstance(tags, str):
                 tags = tags.split(',')
-            domains.append([('product_variant_ids.all_product_tag_ids', 'in', tags)])
+            domains.append([
+                '|',
+                ('product_tag_ids', 'in', tags),
+                ('product_variant_ids.additional_product_tag_ids', 'in', tags),
+            ])
         if min_price:
             domains.append([('list_price', '>=', min_price)])
         if max_price:


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Have an attribute which creates variants dynamically;
2. create a product with two or more dynamic attribute values;
3. add a new tag to the product;
4. publish the product to eCommerce.

Issue
-----
The tag doesn't show up in the side-bar until after a product variant has been created.

Cause
-----
The tags are searched based on `product_ids` instead of `product_template_ids`, leading to tags assigned to dynamically created product variants not showing up until a variant has been created.

Solution
--------
Search tags based on `product_template_ids.is_published` as well as `product_ids.is_published` (in case of `addition_product_tag_ids`).

opw-4985989