### PR TITLE
[FIX] account: fix alignment issue in invoice report

### DIFF
--- a/addons/account/static/src/css/report_invoice.css
+++ b/addons/account/static/src/css/report_invoice.css
@@ -20,3 +20,7 @@
 .tax_computation_company_currency {
     margin-bottom: 5px;
 }
+
+.clearfix {
+    clear: both;
+}

--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -183,7 +183,7 @@
                             </tbody>
                         </table>
                         <div class="overflow-hidden">
-                            <div id="right-elements" t-attf-class="#{'col-5 mt-5' if report_type == 'pdf' else 'col-12 col-md-5'} ms-5 d-inline-block float-end">
+                            <div id="right-elements" t-attf-class="#{'col-5' if report_type == 'pdf' else 'col-12 col-md-5'} ms-5 d-inline-block float-end">
                                 <div id="total" class="clearfix row">
                                     <div class="ms-auto">
                                         <table class="o_total_table table table-borderless avoid-page-break-inside">


### PR DESCRIPTION
**Steps to reproduce:**

1. Install Accounting module.
2. Change document layout to `Boxed` from Settings.
3. Print any invoice → notice that `total section` is shifted downward compared to other PDF layouts.

**Issue:**

<img width="772" height="242" alt="image" src="https://github.com/user-attachments/assets/d4c2aab8-11c1-4584-b544-0fcc7071a06a" />


- The amount `total section` in the invoice PDF is not aligned properly due to extra margin.

**Solution:**

- Remove the unnecessary margin to ensure the total section is aligned correctly across all layouts.

**After Solution:**

<img width="777" height="185" alt="image" src="https://github.com/user-attachments/assets/c9cd1060-f210-4154-afc9-22d7d6a9207f" />


**opw - 4911228**