### PR TITLE
[FIX] project,sale_timesheet: fix tours when there are project templates

### DIFF
--- a/addons/project/static/src/js/tours/project.js
+++ b/addons/project/static/src/js/tours/project.js
@@ -28,6 +28,12 @@ registry.category("web_tour.tours").add('project_tour', {
     tooltipPosition: 'bottom',
     run: "click",
 }, {
+    isActive: ['.o-kanban-button-new.dropdown'], // if the project template dropdown is active
+    trigger: 'button.o-dropdown-item:contains("New Project")',
+    content: markup(_t('Let\'s create a regular <b>project</b>.')),
+    tooltipPosition: 'right',
+    run: "click",
+}, {
     trigger: '.o_project_name input',
     content: markup(_t('Choose a <b>name</b> for your project. <i>It can be anything you want: the name of a customer, of a product, of a team, of a construction site, etc.</i>')),
     tooltipPosition: 'right',

--- a/addons/project/static/tests/tours/project_tour.js
+++ b/addons/project/static/tests/tours/project_tour.js
@@ -15,6 +15,10 @@ registry.category("web_tour.tours").add('project_test_tour', {
         trigger: '.o-kanban-button-new',
         run: "click",
     }, {
+        isActive: ['.o-kanban-button-new.dropdown'], // if the project template dropdown is active
+        trigger: 'button.o-dropdown-item:contains("New Project")',
+        run: "click",
+    }, {
         trigger: '.o_project_name input',
         run: 'edit New Project',
         id: 'project_creation',

--- a/addons/project/static/tests/tours/project_update_tour_tests.js
+++ b/addons/project/static/tests/tours/project_update_tour_tests.js
@@ -14,6 +14,10 @@ registry.category("web_tour.tours").add('project_update_tour', {
     trigger: '.o-kanban-button-new',
     run: "click",
 }, {
+    isActive: ['.o-kanban-button-new.dropdown'], // if the project template dropdown is active
+    trigger: 'button.o-dropdown-item:contains("New Project")',
+    run: "click",
+}, {
     trigger: '.o_project_name input',
     run: "edit New Project",
 }, {

--- a/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
+++ b/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
@@ -32,6 +32,12 @@ registry.category("web_tour.tours").add('sale_timesheet_tour', {
     content: 'Add a new project.',
     run: "click",
 }, {
+    isActive: ['button.o-kanban-button-new.dropdown'], // if the project template dropdown is active
+    trigger: 'button.o-dropdown-item:contains("New Project")',
+    content: 'Let\'s create a regular project.',
+    tooltipPosition: 'right',
+    run: "click",
+}, {
     trigger: '.o_field_widget.o_project_name input',
     content: 'Select your project name (e.g. Project for Freeman)',
     run: "edit Project for Freeman",
@@ -163,6 +169,12 @@ registry.category("web_tour.tours").add('sale_timesheet_tour', {
 }, {
     trigger: 'button.o_list_button_add',
     content: 'Click on Create button to create a new project and see the different configuration available for the project.',
+    run: "click",
+}, {
+    isActive: ['button.o_list_button_add.dropdown'], // if the project template dropdown is active
+    trigger: 'button.o-dropdown-item:contains("New Project")',
+    content: 'Let\'s create a regular project.',
+    tooltipPosition: 'right',
     run: "click",
 },
 {


### PR DESCRIPTION
Before this commit, project tours block on the Kanban and List "New" button being turned into a dropdown list when there are active project templates.
These tours cannot be fixed by simply archiving or unlinking project templates before running them in the tests, because two of them are onboarding tours which need to work in both situations.

With this commit, we add a new step in the tours that clicks on the "New Project" dropdown item when the button is a dropdown. Otherwise, the step will be skipped.

Task-id: none (runbot builds including demo data were red)