### PR TITLE
[IMP] orm: improve prefetching

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2947,7 +2947,7 @@ class AccountMove(models.Model):
                 not reference_date
                 or not self.invoice_date
                 or (
-                    (existing_discount_date := next(iter(payment_terms)).discount_date)
+                    (existing_discount_date := payment_terms[0].discount_date)
                     and
                     reference_date <= existing_discount_date
                 )

--- a/addons/calendar/models/mail_activity_mixin.py
+++ b/addons/calendar/models/mail_activity_mixin.py
@@ -16,5 +16,4 @@ class MailActivityMixin(models.AbstractModel):
         It evaluates to false if there is no such event."""
         for record in self:
             activities = record.activity_ids
-            activity = next(iter(activities), activities)
-            record.activity_calendar_event_id = activity.calendar_event_id
+            record.activity_calendar_event_id = activities[:1].calendar_event_id

--- a/addons/hr_recruitment_survey/models/survey_survey.py
+++ b/addons/hr_recruitment_survey/models/survey_survey.py
@@ -15,7 +15,8 @@ class SurveySurvey(models.Model):
         super()._compute_allowed_survey_types()
         if self.env.user.has_group('hr_recruitment.group_hr_recruitment_interviewer') or \
                 self.env.user.has_group('survey.group_survey_user'):
-            self.allowed_survey_types = (self.allowed_survey_types or []) + ['recruitment']
+            for survey in self:
+                survey.allowed_survey_types = (survey.allowed_survey_types or []) + ['recruitment']
 
     def get_formview_id(self, access_uid=None):
         if self.survey_type == 'recruitment':

--- a/addons/html_editor/models/ir_ui_view.py
+++ b/addons/html_editor/models/ir_ui_view.py
@@ -63,7 +63,7 @@ class IrUiView(models.Model):
                 views_to_return += self._views_get(called_view, get_children=get_children, bundles=bundles, visited=visited + views_to_return.ids)
 
         if not get_children:
-            return views_to_return
+            return views_to_return.with_prefetch()  # simplify prefetching to avoid memory error
 
         extensions = self._view_get_inherited_children(view)
 
@@ -74,7 +74,7 @@ class IrUiView(models.Model):
                 for ext_view in self._views_get(extension, get_children=extension.active, root=False, visited=visited + views_to_return.ids):
                     if ext_view not in views_to_return:
                         views_to_return += ext_view
-        return views_to_return
+        return views_to_return.with_prefetch()  # simplify prefetching to avoid memory error
 
     @api.model
     def get_related_views(self, key, bundles=False):

--- a/addons/mail/models/mail_activity_mixin.py
+++ b/addons/mail/models/mail_activity_mixin.py
@@ -210,7 +210,7 @@ class MailActivityMixin(models.AbstractModel):
     def _compute_activity_date_deadline(self):
         for record in self:
             activities = record.activity_ids
-            record.activity_date_deadline = next(iter(activities), activities).date_deadline
+            record.activity_date_deadline = activities[:1].date_deadline
 
     def _search_activity_date_deadline(self, operator, operand):
         if operator == 'in' and False in operand:

--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -2146,12 +2146,13 @@ class TestBoM(TestMrpCommon):
         # simulate resequence from UI (reverse C->D and C->E)
         # (see odoo/addons/web/controllers/main.py:1352)
         boms.invalidate_recordset()
-        for i, record in enumerate(boms[0] | boms[1] | boms[3] | boms[2] | boms[4] | boms[5]):
+        # hack warning: the sequence check depends on the prefetching order!
+        for i, record in enumerate(boms.browse(boms.ids[i] for i in [0, 1, 3, 2, 4, 5])):
             record.write({'sequence': i})
 
         # simulate a second resequencing (set C->A before C->D)
         with self.assertRaises(exceptions.ValidationError):
-            for i, record in enumerate(boms[0] | boms[1] | boms[5] | boms[3] | boms[2] | boms[4]):
+            for i, record in enumerate(boms.browse(boms.ids[i] for i in [0, 1, 5, 3, 2, 4])):
                 record.write({'sequence': i})
 
     def test_cycle_on_legit_apply_variants(self):

--- a/addons/payment_paypal/utils.py
+++ b/addons/payment_paypal/utils.py
@@ -39,10 +39,10 @@ def format_shipping_address(tx_sudo):
     address_vals = {}
 
     if 'sale_order_ids' in tx_sudo and tx_sudo.sale_order_ids:
-        order = next(iter(tx_sudo.sale_order_ids))
+        order = tx_sudo.sale_order_ids[0]
         partner_shipping = order.partner_shipping_id
     elif 'invoice_ids' in tx_sudo and tx_sudo.invoice_ids:
-        invoice = next(iter(tx_sudo.invoice_ids))
+        invoice = tx_sudo.invoice_ids[0]
         partner_shipping = invoice.partner_shipping_id
     else:
         return address_vals

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1276,7 +1276,7 @@ class SaleOrder(models.Model):
         pending_email_orders = self.search([('pending_email_template_id', '!=', False)])
         self.env['ir.cron']._commit_progress(remaining=len(pending_email_orders))
         for order in pending_email_orders:
-            order = order[0]  # Avoid pre-fetching after each cache invalidation due to committing.
+            order = order.with_prefetch()  # Avoid pre-fetching after each cache invalidation due to committing.
             order._send_order_notification_mail(
                 order.pending_email_template_id, allow_deferred_sending=False
             )  # Resume the email sending.

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -241,7 +241,7 @@ class TestSaleOrder(SaleCommon):
         })
         no_variant_product = no_variant_product_tmpl.product_variant_id
         ptals = no_variant_product_tmpl.valid_product_template_attribute_line_ids
-        ptav1 = next(iter(ptals.product_template_value_ids))
+        ptav1 = ptals.product_template_value_ids[0]
         product_with_desc = self.env['product.product'].create({
             'name': "Product with description",
             'description_sale': "Additional\ninfo.",

--- a/addons/test_mail/tests/test_mail_message.py
+++ b/addons/test_mail/tests/test_mail_message.py
@@ -163,11 +163,11 @@ class TestMessageValues(MailCommon):
         self.assertEqual(m2_records, record3)
         self.assertEqual(m2_records._prefetch_ids, tuple(record3.ids))
         # methods called on individual message from a batch: prefetch from batch is kept
-        records_by_model_name = next(iter(messages))._records_by_model_name()
+        records_by_model_name = messages[0]._records_by_model_name()
         test_simple_records = records_by_model_name["mail.test.simple"]
         self.assertEqual(test_simple_records, record1)
         self.assertEqual(test_simple_records._prefetch_ids, tuple((record1 + record2).ids))
-        record_by_message = next(iter(messages))._record_by_message()
+        record_by_message = messages[0]._record_by_message()
         m0_records = record_by_message[messages[0]]
         self.assertEqual(m0_records, record1)
         self.assertEqual(m0_records._prefetch_ids, tuple((record1 + record2).ids))

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -992,7 +992,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     @users('employee')
     @warmup
     def test_message_get_suggested_recipients(self):
-        record = self.test_records_recipients[0].with_env(self.env)
+        record = self.test_records_recipients[0].with_env(self.env).with_prefetch()
         with self.assertQueryCount(employee=22):  # tm: 16
             recipients = record._message_get_suggested_recipients(no_create=False)
         new_partner = self.env['res.partner'].search([('email_normalized', '=', 'only.email.1@test.example.com')])

--- a/addons/test_website_modules/tests/test_performance.py
+++ b/addons/test_website_modules/tests/test_performance.py
@@ -374,9 +374,9 @@ class TestWebsiteAllPerformanceShop(TestWebsiteAllPerformance):
         # To increase the query count you must ask the permission to al
         query_count, queries = self._get_queries_shop()
 
-        query_count += 3
+        query_count += 2
         queries['account_tax'] += 1
-        queries['account_account_tag'] += 2
+        queries['account_account_tag'] += 1
 
         if self._has_demo_data():
             query_count += 2

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -448,7 +448,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
 
         pager = website.pager(url=url, total=product_count, page=page, step=ppg, scope=5, url_args=post)
         offset = pager['offset']
-        products = search_product[offset:offset + ppg]
+        products = search_product[offset:offset + ppg].with_prefetch()
         products.fetch()
 
         # map each product to its variant, and prefetch the variants

--- a/odoo/addons/base/models/res_config.py
+++ b/odoo/addons/base/models/res_config.py
@@ -540,7 +540,7 @@ class ResConfigSettings(models.TransientModel):
                 old_value = field0.convert_to_record(
                     field0.convert_to_cache(vals[fname0], self), self)
                 for fname in fnames:
-                    old_value = next(iter(old_value), old_value)[fname]
+                    old_value = old_value[:1][fname]
 
                 # determine the new value
                 new_value = field.convert_to_record(

--- a/odoo/addons/base/tests/test_api.py
+++ b/odoo/addons/base/tests/test_api.py
@@ -368,8 +368,8 @@ class TestAPI(SavepointCaseWithUserDemo):
         ners = partners.browse(partners.ids[5:])
         self.assertNotEqual(part._prefetch_ids, ners._prefetch_ids)
 
-        self.assertNotEqual(set(prefetch_ids), set((partners & ners)._prefetch_ids))
-        self.assertNotEqual(set(prefetch_ids), set((partners - ners)._prefetch_ids))
+        self.assertEqual(prefetch_ids, (partners & ners)._prefetch_ids)
+        self.assertEqual(prefetch_ids, (partners - ners)._prefetch_ids)
 
         self.assertEqual(prefetch_ids, (part + ners)._prefetch_ids)
         self.assertEqual(prefetch_ids, (part | ners)._prefetch_ids)

--- a/odoo/addons/base/tests/test_api.py
+++ b/odoo/addons/base/tests/test_api.py
@@ -327,7 +327,6 @@ class TestAPI(SavepointCaseWithUserDemo):
         part = partners.browse(partners.ids[:5])
         self.assertNotEqual(prefetch_ids, partners.browse()._prefetch_ids)
         self.assertNotEqual(prefetch_ids, part._prefetch_ids)
-        self.assertNotEqual(set(prefetch_ids), set(partners.filtered('country_id')._prefetch_ids))
         self.assertNotEqual(set(prefetch_ids), set(partners[0]._prefetch_ids))
         self.assertNotEqual(set(prefetch_ids), set(partners[:5]._prefetch_ids))
 
@@ -336,6 +335,7 @@ class TestAPI(SavepointCaseWithUserDemo):
         self.assertEqual(prefetch_ids, partners.with_user(self.user_demo)._prefetch_ids)
         self.assertEqual(prefetch_ids, partners.with_context(active_test=False)._prefetch_ids)
         self.assertEqual(prefetch_ids, part.with_prefetch(prefetch_ids)._prefetch_ids)
+        self.assertEqual(prefetch_ids, partners.filtered('country_id')._prefetch_ids)
 
         # iteration and relational fields should use the same prefetch set
         self.assertEqual(type(partners).country_id.type, 'many2one')

--- a/odoo/addons/base/tests/test_api.py
+++ b/odoo/addons/base/tests/test_api.py
@@ -457,11 +457,11 @@ class TestAPI(SavepointCaseWithUserDemo):
 
         # check prefetching across x2many field
         prefetch_ids = records.child_ids.ids
-        reversed_ids = list(unique(
+        reversed_ids = [
             child.id
             for record in reversed(records)
             for child in record.child_ids
-        ))
+        ]
 
         self.assertEqual(list(first.child_ids._prefetch_ids), prefetch_ids)
         self.assertEqual(list(last.child_ids._prefetch_ids), reversed_ids)

--- a/odoo/addons/base/tests/test_api.py
+++ b/odoo/addons/base/tests/test_api.py
@@ -327,8 +327,6 @@ class TestAPI(SavepointCaseWithUserDemo):
         part = partners.browse(partners.ids[:5])
         self.assertNotEqual(prefetch_ids, partners.browse()._prefetch_ids)
         self.assertNotEqual(prefetch_ids, part._prefetch_ids)
-        self.assertNotEqual(set(prefetch_ids), set(partners[0]._prefetch_ids))
-        self.assertNotEqual(set(prefetch_ids), set(partners[:5]._prefetch_ids))
 
         # the recordset operations below share the prefetch set
         self.assertEqual(prefetch_ids, partners.browse(partners.ids)._prefetch_ids)
@@ -336,6 +334,8 @@ class TestAPI(SavepointCaseWithUserDemo):
         self.assertEqual(prefetch_ids, partners.with_context(active_test=False)._prefetch_ids)
         self.assertEqual(prefetch_ids, part.with_prefetch(prefetch_ids)._prefetch_ids)
         self.assertEqual(prefetch_ids, partners.filtered('country_id')._prefetch_ids)
+        self.assertEqual(prefetch_ids, partners[0]._prefetch_ids)
+        self.assertEqual(prefetch_ids, partners[:5]._prefetch_ids)
 
         # iteration and relational fields should use the same prefetch set
         self.assertEqual(type(partners).country_id.type, 'many2one')
@@ -383,7 +383,7 @@ class TestAPI(SavepointCaseWithUserDemo):
         prefetch_ids = partners.child_ids._prefetch_ids
         children = [partner.child_ids[:1] for partner in partners]
         for child in children:
-            self.assertNotEqual(set(prefetch_ids), set(child._prefetch_ids))
+            self.assertEqual(set(prefetch_ids), set(child._prefetch_ids))
 
         self.assertNotEqual(set(prefetch_ids), set(partners.browse().concat(*children)._prefetch_ids))
         self.assertNotEqual(set(prefetch_ids), set(partners.browse().union(*children)._prefetch_ids))

--- a/odoo/addons/base/tests/test_api.py
+++ b/odoo/addons/base/tests/test_api.py
@@ -371,8 +371,11 @@ class TestAPI(SavepointCaseWithUserDemo):
         self.assertEqual(prefetch_ids, (partners & ners)._prefetch_ids)
         self.assertEqual(prefetch_ids, (partners - ners)._prefetch_ids)
 
-        self.assertEqual(prefetch_ids, (part + ners)._prefetch_ids)
-        self.assertEqual(prefetch_ids, (part | ners)._prefetch_ids)
+        # those are not the same prefetch object, but they return the same ids
+        self.assertNotEqual(prefetch_ids, (part + ners)._prefetch_ids)
+        self.assertNotEqual(prefetch_ids, (part | ners)._prefetch_ids)
+        self.assertEqual(set(prefetch_ids), set((part + ners)._prefetch_ids))
+        self.assertEqual(set(prefetch_ids), set((part | ners)._prefetch_ids))
 
         # combining concatenation and union with relational fields
         child_ids = partners.child_ids._ids
@@ -385,8 +388,8 @@ class TestAPI(SavepointCaseWithUserDemo):
         for child in children:
             self.assertEqual(set(prefetch_ids), set(child._prefetch_ids))
 
-        self.assertNotEqual(set(prefetch_ids), set(partners.browse().concat(*children)._prefetch_ids))
-        self.assertNotEqual(set(prefetch_ids), set(partners.browse().union(*children)._prefetch_ids))
+        self.assertEqual(set(prefetch_ids), set(partners.browse().concat(*children)._prefetch_ids))
+        self.assertEqual(set(prefetch_ids), set(partners.browse().union(*children)._prefetch_ids))
 
         # incremental concatenation/union should not cause a recursion error
         result = self.env['res.partner']

--- a/odoo/addons/test_orm/models/test_performance.py
+++ b/odoo/addons/test_orm/models/test_performance.py
@@ -101,3 +101,23 @@ class Test_PerformanceSimpleMinded(models.Model):
     parent_id = fields.Many2one('test_performance.simple.minded')
 
     child_ids = fields.One2many('test_performance.simple.minded', 'parent_id')
+
+    def simple_loop(self):
+        for record in self:
+            record.name
+
+    def nested_loop(self):
+        for record in self:
+            for child in record.child_ids:
+                child.name
+
+    def union_once(self):
+        """ Union all first children at once. """
+        return self.browse().union(*[record.child_ids[:1] for record in self])
+
+    def union_loop(self):
+        """ Union all first children in a loop. """
+        result = self.browse()
+        for record in self:
+            result |= record.child_ids[:1]
+        return result

--- a/odoo/addons/test_orm/tests/test_fields.py
+++ b/odoo/addons/test_orm/tests/test_fields.py
@@ -1870,7 +1870,7 @@ class TestFields(TransactionCaseWithUserDemo, TransactionExpressionCase):
         cat1, cat2 = cats
         self.assertEqual(cat2.name, 'ACCESS')
         # both categories should be ready for prefetching
-        self.assertItemsEqual(cat2._prefetch_ids, cats.ids)
+        self.assertEqual(set(cat2._prefetch_ids), set(cats.ids))
         # but due to our (lame) overwrite of `read`, it should not forbid us to read records we have access to
         self.assertFalse(cat2.discussions)
         self.assertEqual(cat2.parent, cat1)

--- a/odoo/orm/fields.py
+++ b/odoo/orm/fields.py
@@ -686,8 +686,7 @@ class Field(typing.Generic[T]):
         one, and return it as a pair `(last_record, last_field)`. """
         for name in self.related.split('.')[:-1]:
             # take the first record when traversing
