### PR TITLE
[IMP] product_expiry*: improve UX for trackable products with expiration

### DIFF
--- a/addons/product_expiry/models/production_lot.py
+++ b/addons/product_expiry/models/production_lot.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import datetime
 from odoo import api, fields, models, SUPERUSER_ID, _
+from odoo.tools import format_date
 
 
 class StockLot(models.Model):
@@ -21,22 +22,27 @@ class StockLot(models.Model):
     product_expiry_alert = fields.Boolean(compute='_compute_product_expiry_alert', help="The Expiration Date has been reached.")
     product_expiry_reminded = fields.Boolean(string="Expiry has been reminded")
 
-    @api.depends('use_expiration_date', 'expiration_date', 'alert_date')
-    @api.depends_context('formatted_display_name')
+    @api.depends('use_expiration_date', 'expiration_date', 'alert_date', 'removal_date')
+    @api.depends_context('formatted_display_name', 'show_lot_removal_date')
     def _compute_display_name(self):
-        lots_to_process_ids = []
+        lots_to_process = self.env['stock.lot']
+        ctx = self.env.context
+        current_date = fields.Datetime.now()
         for lot in self:
-            if lot.env.context.get('formatted_display_name') and lot.use_expiration_date and lot.expiration_date:
-                name = f"{lot.name}"
-                if fields.Datetime.now() >= lot.expiration_date:
+            name = lot.name
+            if ctx.get('show_lot_removal_date') and lot.use_expiration_date and lot.removal_date:
+                name += f" - {format_date(self.env, lot.removal_date)}"
+            if ctx.get('formatted_display_name') and lot.use_expiration_date and lot.expiration_date:
+                if current_date >= lot.expiration_date:
                     name += self.env._("\t--Expired--")
-                elif lot.alert_date and fields.Datetime.now() >= lot.alert_date:
+                elif lot.alert_date and current_date >= lot.alert_date:
                     name += self.env._("\t--Expire on %(date)s--", date=fields.Datetime.to_string(lot.expiration_date))
+            if name != lot.name:
                 lot.display_name = name
             else:
-                lots_to_process_ids.append(lot.id)
-        if lots_to_process_ids:
-            super(StockLot, self.env['stock.lot'].browse(lots_to_process_ids))._compute_display_name()
+                lots_to_process |= lot
+        if lots_to_process:
+            super(StockLot, lots_to_process)._compute_display_name()
 
     @api.depends('expiration_date')
     def _compute_product_expiry_alert(self):

--- a/addons/product_expiry/models/stock_move.py
+++ b/addons/product_expiry/models/stock_move.py
@@ -27,6 +27,15 @@ class StockMove(models.Model):
                 vals['expiration_date'] = vals.get('expiration_date') or expiration_date
         return vals_list
 
+    def action_show_details(self):
+        action = super().action_show_details()
+        if self.use_expiration_date:
+            action['context'].update({
+                'show_lot_removal_date': True,
+                'show_lot_expiration_date': self.has_tracking in ['lot', 'serial'] and self.picking_code == 'incoming' and self.picking_type_id.use_create_lots,
+            })
+        return action
+
     def _generate_serial_move_line_commands(self, field_data, location_dest_id=False, origin_move_line=None):
         """Override to add a default `expiration_date` into the move lines values."""
         move_lines_commands = super()._generate_serial_move_line_commands(field_data, location_dest_id, origin_move_line)

--- a/addons/product_expiry/models/stock_move_line.py
+++ b/addons/product_expiry/models/stock_move_line.py
@@ -14,7 +14,6 @@ class StockMoveLine(models.Model):
         string='Expiration Date', compute='_compute_expiration_date', store=True,
         help='This is the date on which the goods with this Serial Number may'
         ' become dangerous and must not be consumed.')
-    removal_date = fields.Datetime(string='Removal Date', compute='_compute_removal_date', readonly=False, store=True)
     is_expired = fields.Boolean(related='lot_id.product_expiry_alert')
     use_expiration_date = fields.Boolean(
         string='Use Expiration Date', related='product_id.use_expiration_date')
