### PR TITLE
[FIX] base, crm: ensure quick_create of partner use commercial_partner address

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -901,6 +901,7 @@ class ResPartner(models.Model):
             return partners
 
         for partner, vals in zip(partners, vals_list):
+            vals = self._add_missing_default_values(vals)
             partner._fields_sync(vals)
         return partners
 

--- a/odoo/addons/base/tests/test_res_partner.py
+++ b/odoo/addons/base/tests/test_res_partner.py
@@ -454,6 +454,12 @@ class TestPartnerAddressCompany(TransactionCase):
         self.assertFalse(ct1_1.vat)
         self.assertEqual(inv_1.street, 'Invoice Child Street', 'Should take parent address')
         self.assertFalse(inv_1.vat)
+        # test it also works with default_parent_id value in context
+        inv_2 = self.env['res.partner'].with_context(default_parent_id=inv.id).create({
+            'name': 'Address, Child of Invoice',
+        })
+        self.assertEqual(inv_2.street, 'Invoice Child Street', 'Should take parent address')
+        self.assertFalse(inv_2.vat)
 
         # sync P1 with parent, check address is update + other fields in write kept
         ct1_phone = '+320455999999'


### PR DESCRIPTION
**Steps to reproduce:**
- Install Sales/CRM apps
- Go to CRM app
- Create new opportunity card
- Set a company (`commercial_partner_id`)
- Create a new contact using `quick_create`
- The new contact is linked to the company but it doesn't inherit the company address

**Issue:**
Kanban quick create of crm app was modified to allow a company field, which is used as `default_parent_id` when creating a new partner from the card. This properly set the partner `parent_id` and `commercial_partner_id` but without applying the logic of `_fields_sync()` which also added the address (only for quick_create).

**Fix:**
Use `_add_missing_default_values` to check if a default value was
given for `parent_id` in `_fields_sync()`.

related: https://github.com/odoo/odoo/commit/a6c3ebc21c066ab4d5711f535ca5fc858e6485b0

opw-4932114
