### PR TITLE
[FIX] sale_project: show "New" button when returning from task or project

### DIFF
--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -161,6 +161,7 @@ class SaleOrder(models.Model):
         default_project_id = default_line.project_id.id or self.project_id.id or self.project_ids[:1].id or self.tasks_ids.project_id[:1].id
 
         action['context'] = {
+            'create': True,
             'default_sale_order_id': self.id,
             'default_sale_line_id': default_line.id,
             'default_partner_id': self.partner_id.id,
@@ -210,6 +211,7 @@ class SaleOrder(models.Model):
             'view_mode': 'kanban,tree,form',
             'context': {
                 **self._context,
+                'create': True,
                 'default_partner_id': self.partner_id.id,
                 'default_sale_line_id': default_sale_line.id if default_sale_line else False,
                 'default_allow_billable': 1,


### PR DESCRIPTION
**Steps to reproduce:**
   - Install `sale_project`.
   - Create a sale order with a service product.
   - Open the related task and navigate to the sale order.
   - Go back to the task.

**Issue:**
  When navigating `Task > Sale Order > Task`, the **New** button does not appear.This happens because when opening a sale order from a task, the context is passed with `create: false` (to prevent creating a new order). As a result, the context is also carried over  when going back to the task or project, causing the **New** button to remain hidden.

**Fix:**
  Updated the task and project actions to explicitly pass `create: True` in the context, so that it overrides the `create: false` value and ensures the **New** button is visible.

task-5074893
