### PR TITLE
[FIX] point_of_sale: make image variant selectable in PoS

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/product_configurator_popup/product_configurator_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/product_configurator_popup/product_configurator_popup.js
@@ -42,6 +42,10 @@ export class ColorProductAttribute extends BaseProductAttribute {
     static template = "point_of_sale.ColorProductAttribute";
 }
 
+export class ImageProductAttribute extends BaseProductAttribute {
+    static template = "point_of_sale.ImageProductAttribute";
+}
+
 export class MultiProductAttribute extends BaseProductAttribute {
     static template = "point_of_sale.MultiProductAttribute";
     static props = [...BaseProductAttribute.props, "selected?", "customValue?"];
@@ -71,6 +75,7 @@ export class ProductConfiguratorPopup extends Component {
         PillsProductAttribute,
         SelectProductAttribute,
         ColorProductAttribute,
+        ImageProductAttribute,
         MultiProductAttribute,
         Dialog,
     };

--- a/addons/point_of_sale/static/src/app/components/popups/product_configurator_popup/product_configurator_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/product_configurator_popup/product_configurator_popup.xml
@@ -144,6 +144,50 @@
         </div>
     </t>
 
+    <t t-name="point_of_sale.ImageProductAttribute">
+        <div>
+            <t t-set="is_custom" t-value="false"/>
+
+            <ul class="color_attribute_list d-flex gap-3 p-0">
+                <li t-foreach="props.attribute.values()" t-as="value" t-key="value.id" class="color_attribute_list_item">
+                    <t t-set="is_custom" t-value="is_custom || (value.is_custom and value.id == props.selected.id)"/>
+                    <t t-set="img_style" t-value="value.image ? 'background:url(/web/image/product.template.attribute.value/' + value.id + '/image); background-size:cover;' : ''"/>
+                    <t t-set="color_style" t-value="value.is_custom ? '' : 'background-color: ' + value.html_color" />
+                    <span class="d-flex flex-column justify-content-center align-items-center">
+                        <label
+                            t-attf-class="configurator_color rounded-3 border position-relative {{ value.id == props.selected.id ? 'active border-3' : 'border-3 border-secondary' }}"
+                            t-att-class="{'ptav-not-available' : value.excluded}"
+                            t-attf-style="height: 62px; aspect-ratio: 1; {{ img_style or color_style }}"
+                            t-att-data-color="value.name">
+                            <input
+                                type="radio"
+                                t-att-checked="value.id === props.selected.id"
+                                t-on-change="() => props.setSelected(value)"
+                                t-att-name="value.attribute_id.id"
+                                t-attf-id="{{ value.attribute_id.id }}_{{ value.id }}"
+                                class="m-2 opacity-0"
+                            />
+                        </label>
+                        <div class="text-center mt-2 small">
+                            <span t-att-class="{ 'text-muted': value.doHaveConflictWith(props.allSelectedValues) }"
+                                t-esc="value.name"/>
+                        </div>
+
+                        <div t-if="value.price_extra"
+                            class="price-extra-cell d-inline-block mt-1"
+                            t-att-class="{'ptav-not-available' : value.excluded}">
+                            <span class="price_extra px-2 py-1 rounded-pill text-bg-info">
+                                <t t-esc="getFormatPriceExtra(value.price_extra)"/>
+                            </span>
+                        </div>
+                    </span>
+                </li>
+            </ul>
+
+            <input class="custom_value form-control form-control-lg mt-2" t-if="is_custom" type="text" t-att-value="props.customValue" t-on-change="(e) => props.setCustomValue(e.target.value)"/>
+        </div>
+    </t>
+
     <t t-name="point_of_sale.ProductConfiguratorPopup">
         <Dialog title="title">
             <ProductInfoBanner t-if="showInfoBanner" productTemplate="props.productTemplate" product="this.product" />
@@ -172,6 +216,10 @@
                     <MultiProductAttribute t-elif="attribute.attribute_id.display_type === 'multi'" attribute="attribute" 
                         selected="this.state.attributes[attribute.attribute_id.id]?.selected" setSelected="this.setSelected(attribute)" 
                         customValue="this.state.attributes[attribute.attribute_id.id]?.custom_value" setCustomValue="setCustomValue(attribute)"
+                        allSelectedValues="this.selectedValues"/>
+                    <ImageProductAttribute t-elif="attribute.attribute_id.display_type === 'image'" attribute="attribute"
+                        selected="this.state.attributes[attribute.attribute_id.id].selected" setSelected="this.setSelected(attribute)"
+                        customValue="this.state.attributes[attribute.attribute_id.id].custom_value" setCustomValue="setCustomValue(attribute)"
                         allSelectedValues="this.selectedValues"/>
                 </div>
             </div>

--- a/addons/point_of_sale/static/tests/pos/tours/product_variants_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_variants_tour.js
@@ -113,3 +113,16 @@ registry.category("web_tour.tours").add("test_integration_dynamic_always_never_v
             Chrome.endTour(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_image_variants_displayed", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Image Product"),
+            ProductConfiguratorPopup.checkImageVariantVisible(),
+            ProductConfiguratorPopup.checkImageVariantTextVisible("First Image"),
+            ProductConfiguratorPopup.checkImageVariantTextVisible("Second Image"),
+            ProductConfiguratorPopup.checkImagePriceExtraVisible("$ 20"),
+        ].flat(),
+});

