### PR TITLE
[FIX] fix url customization

### DIFF
--- a/addons/website/static/src/components/dialog/seo.js
+++ b/addons/website/static/src/components/dialog/seo.js
@@ -492,6 +492,8 @@ export class OptimizeSEODialog extends Component {
                 'website_id': this.website.currentWebsite.id,
             },
         });
-        this.website.goToWebsite({path: this.url.replace(this.previousSeoName || this.seoNameDefault, seoContext.seoName)});
+        this.website.goToWebsite({
+            path: data.seo_name ? this.url.replace(this.previousSeoName || this.seoNameDefault, data.seo_name) : this.url
+        });
     }
 }

--- a/addons/website/static/src/components/dialog/seo.js
+++ b/addons/website/static/src/components/dialog/seo.js
@@ -411,7 +411,8 @@ export class OptimizeSEODialog extends Component {
             this.canEditSeo = this.data.can_edit_seo;
             this.canEditDescription = this.canEditSeo && 'website_meta_description' in this.data;
             this.canEditTitle = this.canEditSeo && 'website_meta_title' in this.data;
-            this.canEditUrl = this.canEditSeo && 'seo_name' in this.data;
+            // The URL can be edited only if it contains soe_name or seo_name_default as slug.
+            this.canEditUrl = this.canEditSeo && new URL(path).pathname.includes(this.data.seo_name || this.data.seo_name_default);
             seoContext.title = this.canEditTitle && this.data.website_meta_title;
 
             // If website.page, hide the google preview & tell user his page is currently unindexed


### PR DESCRIPTION
This PR fixes two issues relates to the URLs' customization with 2 commits.

- commit 1: prevent the URL customization when the object slug is not contained in the URL, otherwise the change is not reflected in the URL.
- commit 2: replace soe_name in the redirection URL only when it is required to avoid a 404 error.

Enterprise PR: https://github.com/odoo/enterprise/pull/96427

Task-5114394