### PR TITLE
[REF] point_of_sale, pos_*: use registry for payment terminals

### DIFF
--- a/addons/point_of_sale/static/src/@types/registry.d.ts
+++ b/addons/point_of_sale/static/src/@types/registry.d.ts
@@ -1,0 +1,7 @@
+declare module "registries" {
+    import { PaymentInterface } from "@point_of_sale/app/utils/payment/payment_interface";
+
+    interface GlobalRegistryCategories {
+        electronic_payment_interfaces: typeof PaymentInterface;
+    }
+}

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -419,7 +419,9 @@ export class PosStore extends WithLazyGetterTrap {
 
         // Add Payment Interface to Payment Method
         for (const pm of this.models["pos.payment.method"].getAll()) {
-            const PaymentInterface = this.electronic_payment_interfaces[pm.use_payment_terminal];
+            const PaymentInterface = registry
+                .category("electronic_payment_interfaces")
+                .get(pm.use_payment_terminal, null);
             if (PaymentInterface) {
                 pm.payment_terminal = new PaymentInterface(this, pm);
             }
@@ -2700,25 +2702,6 @@ export class PosStore extends WithLazyGetterTrap {
         });
         await validation.validateOrder(false);
     }
-}
-
-PosStore.prototype.electronic_payment_interfaces = {};
-
-/**
- * Call this function to map your PaymentInterface implementation to
- * the use_payment_terminal field. When the POS loads it will take
- * care of instantiating your interface and setting it on the right
- * payment methods.
- *
- * @param {string} use_payment_terminal - value used in the
- * use_payment_terminal selection field
- *
- * @param {Object} ImplementedPaymentInterface - implemented
- * PaymentInterface
- */
-export function register_payment_method(use_payment_terminal, ImplementedPaymentInterface) {
-    PosStore.prototype.electronic_payment_interfaces[use_payment_terminal] =
-        ImplementedPaymentInterface;
 }
 
 export const posService = {

--- a/addons/point_of_sale/static/src/app/utils/payment/payment_interface.js
+++ b/addons/point_of_sale/static/src/app/utils/payment/payment_interface.js
@@ -6,8 +6,8 @@
  *
  * To connect the interface to the right payment methods register it:
  *
- * import { register_payment_method } models from "@point_of_sale/app/store/pos_store";
- * register_payment_method('my_payment', MyPayment);
+ * import { registry } models from "@web/core/registry";
+ * registry.category("electronic_payment_interfaces").add("my_payment", MyPayment);
  *
  * my_payment is the technical name of the added selection in
  * use_payment_terminal.

--- a/addons/pos_adyen/static/src/app/utils/payment/payment_adyen.js
+++ b/addons/pos_adyen/static/src/app/utils/payment/payment_adyen.js
@@ -1,7 +1,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { PaymentInterface } from "@point_of_sale/app/utils/payment/payment_interface";
 import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
-import { register_payment_method } from "@point_of_sale/app/services/pos_store";
+import { registry } from "@web/core/registry";
 import { logPosMessage } from "@point_of_sale/app/utils/pretty_console_log";
 const { DateTime } = luxon;
 
@@ -359,4 +359,4 @@ export class PaymentAdyen extends PaymentInterface {
     }
 }
 
-register_payment_method("adyen", PaymentAdyen);
+registry.category("electronic_payment_interfaces").add("adyen", PaymentAdyen);

--- a/addons/pos_mercado_pago/static/src/app/utils/payment/payment_mercado_pago.js
+++ b/addons/pos_mercado_pago/static/src/app/utils/payment/payment_mercado_pago.js
@@ -1,7 +1,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { PaymentInterface } from "@point_of_sale/app/utils/payment/payment_interface";
 import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
-import { register_payment_method } from "@point_of_sale/app/services/pos_store";
+import { registry } from "@web/core/registry";
 
 export class PaymentMercadoPago extends PaymentInterface {
     async createPaymentIntent() {
@@ -191,4 +191,4 @@ export class PaymentMercadoPago extends PaymentInterface {
     }
 }
 
-register_payment_method("mercado_pago", PaymentMercadoPago);
+registry.category("electronic_payment_interfaces").add("mercado_pago", PaymentMercadoPago);

--- a/addons/pos_pine_labs/static/src/app/utils/payment/payment_pine_labs.js
+++ b/addons/pos_pine_labs/static/src/app/utils/payment/payment_pine_labs.js
@@ -3,7 +3,7 @@ import { PaymentInterface } from "@point_of_sale/app/utils/payment/payment_inter
 import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { serializeDateTime } from "@web/core/l10n/dates";
 import { offlineErrorHandler, handleRPCError } from "@point_of_sale/app/utils/error_handlers";
-import { register_payment_method } from "@point_of_sale/app/services/pos_store";
+import { registry } from "@web/core/registry";
 import { ConnectionLostError, RPCError } from "@web/core/network/rpc";
 
 const REQUEST_TIMEOUT_MS = 5000;
@@ -259,4 +259,4 @@ export class PaymentPineLabs extends PaymentInterface {
     }
 }
 
