### PR TITLE
[FIX] m2o_avatar: Prevent opening record when 'no_open' option is true

### DIFF
--- a/addons/web/static/src/views/fields/many2one_avatar/many2one_avatar_field.js
+++ b/addons/web/static/src/views/fields/many2one_avatar/many2one_avatar_field.js
@@ -18,7 +18,7 @@ export const many2OneAvatarField = {
     component: Many2OneAvatarField,
     extractProps(fieldInfo) {
         const props = many2OneField.extractProps(...arguments);
-        props.canOpen = fieldInfo.viewType === "form";
+        props.canOpen = props.canOpen && fieldInfo.viewType === "form";
         return props;
     },
 };

--- a/doc/cla/individual/mohandgesm.md
+++ b/doc/cla/individual/mohandgesm.md
@@ -1,0 +1,11 @@
+Sudan, 2025-09-21
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Mohand-GesmElkhalig mohandgesm8420@gmail.com https://github.com/mohandgesm


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

The ‘Many2OneAvatar‘ widget did not respect the ‘no_open‘ option when determining if the record could be opened on click.

The logic for setting ‘props.canOpen‘ was overwriting the initial value (which respected ‘no_open‘), making it always ‘true‘ if a form view was available for the related model.

before:
props.canOpen = fieldInfo.viewType === "form";

after:
props.canOpen = props.canOpen && fieldInfo.viewType === "form";

This change ensures that if ‘props.canOpen‘ is initially ‘false‘ due to the ‘no_open‘ option, it remains  ‘false‘, thereby preventing the record from being opened.

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
