### PR TITLE
[FIX] mail: hide unpin button for guest users

### DIFF
--- a/addons/mail/static/src/core/common/message_card_list.js
+++ b/addons/mail/static/src/core/common/message_card_list.js
@@ -35,6 +35,7 @@ export class MessageCardList extends Component {
 
     setup() {
         super.setup();
+        this.store = useState(useService("mail.store"));
         this.ui = useState(useService("ui"));
         useSubEnv({ messageCard: true });
         useVisible("load-more", (isVisible) => {

--- a/addons/mail/static/src/core/common/message_card_list.xml
+++ b/addons/mail/static/src/core/common/message_card_list.xml
@@ -6,7 +6,7 @@
                 <div class="card-body py-2">
                     <div class="position-absolute top-0 end-0 z-1 mx-2 my-1">
                         <a role="button" class="o-mail-MessageCard-jump rounded bg-400 badge opacity-0" t-att-class="{ 'opacity-100 py-1 px-2': ui.isSmall }" t-on-click="() => this.onClickJump(message)">Jump</a>
-                        <button t-if="props.mode === 'pin'" class="btn btn-link text-reset ms-2 p-0" t-att-class="{ 'fs-5': ui.isSmall }" title="Unpin" t-on-click="message.unpin">
+                        <button t-if="props.mode === 'pin' and store.self.type === 'partner'" class="btn btn-link text-reset ms-2 p-0" t-att-class="{ 'fs-5': ui.isSmall }" title="Unpin" t-on-click="message.unpin">
                             <i class="oi oi-close"/>
                         </button>
                     </div>

--- a/addons/mail/static/tests/discuss/message_pin/pinned_messages.test.js
+++ b/addons/mail/static/tests/discuss/message_pin/pinned_messages.test.js
@@ -7,11 +7,20 @@ import {
     start,
     startServer,
 } from "@mail/../tests/mail_test_helpers";
-import { describe, test } from "@odoo/hoot";
+import { describe, test, expect } from "@odoo/hoot";
 import { disableAnimations } from "@odoo/hoot-mock";
 
 describe.current.tags("desktop");
 defineMailModels();
+
+async function assertPinnedPanelUnpinCount(expectedCount) {
+    await contains("[title='Unpin']", { count: expectedCount });
+    await click(".o-mail-Discuss-header button[title='Pinned Messages']");
+    await contains(".o-discuss-PinnedMessagesPanel .o-mail-Message", {
+        text: "Test pinned message",
+    });
+    expect(".o-discuss-PinnedMessagesPanel button[title='Unpin']").toHaveCount(expectedCount);
+}
 
 test("Pin message", async () => {
     const pyEnv = await startServer();
@@ -142,4 +151,38 @@ test("Jump to message from notification", async () => {
     await contains(".o-mail-Thread", { scroll: "bottom" });
     await click(".o_mail_notification a", { text: "message" });
     await contains(".o-mail-Thread", { count: 0, scroll: "bottom" });
+});
+
+test("Guest user cannot see unpin button", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "General",
+        channel_type: "channel",
+    });
+    pyEnv["mail.message"].create({
+        body: "Test pinned message",
+        model: "discuss.channel",
+        res_id: channelId,
+        pinned_at: "2023-03-30 11:27:11",
+    });
+    await start({ authenticateAs: false });
+    await openDiscuss(channelId);
+    await contains(".o-mail-Message", { text: "Test pinned message" });
+    expect(".o-mail-Message [title='Expand']").toHaveCount(0);
+    await assertPinnedPanelUnpinCount(0);
+});
+
+test("Internal user can see unpin button", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    pyEnv["mail.message"].create({
+        body: "Test pinned message",
+        model: "discuss.channel",
+        res_id: channelId,
+        pinned_at: "2023-03-30 11:27:11",
+    });
+    await start();
+    await openDiscuss(channelId);
+    await click(".o-mail-Message [title='Expand']");
+    await assertPinnedPanelUnpinCount(1);
 });


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
----------------------------------------------
Currently, guest users in PinnedMessagesPanel can see the unpin button on pinned messages,
but the server correctly rejects their unpin requests. This creates confusion
and a poor user experience where external users see functionality that doesn't
work for them.

**Current behavior before PR:**
----------------------------------------------
- Guest users see the unpin button on pinned messages
- Clicking the unpin button results in server rejection
- UI shows functionality that guest users cannot actually use

**Desired behavior after PR is merged:**
----------------------------------------------
- Guest users cannot see the unpin button on pinned messages
- Internal users continue to have full pin/unpin functionality
- UI accurately reflects user permissions and capabilities
- Better user experience with appropriate access control

Task-5033295

----------------------------------------------
I confirm I have signed the CLA and read the PR guidelines at https://www.odoo.com/submit-pr
