### PR TITLE
[FIX] website_sale_loyalty: fix non deterministic tour `check_shipping_discount`

### DIFF
--- a/addons/website_sale_loyalty/static/tests/tours/test_website_sale_free_shipping_discount_line.js
+++ b/addons/website_sale_loyalty/static/tests/tours/test_website_sale_free_shipping_discount_line.js
@@ -52,6 +52,10 @@ webTours.add("check_shipping_discount", {
         },
         goToCart({ quantity: 3 }),
         goToCheckout(),
+        {
+            content: "Wait for interaction to be ready",
+            trigger: `body[is-ready=true]`,
+        },
         selectDelivery("delivery2"),
         ...assertCartAmounts({
             delivery: "10.00", // delivery2 is $10, ignoring shipping discount
@@ -65,6 +69,10 @@ webTours.add("check_shipping_discount", {
             expectUnloadPage: true,
         },
         ...assertRewardAmounts({ discount: "- 304.00" }),
+        {
+            content: "Wait for interaction to be ready",
+            trigger: `body[is-ready=true]`,
+        },
         selectDelivery("delivery1"),
         ...assertCartAmounts({ delivery: "5.00" }),
         ...assertRewardAmounts({ discount: "- 300.00", shipping: "- 5.00" }),


### PR DESCRIPTION
This commit fixes non-deterministic `website_sale_loyalty` tour, which was randomly failing because of the interaction's life cycle behavior where our tour runs too fast before even handlers are attached in interaction.

error-229963

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
