### PR TITLE
[FIX] lunch: correct handling of new order lines during creation

### DIFF
--- a/addons/lunch/models/lunch_order.py
+++ b/addons/lunch/models/lunch_order.py
@@ -165,8 +165,9 @@ class LunchOrder(models.Model):
             lines = self._find_matching_lines({
                 **vals,
                 'toppings': self._extract_toppings(vals),
+                'state': 'new',
             })
-            if lines.filtered(lambda l: l.state == 'new'):
+            if lines:
                 # YTI FIXME This will update multiple lines in the case there are multiple
                 # matching lines which should not happen through the interface
                 lines.update_quantity(1)

--- a/addons/lunch/tests/test_order.py
+++ b/addons/lunch/tests/test_order.py
@@ -51,3 +51,37 @@ class TestOrder(TestsCommon):
         self.assertTrue(order2.active)
         self.assertEqual(order1.quantity, 1)
         self.assertEqual(order2.quantity, 1)
+
+    @common.users('cle-lunch-manager')
+    def test_create_only_updates_new_orders(self):
+        """
+        Test that creating a new order only increments quantity for orders
+        in 'new' state, not 'ordered'.
+        """
+        order_ordered = self.env['lunch.order'].create({
+            'product_id': self.product_pizza.id,
+            'user_id': self.env.user.id,
+            'lunch_location_id': self.location_office_1.id,
+            'quantity': 1,
+        })
+        order_ordered.action_order()
+        self.assertEqual(order_ordered.state, 'ordered')
+        self.assertEqual(order_ordered.quantity, 1)
+
+        order_new = self.env['lunch.order'].create({
+            'product_id': self.product_pizza.id,
+            'user_id': self.env.user.id,
+            'lunch_location_id': self.location_office_1.id,
+            'quantity': 1,
+        })
+        self.assertEqual(order_new.state, 'new')
+        self.assertEqual(order_new.quantity, 1)
+
+        self.env['lunch.order'].create({
+            'product_id': self.product_pizza.id,
+            'user_id': self.env.user.id,
+            'lunch_location_id': self.location_office_1.id,
+        })
+
+        self.assertEqual(order_new.quantity, 2, "New order should be incremented")
+        self.assertEqual(order_ordered.quantity, 1, "Ordered order should NOT be incremented")


### PR DESCRIPTION
**Issue**
When a user has two instances of the same product in their lunch cart, one with state "To order" and one with state "Ordered", and places a new order for that product, both the "To order" and "Ordered" records have their quantity incremented. Only the "To order" record should be updated.

**Steps to Reproduce**
- Add two lunch orders for the same product: one with state "To order" and one with state "Ordered".
- Place a new order for the same product.
- Observe that both records ("To order" and "Ordered") have their quantity incremented.

**Root Cause and Changes Made**
The _find_matching_lines method does not restrict the search to orders with state "new" ("To order"). As a result, it returns all matching records for the product, regardless of their state. When update_quantity is called, it updates the quantity for all these records.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
