### PR TITLE
[REV] point_of_sale: display correct default pricelist when creating partner

### DIFF
--- a/addons/point_of_sale/models/product.py
+++ b/addons/point_of_sale/models/product.py
@@ -386,15 +386,6 @@ class ProductPricelist(models.Model):
     def _load_pos_data_fields(self, config_id):
         return ['id', 'name', 'display_name', 'item_ids']
 
-    def _get_partner_pricelist_multi(self, partner_ids):
-        pricelist = self.env['pos.config'].browse(
-            self.env.context.get("pos_config_id")
-        ).pricelist_id
-        if pricelist:
-            return dict.fromkeys(partner_ids, pricelist)
-
-        return super()._get_partner_pricelist_multi(partner_ids)
-
 
 class ProductPricelistItem(models.Model):
     _name = 'product.pricelist.item'

--- a/addons/point_of_sale/static/src/app/missing_fields.js
+++ b/addons/point_of_sale/static/src/app/missing_fields.js
@@ -10,9 +10,3 @@ class DefaultField extends Component {
 }
 registry.category("fields").add("list.many2one_avatar_user", { component: DefaultField });
 registry.category("fields").add("list.list_activity", { component: DefaultField });
-registry.category("fields").add("x2many_buttons", { component: DefaultField });
-registry.category("fields").add("field_partner_autocomplete", { component: DefaultField });
-registry.category("fields").add("res_partner_many2one", { component: DefaultField });
-registry.category("fields").add("many2one_avatar_user", { component: DefaultField });
-registry.category("fields").add("auto_save_res_partner", { component: DefaultField });
-registry.category("fields").add("website_redirect_button", { component: DefaultField });

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1856,9 +1856,7 @@ export class PosStore extends Reactive {
         });
     }
     editPartnerContext(partner) {
-        return {
-            pos_config_id: this.config.id,
-        };
+        return {};
     }
     /**
      * @param {import("@point_of_sale/app/models/res_partner").ResPartner?} partner leave undefined to create a new partner

--- a/addons/point_of_sale/static/tests/tours/pricelist_tour.js
+++ b/addons/point_of_sale/static/tests/tours/pricelist_tour.js
@@ -44,28 +44,3 @@ registry.category("web_tour.tours").add("pos_pricelist", {
             ProductScreen.closePos(),
         ].flat(),
 });
-
-registry.category("web_tour.tours").add("test_default_pricelist_when_creating_partner", {
-    steps: () =>
-        [
-            Chrome.startPoS(),
-            Dialog.confirm("Open Register"),
-            ProductScreen.clickPartnerButton(),
-            ProductScreen.clickCreateCustomerButton(),
-            ProductScreen.clickPartnerTab("Sales"),
-            {
-                content: "Get the displayed pricelist",
-                trigger: "input#property_product_pricelist_0",
-                run: function () {
-                    const value = document.querySelector(
-                        "input#property_product_pricelist_0"
-                    )?.value;
-                    if (value !== "Default Pricelist (USD)") {
-                        throw new Error(
-                            `The default pricelist should be the one displayed, but "${value}" is.`
-                        );
-                    }
-                },
-            },
-        ].flat(),
-});

--- a/addons/point_of_sale/static/tests/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/product_screen_util.js
@@ -229,32 +229,6 @@ export function inputCustomerSearchbar(value) {
         },
     ];
 }
-export function clickCreateCustomerButton() {
-    const steps = [
-        {
-            isActive: ["desktop"],
-            content: "click Create button to add a customer",
-            trigger: 'button.btn.btn-primary.btn-lg:contains("Create")',
-            run: "click",
-        },
-        {
-            isActive: ["mobile"],
-            content: "click Create button to add a customer",
-            trigger: 'button.btn.btn-primary.btn-lg:contains("New")',
-            run: "click",
-        },
-    ];
-    return steps;
-}
-export function clickPartnerTab(name) {
-    return [
-        {
-            content: `click '${name}' tab`,
-            trigger: `.nav-tabs .nav-link:contains("${name}")`,
-            run: "click",
-        },
-    ];
-}
 export function clickRefund() {
     return [clickReview(), ...clickControlButton("Refund")];
 }

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -2132,21 +2132,6 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_click_all_orders_keep_customer', login="pos_user")
 
-    def test_default_pricelist_when_creating_partner(self):
-        """
-        When creating a new partner from the PoS, the pricelist displayed by default should
-        be the default pricelist set in the PoS configuration.
-        """
-        pricelist = self.env['product.pricelist'].create({
-            'name': 'Default Pricelist'
-        })
-        self.main_pos_config.write({
-            'available_pricelist_ids': [Command.set([pricelist.id])],
-            'pricelist_id': pricelist.id,
-        })
-        self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_default_pricelist_when_creating_partner', login="pos_user")
-
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):
     browser_size = '375x667'


### PR DESCRIPTION
This reverts commit 0635af99d3617511e82ebe20155296e86e87c92c.

An issue appeared after the above commit. Inside the pos, when creating a new customer the name field is invisible, not allowing it to be filled. Customer creation is impossible as it is a required field.

opw-5111673