### PR TITLE
[FIX] project_sms, sale_sms: access templates as project manager

### DIFF
--- a/addons/project_sms/__manifest__.py
+++ b/addons/project_sms/__manifest__.py
@@ -6,7 +6,7 @@
     'summary': 'Send text messages when project/task stage move',
     'description': "Send text messages when project/task stage move",
     'category': 'Hidden',
-    'version': '1.0',
+    'version': '1.1',
     'depends': ['project', 'sms'],
     'data': [
         'views/project_stage_views.xml',

--- a/addons/project_sms/security/project_sms_security.xml
+++ b/addons/project_sms/security/project_sms_security.xml
@@ -4,7 +4,7 @@
         <field name="name">SMS Template: project manager CUD on project/task</field>
         <field name="model_id" ref="sms.model_sms_template"/>
         <field name="groups" eval="[(4, ref('project.group_project_manager'))]"/>
-        <field name="domain_force">[('model_id.model', 'in', ('project.task.type', 'project.project.stage'))]</field>
+        <field name="domain_force">[('model', 'in', ('project.task', 'project.project'))]</field>
         <field name="perm_read" eval="False"/>
     </record>
 </odoo>

--- a/addons/project_sms/upgrades/1.1/pre-migrate.py
+++ b/addons/project_sms/upgrades/1.1/pre-migrate.py
@@ -1,0 +1,13 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+def migrate(cr, version):
+    cr.execute("""
+        UPDATE ir_rule r
+           SET domain_force = '[(''model'', ''in'', (''project.task'', ''project.project''))]'
+          FROM ir_model_data d
+         WHERE d.res_id = r.id
+           AND r.domain_force = '[(''model_id.model'', ''in'', (''project.task.type'', ''project.project.stage''))]'
+           AND d.model = 'ir.rule'
+           AND d.module = 'project_sms'
+           AND d.name = 'ir_rule_sms_template_project_manager'
+    """)

--- a/addons/sale_sms/security/security.xml
+++ b/addons/sale_sms/security/security.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record model="ir.rule" id="ir_rule_sms_template_so_sale_manager">
-        <field name="name">SMS Template: sale manager CRUD on sale orders</field>
+        <field name="name">SMS Template: sale manager CUD on sale orders</field>
         <field name="model_id" ref="sms.model_sms_template"/>
         <field name="groups" eval="[(4, ref('sales_team.group_sale_manager'))]"/>
         <field name="domain_force">[('model_id.model', 'in', ('sale.order', 'res.partner'))]</field>
+        <field name="perm_read" eval="False"/>
     </record>
 </odoo>


### PR DESCRIPTION
**Issue**
Project administrators are not able to manage SMS templates related to project models.

**Steps to reproduce**
- Have `project_sms` and `sale_sms` installed.
- Have a regular user (not admin) with Project: "Administrator" and Sales: "Administrator" rights.
- Go to Project/Task kanban view > cog icon on top of columns > edit > try to open/modify the SMS template.
Issue: access rights error

**Cause**
- the rule in `sale_sms` is problematic because it is the only record rule affecting read operations, while other modules only target CUD operations. It has the effect of restricting read operations for Sale:Administrator users.
- the rule in `project_sms` was referencing the wrong models, SMS templates are linked to `project.project` and `project.task`.

opw-4908909