### PR TITLE
[FIX] portal: Open T&C links in a new tab

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -13,6 +13,7 @@ import logging
 from markupsafe import Markup
 import re
 import os
+from lxml import etree, html
 from textwrap import shorten
 
 from odoo import api, fields, models, _, modules
@@ -651,7 +652,7 @@ class AccountMove(models.Model):
     # === Misc Information === #
     narration = fields.Html(
         string='Terms and Conditions',
-        compute='_compute_narration', store=True, readonly=False,
+        compute='_compute_narration', inverse='_inverse_narration', store=True, readonly=False,
     )
     is_move_sent = fields.Boolean(
         readonly=True,
@@ -1949,6 +1950,10 @@ class AccountMove(models.Model):
                 narration = _('Terms & Conditions: %s', baseurl)
                 del context
             move.narration = narration or False
+
+    def _inverse_narration(self):
+        for move in self:
+            move.narration = self._set_links_to_new_tab(move.narration)
 
     def _get_partner_credit_warning_exclude_amount(self):
         # to extend in module 'sale'; see there for details
@@ -3935,6 +3940,22 @@ class AccountMove(models.Model):
 
     def check_move_sequence_chain(self):
         return self.filtered(lambda move: move.name != '/')._is_end_of_seq_chain()
+
+    @api.model
+    def _set_links_to_new_tab(self, narration_html):
+        """
+        Parses the given HTML string and adds target="_blank" to all <a> tags
+        to ensure they open in a new tab.
+        """
+        if not isinstance(narration_html, (str, bytes)):
+            return narration_html
+        try:
+            root = html.fromstring(narration_html)
+            for link in root.xpath('//a'):
+                link.set('target', '_blank')
+            return html.tostring(root, encoding='unicode')
+        except etree.ParserError:
+            return narration_html
 
     def _get_unlink_logger_message(self):
         """ Before unlink, get a log message for audit trail if restricted.

--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -489,7 +489,7 @@
                                     </div>
                                 </div>
                                 <!--terms and conditions-->
-                                <div class="text-muted mb-3" t-attf-style="#{'text-align:justify;text-justify:inter-word;' if o.company_id.terms_type != 'html' else ''}" t-if="not is_html_empty(o.narration)" name="comment">
+                                <div class="text-muted mb-3" t-if="not is_html_empty(o.narration)" name="comment">
                                     <span t-field="o.narration"/>
                                 </div>
                             </div>

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -147,6 +147,7 @@ class SaleOrder(models.Model):
     note = fields.Html(
         string="Terms and conditions",
         compute='_compute_note',
+        inverse='_inverse_note',
         store=True, readonly=False, precompute=True)
 
     partner_invoice_id = fields.Many2one(
@@ -396,6 +397,10 @@ class SaleOrder(models.Model):
                 if order.partner_id.lang:
                     order = order.with_context(lang=order.partner_id.lang)
                 order.note = order.env.company.invoice_terms
+
+    def _inverse_note(self):
+        for sales_order in self:
+            sales_order.note = self.env['account.move']._set_links_to_new_tab(sales_order.note)
 
     @api.model
     def _get_note_url(self):


### PR DESCRIPTION
Problem:
Links placed in the Terms and Conditions field on quotations and invoices open in the same browser tab on the customer portal. This navigates the user away from their document, and since the URL does not change, it can be confusing to return to the previous view.

Solution:
Inject `target="_blank"` into all `<a>` tags.

This ensures that all external links within the terms and conditions open in a new tab, providing a better and more intuitive user experience.

task-5114681

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
