### PR TITLE
[FIX] account: prevent draggable upload button in dashboard

### DIFF
--- a/addons/account/static/src/components/bills_upload/bills_upload.xml
+++ b/addons/account/static/src/components/bills_upload/bills_upload.xml
@@ -96,7 +96,7 @@
 
     <t t-name="account.JournalUploadLink">
         <div t-att-class="props.btnClass" groups="account.group_account_invoice">
-            <a href="#" t-out="props.linkText"/>
+            <a href="#" t-out="props.linkText" draggable="false"/>
         </div>
     </t>
 


### PR DESCRIPTION
Issue:
- In the dashboard, the upload button (purchase journal and others) could be dragged.
- This caused unintended movement of the upload UI element.

Fix:
- Added `draggable=false` to the upload button element.
- Ensures the button remains fixed and cannot be dragged around.

TaskID-5114617