### PR TITLE
[FIX] stock: even more fixes for pack in pack

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -272,7 +272,7 @@ class StockMove(models.Model):
                 move.package_ids = move.move_line_ids.package_history_id.outermost_dest_id
             else:
                 # Only display the top-level packages until the move is done.
-                move.package_ids = move.move_line_ids.result_package_id.mapped(lambda p: p.outermost_package_id or p)
+                move.package_ids = move.move_line_ids.result_package_id.outermost_package_id
 
     @api.depends('move_line_ids.picked', 'state')
     def _compute_picked(self):

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -265,7 +265,7 @@ class StockMove(models.Model):
         for move in self:
             move.has_lines_without_result_package = move.move_line_ids.result_package_id and any(not line.result_package_id for line in move.move_line_ids)
 
-    @api.depends('move_line_ids', 'move_line_ids.result_package_id')
+    @api.depends('move_line_ids', 'move_line_ids.result_package_id', 'move_line_ids.result_package_id.outermost_package_id')
     def _compute_package_ids(self):
         for move in self:
             if move.state in ['done', 'cancel']:

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -52,7 +52,7 @@ class StockMoveLine(models.Model):
     result_package_id = fields.Many2one(
         'stock.package', 'Destination Package',
         ondelete='restrict', required=False, check_company=True,
-        domain="['|', '|', ('location_id', '=', location_dest_id), ('id', '=', package_id), '&', ('location_id', '=', False), '|', ('move_line_ids', '=', False), ('move_line_ids.location_dest_id', '=?', location_dest_id)]",
+        domain="['|', '|', ('location_id', '=', location_dest_id), ('id', '=', package_id), '&', ('location_id', '=', False), '|', ('move_line_ids', '=', False), ('move_line_ids.location_dest_id', '=', location_dest_id)]",
         help="If set, the operations are packed into this package")
     result_package_dest_name = fields.Char('Destination Package Name', related='result_package_id.dest_complete_name')
     package_history_id = fields.Many2one('stock.package.history', string="Package History", index='btree_not_null')

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -52,7 +52,7 @@ class StockMoveLine(models.Model):
     result_package_id = fields.Many2one(
         'stock.package', 'Destination Package',
         ondelete='restrict', required=False, check_company=True,
-        domain="['|', '|', ('location_id', '=', False), ('location_id', '=', location_dest_id), ('id', '=', package_id)]",
+        domain="['|', '|', ('location_id', '=', location_dest_id), ('id', '=', package_id), '&', ('location_id', '=', False), '|', ('move_line_ids', '=', False), ('move_line_ids.location_dest_id', '=?', location_dest_id)]",
         help="If set, the operations are packed into this package")
     result_package_dest_name = fields.Char('Destination Package Name', related='result_package_id.dest_complete_name')
     package_history_id = fields.Many2one('stock.package.history', string="Package History", index='btree_not_null')
@@ -1043,6 +1043,7 @@ class StockMoveLine(models.Model):
                 'all_move_line_ids': move_lines.ids,
                 'default_move_line_ids': self.ids,
                 'default_location_dest_id': self.location_dest_id.id,
+                'picking_ids': move_lines.picking_id.ids,
             }
             return action
 

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -258,7 +258,7 @@ class StockMoveLine(models.Model):
         if self.env.context.get('avoid_putaway_rules'):
             return
         self = self.with_context(do_not_unreserve=True)
-        for package, smls in groupby(self, lambda sml: sml.result_package_id):
+        for package, smls in groupby(self, lambda sml: sml.result_package_id.outermost_package_id):
             smls = self.env['stock.move.line'].concat(*smls)
             excluded_smls = set(smls.ids)
             if package.package_type_id:
@@ -984,7 +984,7 @@ class StockMoveLine(models.Model):
                 'parent_orig_name': package.parent_package_id.complete_name,
                 'parent_dest_id': package.package_dest_id.id,
                 'parent_dest_name': package.package_dest_id.dest_complete_name,
-                'outermost_dest_id': package.outermost_package_id.id or package.id,
+                'outermost_dest_id': package.outermost_package_id.id,
             })
 
         return history_vals
@@ -1144,7 +1144,7 @@ class StockMoveLine(models.Model):
         if done_pack and not self.env.context.get('force_move_lines'):
             return done_pack
         elif lines_with_pack_to_pack := move_lines._to_pack(without_pack=False):
-            packs_to_pack = lines_with_pack_to_pack.result_package_id.mapped(lambda p: p.outermost_package_id or p)
+            packs_to_pack = lines_with_pack_to_pack.result_package_id.outermost_package_id
             if done_pack:
                 packs_to_pack = packs_to_pack.filtered(lambda p: p.id != done_pack.id)
                 package_id = done_pack.id

--- a/addons/stock/models/stock_package.py
+++ b/addons/stock/models/stock_package.py
@@ -228,8 +228,12 @@ class StockPackage(models.Model):
         return [('id', 'in', all_package_ids)]
 
     def _search_move_line_ids(self, operator, value):
-        if operator != 'in':
+        if operator not in ('in', 'any'):
             return NotImplemented
