### PR TITLE
[FIX] stock_account: remove confusing columns

### DIFF
--- a/addons/stock_account/views/stock_move_views.xml
+++ b/addons/stock_account/views/stock_move_views.xml
@@ -6,9 +6,7 @@
         <field name="model">stock.move</field>
         <field name="arch" type="xml">
             <field name="state" position="after">
-                <field name="value" optional="hide"/>
                 <field name="remaining_qty" optional="hide"/>
-                <field name="remaining_value" optional="hide"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
The columns for move value and move remaining value should not be
available in the Moves Analysis report.
Instead, the user can go to the Stock report (same menu, top option)
and click on the Total Value of a product to see the evolution
of the valuation for this product.

testing pad 19

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
