### PR TITLE
[IMP] account_edi_ubl_cii: Use new helpers by default in BIS3 extensions

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -74,6 +74,8 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         }
 
     def _get_country_vals(self, country):
+        # Old helper used only for non-BIS3 UBLs, removed in saas-18.4.
+        # If you change this method, please change the corresponding new helper as well (at the end of this file).
         return {
             'country': country,
 
@@ -82,11 +84,15 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         }
 
     def _get_partner_party_identification_vals_list(self, partner):
+        # Old helper used only for non-BIS3 UBLs, removed in saas-18.4.
+        # If you change this method, please change the corresponding new helper as well (at the end of this file).
         if partner.ref:
             return [{'id': partner.ref}]
         return []
 
     def _get_partner_address_vals(self, partner):
+        # Old helper used only for non-BIS3 UBLs, removed in saas-18.4.
+        # If you change this method, please change the corresponding new helper as well (at the end of this file).
         return {
             'street_name': partner.street,
             'additional_street_name': partner.street2,
@@ -98,6 +104,8 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         }
 
     def _get_partner_party_tax_scheme_vals_list(self, partner, role):
+        # Old helper used only for non-BIS3 UBLs, removed in saas-18.4.
+        # If you change this method, please change the corresponding new helper as well (at the end of this file).
         # [BR-CO-09] if the PartyTaxScheme/TaxScheme/ID == 'VAT', CompanyID must start with a country code prefix.
         # In some countries however, the CompanyID can be with or without country code prefix and still be perfectly
         # valid (RO, HU, non-EU countries).
@@ -117,6 +125,8 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         }]
 
     def _get_partner_party_legal_entity_vals_list(self, partner):
+        # Old helper used only for non-BIS3 UBLs, removed in saas-18.4.
+        # If you change this method, please change the corresponding new helper as well (at the end of this file).
         return [{
             'commercial_partner': partner,
             'registration_name': partner.name,
@@ -125,6 +135,8 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         }]
 
     def _get_partner_contact_vals(self, partner):
+        # Old helper used only for non-BIS3 UBLs, removed in saas-18.4.
+        # If you change this method, please change the corresponding new helper as well (at the end of this file).
         return {
             'id': partner.id,
             'name': partner.name,
@@ -133,6 +145,8 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         }
 
     def _get_partner_person_vals(self, partner):
+        # Old helper used only for non-BIS3 UBLs, removed in saas-18.4.
+        # If you change this method, please change the corresponding new helper as well (at the end of this file).
         """
         This is optional and meant to be overridden when required under the form:
         {
@@ -144,6 +158,8 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         return {}
 
     def _get_partner_party_vals(self, partner, role):
+        # Old helper used only for non-BIS3 UBLs, removed in saas-18.4.
+        # If you change this method, please change the corresponding new helper as well (at the end of this file).
         return {
             'partner': partner,
             'party_identification_vals': self.with_context(ubl_partner_role=role)._get_partner_party_identification_vals_list(partner.commercial_partner_id),
@@ -156,6 +172,8 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         }
 
     def _get_invoice_period_vals_list(self, invoice):
+        # Old helper used only for non-BIS3 UBLs, removed in saas-18.4.
+        # If you change this method, please change the corresponding new helper as well (at the end of this file).
         """
         For now, we cannot fill this data from an invoice
         This corresponds to the 'delivery or invoice period'. For UBL Bis 3, in the case of intra-community supply,
@@ -168,6 +186,8 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         return []
 
     def _get_additional_document_reference_list(self, invoice):
+        # Old helper used only for non-BIS3 UBLs, removed in saas-18.4.
+        # If you change this method, please change the corresponding new helper as well (at the end of this file).
         """
         This is optional and meant to be overridden when required under the form:
         {
@@ -182,6 +202,8 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         return []
 
     def _get_delivery_vals_list(self, invoice):
+        # Old helper used only for non-BIS3 UBLs, removed in saas-18.4.
+        # If you change this method, please change the corresponding new helper as well (at the end of this file).
         # the data is optional, except for ubl bis3 (see the override, where we need to set a default delivery address)
         return [{
             'actual_delivery_date': invoice.delivery_date,
@@ -192,6 +214,8 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         }]
 
     def _get_bank_address_vals(self, bank):
+        # Old helper used only for non-BIS3 UBLs, removed in saas-18.4.
+        # If you change this method, please change the corresponding new helper as well (at the end of this file).
         return {
             'street_name': bank.street,
             'additional_street_name': bank.street2,
@@ -203,6 +227,8 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         }
 
     def _get_financial_institution_vals(self, bank):
+        # Old helper used only for non-BIS3 UBLs, removed in saas-18.4.
+        # If you change this method, please change the corresponding new helper as well (at the end of this file).
         return {
             'bank': bank,
             'id': bank.bic,
@@ -212,6 +238,8 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         }
 
     def _get_financial_institution_branch_vals(self, bank):
+        # Old helper used only for non-BIS3 UBLs, removed in saas-18.4.
+        # If you change this method, please change the corresponding new helper as well (at the end of this file).
         return {
             'bank': bank,
             'id': bank.bic,
@@ -220,6 +248,8 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         }
 
     def _get_financial_account_vals(self, partner_bank):
+        # Old helper used only for non-BIS3 UBLs, removed in saas-18.4.
+        # If you change this method, please change the corresponding new helper as well (at the end of this file).
         vals = {
             'bank_account': partner_bank,
             'id': partner_bank.acc_number.replace(' ', ''),
@@ -231,6 +261,8 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         return vals
 
     def _get_invoice_payment_means_vals_list(self, invoice):
+        # Old helper used only for non-BIS3 UBLs, removed in saas-18.4.
+        # If you change this method, please change the corresponding new helper as well (at the end of this file).
         if invoice.move_type == 'out_invoice':
             if invoice.partner_bank_id:
                 payment_means_code, payment_means_name = (30, 'credit transfer')
@@ -258,6 +290,8 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         return [vals]
 
     def _get_invoice_payment_terms_vals_list(self, invoice):
+        # Old helper used only for non-BIS3 UBLs, removed in saas-18.4.
+        # If you change this method, please change the corresponding new helper as well (at the end of this file).
         payment_term = invoice.invoice_payment_term_id
         if payment_term:
             # The payment term's note is automatically embedded in a <p> tag in Odoo
@@ -266,6 +300,8 @@ class AccountEdiXmlUBL20(models.AbstractModel):
             return []
 
     def _get_invoice_tax_totals_vals_list(self, invoice, taxes_vals):
+        # Old helper used only for non-BIS3 UBLs, removed in saas-18.4.
+        # If you change this method, please change the corresponding new helper as well (at the end of this file).
         tax_totals_vals = {
             'currency': invoice.currency_id,
             'currency_dp': self._get_currency_decimal_places(invoice.currency_id),
@@ -328,6 +364,8 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         return [tax_totals_vals]
 
     def _get_invoice_line_item_vals(self, line, taxes_vals):
+        # Old helper used only for non-BIS3 UBLs, removed in saas-18.4.
+        # If you change this method, please change the corresponding new helper as well (at the end of this file).
         """ Method used to fill the cac:InvoiceLine/cac:Item node.
         It provides information about what the product you are selling.
 
@@ -355,6 +393,8 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         }
 
     def _get_document_allowance_charge_vals_list(self, invoice, taxes_vals=None):
+        # Old helper used only for non-BIS3 UBLs, removed in saas-18.4.
+        # If you change this method, please change the corresponding new helper as well (at the end of this file).
         """
         https://docs.peppol.eu/poacc/billing/3.0/bis/#_document_level_allowance_or_charge
         Usage for early payment discounts:
@@ -398,6 +438,8 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         return vals_list
 
     def _get_pricing_exchange_rate_vals_list(self, invoice):
+        # Old helper used only for non-BIS3 UBLs, removed in saas-18.4.
+        # If you change this method, please change the corresponding new helper as well (at the end of this file).
         """ To be overridden if needed to fill the PricingExchangeRate node.
 
         This is used when the currency of the 'Exchange' (e.g.: an invoice) is not the same as the Document currency.
@@ -412,6 +454,8 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         return []
 
     def _get_invoice_line_allowance_vals_list(self, line, tax_values_list=None):
+        # Old helper used only for non-BIS3 UBLs, removed in saas-18.4.
+        # If you change this method, please change the corresponding new helper as well (at the end of this file).
         """ Method used to fill the cac:{Invoice,CreditNote,DebitNote}Line>cac:AllowanceCharge node.
 
         Allowances are distinguished from charges using the ChargeIndicator node with 'false' as value.
@@ -465,6 +509,8 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         return [allowance_vals] + fixed_tax_charge_vals_list
 
     def _get_invoice_line_price_vals(self, line):
+        # Old helper used only for non-BIS3 UBLs, removed in saas-18.4.
+        # If you change this method, please change the corresponding new helper as well (at the end of this file).
         """ Method used to fill the cac:InvoiceLine/cac:Price node.
         It provides information about the price applied for the goods and services invoiced.
 
@@ -498,12 +544,16 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         }
 
     def _get_invoice_line_tax_totals_vals_list(self, line, taxes_vals):
+        # Old helper used only for non-BIS3 UBLs, removed in saas-18.4.
+        # If you change this method, please change the corresponding new helper as well (at the end of this file).
         """ Method used to fill the cac:TaxTotal node on a line level.
         Uses the same method as the invoice TaxTotal, but can be overridden in other formats.
         """
         return self._get_invoice_tax_totals_vals_list(line.move_id, taxes_vals)
 
     def _get_invoice_line_vals(self, line, line_id, taxes_vals):
+        # Old helper used only for non-BIS3 UBLs, removed in saas-18.4.
+        # If you change this method, please change the corresponding new helper as well (at the end of this file).
         """ Method used to fill the cac:{Invoice,CreditNote,DebitNote}Line node.
         It provides information about the document line.
 
@@ -538,6 +588,8 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         }
 
     def _get_invoice_monetary_total_vals(self, invoice, taxes_vals, line_extension_amount, allowance_total_amount, charge_total_amount):
+        # Old helper used only for non-BIS3 UBLs, removed in saas-18.4.
+        # If you change this method, please change the corresponding new helper as well (at the end of this file).
         """ Method used to fill the cac:{Legal,Requested}MonetaryTotal node"""
         # We only handle rounding amounts that do not belong to any tax ('add_invoice_line' cash rounding strategy).
         # Rounding amounts belonging to a tax ('biggest_tax' strategy) are included already in the tax amounts.
@@ -557,18 +609,24 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         }
 
     def _apply_invoice_tax_filter(self, base_line, tax_values):
+        # Old helper used only for non-BIS3 UBLs, removed in saas-18.4.
+        # If you change this method, please change the corresponding new helper as well (at the end of this file).
         """
             To be overridden to apply a specific tax filter
         """
         return True
 
     def _apply_invoice_line_filter(self, invoice_line):
+        # Old helper used only for non-BIS3 UBLs, removed in saas-18.4.
+        # If you change this method, please change the corresponding new helper as well (at the end of this file).
         """
             To be overridden to apply a specific invoice line filter
         """
         return True
 
     def _get_early_payment_discount_grouped_by_tax_rate(self, invoice):
+        # Old helper used only for non-BIS3 UBLs, removed in saas-18.4.
+        # If you change this method, please change the corresponding new helper as well (at the end of this file).
         """
         Get the early payment discounts grouped by the tax rate of the product it is linked to
         :returns {float: float}: mapping tax amounts to early payment discount amounts
@@ -582,6 +640,8 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         return tax_to_discount
 
     def _get_tax_grouping_key(self, base_line, tax_data):
+        # Old helper used only for non-BIS3 UBLs, removed in saas-18.4.
+        # If you change this method, please change the corresponding new helper as well (at the end of this file).
         tax = tax_data['tax']
         customer = base_line['record'].move_id.commercial_partner_id
         supplier = base_line['record'].move_id.company_id.partner_id.commercial_partner_id
@@ -599,6 +659,8 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         return grouping_key
 
     def _export_invoice_vals(self, invoice):
+        # Old helper used only for non-BIS3 UBLs, removed in saas-18.4.
+        # If you change this method, please change the corresponding new helper as well (at the end of this file).
         # Validate the structure of the taxes
         self._validate_taxes(invoice.invoice_line_ids.tax_ids)
 
@@ -737,6 +799,8 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         return vals
 
     def _get_note_vals_list(self, invoice):
+        # Old helper used only for non-BIS3 UBLs, removed in saas-18.4.
+        # If you change this method, please change the corresponding new helper as well (at the end of this file).
         return [{'note': html2plaintext(invoice.narration)}] if invoice.narration else []
 
     def _export_invoice_constraints(self, invoice, vals):
@@ -761,6 +825,8 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         return etree.tostring(cleanup_xml_node(xml_content), xml_declaration=True, encoding='UTF-8'), set(errors)
 
     def _get_document_type_code_vals(self, invoice, invoice_data):
+        # Old helper used only for non-BIS3 UBLs, removed in saas-18.4.
+        # If you change this method, please change the corresponding new helper as well (at the end of this file).
         """Returns the values used for the `DocumentTypeCode` node"""
         # To be overriden by custom format if required
         return {'attrs': {}, 'value': None}

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_a_nz.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_a_nz.py
@@ -27,6 +27,8 @@ class AccountEdiXmlUBLANZ(models.AbstractModel):
 
     def _get_partner_party_tax_scheme_vals_list(self, partner, role):
         # EXTENDS account.edi.xml.ubl_bis3
