### PR TITLE
[FIX] html_builder: correct options layout issues

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_fontfamilypicker.scss
+++ b/addons/html_builder/static/src/core/building_blocks/builder_fontfamilypicker.scss
@@ -1,0 +1,4 @@
+.o-hidden-font-family-picker + .o-hb-select-toggle {
+    --btn-padding-x: #{map-get($spacers , 2)};
+    line-height: 1;
+}

--- a/addons/html_builder/static/src/core/building_blocks/builder_fontfamilypicker.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_fontfamilypicker.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="html_builder.BuilderFontFamilyPicker">
-    <BuilderSelect>
+    <BuilderSelect className="'o-hidden-font-family-picker'">
         <t t-foreach="fonts" t-as="font" t-key="font_index">
             <BuilderSelectItem t-props="forwardProps(font)">
                 <div class="d-flex justify-content-between">

--- a/addons/html_builder/static/src/core/building_blocks/builder_row.scss
+++ b/addons/html_builder/static/src/core/building_blocks/builder_row.scss
@@ -1,10 +1,12 @@
 @mixin sublevel-line($_level-left: 0) {
     position: absolute;
+    top: 0;
+    bottom: 0;
+    left: $_level-left - $o-we-border-width;
     border: $o-we-border-width solid var(--o-hb-row-sublevel-color, #{mix($o-we-bg-lighter, $o-we-fg-light)});
     border-width: 0 0 $o-we-border-width $o-we-border-width;
-    height: calc(100% + #{$o-hb-row-spacing * 3});
     pointer-events: none;
-    transform: translate($_level-left - $o-we-border-width, ($o-hb-row-min-height * -0.65) - $o-we-border-width);
+    transform: translate(0, ($o-hb-row-min-height + $o-hb-row-spacing) * -0.5 + $o-we-border-width);
     content: "";
 }
 
@@ -44,7 +46,6 @@
         min-width: 0;
         flex: 0 0 44%;
         z-index: $_z-index;
-        position: relative;
         background-color: var(--o-hb-row-bg-color, #{$o-we-bg-lighter});
         padding: $o-hb-row-spacing 0 $o-hb-row-spacing $o-hb-row-padding-left;
         align-self: baseline;
@@ -124,7 +125,7 @@
 
             & > .hb-row-label::after {
                 width: $_level-width;
-                left: $_level-left;
+                left: $_level-left - $o-we-border-width;
             }
         }
 

--- a/addons/html_builder/static/src/core/building_blocks/select_many2x.scss
+++ b/addons/html_builder/static/src/core/building_blocks/select_many2x.scss
@@ -17,6 +17,7 @@
 
     .o-hb-selectMany2X-toggle {
         &, &.btn-light.bg-light {
+            --btn-padding-x: #{map-get($spacers , 2)};
 
             @include button-variant(
                 $background: $o-we-item-clickable-bg,

--- a/addons/html_builder/static/src/plugins/shadow_option.xml
+++ b/addons/html_builder/static/src/plugins/shadow_option.xml
@@ -4,7 +4,7 @@
 <t t-name="html_builder.ShadowOption">
     <BuilderRow label.translate="Shadow">
        <BuilderButtonGroup action="props.setShadowModeAction">
-         <BuilderButton actionValue="'none'" id="'no_shadow'">None</BuilderButton>
+         <BuilderButton actionValue="'none'" id="'no_shadow'" className="'lh-1'">None</BuilderButton>
          <BuilderButton actionValue="'outset'" title.translate="Outset" iconImg="'/html_builder/static/img/options/shadow_out.svg'"/>
          <BuilderButton actionValue="'inset'" title.translate="Inset" iconImg="'/html_builder/static/img/options/shadow_in.svg'"/>
        </BuilderButtonGroup>


### PR DESCRIPTION
This PR fixes several options-related issues in the HTML Builder:
1. Improved the vertical sublevel line, which appeared blurry due to the transform property and an incorrect height. You can see the problem by "zooming out" multiple times.
2. Harmonized the padding of the visibility layout options and the background image position to align with the other pickers.
3. Fixed the height of the font-family picker: when you select a font-family, the height of the picker may change according to your selection (that's the case with Roboto for example - It's more "apparent" in the case of headings when it's next to the delete button as shown in the screenshot.)
4. Fixed the height of the “None” shadow option
=> these 2 issues where caused by the font metrics.


task-4985348


1 & 2
<img width="423" height="500" alt="image (1)" src="https://github.com/user-attachments/assets/a9304b67-607a-424a-94de-dd3dacece84f" />

3
<img width="1037" height="293" alt="Screenshot 2025-10-02 at 13 14 37" src="https://github.com/user-attachments/assets/d5982d34-2987-49d9-95cf-c78294521995" />

4
<img width="1542" height="231" alt="image" src="https://github.com/user-attachments/assets/13cbfa8f-dd72-41dc-82f2-c371f6ff2d77" />


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
