### PR TITLE
[FIX] pos_self_order: handle selected category when there are no top categories

### DIFF
--- a/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.js
+++ b/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.js
@@ -32,7 +32,10 @@ export class ProductListPage extends Component {
         }
         const availableCategories = this.selfOrder.availableCategories;
         const topCategories = availableCategories.filter((category) => !category.parent_id);
-        const selectedCategory = initCategories ? topCategories[0] : this.selfOrder.currentCategory;
+        const selectedCategory =
+            initCategories && topCategories.length > 0
+                ? topCategories[0]
+                : this.selfOrder.currentCategory;
 
         this.state = useState({
             selectedCategory: selectedCategory,

--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -159,8 +159,13 @@ export class SelfOrder extends Reactive {
     getAvailableCategories() {
         let now = luxon.DateTime.now();
         now = now.hour + now.minute / 60;
+        const isKiosk = this.config.self_ordering_mode === "kiosk";
         const availableCategories = this.productCategories
-            .filter((c) => this.productByCategIds[c.id]?.length > 0)
+            .filter(
+                (c) =>
+                    this.productByCategIds[c.id]?.length > 0 ||
+                    (isKiosk && c.child_ids.some((child) => child.id in this.productByCategIds))
+            )
             .sort((a, b) => a.sequence - b.sequence);
         return availableCategories.filter((c) => {
             const hourStart = c.hour_after;

--- a/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
@@ -249,3 +249,16 @@ registry.category("web_tour.tours").add("test_self_order_kiosk_product_availabil
         Utils.clickBtn("Close"),
     ],
 });
+
+registry.category("web_tour.tours").add("test_self_order_parent_category", {
+    steps: () => [
+        Utils.clickBtn("Order Now"),
+        ProductPage.clickChildCategory("Test Child Category 1"),
+        ProductPage.clickProduct("Coca-Cola"),
+        ProductPage.clickChildCategory("Test Child Category 2"),
+        ProductPage.clickProduct("Pepsi"),
+        Utils.clickBtn("Checkout"),
+        Utils.clickBtn("Order"),
+        Utils.clickBtn("Close"),
+    ],
+});

--- a/addons/pos_self_order/static/tests/tours/utils/product_page_util.js
+++ b/addons/pos_self_order/static/tests/tours/utils/product_page_util.js
@@ -13,6 +13,14 @@ export function clickCategory(categoryName) {
     };
 }
 
+export function clickChildCategory(childCategoryName) {
+    return {
+        content: `Click on child category '${childCategoryName}'`,
+        trigger: `.child_category_btn:contains('${childCategoryName}')`,
+        run: "click",
+    };
+}
+
 export function waitProduct(productName) {
     return {
         content: `Wait for product '${productName}'`,

--- a/addons/pos_self_order/tests/test_self_order_kiosk.py
+++ b/addons/pos_self_order/tests/test_self_order_kiosk.py
@@ -208,3 +208,48 @@ class TestSelfOrderKiosk(SelfOrderCommonTest):
         self.pos_config.current_session_id.set_opening_control(0, "")
         self_route = self.pos_config._get_self_order_route()
         self.start_tour(self_route, 'test_self_order_pricelist')
+
+    def test_self_order_parent_category(self):
+        # Create a parent POS category and two child POS categories
+        test_parent_category = self.env['pos.category'].create({
+            'name': "Test Parent Category",
+        })
+        test_child_category1 = self.env['pos.category'].create({
+            'name': "Test Child Category 1",
+            'parent_id': test_parent_category.id
+        })
+        test_child_category2 = self.env['pos.category'].create({
+            'name': "Test Child Category 2",
+            'parent_id': test_parent_category.id
+        })
+
+        # Create sample products for testing for child categories
+        self.env['product.product'].create({
+            'name': "Coca-Cola",
+            'list_price': 2.53,
+            'taxes_id': False,
+            'available_in_pos': True,
+            'pos_categ_ids': [Command.link(test_child_category1.id)],
+        })
+        self.env['product.product'].create({
+            'name': "Pepsi",
+            'list_price': 100,
+            'taxes_id': False,
+            'available_in_pos': True,
+            'pos_categ_ids': [Command.link(test_child_category2.id)],
+        })
+
+        self.pos_config.write({
+            'self_ordering_mode': 'kiosk',
+            'self_ordering_pay_after': 'each',
+            'iface_available_categ_ids': [Command.set([test_parent_category.id, test_child_category1.id, test_child_category2.id])],
+            'limit_categories': True,
+            'use_presets': False,
+            'default_preset_id': False,
+            'available_preset_ids': [Command.clear()],
+        })
+
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.pos_config.current_session_id.set_opening_control(0, "")
+        self_route = self.pos_config._get_self_order_route()
+        self.start_tour(self_route, "test_self_order_parent_category")


### PR DESCRIPTION
Problem: When the available categories for a point of sale contain one parent category and its child categories and the parent category itself does not have any products, the code filters out the top categories as those that have no parent category. If, in such a case, no products belong to the parent category itself, the selected category is undefined which leads to a blank white screen and the javascript error visible on the console.

Purpose: If there are no top categories, the screen should ideally load the current category computed before. This fix leads to the one of the child categories being the selected category and the kiosk screen loads properly

Steps to Reproduce on Runbot:
1. Create a point of sale. Go to Settings, choose no presets and “Kiosk” in the self-ordering option.
2. Create a parent POS category and two child POS categories.
3. Ensure there are products belonging to the two child categories and none to the parent category
4. Open settings for the POS and choose only these three categories in the “Restrict Categories” section.
5. Go to the point of sale and open the kiosk. Click on “Order Now”. The white screen appears and the js traceback error is visible on the console

opw-5058245

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
