### PR TITLE
[PERF] account: speed up aml search

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -307,7 +307,7 @@
                 <search string="Search Journal Items">
                     <field name="name" string="Journal Item" filter_domain="[
                         '|', '|', '|',
-                        ('name', 'ilike', self), ('ref', 'ilike', self), ('account_id', 'ilike', self), ('partner_id', 'ilike', self)]"/>
+                        ('name', 'ilike', self), ('ref', 'ilike', self), ('search_account_id', 'ilike', self), ('search_partner_id', 'ilike', self)]"/>
                     <field name="name"/>
                     <field name="ref"/>
                     <field name="invoice_date"/>
@@ -430,7 +430,7 @@
                 <search string="Search Journal Items">
                     <field name="name" string="Journal Item" filter_domain="[
                         '|', '|', '|',
-                        ('name', 'ilike', self), ('ref', 'ilike', self), ('account_id', 'ilike', self), ('partner_id', 'ilike', self)]"/>
+                        ('name', 'ilike', self), ('ref', 'ilike', self), ('search_account_id', 'ilike', self), ('search_partner_id', 'ilike', self)]"/>
                     <field name="name"/>
                     <field name="move_id"/>
                     <field name="ref"/>


### PR DESCRIPTION
Description
-----
Currently, the default journal items view searches ilike over `account_id` and `partner_id`. This generates subqueries and causes Postgres to use a sequential scan instead of hitting the trigram indexes when OR'd. Instead we can leverage the fact that the number of accounts and partners are usually low compared to the number of aml's, by resolving the many2one domain first and injecting the matched ids into the final domain. We make use of the existing `search_account_id` field and apply a similar logic for a new `search_partner_id` field. Since the number of partners can be much larger than the number of accounts, we fall back to the original domain if too many ids are returned.

Benchmarks
-----
|Counts                              |Before|After|
|------------------------------------|------|-----|
|700k amls, 80k partners, 5k accounts|2.87s |0.45s|
|7M amls, 800k partners, 50k accounts|29s   |4s   |

opw-5047423