### PR TITLE
[FIX] mail: show ellipsis icon in message email read more/less

### DIFF
--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -212,6 +212,9 @@ For more specific needs, you may also assign custom-defined actions
         'mail.assets_lamejs': [
             'mail/static/lib/lame/lame.js',
         ],
+        "mail.assets_message_email": [
+            "web/static/lib/odoo_ui_icons/style.css",
+        ],
         'mail.assets_public': [
             'web/static/lib/jquery/jquery.js',
             'web/static/lib/odoo_ui_icons/style.css',

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -40,6 +40,7 @@ import { MessageActionMenuMobile } from "./message_action_menu_mobile";
 import { discussComponentRegistry } from "./discuss_component_registry";
 import { NotificationMessage } from "./notification_message";
 import { useLongPress } from "@mail/utils/common/hooks";
+import { loadCssFromBundle } from "@mail/utils/common/misc";
 
 /**
  * @typedef {Object} Props
@@ -137,6 +138,7 @@ export class Message extends Component {
             if (this.shadowBody.el) {
                 this.shadowRoot = this.shadowBody.el.attachShadow({ mode: "open" });
                 const color = cookie.get("color_scheme") === "dark" ? "white" : "black";
+                loadCssFromBundle(this.shadowRoot, "mail.assets_message_email");
                 const shadowStyle = document.createElement("style");
                 shadowStyle.textContent = `
                     * {

--- a/addons/portal/static/src/chatter/frontend/portal_chatter_service.js
+++ b/addons/portal/static/src/chatter/frontend/portal_chatter_service.js
@@ -1,11 +1,11 @@
 import { PortalChatter } from "@portal/chatter/frontend/portal_chatter";
 import { App } from "@odoo/owl";
-import { AssetsLoadingError, getBundle } from "@web/core/assets";
 import { registry } from "@web/core/registry";
 import { rpc } from "@web/core/network/rpc";
 import { session } from "@web/session";
 import { _t } from "@web/core/l10n/translation";
 import { getTemplate } from "@web/core/templates";
+import { loadCssFromBundle } from "@mail/utils/common/misc";
 
 export class PortalChatterService {
     constructor(env, services) {
@@ -19,31 +19,7 @@ export class PortalChatterService {
 
     async createShadow(root) {
         const shadow = root.attachShadow({ mode: "open" });
-        try {
-            const res = await getBundle("portal.assets_chatter_style");
-            for (const url of res.cssLibs) {
-                const link = document.createElement("link");
-                link.rel = "stylesheet";
-                link.href = url;
-                shadow.appendChild(link);
-                await new Promise((res, rej) => {
-                    link.addEventListener("load", res);
-                    link.addEventListener("error", rej);
-                });
-            }
-        } catch (e) {
-            if (e instanceof AssetsLoadingError && e.cause instanceof TypeError) {
-                // an AssetsLoadingError caused by a TypeError means that the
-                // fetch request has been cancelled by the browser. It can occur
-                // when the user changes page, or navigate away from the website
-                // client action, so the iframe is unloaded. In this case, we
-                // don't care abour reporting the error, it is actually a normal
-                // situation.
-                return new Promise(() => {});
-            } else {
-                throw e;
-            }
-        }
+        await loadCssFromBundle(shadow, "portal.assets_chatter_style");
         return shadow;
     }
 


### PR DESCRIPTION
Before this commit, when a message is of type "email" and contains parts are in foldable with more/less (like `<quote>`), the icon of the button for fold/unfold is missing.

This happens because the icon is `.oi` and requires `odoo_ui_icons`. Message of type "email" have their content inside a shadow DOM, because we want to preserve the style of email inside the web client, at least in white theme. Shadow-DOM prevents the parent document to pass `odoo_ui_icons` thus the Shadow-DOM could not apply expected style on `.oi` icons.

This commit fixes the issue by passing the required CSS as stylesheet to the shadow DOM, so that `.oi` icons are working inside the shadow DOM of message content of type "email".