### PR TITLE
[FIX] base: no ID-LIKE entry in archlinux

### DIFF
--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -345,7 +345,7 @@ class IrModuleModule(models.Model):
             install_package = None
             if platform.system() == 'Linux':
                 distro = platform.freedesktop_os_release()
-                id_likes = {distro['ID'], *distro.get('ID_LIKE').split()}
+                id_likes = {distro['ID'], *distro.get('ID_LIKE', '').split()}
                 if 'debian' in id_likes or 'ubuntu' in id_likes:
                     if package := terp['external_dependencies'].get('apt', {}).get(e.dependency):
                         install_package = f'apt install {package}'


### PR DESCRIPTION
The `platform.freedesktop_os_release()` function returns the content of the `/etc/os-release` file as a `dict[str, str]`. The entry `ID` is the name of the OS (`linuxmint` on Linux Mint) and `ID_LIKE` is the name of the OS `ID` is derived from (`ubuntu debian` on Mint).

In ArchLinux the `ID` is `arch` and `ID_LIKE` entry is missing.

Reported-By: Muhammad Al-Habib Ouadhour <houadhour@yandex.com>

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