+        if operator == 'any':
+            operator = 'in'
+            if isinstance(value, Domain):
+                value = self.env['stock.move.line']._search(value)
 
         domain = Domain('state', 'not in', ['done', 'cancel'])
         pack_operator = 'in'

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -889,7 +889,7 @@ class StockPicking(models.Model):
             packages_weight = picking.move_line_ids.result_package_id.sudo()._get_weight(picking.id)
 
             shipping_weight = picking.weight_bulk
-            relevant_packages = picking.move_line_ids.result_package_id.mapped(lambda p: p.outermost_package_id or p)
+            relevant_packages = picking.move_line_ids.result_package_id.outermost_package_id
             children_packages_by_pack = relevant_packages._get_all_children_package_dest_ids()[0]
             for package in relevant_packages:
                 if package.shipping_weight:

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1913,7 +1913,7 @@ class StockPicking(models.Model):
             'type': 'ir.actions.act_window',
             'domain': [('picking_ids', 'in', self.ids)],
             'context': {
-                'picking_id': self.id,
+                'picking_ids': self.ids,
                 'location_id': self.location_id.id,
                 'can_add_entire_packs': self.picking_type_code != 'incoming',
                 'search_default_main_packages': True,

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -561,7 +561,7 @@ class StockQuant(models.Model):
             if record.env.context.get('formatted_display_name'):
                 name = f"{record.location_id.name}"
                 if record.package_id:
-                    name += f"\t--{record.package_id.name}--"
+                    name += f"\t--{record.package_id.display_name}--"
                 if record.lot_id:
                     name += (' ' if record.package_id else '\t') + f"--{record.lot_id.name}--"
                 record.display_name = name
@@ -570,7 +570,7 @@ class StockQuant(models.Model):
                 if record.lot_id:
                     name.append(record.lot_id.name)
                 if record.package_id:
-                    name.append(record.package_id.name)
+                    name.append(record.package_id.display_name)
                 if record.owner_id:
                     name.append(record.owner_id.name)
                 record.display_name = ' - '.join(name)

--- a/addons/stock/report/report_stockpicking_operations.xml
+++ b/addons/stock/report/report_stockpicking_operations.xml
@@ -237,9 +237,11 @@
                                             </td>
                                             <td t-if="o.picking_type_id.code != 'incoming'" groups="stock.group_stock_multi_locations">
                                                 <span t-field="package.location_id"/>
+                                                <span t-field="package.parent_package_id"/>
                                             </td>
                                             <td t-if="o.picking_type_id.code != 'outgoing'" groups="stock.group_stock_multi_locations">
                                                 <span t-field="package.location_dest_id"/>
+                                                <span t-field="package.package_dest_id"/>
                                             </td>
                                         </tr>
                                     </t>
@@ -256,9 +258,11 @@
                                             </td>
                                             <td t-if="o.picking_type_id.code != 'incoming'" groups="stock.group_stock_multi_locations">
                                                 <span t-field="package_history.location_id"/>
+                                                <span t-field="package_history.parent_orig_id"/>
                                             </td>
                                             <td t-if="o.picking_type_id.code != 'outgoing'" groups="stock.group_stock_multi_locations">
                                                 <span t-field="package_history.location_dest_id"/>
+                                                <span t-field="package_history.parent_dest_id"/>
                                             </td>
                                         </tr>
                                     </t>

--- a/addons/stock/static/src/views/list/stock_add_package_list_view.js
+++ b/addons/stock/static/src/views/list/stock_add_package_list_view.js
@@ -11,7 +11,9 @@ export class AddPackageListRenderer extends ListRenderer {
         this.orm = useService("orm");
         this.actionService = useService("action");
         this.addDialog = useOwnedDialogs();
-        this.pickingId = this.props.list.context.picking_id || 0;
+        this.pickingId = this.props.list.context.picking_ids?.length
+            ? this.props.list.context.picking_ids[0]
+            : 0;
         this.locationId = this.props.list.context.location_id || 0;
         this.canAddEntirePacks = this.props.list.context?.can_add_entire_packs;
     }

--- a/addons/stock/tests/test_packing.py
+++ b/addons/stock/tests/test_packing.py
@@ -1398,7 +1398,7 @@ class TestPacking(TestPackingCommon):
         self.assertEqual(quantB.package_id.id, pack.id, "Product B should still be in the initial package.")
 
     def test_expected_to_pack(self):
-        """ Test direct calling of `_to_pack` since it doesn't handle all multi-record cases
+        """ Test direct calling of `_get_lines_and_packages_to_pack` since it doesn't handle all multi-record cases
         It's unlikely this situations will occur, but in case it is for customizations/future features,
         ensure that we don't have unexpected behavior """
 
@@ -1452,9 +1452,9 @@ class TestPacking(TestPackingCommon):
 
         # can't mix operation types
         with self.assertRaises(UserError):
-            move_lines_to_pack = (internal_picking_1 | in_picking_1).move_line_ids._to_pack()
+            move_lines_to_pack, __ = (internal_picking_1 | in_picking_1).move_line_ids._get_lines_and_packages_to_pack()
 
-        move_lines_to_pack = (internal_picking_1 | internal_picking_2).move_line_ids._to_pack()
+        move_lines_to_pack, __ = (internal_picking_1 | internal_picking_2).move_line_ids._get_lines_and_packages_to_pack()
         self.assertEqual(len(move_lines_to_pack), 2, "all move lines in pickings should have been selected to pack")
 
     def test_package_selection(self):

--- a/addons/stock/tests/test_packing.py
+++ b/addons/stock/tests/test_packing.py
@@ -27,6 +27,10 @@ class TestPackingCommon(TransactionCase):
             'usage': 'internal',
             'location_id': cls.stock_location.id,
         })
