### PR TITLE
[IMP] website: inline new content access checks

### DIFF
--- a/addons/website/controllers/backend.py
+++ b/addons/website/controllers/backend.py
@@ -1,7 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import werkzeug
-
 from odoo import http
 from odoo.http import request
 
@@ -36,23 +34,6 @@ class WebsiteBackend(http.Controller):
     @http.route('/website/iframefallback', type="http", auth='user', website=True, readonly=True)
     def get_iframe_fallback(self):
         return request.render('website.iframefallback')
-
-    @http.route('/website/check_new_content_access_rights', type="jsonrpc", auth='user', readonly=True)
-    def check_create_access_rights(self, models):
-        """
-        TODO: In master, remove this route and method and find a better way
-        to do this. This route is only here to ensure that the "New Content"
-        modal displays the correct elements for each user, and there might be
-        a way to do it with the framework rather than having a dedicated
-        controller route. (maybe by using a template or a JS util)
-        """
-        if not request.env.user.has_group('website.group_website_restricted_editor'):
-            raise werkzeug.exceptions.Forbidden()
-
-        return {
-            model: request.env[model].has_access('create')
-            for model in models
-        }
 
     @http.route('/website/track_installing_modules', type='jsonrpc', auth='user', readonly=True)
     def website_track_installing_modules(self, selected_features, total_features=None):

--- a/addons/website/static/tests/new_content_systray_item.test.js
+++ b/addons/website/static/tests/new_content_systray_item.test.js
@@ -1,17 +1,23 @@
 import { expect, test } from "@odoo/hoot";
-import { mountWithCleanup, onRpc, contains } from "@web/../tests/web_test_helpers";
+import {
+    mountWithCleanup,
+    onRpc,
+    contains,
+    mockService,
+} from "@web/../tests/web_test_helpers";
 import { NewContentSystrayItem } from "@website/client_actions/website_preview/new_content_systray_item";
 import { defineWebsiteModels } from "./builder/website_helpers";
 
 defineWebsiteModels();
 
 function setupTest() {
+    mockService("website", {
+        get isRestrictedEditor() {
+            return true;
+        },
+    });
     onRpc("/web/dataset/call_kw/ir.module.module/search_read", () => {
         expect.step("/web/dataset/call_kw/ir.module.module/search_read");
-        return [];
-    });
-    onRpc("/website/check_new_content_access_rights", () => {
-        expect.step("/website/check_new_content_access_rights");
         return [];
     });
     onRpc("/website/get_new_page_templates", () => {
@@ -35,7 +41,6 @@ test("can display a newcontent modal", async () => {
     expect("div.o_new_content_menu_choices").toHaveCount(1);
     expect.verifySteps([
         "/web/dataset/call_kw/ir.module.module/search_read",
-        "/website/check_new_content_access_rights",
         "/website/get_new_page_templates",
     ]);
 });


### PR DESCRIPTION
Since [1], a TODO was pending to remove a dedicated controller route
used only to filter elements in the "New Content" modal per user.
This commit addresses it by moving the filtering logic to existing
client-side services and relying on the generic has_access RPC provided
by the user service, instead of an ad-hoc controller.

This removes the temporary route and avoids an extra RPC call for
non-restricted editors.

[1]: https://github.com/odoo/odoo/commit/1ebcdb00231aa1854f6366c61055e2543cf94a51

