### PR TITLE
[CLN] product: removes unecessary write on model_template

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -509,16 +509,6 @@ class ProductTemplate(models.Model):
         templates = super(ProductTemplate, self).create(vals_list)
         if self.env.context.get("create_product_product", True):
             templates._create_variant_ids()
-
-        # This is needed to set given values to first variant after creation
-        for template, vals in zip(templates, vals_list):
-            related_vals = {}
-            for field_name in self._get_related_fields_variant_template():
-                if vals.get(field_name):
-                    related_vals[field_name] = vals[field_name]
-            if related_vals:
-                template.write(related_vals)
-
         return templates
 
     def write(self, vals):


### PR DESCRIPTION
Variant creation is triggered after `product.template.attribute.line`.
Because of that, product template field that should be copied to their
variant when creating a new product are handled correctly by their corresponding inverse function.
see: https://github.com/odoo/odoo/pull/225863