### PR TITLE
[FIX] portal: prevent portal users changing account holder name

### DIFF
--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -202,6 +202,9 @@ class CustomerPortal(Controller):
                         values[field] = False
                 values.update({'zip': values.pop('zipcode', '')})
                 self.on_account_update(values, partner)
+                # If name is not changed then pop it from the values, as it affects the bank account holder name
+                if values['name'].strip() == partner.name.strip():
+                    values.pop('name')
                 partner.sudo().write(values)
                 if redirect:
                     return request.redirect(redirect)

--- a/addons/portal/tests/test_portal.py
+++ b/addons/portal/tests/test_portal.py
@@ -1,10 +1,47 @@
 from odoo import Command
 from odoo.http import Request
+from odoo.addons.mail.tests.common import mail_new_test_user
 from odoo.tests.common import HttpCase, tagged
 
 
 @tagged('-at_install', 'post_install')
 class TestUsersHttp(HttpCase):
+
+    def test_account_holder_name_update(self):
+        """Test that bank account holder name updates when partner name changes via /my/account route."""
+        login = 'test_portal_user'
+        portal_user = mail_new_test_user(
+            self.env,
+            login,
+            name='Partner A',
+        )
+
+        bank_account = self.env['res.partner.bank'].create({
+            'acc_number': '123456789',
+            'partner_id': portal_user.partner_id.id,
+            'acc_holder_name': 'Partner A Holder',
+            'acc_type': 'bank',
+        })
+
+        common_data = {
+            'phone': '1234567890',
+            'email': 'test@example.com',
+            'street': '123 Main St',
+            'city': 'Anytown',
+            'zipcode': '12345',
+            'country_id': self.env.ref('base.us').id,
+        }
+
+        self.authenticate(login, login)
+        # request 1: request without changing partner name
+        response = self.url_open(url='/my/account', data={**common_data, 'name': portal_user.partner_id.name, 'csrf_token': Request.csrf_token(self)})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(bank_account.acc_holder_name, 'Partner A Holder')
+
+        # request 2: request with changed partner name
+        response2 = self.url_open(url='/my/account', data={**common_data, 'name': 'Partner New Name', 'csrf_token': Request.csrf_token(self)})
+        self.assertEqual(response2.status_code, 200)
+        self.assertEqual(bank_account.acc_holder_name, 'Partner New Name')
 
     def test_deactivate_portal_user(self):
         # Create a portal user with data which should be removed on deactivation


### PR DESCRIPTION
Steps to Reproduce:
-------------------------
1. Install the Website and Employees modules.
2. Create a Test User and It's Employee.
3. On the Employee record, go to Private Information, create a Bank Account
with a custom Account Holder Name.
4. Log in to the Website using the Test User.
5. Navigate to My Account and click Edit Information.
6. Fill in the address details (without changing the Name) and click Save.
7. Go back to the Employee’s Bank Account and check the Account Holder Name.

Observation:
-------------------------
The Account Holder Name was overwritten to the partner's name.

Issue:
-------------------------
In `_compute_account_holder_name` method,
https://github.com/odoo/odoo/blob/c3b543631bde96260082484a3baac19d942f6b9f/odoo/addons/base/models/res_bank.py#L104-L107
The Account Holder Name is always recomputed using the Partner’s name.
When submitting the form from the frontend, the name field is included in the
values sent to update the Partner, even if the user did not actually change
the name.
https://github.com/odoo/odoo/blob/be3a4283c383d187570f5a73f337030e6ae9d05c/addons/portal/controllers/portal.py#L196-L205
which re-triggers this compute and as a result, the Partner’s name overwrites
the Account Holder Name on the linked Bank Account

Solution:
 -------------------------
Prevent the Account Holder Name compute method from being triggered when
updating information from the frontend if the Partner’s name has not been
changed.


opw-5059247