### PR TITLE
[FIX] html_editor: undo does not revert image to initial transform state

### DIFF
--- a/addons/html_editor/static/src/main/media/image_transformation.js
+++ b/addons/html_editor/static/src/main/media/image_transformation.js
@@ -178,12 +178,12 @@ export class ImageTransformation extends Component {
         settings.scalex = Math.round(settings.scalex * 100) / 100;
         settings.scaley = Math.round(settings.scaley * 100) / 100;
         this.positionTransfoContainer();
-        this.props.onChange();
     }
 
     mouseUp() {
         this.isCurrentlyTransforming = false;
         this.transfo.active = null;
+        this.props.onChange();
     }
 
     mouseDown(ev) {


### PR DESCRIPTION
**Current behavior before PR:**

- When rotating, resizing, or dragging an image using the transform container, pressing Ctrl+Z did not revert the image to its initial state (when the transform container was opened).
- Instead, it required multiple undo operations to return to the initial state.

**Desired behavior after PR is merged:**

- Pressing Ctrl+Z now correctly reverts the image to its initial state in a single undo, after a transformation.

task-5114320