### PR TITLE
[FIX] hw_drivers: browser url saved in conf

### DIFF
--- a/addons/hw_drivers/browser.py
+++ b/addons/hw_drivers/browser.py
@@ -45,6 +45,7 @@ class Browser:
         self.state = BrowserState.NORMAL
         self._x_screen = _x_screen
         self._set_environment(env)
+        self.open_browser()
 
     def _set_environment(self, env):
         """
@@ -57,7 +58,7 @@ class Browser:
         for key in ['HOME', 'XDG_RUNTIME_DIR', 'XDG_CACHE_HOME']:
             self.env[key] = '/tmp/' + self._x_screen
 
-    def open_browser(self, url=None, state=BrowserState.NORMAL):
+    def open_browser(self, url=None, state=BrowserState.FULLSCREEN):
         """
         open the browser with the given URL, or reopen it if it is already open
         :param url: URL to open in the browser

--- a/addons/hw_drivers/iot_handlers/drivers/DisplayDriver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/DisplayDriver_L.py
@@ -32,22 +32,17 @@ class DisplayDriver(Driver):
         self.device_name = device['name']
         self.owner = False
         self.customer_display_data = {}
-        self.url, self.orientation = helpers.load_browser_state()
         if self.device_identifier != 'distant_display':
+            saved_url, self.orientation = helpers.load_browser_state()
+            self.url = saved_url or self.get_url_from_db() or 'http://localhost:8069/status/'
             self._x_screen = device.get('x_screen', '0')
-            self.browser = Browser(
-                self.url or 'http://localhost:8069/status/',
-                self._x_screen,
-                os.environ.copy(),
-            )
-            self.update_url(self.get_url_from_db())
+            self.browser = Browser(self.url, self._x_screen, os.environ.copy())
+            self.set_orientation(self.orientation)
 
         self._actions.update({
             'update_url': self._action_update_url,
             'display_refresh': self._action_display_refresh,
         })
-
-        self.set_orientation(self.orientation)
 
     @classmethod
     def supported(cls, device):
@@ -94,6 +89,7 @@ class DisplayDriver(Driver):
 
     def _action_update_url(self, data):
         if self.device_identifier != 'distant_display':
+            helpers.save_browser_state(url=data.get('url'))
             self.update_url(data.get('url'))
 
     def _action_display_refresh(self, data):

--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -697,10 +697,12 @@ def save_browser_state(url=None, orientation=None):
     :param url: The URL the browser is on (if None, the URL is not saved)
     :param orientation: The orientation of the screen (if None, the orientation is not saved)
     """
-    update_conf({
-        'browser_url': url,
-        'screen_orientation': orientation.name.lower() if orientation else None,
-    })
+    to_update = {
+        "browser_url": url,
+        "screen_orientation": orientation.name.lower() if orientation else None,
+    }
+    # Only update the values that are not None
+    update_conf({k: v for k, v in to_update.items() if v is not None})
 
 
 def load_browser_state():


### PR DESCRIPTION
The browser on the IoT Box was always reopening on the url saved in the database instead of the one saved in odoo.conf.

When opening the browser, we used to set the orientation and save it in the configuration. As we only set the orientation and not the url at this point, we were mistakenly removing the url from odoo.conf.

As it was not set anymore, when reopening the browser later (e.g. after reboot), no url was available in conf, so we fell back on the db's one.

Task: 5103536
