### PR TITLE
[FIX] l10n_tr_nilvera_einvoice: commit as we loop

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice/models/account_move.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_move.py
@@ -197,7 +197,7 @@ class AccountMove(models.Model):
                 elif not move.ref and (nilvera_reference := document_uuids_references.get(document_uuid)):
                     move.ref = nilvera_reference
                     self._l10n_tr_nilvera_add_pdf_to_invoice(client, move, document_uuid, document_category, invoice_channel)
-            self._cr.commit()
+                self._cr.commit()
 
     def _l10n_tr_get_nilvera_invoice_journal(self, journal_type):
         journal = self._l10n_tr_get_document_category_default_journal(journal_type)


### PR DESCRIPTION
Following bcab79c0ba9b550726164d80a22b50e689a2789c we are no longer committing changes in `_l10n_tr_nilvera_get_documents` as we loop through documents. The idea behind having that commit inside the loop was to avoid having to rollback all changes if we timeout or an error occurs. This is especially important when importing the current maximum amount of documents (30).

This commit restores that behavior.

No Task ID.
