### PR TITLE
[FIX] core: unavailable modules - do not check dependencies

### DIFF
--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -339,8 +339,10 @@ class IrModuleModule(models.Model):
         return [('state', '=', 'installed')]
 
     def check_external_dependencies(self, module_name, newstate='to install'):
+        manifest = modules.Manifest.for_addon(module_name)
+        if not manifest:
+            return  # unavailable module, there is no point in checking dependencies
         try:
-            manifest = modules.Manifest.for_addon(module_name)
             manifest.check_manifest_dependencies()
         except MissingDependency as e:
             if newstate == 'to install':


### PR DESCRIPTION
`Manifest.for_addon(module_name)` returns `None` if the module is unavailable in the addons path. This is a common case during upgrades.

https://github.com/odoo/odoo/blob/ef15cb776ebdd409691cef03835b51fcf7e808da/odoo/modules/module.py#L280

See also: 8e496b3df0df708280c77b9a1ae15c46e922c3bc

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
