### PR TITLE
[FIX] pos_self_order: reset order ui state on back navigation

### DIFF
--- a/addons/pos_online_payment_self_order/static/tests/tours/pos_self_order_mobile_online_payment_tour.js
+++ b/addons/pos_online_payment_self_order/static/tests/tours/pos_self_order_mobile_online_payment_tour.js
@@ -55,3 +55,21 @@ registry
                 Utils.clickBtn("Pay"),
             ].flat(),
     });
+
+registry.category("web_tour.tours").add("test_kiosk_cart_restore_and_cancel", {
+    test: true,
+    steps: () => [
+        Utils.clickBtn("Order Now"),
+        ProductPage.clickProduct("Coca-Cola"),
+        ProductPage.clickProduct("Fanta"),
+        Utils.clickBtn("Checkout"),
+        CartPage.checkProduct("Coca-Cola", "2.53", "1"),
+        CartPage.checkProduct("Fanta", "2.53", "1"),
+        Utils.clickBtn("Pay"),
+        Utils.clickBtn("Back"),
+        CartPage.checkProduct("Coca-Cola", "2.53", "1"),
+        CartPage.checkProduct("Fanta", "2.53", "1"),
+        Utils.clickBackBtn(),
+        ...ProductPage.clickCancel(),
+    ],
+});

--- a/addons/pos_online_payment_self_order/tests/test_self_order_mobile.py
+++ b/addons/pos_online_payment_self_order/tests/test_self_order_mobile.py
@@ -87,3 +87,38 @@ class TestSelfOrderMobile(SelfOrderCommonTest, OnlinePaymentCommon):
 
         # Check self-order in pos-terminal order button remains enabled
         self.start_tour('/pos/ui?config_id=%d' % self.pos_config.id, 'test_online_payment_pos_self_order_preparation_changes', login='pos_user')
+
+    def test_kiosk_cart_restore_and_cancel(self):
+        """
+        Verify that the cart restores correctly after back navigation from payment
+        and that order cancellation works as expected.
+        """
+
+        self.pos_config.write({
+            'self_ordering_mode': 'kiosk',
+            'self_ordering_pay_after': 'each',
+            'payment_method_ids': [Command.set(self.online_payment_method.ids)],
+            'use_presets': False,
+        })
+
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.pos_config.current_session_id.set_opening_control(0, "")
+        self_route = self.pos_config._get_self_order_route()
+        self.start_tour(self_route, "test_kiosk_cart_restore_and_cancel")
+
+        kiosk_order = self.env['pos.order'].search(
+            [('config_id', '=', self.pos_config.id), ('state', '=', 'cancel')],
+            order="id desc", limit=1
+        )
+
+        # Collect order lines in a dict by product name
+        order_lines = {line.product_id.name: line for line in kiosk_order.lines}
+        self.assertEqual(len(order_lines), 2, "There should be exactly 2 order lines")
+
+        coca_line = order_lines.get("Coca-Cola")
+        self.assertIsNotNone(coca_line, "Expected order line not found")
+        self.assertEqual(coca_line.qty, 1, "Order line quantity mismatch")
+
+        fanta_line = order_lines.get("Fanta")
+        self.assertIsNotNone(fanta_line, "Expected order line not found")
+        self.assertEqual(fanta_line.qty, 1, "Order line quantity mismatch")

--- a/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
+++ b/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
@@ -8,7 +8,6 @@ import { useScrollShadow } from "../../utils/scroll_shadow_hook";
 import { useTrackedAsync } from "@point_of_sale/app/hooks/hooks";
 import { OrderReceipt } from "@point_of_sale/app/screens/receipt_screen/receipt/order_receipt";
 import { CancelPopup } from "@pos_self_order/app/components/cancel_popup/cancel_popup";
-import { rpc } from "@web/core/network/rpc";
 import { _t } from "@web/core/l10n/translation";
 import { formatProductName } from "../../utils";
 
@@ -68,17 +67,7 @@ export class CartPage extends Component {
         this.dialog.add(CancelPopup, {
             title: _t("Cancel order"),
             confirm: async () => {
-                try {
-                    await rpc("/pos-self-order/remove-order", {
-                        access_token: this.selfOrder.access_token,
-                        order_id: this.selfOrder.currentOrder.id,
-                        order_access_token: this.selfOrder.currentOrder.access_token,
-                    });
-                    this.selfOrder.currentOrder.state = "cancel";
-                    this.router.navigate("default");
-                } catch (error) {
-                    this.selfOrder.handleErrorNotification(error);
-                }
+                this.selfOrder.cancelBackendOrder();
             },
         });
     }

