### PR TITLE
[FIX] survey: fix the survey kanban view

### DIFF
--- a/addons/survey/static/src/views/survey_views.js
+++ b/addons/survey/static/src/views/survey_views.js
@@ -69,7 +69,6 @@ registry.category('views').add('survey_view_tree', {
 export class SurveyKanbanRenderer extends KanbanRenderer {
     setup() {
         super.setup();
-        this.canCreate = this.props.archInfo.activeActions.create;
         if (this.canCreate) {
             useSurveyLoadSampleHook('.o_survey_load_sample');
         }


### PR DESCRIPTION
Similar error as in #103351, but now in the kanban view instead of in the list view.

We encountered an error when opening the survey kanban view because the renderer override attempted to assign a value to the "canCreate" property, which is defined as a getter only. To solve this, we now rely on the existing "canCreate" property directly.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
