### PR TITLE
[FIX] point_of_sale: cash in/out deletion rights

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -168,6 +168,7 @@ class PosSession(models.Model):
         data[0]['_base_url'] = self.get_base_url()
         data[0]['_data_server_date'] = server_date or self.env.cr.now()
         data[0]['_has_cash_move_perm'] = self.env.user.has_group('account.group_account_invoice')
+        data[0]['_has_cash_delete_perm'] = self.env.user.has_group('account.group_account_basic')
         data[0]['_has_available_products'] = self._pos_has_valid_product()
         data[0]['_pos_special_products_ids'] = self.env['pos.config']._get_special_products().ids
         return super()._post_read_pos_data(data)

--- a/addons/point_of_sale/static/src/app/components/popups/cash_move_popup/cash_move_list_popup/cash_move_list_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/cash_move_popup/cash_move_list_popup/cash_move_list_popup.js
@@ -4,6 +4,7 @@ import { useTrackedAsync } from "@point_of_sale/app/hooks/hooks";
 import { usePos } from "@point_of_sale/app/hooks/pos_hook";
 import { Dialog } from "@web/core/dialog/dialog";
 import { _t } from "@web/core/l10n/translation";
+import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 
 export class CashMoveListPopup extends Component {
     static template = "point_of_sale.CashMoveListPopup";
@@ -17,6 +18,7 @@ export class CashMoveListPopup extends Component {
         super.setup();
         this.pos = usePos();
         this.ui = useService("ui");
+        this.dialog = useService("dialog");
         this.callbacks = this.props.cashMoves.reduce(
             (acc, cm) => ({
                 ...acc,
@@ -35,13 +37,25 @@ export class CashMoveListPopup extends Component {
     }
 
     async onDeleteCm(cm) {
-        await this.pos.data.call(
-            "pos.session",
-            "delete_cash_in_out",
-            [[this.pos.session.id], cm.id, this.props.partnerId],
-            {},
-            true
-        );
-        this.props.cashMoves = this.props.cashMoves.filter((cashMove) => cashMove.id !== cm.id);
+        try {
+            await this.pos.data.call(
+                "pos.session",
+                "delete_cash_in_out",
+                [[this.pos.session.id], cm.id, this.props.partnerId],
+                {},
+                true
+            );
+            this.props.cashMoves = this.props.cashMoves.filter((cashMove) => cashMove.id !== cm.id);
+        } catch (error) {
+            this.dialog.add(AlertDialog, {
+                title: _t("Odoo Server Error"),
+                body: error.data.message,
+            });
+            throw error;
+        }
+    }
+
+    get hasCashDeletePerm() {
+        return this.pos.session._has_cash_delete_perm;
     }
 }

--- a/addons/point_of_sale/static/src/app/components/popups/cash_move_popup/cash_move_list_popup/cash_move_list_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/cash_move_popup/cash_move_list_popup/cash_move_list_popup.xml
@@ -27,7 +27,7 @@
                                         <div class="cash-move-amount fw-bolder"><t t-esc="getAmount(cm)"></t></div>
                                     </td>
                                     
-                                    <td class="text-end delete-row">
+                                    <td class="text-end delete-row" t-if="hasCashDeletePerm">
                                         <button t-on-click.stop="callbacks[cm.id].call" class="btn btn-link btn-lg text-danger">
                                             <i t-if="callbacks[cm.id].status != 'loading'" class="fa fa-trash" aria-hidden="true"/>
                                             <i t-else="" class="fa fa-spin fa-circle-o-notch" aria-hidden="true" />

--- a/addons/point_of_sale/static/src/app/components/popups/cash_move_popup/cash_move_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/cash_move_popup/cash_move_popup.js
@@ -61,19 +61,24 @@ export class CashMovePopup extends Component {
             `${_t("Cash")} ${translatedType} - ${_t("Amount")}: ${formattedAmount}`,
             "CASH_DRAWER_ACTION"
         );
-        const data = {
-            company: this.pos.company,
-            config: this.pos.config,
-            preset_id: this.pos.config.defualt_preset_id,
-            getCashierName: () => this.pos.getCashier().name,
-        };
+        const order = this.pos.models["pos.order"].create({
+            session_id: this.session,
+            company_id: this.company,
+            config_id: this.config,
+            user_id: this.user,
+            ticket_code: "",
+            tracking_number: "",
+            sequence_number: 0,
+            pos_reference: "",
+        });
         await this.printer.print(CashMoveReceipt, {
             reason,
             translatedType,
-            order: data,
+            order: order,
             formattedAmount,
             date: new Date().toLocaleString(),
         });
+        this.pos.models["pos.order"].delete(order);
 
         this.props.close();
         this.notification.add(

--- a/addons/point_of_sale/static/tests/pos/tours/utils/cash_move_list_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/cash_move_list_util.js
@@ -6,6 +6,14 @@ export function checkCashMoveShown(amount) {
         trigger: `.cash-move-list .cash-move-row .cash-move-amount:contains(${amount})`,
     };
 }
+export function noCashMoveDeleteButton() {
+    return [
+        negateStep({
+            content: `Check that the delete button is not present`,
+            trigger: `.cash-move-list .cash-move-row .delete-row`,
+        }),
+    ];
+}
 export function deleteCashMove(amount) {
     return [
         {


### PR DESCRIPTION
Before this commit, a user with "account.group_account_invoice" group could try to delete a cash in/out in the pos but had no feedback. Actually, his request was refused but we never tell the user why. We now display the error but also do not give the possibility to the user to delete a cash in/out if he does not have the right group.

There was also errors appearing when printing the CashMoveReceipt. We call the ReceiptHeader in the CashMoveReceipt but without giving it a real order which could cause problems cause in the ReceiptHeader we consider the order that is given as a real one and we can call methods and stuff from the model. We now create a dummy order to give to the ReceiptHeader.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