--- a/addons/pos_self_order/static/src/app/pages/payment_page/payment_page.js
+++ b/addons/pos_self_order/static/src/app/pages/payment_page/payment_page.js
@@ -32,6 +32,11 @@ export class PaymentPage extends Component {
         return this.selfOrder.paymentError || this.state.selection;
     }
 
+    back() {
+        this.selfOrder.currentOrder.uiState.lineChanges = {};
+        this.router.back();
+    }
+
     selectMethod(methodId) {
         this.state.selection = false;
         this.state.paymentMethodId = methodId;

--- a/addons/pos_self_order/static/src/app/pages/payment_page/payment_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/payment_page/payment_page.xml
@@ -27,7 +27,7 @@
             </div>
 
             <div class="o_self_footer container o_self_container d-flex justify-content-between align-items-center position-relative py-3">
-                <button class="btn btn-secondary btn-lg" t-if="state.selection || selectedPaymentMethod.is_online_payment || this.selfOrder.paymentError" t-on-click="() => this.router.back()">Back</button>
+                <button class="btn btn-secondary btn-lg" t-if="state.selection || selectedPaymentMethod.is_online_payment || this.selfOrder.paymentError" t-on-click="back">Back</button>
                 <button class="btn btn-primary btn-lg" t-if="!state.selection and selfOrder.paymentError" t-on-click="startPayment">Retry</button>
             </div>
 

--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -563,6 +563,15 @@ export class SelfOrder extends Reactive {
     }
 
     cancelOrder() {
+        if (
+            this.config.self_ordering_mode === "kiosk" &&
+            this.hasPaymentMethod() &&
+            typeof this.currentOrder.id === "number"
+        ) {
+            this.cancelBackendOrder();
+            return;
+        }
+
         const lineToDelete = [];
         for (const line of this.currentOrder.lines) {
             const changes = line.changes;
@@ -599,6 +608,20 @@ export class SelfOrder extends Reactive {
             this.router.navigate("default");
             this.currentOrder.delete();
             this.selectedOrderUuid = null;
+        }
+    }
+
+    async cancelBackendOrder() {
+        try {
+            await rpc("/pos-self-order/remove-order", {
+                access_token: this.access_token,
+                order_id: this.currentOrder.id,
+                order_access_token: this.currentOrder.access_token,
+            });
+            this.currentOrder.state = "cancel";
+            this.router.navigate("default");
+        } catch (error) {
+            this.handleErrorNotification(error);
         }
     }
 

--- a/addons/pos_self_order/static/tests/unit/services/self_order_service.test.js
+++ b/addons/pos_self_order/static/tests/unit/services/self_order_service.test.js
@@ -248,4 +248,20 @@ describe("self_order_service", () => {
             expect(models["pos.order.line"].length).toBe(2);
         });
     });
+
+    test("cancelBackendOrder", async () => {
+        const store = await setupSelfPosEnv();
+        const order = await getFilledSelfOrder(store);
+
+        const syncOrder = await store.sendDraftOrderToServer();
+        expect(order.id).toBeOfType("number");
+        expect(order.lines[0].id).toBeOfType("number");
+        expect(order.lines[1].id).toBeOfType("number");
+        expect(syncOrder.id).toBe(order.id);
+
+        await store.cancelBackendOrder();
+
+        expect(order.state).toBe("cancel");
+        expect(store.router.activeSlot).toBe("default");
+    });
 });

--- a/addons/pos_self_order/static/tests/unit/utils.js
+++ b/addons/pos_self_order/static/tests/unit/utils.js
@@ -29,6 +29,7 @@ export function initMockRpc() {
     onRpc("/pos-self-order/process-order/kiosk", mockProcssOrder);
     onRpc("/pos-self-order/process-order/mobile", mockProcssOrder);
     onRpc("/pos-self-order/get-slots/", () => ({ usage_utc: {} }));
+    onRpc("/pos-self-order/remove-order", () => ({}));
 }
 
 export const setupSelfPosEnv = async (mode = "kiosk") => {


### PR DESCRIPTION
Steps to reproduce:
===================
- Start a self-order session.
- Add some products to the cart.
- Navigate to the payment page.
- Click the back button.

Issue:
======
- When going back to the cart page from the payment page,
products in the cart are not editable.
- On the product page, the cart total shows 0.

Cause:
======
- `lineChanges` were not cleared on back navigation, leaving previous data
in the cart.

Fix:
====
- Clear `lineChanges` when navigating back from the payment page to
ensure a clean state.

Task: 5055279