### PR TITLE
[IMP] web: Remove space when looking for States

### DIFF
--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -791,7 +791,7 @@
             margin-right: 2%;
         }
         .o_address_state span {
-            margin-right: 2%;
+            margin-right: 0;
         }
         &.o_zip_city {
             .o_address_zip span {


### PR DESCRIPTION
There is a 2% margin added when searching for country states

Remove this margin to have the field look like the majority of `many2one` fields

task-5123126

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
