### PR TITLE
[FIX] crm: change free credit number communication

### DIFF
--- a/addons/crm/data/digest_data.xml
+++ b/addons/crm/data/digest_data.xml
@@ -33,7 +33,7 @@
             <field name="tip_description" type="html">
 <div>
     <p class="tip_title">Tip: Did you know Odoo has built-in lead mining?</p>
-    <p class="tip_content">For a sales team, there is nothing worse than being dry on leads. Fortunately, in just a few clicks, you can generate leads specifically targeted to your needs: company size, industry, etc. To help you test the feature, we offer you 200 credits for free.</p>
+    <p class="tip_content">For a sales team, there is nothing worse than being dry on leads. Fortunately, in just a few clicks, you can generate leads specifically targeted to your needs: company size, industry, etc. To help you test the feature, we offer you 20 credits for free.</p>
     <img src="https://download.odoocdn.com/digests/crm/static/src/img/milk-generate-leads.gif" width="540" class="illustration_border" />
 </div>
             </field>


### PR DESCRIPTION
## Versions
17.0+

## Issue
The Periodic Digest contains wrong information in a tip. 20 credits are given for specific target lead generation, not 200.

opw-5114252