### PR TITLE
[FIX] sale_project_stock: tax access for sale line values

### DIFF
--- a/addons/sale_project_stock/models/stock_move.py
+++ b/addons/sale_project_stock/models/stock_move.py
@@ -40,8 +40,9 @@ class StockMove(models.Model):
         """ Generate the sale.line creation value from the current stock move """
         self.ensure_one()
 
+        order = order.sudo()
         fpos = order.fiscal_position_id or order.fiscal_position_id._get_fiscal_position(order.partner_id)
-        product_taxes = self.product_id.taxes_id._filter_taxes_by_company(order.company_id)
+        product_taxes = self.product_id.sudo().taxes_id._filter_taxes_by_company(order.company_id)
         taxes = fpos.map_tax(product_taxes)
 
         return {


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When getting the sale line values as a stock user, we get an access error when trying to access taxes. We should bypass access checks for these values. The lines are already created with sudo.

Current behavior before PR:
User cannot read account.tax model.

Desired behavior after PR is merged:
Avoid error.

(runbot.build.error/231611 - test_picking_reinvoicing)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
