### PR TITLE
[FIX] point_of_sale: remove extra ok button

### DIFF
--- a/addons/point_of_sale/static/src/scss/pos.scss
+++ b/addons/point_of_sale/static/src/scss/pos.scss
@@ -202,7 +202,10 @@ body.modal-open {
 .pos .internal-note-container span {
     text-align: start;
 }
-
+// Remove extra ok button
+.modal-footer button.o-default-button:nth-child(3) {
+    display: none;
+}
 .pos .internal-note-container span > div {
     white-space: normal;
 }


### PR DESCRIPTION
Before this commit:
- An extra `ok` button was displayed in popups that contain the modal class.

After this commit:
- The extra `ok` button has been removed.

task-4919745
