### PR TITLE
[FIX] l10n_tr_nilvera_einvoice: fix value returned for import file type

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice/models/account_move.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_move.py
@@ -58,7 +58,7 @@ class AccountMove(models.Model):
             and (customization_id := file_data['xml_tree'].findtext('{*}CustomizationID'))
             and 'TR1.2' in customization_id
         ):
-            return 'account_edi.xml.ubl.tr'
+            return 'account.edi.xml.ubl.tr'
 
         return super()._get_import_file_type(file_data)
 


### PR DESCRIPTION
The imported records are not being decoded correctly due to _get_edi_decoder returning an empty value. This happens because the value of import_file_type for UBL.TR is incorrectly returned as TR by _get_import_file_type. As a result, the decoder cannot be found and the records are left empty.

task-4714467
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
