### PR TITLE
[IMP] account:  Remove 'Dynamic reports' setting

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -11284,11 +11284,6 @@ msgid "Nasty charges and interests from your bank"
 msgstr ""
 
 #. module: account
-#: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
-msgid "Navigate easily through reports and see what is behind the numbers"
-msgstr ""
-
-#. module: account
 #: model:ir.model.fields.selection,name:account.selection__account_cash_rounding__rounding_method__half-up
 #: model:ir.model.fields.selection,name:account.selection__account_report__integer_rounding__half-up
 msgid "Nearest"

--- a/addons/account/models/res_config_settings.py
+++ b/addons/account/models/res_config_settings.py
@@ -81,7 +81,6 @@ class ResConfigSettings(models.TransientModel):
     show_sale_receipts = fields.Boolean(string='Sale Receipt', config_parameter='account.show_sale_receipts')
     module_account_budget = fields.Boolean(string='Budget Management')
     module_account_payment = fields.Boolean(string='Invoice Online Payment')
-    module_account_reports = fields.Boolean("Dynamic Reports")
     module_account_check_printing = fields.Boolean("Allow check printing and deposits")
     module_account_batch_payment = fields.Boolean(string='Use batch payments',
         help='This allows you grouping payments into a single batch and eases the reconciliation process.\n'

--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -333,9 +333,6 @@
                         <t groups="account.group_account_user">
                             <block title="Fiscal Periods" id="accounting_reports">
                                 <setting id="fiscalyear" invisible="1" groups="account.group_account_user"/>
-                                <setting id="dynamic_report" groups="account.group_account_user" help="Navigate easily through reports and see what is behind the numbers">
-                                    <field name="module_account_reports" widget="upgrade_boolean"/>
-                                </setting>
                             </block>
                         </t>
                         <block title="Analytics" id="analytic" groups="account.group_account_user">
@@ -351,7 +348,7 @@
                                 <field name="module_product_margin"/>
                             </setting>
                         </block>
-                        <block title="Reporting" id="account_reports_settings" groups="account.group_account_user" invisible="not module_account_reports">
+                        <block title="Reporting" id="account_reports_settings" groups="account.group_account_user">
                             <setting string="Restrictive Audit Trail" company_dependent="1" invisible="force_restrictive_audit_trail" help="Log changes to posted journal entries immutably">
                                 <field name="restrictive_audit_trail"/>
                             </setting>


### PR DESCRIPTION
Before PR:
- The setting was available but never actively used.
- Disabling it could uninstall 'account_reports', which are required for most accounting features.

After PR:
- The 'Dynamic reports' setting has been removed from the system.

Impact:
- Prevents accidental removal of essential accounting functionality.
- Simplifies configuration by removing an unused option.

Related enterprise PR: https://github.com/odoo/enterprise/pull/95544
Related upgrade PR: https://github.com/odoo/upgrade/pull/8501

task-5107465