### PR TITLE
[FIX] web: fix indeterministic test on interactions

### DIFF
--- a/addons/web/static/tests/public/interaction.test.js
+++ b/addons/web/static/tests/public/interaction.test.js
@@ -1,6 +1,14 @@
 import { beforeEach, describe, expect, test } from "@odoo/hoot";
 
-import { animationFrame, click, dblclick, queryAll, queryFirst, queryOne } from "@odoo/hoot-dom";
+import {
+    animationFrame,
+    click,
+    dblclick,
+    freezeTime,
+    queryAll,
+    queryFirst,
+    queryOne,
+} from "@odoo/hoot-dom";
 import { advanceTime, Deferred } from "@odoo/hoot-mock";
 import { patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { Colibri } from "@web/public/colibri";
@@ -2222,6 +2230,7 @@ describe("debounced (2)", () => {
     });
 
     test("debounced is not called if the interaction is destroyed in the meantime", async () => {
+        freezeTime();
         class Test extends Interaction {
             static selector = ".test";
             setup() {


### PR DESCRIPTION
This commit is a backport of commit [1de8529] which was only merged in 18.3+.

Hoot provides us with "time control" features such as "advanceTime", which is useful for testing scenarios where we want to wait for some events to happen (such as a debounced function), but without actually waiting too much.

The way it works is that hoot simply override setTimeout and related functions to keep track of all handlers and their scheduled time. However, this is not enough, as the real setTimeout is still by default called, so it can happen in some tests that when we advance the time by some amount, say 500ms, if the cpu load is very high, then other handlers that are scheduled AFTER the 500ms may have run as well.

To fix this, we can use the freezeTime feature from hoot. It simply give the full control to hoot, and does not call the real setTimeout function.

[1de8529]: https://github.com/odoo/odoo/commit/1de852933f5c331ae4e353bb7f427a2f62026eb4

runbot-230297