### PR TITLE
[FIX] pos_restaurant: close bill split on last payment

### DIFF
--- a/addons/pos_restaurant/static/src/app/screens/split_bill_screen/split_bill_screen.js
+++ b/addons/pos_restaurant/static/src/app/screens/split_bill_screen/split_bill_screen.js
@@ -96,13 +96,18 @@ export class SplitBillScreen extends Component {
     }
 
     async paySplittedOrder() {
-        if (this.getNumberOfProducts() > 0) {
+        const totalQty = this.currentOrder.lines.reduce((sum, line) => sum + line.qty, 0);
+        const selectedQty = this.getNumberOfProducts();
+
+        if (selectedQty > 0 && selectedQty < totalQty) {
             const originalOrder = this.currentOrder;
             await this.createSplittedOrder();
             originalOrder.setScreenData({ name: "SplitBillScreen" });
         }
+
         this.pos.pay();
     }
+
     async transferSplittedOrder(event) {
         // Prevents triggering the 'startTransferOrder' event listener
         event.stopPropagation();

--- a/addons/pos_restaurant/static/tests/tours/split_bill_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/split_bill_screen_tour.js
@@ -77,6 +77,20 @@ registry.category("web_tour.tours").add("SplitBillScreenTour", {
             ProductScreen.isShown(),
             ProductScreen.clickOrderline("Water", "1"),
             ProductScreen.clickOrderline("Minute Maid", "2"),
+
+            //Split pay by selecting products
+            ProductScreen.clickControlButton("Split"),
+            SplitBillScreen.clickOrderline("Water"),
+            SplitBillScreen.clickButton("Pay"),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.clickContinueOrder(),
+            SplitBillScreen.clickOrderline("Minute Maid"),
+            SplitBillScreen.clickOrderline("Minute Maid"),
+            SplitBillScreen.clickButton("Pay"),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.clickNextOrder(),
         ].flat(),
 });
 


### PR DESCRIPTION
When splitting a bill, a specific flow would leave the bill splitting screen open event when everything was paid.

Steps to reproduce:
-------------------
* In pos restaurant add 2 product to the order
* Select Action > Split
* Select a product
* Click Pay(ment) and validate the payment
* Continue
* Select the last product
* Click Pay(ment) and validate the payment
* Continue

> Observation:
The Bill splitting screen is still open at 0$

Why the fix:
------------
When one or more products are selected a new order is created with those products. If the quantities match, it's the last payement for that bill, we can directly pay. The original order will then be closed.

opw-5006042