### PR TITLE
[FIX] web_hierarchy: fix hierarchy view traceback errors

### DIFF
--- a/addons/web_hierarchy/static/src/hierarchy_renderer.js
+++ b/addons/web_hierarchy/static/src/hierarchy_renderer.js
@@ -99,17 +99,18 @@ export class HierarchyRenderer extends Component {
     get rows() {
         const rootNodes = this.props.model.root.rootNodes;
         const rows = [{ nodes: rootNodes }];
-        const processNode = (node) => {
-            if (!node.isLeaf) {
-                rows.push({ parentNode: node, nodes: node.nodes});
-                for (const subNode of node.nodes) {
-                    processNode(subNode);
+        const processNode = (node, rootNode) => {
+            const subNodes = node.nodes;
+            if (subNodes.length && !subNodes.includes(rootNode)) {
+                rows.push({ parentNode: node, nodes: subNodes });
+                for (const subNode of subNodes) {
+                    processNode(subNode, rootNode);
                 }
             }
         };
 
-        for (const node of this.props.model.root.rootNodes) {
-            processNode(node);
+        for (const node of rootNodes) {
+            processNode(node, node);
         }
 
         return rows;


### PR DESCRIPTION
This commit fixes some traceback errors in the web_hierarchy module by refining the cycle detection of records in hierarchies. Infinite loops in case of a cycle's presence in the `removeChildNodes` and `processNode` methods are now prevented. Additionally, tree re-rooting in case of the presence of two nodes in the same tree, which implies a cycle's existence, is now avoided. There was an edge case where an employee could be their own manager, creating two child nodes of that employee. The case is now handled by making sure that records are unique for each parent ID in the `recordsPerParentId` object.

task-5022670

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
