### PR TITLE
[REM] mail: remove unused /mail/thread/recipients/fields route

### DIFF
--- a/addons/mail/controllers/thread.py
+++ b/addons/mail/controllers/thread.py
@@ -89,13 +89,6 @@ class ThreadController(http.Controller):
             for info in suggested if info['partner_id']
         ]
 
-    @http.route("/mail/thread/recipients/fields", methods=["POST"], type="jsonrpc", auth="user")
-    def mail_thread_recipients_fields(self, thread_model):
-        return {
-            'partner_fields': request.env[thread_model]._mail_get_partner_fields(),
-            'primary_email_field': [request.env[thread_model]._mail_get_primary_email_field()]
-        }
-
     @http.route("/mail/thread/recipients/get_suggested_recipients", methods=["POST"], type="jsonrpc", auth="user")
     def mail_thread_recipients_get_suggested_recipients(self, thread_model, thread_id, partner_ids=None, main_email=False):
         """This method returns the suggested recipients with updates coming from the frontend.

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -911,14 +911,6 @@ async function mail_thread_messages(request) {
     };
 }
 
-registerRoute("/mail/thread/recipients/fields", mail_thread_recipients_fields);
-async function mail_thread_recipients_fields(request) {
-    return {
-        partner_fields: [],
-        primary_email_field: [],
-    };
-}
-
 registerRoute("mail/thread/update_suggested_recipents", mail_thread_update_suggested_recipients);
 async function mail_thread_update_suggested_recipients(request) {
     return [];


### PR DESCRIPTION
Since PR #208393, the `/mail/thread/recipients/fields` route is no longer in use. However it was kept in the stables due to the stable policies. This change removes the route.

