### PR TITLE
[FIX] web: prevent the display of empty badges

### DIFF
--- a/addons/web/static/src/views/fields/badge_selection/list_badge_selection_field.js
+++ b/addons/web/static/src/views/fields/badge_selection/list_badge_selection_field.js
@@ -13,7 +13,8 @@ export class ListBadgeSelectionField extends BadgeSelectionField {
         if (this.props.readonly) {
             if (
                 this.props.colorField &&
-                Number.isInteger(this.props.record.data[this.props.colorField])
+                Number.isInteger(this.props.record.data[this.props.colorField]) &&
+                this.props.record.data[this.props.name]
             ) {
                 return `o_badge_color_${this.props.record.data[this.props.colorField]}`;
             }

--- a/addons/web/static/tests/views/fields/badge_selection_field.test.js
+++ b/addons/web/static/tests/views/fields/badge_selection_field.test.js
@@ -182,7 +182,8 @@ test("BadgeSelectionField widget in list with the color_field option", async () 
         `,
     });
 
-
+    // Ensure that the first partner has no tag displayed (20 is the default color).
+    expect(`.o_field_selection_badge[name="product_id"] .o_badge_color_20`).toHaveCount(0);
     // Ensure that the correct o_badge_color is used.
     expect(`.o_field_selection_badge[name="product_id"] .o_badge_color_6`).toHaveCount(1);
     expect(`.o_field_selection_badge[name="product_id"] .o_badge_color_7`).toHaveCount(0);


### PR DESCRIPTION
A condition was added in the check of listBadgeSelectionField in
order to prevent the display of empty badges.

task-5096109
