### PR TITLE
[FIX] payment/_custom: avoid errors if post_init_hook is re-executed

### DIFF
--- a/addons/payment_custom/__init__.py
+++ b/addons/payment_custom/__init__.py
@@ -7,8 +7,8 @@ from odoo.addons.payment import setup_provider, reset_payment_provider
 
 
 def post_init_hook(env):
-    setup_provider(env, 'custom')
+    setup_provider(env, 'custom', custom_mode='wire_transfer')
 
 
 def uninstall_hook(env):
-    reset_payment_provider(env, 'custom')
+    reset_payment_provider(env, 'custom', custom_mode='wire_transfer')


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

If the `post_init_hook` is executed a second time for some reason (ie., reinstalling the module), then errors happen:
- It will create again copies of providers.
- If you have installed `delivery`, then the `main_provider` to copy may not be the one with `custom_mode='wire_transfer'.`

This PR avoids these errors.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr