### PR TITLE
[IMP] web: fix kanban view print

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_record.scss
+++ b/addons/web/static/src/views/kanban/kanban_record.scss
@@ -24,7 +24,13 @@
     }
 
     @include media-only(print) {
+        height: auto;
         font-size: 0.8rem;
+        page-break-inside: avoid;
+
+        &:not(.o_kanban_ghost) > * {
+            height: auto;
+        }
     }
 
     &:not(.o_kanban_ghost) {


### PR DESCRIPTION
This PR fixes the kanban view print to better handle the page break. 
The issue was caused by the flex layout: when printing, heights often misbehave on the last row or at page breaks.

task-4630646

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
