### PR TITLE
[REF] account,web: move widget json_checkboxes to analytic

### DIFF
--- a/addons/web/static/src/views/fields/json_checkboxes/json_checkboxes_field.js
+++ b/addons/web/static/src/views/fields/json_checkboxes/json_checkboxes_field.js
@@ -2,9 +2,8 @@ import { Component, useState } from "@odoo/owl";
 import { CheckBox } from "@web/core/checkbox/checkbox";
 import { registry } from "@web/core/registry";
 import { standardFieldProps } from "@web/views/fields/standard_field_props";
-import {debounce} from "@web/core/utils/timing";
+import { debounce } from "@web/core/utils/timing";
 import { useRecordObserver } from "@web/model/relational_model/utils";
-
 
 export class JsonCheckboxes extends Component {
     static template = "account.JsonCheckboxes";
@@ -14,7 +13,6 @@ export class JsonCheckboxes extends Component {
     };
 
     setup() {
-        super.setup();
         this.checkboxes = useState(this.props.record.data[this.props.name]);
         this.debouncedCommitChanges = debounce(this.commitChanges.bind(this), 100);
 
@@ -28,15 +26,15 @@ export class JsonCheckboxes extends Component {
     }
 
     onChange(key, checked) {
-        this.checkboxes[key]['checked'] = checked;
+        this.checkboxes[key].checked = checked;
         this.debouncedCommitChanges();
     }
-
 }
 
 export const jsonCheckboxes = {
     component: JsonCheckboxes,
     supportedTypes: ["json"],
-}
+};
 
-registry.category("fields").add("account_json_checkboxes", jsonCheckboxes);
+registry.category("fields").add("json_checkboxes", jsonCheckboxes);
+registry.category("fields").add("account_json_checkboxes", jsonCheckboxes); // TODO: remove in saas~19.1

--- a/addons/web/static/src/views/fields/json_checkboxes/json_checkboxes_field.js
+++ b/addons/web/static/src/views/fields/json_checkboxes/json_checkboxes_field.js
@@ -1,3 +1,4 @@
+import { _t } from "@web/core/l10n/translation";
 import { Component, useState } from "@odoo/owl";
 import { CheckBox } from "@web/core/checkbox/checkbox";
 import { registry } from "@web/core/registry";
