### PR TITLE
[FIX] stock: prevent deletion of moves in ready transfers

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -785,7 +785,7 @@ class MrpProduction(models.Model):
                 continue
             production_with_move_finished_ids_to_unlink_ids.add(production.id)
 
-        production_with_move_finished_ids_to_unlink = self.browse(production_with_move_finished_ids_to_unlink_ids)
+        production_with_move_finished_ids_to_unlink = self.with_context(skip_state_check=True).browse(production_with_move_finished_ids_to_unlink_ids)
 
         # delete to remove existing moves from database and clear to remove new records
         production_with_move_finished_ids_to_unlink.move_finished_ids = [Command.delete(m) for m in production_with_move_finished_ids_to_unlink.move_finished_ids.ids]

--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -435,7 +435,7 @@ class StockMove(models.Model):
                     move_data.update({'product_id': vals.get('product_id')})
                 updated_product_move = self.create(moves_data)
                 updated_product_move._action_confirm()
-                move_to_unlink.unlink()
+                move_to_unlink.with_context(skip_state_check=True).unlink()
                 self = other_move + updated_product_move
         if self.env.context.get('force_manual_consumption'):
             vals['manual_consumption'] = True
@@ -533,7 +533,7 @@ class StockMove(models.Model):
         move_to_unlink = self.env['stock.move'].browse(moves_ids_to_unlink).sudo()
         move_to_unlink.quantity = 0
         move_to_unlink._action_cancel()
-        move_to_unlink.unlink()
+        move_to_unlink.with_context(skip_state_check=True).unlink()
         return self.env['stock.move'].browse(moves_ids_to_return)
 
     def action_show_details(self):

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1992,8 +1992,8 @@ Please change the quantity done or the rounding precision of your unit of measur
 
     @api.ondelete(at_uninstall=False)
     def _unlink_if_draft_or_cancel(self):
-        if any(move.state not in ('draft', 'cancel') and (move.move_orig_ids or move.move_dest_ids) for move in self):
-            raise UserError(_('You can not delete moves linked to another operation'))
+        if not self.env.context.get('skip_state_check') and self.filtered(lambda m: m.state not in ('draft', 'cancel')):
+            raise UserError(_('You can only delete draft or cancelled moves.'))
 
     def unlink(self):
         # With the non plannified picking, draft moves could have some move lines.

--- a/addons/stock/tests/test_move2.py
+++ b/addons/stock/tests/test_move2.py
@@ -2190,9 +2190,12 @@ class TestSinglePicking(TestStockCommon):
         picking = picking.save()
         self.assertEqual(picking.state, 'assigned')
 
-        picking = Form(picking)
-        picking.move_ids_without_package.remove(0)
-        picking = picking.save()
+        picking_form = Form(picking)
+        picking_form.move_ids_without_package.remove(0)
+        with self.assertRaises(UserError):
+            picking_form.save()
+        picking.action_cancel()
+        picking = picking_form.save()
         self.assertEqual(len(picking.move_ids_without_package), 0)
 
     def test_additional_move_1(self):


### PR DESCRIPTION
Steps to Reproduce:
-------------------------
1. Create a PO with 2 PO lines.
2. On receipt, delete 1 move line.

Observation:
-------------------------
1. No user error is raised.

Issue:
-------------------------
When deleting a move from the receipt, if the move is not linked to any parent (`move_orig_ids`) or child (`move_dest_ids`) moves, the condition in the code evaluates to `False`. As a result, the `UserError` meant to prevent deletion is bypassed.
https://github.com/odoo/odoo/blob/ff1893a627fdde7cf752a0f6c19a02780cdf9774/addons/stock/models/stock_move.py#L1993-L1995

Solution:
-------------------------
1. When the unlink method is called internally (from the ORM side), pass a
specific context key (e.g. skip_state_check=True). Inside the
`_unlink_if_draft_or_cancel` method, use this context to bypass the state check.

2. When the user manually performs a delete operation (from the UI), no such
context will be passed. In that case, the state check will still apply, and a
`UserError` will be raised if the record is not in a valid state.

opw-5081681