@@ -27,8 +26,6 @@ class StockMoveLine(models.Model):
         """
         if not column_exists(self.env.cr, "stock_move_line", "expiration_date"):
             create_column(self.env.cr, "stock_move_line", "expiration_date", "timestamp")
-        if not column_exists(self.env.cr, "stock_move_line", "removal_date"):
-            create_column(self.env.cr, "stock_move_line", "removal_date", "timestamp")
         return super()._auto_init()
 
     @api.depends('product_id', 'lot_id.expiration_date', 'picking_id.scheduled_date', 'quant_id')
@@ -44,16 +41,13 @@ class StockMoveLine(models.Model):
                 else:
                     move_line.expiration_date = False
 
-    @api.depends('product_id', 'expiration_date', 'lot_id.removal_date')
-    def _compute_removal_date(self):
-        for move_line in self:
-            if move_line.lot_id.removal_date:
-                move_line.removal_date = move_line.lot_id.removal_date
-            elif move_line.picking_type_use_create_lots:
-                if move_line.product_id.use_expiration_date and move_line.expiration_date:
-                    move_line.removal_date = move_line.expiration_date - datetime.timedelta(days=move_line.product_id.removal_time)
-                else:
-                    move_line.removal_date = False
+    def _get_removal_date(self):
+        self.ensure_one()
+        if self.lot_id.removal_date:
+            return self.lot_id.removal_date
+        if self.picking_type_use_create_lots and not self.picking_type_use_existing_lots and self.expiration_date:
+            return self.expiration_date - datetime.timedelta(days=self.product_id.removal_time)
+        return False
 
     def _prepare_new_lot_vals(self):
         vals = super()._prepare_new_lot_vals()

--- a/addons/product_expiry/models/stock_picking.py
+++ b/addons/product_expiry/models/stock_picking.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-import datetime
+from datetime import datetime
 
 from odoo import models, _
 
@@ -8,22 +8,26 @@ from odoo import models, _
 class StockPicking(models.Model):
     _inherit = "stock.picking"
 
+    def _get_move_lines_to_warn(self):
+        current_datetime = datetime.now()
+        return self.move_line_ids.filtered(
+            lambda ml: ml.lot_id.product_expiry_alert or (
+                (removal_date := ml._get_removal_date()) and removal_date <= current_datetime
+            )
+        )
+
     def _pre_action_done_hook(self):
         res = super()._pre_action_done_hook()
         # We use the 'skip_expired' context key to avoid to make the check when
         # user did already confirmed the wizard about expired lots.
         if res is True and not self.env.context.get('skip_expired'):
-            pickings_to_warn_expired = self._check_expired_lots()
+            pickings_to_warn_expired = self._get_move_lines_to_warn().picking_id
             if pickings_to_warn_expired:
                 return pickings_to_warn_expired._action_generate_expired_wizard()
         return res
 
-    def _check_expired_lots(self):
-        expired_pickings = self.move_line_ids.filtered(lambda ml: ml.lot_id.product_expiry_alert or (ml.removal_date and ml.removal_date <= datetime.datetime.now())).picking_id
-        return expired_pickings
-
     def _action_generate_expired_wizard(self):
-        expired_lot_ids = self.move_line_ids.filtered(lambda ml: ml.lot_id.product_expiry_alert or (ml.removal_date and ml.removal_date <= datetime.datetime.now())).lot_id.ids
+        expired_lot_ids = self._get_move_lines_to_warn().lot_id.ids
         view_id = self.env.ref('product_expiry.confirm_expiry_view').id
         context = dict(self.env.context)
 

--- a/addons/product_expiry/models/stock_picking.py
+++ b/addons/product_expiry/models/stock_picking.py
@@ -41,3 +41,12 @@ class StockPicking(models.Model):
             'target': 'new',
             'context': context,
         }
+
+    def action_detailed_operations(self):
+        action = super().action_detailed_operations()
+        if any(self.move_ids.mapped('use_expiration_date')):
+            action['context'].update({
+                'show_lot_removal_date': True,
+                'show_lot_expiration_date': self.has_tracking and self.picking_type_code == 'incoming' and self.use_create_lots,
+            })
+        return action

--- a/addons/product_expiry/tests/test_stock_lot.py
+++ b/addons/product_expiry/tests/test_stock_lot.py
@@ -738,5 +738,5 @@ class TestStockLot(TestStockCommon):
             'default_lot_ids': [lot.id],
         }
         wizard = self.env['expiry.picking.confirmation'].with_context(context).create({})
-        self.assertFalse(wizard.picking_ids.move_line_ids.removal_date)
+        self.assertFalse(wizard.picking_ids.move_line_ids._get_removal_date())
         wizard.process_no_expired()

--- a/addons/product_expiry/tests/test_stock_lot.py
+++ b/addons/product_expiry/tests/test_stock_lot.py
@@ -740,37 +740,3 @@ class TestStockLot(TestStockCommon):
         wizard = self.env['expiry.picking.confirmation'].with_context(context).create({})
         self.assertFalse(wizard.picking_ids.move_line_ids.removal_date)
         wizard.process_no_expired()
-
-    def test_lot_dates_form_update(self):
-        """
-        Ensure that we can edit the removal_date and expiration_date fields at the same time
-        Without triggering the compute method for the expiration when saving modifications.
-        """
-        delta = timedelta(seconds=10)
-        today = datetime.today()
-        receipt = self.env['stock.picking'].create({
-            'location_id': self.supplier_location.id,
-            'location_dest_id': self.stock_location.id,
-            'picking_type_id': self.picking_type_in.id,
-            'scheduled_date': today,
-            'move_ids': [
-                Command.create({
-                    'product_id': self.apple_product.id,
-                    'location_id': self.supplier_location.id,
-                    'location_dest_id': self.stock_location.id,
-                    'product_uom_qty': 1,
-                }),
-            ],
-        })
-        receipt.action_confirm()
-        self.assertAlmostEqual(receipt.move_line_ids.expiration_date, today + timedelta(days=10), delta=delta)
-        self.assertAlmostEqual(receipt.move_line_ids.removal_date, today + timedelta(days=8), delta=delta)
-
-        with Form(receipt.move_ids, view="stock.view_stock_move_operations") as move_form:
-            with move_form.move_line_ids.edit(0) as line_form:
-                line_form.lot_name = 'lot 1'
-                line_form.expiration_date = today + timedelta(days=15)
-                line_form.removal_date = today + timedelta(days=10)
-
-        self.assertAlmostEqual(receipt.move_line_ids.expiration_date, today + timedelta(days=15), delta=delta)
-        self.assertAlmostEqual(receipt.move_line_ids.removal_date, today + timedelta(days=10), delta=delta)

--- a/addons/product_expiry/views/stock_move_views.xml
+++ b/addons/product_expiry/views/stock_move_views.xml
@@ -20,14 +20,13 @@
             <xpath expr="//field[@name='lot_id']" position="after">
                 <field name="is_expired" column_invisible="True"/>
             </xpath>
-            <xpath expr="//field[@name='lot_name']" position="after" >
+            <xpath expr="//field[@name='lot_name']" position="after">
                 <field name="picking_type_use_existing_lots" column_invisible="True"/>
-                <field name="expiration_date" force_save="1" column_invisible="not parent.use_expiration_date" readonly="picking_type_use_existing_lots"
-                 decoration-danger="is_expired if state == 'done' else expiration_date &lt; context_today().strftime('%Y-%m-%d')"
-                 decoration-bf="is_expired if state == 'done' else expiration_date &lt; context_today().strftime('%Y-%m-%d')"/>
-                <field name="removal_date" force_save="1" column_invisible="not parent.use_expiration_date" readonly="picking_type_use_existing_lots"
-                 decoration-danger="removal_date &lt; (context_today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')"
-                 decoration-bf="removal_date &lt; (context_today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')"/>
+                <field name="expiration_date" force_save="1"
+                    column_invisible="not context.get('show_lot_expiration_date')"
+                    readonly="picking_type_use_existing_lots"
+                    decoration-danger="is_expired if state == 'done' else expiration_date &lt; context_today().strftime('%Y-%m-%d')"
+                    decoration-bf="is_expired if state == 'done' else expiration_date &lt; context_today().strftime('%Y-%m-%d')"/>
             </xpath>
         </field>
     </record>
@@ -40,11 +39,12 @@
             <xpath expr="//field[@name='lot_name']" position="after">
                 <field name="picking_type_use_existing_lots" column_invisible="True"/>
                 <field name="tracking" column_invisible="True"/>
-                <field name="expiration_date" decoration-danger="is_expired if state == 'done' else expiration_date &lt; context_today().strftime('%Y-%m-%d')"
-                 decoration-bf="is_expired if state == 'done' else expiration_date &lt; context_today().strftime('%Y-%m-%d')"
-                 force_save="1" readonly="picking_type_use_existing_lots" invisible="tracking not in ['lot', 'serial']"/>
-                <field name="removal_date" force_save="1" readonly="1" invisible="tracking not in ['lot', 'serial']"
-                 decoration-danger="removal_date &lt; (context_today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')" decoration-bf="removal_date &lt; (context_today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')"/>
+                <field name="expiration_date" force_save="1"
+                    column_invisible="not context.get('show_lot_expiration_date')"
+                    invisible="not (tracking in ['lot', 'serial'] and use_expiration_date)"
+                    readonly="picking_type_use_existing_lots"
+                    decoration-danger="is_expired if state == 'done' else expiration_date &lt; context_today().strftime('%Y-%m-%d')"
+                    decoration-bf="is_expired if state == 'done' else expiration_date &lt; context_today().strftime('%Y-%m-%d')"/>
             </xpath>
             <xpath expr="//field[@name='lot_id']" position="after">
                 <field name="is_expired" column_invisible="True"/>

--- a/addons/product_expiry/views/stock_quant_views.xml
+++ b/addons/product_expiry/views/stock_quant_views.xml
@@ -11,7 +11,7 @@
                 </attribute>
             </xpath>
             <xpath expr="//field[@name='quantity']" position="after" >
-                <field name="removal_date"/>
+                <field name="removal_date" column_invisible="context.get('show_lot_removal_date')"/>
             </xpath>
         </field>
     </record>

--- a/addons/product_expiry/wizard/confirm_expiry.py
+++ b/addons/product_expiry/wizard/confirm_expiry.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from datetime import datetime
-
 from odoo import api, fields, models, _
 
 
@@ -45,7 +43,5 @@ class ExpiryPickingConfirmation(models.TransientModel):
     def process_no_expired(self):
         """ Remove the expired mls and confirm the picking. """
         pickings_to_validate = self.env['stock.picking'].browse(self.env.context.get('button_validate_picking_ids'))
-        self.picking_ids.move_line_ids.filtered(
-            lambda ml: ml.use_expiration_date and ml.removal_date and ml.removal_date < datetime.now()
-        ).unlink()
+        self.picking_ids._get_move_lines_to_warn().unlink()
         return pickings_to_validate.button_validate()

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1103,7 +1103,11 @@ Please change the quantity done or the rounding precision in your settings.""",
                 if key in self.env['stock.move.line'] and isinstance(self.env['stock.move.line'][key], models.Model):
                     values[key] = {
                         'id': value,
-                        'display_name': self.env['stock.move.line'][key].browse(value).display_name
+                        'display_name': (
+                            self.env['stock.move.line'][key]
+                            .browse(value)
+                            .with_context(show_lot_removal_date=context_data.get('show_lot_removal_date')).display_name
+                        ),
                     }
         if product.lot_sequence_id and first_lot:
             current_sequence = product.lot_sequence_id._get_current_sequence()

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -573,7 +573,7 @@ class StockQuant(models.Model):
                     continue
                 name = [record.location_id.display_name]
                 if record.lot_id:
