### PR TITLE
[FIX] product: fix product search in po to be case insensitive

### DIFF
--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -637,7 +637,7 @@ class ProductProduct(models.Model):
         products = self.browse()
         domain = Domain(domain or Domain.TRUE)
         if operator in positive_operators:
-            products = self.search_fetch(domain & Domain('default_code', '=', name), ['display_name'], limit=limit) \
+            products = self.search_fetch(domain & Domain('default_code', operator, name), ['display_name'], limit=limit) \
                 or self.search_fetch(domain & Domain('barcode', '=', name), ['display_name'], limit=limit)
         if not products:
             if is_positive:

--- a/addons/product/tests/test_name.py
+++ b/addons/product/tests/test_name.py
@@ -56,3 +56,38 @@ class TestName(TransactionCase):
         res_ids = [r[0] for r in res]
         self.assertIn(template_dyn.id, res_ids)
         self.assertIn(product.product_tmpl_id.id, res_ids)
+
+    def test_product_product_search_name_is_case_insensitive(self):
+        # case 1: in case of 2 different products with same name but different case in default_code
+        product_1 = self.env['product.product'].create({
+            'name': 'Test Product',
+            'default_code': 'Aa1',
+        })
+
+        product_2 = self.env['product.product'].create({
+            'name': 'Test Product',
+            'default_code': 'aa1',
+        })
+        res_products = self.env['product.product'].name_search(name='Aa1')
+        res_products_ids = [r[0] for r in res_products]
+        self.assertIn(product_1.id, res_products_ids)
+        self.assertIn(product_2.id, res_products_ids)
+
+        # case 2: in case of 2 variants of the same product template with different case in default_code
+        product_template = self.env['product.template'].create({
+            'name': 'Test Product Template',
+        })
+        variant_1 = self.env['product.product'].create({
+            'name': 'Test Product',
+            'default_code': 'Bb1',
+            'product_tmpl_id': product_template.id,
+        })
+        variant_2 = self.env['product.product'].create({
+            'name': 'Test Product',
+            'default_code': 'bb1',
+            'product_tmpl_id': product_template.id,
+        })
+        res_variants = self.env['product.product'].name_search(name='Bb1')
+        res_variants_ids = [r[0] for r in res_variants]
+        self.assertIn(variant_1.id, res_variants_ids)
+        self.assertIn(variant_2.id, res_variants_ids)


### PR DESCRIPTION
This commit fixes the issue where products search in PO line is case sensitive.

Before this commit:
Search on `product.product` (which is used in PO lines) was case sensitive if the search term matches exactly the `default_code` because it used exact equal `=` in the search matching.

To reproduce the issue:
1. Create two products:
    - Product 1: Name = TEST, Internal Reference = Aa1
    - Product 2: Name = TEST, Internal Reference = aa1
    [OR make one product with two variants with Internal References Aa1 and aa1 for each variant].
2. Make sure the `Variant Grid Entry` is unchecked and its module is uninstalled.
3. Create an SO: search for "Aa1" → both products are suggested.
4. Create a PO: search for "Aa1" → only one product is suggested.

After this commit:
Search on `product.product` is now case insensitive when matching with `default_code`.

Task-5080161