### PR TITLE
[FIX] account: resolve invoice pdf description issue

### DIFF
--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
@@ -44,14 +44,10 @@ export class ProductLabelSectionAndNoteField extends ProductNameAndDescriptionFi
         return record.data.display_type === "line_note";
     }
 
-    updateLabel(value) {
-        this.props.record.update({
-            name: String(
-                (this.productName && value && this.productName.concat("\n", value))
-                || (this.productName && !value && this.productName)
-                || (value || '')
-            ),
-        });
+    parseLabel(value) {
+        return (this.productName && value && this.productName.concat("\n", value))
+            || (this.productName && !value && this.productName)
+            || (value || "");
     }
 
     shouldShowWarning() {


### PR DESCRIPTION
Before this commit,
When printing an invoice for a product with a manually added or edited description, only the description appeared in the PDF.

Technical Reason:
In commit https://github.com/odoo/odoo/commit/4f839fad0fb20688a740282e4172dbffa095fc51, the `updateLabel` function was added, which was used everywhere until version 18.4.
From version 19 onward, it was replaced by `parseLabel` in https://github.com/odoo/odoo/commit/bc6592a8514d6557037868a0f42265070fa02263. As a result, the previous function no longer works.

After this commit,
Both product name and description will be displayed properly in the invoice PDF.

task-5109497