-            corecord = record[name]
-            record = next(iter(corecord), corecord)
+            record = record[name][:1]
         return record, self.related_field
 
     def traverse_related_sql(self, model: BaseModel, alias: str, query: Query) -> tuple[BaseModel, Field, str]:
@@ -741,7 +740,7 @@ class Field(typing.Generic[T]):
         values = list(records)
         for name in self.related.split('.')[:-1]:
             try:
-                values = [next(iter(val := value[name]), val) for value in values]
+                values = [value[name][:1] for value in values]
             except AccessError as e:
                 description = records.env['ir.model']._get(records._name).name
                 env = records.env

--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -4,7 +4,6 @@ import itertools
 import logging
 import typing
 from collections import defaultdict
-from collections.abc import Reversible
 from operator import attrgetter
 
 from odoo.exceptions import AccessError, MissingError, UserError
@@ -19,7 +18,7 @@ from .fields_reference import Many2oneReference
 from .identifiers import NewId
 from .models import BaseModel
 from .query import Query
-from .utils import COLLECTION_TYPES, SQL_OPERATORS, check_pg_name
+from .utils import COLLECTION_TYPES, Prefetch, SQL_OPERATORS, check_pg_name
 
 if typing.TYPE_CHECKING:
     from collections.abc import Sequence
