### PR TITLE
[FIX] lunch: adjust merge write logic

### DIFF
--- a/addons/lunch/models/lunch_order.py
+++ b/addons/lunch/models/lunch_order.py
@@ -182,7 +182,7 @@ class LunchOrder(models.Model):
 
         if merge_needed:
             lines_to_deactivate = self.env['lunch.order']
-            for line in self:
+            for line in self.filtered(lambda line: line.state not in ['sent', 'confirmed']):
                 # Only write on topping_ids_1 because they all share the same table
                 # and we don't want to remove all the records
                 # _extract_toppings will pop topping_ids_1, topping_ids_2 and topping_ids_3 from values
@@ -199,7 +199,7 @@ class LunchOrder(models.Model):
                     'toppings': toppings,
                     'lunch_location_id': values.get('lunch_location_id', default_location_id),
                     'state': values.get('state'),
-                })
+                }) - line
                 if matching_lines:
                     lines_to_deactivate |= line
                     matching_lines.update_quantity(line.quantity)

--- a/addons/lunch/tests/__init__.py
+++ b/addons/lunch/tests/__init__.py
@@ -3,5 +3,6 @@
 
 from . import common
 from . import test_alert
+from . import test_order
 from . import test_supplier
 from . import test_ui

--- a/addons/lunch/tests/test_order.py
+++ b/addons/lunch/tests/test_order.py
@@ -1,0 +1,53 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import common
+from odoo.addons.lunch.tests.common import TestsCommon
+
+
+class TestOrder(TestsCommon):
+
+    @common.users('cle-lunch-manager')
+    def test_order_not_self_archived_on_state_update(self):
+        """
+        Test that updating an order's state doesn't cause it to match itself
+        and get archived (clicking "Receive" multiple times).
+        """
+        order = self.env['lunch.order'].create({
+            'product_id': self.product_pizza.id,
+            'user_id': self.env.user.id,
+            'lunch_location_id': self.location_office_1.id,
+            'quantity': 1,
+        })
+        order.write({'state': 'confirmed'})
+        order.write({'state': 'confirmed'})
+
+        self.assertTrue(order.active)
+        self.assertEqual(order.quantity, 1)
+
+    @common.users('cle-lunch-manager')
+    def test_orders_not_used_as_merge_targets(self):
+        """
+        Test that confirmed or sent orders are excluded from merge logic to prevent
+        orders being archived without quantity updates.
+        """
+        order1 = self.env['lunch.order'].create({
+            'product_id': self.product_pizza.id,
+            'user_id': self.env.user.id,
+            'lunch_location_id': self.location_office_1.id,
+            'quantity': 1,
+            'note': 'Pizza',
+        })
+        order1.write({'state': 'confirmed'})
+
+        order2 = self.env['lunch.order'].create({
+            'product_id': self.product_pizza.id,
+            'user_id': self.env.user.id,
+            'lunch_location_id': self.location_office_1.id,
+            'quantity': 1,
+            'note': 'Pizza',
+        })
+
+        self.assertTrue(order1.active)
+        self.assertTrue(order2.active)
+        self.assertEqual(order1.quantity, 1)
+        self.assertEqual(order2.quantity, 1)


### PR DESCRIPTION
**Issue**
The lunch order merge logic was causing orders to be unexpectedly archived when they shouldn't be. Users would see their orders disappear from the list view after certain operations like clicking "Receive" multiple times or when trying to merge orders with existing ones in immutable states.

**Steps to Reproduce**
1st problem
- Create a lunch order
- From the order list view, select the order and click the "Receive" button
- Select and click the "Receive" button again on the same order
- The order gets archived and disappears from the view

2nd problem
- Create a lunch order
- From the order list view, select the order and click the "Receive" button
- Place another order for the same product as before
- From the order list view, once the second order is set to received, it gets archived and the update quantity logic not triggered

**Root Cause and Solution**
1st problem: When searching for matching orders to merge, the current order being processed could match itself, leading to self-deactivation. Fixed by adding matching_lines = matching_lines - line to exclude the current record from potential merge targets.

2nd problem: The merge logic was trying to combine new orders with existing "sent" and "confirmed" orders, but the update_quantity method correctly excludes these states since they shouldn't be modified once sent/received. This created a mismatch where orders would be archived but quantities wouldn't update. Fixed by excluding "sent" and "confirmed" states from merge target searches entirely.

Task ID: 5123211

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
