### PR TITLE
[IMP] account_peppol: graceful service errors

### DIFF
--- a/addons/account_peppol/wizard/peppol_config_wizard.py
+++ b/addons/account_peppol/wizard/peppol_config_wizard.py
@@ -1,6 +1,9 @@
 from markupsafe import Markup
 
 from odoo import api, Command, fields, models, _
+from odoo.exceptions import UserError
+
+from odoo.addons.account_edi_proxy_client.models.account_edi_proxy_user import AccountEdiProxyError
 
 
 class PeppolService(models.TransientModel):
@@ -61,7 +64,10 @@ class PeppolConfigWizard(models.TransientModel):
     def _compute_service_json(self):
         for wizard in self:
             if wizard.account_peppol_proxy_state == 'receiver':
-                wizard.service_json = wizard.account_peppol_edi_user._peppol_get_services().get('services')
+                try:
+                    wizard.service_json = wizard.account_peppol_edi_user._peppol_get_services().get('services')
+                except (AccountEdiProxyError, UserError):
+                    wizard.service_json = False
             else:
                 wizard.service_json = False
 
@@ -88,7 +94,7 @@ class PeppolConfigWizard(models.TransientModel):
                     )
             wizard.service_info = message
 
-    @api.depends('account_peppol_proxy_state')
+    @api.depends('account_peppol_proxy_state', 'service_json')
     def _compute_service_ids(self):
         """Get the selectable document types.
 
@@ -97,7 +103,7 @@ class PeppolConfigWizard(models.TransientModel):
         """
         supported_doctypes = self.env['res.company']._peppol_supported_document_types()
         for wizard in self:
-            if wizard.account_peppol_proxy_state == 'receiver':
+            if wizard.account_peppol_proxy_state == 'receiver' and wizard.service_json:
                 wizard.service_ids = [
                     Command.create({
                         'document_identifier': identifier,

--- a/addons/account_peppol/wizard/peppol_config_wizard.xml
+++ b/addons/account_peppol/wizard/peppol_config_wizard.xml
@@ -26,8 +26,7 @@
                     </div>
                     <field name="account_peppol_migration_key"/>
                 </group>
-                <group string="Configure your Peppol Services and allowed formats" invisible="account_peppol_proxy_state != 'receiver'">
-                    <field name="service_json" invisible="1"/>
+                <group string="Configure your Peppol Services and allowed formats" invisible="not service_ids">
                     <div colspan="2">
                         <field name="service_info" role="status" class="o_field_html alert alert-info" invisible="not service_info"/>
                         <field name="service_ids"


### PR DESCRIPTION
Handle `api/peppol/2/get_services` errors gracefully, without blocking critical section of peppol functionnal flow (deletion).

If the API endpoint for services returns an error (which should not be affecting any users), the whole peppol config wizard is no longer accessible. The users will therefore not be able to unregister.

Note that with this change, if we get an API error, all services will be marked as disabled (which is fair, and better than displaying an API request error)

no-task