### PR TITLE
[FIX] mail: align '+' composer action

### DIFF
--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -155,7 +155,7 @@
 </t>
 
 <t t-name="mail.Composer.moreActions">
-    <button class="btn btn-link p-0" t-att-disabled="areAllActionsDisabled" t-ref="more-actions">
+    <button class="btn btn-link p-0 d-flex" t-att-disabled="areAllActionsDisabled" t-ref="more-actions">
         <div class="o-mail-Composer-mainActions d-flex flex-grow-1 align-items-baseline">
             <t t-set="moreName">More Actions</t>
             <ActionList inline="true" actions="[{


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/225585

PR above made some improvements to composer, notably making it so that the "+" button can be disabled.

It introduced however a small visual regression: this button is misaligned with the rest of composer.

This happens because it had its `d-flex` removed from actionsContainerClass.

This commit fixes by adding explicit `d-flex` on button, thus re-aligning it like before.

Before
<img width="735" height="104" alt="Screenshot 2025-09-29 at 13 44 05" src="https://github.com/user-attachments/assets/14588b0b-58f1-4500-b15a-5a344b87196f" />

After
<img width="733" height="110" alt="Screenshot 2025-09-29 at 13 43 43" src="https://github.com/user-attachments/assets/cd9310ea-fc31-4888-80c0-8ef34aec7b83" />
