### PR TITLE
[IMP] stock: autofill location in replenishment rules based on active filter

### DIFF
--- a/addons/stock/static/src/views/stock_orderpoint_list_controller.js
+++ b/addons/stock/static/src/views/stock_orderpoint_list_controller.js
@@ -33,4 +33,12 @@ export class StockOrderpointListController extends ListController {
             onClose: () => { this.actionService.doAction({type: 'ir.actions.client', tag: 'reload'}); },
         });
     }
+
+    async createRecord() {
+        const location_id = this.env.searchModel.categories.find((category) => category.fieldName === "location_id")?.activeValueId;
+        await super.createRecord(...arguments);
+        if (this.editedRecord && location_id) {
+            this.editedRecord.update({ location_id: { id: location_id } });
+        }
+    }
 }


### PR DESCRIPTION
Purpose:
======================
In a setup with multiple locations, When a user filters the Replenishment Rules (RRs) by `location` and then creates a new RR, the `Location` field was automatically filled with the default `WH/Stock`, but not based on the selected filter. This forced users to manually change the location, requiring `extra clicks` which slows down the process and affects the user experience.

With This Commit:
======================
When create a new RR, the `Location` field is now automatically set based on the currently selected filter. Users no longer need to manually change the location, `avoiding extra clicks` and improving the overall user experience.

TaskID-4947796