@@ -355,12 +354,12 @@ class Many2one(_Relational):
     def convert_to_record(self, value, record):
         # use registry to avoid creating a recordset for the model
         ids = () if value is None else (value,)
-        prefetch_ids = PrefetchMany2one(record, self)
+        prefetch_ids = Prefetch.relational(self, record)
         return record.pool[self.comodel_name](record.env, ids, prefetch_ids)
 
     def convert_to_record_multi(self, values, records):
         # return the ids as a recordset without duplicates
-        prefetch_ids = PrefetchMany2one(records, self)
+        prefetch_ids = Prefetch.relational(self, records)
         ids = tuple(unique(id_ for id_ in values if id_ is not None))
         return records.pool[self.comodel_name](records.env, ids, prefetch_ids)
 
@@ -649,7 +648,7 @@ class _RelationalMulti(_Relational):
 
     def convert_to_record(self, value, record):
         # use registry to avoid creating a recordset for the model
-        prefetch_ids = PrefetchX2many(record, self)
+        prefetch_ids = Prefetch.relational(self, record)
         Comodel = record.pool[self.comodel_name]
         corecords = Comodel(record.env, value, prefetch_ids)
         if (
@@ -661,7 +660,7 @@ class _RelationalMulti(_Relational):
 
     def convert_to_record_multi(self, values, records):
         # return the list of ids as a recordset without duplicates
-        prefetch_ids = PrefetchX2many(records, self)
+        prefetch_ids = Prefetch.relational(self, records)
         Comodel = records.pool[self.comodel_name]
         ids = tuple(unique(id_ for ids in values for id_ in ids))
         corecords = Comodel(records.env, ids, prefetch_ids)
@@ -1734,52 +1733,4 @@ class Many2many(_RelationalMulti):
             SQL.identifier(alias, 'id'),
             SQL.identifier(rel_alias, rel_id2),
             coquery.subselect(),
-        )
-
-
-class PrefetchMany2one(Reversible):
-    """ Iterable for the values of a many2one field on the prefetch set of a given record. """
-    __slots__ = ('field', 'record')
-
-    def __init__(self, record: BaseModel, field: Many2one):
-        self.record = record
-        self.field = field
-
-    def __iter__(self):
-        field_cache = self.field._get_cache(self.record.env)
-        return unique(
-            coid for id_ in self.record._prefetch_ids
-            if (coid := field_cache.get(id_)) is not None
-        )
-
-    def __reversed__(self):
-        field_cache = self.field._get_cache(self.record.env)
-        return unique(
-            coid for id_ in reversed(self.record._prefetch_ids)
-            if (coid := field_cache.get(id_)) is not None
-        )
-
-
-class PrefetchX2many(Reversible):
-    """ Iterable for the values of an x2many field on the prefetch set of a given record. """
-    __slots__ = ('field', 'record')
-
-    def __init__(self, record: BaseModel, field: _RelationalMulti):
-        self.record = record
-        self.field = field
-
-    def __iter__(self):
-        field_cache = self.field._get_cache(self.record.env)
-        return unique(
-            coid
-            for id_ in self.record._prefetch_ids
-            for coid in field_cache.get(id_, ())
-        )
-
-    def __reversed__(self):
-        field_cache = self.field._get_cache(self.record.env)
-        return unique(
-            coid
-            for id_ in reversed(self.record._prefetch_ids)
-            for coid in field_cache.get(id_, ())
         )

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -5938,7 +5938,8 @@ class BaseModel(metaclass=MetaModel):
             if self._name != other._name:
                 raise TypeError(f"inconsistent models in: {self} - {other}")
             other_ids = set(other._ids)
