### PR TITLE
[FIX] website_sale: use aspect ratio setting for zoom-on-click carousel

### DIFF
--- a/addons/website_sale/static/src/interactions/website_sale.js
+++ b/addons/website_sale/static/src/interactions/website_sale.js
@@ -47,6 +47,7 @@ export class WebsiteSale extends Interaction {
         this.filmStripIsDown = false;
         this.filmStripScrollLeft = 0;
         this.filmStripMoved = false;
+        this.imageRatio = this.el.dataset.imageRatio;
     }
 
     start() {
@@ -210,11 +211,12 @@ export class WebsiteSale extends Interaction {
         if (salePage.dataset.ecomZoomClick) {
             // In this case we want all the images not just the ones that are "zoomables"
             const images = this.el.querySelectorAll('.product_detail_img');
-            for (const image of images ) {
+            for (const [idx, image] of images.entries()) {
                 const handler = () => {
                     this.services.dialog.add(ProductImageViewer, {
-                        selectedImageIdx: [...images].indexOf(image),
+                        selectedImageIdx: idx,
                         images,
+                        imageRatio: this.imageRatio,
                     });
                 };
                 image.addEventListener("click", handler);

--- a/addons/website_sale/static/src/js/components/website_sale_image_viewer.js
+++ b/addons/website_sale/static/src/js/components/website_sale_image_viewer.js
@@ -11,6 +11,7 @@ export class ProductImageViewer extends Dialog {
         ...Dialog.props,
         images: { type: NodeList, required: true },
         selectedImageIdx: { type: Number, optional: true },
+        imageRatio: { type: String, optional: true },
         close: Function,
     };
 

--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -1008,6 +1008,7 @@ $-product-ratios-map: (
 );
 
 @each $-ratio-name, $-ratio-value in $-product-ratios-map {
+    .o_wsale_image_viewer_ratio_#{$-ratio-name},
     .o_wsale_product_page_opt_image_ratio_#{$-ratio-name} {
         --o-wsale-product-image-ratio: #{$-ratio-value};
     }

--- a/addons/website_sale/static/src/scss/website_sale_frontend.scss
+++ b/addons/website_sale/static/src/scss/website_sale_frontend.scss
@@ -28,19 +28,16 @@
             list-style: none;
             transition: transform 250ms ease-out;
 
-            .o_wsale_image_viewer_thumbnail {
-                aspect-ratio: 1/1;
-                width: 128px;
-            }
-
             li > div {
                 background: $body-bg;
 
-                img {
+                img.o_wsale_image_viewer_thumbnail {
+                    aspect-ratio: var(--o-wsale-product-image-ratio, 1/1);
                     border: 4px solid transparent;
+                    height: 128px;
 
                     &:not(.active, :hover) {
-                        opacity: 0.5;
+                        opacity: 0.75;
                     }
 
                     &.active {

--- a/addons/website_sale/static/src/xml/website_sale_image_viewer.xml
+++ b/addons/website_sale/static/src/xml/website_sale_image_viewer.xml
@@ -27,14 +27,18 @@
                     </div>
                     <t t-if="images.length > 1">
                         <!-- Footer -->
-                        <div class="o_wsale_image_viewer_carousel position-absolute bottom-0 d-flex" role="toolbar">
+                        <div
+                            class="o_wsale_image_viewer_carousel position-absolute bottom-0 d-flex"
+                            t-attf-class="o_wsale_image_viewer_ratio_#{props.imageRatio ?? 'auto'}"
+                            role="toolbar"
+                        >
                             <ol class="d-flex justify-content-start ps-0 pt-2 pt-lg-0 mx-auto my-0 text-start">
                                 <t t-foreach="images" t-as="image" t-key="image.thumbnailSrc">
                                     <li t-attf-class="align-top position-relative px-1 pb-1 {{image === selectedImage ? 'active' : ''}}" t-on-click="() => this.selectedImage = image">
-                                        <div>
+                                        <div class="bg-body">
                                             <img
                                                 t-att-src="image.thumbnailSrc"
-                                                class="img o_wsale_image_viewer_thumbnail bg-body object-fit-contain"
+                                                class="img o_wsale_image_viewer_thumbnail object-fit-cover"
                                                 t-att-class="{'active': image === selectedImage}"
                                                 t-att-alt="props.title"
                                                 loading="lazy"

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1988,6 +1988,7 @@
                             o_wsale_product_page_opt_image_ratio_mobile_{{website.product_page_image_ratio_mobile}}
                             o_wsale_product_page_opt_image_radius_{{website.product_page_image_roundness}}
                          "
+                         t-att-data-image-ratio="website.product_page_image_ratio"
                          t-att-data-view-track="view_track and '1' or '0'"
                 >
                     <div class="o_wsale_content_contained container d-flex flex-wrap align-items-center py-3">


### PR DESCRIPTION
Steps
-----
1. Open a product page in eCommerce;
2. open the editor;
3. change the auto-crop setting to a non-default value;
4. enable zoom-on-click;
5. save & click to zoom.

Issue
-----
The thumbnails use a square aspect ratio.

Cause
-----
Their aspect ratio is hardcoded to be '1/1'.

Solution
--------
1. When instantiating the `ProductImageViewer` dialog, get the aspect ratio used by `.oe_website_sale`, and propagate it into a class name.
2. Use the CSS rules introduced by 670b1daa2254d to apply the correct aspect ratio based on the class name.

opw-4908881