### PR TITLE
[FIX] stock: recompute qty_to_order when horizon changes

### DIFF
--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -436,6 +436,12 @@ class StockWarehouseOrderpoint(models.Model):
         # Remove previous automatically created orderpoint that has been refilled.
         orderpoints_removed = orderpoints._unlink_processed_orderpoints()
         orderpoints = orderpoints - orderpoints_removed
+        param_env = self.env['ir.config_parameter'].sudo()
+        global_visibility_days = action['context'].get('global_visibility_days', int(self.get_visibility_days()))
+        last_used_horizon_days = int(param_env.get_param("stock.last_horizon_days", self.get_visibility_days()))
+        if last_used_horizon_days != global_visibility_days:
+            orderpoints._compute_qty_to_order_computed()
+            param_env.set_param("stock.last_horizon_days", global_visibility_days)
         to_refill = defaultdict(float)
         all_product_ids = self._get_orderpoint_products()
         all_replenish_location_ids = self._get_orderpoint_locations()


### PR DESCRIPTION
## **Issue Before This PR:**
When the `horizon (visibility days)` is updated from the left panel, the `quantity to order` for orderpoints was not automatically recomputed. This caused an inconsistency between the expected replenishment quantity and the value displayed in the orderpoint list, leading to confusion in stock planning.

## **Steps to Reproduce:**
- Install `Inventory (stock)` and `Sales (sale_management)` module,
- Add a product with 0 on-hand quantity,
- Create a replenishment rule for this product with manual trigger,
- Create a sale order with the same product with delivery date 10 days later,
- Confirm the sale order,
- Open the replenishment menu in Inventory,
- Change the horizon (visibility days) to 10,
- Observe that qty_to_order is not updated automatically, causing inconsistency.

## **Cause of the Issue:**
This bug was introduced in PR #213745, where `qty_to_order_computed` was made `store=True` and `qty_forecast` was removed from its `depends`. As a result, the compute method is not called on relevant changes and the value does not get updated.

## **With This PR:**
The `_compute_qty_to_order_computed` is now manually called which updates the value each time the horizon is updated.
This ensures that the `qty_to_order` field reflects the correct values and resolves the inconsistency in replenishment quantities.

TaskID: [4988468](https://www.odoo.com/odoo/project/966/tasks/4988468)