### PR TITLE
[FIX] html_editor: allow font color on space characters

### DIFF
--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -297,7 +297,7 @@ export class ColorPlugin extends Plugin {
                         font = [];
                     }
                 } else if (
-                    (node.nodeType === Node.TEXT_NODE && !isWhitespace(node) && !isZwnbsp(node)) ||
+                    (node.nodeType === Node.TEXT_NODE && !isZwnbsp(node)) ||
                     (node.nodeName === "BR" && isEmptyBlock(node.parentNode)) ||
                     (node.nodeType === Node.ELEMENT_NODE &&
                         ["inline", "inline-block"].includes(getComputedStyle(node).display) &&

--- a/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
+++ b/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
@@ -1,5 +1,5 @@
 import { Plugin } from "@html_editor/plugin";
-import { isZWS } from "@html_editor/utils/dom_info";
+import { isEmptyTextNode, isZWS } from "@html_editor/utils/dom_info";
 import { reactive } from "@odoo/owl";
 import { composeToolbarButton, Toolbar } from "./toolbar";
 import { hasTouch } from "@web/core/browser/feature_detection";
@@ -356,8 +356,7 @@ export class ToolbarPlugin extends Plugin {
             .filter(
                 (node) =>
                     this.dependencies.selection.isNodeEditable(node) &&
-                    (node.nodeType !== Node.TEXT_NODE ||
-                        (node.textContent.trim().length && !isZWS(node)))
+                    (node.nodeType !== Node.TEXT_NODE || (!isEmptyTextNode(node) && !isZWS(node)))
             )
             .filter((node) => {
                 const element = closestElement(node);

--- a/addons/html_editor/static/src/utils/dom_info.js
+++ b/addons/html_editor/static/src/utils/dom_info.js
@@ -15,7 +15,25 @@ export function isEmpty(el) {
 }
 
 export function isEmptyTextNode(node) {
-    return node.nodeType === Node.TEXT_NODE && node.textContent.trim().length === 0;
+    if (node.nodeType !== Node.TEXT_NODE) {
+        return false;
+    }
+    if (!node.textContent) {
+        return true;
+    }
+    const trimmedContent = node.textContent.trim();
+    if (!trimmedContent) {
+        // Only `\n` is considered as empty
+        if (node.textContent.includes("\n")) {
+            return true;
+        }
+        // Only spaces is not considered as empty
+        // we technically can apply styles on spaces
+        if (node.textContent) {
+            return false;
+        }
+    }
+    return !trimmedContent;
 }
 
 /**

--- a/addons/html_editor/static/tests/format/font_size.test.js
+++ b/addons/html_editor/static/tests/format/font_size.test.js
@@ -234,3 +234,19 @@ test("should update the font class if the parent already has one", async () => {
         contentAfter: '<h2 class="h4-fs"><span class="h3-fs">[abcdefg]</span></h2>',
     });
 });
+
+test("should apply font size on space", async () => {
+    await testEditor({
+        contentBefore: `<div><p>a[ ]b</p></div>`,
+        stepFunction: setFontSize("36px"),
+        contentAfter: `<div><p>a<span style="font-size: 36px;">[ ]</span>b</p></div>`,
+    });
+});
+
+test("should apply font size on non breaking space", async () => {
+    await testEditor({
+        contentBefore: `<div><p>a[&nbsp;]b</p></div>`,
+        stepFunction: setFontSize("36px"),
+        contentAfter: `<div><p>a<span style="font-size: 36px;">[&nbsp;]</span>b</p></div>`,
+    });
+});


### PR DESCRIPTION
Problem:
When trying to apply font color on a space, the color picker suddenly closes.

Solution:
Allow adding styles on space characters.

Steps to reproduce:
1. Add text "A B".
2. Select the space only.
3. Try to change font color.
4. Observe that the color picker suddenly dismisses.

task-5111480

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
