### PR TITLE
[FIX] account: Prevent branch default tax from being set on products with a different tax

### DIFF
--- a/addons/account/models/product.py
+++ b/addons/account/models/product.py
@@ -151,7 +151,7 @@ class ProductTemplate(models.Model):
         # If no company was set for the product, the product will be available for all companies and therefore should
         # have the default taxes of the other companies as well. sudo() is used since we're going to need to fetch all
         # the other companies default taxes which the user may not have access to.
-        other_companies = self.env['res.company'].sudo().search([('id', 'not in', self.env.companies.ids)])
+        other_companies = self.env['res.company'].sudo().search(['!', ('id', 'child_of', self.env.companies.ids)])
         if other_companies and products:
             products_without_company = products.filtered(lambda p: not p.company_id).sudo()
             products_without_company._force_default_tax(other_companies)


### PR DESCRIPTION
**Issue description:**
The logic introduced in #127196 adds default taxes from "other" companies to products created without a specific company.
However, because child companies (branches) share taxes with their parent company, when creating a new product using the parent company and setting a specific tax (different from the default), the default tax was incorrectly added back to the product.
This happened because the logic considered the branch an "other company" and applied its default tax.

**FIX:**
Exclude branch companies from the domain when we set the default tax of other companies on the product.

**Steps to reproduce:**
1. Create a branch company. (It will automatically have the same default tax as its parent).
2. With the parent company selected, create a new product, leaving the 'Company' field empty, and change its sales tax to any tax other than the default, and save.
3. Notice that the default tax is set again on the product.

opw-5094415

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