+        cls.pack_type_box, cls.pack_type_pallet = cls.env['stock.package.type'].create([
+            {'name': 'Test Box', 'sequence_code': 'TBOX'},
+            {'name': 'Test Pallet', 'sequence_code': 'TPAL'},
+        ])
 
 
 class TestPacking(TestPackingCommon):
@@ -589,6 +593,74 @@ class TestPacking(TestPackingCommon):
             "The move line destination location must be the one from the picking.")
         internal_transfer.button_validate()
 
+    def test_pack_in_pack_putaway(self):
+        """ Ensure that if different putaway rules are set for different package type, then the putaway
+            related to the outermost package of each move line should apply.
+        """
+        supplier_location = self.env.ref('stock.stock_location_suppliers')
+        shelf2 = self.env['stock.location'].create({
+            'name': 'shelf2',
+            'usage': 'internal',
+            'location_id': self.stock_location.id,
+        })
+
+        # Creates a new putaway rule for Boxes -> Shelf 1 and Pallets -> Shelf 2.
+        self.env['stock.putaway.rule'].create([
+            {
+                'package_type_ids': [Command.link(self.pack_type_box.id)],
+                'location_in_id': self.stock_location.id,
+                'location_out_id': self.shelf1.id,
+                },
+            {
+                'package_type_ids': [Command.link(self.pack_type_pallet.id)],
+                'location_in_id': self.stock_location.id,
+                'location_out_id': shelf2.id,
+            },
+        ])
+
+        receipt = self.env['stock.picking'].create({
+            'picking_type_id': self.picking_type_in.id,
+            'location_id': supplier_location.id,
+            'location_dest_id': self.stock_location.id,
+            'move_ids': [
+                Command.create({
+                    'product_id': self.productA.id,
+                    'location_id': supplier_location.id,
+                    'location_dest_id': self.stock_location.id,
+                    'product_uom_qty': 3,
+                }),
+                Command.create({
+                    'product_id': self.productB.id,
+                    'location_id': supplier_location.id,
+                    'location_dest_id': self.stock_location.id,
+                    'product_uom_qty': 5,
+                }),
+            ]
+        })
+        receipt.action_confirm()
+        move_A = receipt.move_ids.filtered(lambda m: m.product_id == self.productA)
+        move_B = receipt.move_ids - move_A
+
+        # Put each line in a different Box, each should now go to Shelf 1
+        pack_A = move_A.move_line_ids.action_put_in_pack(package_type_id=self.pack_type_box.id)
+        pack_B = move_B.move_line_ids.action_put_in_pack(package_type_id=self.pack_type_box.id)
+        self.assertEqual(receipt.move_line_ids.location_dest_id, self.shelf1)
+
+        # Put the Box of Product A on a Pallet, this move should now go to Shelf 2
+        move_A.move_line_ids.action_put_in_pack(package_type_id=self.pack_type_pallet.id)
+        self.assertEqual(move_A.move_line_ids.location_dest_id, shelf2)
+        self.assertEqual(move_B.move_line_ids.location_dest_id, self.shelf1)
+
+        # Remove the Pallet as destination for the Box of Product A, should now go back to Shelf 1
+        move_A.move_line_ids.result_package_id.package_dest_id.with_context(picking_id=receipt.id).action_remove_package()
+        self.assertEqual(move_A.move_line_ids.location_dest_id, self.shelf1)
+
+        # Put both Boxes on a new Pallet, and validate. Both goods should be in Shelf 2
+        receipt.move_line_ids.action_put_in_pack(package_type_id=self.pack_type_pallet.id)
+        receipt.button_validate()
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, shelf2, package_id=pack_A), 3)
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productB, shelf2, package_id=pack_B), 5)
+
     def test_partial_put_in_pack(self):
         """ Create a simple move in a delivery. Reserve the quantity but set as quantity done only a part.
         Call Put In Pack button. """
@@ -889,12 +961,9 @@ class TestPacking(TestPackingCommon):
         # Required for `result_package_id` to be visible in the view
         self.env.user.write({'group_ids': [(4, self.env.ref('stock.group_tracking_lot').id)]})
 
-        package_type = self.env['stock.package.type'].create({
-            'name': "Super Pallet",
-        })
         package_01, package_02 = self.env['stock.package'].create([{
             'name': 'Pallet %s' % i,
-            'package_type_id': package_type.id,
+            'package_type_id': self.pack_type_pallet.id,
         } for i in [1, 2]])
 
         # max 100kg (so 100 x P) and max 1 pallet -> we will work with pallets,
