### PR TITLE
[FIX] account: render product label as text outside edit mode

### DIFF
--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.scss
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.scss
@@ -4,6 +4,10 @@
         resize: none;
     }
 
+    div.o_input {
+        white-space: pre-wrap;
+    }
+
     @include media-only(print) {
         height: auto !important;
     }

--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.xml
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.xml
@@ -40,16 +40,21 @@
                         />
                     </t>
                 </div>
+                <div
+                    t-if="props.readonly"
+                    class="o_input d-print-none border-0 fst-italic"
+                    t-att-class="{ ...sectionAndNoteClasses, 'd-none': !(columnIsProductAndLabel.value and label) }"
+                    t-out="label"
+                />
                 <textarea
+                    t-else=""
                     class="o_input d-print-none border-0 fst-italic"
                     placeholder="Enter a description"
                     rows="1"
                     type="text"
-                    t-att-class="{ ...sectionAndNoteClasses, 'd-none': !(columnIsProductAndLabel.value and (label or !props.readonly and labelVisibility.value)) }"
-                    t-att-readonly="props.readonly and isProductClickable ? '1' : ''"
+                    t-att-class="{ ...sectionAndNoteClasses, 'd-none': !(columnIsProductAndLabel.value and (label or labelVisibility.value)) }"
                     t-att-value="label"
                     t-ref="labelNodeRef"
-                    t-key="props.readonly"
                 />
             </t>
             <t t-if="isPrintMode.value">

--- a/addons/sale/static/src/js/tours/tour_utils.js
+++ b/addons/sale/static/src/js/tours/tour_utils.js
@@ -66,7 +66,7 @@ function checkSOLDescriptionContains(productName, text) {
     // TODO in the future: handle edit mode and look directly into the textarea value
     let trigger = `.o_field_product_label_section_and_note_cell:contains("${productName}")`;
     if (text) {
-        trigger = `${trigger} textarea`;
+        trigger = `${trigger} .o_input`;
     }
     return { trigger };
 }

--- a/addons/sale/static/tests/sale_product_field.test.js
+++ b/addons/sale/static/tests/sale_product_field.test.js
@@ -97,7 +97,7 @@ test("Hide product name if its not translated", async () => {
         resId: soId,
     });
 
-    expect(".o_field_product_label_section_and_note_cell textarea").toHaveValue("A description");
+    expect(".o_field_product_label_section_and_note_cell .o_input").toHaveText("A description");
 });
 
 test("If translated product name already in the SOL name, should not hide the translated product name", async () => {
@@ -120,7 +120,7 @@ test("If translated product name already in the SOL name, should not hide the tr
         resId: soId,
     });
 
-    expect(".o_field_product_label_section_and_note_cell textarea").toHaveValue(
+    expect(".o_field_product_label_section_and_note_cell .o_input").toHaveText(
         [translatedProductName, "A description"].join("\n")
     );
 });
@@ -146,11 +146,11 @@ test("Editing the description shouldn't show the translated product name", async
         resModel: "sale.order",
         resId: soId,
     });
-
+    await contains(".o_field_product_label_section_and_note_cell").click();
     await contains(".o_field_product_label_section_and_note_cell textarea").edit("A description");
     await clickSave();
 
-    expect(".o_field_product_label_section_and_note_cell textarea").toHaveValue("A description");
+    expect(".o_field_product_label_section_and_note_cell .o_input").toHaveText("A description");
     expect(sol.name).toBe([translatedProductName, "A description"].join("\n"));
 });
 
@@ -174,7 +174,7 @@ test("No description should be shown if there does not exist one apart from the 
         resId: soId,
     });
 
-    expect(".o_field_product_label_section_and_note_cell textarea").not.toBeVisible();
+    expect(".o_field_product_label_section_and_note_cell .o_input").not.toBeVisible();
 });
 
 test("No description should be shown if there does not exist one apart from the translated product name", async () => {
@@ -197,5 +197,5 @@ test("No description should be shown if there does not exist one apart from the 
         resId: soId,
     });
 
-    expect(".o_field_product_label_section_and_note_cell textarea").not.toBeVisible();
+    expect(".o_field_product_label_section_and_note_cell .o_input").not.toBeVisible();
 });


### PR DESCRIPTION
The product_label_section_and_note_field product description used a textarea even outside edition. This caused height miscalculations due to a conflict between the autoresize and magicColumnWidth hooks.

To fix this, the description is now rendered as plain text when not in edit mode, ensuring autoresize only applies once the field enters edition.

task-5040151
