### PR TITLE
[FIX] project: allow portal users with edit-limited access to create tasks

### DIFF
--- a/addons/project/__manifest__.py
+++ b/addons/project/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'Project',
-    'version': '1.3',
+    'version': '1.4',
     'website': 'https://www.odoo.com/app/project',
     'category': 'Services/Project',
     'sequence': 45,

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -1093,6 +1093,9 @@ class ProjectTask(models.Model):
         if not self._has_field_access(self._fields['user_ids'], 'write'):
             # remove user_ids if we have no access to it
             new_context.pop('default_user_ids', False)
+        if not self._has_field_access(self._fields['milestone_id'], 'write'):
+            # remove milestone_id if we have no access to it
+            new_context.pop('default_milestone_id', False)
         self = self.with_context(new_context)
 
         self.browse().check_access('create')

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -1089,6 +1089,7 @@ class ProjectTask(models.Model):
         # (portal) users that don't have write access can still create a task
         # in the project that will be checked using record rules
         new_context["default_create_in_project_id"] = default_project_id
+        is_portal = self.env.user._is_portal() and not self.env.su
         if not self._has_field_access(self._fields['user_ids'], 'write'):
             # remove user_ids if we have no access to it
             new_context.pop('default_user_ids', False)
@@ -1096,6 +1097,7 @@ class ProjectTask(models.Model):
 
         self.browse().check_access('create')
         default_stage = dict()
+        child_ids_list = []
         for vals, additional_vals in zip(vals_list, additional_vals_list):
             project_id = vals.get('project_id') or default_project_id
 
@@ -1110,8 +1112,11 @@ class ProjectTask(models.Model):
             if not vals.get('name') and vals.get('display_name'):
                 vals['name'] = vals['display_name']
 
-            if self.env.user._is_portal() and not self.env.su:
+            if is_portal:
                 self._ensure_fields_write(vals, defaults=True)
+                child_ids_list.append(vals.pop('child_ids', None))
+            else:
+                child_ids_list.append(None)
 
             if project_id and not "company_id" in vals:
                 additional_vals["company_id"] = self.env["project.project"].browse(
@@ -1185,6 +1190,10 @@ class ProjectTask(models.Model):
                     continue
                 task._send_email_notify_to_cc(partners_with_internal_user)
                 task.message_subscribe(partners_with_internal_user.ids)
+        if is_portal:
+            for task, child_ids in zip(tasks, child_ids_list):
+                if child_ids:
+                    task.write({'child_ids': child_ids})
         return tasks
 
     def write(self, vals):

--- a/addons/project/security/project_security.xml
+++ b/addons/project/security/project_security.xml
@@ -230,6 +230,23 @@
             ('project_id.privacy_visibility', '=', 'portal'),
             ('active', '=', True),
             '|',
+                ('message_partner_ids', 'child_of', [user.partner_id.commercial_partner_id.id]),
+                ('project_id.collaborator_ids.partner_id', '=', user.partner_id.id),
+        ]</field>
+        <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
+        <field name="perm_read" eval="False"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_unlink" eval="False"/>
+    </record>
+
+    <record id="project_task_rule_portal_project_sharing_write_followers" model="ir.rule">
+        <field name="name">Project/Task: portal users can edit followed tasks or full-access collaborations</field>
+        <field name="model_id" ref="project.model_project_task"/>
+        <field name="domain_force">[
+            ('project_id.privacy_visibility', '=', 'portal'),
+            ('active', '=', True),
+            '|',
                 '&amp;',
                     ('message_partner_ids', 'child_of', [user.partner_id.commercial_partner_id.id]),
                     ('project_id.collaborator_ids.partner_id', 'in', [user.partner_id.id]),
@@ -239,10 +256,7 @@
                 ]),
         ]</field>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
-        <field name="perm_read" eval="False"/>
         <field name="perm_write" eval="True"/>
-        <field name="perm_create" eval="True"/>
-        <field name="perm_unlink" eval="False"/>
     </record>
 
     <record model="ir.rule" id="update_comp_rule">

--- a/addons/project/tests/test_project_sharing.py
+++ b/addons/project/tests/test_project_sharing.py
@@ -749,3 +749,46 @@ class TestProjectSharing(TestProjectSharingCommon):
         self.assertEqual(task.state, '1_done', "The portal user with edit rights should be able to mark the task as done.")
         next_task = task.recurrence_id.task_ids.filtered(lambda t: t != task)
         self.assertTrue(next_task, "The next occurrence of the recurrent task should be created.")
