### PR TITLE
19.0 multiple small issues hupo

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -1276,15 +1276,6 @@ class HrExpense(models.Model):
             expense_state[state]['amount'] += total_amount_sum
         return expense_state
 
-    def action_get_attachment_view(self):
-        self.ensure_one()
-        res = self.env['ir.actions.act_window']._for_xml_id('base.action_attachment')
-        res.update({
-            'domain': [('res_model', '=', 'hr.expense'), ('res_id', 'in', self.ids)],
-            'context': {'default_res_model': 'hr.expense', 'default_res_id': self.id},
-        })
-        return res
-
     def action_approve_duplicates(self):
         root = self.env['ir.model.data']._xmlid_to_res_id("base.partner_root")
         for expense in self.duplicate_expense_ids:

--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -1200,6 +1200,11 @@ class HrExpense(models.Model):
         return _("Untitled Expense %s", *args)
 
     @api.model
+    def get_untitled_expense_name_at_current_date(self):
+        """ Done in a specific function to be called by hr_expense_extract to keep the same translation """
+        return _("Untitled Expense %s", format_date(self.env, fields.Date.context_today(self)))
+
+    @api.model
     def create_expense_from_attachments(self, attachment_ids=None, view_type='list'):
         """
             Create the expenses from files.
@@ -1222,7 +1227,7 @@ class HrExpense(models.Model):
 
         for attachment in attachments:
             vals = {
-                'name': self._get_untitled_expense_name(format_date(self.env, fields.Date.context_today(self))),
+                'name': self.get_untitled_expense_name_at_current_date(),
                 'price_unit': 0,
                 'product_id': product.id,
             }

--- a/addons/hr_expense/static/src/components/chatter_patch.js
+++ b/addons/hr_expense/static/src/components/chatter_patch.js
@@ -1,0 +1,51 @@
+import { patch } from "@web/core/utils/patch";
+import { Chatter } from "@mail/chatter/web_portal/chatter";
+import { isDragSourceExternalFile } from "@mail/utils/common/misc";
+import { useCustomDropzone } from "@web/core/dropzone/dropzone_hook";
+import { MailAttachmentDropzone } from "@mail/core/common/mail_attachment_dropzone";
+
+/**
+ * Patch Chatter to add custom logic before the onDrop event.
+ */
+patch(Chatter.prototype, {
+    setup() {
+        super.setup(...arguments);
+
+        if (this.props.record?.resModel === 'hr.expense') {
+            useCustomDropzone(this.rootRef, MailAttachmentDropzone, {
+                extraClass: "o-mail-Chatter-dropzone",
+
+                onDrop: async (ev) => {
+                    if (this.state.composerType) {
+                        return;
+                    }
+
+                    if (isDragSourceExternalFile(ev.dataTransfer)) {
+                        const files = [...ev.dataTransfer.files];
+                        if (!this.state.thread.id) {
+
+                            // custom code to automatically fill the name because it is a required field
+                            if (this.props.record.data.name === "") {
+                                const untitled_expense = await this.orm.call('hr.expense', 'get_untitled_expense_name_at_current_date', [], {});
+                                await this.props.record.update({ 'name': untitled_expense });
+                            }
+
+                            const saved = await this.props.saveRecord?.();
+                            if (!saved) {
+                                return;
+                            }
+                        }
+                        Promise.all(files.map((file) => this.attachmentUploader.uploadFile(file))).then(
+                            () => {
+                                if (this.props.hasParentReloadOnAttachmentsChanged) {
+                                    this.reloadParentView();
+                                }
+                            }
+                        );
+                        this.state.isAttachmentBoxOpened = true;
+                    }
+                },
+            });
+        }
+    },
+});

--- a/addons/hr_expense/static/src/components/nb_attachment.xml
+++ b/addons/hr_expense/static/src/components/nb_attachment.xml
@@ -3,7 +3,7 @@
     <t t-if="nb_attachment > 0" t-name="hr_expense.AttachmentNumber" >
         <div>
             <span class="fa fa-paperclip pe-1 align-middle"/>
-            <t class="text-center" t-out="nb_attachment"/>
+            <sup><t class="text-center" t-out="nb_attachment"/></sup>
         </div>
     </t>
 </templates>

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -45,9 +45,6 @@
                     <field name="tax_amount" sum="Total Taxes" readonly="True"
                            optional="hide" groups="account.group_account_invoice,account.group_account_readonly"/>
                     <field name="nb_attachment" widget="nb_attachment" nolabel="1" readonly="True"/>
-                    <button name="action_get_attachment_view" type="object" icon="fa-paperclip"
-                            aria-label="View Attachments" title="View Attachments" class="float-end pe-0"
-                            readonly="True" invisible="nb_attachment == 0"/>
                     <field name="total_amount" sum="Total Amount" widget='monetary'
                            readonly="not is_editable or product_has_cost"
                            options="{'currency_field': 'company_currency_id'}" decoration-bf="1"/>

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -285,7 +285,7 @@
                     </div>
                 </sheet>
                 <div class="o_attachment_preview o_center_attachment"/>
-                <chatter/>
+                <chatter reload_on_attachment="True"/>
                 </form>
             </field>
         </record>


### PR DESCRIPTION
[IMP] hr_expense: enable attachment drop on expense form view

Steps to reproduce the use case that is improved:
- create a new expense (without writing anything)
- drag and drop an attachment

-> Some required field prevent this behavior

Solution: Pre-fill values that are required when dropping
an attachment.

----------------------------------------------------------------------------------------------

[FIX] hr_expense: remove duplicate attachment link

remove an unnecessary link to the attachments of expenses
in the list view.

task-4684825
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
