### PR TITLE
[FIX] mail: add inbox standalone messages to MessagingMenu

### DIFF
--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -1,6 +1,7 @@
 import { Store as BaseStore, makeStore, Record } from "@mail/core/common/record";
 import { threadCompareRegistry } from "@mail/core/common/thread_compare";
 import { cleanTerm, prettifyMessageContent } from "@mail/utils/common/format";
+import { compareDatetime } from "@mail/utils/common/misc";
 
 import { reactive } from "@odoo/owl";
 
@@ -200,6 +201,15 @@ export class Store extends BaseStore {
                 }
             }
             return thread2.localId > thread1.localId ? 1 : -1;
+        },
+    });
+
+    standaloneInboxMessages = Record.many("mail.message", {
+        compute() {
+            const messages = this.store.inbox.messages.filter((m) => !m.thread);
+            return messages.sort(
+                (m1, m2) => compareDatetime(m2.datetime, m1.datetime) || m2.id - m1.id
+            );
         },
     });
 
@@ -422,7 +432,9 @@ export class Store extends BaseStore {
                 // Prevent duplicate inbox push notifications since they're already handled by
                 // `mail.message/inbox` bus notifications, and the `modelsHandleByPush` heuristic
                 // in `out_of_focus_service.js` isn't reliable enough to detect these cases.
-                const isInbox = this.store.self.notification_preference === "inbox" && model !== "discuss.channel";
+                const isInbox =
+                    this.store.self.notification_preference === "inbox" &&
+                    model !== "discuss.channel";
                 if ((isTabFocused && thread?.isDisplayed) || isInbox) {
                     navigator.serviceWorker.controller?.postMessage({
                         type: "notification-display-response",

--- a/addons/mail/static/src/core/public_web/messaging_menu.js
+++ b/addons/mail/static/src/core/public_web/messaging_menu.js
@@ -43,6 +43,19 @@ export class MessagingMenu extends Component {
         this.markAsRead(thread);
     }
 
+    onClickInboxMsg(isMarkAsRead, msg) {
+        if (!isMarkAsRead) {
+            this.store.inbox.highlightMessage = msg;
+            this.env.services.action.doAction({
+                tag: "mail.action_discuss",
+                type: "ir.actions.client",
+                context: { active_id: "mail.box_inbox" },
+            });
+            return;
+        }
+        msg.setDone();
+    }
+
     markAsRead(thread) {
         if (thread.needactionMessages.length > 0) {
             thread.markAllMessagesAsRead();
@@ -117,6 +130,17 @@ export class MessagingMenu extends Component {
 
     get threads() {
         return this.store.menuThreads;
+    }
+
+    get visibleStandaloneMessages() {
+        const tab = this.store.discuss.activeTab;
+        if (tab !== "main") {
+            return [];
+        }
+        if (this.store.discuss.searchTerm) {
+            return [];
+        }
+        return this.store.standaloneInboxMessages;
     }
 
     /**

--- a/addons/mail/static/src/core/public_web/messaging_menu.xml
+++ b/addons/mail/static/src/core/public_web/messaging_menu.xml
@@ -8,6 +8,32 @@
 <t t-name="mail.MessagingMenu.content">
     <div t-if="!(ui.isSmall and env.inDiscussApp and store.discuss.activeTab === 'main')" t-att-class="`${discussSystray.contentClass} o-mail-MessagingMenu ${ui.isSmall ? 'o-small' : ''}`">
         <div t-if="!env.inDiscussApp or store.discuss.activeTab !== 'main'" class="o-mail-MessagingMenu-list d-flex flex-column overflow-auto flex-grow-1 list-group list-group-flush px-2 py-1 gap-1" t-ref="notification-list">
+            <t t-set="itemIndex" t-value="0"/>
+            <t t-foreach="visibleStandaloneMessages" name="standaloneInboxMessages" t-as="message" t-key="message.id">
+                <NotificationItem
+                    isActive="state.activeIndex === itemIndex"
+                    counter="1"
+                    datetime="message?.datetime"
+                    iconSrc="store.DEFAULT_AVATAR"
+                    hasMarkAsReadButton="1"
+                    muted="0"
+                    onClick="(isMarkAsRead) => this.onClickInboxMsg(isMarkAsRead, message)"
+                    onSwipeRight="hasTouch() ? { action: () => message.setDone(), icon: 'fa-check-circle', bgColor: 'bg-success' } : undefined"
+                    onSwipeLeft="undefined"
+                    nameMaxLine="1"
+                    textMaxLine="2"
+                >
+                    <t t-set-slot="name">
+                        <t t-esc="message?.authorName or ''"/>
+                    </t>
+                    <t t-set-slot="body">
+                        <t t-esc="message?.inlineBody or message?.subtype_description" t-att-class="{ 'opacity-75': message?.isEmpty }"/>
+                    </t>
+                    <t t-set-slot="icon">
+                    </t>
+                </NotificationItem>
+                <t t-set="itemIndex" t-value="itemIndex + 1"/>
+            </t>
             <t t-foreach="threads" name="threads" t-as="thread" t-key="thread.localId">
                 <t t-set="message" t-value="thread.isChatChannel or (thread.channel_type === 'channel' and thread.needactionMessages.length === 0) ? thread.newestPersistentOfAllMessage : thread.needactionMessages.at(-1)"/>
                 <NotificationItem

--- a/addons/mail/static/src/core/web/messaging_menu_patch.js
+++ b/addons/mail/static/src/core/web/messaging_menu_patch.js
@@ -64,6 +64,7 @@ patch(MessagingMenu.prototype, {
     get hasPreviews() {
         return (
             this.threads.length > 0 ||
+            this.visibleStandaloneMessages.length > 0 ||
             (this.store.failures.length > 0 &&
                 this.store.discuss.activeTab === "main" &&
                 !this.env.inDiscussApp) ||

--- a/addons/mail/static/src/core/web/messaging_menu_patch.xml
+++ b/addons/mail/static/src/core/web/messaging_menu_patch.xml
@@ -25,17 +25,17 @@
                         <button class="o-mail-MessagingMenu-headerFilter btn btn-link px-2 py-1 m-1 lh-1" t-att-class="store.discuss.activeTab === 'main' ? 'fw-bold o-active shadow-sm' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'main'">All</button>
                         <button class="o-mail-MessagingMenu-headerFilter btn btn-link px-2 py-1 m-1 lh-1" t-att-class="store.discuss.activeTab === 'chat' ? 'fw-bold o-active shadow-sm' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'chat'">Chats</button>
                         <button class="o-mail-MessagingMenu-headerFilter btn btn-link px-2 py-1 m-1 lh-1" t-att-class="store.discuss.activeTab === 'channel' ? 'fw-bold o-active shadow-sm' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'channel'">Channels</button>
-                        <button t-if="threads.length >= 20 and store.channels.status !== 'fetching'" class="btn btn-link py-1 rounded-0 text-muted" type="button" title="Quick search" t-on-click="toggleSearch"><i class="fa fa-fw fa-search"/></button>
+                        <button t-if="(threads.length + visibleStandaloneMessages.length) >= 20 and store.channels.status !== 'fetching'" class="btn btn-link py-1 rounded-0 text-muted" type="button" title="Quick search" t-on-click="toggleSearch"><i class="fa fa-fw fa-search"/></button>
                         <button t-if="store.channels.status === 'fetching'" class="btn btn-light py-1 rounded-0" disabled="true" type="button"><i class="fa fa-fw fa-circle-o-notch fa-spin"/></button>
                     </t>
                 </t>
             </div>
         </xpath>
-        <xpath expr="//*[@name='threads']" position="before">
+        <xpath expr="//*[@name='standaloneInboxMessages']" position="before">
             <div t-if="store.channels.status !== 'fetching' and !hasPreviews and !store.discuss.searchTerm" class="d-flex justify-content-center py-4 px-2 text-muted">
                 No conversation yet...
             </div>
-            <div t-if="store.discuss.searchTerm and !threads.length" class="d-flex justify-content-center py-4 px-2 text-muted">
+            <div t-if="store.discuss.searchTerm and !threads.length and !visibleStandaloneMessages.length" class="d-flex justify-content-center py-4 px-2 text-muted">
                 No thread found.
             </div>
             <t t-set="itemIndex" t-value="0"/>

--- a/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
+++ b/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
@@ -1262,3 +1262,28 @@ test("failure is removed from messaging menu when message is deleted", async () 
     pyEnv["mail.message"].unlink([messageId]);
     await contains(".o-mail-NotificationItem", { count: 0 });
 });
+
+test("ensure messaging menu shows standalone inbox messages", async () => {
+    const pyEnv = await startServer();
+    const partnerId = pyEnv["res.partner"].create({ name: "Partner1" });
+    // no record set
+    const messageId = pyEnv["mail.message"].create({
+        author_id: partnerId,
+        body: "Message with needaction",
+        needaction: true,
+    });
+    pyEnv["mail.notification"].create({
+        mail_message_id: messageId,
+        notification_status: "sent",
+        notification_type: "inbox",
+        res_partner_id: serverState.partnerId,
+    });
+
+    await start();
+    await click(".o_menu_systray i[aria-label='Messages']");
+    await contains(".o-mail-NotificationItem");
+    await contains(".o-mail-NotificationItem .badge", { text: "1" });
+    await click(".o-mail-NotificationItem");
+    await contains(".o-mail-Message-author", { text: "Partner1" });
+    await contains(".o-mail-Message-textContent", { text: "Message with needaction" });
+});


### PR DESCRIPTION
**Steps to reproduce:**
- Set handle notifications in Odoo for one user
- Go to `Sign` app with another user
- Create a signature request for the first user
- The first user is properly notified of the signature request, as the counter badge is updated.
- When clicking on the badge, no new message is shown.

**Issue:**
Inbox messages are not considered in the `MessagingMenu` when they are not linked to any record. It's the case when a signature request is sent and while the notification counter is updated, the message can't be seen in the top bar menu, it's only visible in the `Discuss` app > Inbox which is quite confusing for the users.

In previous versions the behavior was different as the signature request was either considered as an activity or no notification was sent.

Also if the inbox message is linked to a record, it only appears in the `all` filter of the menu.

**Fix:**
Added the inbox explicitly to the top `MessagingMenu` to be able to read the corresponding messages.

We could also link the signature to its record when sending the message instead of `self.env['sign.request']._message_send_mail()` but it might cause access rights issues.

Also ensured that a category `others` was used for such messages, and prevented an error caused by clicking on the conversation when the `Discuss` app was opened.

Unfortunatly doing this will show duplicates in the notifications of the menu for messages which are in the inbox but which have a record set. (e.g. when such message appears, it will have one line in the inbox and one for the record itself) So we need to filter out the messages which have a thread from their record in the views to avoid it.

related: https://github.com/odoo/enterprise/commit/463d6a2aae536356e6dee6b902f2e881dbc4fbda

opw-4969005

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
