### PR TITLE
[IMP] mail: port border-style fixes to convert_inline

### DIFF
--- a/addons/mail/static/src/views/web/fields/html_mail_field/convert_inline.js
+++ b/addons/mail/static/src/views/web/fields/html_mail_field/convert_inline.js
@@ -523,6 +523,7 @@ export function classToStyle(element, cssRules) {
                 style = `${key}:${value};${style}`;
             }
         }
+        style = correctBorderAttributes(style);
         if (Object.keys(style || {}).length === 0) {
             writes.push(() => {
                 node.removeAttribute("style");
@@ -1954,4 +1955,63 @@ function removeBlacklistedStyles(rule, node) {
         styles[key] = value;
     }
     return styles;
+}
+
+/**
+ * Corrects the `border-style` attribute in the provided inline style string.
+ * This is specifically for Outlook, which displays borders even when their widths are set to 0px.
+ * If all border widths are 0, the function updates `border-style` to `none`.
+ *
+ * @param {string} style - The inline style string to correct.
+ * @returns {string} - The corrected inline style string.
+ */
+function correctBorderAttributes(style) {
+    const stylesObject = style
+        .replace(/\s+/g, " ")
+        .split(";")
+        .reduce((styles, styleString) => {
+            const [attribute, value] = styleString.split(":").map((str) => str.trim());
+            if (attribute) {
+                styles[attribute] = value;
+            }
+            return styles;
+        }, {});
+
+    const BORDER_WIDTHS_ATTRIBUTES = [
+        "border-bottom-width",
+        "border-left-width",
+        "border-right-width",
+        "border-top-width",
+    ];
+
+    const isBorderStyleApplied = BORDER_WIDTHS_ATTRIBUTES.some(
+        (attribute) => attribute in stylesObject
+    );
+
+    if (!isBorderStyleApplied) {
+        return style;
+    }
+
+    const totalBorderWidth = BORDER_WIDTHS_ATTRIBUTES.reduce((totalWidth, attribute) => {
+        const widthValue = stylesObject[attribute] || "0px";
+        const numericWidth = parseFloat(widthValue.replace("px", "")) || 0;
+        return totalWidth + numericWidth;
+    }, 0);
+
+    if (totalBorderWidth === 0) {
+        let correctedStyle = style.trim();
+        if (correctedStyle.slice(-1) != ";") {
+            correctedStyle += ";";
+        }
+        correctedStyle = correctedStyle.replace(
+            /(;|^)\s*border-style\s*:[^;]*(;|$)|$/,
+            "$1border-style:none$2"
+        );
+        return correctedStyle;
+    }
+
+    if (/border-style\s*:/i.test(style)) {
+        return style;
+    }
+    return style.trim().replace(/;?$/, "; border-style: solid;");
 }

--- a/addons/mail/static/tests/inline/convert_inline.test.js
+++ b/addons/mail/static/tests/inline/convert_inline.test.js
@@ -1416,6 +1416,48 @@ describe("Convert classes to inline styles", () => {
 
         // @todo to adapt when hoot has a better way to remove it
     });
+
+    test("Correct border attributes for outlook", async () => {
+        styleSheet.insertRule(
+            `
+            .test-border-zero {
+                border-bottom-width: 0px;
+                border-left-width: 0px;
+                border-right-width: 0px;
+                border-top-width: 0px;
+                border-style: solid;
+            }
+        `,
+            0
+        );
+
+        styleSheet.insertRule(
+            `
+            .test-border-one {
+                border-bottom-width: 1px;
+                border-left-width: 1px;
+                border-right-width: 1px;
+                border-top-width: 1px;
+                border-style: solid;
+            }
+        `,
+            1
+        );
+
+        editable.innerHTML = `<div><div class="test-border-zero"></div></div>`;
+        classToStyle(editable, getCSSRules(editable.ownerDocument));
+        expect(editable).toHaveInnerHTML(
+            `<div><div class="test-border-zero" style="border-style:none;box-sizing:border-box;border-top-width:0px;border-right-width:0px;border-left-width:0px;border-bottom-width:0px;"></div></div>`,
+            { message: "Should change border-style to none" }
+        );
+
+        editable.innerHTML = `<div><div class="test-border-one"></div></div>`;
+        classToStyle(editable, getCSSRules(editable.ownerDocument));
+        expect(editable).toHaveInnerHTML(
+            `<div><div class="test-border-one" style="border-style:solid;box-sizing:border-box;border-top-width:1px;border-right-width:1px;border-left-width:1px;border-bottom-width:1px;"></div></div>`,
+            { message: "Should keep border style solid" }
+        );
+    });
 });
 
 describe("Properly add MSO conditions", () => {


### PR DESCRIPTION
This commit ports the following fixes to `convert_inline` of `mail`:

- https://github.com/odoo/odoo/commit/8923f32426fc64e90db249fad47d7ca7e338adef
  [FIX] web_editor: adapt border-style value based on border widths

- https://github.com/odoo/odoo/commit/7de31c6261d2fe9f58b0c6cb635977e77eecd9d6
  [FIX] web_editor: ensure image border visible in emails
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
