### PR TITLE
[FIX] website_sale: Fix preview for 1:1 aspect ratio thumbnails

### DIFF
--- a/addons/sale/static/src/js/product/product.scss
+++ b/addons/sale/static/src/js/product/product.scss
@@ -19,12 +19,6 @@
     @include media-breakpoint-up(md) {
         width: 120px;
     }
-
-    img {
-        aspect-ratio: 1;
-        object-fit: cover;
-        object-position: center;
-    }
 }
 
 @include media-breakpoint-up(md) {

--- a/addons/website_sale/static/src/scss/primary_variables.scss
+++ b/addons/website_sale/static/src/scss/primary_variables.scss
@@ -3,3 +3,11 @@ $o-wsale-products-layout-grid-ratio: 1.0 !default;
 $o-wsale-dropdown-width-overflow: 8em !default;
 
 $o-wsale-input-max-width: 32em !default;
+
+$o-wsale-shop-ratios: (
+    '16_9': 16/9,
+    '4_3': 4/3,
+    '6_5': 6/5,
+    '4_5': 4/5,
+    '2_3': 2/3
+) !default;

--- a/addons/website_sale/static/src/scss/product_tile.scss
+++ b/addons/website_sale/static/src/scss/product_tile.scss
@@ -1163,25 +1163,17 @@ $_wsale_products_roundness_map: (
 }
 
 // ==== Products list thumb options
-.o_wsale_products_opt_thumb_16_9 {
-    --o-wsale-card-thumb-aspect-ratio: 16/9;
-}
-.o_wsale_products_opt_thumb_4_3 {
-    --o-wsale-card-thumb-aspect-ratio: 4/3;
-}
-.o_wsale_products_opt_thumb_6_5 {
-    --o-wsale-card-thumb-aspect-ratio: 6/5;
-}
-.o_wsale_products_opt_thumb_4_5 {
-    --o-wsale-card-thumb-aspect-ratio: 4/5;
-}
-.o_wsale_products_opt_thumb_2_3 {
-    --o-wsale-card-thumb-aspect-ratio: 2/3;
-}
-.o_wsale_products_opt_thumb_cover {
-    --o-wsale-card-thumb-fill-mode: cover;
-}
+#o_wsale_products_grid, #o_comparelist_table, .s_dynamic_snippet_products {
+    @each $name, $ratio in $o-wsale-shop-ratios {
+        &.o_wsale_products_opt_thumb_#{$name} {
+            --o-wsale-card-thumb-aspect-ratio: #{$ratio};
+        }
+    }
 
+    &.o_wsale_products_opt_thumb_cover {
+        --o-wsale-card-thumb-fill-mode: cover;
+    }
+}
 
 // ==== Actions
 

--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -1888,38 +1888,25 @@ $-product-radius-map: (
 
 // Unified product image aspect ratios
 
-%o-wsale-product-img {
+%o-wsale-shop-thumb {
     object-fit: cover;
     object-position: center;
+    aspect-ratio: var(--o-wsale-shop-thumb-aspect-ratio, 1);
 }
 
-@mixin o-wsale-product-img-ratio($ratio) {
-    .o_cart_product_image img,
-    .o_sale_product_configurator_img img,
-    .o_wsale_comparison_bottom_bar img,
-    .o_wsale_compare_table_column img,
-    .product-card img {
-        aspect-ratio: $ratio;
-        @extend %o-wsale-product-img;
+@each $name, $ratio in $o-wsale-shop-ratios {
+    body.o_wsale_products_opt_thumb_#{$name} {
+        --o-wsale-shop-thumb-aspect-ratio: #{$ratio};
     }
 }
 
-.o_wsale_products_opt_thumb_16_9 { @include o-wsale-product-img-ratio(16/9); }
-.o_wsale_products_opt_thumb_4_3 { @include o-wsale-product-img-ratio(4/3); }
-.o_wsale_products_opt_thumb_6_5 { @include o-wsale-product-img-ratio(6/5); }
-.o_wsale_products_opt_thumb_4_5 { @include o-wsale-product-img-ratio(4/5); }
-.o_wsale_products_opt_thumb_2_3 { @include o-wsale-product-img-ratio(2/3); }
-
 .o_cart_product_image img {
     max-width: 64px;
-    aspect-ratio: 1/1; // Default fallback
-    @extend %o-wsale-product-img;
+    @extend %o-wsale-shop-thumb;
 }
 
-.o_sale_product_configurator_img img,
-.product-card img {
-    aspect-ratio: 1/1; // Default fallback
-    @extend %o-wsale-product-img;
+.o_sale_product_configurator_img img {
+    @extend %o-wsale-shop-thumb;
 }
 
 .oe_website_sale {

--- a/addons/website_sale_comparison/static/src/scss/website_sale_comparison.scss
+++ b/addons/website_sale_comparison/static/src/scss/website_sale_comparison.scss
@@ -37,6 +37,10 @@
 
         width: var(--o-website-sale-comparison-table-column-width);
         padding: 0 var(--o-website-sale-comparison-table-column-padding-x);
+
+        img {
+            @extend %o-wsale-shop-thumb;
+        }
     }
 
     #o_comparelist_table {
@@ -128,9 +132,7 @@
     .o_wsale_comparison_bottom_bar_image {
         width: 2.5rem;
         height: fit-content;
-        aspect-ratio: var(--wsale-product-thumb-aspect-ratio, 1/1);
-        object-fit: cover;
-        object-position: center;
+        @extend %o-wsale-shop-thumb;
     }
 }
 


### PR DESCRIPTION
Before this PR, the 1:1 aspect ratio option in the editor (/shop) showed no preview on hover and didn't apply correctly until saving. It treated 1:1 as a special case that removed all classes instead of applying an explicit one.

This PR fixes the issue by adding explicit o_wsale_products_opt_thumb_1_1 class support.

task-5123229

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