@@ -903,7 +972,7 @@ class TestPacking(TestPackingCommon):
             'name': 'Super Storage Category',
             'max_weight': 100,
             'package_capacity_ids': [(0, 0, {
-                'package_type_id': package_type.id,
+                'package_type_id': self.pack_type_pallet.id,
                 'quantity': 1,
             })]
         })
@@ -920,7 +989,7 @@ class TestPacking(TestPackingCommon):
         self.env['stock.putaway.rule'].create({
             'location_in_id': self.stock_location.id,
             'location_out_id': self.stock_location.id,
-            'package_type_ids': [(4, package_type.id)],
+            'package_type_ids': [Command.link(self.pack_type_pallet.id)],
             'storage_category_id': stor_category.id,
             'sublocation': 'closest_location',
         })
@@ -991,12 +1060,9 @@ class TestPacking(TestPackingCommon):
         # Required for `result_package_id` to be visible in the view
         self.env.user.write({'group_ids': [(4, self.env.ref('stock.group_tracking_lot').id)]})
 
-        package_type = self.env['stock.package.type'].create({
-            'name': "Super Pallet",
-        })
         package_01, package_02 = self.env['stock.package'].create([{
             'name': 'Pallet %s' % i,
-            'package_type_id': package_type.id,
+            'package_type_id': self.pack_type_pallet.id,
         } for i in [1, 2]])
 
         # max 100kg and max 2 pallets
@@ -1004,7 +1070,7 @@ class TestPacking(TestPackingCommon):
             'name': 'Super Storage Category',
             'max_weight': 100,
             'package_capacity_ids': [(0, 0, {
-                'package_type_id': package_type.id,
+                'package_type_id': self.pack_type_pallet.id,
                 'quantity': 2,
             })]
         })
@@ -1023,7 +1089,7 @@ class TestPacking(TestPackingCommon):
         self.env['stock.putaway.rule'].create({
             'location_in_id': self.stock_location.id,
             'location_out_id': self.stock_location.id,
-            'package_type_ids': [(4, package_type.id)],
+            'package_type_ids': [Command.link(self.pack_type_pallet.id)],
             'storage_category_id': stor_category.id,
             'sublocation': 'closest_location',
         })
@@ -1095,16 +1161,12 @@ class TestPacking(TestPackingCommon):
         supplier_location = self.env.ref('stock.stock_location_suppliers')
         input_location = self.warehouse.wh_input_stock_loc_id
 
-        package_type = self.env['stock.package.type'].create({
-            'name': "package type",
-        })
-
         storage_category = self.env['stock.storage.category'].create({
             'name': "storage category",
             'allow_new_product': "same",
             'max_weight': 1000,
             'package_capacity_ids': [(0, 0, {
-                'package_type_id': package_type.id,
+                'package_type_id': self.pack_type_pallet.id,
                 'quantity': 2,
             })],
         })
@@ -1121,7 +1183,7 @@ class TestPacking(TestPackingCommon):
             'location_out_id': self.stock_location.id,
             'storage_category_id': storage_category.id,
             'sublocation': 'closest_location',
