### PR TITLE
[FIX] website_hr_recruitment: fix traceback for portal users on job page

### DIFF
--- a/addons/website_hr_recruitment/controllers/main.py
+++ b/addons/website_hr_recruitment/controllers/main.py
@@ -111,7 +111,7 @@ class WebsiteHrRecruitment(WebsiteForm):
 
         env = request.env(context=dict(request.env.context, show_address=True, no_tag_br=True))
         website = request.website
-        department = env['hr.department'].browse(to_int(department_id)).exists()
+        department = env['hr.department'].browse(to_int(department_id)).exists().sudo()
         country = env['res.country'].browse(to_int(country_id)).exists()
         office = env['res.partner'].browse(to_int(office_id)).exists()
         contract_type = env['hr.contract.type'].browse(to_int(contract_type_id)).exists().sudo()


### PR DESCRIPTION
**Steps to reproduce:**
1. Install `website_hr_recruitment`
2. Open the job website page and, through editor add a filter for department
3. Switch to a portal user and change the department filter

**Issue:**
- The controller passes department_id to the template, but unlike before this commit https://github.com/odoo/odoo/commit/0ab6e84c54f134c8744d8f94108a715e989b2815,
where the code used sudo() to sort departents
https://github.com/odoo/odoo/blob/6159c6527cfa38ea0c92e6f3fa6025ee534a1acb/addons/website_hr_recruitment/controllers/main.py#L81
it now just passes the department_id without actually returning a full record with accessible fields.
In the template, the filter rendering uses selected_filter.name, which triggers an AccessError for portal users.

**Solution:**
- Apply `sudo()` when accessing `hr.department` to avoid access errors
for portal users.

opw-5103910