### PR TITLE
[FIX] account, web: remove double border and review sections

### DIFF
--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
@@ -14,7 +14,8 @@ export class ProductLabelSectionAndNoteField extends ProductNameAndDescriptionFi
 
     get sectionAndNoteClasses() {
         return {
-            "fw-bold": this.isSection(),
+            "fw-bolder": this.isSection,
+            "fw-bold": this.isSubSection,
             "fst-italic": this.isNote(),
             "text-warning": this.shouldShowWarning(),
         };
@@ -29,14 +30,16 @@ export class ProductLabelSectionAndNoteField extends ProductNameAndDescriptionFi
         )
     }
 
-    isSection(record = null) {
-        record = record || this.props.record;
-        return ["line_section", "line_subsection"].includes(record.data.display_type);
+    get isSection() {
+        return this.props.record.data.display_type === "line_section";
     }
 
-    isTopSection(record = null) {
-        record = record || this.props.record;
-        return record.data.display_type === "line_section";
+    get isSubSection() {
+        return this.props.record.data.display_type === "line_subsection";
+    }
+
+    get isSectionOrSubSection() {
+        return this.isSection || this.isSubSection;
     }
 
     isNote(record = null) {
@@ -54,7 +57,7 @@ export class ProductLabelSectionAndNoteField extends ProductNameAndDescriptionFi
         return (
             !this.productName &&
             this.props.show_label_warning &&
-            !this.isSection() &&
+            !this.isSectionOrSubSection &&
             !this.isNote()
         );
     }

--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.xml
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.xml
@@ -15,7 +15,7 @@
                     t-key="props.readonly"
                 />
             </t>
-            <t t-elif="isSection()">
+            <t t-elif="isSectionOrSubSection">
                 <input
                     type="text"
                     class="o_input text-wrap border-0 w-100"

--- a/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_backend.scss
+++ b/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_backend.scss
@@ -18,42 +18,48 @@ table.o_section_and_note_list_view {
                 width: 1px;  // to prevent the column to expand
             }
 
-            td[name="price_subtotal"] {
-                color: $gray-700;
+            .o_field_product_label_section_and_note_cell .o_input {
+                text-overflow: ellipsis;
             }
         }
 
         &.o_is_line_section {
             --table-hover-bg: #{rgba($body-emphasis-color, .08)};
             --table-bg-type: #{rgba($body-emphasis-color, .06)};
+            --ListRenderer-data-row-focused-striped-bg: var(--table-bg-type);
 
-            .o_handle_cell .o_row_handle {
-                transition: opacity $_SectionAndNote-transition;
+            font-weight: $font-weight-bolder;
+
+            &:where(:not(:empty)) {
+                // When dragging, an empty tr is created we don't want
+                // a border here.
+                border-top-color: var(--o-SectionAndNote-border-color);
             }
 
-            &:where(:not(.o_selected_row)) {
-                div:has(> div.o_field_product_label_section_and_note_cell) {
-                    transition: transform $_SectionAndNote-transition;
-                    position: absolute;
-                }
-
-                &:not(:hover, .o_dragged) {
-                    div:has(> div.o_field_product_label_section_and_note_cell) {
-                        transform: translateX(($font-size-base + $table-cell-padding-x-sm * 2) * -1);
-                    }
-
-                    .o_handle_cell .o_row_handle {
-                        cursor: default;
-                        pointer-events: none;
-                        opacity: 0;
-                    }
-                }
+            &.o_dragged {
+                border-width: $border-width 0;
             }
         }
 
         &.o_is_line_subsection {
             --table-hover-bg: #{rgba($body-emphasis-color, .05)};
             --table-bg-type: #{rgba($body-emphasis-color, .03)};
+
+            font-weight: $font-weight-bold;
+
+            &.o_dragged {
+                // We rely on td borders, when dragged we need to remove
+                // the borders on .o_data_row to avoid double borders
+                --ListRenderer-data-row-border-bottom-width: 0;
+            }
+
+            td {
+                border-bottom-width: $border-width;
+
+                &:not(.o_handle_cell) {
+                    border-color: var(--o-SectionAndNote-border-color);
+                }
+            }
         }
 
         // Check if next sibling is a section to apply a border-color.

--- a/addons/sale/static/src/js/sale_order_line_field/sale_order_line_field.js
+++ b/addons/sale/static/src/js/sale_order_line_field/sale_order_line_field.js
@@ -94,7 +94,7 @@ export class SaleOrderLineListRenderer extends ProductLabelSectionAndNoteListRen
         if (this.isCombo(record) || this.isComboItem(record)) {
             classNames = classNames.replace('o_row_draggable', '');
         }
-        return `${classNames} ${this.isCombo(record) ? 'o_is_line_section' : ''}`;
+        return `${classNames} ${this.isCombo(record) ? 'o_is_line_section o_is_line_section_no_indent' : ''}`;
     }
 
     isCellReadonly(column, record) {

--- a/addons/sale/static/src/js/sale_product_field.js
+++ b/addons/sale/static/src/js/sale_product_field.js
@@ -135,7 +135,7 @@ export class SaleOrderLineProductField extends ProductLabelSectionAndNoteField {
         return {
             ...super.sectionAndNoteClasses,
             "text-warning":
-                !this.isSection() && !this.isNote() && !this.productName && !this.isDownpayment,
+                !this.isSectionOrSubSection && !this.isNote() && !this.productName && !this.isDownpayment,
         };
     }
 

--- a/addons/web/static/src/views/list/list_renderer.scss
+++ b/addons/web/static/src/views/list/list_renderer.scss
@@ -501,13 +501,13 @@
         */
         // 1. we set the global separator (gray line) of the table on the row (bottom) and not on the cell (bottom)
         .o_data_row {
-            border-bottom-width: 1px;
+            border-bottom-width: var(--ListRenderer-data-row-border-bottom-width, 1px);
 
             &:not(.o_selected_row):not(.o_data_row_selected):focus-within > * {
                 $-focus-bg: rgba(var(--#{$variable-prefix}emphasis-color-rgb), #{$table-hover-bg-factor * 2});
 
                 --#{$variable-prefix}table-accent-bg: #{$-focus-bg};
-                --#{$variable-prefix}table-striped-bg: #{$-focus-bg};
+                --#{$variable-prefix}table-striped-bg: var(--ListRenderer-data-row-focused-striped-bg, #{$-focus-bg});
             }
         }
 

--- a/addons/web/static/src/views/list/list_renderer.scss
+++ b/addons/web/static/src/views/list/list_renderer.scss
@@ -512,11 +512,11 @@
         }
 
         // 2. we remove the bottom border (added by BS5) on all cells (this force to show the top border of selected cell)
-        .o_data_row > .o_data_cell {
+        .o_data_row > td {
             border-bottom-width: 0;
         }
         // 3. we add only a bottom border to selected cells (this force to show the bottom border of the selected cell)
-        .o_data_row.o_data_row_selected > .o_data_cell {
+        .o_data_row.o_data_row_selected > td {
             border-bottom-width: 1px;
         }
     }


### PR DESCRIPTION
If we drag a row, there is a double border bottom under the `.o_list_record_remove`. This is due to the selector removing the border bottom being applied only on `.o_data_cell` since it's not a data-cell. This PR apply it on the td instead to be more generic.

Sections and subsection's design was updated in https://github.com/odoo/odoo/commit/520bb2ff8eb165e4a9389db6300192f9b4a05dfd  but the differentiation was too light. It also introduces issue: 

- Double border on subsection on drag
- Empty tr having the main section border
- Tax Incl. prices not receiving price styling
- Combo lines were animated on hover but they are not draggable
- Fix section hover not being applied in the quotation templates
- Avoid long section name being cropped too early
- Focus-within state applying wrong color on even sections

task-5125867

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
