### PR TITLE
[FIX] project: show “Back to edit mode” banner on task detail page in portal

### DIFF
--- a/addons/project/views/project_portal_project_task_templates.xml
+++ b/addons/project/views/project_portal_project_task_templates.xml
@@ -164,13 +164,15 @@
         <xpath expr="//t[@t-call='portal.portal_layout']" position="attributes">
             <attribute name="t-call">project.task_link_preview_portal_layout</attribute>
         </xpath>
-        <xpath expr="//div[hasclass('o_portal_sidebar')]" position="inside">
-            <t t-set="title" t-value="task.name"/>
+        <xpath expr="//t[@t-call='project.task_link_preview_portal_layout']" position="before">
             <t t-set="o_portal_fullwidth_alert" groups="project.group_project_user">
                 <t t-call="portal.portal_back_in_edit_mode">
                     <t t-set="backend_url" t-value="'/odoo/action-project.action_view_my_task/%s' % (task.id)"/>
                 </t>
             </t>
+        </xpath>
+        <xpath expr="//div[hasclass('o_portal_sidebar')]" position="inside">
+            <t t-set="title" t-value="task.name"/>
 
             <div class="row o_project_portal_sidebar">
                 <t t-call="portal.portal_record_sidebar">


### PR DESCRIPTION

Steps to Reproduce:
- Log in as an internal user with project access.
- Open a project’s portal page: /my/projects/.
- Open a task’s portal page: /my/tasks/ (or via /my/projects/<id>/task/).
- Compare the banner visibility between the project page and the task page.

Current Behavior:
The “Back to edit mode” banner appears on the project page but is missing on the task detail page. This leads to an inconsistent experience when previewing portal content and causes failure of the industry_fsm tour.

Expected Behavior:
The “Back to edit mode” banner should consistently appear on the task detail page as well, allowing users to return to edit mode from any portal view.

Task-5083445

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
