### PR TITLE
[FIX] orm: searching non-stored m2m fields message

### DIFF
--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -740,6 +740,8 @@ class _RelationalMulti(_Relational):
         assert field_expr == self.name, "Supporting condition only to field"
         model._check_field_access(self, 'read')
         comodel = model.env[self.comodel_name]
+        if not self.store:
+            raise ValueError(f"Cannot convert {self} to SQL because it is not stored")
 
         # update the operator to 'any'
         if operator in ('in', 'not in'):


### PR DESCRIPTION
When searching non-stored many2many fields, fail with a user-friendly message.

`self.env['account.payment'].search([('reconciled_invoice_ids', '=', 1)])` today results in an AttributeError when trying to get the SQL for the bridge table name.

task-5061329



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
