### PR TITLE
[FIX] hr_recruitment_skills: fix talent's skills disappearing when creating application

### DIFF
--- a/addons/hr_recruitment_skills/models/hr_applicant.py
+++ b/addons/hr_recruitment_skills/models/hr_applicant.py
@@ -149,8 +149,7 @@ class HrApplicant(models.Model):
             # This is required for the talent pool mechanism to work. Duplicating an hr.applicant record without this
             # check will cause the skills to not be duplicated or disappear randomly.
             for vals in vals_list:
-                skills = vals.pop("current_applicant_skill_ids", []) + vals.get("applicant_skill_ids", [])
-                vals["applicant_skill_ids"] = self.env["hr.applicant.skill"]._get_transformed_commands(skills, self)
+                vals["applicant_skill_ids"] = vals.pop("current_applicant_skill_ids", []) + vals.get("applicant_skill_ids", [])
         return super().create(vals_list)
 
     def write(self, vals):


### PR DESCRIPTION
Steps to reproduce:
- In recruitment, go to any talent pool
- Create a new talent and add skills
- Click on the "Create Applications" button
- The applicant will have the skills but the talent will lose them

Reason:
When the application is created from the talent, the transmitted skills were treated as duplicates of the new ones and thus deleted to preserve the working logic of skills.

How it was fixed:
By correcting the create function, the skills are not considered duplicates anymore, allowing the talent to keep their skills.

Task ID: 5083085