### PR TITLE
[IMP] l10n_in_*: truncate product descriptions for e-invoicing and ewaybill

### DIFF
--- a/addons/l10n_in_edi/models/account_move.py
+++ b/addons/l10n_in_edi/models/account_move.py
@@ -505,7 +505,7 @@ class AccountMove(models.Model):
             'TotItemVal': in_round((sign * line.balance) + line_tax_details.get('tax_amount', 0.00)),
         }
         if line.name:
-            line_details['PrdDesc'] = line.name.replace("\n", "")
+            line_details['PrdDesc'] = line.name.replace("\n", "")[:300]
         return line_details
 
     def _l10n_in_edi_generate_invoice_json_managing_negative_lines(self, json_payload):

--- a/addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py
@@ -590,9 +590,9 @@ class L10nInEwaybill(models.Model):
         round_value = self.env['account.move']._l10n_in_round_value
         tax_details_by_code = self.env['account.move']._get_l10n_in_tax_details_by_line_code(tax_details.get('tax_details', {}))
         line_details = {
-            'productName': line.product_id.name,
+            'productName': line.product_id.name[:100] if line.product_id else "",
             'hsnCode': extract_digits(line.l10n_in_hsn_code),
-            'productDesc': line.name,
+            'productDesc': line.name[:100] if line.name else "",
             'quantity': line.quantity,
             'qtyUnit': line.product_uom_id.l10n_in_code and line.product_uom_id.l10n_in_code.split('-')[0] or 'OTH',
             'taxableAmount': round_value(line.balance * sign),

--- a/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py
@@ -220,9 +220,9 @@ class L10nInEwaybill(models.Model):
             AccountMove = self.env['account.move']
             product = line.product_id
             line_details = {
-                'productName': product.name,
+                'productName': product.name[:100],
                 'hsnCode': AccountMove._l10n_in_extract_digits(product.l10n_in_hsn_code),
-                'productDesc': product.name,
+                'productDesc': line.description_picking[:100] if line.description_picking else "",
                 'quantity': line.quantity,
                 'qtyUnit': (
                     line.product_uom.l10n_in_code

--- a/addons/l10n_in_ewaybill_stock/views/l10n_in_ewaybill_views.xml
+++ b/addons/l10n_in_ewaybill_stock/views/l10n_in_ewaybill_views.xml
@@ -54,6 +54,7 @@
                                 <list editable="bottom" create="0" delete="0">
                                     <field name="company_currency_id" column_invisible="1"/> <!-- To display the currency symbol  -->
                                     <field name="product_id" readonly="1"/>
+                                    <field name="description_picking" string="Description" help="Max 100-character description is allowed" readonly="1"/>
                                     <field name="quantity" string="Quantity" readonly="1"/>
                                     <field name="ewaybill_price_unit" string="Unit Price"/>
                                     <field name="ewaybill_tax_ids" widget="many2many_tax_tags"/>


### PR DESCRIPTION
Product descriptions in invoice lines must comply with character limits:

- E-invoicing: maximum 300 characters
- E-waybill: maximum 100 characters for both product names and descriptions

Descriptions exceeding these limits are automatically truncated in the generated JSON.

task-5061450
