### PR TITLE
[FIX] l10n_fr_facturx_chorus_pro: fixes for Peppol Chorus Pro invoicing

### DIFF
--- a/addons/l10n_fr_facturx_chorus_pro/models/account_edi_xml_ubl_bis3.py
+++ b/addons/l10n_fr_facturx_chorus_pro/models/account_edi_xml_ubl_bis3.py
@@ -1,4 +1,4 @@
-from odoo import models, _
+from odoo import api, models, _
 
 
 CHORUS_PRO_PEPPOL_ID = "0009:11000201100044"
@@ -12,6 +12,10 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
     Chorus Pro documentation: https://communaute.chorus-pro.gouv.fr/wp-content/uploads/2017/07/Specifications_Externes_Annexe_EDI_V4.22.pdf
     """
 
+    @api.model
+    def _is_customer_behind_chorus_pro(self, customer):
+        return customer.peppol_eas and customer.peppol_endpoint and customer.peppol_eas + ":" + customer.peppol_endpoint == CHORUS_PRO_PEPPOL_ID
+
     def _export_invoice_vals(self, invoice):
         """
         * Pagero doc states that the siret of the final customer (that has the Chorus peppol ID) should be located in
@@ -21,6 +25,10 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
         """
         # EXTENDS 'account.edi.xml.ubl_bis3'
         vals = super()._export_invoice_vals(invoice)
+        customer = vals['customer'].commercial_partner_id
+        if not self._is_customer_behind_chorus_pro(customer):
+            return vals
+
         if invoice.buyer_reference:
             # Pagero doc states that the 'Service Code' should be in the BuyerReference node
             vals['vals']['buyer_reference'] = invoice.buyer_reference
@@ -28,30 +36,44 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
             # Pagero doc states that the 'Commitment Number' should be in the OrderReference/ID node
             vals['vals']['order_reference'] = invoice.purchase_order_reference
 
-        customer = vals['customer'].commercial_partner_id
-        if customer.peppol_eas and customer.peppol_endpoint and customer.peppol_eas + ":" + customer.peppol_endpoint == CHORUS_PRO_PEPPOL_ID:
-            for role in ('supplier', 'customer'):
-                partner = vals[role].commercial_partner_id
-                if 'siret' in partner._fields and partner.siret and partner.country_code == 'FR':
-                    vals['vals'][f'accounting_{role}_party_vals']['party_vals']['party_identification_vals'] = [{
-                        'id': partner.siret,
-                        'id_attrs': {'schemeName': 1},
-                    }]
-                else:
-                    vals['vals'][f'accounting_{role}_party_vals']['party_vals']['party_identification_vals'] = [{
-                        'id': partner.vat,
-                        'id_attrs': {'schemeName': 2},
-                    }]
+        for role in ('supplier', 'customer'):
+            partner = vals[role].commercial_partner_id
+            if 'siret' in partner._fields and partner.siret and partner.country_code == 'FR':
+                vals['vals'][f'accounting_{role}_party_vals']['party_vals']['party_identification_vals'] = [{
+                    'id': partner.siret,
+                    'id_attrs': {'schemeID': '0009'},
+                }]
+            else:
+                vals['vals'][f'accounting_{role}_party_vals']['party_vals']['party_identification_vals'] = [{
+                    'id': partner.vat,
+                }]
         return vals
+
+    def _get_partner_party_legal_entity_vals_list(self, partner):
+        # EXTENDS account.edi.xml.ubl_bis3
+        vals_list = super()._get_partner_party_legal_entity_vals_list(partner)
+
+        if not self._is_customer_behind_chorus_pro(partner):
+            return vals_list
+
+        for vals in vals_list:
+            if 'siret' in partner._fields and partner.siret:
+                # Siret of the final receiver is mandatory when invoicing through Chorus Pro.
+                # If this condition is not met, it will fail in the constraint check.
+                vals.update({
+                    'company_id': partner.siret,
+                    'company_id_attrs': {'schemeID': '0009'},
+                })
+        return vals_list
 
     def _export_invoice_constraints(self, invoice, vals):
         constraints = super()._export_invoice_constraints(invoice, vals)
         customer, supplier = vals['customer'].commercial_partner_id, vals['supplier']
-        if customer.peppol_eas and customer.peppol_endpoint and customer.peppol_eas + ":" + customer.peppol_endpoint == CHORUS_PRO_PEPPOL_ID:
+        if self._is_customer_behind_chorus_pro(customer):
             if 'siret' not in customer._fields or not customer.siret:
-                constraints['chorus_customer'] = _("The siret is mandatory for the customer when invoicing to Chorus Pro.")
+                constraints['chorus_customer'] = _("The siret of the final recipient is mandatory for the customer when invoicing through Chorus Pro.")
             if supplier.country_code == 'FR' and ('siret' not in supplier._fields or not supplier.siret):
                 constraints['chorus_supplier'] = _("The siret is mandatory for french suppliers when invoicing to Chorus Pro.")
             if not invoice.partner_bank_id.bank_id.bic:
-                constraints['chorus_financial_institution_branch'] = _("The BIC of the payee's bank is mandatory when invoicing to Chorus Pro.")
+                constraints['chorus_financial_institution_branch'] = _("The BIC of the payee's bank is mandatory when invoicing through Chorus Pro.")
         return constraints

--- a/addons/l10n_fr_facturx_chorus_pro/tests/test_chorus_pro_xml.py
+++ b/addons/l10n_fr_facturx_chorus_pro/tests/test_chorus_pro_xml.py
@@ -51,11 +51,15 @@ class TestChorusProXml(TestAccountMoveSendCommon):
 
         supplier_identification_node = xml_etree.find("{*}AccountingSupplierParty/{*}Party/{*}PartyIdentification/{*}ID")
         self.assertEqual(supplier_identification_node.text, "02546465000024")
-        self.assertEqual(supplier_identification_node.attrib, {'schemeName': '1'})
+        self.assertEqual(supplier_identification_node.attrib, {'schemeID': '0009'})
 
         customer_identification_node = xml_etree.find("{*}AccountingCustomerParty/{*}Party/{*}PartyIdentification/{*}ID")
         self.assertEqual(customer_identification_node.text, "21440109300015")
-        self.assertEqual(customer_identification_node.attrib, {'schemeName': '1'})
+        self.assertEqual(customer_identification_node.attrib, {'schemeID': '0009'})
+
+        customer_legal_entity_node = xml_etree.find("{*}AccountingCustomerParty/{*}Party/{*}PartyLegalEntity/{*}CompanyID")
+        self.assertEqual(customer_legal_entity_node.text, "21440109300015")
+        self.assertEqual(customer_legal_entity_node.attrib, {'schemeID': '0009'})
 
         self.assertEqual(xml_etree.findtext("{*}BuyerReference"), "buyer_ref_123")
         self.assertEqual(xml_etree.findtext("{*}OrderReference/{*}ID"), "order_ref_123")
@@ -74,6 +78,6 @@ class TestChorusProXml(TestAccountMoveSendCommon):
         })
         invoice.action_post()
         invoice.partner_bank_id = None
-        with self.assertRaisesRegex(UserError, "The BIC of the payee's bank is mandatory when invoicing to Chorus Pro."):
+        with self.assertRaisesRegex(UserError, "The BIC of the payee's bank is mandatory when invoicing through Chorus Pro."):
             wizard = self.create_send_and_print(invoice, checkbox_ubl_cii_xml=True, checkbox_download=True, checkbox_send_mail=False)
             wizard.action_send_and_print()


### PR DESCRIPTION
1. We didn't met one of the specific requirement of the BIS3 invoices
to be sent through Chorus Pro.

> The SIRET number for the final recipient, behind Chorus Pro should always be sent in the following tag:
Invoice/cac:AccountingCustomerParty/PartyLegalEntity/CompanyID

2. One of the attributes of the CompanyID was set to schemeName which is not a valid
attribute of the Peppol BIS3 specification.
Fixed in 18.0+: https://github.com/odoo/odoo/commit/c3ae4b29c51c7b0cff11aac5f4bf4aab5fad16c9

task-none (possible opw-4972189, but might not be the only problem)

Source:
<img width="787" height="673" alt="image" src="https://github.com/user-attachments/assets/2a410fa8-572a-4738-aa5d-764e91271880" />
https://www.pagero.com/onboarding/aife/aife-en