### PR TITLE
[IMP] pos_restaurant: add different color from category on products

### DIFF
--- a/addons/pos_restaurant/data/scenarios/bar_demo_data.xml
+++ b/addons/pos_restaurant/data/scenarios/bar_demo_data.xml
@@ -152,6 +152,7 @@
             <field name="pos_categ_ids" eval="[(4, ref('pos_category_soft_drinks'))]"/>
             <field name="categ_id" ref="product_category_drinks"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-water.png"/>
+            <field name="color">8</field>
         </record>
         <record id="minute_maid" model="product.product">
             <field name="available_in_pos">True</field>
@@ -169,6 +170,7 @@
             <field name="pos_categ_ids" eval="[(4, ref('pos_category_soft_drinks'))]"/>
             <field name="categ_id" ref="product_category_drinks"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-green_tea.png"/>
+            <field name="color">7</field>
         </record>
         <record id="ice_tea" model="product.product">
             <field name="available_in_pos">True</field>
@@ -193,6 +195,7 @@
             <field name="pos_categ_ids" eval="[(4, ref('pos_category_soft_drinks'))]"/>
             <field name="categ_id" ref="product_category_drinks"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-fanta.png"/>
+            <field name="color">2</field>
         </record>
 	</data>
 </odoo>

--- a/addons/pos_restaurant/data/scenarios/restaurant_demo_data.xml
+++ b/addons/pos_restaurant/data/scenarios/restaurant_demo_data.xml
@@ -85,6 +85,7 @@
             <field name="available_in_pos" eval="True"/>
             <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('food')])]" />
+            <field name="color">2</field>
         </record>
 
         <function model="ir.model.data" name="_update_xmlids">
@@ -321,6 +322,7 @@
             <field name="available_in_pos" eval="True"/>
             <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('food')])]" />
+            <field name="color">3</field>
         </record>
 
         <function model="ir.model.data" name="_update_xmlids">
@@ -390,6 +392,7 @@
             <field name="pos_categ_ids" eval="[(6, 0, [ref('food')])]"/>
             <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-sandwich.png"/>
+            <field name="color">1</field>
         </record>
         <record id="pos_food_tuna" model="product.product">
             <field name="available_in_pos">True</field>
@@ -417,6 +420,7 @@
             <field name="pos_categ_ids" eval="[(6, 0, [ref('food')])]"/>
             <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-club.png"/>
+            <field name="color">6</field>
         </record>
         <record id="pos_food_maki" model="product.product">
             <field name="available_in_pos">True</field>
@@ -474,6 +478,7 @@
             <field name="pos_categ_ids" eval="[(6, 0, [ref('drinks')])]"/>
             <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-water.png"/>
+            <field name="color">8</field>
         </record>
 
         <record id="minute_maid" model="product.product">
@@ -502,6 +507,7 @@
             <field name="pos_categ_ids" eval="[(6, 0, [ref('drinks')])]"/>
             <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-green_tea.png"/>
+            <field name="color">7</field>
         </record>
 
         <record id="milkshake_banana" model="product.product">
@@ -538,6 +544,7 @@
             <field name="pos_categ_ids" eval="[(6, 0, [ref('drinks')])]"/>
             <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/th-fanta.png"/>
+            <field name="color">2</field>
         </record>
 
         <!-- Combo -->
@@ -641,6 +648,7 @@
             <field name="pos_categ_ids" eval="[(6, 0, [ref('food')])]"/>
             <field name="taxes_id" eval="[(5,)]"/>
             <field name="supplier_taxes_id" eval="[(5,)]"/>
+            <field name="color">11</field>
         </record>
     </data>
 </odoo>


### PR DESCRIPTION
In this commit:
------------------
- We’ve added random colors to the below products in onboarding to help customers understand that they can choose different colors for products than the selected pos category.

### Products assigned new colors:
- Water
- Green Tea
- Fanta
- Bacon Burger
- Pasta 4 Formaggi
- Chicken Curry Sandwich
- Club Sandwich
- Sushi Lunch Combo

task: 5103944