### PR TITLE
[FIX] point_of_sale, web: apply dialog scss and hide "Ok" button in form dialogs

### DIFF
--- a/addons/l10n_es_edi_tbai_pos/static/src/app/components/popups/add_tbai_refund_reason_popup/add_tbai_refund_reason_popup.xml
+++ b/addons/l10n_es_edi_tbai_pos/static/src/app/components/popups/add_tbai_refund_reason_popup/add_tbai_refund_reason_popup.xml
@@ -15,7 +15,7 @@
                 </select>
             </div>
             <t t-set-slot="footer">
-                <button class="btn btn-primary o-default-button" t-on-click="confirm">Ok</button>
+                <button class="btn btn-primary" t-on-click="confirm">Ok</button>
             </t>
         </Dialog>
     </t>

--- a/addons/l10n_es_edi_verifactu_pos/static/src/app/components/popups/add_verifactu_refund_reason_popup/add_verifactu_refund_reason_popup.xml
+++ b/addons/l10n_es_edi_verifactu_pos/static/src/app/components/popups/add_verifactu_refund_reason_popup/add_verifactu_refund_reason_popup.xml
@@ -16,7 +16,7 @@
                 </select>
             </div>
             <t t-set-slot="footer">
-                <button class="btn btn-primary o-default-button" t-on-click="confirm">Ok</button>
+                <button class="btn btn-primary" t-on-click="confirm">Ok</button>
             </t>
         </Dialog>
     </t>

--- a/addons/l10n_sa_pos/static/src/app/add_zatca_refund_reason_popup/add_zatca_refund_reason_popup.xml
+++ b/addons/l10n_sa_pos/static/src/app/add_zatca_refund_reason_popup/add_zatca_refund_reason_popup.xml
@@ -15,7 +15,7 @@
                 </select>
             </div>
             <t t-set-slot="footer">
-                <button class="btn btn-primary o-default-button" t-on-click="confirm">Ok</button>
+                <button class="btn btn-primary" t-on-click="confirm">Ok</button>
             </t>
         </Dialog>
     </t>

--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -167,7 +167,6 @@
             "web/static/src/scss/ui.scss",
 
             ('remove', 'web/static/src/core/errors/error_handlers.js'), # error handling in PoS is different from the webclient
-            ('remove', '/web/static/src/core/dialog/dialog.scss'),
             'web/static/src/core/currency.js',
             # barcode scanner
             'barcodes/static/src/barcode_service.js',

--- a/addons/point_of_sale/static/src/app/components/popups/number_popup/number_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/number_popup/number_popup.xml
@@ -13,10 +13,10 @@
             <Numpad buttons="props.buttons"/>
             <t t-set-slot="footer">
                 <div class="d-flex flex-grow-1 justify-content-center">
-                    <button t-att-disabled="!props.isValid(state.buffer)" class="btn btn-primary btn-lg lh-lg o-default-button me-2" tabindex="1" t-on-click="confirm">
+                    <button t-att-disabled="!props.isValid(state.buffer)" class="btn btn-primary btn-lg lh-lg me-2" tabindex="1" t-on-click="confirm">
                         <t t-esc="confirmButtonLabel"/>
                     </button>
-                    <button class="btn btn-secondary btn-lg lh-lg o-default-button" tabindex="1" t-on-click="cancel">
+                    <button class="btn btn-secondary btn-lg lh-lg" tabindex="1" t-on-click="cancel">
                         Discard
                     </button>
                 </div>

--- a/addons/point_of_sale/static/src/app/components/popups/optional_products_popup/optional_products_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/optional_products_popup/optional_products_popup.xml
@@ -66,8 +66,8 @@
 
             <t t-set-slot="footer">
                 <div class="d-flex flex-row gap-2 w-100">
-                    <button class="btn btn-primary btn-lg lh-lg w-50 o-default-button" t-on-click="confirm" t-att-disabled="buttonDisabled">Add</button>
-                    <button class="btn btn-secondary btn-lg lh-lg w-50 o-default-button" t-on-click="cancel">Discard</button>
+                    <button class="btn btn-primary btn-lg lh-lg w-50" t-on-click="confirm" t-att-disabled="buttonDisabled">Add</button>
+                    <button class="btn btn-secondary btn-lg lh-lg w-50" t-on-click="cancel">Discard</button>
                 </div>
             </t>
         </Dialog>