-                    name.append(record.lot_id.name)
+                    name.append(record.lot_id.display_name)
                 if record.package_id:
                     name.append(record.package_id.display_name)
                 if record.owner_id:

--- a/addons/stock/static/src/fields/stock_move_line_x2_many_field.js
+++ b/addons/stock/static/src/fields/stock_move_line_x2_many_field.js
@@ -44,6 +44,7 @@ export class SMLX2ManyField extends X2ManyField {
             ...context,
             single_product: true,
             list_view_ref: "stock.view_stock_quant_tree_simple",
+            show_lot_removal_date: this.props.context.show_lot_removal_date,
         };
         const productName = this.props.record.data.product_id.display_name;
         const title = _t("Add line: %s", productName);


### PR DESCRIPTION
*: stock, mrp_subcontracting

When working with tracked products `(using expiration date)`, users often
need to choose between multiple lots based on `expiration-related info`.
Having this information available only after selection makes this process less efficient.

This below changes improves how expiration information is presented by
making it available at selection time, allowing users to compare lots
more easily while keeping the interface clean.

- Move removal date into lot display name instead of a separate column.
- Show expiration date only for incoming (receipt) operations when
  "Create New Lot/Serial Number" is enabled, and hide it for other transfers.
- Show removal date alongside the lot name in the pick from (quant_id).

This ensures expiration information is available at selection time,
resulting in a cleaner and more intuitive user experience and making
lot handling easier during stock operations.

Upgrade PR: https://github.com/odoo/upgrade/pull/9929

Task - 4943639