### PR TITLE
[FIX] account: keep fields in `tocompute` after `_set_next_sequence`

### DIFF
--- a/addons/account/models/sequence_mixin.py
+++ b/addons/account/models/sequence_mixin.py
@@ -431,6 +431,9 @@ class SequenceMixin(models.AbstractModel):
         self.ensure_one()
         format_string, format_values = self._get_next_sequence_format()
 
+        sequence = self._locked_increment(format_string, format_values)
+        self.with_context(clear_sequence_mixin_cache=False)[self._sequence_field] = sequence
+
         registry = self.env.registry
         triggers = registry._field_triggers[self._fields[self._sequence_field]]
         for inverse_field, triggered_fields in triggers.items():
@@ -439,9 +442,6 @@ class SequenceMixin(models.AbstractModel):
                     continue
                 for field in registry.field_inverses[inverse_field[0]] if inverse_field else [None]:
                     self.env.add_to_compute(triggered_field, self[field.name] if field else self)
-
-        sequence = self._locked_increment(format_string, format_values)
-        self.with_context(clear_sequence_mixin_cache=False)[self._sequence_field] = sequence
 
         self._compute_split_sequence()
 

--- a/doc/cla/corporate/forgeflow.md
+++ b/doc/cla/corporate/forgeflow.md
@@ -25,3 +25,4 @@ Arnau Cruz arnau.cruz@forgeflow.com https://github.com/ArnauCForgeFlow
 Ricard Calvo ricard.calvo@forgeflow.com https://github.com/RicardCForgeFlow
 Marina Alapont marina.alapont@forgeflow.com https://github.com/MarinaAForgeFlow
 Thiago Mulero thiago.mulero@forgeflow.com https://github.com/ThiagoMForgeFlow
+Laura Cazorla laura.cazorla@forgeflow.com https://github.com/LauraCForgeFlow


### PR DESCRIPTION
Backport of #225558 to 18.0.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
