### PR TITLE
[FIX] point_of_sale: payment terminal text too small

### DIFF
--- a/addons/point_of_sale/static/src/css/pos_receipts.css
+++ b/addons/point_of_sale/static/src/css/pos_receipts.css
@@ -68,11 +68,11 @@
 
 .pos-payment-terminal-receipt {
     text-align: center;
-    font-size: 75%;
 }
 
 .pos-payment-terminal-receipt pre {
     font-family: inherit;
+    font-size: 75%;
 }
 
 .responsive-price {


### PR DESCRIPTION
When you pay with a payment terminal, it can produce some text which gets appended to the bottom of the POS receipt. Before this commit, this text appears too small to be legible when printed on a receipt printer. This is because the font size styling was in the wrong place, and in the UI it fell back to bootstrap's CSS which makes it fairly large, but html2canvas renders it very small.

After this commit, the problem is fixed by moving the font size styling to the correct place to apply to the text. In the UI, the text is actually slightly smaller than before, but when printed it is bigger and consistent with the UI.

Before/After (UI):
<img width="346" height="325" alt="image" src="https://github.com/user-attachments/assets/0a9dceb3-e224-473f-b02f-ff94b81b0a8d" />
<img width="349" height="319" alt="image" src="https://github.com/user-attachments/assets/b096172a-4a98-4249-a5d4-00c8a46ab4d0" />


Before/After (Receipt):
<img width="513" height="503" alt="image" src="https://github.com/user-attachments/assets/e1d6ba27-1ff6-4853-b617-1c010857f1eb" />
<img width="516" height="528" alt="image" src="https://github.com/user-attachments/assets/82cb2431-707f-40c7-a9a5-f439d3934e16" />


task-5116506

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
