### PR TITLE
[FIX] pos_self_order: make cancel button conditional

### DIFF
--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -783,7 +783,6 @@ export class SelfOrder extends Reactive {
                 cleanOrders = true;
             } else if (error?.data?.name === "odoo.exceptions.UserError") {
                 message = error.data.message;
-                this.resetTableIdentifier();
             }
         } else if (error instanceof ConnectionLostError) {
             message = _t("Connection lost, please try again later");

--- a/addons/pos_self_order/static/tests/tours/utils/cart_page_util.js
+++ b/addons/pos_self_order/static/tests/tours/utils/cart_page_util.js
@@ -145,3 +145,9 @@ export function removeLine(productName) {
         run: "click",
     };
 }
+
+export function isShown() {
+    return {
+        trigger: `.order-cart-content`,
+    };
+}


### PR DESCRIPTION
Currently, it is possible to cancel orders that have been sent to the kitchen display. However when doing so, the kitchen displayd does not receive any information about the cancellation.

Steps to reproduce:
-------------------
- Modify restaurant and enable self ordering
- Open self an place an order (not paid but sent to kitchen)
- Go back to "My orders" and cancel it
> Order is cancelled in backend but not in the kitchen display

Why the fix:
------------
When an order is sent to the kitchen the only way to cancel it should be by going to the register. Therefore now, if an order is present on the kitchen display we will not show the cancel button.

opw-5030223

Enterprise: https://github.com/odoo/enterprise/pull/95770