### PR TITLE
[IMP] website(_links): redesign the default contact page

### DIFF
--- a/addons/html_editor/static/src/scss/html_editor.frontend.scss
+++ b/addons/html_editor/static/src/scss/html_editor.frontend.scss
@@ -54,12 +54,7 @@
         }
 
         &.o_grid_item_image img {
-            // See BORDER_VARIABLES_RULES_EXTENSION
-            border-radius:
-                calc(var(--box-border-top-left-radius, 0px) - max(var(--box-border-top-width, 0px), var(--box-border-left-width, 0px)))
-                calc(var(--box-border-top-right-radius, 0px) - max(var(--box-border-top-width, 0px), var(--box-border-right-width, 0px)))
-                calc(var(--box-border-bottom-right-radius, 0px) - max(var(--box-border-bottom-width, 0px), var(--box-border-right-width, 0px)))
-                calc(var(--box-border-bottom-left-radius, 0px) - max(var(--box-border-bottom-width, 0px), var(--box-border-left-width, 0px)));
+            @extend %o-we-inner-border-radius;
         }
     }
 }
@@ -218,4 +213,22 @@ body.editor_enable:not(.o_basic_theme) .odoo-editor-editable {
     .rounded#{$class-suffix} {
         @extend %box-border-radius-rules;
     }
+}
+
+// For border with all 4 edges of equal value the max function is useless,
+// but in case the border is uneven it approximates the correct roundness
+// See BORDER_VARIABLES_RULES_EXTENSION
+//
+// --box-border-XXX-(radius|width) : editor Round Corners user input
+// --box-border-(radius|width) : rounded-XXX classes
+// --border-(radius|width) : theme (+ default bootstrap)
+//
+// Generic rule for inner elements to inherit a parent's border-radius
+// without requiring overflow: hidden on the parent.
+%o-we-inner-border-radius {
+    border-radius:
+        calc(var(--box-border-top-left-radius, 0px) - max(var(--box-border-top-width, 0px), var(--box-border-left-width, 0px)))
+        calc(var(--box-border-top-right-radius, 0px) - max(var(--box-border-top-width, 0px), var(--box-border-right-width, 0px)))
+        calc(var(--box-border-bottom-right-radius, 0px) - max(var(--box-border-bottom-width, 0px), var(--box-border-right-width, 0px)))
+        calc(var(--box-border-bottom-left-radius, 0px) - max(var(--box-border-bottom-width, 0px), var(--box-border-left-width, 0px)));
 }

--- a/addons/website/data/website_data.xml
+++ b/addons/website/data/website_data.xml
@@ -32,22 +32,14 @@
             }"/>
             <span class="hidden" data-for="contactus_form" t-att-data-values="contactus_form_values"/>
             <div id="wrap" class="oe_structure oe_empty">
-                <section class="s_title parallax s_parallax_is_fixed bg-black-50 pt24 pb24" data-vcss="001" data-snippet="s_title" data-scroll-background-ratio="1">
-                    <span class="s_parallax_bg_wrap">
-                        <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_parallax_default_image'); background-position: 50% 0;"/>
-                    </span>
-                    <div class="o_we_bg_filter bg-black-50"/>
+                <section class="s_form_aside pt48 pb120" data-snippet="s_form_aside" data-name="Form Aside" data-oe-shape-data="{'shape': 'html_builder/Connections/14', 'colors': {'c5': 'o-color-1'}, 'showOnMobile': true}" style="position: relative;">
+                    <div class="o_we_shape o_html_builder_Connections_14 o_shape_show_mobile" style="background-image: url('/html_editor/shape/html_builder/Connections/14.svg?c5=o-color-1');"/>
                     <div class="container">
-                        <h1>Contact us</h1>
-                    </div>
-                </section>
-                <section class="s_text_block pt40 pb40 o_colored_level " data-snippet="s_text_block">
-                    <div class="container s_allow_columns">
                         <div class="row">
-                            <div class="col-lg-7 mt-4 mt-lg-0">
+                            <div class="col-12 col-lg-6 order-lg-0" style="order: 1;">
+                                <h1 class="h2-fs">Contact us</h1>
                                 <p class="lead">
-                                    Contact us about anything related to our company or services.<br/>
-                                    We'll do our best to get back to you as soon as possible.
+                                    Contact us about anything related to our company or services.
                                 </p>
                                 <section class="s_website_form" data-vcss="001" data-snippet="s_website_form">
                                     <div class="container">
@@ -58,40 +50,41 @@
                                                         <span class="s_website_form_label_content">Name</span>
                                                         <span class="s_website_form_mark"> *</span>
                                                     </label>
