### PR TITLE
[FIX] web: Hoot - issue levels

### DIFF
--- a/addons/web/static/lib/hoot/core/expect.js
+++ b/addons/web/static/lib/hoot/core/expect.js
@@ -303,7 +303,7 @@ function listJoin(list, separator, lastSeparator) {
 /** @type {typeof makeLabel} */
 function makeLabelOrString(...args) {
     const label = makeLabel(...args);
-    if (logger.allows("debug")) {
+    if (logger.canLog("debug")) {
         debugLabelCache.set(label, args[0]);
     }
     return label[1] === null ? label[0] : label;
@@ -1010,7 +1010,7 @@ export class CaseResult {
             }
         }
         if (caseEvent) {
-            if (logger.allows("debug") && CASE_EVENT_LOG_COLORS.includes(type)) {
+            if (logger.canLog("debug") && CASE_EVENT_LOG_COLORS.includes(type)) {
                 const colorName = caseEvent.pass === false ? "rose" : CASE_EVENT_TYPES[type].color;
                 const logArgs = [[caseEvent.label, getColorHex(colorName)]];
                 for (const part of caseEvent.message) {

--- a/addons/web/static/lib/hoot/core/fixture.js
+++ b/addons/web/static/lib/hoot/core/fixture.js
@@ -75,7 +75,7 @@ export function makeFixtureManager(runner) {
 
     function getFixture() {
         if (!allowFixture) {
-            throw new HootError(`Cannot access fixture outside of a test.`);
+            throw new HootError(`cannot access fixture outside of a test.`);
         }
         if (!currentFixture) {
             // Prepare fixture once to not force layouts/reflows

--- a/addons/web/static/lib/hoot/core/job.js
+++ b/addons/web/static/lib/hoot/core/job.js
@@ -35,7 +35,9 @@ const {
 function validateConfig(config) {
     for (const [key, value] of $entries(config)) {
         if (!isOfType(value, CONFIG_TAG_SCHEMA[key])) {
-            throw new HootError(`invalid config tag: parameter "${key}" does not exist`);
+            throw new HootError(`invalid config tag: parameter "${key}" does not exist`, {
+                level: "critical",
+            });
         }
     }
 }

--- a/addons/web/static/lib/hoot/core/logger.js
+++ b/addons/web/static/lib/hoot/core/logger.js
@@ -20,6 +20,7 @@ const {
         trace: $trace,
         warn: $warn,
     },
+    Object: { entries: $entries, getOwnPropertyDescriptors: $getOwnPropertyDescriptors },
 } = globalThis;
 
 //-----------------------------------------------------------------------------
@@ -57,63 +58,27 @@ function unstyledArguments(args) {
     return [args.join(" ")];
 }
 
-const DEBUG_PREFIX = ["DEBUG", getColorHex("purple")];
-const DEFAULT_PREFIX = ["HOOT", getColorHex("primary")];
-const ERROR_PREFIX = ["ERROR", getColorHex("rose")];
-const WARNING_PREFIX = ["WARNING", getColorHex("amber")];
-let nextNetworkLogId = 1;
-
-//-----------------------------------------------------------------------------
-// Exports
-//-----------------------------------------------------------------------------
-
-/**
- * @param {string} prefix
- * @param {string} title
- */
-export function makeNetworkLogger(prefix, title) {
-    const id = nextNetworkLogId++;
-    return {
-        /**
-         * Request logger: blue-ish.
-         * @param {() => any} getData
-         */
-        async logRequest(getData) {
-            if (!logger.allows("debug")) {
-                return;
-            }
-            const color = `color: #66e`;
-            const styles = [`${color}; font-weight: bold;`, color];
-            $groupCollapsed(`-> %c${prefix}#${id}%c<${title}>`, ...styles, await getData());
-            $trace("request trace");
-            $groupEnd();
-        },
-        /**
-         * Response logger: orange.
-         * @param {() => any} getData
-         */
-        async logResponse(getData) {
-            if (!logger.allows("debug")) {
-                return;
-            }
-            const color = `color: #f80`;
-            const styles = [`${color}; font-weight: bold;`, color];
-            $log(`<- %c${prefix}#${id}%c<${title}>`, ...styles, await getData());
-        },
-    };
-}
-
-export const LOG_LEVELS = {
-    runner: 0,
-    suites: 1,
-    tests: 2,
-    debug: 3,
-};
-
-export const logger = {
+class Logger {
     /** @private */
-    currentLevel: urlParams.loglevel ?? LOG_LEVELS.runner,
-    suppressed: "",
+    issueLevel;
+    /** @private */
+    logLevel;
+
+    constructor(logLevel, issueLevel) {
+        this.logLevel = logLevel;
+        this.issueLevel = issueLevel;
+
+        // Pre-bind all methods for ease of use
+        for (const [key, desc] of $entries($getOwnPropertyDescriptors(Logger.prototype))) {
+            if (key !== "constructor" && typeof desc.value === "function") {
+                this[key] = this[key].bind(this);
+            }
+        }
+    }
+
+    get global() {
+        return new Logger(this.logLevel, ISSUE_LEVELS.global);
+    }
 
     // Standard console methods
 
@@ -122,19 +87,32 @@ export const logger = {
      */
     debug(...args) {
         $debug(...styledArguments(args));
-    },
+    }
     /**
      * @param {...any} args
      */
     error(...args) {
-        if (logger.suppressed) {
-            $groupCollapsed(...styledArguments([logger.suppressed], ...ERROR_PREFIX));
-            $trace(...args);
-            $groupEnd();
-        } else {
-            $trace(...styledArguments(args, ...ERROR_PREFIX));
+        switch (this.issueLevel) {
+            case ISSUE_LEVELS.suppressed: {
+                $groupCollapsed(...styledArguments(["suppressed"], ...ERROR_PREFIX));
+                $trace(...args);
+                $groupEnd();
+                break;
+            }
+            case ISSUE_LEVELS.trace: {
+                $trace(...styledArguments(args, ...ERROR_PREFIX));
+                break;
+            }
+            case ISSUE_LEVELS.global: {
+                $error(...styledArguments(args));
+                break;
+            }
+            default: {
+                $error(...args);
+                break;
+            }
         }
-    },
+    }
     /**
      * @param {any} arg
      * @param {() => any} callback
@@ -143,31 +121,40 @@ export const logger = {
         $groupCollapsed(...styledArguments([title]));
         callback();
         $groupEnd();
-    },
+    }
     /**
      * @param  {...any} args
      */
     table(...args) {
         $table(...args);
-    },
+    }
     /**
      * @param  {...any} args
      */
     trace(...args) {
         $trace(...args);
-    },
+    }
     /**
      * @param {...any} args
      */
     warn(...args) {
-        if (logger.suppressed) {
-            $groupCollapsed(...styledArguments([logger.suppressed], ...WARNING_PREFIX));
-            $trace(...args);
-            $groupEnd();
-        } else {
-            $warn(...styledArguments(args));
+        switch (this.issueLevel) {
+            case ISSUE_LEVELS.suppressed: {
+                $groupCollapsed(...styledArguments(["suppressed"], ...WARNING_PREFIX));
+                $trace(...args);
+                $groupEnd();
+                break;
+            }
+            case ISSUE_LEVELS.global: {
+                $warn(...styledArguments(args));
+                break;
+            }
+            default: {
+                $warn(...args);
+                break;
+            }
         }
-    },
+    }
 
     // Level-specific methods
 
@@ -175,16 +162,16 @@ export const logger = {
      * @param {...any} args
      */
     logDebug(...args) {
-        if (!logger.allows("debug")) {
+        if (!this.canLog("debug")) {
             return;
         }
         $debug(...styledArguments(args, ...DEBUG_PREFIX));
-    },
+    }
     /**
      * @param {import("./suite").Suite} suite
      */
     logSuite(suite) {
-        if (!logger.allows("suites")) {
+        if (!this.canLog("suites")) {
             return;
         }
         const args = [`${stringify(suite.fullName)} ended`];
@@ -208,12 +195,12 @@ export const logger = {
             );
         }
         $log(...styledArguments(args));
-    },
+    }
     /**
      * @param {import("./test").Test} test
      */
     logTest(test) {
-        if (!logger.allows("tests")) {
+        if (!this.canLog("tests")) {
             return;
         }
         const { fullName, lastResults } = test;
@@ -226,63 +213,165 @@ export const logger = {
                 `ms)`,
             ])
         );
-    },
+    }
     /**
      * @param {[label: string, color: string]} prefix
      * @param {...any} args
      */
     logTestEvent(prefix, ...args) {
         $log(...styledArguments(args, ...prefix));
-    },
+    }
     /**
      * @param {...any} args
      */
     logRun(...args) {
-        if (!logger.allows("runner")) {
+        if (!this.canLog("runner")) {
             return;
         }
         $log(...styledArguments(args));
-    },
+    }
     /**
      * @param {...any} args
      */
     logGlobal(...args) {
         $dir(...unstyledArguments(args));
-    },
-    /**
-     * @param {...any} args
-     */
-    logGlobalError(...args) {
-        $error(...styledArguments(args));
-    },
-    /**
-     * @param {...any} args
-     */
-    logGlobalWarning(...args) {
-        $warn(...styledArguments(args));
-    },
+    }
 
     // Other methods
 
     /**
      * @param {keyof typeof LOG_LEVELS} level
      */
-    allows(level) {
-        return logger.currentLevel >= LOG_LEVELS[level];
-    },
+    canLog(level) {
+        return this.logLevel >= LOG_LEVELS[level];
+    }
+    /**
+     * @param {keyof typeof ISSUE_LEVELS} level
+     */
+    setIssueLevel(level) {
+        const restoreIssueLevel = () => {
+            this.issueLevel = previous;
+        };
+        const previous = this.issueLevel;
+        this.issueLevel = ISSUE_LEVELS[level];
+        return restoreIssueLevel;
+    }
     /**
      * @param {keyof typeof LOG_LEVELS} level
      */
-    setLevel(level) {
-        logger.currentLevel = LOG_LEVELS[level];
-    },
-    /**
-     * @param {string} reason
-     */
-    suppressIssues(reason) {
-        logger.suppressed = reason || "(suppressed)";
-        return function restore() {
-            logger.suppressed = "";
+    setLogLevel(level) {
+        const restoreLogLevel = () => {
+            this.logLevel = previous;
         };
-    },
+        const previous = this.logLevel;
+        this.logLevel = LOG_LEVELS[level];
+        return restoreLogLevel;
+    }
+}
+
+const DEBUG_PREFIX = ["DEBUG", getColorHex("purple")];
+const DEFAULT_PREFIX = ["HOOT", getColorHex("primary")];
+const ERROR_PREFIX = ["ERROR", getColorHex("rose")];
+const WARNING_PREFIX = ["WARNING", getColorHex("amber")];
+let nextNetworkLogId = 1;
+
+//-----------------------------------------------------------------------------
+// Exports
+//-----------------------------------------------------------------------------
+
+/**
+ * @param {string} prefix
+ * @param {string} title
+ */
+export function makeNetworkLogger(prefix, title) {
+    const id = nextNetworkLogId++;
+    return {
+        /**
+         * Request logger: blue-ish.
+         * @param {() => any} getData
+         */
+        async logRequest(getData) {
+            if (!logger.canLog("debug")) {
+                return;
+            }
+            const color = `color: #66e`;
+            const styles = [`${color}; font-weight: bold;`, color];
+            $groupCollapsed(`-> %c${prefix}#${id}%c<${title}>`, ...styles, await getData());
+            $trace("request trace");
+            $groupEnd();
+        },
+        /**
+         * Response logger: orange.
+         * @param {() => any} getData
+         */
+        async logResponse(getData) {
+            if (!logger.canLog("debug")) {
+                return;
+            }
+            const color = `color: #f80`;
+            const styles = [`${color}; font-weight: bold;`, color];
+            $log(`<- %c${prefix}#${id}%c<${title}>`, ...styles, await getData());
+        },
+    };
+}
+
+export const ISSUE_LEVELS = {
+    /**
+     * Suppressed:
+     *
+     * Condition:
+     *  - typically: in "todo" tests where issues should be ignored
+     *
+     * Effect:
+     *  - all errors and warnings are replaced by 'trace' calls
+     */
+    suppressed: 0,
+    /**
+     * Trace:
+     *
+     * Condition:
+     *  - default level within a test run
+     *
+     * Effect:
+     *  - warnings are left as-is;
+     *  - errors are replaced by 'trace' calls, so that the actual console error
+     *    comes from the test runner with a summary of all failed reasons.
+     */
+    trace: 1,
+    /**
+     * Global:
+     *
+     * Condition:
+     *  - errors which should be reported globally but not interrupt the run
+     *
+     * Effect:
+     *  - warnings are left as-is;
+     *  - errors are wrapped with a "HOOT" prefix, as to not stop the current test
+     *    run. Can typically be used to log test failed reasons.
+     */
+    global: 2,
+    /**
+     * Critical:
+     *
+     * Condition:
+     *  - any error compromising the whole test run and should cancel or interrupt it
+     *  - default level outside of a test run (import errors, module root errors, etc.)
+     *
+     * Effect:
+     *  - warnings are left as-is;
+     *  - errors are left as-is, as to tell the server test to stop the current
+     *    (Python) test.
+     */
+    critical: 3,
 };
+export const LOG_LEVELS = {
+    runner: 0,
+    suites: 1,
+    tests: 2,
+    debug: 3,
+};
+
+export const logger = new Logger(
+    urlParams.loglevel ?? LOG_LEVELS.runner,
+    ISSUE_LEVELS.critical // by default, all errors are "critical", i.e. should abort the whole run
+);

--- a/addons/web/static/lib/hoot/core/suite.js
+++ b/addons/web/static/lib/hoot/core/suite.js
@@ -37,14 +37,19 @@ const SHARED_CURRENT_JOBS = $freeze([]);
 
 /**
  * @param {Pick<Suite, "name" | "parent">} suite
- * @param {...string} message
+ * @param {Error | string} message
  * @returns {HootError}
  */
-export function suiteError({ name, parent }, ...message) {
+export function suiteError({ name, parent }, message) {
     const parentString = parent ? ` (in parent suite ${stringify(parent.name)})` : "";
-    return new HootError(
-        `error while registering suite ${stringify(name)}${parentString}: ${message.join("\n")}`
-    );
+    const errorOptions = { level: "critical" };
+    let errorMessage = `error while registering suite ${stringify(name)}${parentString}`;
+    if (message instanceof Error) {
+        errorOptions.cause = message;
+    } else {
+        errorMessage += `: ${message}`;
+    }
+    return new HootError(errorMessage, errorOptions);
 }
 
 export class Suite extends Job {

--- a/addons/web/static/lib/hoot/core/tag.js
+++ b/addons/web/static/lib/hoot/core/tag.js
@@ -98,7 +98,8 @@ export function applyTags(job, tags) {
             throw new HootError(
                 `cannot apply tag ${stringify(tag.name)} on test/suite ${stringify(
                     job.name
-                )} as it explicitly excludes tags ${excluded.map(stringify).join(" & ")}`
+                )} as it explicitly excludes tags ${excluded.map(stringify).join(" & ")}`,
+                { level: "global" }
             );
         }
         job.tags.push(tag);
@@ -123,7 +124,9 @@ export function defineTags(...definitions) {
     return definitions.map((def) => {
         const tagKey = def.key || normalize(def.name.toLowerCase());
         if (existingTags[tagKey]) {
-            throw new HootError(`duplicate definition for tag "${def.name}"`);
+            throw new HootError(`duplicate definition for tag "${def.name}"`, {
+                level: "global",
+            });
         }
         checkTagSimilarity(tagKey, def.name);
 

--- a/addons/web/static/lib/hoot/core/test.js
+++ b/addons/web/static/lib/hoot/core/test.js
@@ -15,7 +15,7 @@ import { Tag } from "./tag";
 //-----------------------------------------------------------------------------
 
 const {
-    Object: { assign: $assign, freeze: $freeze },
+    Object: { freeze: $freeze },
 } = globalThis;
 
 //-----------------------------------------------------------------------------
@@ -35,11 +35,9 @@ const SHARED_RESULTS = $freeze([]);
  */
 export function testError({ name, parent }, ...message) {
     const parentString = parent ? ` (in suite ${stringify(parent.name)})` : "";
-    return $assign(
-        new HootError(
-            `error while registering test ${stringify(name)}${parentString}: ${message.join("\n")}`
-        ),
-        { global: true }
+    return new HootError(
+        `error while registering test ${stringify(name)}${parentString}: ${message.join("\n")}`,
+        { level: "critical" }
     );
 }
 

--- a/addons/web/static/lib/hoot/hoot_utils.js
+++ b/addons/web/static/lib/hoot/hoot_utils.js
@@ -1255,7 +1255,9 @@ export function makeRuntimeHook(name) {
                 valid ||= Boolean(last.global);
             }
             if (!valid) {
-                throw new HootError(`cannot call "${name}" callback outside of a suite`);
+                throw new HootError(`cannot call "${name}" callback outside of a suite`, {
+                    level: "critical",
+                });
             }
             return runner[name](...callbacks);
         },
@@ -1764,6 +1766,22 @@ export class ElementMap extends Map {
 
 export class HootError extends Error {
     name = "HootError";
+    /** @type {keyof typeof import("./core/logger").ISSUE_LEVELS} */
+    level;
+
+    /**
+     *
+     * @param {string} [message]
+     * @param {ErrorOptions & {
+     *  level?: keyof typeof import("./core/logger").ISSUE_LEVELS;
+     * }} [options]
+     */
+    constructor(message, options) {
+        super(message, options);
+
+        // See 'logger.js' for details on each issue level
+        this.level = options?.level;
+    }
 }
 
 /** @template [T=string] */

--- a/addons/web/static/lib/hoot/mock/navigator.js
+++ b/addons/web/static/lib/hoot/mock/navigator.js
@@ -176,7 +176,7 @@ function makeUserAgent(platform) {
  */
 function throwNotImplemented(fnName) {
     return function notImplemented() {
-        throw new HootError(`Unmocked navigator method: ${fnName}`);
+        throw new HootError(`unmocked navigator method: ${fnName}`);
     };
 }
 


### PR DESCRIPTION
This commit associates separate "issue levels" to the test runner's internal logger. These affect the logging and reporting of issues, i.e. errors and warnings:

- suppressed (by 'test.todo'): issues are traced in the console but not reported in test results;

- trace (default in test runs): issues are traced in the console and reported in test results;

- global: issues are warned/errored in the console with "HOOT" prefix (i.e. won't interrupt the test run);

- critical (default outside of test runs): issues are warned/errored in the console without "HOOT" prefix, thus interrupting the whole test run.

This fix should hopefully solve errors that were too quiet before test run, or too "important" during the run.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
