### PR TITLE
[FIX] html_editor: change tag when modifying phrasing content

### DIFF
--- a/addons/html_editor/static/src/core/base_container_plugin.js
+++ b/addons/html_editor/static/src/core/base_container_plugin.js
@@ -142,6 +142,9 @@ export class BaseContainerPlugin extends Plugin {
     }
 
     normalizeDivBaseContainers(element = this.editable) {
+        if (this.config.baseContainer && this.config.baseContainer !== "DIV") {
+            return;
+        }
         const newBaseContainers = [];
         const divSelector = `div:not(.${BASE_CONTAINER_CLASS})`;
         const targets = [...element.querySelectorAll(divSelector)];

--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -29,6 +29,7 @@ import {
     listElementSelector,
     paragraphRelatedElementsSelector,
     isEditorTab,
+    isPhrasingContent,
 } from "../utils/dom_info";
 import {
     childNodes,
@@ -572,6 +573,7 @@ export class DomPlugin extends Plugin {
         for (const block of deepestTargetedBlocks) {
             if (
                 isParagraphRelatedElement(block) ||
+                isPhrasingContent(block) ||
                 block.nodeName === "PRE" || // TODO remove: PRE should be a paragraphRelatedElement
                 isListItemElement(block)
             ) {

--- a/addons/html_editor/static/tests/tags.test.js
+++ b/addons/html_editor/static/tests/tags.test.js
@@ -4,6 +4,7 @@ import { setupEditor, testEditor } from "./_helpers/editor";
 import { getContent, setSelection } from "./_helpers/selection";
 import { insertText, tripleClick, undo } from "./_helpers/user_actions";
 import { animationFrame, tick } from "@odoo/hoot-mock";
+import { defineStyle } from "@web/../tests/web_test_helpers";
 
 function setTag(tagName) {
     return (editor) => editor.shared.dom.setTag({ tagName });
@@ -50,6 +51,32 @@ describe("to paragraph", () => {
             contentBefore: `<div>[ab]</div>`,
             stepFunction: setTag("p"),
             contentAfter: "<p>[ab]</p>",
+        });
+    });
+
+    test("should turn a block <small> element into a paragraph", async () => {
+        defineStyle("small { display: block; }");
+        await testEditor({
+            contentBefore: "<small>[abc]</small>",
+            stepFunction: setTag("p"),
+            contentAfter: "<p>[abc]</p>",
+        });
+    });
+
+    test("shouldn't turn a normal <small> element into a paragraph", async () => {
+        await testEditor({
+            contentBefore: "<small>[abc]</small>",
+            stepFunction: setTag("p"),
+            contentAfter: "<p><small>[]abc</small></p>",
+        });
+    });
+
+    test("shouldn't turn a div into a paragraph (if div isn't eligible for a baseContainer)", async () => {
+        await testEditor({
+            contentBefore: "<div><small>[abc]</small></div>",
+            stepFunction: setTag("p"),
+            contentAfter: "<div><p><small>[abc]</small></p></div>",
+            config: { baseContainer: "P" },
         });
     });
 
@@ -165,6 +192,32 @@ describe("to heading 1", () => {
             contentBefore: "<p>a[b</p><h1>cd</h1><h2>e]f</h2>",
             stepFunction: setTag("h1"),
             contentAfter: "<h1>a[b</h1><h1>cd</h1><h1>e]f</h1>",
+        });
+    });
+
+    test("should turn a block <small> element into a heading", async () => {
+        defineStyle("small { display: block; }");
+        await testEditor({
+            contentBefore: "<small>[abc]</small>",
+            stepFunction: setTag("h1"),
+            contentAfter: "<h1>[abc]</h1>",
+        });
+    });
+
+    test("shouldn't turn a normal <small> element into a heading", async () => {
+        await testEditor({
+            contentBefore: "<small>[abc]</small>",
+            stepFunction: setTag("h1"),
+            contentAfter: "<h1><small>[]abc</small></h1>",
+        });
+    });
+
+    test("shouldn't turn a div into a heading (if div isn't eligible for a baseContainer)", async () => {
+        await testEditor({
+            contentBefore: "<div><small>[abc]</small></div>",
+            stepFunction: setTag("h1"),
+            contentAfter: "<div><h1><small>[abc]</small></h1></div>",
+            config: { baseContainer: "P" },
         });
     });
 


### PR DESCRIPTION
Before this commit we would insert a block inside of a phrasing content
if it's displayed as a block and we change its font style.
For example, if we tried to modify text inside of a `<small>` that has
`display: block` style, it would insert a new block inside of it.
Steps to see the issue:
- Have an open editor with `<small>Text</small>` content, that has
`display: block` style
- Select "Text" and change the font style to paragraph

=> It will be `<small><p>Text</p></small>` which is not valid HTML, and
it will be parsed by a browser as `<small></small><p>Text</p>`, which is
not the expected behavior.

task-5123274