-                                                    <input id="contact1" type="text" class="form-control s_website_form_input" name="name" required="" data-fill-with="name"/>
+                                                    <input id="contact1" type="text" placeholder="John Doe" class="form-control s_website_form_input" name="name" required="" data-fill-with="name"/>
                                                 </div>
                                                 <div class="mb-3 col-lg-6 s_website_form_field s_website_form_custom" data-type="char" data-name="Field">
                                                     <label class="s_website_form_label" style="width: 200px" for="contact2">
                                                         <span class="s_website_form_label_content">Phone Number</span>
                                                     </label>
-                                                    <input id="contact2" type="tel" class="form-control s_website_form_input" name="phone" data-fill-with="phone"/>
+                                                    <input id="contact2" type="tel" placeholder="+1 555-555-5556" class="form-control s_website_form_input" name="phone" data-fill-with="phone"/>
                                                 </div>
                                                 <div class="mb-3 col-lg-6 s_website_form_field s_website_form_required s_website_form_model_required" data-type="email" data-name="Field">
                                                     <label class="s_website_form_label" style="width: 200px" for="contact3">
                                                         <span class="s_website_form_label_content">Email</span>
                                                         <span class="s_website_form_mark"> *</span>
                                                     </label>
-                                                    <input id="contact3" type="email" class="form-control s_website_form_input" name="email_from" required="" data-fill-with="email"/>
+                                                    <input id="contact3" type="email" placeholder="example@mail.com" class="form-control s_website_form_input" name="email_from" required="" data-fill-with="email"/>
                                                 </div>
                                                 <div class="mb-3 col-lg-6 s_website_form_field s_website_form_custom" data-type="char" data-name="Field">
                                                     <label class="s_website_form_label" style="width: 200px" for="contact4">
                                                         <span class="s_website_form_label_content">Company</span>
                                                     </label>
-                                                    <input id="contact4" type="text" class="form-control s_website_form_input" name="company" data-fill-with="commercial_company_name"/>
+                                                    <input id="contact4" type="text" placeholder="ACME Corp" class="form-control s_website_form_input" name="company" data-fill-with="commercial_company_name"/>
                                                 </div>
                                                 <div class="mb-3 col-12 s_website_form_field s_website_form_required s_website_form_model_required" data-type="char" data-name="Field">
                                                     <label class="s_website_form_label" style="width: 200px" for="contact5">
                                                         <span class="s_website_form_label_content">Subject</span>
                                                         <span class="s_website_form_mark"> *</span>
                                                     </label>
-                                                    <input id="contact5" type="text" class="form-control s_website_form_input" name="subject" required=""/>
+                                                    <input id="contact5" type="text" placeholder="Describe your request" class="form-control s_website_form_input" name="subject" required=""/>
                                                 </div>
                                                 <div class="mb-3 col-12 s_website_form_field s_website_form_custom s_website_form_required" data-type="text" data-name="Field">
                                                     <label class="s_website_form_label" style="width: 200px" for="contact6">
-                                                        <span class="s_website_form_label_content">Question</span>
+                                                        <span class="s_website_form_label_content">Message</span>
                                                         <span class="s_website_form_mark"> *</span>
                                                     </label>
-                                                    <textarea id="contact6" class="form-control s_website_form_input" name="description" required="" rows="8"></textarea>
+                                                    <textarea id="contact6" placeholder="Write down your message" class="form-control s_website_form_input" name="description" required="" rows="6"></textarea>
+                                                    <div class="s_website_form_field_description small form-text text-muted">We typically respond within 1-2 business days.</div>
                                                 </div>
                                                 <div class="mb-3 col-12 s_website_form_field s_website_form_dnone">
                                                     <div class="row s_col_no_resize s_col_no_bgcolor">
@@ -105,21 +98,111 @@
                                                 </div>
                                                 <div class="mb-0 py-2 col-12 s_website_form_submit s_website_form_no_submit_label text-end" data-name="Submit Button">
                                                     <div style="width: 200px;" class="s_website_form_label"/>
-                                                    <a href="#" role="button" class="btn btn-primary s_website_form_send">Submit</a>
                                                     <span id="s_website_form_result"></span>
+                                                    <a href="#" role="button" class="btn btn-primary s_website_form_send">Send Message</a>
                                                 </div>
                                             </div>
                                         </form>
                                     </div>
                                 </section>
                             </div>
