### PR TITLE
[FIX] html_editor: render figcaption optional in caption area

### DIFF
--- a/addons/html_editor/static/src/others/embedded_components/plugins/caption_plugin/caption_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/caption_plugin/caption_plugin.js
@@ -56,7 +56,7 @@ export class CaptionPlugin extends Plugin {
             // Embed the captions.
             const image = figure.querySelector("img");
             figure.before(image);
-            const caption = figure.querySelector("figcaption").textContent;
+            const caption = figure.querySelector("figcaption")?.textContent;
             figure.remove();
             this.addImageCaption(image, caption, false);
         }

--- a/addons/html_editor/static/tests/caption.test.js
+++ b/addons/html_editor/static/tests/caption.test.js
@@ -963,3 +963,25 @@ test("previewing an image without caption doesn't show the caption as title (eve
     titleSpan = queryOne(".o-FileViewer .o-FileViewer-header span.text-truncate");
     expect(titleSpan.textContent).toBe(base64Img.replaceAll("\n", "%0A"));
 });
+
+test("should properly parse figure without fig caption", async () => {
+    await testEditor({
+        config: configWithEmbeddedCaption,
+        contentBefore: unformat(
+            `<figure>
+                <img class="img-fluid test-image" src="${base64Img}">
+            </figure>`
+        ),
+        contentBeforeEdit: unformat(
+            `<p><br></p>
+            <figure contenteditable="false">
+                <img class="img-fluid test-image o_editable_media" src="${base64Img}" data-caption-id="1" data-caption="">
+                <figcaption data-embedded="caption" data-oe-protected="true" contenteditable="false" class="mt-2" data-embedded-props='{"id":"1","focusInput":false}'>
+                <input type="text" maxlength="100" class="border-0 p-0" placeholder="Write your caption here">
+                </figcaption>
+            </figure>
+            <p><br></p>
+            `
+        ),
+    });
+});


### PR DESCRIPTION
When a image that has a figure tag without fig caption tag is rendered in a caption area it create a traceback.

### Steps to reproduce:

* Write an email with an image that has a "figure" tag but no "fig caption"
* Send it to an helpdesk alias to create a ticket
* Open the ticket -> traceback

### Issue:

When a "figure" tag was processed, it wasn't taking into account the possibility of not having "figcaption" which created the traceback.
https://github.com/odoo/odoo/blob/2769717bb0632ee7b813e131a94e77885b54493f/addons/html_editor/static/src/others/embedded_components/plugins/caption_plugin/caption_plugin.js#L56-L59

opw-5080370