### PR TITLE
Saas 18.4 fix pricelist description separator bvr

### DIFF
--- a/addons/website/static/src/builder/plugins/options/pricelist_option/pricelist_boxed_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/pricelist_option/pricelist_boxed_option_plugin.js
@@ -1,5 +1,6 @@
 import { BEGIN, SNIPPET_SPECIFIC_END } from "@html_builder/utils/option_sequence";
 import { Plugin } from "@html_editor/plugin";
+import { isElement } from "@html_editor/utils/dom_info";
 import { withSequence } from "@html_editor/utils/resource";
 import { registry } from "@web/core/registry";
 import { AddProductOption } from "./add_product_option";
@@ -35,6 +36,13 @@ class PriceListBoxedOptionPlugin extends Plugin {
             dropNear: ".s_pricelist_boxed_item",
         },
         is_movable_selector: { selector: ".s_pricelist_boxed_item", direction: "vertical" },
+        // Protect pricelist item, price, and description blocks from being
+        // split/merged by the delete plugin.
+        unsplittable_node_predicates: (node) =>
+            isElement(node) &&
+            node.matches(
+                ".s_pricelist_boxed_item, .s_pricelist_boxed_item_price, .s_pricelist_boxed_item_description"
+            ),
     };
 }
 

--- a/addons/website/static/src/builder/plugins/options/pricelist_option/pricelist_cafe_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/pricelist_option/pricelist_cafe_plugin.js
@@ -1,6 +1,7 @@
 import { VerticalAlignmentOption } from "@html_builder/plugins/vertical_alignment_option";
 import { BEGIN, SNIPPET_SPECIFIC_END } from "@html_builder/utils/option_sequence";
 import { Plugin } from "@html_editor/plugin";
+import { isElement } from "@html_editor/utils/dom_info";
 import { withSequence } from "@html_editor/utils/resource";
 import { registry } from "@web/core/registry";
 import { AddProductOption } from "./add_product_option";
@@ -41,6 +42,13 @@ class PriceListCafePlugin extends Plugin {
             dropNear: ".s_pricelist_cafe_item",
         },
         is_movable_selector: { selector: ".s_pricelist_cafe_item", direction: "vertical" },
+        // Protect pricelist item, price, and description blocks from being
+        // split/merged by the delete plugin.
+        unsplittable_node_predicates: (node) =>
+            isElement(node) &&
+            node.matches(
+                ".s_pricelist_cafe_item, .s_pricelist_cafe_item_price, .s_pricelist_cafe_item_description"
+            ),
     };
 }
 

--- a/addons/website/static/src/builder/plugins/options/pricelist_option/product_catalog_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/pricelist_option/product_catalog_plugin.js
@@ -1,5 +1,6 @@
 import { BEGIN, SNIPPET_SPECIFIC_END } from "@html_builder/utils/option_sequence";
 import { Plugin } from "@html_editor/plugin";
+import { isElement } from "@html_editor/utils/dom_info";
 import { withSequence } from "@html_editor/utils/resource";
 import { registry } from "@web/core/registry";
 import { AddProductOption } from "./add_product_option";
@@ -35,6 +36,13 @@ class ProductCatalogOptionPlugin extends Plugin {
             dropNear: ".s_product_catalog_dish",
         },
         is_movable_selector: { selector: ".s_product_catalog_dish", direction: "vertical" },
+        // Protect pricelist item, price, and description blocks from being
+        // split/merged by the delete plugin.
+        unsplittable_node_predicates: (node) =>
+            isElement(node) &&
+            node.matches(
+                ".s_product_catalog_dish, .s_product_catalog_dish_price, .s_product_catalog_dish_description"
+            ),
     };
 }
 


### PR DESCRIPTION
**[FIX] website: keep pricelist blocks intact**

Build the unsplittable selector from the three pricelist snippet base
classes so that the HTML editor no longer splits or merges their item,
price, or description elements when users delete content with Backspace.

Steps to reproduce:

- Drag and drop a pricelist snippet (e.g., Pricelist Cafe).
- Place the cursor before the first letter of one of the descriptions.
- Press Backspace.
- Bug: the description content is merged with the price.

task-5117864