### PR TITLE
[IMP] discuss: upgrade to SFU as fallback for p2p failures

### DIFF
--- a/addons/mail/controllers/discuss/rtc.py
+++ b/addons/mail/controllers/discuss/rtc.py
@@ -88,6 +88,13 @@ class RtcController(http.Controller):
         # sudo: discuss.channel.rtc.session - member of current user can leave call
         member.sudo()._rtc_leave_call()
 
+    @http.route("/mail/rtc/channel/upgrade_connection", methods=["POST"], type="json", auth="user")
+    def channel_upgrade(self, channel_id):
+        member = request.env["discuss.channel.member"].search([("channel_id", "=", channel_id), ("is_self", "=", True)])
+        if not member:
+            raise NotFound()
+        member.sudo()._join_sfu(force=True)
+
     @http.route("/mail/rtc/channel/cancel_call_invitation", methods=["POST"], type="json", auth="public")
     @add_guest_to_context
     def channel_call_cancel_invitation(self, channel_id, member_ids=None):

--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -354,8 +354,8 @@ class ChannelMember(models.Model):
             self.channel_id.message_post(body=_("%s started a live conference", self.partner_id.name or self.guest_id.name), message_type='notification')
             self._rtc_invite_members()
 
-    def _join_sfu(self, ice_servers=None):
-        if len(self.channel_id.rtc_session_ids) < SFU_MODE_THRESHOLD:
+    def _join_sfu(self, ice_servers=None, force=False):
+        if len(self.channel_id.rtc_session_ids) < SFU_MODE_THRESHOLD and not force:
             if self.channel_id.sfu_channel_uuid:
                 self.channel_id.sfu_channel_uuid = None
                 self.channel_id.sfu_server_url = None

--- a/addons/mail/static/src/discuss/call/common/peer_to_peer.js
+++ b/addons/mail/static/src/discuss/call/common/peer_to_peer.js
@@ -12,6 +12,7 @@ export const UPDATE_EVENT = Object.freeze({
     CONNECTION_CHANGE: "connection_change",
     DISCONNECT: "disconnect",
     INFO_CHANGE: "info_change",
+    RECOVERY: "recovery",
     TRACK: "track",
 });
 const LOG_LEVEL = Object.freeze({
@@ -688,6 +689,7 @@ export class PeerToPeer extends EventTarget {
                 if (!peer?.connection || !this.channelId || (connectionSuccess && iceSuccess)) {
                     return;
                 }
+                this._emitUpdate({ name: UPDATE_EVENT.RECOVERY, payload: { id } });
                 this._emitLog(id, `attempting to recover connection: ${reason}`, LOG_LEVEL.ERROR);
                 this._busNotify(INTERNAL_EVENT.DISCONNECT, { targets: [peer.id] });
                 this.removePeer(peer.id);

--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -235,6 +235,15 @@ export class Rtc extends Record {
     cleanups = [];
     /** @type {number} */
     sfuTimeout;
+    /** @type {number} count of how many times the p2p service attempted a connection recovery */
+    _p2pRecoveryCount = 0;
+    upgradeConnectionDebounce = debounce(
+        () => {
+            this._upgradeConnection();
+        },
+        15000,
+        { leading: true, trailing: false }
+    );
 
     callActions = Record.attr([], {
         compute() {
@@ -768,6 +777,22 @@ export class Rtc extends Record {
                     }, 2000);
                 }
                 return;
+            case "recovery": {
+                const { id } = payload;
+                const session = await this.store.RtcSession.getWhenReady(id);
+                if (
+                    !this.store.self.isInternalUser ||
+                    this.serverInfo ||
+                    this.state.fallbackMode ||
+                    !session?.channel.eq(this.state.channel)
+                ) {
+                    return;
+                }
+                this._p2pRecoveryCount++;
+                if (this._p2pRecoveryCount > 1 || !hasTurn(this.iceServers)) {
+                    this.upgradeConnectionDebounce();
+                }
+            }
         }
     }
 
@@ -811,6 +836,18 @@ export class Rtc extends Record {
                 }
                 return;
         }
+    }
+
+    async _upgradeConnection() {
+        const channelId = this.state.channel?.id;
+        if (this.serverInfo || this.state.fallbackMode || !channelId) {
+            return;
+        }
+        await rpc(
+            "/mail/rtc/channel/upgrade_connection",
+            { channel_id: channelId },
+            { silent: true }
+        );
     }
 
     async _downgradeConnection() {
@@ -1035,6 +1072,7 @@ export class Rtc extends Record {
         browser.clearTimeout(this.sfuTimeout);
         this.sfuClient = undefined;
         this.network = undefined;
+        this._p2pRecoveryCount = 0;
         this.state.updateAndBroadcastDebounce?.cancel();
         this.state.disconnectAudioMonitor?.();
         this.state.audioTrack?.stop();


### PR DESCRIPTION
This commit makes it so that in the case of unsuccessful peer-to-peer connections, the client will request to the Odoo server to upgrade the channel with a SFU.

backport of: odoo/odoo#200122 and odoo/odoo#206411


