### PR TITLE
[FIX] appointment: Add conditional logic for bug w/booking appointments

### DIFF
--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -417,11 +417,11 @@ class ResourceCalendar(models.Model):
                                 remaining_hours -= allocate_hours
 
                                 if booking_apt:
-                                    # If an appoinment is being booked, create interval starting start_dt
+                                    # If an appoinment is being booked, create an interval starting start_dt
                                     start_time = start_datetime
                                     end_time = start_time + timedelta(hours=allocate_hours)
                                 else:
-                                    # If an appointment isn't being booked, create interval centered at 12:00 PM
+                                    # If an appointment isn't being booked, create an interval centered at 12:00 PM
                                     midpoint = tz.localize(datetime.combine(current_day, time(12, 0)))
                                     start_time = midpoint - timedelta(hours=allocate_hours / 2)
                                     end_time = midpoint + timedelta(hours=allocate_hours / 2)


### PR DESCRIPTION
calendar.resource has a method, `_attendance_interval_batch`, that
can cause a bug if someone is trying to book an appointment with a 
staff with flexible hours.There's an elif block that you enter if the 
calendar.resource has flexible hours. In that block, we determine 
how much time is allocated for the appointment. For instance, 1 hour
 if the appointment is meant to be 1 hour long and the staff still has at
least 1 hour left to work that week. Then, a work interval gets centered
around 12 noon. 12 noon is hard-coded in. If there's one hour 
allocated for the appointment, that work interval will always be from
11:30 to 12:30, no matter what appointment time slot was selected. So,
unless by lucky coincidence, the person selected an 11:30 appointment,
they won't be able to schedule an appointment at all.

The hard coding with 12 noon was implemented 4 months ago. It's 
meant to "solve issues in various apps such as work entry generation, 
attendance overtime calculation and time off calculations." Since the 
hard coding around 12 noon serves useful purposes, I didn't remove it.
Instead, I added a flag `booking_apt=True` to signal that an
appointment is currently being booking. And I added conditional logic
so the work interval won't be centered around noon iff an appointment
is being booked.

I introduced the flag in the appointment.type method 
`is_appointment_slot_valid`. I originally tried introducing it in a 
function further up the call stack, but that lead to the flag being true
when the current process was getting all possible appointment slots,
and it broke that process. It seemed clear from 
`_is_appointment_slot_valid`'s title and docstring that its sole purpose
is to check whether an appointment being booked is at a valid time.

Solves ticket 5094795

Description of the issue/feature this PR addresses:
It solves ticket 5094795.

Current behavior before PR:
If you try to book an appointment with a staff with a flexible schedule,
and the appointment type's `work_hours_activate` field is true, you'll
get a 404 page missing error. (See ticket.)

Desired behavior after PR is merged:
You will not get a 404 page missing error anymore, and will be able
to successfully book an appointment.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
