### PR TITLE
[FIX] payment_razorpay: avoid dual-auth methods

### DIFF
--- a/addons/payment_razorpay/models/payment_provider.py
+++ b/addons/payment_razorpay/models/payment_provider.py
@@ -193,12 +193,14 @@ class PaymentProvider(models.Model):
         """
         self.ensure_one()
         url = f'https://api.razorpay.com/{api_version}/{endpoint}'
-        headers = None
-        if self.razorpay_access_token:
+        if self.razorpay_key_id and self.razorpay_key_secret:
+            headers = None
+            auth = (self.razorpay_key_id, self.razorpay_key_secret)
+        else:
             if self.razorpay_access_token_expiry < fields.Datetime.now():
                 self._razorpay_refresh_access_token()
             headers = {'Authorization': f'Bearer {self.razorpay_access_token}'}
-        auth = (self.razorpay_key_id, self.razorpay_key_secret) if self.razorpay_key_id else None
+            auth = None
         try:
             if method == 'GET':
                 response = requests.get(


### PR DESCRIPTION
In a specific context, Razorpay rejects connections using both Key ID/Secret and an access token simultaneously.

To reproduce, it's require a real production Razorpay account since Oauth is not available in test mode.

Step to reproduce:
- Configure Key ID/Secret and connect via OAuth on the Razorpay payment provider.
- On iOS/Android, making a payment on the website triggers a "403 Forbidden" error because Razorpay redirect to `/payment/razorpay/return` and the signature from Razorpay not correspond to the expected signature computed with the Key Secret.

This fix prioritizes call with Key ID/Secret over token authentication. if not configured.

opw-5100194
opw-4989944
opw-5039880