### PR TITLE
[FIX] website_customer: filter option not on /partners


### DIFF
--- a/addons/website_customer/__manifest__.py
+++ b/addons/website_customer/__manifest__.py
@@ -24,6 +24,11 @@ Publish your customers as business references on your website to attract new pot
         'security/ir_rule.xml',
         'views/snippets.xml',
     ],
+    'assets': {
+        'web.assets_backend': [
+            'website_customer/static/src/scss/website_preview.scss',
+        ],
+    },
     'installable': True,
     'license': 'LGPL-3',
 }

--- a/addons/website_customer/static/src/scss/website_preview.scss
+++ b/addons/website_customer/static/src/scss/website_preview.scss
@@ -1,0 +1,5 @@
+// hide website_customer options from showing on website_crm_partner_assign.index
+.o_website_preview:not([data-view-xmlid="website_customer.index"])
+we-customizeblock-options:has(we-button[data-customize-website-views="website_customer.opt_country_list"]) {
+    display: none!important;
+}


### PR DESCRIPTION

Scenario:

- install website_customer and website_crm_partner_assign
- go to /partners
- in edit mode, disable the option "Countries Filter"

Result: nothing happen

Cause: there is no filter options on /partners page, but the options of
/customers page are targetting class o_wcrm_filters_top that is common
to both page, so they are shown on /partners incorrectly.

Fix in stable: change the selector to only show options on /customers.

Fix in master: in website_customer, change the o_wcrm_filters_top class
to o_wc_filters_top class.

opw-5102381
