### PR TITLE
[IMP] pos_epson_printer: compute epos certificate domain

### DIFF
--- a/addons/pos_epson_printer/models/pos_config.py
+++ b/addons/pos_epson_printer/models/pos_config.py
@@ -1,9 +1,22 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import api, fields, models
+from odoo.addons.pos_epson_printer.models.pos_printer import format_epson_certified_domain
+
 
 class PosConfig(models.Model):
     _inherit = 'pos.config'
 
-    epson_printer_ip = fields.Char(string='Epson Printer IP', help="Local IP address of an Epson receipt printer.")
+    epson_printer_ip = fields.Char(
+        string='Epson Printer IP',
+        help=(
+             "Local IP address of an Epson receipt printer, or its serial number if the "
+             "'Automatic Certificate Update' option is enabled in the printer settings."
+        )
+    )
+
+    @api.onchange("epson_printer_ip")
+    def _onchange_epson_printer_ip(self):
+        for rec in self:
+            if rec.epson_printer_ip:
+                rec.epson_printer_ip = format_epson_certified_domain(rec.epson_printer_ip)

--- a/addons/pos_epson_printer/models/pos_printer.py
+++ b/addons/pos_epson_printer/models/pos_printer.py
@@ -1,15 +1,43 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from base64 import b32encode
+from hashlib import sha256
 from odoo import fields, models, api, _
 from odoo.exceptions import ValidationError
+
+
+def format_epson_certified_domain(serial_number):
+    """Epson printers can be configured to use a wildcard certificate,
+    for a domain name derived from the printer serial number.
+
+    :param serial_number: The printer serial number or an IP address.
+    :return: The corresponding domain name, or the original IP address.
+    """
+    if "." in serial_number:
+        # If the field is provided an epson serial number, convert it to a domain name
+        # Note: serial numbers should not contain dots, as IPs or URLs would.
+        return serial_number
+
+    epson_domain = "omnilinkcert.epson.biz"
+
+    sha256_hash = sha256(serial_number.encode()).digest()
+    base32_text = b32encode(sha256_hash).decode().rstrip("=")
+    return f"{base32_text.lower()}.{epson_domain}"
+
 
 class PosPrinter(models.Model):
 
     _inherit = 'pos.printer'
 
     printer_type = fields.Selection(selection_add=[('epson_epos', 'Use an Epson printer')])
-    epson_printer_ip = fields.Char(string='Epson Printer IP Address', help="Local IP address of an Epson receipt printer.", default="0.0.0.0")
+    epson_printer_ip = fields.Char(
+        string='Epson Printer IP Address',
+        help=(
+            "Local IP address of an Epson receipt printer, or its serial number if the "
+            "'Automatic Certificate Update' option is enabled in the printer settings."
+        ),
+        default="0.0.0.0"
+    )
 
     @api.constrains('epson_printer_ip')
     def _constrains_epson_printer_ip(self):
@@ -22,3 +50,9 @@ class PosPrinter(models.Model):
         params = super()._load_pos_data_fields(config_id)
         params += ['epson_printer_ip']
         return params
+
+    @api.onchange("epson_printer_ip")
+    def _onchange_epson_printer_ip(self):
+        for rec in self:
+            if rec.epson_printer_ip:
+                rec.epson_printer_ip = format_epson_certified_domain(rec.epson_printer_ip)

--- a/addons/pos_epson_printer/models/res_config_settings.py
+++ b/addons/pos_epson_printer/models/res_config_settings.py
@@ -1,7 +1,7 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import fields, models, api
+from odoo.addons.pos_epson_printer.models.pos_config import format_epson_certified_domain
 
 
 class ResConfigSettings(models.TransientModel):
@@ -24,3 +24,9 @@ class ResConfigSettings(models.TransientModel):
                 res_config.pos_epson_printer_ip = ''
             else:
                 res_config.pos_epson_printer_ip = res_config.pos_config_id.epson_printer_ip
+
+    @api.onchange("pos_epson_printer_ip")
+    def _onchange_epson_printer_ip(self):
+        for rec in self:
+            if rec.pos_epson_printer_ip:
+                rec.pos_epson_printer_ip = format_epson_certified_domain(rec.pos_epson_printer_ip)


### PR DESCRIPTION
On EPSON printers, we can enable an option ('Automatic Certificate Update') to get a certified (https) url resolving to the ip address of the printer. This domain is computed based on the serial number of the printer.

We updated the configuration to compute the domain if a serial number has been provided instead of an IP address or an url.

Task: 4384790
