### PR TITLE
[FIX] point_of_sale: create missing pos locations

### DIFF
--- a/addons/point_of_sale/models/stock_warehouse.py
+++ b/addons/point_of_sale/models/stock_warehouse.py
@@ -46,5 +46,6 @@ class Warehouse(models.Model):
     def _create_missing_pos_picking_types(self):
         warehouses = self.env['stock.warehouse'].search([('pos_type_id', '=', False)])
         for warehouse in warehouses:
+            warehouse._create_missing_locations({})
             new_vals = warehouse._create_or_update_sequences_and_picking_types()
             warehouse.write(new_vals)


### PR DESCRIPTION
DBs are failing [here](https://github.com/odoo/odoo/blob/9ace6d7da6ae826ccace15fc21a262463c3e3886/addons/stock/models/stock_warehouse.py#L387) when `values["default_location_src_id"]` or `values["default_location_dest_id"]` are `False`. This happens when some `stock.warehouse` have null `stock.picking.type` references so the picking types have to be created, but the `stock.warehouse` fields use to compute `stock_picking_type` `default_location_dest_id` and `default_location_src_id` are null. To avoid this, we make sure the missing location of all `stock.warehouse` are created before creating the `stock.picking.type`.

The problem happens from 17.3 and later on, because the concerned fields are required from this version.
`stock.picking.type.default_location_dest_id` [definition](https://github.com/odoo/odoo/blob/e1fb54cb3d5db9c906946fa11ff49c1ca86d3722/addons/stock/models/stock_picking.py#L37)

### To reproduce:
1. install odoo { 17.3 - ... } with stock,mrp
2. nullify the following fields in some warehouse:
&emsp;Stock After Manufacturing Location
&emsp;Picking Before Manufacturing Location
&emsp;Stock After Manufacturing Operation Type
&emsp;Picking Before Manufacturing Operation Type
To check the fields:
&emsp;Developper mode
&emsp;Settings > Warehouse > Multi-Step Routes: True
&emsp;Warehouse > SomeWarehouse > Technical Information
To make them null:
&emsp;Rules: Archived + Operation Type contains 'Pick Components' > Delete
&emsp;Operation Types: Archived > Delete 'Pick Components' & 'Store Finished Products'
&emsp;Locations: Archived > Delete 'WH/Pre-Production' & 'WH/Post-Production'
(or `update stock_warehouse set pbm_type_id=null,pbm_loc_id=null,sam_type_id=null,sam_loc_id=null` with SQL)
3. install point_of_sale

Linked pr: https://github.com/odoo/upgrade/pull/8360
Linked tbg: [tbg](https://upgrade.odoo.com/odoo/tbg/877/upgrade.request/3051298/tbg/877/3051298/upgrade.request/3051298/tbg/877)
```
vval_3051298> select id,pbm_type_id,pbm_loc_id,sam_type_id,sam_loc_id from stock_warehouse order by id
+----+-------------+------------+-------------+------------+
| id | pbm_type_id | pbm_loc_id | sam_type_id | sam_loc_id |
|----+-------------+------------+-------------+------------|
| 1  | 36          | 64         | 37          | 65         |
| 2  | 39          | 66         | 40          | 67         |
| 4  | 42          | 68         | 43          | 69         |
| 5  | 45          | 70         | 46          | 71         |
| 6  | <null>      | <null>     | <null>      | <null>     |
+----+-------------+------------+-------------+------------+
```

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
