### PR TITLE
[FIX] l10n_mx: update translation

### DIFF
--- a/addons/l10n_mx/i18n/es_419.po
+++ b/addons/l10n_mx/i18n/es_419.po
@@ -148,6 +148,11 @@ msgid "Exempt"
 msgstr "Exento"
 
 #. module: l10n_mx
+#: model:account.report.column,name:l10n_mx.diot_report_exempt_imp
+msgid "Exempt Imports"
+msgstr "Importaciones exentas"
+
+#. module: l10n_mx
 #: model:ir.model.fields.selection,name:l10n_mx.selection__account_tax__l10n_mx_factor_type__exento
 msgid "Exento"
 msgstr "Exento"
@@ -185,9 +190,9 @@ msgstr ""
 "legales relacionados."
 
 #. module: l10n_mx
-#: model:account.report.column,name:l10n_mx.diot_report_importation_16
+#: model:account.report.column,name:l10n_mx.diot_report_paid_16_imp_wnc
 msgid "Importation 16%"
-msgstr "Importación al 16%"
+msgstr "Importación 16%"
 
 #. module: l10n_mx
 #: model_terms:res.company,invoice_terms_html:l10n_mx.demo_company_mx
@@ -200,6 +205,31 @@ msgstr ""
 "cualquier demanda mediante una carta enviada por entrega certificada a su "
 "domicilio dentro de los 8 días posteriores a la entrega de los bienes o la "
 "prestación de los servicios."
+
+#. module: l10n_mx
+#: model:account.report.column,name:l10n_mx.diot_report_paid_16_imp
+msgid "Importation 16% - Creditable"
+msgstr "Importación 16% - acreditable"
+
+#. module: l10n_mx
+#: model:account.report.column,name:l10n_mx.diot_report_paid_16_imp_nc
+msgid "Importation 16% - Non-Creditable"
+msgstr "Importación 16% - no acreditable"
+
+#. module: l10n_mx
+#: model:account.report.column,name:l10n_mx.diot_report_paid_16_imp_int_wnc
+msgid "Intangible Imports 16%"
+msgstr "Importaciones intangibles 16%"
+
+#. module: l10n_mx
+#: model:account.report.column,name:l10n_mx.diot_report_paid_16_imp_int
+msgid "Intangible Imports 16% - Creditable"
+msgstr "Importaciones intangibles 16% - acreditables"
+
+#. module: l10n_mx
+#: model:account.report.column,name:l10n_mx.diot_report_paid_16_imp_int_nc
+msgid "Intangible Imports 16% - Non-Creditable"
+msgstr "Importaciones intangibles 16% - no acreditables"
 
 #. module: l10n_mx
 #: model:uom.uom,name:l10n_mx.product_uom_job
@@ -226,6 +256,11 @@ msgstr ""
 "factor que se aplica a la base del impuesto."
 
 #. module: l10n_mx
+#: model:account.report.column,name:l10n_mx.diot_report_no_obj
+msgid "No Tax Object"
+msgstr "Sin objeto fiscal"
+
+#. module: l10n_mx
 #: model_terms:res.company,invoice_terms_html:l10n_mx.demo_company_mx
 msgid ""
 "Our invoices are payable within 21 working days, unless another payment "
@@ -248,29 +283,74 @@ msgid "Paid 0%"
 msgstr "Pagado al 0%"
 
 #. module: l10n_mx
-#: model:account.report.column,name:l10n_mx.diot_report_paid_16
+#: model:account.report.column,name:l10n_mx.diot_report_paid_16_wnc
 msgid "Paid 16%"
 msgstr "Pagado al 16%"
 
 #. module: l10n_mx
-#: model:account.report.column,name:l10n_mx.diot_report_paid_16_non_cred
+#: model:account.report.column,name:l10n_mx.diot_report_paid_16
+msgid "Paid 16% - Creditable"
+msgstr "Pagado al 16% - acreditable"
+
+#. module: l10n_mx
+#: model:account.report.column,name:l10n_mx.diot_report_paid_16_nc
 msgid "Paid 16% - Non-Creditable"
-msgstr "Pagado al 16% - No acreditable"
+msgstr "Pagado al 16% - no acreditable"
 
 #. module: l10n_mx
-#: model:account.report.column,name:l10n_mx.diot_report_paid_8
-msgid "Paid 8 %"
-msgstr "Pagado al 8%"
+#: model:account.report.column,name:l10n_mx.diot_report_paid_8_n
+msgid "Paid 8 % N. - Creditable"
+msgstr "Pagado al 8 % N. - acreditable"
 
 #. module: l10n_mx
