### PR TITLE
[FIX] website_sale: remove internal ref code from alternative product titles

### DIFF
--- a/addons/website_sale/data/product_snippet_template_data.xml
+++ b/addons/website_sale/data/product_snippet_template_data.xml
@@ -65,9 +65,9 @@
                                     <a
                                         class="text-decoration-none"
                                         t-att-href="product.website_url"
-                                        t-att-content="product.display_name"
-                                        t-att-title="product.display_name"
-                                        t-field="product.display_name"
+                                        t-att-content="data.get('display_name')"
+                                        t-att-title="data.get('display_name')"
+                                        t-out="data.get('display_name')"
                                     />
                                 </h2>
                                 <!-- Description -->


### PR DESCRIPTION
**Steps to reproduce:**
1. Install eCommerce.
2. Open a product > Sales Tab > Alternative Products
3. Add products with  an internal reference (default_code) and Attributes.
4. Go to website > scroll down to the alternative products section.

**Issue:**
- The "Alternative Products" snippet displays the product's internal reference 
  in the title.
- This occurs only for products with attributes and variants(attribute_line_ids)
- The behavior is inconsistent with the main product page, where only the 
  product name is shown

Cause :
- The QWeb template was accessing the product name through values['data']['_record'] (which is a product.template) 
whose display_name includes internal reference  (e.g., [E-COM06] Corner Desk Right Sit).
 This occurs for products that have attribute_line_ids.
https://github.com/odoo/odoo/blob/f0a34badefd432e9c2ab36acaf018d20d0e342fe/addons/website_sale/data/product_snippet_template_data.xml#L17-L20
    <img width="1920" height="458" alt="image" src="https://github.com/user-attachments/assets/c3088149-b6c8-4cd7-8db4-129f0282a09d" />
- However, values['data'] already contains a clean display_name 
  (e.g., Corner Desk Right Sit) i.e. as expected.

**Solution:**
- Updated the QWeb template to use the correct field from the prepared data:
             `t-out="data.get('display_name') or product.display_name"`
- This ensures that the title displays a clean product name consistent with the
   main product page, without the internal reference

**opw-5122632**
