### PR TITLE
[FIX] base: improved disjoint group performance and clear_cache

### DIFF
--- a/odoo/addons/base/tests/test_groups.py
+++ b/odoo/addons/base/tests/test_groups.py
@@ -701,11 +701,101 @@ class TestGroupsOdoo(common.TransactionCase):
 
         user.group_ids = self.env.ref('base.group_user') + self.test_group
 
+        self.assertEqual(set(self.test_group.all_implied_ids.get_external_id().values()), {'base.base_test_group', 'base.group_user', 'base.group_no_one'})
+
         # update res.group implied_ids having the effect that users have distinct groups
         with self.assertRaises(ValidationError, msg="The user cannot have more than one user types."):
             self.test_group.implied_ids += self.env.ref('base.group_public')
+
+        self.assertEqual(set(self.test_group.all_implied_ids.get_external_id().values()), {'base.base_test_group', 'base.group_user', 'base.group_no_one'})
+
         with self.assertRaises(ValidationError, msg="The user cannot have more than one user types."):
             self.env.ref('base.group_public').implied_by_ids = self.test_group
 
-        # this works because public user is inactive
-        self.env.ref('base.group_public').implied_ids += self.test_group
+        self.assertEqual(set(self.env.ref('base.group_public').implied_by_ids.get_external_id().values()), set())
+
+        with self.assertRaises(ValidationError, msg="This makes a group imply two disjoint groups."):
+            self.env.ref('base.group_public').implied_ids += self.test_group
+
+        self.assertEqual(set(self.env.ref('base.group_public').all_implied_ids.get_external_id().values()), {'base.group_public'})
+
+        new_group = self.env['res.groups'].create({
+            'name': 'test group',
+        })
+        self.env["ir.model.data"].create({
+            "module": "base",
+            "name": "new_group",
+            "model": "res.groups",
+            "res_id": new_group.id,
+        })
+        self.env.ref('base.group_public').implied_ids += new_group
+        self.assertEqual(set(self.env.ref('base.group_public').all_implied_ids.get_external_id().values()), {'base.group_public', 'base.new_group'})
+
+    def test_groups_7_distinct(self):
+        def create(name, implied_by_ids=[]):
+            group = self.env['res.groups'].create({
+                'name': f'test group {name}',
+                'implied_by_ids': [g.id for g in implied_by_ids],
+            })
+            self.env["ir.model.data"].create({
+                "module": "base",
+                "name": f"test_group_{name}",
+                "model": "res.groups",
+                "res_id": group.id,
+            })
+            return group
+
+        #       A
+        #         \
+        #  [B]      C
+        #  / \     / \
+        # D   E*  F   G*
+        #
+        a = create('a')
+        b = create('b')
+        c = create('c', [a])
+        create('d', [b])
+        e = self.env.ref('base.group_public')
+        e.implied_by_ids = b
+        create('f', [c])
+        g = self.env.ref('base.group_user')
+        g.implied_by_ids = c
+
+        #       A
+        #    /     \
+        #  [B]      C
+        #  / \     / \
+        # D   E*  F   G*
+        #
+        with self.assertRaises(ValidationError, msg="This makes a group imply two disjoint groups."):
+            b.implied_by_ids += a
+
+        user = self.env['res.users'].create({
+            'name': 'Test User',
+            'login': 'a_user',
+            'email': 'a@user.com',
+        })
+        user.group_ids = a
+
+        with self.assertRaises(ValidationError, msg=f"User 'A User' cannot be at the same time in exclusive groups {e.name!r}, {g.name!r}"):
+            user.group_ids += b
+
+        #       A
+        #
+        #  [B]      C
+        #  / \     / \
+        # D   E*  F   G*
+        #
+        a.implied_ids = self.env['res.groups']
+        user.group_ids += b
+        with self.assertRaises(ValidationError, msg=f"User 'A User' cannot be at the same time in exclusive groups {e.name!r}, {g.name!r}"):
+            a.implied_ids += c
+
+        #       A
+        #         \
+        #  [B]      C
+        #  / \     / \
+        # D   E*  F   G*
+        #
+        with self.assertRaises(ValidationError, msg=f"User 'A User' cannot be at the same time in exclusive groups {e.name!r}, {g.name!r}"):
+            user.group_ids += c

--- a/odoo/addons/base/tests/test_user_has_group.py
+++ b/odoo/addons/base/tests/test_user_has_group.py
@@ -154,13 +154,12 @@ class TestHasGroup(TransactionCase):
             dict(xml_id='test_two_user_types.implied_groups', values={'name': 'Test Group'})
         ])
         grp_test.implied_ids += self.grp_internal
-        grp_test.implied_ids += self.grp_portal
 
         with self.assertRaises(ValidationError):
             self.env['res.users'].create({
                 'login': 'test_two_user_types',
                 'name': "Test User with two user types",
-                'group_ids': [Command.set([grp_test.id])]
+                'group_ids': [Command.set([grp_test.id, self.grp_portal.id])]
             })
 
         #Add a user with portal to the group Internal


### PR DESCRIPTION
1) Search is inefficient for databases with many users. The OR condition on the join between user and group is not optimal. The choice is to test first if the group itself generates an incompatible disjoint and then to test only the join that may be faulty.

2) When there is a validation error, the cache containing the group involvement was not invalidated, which could create inconsistencies in access.