-                            <div class="col-lg-4 offset-lg-1 mt-4 mt-lg-0">
-                                <h5>My Company</h5>
-                                <ul class="list-unstyled mb-0 ps-2">
-                                    <li><i class="fa fa-map-marker fa-fw me-2"/><span class="o_force_ltr">3575 Fake Buena Vista Avenue</span></li>
-                                    <li><i class="fa fa-phone fa-fw me-2"/><span class="o_force_ltr">+1 555-555-5556</span></li>
-                                    <li><i class="fa fa-1x fa-fw fa-envelope me-2"/><span>info@yourcompany.example.com</span></li>
-                                </ul>
+                            <div class="col-12 col-lg-5 offset-lg-1 pt0 pb32 order-lg-0" style="order: 0;">
+                                <img src="/web/image/website.s_form_aside_default_image" class="img img-fluid rounded" alt=""/>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+                <section class="s_title o_cc o_cc4 pt136 pb128" data-vcss="001" data-snippet="s_title" data-name="Title">
+                    <div class="container">
+                        <h2 class="display-4-fs" style="text-align: center;">50,000+ companies use our services <br/>to grow their businesses.</h2>
+                        <p class="lead" style="text-align: center;">Join us and make your company a better place.</p>
+                    </div>
+                </section>
+                <section class="s_faq_list pt120 pb56" data-snippet="s_faq_list" data-name="FAQ List" data-oe-shape-data="{'shape': 'html_builder/Connections/14', 'colors': {'c5': 'o-color-1'}, 'flip': ['y'], 'showOnMobile': true}">
+                    <div class="o_we_shape o_html_builder_Connections_14 o_shape_show_mobile" style="background-image: url('/html_editor/shape/html_builder/Connections/14.svg?c5=o-color-1&amp;flip=y'); background-position: 50% 0%;"/>
+                    <div class="container">
+                        <div class="row s_nb_column_fixed">
+                            <div class="col-lg-12 pb24">
+                                <h2 class="h3-fs">Need help?</h2>
+                                <p class="lead">In this section, you can address common questions efficiently.</p>
+                            </div>
+                            <div class="col-lg-4 pt16 pb16">
+                                <h3 class="h6-fs"><strong>What sets us apart?</strong></h3>
+                                <p>We deliver personalized solutions, ensuring that every customer receives top-tier service tailored to their needs.</p>
+                            </div>
+                            <div class="col-lg-4 pt16 pb16">
+                                <h3 class="h6-fs"><strong>Is the website user-friendly?</strong></h3>
+                                <p>Our website is designed for easy navigation, allowing you to find the information you need quickly and efficiently.</p>
+                            </div>
+                            <div class="col-lg-4 pt16 pb16">
+                                <h3 class="h6-fs"><strong>Can you trust our partners?</strong></h3>
+                                <p>We collaborate with trusted, high-quality partners to bring you reliable and top-notch products and services.</p>
+                            </div>
+                            <div class="col-lg-4 pt16 pb16">
+                                <h3 class="h6-fs"><strong>What support do we offer?</strong></h3>
+                                <p>We provide 24/7 support through various channels, including live chat, email, and phone, to assist with any queries.</p>
+                            </div>
+                            <div class="col-lg-4 pt16 pb16">
+                                <h3 class="h6-fs"><strong>How is your data secured?</strong></h3>
+                                <p>Your data is protected by advanced encryption and security protocols, keeping your personal information safe.</p>
+                            </div>
+                            <div class="col-lg-4 pt16 pb16">
+                                <h3 class="h6-fs"><strong>Are links to other websites approved?</strong></h3>
+                                <p>Although this Website may be linked to other websites, we are not, directly or indirectly, implying any approval.</p>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+                <div class="s_hr pt32 pb32" data-snippet="s_hr" data-name="Separator">
+                    <hr class="w-100 mx-auto"/>
+                </div>
+                <section class="s_accordion_image pt64 pb120" data-snippet="s_accordion_image" data-name="Accordion Image">
+                    <div class="container">
+                        <div class="row align-items-start">
+                            <div class="col-lg-7 pt16">
+                                <section class="s_map pt248 pb248 rounded-3" data-map-type="m" data-map-zoom="12" data-snippet="s_map" data-map-address="250 Executive Park Blvd, Suite 3400 San Francisco California (US) United States" data-name="Map">
+                                    <div class="map_container o_not_editable">
+                                        <div class="css_non_editable_mode_hidden">
+                                            <div class="missing_option_warning alert alert-info rounded-0 fade show d-none d-print-none">
+                                                An address must be specified for a map to be embedded
+                                            </div>
+                                        </div>
+                                        <iframe class="s_map_embedded o_not_editable" src="https://maps.google.com/maps?q=250%20Executive%20Park%20Blvd%2C%20Suite%203400%20San%20Francisco%20California%20(US)%20United%20States&amp;t=m&amp;z=12&amp;ie=UTF8&amp;iwloc=&amp;output=embed" width="100%" height="100%" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" aria-label="Map"></iframe>
+                                        <div class="s_map_color_filter"></div>
+                                    </div>
+                                </section>
+                            </div>
+                            <div class="col-lg-4 offset-lg-1 pt24">
+                                <h2 class="h3-fs">Come Visit Us</h2>
+                                <p class="lead">Easy ways to reach us, no matter your favorite transport.</p>
+                                <div class="s_accordion" data-snippet="s_accordion" data-name="Accordion" data-vcss="000">
+                                    <div id="o_contactus_accordion" class="s_accordion_highlight accordion">
+                                        <div class="accordion-item position-relative z-1" data-name="Accordion Item">
+                                            <button type="button" id="o_contactus_accordion_btn_1" class="accordion-header accordion-button justify-content-between gap-2 bg-transparent h6-fs fw-bold text-decoration-none text-reset transition-none" data-bs-target="#o_contactus_accordion_1" aria-controls="o_contactus_accordion_1" data-bs-toggle="collapse" aria-expanded="true"><span class="flex-grow-1">By Train</span></button>
+                                            <div id="o_contactus_accordion_1" class="accordion-collapse collapse show" data-bs-parent="#o_contactus_accordion" role="region" aria-labelledby="o_contactus_accordion_btn_1">
+                                                <div class="accordion-body">
+                                                    <p>Take BART to Balboa Park Station. From there, board the 29 bus toward Bayview and get off at Executive Park. The building at 250 Executive Park Blvd, Suite 3400, is just a short walk from the stop.</p>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="accordion-item position-relative z-1" data-name="Accordion Item">
+                                            <button type="button" id="o_contactus_accordion_btn_2" class="accordion-header accordion-button collapsed justify-content-between gap-2 bg-transparent h6-fs fw-bold text-decoration-none text-reset transition-none" data-bs-target="#o_contactus_accordion_2" aria-controls="o_contactus_accordion_2" data-bs-toggle="collapse" aria-expanded="false"><span class="flex-grow-1">By Car</span></button>
+                                            <div id="o_contactus_accordion_2" class="accordion-collapse collapse" data-bs-parent="#o_contactus_accordion" role="region" aria-labelledby="o_contactus_accordion_btn_2">
+                                                <div class="accordion-body">
+                                                    <p>From downtown San Francisco, follow US-101 South and exit at Bayshore Boulevard. Turn left onto Executive Park Blvd, then continue straight until you reach 250 Executive Park Blvd. Parking is available on-site near Suite 3400.</p>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="accordion-item position-relative z-1" data-name="Accordion Item">
+                                            <button type="button" id="o_contactus_accordion_btn_3" class="accordion-header accordion-button collapsed justify-content-between gap-2 bg-transparent h6-fs fw-bold text-decoration-none text-reset transition-none" data-bs-target="#o_contactus_accordion_3" aria-controls="o_contactus_accordion_3" data-bs-toggle="collapse" aria-expanded="false"><span class="flex-grow-1">By Bike</span></button>
+                                            <div id="o_contactus_accordion_3" class="accordion-collapse collapse" data-bs-parent="#o_contactus_accordion" role="region" aria-labelledby="o_contactus_accordion_btn_3">
+                                                <div class="accordion-body">
+                                                    <p>Cyclists can follow the Bay Trail south from downtown and connect through Geneva Avenue. Head toward Executive Park Blvd, where bike racks are available at 250 Executive Park Blvd, Suite 3400.</p>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -139,25 +222,14 @@
             <t name="Thanks (Contact us)" t-name="website.contactus_thanks">
                 <t t-call="website.layout">
                     <div id="wrap" class="oe_structure oe_empty">
