### PR TITLE
[FIX] point_of_sale: auto-validation payment with rounding

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -568,12 +568,10 @@ export class PaymentScreen extends Component {
         // the current order is fully paid and due is zero.
         this.pos.paymentTerminalInProgress = false;
         const config = this.pos.config;
-        const currency = this.pos.currency;
         const currentOrder = line.pos_order_id;
         if (
             isPaymentSuccessful &&
             currentOrder.is_paid() &&
-            floatIsZero(currentOrder.get_due(), currency.decimal_places) &&
             config.auto_validate_terminal_payment
         ) {
             this.validateOrder(false);
@@ -609,13 +607,8 @@ export class PaymentScreen extends Component {
     async sendForceDone(line) {
         line.set_payment_status("done");
         const config = this.pos.config;
-        const currency = this.pos.currency;
         const currentOrder = line.pos_order_id;
-        if (
-            currentOrder.is_paid() &&
-            floatIsZero(currentOrder.get_due(), currency.decimal_places) &&
-            config.auto_validate_terminal_payment
-        ) {
+        if (currentOrder.is_paid() && config.auto_validate_terminal_payment) {
             this.validateOrder(true);
         }
     }


### PR DESCRIPTION
Ensure that when a payment is made via a payment terminal and cash rounding is applied, the payment is automatically validated once the response is received.

Previously, validation did not always occur because we relied on `get_due` is not exactly what is left to pay, as it does not account for cash rounding rounded amounts.

The condition for auto-validation was simplified, since `is_paid` already checks whether there is nothing left to pay. Thus, using `get_due` is redundant.

Steps to reproduce:
1. Create a cash rounding and set it on the POS.
2. Sell a product priced at e.g. 1.99 EUR, paid via a terminal (e.g. Worldline).
3. Notice the payment is not auto-validated and requires manual validation, which can lead to mistakes or missed manual validations.

opw-4862684