### PR TITLE
WEB: Fixed UncaughtPromiseError in debug mode when user ID changed

### DIFF
--- a/addons/web/static/src/legacy/action_adapters.js
+++ b/addons/web/static/src/legacy/action_adapters.js
@@ -74,6 +74,9 @@ class ActionAdapter extends ComponentAdapter {
             Object.assign(this.tempQuery, query);
             return;
         }
+        if (!this.widget && this.__widget) {
+            this.widget = this.__widget;
+        }
         if (this.widget) {
             const actionTitle = this.widget.getTitle();
             if (actionTitle) {


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In Odoo 15, when using debug mode in the Users view, manually changing a user’s ID to another user’s ID from url and then clicking the debug icon raises a TypeError. This occurs because getSelectedIds is called on a null record. [Link](https://github.com/odoo/odoo/issues/227909)

- Fixed this issue.

Current behavior before PR:
1.Enable debug mode in Odoo.
2.Go to Users.
3.Select any user.
4.Manually change the user’s ID to another user’s ID from URL (e.g., 3).
5.Click on the debug icon in the top-right corner.
6.It raises TypeError.

Desired behavior after PR is merged:
1.Enable debug mode in Odoo.
2.Go to Users.
3.Select any user.
4.Manually change the user’s ID to another user’s ID from URL (e.g., 3).
5.Click on the debug icon in the top-right corner.
6.It won't raises TypeError.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
