### PR TITLE
[FIX] l10n_cl: use country id in csv data file

### DIFF
--- a/addons/l10n_cl/data/res.bank.csv
+++ b/addons/l10n_cl/data/res.bank.csv
@@ -1,33 +1,33 @@
-id,name,l10n_cl_sbif_code,country
-bank_001_0,Banco de Chile,001,Chile
-bank_001_1,Banco Edwards,001,Chile
-bank_001_2,Citi,001,Chile
-bank_001_3,Atlas,001,Chile
-bank_001_4,CrediChile,001,Chile
-bank_009_0,Banco Internacional,009,Chile
-bank_012_0,Banco Estado,012,Chile
-bank_014_0,Scotiabank Chile,014,Chile
-bank_016_0,Banco De Credito e Inversiones (BCI),016,Chile
-bank_016_1,Tbanc,016,Chile
-bank_016_2,BCI Nova,016,Chile
-bank_027_0,Corpbanca,027,Chile
-bank_027_1,Banco Condell,027,Chile
-bank_028_0,Banco Bice,028,Chile
-bank_031_0,Hsbc Bank,031,Chile
-bank_037_0,Banco Santander-Chile,037,Chile
-bank_037_1,Banefe,037,Chile
-bank_039_0,Banco Itaú Chile,039,Chile
-bank_049_0,Banco Security,049,Chile
-bank_051_0,Banco Falabella,051,Chile
-bank_052_0,Deutsche Bank,052,Chile
-bank_053_0,Banco Ripley,053,Chile
-bank_054_0,Rabobank Chile (Ex Hns Banco),054,Chile
-bank_055_0,Banco Consorcio (Ex Banco Monex),055,Chile
-bank_056_0,Banco Penta,056,Chile
-bank_057_0,Banco Paris,057,Chile
-bank_504_0,Banco Bilbao Vizcaya Argentaria Chile (BBVA),504,Chile
-bank_504_1,BBVA Express,504,Chile
-bank_059_0,Banco Btg Pactual Chile,059,Chile
-bank_017_0,Banco Do Brasil S.A.,017,Chile
-bank_041_0,Jp Morgan Chase Bank  N. A.,041,Chile
-bank_043_0,Banco De La Nacion Argentina,043,Chile
+id,name,l10n_cl_sbif_code,country:id
+bank_001_0,Banco de Chile,001,base.cl
+bank_001_1,Banco Edwards,001,base.cl
+bank_001_2,Citi,001,base.cl
+bank_001_3,Atlas,001,base.cl
+bank_001_4,CrediChile,001,base.cl
+bank_009_0,Banco Internacional,009,base.cl
+bank_012_0,Banco Estado,012,base.cl
+bank_014_0,Scotiabank Chile,014,base.cl
+bank_016_0,Banco De Credito e Inversiones (BCI),016,base.cl
+bank_016_1,Tbanc,016,base.cl
+bank_016_2,BCI Nova,016,base.cl
+bank_027_0,Corpbanca,027,base.cl
+bank_027_1,Banco Condell,027,base.cl
+bank_028_0,Banco Bice,028,base.cl
+bank_031_0,Hsbc Bank,031,base.cl
+bank_037_0,Banco Santander-Chile,037,base.cl
+bank_037_1,Banefe,037,base.cl
+bank_039_0,Banco Itaú Chile,039,base.cl
+bank_049_0,Banco Security,049,base.cl
+bank_051_0,Banco Falabella,051,base.cl
+bank_052_0,Deutsche Bank,052,base.cl
+bank_053_0,Banco Ripley,053,base.cl
+bank_054_0,Rabobank Chile (Ex Hns Banco),054,base.cl
+bank_055_0,Banco Consorcio (Ex Banco Monex),055,base.cl
+bank_056_0,Banco Penta,056,base.cl
+bank_057_0,Banco Paris,057,base.cl
+bank_504_0,Banco Bilbao Vizcaya Argentaria Chile (BBVA),504,base.cl
+bank_504_1,BBVA Express,504,base.cl
+bank_059_0,Banco Btg Pactual Chile,059,base.cl
+bank_017_0,Banco Do Brasil S.A.,017,base.cl
+bank_041_0,Jp Morgan Chase Bank  N. A.,041,base.cl
+bank_043_0,Banco De La Nacion Argentina,043,base.cl