-#: model:account.report.column,name:l10n_mx.diot_report_paid_8_non_cred
-msgid "Paid 8 % - Non-Creditable"
-msgstr "Pagado al 8% - No acreditable"
+#: model:account.report.column,name:l10n_mx.diot_report_paid_8_n_nc
+msgid "Paid 8 % N. - Non-Creditable"
+msgstr "Pagado al 8 % N. - No acreditable"
 
 #. module: l10n_mx
-#: model:account.report.column,name:l10n_mx.diot_report_refunds
-msgid "Refunds"
-msgstr "Reembolsos"
+#: model:account.report.column,name:l10n_mx.diot_report_paid_8_n_wnc
+msgid "Paid 8 % Northern"
+msgstr "Pagado al 8 % del norte"
+
+#. module: l10n_mx
+#: model:account.report.column,name:l10n_mx.diot_report_paid_8_s
+msgid "Paid 8 % S. - Creditable"
+msgstr "Pagado al 8 % S. - acreditable"
+
+#. module: l10n_mx
+#: model:account.report.column,name:l10n_mx.diot_report_paid_8_s_nc
+msgid "Paid 8 % S. - Non-Creditable"
+msgstr "Pagado al 8 % S. - No acreditable"
+
+#. module: l10n_mx
+#: model:account.report.column,name:l10n_mx.diot_report_paid_8_s_wnc
+msgid "Paid 8 % Southern"
+msgstr "Pagado al 8 % del sur"
+
+#. module: l10n_mx
+#: model:account.report.column,name:l10n_mx.diot_report_paid_16_r
+msgid "Refunds 16%"
+msgstr "Reembolsos 16%"
+
+#. module: l10n_mx
+#: model:account.report.column,name:l10n_mx.diot_report_paid_8_n_r
+msgid "Refunds 8 % Northern"
+msgstr "Reembolsos 8 % del norte"
+
+#. module: l10n_mx
+#: model:account.report.column,name:l10n_mx.diot_report_paid_8_s_r
+msgid "Refunds 8 % Southern"
+msgstr "Reembolsos 8 % del sur"
+
+#. module: l10n_mx
+#: model:account.report.column,name:l10n_mx.diot_report_paid_16_imp_r
+msgid "Refunds Importation 16%"
+msgstr "Importación de reembolsos 16%"
+
+#. module: l10n_mx
+#: model:account.report.column,name:l10n_mx.diot_report_paid_16_imp_int_r
+msgid "Refunds Intangible Imports 16%"
+msgstr "Reembolsos importaciones intangibles 16%"
 
 #. module: l10n_mx
 #: model:ir.model.fields,field_description:l10n_mx.field_account_tax__l10n_mx_tax_type

--- a/addons/l10n_mx/i18n/l10n_mx.pot
+++ b/addons/l10n_mx/i18n/l10n_mx.pot
@@ -126,6 +126,11 @@ msgid "Exempt"
 msgstr ""
 
 #. module: l10n_mx
+#: model:account.report.column,name:l10n_mx.diot_report_exempt_imp
+msgid "Exempt Imports"
+msgstr ""
+
+#. module: l10n_mx
 #: model:ir.model.fields.selection,name:l10n_mx.selection__account_tax__l10n_mx_factor_type__exento
 msgid "Exento"
 msgstr ""
@@ -159,8 +164,9 @@ msgid ""
 "the client."
 msgstr ""
 
+
 #. module: l10n_mx
-#: model:account.report.column,name:l10n_mx.diot_report_importation_16
+#: model:account.report.column,name:l10n_mx.diot_report_paid_16_imp_wnc
 msgid "Importation 16%"
 msgstr ""
 
@@ -171,6 +177,30 @@ msgid ""
 "any claim by means of a letter sent by recorded delivery to its registered "
 "office within 8 days of the delivery of the goods or the provision of the "
 "services."
+
+#. module: l10n_mx
+#: model:account.report.column,name:l10n_mx.diot_report_paid_16_imp
+msgid "Importation 16% - Creditable"
+msgstr ""
+
+#. module: l10n_mx
+#: model:account.report.column,name:l10n_mx.diot_report_paid_16_imp_nc
+msgid "Importation 16% - Non-Creditable"
+msgstr ""
+
+#. module: l10n_mx
+#: model:account.report.column,name:l10n_mx.diot_report_paid_16_imp_int_wnc
+msgid "Intangible Imports 16%"
+msgstr ""
+
+#. module: l10n_mx
+#: model:account.report.column,name:l10n_mx.diot_report_paid_16_imp_int
+msgid "Intangible Imports 16% - Creditable"
+msgstr ""
+
+#. module: l10n_mx
+#: model:account.report.column,name:l10n_mx.diot_report_paid_16_imp_int_nc
+msgid "Intangible Imports 16% - Non-Creditable"
 msgstr ""
 
 #. module: l10n_mx
