### PR TITLE
[FIX] hr_holidays: only list time off types requiring allocation

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -9,6 +9,7 @@ from calendar import monthrange
 from odoo import api, fields, models, _
 from odoo.addons.hr_holidays.models.hr_leave import get_employee_from_context
 from odoo.exceptions import AccessError, UserError, ValidationError
+from odoo.osv import expression
 from odoo.tools.float_utils import float_round
 from odoo.tools.date_utils import get_timedelta
 
@@ -32,9 +33,13 @@ class HrLeaveAllocation(models.Model):
         return self.env['hr.leave.type'].search(domain, limit=1)
 
     def _domain_holiday_status_id(self):
+        domain = [
+            ('company_id', 'in', self.env.companies.ids + [False]),
+            ('requires_allocation', '=', 'yes'),
+        ]
         if self.env.user.has_group('hr_holidays.group_hr_holidays_user'):
-            return [('requires_allocation', '=', 'yes')]
-        return [('employee_requests', '=', 'yes')]
+            return domain
+        return expression.AND([domain, [('employee_requests', '=', 'yes')]])
 
     def _domain_employee_id(self):
         domain = [('company_id', 'in', self.env.companies.ids)]


### PR DESCRIPTION
To reproduce:
=============
- Create time off tyoe that does not require allocation
- Go to timeoff > Allocation > Group allocation -> you can select the created time off type

Problem:
========
we didn't have a domain on `holiday_status_id` field, so all time off types were available for selection.

Solution:
=========
Add a domain on `holiday_status_id` field to only show time off types that require allocations the same way as when creating a single allocation.

opw-5113959

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
