### PR TITLE
[FIX] discuss: fix call ui indicators

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_participant_card.js
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.js
@@ -17,7 +17,7 @@ import { usePopover } from "@web/core/popover/popover_hook";
 import { useService } from "@web/core/utils/hooks";
 import { rpc } from "@web/core/network/rpc";
 
-const HIDDEN_CONNECTION_STATES = new Set([undefined, "connected", "completed"]);
+const HIDDEN_CONNECTION_STATES = new Set(["connected", "completed"]);
 
 export class CallParticipantCard extends Component {
     static props = ["className", "cardData", "thread", "minimized?", "inset?"];

--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -728,7 +728,7 @@ export class Rtc extends Record {
                 }
                 for (const [id, info] of Object.entries(payload)) {
                     const session = await this.store.RtcSession.getWhenReady(Number(id));
-                    if (!session || !this.state.channel) {
+                    if (!this.state.channel || session?.eq(this.selfSession)) {
                         return;
                     }
                     // `isRaisingHand` is turned into the Date `raisingHand`

--- a/addons/mail/static/src/discuss/call/common/rtc_session_model.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_session_model.js
@@ -10,7 +10,7 @@ export class RtcSession extends Record {
     static get(data) {
         return super.get(data);
     }
-    /** @returns {Promies<import("models").RtcSession>} */
+    /** @returns {Promise<import("models").RtcSession>} */
     static async getWhenReady(id) {
         const session = this.get(id);
         if (!session) {


### PR DESCRIPTION
This commit fixes:
- the SFU could send outdated information about our own session during the initialisation of the connection. This can lead to the microphone being muted when joining a call if the updates occur when the user rtc session is marked as mute when querying the audio stream.
- the warning indicator was hidden if the connection state was undefined this could lead to a missing warning during some recovery steps when session data is reset.