--- a/addons/point_of_sale/static/src/app/components/popups/product_configurator_popup/product_configurator_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/product_configurator_popup/product_configurator_popup.xml
@@ -178,12 +178,12 @@
             <t t-set-slot="footer">
                 <div class="d-flex flex-row gap-2 w-100">
                     <button
-                            class="btn btn-primary btn-lg lh-lg w-50 o-default-button"
+                            class="btn btn-primary btn-lg lh-lg w-50"
                             t-att-class="{'disabled': isArchivedCombination() or !this.isValidCombination()}"
                             t-on-click="confirm">
                             Add
                         </button>
-                    <button class="btn btn-secondary btn-lg lh-lg w-50 o-default-button" t-on-click="props.close">Discard</button>
+                    <button class="btn btn-secondary btn-lg lh-lg w-50" t-on-click="props.close">Discard</button>
                 </div>
             </t>
         </Dialog>

--- a/addons/point_of_sale/static/src/app/components/popups/text_input_popup/text_input_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/text_input_popup/text_input_popup.xml
@@ -13,8 +13,8 @@
             </t>
             <textarea t-att-rows="props.rows" class="form-control form-control-lg mx-auto" type="text" t-model="state.inputValue" t-ref="input" t-att-placeholder="props.placeholder" t-on-keydown="onKeydown" />
             <t t-set-slot="footer">
-                <button class="btn btn-primary btn-lg lh-lg o-default-button" t-on-click="confirm">Apply</button>
-                <button class="btn btn-secondary btn-lg lh-lg o-default-button" t-on-click="close">Discard</button>
+                <button class="btn btn-primary btn-lg lh-lg" t-on-click="confirm">Apply</button>
+                <button class="btn btn-secondary btn-lg lh-lg" t-on-click="close">Discard</button>
             </t>
         </Dialog>
     </t>

--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.xml
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.xml
@@ -63,7 +63,7 @@
                         title="Add a customer">
                     New 
                     </button>
-                    <button class="btn btn-secondary btn-lg lh-lg o-default-button flex-fill" t-on-click="() => this.clickPartner(this.props.partner)">Discard</button>
+                    <button class="btn btn-secondary btn-lg lh-lg flex-fill" t-on-click="() => this.clickPartner(this.props.partner)">Discard</button>
                 </div>
             </t>
         </Dialog>

