### PR TITLE
[FIX] account_edi_ubl_cii: Re-fix OIN EAS on BIS3 + NLCIUS

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -591,7 +591,7 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
             nl_id = commercial_partner.company_registry if commercial_partner.peppol_eas not in ('0106', '0190') else commercial_partner.peppol_endpoint
             party_node['cac:PartyLegalEntity']['cbc:CompanyID'] = {
                 '_text': nl_id,
-                'schemeID': '0190' if nl_id and len(nl_id) == 9 else '0106'
+                'schemeID': '0190' if nl_id and len(nl_id) == 20 else '0106'
             }
         elif commercial_partner.country_id.code == 'LU' and commercial_partner.company_registry:
             party_node['cac:PartyLegalEntity']['cbc:CompanyID'] = {

--- a/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
@@ -515,10 +515,10 @@ class TestAccountEdiUblCii(AccountTestInvoicingCommon):
             'invoice_line_ids': [Command.create({'product_id': self.product_a.id})],
         })
 
-        invoice.partner_id.commercial_partner_id.invoice_edi_format = 'nlcius'
+        invoice.partner_id.commercial_partner_id.invoice_edi_format = 'ubl_bis3'
         invoice.action_post()
         invoice.invoice_date_due = fields.Date.from_string('2024-12-31')
-        builder = invoice.partner_id.commercial_partner_id._get_edi_builder('nlcius')
+        builder = invoice.partner_id.commercial_partner_id._get_edi_builder('ubl_bis3')
         xml_content = builder._export_invoice(invoice)[0]
         xml_tree = etree.fromstring(xml_content)
         scheme_ID = xml_tree.find('.//cac:PartyLegalEntity/cbc:CompanyID[@schemeID]', {


### PR DESCRIPTION
We previously [1] fixed the EAS that was incorrectly set to 0106 instead of 0190 in case of OIN (lenght = 20).
This fix was overriden in the backport of the 19.0 dict helpers [2].

[1]: https://github.com/odoo/odoo/pull/219424
[2]: https://github.com/odoo/odoo/pull/215610

opw-5107445