### PR TITLE
[FIX] stock: make lot_ids readonly on product tracked by lot

### DIFF
--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -301,6 +301,7 @@
                                     <field name="product_uom" groups="!uom.group_uom" column_invisible="True"/>
                                     <field name="picked" optional="hide" column_invisible="parent.state=='draft'"/>
                                     <field name="lot_ids" widget="many2many_tags"
+                                        readonly="has_tracking != 'serial'"
                                         column_invisible="parent.state == 'draft'"
                                         groups="stock.group_production_lot"
                                         invisible="not show_details_visible or has_tracking == 'none'"


### PR DESCRIPTION
### Steps to reproduce:

- In the setting enable lots and serial numbers
- Create a product tracked by LOT
- Create and confirm a receipt for 1 unit of that product
- Create a new lot: LOT001 from the move in the picking form
- Click Validate
#### > Invalid operation: you need to provide Lot/Serial numbers of the product

### Cause of the issue:

The set method of the `lot_ids` field of the `stock.move` model does nothing for product tracked by lots:
https://github.com/odoo/odoo/blob/7a8f9b7fe4dded4cfa140103d51b52e08149cadb/addons/stock/models/stock_move.py#L575-L579 In particular, while the lot appears on the move in the view, none of the move lines refer to it and the transfer can not be validated as indeed no lots are provided to these reservations.

### Fix:

The feature of writing `lot_ids` for lots has been introduced in https://github.com/odoo/odoo/commit/4bb4e08066449177f89382718ceadd840ce90d0e https://github.com/odoo/odoo/blob/1c52e2e9e8e00a19e2db00bf70d658496f9a0f29/addons/stock/models/stock_move.py#L596-L600 But this major refactoring can of course not be backported in 18.0. Therefore, it was decided put the field in readonly when its set method is inefficient.

opw-5093217
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
