### PR TITLE
[IMP] base: improve uninstall wizard UI

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -225,7 +225,7 @@ class IrModel(models.Model):
                                default=_default_field_id)
     inherited_model_ids = fields.Many2many('ir.model', compute='_inherited_models', string="Inherited models",
                                            help="The list of models that extends the current model.")
-    state = fields.Selection([('manual', 'Custom Object'), ('base', 'Base Object')], string='Type', default='manual', readonly=True)
+    state = fields.Selection([('manual', 'Custom'), ('base', 'Base')], string='Type', default='manual', readonly=True)
     access_ids = fields.One2many('ir.model.access', 'model_id', string='Access')
     rule_ids = fields.One2many('ir.rule', 'model_id', string='Record Rules')
     abstract = fields.Boolean(string="Abstract Model")

--- a/odoo/addons/base/static/src/css/modules.css
+++ b/odoo/addons/base/static/src/css/modules.css
@@ -20,6 +20,10 @@
 .o_modules_field .o_modules_kanban .o_kanban_renderer {
     --KanbanRecord-width: 280px;
     --KanbanRecord-width-small: 280px;
+    .o_module_uninstalled {
+        /* img 50px + border 1px x 2 + padding 8px x 2 */
+        height: 68px;
+    }
 }
 
 .o_module_form.o_form_view .oe_avatar > img {

--- a/odoo/addons/base/wizard/base_module_uninstall.py
+++ b/odoo/addons/base/wizard/base_module_uninstall.py
@@ -8,36 +8,39 @@ class BaseModuleUninstall(models.TransientModel):
     _name = 'base.module.uninstall'
     _description = "Module Uninstall"
 
-    show_all = fields.Boolean()
     module_ids = fields.Many2many(
         'ir.module.module', string="Module(s)", required=True,
         domain=[('state', 'in', ['installed', 'to upgrade', 'to install'])],
         ondelete='cascade', readonly=True,
     )
+    impacted_application_count = fields.Integer(compute='_compute_impacted_module_ids')
+    impacted_application_ids = fields.Many2many('ir.module.module', string="Impacted applications",
+                                  compute='_compute_impacted_module_ids')
+    impacted_module_count = fields.Integer(compute='_compute_impacted_module_ids')
     impacted_module_ids = fields.Many2many('ir.module.module', string="Impacted modules",
                                   compute='_compute_impacted_module_ids')
-    model_ids = fields.Many2many('ir.model', string="Impacted data models",
+    model_count = fields.Integer(compute='_compute_model_ids')
+    model_ids = fields.Many2many('ir.model', string="Models to be deleted",
                                  compute='_compute_model_ids')
 
     def _get_modules(self):
         """ Return all the modules impacted by self. """
         return self.module_ids.downstream_dependencies(self.module_ids)
 
-    @api.depends('module_ids', 'show_all')
+    @api.depends('module_ids')
     def _compute_impacted_module_ids(self):
         for wizard in self:
-            modules = wizard._get_modules().sorted(lambda m: (not m.application, m.sequence))
-            wizard.impacted_module_ids = modules if wizard.show_all else wizard._modules_to_display(modules)
-
-    @api.model
-    def _modules_to_display(self, modules):
-        return modules.filtered('application')
+            modules = wizard._get_modules().sorted(lambda m: (m.sequence, m.name))
+            wizard.impacted_application_ids = modules.filtered('application')
+            wizard.impacted_application_count = len(wizard.impacted_application_ids)
+            wizard.impacted_module_ids = modules - wizard.impacted_application_ids
+            wizard.impacted_module_count = len(wizard.impacted_module_ids)
 
     def _get_models(self):
         """ Return the models (ir.model) to consider for the impact. """
         return self.env['ir.model'].search([('transient', '=', False)])
 
-    @api.depends('impacted_module_ids')
+    @api.depends('module_ids')
     def _compute_model_ids(self):
         ir_models = self._get_models()
         ir_models_xids = ir_models._get_external_ids()
@@ -51,14 +54,10 @@ class BaseModuleUninstall(models.TransientModel):
 
                 # find the models that have all their XIDs in the given modules
                 wizard.model_ids = ir_models.filtered(lost).sorted('name')
+                wizard.model_count = len(wizard.model_ids)
             else:
                 wizard.model_ids = False
-
-    @api.onchange('module_ids')
-    def _onchange_module_ids(self):
-        # if the user selects only technical modules, show technical modules.
-        if self.module_ids and not any(m.application for m in self.module_ids):
-            self.show_all = True
+                wizard.model_count = 0
 
     def action_uninstall(self):
         modules = self.module_ids

--- a/odoo/addons/base/wizard/base_module_uninstall_views.xml
+++ b/odoo/addons/base/wizard/base_module_uninstall_views.xml
@@ -6,44 +6,71 @@
             <field name="name">Uninstall module</field>
             <field name="model">base.module.uninstall</field>
             <field name="arch" type="xml">
-                <form string="Uninstall module">
-                    <div class="alert alert-warning oe_button_box" role="alert">
-                        <p class="mt-3">
-                            Uninstalling modules can be risky, we recommend you to try it on a duplicate or test database first.
-                        </p>
+                <form string="Uninstallation">
+                    <div>Uninstalling modules can be risky. We recommend to try it on a testing environment first.</div>
+                    <div>
+                        This will remove:
+                        <ul>
+                            <li invisible="not impacted_application_count"><field name="impacted_application_count" readonly="1"/> <span invisible="impacted_application_count == 1"> apps</span><span invisible="impacted_application_count > 1"> app</span></li>
+                            <li invisible="not impacted_module_count"><field name="impacted_module_count" readonly="1"/> <span invisible="impacted_module_count == 1"> modules</span><span invisible="impacted_module_count > 1"> module</span></li>
+                            <li invisible="not model_count"><field name="model_count" readonly="1"/><span invisible="model_count == 1"> models</span><span invisible="model_count > 1"> model</span></li>
+                        </ul>
                     </div>
-                    <div class="d-flex bd-highlight">
-                        <div class="me-auto p-2 bd-highlight"><h3>Apps to Uninstall</h3></div>
-                        <div class="p-2 bd-highlight"><field name="show_all"/> Show All</div>
-                    </div>
-                    <field name="impacted_module_ids" mode="kanban" class="o_modules_field">
-                        <kanban create="false" class="o_modules_kanban">
-                            <field name="state"/>
-                                <templates>
-                                    <t t-name="card" class="flex-row align-items-center">
-                                        <aside>
-                                            <field name="icon" widget="image_url" options="{'size': [50, 50]}" alt="Icon"/>
-                                        </aside>
-                                        <main t-att-title="record.shortdesc.value">
-                                            <field class="fw-bold fs-5 mb-0" name="shortdesc" />
-                                            <p class="text-muted small my-1 lh-sm">
-                                                <field groups="!base.group_no_one" name="summary" />
-                                                <code groups="base.group_no_one">
-                                                    <field name="name" />
-                                                </code>
-                                            </p>
-                                        </main>
-                                    </t>
-                                </templates>
-                        </kanban>
-                    </field>
-                    <h3>Documents to Delete</h3>
-                    <field name="model_ids" string="Models" nolabel="1">
-                        <list string="Models">
-                            <field name="name" string="Document"/>
-                            <field name="count"/>
-                        </list>
-                    </field>
+                    <notebook>
+                        <page string="Apps" invisible="not impacted_application_count">
+                            <field name="impacted_application_ids" mode="kanban" class="o_modules_field">
+                                <kanban create="false" class="o_modules_kanban" limit="12">
+                                    <field name="state"/>
+                                    <templates>
+                                        <t t-name="card" class="flex-row align-items-center o_module_uninstalled">
+                                            <aside>
+                                                <field name="icon" widget="image_url" options="{'size': [50, 50]}" alt="Icon"/>
+                                            </aside>
+                                            <main t-att-title="record.shortdesc.value" class="overflow-auto">
+                                                <field class="fw-bold fs-5 mb-0" name="shortdesc" />
+                                                <p class="text-muted small my-1 lh-sm">
+                                                    <code groups="base.group_no_one">
+                                                        <field name="name" />
+                                                    </code>
+                                                </p>
+                                            </main>
+                                        </t>
+                                    </templates>
+                                </kanban>
+                            </field>
+                        </page>
+                        <page string="Modules" invisible="not impacted_module_ids">
+                            <field name="impacted_module_ids" mode="kanban" class="o_modules_field">
+                                <kanban create="false" class="o_modules_kanban" limit="12">
+                                    <field name="state"/>
+                                    <templates>
+                                        <t t-name="card" class="flex-row align-items-center o_module_uninstalled">
+                                            <aside>
+                                                <field name="icon" widget="image_url" options="{'size': [50, 50]}" alt="Icon"/>
+                                            </aside>
+                                            <main t-att-title="record.shortdesc.value" class="overflow-auto">
+                                                <field class="fw-bold fs-5 mb-0" name="shortdesc" />
+                                                <p class="text-muted small my-1 lh-sm">
+                                                    <code groups="base.group_no_one">
+                                                        <field name="name" />
+                                                    </code>
+                                                </p>
+                                            </main>
+                                        </t>
+                                    </templates>
+                                </kanban>
+                            </field>
+                        </page>
+                        <page string="Models" invisible="not model_count">
+                            <field name="model_ids" string="Models" nolabel="1">
+                                <list limit="20">
+                                    <field name="name" string="Model"/>
+                                    <field name="state" string="Type"/>
+                                    <field name="count" string="# Records"/>
+                                </list>
+                            </field>
+                        </page>
+                    </notebook>
                     <footer>
                         <button string="Uninstall" class="btn-secondary" type="object" name="action_uninstall" data-hotkey="q"/>
                         <button string="Discard" class="btn-primary" special="cancel" data-hotkey="x"/>


### PR DESCRIPTION
The uninstall wizard has been redesigned with several improvements:

- Apps and non-app modules are now shown separately, instead of hiding non-app modules behind a Show all checkbox.

- The wizard now warns the user with the number of apps, modules and records affected by the uninstallation and the details are shown unconditionally inside a notebook.

task-5111398