-            return self.browse(id_ for id_ in self._ids if id_ not in other_ids)
+            ids = tuple(id_ for id_ in self._ids if id_ not in other_ids)
+            return self.__class__(self.env, ids, self._prefetch_ids)
         except AttributeError:
             raise TypeError(f"unsupported operand types in: {self} - {other!r}")
 
@@ -5950,7 +5951,8 @@ class BaseModel(metaclass=MetaModel):
             if self._name != other._name:
                 raise TypeError(f"inconsistent models in: {self} & {other}")
             other_ids = set(other._ids)
-            return self.browse(OrderedSet(id_ for id_ in self._ids if id_ in other_ids))
+            ids = {id_: None for id_ in self._ids if id_ in other_ids}
+            return self.__class__(self.env, tuple(ids), self._prefetch_ids)
         except AttributeError:
             raise TypeError(f"unsupported operand types in: {self} & {other!r}")
 

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -6056,10 +6056,8 @@ class BaseModel(metaclass=MetaModel):
         if isinstance(key, str):
             # important: one must call the field's getter
             return self._fields[key].__get__(self)
-        elif isinstance(key, slice):
-            return self.browse(self._ids[key])
-        else:
-            return self.browse((self._ids[key],))
+        ids = self._ids[key] if isinstance(key, slice) else (self._ids[key],)
+        return self.__class__(self.env, ids, self._prefetch_ids)
 
     def __setitem__(self, key: str, value: typing.Any):
         """ Assign the field ``key`` to ``value`` in record ``self``. """


### PR DESCRIPTION
Keep the prefetching info in the result of methods `filtered()`, `records[int_or_slice]`, `concat()` and `union()`.

task 5123411