### PR TITLE
[IMP] tests: Use a savepoint for `assertRaisesRegex`

### DIFF
--- a/addons/account/tests/test_account_move_entry.py
+++ b/addons/account/tests/test_account_move_entry.py
@@ -1105,17 +1105,17 @@ class TestAccountMove(AccountTestInvoicingCommon):
         })
         honest_move.action_post()
 
-        with self.assertRaisesRegex(UserError, 'not balanced'), contextlib.closing(self.env.cr.savepoint()):
+        with self.assertRaisesRegex(UserError, 'not balanced'):
             self.env['account.move'].create({'line_ids': [Command.set(honest_move.line_ids[0].ids)]})
 
-        with self.assertRaisesRegex(UserError, 'not balanced'), contextlib.closing(self.env.cr.savepoint()):
+        with self.assertRaisesRegex(UserError, 'not balanced'):
             self.env['account.move'].create({'line_ids': [Command.link(honest_move.line_ids[0].id)]})
 
         stealer_move = self.env['account.move'].create({})
-        with self.assertRaisesRegex(UserError, 'not balanced'), contextlib.closing(self.env.cr.savepoint()):
+        with self.assertRaisesRegex(UserError, 'not balanced'):
             stealer_move.write({'line_ids': [Command.set(honest_move.line_ids[0].ids)]})
 
-        with self.assertRaisesRegex(UserError, 'not balanced'), contextlib.closing(self.env.cr.savepoint()):
+        with self.assertRaisesRegex(UserError, 'not balanced'):
             stealer_move.write({'line_ids': [Command.link(honest_move.line_ids[0].id)]})
 
     def test_validate_move_wizard_with_auto_post_entry(self):

--- a/addons/l10n_it_edi/tests/test_edi_import.py
+++ b/addons/l10n_it_edi/tests/test_edi_import.py
@@ -198,6 +198,8 @@ class TestItEdiImport(TestItEdi):
             self.company.l10n_it_edi_purchase_journal_id = preferred_journal
 
         preferred_journal.default_account_id = self.company_data_2['default_journal_purchase'].default_account_id.id
+        # Retry setting the company's default purchase journal: no error since default_account_id is set
+        self.company.l10n_it_edi_purchase_journal_id = preferred_journal
 
         with tools.file_open(f'{self.module}/tests/import_xmls/{filename}', mode='rb') as fd:
             fake_bill_content = fd.read()

--- a/addons/l10n_ro_edi/tests/test_xml_ubl_ro.py
+++ b/addons/l10n_ro_edi/tests/test_xml_ubl_ro.py
@@ -262,12 +262,10 @@ class TestUBLRO(TestUBLCommon):
     def test_export_constraints(self):
         self.company_data['company'].company_registry = False
         for required_field in ('city', 'street', 'state_id', 'vat'):
-            prev_val = self.company_data["company"][required_field]
-            self.company_data["company"][required_field] = False
-            invoice = self.create_move("out_invoice", send=False)
             with self.assertRaisesRegex(UserError, "required"):
+                self.company_data["company"][required_field] = False
+                invoice = self.create_move("out_invoice", send=False)
                 invoice._generate_and_send(allow_fallback_pdf=False, template_id=self.move_template.id)
-            self.company_data["company"][required_field] = prev_val
 
         self.company_data["company"].city = "Bucharest"
         invoice = self.create_move("out_invoice", send=False)

--- a/addons/marketing_card/tests/test_campaign.py
+++ b/addons/marketing_card/tests/test_campaign.py
@@ -421,8 +421,6 @@ class TestMarketingCardSecurity(MarketingCardCommon):
 
         with self.assertRaisesRegex(exceptions.AccessError, 'You are not allowed to modify'):
             campaign.body_html = arbitrary_qweb
-            # Flush to simulate the end of the transaction and trigger all recomputes
-            self.env.cr.flush()
 
         # Ensure that the value is well not written in db, nor on the current campaign, nor on the related.
         self.assertTrue(arbitrary_qweb not in campaign.body_html)

--- a/addons/sale_stock/tests/test_sale_stock.py
+++ b/addons/sale_stock/tests/test_sale_stock.py
@@ -2026,18 +2026,18 @@ class TestSaleStock(TestSaleStockCommon, ValuationReconciliationTestCommon):
         })
         # Since you dont have any warehouse for your company  you should raise a RedirectWarning
         error_message = "Please create a warehouse for company Company 2."
-        with self.assertRaisesRegex(RedirectWarning, error_message), self.env.cr.savepoint():
+        with self.assertRaisesRegex(RedirectWarning, error_message):
             so.with_company(new_company).action_confirm()
         warehouse.active = True
         # Since you have a warehouse which is not linked to the SO you should raise a UserError
         error_message = "You must set a warehouse on your sale order to proceed."
-        with self.assertRaisesRegex(UserError, error_message), self.env.cr.savepoint():
+        with self.assertRaisesRegex(UserError, error_message):
             so.with_company(new_company).action_confirm()
         # check the flow with 2 available warehouses for that company
         self.env['stock.warehouse'].create({'name': 'Warehouse 2', 'code': 'WH2', 'company_id': new_company.id})
         # Since you have a warehouse which is not linked to the SO you should raise a UserError
         error_message = "You must set a warehouse on your sale order to proceed."
-        with self.assertRaisesRegex(UserError, error_message), self.env.cr.savepoint():
+        with self.assertRaisesRegex(UserError, error_message):
             so.with_company(new_company).action_confirm()
 
     def test_custom_delivery_route_new_sale_line(self):

