### PR TITLE
[FIX] point_of_sale: remove partner autocomplete from missing fields

### DIFF
--- a/addons/point_of_sale/static/src/app/missing_fields.js
+++ b/addons/point_of_sale/static/src/app/missing_fields.js
@@ -11,7 +11,6 @@ class DefaultField extends Component {
 registry.category("fields").add("list.many2one_avatar_user", { component: DefaultField });
 registry.category("fields").add("list.list_activity", { component: DefaultField });
 registry.category("fields").add("x2many_buttons", { component: DefaultField });
-registry.category("fields").add("field_partner_autocomplete", { component: DefaultField });
 registry.category("fields").add("res_partner_many2one", { component: DefaultField });
 registry.category("fields").add("many2one_avatar_user", { component: DefaultField });
 registry.category("fields").add("auto_save_res_partner", { component: DefaultField });


### PR DESCRIPTION
**Steps to reproduce:**
- Install `point_of_sale`
- Open a POS session
- Click on customer (bottom left) -> Create new customer
- Try to enter the name and save

**Issue:**
- Unable to set customer name
- Error shown: "Invalid field: Name"

**Cause:**
- after commit https://github.com/odoo/odoo/commit/0635af99d3617511e82ebe20155296e86e87c92c the field_partner_autocomplete widget was set as the default for missing fields. But the name field of res.partner also uses this widget without a default value, which blocks entering a customer’s name when creating a new record.
https://github.com/odoo/odoo/blob/0635af99d3617511e82ebe20155296e86e87c92c/addons/point_of_sale/static/src/app/missing_fields.js#L14

**Solution:**
- Remove 'field_partner_autocomplete' widget from the missing field component, as we can't set a default value for name.

opw-5113044

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