-            'package_type_ids': [(4, package_type.id, 0)],
+            'package_type_ids': [Command.link(self.pack_type_pallet.id)],
         })
 
         receipt = self.env['stock.picking'].create({
@@ -1141,7 +1203,7 @@ class TestPacking(TestPackingCommon):
 
         moves = receipt.move_ids
         moves.move_line_ids.quantity = 1
-        moves.move_line_ids.result_package_id = self.env['stock.package'].create({'package_type_id': package_type.id})
+        moves.move_line_ids.result_package_id = self.env['stock.package'].create({'package_type_id': self.pack_type_pallet.id})
         moves.picked = True
         receipt.button_validate()
         internal_picking = moves.move_dest_ids.picking_id
@@ -1151,7 +1213,7 @@ class TestPacking(TestPackingCommon):
         internal_picking.action_cancel()
 
         # Second test part
-        package = self.env['stock.package'].create({'package_type_id': package_type.id})
+        package = self.env['stock.package'].create({'package_type_id': self.pack_type_pallet.id})
         self.env['stock.quant']._update_available_quantity(self.productA, loc01, 1.0, package_id=package)
 
         receipt = self.env['stock.picking'].create({
@@ -1176,7 +1238,7 @@ class TestPacking(TestPackingCommon):
             'product_uom_id': self.productA.uom_id.id,
             'location_id': supplier_location.id,
             'location_dest_id': input_location.id,
-            'result_package_id': self.env['stock.package'].create({'package_type_id': package_type.id}).id,
+            'result_package_id': self.env['stock.package'].create({'package_type_id': self.pack_type_pallet.id}).id,
             'picking_id': receipt.id,
         } for _ in range(2)])
         receipt.move_ids.picked = True
@@ -1214,7 +1276,7 @@ class TestPacking(TestPackingCommon):
             'product_uom_id': product.uom_id.id,
             'location_id': supplier_location.id,
             'location_dest_id': input_location.id,
-            'result_package_id': self.env['stock.package'].create({'package_type_id': package_type.id}).id,
+            'result_package_id': self.env['stock.package'].create({'package_type_id': self.pack_type_pallet.id}).id,
             'picking_id': receipt.id,
         } for product, move in [
             (self.productA, moves[0]),
@@ -1726,21 +1788,16 @@ class TestPackagePropagation(TestPackingCommon):
     def test_reusable_package_propagation(self):
         """ Test a reusable package should not be propagated to the next picking
         of a mto chain """
-        reusable_type = self.env['stock.package.type'].create({
-            'name': 'Reusable',
-            'package_use': 'reusable',
-        })
+        # Make the Pallet type resuable while the Box type stays disposable.
+        self.pack_type_pallet.package_use = 'reusable'
+        self.pack_type_box.package_use = 'disposable'
         reusable_package = self.env['stock.package'].create({
             'name': 'Reusable Package',
-            'package_type_id': reusable_type.id,
-        })
-        disposable_type = self.env['stock.package.type'].create({
-            'name': 'Disposable',
-            'package_use': 'disposable',
+            'package_type_id': self.pack_type_pallet.id,
         })
         disposable_package = self.env['stock.package'].create({
             'name': 'disposable Package',
-            'package_type_id': disposable_type.id,
+            'package_type_id': self.pack_type_box.id,
         })
         self.productA = self.env['product.product'].create({
             'name': 'productA',

--- a/addons/stock/tests/test_packing.py
+++ b/addons/stock/tests/test_packing.py
@@ -2032,3 +2032,108 @@ class TestPackagePropagation(TestPackingCommon):
         self.assertEqual(boxes.package_dest_id.picking_ids, receipt)
         self.assertFalse((pallet | container).package_dest_id)
         self.assertFalse((pallet | container).picking_ids)
+
+    def test_package_removal(self):
+        """ Checks that the button 'Remove' in the package view in pickings behaves as expected:
+            - Only removes related move/move lines from the picking if it was only added through an entire pack
+            - Otherwise, just removes the package as destination
+            - When removing a destination container, don't remove its children, just reset their destination
+        """
+        pack1, pack2, pack3 = self.env['stock.package'].create([{} for _ in range(3)])
+        self.env['stock.quant']._update_available_quantity(self.productA, self.warehouse.lot_stock_id, 2, package_id=pack1)
+        self.env['stock.quant']._update_available_quantity(self.productB, self.warehouse.lot_stock_id, 3, package_id=pack2)
+        (pack1 | pack2).parent_package_id = pack3
+
+        pick = self.env['stock.picking'].create({
+            'picking_type_id': self.warehouse.pick_type_id.id,
+            'location_id': self.warehouse.lot_stock_id.id,
+            'location_dest_id': self.pack_location.id,
+            'move_ids': [
+                Command.create({
+                    'product_id': self.productB.id,
+                    'product_uom_qty': 2,
+                    'location_id': self.warehouse.lot_stock_id.id,
+                    'location_dest_id': self.pack_location.id,
+                }),
+            ],
+        })
+        pick.action_confirm()
+        self.assertRecordValues(pick.move_line_ids, [
+            {'product_id': self.productB.id, 'package_id': pack2.id, 'result_package_id': False, 'is_entire_pack': False},
+        ])
+
+        pick.action_add_entire_packs(pack3.id)
+        self.assertRecordValues(pick.move_ids.sorted('product_id'), [
+            {'product_id': self.productA.id, 'package_ids': pack3.ids, 'product_uom_qty': 0},
+            {'product_id': self.productB.id, 'package_ids': pack3.ids, 'product_uom_qty': 2},
+        ])
+        self.assertRecordValues(pick.move_line_ids.sorted('product_id'), [
+            {'product_id': self.productA.id, 'package_id': pack1.id, 'result_package_id': pack1.id, 'is_entire_pack': True},
+            {'product_id': self.productB.id, 'package_id': pack2.id, 'result_package_id': pack2.id, 'is_entire_pack': True},
+        ])
+        self.assertEqual(pack1.package_dest_id, pack3)
+        self.assertEqual(pack2.package_dest_id, pack3)
+
+        # Remove pack3 from picking, this should only remove it as destination container
+        pack3.with_context(picking_ids=pick.ids).action_remove_package()
+        self.assertRecordValues(pick.move_ids.sorted('product_id'), [
+            {'product_id': self.productA.id, 'package_ids': pack1.ids, 'product_uom_qty': 0},
+            {'product_id': self.productB.id, 'package_ids': pack2.ids, 'product_uom_qty': 2},
+        ])
+        self.assertRecordValues(pick.move_line_ids.sorted('product_id'), [
+            {'product_id': self.productA.id, 'package_id': pack1.id, 'result_package_id': pack1.id, 'is_entire_pack': True},
+            {'product_id': self.productB.id, 'package_id': pack2.id, 'result_package_id': pack2.id, 'is_entire_pack': True},
+        ])
+        self.assertFalse((pack1 | pack2).package_dest_id)
+
+        # Remove pack1 from picking, this should also remove its related move & move line
+        pack1.with_context(picking_ids=pick.ids).action_remove_package()
+        self.assertRecordValues(pick.move_ids.sorted('product_id'), [
+            {'product_id': self.productB.id, 'package_ids': pack2.ids, 'product_uom_qty': 2},
+        ])
+        self.assertRecordValues(pick.move_line_ids.sorted('product_id'), [
+            {'product_id': self.productB.id, 'package_id': pack2.id, 'result_package_id': pack2.id, 'is_entire_pack': True},
+        ])
+
+        # Remove pack2 from picking, this shouldn't remove its related move
+        pack2.with_context(picking_ids=pick.ids).action_remove_package()
+        self.assertRecordValues(pick.move_ids.sorted('product_id'), [
+            {'product_id': self.productB.id, 'package_ids': [], 'product_uom_qty': 2},
+        ])
+        self.assertFalse(pick.move_line_ids)
+
+    def test_mid_level_package_removal(self):
+        """ Checks that if a package is removed from a picking and implicitly disconnects the top-level packages from the bottom level ones,
+            Then those upper level packages reset their package_dest_id.
+        """
+        packages = self.env['stock.package'].create([{
+            'name': f"p{i}",
+        } for i in range(4)])
+        self.env['stock.quant']._update_available_quantity(self.productA, self.warehouse.lot_stock_id, 2, package_id=packages[3])
+
+        # From top to bottom, packages should be organized as p0 (highest level) > p1 > p2 > p3 (lowest level, contains products)
+        for ind in range(3, 0, -1):
+            packages[ind].parent_package_id = packages[ind - 1]
+        self.assertEqual(packages[3].complete_name, 'p0 > p1 > p2 > p3')
+
+        pick = self.env['stock.picking'].create({
+            'picking_type_id': self.warehouse.pick_type_id.id,
+            'location_id': self.warehouse.lot_stock_id.id,
+            'location_dest_id': self.pack_location.id,
+        })
+        pick.action_add_entire_packs(packages[0].id)
+        self.assertEqual(packages[3].dest_complete_name, 'p0 > p1 > p2 > p3')
+
+        # Remove p3, this should break the link with p2 and p1, so we need to make sure their package_dest_id is reset
+        self.assertEqual(packages[0].move_line_ids, pick.move_line_ids)
+        packages[2].with_context(picking_ids=pick.ids).action_remove_package()
+
+        self.assertEqual(packages[3].complete_name, 'p0 > p1 > p2 > p3')
+        self.assertEqual(packages[3].dest_complete_name, 'p3')
+
+        self.assertRecordValues(packages, [
+            {'name': 'p0', 'parent_package_id': False, 'package_dest_id': False},
+            {'name': 'p1', 'parent_package_id': packages[0].id, 'package_dest_id': False},
+            {'name': 'p2', 'parent_package_id': packages[1].id, 'package_dest_id': False},
+            {'name': 'p3', 'parent_package_id': packages[2].id, 'package_dest_id': False},
+        ])

--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -182,7 +182,7 @@
                     <field name="picking_type_id" column_invisible="True"/>
                     <field name="quant_id"
                         domain="[('product_id', '=', product_id), ('location_id', 'child_of', parent.location_id)]"
-                        context="{'default_location_id': location_id, 'default_product_id': product_id, 'search_view_ref': 'stock.quant_search_view', 'list_view_ref': 'stock.view_stock_quant_tree', 'form_view_ref': 'stock.view_stock_quant_form', 'readonly_form': True}"
+                        context="{'default_location_id': location_id, 'default_product_id': product_id, 'search_view_ref': 'stock.quant_search_view', 'list_view_ref': 'stock.view_stock_quant_tree', 'form_view_ref': 'stock.view_stock_quant_form', 'readonly_form': True, 'show_src_package': 1}"
                         widget="pick_from"
                         column_invisible="not parent.show_quant"
                         options="{'no_create': True, 'no_open': True}"/>
@@ -235,7 +235,7 @@
                     <field name="package_id" column_invisible="True" context="{'show_src_package': 1}"/>
                     <field name="quant_id" column_invisible="context.get('picking_code') == 'incoming'"
                         domain="[('product_id', '=', product_id), ('location_id', 'child_of', picking_location_id)]"
-                        context="{'default_location_id': location_id, 'default_product_id': product_id, 'search_view_ref': 'stock.quant_search_view', 'list_view_ref': 'stock.view_stock_quant_tree_simple', 'form_view_ref': 'stock.view_stock_quant_form', 'readonly_form': False}"
+                        context="{'default_location_id': location_id, 'default_product_id': product_id, 'search_view_ref': 'stock.quant_search_view', 'list_view_ref': 'stock.view_stock_quant_tree_simple', 'form_view_ref': 'stock.view_stock_quant_form', 'readonly_form': False, 'show_src_package': 1}"
                         readonly="state in ('done', 'cancel') and is_locked"
                         widget="pick_from"
                         options="{'no_open': True}"/>

--- a/addons/stock/views/stock_package_views.xml
+++ b/addons/stock/views/stock_package_views.xml
@@ -103,7 +103,7 @@
                 </header>
                 <field name="name" string="Package"/>
                 <field name="package_type_id"/>
-                <field name="json_popover" widget="popover_widget" string=" " invisible="not json_popover" width="20px"/>
+                <field name="json_popover" widget="popover_widget" nolabel="1" invisible="not json_popover" width="18px"/>
                 <field name="location_dest_id" options="{'no_create': True}"/>
                 <field name="parent_package_id" string="Origin Container" readonly="1"/>
                 <field name="package_dest_id" domain="[('id', '!=', id), '|', '|', '|', ('location_id', '=', False), ('location_id', '=', location_dest_id), ('id', '=', parent_package_id), ('location_dest_id', '=', location_dest_id)]"/>

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -146,15 +146,15 @@
                             invisible="not has_scrap_move"/>
                         <button name="action_see_packages" string="Packages" type="object"
                             class="oe_stat_button" icon="fa-cubes"
-                            invisible="state == 'done'" groups="stock.group_tracking_lot">
-                            <div class="o_form_field o_stat_info">
+                            invisible="state == 'done' or not packages_count" groups="stock.group_tracking_lot">
+                            <div class="o_stat_info">
                                 <span class="o_stat_text">Packages</span>
                             </div>
                         </button>
-                        <button name="action_see_package_histories" type="object"
+                        <button name="action_see_package_histories" string="Packages" type="object"
                             class="oe_stat_button" icon="fa-cubes"
-                            invisible="state != 'done'" groups="stock.group_tracking_lot">
-                            <div class="o_form_field o_stat_info">
+                            invisible="state != 'done' or not packages_count" groups="stock.group_tracking_lot">
+                            <div class="o_stat_info">
                                 <span class="o_stat_text">Packages</span>
                             </div>
                         </button>

--- a/addons/stock/wizard/stock_put_in_pack_views.xml
+++ b/addons/stock/wizard/stock_put_in_pack_views.xml
@@ -8,7 +8,7 @@
                 <group>
                     <field name="package_type_id" placeholder="Select a Package Type" options="{'no_create': True}"/>
                     <field name="result_package_id"
-                           domain="[('package_type_id', '=?', package_type_id), '|', '|', ('location_id', '=', False), ('location_id', '=', location_dest_id), ('id', 'in', origin_package_ids)]"
+                           domain="[('package_type_id', '=?', package_type_id), '|', '|', ('location_id', '=', location_dest_id), ('id', 'in', origin_package_ids), '&amp;', ('location_id', '=', False), '|', ('move_line_ids', '=', False), ('move_line_ids.location_dest_id', '=', location_dest_id)]"
                            context="{'default_package_type_id': package_type_id, 'show_src_package': 1}"
                            widget="package_m2o"
                            placeholder="Leave empty to create new"/>

--- a/addons/stock_delivery/tests/test_packing_delivery.py
+++ b/addons/stock_delivery/tests/test_packing_delivery.py
@@ -256,14 +256,14 @@ class TestPacking(TestPackingCommon):
         ml_1.copy({'picking_id': delivery_2.id, 'quantity': 1})
         # recreate the `action_put_in_pack`` steps so we don't have to add test to new module for batch pickings
         # to use batch version of method (which bypass the ensure_one() check in the stock_picking action)
-        move_lines_to_pack = (delivery_1 | delivery_2).move_line_ids._to_pack()
+        move_lines_to_pack, __ = (delivery_1 | delivery_2).move_line_ids._get_lines_and_packages_to_pack()
         self.assertEqual(len(move_lines_to_pack), 2, 'There should be move lines that can be "put in pack"')
         with self.assertRaises(UserError):
             move_lines_to_pack._pre_put_in_pack_hook()
 
         # Test that same carrier + put in pack = OK!
         delivery_2.carrier_id = delivery_1.carrier_id
-        move_lines_to_pack = (delivery_1 | delivery_2).move_line_ids._to_pack()
+        move_lines_to_pack, __ = (delivery_1 | delivery_2).move_line_ids._get_lines_and_packages_to_pack()
         self.assertEqual(len(move_lines_to_pack), 2, 'There should be move lines that can be "put in pack"')
         move_lines_to_pack._pre_put_in_pack_hook()
         package = move_lines_to_pack._put_in_pack()

--- a/addons/stock_delivery/wizard/stock_put_in_pack_views.xml
+++ b/addons/stock_delivery/wizard/stock_put_in_pack_views.xml
@@ -22,7 +22,7 @@
             </field>
             <field name="result_package_id" position="attributes">
                 <attribute name="domain">
-                    [('package_carrier_type', '=?', package_carrier_type), ('package_type_id', '=?', package_type_id), '|', '|', ('location_id', '=', False), ('location_id', '=', location_dest_id), ('id', 'in', origin_package_ids)]
+                    [('package_carrier_type', '=?', package_carrier_type), ('package_type_id', '=?', package_type_id), '|', '|', ('location_id', '=', location_dest_id), ('id', 'in', origin_package_ids), '&amp;', ('location_id', '=', False), '|', ('move_line_ids', '=', False), ('move_line_ids.location_dest_id', '=', location_dest_id)]
                 </attribute>
             </field>
         </field>

--- a/addons/stock_picking_batch/models/stock_picking_batch.py
+++ b/addons/stock_picking_batch/models/stock_picking_batch.py
@@ -379,6 +379,19 @@ class StockPickingBatch(models.Model):
 
     def action_see_packages(self):
         self.ensure_one()
+        if self.state == 'done':
+            return {
+                'name': self.env._("Packages"),
+                'res_model': 'stock.package.history',
+                'view_mode': 'list',
+                'views': [(False, 'list')],
+                'type': 'ir.actions.act_window',
+                'domain': [('picking_ids', 'in', self.picking_ids.ids)],
+                'context': {
+                    'search_default_main_packages': True,
+                }
+            }
+
         return {
             'name': self.env._("Packages"),
             'res_model': 'stock.package',

--- a/addons/stock_picking_batch/models/stock_picking_batch.py
+++ b/addons/stock_picking_batch/models/stock_picking_batch.py
@@ -387,7 +387,7 @@ class StockPickingBatch(models.Model):
             'type': 'ir.actions.act_window',
             'domain': [('picking_ids', 'in', self.picking_ids.ids)],
             'context': {
-                'picking_id': self.picking_ids[:1].id,
+                'picking_ids': self.picking_ids.ids,
                 'location_id': self.picking_ids[:1].location_id.id,
                 'can_add_entire_packs': self.picking_type_code != 'incoming',
                 'search_default_main_packages': True,

--- a/addons/stock_picking_batch/views/stock_picking_batch_views.xml
+++ b/addons/stock_picking_batch/views/stock_picking_batch_views.xml
@@ -61,15 +61,15 @@
                 <field name="lot_id"   groups="stock.group_production_lot" readonly="tracking not in ['lot', 'serial']" column_invisible="context.get('picking_code') != 'incoming' or context.get('show_lots_text')"/>
                 <field name="lot_name" string="Lot/Serial Number" groups="stock.group_production_lot"
                        readonly="tracking not in ['lot', 'serial']" column_invisible="context.get('picking_code') != 'incoming' or not context.get('show_lots_text')"/>
+                <field name="package_id" groups="stock.group_tracking_lot" column_invisible="True" context="{'show_src_package': 1}"/>
                 <field name="quant_id" column_invisible="context.get('picking_code') == 'incoming'"
                         domain="[('product_id', '=', product_id), ('location_id', 'child_of', picking_location_id)]"
-                        context="{'default_location_id': location_id, 'default_product_id': product_id, 'search_view_ref': 'stock.quant_search_view', 'list_view_ref': 'stock.view_stock_quant_tree_simple', 'form_view_ref': 'stock.view_stock_quant_form', 'readonly_form': False}"
+                        context="{'default_location_id': location_id, 'default_product_id': product_id, 'search_view_ref': 'stock.quant_search_view', 'list_view_ref': 'stock.view_stock_quant_tree_simple', 'form_view_ref': 'stock.view_stock_quant_form', 'readonly_form': False, 'show_src_package': 1}"
                         readonly="state in ('done', 'cancel') and is_locked"
                         widget="pick_from"
                         options="{'no_open': True}"/>
                 <field name="location_id" column_invisible="True"/>
                 <field name="location_dest_id"/>
-                <field name="package_id" groups="stock.group_tracking_lot" column_invisible="True"/>
                 <field name="result_package_id" groups="stock.group_tracking_lot" widget="package_m2o" context="{'show_dest_package': 1}"/>
                 <field name="quantity"/>
                 <field name="product_uom_id" options="{'no_create': True}" widget="many2one_uom"

--- a/addons/stock_picking_batch/views/stock_picking_batch_views.xml
+++ b/addons/stock_picking_batch/views/stock_picking_batch_views.xml
@@ -109,6 +109,13 @@
                 </header>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
+                        <button name="action_see_packages" string="Packages" type="object"
+                            class="oe_stat_button" icon="fa-cubes"
+                            groups="stock.group_tracking_lot">
+                            <div class="o_stat_info">
+                                <span class="o_stat_text">Packages</span>
+                            </div>
+                        </button>
                         <button name="action_batch_detailed_operations"
                                 class="oe_stat_button"
                                 icon="fa-bars"
@@ -122,13 +129,6 @@
                             class="oe_stat_button" icon="fa-list"
                             invisible="not show_allocation"
                             groups="stock.group_reception_report"/>
-                        <button name="action_see_packages" string="Packages" type="object"
-                            class="oe_stat_button" icon="fa-cubes"
-                            invisible="state == 'done'" groups="stock.group_tracking_lot">
-                            <div class="o_form_field o_stat_info">
-                                <span class="o_stat_text">Packages</span>
-                            </div>
-                        </button>
                     </div>
                     <div class="oe_title">
                         <h1><field name="name" class="oe_inline"/></h1>


### PR DESCRIPTION
Summary of the fixes for the Put/Pack in pack:
- Avoid an error when trying to click on 'Move a Pack' on an unsaved picking.
- Apply putaway rules at with multi-level packages, considering higher-level packages first.
- Consider higher-level packages when checking package routes.
- Updates the picking operation pdf.
- For pickings, no longer display the 'Packages' stat button if no package are set as destination. We keep it for batches however, as it's currently the only way to add entire packs into a batch.
- Be more lenient with the 'Remove' button for packages in a picking.
- Allow to select the right packages as destination in a picking.
- Change priority of move line when using 'Put in Pack', always prioritizing `picked` lines.
- Avoid `Unnamed` packages when creating a new package without a name from a list view.
- Display the parent packages in the 'Pick from' auto-complete.

For more detail about each fix, read the related commit.

Task-5116567

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
