### PR TITLE
[FIX] web: browser back on invalid form doesn't lock ui

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -1449,7 +1449,7 @@ export function makeActionManager(env, router = _router) {
                         pick(options, "forceLeave")
                     );
                     if (!canProceed) {
-                        return new Promise(() => {});
+                        return;
                     }
                 }
                 return _executeActWindowAction(action, options);

--- a/addons/web/static/tests/webclient/actions/load_state.test.js
+++ b/addons/web/static/tests/webclient/actions/load_state.test.js
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, test } from "@odoo/hoot";
+import { queryAllAttributes, queryAllTexts, queryFirst, runAllTimers } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import { Component, onMounted, xml } from "@odoo/owl";
 import {
@@ -27,7 +28,6 @@ import { redirect } from "@web/core/utils/urls";
 import { ControlPanel } from "@web/search/control_panel/control_panel";
 import { _t as basic_t } from "@web/core/l10n/translation";
 import { user } from "@web/core/user";
-import { queryAllAttributes, queryAllTexts, queryFirst } from "@odoo/hoot-dom";
 
 function _t() {
     odoo.translationContext = "web";
@@ -1740,6 +1740,37 @@ describe(`new urls`, () => {
             'set current_state-{"actionStack":[{"displayName":"Kanban Partners","action":200},{"displayName":"List Partners with active id","action":300,"active_id":5},{"displayName":"First record","action":100,"view_type":"form","resId":1}],"resId":1,"action":100}',
             'set current_action-{"binding_type":"action","binding_view_types":"list,form","id":100,"type":"ir.actions.act_window","xml_id":100,"res_model":"partner","res_id":1,"name":"Partners","views":[[false,"form"],[false,"list"]],"context":{},"embedded_action_ids":[],"group_ids":[],"limit":80,"mobile_view_mode":"kanban","target":"current","view_ids":[],"view_mode":"list,form","cache":true}',
         ]);
+    });
+
+    test(`browser back on invalid form view`, async () => {
+        Partner._fields.foo.required = true;
+        await mountWebClient();
+        await getService("action").doAction({
+            type: "ir.actions.act_window",
+            res_model: "partner",
+            name: "Partners",
+            views: [
+                [false, "list"],
+                [false, "form"],
+            ],
+        });
+
+        await runAllTimers(); // wait for router pushState
+        expect(`.o_list_view`).toHaveCount(1);
+
+        await contains(".o_data_cell").click();
+        await runAllTimers(); // wait for router pushState
+        expect(`.o_form_view`).toHaveCount(1);
+
+        await contains(".o_field_widget[name=foo] input").edit("");
+        browser.history.back(); // Click on back button
+        await animationFrame();
+        expect(`.o_form_view`).toHaveCount(1);
+        expect(`.o_field_widget[name=foo]`).toHaveClass("o_field_invalid");
+        // In webclient, we listen to the "ROUTE_CHANGE" event to load the new state,
+        // and we set `pointer-events: none` during the loadState. In this case,
+        // we assert that the rule has been correctly removed.
+        expect(document.body.style.pointerEvents).not.toBe("none");
     });
 });
 


### PR DESCRIPTION
Be in an invalid form view and do browser back. The form view can't be saved as it is invalid, so it can't be left. Before this commit, the body was `pointer-events: none`, i.e. the user couldn't interact with the webclient anymore.

This is due to a code in webclient.js, which listens to the `ROUTE_CHANGE` event and calls `loadState`. PR [1] prevented the user to interact with the UI during the state loading, as it could lead to weird side-effects. To achieve this, it set the `point-events: none` rule on the body, and reset it once the promise returned by loadState was fullfilled.

Unfortunately, in the above mentionned case, loadState returned a promise that was left pending forever, leading to a fully locked webclient. This commit fixes the issue by returning nothing, like we already do in other similar cases in the action service, when the requested action can't be executed.

[1] https://github.com/odoo/odoo/pull/205290

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