-                        <section class="s_text_block pt40 pb40 o_colored_level " data-snippet="s_text_block">
+                        <section class="s_text_block pt80 pb80" data-snippet="s_text_block" data-name="Thank You Section">
                             <div class="container s_allow_columns">
                                 <div class="row">
-                                    <div class="col-lg-6 offset-lg-1 text-center">
-                                        <div class="d-inline-block mx-auto p-4">
-                                            <i class="fa fa-paper-plane fa-2x mb-3 rounded-circle text-bg-success" role="presentation"/>
-                                            <h1 class="fw-bolder">Thank You!</h1>
-                                            <p class="lead mb-0">Your message has been sent.</p>
-                                            <p class="lead">We will get back to you shortly.</p>
-                                            <a href="/">Go to Homepage</a>
-                                        </div>
-                                    </div>
-                                    <div class="col-lg-4 offset-lg-1">
-                                        <h5>My Company</h5>
-                                        <ul class="list-unstyled mb-0 ps-2">
-                                            <li><i class="fa fa-map-marker fa-fw me-2"/><span class="o_force_ltr">3575 Fake Buena Vista Avenue</span></li>
-                                            <li><i class="fa fa-phone fa-fw me-2"/><span class="o_force_ltr">+1 555-555-5556</span></li>
-                                            <li><i class="fa fa-1x fa-fw fa-envelope me-2"/><span>info@yourcompany.example.com</span></li>
-                                        </ul>
+                                    <div class="col-lg-12" style="text-align: center;">
+                                        <i class="fa fa-paper-plane fa-2x mb-3 rounded-circle text-bg-success" role="presentation"/>
+                                        <h1 class="fw-bolder">Thank You!</h1>
+                                        <p class="lead">Your message has been sent. <br/>We will get back to you shortly.</p>
+                                        <a href="/">Go to Homepage</a>
                                     </div>
                                 </div>
                             </div>

