### PR TITLE
[FIX] l10n_latam_check: Fix when transfer third party check

### DIFF
--- a/addons/l10n_latam_check/models/account_payment.py
+++ b/addons/l10n_latam_check/models/account_payment.py
@@ -342,7 +342,7 @@ class AccountPayment(models.Model):
         for rec in third_party_checks:
             dest_payment_method_code = 'in_third_party_checks' if rec.payment_type == 'outbound' else 'out_third_party_checks'
             dest_payment_method = rec.destination_journal_id.inbound_payment_method_line_ids.filtered(
-                lambda x: x.code == dest_payment_method_code)
+                lambda x: x.code == dest_payment_method_code)[:1]
             if dest_payment_method:
                 super(AccountPayment, rec.with_context(
                     default_payment_method_line_id=dest_payment_method.id,

--- a/addons/l10n_latam_check/wizards/l10n_latam_payment_mass_transfer.py
+++ b/addons/l10n_latam_check/wizards/l10n_latam_payment_mass_transfer.py
@@ -66,7 +66,7 @@ class L10nLatamPaymentMassTransfer(models.TransientModel):
         payment_vals_list = []
 
         pay_method_line = self.journal_id._get_available_payment_method_lines('outbound').filtered(
-            lambda x: x.code == 'out_third_party_checks')
+            lambda x: x.code == 'out_third_party_checks')[:1]
 
         for check in checks:
             payment_vals_list.append({


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

The same third-party check payment method (e.g., in_third_party_checks) can currently be assigned multiple times to the same journal, either as inbound or outbound.
This misconfiguration leads to unexpected behavior and runtime errors when using the payment transfer wizard.

It is possible to assign a third-party check payment method more than once to a journal.

When transferring a third-party check via the wizard (l10n_latam_payment_mass_transfer), the system may raise:

pgsql
Copy
Edit
ValueError: Expected singleton
because more than one payment method line is returned.


**Current behavior before PR:**
Odoo allows assigning the same third-party check payment method more than once to the same journal.

During a mass transfer of third-party checks, the system fails when determining the destination payment method, as multiple candidates are returned.

This results in runtime errors (Expected singleton) and prevents the transfer from completing.
Desired behavior after PR is merged:


**Desired behavior after PR is merged:**


Ensure that the transfer wizard can always determine a unique destination payment method for third-party checks.

When transferring between third-party check journals, the system will:

Explicitly set the paired transfer payment method as in_third_party_checks or out_third_party_checks, depending on the direction.

Set the l10n_latam_check_id field on the paired transfer, ensuring compatibility with l10n_latam_check_operation_ids and related warnings/constraints.

This guarantees consistent and error-free behavior when creating paired internal transfer payments for third-party checks.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
