### PR TITLE
[FIX] stock_account: use accounting_date for journal entry creation

### DIFF
--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -154,6 +154,7 @@ class StockMove(models.Model):
         account_move = self.env['account.move'].create({
             'journal_id': self.company_id.account_stock_journal_id.id,
             'line_ids': [Command.create(aml_vals) for aml_vals in aml_vals_list],
+            'date': self.env.context.get('force_period_date') or fields.Date.context_today(self),
         })
         self.env['stock.move'].browse(move_to_link).account_move_id = account_move.id
         account_move._post()


### PR DESCRIPTION
Prerequisites:
---------------
* Install the stock and accounting
* Configure Product Category:
   * Go to Inventory >Configuration > Categories
   * Create a new category (e.g.,Test)
   * Set Inventory Valuation to "Perpetual (at invoicing)"
* Create a new storable product and assign it to the new category
* Go to Inventory > Configuration > Warehouse Management > Locations
* Remove the `internal location` filter and select `Inventory adjustment`
* On `Inventory Variation`, select Stock Valuation
 
To reproduce:
--------------
1. Go to Inventory >Operations > Physical Inventory
2. Select Accounting date from the optional view button
3. Create a record with a past accounting date
4. Check the related journal entry date

Issue:
------
The journal entry is created with today’s date instead of the specified accounting date.

Cause of the issue:
--------------------
After this 08b62a4, `accounting_date` is not considered when creating the journal entry, causing this issue.
https://github.com/odoo/odoo/blob/db9053adcfb36d9d522079c4b3fd03ae2c7a6504/addons/stock_account/models/stock_move.py#L148-L151

Solution:
---------
Use `accounting_date` if available when creating the journal entry.

opw-5091817

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
