### PR TITLE
[FIX] mail: properly clean up app on PiP window close

### DIFF
--- a/addons/mail/static/src/core/common/mail_popout_service.js
+++ b/addons/mail/static/src/core/common/mail_popout_service.js
@@ -34,7 +34,7 @@ export const mailPopoutService = {
                 return;
             }
             const doc = popout.externalWindow?.document;
-            if (doc) {
+            if (doc && !popout.externalWindow?.closed) {
                 doc.head.textContent = "";
                 if (useAlternativeAssets) {
                     await mailPopoutService.addAssets(popout.externalWindow);

--- a/addons/mail/static/src/discuss/call/common/pip_service.js
+++ b/addons/mail/static/src/discuss/call/common/pip_service.js
@@ -26,6 +26,7 @@ export const callPipService = {
         function closePip() {
             state.active = false;
             pipWindow?.close();
+            popout.reset();
         }
         /**
          * @param {Object} [param0] native pip options


### PR DESCRIPTION
**Description of the issue this PR addresses:**
When closing a Picture-in-Picture (PiP) window, the app mounted on it was not destroyed. As a result, the `Meeting` component remained mounted even though the call was disconnected, leading to errors. The cleanup of the mounted app only occurred when creating a new PiP window, not when closing one.

**Current behavior before PR:**

* Closing a PiP window does not destroy the mounted app.
* `Meeting` component stays mounted after call disconnect.
* Errors occur due to leftover state.

**Desired behavior after PR is merged:**

* The app mounted on the PiP window is properly destroyed as soon as the PiP window is closed.
* No errors occur from a lingering `Meeting` component after closing.

**Steps to reproduce:**
- Join a call
- Open the call in PiP
- Disconnect the call either via PiP or from the Discuss app -> traceback
OR
- Close PiP window, then disconnect the call from the Discuss app -> traceback

task-[5112773](https://www.odoo.com/odoo/project/1519/tasks/5112773)