### PR TITLE
[FIX] pos_sale: prevent failure when importing lot-tracked products without lot

### DIFF
--- a/addons/pos_sale/static/src/app/order_management_screen/sale_order_management_screen/sale_order_management_screen.js
+++ b/addons/pos_sale/static/src/app/order_management_screen/sale_order_management_screen/sale_order_management_screen.js
@@ -255,7 +255,9 @@ export class SaleOrderManagementScreen extends ControlButtonsMixin(Component) {
                             remaining_quantity -= splitted_line.quantity;
                         }
                     } else if (new_line.get_product().tracking == "lot") {
+                        let total_lot_quantity = 0;
                         for (const lot of line.lot_names) {
+                            total_lot_quantity += line.lot_qty_by_name[lot] || 0;
                             const splitted_line = new Orderline({ env: this.env }, line_values);
                             splitted_line.set_quantity(line.lot_qty_by_name[lot] || 0, true);
                             splitted_line.set_unit_price(line.price_unit);
@@ -265,6 +267,14 @@ export class SaleOrderManagementScreen extends ControlButtonsMixin(Component) {
                                 newPackLotLines: [{ lot_name: lot }],
                                 setQuantity: false,
                             });
+                            this.pos.get_order().add_orderline(splitted_line);
+                        }
+                        if (total_lot_quantity < new_line.quantity) {
+                            const remaining_quantity = new_line.quantity - total_lot_quantity;
+                            const splitted_line = new Orderline({ env: this.env }, line_values);
+                            splitted_line.set_quantity(remaining_quantity, true);
+                            splitted_line.set_unit_price(line.price_unit);
+                            splitted_line.set_discount(line.discount);
                             this.pos.get_order().add_orderline(splitted_line);
                         }
                     } else {

--- a/addons/pos_sale/static/tests/tours/PosSaleTour.js
+++ b/addons/pos_sale/static/tests/tours/PosSaleTour.js
@@ -388,3 +388,17 @@ registry.category("web_tour.tours").add("test_multiple_lots_sale_order", {
             ReceiptScreen.isShown(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_import_so_to_pos_no_existing_lot", {
+    steps: () =>
+        [
+            ProductScreen.confirmOpeningPopup(),
+            ProductScreen.clickQuotationButton(),
+            ProductScreen.selectNthOrder(1),
+            {
+                'content': 'Ensure at least one line is imported',
+                'trigger': '.order-container .orderline',
+                run: 'click',
+            },
+        ].flat(),
+});

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -1326,3 +1326,24 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         self.assertEqual(mls[0].quantity, 1)
         self.assertEqual(mls[1].lot_id.name, '1002')
         self.assertEqual(mls[1].quantity, 2)
+
+    def test_import_so_to_pos_no_existing_lot(self):
+        self.product = self.env['product.product'].create({
+            'name': 'Product',
+            'available_in_pos': True,
+            'type': 'product',
+            'lst_price': 10.0,
+            'taxes_id': False,
+            'tracking': 'lot',
+        })
+        self.env['sale.order'].create({
+            'partner_id': self.env['res.partner'].create({'name': 'Test Partner'}).id,
+            'order_line': [(0, 0, {
+                'product_id': self.product.id,
+                'name': self.product.name,
+                'product_uom_qty': 31,
+                'product_uom': self.product.uom_id.id,
+            })],
+        })
+        self.main_pos_config.open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_import_so_to_pos_no_existing_lot', login="accountman")


### PR DESCRIPTION
## Issue:
When you have a Sale Order containing products tracked by lots, and there are not enough quantities in the existing lots, importing the SO into the POS does not add the sub-lines that are not linked to a lot However, it is still possible to add these products manually in the POS interface

## Cause:
The sub lines are only added for the quantities linked to lots using a loop on `lot_names`: https://github.com/odoo/odoo/blob/47898975c7af83559ea95fb86e07c19feea1d2d7/addons/pos_sale/static/src/app/order_management_screen/sale_order_management_screen/sale_order_management_screen.js#L257-L269 If there is no `lot_names` or there is missing quantity, the condition doesn’t match to add the line and the sub line is skipped

## Steps to reproduce:
- Create a storable product tracked by lots
- Create a Sale Order for that product
- Open a POS session and open the Sale Order
- Before the fix, product lines without lots were not added automatically

opw-5099616