@@ -10,6 +11,7 @@ export class JsonCheckboxes extends Component {
     static components = { CheckBox };
     static props = {
         ...standardFieldProps,
+        stacked: { type: Boolean, optional: true },
     };
 
     setup() {
@@ -33,7 +35,23 @@ export class JsonCheckboxes extends Component {
 
 export const jsonCheckboxes = {
     component: JsonCheckboxes,
+    supportedOptions: [
+        {
+            label: _t("Stacked"),
+            name: "stacked",
+            type: "boolean",
+            help: _t(
+                "If checked, the checkboxes will be displayed in a column. Otherwise, they will be inlined."
+            ),
+        },
+    ],
     supportedTypes: ["json"],
+    extractProps({ options }) {
+        const stacked = Boolean(options.stacked);
+        return {
+            stacked,
+        };
+    },
 };
 
 registry.category("fields").add("json_checkboxes", jsonCheckboxes);

--- a/addons/web/static/src/views/fields/json_checkboxes/json_checkboxes_field.xml
+++ b/addons/web/static/src/views/fields/json_checkboxes/json_checkboxes_field.xml
@@ -4,7 +4,7 @@
     <t t-name="account.JsonCheckboxes">
         <div aria-atomic="true">
             <t t-foreach="checkboxes" t-as="checkbox" t-key="checkbox">
-                <div class="d-inline-block me-3">
+                <div t-att-class="props.stacked ? 'd-block' : 'd-inline-block me-3'">
                     <CheckBox
                         id="checkbox"
                         value="checkbox_value.checked"

--- a/addons/web/static/src/views/fields/json_checkboxes/json_checkboxes_field.xml
+++ b/addons/web/static/src/views/fields/json_checkboxes/json_checkboxes_field.xml
@@ -4,21 +4,21 @@
     <t t-name="account.JsonCheckboxes">
         <div aria-atomic="true">
             <t t-foreach="checkboxes" t-as="checkbox" t-key="checkbox">
-                <span class="d-inline-block me-3">
+                <div class="d-inline-block me-3">
                     <CheckBox
                         id="checkbox"
-                        value="checkbox_value['checked']"
-                        disabled="checkbox_value['readonly']"
+                        value="checkbox_value.checked"
+                        disabled="props.readonly || checkbox_value.readonly"
                         onChange="(ev) => this.onChange(checkbox, ev)"
                     >
-                        <t t-esc="checkbox_value['label']" />
+                        <t t-esc="checkbox_value.label" />
                     </CheckBox>
-                    <i t-if="checkbox_value['question_circle']"
+                    <i t-if="checkbox_value.question_circle"
                        class="fa fa-question-circle"
                        role="img"
                        aria-label="Warning"
-                       t-att-title="checkbox_value['question_circle']"/>
-                </span>
+                       t-att-title="checkbox_value.question_circle"/>
+                </div>
             </t>
         </div>
     </t>

--- a/addons/web/static/tests/views/fields/json_checkboxes_field.test.js
+++ b/addons/web/static/tests/views/fields/json_checkboxes_field.test.js
@@ -1,0 +1,164 @@
+import { expect, test } from "@odoo/hoot";
+import { runAllTimers } from "@odoo/hoot-mock";
+import {
+    clickSave,
+    contains,
+    defineModels,
+    fields,
+    models,
+    mountView,
+    onRpc,
+} from "@web/../tests/web_test_helpers";
+
+class Partner extends models.Model {
+    int_field = fields.Integer({ sortable: true });
+    json_checkboxes_field = fields.Json({ string: "Json Checkboxes Field" });
+    _records = [
+        {
+            id: 1,
+            int_field: 10,
+            json_checkboxes_field: {
+                key1: { checked: true, label: "First Key" },
+                key2: { checked: false, label: "Second Key" },
+            },
+        },
+    ];
+}
+
+defineModels([Partner]);
+
+test("JsonCheckBoxesField", async () => {
+    const commands = [
+        {
+            key1: { checked: true, label: "First Key" },
+            key2: { checked: true, label: "Second Key" },
+        },
+        {
+            key1: { checked: false, label: "First Key" },
+            key2: { checked: true, label: "Second Key" },
+        },
+    ];
+    onRpc("web_save", (args) => {
+        expect.step("web_save");
+        expect(args.args[1].json_checkboxes_field).toEqual(commands.shift());
+    });
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: `
+            <form>
+                <group>
+                    <field name="json_checkboxes_field" widget="json_checkboxes" />
+                </group>
+            </form>`,
+    });
+
+    expect("div.o_field_widget div.form-check").toHaveCount(2);
+
+    expect("div.o_field_widget div.form-check input:eq(0)").toBeChecked();
+    expect("div.o_field_widget div.form-check input:eq(1)").not.toBeChecked();
+
+    expect("div.o_field_widget div.form-check input:disabled").toHaveCount(0);
+
+    // check a value by clicking on input
+    await contains("div.o_field_widget div.form-check input:eq(1)").click();
+    await runAllTimers();
+    await clickSave();
+    expect("div.o_field_widget div.form-check input:checked").toHaveCount(2);
+
+    // uncheck a value by clicking on label
+    await contains("div.o_field_widget div.form-check > label").click();
+    await runAllTimers();
+    await clickSave();
+    expect("div.o_field_widget div.form-check input:eq(0)").not.toBeChecked();
+    expect("div.o_field_widget div.form-check input:eq(1)").toBeChecked();
+
+    expect.verifySteps(["web_save", "web_save"]);
+});
+
+test("JsonCheckBoxesField (readonly field)", async () => {
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: `
+            <form>
+                <group>
+                    <field name="json_checkboxes_field" widget="json_checkboxes" readonly="True" />
+                </group>
+            </form>`,
+    });
+
+    expect("div.o_field_widget div.form-check").toHaveCount(2, {
+        message: "should have fetched and displayed the 2 values of the many2many",
+    });
+    expect("div.o_field_widget div.form-check input:disabled").toHaveCount(2, {
+        message: "the checkboxes should be disabled",
+    });
+
+    await contains("div.o_field_widget div.form-check > label:eq(1)").click();
+
+    expect("div.o_field_widget div.form-check input:eq(0)").toBeChecked();
+    expect("div.o_field_widget div.form-check input:eq(1)").not.toBeChecked();
+});
+
+test("JsonCheckBoxesField (some readonly)", async () => {
+    Partner._records[0].json_checkboxes_field = {
+        key1: { checked: true, label: "First Key" },
+        key2: { checked: false, readonly: true, label: "Second Key" },
+    };
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: `
+            <form>
+                <group>
+                    <field name="json_checkboxes_field" widget="json_checkboxes" />
+                </group>
+            </form>`,
+    });
+
+    expect("div.o_field_widget div.form-check").toHaveCount(2, {
+        message: "should have fetched and displayed the 2 values of the many2many",
+    });
+    expect("div.o_field_widget div.form-check input:eq(0):enabled").toHaveCount(1, {
+        message: "first checkbox should be enabled",
+    });
+    expect("div.o_field_widget div.form-check input:eq(1):disabled").toHaveCount(1, {
+        message: "second checkbox should be disabled",
+    });
+
+    await contains("div.o_field_widget div.form-check > label:eq(1)").click();
+
+    expect("div.o_field_widget div.form-check input:eq(0)").toBeChecked();
+    expect("div.o_field_widget div.form-check input:eq(1)").not.toBeChecked();
+});
+
+test("JsonCheckBoxesField (question circle)", async () => {
+    Partner._records[0].json_checkboxes_field = {
+        key1: { checked: true, label: "First Key" },
+        key2: { checked: false, label: "Second Key", question_circle: "Some info about this" },
+    };
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: `
+            <form>
+                <group>
+                    <field name="json_checkboxes_field" widget="json_checkboxes" />
+                </group>
+            </form>`,
+    });
+
+    expect("div.o_field_widget div.form-check:eq(0) ~ i.fa-question-circle").toHaveCount(0, {
+        message: "first checkbox should not have a question circle",
+    });
+    expect(
+        "div.o_field_widget div.form-check:eq(1) ~ i.fa-question-circle[title='Some info about this']"
+    ).toHaveCount(1, {
+        message: "second checkbox should have a question circle",
+    });
+});

