### PR TITLE
[FIX] l10n_tr_nilvera_einvoice: Remove hyperlink reference XML Note

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
@@ -4,6 +4,7 @@ from num2words import num2words
 
 from odoo import api, models
 from odoo.exceptions import UserError
+from odoo.tools import html2plaintext
 
 
 class AccountEdiXmlUblTr(models.AbstractModel):
@@ -66,6 +67,9 @@ class AccountEdiXmlUblTr(models.AbstractModel):
                 if vals['currency_id'] != vals['company_currency_id'] else None,
             'cbc:LineCountNumeric': {'_text': len(invoice.line_ids)},
             'cbc:BuyerReference': None,  # Nilvera will reject any <BuyerReference> tag, so remove it
+            'cbc:Note': {
+                '_text': html2plaintext(invoice.narration, include_references=False) if invoice.narration else None,
+            },
         })
 
         if invoice.invoice_line_ids._fields.get('deferred_start_date'):


### PR DESCRIPTION
Currently, when we add some hyperlinks in the Terms and Conditions of the invoice, it comes along with the hyperlink reference in the 'cbc:Note' tag in the XML.
Example:
```xml
<cbc:Note>
Terms: Payment:  https://www.odoo.com [1]
Refund: https://www.google.com [2]

[1] https://www.odoo.com
[2] https://www.google.com
</cbc:Note>
```

This PR removes that hyperlink references in the e-invoice XML.

task-5027935

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
