### PR TITLE
[REF] stock: simpler order to max for orderpoints

### DIFF
--- a/addons/purchase_stock/tests/test_purchase_order.py
+++ b/addons/purchase_stock/tests/test_purchase_order.py
@@ -700,7 +700,8 @@ class TestPurchaseOrder(ValuationReconciliationTestCommon):
         orderpoint = self.env['stock.warehouse.orderpoint'].create({
             'product_id': product.id,
             'qty_to_order': 1.0,
-            'location_id': stock_location.id
+            'location_id': stock_location.id,
+            'trigger': 'manual',
         })
         orderpoint.action_replenish()
         po = self.env['purchase.order'].search([("product_id", "=", product.id)], limit=1)

--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -87,6 +87,7 @@ class StockWarehouseOrderpoint(models.Model):
     qty_to_order = fields.Float('To Order', compute='_compute_qty_to_order', inverse='_inverse_qty_to_order', search='_search_qty_to_order', digits='Product Unit')
     qty_to_order_computed = fields.Float('To Order Computed', store=True, compute='_compute_qty_to_order_computed', digits='Product Unit')
     qty_to_order_manual = fields.Float('To Order Manual', digits='Product Unit')
+    qty_to_order_to_max = fields.Float('To Order to Reach Max', compute='_compute_qty_to_order_to_max', digits='Product Unit')
 
     days_to_order = fields.Float(compute='_compute_days_to_order', help="Numbers of days  in advance that replenishments demands are created.")
 
@@ -339,11 +340,10 @@ class StockWarehouseOrderpoint(models.Model):
         action['res_id'] = res.id
         return action
 
-    def action_replenish(self, force_to_max=False):
+    def action_replenish(self):
         now = self.env.cr.now()
-        if force_to_max:
-            for orderpoint in self:
-                orderpoint.qty_to_order = orderpoint._get_multiple_rounded_qty(orderpoint.product_max_qty - orderpoint.qty_forecast)
+        for orderpoint in self:
+            orderpoint.qty_to_order = orderpoint.qty_to_order_manual or orderpoint.qty_to_order_to_max
         try:
             self._procure_orderpoint_confirm(company_id=self.env.company)
         except UserError as e:
@@ -429,6 +429,11 @@ class StockWarehouseOrderpoint(models.Model):
         for orderpoint in orderpoints:
             orderpoint.qty_to_order_computed = orderpoint._get_qty_to_order(qty_in_progress_by_orderpoint=qty_in_progress_by_orderpoint)
         (self - orderpoints).qty_to_order_computed = False
+
+    @api.depends('replenishment_uom_id', 'product_max_qty')
+    def _compute_qty_to_order_to_max(self):
+        for orderpoint in self:
+            orderpoint.qty_to_order_to_max = max(0, orderpoint._get_multiple_rounded_qty(orderpoint.product_max_qty - orderpoint.qty_forecast))
 
     def _get_default_rule(self):
         self.ensure_one()

--- a/addons/stock/static/src/views/stock_orderpoint_list_controller.js
+++ b/addons/stock/static/src/views/stock_orderpoint_list_controller.js
@@ -15,11 +15,10 @@ export class StockOrderpointListController extends ListController {
         return this.model.root.selection.length;
     }
 
