### PR TITLE
[FIX] website_sale_collect: fix checkout address page when no deliverable product

### DIFF
--- a/addons/website_sale_collect/static/src/interactions/checkout.js
+++ b/addons/website_sale_collect/static/src/interactions/checkout.js
@@ -11,14 +11,16 @@ patch(Checkout.prototype, {
             '.js_wsc_update_product_qty': { 't-on-click': this.onClickUpdateProductQty.bind(this) },
         });
         this.deliveryAddressTitle = this.el.querySelector('[name="delivery_address_title"]');
-        this.deliveryTitle = this.deliveryAddressTitle.textContent;
-        this.useDeliveryAsBillingLabel = this.el.querySelector(
-            '[name="use_delivery_as_billing_text"]'
-        );
-        this.useDeliveryAsBillingLabelText = this.useDeliveryAsBillingLabel.textContent;
-        this.inStoreTitle = _t('Contact Details');
-        this.useDeliveryAsBillingLabelInStoreText = _t('Same as contact details');
-        this._adaptDeliveryTitles();
+        if (this.deliveryAddressTitle) {
+            this.deliveryTitle = this.deliveryAddressTitle.textContent;
+            this.useDeliveryAsBillingLabel = this.el.querySelector(
+                '[name="use_delivery_as_billing_text"]'
+            );
+            this.useDeliveryAsBillingLabelText = this.useDeliveryAsBillingLabel.textContent;
+            this.inStoreTitle = _t('Contact Details');
+            this.useDeliveryAsBillingLabelInStoreText = _t('Same as contact details');
+            this._adaptDeliveryTitles();
+        }
     },
 
     async selectDeliveryMethod(ev) {


### PR DESCRIPTION
This commit fixes the js error triggered on the address page of the checkout. The js targets the H5 tag containing the title of the delivery div. However, if there is no deliverable product such as event tickets, this div is not rendered and an error is triggered by the js when it tries to use the textContent attribute of the undefined element.

Reproduce:
Register for an event with paid tickets. The error will be triggered on the address page of the checkout.

Task-5107362