### PR TITLE
[REF] web: handle statusbar field current stage outside of search domain

### DIFF
--- a/addons/web/static/src/views/fields/statusbar/statusbar_field.js
+++ b/addons/web/static/src/views/fields/statusbar/statusbar_field.js
@@ -99,14 +99,8 @@ export class StatusBarField extends Component {
                 if (foldField) {
                     fieldNames.push(foldField);
                 }
-                const value = record.data[fieldName];
                 let domain = getFieldDomain(record, fieldName, props.domain);
                 domain = Domain.and([this.getDomain(), domain]).toList();
-                if (domain.length && value) {
-                    domain = Domain.or([[["id", "=", value.id]], domain]).toList(
-                        record.evalContext
-                    );
-                }
                 return orm.searchRead(relation, domain, fieldNames).catch((error) => {
                     if (error instanceof ConnectionLostError) {
                         if (this.props.record.data[this.props.name]) {
@@ -158,7 +152,7 @@ export class StatusBarField extends Component {
                         }
                         const items = this.getAllItems();
                         return items.length && !items.at(-1).isSelected;
-                    }
+                    },
                 }
             );
         }
@@ -267,12 +261,22 @@ export class StatusBarField extends Component {
         const currentValue = record.data[name];
         if (this.field.type === "many2one") {
             // Many2one
-            return this.specialData.data.map((option) => ({
+            const items = this.specialData.data.map((option) => ({
                 value: option.id,
                 label: option.display_name,
                 isFolded: option[foldField],
                 isSelected: Boolean(currentValue && option.id === currentValue.id),
             }));
+
+            if (currentValue && !items.find((item) => item.value === currentValue.id)) {
+                items.unshift({
+                    value: currentValue.id,
+                    label: currentValue.display_name,
+                    isFolded: false,
+                    isSelected: true,
+                });
+            }
+            return items;
         } else {
             // Selection
             let { selection } = this.field;

--- a/addons/web/static/tests/views/fields/statusbar_field.test.js
+++ b/addons/web/static/tests/views/fields/statusbar_field.test.js
@@ -189,7 +189,7 @@ test("static statusbar widget on many2one field with domain", async () => {
     serverState.userId = 17;
 
     onRpc("search_read", ({ kwargs }) => {
-        expect(kwargs.domain).toEqual(["|", ["id", "=", 4], ["user_id", "=", 17]], {
+        expect(kwargs.domain).toEqual([["user_id", "=", 17]], {
             message: "search_read should sent the correct domain",
         });
     });
@@ -391,7 +391,7 @@ test("clickable statusbar should change m2o fetching domain in edit mode", async
     });
 
     expect(".o_statusbar_status button:not(.dropdown-toggle)").toHaveCount(3);
-    await click(".o_statusbar_status button:not(.dropdown-toggle):eq(-1)");
+    await click(".o_statusbar_status button:not(.dropdown-toggle):eq(1)");
     await animationFrame();
     expect(".o_statusbar_status button:not(.dropdown-toggle)").toHaveCount(2);
 });
@@ -943,14 +943,14 @@ test("correctly load statusbar when dynamic domain changes", async () => {
         `,
     });
     expect(queryAllTexts(".o_statusbar_status button:not(.d-none)")).toEqual(["Stage Project 1"]);
-    expect.verifySteps([["|", ["id", "=", 1], ["project_ids", "in", 1]]]);
+    expect.verifySteps([[["project_ids", "in", 1]]]);
     await click(`[name="project_id"] .dropdown input`);
     await animationFrame();
     await click(`[name="project_id"] .dropdown .dropdown-menu .ui-menu-item:contains("Project 2")`);
     await animationFrame();
 
     expect(queryAllTexts(".o_statusbar_status button:not(.d-none)")).toEqual(["Stage Project 2"]);
-    expect.verifySteps([["|", ["id", "=", 2], ["project_ids", "in", 2]]]);
+    expect.verifySteps([[["project_ids", "in", 2]]]);
     await clickSave();
     expect(queryAllTexts(".o_statusbar_status button:not(.d-none)")).toEqual(["Stage Project 2"]);
     expect.verifySteps([]);


### PR DESCRIPTION
Previously, the domain in the statusbar field always included the current stage (C) via [["id", "=", value.id]]. That meant RPC params were unique per record status and led to sequences like A > B > C > D.

Now, the domain only returns valid stages (e.g. A, B, D). If the current stage (C) is not in the search result, it is prepended as the starting stage, producing: C > A > B > D.

This refactoring simplifies domain logic, avoids unnecessary variations in RPC params, improves cache efficiency (params are no longer unique), and reduces the number of RPCs performed.