@@ -196,6 +226,11 @@ msgid ""
 msgstr ""
 
 #. module: l10n_mx
+#: model:account.report.column,name:l10n_mx.diot_report_no_obj
+msgid "No Tax Object"
+msgstr ""
+
+#. module: l10n_mx
 #. odoo-python
 #: code:addons/l10n_mx/models/template_mx.py:0
 msgid "Other Income"
@@ -218,28 +253,33 @@ msgid "Paid 0%"
 msgstr ""
 
 #. module: l10n_mx
-#: model:account.report.column,name:l10n_mx.diot_report_paid_16
+#: model:account.report.column,name:l10n_mx.diot_report_paid_16_wnc
 msgid "Paid 16%"
 msgstr ""
 
 #. module: l10n_mx
-#: model:account.report.column,name:l10n_mx.diot_report_paid_16_non_cred
+#: model:account.report.column,name:l10n_mx.diot_report_paid_16
+msgid "Paid 16% - Creditable"
+msgstr ""
+
+#. module: l10n_mx
+#: model:account.report.column,name:l10n_mx.diot_report_paid_16_nc
 msgid "Paid 16% - Non-Creditable"
 msgstr ""
 
 #. module: l10n_mx
-#: model:account.report.column,name:l10n_mx.diot_report_paid_8
-msgid "Paid 8 %"
+#: model:account.report.column,name:l10n_mx.diot_report_paid_8_n
+msgid "Paid 8 % N. - Creditable"
 msgstr ""
 
 #. module: l10n_mx
-#: model:account.report.column,name:l10n_mx.diot_report_paid_8_non_cred
-msgid "Paid 8 % - Non-Creditable"
+#: model:account.report.column,name:l10n_mx.diot_report_paid_8_n_nc
+msgid "Paid 8 % N. - Non-Creditable"
 msgstr ""
 
 #. module: l10n_mx
-#: model:account.report.column,name:l10n_mx.diot_report_refunds
-msgid "Refunds"
+#: model:account.report.column,name:l10n_mx.diot_report_paid_8_n_wnc
+msgid "Paid 8 % Northern"
 msgstr ""
 
 #. module: l10n_mx
@@ -248,9 +288,49 @@ msgid "SAT Tax Type"
 msgstr ""
 
 #. module: l10n_mx
+#: model:account.report.column,name:l10n_mx.diot_report_paid_8_s
+msgid "Paid 8 % S. - Creditable"
+msgstr ""
+
+#. module: l10n_mx
+#: model:account.report.column,name:l10n_mx.diot_report_paid_8_s_nc
+msgid "Paid 8 % S. - Non-Creditable"
+msgstr ""
+
+#. module: l10n_mx
 #: model_terms:res.company,invoice_terms_html:l10n_mx.demo_company_mx
 msgid "STANDARD TERMS AND CONDITIONS OF SALE"
+
+#. module: l10n_mx
+#: model:account.report.column,name:l10n_mx.diot_report_paid_8_s_wnc
+msgid "Paid 8 % Southern"
 msgstr ""
+
+#. module: l10n_mx
+#: model:account.report.column,name:l10n_mx.diot_report_paid_16_r
+msgid "Refunds 16%"
+msgstr ""
+
+#. module: l10n_mx
+#: model:account.report.column,name:l10n_mx.diot_report_paid_8_n_r
+msgid "Refunds 8 % Northern"
+msgstr ""
+
+#. module: l10n_mx
+#: model:account.report.column,name:l10n_mx.diot_report_paid_8_s_r
+msgid "Refunds 8 % Southern"
+msgstr ""
+
+#. module: l10n_mx
+#: model:account.report.column,name:l10n_mx.diot_report_paid_16_imp_r
+msgid "Refunds Importation 16%"
+msgstr ""
+
+#. module: l10n_mx
+#: model:account.report.column,name:l10n_mx.diot_report_paid_16_imp_int_r
+msgid "Refunds Intangible Imports 16%"
+msgstr ""
+
 
 #. module: l10n_mx
 #: model:uom.category,name:l10n_mx.product_uom_categ_service


### PR DESCRIPTION
After DIOT 2025 rework in 4e6bee49e98b055e5aebe89fb19ab6317003b682 
the report is missing some es translations

Steps to reproduce:
- With an MX Company and Spanish es_419 language set
- Open Accounting > Reporting > Tax Report
- Choose report Diot MX

opw-5016650