### PR TITLE
[FIX] hr_contract_salary: fixes whitelist company issue

### DIFF
--- a/addons/hr/models/hr_version.py
+++ b/addons/hr/models/hr_version.py
@@ -407,7 +407,8 @@ class HrVersion(models.Model):
     def get_values_from_contract_template(self, contract_template_id):
         if not contract_template_id:
             return {}
-        whitelist = self._get_whitelist_fields_from_template()
+        company = contract_template_id.company_id or self.env.company
+        whitelist = self.with_company(company)._get_whitelist_fields_from_template()
         contract_template_vals = contract_template_id.copy_data()[0]
         return {
             field: value


### PR DESCRIPTION
    in this commit, fixes issue when open simulation page
    through recruitment offer values of benefits not updated.

    issue:
     get only default first company while triggering get
     white list method.

    task-4929771

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
