### PR TITLE
[FIX] website: accept website_meta_og_img with domain

### DIFF
--- a/addons/website/models/mixins.py
+++ b/addons/website/models/mixins.py
@@ -2,6 +2,7 @@
 
 import logging
 import re
+import urllib.parse
 
 from odoo import api, fields, models, _
 from odoo.fields import Domain
@@ -89,8 +90,12 @@ class WebsiteSeoMetadata(models.AbstractModel):
         if self.website_meta_description:
             opengraph_meta['og:description'] = self.website_meta_description
             twitter_meta['twitter:description'] = self.website_meta_description
-        opengraph_meta['og:image'] = url_join(root_url, self.env['ir.http']._url_for(self.website_meta_og_img or opengraph_meta['og:image']))
-        twitter_meta['twitter:image'] = url_join(root_url, self.env['ir.http']._url_for(self.website_meta_og_img or twitter_meta['twitter:image']))
+        # 19.0: remove domain of absolute URL before odoo/odoo#228253
+        og_image = self.website_meta_og_img and urllib.parse.urlunsplit(
+            ["", "", *urllib.parse.urlsplit(self.website_meta_og_img)[2:]]
+        )
+        opengraph_meta['og:image'] = url_join(root_url, self.env['ir.http']._url_for(og_image or opengraph_meta['og:image']))
+        twitter_meta['twitter:image'] = url_join(root_url, self.env['ir.http']._url_for(og_image or twitter_meta['twitter:image']))
         return {
             'opengraph_meta': opengraph_meta,
             'twitter_meta': twitter_meta,

--- a/addons/website/tests/test_page.py
+++ b/addons/website/tests/test_page.py
@@ -307,6 +307,21 @@ class WithContext(HttpCase):
         canonical_url = root_html.xpath('//link[@rel="canonical"]')[0].attrib['href']
         self.assertIn(canonical_url, [f"{website.domain}/", f"{website.domain}/page_1"])
 
+    def test_opengraph_image_with_absolute_url(self):
+        base_url = self.base_url()
+        with MockRequest(self.env, website=self.env['website'].browse(1)):
+            self.page.website_meta_og_img = 'http://wrong.example.com/favicon.ico'
+            r = self.url_open(self.page.url)
+            self.assertEqual(r.status_code, 200)
+            self.assertIn(f'"og:image" content="{base_url}/favicon.ico"', r.text)
+            self.assertIn(f'"twitter:image" content="{base_url}/favicon.ico"', r.text)
+
+            self.page.website_meta_og_img = '/logo'
+            r = self.url_open(self.page.url)
+            self.assertEqual(r.status_code, 200)
+            self.assertIn(f'"og:image" content="{base_url}/logo"', r.text)
+            self.assertIn(f'"twitter:image" content="{base_url}/logo"', r.text)
+
     def test_website_homepage_url_change(self):
         website = self.env['website'].browse([1])
         self.assertFalse(website.homepage_url)


### PR DESCRIPTION
In 17.0 up to master, website_meta_og_img for newly added cover image should be a relative URL instead of an absolute URL since 27th september 2025 commit 4c5d9861e389534f9ca684b9faa1ce6289df5639.

This solves an issue in 19.0 where:

- if you have a website_meta_og_img field with absolute URL
- and then you change domain or have multiple domain

=> you would get an error 500 on the page with that website_meta_og_img

But for existing 19.0 instances that have set custom website_meta_og_img before the fix, the issue could still happen at any moment they change domain.

This fix allows to have an absolute URL in website_meta_og_img and modify it on the fly only in 19.0 version.

note: a migration script (the same than [1] but in 19.0 to saas-19.1) should be added to ensure there is no remaining absolute URL.

[1]: odoo/upgrade@5408746b110d660901645b9c7b9aa9cee7aaf235

opw-5101875
opw-5102079
opw-5105258
opw-5107443
opw-5111474
opw-5112343
opw-5113844
opw-5114544