### PR TITLE
[FIX] hr_org_chart: fix recursion error in _get_subordinates

### DIFF
--- a/addons/hr_org_chart/tests/test_employee.py
+++ b/addons/hr_org_chart/tests/test_employee.py
@@ -10,10 +10,12 @@ class TestEmployee(TestHrCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.employee_georges, cls.employee_paul, cls.employee_pierre = cls.env['hr.employee'].with_user(cls.res_users_hr_officer).create([
+        cls.employee_georges, cls.employee_paul, cls.employee_pierre, cls.employee_john, cls.employee_alice = cls.env['hr.employee'].with_user(cls.res_users_hr_officer).create([
             {'name': 'Georges'},
             {'name': 'Paul'},
             {'name': 'Pierre'},
+            {'name': 'John'},
+            {'name': 'Alice'},
         ])
 
     def test_is_subordinate(self):
@@ -106,4 +108,69 @@ class TestEmployee(TestHrCommon):
         self.assertIn(
             {'id': self.employee_georges.id, 'parent_id': (self.employee_paul.id, self.employee_paul.name)},
             result
+        )
+
+    def test_compute_subordinates(self):
+        # hierarchy
+        #
+        #   georges
+        #      |
+        #     paul
+        #    /    \
+        # pierre   \
+        #         john
+        #            \
+        #           alice
+
+        self.employee_paul.parent_id = self.employee_georges
+        self.employee_pierre.parent_id = self.employee_paul
+        self.employee_john.parent_id = self.employee_paul
+        self.employee_alice.parent_id = self.employee_john
+
+        self.assertEqual(
+            self.employee_georges.subordinate_ids,
+            self.employee_paul
+            | self.employee_pierre
+            | self.employee_john
+            | self.employee_alice,
+        )
+        self.assertEqual(
+            self.employee_paul.subordinate_ids,
+            self.employee_pierre | self.employee_john | self.employee_alice,
+        )
+        self.assertEqual(self.employee_pierre.subordinate_ids, self.env["hr.employee"])
+        self.assertEqual(self.employee_john.subordinate_ids, self.employee_alice)
+        self.assertEqual(self.employee_alice.subordinate_ids, self.env["hr.employee"])
+
+        # create a cycle between Alice and Georges
+        self.employee_georges.parent_id = self.employee_alice
+
+        self.assertEqual(
+            self.employee_georges.subordinate_ids,
+            self.employee_paul
+            | self.employee_pierre
+            | self.employee_john
+            | self.employee_alice,
+        )
+        self.assertEqual(
+            self.employee_paul.subordinate_ids,
+            self.employee_georges
+            | self.employee_pierre
+            | self.employee_john
+            | self.employee_alice,
+        )
+        self.assertEqual(self.employee_pierre.subordinate_ids, self.env["hr.employee"])
+        self.assertEqual(
+            self.employee_john.subordinate_ids,
+            self.employee_paul
+            | self.employee_pierre
+            | self.employee_georges
+            | self.employee_alice,
+        )
+        self.assertEqual(
+            self.employee_alice.subordinate_ids,
+            self.employee_paul
+            | self.employee_pierre
+            | self.employee_john
+            | self.employee_georges,
         )


### PR DESCRIPTION
This commit fixes a recursion error that occurs in `_get_subordinates`. An iterative approach is used instead of the current recursive implementation.

task-5118697

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
