### PR TITLE
[IMP] l10n_in: set default outstanding accounts on bank journals

### DIFF
--- a/addons/l10n_in/models/__init__.py
+++ b/addons/l10n_in/models/__init__.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from . import template_in
 from . import account_invoice
+from . import account_journal
 from . import account_move_line
 from . import account_payment
 from . import account_tax

--- a/addons/l10n_in/models/account_journal.py
+++ b/addons/l10n_in/models/account_journal.py
@@ -1,0 +1,24 @@
+from odoo import api, models
+
+
+class AccountJournal(models.Model):
+    _inherit = 'account.journal'
+
+    def _set_l10n_in_payment_accounts_for_type(self, pay_type):
+        """Helper to set default outstanding accounts for inbound/outbound."""
+        for journal in self.filtered(lambda j: j.type == "bank" and j.company_id.chart_template == "in"):
+            self.env['account.chart.template']._set_l10n_in_default_outstanding_payment_accounts(
+                journal.company_id,
+                bank_journal=journal,
+                pay_type=pay_type,
+            )
+
+    @api.depends('type', 'currency_id')
+    def _compute_inbound_payment_method_line_ids(self):
+        super()._compute_inbound_payment_method_line_ids()
+        self._set_l10n_in_payment_accounts_for_type("inbound")
+
+    @api.depends('type', 'currency_id')
+    def _compute_outbound_payment_method_line_ids(self):
+        super()._compute_outbound_payment_method_line_ids()
+        self._set_l10n_in_payment_accounts_for_type("outbound")


### PR DESCRIPTION
Before:
- By default, Odoo does not assign outstanding accounts (debit/credit) to bank journals. Users must configure them manually from within the journal.
- This often left setups incomplete, resulting in missing entries in the CoA.

After:
- For the Indian localisation, outstanding accounts are now automatically set on bank journals’ inbound and outbound manual payment methods.
- The payment accounts are applied by default during CoA loading and whenever payment method lines are recomputed, ensuring accounts remain consistent.

Explanation:
This improvement removes manual setup steps, and ensures a ready-to-use bank journal configuration with default outstanding accounts out of the box.

task-5055756
