### PR TITLE
[IMP] website_livechat, *: visitor history calculation on the client side

### DIFF
--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -1330,6 +1330,7 @@ export class StoreMany extends StoreRelation {
             })
         );
         this.mode = mode;
+        this.sort = sort;
     }
     _copy_with_records(target, record) {
         const res = super._copy_with_records(target, record);

--- a/addons/website/static/src/common/@types/models.d.ts
+++ b/addons/website/static/src/common/@types/models.d.ts
@@ -1,17 +1,25 @@
 declare module "models" {
     import { Website as WebsiteClass } from "@website/common/website_model";
+    import { WebsitePage as WebsitePageClass } from "@website/common/website_page_model";
+    import { WebsiteTrack as WebsiteTrackClass } from "@website/common/website_track_model";
     import { WebsiteVisitor as WebsiteVisitorClass } from "@website/common/website_visitor_model";
 
     export interface Website extends WebsiteClass {}
+    export interface WebsitePage extends WebsitePageClass {}
+    export interface WebsiteTrack extends WebsiteTrackClass {}
     export interface WebsiteVisitor extends WebsiteVisitorClass {}
 
     export interface Store {
         website: StaticMailRecord<Website, typeof WebsiteClass>;
+        "website.page": StaticMailRecord<WebsitePage, typeof WebsitePageClass>;
+        "website.track": StaticMailRecord<WebsiteTrack, typeof WebsiteTrackClass>;
         "website.visitor": StaticMailRecord<WebsiteVisitor, typeof WebsiteVisitorClass>;
     }
 
     export interface Models {
         "website": Website;
+        "website.page": WebsitePage;
+        "website.track": WebsiteTrack;
         "website.visitor": WebsiteVisitor;
     }
 }

--- a/addons/website/static/src/common/website_page_model.js
+++ b/addons/website/static/src/common/website_page_model.js
@@ -1,0 +1,11 @@
+import { Record } from "@mail/model/export";
+
+export class WebsitePage extends Record {
+    static _name = "website.page";
+    static id = "id";
+
+    /** @type {string} */
+    name;
+}
+
+WebsitePage.register();

--- a/addons/website/static/src/common/website_track_model.js
+++ b/addons/website/static/src/common/website_track_model.js
@@ -1,0 +1,11 @@
+import { fields, Record } from "@mail/model/export";
+
+export class WebsiteTrack extends Record {
+    static _name = "website.track";
+    static id = "id";
+
+    page_id = fields.One("website.page");
+    visit_datetime = fields.Datetime();
+}
+
+WebsiteTrack.register();

--- a/addons/website_livechat/models/discuss_channel.py
+++ b/addons/website_livechat/models/discuss_channel.py
@@ -51,9 +51,6 @@ class DiscussChannel(models.Model):
             ),
         ]
 
-    def _get_visitor_history(self, visitor):
-        return visitor._get_visitor_history()
-
     def _get_visitor_leave_message(self, operator=False, cancel=False):
         if not cancel:
             if self.livechat_visitor_id.id:

--- a/addons/website_livechat/static/src/web/@types/models.d.ts
+++ b/addons/website_livechat/static/src/web/@types/models.d.ts
@@ -1,7 +1,7 @@
 declare module "models" {
     export interface WebsiteVisitor {
         discuss_channel_ids: Thread[];
-        page_visit_history: Array<[string, string]>;
+        last_track_ids: WebsiteTrack[];
         pageVisitHistoryText: Readonly<string>;
     }
 }

--- a/addons/website_livechat/static/src/web/website_visitor_model_patch.js
+++ b/addons/website_livechat/static/src/web/website_visitor_model_patch.js
@@ -1,6 +1,5 @@
 import { fields } from "@mail/model/export";
 
-import { deserializeDateTime } from "@web/core/l10n/dates";
 import { patch } from "@web/core/utils/patch";
 
 import { WebsiteVisitor } from "@website/common/website_visitor_model";
@@ -11,19 +10,19 @@ const { DateTime } = luxon;
 const websiteVisitorPatch = {
     setup() {
         super.setup();
-        /** @type {Array<[string, string]>} */
-        this.page_visit_history = [];
         this.discuss_channel_ids = fields.Many("mail.thread");
+        this.last_track_ids = fields.Many("website.track");
     },
     /** @returns {string} */
     get pageVisitHistoryText() {
-        const history = [];
-        for (const h of this.page_visit_history) {
-            const [label, date] = h;
-            const time = deserializeDateTime(date).toLocaleString(DateTime.TIME_24_SIMPLE);
-            history.push(`${label} (${time})`);
-        }
-        return history.join(" → ");
+        return this.last_track_ids
+            .map(
+                (track) =>
+                    `${track.page_id.name} (${track.visit_datetime.toLocaleString(
+                        DateTime.TIME_24_SIMPLE
+                    )})`
+            )
+            .join(" → ");
     },
 };
 patch(WebsiteVisitor.prototype, websiteVisitorPatch);

--- a/addons/website_livechat/static/tests/livechat_channel_info_list_patch.test.js
+++ b/addons/website_livechat/static/tests/livechat_channel_info_list_patch.test.js
@@ -47,5 +47,5 @@ test("shows language, country and recent page views", async () => {
     await contains(`.o_country_flag[data-src*='/country_flags/${country.code.toLowerCase()}.png']`);
     await contains("h6", { text: "Recent page views" });
     await contains("div > span", { text: "General website" });
-    await contains("span", { text: "Home (21:00) → Contact (21:20)" });
+    await contains("span", { text: "Contact (21:20) → Home (21:00)" });
 });

