### PR TITLE
[FIX] l10n_es_pos: not reset fiscal pos on order validation

### DIFF
--- a/addons/l10n_es_pos/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/l10n_es_pos/static/src/overrides/components/payment_screen/payment_screen.js
@@ -30,9 +30,17 @@ patch(PaymentScreen.prototype, {
                         this.pos.config.pricelist_id?.id != order.pricelist_id?.id
                             ? order.pricelist_id.id
                             : false;
+                    const setFiscalPosition =
+                        this.pos.config.default_fiscal_position_id?.id !=
+                        order.fiscal_position_id?.id
+                            ? order.fiscal_position_id?.id
+                            : false;
                     order.set_partner(this.pos.config.simplified_partner_id);
                     if (setPricelist) {
                         order.set_pricelist(setPricelist);
+                    }
+                    if (setFiscalPosition !== false) {
+                        order.update({ fiscal_position_id: setFiscalPosition });
                     }
                 }
             }

--- a/addons/l10n_es_pos/static/tests/tours/spanish_pos_tour.js
+++ b/addons/l10n_es_pos/static/tests/tours/spanish_pos_tour.js
@@ -84,6 +84,7 @@ registry.category("web_tour.tours").add("test_simplified_invoice_not_override_se
             Dialog.confirm("Open Register"),
             ProductScreen.addOrderline("Desk Pad", "1"),
             ProductScreen.clickPriceList("Test pricelist"),
+            ProductScreen.clickFiscalPosition("Original Tax"),
             ProductScreen.clickPayButton(),
             PaymentScreen.clickPaymentMethod("Cash"),
             PaymentScreen.clickValidate(),

--- a/addons/l10n_es_pos/tests/test_frontend.py
+++ b/addons/l10n_es_pos/tests/test_frontend.py
@@ -149,10 +149,12 @@ class TestUi(TestPointOfSaleHttpCommon):
         during the order"""
         self.assertTrue(len(self.main_pos_config.available_pricelist_ids.ids) > 1)
         self.main_pos_config.l10n_es_simplified_invoice_journal_id = self.main_pos_config.journal_id
+        self.main_pos_config.default_fiscal_position_id = self.fiscal_pos_a.id
         self.main_pos_config.open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_simplified_invoice_not_override_set_pricelist', login="pos_user")
         order = self.env['pos.order'].search([('partner_id', '=', self.main_pos_config.simplified_partner_id.id)])
         self.assertNotEqual(order.pricelist_id, self.main_pos_config.simplified_partner_id.property_product_pricelist)
+        self.assertNotEqual(order.fiscal_position_id, self.fiscal_pos_a)
 
     def test_simplified_partner_inactive_case(self):
         self.main_pos_config.simplified_partner_id.active = False


### PR DESCRIPTION
Currently, when you use a default fiscal position in the pos, if you switch to no fiscal position, upon order validation the tax amount is counted as change.

Steps to reproduce:
-------------------
* Install l10n_es_pos, switch to es company
* In the config of a shop, use fiscal position, set some as available, one as default
* Open shop session
* Add a product that has taxes
* Switch fiscal position to one that has 0% taxes
* There should not be taxes in the cart at this point
* Go to pay the order (cash or bank)
> Observation: On the receipt the previous tax value is counted as
  change

Why the fix:
------------
The issue happens because of the simplified invoice mechanism present in the ES localization. When you validate an order and that order can apply for simplified invoice, if there is no customer on the order the partner is set with the simplified partner. When setting a partner on the order we update the fiscal position and pricelist.
https://github.com/odoo/odoo/blob/1358f93a4c73de5a28cda72ec78769625c863efd/addons/point_of_sale/static/src/app/models/pos_order.js#L929

The fiscal position is updated with the partner's fiscal position or the default one if none on the partner.
https://github.com/odoo/odoo/blob/1358f93a4c73de5a28cda72ec78769625c863efd/addons/point_of_sale/static/src/app/models/pos_order.js#L986-L995

Instead of the fallback on the default fiscal position in the case it is not set on a partner we fallback on the order current fiscal position. If it is different than the default one is means that it was changed intentionally and there's a high chance we want to keep it, otherwise it will already be the default fp.

opw-5051231