### PR TITLE
[FIX] hr_holidays: only set employee if employee model

### DIFF
--- a/addons/hr_holidays/static/src/views/calendar/calendar_model.js
+++ b/addons/hr_holidays/static/src/views/calendar/calendar_model.js
@@ -107,7 +107,7 @@ export class TimeOffCalendarModel extends CalendarModel {
     }
 
     get employeeId() {
-        return (this.meta.context.employee_id && this.meta.context.employee_id[0]) || this.meta.context.active_id || null;
+        return (this.meta.context.employee_id && this.meta.context.employee_id[0]) || (this.meta.context.active_model == "hr.employee" && this.meta.context.active_id) || null;
     }
 
     fetchRecords(data) {


### PR DESCRIPTION
Since the active model in the time off view can be res.users when we come from the user preferences, we need to check that the context model is the correct one before using the active_id, otherwise we'll try to fetch an employee with the id of the user.

This has been introduced in recent fix: https://github.com/odoo/odoo/commit/c82c4a0f2674b117cdc2b0d35fe4393b8f35285a


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
