### PR TITLE
[18.0][FIX] mail: Sort mail.message by date, id.

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -1102,17 +1102,34 @@ class Message(models.Model):
                 [("subtype_id.description", "ilike", search_term)],
             ])])
             res["count"] = self.search_count(domain)
+
+        # TODO User setting to sort by date other than create_date?
+        def _domain(message, date_oper, id_oper=''):
+            return expression.OR([
+                [('create_date', date_oper, message.create_date)],
+                expression.AND([
+                    [('create_date', '=', message.create_date)],
+                    [('id', id_oper or date_oper, message.id)]])])
+        _order_asc = 'create_date ASC, id ASC'
+        _order_desc = 'create_date DESC, id DESC'
+        _sort_key = lambda m: (m.create_date, m.id)
+
         if around is not None:
-            messages_before = self.search(domain=[*domain, ('id', '<=', around)], limit=limit // 2, order="id DESC")
-            messages_after = self.search(domain=[*domain, ('id', '>', around)], limit=limit // 2, order='id ASC')
-            return {**res, "messages": (messages_after + messages_before).sorted('id', reverse=True)}
-        if before:
-            domain = expression.AND([domain, [('id', '<', before)]])
-        if after:
-            domain = expression.AND([domain, [('id', '>', after)]])
-        res["messages"] = self.search(domain, limit=limit, order='id ASC' if after else 'id DESC')
-        if after:
-            res["messages"] = res["messages"].sorted('id', reverse=True)
+            limit /= 2
+            if around and (around := self.browse(around).exists()):
+                messages_before = self.search(expression.AND([domain, _domain(around, '<', '<=')]), limit=limit, order=_order_desc)
+                messages_after = self.search(expression.AND([domain, _domain(around, '>')]), limit=limit, order=_order_asc).sorted(_sort_key, reverse=True)
+                res["messages"] = messages_after + messages_before
+            else:
+                res["messages"] = self.search(domain, limit=limit, order=_order_asc).sorted(_sort_key, reverse=True)
+        else:
+            if before and (before := self.browse(before).exists()):
+                domain = expression.AND([domain, _domain(before, '<')])
+            if after and (after := self.browse(after).exists()):
+                domain = expression.AND([domain, _domain(after, '>')])
+            res["messages"] = self.search(domain, limit=limit, order=_order_asc if after else _order_desc)
+            if after:
+                res["messages"] = res["messages"].sorted(_sort_key, reverse=True)
         return res
 
     def _message_notifications_to_store(self, store: Store):

--- a/addons/mail/static/tests/mock_server/mock_models/mail_message.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_message.js
@@ -9,6 +9,8 @@ import {
     serverState,
 } from "@web/../tests/web_test_helpers";
 
+const { DateTime } = luxon;
+
 /** @typedef {import("@web/core/domain").DomainListRepr} DomainListRepr */
 
 export class MailMessage extends models.ServerModel {
@@ -465,30 +467,43 @@ export class MailMessage extends models.ServerModel {
             domain.push(["body", "ilike", search_term]);
             res.count = this.search_count(domain);
         }
+
+        // TODO User setting to sort by date other than create_date?
+        const _browse = (id) => this.filter(item => item.id == id)?.[0];
+        const _domain = (message, date_oper, id_oper) => [
+            "|",
+            ["create_date", date_oper, message.create_date],
+            "&",
+            ["create_date", "=", message.create_date],
+            ["id", id_oper || date_oper, message.id],
+        ];
+        const _sort_asc = (m1, m2) => (DateTime.fromJSDate(m1.create_date).ts - DateTime.fromJSDate(m2.create_date).ts) || (m1.id - m2.id);
+        const _sort_desc = (m1, m2) => (DateTime.fromJSDate(m2.create_date).ts - DateTime.fromJSDate(m1.create_date).ts) || (m2.id - m1.id);
+
         if (around !== undefined) {
-            const messagesBefore = this._filter(domain.concat([["id", "<=", around]])).sort(
-                (m1, m2) => m2.id - m1.id
-            );
-            messagesBefore.length = Math.min(messagesBefore.length, limit / 2);
-            const messagesAfter = this._filter(domain.concat([["id", ">", around]])).sort(
-                (m1, m2) => m1.id - m2.id
-            );
-            messagesAfter.length = Math.min(messagesAfter.length, limit / 2);
-            const messages = messagesAfter
-                .concat(messagesBefore.reverse())
-                .sort((m1, m2) => m2.id - m1.id);
-            return { ...res, messages };
+            limit /= 2;
+            if (around && (around = _browse(around))) {
+                const messagesBefore = this._filter(domain.concat(_domain(around, "<", "<="))).sort(_sort_desc);
+                messagesBefore.length = Math.min(messagesBefore.length, limit);
+                const messagesAfter = this._filter(domain.concat(_domain(around, ">"))).sort(_sort_asc);
+                messagesAfter.length = Math.min(messagesAfter.length, limit);
+                res.messages = messagesAfter.concat(messagesBefore.reverse()).sort(_sort_desc);
+            } else {
+                let messages = this._filter(domain).sort(_sort_asc);
+                messages.length = Math.min(messages.length, limit);
+                res.messages = messages.sort(_sort_desc);
+            }
+        } else {
+            if (before && (before = _browse(before))) {
+                domain.push(..._domain(before, "<"));
+            }
+            if (after && (after = _browse(after))) {
+                domain.push(..._domain(after, ">"));
+            }
+            let messages = this._filter(domain).sort(_sort_desc);
+            messages.length = Math.min(messages.length, limit);
+            res.messages = messages;
         }
-        if (before) {
-            domain.push(["id", "<", before]);
-        }
-        if (after) {
-            domain.push(["id", ">", after]);
-        }
-        const messages = this._filter(domain).sort((m1, m2) => m2.id - m1.id);
-        // pick at most 'limit' messages
-        messages.length = Math.min(messages.length, limit);
-        res.messages = messages;
         return res;
     }
 


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

Alternate implementation of #203708:

### Current behavior before PR:

Chatter messages were not always ordered correctly by date.

### Desired behavior after PR is merged:

Chatter messages are now consistently displayed in chronological order.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
