### PR TITLE
[FIX] pos_hr: make help of advanced_employee_ids field consistent

### DIFF
--- a/addons/pos_hr/models/pos_config.py
+++ b/addons/pos_hr/models/pos_config.py
@@ -12,7 +12,7 @@ class PosConfig(models.Model):
         help='If left empty, all employees can log in to PoS')
     advanced_employee_ids = fields.Many2many(
         'hr.employee', 'pos_hr_advanced_employee_hr_employee', string="Employees with manager access",
-        help='If left empty, only Odoo users have extended rights in PoS')
+        help='Employees linked to users with the PoS Manager role are automatically added to this list')
 
     def write(self, vals):
         if 'advanced_employee_ids' not in vals:

--- a/addons/pos_hr/models/res_config_settings.py
+++ b/addons/pos_hr/models/res_config_settings.py
@@ -10,7 +10,7 @@ class ResConfigSettings(models.TransientModel):
     pos_basic_employee_ids = fields.Many2many(related='pos_config_id.basic_employee_ids', readonly=False,
         help='If left empty, all employees can log in to PoS')
     pos_advanced_employee_ids = fields.Many2many(related='pos_config_id.advanced_employee_ids', readonly=False,
-        help='If left empty, only Odoo users have extended rights in PoS')
+        help='Employees linked to users with the PoS Manager role are automatically added to this list')
 
     @api.model_create_multi
     def create(self, vals_list):


### PR DESCRIPTION
Before this commit, the help text of the advanced_employee_ids field was inconsistent with its behavior, as it was not possible to keep it empty. This commit updates the help to reflect the actual behavior.

opw-5112862

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