--- a/addons/website_livechat/tests/test_livechat_basic_flow.py
+++ b/addons/website_livechat/tests/test_livechat_basic_flow.py
@@ -23,43 +23,6 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
         )
         self.assertTrue(channel, 'Channel should be created after sending the first message')
 
-    def test_visitor_banner_history(self):
-        # create visitor history
-        self.env['website.track'].create([{
-            'page_id': self.env.ref('website.homepage_page').id,
-            'visitor_id': self.visitor.id,
-            'visit_datetime': self.base_datetime,
-        }, {
-            'page_id': self.env.ref('website.contactus_page').id,
-            'visitor_id': self.visitor.id,
-            'visit_datetime': self.base_datetime - datetime.timedelta(minutes=10),
-        }, {
-            'page_id': self.env.ref('website.homepage_page').id,
-            'visitor_id': self.visitor.id,
-            'visit_datetime': self.base_datetime - datetime.timedelta(minutes=20),
-        }])
-
-        handmade_history = [
-            (
-                self.env.ref("website.homepage_page").name,
-                (self.base_datetime - datetime.timedelta(minutes=20)).strftime(
-                    "%Y-%m-%d %H:%M:%S"
-                ),
-            ),
-            (
-                self.env.ref("website.contactus_page").name,
-                (self.base_datetime - datetime.timedelta(minutes=10)).strftime(
-                    "%Y-%m-%d %H:%M:%S"
-                ),
-            ),
-            (
-                self.env.ref("website.homepage_page").name,
-                self.base_datetime.strftime("%Y-%m-%d %H:%M:%S"),
-            ),
-        ]
-
-        self.assertEqual(self.visitor._get_visitor_history(), handmade_history)
-
     def test_livechat_username(self):
         # Open a new live chat
         res = self.url_open(url=self.open_chat_url, json=self.open_chat_params)
@@ -200,6 +163,41 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
         guest = self.env["mail.guest"].search([], order="id desc", limit=1)
         operator_member = channel.channel_member_ids.filtered(lambda m: m.partner_id == self.operator.partner_id)
         guest_member = channel.channel_member_ids.filtered(lambda m: m.guest_id == guest)
+        page_1, page_2 = self.env["website.page"].create(
+            [
+                {
+                    "name": "Test Page 1",
+                    "type": "qweb",
+                    "url": "/page_1",
+                    "website_id": self.env.ref("website.default_website").id,
+                },
+                {
+                    "name": "Test Page 2",
+                    "type": "qweb",
+                    "url": "/page_2",
+                    "website_id": self.env.ref("website.default_website").id,
+                },
+            ]
+        )
+        track_ids = self.env["website.track"].create(
+            [
+                {
+                    "page_id": page_1.id,
+                    "visitor_id": self.visitor.id,
+                    "visit_datetime": self.base_datetime - datetime.timedelta(minutes=20),
+                },
+                {
+                    "page_id": page_2.id,
+                    "visitor_id": self.visitor.id,
+                    "visit_datetime": self.base_datetime - datetime.timedelta(minutes=10),
+                },
+                {
+                    "page_id": page_1.id,
+                    "visitor_id": self.visitor.id,
+                    "visit_datetime": self.base_datetime,
+                },
+            ]
+        )
         self.assertEqual(
             Store().add(channel).get_result(),
             {
@@ -294,13 +292,34 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
                 "website": [
                     {"id": self.env.ref("website.default_website").id, "name": "My Website"}
                 ],
+                "website.page": [
+                    {"id": page_1.id, "name": "Test Page 1"},
+                    {"id": page_2.id, "name": "Test Page 2"},
+                ],
+                "website.track": [
+                    {
+                        "id": track_ids[2].id,
+                        "page_id": page_1.id,
+                        "visit_datetime": fields.Datetime.to_string(track_ids[2].visit_datetime),
+                    },
+                    {
+                        "id": track_ids[1].id,
+                        "page_id": page_2.id,
+                        "visit_datetime": fields.Datetime.to_string(track_ids[1].visit_datetime),
+                    },
+                    {
+                        "id": track_ids[0].id,
+                        "page_id": page_1.id,
+                        "visit_datetime": fields.Datetime.to_string(track_ids[0].visit_datetime),
+                    },
+                ],
                 "website.visitor": [
                     {
                         "country_id": self.env["ir.model.data"]._xmlid_to_res_id("base.be"),
                         "display_name": f"Website Visitor #{self.visitor.id}",
-                        "page_visit_history": [],
                         "id": self.visitor.id,
                         "lang_id": self.env.ref("base.lang_en").id,
+                        "last_track_ids": track_ids.ids[::-1],
                         "partner_id": False,
                         "website_id": self.env.ref("website.default_website").id,
                     }


### PR DESCRIPTION
*: mail, website

This change introduces the `websiteTrack` JS model. By sending related
website track records through the `store`, visitor history is now calculated
based on those records in the client part.
Using a batched query instead of separate searches for each visitor in this
change, significantly reduces the number of queries when fetching data for
multiple visitors.

task-4676121
