### PR TITLE
[FIX] html_editor: testcases for formatting on collapsed selection

### DIFF
--- a/addons/html_editor/static/tests/format/bold.test.js
+++ b/addons/html_editor/static/tests/format/bold.test.js
@@ -6,7 +6,14 @@ import { setupEditor, testEditor } from "../_helpers/editor";
 import { unformat } from "../_helpers/format";
 import { getContent } from "../_helpers/selection";
 import { BOLD_TAGS, notStrong, span, strong, em } from "../_helpers/tags";
-import { bold, italic, simulateArrowKeyPress, tripleClick } from "../_helpers/user_actions";
+import {
+    bold,
+    insertText,
+    italic,
+    simulateArrowKeyPress,
+    tripleClick,
+    undo,
+} from "../_helpers/user_actions";
 import { expectElementCount } from "../_helpers/ui_expectations";
 
 const styleH1Bold = `h1 { font-weight: bold; }`;
@@ -385,4 +392,22 @@ test("should not remove empty bold tag in an empty block when changing selection
     await simulateArrowKeyPress(editor, "ArrowUp");
     await tick(); // await selectionchange
     expect(getContent(el)).toBe(`<p>[]abcd</p><p>${strong("\u200B", "first")}</p>`);
+});
+
+test("should not add history step for bold on collapsed selection", async () => {
+    const { editor, el } = await setupEditor("<p>abcd[]</p>");
+
+    patchWithCleanup(console, { warn: () => {} });
+
+    // Collapsed formatting shortcuts (e.g. Ctrl+B) shouldn’t create a history
+    // step. The empty inline tag is temporary: auto-cleaned if unused. We want
+    // to avoid having a phantom step in the history.
+    await press(["ctrl", "b"]);
+    expect(getContent(el)).toBe(`<p>abcd${strong("[]\u200B", "first")}</p>`);
+
+    await insertText(editor, "A");
+    expect(getContent(el)).toBe(`<p>abcd${strong("A[]")}</p>`);
+
+    undo(editor);
+    expect(getContent(el)).toBe(`<p>abcd[]</p>`);
 });

--- a/addons/html_editor/static/tests/format/strike_through.test.js
+++ b/addons/html_editor/static/tests/format/strike_through.test.js
@@ -1,5 +1,7 @@
 import { expect, test } from "@odoo/hoot";
 import { tick } from "@odoo/hoot-mock";
+import { press } from "@odoo/hoot-dom";
+import { patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { setupEditor, testEditor } from "../_helpers/editor";
 import { getContent, setSelection } from "../_helpers/selection";
 import { s, span } from "../_helpers/tags";
@@ -8,6 +10,7 @@ import {
     strikeThrough,
     tripleClick,
     simulateArrowKeyPress,
+    undo,
 } from "../_helpers/user_actions";
 import { unformat } from "../_helpers/format";
 
@@ -258,4 +261,22 @@ test("should remove empty strikeThrough when changing selection", async () => {
     await simulateArrowKeyPress(editor, "ArrowLeft");
     await tick(); // await selectionchange
     expect(getContent(el)).toBe(`<p>a[]bcd</p>`);
+});
+
+test("should not add history step for strikethrough on collapsed selection", async () => {
+    const { editor, el } = await setupEditor("<p>abcd[]</p>");
+
+    patchWithCleanup(console, { warn: () => {} });
+
+    // Collapsed formatting shortcuts (e.g. Ctrl+5) shouldn’t create a history
+    // step. The empty inline tag is temporary: auto-cleaned if unused. We want
+    // to avoid having a phantom step in the history.
+    await press(["ctrl", "5"]);
+    expect(getContent(el)).toBe(`<p>abcd${s("[]\u200B", "first")}</p>`);
+
+    await insertText(editor, "A");
+    expect(getContent(el)).toBe(`<p>abcd${s("A[]")}</p>`);
+
+    undo(editor);
+    expect(getContent(el)).toBe(`<p>abcd[]</p>`);
 });

--- a/addons/html_editor/static/tests/format/underline.test.js
+++ b/addons/html_editor/static/tests/format/underline.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "@odoo/hoot";
 import { tick } from "@odoo/hoot-mock";
+import { press } from "@odoo/hoot-dom";
 import { patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { setupEditor, testEditor } from "../_helpers/editor";
 import { getContent } from "../_helpers/selection";
@@ -10,6 +11,7 @@ import {
     simulateArrowKeyPress,
     tripleClick,
     underline,
+    undo,
 } from "../_helpers/user_actions";
 import { unformat } from "../_helpers/format";
 
@@ -357,4 +359,22 @@ describe("with italic", () => {
         await tick(); // await selectionchange
         expect(getContent(el)).toBe(`<p>a[]bcd</p>`);
     });
+});
+
+test("should not add history step for underline on collapsed selection", async () => {
+    const { editor, el } = await setupEditor("<p>abcd[]</p>");
+
+    patchWithCleanup(console, { warn: () => {} });
+
+    // Collapsed formatting shortcuts (e.g. Ctrl+U) shouldn’t create a history
+    // step. The empty inline tag is temporary: auto-cleaned if unused. We want
+    // to avoid having a phantom step in the history.
+    await press(["ctrl", "u"]);
+    expect(getContent(el)).toBe(`<p>abcd${u("[]\u200B", "first")}</p>`);
+
+    await insertText(editor, "A");
+    expect(getContent(el)).toBe(`<p>abcd${u("A[]")}</p>`);
+
+    undo(editor);
+    expect(getContent(el)).toBe(`<p>abcd[]</p>`);
 });


### PR DESCRIPTION
Description of the issue this PR addresses:

This PR adds test cases for formatting shortcuts (e.g., Ctrl+B) on a collapsed selection.
An empty inline tag is inserted temporarily and auto-cleaned if unused, so no individual history step are created.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
