### PR TITLE
[FIX] website_sale: enable pricelists for GeoIP test

### DIFF
--- a/addons/website_sale/tests/test_website_sale_cart.py
+++ b/addons/website_sale/tests/test_website_sale_cart.py
@@ -401,6 +401,7 @@ class TestWebsiteSaleCart(ProductAttributesCommon, WebsiteSaleCommon):
         """Check that, when adding a new partner to a website order, the partner's GeoIP
         is factored into the pricelist recomputation.
         """
+        self._enable_pricelists()
         eu_group = self.env.ref('base.europe')
         not_eu_group = self.env['res.country.group'].create({
             'name': "Not EU",


### PR DESCRIPTION
Versions
--------
- saas-18.3+

Steps
-----
1. Have a database without demo data;
2. run `test_cart_new_pricelist_from_geoip`.

Issue
-----
Test fails, due to the order not having a pricelist.

Cause
-----
Pricelists aren't enabled by default without demo data.

Solution
--------
Call `self._enable_pricelists()` at the start of the test.

runbot-232989
