### PR TITLE
[IMP] hr_holidays: improve accrual rounding in Allocation Request

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -149,7 +149,8 @@ class HrLeaveAllocation(models.Model):
             return _(
                 '%(name)s (%(duration)s hour(s))',
                 name=self.holiday_status_id.name,
-                duration=self.number_of_days * self.employee_id._get_hours_per_day(self.date_from),
+                duration=float_round((self.number_of_days * self.employee_id._get_hours_per_day(self.date_from)),
+                precision_digits=2),
             )
         return _(
             '%(name)s (%(duration)s day(s))',


### PR DESCRIPTION
Before this commit:
- Allocation name displayed with high-precision float value.

After this commit:
- Allocation name displays float value rounded to two decimal places.

task-5116368
