### PR TITLE
[IMP] l10n_sa: allow backdating invoices via confirmation date

### DIFF
--- a/addons/l10n_sa/views/report_invoice.xml
+++ b/addons/l10n_sa/views/report_invoice.xml
@@ -1,6 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <template id="arabic_english_invoice" inherit_id="l10n_gcc_invoice.arabic_english_invoice">
+        <div name="invoice_date" position="after">
+            <div class="row" t-if="o.l10n_sa_confirmation_datetime and o.move_type in ('out_invoice', 'out_refund')" name="issue_date">
+                <div class="col-2 offset-6">
+                    <strong style="white-space:nowrap">Issue Date:
+                    </strong>
+                </div>
+                <div class="col-2">
+                    <span t-out="o.get_l10n_sa_confirmation_datetime_sa_tz()"/>
+                </div>
+                <div class="col-2 text-end">
+                    <strong style="white-space:nowrap">:
+                        تاريخ الإصدار
+                    </strong>
+                </div>
+            </div>
+        </div>
+        <div name="invoice_date" position="attributes">
+            <attribute name="t-att-class">'d-none' if o.l10n_sa_confirmation_datetime and o.move_type in ('out_invoice', 'out_refund') else 'row'</attribute>
+        </div>
         <xpath expr="//div[@name='due_date']" position="after">
             <div class="row" t-if="o.l10n_sa_delivery_date" name="delivery_date">
                 <div class="col-6"></div>
@@ -112,9 +131,6 @@
         </xpath>
         <xpath expr="//div[hasclass('clearfix')]" position="attributes">
             <attribute name="class">clearfix pt-2 pb-2</attribute>
-        </xpath>
-        <xpath expr="//div[hasclass('page')]">
-            <t t-set="additional_footer_text" t-value="o.get_l10n_sa_confirmation_datetime_sa_tz()"/> <!-- This is to show the issue date on the footer of all layouts. -->
         </xpath>
     </template>
 </odoo>

--- a/addons/l10n_sa/views/view_move_form.xml
+++ b/addons/l10n_sa/views/view_move_form.xml
@@ -5,8 +5,18 @@
             <field name="model">account.move</field>
             <field name="inherit_id" ref="account.view_move_form"/>
             <field name="arch" type="xml">
+                <xpath expr="//label[@for='invoice_date'][1]" position="attributes">
+                    <attribute name="attrs">{"invisible": ['|', ('move_type', 'not in', ('out_invoice', 'out_refund', 'out_receipt')), ('l10n_sa_show_delivery_date', '=', True)]}</attribute>
+                </xpath>
+                <xpath expr="//label[@for='invoice_date'][2]" position="attributes">
+                    <attribute name="attrs">{"invisible": ['|', ('move_type', 'not in', ('in_invoice', 'out_refund', 'out_receipt')), ('l10n_sa_show_delivery_date', '=', True)]}</attribute>
+                </xpath>
+                <field name="invoice_date" position="attributes">
+                    <attribute name="attrs">{"invisible": [('l10n_sa_show_delivery_date', '=', True)]}</attribute>
+                </field>
                 <field name="invoice_date" position="after">
-                    <field name="l10n_sa_show_delivery_date" invisible="1"/>
+                    <field name="l10n_sa_confirmation_datetime" attrs="{'invisible': [('l10n_sa_show_delivery_date', '=', False)], 'required': [('l10n_sa_show_delivery_date', '=', True)], 'readonly': [('state', '!=', 'draft')]}"/>
+                    <field name="l10n_sa_show_delivery_date" invisible='1' />
                     <field name="l10n_sa_delivery_date" attrs="{'invisible': [('l10n_sa_show_delivery_date', '=', False)], 'required': [('l10n_sa_show_delivery_date', '=', True)]}"/>
                 </field>
             </field>

--- a/addons/l10n_sa_edi/__manifest__.py
+++ b/addons/l10n_sa_edi/__manifest__.py
@@ -29,6 +29,7 @@ E-invoice implementation for Saudi Arabia; Integration with ZATCA
         'wizard/account_move_reversal_views.xml',
         'views/account_tax_views.xml',
         'views/account_journal_views.xml',
+        'views/account_move_views.xml',
         'views/res_partner_views.xml',
         'views/res_company_views.xml',
         'views/res_config_settings_view.xml',

--- a/addons/l10n_sa_edi/models/account_edi_format.py
+++ b/addons/l10n_sa_edi/models/account_edi_format.py
@@ -443,8 +443,8 @@ class AccountEdiFormat(models.Model):
             errors.append(_set_missing_partner_fields(supplier_missing_info, _("Supplier")))
         if customer_missing_info:
             errors.append(_set_missing_partner_fields(customer_missing_info, _("Customer")))
