### PR TITLE
[FIX] hr_holidays: leave custom hours gets unchecked when changing time off type

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -408,13 +408,21 @@ class HolidaysRequest(models.Model):
     @api.depends('holiday_status_id', 'request_unit_hours')
     def _compute_request_unit_half(self):
         for holiday in self:
-            if holiday.holiday_status_id or holiday.request_unit_hours:
+            if (holiday.holiday_status_id and holiday.leave_type_request_unit == 'day'):
+                holiday.request_unit_half = False
+                holiday.request_hour_from = False
+                holiday.request_hour_to = False
+            elif holiday.request_unit_hours:
                 holiday.request_unit_half = False
 
     @api.depends('holiday_status_id', 'request_unit_half')
     def _compute_request_unit_hours(self):
         for holiday in self:
-            if holiday.holiday_status_id or holiday.request_unit_half:
+            if (holiday.holiday_status_id and holiday.leave_type_request_unit == 'day'):
+                holiday.request_unit_hours = False
+                holiday.request_hour_from = False
+                holiday.request_hour_to = False
+            elif holiday.request_unit_half:
                 holiday.request_unit_hours = False
 
     @api.depends('employee_ids')


### PR DESCRIPTION

- made the value of checkboxes for `request_unit_half` and `request_unit_hours` stay the same when switching between timeoffs that can have hourly type task-id: 5085389


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
