### PR TITLE
[FIX] discuss: prevent crash when updating session info

### DIFF
--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -737,7 +737,7 @@ export class Rtc extends Record {
                 }
                 for (const [id, info] of Object.entries(payload)) {
                     const session = await this.store.RtcSession.getWhenReady(Number(id));
-                    if (!this.state.channel || session?.eq(this.selfSession)) {
+                    if (!this.state.channel || !session || session.eq(this.selfSession)) {
                         return;
                     }
                     // `isRaisingHand` is turned into the Date `raisingHand`


### PR DESCRIPTION
Before this commit, since a regression introduced in https://github.com/odoo/odoo/pull/228601

A traceback could occur when updating a session that does not exist. For example if the event is received after the session is removed.
