### PR TITLE
[FIX] account: fix `bank_statements_source` selection

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -240,7 +240,7 @@ class AccountJournal(models.Model):
         index='btree_not_null',
         check_company=True,
         domain="[('partner_id','=', company_partner_id)]")
-    bank_statements_source = fields.Selection(selection=_get_bank_statements_available_sources, string='Bank Feeds', default='undefined', help="Defines how the bank statements will be registered")
+    bank_statements_source = fields.Selection(selection='_get_bank_statements_available_sources', string='Bank Feeds', default='undefined', help="Defines how the bank statements will be registered")
     bank_acc_number = fields.Char(related='bank_account_id.acc_number', readonly=False)
     bank_id = fields.Many2one('res.bank', related='bank_account_id.bank_id', readonly=False)
 


### PR DESCRIPTION
Currently the selection options from other modules are missing in field `bank_statements_source`.
It broke in commit 65e7a6727597bf7896c864dbd13c873ce4ae6e30.

The issue is that a function is passed directly as `selection` argument to the field (`selection=_get_bank_statements_available_sources`). But that way the inheritance is ignored / the extending functions of other modules are not called / ignored.

After this commit the function name is passed to `selection`. That way the inheritance / extending functions work again.

task-None