### PR TITLE
[IMP] account_peppol: graceful service errors

### DIFF
--- a/addons/account_peppol/models/res_config_settings.py
+++ b/addons/account_peppol/models/res_config_settings.py
@@ -3,6 +3,7 @@
 from odoo import _, api, fields, models, modules, tools
 from odoo.exceptions import UserError, ValidationError
 
+from odoo.addons.account_edi_proxy_client.models.account_edi_proxy_user import AccountEdiProxyError
 from odoo.addons.account_peppol.tools.demo_utils import handle_demo
 
 
@@ -116,9 +117,13 @@ class ResConfigSettings(models.TransientModel):
         return True
 
     def button_account_peppol_configure_services(self):
+        try:
+            services = self.account_peppol_edi_user._peppol_get_services().get('services', {})
+        except AccountEdiProxyError:
+            services = {}
         wizard = self.env['account_peppol.service.wizard'].create({
             'edi_user_id': self.account_peppol_edi_user.id,
-            'service_json': self.account_peppol_edi_user._peppol_get_services().get('services'),
+            'service_json': services,
         })
         return {
             'type': 'ir.actions.act_window',


### PR DESCRIPTION
Handle `api/peppol/2/get_services` errors gracefully, without blocking critical section of peppol functionnal flow (deletion).

If the API endpoint for services returns an error (which should not be affecting any users), the whole peppol config wizard is no longer accessible. The users will therefore not be able to unregister.

no-task

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
