### PR TITLE
[IMP] account: add hook to define attachments to sync with Documents

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -7016,3 +7016,10 @@ class AccountMove(models.Model):
                 }]
             case _:
                 return []
+
+    def _get_document_attachments_to_sync(self):
+        """
+        Return the set of attachments of the move that should be synchronized
+        with the Documents app.
+        """
+        return self.message_main_attachment_id


### PR DESCRIPTION
Introduce the method `_get_document_attachments_to_sync` on account moves to determine which attachments should be synchronized with the Documents app.

task-4954622


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
