### PR TITLE
[FIX] website: ensure video container fills available width 

### DIFF
--- a/addons/website/static/src/snippets/s_masonry_block/001.scss
+++ b/addons/website/static/src/snippets/s_masonry_block/001.scss
@@ -2,6 +2,10 @@
     display: flex;
     flex-direction: column;
     justify-content: center;
+
+    div.media_iframe_video {
+      width: 100%;
+    }
 }
 
 .s_masonry_block[data-vcss='001'] .row.o_grid_mode {

--- a/addons/website/static/src/snippets/s_quadrant/000.scss
+++ b/addons/website/static/src/snippets/s_quadrant/000.scss
@@ -2,5 +2,9 @@
     .o_grid_item {
         display: flex;
         flex-direction: column;
+        
+        div.media_iframe_video {
+            width: 100%;
+        }
     }
 }


### PR DESCRIPTION
To reproduce:
=============
1- In Website edit mode, drop the "Masonry" snippet.
2- Add a video in one of the text blocks.
-> It will appear smaller than expected, with no way to make it larger

Why:
====
The child iframe already had width: 100%,
but it can only stretch to 100% of its parent container.
If the parent container (.media_iframe_video) doesn't have an explicit
width, it defaults to its minimum content size.
This issue happens specifically in blocks where the columns are
display: flex. As a result, the iframe ends up being too narrow
despite having width: 100%.


Solution:
=========
By adding width: 100% to the container itself,
it now fills the grid cell, and the iframe inside fills the container.

opw-5104640