### PR TITLE
[FIX] base: add check if manifest isn't present

### DIFF
--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -341,7 +341,8 @@ class IrModuleModule(models.Model):
     def check_external_dependencies(self, module_name, newstate='to install'):
         try:
             manifest = modules.Manifest.for_addon(module_name)
-            manifest.check_manifest_dependencies()
+            if isinstance(manifest, modules.Manifest):
+                manifest.check_manifest_dependencies()
         except MissingDependency as e:
             if newstate == 'to install':
                 msg = _('Unable to install module "%(module)s" because an external dependency is not met: %(dependency)s', module=module_name, dependency=e.dependency)


### PR DESCRIPTION
[upg-3148374](https://upgrade.odoo.com/odoo/request/3148374)
[upg-3152860](https://upgrade.odoo.com/odoo/request/3152860)

## Description of the issue/feature this PR addresses:

For Odoo Online database upgrades with custom modules, the manifest cannot be loaded as it is not present in the request.

Before commit 8e496b3df0df708280c77b9a1ae15c46e922c3bc, module manifest info was inside a dictionary, which could be empty for custom modules. This dictionary was then passed as an argument to the method `odoo.modules.check_manifest_dependencies()`, and if the dictionary was empty, then the process would simply continue.

See: https://github.com/odoo/odoo/blob/saas-18.2/odoo/modules/module.py#L527-L529

## Current behavior before PR:

After the aforementioned commit, manifests are now Python objects of the new class "Manifest", or None if they cannot be retrieved. In addition, the method `check_manifest_dependencies` is now bound to the class.

See: https://github.com/odoo/odoo/blob/19.0/odoo/addons/base/models/ir_module.py#L343C13-L344

This means that, if the Manifest object is None, we can get an AttributeError exception: "'NoneType' object has no attribute 'check_manifest_dependencies'"

Steps to reproduce:
1. Using an Odoo Online database with custom modules, create an upgrade request targeting 19.0.
3. Request fails after loading the module "base"

```
2025-09-25 03:14:35,651 27 WARNING db_3148374 odoo.modules.module: module cbs_l10n_mx_edi: manifest not found
2025-09-25 03:14:35,660 27 WARNING db_3148374 odoo.modules.loading: Transient module states were reset
2025-09-25 03:14:35,660 27 ERROR db_3148374 odoo.registry: Failed to load registry
2025-09-25 03:14:35,660 27 CRITICAL db_3148374 odoo.service.server: Failed to initialize database `db_3148374`.
Traceback (most recent call last):
  File "/home/odoo/src/odoo/19.0/odoo/service/server.py", line 1509, in preload_registries
    registry = Registry.new(dbname, update_module=update_module, install_modules=config['init'], upgrade_modules=config['update'], reinit_modules=config['reinit'])
  File "/home/odoo/src/odoo/19.0/odoo/tools/func.py", line 88, in locked
    return func(inst, *args, **kwargs)
  File "/home/odoo/src/odoo/19.0/odoo/orm/registry.py", line 185, in new
    load_modules(
  File "/home/odoo/src/odoo/19.0/odoo/modules/loading.py", line 424, in load_modules
    modules.button_upgrade()
  File "/home/odoo/src/odoo/19.0/odoo/addons/base/models/ir_module.py", line 70, in check_and_log
    return method(self, *args, **kwargs)
  File "/home/odoo/src/odoo/19.0/odoo/addons/base/models/ir_module.py", line 708, in button_upgrade
    self.check_external_dependencies(module.name, 'to upgrade')
  File "/home/odoo/src/odoo/19.0/odoo/addons/base/models/ir_module.py", line 344, in check_external_dependencies
    manifest.check_manifest_dependencies()
AttributeError: 'NoneType' object has no attribute 'check_manifest_dependencies'
```
## Desired behavior after PR is merged:

To address this issue, we add a check to verify that the manifest info is an instance of the class "Manifest" before executing a class method. If null, then the method is not executed and the upgrade request would be allowed to continue as usual.

---

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