+
+    def test_portal_user_with_edit_limited_access_can_create_task(self):
+        """
+        Test that a portal user with 'edit_limited' access can create a task in a shared project.
+        """
+        ProjectShare = self.env['project.share.wizard'].with_context(
+            active_model="project.project",
+            active_id=self.project_portal.id,
+        )
+        self.project_portal.write({
+            'collaborator_ids': [
+                Command.create({'partner_id': self.user_portal.partner_id.id}),
+            ],
+        })
+        with Form(ProjectShare) as project_share_form:
+            with project_share_form.collaborator_ids.edit(0) as collaborator_form:
+                collaborator_form.access_mode = 'edit_limited'
+
+        portal_task = self.env['project.task'].with_user(self.user_portal).with_context(
+            default_project_id=self.project_portal.id,
+        ).create({
+            'name': 'Portal Task',
+            'child_ids': [
+                Command.create({'name': 'Limited Edit Subtask'}),
+            ],
+        })
+        subtask = portal_task.child_ids[0]
+
+        self.assertTrue(
+            subtask, "Portal user with edit_limited access should be able to create a subtask."
+        )
+        self.assertEqual(
+            portal_task.project_id, self.project_portal,
+            "Parent task should belong to the shared project."
+        )
+        self.assertEqual(
+            subtask.project_id, self.project_portal,
+            "Subtask should belong to the shared project."
+        )
+        self.assertEqual(
+            subtask.parent_id, portal_task,
+            "Subtask should be linked to the correct parent task."
+        )

--- a/addons/project/tests/test_project_sharing.py
+++ b/addons/project/tests/test_project_sharing.py
@@ -792,3 +792,26 @@ class TestProjectSharing(TestProjectSharingCommon):
             subtask.parent_id, portal_task,
             "Subtask should be linked to the correct parent task."
         )
+
+    def test_portal_user_with_access_can_create_sub_task(self):
+        """Ensure a portal user with project sharing access can create a task, a subtask,
+        and a subtask of that subtask, when milestone is provided in context.
+        """
+        self.project_portal.write({
+            'collaborator_ids': [
+                Command.create({'partner_id': self.user_portal.partner_id.id}),
+            ],
+        })
+        portal_task = self.env['project.task'].with_user(self.user_portal).with_context(
+            default_project_id=self.project_portal.id,
+            default_milestone_id=False,
+        ).create({
+            'name': 'Portal Task',
+            'child_ids': [
+                Command.create({'name': 'Subtask'}),
+            ],
+        })
+        self.assertEqual(portal_task.name, 'Portal Task')
+        self.assertEqual(portal_task.subtask_count, 1)
+        subtask = portal_task.child_ids[0]
+        self.assertEqual(subtask.name, 'Subtask')

--- a/addons/project/upgrades/1.4/pre-migrate.py
+++ b/addons/project/upgrades/1.4/pre-migrate.py
@@ -1,0 +1,29 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+
+def migrate(cr, version):
+    cr.execute("""
+        UPDATE ir_rule r
+           SET domain_force = '[
+                ("project_id.privacy_visibility", "=", "portal"),
+                ("active", "=", True),
+                "|",
+                    ("message_partner_ids", "child_of", [user.partner_id.commercial_partner_id.id]),
+                    ("project_id.collaborator_ids.partner_id", "=", user.partner_id.id),
+            ]'
+          FROM ir_model_data d
+         WHERE d.res_id = r.id
+           AND r.domain_force = '[
+            (''project_id.privacy_visibility'', ''='', ''portal''),
+            (''active'', ''='', True),
+            ''|'',
+                (''message_partner_ids'', ''child_of'', [user.partner_id.commercial_partner_id.id]),
+                (''project_id.collaborator_ids'', ''any'', [
+                    (''partner_id'', ''='', user.partner_id.id),
+                    (''limited_access'', ''='', False),
+                ]),
+        ]'
+           AND d.model = 'ir.rule'
+           AND d.module = 'project'
+           AND d.name = 'project_task_rule_portal_project_sharing'
+    """)

--- a/addons/project/views/project_sharing_project_task_views.xml
+++ b/addons/project/views/project_sharing_project_task_views.xml
@@ -115,7 +115,8 @@
                     <div class="oe_button_box" name="button_box">
                         <field name="display_parent_task_button" invisible="1"/>
                         <field name="recurrence_id" invisible="1" />
-                        <button name="action_project_sharing_view_parent_task" type="object" class="oe_stat_button" icon="fa-tasks" invisible="not display_parent_task_button">
+                        <button name="action_project_sharing_view_parent_task" type="object" class="oe_stat_button" icon="fa-tasks" invisible="not display_parent_task_button"
+                            context="{'default_project_id': project_id}">
                             <div class="o_stat_info">
                                 <span class="o_stat_text">Parent Task</span>
                             </div>

