### PR TITLE
[FIX] account: ensure analytic lines are created when posting vendor bills with `autocheck_on_post=False`

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5055,7 +5055,7 @@ class AccountMove(models.Model):
         # reconcile if state is in draft and move has reversal_entry_id set
         draft_reverse_moves = to_post.filtered(lambda move: move.reversed_entry_id and move.reversed_entry_id.state == 'posted')
 
-        to_post.write({
+        to_post.with_context(posting_move=True).write({
             'state': 'posted',
             'posted_before': True,
         })

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1676,7 +1676,7 @@ class AccountMoveLine(models.Model):
                                 body=msg,
                                 tracking_value_ids=tracking_value_ids
                             )
-            if not self.env.context.get('skip_analytic_sync'):
+            if not self.env.context.get('skip_analytic_sync') and not self.env.context.get('posting_move'):
                 self.filtered(lambda l: l.parent_state == 'draft').analytic_line_ids.with_context(skip_analytic_sync=True).unlink()
 
         return result


### PR DESCRIPTION
**Issue**
When unchecking the *Auto-check on Post* option on a vendor bill journal, analytic items are not created when posting the invoice, even if analytic accounts were set on the bill lines.

**Steps to Reproduce**
1. Navigate to *Accounting > Configuration > Journals > Vendor Bills*
2. Uncheck *Auto-Check on Post*
3. Activate *Analytic Accounting* in settings
4. Create a vendor bill with one line and set analytic accounts
5. Post the entry
6. Navigate to *Accounting > Accounting > Analytic Items*
7. No analytic items are created

**Root Cause**
When `autocheck_on_post` is disabled, the `account.move` is still in draft during the `write({'state': 'posted'})` call. In `account.move.line.write`, the following logic runs:

```python
if not self.env.context.get('skip_analytic_sync'):
    self.filtered(lambda l: l.parent_state == 'draft').analytic_line_ids.with_context(skip_analytic_sync=True).unlink()
```
At this point, analytic lines were already created, but since the parent move is still in draft, they get incorrectly unlinked. This leads to posted vendor bills without analytic items.

**Fix**
Introduce a posting_move context flag when posting moves. Skip the unlinking of analytic lines if the move is in the process of posting (context.get('posting_move')). This prevents the accidental removal of freshly created analytic lines.

Opw-5053179
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
