### PR TITLE
[FIX] point_of_sale: remove draft order

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -169,7 +169,7 @@ export class TicketScreen extends Component {
                 }
             }
         }
-        if (this.pos.isOpenOrderShareable()) {
+        if (this.pos.isOpenOrderShareable() || order.server_id) {
             await this.pos._removeOrdersFromServer();
         }
         return true;

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -552,7 +552,7 @@ export class PosStore extends Reactive {
                 delete this.toRefundLines[line.refunded_orderline_id];
             }
         }
-        if (this.isOpenOrderShareable() && removeFromServer) {
+        if ((this.isOpenOrderShareable() || order.server_id) && removeFromServer) {
             if (this.ordersToUpdateSet.has(order)) {
                 this.ordersToUpdateSet.delete(order);
             }

--- a/addons/point_of_sale/static/tests/tours/TicketScreen.tour.js
+++ b/addons/point_of_sale/static/tests/tours/TicketScreen.tour.js
@@ -248,3 +248,33 @@ registry.category("web_tour.tours").add("FiscalPositionTwoTaxIncluded", {
             ProductScreen.isShown(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_draft_order_deletion_with_printer", {
+    steps: () =>
+        [
+            ProductScreen.confirmOpeningPopup(),
+            ProductScreen.clickHomeCategory(),
+            ProductScreen.clickDisplayedProduct("Desk Pad"),
+            Chrome.clickMenuButton(),
+            Chrome.clickTicketButton(),
+            TicketScreen.clickNewTicket(),
+            ProductScreen.clickDisplayedProduct("Desk Pad"),
+            Chrome.clickMenuButton(),
+            Chrome.clickTicketButton(),
+            TicketScreen.selectFilter("All active order"),
+            TicketScreen.selectOrder("-0001"),
+            {
+                trigger: ".ticket-screen .load-order-button",
+            },
+            ProductScreen.clickDisplayedProduct("Desk Pad"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.clickNextOrder(),
+            Chrome.clickMenuButton(),
+            Chrome.clickTicketButton(),
+            TicketScreen.deleteOrder("-0002"),
+            Chrome.confirmPopup(),
+            Chrome.closeSession(),
+        ].flat(),
+});

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1360,6 +1360,22 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'test_combo_with_custom_attribute', login="pos_user")
 
+    def test_draft_order_deletion_with_printer(self):
+        self.env['pos.printer'].create({
+            'name': 'Printer',
+            'printer_type': 'epson_epos',
+            'epson_printer_ip': '0.0.0.0',
+            'product_categories_ids': [Command.set(self.env['pos.category'].search([]).ids)],
+        })
+
+        self.main_pos_config.write({
+            'is_order_printer': True,
+            'printer_ids': [Command.set(self.env['pos.printer'].search([]).ids)],
+        })
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'test_draft_order_deletion_with_printer', login="pos_user")
+
+
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):
     browser_size = '375x667'


### PR DESCRIPTION
In certain conditions some draft orders could be saved on the server but you wouldn't be able to delete them. This prevented you to close the PoS.

Steps to reproduce:
-------------------
* Use a PoS that is NOT a restaurant
* Make sure the PoS has a preparation display
* Open the PoS
* Leave the first order empty and create a new one
* In the second order add any items
* Go back to the first order, add items and validate it
* Delete the second order from the order list
* Now try to close the session
> Observation: You will get an error saying you still have draft order

Why the fix:
------------
When you have a preparation display linked to the PoS, when you pay an order it will synchronize all the order of the PoS. So the draft order will be saved on the server. But when deleting it, it is not deleted from the server because the function `isOpenOrderShareable` would return false. To fix this we make sure to delete the order from the server if the order has a server_id.

opw-4946204