-register_payment_method("pine_labs", PaymentPineLabs);
+registry.category("electronic_payment_interfaces").add("pine_labs", PaymentPineLabs);

--- a/addons/pos_qfpay/static/src/app/payment_qfpay.js
+++ b/addons/pos_qfpay/static/src/app/payment_qfpay.js
@@ -1,7 +1,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { PaymentInterface } from "@point_of_sale/app/utils/payment/payment_interface";
 import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
-import { register_payment_method } from "@point_of_sale/app/services/pos_store";
+import { registry } from "@web/core/registry";
 
 import { QFPay, QFPayError } from "./qfpay";
 
@@ -165,4 +165,4 @@ export class PaymentQFpay extends PaymentInterface {
     }
 }
 
-register_payment_method("qfpay", PaymentQFpay);
+registry.category("electronic_payment_interfaces").add("qfpay", PaymentQFpay);

--- a/addons/pos_razorpay/static/src/app/utls/payment/payment_razorpay.js
+++ b/addons/pos_razorpay/static/src/app/utls/payment/payment_razorpay.js
@@ -2,7 +2,7 @@ import { _t } from "@web/core/l10n/translation";
 import { PaymentInterface } from "@point_of_sale/app/utils/payment/payment_interface";
 import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { serializeDateTime } from "@web/core/l10n/dates";
-import { register_payment_method } from "@point_of_sale/app/services/pos_store";
+import { registry } from "@web/core/registry";
 
 const REQUEST_TIMEOUT = 10000;
 const { DateTime } = luxon;
@@ -306,4 +306,4 @@ export class PaymentRazorpay extends PaymentInterface {
     }
 }
 
-register_payment_method("razorpay", PaymentRazorpay);
+registry.category("electronic_payment_interfaces").add("razorpay", PaymentRazorpay);

--- a/addons/pos_stripe/static/src/app/payment_stripe.js
+++ b/addons/pos_stripe/static/src/app/payment_stripe.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { PaymentInterface } from "@point_of_sale/app/utils/payment/payment_interface";
 import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
-import { register_payment_method } from "@point_of_sale/app/services/pos_store";
+import { registry } from "@web/core/registry";
 import { logPosMessage } from "@point_of_sale/app/utils/pretty_console_log";
 
 export class PaymentStripe extends PaymentInterface {
@@ -335,4 +335,4 @@ export class PaymentStripe extends PaymentInterface {
     }
 }
 
-register_payment_method("stripe", PaymentStripe);
+registry.category("electronic_payment_interfaces").add("stripe", PaymentStripe);

--- a/addons/pos_viva_com/static/src/app/payment_viva_com.js
+++ b/addons/pos_viva_com/static/src/app/payment_viva_com.js
@@ -3,7 +3,7 @@ import { PaymentInterface } from "@point_of_sale/app/utils/payment/payment_inter
 import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { roundPrecision } from "@web/core/utils/numbers";
 import { uuidv4 } from "@point_of_sale/utils";
-import { register_payment_method } from "@point_of_sale/app/services/pos_store";
+import { registry } from "@web/core/registry";
 
 // Due to consistency issues with the webhook, we also poll
 // the status of the payment periodically as a fallback.
@@ -209,4 +209,4 @@ export class PaymentVivaCom extends PaymentInterface {
     }
 }
 
-register_payment_method("viva_com", PaymentVivaCom);
+registry.category("electronic_payment_interfaces").add("viva_com", PaymentVivaCom);


### PR DESCRIPTION
* = {adyen, mercado_pago, pine_labs, qfpay, razorpay, stripe, viva_com}

Before this commit, payment terminal JS classes were registered using the `register_payment_method` function in the POS, which added them to an internal map of classes. Then this map was used to instantiate the correct JS class for each payment terminal.

After this commit, we use the `registry` from the `web` module to do the same thing. This has the advantage of not being locked only to the `pos_store` class, meaning in the future we will be able to use this registry in `pos_self_order` also. At this stage though there is no change in functionality.

task-4882726

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
