### PR TITLE
[IMP] web:  display app icon header

### DIFF
--- a/addons/web/static/src/webclient/menus/menu_command_item.xml
+++ b/addons/web/static/src/webclient/menus/menu_command_item.xml
@@ -4,8 +4,8 @@
   <t t-name="web.AppIconCommand">
     <div class="o_command_default position-relative d-flex align-items-center px-4 py-2 cursor-pointer">
       <img t-if="props.webIconData" class="me-2 o_app_icon position-relative rounded-1" t-attf-src="{{props.webIconData}}"/>
-      <div t-else="" class="me-2 o_app_icon d-flex align-items-center justify-content-center" t-attf-style="background-color:{{props.webIcon.backgroundColor}}" >
-        <i t-att-class="props.webIcon.iconClass" t-attf-style="color:{{props.webIcon.color}}"></i>
+      <div t-else="" class="me-2 o_app_icon d-flex align-items-center justify-content-center">
+        <i t-att-class="`${props.webIcon.iconClass} fa-2x`" t-attf-style="color:{{props.webIcon.color}}"></i>
       </div>
       <t t-slot="name"/>
       <span class="ms-auto flex-shrink-0">

--- a/addons/web/static/src/webclient/navbar/navbar.js
+++ b/addons/web/static/src/webclient/navbar/navbar.js
@@ -85,7 +85,17 @@ export class NavBar extends Component {
     }
 
     get currentApp() {
-        return this.menuService.getCurrentApp();
+        const app = this.menuService.getCurrentApp();
+        if (app?.webIcon) {
+            const [webIconClass, webIconColor, webIconBg] = app.webIcon.split(",");
+            return {
+                ...app,
+                webIconClass,
+                webIconColor,
+                webIconBg,
+            };
+        }
+        return app;
     }
 
     get currentAppSections() {

--- a/addons/web/static/src/webclient/navbar/navbar.scss
+++ b/addons/web/static/src/webclient/navbar/navbar.scss
@@ -76,7 +76,8 @@
         // Animate on large screen without 'reduced-motion' only.
         // --------------------------------------------------------------------
         @include media-breakpoint-up(md) {
-            &.hasImage:not(.o_menu_toggle_back) {
+            &.hasImage:not(.o_menu_toggle_back),
+            &.hasFaIcon:not(.o_menu_toggle_back) {
                 .o_menu_toggle_icon {
                     opacity: 0;
                 }
@@ -105,7 +106,8 @@
                     transition: all .1s;
                 }
 
-                &.hasImage:not(.o_menu_toggle_back) {
+                &.hasImage:not(.o_menu_toggle_back),
+                &.hasFaIcon:not(.o_menu_toggle_back) {
                     transform: none;
                     transition: none;
 

--- a/addons/web/static/src/webclient/navbar/navbar.xml
+++ b/addons/web/static/src/webclient/navbar/navbar.xml
@@ -115,6 +115,7 @@
           <nav class="o_burger_menu_content flex-grow-1 flex-shrink-1 overflow-auto o_burger_menu_app">
                 <div t-if="!state.isAllAppsMenuOpened and currentApp" class="d-flex align-items-center m-3 mb-0">
                   <img style="height: 2em;" t-if="currentApp.webIconData" class="o_app_icon me-2" t-attf-src="{{currentApp.webIconData}}"/>
+                  <i t-elif="currentApp.webIcon" t-att-class="`${currentApp.webIconClass} fa-2x me-2`" t-att-style="'color:' + currentApp.webIconColor"></i>
                   <span class="fs-4 fw-bolder"><t t-esc="currentApp.name"/></span>
                 </div>
                 <ul class="list-unstyled py-2 ps-0 mb-0">
@@ -131,6 +132,7 @@
                         <li t-att-data-menu-xmlid="app.xmlid" class="o_app fw-bolder py-2" t-att-class="{'bg-primary-subtle': menuService.getCurrentApp() === app}" t-on-click="() => {this.onNavBarDropdownItemSelection(app); this._closeAppMenuSidebar();}">
                           <div class="d-flex align-items-center">
                             <img style="height: 3em;" t-if="app.webIconData" class="o_app_icon me-2" t-attf-src="{{app.webIconData}}"/>
+                            <i t-elif="app.webIcon" t-att-class="app.webIcon.split(',')[0] + ' fa-3x me-2'" t-att-style="'color:' + app.webIcon.split(',')[1]"></i>
                             <t t-esc="app.name"/>
                           </div>
                         </li>


### PR DESCRIPTION
**Purpose:**
Previously, when a user edited an app's icon in Studio and selected a Font Awesome icon instead of an image, the icon was not displayed in the navbar or mobile sidebar. This commit ensures the icon now displays correctly in both locations.

task-5085482

Enterprise : https://github.com/odoo/enterprise/pull/95725

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