--- a/addons/point_of_sale/static/tests/pos/tours/utils/product_configurator_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/product_configurator_util.js
@@ -171,3 +171,30 @@ export function isAddEnabled() {
         },
     ];
 }
+
+export function checkImageVariantVisible() {
+    return [
+        {
+            content: `Check that the image is displayed`,
+            trigger: `.configurator_color.rounded-3`,
+        },
+    ];
+}
+
+export function checkImageVariantTextVisible(variantName) {
+    return [
+        {
+            content: `Check that the variant is visible`,
+            trigger: `.text-center.mt-2.small span:contains("${variantName}")`,
+        },
+    ];
+}
+
+export function checkImagePriceExtraVisible(price) {
+    return [
+        {
+            content: `Check that the extra price is displayed`,
+            trigger: `.price_extra.px-2.py-1.rounded-pill.text-bg-info:contains("${price}")`,
+        },
+    ];
+}

--- a/addons/point_of_sale/tests/test_pos_product_variants.py
+++ b/addons/point_of_sale/tests/test_pos_product_variants.py
@@ -256,3 +256,36 @@ class TestPoSProductVariants(ProductVariantsCommon, TestPointOfSaleHttpCommon):
         })
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_integration_dynamic_always_never_variant_price', login="pos_user")
+
+    def test_image_variants_displayed(self):
+        """
+        Tests that the user can correctly chose variants in the product_configurator_popup
+        if the variant was set as Image
+        """
+        image_attribute = self.env['product.attribute'].create({
+            'name': 'Images',
+            'display_type': 'image',
+            'create_variant': 'always',
+        })
+        images = self.env['product.attribute.value'].create([{
+            'name': 'First Image',
+            'attribute_id': image_attribute.id,
+        }, {
+            'name': 'Second Image',
+            'attribute_id': image_attribute.id,
+            'default_extra_price': 20,
+        }])
+        product_template = self.env['product.template'].create({
+            'name': 'Image Product',
+            'is_storable': True,
+            'taxes_id': False,
+            'available_in_pos': True,
+        })
+        self.env['product.template.attribute.line'].create({
+            'product_tmpl_id': product_template.id,
+            'attribute_id': image_attribute.id,
+            'value_ids': [Command.set([images[0].id, images[1].id])],
+        })
+
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_image_variants_displayed', login="pos_user")


### PR DESCRIPTION
**Steps to reproduce:**
- Make a variant category, make it an Image
- Add it to a product, go to PoS and order the product
- The product variants will not be shown and can't be selected

**Why the fix:**
Since 19.0, there is a new kind of variant, Image, but it was not taken in the conditional statement for the product popup for the variants. As it didn't fall into any category, nothing was shown.

At the moment this is basically the same as the Color option, but with an extra label below to provide more information. This it will be IMP later on with images like in the Sales module.

opw-5099123