### PR TITLE
[IMP] website_sale: allow sharing carts via Web Share API or clipboard

### DIFF
--- a/addons/website_sale/controllers/cart.py
+++ b/addons/website_sale/controllers/cart.py
@@ -578,7 +578,7 @@ class Cart(PaymentPortal):
             )
             order_shared_products = [line.product_id.id for line in lines]
 
-        website_id = order_sudo.website_id or request.env.website
+        website_id = order_sudo.website_id or request.website
 
         # Build comma-separated IDs for URL
         params = url_encode({

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -882,4 +882,3 @@ class SaleOrder(models.Model):
         return self._is_cart_ready_to_share() and any(
             line._is_share_allowed() for line in self.order_line if line.product_id
         )
-

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -872,3 +872,14 @@ class SaleOrder(models.Model):
         """Recompute taxes and prices for the current cart."""
         self._recompute_taxes()
         self._recompute_prices()
+
+    def _is_cart_ready_to_share(self):
+        """ Whether the cart is valid and can be shared."""
+        return bool(self)
+
+    def _is_share_cart_allowed(self):
+        self.ensure_one()
+        return self._is_cart_ready_to_share() and any(
+            line._is_share_allowed() for line in self.order_line if line.product_id
+        )
+

--- a/addons/website_sale/models/sale_order_line.py
+++ b/addons/website_sale/models/sale_order_line.py
@@ -130,3 +130,11 @@ class SaleOrderLine(models.Model):
         :rtype: bool
         """
         return self.product_id.is_published and not self.is_delivery
+
+    def _is_share_allowed(self):
+        self.ensure_one()
+        return (
+            bool(self.product_id)
+            and self.product_id._is_add_to_cart_allowed()
+            and self._show_in_cart()
+        )

--- a/addons/website_sale/static/src/interactions/share_cart.js
+++ b/addons/website_sale/static/src/interactions/share_cart.js
@@ -1,0 +1,55 @@
+import { Interaction } from "@web/public/interaction";
+import { registry } from "@web/core/registry";
+import { _t } from "@web/core/l10n/translation";
+
+export class ShareCart extends Interaction {
+    static selector = ".o_wsale_share_cart";
+    dynamicContent = {
+        "#share_cart_button": {
+            "t-on-click": (ev) => this.onShareClick(ev)
+        }
+    };
+
+    /**
+     * Handles the "Share Cart" button click using the native Web Share API if available,
+     * or falling back to copying the share link to the clipboard.
+     *
+     * :param Event ev: The click event on the share cart button.
+     * :rtype: Promise<void>
+     */
+    async onShareClick(ev) {
+        ev.preventDefault();
+
+        const shareCartEl = ev.currentTarget;
+        if (!shareCartEl) {
+            return;
+        }
+
+        // Read all share data from the backend via data-share-vals
+        const shareVals = JSON.parse(shareCartEl.dataset.shareVals || "{}");
+        const shareLink = shareVals.share_link;
+        const shareTitle = shareVals.share_title || _t("My cart");
+        const shareText = shareVals.share_description || "";
+
+        if (!shareLink) {
+            return;
+        }
+
+        try {
+            if (navigator.share) {
+                await navigator.share({
+                    title: shareTitle,
+                    text: shareText,
+                    url: shareLink
+                });
+            } else {
+                await navigator.clipboard.writeText(shareLink);
+            }
+        } catch (err) {
+            console.warn("Error sharing or copying the cart link:", err);
+        }
+    }
+
+}
+
+registry.category("public.interactions").add("website_sale.share_cart", ShareCart);

--- a/addons/website_sale/static/src/interactions/share_cart.js
+++ b/addons/website_sale/static/src/interactions/share_cart.js
@@ -52,4 +52,27 @@ export class ShareCart extends Interaction {
 
 }
 
+export class ShareCartProductList extends Interaction {
+    static selector = "[name=\"shared_product\"]";
+    dynamicContent = {
+        "button.js_add_shared_products": { "t-on-click": this.addSharedProduct }
+    };
+
+    /**
+     * @param {Event} ev
+     */
+    addSharedProduct(ev) {
+        const dataset = ev.currentTarget.dataset;
+        this.services["cart"].add({
+            productTemplateId: parseInt(dataset.productTemplateId),
+            productId: parseInt(dataset.productId),
+            isCombo: dataset.productType === "combo"
+        }, {
+            isBuyNow: true,
+            showQuantity: Boolean(dataset.showQuantity)
+        });
+    }
+}
+
+registry.category("public.interactions").add("website_sale.share_cart_product", ShareCartProductList);
 registry.category("public.interactions").add("website_sale.share_cart", ShareCart);

--- a/addons/website_sale/static/src/js/cart_service.js
+++ b/addons/website_sale/static/src/js/cart_service.js
@@ -462,7 +462,17 @@ export class CartService {
         });
         // TODO should not redirect if errors in data.
         if (shouldRedirectToCart || session.add_to_cart_action === 'go_to_cart') {
-            window.location = '/shop/cart';
+            const urlParams = new URLSearchParams(window.location.search);
+            const sharedProducts = urlParams.get('shared_products');
+            let redirectUrl = '/shop/cart';
+
+            // If shared products exist in the URL, preserve them
+            // so they continue to appear in the cart/checkout
+            if (sharedProducts) {
+                redirectUrl += `?shared_products=${encodeURIComponent(sharedProducts)}`;
+            }
+
+            window.location = redirectUrl;
             return data.quantity;
         }
         if (data.cart_quantity && (

--- a/addons/website_sale/static/src/js/website_sale_utils.js
+++ b/addons/website_sale/static/src/js/website_sale_utils.js
@@ -73,6 +73,12 @@ function updateCartSummary(data) {
             div => div.innerHTML = data['website_sale.total']
         );
     }
+    if (data['website_sale.share_cart_button']) {
+        const shareCartEl = document.querySelector('.o_wsale_share_cart');
+        if (shareCartEl) {
+            shareCartEl.outerHTML = markup(data['website_sale.share_cart_button']);
+        }
+    }
 }
 
 /**

--- a/addons/website_sale/static/src/js/website_sale_utils.js
+++ b/addons/website_sale/static/src/js/website_sale_utils.js
@@ -76,7 +76,7 @@ function updateCartSummary(data) {
     if (data['website_sale.share_cart_button']) {
         const shareCartEl = document.querySelector('.o_wsale_share_cart');
         if (shareCartEl) {
-            shareCartEl.outerHTML = markup(data['website_sale.share_cart_button']);
+            shareCartEl.outerHTML = data['website_sale.share_cart_button'];
         }
     }
 }

--- a/addons/website_sale/views/templates/checkout/cart_templates.xml
+++ b/addons/website_sale/views/templates/checkout/cart_templates.xml
@@ -54,7 +54,7 @@
             </div>
         </t>
         <div id="cart_products"
-             t-if="website_sale_order and website_sale_order.website_order_line"
+             t-if="(website_sale_order and website_sale_order.website_order_line) or shared_products"
              class="js_cart_lines d-flex flex-column mb32">
             <t t-foreach="website_sale_order.website_order_line" t-as="line">
                 <t t-set="is_combo" t-value="line.product_type == 'combo'"/>
@@ -307,6 +307,7 @@
                 <div class="d-flex align-items-center mb-3">
                     <h4 class="mb-0">Order summary</h4>
                     <div class="ms-3 border-start ps-2"><t t-call="website_sale.quick_reorder_button"/></div>
+                    <div class="ms-3 border-start ps-2"><t t-call="website_sale.share_cart_button"/></div>
                 </div>
                 <div t-if="abandoned_proceed or access_token" class="alert alert-info mt8 mb8" role="alert"> <!-- abandoned cart choices -->
                     <t t-if="abandoned_proceed">
@@ -483,12 +484,33 @@
         name="Accessory Products in my cart"
     >
         <xpath expr="//div[@id='cart_products']" position="inside">
-            <h5 t-attf-class="mt-3 mb-0" t-if="suggested_products">Suggested accessories</h5>
-            <div t-if="suggested_products"
+            <t t-call="website_sale.cart_extra_product_list"
+               products="suggested_products"
+               title="'Suggested accessories'"
+            />
+        </xpath>
+    </template>
+
+    <template
+        id="website_sale.shared_products_list"
+        inherit_id="website_sale.cart_lines"
+        name="Shared Products in my cart"
+    >
+        <xpath expr="//div[@id='cart_products']" position="inside">
+            <t t-call="website_sale.cart_extra_product_list"
+               products="shared_products"
+               title="'Shared Products'"
+            />
+        </xpath>
+    </template>
+
+    <template id="website_sale.cart_extra_product_list">
+        <h5 t-attf-class="mt-3 mb-0" t-if="products" t-out="title"/>
+        <div t-if="products"
                  id="suggested_products"
                  class="d-flex flex-column align-items-stretch">
                 <div
-                    t-foreach="suggested_products"
+                    t-foreach="products"
                     t-as="product"
                     t-attf-class="d-flex gap-3 py-4 #{not product_last and 'border-bottom'}"
                     t-att-data-publish="product.website_published and 'on' or 'off'"
@@ -550,7 +572,19 @@
                     </div>
                 </div>
             </div>
-        </xpath>
+    </template>
+
+    <template id="website_sale.share_cart_button">
+        <span class="o_wsale_share_cart" t-if="website_sale_order and website_sale_order._is_share_cart_allowed()" title="Share My Cart">
+            <button
+                id="share_cart_button"
+                type="button"
+                class="btn btn-sm btn-link"
+                t-att-data-share-vals="json.dumps(cart_share_values)"
+            >
+                <i class="fa fa-share me-2"/>Share My Cart
+            </button>
+        </span>
     </template>
 
 </odoo>

--- a/addons/website_sale/views/templates/checkout/cart_templates.xml
+++ b/addons/website_sale/views/templates/checkout/cart_templates.xml
@@ -484,33 +484,12 @@
         name="Accessory Products in my cart"
     >
         <xpath expr="//div[@id='cart_products']" position="inside">
-            <t t-call="website_sale.cart_extra_product_list"
-               products="suggested_products"
-               title="'Suggested accessories'"
-            />
-        </xpath>
-    </template>
-
-    <template
-        id="website_sale.shared_products_list"
-        inherit_id="website_sale.cart_lines"
-        name="Shared Products in my cart"
-    >
-        <xpath expr="//div[@id='cart_products']" position="inside">
-            <t t-call="website_sale.cart_extra_product_list"
-               products="shared_products"
-               title="'Shared Products'"
-            />
-        </xpath>
-    </template>
-
-    <template id="website_sale.cart_extra_product_list">
-        <h5 t-attf-class="mt-3 mb-0" t-if="products" t-out="title"/>
-        <div t-if="products"
+            <h5 t-attf-class="mt-3 mb-0" t-if="suggested_products">Suggested accessories</h5>
+            <div t-if="suggested_products"
                  id="suggested_products"
                  class="d-flex flex-column align-items-stretch">
                 <div
-                    t-foreach="products"
+                    t-foreach="suggested_products"
                     t-as="product"
                     t-attf-class="d-flex gap-3 py-4 #{not product_last and 'border-bottom'}"
                     t-att-data-publish="product.website_published and 'on' or 'off'"
@@ -572,6 +551,7 @@
                     </div>
                 </div>
             </div>
+        </xpath>
     </template>
 
     <template id="website_sale.share_cart_button">
@@ -585,6 +565,82 @@
                 <i class="fa fa-share me-2"/>Share My Cart
             </button>
         </span>
+    </template>
+
+    <template
+        id="website_sale.shared_cart_products_list"
+        inherit_id="website_sale.cart_lines"
+        name="Shared Products"
+    >
+        <xpath expr="//div[@id='cart_products']" position="inside">
+            <h5 t-attf-class="mt-3 mb-0" t-if="shared_products">Shared Products</h5>
+            <div t-if="shared_products"
+                 id="shared_products"
+                 class="d-flex flex-column align-items-stretch">
+                <div
+                    t-foreach="shared_products"
+                    t-as="product"
+                    t-attf-class="d-flex gap-3 py-4 #{not product_last and 'border-bottom'}"
+                    t-att-data-publish="product.website_published and 'on' or 'off'"
+                    name="shared_product"
+                >
+                    <div class="o_cart_product_image">
+                        <a t-att-href="product.website_url">
+                            <div t-field="product.image_128" t-options="{'widget': 'image', 'qweb_img_responsive': False, 'class': 'border rounded'}"/>
+                        </a>
+                    </div>
+                    <div class="flex-grow-1">
+                        <div class="d-flex justify-content-between">
+                            <div>
+                                <a class="text-reset" t-att-href="product.website_url">
+                                    <h6
+                                        class="align-top text-wrap"
+                                        t-out="product.with_context(display_default_code=False).display_name"
+                                    />
+                                </a>
+                                <div
+                                    class="mb-2 small text-muted"
+                                    t-field="product.description_sale"
+                                />
+                            </div>
+                            <div class="d-flex flex-column gap-2 align-items-end">
+                                <h6
+                                    class="d-flex mb-0 text-end"
+                                    name="shared_product_price_container"
+                                >
+                                    <t
+                                        t-set="combination_info"
+                                        t-value="product._get_combination_info_variant()"
+                                    />
+                                    <del
+                                        name="shared_product_list_price"
+                                        t-attf-class="me-2 text-nowrap text-muted {{'' if combination_info['has_discounted_price'] else 'd-none'}}"
+                                        t-out="combination_info['list_price']"
+                                        t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"
+                                    />
+                                    <span
+                                        name="shared_product_price"
+                                        class="text-nowrap"
+                                        t-out="combination_info['price']"
+                                        t-options="{'widget': 'monetary','display_currency': website.currency_id}"
+                                    />
+                                </h6>
+                                <button
+                                    class="js_add_shared_products btn btn-primary text-nowrap"
+                                    t-att-data-product-id="product.id"
+                                    t-att-data-product-template-id="product.product_tmpl_id.id"
+                                    t-att-data-product-type="product.type"
+                                    t-att-data-show-quantity="is_view_active('website_sale.product_quantity')"
+                                >
+                                    <i class="d-md-none fa fa-shopping-cart" role="presentation"/>
+                                    <span class="d-none d-md-inline">Add to cart</span>
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </xpath>
     </template>
 
 </odoo>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
---
Currently, Odoo does not provide a way for website users to share their shopping
cart with others. This makes collaborative shopping or sending a pre-filled cart
to another person impossible.

Current behavior before PR:
---
- No "Share Cart" button available in the website shop.
- Users cannot generate a cart link to share with others.

Desired behavior after PR is merged:
---
- A new "Share Cart" button is added to the website cart.
- Users can share their cart link using the native Web Share API when supported,
  or copy the link to the clipboard as a fallback.
- The backend prepares `share_link`, `share_title`, and `share_description`
  which are exposed via `data-share-vals`.
- Shared products are preserved during checkout via the `shared_products` query
  parameter.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

