### PR TITLE
[FIX] pos_restaurant: guest preset when payment

### DIFF
--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -120,22 +120,17 @@ patch(PosStore.prototype, {
         }
         return result;
     },
-
-    async sendOrderInPreparationUpdateLastChange(order, opts = {}) {
+    async ensureGuestCustomerCount(order) {
         const currentPreset = order.preset_id;
-        if (
-            this.config.use_presets &&
-            currentPreset?.use_guest &&
-            !order.uiState.guestSetted &&
-            !opts.cancelled
-        ) {
-            const response = await this.setCustomerCount(order);
-            if (!response) {
-                return;
+        if (this.config.use_presets && currentPreset?.use_guest && !order.uiState.guestSetted) {
+            await this.setCustomerCount(order);
+            if (order.getCustomerCount() === 0 && order.table_id) {
+                order.setCustomerCount(order.table_id.seats);
             }
             order.uiState.guestSetted = true;
         }
-
+    },
+    async sendOrderInPreparationUpdateLastChange(order, opts = {}) {
         if (!opts.cancelled) {
             order.cleanCourses();
             const firstCourse = order.getFirstCourse();
@@ -546,6 +541,7 @@ patch(PosStore.prototype, {
     },
     async submitOrder() {
         const order = this.getOrder();
+        await this.ensureGuestCustomerCount(order);
         await this.sendOrderInPreparationUpdateLastChange(order);
         this.addPendingOrder([order.id]);
         this.showDefault();
@@ -565,6 +561,7 @@ patch(PosStore.prototype, {
                 return;
             }
             try {
+                await this.ensureGuestCustomerCount(order);
                 this.env.services.ui.block();
                 await this.sendOrderInPreparationUpdateLastChange(order);
             } finally {

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -1111,3 +1111,21 @@ registry.category("web_tour.tours").add("test_combo_synchronisation", {
             },
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_guest_count_bank_payment", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            FloorScreen.clickTable("2"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            Order.hasLine({ productName: "Coca-Cola" }),
+            ProductScreen.clickPayButton(false),
+            ProductScreen.confirmOrderWarningDialog(),
+            NumberPopup.enterValue("5"),
+            NumberPopup.isShown("5"),
+            Dialog.confirm(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickBackToProductScreen(),
+            ProductScreen.isShown(),
+        ].flat(),
+});

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -611,6 +611,10 @@ class TestFrontend(TestFrontendCommon):
             'resource_calendar_id': resource_calendar
         })
         self.start_pos_tour('test_preset_timing_restaurant')
+        self.preset_eat_in.write({
+            'use_guest': True,
+        })
+        self.start_pos_tour('test_guest_count_bank_payment')
 
     def test_combo_preparation_receipt_layout(self):
         setup_product_combo_items(self)


### PR DESCRIPTION
Steps to preproduce:
- Set a preset with Guests amount
- Make an order with that preset with a product set on preparation display
- Go to payment without ordering
- Pay and send order to preparation display
- The ui is blocked and it is not possible to select the number of Guests

Issue:
In this PR: [#216523](https://github.com/odoo/odoo/pull/216523) the ui is blocked when paying
and calling sendOrderInPreparationUpdateLastChange, since the selection
of the number of guest is made inside that method the uiBlok blocks the
popup.

Fix:
Extract the part of the code responsible for the selection of the number
of guest.

Additional note:
If the user dismisses the popup or selects 0, the default number of
guests will be set to the table maximum number of guests, as defined
in the specification of task-4497128.

opw-5113007