-        if invoice.invoice_date > fields.Date.context_today(self.with_context(tz='Asia/Riyadh')):
-            errors.append(_("- Please, make sure the invoice date is set to either the same as or before Today."))
+        if invoice.l10n_sa_confirmation_datetime > fields.Datetime.now():
+            errors.append(_("- Please, make sure the Issue Date is set to either the same as or before Today."))
         if invoice.move_type in ('in_refund', 'out_refund') and not invoice._l10n_sa_check_refund_reason():
             errors.append(
                 _("- Please, make sure either the Reversed Entry or the Reversal Reason are specified when confirming a Credit/Debit note"))

--- a/addons/l10n_sa_edi/models/account_move.py
+++ b/addons/l10n_sa_edi/models/account_move.py
@@ -294,6 +294,12 @@ class AccountMove(models.Model):
             'total_tax': invoice_vals['vals']['tax_total_vals'][-1]['tax_amount'],
         }
 
+    def button_draft(self):
+        for move in self:
+            if move.company_id.country_code == 'SA' and move.edi_error_count:
+                move.edi_document_ids.filtered(lambda doc: doc.state not in ('sent', 'cancelled')).state = 'cancelled'
+        super().button_draft()
+
 
 class AccountMoveLine(models.Model):
     _inherit = 'account.move.line'

--- a/addons/l10n_sa_edi/tests/test_edi_zatca.py
+++ b/addons/l10n_sa_edi/tests/test_edi_zatca.py
@@ -4,7 +4,7 @@ from freezegun import freeze_time
 import logging
 from pytz import timezone
 
-from odoo import Command
+from odoo import Command, fields
 from odoo.tests import tagged
 from odoo.tools import misc
 
@@ -225,7 +225,7 @@ class TestEdiZatca(TestSaEdiCommon):
             user=self.user_saudi,
         )
         errors = self.edi_format.with_user(self.user_saudi.id)._check_move_configuration(move)
-        msg = '- Please, make sure the invoice date is set to either the same as or before Today.'
+        msg = '- Please, make sure the Issue Date is set to either the same as or before Today.'
         self.assertFalse(msg in errors)
 
     @freeze_time("2022-09-21 15:30:00", tz_offset=0)
@@ -240,6 +240,7 @@ class TestEdiZatca(TestSaEdiCommon):
             price=320.0,
             user=self.user_saudi,
         )
+        move.l10n_sa_confirmation_datetime = fields.Datetime.from_string("2022-09-22 15:30:00")
         errors = self.edi_format.with_user(self.user_saudi.id)._check_move_configuration(move)
-        msg = '- Please, make sure the invoice date is set to either the same as or before Today.'
+        msg = '- Please, make sure the Issue Date is set to either the same as or before Today.'
         self.assertTrue(msg in errors)

--- a/addons/l10n_sa_edi/views/account_move_views.xml
+++ b/addons/l10n_sa_edi/views/account_move_views.xml
@@ -1,0 +1,20 @@
+<odoo>
+    <data>
+        <record id="view_move_form" model="ir.ui.view">
+            <field name="name">account.move.form.inherit.l10n_sa_edi</field>
+            <field name="model">account.move</field>
+            <field name="inherit_id" ref="l10n_sa.view_move_form"/>
+            <field name="arch" type="xml">
+                <field name="l10n_sa_confirmation_datetime" position="before">
+                    <field name="edi_document_ids" invisible="1" />
+                </field>
+                <field name="l10n_sa_confirmation_datetime" position="attributes">
+                    <attribute name="attrs">{'invisible': [('l10n_sa_show_delivery_date', '=', False)], 'readonly': ['|', ('state', '!=', 'draft'), ('edi_document_ids', '!=', [])]}</attribute>
+                </field>
+                <field name="invoice_date" position="attributes">
+                    <attribute name="attrs">{'invisible': [('l10n_sa_show_delivery_date', '=', True)], 'readonly': ['|', ('state', '!=', 'draft'), ('edi_document_ids', '!=', [])]}</attribute>
+                </field>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
Previously, l10n_sa_confirmation_datetime was automatically set when invoices were confirmed, causing issues when users needed to backdate invoices. This created mismatches between Odoo's invoice date recognition and ZATCA's VAT liability calculation, forcing invoices into wrong tax return periods.

Changes:
- Expose l10n_sa_confirmation_datetime as "Issue Date" in form view
- Allow manual setting of l10n_sa_confirmation_datetime before invoice confirmation
- Preserve original Issue Date for rejected Phase 2 invoices (400 errors)
- Hide Invoice Date field but sync it with Issue Date
- Update PDF to display Issue Date instead of Invoice Date
- Remove footer date from PDF
- Extend future date validation to include Issue Date

task-5009969

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