-    async onClickOrder(force_to_max) {
+    async onClickOrder() {
         const resIds = await this.model.root.getResIds(true);
         const action = await this.model.orm.call(this.props.resModel, 'action_replenish', [resIds], {
             context: this.props.context,
-            force_to_max: force_to_max,
         });
         if (action) {
             await this.actionService.doAction(action);

--- a/addons/stock/static/src/views/stock_orderpoint_list_view.xml
+++ b/addons/stock/static/src/views/stock_orderpoint_list_view.xml
@@ -3,20 +3,11 @@
 
     <t t-name="stock.StockOrderpoint.listView" t-inherit="web.ListView">
         <xpath expr="//SelectionBox" position="after">
-            <Dropdown>
-                <button class="btn btn-secondary">
-                    <span class="o_dropdown_title">Order</span>
-                    <i class="fa fa-caret-down ms-1"/>
-                </button>
-                <t t-set-slot="content">
-                    <DropdownItem t-if="hasSelectedRecords" onSelected="() => this.onClickOrder(false)">
-                        Order
-                    </DropdownItem>
-                    <DropdownItem t-if="hasSelectedRecords" onSelected="() => this.onClickOrder(true)">
-                        Order To Max
-                    </DropdownItem>
-                </t>
-            </Dropdown>
+            <button t-if="hasSelectedRecords" type="button" t-on-click="onClickOrder"
+                    class="o_button_snooze btn btn-secondary me-1" data-tooltip="Replenish products up to the Max Quantity
+                    set. If a Quantity To Order has been manually forced, this quantity will be ordered instead.">
+                Order
+            </button>
             <button t-if="hasSelectedRecords" type="button" t-on-click="onClickSnooze"
                     class="o_button_snooze btn btn-secondary me-1">
                 Snooze

--- a/addons/stock/static/src/widgets/max_qty_to_order_field.js
+++ b/addons/stock/static/src/widgets/max_qty_to_order_field.js
@@ -1,0 +1,19 @@
+import { registry } from "@web/core/registry";
+import { FloatField, floatField } from '@web/views/fields/float/float_field';
+
+export class MaxQtyToOrderField extends FloatField {
+    get value() {
+        if (this.props.record.selected && !this.props.record.data.qty_to_order_manual) {
+            return this.props.record.data.qty_to_order_to_max
+        } else {
+            return super.value;
+        }
+    }
+}
+
+export const maxQtyToOrderField = {
+    ...floatField,
+    component: MaxQtyToOrderField,
+}
+
+registry.category("fields").add("stock.max_qty_to_order", maxQtyToOrderField);

--- a/addons/stock/tests/test_warehouse.py
+++ b/addons/stock/tests/test_warehouse.py
@@ -519,10 +519,11 @@ class TestWarehouse(TestStockCommon):
         self.assertEqual(self.env['stock.quant']._get_available_quantity(self.product_3, warehouse_A.lot_stock_id), 1)
         self.assertEqual(self.env['stock.quant']._get_available_quantity(self.product_3, warehouse_B.lot_stock_id), 0)
 
-        orderpoint = self.env['stock.warehouse.orderpoint'].create({
+        orderpoint = self.env['stock.warehouse.orderpoint'].with_user(self.user_stock_manager).create({
             'location_id': warehouse_B.lot_stock_id.id,
             'product_id': self.product_3.id,
             'qty_to_order': 1.0,
+            'trigger': 'manual',
         })
         orderpoint.action_replenish()
         # Check that the orderpoint generated the source move from the furthest location.

--- a/addons/stock/views/stock_orderpoint_views.xml
+++ b/addons/stock/views/stock_orderpoint_views.xml
@@ -47,7 +47,8 @@
                 <field name="product_min_qty" string="Min" optional="show"/>
                 <field name="product_max_qty" string="Max" optional="show"/>
                 <field name="replenishment_uom_id" widget="stock.forced_placeholder" options="{'no_create': True, 'placeholder_field': 'replenishment_uom_id_placeholder'}" optional="hide" decoration-muted="not replenishment_uom_id"/>
-                <field name="qty_to_order" readonly="trigger == 'auto'"/>
+                <field name="qty_to_order_to_max" column_invisible="true"/>
+                <field name="qty_to_order" widget="stock.max_qty_to_order" readonly="trigger == 'auto'"/>
                 <field name="qty_to_order_manual" column_invisible="True"/>
                 <button name="action_remove_manual_qty_to_order" type="object" icon="fa-undo" title="Remove manually entered value and replace by the quantity to order based on the forecasted quantities" invisible="not qty_to_order_manual"/>
                 <button name="action_remove_manual_qty_to_order" type="object" icon="fa-undo" title="-" class="disabled opacity-0" invisible="qty_to_order_manual"/>


### PR DESCRIPTION
Removing the dropdown menu "Order" button when selecting records in the Replenishment Dashboard and only leaving the "Order" button. 

Also, selecting records in list view will change the Qty To Order to show the necessary quantity to reach the max: Max Qty - Forecast Qty

If a qty to order has been manually set, it won't be modified and is what will be used when clicking on the "Order" button.

task 5072869

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