--- a/addons/web/static/tests/views/fields/json_checkboxes_field.test.js
+++ b/addons/web/static/tests/views/fields/json_checkboxes_field.test.js
@@ -162,3 +162,57 @@ test("JsonCheckBoxesField (question circle)", async () => {
         message: "second checkbox should have a question circle",
     });
 });
+
+test("JsonCheckBoxesField (implicit inline mode)", async () => {
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: `
+            <form>
+                <group>
+                    <field name="json_checkboxes_field" widget="json_checkboxes" />
+                </group>
+            </form>`,
+    });
+
+    expect("div.o_field_widget .d-inline-block div.form-check").toHaveCount(2, {
+        message: "should show the checkboxes in inlined mode",
+    });
+});
+
+test("JsonCheckBoxesField (explicit inline mode)", async () => {
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: `
+            <form>
+                <group>
+                    <field name="json_checkboxes_field" widget="json_checkboxes" options="{'stacked': 0}" />
+                </group>
+            </form>`,
+    });
+
+    expect("div.o_field_widget .d-inline-block div.form-check").toHaveCount(2, {
+        message: "should show the checkboxes in inlined mode",
+    });
+});
+
+test("JsonCheckBoxesField (stacked mode)", async () => {
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: `
+            <form>
+                <group>
+                    <field name="json_checkboxes_field" widget="json_checkboxes" options="{'stacked': 1}" />
+                </group>
+            </form>`,
+    });
+
+    expect("div.o_field_widget .d-block div.form-check").toHaveCount(2, {
+        message: "should show the checkboxes in stacked mode",
+    });
+});


### PR DESCRIPTION
### [REF] account,web: move widget json_checkboxes to web

The `json_checkboxes` widget could be used in other modules than `account` and its descendants.
With this commit, we move it to `analytic`, which is shared by a lot more modules, which will make it available to them.
In particular, we will use it in the new enterprise `databases` module.

We keep the name account_json_checkboxes for the stable backward compatibility.

Task-id: 5062431

### [IMP] web: add stacked mode to widget json_checkboxes

With this commit, the json_checkboxes widget, which displays inlined checkboxes by default, now has a `stacked` option that allows displaying the checkboxes in a column.

Task-id: 5062431