### PR TITLE
[FIX] mail: extra link beside the new mention when editing a message

### DIFF
--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -6,7 +6,6 @@ import {
     convertBrToLineBreak,
     decorateEmojis,
     htmlToTextContentInline,
-    prettifyMessageContent,
 } from "@mail/utils/common/format";
 
 import { browser } from "@web/core/browser/browser";
@@ -548,7 +547,7 @@ export class Message extends Record {
             attachment_tokens: attachments
                 .concat(this.attachment_ids)
                 .map((attachment) => attachment.ownership_token),
-            body: await prettifyMessageContent(body, { validMentions }),
+            body,
             partner_ids: validMentions?.partners?.map((partner) => partner.id),
             role_ids: validMentions?.roles?.map((role) => role.id),
         };

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -567,10 +567,9 @@ test("can add new mentions when editing message", async () => {
     await click(".o-mail-Composer-suggestion strong", { text: "TestPartner" });
     await contains(".o-mail-Composer-input", { value: "Hello @TestPartner " });
     await click(".o-mail-Message button", { text: "save" });
-    await contains(".o-mail-Message", {
-        text: "Hello @TestPartner (edited)",
-        contains: ["a.o_mail_redirect", { text: "@TestPartner" }],
-    });
+    await contains(".o-mail-Message", { text: "Hello @TestPartner (edited)" });
+    await contains(".o-mail-Message a.o_mail_redirect", { count: 1 });
+    await contains(".o-mail-Message a.o_mail_redirect", { text: "@TestPartner" });
 });
 
 test("Other messages are grayed out when replying to another one", async () => {


### PR DESCRIPTION
Before PR #223808, `prettifyMessageContent()` was called when posting or editing
 a message. With the mentioned PR, prettifying happens while typing. So
 prettifying the content again when editing, causes creating an extra `a` tag in
  the  message  content. The part related to posting a message is already taken
  care of in that PR. This PR removes the prettifying when editing a message.

task-5123493

