### PR TITLE
[FIX] iot_box_image: inifinite wait to start odoo

### DIFF
--- a/addons/iot_box_image/overwrite_before_init/etc/systemd/system/odoo.service
+++ b/addons/iot_box_image/overwrite_before_init/etc/systemd/system/odoo.service
@@ -2,7 +2,7 @@
 Description=Odoo IoT Box service
 After=cups.socket network-online.target NetworkManager.service rc-local.service
 Wants=network-online.target
-StartLimitIntervalSec=0 # infinetely wait for Odoo to start
+StartLimitIntervalSec=0
 
 [Service]
 User=odoo


### PR DESCRIPTION
This PR fixes an error in Odoo journalctl logs:
```
Sep 12 01:11:48 iotbox systemd[1]: Starting odoo.service - Odoo IoT Box service... Sep 12 01:11:49 iotbox systemd[1]: /etc/systemd/system/odoo.service:5: Failed to parse sec value, ignoring: 0 # infinetely wait for Odoo to start Sep 12 
```
It looks like systemd attemps to interpret inline comments, which this PR removes

task-5113737
