### PR TITLE
[FIX] point_of_sale: ensure record creation before setup

### DIFF
--- a/addons/point_of_sale/static/src/app/models/related_models.js
+++ b/addons/point_of_sale/static/src/app/models/related_models.js
@@ -994,6 +994,7 @@ export function createRelatedModels(modelDefs, modelClasses = {}, opts = {}) {
     function loadData(rawData, load = [], fromSerialized = false) {
         const results = {};
         const ignoreConnection = {};
+        const modelToSetup = [];
 
         for (const model in rawData) {
             ignoreConnection[model] = [];
@@ -1065,7 +1066,7 @@ export function createRelatedModels(modelDefs, modelClasses = {}, opts = {}) {
                     }
 
                     oldRecord.update(record, { silent: true });
-                    oldRecord.setup(record);
+                    modelToSetup.push({ raw: record, record: oldRecord });
                     ignoreConnection[model].push(record.id);
                     results[model].push(oldRecord);
                     Object.assign(baseData[model][record.id], raw);
@@ -1078,7 +1079,6 @@ export function createRelatedModels(modelDefs, modelClasses = {}, opts = {}) {
         }
 
         const alreadyLinkedSet = new Set();
-        const modelToSetup = [];
 
         // link the related records
         for (const model in rawData) {

--- a/addons/point_of_sale/static/tests/tours/receipt_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/receipt_screen_tour.js
@@ -7,6 +7,7 @@ import * as NumberPopup from "@point_of_sale/../tests/tours/utils/number_popup_u
 import * as Order from "@point_of_sale/../tests/tours/utils/generic_components/order_widget_util";
 import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
 import * as Numpad from "@point_of_sale/../tests/tours/utils/numpad_util";
+import * as ProductConfigurator from "@point_of_sale/../tests/tours/utils/product_configurator_util";
 import { registry } from "@web/core/registry";
 import { inLeftSide } from "@point_of_sale/../tests/tours/utils/common";
 
@@ -194,5 +195,25 @@ registry.category("web_tour.tours").add("test_auto_validate_force_done", {
                 run: "click",
             },
             ReceiptScreen.receiptIsThere(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_free_text_custom_attribute_on_receipt", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Configurable Chair"),
+            ProductConfigurator.pickRadio("Other"),
+            ProductConfigurator.fillCustomAttribute("Custom Fabric"),
+            Dialog.confirm(),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.receiptIsThere(),
+            Order.hasLine({
+                productName: "Configurable Chair (Fabrics: Other: Custom Fabric)",
+            }),
+            ReceiptScreen.clickNextOrder(),
         ].flat(),
 });

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -2132,6 +2132,14 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_click_all_orders_keep_customer', login="pos_user")
 
+    def test_free_text_custom_attribute_on_receipt(self):
+        """ Test that free text (custom) attribute values are correctly shown on the PoS receipt screen. """
+        configurable_product = self.env['product.product'].search([('name', '=', 'Configurable Chair'), ('available_in_pos', '=', 'True')], limit=1)
+        configurable_product.attribute_line_ids[:2].unlink()
+        self.main_pos_config.with_user(self.pos_admin).open_ui()
+        self.start_pos_tour('test_free_text_custom_attribute_on_receipt', login="pos_admin")
+
+
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):
     browser_size = '375x667'


### PR DESCRIPTION
This commit change the behavior of loadData to ensure that all records are linked & created before calling setup method of each of them.

related task: 4922193