+        # Old helper not used by default (see _export_invoice override in account.edi.xml.ubl_bis3)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals_list = super()._get_partner_party_tax_scheme_vals_list(partner, role)
 
         for vals in vals_list:
@@ -37,6 +39,8 @@ class AccountEdiXmlUBLANZ(models.AbstractModel):
 
     def _get_partner_party_vals(self, partner, role):
         # EXTENDS account.edi.xml.ubl_bis3
+        # Old helper not used by default (see _export_invoice override in account.edi.xml.ubl_bis3)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals = super()._get_partner_party_vals(partner, role)
         vals.setdefault('party_tax_scheme_vals', [])
 
@@ -52,6 +56,8 @@ class AccountEdiXmlUBLANZ(models.AbstractModel):
 
     def _get_partner_party_legal_entity_vals_list(self, partner):
         # EXTENDS account.edi.xml.ubl_bis3
+        # Old helper not used by default (see _export_invoice override in account.edi.xml.ubl_bis3)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals_list = super()._get_partner_party_legal_entity_vals_list(partner)
 
         for vals in vals_list:
@@ -69,6 +75,8 @@ class AccountEdiXmlUBLANZ(models.AbstractModel):
 
     def _get_tax_category_list(self, customer, supplier, taxes):
         # EXTENDS account.edi.xml.ubl_bis3
+        # Old helper not used by default (see _export_invoice override in account.edi.xml.ubl_bis3)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals_list = super()._get_tax_category_list(customer, supplier, taxes)
         for vals in vals_list:
             vals['tax_scheme_vals'] = {'id': 'GST'}
@@ -76,6 +84,8 @@ class AccountEdiXmlUBLANZ(models.AbstractModel):
 
     def _export_invoice_vals(self, invoice):
         # EXTENDS account.edi.xml.ubl_21
+        # Old helper not used by default (see _export_invoice override in account.edi.xml.ubl_bis3)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals = super()._export_invoice_vals(invoice)
 
         vals['vals'].update({

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_a_nz.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_a_nz.py
@@ -93,3 +93,45 @@ class AccountEdiXmlUBLANZ(models.AbstractModel):
         })
 
         return vals
+
+    # -------------------------------------------------------------------------
+    # EXPORT: New (dict_to_xml) helpers
+    # -------------------------------------------------------------------------
+
+    def _add_invoice_header_nodes(self, document_node, vals):
+        # EXTENDS account.edi.xml.ubl_21
+        super()._add_invoice_header_nodes(document_node, vals)
+        document_node['cbc:CustomizationID'] = {'_text': self._get_customization_ids()['ubl_a_nz']}
+
+    def _get_party_node(self, vals):
+        # EXTENDS account.edi.xml.ubl_bis3
+        party_node = super()._get_party_node(vals)
+        partner = vals['partner']
+        commercial_partner = partner.commercial_partner_id
+
+        if commercial_partner.country_code == 'AU' and commercial_partner.vat:
+            vat = commercial_partner.vat.replace(" ", "")
+            party_node['cbc:EndpointID']['_text'] = vat
+            party_node['cac:PartyTaxScheme'][0]['cbc:CompanyID']['_text'] = vat
+            party_node['cac:PartyLegalEntity']['cbc:CompanyID'] = {
+                '_text': vat,
+                'schemeID': '0151',
+            }
+
+        elif commercial_partner.country_code == 'NZ':
+            party_node['cbc:EndpointID']['_text'] = commercial_partner.company_registry
+            party_node['cac:PartyTaxScheme'][0]['cbc:CompanyID']['_text'] = commercial_partner.company_registry
+            party_node['cac:PartyLegalEntity']['cbc:CompanyID'] = {
+                '_text': commercial_partner.company_registry,
+                'schemeID': '0088',
+            }
+
+        party_node['cac:PartyTaxScheme'][0]['cac:TaxScheme']['cbc:ID']['_text'] = 'GST'
+
+        return party_node
+
+    def _get_tax_category_node(self, vals):
+        # EXTENDS account.edi.xml.ubl_bis3
+        tax_category_node = super()._get_tax_category_node(vals)
+        tax_category_node['cac:TaxScheme']['cbc:ID']['_text'] = 'GST'
+        return tax_category_node

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -511,14 +511,11 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
     # -------------------------------------------------------------------------
 
     def _export_invoice(self, invoice, convert_fixed_taxes=True):