--- a/addons/sale_timesheet/models/project_task.py
+++ b/addons/sale_timesheet/models/project_task.py
@@ -73,7 +73,10 @@ class ProjectTask(models.Model):
         super()._inverse_partner_id()
         for task in self:
             if task.allow_billable and not task.sale_line_id:
-                task.sale_line_id = task.sudo().last_sol_of_customer
+                if self.env.user._is_portal():
+                    task.sudo().sale_line_id = task.sudo().last_sol_of_customer
+                else:
+                    task.sale_line_id = task.sudo().last_sol_of_customer
 
     @api.depends('sale_line_id.order_partner_id', 'parent_id.sale_line_id', 'project_id.sale_line_id', 'allow_billable')
     def _compute_sale_line(self):


### PR DESCRIPTION
**[FIX] project: allow portal users with edit-limited access to create tasks**

Steps to Reproduce:
- As an internal user, share a project with a portal user and assign them `Edit with limited access`.
- Log in as the portal user.
- Open the shared project and navigate to the task list.
- Create a new task or subtask and try to save it.
- Observe that the portal user is unable to create or save the task.

Issue:
- When a project is shared with a portal user and assigned `Edit with limited access`, the portal user is unable to create or save tasks in the shared project.

Cause:
- The security rule project_task_rule_portal_project_sharing was too restrictive and did not grant create access for portal users with `Edit with limited access` rights. As a result, the record creation failed despite being allowed in the UI.

Solution:
- Update the `project_task_rule_portal_project_sharing` rule to properly include create access for portal users with `Edit with limited access`, ensuring they can create and save tasks/subtasks in project sharing.

**[FIX] project: allow portal users to create tasks with subtasks**

Steps to reproduce:
- Share a project with a portal user and give them Edit (limited) access.
- Log in as the portal user.
- Try to create a new task with a subtask in a single operation

Cause:
- When creating a task together with its subtasks, the `parent_id` record rule blocked access. At the moment of creation, the portal user was not yet a follower of the parent task, so they could not read it, leading to an access error.

Solution:
  &nbsp;&nbsp; For portal users:
- Temporarily strip `child_ids` from the creation values.
- Create the parent tasks first.
- Subscribe the portal user as a follower of the parent.
- Write back the subtasks (child_ids).

For non-portal users, the flow remains unchanged, and subtasks are created in one go.


**[FIX] project: allow portal users to create subtasks when milestone is in context**

- Share a project with a portal user having Edit or Edit with limited access permissions.
- Log in as that portal user.
- Open the shared project and create a new task with a subtask.
- From the task form, open the subtask by clicking the `View Task` button in the subtask list.
- In that subtask, create another subtask (a subtask of the subtask).
- Click Save and observe that the record cannot be saved.

Cause
- When a portal user creates a subtask of a subtask in a shared project, they do not yet have access to the `milestone_id` field. As a result, even though a milestone is present in the context, it cannot be assigned during record creation, causing the subtask to fail when saving.

Solution:
- In the create method, we extract the milestone_id into `additional_vals_list` and assign the milestone after task creation using `sudo`.


**[FIX] project: fix project sharing warning on task creation**

Steps to Reproduce:
- As an internal user, share a project with a portal user and assign
  Edit with limited access.
- Log in as the portal user.
- Open the shared project and go to the task list.
- Create a task, then create its subtask, and open the subtask form.
- Click the parent task stat button and attempt to create a new task.
- Notice the following warning appears in the logs.
`You do not have enough rights to access the field "create_uid" on Task
 (project.task)`

Cause:
- The stat button opens the task creation form without a safe context, causing
  Odoo to read restricted fields (like create_uid), which portal users cannot
  access.

Solution
- Pass a context to the button to avoid reading restricted fields:
  `context="{'default_project_id': project_id}"`


**[FIX] project: prevent partner access error for shared users**

Steps to Reproduce:
- Install Project.
- Share a project with a project sharing user having Edit or Edit with limited
  access permissions.
- Log in as that shared user.
- Open the shared project and create a task from the list or kanban view.

Issue
- Creating the task fails with an AccessError on the Customer(`partner_id`).

Cause
- The customer field is editable for project sharing users who should not be
  allowed to modify it. As a result, `partner_id` is included during task
  creation and triggers an access error.

Solution
- Correct the readonly condition on the customer field so unauthorized users
  cannot modify it.


task-5075150


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
