### PR TITLE
[FIX] sale: prevent edit locked sale order line

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -1308,7 +1308,7 @@ class SaleOrderLine(models.Model):
         """
         return [
             'product_id', 'name', 'price_unit', 'product_uom_id', 'product_uom_qty',
-            'tax_ids', 'analytic_distribution', 'discount'
+            'tax_ids', 'analytic_distribution', 'discount', 'order_id',
         ]
 
     def _update_line_quantity(self, values):

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -307,6 +307,10 @@ class TestSaleOrder(SaleCommon):
         with self.assertRaises(UserError):
             self.sale_order.action_confirm()
 
+        order_line = self.sale_order.order_line[0]
+        with self.assertRaises(UserError):
+            order_line.order_id = self._create_sale_order()
+
         self.sale_order.action_unlock()
         self.assertEqual(self.sale_order.state, 'sale')
 


### PR DESCRIPTION
The `order_id` field is a protected field for locked sale order line.

opw-5125538