### PR TITLE
[FIX] website_sale_collect: allow out-of-stock collect if enabled

### DIFF
--- a/addons/website_sale_collect/models/sale_order.py
+++ b/addons/website_sale_collect/models/sale_order.py
@@ -118,7 +118,7 @@ class SaleOrder(models.Model):
         """
         unavailable_order_lines = self.env['sale.order.line']
         for ol in self.order_line:
-            if ol.is_storable:
+            if ol.is_storable and not ol.product_id.allow_out_of_stock_order:
                 product_free_qty = ol.product_id.with_context(warehouse_id=wh_id).free_qty
                 if ol.product_uom_qty > product_free_qty:
                     ol.shop_warning = _(

--- a/addons/website_sale_collect/tests/test_click_and_collect_flow.py
+++ b/addons/website_sale_collect/tests/test_click_and_collect_flow.py
@@ -1,28 +1,43 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.tests import tagged
-
 from odoo.tests.common import HttpCase
+
 from odoo.addons.website_sale_collect.tests.common import ClickAndCollectCommon
 
 
 @tagged('post_install', '-at_install')
 class TestClickAndCollectFlow(HttpCase, ClickAndCollectCommon):
 
-    def test_buy_with_click_and_collect_as_public_user(self):
-        self.storable_product.name = "Test CAC Product"
-        self.provider.write(
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.storable_product.name = "Test CAC Product"
+        cls.provider.write(
             {
                 'state': 'enabled',
                 'is_published': True,
             }
         )
-        self.in_store_dm.warehouse_ids[0].partner_id = self.env['res.partner'].create(
+        cls.in_store_dm.warehouse_ids[0].partner_id = cls.env['res.partner'].create(
             {
-                **self.dummy_partner_address_values,
+                **cls.dummy_partner_address_values,
                 'name': "Shop 1",
                 'partner_latitude': 1.0,
                 'partner_longitude': 2.0,
             }
         )
+
+    def test_buy_with_click_and_collect_as_public_user(self):
+        """
+        Test the basic flow of buying with click and collect as a public user with more than
+        one delivery method available
+        """
+        self.start_tour('/', 'website_sale_collect_buy_product')
+
+    def test_allow_out_of_stock_collect(self):
+        """Test that click & collect allows ordering out of stock products when enabled."""
+        self.storable_product.allow_out_of_stock_order = True
+        self._add_product_qty_to_wh(self.storable_product.id, 0, self.warehouse.lot_stock_id.id)
+        self.assertFalse(self.storable_product.free_qty)
         self.start_tour('/', 'website_sale_collect_buy_product')

--- a/addons/website_sale_collect/utils.py
+++ b/addons/website_sale_collect/utils.py
@@ -15,7 +15,7 @@ def format_product_stock_values(product, wh_id=None, free_qty=None):
         if free_qty is None:
             free_qty = product.with_context(warehouse_id=wh_id).free_qty
         return {
-            'in_stock': free_qty > 0,
+            'in_stock': free_qty > 0 or product.allow_out_of_stock_order,
             'show_quantity': product.show_availability and product.available_threshold >= free_qty,
             'quantity': free_qty,
         }


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Publish the "Pickup in store" delivery method;
2. have an out-of-stock product with "Continue selling" enabled;
3. go to the product's shop page;
4. add to cart;
5. try to check out using "Pickup in store" delivery method.

Issue
-----
Delivery method cannot be selected.

Cause
-----
The `website_sale_collect` module currently only checks whether the product is in stock, and not whether the product is allowed to sell when it's out of stock.

Solution
--------
Check the `allow_out_of_stock_order` in `_get_unavailable_order_lines` and `format_product_stock_values`, so that the `in_stock` value used to check availability is `True` iff the products are in stock or have `allow_out_of_stock_order` enabled.

opw-5080295