### PR TITLE
[FIX] hr_org_chart: fix recursion error in _get_subordinates

### DIFF
--- a/addons/hr_org_chart/models/hr_org_chart_mixin.py
+++ b/addons/hr_org_chart/models/hr_org_chart_mixin.py
@@ -20,15 +20,17 @@ class HrEmployeeBase(models.AbstractModel):
         member of the RD department, managed by the CTO itself managed by the CEO).
         In that case, the manager in not counted as a subordinate if it's in the 'parents' set.
         """
-        if not parents:
-            parents = self.env[self._name]
-
-        indirect_subordinates = self.env[self._name]
-        parents |= self
-        direct_subordinates = self.child_ids - parents
-        child_subordinates = direct_subordinates._get_subordinates(parents=parents) if direct_subordinates else self.browse()
-        indirect_subordinates |= child_subordinates
-        return indirect_subordinates | direct_subordinates
+        self.ensure_one()
+        to_process = [self]
+        visited = set()
+        subordinates = self.env[self._name]
+        while to_process:
+            current = to_process.pop()
+            visited.add(current)
+            not_visited_children = current.child_ids.filtered(lambda e: e not in visited)
+            subordinates |= not_visited_children
+            to_process.extend(list(not_visited_children))
+        return subordinates
 
 
     @api.depends('child_ids', 'child_ids.child_all_count')

--- a/addons/hr_org_chart/tests/__init__.py
+++ b/addons/hr_org_chart/tests/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_employee_deletion
+from . import test_employee

--- a/addons/hr_org_chart/tests/test_employee.py
+++ b/addons/hr_org_chart/tests/test_employee.py
@@ -1,0 +1,84 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import tagged
+
+from odoo.addons.hr.tests.common import TestHrCommon
+
+
+@tagged('-at_install', 'post_install')
+class TestEmployee(TestHrCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.employee_georges, cls.employee_paul, cls.employee_pierre, cls.employee_john, cls.employee_alice = cls.env['hr.employee'].with_user(cls.res_users_hr_officer).create([
+            {'name': 'Georges'},
+            {'name': 'Paul'},
+            {'name': 'Pierre'},
+            {'name': 'John'},
+            {'name': 'Alice'},
+        ])
+
+    def test_compute_subordinates(self):
+        # hierarchy
+        #
+        #   georges
+        #      |
+        #     paul
+        #    /    \
+        # pierre   \
+        #         john
+        #            \
+        #           alice
+
+        self.employee_paul.parent_id = self.employee_georges
+        self.employee_pierre.parent_id = self.employee_paul
+        self.employee_john.parent_id = self.employee_paul
+        self.employee_alice.parent_id = self.employee_john
+
+        self.assertEqual(
+            self.employee_georges.subordinate_ids,
+            self.employee_paul
+            | self.employee_pierre
+            | self.employee_john
+            | self.employee_alice,
+        )
+        self.assertEqual(
+            self.employee_paul.subordinate_ids,
+            self.employee_pierre | self.employee_john | self.employee_alice,
+        )
+        self.assertEqual(self.employee_pierre.subordinate_ids, self.env["hr.employee"])
+        self.assertEqual(self.employee_john.subordinate_ids, self.employee_alice)
+        self.assertEqual(self.employee_alice.subordinate_ids, self.env["hr.employee"])
+
+        # create a cycle between Alice and Georges
+        self.employee_georges.parent_id = self.employee_alice
+
+        self.assertEqual(
+            self.employee_georges.subordinate_ids,
+            self.employee_paul
+            | self.employee_pierre
+            | self.employee_john
+            | self.employee_alice,
+        )
+        self.assertEqual(
+            self.employee_paul.subordinate_ids,
+            self.employee_georges
+            | self.employee_pierre
+            | self.employee_john
+            | self.employee_alice,
+        )
+        self.assertEqual(self.employee_pierre.subordinate_ids, self.env["hr.employee"])
+        self.assertEqual(
+            self.employee_john.subordinate_ids,
+            self.employee_paul
+            | self.employee_pierre
+            | self.employee_georges
+            | self.employee_alice,
+        )
+        self.assertEqual(
+            self.employee_alice.subordinate_ids,
+            self.employee_paul
+            | self.employee_pierre
+            | self.employee_john
+            | self.employee_georges,
+        )


### PR DESCRIPTION
This commit fixes a recursion error that occurs in `_get_subordinates`. An iterative approach is used instead of the current recursive implementation.

task-5118697

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
