### PR TITLE
[FIX] product_expiry: Don't display red lines for every product

### DIFF
--- a/addons/product_expiry/views/stock_quant_views.xml
+++ b/addons/product_expiry/views/stock_quant_views.xml
@@ -7,7 +7,7 @@
         <field name="arch" type="xml">
             <xpath expr="//list" position="attributes">
                 <attribute name="decoration-danger">
-                    removal_date &lt; current_date or quantity &lt; 0
+                    (removal_date and removal_date &lt; current_date) or quantity &lt; 0
                 </attribute>
             </xpath>
             <xpath expr="//field[@name='quantity']" position="after" >


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

For stock users (not admins), the stock quantities list view display red lines for every product.

Current behavior before PR:

<img width="2243" height="217" alt="image" src="https://github.com/user-attachments/assets/330c591c-6ef4-46cb-8336-fa39fb483333" />


Desired behavior after PR is merged:

Red lines are only displayed for products with a removal date and a removal date < current date


<img width="2241" height="290" alt="image" src="https://github.com/user-attachments/assets/fe37adc7-e736-447e-a21e-e2fae984e074" />




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
