### PR TITLE
[FIX] mass_mailing: Correctly determine destination list ID during merge

### DIFF
--- a/addons/mass_mailing/wizard/mailing_list_merge.py
+++ b/addons/mass_mailing/wizard/mailing_list_merge.py
@@ -21,9 +21,9 @@ class MassMailingListMerge(models.TransientModel):
                 'src_list_ids': [(6, 0, src_list_ids)],
             })
         if not res.get('dest_list_id') and 'dest_list_id' in fields:
-            src_list_ids = res.get('src_list_ids') or self.env.context.get('active_ids')
+            dest_list_id = res.get('dest_list_id') or self.env.context.get('active_ids')
             res.update({
-                'dest_list_id': src_list_ids and src_list_ids[0] or False,
+                'dest_list_id': dest_list_id and dest_list_id[0] or False,
             })
         return res
 

--- a/doc/cla/individual/mohandgesm.md
+++ b/doc/cla/individual/mohandgesm.md
@@ -1,0 +1,11 @@
+Sudan, 2025-09-21
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Mohand-GesmElkhalig mohandgesm8420@gmail.com https://github.com/mohandgesm


### PR DESCRIPTION
When merging mailing lists, the logic for pre-filling the destination list
ID ('dest_list_id') was incorrectly retrieving and checking 'src_list_ids'
(source lists) instead of the list of potentially active/destination IDs.

This change modifies the assignment to use 'dest_list_id' (or the active
context IDs) for determining the default value, resolving an error when
initiating the merge wizard.

Closes #228958

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
