### PR TITLE
[IMP] html_editor: close image description box on escape

### DIFF
--- a/addons/html_editor/static/src/main/media/image_description.js
+++ b/addons/html_editor/static/src/main/media/image_description.js
@@ -1,6 +1,7 @@
 import { Component } from "@odoo/owl";
 import { Dialog } from "@web/core/dialog/dialog";
 import { toolbarButtonProps } from "@html_editor/main/toolbar/toolbar";
+import { useHotkey } from "@web/core/hotkeys/hotkey_hook";
 
 export class ImageDescription extends Component {
     static components = { Dialog };
@@ -31,6 +32,7 @@ export class ImageDescriptionPopover extends Component {
             description: this.props.description,
             tooltip: this.props.tooltip,
         };
+        useHotkey("escape", () => this.props.close());
     }
 
     onSave() {

--- a/addons/html_editor/static/tests/image.test.js
+++ b/addons/html_editor/static/tests/image.test.js
@@ -123,6 +123,26 @@ test("can add an image description & tooltip", async () => {
     expect("img").toHaveAttribute("title", "tooltip modified");
 });
 
+test("should close image description popover on escape", async () => {
+    await setupEditor(`
+        <img src="${base64Img}" alt="description" title="tooltip">
+    `);
+    await click("img");
+    await waitFor(".o-we-toolbar");
+
+    await click(".o-we-toolbar .btn-group[name='image_description'] button");
+    await animationFrame();
+
+    expect(".o-we-image-description-popover").toHaveCount(1);
+    await contains("input[name='description']").edit("description modified");
+    await contains("input[name='tooltip']").edit("tooltip modified");
+    await press("Escape");
+    await animationFrame();
+    expect(".o-we-image-description-popover").toHaveCount(0);
+    expect("img").toHaveAttribute("alt", "description");
+    expect("img").toHaveAttribute("title", "tooltip");
+});
+
 test("can edit an image description & tooltip", async () => {
     await setupEditor(`
         <img class="img-fluid test-image" src="${base64Img}" alt="description" title="tooltip">


### PR DESCRIPTION
This PR aims to ensure that image description box gets closed when pressing escape key.

task-5114224





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
