### PR TITLE
[FIX] website_sale(_loyalty): fix `website_sale`'s indeterministic tours

### DIFF
--- a/addons/website_sale/static/src/js/tours/tour_utils.js
+++ b/addons/website_sale/static/src/js/tours/tour_utils.js
@@ -272,3 +272,13 @@ export function selectPriceList(pricelist) {
         },
     ];
 }
+
+/**
+ * Used for resolving indeterministic behavior of tours
+ */
+export function waitForInteractionToLoad() {
+    return {
+        content: "Wait for interaction to be ready",
+        trigger: `body[is-ready=true]`,
+    };
+}

--- a/addons/website_sale/static/tests/tours/website_sale_complete_flow.js
+++ b/addons/website_sale/static/tests/tours/website_sale_complete_flow.js
@@ -74,6 +74,7 @@ import { pay } from "@website_sale/js/tours/tour_utils";
         run: "click",
         expectUnloadPage: true,
     },
+    tourUtils.waitForInteractionToLoad(),
     {
         content: "Billing address is not same as delivery address",
         trigger: '#use_delivery_as_billing',

--- a/addons/website_sale_loyalty/static/tests/tours/test_website_sale_free_shipping_discount_line.js
+++ b/addons/website_sale_loyalty/static/tests/tours/test_website_sale_free_shipping_discount_line.js
@@ -6,6 +6,7 @@ import {
     goToCart,
     goToCheckout,
     pay,
+    waitForInteractionToLoad,
 } from "@website_sale/js/tours/tour_utils";
 
 function assertRewardAmounts(rewards) {
@@ -52,10 +53,7 @@ webTours.add("check_shipping_discount", {
         },
         goToCart({ quantity: 3 }),
         goToCheckout(),
-        {
-            content: "Wait for interaction to be ready",
-            trigger: `body[is-ready=true]`,
-        },
+        waitForInteractionToLoad(),
         selectDelivery("delivery2"),
         ...assertCartAmounts({
             delivery: "10.00", // delivery2 is $10, ignoring shipping discount
@@ -69,10 +67,7 @@ webTours.add("check_shipping_discount", {
             expectUnloadPage: true,
         },
         ...assertRewardAmounts({ discount: "- 304.00" }),
-        {
-            content: "Wait for interaction to be ready",
-            trigger: `body[is-ready=true]`,
-        },
+        waitForInteractionToLoad(),
         selectDelivery("delivery1"),
         ...assertCartAmounts({ delivery: "5.00" }),
         ...assertRewardAmounts({ discount: "- 300.00", shipping: "- 5.00" }),


### PR DESCRIPTION
This commit fixes some indeterministic tours which was introduced after the refactor of some public widgets to interaction in eCommerce and portal-related modules.

error-232883

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