--- a/addons/point_of_sale/static/tests/pos/tours/pos_combo_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/pos_combo_tour.js
@@ -24,8 +24,7 @@ registry.category("web_tour.tours").add("ProductComboPriceTaxIncludedTour", {
             Dialog.is("Attribute selection"),
             {
                 content: "dialog discard",
-                trigger:
-                    ".modal-footer .o-default-button:contains(/^Add$/) + .o-default-button:contains(/^Discard$/)",
+                trigger: ".modal-footer button:contains(/^Add$/) + button:contains(/^Discard$/)",
                 run: "click",
             },
             combo.select("Combo Product 5"),

--- a/addons/pos_event/static/src/app/components/popup/event_configurator_popup/event_configurator_popup.xml
+++ b/addons/pos_event/static/src/app/components/popup/event_configurator_popup/event_configurator_popup.xml
@@ -34,8 +34,8 @@
                 </t>
             </div>
             <t t-set-slot="footer">
-                <button class="btn btn-secondary o-default-button" t-on-click="cancel">Cancel</button>
-                <button class="btn btn-primary o-default-button" t-on-click="confirm">Confirm</button>
+                <button class="btn btn-secondary" t-on-click="cancel">Cancel</button>
+                <button class="btn btn-primary" t-on-click="confirm">Confirm</button>
             </t>
         </Dialog>
     </t>

--- a/addons/pos_event/static/src/app/components/popup/event_registration_popup/event_registration_popup.xml
+++ b/addons/pos_event/static/src/app/components/popup/event_registration_popup/event_registration_popup.xml
@@ -42,8 +42,8 @@
                 </t>
             </div>
             <t t-set-slot="footer">
-                <button class="btn btn-secondary o-default-button" t-on-click="close">Cancel</button>
-                <button class="btn btn-primary o-default-button" t-on-click="confirm">Confirm</button>
+                <button class="btn btn-secondary" t-on-click="close">Cancel</button>
+                <button class="btn btn-primary" t-on-click="confirm">Confirm</button>
             </t>
         </Dialog>
     </t>

--- a/addons/pos_event/static/src/app/components/popup/event_slot_selection_popup/event_slot_selection_popup.xml
+++ b/addons/pos_event/static/src/app/components/popup/event_slot_selection_popup/event_slot_selection_popup.xml
@@ -24,8 +24,8 @@
                 </div>
             </div>
             <t t-set-slot="footer">
-                <button class="btn btn-secondary o-default-button" t-on-click="cancel">Cancel</button>
-                <button class="btn btn-primary o-default-button" t-on-click="confirm">Confirm</button>
+                <button class="btn btn-secondary" t-on-click="cancel">Cancel</button>
+                <button class="btn btn-primary" t-on-click="confirm">Confirm</button>
             </t>
         </Dialog>
     </t>

--- a/addons/pos_loyalty/static/src/app/components/popups/manage_giftcard_popup/manage_giftcard_popup.xml
+++ b/addons/pos_loyalty/static/src/app/components/popups/manage_giftcard_popup/manage_giftcard_popup.xml
@@ -49,7 +49,7 @@
                     onChange.bind="onExpDateChange" />
             </div>
             <t t-set-slot="footer">
-                <button class="btn btn-primary o-default-button" t-on-click="addBalance" t-att-disabled="state.loading">
+                <button class="btn btn-primary" t-on-click="addBalance" t-att-disabled="state.loading">
                     <t t-if="state.lockGiftCardFields">
                         Add existing Gift Card
                     </t>

--- a/addons/pos_restaurant/static/src/app/components/popup/edit_order_name_popup/edit_order_name_popup.xml
+++ b/addons/pos_restaurant/static/src/app/components/popup/edit_order_name_popup/edit_order_name_popup.xml
@@ -22,7 +22,7 @@
                 <textarea t-att-rows="props.rows" class="h-100 flex-grow-1 form-control form-control-lg mx-auto" type="text" t-model="state.inputValue" t-ref="input" t-att-placeholder="props.placeholder" t-on-keydown="onKeydown" />
             </div>
         </xpath>
-        <xpath expr="//button[hasclass('o-default-button', 'btn-primary')]" position="attributes">
+        <xpath expr="//t[@t-set-slot='footer']/button[hasclass('btn-primary')]" position="attributes">
             <attribute name="t-attf-class">{{state.inputValue ? '' : 'disabled'}}</attribute>
         </xpath>
     </t>

--- a/addons/web/static/src/core/dialog/dialog.scss
+++ b/addons/web/static/src/core/dialog/dialog.scss
@@ -14,8 +14,18 @@
             margin: 0; // Reset boostrap.
         }
 
-        button.o-default-button:not(:only-child) {
-            display: none;
+        // hide default buttons if there are non-default elements
+        // such as buttons added by the form dialog
+        &:has(> button.o-default-button):has(> :not(.o-default-button)) {
+            button.o-default-button {
+                display: none;
+            }
+        }
+        // in case the buttons were moved inside a div
+        *:has(> button.o-default-button):has(:not(.o-default-button)) {
+            button.o-default-button {
+                display: none;
+            }
         }
         
         @include media-breakpoint-down(md) {


### PR DESCRIPTION
When dialogs were added to POS in [1] the dialog scss file was explicitly excluded for unspecified reasons.

However since [2] there is some pure scss style to hide the default "Ok" button when there are any other buttons on the dialog. Which was previously done in javascript. As a result "Ok" always appears in POS form dialogs.

After testing there does not seem to be any reason not to include the dialog scss styles so they're added back.
However as all the "popup" dialogs in point_of_sale use "default buttons", and there are sometimes multiple "default buttons" we do want to support multiple default buttons. As currently the logic assumes only one exists.

task-5103532

[1]: https://github.com/odoo/odoo/commit/0957ab329999852e61facf8591c7982424645e5d
[2]: https://github.com/odoo/odoo/commit/1cf179bbf1c49a6d69588911c2a3d98dbeadd3d9
