### PR TITLE
[FIX] stock: avoid traceback when no package was set

### DIFF
--- a/addons/stock/static/src/widgets/stock_package_m2o.js
+++ b/addons/stock/static/src/widgets/stock_package_m2o.js
@@ -40,7 +40,7 @@ export class StockPackageMany2One extends Component {
 
     get displayValue() {
         const displayVal = this.props.record.data[this.props.name];
-        if (this.isDone) {
+        if (this.isDone && displayVal?.display_name) {
             displayVal["display_name"] = displayVal["display_name"].split(" > ").pop();
         }
         return displayVal;


### PR DESCRIPTION
Steps to reproduce:
- Inventory -> Settings -> Enable Packages
- Create a reception
- Add a Product, put some quantity
- Validate the reception
- Open the move's details

Issue:
A traceback is generated, as now we're in a 'done' context and the widget should only display the closest package for each move line.

But it didn't check whether there was a package assigned to the move line in the first place.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
