### PR TITLE
[FIX] l10n_fr_hr_holidays: holiday support in time off

### DIFF
--- a/addons/l10n_fr_hr_holidays/models/hr_leave.py
+++ b/addons/l10n_fr_hr_holidays/models/hr_leave.py
@@ -5,6 +5,8 @@ from dateutil.relativedelta import relativedelta
 from odoo import fields, models, api, _
 from odoo.exceptions import UserError
 
+import pytz
+
 class HrLeave(models.Model):
     _inherit = 'hr.leave'
 
@@ -115,8 +117,27 @@ class HrLeave(models.Model):
             fr_leaves = self.filtered(lambda leave: leave._l10n_fr_leave_applies())
             duration_by_leave_id = super(HrLeave, self - fr_leaves)._get_durations(resource_calendar=resource_calendar)
             fr_leaves_by_company = fr_leaves.grouped('company_id')
+            if fr_leaves:
+                public_holidays = self.env['resource.calendar.leaves'].search([
+                    ('resource_id', '=', False),
+                    ('company_id', 'in', fr_leaves.company_id.ids + [False]),
+                    ('date_from', '<', max(fr_leaves.mapped('date_to')) + relativedelta(days=1)),
+                    ('date_to', '>', min(fr_leaves.mapped('date_from')) - relativedelta(days=1)),
+                ])
             for company, leaves in fr_leaves_by_company.items():
                 company_cal = company.resource_calendar_id
+                holidays_days_list = []
+                public_holidays_filtered = public_holidays.filtered_domain([
+                    ('calendar_id', 'in', [False, company_cal.id]),
+                    ('company_id', '=', company.id)
+                ])
+                for holiday in public_holidays_filtered:
+                    tz = pytz.timezone(holiday.write_uid.tz)
+                    current = holiday.date_from.replace(tzinfo=pytz.utc).astimezone(tz).date()
+                    holiday_date_to = holiday.date_to.replace(tzinfo=pytz.utc).astimezone(tz).date()
+                    while current <= holiday_date_to:
+                        holidays_days_list.append(current)
+                        current += relativedelta(days=1)
                 for leave in leaves:
                     if leave.request_unit_half:
                         duration_by_leave_id.update(leave._get_durations(resource_calendar=company_cal))
@@ -134,6 +155,9 @@ class HrLeave(models.Model):
                     end_date = extended_date_end.date()
                     legal_days = 0.0
                     while current <= end_date:
+                        if current in holidays_days_list:
+                            current += relativedelta(days=1)
+                            continue
                         if company_cal._works_on_date(current):
                             legal_days += 1.0
                         current += relativedelta(days=1)


### PR DESCRIPTION
Currently when a employee has a diferent working schedule than the company's one (part time employee), when he takes time off the computation includes days where he is not working but is an active working day for the company. That is not considering holidays. e.g. 
-employee works monday to wednesday
-company works monday to friday
-there is a holiday on the thursday
taking monday to wednesday should count 4 days.

added holidays support for this case

opw-5082080

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
