### PR TITLE
[FIX] orm: searching non-stored m2m fields message

### DIFF
--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -766,6 +766,8 @@ class _RelationalMulti(_Relational):
     def condition_to_sql(self, field_expr: str, operator: str, value, model: BaseModel, alias: str, query: Query) -> SQL:
         assert field_expr == self.name, "Supporting condition only to field"
         comodel = model.env[self.comodel_name]
+        if not self.store:
+            raise ValueError(f"Cannot convert {self} to SQL because it is not stored")
 
         # update the operator to 'any'
         if operator in ('in', 'not in'):


### PR DESCRIPTION
When searching non-stored many2many fields, fail with a user-friendly message.

`self.env['account.payment'].search([('reconciled_invoice_ids', '=', 1)])` today results in an AttributeError when trying to get the SQL for the bridge table name.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
