### PR TITLE
[FIX] base: correct example dates in date format selection

### DIFF
--- a/odoo/addons/base/models/res_lang.py
+++ b/odoo/addons/base/models/res_lang.py
@@ -58,12 +58,12 @@ class ResLang(models.Model):
     def _get_date_format_selection(self):
         current_year = fields.Date.today().year
         return [
-            ('%d/%m/%Y', '01/31/%s' % current_year),
-            ('%m/%d/%Y', '31/01/%s' % current_year),
-            ('%Y/%m/%d', '%s/31/01' % current_year),
-            ('%d-%m-%Y', '01-31-%s' % current_year),
-            ('%m-%d-%Y', '31-01-%s' % current_year),
-            ('%Y-%m-%d', '%s-31-01' % current_year),
+            ('%d/%m/%Y', '31/01/%s' % current_year),
+            ('%m/%d/%Y', '01/31/%s' % current_year),
+            ('%Y/%m/%d', '%s/01/31' % current_year),
+            ('%d-%m-%Y', '31-01-%s' % current_year),
+            ('%m-%d-%Y', '01-31-%s' % current_year),
+            ('%Y-%m-%d', '%s-01-31' % current_year),
         ]
 
     name = fields.Char(required=True)


### PR DESCRIPTION
**Steps to reproduce:**
1. Set up a fresh v19 database.
2. Go to Settings > Translation > Languages (e.g., English) > Date Format.
3. Turn on debug mode and check field definitions.

**Issue:**
- Date format examples were not aligned correctly with their technical formats,
 causing confusion.

**Cause:**
- The mapping of example dates to format strings was incorrect.

**Solution:**
- Update the example dates to correctly match their corresponding technical 
 date formats.

**opw-5116664**

Incorrect Format (image of field defination):
<img width="237" height="250" alt="image" src="https://github.com/user-attachments/assets/ac0f9dac-2f18-4ef2-8a61-474951efda92" />