--- a/odoo/addons/test_orm/tests/test_fields.py
+++ b/odoo/addons/test_orm/tests/test_fields.py
@@ -3678,7 +3678,8 @@ class TestX2many(TransactionExpressionCase):
             # 1.4 Command.LINK
             # Case: a public/portal user changing the `partner_id` of an admin,
             # to change the email address of the user and ask for a reset password.
-            with self.assertRaisesRegex(AccessError, "not allowed to modify 'User'"):
+            # We get a read error since Command.link need to read the corecord first, see One2many.write_real
+            with self.assertRaisesRegex(AccessError, "doesn't have 'read' access to"):
                 my_partner.write({
                     'user_ids': [Command.link(admin_user.id)],
                 })

--- a/odoo/addons/test_testing_utilities/tests/test_methods.py
+++ b/odoo/addons/test_testing_utilities/tests/test_methods.py
@@ -120,6 +120,13 @@ First differing element 0:
         self.env.cr.execute("SHOW test_testing_utilities.a_flag")
         self.assertEqual(self.env.cr.fetchone(), ('',))
 
+        with self.assertRaisesRegex(CustomError, 'Blabla'):
+            self.env.cr.execute("SET LOCAL test_testing_utilities.a_flag = 'yes'")
+            raise CustomError('Blabla')
+
+        self.env.cr.execute("SHOW test_testing_utilities.a_flag")
+        self.assertEqual(self.env.cr.fetchone(), ('',))
+
     def test_assertRaises_error_at_setup(self):
         """Checks that an exception raised during the *setup* of assertRaises
         bubbles up correctly.

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -518,20 +518,19 @@ class BaseCase(case.TestCase):
                 raise Exception('Wrong request stack cleanup.')
 
     @contextmanager
-    def _assertRaises(self, exception, *, msg=None):
+    def _raisesContext(self, method, expected_exception, *args, **kwargs):
         """ Context manager that clears the environment upon failure. """
         with ExitStack() as init:
             if self.env:
                 init.enter_context(self.env.cr.savepoint())
-                if issubclass(exception, AccessError):
-                    # The savepoint() above calls flush(), which leaves the
-                    # record cache with lots of data.  This can prevent
-                    # access errors to be detected. In order to avoid this
-                    # issue, we clear the cache before proceeding.
+                if issubclass(expected_exception, AccessError):
+                    # When checking for an `AccessError`, the cache is cleared
+                    # before executing the code. This avoids cache pollution issues and
+                    # ensures that access are re-evaluated correctly.
                     self.env.cr.clear()
 
             with ExitStack() as inner:
-                cm = inner.enter_context(super().assertRaises(exception, msg=msg))
+                cm = inner.enter_context(method(expected_exception, *args, **kwargs))
                 # *moves* the cleanups from init to inner, this ensures the
                 # savepoint gets rolled back when `yield` raises `exception`,
                 # but still allows the initialisation to be protected *and* not
@@ -540,12 +539,19 @@ class BaseCase(case.TestCase):
 
                 yield cm
 
-    def assertRaises(self, exception, func=None, *args, **kwargs):
-        if func:
-            with self._assertRaises(exception):
-                func(*args, **kwargs)
-        else:
-            return self._assertRaises(exception, **kwargs)
+    def assertRaises(self, expected_exception, callable=None, *args, **kwargs):
+        if callable:
+            with self._raisesContext(super().assertRaises, expected_exception):
+                callable(*args, **kwargs)
+            return None
+        return self._raisesContext(super().assertRaises, expected_exception, *args, **kwargs)
+
+    def assertRaisesRegex(self, expected_exception, expected_regex, callable=None, *args, **kwargs):
+        if callable:
+            with self._raisesContext(super().assertRaisesRegex, expected_exception, expected_regex):
+                callable(*args, **kwargs)
+            return None
+        return self._raisesContext(super().assertRaisesRegex, expected_exception, expected_regex, *args, **kwargs)
 
     def _patchExecute(self, actual_queries, flush=True):
         Cursor_execute = Cursor.execute

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -485,7 +485,7 @@ class BaseCase(case.TestCase):
         old_uid = self.uid
         old_env = self.env
         try:
-            user = self.env['res.users'].sudo().search([('login', '=', login)])
+            user = self.env['res.users'].sudo().search([('login', '=', login)], order='login')
             assert user, "Login %s not found" % login
             # switch user
             self.uid = user.id
@@ -2543,7 +2543,10 @@ def users(*logins):
                 Users = self.env['res.users'].with_context(active_test=False)
                 user_id = {
                     user.login: user.id
-                    for user in Users.search([('login', 'in', list(logins))])
+                    for user in Users.search_fetch(
+                        [('login', 'in', list(logins))],
+                        ['login'], order='login',
+                    )
                 }
                 for login in logins:
                     with self.subTest(login=login):


### PR DESCRIPTION
In the same way `assertRaises` is overridden to use a savepoint, this commit applies the same logic to `assertRaisesRegex`.

This change wraps the call in a savepoint. This flushes any pending writes that might generate SQL constraint exceptions and rolls back the transaction if the expected exception is caught, ensuring test isolation.



_This is a nice to have change for future deferred api.constrains_

Other minor change:

##### [IMP] tests: Avoid and simplify user query.

Use `search_fetch()` to avoid an extra database query each time the `@users` decorator is used.

Also, force the order to `'login'` when searching on users. This avoids a `LEFT JOIN` on `partner`, which simplifies the query and slightly improves performance.


https://github.com/odoo/enterprise/pull/95863