### PR TITLE
[FIX] hr: Traceback on shared employee link

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -11,7 +11,7 @@ from dateutil.relativedelta import relativedelta
 from markupsafe import Markup
 
 from odoo import api, fields, models, _
-from odoo.exceptions import ValidationError, AccessError
+from odoo.exceptions import ValidationError, AccessError, RedirectWarning
 from odoo.osv import expression
 from odoo.tools import convert, format_date
 
@@ -373,9 +373,16 @@ class HrEmployeePrivate(models.Model):
     def get_views(self, views, options=None):
         if self.browse().has_access('read'):
             return super().get_views(views, options)
-        res = self.env['hr.employee.public'].get_views(views, options)
-        res['models'].update({'hr.employee': res['models']['hr.employee.public']})
-        return res
+        # returning public employee data would cause a traceback when building
+        # the private employee xml view
+        raise RedirectWarning(
+            message=_(
+            """You are not allowed to access "Employee" (hr.employee) records.
+We can redirect you to the public employee list."""
+            ),
+            action=self.env.ref('hr.hr_employee_public_action').id,
+            button_text=_("Employees profile"),
+        )
 
     @api.model
     def _search(self, domain, offset=0, limit=None, order=None):

--- a/addons/hr/static/tests/tours/check_public_employee_link_redirect.js
+++ b/addons/hr/static/tests/tours/check_public_employee_link_redirect.js
@@ -1,0 +1,27 @@
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("check_public_employee_link_redirect", {
+    // starts at /odoo/employee/<employee_id>
+    steps: () => {
+        /* ignoring inactive modals since the modal may appear multiple times
+          thus hiding the inactive ones and playwright doesn't like doing
+          actions on hidden elements */
+        const msgSelector = '.o_dialog:not(.o_inactive_modal) .modal-content .modal-body div[role="alert"] p';
+        const msg = `You are not allowed to access "Employee" (hr.employee) records.
+We can redirect you to the public employee list.`;
+        return [
+            {
+                trigger: msgSelector,
+                content: "See if redirect warning popup appears for current user",
+                timeout: 3000,
+                run: () => {
+                    const errorTxt = document.querySelector(msgSelector).innerText;
+                    if (errorTxt !== msg) {
+                        throw new Error("Could not find correct warning message when visiting private employee without required permissions")
+                    }
+                }
+            },
+        ]
+    },
+});
+

--- a/addons/hr/tests/test_hr_employee.py
+++ b/addons/hr/tests/test_hr_employee.py
@@ -2,7 +2,7 @@
 from datetime import datetime
 from psycopg2.errors import UniqueViolation
 
-from odoo.tests import Form, users, HttpCase, tagged
+from odoo.tests import Form, users, HttpCase, tagged, new_test_user
 from odoo.addons.hr.tests.common import TestHrCommon
 from odoo.tools import mute_logger
 from odoo.exceptions import ValidationError
@@ -487,6 +487,32 @@ class TestHrEmployee(TestHrCommon):
         days = employeeA._get_unusual_days(datetime(2025, 1, 1), datetime(2025, 12, 31))
         self.assertTrue(days)
         self.assertFalse(days['2025-01-04'])
+
+
+@tagged('-at_install', 'post_install')
+class TestHrEmployeeLinks(HttpCase):
+    def test_shared_private_link_permissions(self):
+        """
+        Employees not part of group_hr_user are not supposed to be able to see
+        private employees pages (e.g.: from a shared link).
+        The tour will check if the correct redirection warning appears when such
+        case happens.
+        """
+        user_amy = new_test_user(
+            self.env,
+            name="Amy Rose",
+            login='amy',
+            groups='base.group_user'  # cannot access private employee profiles
+        )
+        employee_sonic = self.env['hr.employee'].create({
+            'name': 'Sonic the Hedgehog',
+        })
+        with mute_logger('odoo.http'):  # ignore raised RedirectWarning
+            self.start_tour(
+                f"/odoo/employees/{employee_sonic.id}",
+                "check_public_employee_link_redirect",
+                login=user_amy.login,
+            )
 
 
 @tagged('-at_install', 'post_install')

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -17,7 +17,7 @@
                     <field name="job_id"/>
                     <field name="coach_id" domain="[('company_id', 'in', allowed_company_ids)]"/>
                     <field name="category_ids" groups="hr.group_hr_user"/>
-                    <field name="private_car_plate" />
+                    <field name="private_car_plate" groups="hr.group_hr_user"/>
                     <separator/>
                     <filter string="Unread Messages" name="message_needaction" domain="[('message_needaction', '=', True)]" groups="mail.group_mail_notification_type_inbox"/>
                     <separator/>


### PR DESCRIPTION
Sharing a link of an employee profile containing private info generated a traceback. Permissions had to be applied to the private field. I've also put a more explicit error message that allows the user to get redirected to the public employee list.

I couldn't find a way to get the employee id from the url before the generic permission warning comes in. Thus I had to resort to redirecting to the general public employees list.

Other tracebacks may happen each time a private field without the corresponding groups is put in the xml. Thus I added a test to prevent us from doing that again.
