### PR TITLE
[FIX] website: fix wait for reposition in test

### DIFF
--- a/addons/website/static/tests/builder/popover.test.js
+++ b/addons/website/static/tests/builder/popover.test.js
@@ -1,28 +1,12 @@
 import { setSelection } from "@html_editor/../tests/_helpers/selection";
 import { expandToolbar } from "@html_editor/../tests/_helpers/toolbar";
 import { expect, test } from "@odoo/hoot";
-import { observe, queryFirst, queryOne, scroll, waitFor } from "@odoo/hoot-dom";
+import { queryFirst, queryOne, scroll, waitFor, waitUntil } from "@odoo/hoot-dom";
 import { contains } from "@web/../tests/web_test_helpers";
 import { defineWebsiteModels, setupWebsiteBuilder } from "./website_helpers";
 import { animationFrame } from "@odoo/hoot-mock";
 
 defineWebsiteModels();
-
-async function waitForReposition(target) {
-    await Promise.race([
-        new Promise((resolve) => {
-            const disconnect = observe(target, (mutations) => {
-                for (const mutation of mutations) {
-                    if (mutation.type === "attributes" && mutation.attributeName === "style") {
-                        disconnect();
-                        resolve();
-                    }
-                }
-            });
-        }),
-        new Promise((_, reject) => setTimeout(() => reject("Timeout waiting for reposition"), 300)),
-    ]);
-}
 
 test("Popovers scroll with iframe", async () => {
     await setupWebsiteBuilder(`<p>plop</p>`);
@@ -41,9 +25,10 @@ test("Popovers scroll with iframe", async () => {
 
     const expectScroll = async (popoverSelector) => {
         const popover = await waitFor(popoverSelector);
-        const previousTop = parseFloat(getComputedStyle(popover).top);
-        // Wait for the initial positioning
-        await waitForReposition(popover);
+        const previousTop = parseFloat(popover.style.top);
+        popover.style.top = "0px";
+        // Wait for the initial call of `reposition`
+        await waitUntil(() => popover.style.top !== "0px", { timeout: 500 });
 
         const delta = 100;
         await scroll(body, { y: delta }, { scrollable: false, force: true });


### PR DESCRIPTION
__Current behavior before commit:__
The timeout in `waitForReposition` is sometimes reached if runbot is on heavy load making the test fail.

__Description of the fix:__
Remove `waitForReposition` and use `waitUntil` instead. This should wait more time if runbot is on heavy load.

The timeout has been increased for security.

Runbot error: https://runbot.odoo.com/odoo/runbot.build.error/232802
