### PR TITLE
[FIX] mail: Sort mail.message by date, id.

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -945,17 +945,30 @@ class MailMessage(models.Model):
                 message_domain |= Domain("id", "in", accessible_tracking_value_ids.mail_message_id.ids)
             domain &= message_domain
             res["count"] = self.search_count(domain)
+
+        # TODO User setting to sort by date other than create_date?
+        def _domain(message, date_oper, id_oper=''):
+            return Domain('create_date', date_oper, message.create_date) | (Domain('create_date', '=', message.create_date) & Domain('id', id_oper or date_oper, message.id))
+        _order_asc = 'create_date ASC, id ASC'
+        _order_desc = 'create_date DESC, id DESC'
+        _sort_key = lambda m: (m.create_date, m.id)
+
         if around is not None:
-            messages_before = self.search(domain & Domain('id', '<=', around), limit=limit // 2, order="id DESC")
-            messages_after = self.search(domain & Domain('id', '>', around), limit=limit // 2, order='id ASC')
-            return {**res, "messages": (messages_after + messages_before).sorted('id', reverse=True)}
-        if before:
-            domain &= Domain('id', '<', before)
-        if after:
-            domain &= Domain('id', '>', after)
-        res["messages"] = self.search(domain, limit=limit, order='id ASC' if after else 'id DESC')
-        if after:
-            res["messages"] = res["messages"].sorted('id', reverse=True)
+            limit /= 2
+            if around and (around := self.browse(around).exists()):
+                messages_before = self.search(domain & _domain(around, '<', '<='), limit=limit, order=_order_desc)
+                messages_after = self.search(domain & _domain(around, '>', '>'), limit=limit, order=_order_asc).sorted(_sort_key, reverse=True)
+                return {**res, "messages": (messages_after + messages_before)}
+            else:
+                res["messages"] = self.search(domain, limit=limit, order=_order_asc).sorted(_sort_key, reverse=True)
+        else:
+            if before and (before := self.browse(before).exists()):
+                domain &= _domain(before, '<', '<')
+            if after and (after := self.browse(after).exists()):
+                domain &= _domain(after, '>', '>')
+            res["messages"] = self.search(domain, limit=limit, order=_order_asc if after else _order_desc)
+            if after:
+                res["messages"] = res["messages"].sorted(_sort_key, reverse=True)
         return res
 
     def _get_tracking_values_domain(self, search_term):

--- a/addons/mail/static/tests/mock_server/mock_models/mail_message.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_message.js
@@ -10,6 +10,8 @@ import {
 } from "@web/../tests/web_test_helpers";
 import { Domain } from "@web/core/domain";
 
+const { DateTime } = luxon;
+
 /** @typedef {import("@web/core/domain").DomainListRepr} DomainListRepr */
 
 export class MailMessage extends models.ServerModel {
@@ -526,30 +528,43 @@ export class MailMessage extends models.ServerModel {
             domain = Domain.and([domain, message_domain]).toList();
             res.count = this.search_count(domain);
         }
+
+        // TODO User setting to sort by date other than create_date?
+        const _browse = (id) => this.filter(item => item.id == id)?.[0];
+        const _domain = (message, date_oper, id_oper) => [
+            "|",
+            ["create_date", date_oper, message.create_date],
+            "&",
+            ["create_date", "=", message.create_date],
+            ["id", id_oper || date_oper, message.id],
+        ];
+        const _sort_asc = (m1, m2) => (DateTime.fromJSDate(m1.create_date).ts - DateTime.fromJSDate(m2.create_date).ts) || (m1.id - m2.id);
+        const _sort_desc = (m1, m2) => (DateTime.fromJSDate(m2.create_date).ts - DateTime.fromJSDate(m1.create_date).ts) || (m2.id - m1.id);
+
         if (around !== undefined) {
-            const messagesBefore = this._filter(domain.concat([["id", "<=", around]])).sort(
-                (m1, m2) => m2.id - m1.id
-            );
-            messagesBefore.length = Math.min(messagesBefore.length, limit / 2);
-            const messagesAfter = this._filter(domain.concat([["id", ">", around]])).sort(
-                (m1, m2) => m1.id - m2.id
-            );
-            messagesAfter.length = Math.min(messagesAfter.length, limit / 2);
-            const messages = messagesAfter
-                .concat(messagesBefore.reverse())
-                .sort((m1, m2) => m2.id - m1.id);
-            return { ...res, messages };
+            limit /= 2;
+            if (around && (around = _browse(around))) {
+                const messagesBefore = this._filter(domain.concat(_domain(around, "<", "<="))).sort(_sort_desc);
+                messagesBefore.length = Math.min(messagesBefore.length, limit);
+                const messagesAfter = this._filter(domain.concat(_domain(around, ">"))).sort(_sort_asc);
+                messagesAfter.length = Math.min(messagesAfter.length, limit);
+                res.messages = messagesAfter.concat(messagesBefore.reverse()).sort(_sort_desc);
+            } else {
+                let messages = this._filter(domain).sort(_sort_asc);
+                messages.length = Math.min(messages.length, limit);
+                res.messages = messages.sort(_sort_desc);
+            }
+        } else {
+            if (before && (before = _browse(before))) {
+                domain.push(..._domain(before, "<"));
+            }
+            if (after && (after = _browse(after))) {
+                domain.push(..._domain(after, ">"));
+            }
+            let messages = this._filter(domain).sort(_sort_desc);
+            messages.length = Math.min(messages.length, limit);
+            res.messages = messages;
         }
-        if (before) {
-            domain.push(["id", "<", before]);
-        }
-        if (after) {
-            domain.push(["id", ">", after]);
-        }
-        const messages = this._filter(domain).sort((m1, m2) => m2.id - m1.id);
-        // pick at most 'limit' messages
-        messages.length = Math.min(messages.length, limit);
-        res.messages = messages;
         return res;
     }
 


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

Alternate implementation of #203708.
Forward port of #229092 handling `odoo.osv.expression` refactor to `odoo.orm.domains.Domain`

### Current behavior before PR:

Chatter messages were not always ordered correctly by date.

### Desired behavior after PR is merged:

Chatter messages are now consistently displayed in chronological order.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
