### PR TITLE
[IMP] mail: add quick voice/video settings in discuss call actions

### DIFF
--- a/addons/mail/static/src/core/common/action.js
+++ b/addons/mail/static/src/core/common/action.js
@@ -1,5 +1,5 @@
 import { isRecord, STORE_SYM } from "@mail/model/misc";
-import { toRaw } from "@odoo/owl";
+import { Component, toRaw } from "@odoo/owl";
 import { DropdownState } from "@web/core/dropdown/dropdown_hooks";
 import { useService } from "@web/core/utils/hooks";
 import { Reactive } from "@web/core/utils/reactive";
@@ -25,6 +25,8 @@ export const ACTION_TAGS = Object.freeze({
  * @property {(action: Action) => Component<Props, Env>} [componentProps]
  * @property {boolean|(action: Action) => boolean} [disabledCondition]
  * @property {boolean} [dropdown]
+ * @property {Component|(action: Action) => Component} [dropdownComponent]
+ * @property {Object|(action: Action) => Object} [dropdownComponentProps]
  * @property {string|(action: Action) => string} [dropdownMenuClass]
  * @property {string|(action: Action) => string} [dropdownPosition]
  * @property {DropdownState|(action: Action) => DropdownState} [dropdownState]
@@ -150,6 +152,31 @@ export class Action {
     /** Determines whether this action opens a dropdown on selection. Value is shaped { template, menuClass } */
     get dropdown() {
         return this._dropdown(this.params) ?? this.definition.dropdown;
+    }
+
+    /** @param {Action} action @returns {Component|undefined} */
+    _dropdownComponent(action) {}
+    /** When action is a dropdown @see dropdown, this determines an optional component to use for the content slot */
+    get dropdownComponent() {
+        return (
+            this._dropdownComponent(this.params) ??
+            (typeof this.definition.dropdownComponent === "function" &&
+            Object.getPrototypeOf(this.definition.dropdownComponent) !== Component
+                ? this.definition.dropdownComponent.call(this, this.params)
+                : this.definition.dropdownComponent)
+        );
+    }
+
+    /** @param {Action} action @returns {Object|undefined} */
+    _dropdownComponentProps(action) {}
+    /** When action is a dropdown @see dropdown, this determines optional props to pass to component of the content slot of dropdown. */
+    get dropdownComponentProps() {
+        return (
+            this._dropdownComponentProps(this.params) ??
+            (typeof this.definition.dropdownComponentProps === "function"
+                ? this.definition.dropdownComponentProps.call(this, this.params)
+                : this.definition.dropdownComponentProps)
+        );
     }
 
     /** @param {Action} action @returns {string|undefined} */

--- a/addons/mail/static/src/core/common/action_list.scss
+++ b/addons/mail/static/src/core/common/action_list.scss
@@ -30,6 +30,13 @@
             &.o-odooControlPanelSwitchStyle i {
                 opacity: var(--mail-ActionList-buttonInlineIconOpacity);
             }
+
+            i.o-xsmaller {
+                transform: translateY(-2px);
+            }
+            &:not(:has(i.o-xsmaller)) {
+                aspect-ratio: 1;
+            }
         }
 
         &:not(.o-inline) > i {

--- a/addons/mail/static/src/core/common/action_list.xml
+++ b/addons/mail/static/src/core/common/action_list.xml
@@ -28,7 +28,8 @@
         <t t-component="Dropdown" menuClass="(action.dropdownMenuClass ?? '') + ' ' + store.discussDropdownMenuClass(this)" position="action.dropdownPosition" state="action.dropdownState">
             <t t-call="mail.Action.main"/>
             <t t-set-slot="content">
-                <t t-if="action.dropdownTemplate" t-call="{{ action.dropdownTemplate }}">
+                <t t-if="action.dropdownComponent" t-component="action.dropdownComponent" t-props="action.dropdownComponentProps"/>
+                <t t-elif="action.dropdownTemplate" t-call="{{ action.dropdownTemplate }}">
                     <t t-set="templateParams" t-value="action.dropdownTemplateParams"/>
                 </t>
                 <t t-elif="action.definition?.isMoreAction">

--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -58,6 +58,14 @@ $o-discuss-talkingColor: lighten($success, 10%);
     &.o-simulateDarkTheme {
         background-color: $gray-800;
         border-color: $gray-700 !important;
+
+        * {
+            color: white;
+        }
+
+        select, .form-check-input {
+            border-color: $gray-600;
+        }
     }
 
     .o_bottom_sheet_sheet:has(&) {

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -198,7 +198,10 @@ export class Store extends BaseStore {
 
     shouldSimulateDarkTheme(ctx) {
         return (
-            (ctx?.env?.inDiscussCallView || ctx?.env?.inCallInvitation) &&
+            (ctx?.env?.inDiscussCallView ||
+                ctx?.env?.inCallInvitation ||
+                ctx?.env.isDiscussPipBanner ||
+                ctx?.env?.inWelcomePage) &&
             this.isOdooWhiteTheme &&
             !ctx?.env.inMeetingSideActions &&
             !ctx?.env.inDiscussActionPanel
@@ -453,7 +456,7 @@ export class Store extends BaseStore {
 
     /** Provides an override point for when the store service has started. */
     onStarted() {
-        this.isOdooWhiteTheme = cookie.get("color_scheme") !== "dark";
+        this.isOdooWhiteTheme = cookie.get("color_scheme") !== "dark" || this.inPublicPage;
         navigator.serviceWorker?.addEventListener("message", ({ data = {} }) => {
             const { type, payload } = data;
             if (type === "notification-display-request") {

--- a/addons/mail/static/src/discuss/call/common/call_dropdown.js
+++ b/addons/mail/static/src/discuss/call/common/call_dropdown.js
@@ -87,7 +87,6 @@ export class CallDropdown extends Component {
     }
 
     onClickMenu(ev) {
-        this.close();
         ev.stopPropagation();
     }
 

--- a/addons/mail/static/src/discuss/call/common/call_dropdown.xml
+++ b/addons/mail/static/src/discuss/call/common/call_dropdown.xml
@@ -3,7 +3,7 @@
 
     <t t-name="discuss.CallDropdown">
         <div class="o-discuss-CallDropdown" t-att-class="props.class">
-            <div t-ref="trigger" t-on-click="handleClick">
+            <div class="d-flex h-100" t-ref="trigger" t-on-click="handleClick">
                 <t t-slot="default"/>
             </div>
 

--- a/addons/mail/static/src/discuss/call/common/call_preview.js
+++ b/addons/mail/static/src/discuss/call/common/call_preview.js
@@ -1,9 +1,10 @@
 import { Action, ACTION_TAGS } from "@mail/core/common/action";
 import { ActionList } from "@mail/core/common/action_list";
 import {
-    blurBackgroundAction,
     cameraOnAction,
     muteAction,
+    quickActionSettings,
+    quickVideoSettings,
 } from "@mail/discuss/call/common/call_actions";
 import { CallPermissionDialog } from "@mail/discuss/call/common/call_permission_dialog";
 import { closeStream, onChange } from "@mail/utils/common/misc";
@@ -75,6 +76,13 @@ export class CallPreview extends Component {
             onChange(this.store.settings, "audioOutputDeviceId", (deviceId) => {
                 this.audioRef.el?.setSinkId?.(deviceId).catch(() => {});
             });
+            onChange(this.store.settings, "useBlur", () => {
+                if (this.store.settings.useBlur) {
+                    this.enableBlur();
+                } else {
+                    this.disableBlur();
+                }
+            });
             onWillDestroy(() => {
                 closeStream(this.state.audioStream);
                 closeStream(this.state.videoStream);
@@ -124,32 +132,35 @@ export class CallPreview extends Component {
             name: ({ action }) => (action.isActive ? _t("Unmute") : _t("Mute")),
             onSelected: () => this.toggleMic(),
         };
-        const blurActionUpdated = {
-            ...blurBackgroundAction,
-            isActive: () => this.state.blurManager,
-            disabledCondition: () => !this.state.videoStream,
-            onSelected: () => this.toggleBlur(),
-            tags: ({ action }) => (action.isActive ? [ACTION_TAGS.SUCCESS] : []),
-        };
         return [
-            new Action({
-                id: "toggle-microphone",
-                owner: this,
-                definition: muteActionUpdated,
-                store: this.store,
-            }),
-            new Action({
-                id: "toggle-camera",
-                owner: this,
-                definition: cameraOnActionUpdated,
-                store: this.store,
-            }),
-            new Action({
-                id: "toggle-blur",
-                owner: this,
-                definition: blurActionUpdated,
-                store: this.store,
-            }),
+            [
+                new Action({
+                    id: "toggle-microphone",
+                    owner: this,
+                    definition: muteActionUpdated,
+                    store: this.store,
+                }),
+                new Action({
+                    id: "audio-settings",
+                    owner: this,
+                    definition: quickActionSettings,
+                    store: this.store,
+                }),
+            ],
+            [
+                new Action({
+                    id: "toggle-camera",
+                    owner: this,
+                    definition: cameraOnActionUpdated,
+                    store: this.store,
+                }),
+                new Action({
+                    id: "video-settings",
+                    owner: this,
+                    definition: quickVideoSettings,
+                    store: this.store,
+                }),
+            ],
         ];
     }
 

--- a/addons/mail/static/src/discuss/call/common/call_settings.js
+++ b/addons/mail/static/src/discuss/call/common/call_settings.js
@@ -1,4 +1,4 @@
-import { Component, onWillStart, useExternalListener, useState } from "@odoo/owl";
+import { Component, onWillStart, useExternalListener, useState, xml } from "@odoo/owl";
 
 import { _t } from "@web/core/l10n/translation";
 import { browser } from "@web/core/browser/browser";
@@ -8,6 +8,7 @@ import { useService } from "@web/core/utils/hooks";
 import { useMicrophoneVolume } from "@mail/utils/common/hooks";
 import { ActionPanel } from "@mail/discuss/core/common/action_panel";
 import { DeviceSelect } from "@mail/discuss/call/common/device_select";
+import { Dialog } from "@web/core/dialog/dialog";
 
 export class CallSettings extends Component {
     static template = "discuss.CallSettings";
@@ -144,4 +145,14 @@ export class CallSettings extends Component {
         this.store.settings.edgeBlurAmount = Number(ev.target.value);
         this.saveEdgeBlurAmount();
     }
+}
+
+export class CallSettingsDialog extends Component {
+    static template = xml`
+        <Dialog size="medium" footer="false" title.translate="Voice &amp; Video Settings">
+            <CallSettings withActionPanel="false"/>
+        </Dialog>
+    `;
+    static props = ["*"];
+    static components = { CallSettings, Dialog };
 }

--- a/addons/mail/static/src/discuss/call/common/call_settings.xml
+++ b/addons/mail/static/src/discuss/call/common/call_settings.xml
@@ -45,7 +45,7 @@
                                 <span class="d-flex invisible text-nowrap">
                                     <t t-out="testText.length > stopText.length ? testText : stopText"/>
                                 </span>
-                                <span class="position-absolute end-0 top-0">
+                                <span class="position-absolute start-0 top-0">
                                     <t t-if="microphoneVolume.isActive" t-out="stopText"/>
                                     <t t-else="" t-out="testText"/>
                                 </span>

--- a/addons/mail/static/src/discuss/call/common/meeting.xml
+++ b/addons/mail/static/src/discuss/call/common/meeting.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.Meeting">
-        <div class="o-mail-Meeting h-100 w-100 d-flex flex-column" t-att-class="{'p-1': !ui.isSmall, 'pb-3': !ui.iSmall and !props.isPip}">
+        <div t-if="store.rtc.channel" class="o-mail-Meeting h-100 w-100 d-flex flex-column" t-att-class="{'p-1': !ui.isSmall, 'pb-3': !ui.iSmall and !props.isPip}">
             <div class="d-flex flex-grow-1 h-100 o-min-height-0 gap-1 position-relative">
                 <div class="o-mail-Meeting-callContainer h-100 flex-grow-1 o-min-width-0" t-att-class="{'d-none': ui.isSmall and threadActions.activeAction?.actionPanelComponentCondition, 'pb-0': ui.isSmall}">
                     <Call hasOverlay="false" isPip="props.isPip"/>

--- a/addons/mail/static/src/discuss/call/common/pip_banner.js
+++ b/addons/mail/static/src/discuss/call/common/pip_banner.js
@@ -1,4 +1,4 @@
-import { Component } from "@odoo/owl";
+import { Component, useSubEnv } from "@odoo/owl";
 import { CallActionList } from "@mail/discuss/call/common/call_action_list";
 import { useService } from "@web/core/utils/hooks";
 
@@ -10,6 +10,7 @@ export class PipBanner extends Component {
     setup() {
         super.setup();
         this.rtc = useService("discuss.rtc");
+        useSubEnv({ isDiscussPipBanner: true });
     }
 
     onClickClose() {

--- a/addons/mail/static/src/discuss/call/common/quick_video_settings.js
+++ b/addons/mail/static/src/discuss/call/common/quick_video_settings.js
@@ -1,0 +1,24 @@
+import { Component } from "@odoo/owl";
+
+import { CallSettingsDialog } from "@mail/discuss/call/common/call_settings";
+import { DeviceSelect } from "@mail/discuss/call/common/device_select";
+
+import { useService } from "@web/core/utils/hooks";
+import { isBrowserSafari } from "@web/core/browser/feature_detection";
+
+export class QuickVideoSettings extends Component {
+    static template = "discuss.QuickVideoSettings";
+    static props = [];
+    static components = { DeviceSelect };
+
+    setup() {
+        super.setup();
+        this.store = useService("mail.store");
+        this.dialogService = useService("dialog");
+        this.isBrowserSafari = isBrowserSafari;
+    }
+
+    onClickVideoSettings() {
+        this.dialogService.add(CallSettingsDialog, {});
+    }
+}

--- a/addons/mail/static/src/discuss/call/common/quick_video_settings.xml
+++ b/addons/mail/static/src/discuss/call/common/quick_video_settings.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+
+    <t t-name="discuss.QuickVideoSettings">
+        <div class="o-discuss-QuickVideoSettings d-flex flex-column gap-1">
+            <label class="btn d-flex flex-column align-items-baseline">
+                <span class="flex-shrink-0 pe-2">
+                    Camera
+                </span>
+                <div class="flex-grow-1"/>
+                <DeviceSelect kind="'videoinput'"/>
+            </label>
+            <div t-if="!isBrowserSafari()" class="btn d-flex" t-on-click="() => store.settings.useBlur = !store.settings.useBlur">
+                <label class="d-flex align-items-center flex-wrap mw-100 cursor-pointer gap-2">
+                    <i class="fa fa-fw fa-photo"/><span class="text-truncate text-wrap">Blur background</span>
+                </label>
+                <div class="flex-grow-1"/>
+                <div class="form-check form-switch">
+                    <input class="form-check-input" type="checkbox" role="switch" t-att-checked="store.settings?.useBlur ? 'checked' : ''"/>
+                </div>
+            </div>
+            <button class="btn d-flex align-items-center gap-2" t-on-click="onClickVideoSettings">
+                <i class="fa fa-fw fa-gear"/><span>Video Settings</span>
+            </button>
+        </div>
+    </t>
+
+</templates>

--- a/addons/mail/static/src/discuss/call/common/quick_voice_settings.js
+++ b/addons/mail/static/src/discuss/call/common/quick_voice_settings.js
@@ -1,0 +1,22 @@
+import { Component } from "@odoo/owl";
+
+import { CallSettingsDialog } from "@mail/discuss/call/common/call_settings";
+import { DeviceSelect } from "@mail/discuss/call/common/device_select";
+
+import { useService } from "@web/core/utils/hooks";
+
+export class QuickVoiceSettings extends Component {
+    static template = "discuss.QuickVoiceSettings";
+    static props = [];
+    static components = { DeviceSelect };
+
+    setup() {
+        super.setup();
+        this.store = useService("mail.store");
+        this.dialogService = useService("dialog");
+    }
+
+    onClickVoiceSettings() {
+        this.dialogService.add(CallSettingsDialog, {});
+    }
+}

--- a/addons/mail/static/src/discuss/call/common/quick_voice_settings.xml
+++ b/addons/mail/static/src/discuss/call/common/quick_voice_settings.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+
+    <t t-name="discuss.QuickVoiceSettings">
+        <div class="o-discuss-QuickVoiceSettings d-flex flex-column gap-1">
+            <label class="btn d-flex flex-column align-items-baseline">
+                <span class="flex-shrink-0 pe-2">
+                    Microphone
+                </span>
+                <div class="flex-grow-1"/>
+                <DeviceSelect kind="'audioinput'"/>
+            </label>
+            <label class="btn d-flex flex-column align-items-baseline">
+                <span class="flex-shrink-0 pe-2">
+                    Audio Output
+                </span>
+                <div class="flex-grow-1"/>
+                <DeviceSelect kind="'audiooutput'"/>
+            </label>
+            <button t-if="store.rtc.selfSession" class="btn d-flex" t-on-click="() => this.store.rtc.toggleDeafen()">
+                <label class="d-flex align-items-center flex-wrap mw-100 cursor-pointer">
+                    <span class="text-truncate text-wrap">Deafen</span>
+                </label>
+                <div class="flex-grow-1"/>
+                <div class="form-check form-switch">
+                    <input class="form-check-input" type="checkbox" role="switch" t-att-checked="store.rtc.selfSession?.is_deaf ? 'checked' : ''"/>
+                </div>
+            </button>
+            <button class="btn d-flex" t-on-click="() => this.store.settings.use_push_to_talk = !this.store.settings.use_push_to_talk">
+                <label class="d-flex align-items-center flex-wrap mw-100 cursor-pointer">
+                    <span class="text-truncate text-wrap">Push-to-Talk</span>
+                </label>
+                <div class="flex-grow-1"/>
+                <div class="form-check form-switch">
+                    <input class="form-check-input" type="checkbox" role="switch" t-att-checked="store.settings.use_push_to_talk ? 'checked' : ''"/>
+                </div>
+            </button>
+            <button class="btn d-flex align-items-center gap-2" t-on-click="onClickVoiceSettings">
+                <i class="fa fa-fw fa-gear"/><span>Voice Settings</span>
+            </button>
+        </div>
+    </t>
+
+</templates>

--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -574,6 +574,7 @@ export class Rtc extends Record {
 
     async openPip(options) {
         if (this.isHost) {
+            this.exitFullscreen();
             await this.pipService.openPip(options);
             return;
         }

--- a/addons/mail/static/src/discuss/call/web/quick_video_settings_patch.js
+++ b/addons/mail/static/src/discuss/call/web/quick_video_settings_patch.js
@@ -1,0 +1,23 @@
+import { useService } from "@web/core/utils/hooks";
+import { _t } from "@web/core/l10n/translation";
+import { patch } from "@web/core/utils/patch";
+import { QuickVideoSettings } from "../common/quick_video_settings";
+
+patch(QuickVideoSettings.prototype, {
+    setup() {
+        super.setup();
+        this.actionService = useService("action");
+    },
+    onClickVideoSettings() {
+        this.actionService.doAction({
+            context: {
+                dialog_size: "medium",
+                footer: false,
+            },
+            name: _t("Voice & Video Settings"),
+            tag: "mail.discuss_call_settings_action",
+            target: "new",
+            type: "ir.actions.client",
+        });
+    },
+});

--- a/addons/mail/static/src/discuss/call/web/quick_voice_settings_patch.js
+++ b/addons/mail/static/src/discuss/call/web/quick_voice_settings_patch.js
@@ -1,0 +1,23 @@
+import { useService } from "@web/core/utils/hooks";
+import { _t } from "@web/core/l10n/translation";
+import { QuickVoiceSettings } from "@mail/discuss/call/common/quick_voice_settings";
+import { patch } from "@web/core/utils/patch";
+
+patch(QuickVoiceSettings.prototype, {
+    setup() {
+        super.setup();
+        this.actionService = useService("action");
+    },
+    onClickVoiceSettings() {
+        this.actionService.doAction({
+            context: {
+                dialog_size: "medium",
+                footer: false,
+            },
+            name: _t("Voice & Video Settings"),
+            tag: "mail.discuss_call_settings_action",
+            target: "new",
+            type: "ir.actions.client",
+        });
+    },
+});

--- a/addons/mail/static/src/discuss/core/public/welcome_page.js
+++ b/addons/mail/static/src/discuss/core/public/welcome_page.js
@@ -1,7 +1,6 @@
 import { CallPreview } from "@mail/discuss/call/common/call_preview";
-import { DeviceSelect } from "@mail/discuss/call/common/device_select";
 
-import { Component, useState } from "@odoo/owl";
+import { Component, useState, useSubEnv } from "@odoo/owl";
 
 import { browser } from "@web/core/browser/browser";
 import { _t } from "@web/core/l10n/translation";
@@ -10,7 +9,7 @@ import { useService } from "@web/core/utils/hooks";
 export class WelcomePage extends Component {
     static props = ["proceed?"];
     static template = "mail.WelcomePage";
-    static components = { CallPreview, DeviceSelect };
+    static components = { CallPreview };
 
     setup() {
         super.setup();
@@ -18,6 +17,7 @@ export class WelcomePage extends Component {
         this.store = useService("mail.store");
         this.ui = useService("ui");
         this.rtc = useService("discuss.rtc");
+        useSubEnv({ inWelcomePage: true });
         this.state = useState({
             userName: this.store.self.name || _t("Guest"),
             hasMicrophone: undefined,

--- a/addons/mail/static/src/discuss/core/public/welcome_page.xml
+++ b/addons/mail/static/src/discuss/core/public/welcome_page.xml
@@ -12,20 +12,6 @@
         <div class="w-100 d-flex justify-content-center gap-5" t-att-class="{'flex-column': ui.isSmall}">
             <div t-if="showCallPreview" class="w-100 rounded-3 overflow-hidden" style="max-width: 640px;">
                 <CallPreview onSettingsChanged="(settings) => this.onCallSettingsChanged(settings)"/>
-                <div class="d-flex flex-column flex-md-row gap-2 text-muted mt-3">
-                    <div class="w-100 text-uppercase">
-                        <i class="fa fa-microphone"></i> Microphone
-                        <DeviceSelect kind="'audioinput'"/>
-                    </div>
-                    <div class="w-100 text-uppercase">
-                        <i class="fa fa-volume-up"></i> Output
-                        <DeviceSelect kind="'audiooutput'"/>
-                    </div>
-                    <div class="w-100 text-uppercase">
-                        <i class="fa fa-camera"></i> Camera
-                        <DeviceSelect kind="'videoinput'"/>
-                    </div>
-                </div>
             </div>
             <div class="d-flex flex-column text-center justify-content-center">
                 <div class="d-flex flex-column gap-2" t-if="store.self_guest and !store.self_partner">

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -50,15 +50,20 @@ test("basic rendering", async () => {
     await contains(".o-discuss-CallParticipantCard[aria-label='Mitchell Admin']");
     await contains(".o-discuss-CallActionList");
     await contains(".o-discuss-CallMenu-buttonContent");
-    await contains(".o-discuss-CallActionList button", { count: 6 });
+    await contains(".o-discuss-CallActionList button", { count: 7 });
     await contains("button[aria-label='Unmute'], button[aria-label='Mute']"); // FIXME depends on current browser permission
-    await contains(".o-discuss-CallActionList button[aria-label='Deafen']");
+    await contains("button[aria-label='Voice Settings']");
     await contains(".o-discuss-CallActionList button[aria-label='Turn camera on']");
+    await contains("button[aria-label='Video Settings']");
     await contains(".o-discuss-CallActionList button[aria-label='Share Screen']");
     await contains("[title='More']");
     await contains(".o-discuss-CallActionList button[aria-label='Disconnect']");
     await click("[title='More']");
+    await contains(".o-dropdown-item", { count: 2 });
     await contains(".o-dropdown-item:contains('Raise Hand')");
+    await contains(".o-dropdown-item:contains('Disable speaker autofocus')");
+    await contains(".o-discuss-Call-layoutActions button", { count: 2 });
+    await contains(".o-discuss-Call-layoutActions button[title='Picture in Picture']");
     await contains(".o-discuss-Call-layoutActions button[title='Fullscreen']");
 });
 
@@ -71,7 +76,6 @@ test("mobile UI", async () => {
     await click("[title='Start Call']");
     await contains(".o-discuss-Call");
     expect(isMobileOS()).toBe(true);
-    await contains(".o-discuss-CallActionList button[aria-label='Deafen']");
     await contains("[title='Share Screen']", { count: 0 });
 });
 
@@ -378,7 +382,8 @@ test("Systray icon shows latest action", async () => {
     await contains(".o-discuss-CallMenu-buttonContent .fa-microphone");
     await click("[title='Mute']");
     await contains(".o-discuss-CallMenu-buttonContent .fa-microphone-slash");
-    await click("[title='Deafen']");
+    await click("[title='Voice Settings']");
+    await click(".dropdown-menu button:contains('Deafen')");
     await contains(".o-discuss-CallMenu-buttonContent .fa-deaf");
     await click("[title='Turn camera on']");
     await contains(".o-discuss-CallMenu-buttonContent .fa-video-camera");
@@ -626,7 +631,6 @@ test("Cross tab calls: tabs can interact with calls remotely", async () => {
     await openDiscuss(channelId);
     expect("[title='Disconnect']").not.toHaveCount();
     expect("[title='Mute']").not.toHaveCount();
-    expect("[title='Deafen']").not.toHaveCount();
     broadcastChannel.postMessage({
         type: CROSS_TAB_HOST_MESSAGE.UPDATE_REMOTE,
         hostedChannelId: channelId,
@@ -639,7 +643,7 @@ test("Cross tab calls: tabs can interact with calls remotely", async () => {
         },
     });
     await contains("[title='Disconnect']");
-    await contains("[title='Deafen']");
+    await contains("[title='Mute']");
 
     broadcastChannel.onmessage = (event) => {
         if (event.data.type === CROSS_TAB_CLIENT_MESSAGE.REQUEST_ACTION) {

--- a/addons/mail/static/tests/tours/discuss_call_invitation_tour.js
+++ b/addons/mail/static/tests/tours/discuss_call_invitation_tour.js
@@ -44,8 +44,11 @@ registry.category("web_tour.tours").add("discuss_call_invitation.js", {
                 trigger: ".o-discuss-CallInvitation-cameraPreview button[title='Unmute']",
             },
             {
-                trigger:
-                    ".o-discuss-CallInvitation-cameraPreview button[title='Blur Background']:disabled",
+                trigger: ".o-discuss-CallInvitation-cameraPreview button[title='Video Settings']",
+                run: "click",
+            },
+            {
+                trigger: "label:contains('Blur background')",
             },
             {
                 trigger: ".o-discuss-CallInvitation button[title='Hide camera preview']",


### PR DESCRIPTION
This commit tweak discuss call actions as follow:
- add new buttons "Voice Settings" and "Video Settings" next to respectively "Mute" and "Camera" actions. These buttons show dropup menu with quick features related to voice and video respectively.

- Quick voice settings menu can change audio devices, toggle deafen, toggle push-to-talk mode, and access full voice settings
- Quick video settings menu can change video device, toggle blur background, and access full video settings

To keep amount of items short in call action list:
- deafen button has been removed: toggle is in quick voice settings menu, and hotkey Shift+d still works like before
- blur background button has been removed: toggle is in quick video settings menu.

Also makes these small fixes:
- call action list in PiP banner also uses simulated dark theme color in white theme
- welcome page and discuss public page shows simulated dark theme color, ignoring cookie as only white theme is supported
- enabling PiP while the call was in full screen quits fullscreen (PiP replaces fullscreen as intended)
- no crash channel.videoCount on disconnect from PiP

Part of Task-4967129

### Before
<img width="229" height="52" alt="before-1" src="https://github.com/user-attachments/assets/bcb6e80d-de40-41b4-80d9-f1e27986ca07" />

in call

<img width="124" height="63" alt="before-2" src="https://github.com/user-attachments/assets/fe3a5e67-24ec-4ff5-8a04-730361a6460a" />

in welcome page

### After
<img width="432" height="199" alt="after-1" src="https://github.com/user-attachments/assets/dcc1679e-a0ec-4ad8-82cb-03ba2c0a84d9" />

in call

<img width="330" height="209" alt="after-2" src="https://github.com/user-attachments/assets/66266e83-faaa-41d9-b8ec-24011106a357" />

in welcome page