### PR TITLE
[FIX] hr_work_entry: use relevant tz for work entry generation

### DIFF
--- a/addons/hr_work_entry/models/hr_version.py
+++ b/addons/hr_work_entry/models/hr_version.py
@@ -561,7 +561,8 @@ class HrVersion(models.Model):
                 version = self.env['hr.version'].browse(vals['version_id'])
                 calendar = version.resource_calendar_id
                 employee = version.employee_id
-                vals['date'] = date_start.date()
+                tz = _get_tz(vals['version_id'])
+                vals['date'] = date_start.astimezone(tz).date()
                 vals['duration'] = mapped_version_data[date_start, date_stop][calendar][employee.id]['hours'] if calendar else 0.0
             vals.pop('date_start', False)
             vals.pop('date_stop', False)

--- a/addons/hr_work_entry/tests/test_work_entry.py
+++ b/addons/hr_work_entry/tests/test_work_entry.py
@@ -97,11 +97,20 @@ class TestWorkEntry(TestWorkEntryBase):
             'contract_date_end': False,
             'wage': 1000,
         })
+        self.env['resource.calendar.leaves'].create({
+            'date_from': pytz.timezone('Asia/Hong_Kong').localize(datetime(2023, 8, 2, 0, 0, 0)).astimezone(pytz.utc).replace(tzinfo=None),
+            'date_to': pytz.timezone('Asia/Hong_Kong').localize(datetime(2023, 8, 2, 23, 59, 59)).astimezone(pytz.utc).replace(tzinfo=None),
+            'calendar_id': hk_resource_calendar_id.id,
+            'work_entry_type_id': self.work_entry_type_leave.id,
+        })
         self.env.company.resource_calendar_id = hk_resource_calendar_id
-        hk_employee.generate_work_entries(datetime(2023, 8, 1), datetime(2023, 8, 1))
+        hk_employee.generate_work_entries(datetime(2023, 8, 1), datetime(2023, 8, 2))
         work_entries = self.env['hr.work.entry'].search([('employee_id', '=', hk_employee.id)])
+        self.assertEqual(len(work_entries), 2)
         self.assertEqual(work_entries[0].date, date(2023, 8, 1))
         self.assertEqual(work_entries[0].duration, 8)
+        self.assertEqual(work_entries[1].date, date(2023, 8, 2))
+        self.assertEqual(work_entries[1].duration, 8)
 
     def test_separate_overlapping_work_entries_by_type(self):
         calendar = self.env['resource.calendar'].create({'name': 'Calendar', 'tz': 'Europe/Brussels'})


### PR DESCRIPTION
**Steps to reproduce**
1. Have a company and employee using a calendar in UTC+8, with attendances in the calendar starting at 7am.
2. Create a global time off generating a work entry.
3. Generate work entries for the employee. Issue: the work entry generated by the global time off is 1 day earlier than expected.

**Cause**
The date used was in UTC, ignoring the tz defined on the version/ employee/company.
https://github.com/odoo/odoo/blob/192c2d98f7bf871c4f221aaa36c1cb2a541d3945/addons/hr_work_entry/models/hr_version.py#L503-L510

opw-5106975