### PR DESCRIPTION
`res.country` records are `noupdate` by default, which means that changes such as the following are not reverted:

```SQL
pied@(none):pied_3131231> SELECT c.name->>'en_US' FROM res_country c JOIN ir_model_data d ON d.res_id = c.id AND d.model = 'res.country' AND d.module = 'base' AND d.name IN ('cl', 'co')
+----------+
| ?column? |
|----------|
| COLOMBIA |
| Colombia |
+----------+
```

Note: in this specific, the change is clearly an error introduced in the data. Still, the error it produces (which follows) can be avoided by referring to the xmlid, instead of the record name.

```
Traceback (most recent call last):
  File "/home/odoo/src/odoo/saas-18.4/odoo/service/server.py", line 1410, in preload_registries
    registry = Registry.new(dbname, update_module=update_module, install_modules=config['init'], upgrade_modules=config['update'])
  File "<decorator-gen-6>", line 2, in new
  File "/home/odoo/src/odoo/saas-18.4/odoo/tools/func.py", line 89, in locked
    return func(inst, *args, **kwargs)
  File "/home/odoo/src/odoo/saas-18.4/odoo/orm/registry.py", line 175, in new
    load_modules(
  File "/home/odoo/src/odoo/saas-18.4/odoo/modules/loading.py", line 455, in load_modules
    load_module_graph(
  File "/home/odoo/src/odoo/saas-18.4/odoo/modules/loading.py", line 226, in load_module_graph
    load_data(env, idref, 'update', kind='data', package=package)
  File "/home/odoo/src/odoo/saas-18.4/odoo/modules/loading.py", line 79, in load_data
    tools.convert_file(env, package.name, filename, idref, mode, noupdate, kind)
  File "/home/odoo/src/odoo/saas-18.4/odoo/tools/convert.py", line 624, in convert_file
    convert_csv_import(env, module, pathname, fp.read(), idref, mode, noupdate)
  File "/home/odoo/src/odoo/saas-18.4/odoo/tools/convert.py", line 680, in convert_csv_import
    raise Exception(env._(
Exception: Module loading l10n_cl failed: file l10n_cl/data/res.bank.csv could not be processed:
No matching record found for name 'Chile' in field 'Country'
No matching record found for name 'Chile' in field 'Country'
No matching record found for name 'Chile' in field 'Country'
No matching record found for name 'Chile' in field 'Country'
No matching record found for name 'Chile' in field 'Country'
No matching record found for name 'Chile' in field 'Country'
No matching record found for name 'Chile' in field 'Country'
No matching record found for name 'Chile' in field 'Country'
No matching record found for name 'Chile' in field 'Country'
No matching record found for name 'Chile' in field 'Country'
No matching record found for name 'Chile' in field 'Country'
No matching record found for name 'Chile' in field 'Country'
No matching record found for name 'Chile' in field 'Country'
No matching record found for name 'Chile' in field 'Country'
No matching record found for name 'Chile' in field 'Country'
No matching record found for name 'Chile' in field 'Country'
No matching record found for name 'Chile' in field 'Country'
No matching record found for name 'Chile' in field 'Country'
No matching record found for name 'Chile' in field 'Country'
No matching record found for name 'Chile' in field 'Country'
No matching record found for name 'Chile' in field 'Country'
No matching record found for name 'Chile' in field 'Country'
No matching record found for name 'Chile' in field 'Country'
No matching record found for name 'Chile' in field 'Country'
No matching record found for name 'Chile' in field 'Country'
No matching record found for name 'Chile' in field 'Country'
No matching record found for name 'Chile' in field 'Country'
No matching record found for name 'Chile' in field 'Country'
No matching record found for name 'Chile' in field 'Country'
No matching record found for name 'Chile' in field 'Country'
No matching record found for name 'Chile' in field 'Country'
No matching record found for name 'Chile' in field 'Country'
```

upg-3131231