--- a/addons/website/static/src/builder/plugins/options/map_option.xml
+++ b/addons/website/static/src/builder/plugins/options/map_option.xml
@@ -55,6 +55,13 @@
                     'solid': [],
                 }"/>
     </BuilderRow>
+    <BuilderRow label.translate="Roundness" preview="false">
+        <BuilderRange
+            action="'setClassRange'"
+            actionParam="['rounded-0','rounded-1','rounded-2','rounded-3','rounded-4','rounded-5']"
+            max="5"
+        />
+    </BuilderRow>
     <BuilderRow label.translate="Description">
         <BuilderCheckbox action="'mapDescription'"/>
     </BuilderRow>

--- a/addons/website/static/src/snippets/s_map/000.scss
+++ b/addons/website/static/src/snippets/s_map/000.scss
@@ -10,6 +10,10 @@ $s-map-desc-hover-alpha: 0.55 !default;
 
     .map_container {
         @include o-position-absolute(0, 0, 0, 0);
+
+        .s_map_embedded {
+            @extend %o-we-inner-border-radius;
+        }
     }
     .description {
         @include o-position-absolute(auto, 0, 0, 0);

--- a/addons/website/views/snippets/s_map.xml
+++ b/addons/website/views/snippets/s_map.xml
@@ -2,7 +2,7 @@
 <odoo>
 
 <template name="Map" id="s_map">
-    <section class="s_map pb56 pt56" data-map-type="m" data-map-zoom="12" t-att-data-map-address="' '.join(filter(None, (user_id.company_id.street, user_id.company_id.city, user_id.company_id.state_id.display_name, user_id.company_id.country_id.display_name)))">
+    <section class="s_map pb56 pt56 rounded-3" data-map-type="m" data-map-zoom="12" t-att-data-map-address="' '.join(filter(None, (user_id.company_id.street, user_id.company_id.city, user_id.company_id.state_id.display_name, user_id.company_id.country_id.display_name)))">
         <div class="map_container o_not_editable">
             <div class="css_non_editable_mode_hidden">
                 <div class="missing_option_warning alert alert-info rounded-0 fade show d-none d-print-none">

--- a/addons/website_links/static/tests/tours/website_links.js
+++ b/addons/website_links/static/tests/tours/website_links.js
@@ -79,7 +79,7 @@ registry.category("web_tour.tours").add('website_links_tour', {
         },
         {
             content: "check that we landed on correct page with correct query strings",
-            trigger: ".s_title h1:contains(/^Contact us$/)",
+            trigger: ".s_form_aside h1:contains(/^Contact us$/)",
             run: function () {
                 const enc = c => encodeURIComponent(c).replace(/%20/g, '+');
                 const expectedUrl = `/contactus?utm_campaign=${enc(campaignValue)}&utm_source=${enc(sourceValue)}&utm_medium=${enc(mediumValue)}`;


### PR DESCRIPTION
The "Contact us" page has been reworked to better showcase the capabilities of the website builder and to rely on modern snippets.

This commit also removes the "company infos" section, following user feedback that expected it to update automatically when company info was changed in the backend.

task-3685590
______

| Before | After |
|--------|--------|
| <img width="1920" height="1209" alt="screencapture-90215389-master-design-theme-runbot184-odoo-contactus-2025-10-01-14_32_31" src="https://github.com/user-attachments/assets/9cb670d4-e800-45a0-9631-43fdfdd0d007" /> | <img width="1920" height="2986" alt="screencapture-localhost-9999-contactus-2025-10-01-14_32_35" src="https://github.com/user-attachments/assets/6d2f3df9-75ba-436c-9321-2fd68c16ec23" /> | 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
