### PR TITLE
[FIX] website_sale: display correct price after applying fiscal position

### DIFF
--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -568,9 +568,10 @@ class ProductTemplate(models.Model):
         tax_display = 'total_excluded' if show_tax == 'tax_excluded' else 'total_included'
 
         # The list_price is always the price of one.
-        return taxes.compute_all(
+        list_price = taxes.with_context(round=False, round_base=False).compute_all(
             price, currency, 1, product_or_template, self.env.user.partner_id
         )[tax_display]
+        return currency.round(list_price)
 
     def create_product_variant(self, product_template_attribute_value_ids):
         """ Create if necessary and possible and return the id of the product


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Configure website to display prices tax-included;
2. have two 15% taxes, one price-included, one price-excluded;
3. create a $10 product that uses the price-included tax;
4. create a fiscal position that maps the included tax to excluded one;
5. assign the fiscal position to the public partner;
6. open the product's shop page as public user.

Issue
-----
The price gets displayed as $10.01.

Cause
-----
When applying the taxes to the price, small errors are introduced by rounding the base price before doing the tax calculations.

Solution
--------
To circumvent issues like these, commits 143ec3739196f and 6045061f818a0 added the `round` & `round_base` context values respectively. By settings these to `False`, we can prevent intermediate rounding that may introduce errors like these.

opw-4945752