-        # Only for BIS3 invoices: if the 'account_edi_ubl_cii.use_new_dict_to_xml_helpers' param is set,
-        # use the new dict_to_xml helpers.
-        if (
-            self._name == 'account.edi.xml.ubl_bis3'
-            and str2bool(
-                self.env['ir.config_parameter'].sudo().get_param('account_edi_ubl_cii.use_new_dict_to_xml_helpers', True),
-                default=True,
-            )
+        # Use the new dict_to_xml helpers by default
+        # unless the 'account_edi_ubl_cii.use_new_dict_to_xml_helpers' param is set to False.
+        if str2bool(
+            self.env['ir.config_parameter'].sudo().get_param('account_edi_ubl_cii.use_new_dict_to_xml_helpers', True),
+            default=True,
         ):
             return self._export_invoice_new(invoice)
 

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -42,6 +42,8 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
 
     def _get_country_vals(self, country):
         # EXTENDS account.edi.xml.ubl_21
+        # Old helper not used by default (see _export_invoice override)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals = super()._get_country_vals(country)
 
         vals.pop('name', None)
@@ -50,6 +52,8 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
 
     def _get_partner_party_tax_scheme_vals_list(self, partner, role):
         # EXTENDS account.edi.xml.ubl_21
+        # Old helper not used by default (see _export_invoice override)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals_list = super()._get_partner_party_tax_scheme_vals_list(partner, role)
 
         if not partner.vat:
@@ -75,6 +79,8 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
 
     def _get_partner_party_legal_entity_vals_list(self, partner):
         # EXTENDS account.edi.xml.ubl_21
+        # Old helper not used by default (see _export_invoice override)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals_list = super()._get_partner_party_legal_entity_vals_list(partner)
 
         for vals in vals_list:
@@ -106,6 +112,8 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
 
     def _get_partner_contact_vals(self, partner):
         # EXTENDS account.edi.xml.ubl_21
+        # Old helper not used by default (see _export_invoice override)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals = super()._get_partner_contact_vals(partner)
 
         vals.pop('id', None)
@@ -114,6 +122,8 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
 
     def _get_partner_party_vals(self, partner, role):
         # EXTENDS account.edi.xml.ubl_21
+        # Old helper not used by default (see _export_invoice override)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         if (
             role == 'delivery'
             # If the user hasn't updated the module, we just don't render `DeliveryParty` because the UBL
@@ -141,6 +151,8 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
 
     def _get_partner_party_identification_vals_list(self, partner):
         # EXTENDS account.edi.xml.ubl_21
+        # Old helper not used by default (see _export_invoice override)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals = super()._get_partner_party_identification_vals_list(partner)
 
         if partner.country_code == 'NL' and partner.peppol_endpoint:
@@ -155,6 +167,8 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
 
     def _get_delivery_vals_list(self, invoice):
         # EXTENDS account.edi.xml.ubl_21
+        # Old helper not used by default (see _export_invoice override)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         supplier = invoice.company_id.partner_id.commercial_partner_id
         customer = invoice.partner_id
 
@@ -185,6 +199,8 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
 
     def _get_partner_address_vals(self, partner):
         # EXTENDS account.edi.xml.ubl_21
+        # Old helper not used by default (see _export_invoice override)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals = super()._get_partner_address_vals(partner)
         # schematron/openpeppol/3.13.0/xslt/CEN-EN16931-UBL.xslt
         # [UBL-CR-225]-A UBL invoice should not include the AccountingCustomerParty Party PostalAddress CountrySubentityCode
@@ -193,6 +209,8 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
 
     def _get_financial_institution_branch_vals(self, bank):
         # EXTENDS account.edi.xml.ubl_21
+        # Old helper not used by default (see _export_invoice override)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals = super()._get_financial_institution_branch_vals(bank)
         # schematron/openpeppol/3.13.0/xslt/CEN-EN16931-UBL.xslt
         # [UBL-CR-664]-A UBL invoice should not include the FinancialInstitutionBranch FinancialInstitution
@@ -203,6 +221,8 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
 
     def _get_invoice_payment_means_vals_list(self, invoice):
         # EXTENDS account.edi.xml.ubl_21
+        # Old helper not used by default (see _export_invoice override)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals_list = super()._get_invoice_payment_means_vals_list(invoice)
 
         for vals in vals_list:
@@ -215,6 +235,8 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
 
     def _get_tax_category_list(self, customer, supplier, taxes):
         # EXTENDS account.edi.xml.ubl_21
+        # Old helper not used by default (see _export_invoice override)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals_list = super()._get_tax_category_list(customer, supplier, taxes)
 
         for vals in vals_list:
@@ -224,6 +246,8 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
 
     def _get_invoice_tax_totals_vals_list(self, invoice, taxes_vals):
         # EXTENDS account.edi.xml.ubl_21
+        # Old helper not used by default (see _export_invoice override)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals_list = super()._get_invoice_tax_totals_vals_list(invoice, taxes_vals)
 
         for vals in vals_list:
@@ -236,6 +260,8 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
 
     def _get_invoice_line_item_vals(self, line, taxes_vals):
         # EXTENDS account.edi.xml.ubl_21
+        # Old helper not used by default (see _export_invoice override)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         line_item_vals = super()._get_invoice_line_item_vals(line, taxes_vals)
 
         for val in line_item_vals['classified_tax_category_vals']:
@@ -249,6 +275,8 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
 
     def _get_invoice_line_allowance_vals_list(self, line, tax_values_list=None):
         # EXTENDS account.edi.xml.ubl_21
+        # Old helper not used by default (see _export_invoice override)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals_list = super()._get_invoice_line_allowance_vals_list(line, tax_values_list=tax_values_list)
 
         for vals in vals_list:
@@ -258,6 +286,8 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
 
     def _get_invoice_line_vals(self, line, line_id, taxes_vals):
         # EXTENDS account.edi.xml.ubl_21
+        # Old helper not used by default (see _export_invoice override)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals = super()._get_invoice_line_vals(line, line_id, taxes_vals)
 
         vals.pop('tax_total_vals', None)
@@ -275,6 +305,8 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
 
     def _export_invoice_vals(self, invoice):
         # EXTENDS account.edi.xml.ubl_21
+        # Old helper not used by default (see _export_invoice override)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals = super()._export_invoice_vals(invoice)
 
         vals['vals'].update({

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_nlcius.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_nlcius.py
@@ -97,3 +97,50 @@ class AccountEdiXmlUBLNL(models.AbstractModel):
         # vals['vals'].pop('issue_date')  # careful, this causes other errors from the validator...
 
         return vals
+
+    # -------------------------------------------------------------------------
+    # EXPORT: New (dict_to_xml) helpers
+    # -------------------------------------------------------------------------
+
+    def _add_invoice_header_nodes(self, document_node, vals):
+        # EXTENDS account.edi.xml.ubl_bis3
+        super()._add_invoice_header_nodes(document_node, vals)
+        document_node['cbc:CustomizationID'] = {'_text': self._get_customization_ids()['nlcius']}
+
+    def _add_invoice_payment_means_nodes(self, document_node, vals):
+        # EXTENDS account.edi.xml.ubl_bis3
+        super()._add_invoice_payment_means_nodes(document_node, vals)
+        # [BR-NL-29] The use of a payment means text (cac:PaymentMeans/cbc:PaymentMeansCode/@name) is not recommended
+        payment_means_node = document_node['cac:PaymentMeans']
+        if 'name' in payment_means_node['cbc:PaymentMeansCode']:
+            payment_means_node['cbc:PaymentMeansCode']['name'] = None
+        if 'listID' in payment_means_node['cbc:PaymentMeansCode']:
+            payment_means_node['cbc:PaymentMeansCode']['listID'] = None
+
+    def _get_address_node(self, vals):
+        # EXTENDS account.edi.xml.ubl_bis3
+        address_node = super()._get_address_node(vals)
+        # [BR-NL-28] The use of a country subdivision (cac:AccountingCustomerParty/cac:Party/cac:PostalAddress
+        # /cbc:CountrySubentity) is not recommended
+        address_node['cbc:CountrySubentity'] = None
+        return address_node
+
+    def _get_line_discount_allowance_charge_node(self, vals):
+        # EXTENDS account.edi.xml.ubl_bis3
+        node = super()._get_line_discount_allowance_charge_node(vals)
+        if node:
+            # [BR-NL-32] Use of Discount reason code ( AllowanceChargeReasonCode ) is not recommended.
+            # [BR-EN-34] Use of Charge reason code ( AllowanceChargeReasonCode ) is not recommended.
+            # Careful! [BR-42]-Each Invoice line allowance (BG-27) shall have an Invoice line allowance reason (BT-139)
+            # or an Invoice line allowance reason code (BT-140).
+            node['cbc:AllowanceChargeReason'] = {'_text': 'Discount'}
+            node['cbc:AllowanceChargeReasonCode'] = None
+        return node
+
+    def _get_tax_category_node(self, vals):
+        # EXTENDS account.edi.xml.ubl_bis3
+        node = super()._get_tax_category_node(vals)
+        # [BR-NL-35] The use of a tax exemption reason code (cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory
+        # /cbc:TaxExemptionReasonCode) is not recommended
+        node['cbc:TaxExemptionReasonCode'] = None
+        return node

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_nlcius.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_nlcius.py
@@ -40,6 +40,8 @@ class AccountEdiXmlUBLNL(models.AbstractModel):
 
     def _get_tax_category_list(self, customer, supplier, taxes):
         # EXTENDS account.edi.xml.ubl_bis3
+        # Old helper not used by default (see _export_invoice override in account.edi.xml.ubl_bis3)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals_list = super()._get_tax_category_list(customer, supplier, taxes)
         for tax in vals_list:
             # [BR-NL-35] The use of a tax exemption reason code (cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory
@@ -49,6 +51,8 @@ class AccountEdiXmlUBLNL(models.AbstractModel):
 
     def _get_partner_address_vals(self, partner):
         # EXTENDS account.edi.xml.ubl_bis3
+        # Old helper not used by default (see _export_invoice override in account.edi.xml.ubl_bis3)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals = super()._get_partner_address_vals(partner)
         # [BR-NL-28] The use of a country subdivision (cac:AccountingCustomerParty/cac:Party/cac:PostalAddress
         # /cbc:CountrySubentity) is not recommended
@@ -57,6 +61,8 @@ class AccountEdiXmlUBLNL(models.AbstractModel):
 
     def _get_invoice_line_allowance_vals_list(self, line, tax_values_list=None):
         # EXTENDS account.edi.xml.ubl_bis3
+        # Old helper not used by default (see _export_invoice override in account.edi.xml.ubl_bis3)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals_list = super()._get_invoice_line_allowance_vals_list(line, tax_values_list=tax_values_list)
         # [BR-NL-32] Use of Discount reason code ( AllowanceChargeReasonCode ) is not recommended.
         # [BR-EN-34] Use of Charge reason code ( AllowanceChargeReasonCode ) is not recommended.
@@ -71,6 +77,8 @@ class AccountEdiXmlUBLNL(models.AbstractModel):
 
     def _get_invoice_payment_means_vals_list(self, invoice):
         # EXTENDS account.edi.xml.ubl_bis3
+        # Old helper not used by default (see _export_invoice override in account.edi.xml.ubl_bis3)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals_list = super()._get_invoice_payment_means_vals_list(invoice)
         # [BR-NL-29] The use of a payment means text (cac:PaymentMeans/cbc:PaymentMeansCode/@name) is not recommended
         for vals in vals_list:
@@ -79,6 +87,8 @@ class AccountEdiXmlUBLNL(models.AbstractModel):
 
     def _export_invoice_vals(self, invoice):
         # EXTENDS account.edi.xml.ubl_bis3
+        # Old helper not used by default (see _export_invoice override in account.edi.xml.ubl_bis3)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals = super()._export_invoice_vals(invoice)
 
         vals['vals']['customization_id'] = self._get_customization_ids()['nlcius']

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_sg.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_sg.py
@@ -30,7 +30,7 @@ class AccountEdiXmlUBLSG(models.AbstractModel):
         # If you change this method, please change the corresponding new helper (at the end of this file).
         vals = super()._get_partner_party_vals(partner, role)
 
-        for party_tax_scheme in vals['party_tax_scheme_vals']:
+        for party_tax_scheme in vals.get('party_tax_scheme_vals', []):
             party_tax_scheme['tax_scheme_vals'] = {'id': 'GST'}
 
         return vals

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_sg.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_sg.py
@@ -26,6 +26,8 @@ class AccountEdiXmlUBLSG(models.AbstractModel):
 
     def _get_partner_party_vals(self, partner, role):
         # EXTENDS account.edi.xml.ubl_bis3
+        # Old helper not used by default (see _export_invoice override in account.edi.xml.ubl_bis3)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals = super()._get_partner_party_vals(partner, role)
 
         for party_tax_scheme in vals['party_tax_scheme_vals']:
@@ -36,6 +38,8 @@ class AccountEdiXmlUBLSG(models.AbstractModel):
     def _get_invoice_payment_means_vals_list(self, invoice):
         """ https://www.peppolguide.sg/billing/bis/#_payment_means_information
         """
+        # Old helper not used by default (see _export_invoice override in account.edi.xml.ubl_bis3)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals_list = super()._get_invoice_payment_means_vals_list(invoice)
         for vals in vals_list:
             vals.update({
@@ -48,6 +52,8 @@ class AccountEdiXmlUBLSG(models.AbstractModel):
     def _get_tax_sg_codes(self, tax):
         """ https://www.peppolguide.sg/billing/bis/#_gst_category_codes
         """
+        # Old helper not used by default (see _export_invoice override in account.edi.xml.ubl_bis3)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         tax_category_code = 'SR'
         if tax.amount == 0:
             tax_category_code = 'ZR'
@@ -55,6 +61,8 @@ class AccountEdiXmlUBLSG(models.AbstractModel):
 
     def _get_tax_category_list(self, customer, supplier, taxes):
         # OVERRIDE
+        # Old helper not used by default (see _export_invoice override in account.edi.xml.ubl_bis3)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         res = []
         for tax in taxes:
             res.append({
@@ -66,6 +74,8 @@ class AccountEdiXmlUBLSG(models.AbstractModel):
 
     def _export_invoice_vals(self, invoice):
         # EXTENDS account.edi.xml.ubl_bis3
+        # Old helper not used by default (see _export_invoice override in account.edi.xml.ubl_bis3)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals = super()._export_invoice_vals(invoice)
 
         vals['vals'].update({

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_sg.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_sg.py
@@ -83,3 +83,40 @@ class AccountEdiXmlUBLSG(models.AbstractModel):
         })
 
         return vals
+
+    # -------------------------------------------------------------------------
+    # EXPORT: New (dict_to_xml) helpers
+    # -------------------------------------------------------------------------
+
+    def _add_invoice_header_nodes(self, document_node, vals):
+        # EXTENDS account.edi.xml.ubl_bis3
+        super()._add_invoice_header_nodes(document_node, vals)
+        document_node['cbc:CustomizationID'] = {'_text': self._get_customization_ids()['ubl_sg']}
+
+    def _add_invoice_payment_means_nodes(self, document_node, vals):
+        """ https://www.peppolguide.sg/billing/bis/#_payment_means_information """
+        super()._add_invoice_payment_means_nodes(document_node, vals)
+        document_node['cac:PaymentMeans']['cbc:PaymentMeansCode'] = {
+            '_text': 54,
+            'name': 'Credit Card',
+        }
+
+    def _get_party_node(self, vals):
+        # EXTENDS account.edi.xml.ubl_bis3
+        party_node = super()._get_party_node(vals)
+        party_node['cac:PartyTaxScheme'][0]['cac:TaxScheme']['cbc:ID']['_text'] = 'GST'
+        return party_node
+
+    def _get_tax_category_code(self, customer, supplier, tax):
+        """ https://www.peppolguide.sg/billing/bis/#_gst_category_codes """
+        if not tax or tax.amount == 0:
+            return 'ZR'
+        return 'SR'
+
+    def _get_tax_category_node(self, vals):
+        # OVERRIDE
+        tax_category_node = super()._get_tax_category_node(vals)
+        tax_category_node['cac:TaxScheme']['cbc:ID']['_text'] = 'GST'
+        tax_category_node['cbc:TaxExemptionReason'] = None
+        tax_category_node['cbc:TaxExemptionReasonCode'] = None
+        return tax_category_node

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_xrechnung.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_xrechnung.py
@@ -22,6 +22,8 @@ class AccountEdiXmlUBLDE(models.AbstractModel):
 
     def _export_invoice_vals(self, invoice):
         # EXTENDS account.edi.xml.ubl_bis3
+        # Old helper not used by default (see _export_invoice override in account.edi.xml.ubl_bis3)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals = super()._export_invoice_vals(invoice)
         vals['vals']['customization_id'] = self._get_customization_ids()['xrechnung']
         if not vals['vals'].get('buyer_reference'):
@@ -30,6 +32,8 @@ class AccountEdiXmlUBLDE(models.AbstractModel):
 
     def _export_invoice_constraints(self, invoice, vals):
         # EXTENDS account.edi.xml.ubl_bis3
+        # Old helper not used by default (see _export_invoice override in account.edi.xml.ubl_bis3)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         constraints = super()._export_invoice_constraints(invoice, vals)
 
         constraints.update({
@@ -41,6 +45,8 @@ class AccountEdiXmlUBLDE(models.AbstractModel):
 
     def _get_partner_party_vals(self, partner, role):
         # EXTENDS account.edi.xml.ubl_bis3
+        # Old helper not used by default (see _export_invoice override in account.edi.xml.ubl_bis3)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals = super()._get_partner_party_vals(partner, role)
 
         if not vals.get('endpoint_id') and partner.email:

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_xrechnung.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_xrechnung.py
@@ -56,3 +56,25 @@ class AccountEdiXmlUBLDE(models.AbstractModel):
             })
 
         return vals
+
+    # -------------------------------------------------------------------------
+    # EXPORT: New (dict_to_xml) helpers
+    # -------------------------------------------------------------------------
+
+    def _add_invoice_header_nodes(self, document_node, vals):
+        # EXTENDS account.edi.xml.ubl_bis3
+        super()._add_invoice_header_nodes(document_node, vals)
+        document_node['cbc:CustomizationID'] = {'_text': self._get_customization_ids()['xrechnung']}
+        if not document_node['cbc:BuyerReference']['_text']:
+            document_node['cbc:BuyerReference']['_text'] = 'N/A'
+
+    def _get_party_node(self, vals):
+        # EXTENDS account.edi.xml.ubl_bis3
+        party_node = super()._get_party_node(vals)
+        partner = vals['partner']
+        if not party_node.get('cbc:EndpointID', {}).get('_text') and partner.email:
+            party_node['cbc:EndpointID'] = {
+                '_text': partner.email,
+                'schemeID': 'EM'
+            }
+        return party_node

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/__init__.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/__init__.py
@@ -6,4 +6,5 @@ from . import test_xml_cii_fr
 from . import test_xml_cii_us
 from . import test_xml_ubl_nl
 from . import test_xml_ubl_au
+from . import test_xml_ubl_sg
 from . import test_xml_ubl_attacheddocument

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/sg_out_invoice.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/sg_out_invoice.xml
@@ -1,0 +1,188 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+  <cbc:CustomizationID>urn:cen.eu:en16931:2017#conformant#urn:fdc:peppol.eu:2017:poacc:billing:international:sg:3.0</cbc:CustomizationID>
+  <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+  <cbc:ID>INV/2017/00001</cbc:ID>
+  <cbc:IssueDate>2017-01-01</cbc:IssueDate>
+  <cbc:DueDate>2017-02-28</cbc:DueDate>
+  <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+  <cbc:Note>test narration</cbc:Note>
+  <cbc:DocumentCurrencyCode>USD</cbc:DocumentCurrencyCode>
+  <cbc:BuyerReference>ref_partner_2</cbc:BuyerReference>
+  <cac:OrderReference>
+    <cbc:ID>ref_move</cbc:ID>
+  </cac:OrderReference>
+  <cac:AdditionalDocumentReference>
+    <cbc:ID>INV_2017_00001.pdf</cbc:ID>
+    <cac:Attachment>
+      <cbc:EmbeddedDocumentBinaryObject mimeCode="application/pdf" filename="INV_2017_00001.pdf">___ignore___</cbc:EmbeddedDocumentBinaryObject>
+    </cac:Attachment>
+  </cac:AdditionalDocumentReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cac:PartyIdentification>
+        <cbc:ID>ref_partner_1</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>partner_1</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Tyersall Avenue</cbc:StreetName>
+        <cbc:CityName>Central Singapore</cbc:CityName>
+        <cbc:PostalZone>248048</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>SG</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>197401143C</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>GST</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_1</cbc:RegistrationName>
+        <cbc:CompanyID>197401143C</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>partner_1</cbc:Name>
+        <cbc:Telephone>+65 9123 4567</cbc:Telephone>
+        <cbc:ElectronicMail>info@outlook.sg</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cac:PartyIdentification>
+        <cbc:ID>ref_partner_2</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>partner_2</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>that other street, 3</cbc:StreetName>
+        <cbc:CityName>East Singapore</cbc:CityName>
+        <cbc:PostalZone>248050</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>SG</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>S16FC0121D</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>GST</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_2</cbc:RegistrationName>
+        <cbc:CompanyID>S16FC0121D</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>partner_2</cbc:Name>
+        <cbc:Telephone>+65 9123 4589</cbc:Telephone>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:Delivery>
+    <cac:DeliveryLocation>
+      <cac:Address>
+        <cbc:StreetName>that other street, 3</cbc:StreetName>
+        <cbc:CityName>East Singapore</cbc:CityName>
+        <cbc:PostalZone>248050</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>SG</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:Address>
+    </cac:DeliveryLocation>
+    <cac:DeliveryParty>
+      <cac:PartyName>
+        <cbc:Name>partner_2</cbc:Name>
+      </cac:PartyName>
+    </cac:DeliveryParty>
+  </cac:Delivery>
+  <cac:PaymentMeans>
+    <cbc:PaymentMeansCode name="Credit Card">54</cbc:PaymentMeansCode>
+    <cbc:PaymentID>INV/2017/00001</cbc:PaymentID>
+    <cac:PayeeFinancialAccount>
+      <cbc:ID>000099998B57</cbc:ID>
+    </cac:PayeeFinancialAccount>
+  </cac:PaymentMeans>
+  <cac:PaymentTerms>
+    <cbc:Note>Payment terms: 30% Advance End of Following Month</cbc:Note>
+  </cac:PaymentTerms>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="USD">160.00</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="USD">1600.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="USD">160.00</cbc:TaxAmount>
+      <cac:TaxCategory>
+        <cbc:ID>SR</cbc:ID>
+        <cbc:Percent>10.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>GST</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="USD">1000.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="USD">0.00</cbc:TaxAmount>
+      <cac:TaxCategory>
+        <cbc:ID>ZR</cbc:ID>
+        <cbc:Percent>0.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>GST</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="USD">2600.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="USD">2600.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="USD">2760.00</cbc:TaxInclusiveAmount>
+    <cbc:PrepaidAmount currencyID="USD">0.00</cbc:PrepaidAmount>
+    <cbc:PayableAmount currencyID="USD">2760.00</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="C62">2.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="USD">1600.00</cbc:LineExtensionAmount>
+    <cac:AllowanceCharge>
+      <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+      <cbc:AllowanceChargeReasonCode>95</cbc:AllowanceChargeReasonCode>
+      <cbc:Amount currencyID="USD">400.00</cbc:Amount>
+    </cac:AllowanceCharge>
+    <cac:Item>
+      <cbc:Description>product_a</cbc:Description>
+      <cbc:Name>product_a</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>SR</cbc:ID>
+        <cbc:Percent>10.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>GST</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="USD">1000.0</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+  <cac:InvoiceLine>
+    <cbc:ID>2</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="DZN">2.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="USD">1000.00</cbc:LineExtensionAmount>
+    <cac:Item>
+      <cbc:Description>product_b</cbc:Description>
+      <cbc:Name>product_b</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>ZR</cbc:ID>
+        <cbc:Percent>0.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>GST</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="USD">500.0</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+</Invoice>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/sg_out_refund.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/sg_out_refund.xml
@@ -1,0 +1,187 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<CreditNote xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+  <cbc:CustomizationID>urn:cen.eu:en16931:2017#conformant#urn:fdc:peppol.eu:2017:poacc:billing:international:sg:3.0</cbc:CustomizationID>
+  <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+  <cbc:ID>RINV/2017/00001</cbc:ID>
+  <cbc:IssueDate>2017-01-01</cbc:IssueDate>
+  <cbc:CreditNoteTypeCode>381</cbc:CreditNoteTypeCode>
+  <cbc:Note>test narration</cbc:Note>
+  <cbc:DocumentCurrencyCode>USD</cbc:DocumentCurrencyCode>
+  <cbc:BuyerReference>ref_partner_2</cbc:BuyerReference>
+  <cac:OrderReference>
+    <cbc:ID>ref_move</cbc:ID>
+  </cac:OrderReference>
+  <cac:AdditionalDocumentReference>
+    <cbc:ID>RINV_2017_00001.pdf</cbc:ID>
+    <cac:Attachment>
+      <cbc:EmbeddedDocumentBinaryObject mimeCode="application/pdf" filename="RINV_2017_00001.pdf">___ignore___</cbc:EmbeddedDocumentBinaryObject>
+    </cac:Attachment>
+  </cac:AdditionalDocumentReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cac:PartyIdentification>
+        <cbc:ID>ref_partner_1</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>partner_1</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Tyersall Avenue</cbc:StreetName>
+        <cbc:CityName>Central Singapore</cbc:CityName>
+        <cbc:PostalZone>248048</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>SG</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>197401143C</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>GST</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_1</cbc:RegistrationName>
+        <cbc:CompanyID>197401143C</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>partner_1</cbc:Name>
+        <cbc:Telephone>+65 9123 4567</cbc:Telephone>
+        <cbc:ElectronicMail>info@outlook.sg</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cac:PartyIdentification>
+        <cbc:ID>ref_partner_2</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>partner_2</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>that other street, 3</cbc:StreetName>
+        <cbc:CityName>East Singapore</cbc:CityName>
+        <cbc:PostalZone>248050</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>SG</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>S16FC0121D</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>GST</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_2</cbc:RegistrationName>
+        <cbc:CompanyID>S16FC0121D</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>partner_2</cbc:Name>
+        <cbc:Telephone>+65 9123 4589</cbc:Telephone>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:Delivery>
+    <cac:DeliveryLocation>
+      <cac:Address>
+        <cbc:StreetName>that other street, 3</cbc:StreetName>
+        <cbc:CityName>East Singapore</cbc:CityName>
+        <cbc:PostalZone>248050</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>SG</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:Address>
+    </cac:DeliveryLocation>
+    <cac:DeliveryParty>
+      <cac:PartyName>
+        <cbc:Name>partner_2</cbc:Name>
+      </cac:PartyName>
+    </cac:DeliveryParty>
+  </cac:Delivery>
+  <cac:PaymentMeans>
+    <cbc:PaymentMeansCode name="Credit Card">54</cbc:PaymentMeansCode>
+    <cbc:PaymentID>RINV/2017/00001</cbc:PaymentID>
+    <cac:PayeeFinancialAccount>
+      <cbc:ID>93999574162167</cbc:ID>
+    </cac:PayeeFinancialAccount>
+  </cac:PaymentMeans>
+  <cac:PaymentTerms>
+    <cbc:Note>Payment terms: 30% Advance End of Following Month</cbc:Note>
+  </cac:PaymentTerms>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="USD">160.00</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="USD">1600.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="USD">160.00</cbc:TaxAmount>
+      <cac:TaxCategory>
+        <cbc:ID>SR</cbc:ID>
+        <cbc:Percent>10.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>GST</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="USD">1000.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="USD">0.00</cbc:TaxAmount>
+      <cac:TaxCategory>
+        <cbc:ID>ZR</cbc:ID>
+        <cbc:Percent>0.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>GST</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="USD">2600.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="USD">2600.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="USD">2760.00</cbc:TaxInclusiveAmount>
+    <cbc:PrepaidAmount currencyID="USD">0.00</cbc:PrepaidAmount>
+    <cbc:PayableAmount currencyID="USD">2760.00</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:CreditNoteLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:CreditedQuantity unitCode="C62">2.0</cbc:CreditedQuantity>
+    <cbc:LineExtensionAmount currencyID="USD">1600.00</cbc:LineExtensionAmount>
+    <cac:AllowanceCharge>
+      <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+      <cbc:AllowanceChargeReasonCode>95</cbc:AllowanceChargeReasonCode>
+      <cbc:Amount currencyID="USD">400.00</cbc:Amount>
+    </cac:AllowanceCharge>
+    <cac:Item>
+      <cbc:Description>product_a</cbc:Description>
+      <cbc:Name>product_a</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>SR</cbc:ID>
+        <cbc:Percent>10.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>GST</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="USD">1000.0</cbc:PriceAmount>
+    </cac:Price>
+  </cac:CreditNoteLine>
+  <cac:CreditNoteLine>
+    <cbc:ID>2</cbc:ID>
+    <cbc:CreditedQuantity unitCode="DZN">2.0</cbc:CreditedQuantity>
+    <cbc:LineExtensionAmount currencyID="USD">1000.00</cbc:LineExtensionAmount>
+    <cac:Item>
+      <cbc:Description>product_b</cbc:Description>
+      <cbc:Name>product_b</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>ZR</cbc:ID>
+        <cbc:Percent>0.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>GST</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="USD">500.0</cbc:PriceAmount>
+    </cac:Price>
+  </cac:CreditNoteLine>
+</CreditNote>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_au.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_au.py
@@ -10,6 +10,7 @@ class TestUBLAU(TestUBLCommon):
     @TestUBLCommon.setup_country('au')
     def setUpClass(cls):
         super().setUpClass()
+        cls.env['ir.config_parameter'].set_param('account_edi_ubl_cii.use_new_dict_to_xml_helpers', 'False')
 
         cls.partner_1 = cls.env['res.partner'].create({
             'name': "partner_1",
@@ -107,6 +108,10 @@ class TestUBLAU(TestUBLCommon):
         self.assertEqual(attachment.name[-8:], "a_nz.xml")
         self._assert_imported_invoice_from_etree(invoice, attachment)
 
+    def test_export_import_invoice_new(self):
+        self.env['ir.config_parameter'].set_param('account_edi_ubl_cii.use_new_dict_to_xml_helpers', 'True')
+        self.test_export_import_invoice()
+
     def test_export_import_refund(self):
         refund = self._generate_move(
             self.partner_1,
@@ -164,6 +169,10 @@ class TestUBLAU(TestUBLCommon):
         )
         self.assertEqual(attachment.name[-8:], "a_nz.xml")
         self._assert_imported_invoice_from_etree(refund, attachment)
+
+    def test_export_import_refund_new(self):
+        self.env['ir.config_parameter'].set_param('account_edi_ubl_cii.use_new_dict_to_xml_helpers', 'True')
+        self.test_export_import_refund()
 
     ####################################################
     # Test import

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_sg.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_sg.py
@@ -1,0 +1,138 @@
+from odoo import Command
+from odoo.tests import tagged
+from odoo.addons.l10n_account_edi_ubl_cii_tests.tests.common import TestUBLCommon
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestUBLSG(TestUBLCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.partner_1 = cls.env['res.partner'].create({
+            'name': "partner_1",
+            'street': 'Tyersall Avenue',
+            'zip': '248048',
+            'city': 'Central Singapore',
+            'vat': '197401143C',
+            'phone': '+65 9123 4567',
+            'email': 'info@outlook.sg',
+            'country_id': cls.env.ref('base.sg').id,
+            'bank_ids': [(0, 0, {'acc_number': '000099998B57'})],
+            'ref': 'ref_partner_1',
+            'invoice_edi_format': 'ubl_sg',
+        })
+
+        cls.partner_2 = cls.env['res.partner'].create({
+            'name': "partner_2",
+            'street': 'that other street, 3',
+            'zip': '248050',
+            'city': 'East Singapore',
+            'vat': 'S16FC0121D',
+            'phone': '+65 9123 4589',
+            'country_id': cls.env.ref('base.sg').id,
+            'bank_ids': [(0, 0, {'acc_number': '93999574162167'})],
+            'ref': 'ref_partner_2',
+            'invoice_edi_format': 'ubl_sg',
+        })
+
+    ####################################################
+    # Test export - import
+    ####################################################
+
+    def test_export_import_invoice(self):
+        tax_10 = self.percent_tax(10)
+        tax_0 = self.percent_tax(0)
+        invoice = self._generate_move(
+            self.partner_1,
+            self.partner_2,
+            move_type='out_invoice',
+            invoice_line_ids=[
+                {
+                    'product_id': self.product_a.id,
+                    'quantity': 2.0,
+                    'price_unit': 1000.0,
+                    'discount': 20.0,
+                    'tax_ids': [(Command.set(tax_10.ids))],
+                },
+                {
+                    'product_id': self.product_b.id,
+                    'quantity': 2.0,
+                    'price_unit': 500.0,
+                    'tax_ids': [(Command.set(tax_0.ids))],
+                },
+            ],
+        )
+        attachment = self._assert_invoice_attachment(
+            invoice.ubl_cii_xml_id,
+            xpaths=f'''
+                <xpath expr="./*[local-name()='ID']" position="replace">
+                    <cbc:ID xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">___ignore___</cbc:ID>
+                </xpath>
+                <xpath expr=".//*[local-name()='InvoiceLine'][1]/*[local-name()='ID']" position="replace">
+                    <cbc:ID xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">___ignore___</cbc:ID>
+                </xpath>
+                <xpath expr=".//*[local-name()='InvoiceLine'][2]/*[local-name()='ID']" position="replace">
+                    <cbc:ID xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">___ignore___</cbc:ID>
+                </xpath>
+                <xpath expr=".//*[local-name()='PaymentMeans']/*[local-name()='PaymentID']" position="replace">
+                    <cbc:PaymentID xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">___ignore___</cbc:PaymentID>
+                </xpath>
+                <xpath expr=".//*[local-name()='AdditionalDocumentReference']/*[local-name()='Attachment']/*[local-name()='EmbeddedDocumentBinaryObject']" position="attributes">
+                    <attribute name="mimeCode">application/pdf</attribute>
+                    <attribute name="filename">{invoice.invoice_pdf_report_id.name}</attribute>
+                </xpath>
+            ''',
+            expected_file_path='from_odoo/sg_out_invoice.xml',
+        )
+        self.assertEqual(attachment.name[-6:], "sg.xml")
+        self._assert_imported_invoice_from_etree(invoice, attachment)
+
+    def test_export_import_refund(self):
+        tax_10 = self.percent_tax(10)
+        tax_0 = self.percent_tax(0)
+        refund = self._generate_move(
+            self.partner_1,
+            self.partner_2,
+            move_type='out_refund',
+            invoice_line_ids=[
+                {
+                    'product_id': self.product_a.id,
+                    'quantity': 2.0,
+                    'price_unit': 1000.0,
+                    'discount': 20.0,
+                    'tax_ids': [(Command.set(tax_10.ids))],
+                },
+                {
+                    'product_id': self.product_b.id,
+                    'quantity': 2.0,
+                    'price_unit': 500.0,
+                    'tax_ids': [(Command.set(tax_0.ids))],
+                },
+            ],
+        )
+        attachment = self._assert_invoice_attachment(
+            refund.ubl_cii_xml_id,
+            xpaths=f'''
+                <xpath expr="./*[local-name()='ID']" position="replace">
+                    <cbc:ID xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">___ignore___</cbc:ID>
+                </xpath>
+                <xpath expr=".//*[local-name()='CreditNoteLine'][1]/*[local-name()='ID']" position="replace">
+                    <cbc:ID xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">___ignore___</cbc:ID>
+                </xpath>
+                <xpath expr=".//*[local-name()='CreditNoteLine'][2]/*[local-name()='ID']" position="replace">
+                    <cbc:ID xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">___ignore___</cbc:ID>
+                </xpath>
+                <xpath expr=".//*[local-name()='PaymentMeans']/*[local-name()='PaymentID']" position="replace">
+                    <cbc:PaymentID xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">___ignore___</cbc:PaymentID>
+                </xpath>
+                <xpath expr=".//*[local-name()='AdditionalDocumentReference']/*[local-name()='Attachment']/*[local-name()='EmbeddedDocumentBinaryObject']" position="attributes">
+                    <attribute name="mimeCode">application/pdf</attribute>
+                    <attribute name="filename">{refund.invoice_pdf_report_id.name}</attribute>
+                </xpath>
+            ''',
+            expected_file_path='from_odoo/sg_out_refund.xml',
+        )
+        self.assertEqual(attachment.name[-6:], "sg.xml")
+        self._assert_imported_invoice_from_etree(refund, attachment)

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_sg.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_sg.py
@@ -9,6 +9,7 @@ class TestUBLSG(TestUBLCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.env['ir.config_parameter'].set_param('account_edi_ubl_cii.use_new_dict_to_xml_helpers', 'False')
 
         cls.partner_1 = cls.env['res.partner'].create({
             'name': "partner_1",
@@ -89,6 +90,10 @@ class TestUBLSG(TestUBLCommon):
         self.assertEqual(attachment.name[-6:], "sg.xml")
         self._assert_imported_invoice_from_etree(invoice, attachment)
 
+    def test_export_import_invoice_new(self):
+        self.env['ir.config_parameter'].set_param('account_edi_ubl_cii.use_new_dict_to_xml_helpers', 'True')
+        self.test_export_import_invoice()
+
     def test_export_import_refund(self):
         tax_10 = self.percent_tax(10)
         tax_0 = self.percent_tax(0)
@@ -136,3 +141,7 @@ class TestUBLSG(TestUBLCommon):
         )
         self.assertEqual(attachment.name[-6:], "sg.xml")
         self._assert_imported_invoice_from_etree(refund, attachment)
+
+    def test_export_import_refund_new(self):
+        self.env['ir.config_parameter'].set_param('account_edi_ubl_cii.use_new_dict_to_xml_helpers', 'True')
+        self.test_export_import_refund()

--- a/addons/l10n_anz_ubl_pint/models/account_edi_xml_pint_anz.py
+++ b/addons/l10n_anz_ubl_pint/models/account_edi_xml_pint_anz.py
@@ -26,6 +26,8 @@ class AccountEdiXmlUBLPINTANZ(models.AbstractModel):
 
     def _get_partner_party_vals(self, partner, role):
         # EXTENDS account.edi.xml.ubl_bis3
+        # Old helper not used by default (see _export_invoice override in account.edi.xml.ubl_bis3)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals = super()._get_partner_party_vals(partner, role)
         vals.setdefault('party_tax_scheme_vals', [])
 
@@ -35,6 +37,8 @@ class AccountEdiXmlUBLPINTANZ(models.AbstractModel):
         return vals
 
     def _get_invoice_tax_totals_vals_list(self, invoice, taxes_vals):
+        # Old helper not used by default (see _export_invoice override in account.edi.xml.ubl_bis3)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals_list = super()._get_invoice_tax_totals_vals_list(invoice, taxes_vals)
         company_currency = invoice.company_id.currency_id
         if invoice.currency_id != company_currency:
@@ -53,6 +57,8 @@ class AccountEdiXmlUBLPINTANZ(models.AbstractModel):
         See https://docs.peppol.eu/poac/aunz/pint-aunz/bis/#_tax_category_code
         """
         # OVERRIDE account_edi_ubl_cii
+        # Old helper not used by default (see _export_invoice override in account.edi.xml.ubl_bis3)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         if not supplier.vat:
             return {
                 'tax_category_code': 'O',
@@ -63,6 +69,8 @@ class AccountEdiXmlUBLPINTANZ(models.AbstractModel):
 
     def _get_tax_category_list(self, customer, supplier, taxes):
         # EXTENDS account_edi_ubl_cii
+        # Old helper not used by default (see _export_invoice override in account.edi.xml.ubl_bis3)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals_list = super()._get_tax_category_list(customer, supplier, taxes)
         for vals in vals_list:
             vals['tax_scheme_vals'] = {'id': 'GST'}
@@ -75,6 +83,8 @@ class AccountEdiXmlUBLPINTANZ(models.AbstractModel):
 
     def _get_partner_party_legal_entity_vals_list(self, partner):
         # EXTENDS account.edi.xml.ubl_bis3
+        # Old helper not used by default (see _export_invoice override in account.edi.xml.ubl_bis3)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals_list = super()._get_partner_party_legal_entity_vals_list(partner)
 
         for vals in vals_list:
@@ -85,6 +95,8 @@ class AccountEdiXmlUBLPINTANZ(models.AbstractModel):
 
     def _get_invoice_line_item_vals(self, line, taxes_vals):
         # EXTENDS account.edi.xml.ubl_bis3
+        # Old helper not used by default (see _export_invoice override in account.edi.xml.ubl_bis3)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         line_item_vals = super()._get_invoice_line_item_vals(line, taxes_vals)
 
         for val in line_item_vals['classified_tax_category_vals']:
@@ -97,6 +109,8 @@ class AccountEdiXmlUBLPINTANZ(models.AbstractModel):
 
     def _export_invoice_vals(self, invoice):
         # EXTENDS account_edi_ubl_cii
+        # Old helper not used by default (see _export_invoice override in account.edi.xml.ubl_bis3)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals = super()._export_invoice_vals(invoice)
 
         vals['vals'].update({

--- a/addons/l10n_anz_ubl_pint/models/account_edi_xml_pint_anz.py
+++ b/addons/l10n_anz_ubl_pint/models/account_edi_xml_pint_anz.py
@@ -20,6 +20,10 @@ class AccountEdiXmlUBLPINTANZ(models.AbstractModel):
     * PINT ANZ Official documentation: https://docs.peppol.eu/poac/aunz/pint-aunz/
     """
 
+    # -------------------------------------------------------------------------
+    # EXPORT: Old helpers
+    # -------------------------------------------------------------------------
+
     def _export_invoice_filename(self, invoice):
         # EXTENDS account_edi_ubl_cii
         return f"{invoice.name.replace('/', '_')}_pint_anz.xml"
@@ -124,6 +128,17 @@ class AccountEdiXmlUBLPINTANZ(models.AbstractModel):
             vals['vals']['tax_currency_code'] = invoice.company_id.currency_id.name  # accounting currency
         return vals
 
+    def _export_invoice_constraints_anz_partner(self, vals):
+        constraints = {}
+        # ALIGNED-IBR-001-AUNZ and ALIGNED-IBR-002-AUNZ
+        for partner_type in ('supplier', 'customer'):
+            partner = vals[partner_type]
+            if partner.country_code == 'AU' and partner.peppol_eas != '0151':
+                constraints[f'au_{partner_type}_eas_0151'] = _("The Peppol EAS must be set to ABN (0151) if the partner country is Australia.")
+            elif partner.country_code == 'NZ' and partner.peppol_eas != '0088':
+                constraints[f'nz_{partner_type}_eas_0088'] = _("The Peppol EAS must be set to EAN (0088) if the partner country is New Zealand.")
+        return constraints
+
     def _export_invoice_constraints(self, invoice, vals):
         # EXTENDS account_edi_ubl_cii
         constraints = super()._export_invoice_constraints(invoice, vals)
@@ -167,12 +182,119 @@ class AccountEdiXmlUBLPINTANZ(models.AbstractModel):
                 self.env._("A tax breakdown of type 'Not subject to tax' should appear at most"
                            " once in the tax breakdown")
 
-        # ALIGNED-IBR-001-AUNZ and ALIGNED-IBR-002-AUNZ
-        for partner_type in ('supplier', 'customer'):
-            partner = vals[partner_type]
-            if partner.country_code == 'AU' and partner.peppol_eas != '0151':
-                constraints[f'au_{partner_type}_eas_0151'] = _("The Peppol EAS must be set to ABN (0151) if the partner country is Australia.")
-            elif partner.country_code == 'NZ' and partner.peppol_eas != '0088':
-                constraints[f'nz_{partner_type}_eas_0088'] = _("The Peppol EAS must be set to EAN (0088) if the partner country is New Zealand.")
+        constraints.update(self._export_invoice_constraints_anz_partner(vals))
+
+        return constraints
+
+    # -------------------------------------------------------------------------
+    # EXPORT: New (dict_to_xml) helpers
+    # -------------------------------------------------------------------------
+
+    def _add_invoice_header_nodes(self, document_node, vals):
+        # EXTENDS account.edi.xml.ubl_bis3
+        super()._add_invoice_header_nodes(document_node, vals)
+
+        # see https://docs.peppol.eu/poac/aunz/pint-aunz/bis/#_identifying_the_a_nz_billing_specialisation
+        document_node['cbc:CustomizationID'] = {'_text': self._get_customization_ids()['pint_anz']}
+        document_node['cbc:ProfileID'] = {'_text': 'urn:peppol:bis:billing'}
+
+        invoice = vals['invoice']
+        if invoice.currency_id != invoice.company_id.currency_id:
+            # see https://docs.peppol.eu/poac/aunz/pint-aunz/bis/#_tax_in_accounting_currency
+            document_node['cbc:TaxCurrencyCode'] = {'_text': invoice.company_id.currency_id.name}  # accounting currency
+
+    def _get_tax_category_code(self, customer, supplier, tax):
+        """ See https://docs.peppol.eu/poac/aunz/pint-aunz/bis/#_tax_category_code """
+        # OVERRIDE account_edi_ubl_cii
+        # A business not registered for GST cannot issue tax invoices.
+        # In this case, the tax category code should be O (Outside scope of tax).
+        if not supplier.vat:
+            return 'O'
+        return super()._get_tax_category_code(customer, supplier, tax)
+
+    def _get_tax_category_node(self, vals):
+        # EXTENDS account.edi.xml.ubl_bis3
+        tax_category_node = super()._get_tax_category_node(vals)
+        tax_category_node['cac:TaxScheme']['cbc:ID']['_text'] = 'GST'
+
+        # As of PINT A-NZ v1.1.0: [aligned-ibrp-o-05-aunz] tax categories of type "Not Subject to tax" (i.e. tax_category_code == 'O') must NOT have
+        # tax rate ('cbc:Percent').
+        if tax_category_node['cbc:ID']['_text'] == 'O' and float_is_zero(tax_category_node['cbc:Percent']['_text'], precision_digits=2):
+            del tax_category_node['cbc:Percent']
+
+        return tax_category_node
+
+    def _get_party_node(self, vals):
+        # EXTENDS account.edi.xml.ubl_bis3
+        party_node = super()._get_party_node(vals)
+        commercial_partner = vals['partner'].commercial_partner_id
+
+        party_node['cac:PartyTaxScheme'][0]['cac:TaxScheme']['cbc:ID']['_text'] = 'GST'
+
+        # In both cases the scheme must be set to a value that comes from the eas.
+        if commercial_partner.country_code in ('AU', 'NZ'):
+            party_node['cac:PartyLegalEntity']['cbc:CompanyID']['schemeID'] = commercial_partner.peppol_eas
+
+        return party_node
+
+    def _add_invoice_tax_total_nodes(self, document_node, vals):
+        # EXTENDS account.edi.xml.ubl_bis3
+        super()._add_invoice_tax_total_nodes(document_node, vals)
+
+        # if company currency != invoice currency, need to add a TaxTotal section in the company currency
+        # see https://docs.peppol.eu/poac/aunz/pint-aunz/bis/#_tax_in_accounting_currency
+        document_node['cac:TaxTotal'] = [document_node['cac:TaxTotal']]
+
+        company_currency = vals['invoice'].company_id.currency_id
+        if vals['invoice'].currency_id != company_currency:
+            self._add_tax_total_node_in_company_currency(document_node, vals)
+
+            # Remove the tax subtotals from the TaxTotal in company currency
+            document_node['cac:TaxTotal'][1]['cac:TaxSubtotal'] = None
+
+    def _export_invoice_constraints_new(self, invoice, vals):
+        # EXTENDS account_edi_ubl_cii
+        constraints = super()._export_invoice_constraints_new(invoice, vals)
+
+        # Tax category must be filled on the line, with a value from SG categories.
+        tax_total_node = vals['document_node']['cac:TaxTotal'][0]
+        for tax_subtotal_node in tax_total_node['cac:TaxSubtotal']:
+            if tax_subtotal_node['cac:TaxCategory']['cbc:ID']['_text'] not in ANZ_TAX_CATEGORIES:
+                constraints['sg_vat_category_required'] = _("You must set a tax category on each taxes of the invoice.\nValid categories are: S, E, Z, G, O")
+
+        # Tax category of type "Not subject to tax" must have tax amount 0
+        count_outside_of_scope_breakdown = 0
+        for tax_subtotal in tax_total_node['cac:TaxSubtotal']:
+            if tax_subtotal['cac:TaxCategory']['cbc:ID']['_text'] != 'O':
+                continue
+            count_outside_of_scope_breakdown += 1
+
+            if float_is_zero(tax_subtotal['cbc:TaxAmount']['_text'], precision_digits=2):
+                continue
+
+            if vals['supplier'].vat:
+                constraints['anz_tax_breakdown_amount'] = \
+                    self.env._("A tax category of type 'Not subject to tax' must have tax"
+                               " amount set to 0")
+            else:
+                # If a company is not GST registered, this module remaps all tax categories
+                # to 'O' (Other/Out of Scope). This causes an issue when a line contained a
+                # non-zero tax, as it would create a tax subtotal with (Code: 'O', Amount:
+                # non-zero), which violates PINT rules.
+                # Since the code silently remaps tax classification code, the original error
+                # message might be misleading for users. This constraint contains better
+                # explaination of error and intructions on how to prevent it.
+                constraints['anz_non_gst_supplier_tax_scope'] = \
+                    self.env._("Suppliers not registered for GST cannot use taxes that are"
+                               " not zero-rated. Please ensure the tax category is set to"
+                               " 'O' (Services outside scope of tax) with a tax amount of 0.")
+
+        # There should be at most one tax breakdown of type "Not subject to tax".
+        if count_outside_of_scope_breakdown > 1 and vals['supplier'].vat:
+            constraints['anz_duplicate_tax_breakdown'] = \
+                self.env._("A tax breakdown of type 'Not subject to tax' should appear at most"
+                           " once in the tax breakdown")
+
+        constraints.update(self._export_invoice_constraints_anz_partner(vals))
 
         return constraints

--- a/addons/l10n_anz_ubl_pint/tests/test_anz_ubl_pint.py
+++ b/addons/l10n_anz_ubl_pint/tests/test_anz_ubl_pint.py
@@ -15,7 +15,7 @@ class TestAnzUBLPint(AccountTestInvoicingCommon):
     @AccountTestInvoicingCommon.setup_country('au')
     def setUpClass(cls):
         super().setUpClass()
-
+        cls.env['ir.config_parameter'].set_param('account_edi_ubl_cii.use_new_dict_to_xml_helpers', 'False')
         cls.other_currency = cls.setup_other_currency('NZD')
 
         # TIN number is required
@@ -55,3 +55,7 @@ class TestAnzUBLPint(AccountTestInvoicingCommon):
             self.get_xml_tree_from_string(actual_xml),
             self.get_xml_tree_from_string(expected_xml),
         )
+
+    def test_invoice_new(self):
+        self.env['ir.config_parameter'].set_param('account_edi_ubl_cii.use_new_dict_to_xml_helpers', 'True')
+        self.test_invoice()

--- a/addons/l10n_jp_ubl_pint/models/account_edi_xml_pint_jp.py
+++ b/addons/l10n_jp_ubl_pint/models/account_edi_xml_pint_jp.py
@@ -20,6 +20,10 @@ class AccountEdiXmlUBLPINTJP(models.AbstractModel):
         # EXTENDS account_edi_ubl_cii
         return f"{invoice.name.replace('/', '_')}_pint_jp.xml"
 
+    # -------------------------------------------------------------------------
+    # EXPORT: Old helpers
+    # -------------------------------------------------------------------------
+
     def _get_partner_address_vals(self, partner):
         # EXTENDS account_edi_ubl_cii
         # Old helper not used by default (see _export_invoice override in account.edi.xml.ubl_bis3)
@@ -107,3 +111,59 @@ class AccountEdiXmlUBLPINTJP(models.AbstractModel):
                 if partner.country_id.code == "JP" and partner.vat:
                     party_vals['party_vals']['party_tax_scheme_vals'][0]['company_id'] = partner.vat
         return vals
+
+    # -------------------------------------------------------------------------
+    # EXPORT: New (dict_to_xml) helpers
+    # -------------------------------------------------------------------------
+
+    def _add_invoice_header_nodes(self, document_node, vals):
+        invoice = vals['invoice']
+        super()._add_invoice_header_nodes(document_node, vals)
+
+        # see https://docs.peppol.eu/poac/jp/pint-jp/bis/#profiles
+        document_node['cbc:CustomizationID'] = {'_text': self._get_customization_ids()['pint_jp']}
+        document_node['cbc:ProfileID'] = {'_text': 'urn:peppol:bis:billing'}
+
+        if invoice.currency_id != invoice.company_id.currency_id:
+            # see https://docs.peppol.eu/poac/jp/pint-jp/bis/#_tax_in_accounting_currency
+            document_node['cbc:TaxCurrencyCode'] = {'_text': invoice.company_id.currency_id.name}  # accounting currency
+
+        # [aligned-ibrp-052] An Invoice MUST have an invoice period (ibg-14) or an Invoice line period (ibg-26).
+        document_node['cac:InvoicePeriod'] = {
+            'cbc:StartDate': {'_text': invoice.invoice_date},
+            'cbc:EndDate': {'_text': invoice.invoice_date},
+        }
+
+    def _add_invoice_tax_total_nodes(self, document_node, vals):
+        super()._add_invoice_tax_total_nodes(document_node, vals)
+
+        # if company currency != invoice currency, need to add a TaxTotal section
+        # see https://docs.peppol.eu/poac/jp/pint-jp/bis/#_tax_in_accounting_currency
+        document_node['cac:TaxTotal'] = [document_node['cac:TaxTotal']]
+
+        company_currency = vals['invoice'].company_id.currency_id
+        if vals['invoice'].currency_id != company_currency:
+            self._add_tax_total_node_in_company_currency(document_node, vals)
+
+    def _get_tax_subtotal_node(self, vals):
+        tax_subtotal_node = super()._get_tax_subtotal_node(vals)
+
+        # If there is a TaxTotal section in company currency,
+        # its TaxSubtotals nodes should contain a 'Percent' node.
+        if (
+            vals['invoice'].currency_id != vals['invoice'].company_id.currency_id
+            and vals['currency_name'] == vals['company_currency_id'].name
+        ):
+            tax_subtotal_node['cbc:Percent'] = tax_subtotal_node['cac:TaxCategory']['cbc:Percent']
+        return tax_subtotal_node
+
+    def _get_address_node(self, vals):
+        address_node = super()._get_address_node(vals)
+        address_node['cbc:CountrySubentityCode'] = None
+        return address_node
+
+    def _get_party_node(self, vals):
+        party_node = super()._get_party_node(vals)
+        # optional, if set: scheme_id should be taken from ISO/IEC 6523 list
+        party_node['cac:PartyLegalEntity']['cbc:CompanyID'] = None
+        return party_node

--- a/addons/l10n_jp_ubl_pint/models/account_edi_xml_pint_jp.py
+++ b/addons/l10n_jp_ubl_pint/models/account_edi_xml_pint_jp.py
@@ -22,12 +22,16 @@ class AccountEdiXmlUBLPINTJP(models.AbstractModel):
 
     def _get_partner_address_vals(self, partner):
         # EXTENDS account_edi_ubl_cii
+        # Old helper not used by default (see _export_invoice override in account.edi.xml.ubl_bis3)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals = super()._get_partner_address_vals(partner)
         vals.pop('country_subentity_code', None)
         return vals
 
     def _get_partner_party_legal_entity_vals_list(self, partner):
         # EXTENDS account_edi_ubl_cii
+        # Old helper not used by default (see _export_invoice override in account.edi.xml.ubl_bis3)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals_list = super()._get_partner_party_legal_entity_vals_list(partner)
         for vals in vals_list:
             vals.pop('company_id')  # optional, if set: scheme_id should be taken from ISO/IEC 6523 list
@@ -35,6 +39,8 @@ class AccountEdiXmlUBLPINTJP(models.AbstractModel):
 
     def _get_invoice_period_vals_list(self, invoice):
         # EXTENDS
+        # Old helper not used by default (see _export_invoice override in account.edi.xml.ubl_bis3)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals_list = super()._get_invoice_period_vals_list(invoice)
         # [aligned-ibrp-052] An Invoice MUST have an invoice period (ibg-14) or an Invoice line period (ibg-26).
         vals_list.append({
@@ -44,6 +50,9 @@ class AccountEdiXmlUBLPINTJP(models.AbstractModel):
         return vals_list
 
     def _get_invoice_tax_totals_vals_list(self, invoice, taxes_vals):
+        # Old helper not used by default (see _export_invoice override in account.edi.xml.ubl_bis3)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
+
         # [aligned-ibr-jp-06]-Tax category tax amount (ibt-117) with currency code JPY and tax category tax amount
         # in accounting currency (ibt-190) shall not have decimal.
         # see also: https://docs.peppol.eu/poac/jp/pint-jp/bis/#_rounding
@@ -77,6 +86,8 @@ class AccountEdiXmlUBLPINTJP(models.AbstractModel):
 
     def _export_invoice_vals(self, invoice):
         # EXTENDS account_edi_ubl_cii
+        # Old helper not used by default (see _export_invoice override in account.edi.xml.ubl_bis3)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals = super()._export_invoice_vals(invoice)
         vals['vals'].update({
             # see https://docs.peppol.eu/poac/jp/pint-jp/bis/#profiles

--- a/addons/l10n_jp_ubl_pint/tests/test_jp_ubl_pint.py
+++ b/addons/l10n_jp_ubl_pint/tests/test_jp_ubl_pint.py
@@ -15,7 +15,7 @@ class TestJpUBLPint(AccountTestInvoicingCommon):
     @AccountTestInvoicingCommon.setup_country('jp')
     def setUpClass(cls):
         super().setUpClass()
-
+        cls.env['ir.config_parameter'].set_param('account_edi_ubl_cii.use_new_dict_to_xml_helpers', 'False')
         cls.other_currency = cls.setup_other_currency('USD')
 
         # TIN number is required
@@ -54,3 +54,7 @@ class TestJpUBLPint(AccountTestInvoicingCommon):
             self.get_xml_tree_from_string(actual_xml),
             self.get_xml_tree_from_string(expected_xml),
         )
+
+    def test_invoice_new(self):
+        self.env['ir.config_parameter'].set_param('account_edi_ubl_cii.use_new_dict_to_xml_helpers', 'True')
+        self.test_invoice()

--- a/addons/l10n_my_ubl_pint/models/account_edi_xml_pint_my.py
+++ b/addons/l10n_my_ubl_pint/models/account_edi_xml_pint_my.py
@@ -16,6 +16,10 @@ class AccountEdiXmlUBLPINTMY(models.AbstractModel):
         # EXTENDS account_edi_ubl_cii
         return f"{invoice.name.replace('/', '_')}_pint_my.xml"
 
+    # -------------------------------------------------------------------------
+    # EXPORT: Old helpers
+    # -------------------------------------------------------------------------
+
     def _export_invoice_vals(self, invoice):
         # EXTENDS account_edi_ubl_cii
         vals = super()._export_invoice_vals(invoice)
@@ -97,6 +101,110 @@ class AccountEdiXmlUBLPINTMY(models.AbstractModel):
                         "Otherwise, you are not allowed to charge sales or services taxes in the e-Invoice."
                     )
                     break
+
+        # In malaysia, tax on good is paid at the manufacturer level. It is thus common to invoice without taxes,
+        # unless invoicing for a service.
+        constraints.pop('tax_on_line', '')
+        constraints.pop('cen_en16931_tax_line', '')
+
+        return constraints
+
+    # -------------------------------------------------------------------------
+    # EXPORT: New (dict_to_xml) helpers
+    # -------------------------------------------------------------------------
+
+    def _get_tax_category_code(self, customer, supplier, tax):
+        """
+        In malaysia, only the following codes can be used: T, E, O
+        https://docs.peppol.eu/poac/my/pint-my/bis/#_tax_category_code
+        """
+        # OVERRIDE account_edi_ubl_cii
+        # If a business is not registered for SST and/or TTx, the business is not allowed to charge sales tax,
+        # service tax or tourism tax in the e-Invoice.
+        # In this case, the tax category code should be 'O' (Outside scope of tax).
+        # For now, we do not properly support Tourism tax (TTx) due to a lack of clarity on the subject.
+        if not supplier.sst_registration_number:
+            return 'O'
+        elif tax.amount != 0:
+            return 'T'
+        else:
+            return 'E'
+
+    def _add_document_tax_grouping_function_vals(self, vals):
+        # OVERRIDE account_edi_ubl_cii
+        # In malaysia, tax on good is paid at the manufacturer level. It is thus common to invoice without taxes,
+        # unless invoicing for a service.
+        super()._add_document_tax_grouping_function_vals(vals)
+
+        tax_grouping_function = vals['tax_grouping_function']
+
+        def modified_tax_grouping_function(base_line, tax_data):
+            tax = tax_data and tax_data['tax']
+            if not tax:
+                return None
+            return tax_grouping_function(base_line, tax_data)
+
+        vals['tax_grouping_function'] = modified_tax_grouping_function
+
+    def _add_invoice_header_nodes(self, document_node, vals):
+        # EXTENDS account.edi.xml.ubl_bis3
+        super()._add_invoice_header_nodes(document_node, vals)
+        document_node['cbc:CustomizationID'] = {'_text': self._get_customization_ids()['pint_my']}
+        document_node['cbc:ProfileID'] = {'_text': 'urn:peppol:bis:billing'}
+
+        invoice = vals['invoice']
+        if invoice.currency_id != invoice.company_id.currency_id:
+            # see https://docs.peppol.eu/poac/my/pint-my/bis/#_tax_in_accounting_currency
+            document_node['cbc:TaxCurrencyCode'] = {'_text': invoice.company_id.currency_id.name}
+
+    def _get_party_node(self, vals):
+        party_node = super()._get_party_node(vals)
+        commercial_partner = vals['partner'].commercial_partner_id
+
+        # See https://docs.peppol.eu/poac/my/pint-my/bis/#_seller_tax_identifier
+        party_node['cac:PartyTaxScheme'][0]['cbc:CompanyID']['_text'] = commercial_partner.sst_registration_number or 'NA'
+
+        if vals['role'] == 'supplier':
+            party_node['cac:PartyTaxScheme'].append(
+                {
+                    **party_node['cac:PartyTaxScheme'][0],
+                    'cbc:CompanyID': {'_text': commercial_partner.vat or 'NA'},
+                    'cac:TaxScheme': {
+                        'cbc:ID': {'_text': 'GST'}
+                    }
+                }
+            )
+
+        return party_node
+
+    def _add_invoice_tax_total_nodes(self, document_node, vals):
+        # EXTENDS account.edi.xml.ubl_bis3
+        super()._add_invoice_tax_total_nodes(document_node, vals)
+
+        document_node['cac:TaxTotal'] = [document_node['cac:TaxTotal']]
+
+        # see https://docs.peppol.eu/poac/my/pint-my/bis/#_tax_in_accounting_currency
+        company_currency = vals['invoice'].company_id.currency_id
+        if vals['invoice'].currency_id != company_currency:
+            self._add_tax_total_node_in_company_currency(document_node, vals)
+
+        # Remove the tax subtotals from the TaxTotal in company currency
+        document_node['cac:TaxTotal'][-1]['cac:TaxSubtotal'] = []
+
+    def _export_invoice_constraints_new(self, invoice, vals):
+        # EXTENDS account_edi_ubl_cii
+        constraints = super()._export_invoice_constraints_new(invoice, vals)
+
+        # A tax category "Outside of tax cope" can only have an amount of 0.
+        tax_total_node = vals['document_node']['cac:TaxTotal'][0]
+        for tax_subtotal_node in tax_total_node['cac:TaxSubtotal']:
+            tax_category_node = tax_subtotal_node['cac:TaxCategory']
+            if tax_category_node['cbc:ID'] == 'O' and tax_subtotal_node['cbc:Percent'] != 0:
+                constraints['peppol_my_sst_registration'] = _(
+                    "If your business is registered for SST, please provide your registration number in your company details.\n"
+                    "Otherwise, you are not allowed to charge sales or services taxes in the e-Invoice."
+                )
+                break
 
         # In malaysia, tax on good is paid at the manufacturer level. It is thus common to invoice without taxes,
         # unless invoicing for a service.

--- a/addons/l10n_my_ubl_pint/tests/expected_xmls/invoice_no_taxes_new.xml
+++ b/addons/l10n_my_ubl_pint/tests/expected_xmls/invoice_no_taxes_new.xml
@@ -1,0 +1,123 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+  <cbc:CustomizationID>urn:peppol:pint:billing-1@my-1</cbc:CustomizationID>
+  <cbc:ProfileID>urn:peppol:bis:billing</cbc:ProfileID>
+  <cbc:ID>INV/2019/00001</cbc:ID>
+  <cbc:IssueDate>2019-01-01</cbc:IssueDate>
+  <cbc:DueDate>2019-01-01</cbc:DueDate>
+  <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+  <cbc:DocumentCurrencyCode>MYR</cbc:DocumentCurrencyCode>
+  <cac:OrderReference>
+    <cbc:ID>INV/2019/00001</cbc:ID>
+  </cac:OrderReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cac:PartyName>
+        <cbc:Name>company_1_data</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>that one street, 5</cbc:StreetName>
+        <cbc:CityName>Main city</cbc:CityName>
+        <cbc:CountrySubentity>Johor</cbc:CountrySubentity>
+        <cac:Country>
+          <cbc:IdentificationCode>MY</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>NA</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>NOT_EU_VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>C2584563200</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>GST</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
+        <cbc:CompanyID>C2584563200</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>company_1_data</cbc:Name>
+        <cbc:Telephone>+60123456789</cbc:Telephone>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cac:PartyName>
+        <cbc:Name>partner_a</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>that other street, 3</cbc:StreetName>
+        <cbc:CityName>Main city</cbc:CityName>
+        <cbc:CountrySubentity>Johor</cbc:CountrySubentity>
+        <cac:Country>
+          <cbc:IdentificationCode>MY</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>NA</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>NOT_EU_VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_a</cbc:RegistrationName>
+        <cbc:CompanyID>C2584563201</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>partner_a</cbc:Name>
+        <cbc:Telephone>+60123456786</cbc:Telephone>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:Delivery>
+    <cac:DeliveryLocation>
+      <cac:Address>
+        <cbc:StreetName>that other street, 3</cbc:StreetName>
+        <cbc:CityName>Main city</cbc:CityName>
+        <cbc:CountrySubentity>Johor</cbc:CountrySubentity>
+        <cac:Country>
+          <cbc:IdentificationCode>MY</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:Address>
+    </cac:DeliveryLocation>
+    <cac:DeliveryParty>
+      <cac:PartyName>
+        <cbc:Name>partner_a</cbc:Name>
+      </cac:PartyName>
+    </cac:DeliveryParty>
+  </cac:Delivery>
+  <cac:PaymentMeans>
+    <cbc:PaymentMeansCode name="mutually defined">ZZZ</cbc:PaymentMeansCode>
+    <cbc:PaymentID>INV/2019/00001</cbc:PaymentID>
+  </cac:PaymentMeans>
+  <cac:PaymentTerms>
+    <cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+  </cac:PaymentTerms>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="MYR">0.00</cbc:TaxAmount>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="MYR">1000.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="MYR">1000.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="MYR">1000.00</cbc:TaxInclusiveAmount>
+    <cbc:PrepaidAmount currencyID="MYR">0.00</cbc:PrepaidAmount>
+    <cbc:PayableAmount currencyID="MYR">1000.00</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="MYR">1000.00</cbc:LineExtensionAmount>
+    <cac:Item>
+      <cbc:Description>product_a</cbc:Description>
+      <cbc:Name>product_a</cbc:Name>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="MYR">1000.0</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+</Invoice>

--- a/addons/l10n_ro_edi/models/account_edi_xml_ubl_ciusro.py
+++ b/addons/l10n_ro_edi/models/account_edi_xml_ubl_ciusro.py
@@ -106,7 +106,11 @@ class AccountEdiXmlUBLRO(models.AbstractModel):
     def _export_invoice_constraints(self, invoice, vals):
         # EXTENDS 'account_edi_ubl_cii'
         constraints = super()._export_invoice_constraints(invoice, vals)
+        constraints.update(self._export_invoice_constraints_ciusro(vals))
+        return constraints
 
+    def _export_invoice_constraints_ciusro(self, vals):
+        constraints = {}
         # Default VAT is only allowed for the receiver (customer), not the provider (supplier)
         supplier = vals['supplier'].commercial_partner_id
         if (
@@ -138,4 +142,66 @@ class AccountEdiXmlUBLRO(models.AbstractModel):
                     "where X is a number between 1-6.",
                     partner.display_name)
 
+        return constraints
+
+    # -------------------------------------------------------------------------
+    # EXPORT: New (dict_to_xml) helpers
+    # -------------------------------------------------------------------------
+
+    def _add_invoice_header_nodes(self, document_node, vals):
+        # EXTENDS account.edi.xml.ubl_bis3
+        super()._add_invoice_header_nodes(document_node, vals)
+        document_node['cbc:CustomizationID'] = {
+            '_text': 'urn:cen.eu:en16931:2017#compliant#urn:efactura.mfinante.ro:CIUS-RO:1.0.1'
+        }
+        document_node['cbc:TaxCurrencyCode'] = {'_text': 'RON'}
+
+    def _get_address_node(self, vals):
+        address_node = super()._get_address_node(vals)
+        partner = vals['partner']
+
+        if partner.state_id:
+            address_node['cbc:CountrySubentity']['_text'] = partner.country_code + '-' + partner.state_id.code
+
+            # Romania requires the CityName to be in the format of "SECTORX" if the address state is in Bucharest.
+            if partner.state_id.code == 'B' and partner.city:
+                address_node['cbc:CityName']['_text'] = get_formatted_sector_ro(partner.city)
+
+        return address_node
+
+    def _get_party_node(self, vals):
+        party_node = super()._get_party_node(vals)
+        commercial_partner = vals['partner'].commercial_partner_id
+
+        # Use the default VAT if the VAT is not filled or just has a placeholder
+        if not _has_vat(commercial_partner.vat):
+            if vals['role'] == 'supplier' and commercial_partner.company_registry:
+                # Use company_registry (Company ID) as the VAT replacement
+                vat_replacement = commercial_partner.company_registry
+            else:
+                vat_replacement = DEFAULT_VAT
+
+            party_node['cac:PartyTaxScheme'][0]['cbc:CompanyID']['_text'] = vat_replacement
+            party_node['cac:PartyTaxScheme'][0]['cac:TaxScheme']['cbc:ID']['_text'] = (
+                'VAT' if vat_replacement[:2].isalpha() else 'NOT_EU_VAT'
+            )
+            party_node['cac:PartyLegalEntity']['cbc:CompanyID']['_text'] = vat_replacement
+
+        return party_node
+
+    def _add_document_tax_total_nodes(self, document_node, vals):
+        super()._add_document_tax_total_nodes(document_node, vals)
+
+        document_node['cac:TaxTotal'] = [document_node['cac:TaxTotal']]
+
+        company_currency = vals['invoice'].company_id.currency_id
+        if vals['invoice'].currency_id != company_currency:
+            self._add_tax_total_node_in_company_currency(document_node, vals)
+
+            # Remove the tax subtotals from the TaxTotal in company currency
+            document_node['cac:TaxTotal'][1]['cac:TaxSubtotal'] = None
+
+    def _export_invoice_constraints_new(self, invoice, vals):
+        constraints = super()._export_invoice_constraints_new(invoice, vals)
+        constraints.update(self._export_invoice_constraints_ciusro(vals))
         return constraints

--- a/addons/l10n_ro_edi/models/account_edi_xml_ubl_ciusro.py
+++ b/addons/l10n_ro_edi/models/account_edi_xml_ubl_ciusro.py
@@ -24,6 +24,8 @@ class AccountEdiXmlUBLRO(models.AbstractModel):
 
     def _get_partner_address_vals(self, partner):
         # EXTENDS 'account_edi_ubl_cii'
+        # Old helper not used by default (see _export_invoice override in account.edi.xml.ubl_bis3)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals = super()._get_partner_address_vals(partner)
 
         if partner.state_id:
@@ -37,6 +39,8 @@ class AccountEdiXmlUBLRO(models.AbstractModel):
 
     def _get_invoice_tax_totals_vals_list(self, invoice, taxes_vals):
         # EXTENDS 'account_edi_ubl_cii'
+        # Old helper not used by default (see _export_invoice override in account.edi.xml.ubl_bis3)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals_list = super()._get_invoice_tax_totals_vals_list(invoice, taxes_vals)
 
         if invoice.currency_id.name != 'RON':
@@ -51,6 +55,8 @@ class AccountEdiXmlUBLRO(models.AbstractModel):
 
     def _get_partner_party_tax_scheme_vals_list(self, partner, role):
         # EXTENDS 'account_edi_ubl_cii'
+        # Old helper not used by default (see _export_invoice override in account.edi.xml.ubl_bis3)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals_list = super()._get_partner_party_tax_scheme_vals_list(partner, role)
 
         if not _has_vat(partner.vat):
@@ -70,6 +76,8 @@ class AccountEdiXmlUBLRO(models.AbstractModel):
 
     def _export_invoice_vals(self, invoice):
         # EXTENDS 'account_edi_ubl_cii'
+        # Old helper not used by default (see _export_invoice override in account.edi.xml.ubl_bis3)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals = super()._export_invoice_vals(invoice)
 
         vals['vals'].update({
@@ -88,6 +96,8 @@ class AccountEdiXmlUBLRO(models.AbstractModel):
 
     def _get_document_type_code_vals(self, invoice, invoice_data):
         # EXTENDS 'account_edi_ubl_cii
+        # Old helper not used by default (see _export_invoice override in account.edi.xml.ubl_bis3)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals = super()._get_document_type_code_vals(invoice, invoice_data)
         # [UBL-SR-43] DocumentTypeCode should only show up on a CreditNote XML with the value '50'
         vals['value'] = '50' if invoice.move_type == 'out_refund' else False

--- a/addons/l10n_ro_edi/tests/test_xml_ubl_ro.py
+++ b/addons/l10n_ro_edi/tests/test_xml_ubl_ro.py
@@ -9,6 +9,7 @@ class TestUBLROCommon(TestUBLCommon):
     @TestUBLCommon.setup_country('ro')
     def setUpClass(cls):
         super().setUpClass()
+        cls.env['ir.config_parameter'].set_param('account_edi_ubl_cii.use_new_dict_to_xml_helpers', 'False')
         cls.company_data['company'].write({
             'country_id': cls.env.ref('base.ro').id,  # needed to compute peppol_endpoint based on VAT
             'state_id': cls.env.ref('base.RO_B').id,
@@ -93,10 +94,18 @@ class TestUBLRO(TestUBLROCommon):
         attachment = self.get_attachment(invoice)
         self._assert_invoice_attachment(attachment, xpaths=None, expected_file_path='from_odoo/ciusro_out_invoice.xml')
 
+    def test_export_invoice_new(self):
+        self.env['ir.config_parameter'].set_param('account_edi_ubl_cii.use_new_dict_to_xml_helpers', 'True')
+        self.test_export_invoice()
+
     def test_export_credit_note(self):
         refund = self.create_move("out_refund", currency_id=self.company.currency_id.id)
         attachment = self.get_attachment(refund)
         self._assert_invoice_attachment(attachment, xpaths=None, expected_file_path='from_odoo/ciusro_out_refund.xml')
+
+    def test_export_credit_note_new(self):
+        self.env['ir.config_parameter'].set_param('account_edi_ubl_cii.use_new_dict_to_xml_helpers', 'True')
+        self.test_export_credit_note()
 
     def test_export_credit_note_with_negative_quantity(self):
         refund = self._generate_move(
@@ -132,10 +141,18 @@ class TestUBLRO(TestUBLROCommon):
         attachment = self.get_attachment(refund)
         self._assert_invoice_attachment(attachment, xpaths=None, expected_file_path='from_odoo/ciusro_out_refund_negative_quantity.xml')
 
+    def test_export_credit_note_with_negative_quantity_new(self):
+        self.env['ir.config_parameter'].set_param('account_edi_ubl_cii.use_new_dict_to_xml_helpers', 'True')
+        self.test_export_credit_note_with_negative_quantity()
+
     def test_export_invoice_different_currency(self):
         invoice = self.create_move("out_invoice")
         attachment = self.get_attachment(invoice)
         self._assert_invoice_attachment(attachment, xpaths=None, expected_file_path='from_odoo/ciusro_out_invoice_different_currency.xml')
+
+    def test_export_invoice_different_currency_new(self):
+        self.env['ir.config_parameter'].set_param('account_edi_ubl_cii.use_new_dict_to_xml_helpers', 'True')
+        self.test_export_invoice_different_currency()
 
     def test_export_invoice_without_country_code_prefix_in_vat(self):
         self.company_data['company'].write({'vat': '1234567897'})
@@ -144,11 +161,19 @@ class TestUBLRO(TestUBLROCommon):
         attachment = self.get_attachment(invoice)
         self._assert_invoice_attachment(attachment, xpaths=None, expected_file_path='from_odoo/ciusro_out_invoice_no_prefix_vat.xml')
 
+    def test_export_invoice_without_country_code_prefix_in_vat_new(self):
+        self.env['ir.config_parameter'].set_param('account_edi_ubl_cii.use_new_dict_to_xml_helpers', 'True')
+        self.test_export_invoice_without_country_code_prefix_in_vat()
+
     def test_export_no_vat_but_have_company_registry(self):
         self.company_data['company'].write({'vat': False, 'company_registry': 'RO1234567897'})
         invoice = self.create_move("out_invoice", currency_id=self.company.currency_id.id)
         attachment = self.get_attachment(invoice)
         self._assert_invoice_attachment(attachment, xpaths=None, expected_file_path='from_odoo/ciusro_out_invoice.xml')
+
+    def test_export_no_vat_but_have_company_registry_new(self):
+        self.env['ir.config_parameter'].set_param('account_edi_ubl_cii.use_new_dict_to_xml_helpers', 'True')
+        self.test_export_no_vat_but_have_company_registry()
 
     def test_export_no_vat_but_have_company_registry_without_prefix(self):
         self.company_data['company'].write({'vat': False, 'company_registry': '1234567897'})
@@ -157,11 +182,19 @@ class TestUBLRO(TestUBLROCommon):
         attachment = self.get_attachment(invoice)
         self._assert_invoice_attachment(attachment, xpaths=None, expected_file_path='from_odoo/ciusro_out_invoice_no_prefix_vat.xml')
 
+    def test_export_no_vat_but_have_company_registry_without_prefix_new(self):
+        self.env['ir.config_parameter'].set_param('account_edi_ubl_cii.use_new_dict_to_xml_helpers', 'True')
+        self.test_export_no_vat_but_have_company_registry_without_prefix()
+
     def test_export_no_vat_and_no_company_registry_raises_error(self):
         self.company_data['company'].write({'vat': False, 'company_registry': False})
         invoice = self.create_move("out_invoice", send=False)
         with self.assertRaisesRegex(UserError, "doesn't have a VAT nor Company ID"):
             invoice._generate_and_send(allow_fallback_pdf=False, mail_template_id=self.move_template.id)
+
+    def test_export_no_vat_and_no_company_registry_raises_error_new(self):
+        self.env['ir.config_parameter'].set_param('account_edi_ubl_cii.use_new_dict_to_xml_helpers', 'True')
+        self.test_export_no_vat_and_no_company_registry_raises_error()
 
     def test_export_constraints(self):
         self.company_data['company'].company_registry = False
@@ -177,3 +210,7 @@ class TestUBLRO(TestUBLROCommon):
         invoice = self.create_move("out_invoice", send=False)
         with self.assertRaisesRegex(UserError, "city name must be 'SECTORX'"):
             invoice._generate_and_send(allow_fallback_pdf=False, mail_template_id=self.move_template.id)
+
+    def test_export_constraints_new(self):
+        self.env['ir.config_parameter'].set_param('account_edi_ubl_cii.use_new_dict_to_xml_helpers', 'True')
+        self.test_export_constraints()

--- a/addons/l10n_sg_ubl_pint/models/account_edi_xml_pint_sg.py
+++ b/addons/l10n_sg_ubl_pint/models/account_edi_xml_pint_sg.py
@@ -26,6 +26,10 @@ class AccountEdiXmlUBLPINTSG(models.AbstractModel):
         # OVERRIDE account_edi_ubl_cii
         return f"{invoice.name.replace('/', '_')}_pint_sg.xml"
 
+    # -------------------------------------------------------------------------
+    # EXPORT: Old helpers
+    # -------------------------------------------------------------------------
+
     def _get_partner_party_vals(self, partner, role):
         # EXTENDS account_edi_ubl_cii
         # Old helper not used by default (see _export_invoice override in account.edi.xml.ubl_bis3)
@@ -117,5 +121,85 @@ class AccountEdiXmlUBLPINTSG(models.AbstractModel):
             if tax_category['tax_category_id'] in SG_GST_CODES_REQUIRING_ADDRESS:
                 constraints['sg_seller_street_addr_required'] = self._check_required_fields(vals['supplier'], 'street')
                 constraints['sg_seller_post_code_required'] = self._check_required_fields(vals['supplier'], 'zip')
+
+        return constraints
+
+    # -------------------------------------------------------------------------
+    # EXPORT: New (dict_to_xml) helpers
+    # -------------------------------------------------------------------------
+
+    def _add_invoice_header_nodes(self, document_node, vals):
+        # EXTENDS account.edi.xml.ubl_bis3
+        super()._add_invoice_header_nodes(document_node, vals)
+        invoice = vals['invoice']
+
+        # see https://docs.peppol.eu/poac/sg/2024-Q2/pint-sg/bis/#_bis_identifiers
+        document_node['cbc:CustomizationID'] = {'_text': self._get_customization_ids()['pint_sg']}
+        document_node['cbc:ProfileID'] = {'_text': 'urn:peppol:bis:billing'}
+        document_node['cbc:UUID'] = {'_text': invoice._l10n_sg_get_uuid()}
+
+        if invoice.currency_id != invoice.company_id.currency_id:
+            # see https://docs.peppol.eu/poac/sg/2024-Q2/pint-sg/bis/#_invoice_totals_in_gst_accounting_currency
+            document_node['cbc:TaxCurrencyCode'] = {
+                '_text': invoice.company_id.currency_id.name
+            }  # accounting currency
+
+            amounts_in_accounting_currency = (
+                ('sgdtotal-excl-gst', invoice.amount_untaxed_signed),
+                ('sgdtotal-incl-gst', invoice.amount_total_signed),
+            )
+            # [BR-53-GST-SG] - If the GST accounting currency code (BT-6-GST) is present, then the Invoice total GST amount (BT-111-GST),
+            # Invoice total including GST amount and Invoice Total excluding GST amount in accounting currency shall be provided.
+
+            document_node['cac:AdditionalDocumentReference'] = [
+                {
+                    'cbc:ID': {'_text': invoice.company_id.currency_id.name},
+                    'cbc:DocumentTypeCode': {'_text': code},
+                    'cbc:DocumentDescription': {'_text': amount},
+                }
+                for code, amount in amounts_in_accounting_currency
+            ]
+
+    def _add_invoice_tax_total_nodes(self, document_node, vals):
+        # EXTENDS account.edi.xml.ubl_bis3
+        super()._add_invoice_tax_total_nodes(document_node, vals)
+        document_node['cac:TaxTotal'] = [document_node['cac:TaxTotal']]
+
+        company_currency = vals['invoice'].company_id.currency_id
+        if vals['invoice'].currency_id != company_currency:
+            self._add_tax_total_node_in_company_currency(document_node, vals)
+
+            # Remove the tax subtotals from the TaxTotal in company currency
+            document_node['cac:TaxTotal'][1]['cac:TaxSubtotal'] = None
+
+    def _get_party_node(self, vals):
+        party_node = super()._get_party_node(vals)
+        party_node['cac:PartyTaxScheme'][0]['cac:TaxScheme']['cbc:ID']['_text'] = 'GST'
+        return party_node
+
+    def _get_tax_category_node(self, vals):
+        # EXTENDS account_edi_ubl_cii
+        tax_category_node = super()._get_tax_category_node(vals)
+        tax_category_node['cac:TaxScheme']['cbc:ID']['_text'] = 'GST'
+        return tax_category_node
+
+    def _export_invoice_constraints_new(self, invoice, vals):
+        # EXTENDS account_edi_ubl_cii
+        constraints = super()._export_invoice_constraints_new(invoice, vals)
+
+        # Tax category must be filled on the line, with a value from SG categories.
+        tax_total_node = vals['document_node']['cac:TaxTotal'][0]
+        for tax_subtotal_node in tax_total_node['cac:TaxSubtotal']:
+            if tax_subtotal_node['cac:TaxCategory']['cbc:ID']['_text'] not in SG_TAX_CATEGORIES:
+                constraints['sg_vat_category_required'] = _("You must set a Singaporean tax category on each taxes of the invoice.")
+
+            # Invoice with GST category code of value 'SR', 'SRCA-S', 'SRCA-C', 'ZR', 'SRRC',
+            # 'SROVR-RS', 'SROVR-LVG', 'SRLVG', 'NA' should contain seller address line and seller
+            # post code
+            if tax_subtotal_node['cac:TaxCategory']['cbc:ID']['_text'] in SG_GST_CODES_REQUIRING_ADDRESS:
+                constraints['sg_seller_street_addr_required'] = \
+                    self._check_required_fields(vals['supplier'], 'street')
+                constraints['sg_seller_post_code_required'] = \
+                    self._check_required_fields(vals['supplier'], 'zip')
 
         return constraints

--- a/addons/l10n_sg_ubl_pint/models/account_edi_xml_pint_sg.py
+++ b/addons/l10n_sg_ubl_pint/models/account_edi_xml_pint_sg.py
@@ -28,6 +28,8 @@ class AccountEdiXmlUBLPINTSG(models.AbstractModel):
 
     def _get_partner_party_vals(self, partner, role):
         # EXTENDS account_edi_ubl_cii
+        # Old helper not used by default (see _export_invoice override in account.edi.xml.ubl_bis3)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals = super()._get_partner_party_vals(partner, role)
         vals.setdefault('party_tax_scheme_vals', [])
 
@@ -38,6 +40,8 @@ class AccountEdiXmlUBLPINTSG(models.AbstractModel):
 
     def _get_invoice_tax_totals_vals_list(self, invoice, taxes_vals):
         # EXTENDS account_edi_ubl_cii
+        # Old helper not used by default (see _export_invoice override in account.edi.xml.ubl_bis3)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals_list = super()._get_invoice_tax_totals_vals_list(invoice, taxes_vals)
         company_currency = invoice.company_id.currency_id
         if invoice.currency_id != company_currency:
@@ -53,6 +57,8 @@ class AccountEdiXmlUBLPINTSG(models.AbstractModel):
 
     def _get_tax_category_list(self, customer, supplier, taxes):
         # EXTENDS account_edi_ubl_cii
+        # Old helper not used by default (see _export_invoice override in account.edi.xml.ubl_bis3)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals_list = super()._get_tax_category_list(customer, supplier, taxes)
         for vals in vals_list:
             vals['tax_scheme_vals'] = {'id': 'GST'}
@@ -60,6 +66,8 @@ class AccountEdiXmlUBLPINTSG(models.AbstractModel):
 
     def _get_additional_document_reference_list(self, invoice):
         # EXTENDS account.edi.xml.ubl_20
+        # Old helper not used by default (see _export_invoice override in account.edi.xml.ubl_bis3)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         additional_document_reference_list = super()._get_additional_document_reference_list(invoice)
         if invoice.currency_id != invoice.company_id.currency_id:
             amounts_in_accounting_currency = (
@@ -77,6 +85,8 @@ class AccountEdiXmlUBLPINTSG(models.AbstractModel):
 
     def _export_invoice_vals(self, invoice):
         # EXTENDS account_edi_ubl_cii
+        # Old helper not used by default (see _export_invoice override in account.edi.xml.ubl_bis3)
+        # If you change this method, please change the corresponding new helper (at the end of this file).
         vals = super()._export_invoice_vals(invoice)
 
         vals['vals'].update({


### PR DESCRIPTION
Since commit 52e984037 we have enabled the new helpers by default for generating BIS3 UBLs. But we didn't enable them in the UBL formats that depend on BIS3 (NLCIUS, XRechnung, Chorus Pro etc). That was to first fix any issues in BIS3 in case the new helpers had broken something.

Since the new helpers seem to be working fine for BIS3, we are now making them the default for all the formats that depend on BIS3 as well.

We also add comments in the old helper methods to indicate that they are no longer used by default for BIS3 and its extensions.

task-none