### PR TITLE
[FIX] account,l10n_gcc_invoice: missing cash rounding in printed invoice

### DIFF
--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -4831,3 +4831,42 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
         invoice_terms[1].no_followup = False
         self.assertFalse(invoice.no_followup)
         self.assertEqual(invoice_terms.mapped('no_followup'), [False, False, False])
+
+    def test_invoice_epd_cash_rounding_amount(self):
+        """
+        This test checks the correct calculation of early payment discount on an
+        invoice having also cash discount applied
+        """
+        tax = self.env['account.tax'].create({
+            'name': '8.1%',
+            'type_tax_use': 'sale',
+            'amount': 8.1,
+        })
+        self.cash_rounding_a.rounding_method = 'HALF-UP'
+        payment_terms = self.env['account.payment.term'].create({
+            'name': "2/7 Net 30",
+            'company_id': self.company_data['company'].id,
+            'discount_percentage': 2,
+            'discount_days': 7,
+            'early_discount': True,
+        })
+
+        invoice = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_payment_term_id': payment_terms.id,
+            'invoice_cash_rounding_id': self.cash_rounding_a.id,
+            'invoice_line_ids': [Command.create({
+                'name': 'test line',
+                'price_unit': 50.00,
+                'tax_ids': [Command.set(tax.ids)],
+            })],
+        })
+        invoice.action_post()
+        discounted_amount = invoice.invoice_payment_term_id._get_amount_due_after_discount(
+            invoice.amount_total,
+            invoice.amount_tax,
+            currency=invoice.currency_id,
+            cash_rounding=invoice.invoice_cash_rounding_id,
+        )
+        self.assertEqual(discounted_amount, 52.95)

--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -426,7 +426,7 @@
                                                 <t t-if="o._is_eligible_for_early_payment_discount(o.currency_id,o.invoice_date)">
                                                     <td>
                                                         <span t-options='{"widget": "monetary", "display_currency": o.currency_id}'
-                                                              t-out="o.invoice_payment_term_id._get_amount_due_after_discount(o.amount_total, o.amount_tax)">30.00</span> due if paid before
+                                                              t-out="o.invoice_payment_term_id._get_amount_due_after_discount(o.amount_total, o.amount_tax, currency=o.currency_id, cash_rounding=o.invoice_cash_rounding_id)">30.00</span> due if paid before
                                                         <span t-out="o.invoice_payment_term_id._get_last_discount_date_formatted(o.invoice_date)">2024-01-01</span>
                                                     </td>
                                                 </t>

--- a/addons/account_payment/tests/test_account_payment.py
+++ b/addons/account_payment/tests/test_account_payment.py
@@ -287,8 +287,9 @@ class TestAccountPayment(AccountPaymentCommon):
             flow='direct',
             state='done',
             amount=invoice.invoice_payment_term_id._get_amount_due_after_discount(
-                total_amount=invoice.amount_residual,
-                untaxed_amount=invoice.amount_tax,
+                invoice.amount_residual,
+                invoice.amount_tax,
+                currency=invoice.currency_id,
             ),
             invoice_ids=[invoice.id],
             partner_id=self.partner.id,

--- a/addons/l10n_gcc_invoice/views/report_invoice.xml
+++ b/addons/l10n_gcc_invoice/views/report_invoice.xml
@@ -160,12 +160,14 @@
             <xpath expr="//div[@id='total_payment_term_details_table']//td" position="before">
                 <td name="td_payment_term_ar" t-if="display_in_ar" t-translation="off">
                     <span t-options='{"widget": "monetary", "display_currency": o_sec.currency_id}'
-                          t-out="o_sec.invoice_payment_term_id._get_amount_due_after_discount(o_sec.amount_total, o_sec.amount_tax)" dir="rtl">30.00</span> المبلغ المستحق إذا تم الدفع قبل
+                          t-out="o_sec.invoice_payment_term_id._get_amount_due_after_discount(o_sec.amount_total, o_sec.amount_tax, currency=o.currency_id, cash_rounding=o.invoice_cash_rounding_id)"
+                          dir="rtl">30.00</span> المبلغ المستحق إذا تم الدفع قبل
                     <span t-out="o_sec.invoice_payment_term_id._get_last_discount_date_formatted(o_sec.invoice_date)" dir="rtl">2024-01-01</span>
                 </td>
                 <td name="td_payment_term_en" t-if="display_in_en" t-translation="off">
                     <span t-options='{"widget": "monetary", "display_currency": o_sec.currency_id}'
-                          t-out="o_sec.invoice_payment_term_id._get_amount_due_after_discount(o_sec.amount_total, o_sec.amount_tax)" dir="ltr">30.00</span> due if paid before
+                          t-out="o_sec.invoice_payment_term_id._get_amount_due_after_discount(o_sec.amount_total, o_sec.amount_tax, currency=o.currency_id, cash_rounding=o.invoice_cash_rounding_id)"
+                          dir="ltr">30.00</span> due if paid before
                     <span t-out="o_sec.invoice_payment_term_id._get_last_discount_date_formatted(o_sec.invoice_date)" dir="ltr">2024-01-01</span>
                 </td>
             </xpath>


### PR DESCRIPTION
**Steps to reproduce**
- Create a tax of 8.1%
- Activate and create a cash rounding with rounding precision 0.05
- Use the existing '2/7 Net 30' payment term (or create a new 2% early discount one)
- Create a new invoice:
  - Add payment terms
  - Add cash rounding method
  - Add line with price 50, 8.1% tax
- Invoice total will be 54.05

**Issue**

Print the invoice: The invoice will show "$ 52.97 due if paid before 09/12/2025"
However 52.97 is the amount with just the 2% early payment discount applied With cash rounding applied, it should display 52.95

This occurs because when retrieving the amount from the invoice template the system applies only the early payment discount

opw-4914545

PR in 17.0: https://github.com/odoo/odoo/pull/225759

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
