### PR TITLE
[FIX] hr_holidays: consider taken leaves for future accrual

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -583,6 +583,7 @@ class HolidaysAllocation(models.Model):
             return 0
 
         fake_allocation = self.env['hr.leave.allocation'].with_context(default_date_from=accrual_date).new(origin=self)
+        fake_allocation.leaves_taken = self.with_context(default_date_from=accrual_date).leaves_taken
         fake_allocation.sudo().with_context(default_date_from=accrual_date)._process_accrual_plans(accrual_date, log=False)
         if self.holiday_status_id.request_unit in ['hour']:
             res = float_round(fake_allocation.number_of_hours_display - self.number_of_hours_display, precision_digits=2)


### PR DESCRIPTION
Computing the future accrued days/hours would become incorrect when using a cap when total lifetime accrued allocation was higher than the cap. This caused issues when looking at how much accrued time an employee would have on a certain date where the accrued time would be correct on today, but become incorrect on any other future day.

This was due to the fake allocation being used to compute the remaining time not considering the taken leaves, thus the cap was the maximum being considered across lifetime accrued time.

opw-5059276
