### PR TITLE
[ADD] portal_address_extended: generic address handling when enfroce_cities=True

### DIFF
--- a/addons/l10n_br/__manifest__.py
+++ b/addons/l10n_br/__manifest__.py
@@ -53,7 +53,7 @@ Create electronic sales invoices with Avatax.
     'depends': [
         'account',
         'account_qr_code_emv',
-        'base_address_extended',
+        'portal_address_extended',
         'l10n_latam_base',
         'l10n_latam_invoice_document',
     ],

--- a/addons/l10n_br/controllers/portal.py
+++ b/addons/l10n_br/controllers/portal.py
@@ -14,8 +14,8 @@ class L10nBRPortalAccount(L10nLatamBasePortalAccount):
         rendering_values = super()._prepare_address_form_values(partner_sudo, *args, **kwargs)
         if self._is_brazilean_fiscal_country():
             rendering_values.update({
-                'city_sudo': partner_sudo.city_id,
-                'cities_sudo': request.env['res.city'].sudo().search([
+                'city': partner_sudo.city_id,
+                'state_cities': request.env['res.city'].sudo().search([
                     ('country_id.code', '=', 'BR'),
                 ]),
             })
@@ -25,8 +25,8 @@ class L10nBRPortalAccount(L10nLatamBasePortalAccount):
         mandatory_fields = super()._get_mandatory_address_fields(country_sudo)
         if country_sudo.code == 'BR' and self._is_brazilean_fiscal_country():
             mandatory_fields.update({
-                'street_name', 'street2', 'street_number', 'city_id',
+                'street_name', 'street2', 'street_number',
             })
-            mandatory_fields -= {'street', 'city'}  # Brazil uses the base_extended_address fields added above
+            mandatory_fields.remove('street')
 
         return mandatory_fields

--- a/addons/l10n_br/data/res_country_data.xml
+++ b/addons/l10n_br/data/res_country_data.xml
@@ -3,6 +3,7 @@
     <data>
         <record id="base.br" model="res.country">
             <field name="address_view_id" ref="br_partner_address_form" />
+            <field name="enforce_cities" eval="1"/>
         </record>
     </data>
 </odoo>

--- a/addons/l10n_br/models/res_partner.py
+++ b/addons/l10n_br/models/res_partner.py
@@ -12,6 +12,6 @@ class ResPartner(models.Model):
 
     def _get_frontend_writable_fields(self):
         frontend_writable_fields = super()._get_frontend_writable_fields()
-        frontend_writable_fields.update({'city_id', 'street_number', 'street_name', 'street_number2'})
+        frontend_writable_fields.update({'street_number', 'street_name', 'street_number2'})
 
         return frontend_writable_fields

--- a/addons/l10n_br/views/portal_address_templates.xml
+++ b/addons/l10n_br/views/portal_address_templates.xml
@@ -2,28 +2,9 @@
 <odoo>
 
     <template id="address_form_fields" inherit_id="portal.address_form_fields">
-        <!-- o_city must remain in DOM, otherwise the standard portal js breaks. -->
-        <input id="o_city" position="attributes">
-            <attribute name="class" separator=" " add="o_standard_address"/>
-        </input>
-        <input id="o_city" position="after">
-            <div t-if="res_company.account_fiscal_country_id.code == 'BR'" class="o_select_city">
-                <!-- will be replaced with SelectMenuWrapper -->
-                <select id="o_city_id" name="city_id" class="form-select">
-                    <option value="">City...</option>
-                    <option
-                        t-foreach="cities_sudo"
-                        t-as="c"
-                        t-att-value="c.id"
-                        t-att-selected="c.id == city_sudo.id"
-                        t-att-code="c.id"
-                        t-att-state-id="c.state_id.id"
-                        t-att-zip-ranges="c.l10n_br_zip_ranges"
-                        t-out="c.name"
-                    />
-                </select>
-            </div>
-        </input>
+        <xpath expr="//select[@name='city_id']/option[not(@value='')]" position="attributes">
+            <attribute name="t-att-zip-ranges" add="c.l10n_br_zip_ranges"/>
+        </xpath>
         <!-- put base_address_extended fields separately to be more user-friendly -->
         <div id="div_street" position="attributes">
             <attribute name="class" separator=" " add="o_standard_address"/>

--- a/addons/l10n_cl/__manifest__.py
+++ b/addons/l10n_cl/__manifest__.py
@@ -18,6 +18,7 @@ Plan contable chileno e impuestos de acuerdo a disposiciones vigentes.
         'l10n_latam_invoice_document',
         'uom',
         'account',
+        'portal_address_extended',
     ],
     'auto_install': ['account'],
     'data': [
@@ -35,9 +36,11 @@ Plan contable chileno e impuestos de acuerdo a disposiciones vigentes.
         'data/l10n_latam.document.type.csv',
         'data/product_data.xml',
         'data/uom_data.xml',
-        'data/res.currency.csv',
-        'data/res_currency_data.xml',
+        'data/res.city.csv',
         'data/res.country.csv',
+        'data/res.currency.csv',
+        'data/res_country.xml',
+        'data/res_currency_data.xml',
         'data/res_partner.xml',
     ],
     'demo': [

--- a/addons/l10n_cl/data/res.city.csv
+++ b/addons/l10n_cl/data/res.city.csv
@@ -1,0 +1,347 @@
+id,name,state_id:id,country_id:id
+city_cl_01,"Arica",base.state_cl_15,base.cl
+city_cl_02,"Camarones",base.state_cl_15,base.cl
+city_cl_03,"Putre",base.state_cl_15,base.cl
+city_cl_04,"General Lagos",base.state_cl_15,base.cl
+city_cl_05,"Iquique",base.state_cl_01,base.cl
+city_cl_06,"Camiña",base.state_cl_01,base.cl
+city_cl_07,"Colchane",base.state_cl_01,base.cl
+city_cl_08,"Huara",base.state_cl_01,base.cl
+city_cl_09,"Pica",base.state_cl_01,base.cl
+city_cl_10,"Pozo Almonte",base.state_cl_01,base.cl
+city_cl_11,"Alto Hospicio",base.state_cl_01,base.cl
+city_cl_12,"Antofagasta",base.state_cl_02,base.cl
+city_cl_13,"Mejillones",base.state_cl_02,base.cl
+city_cl_14,"Sierra Gorda",base.state_cl_02,base.cl
+city_cl_15,"Taltal",base.state_cl_02,base.cl
+city_cl_16,"Calama",base.state_cl_02,base.cl
+city_cl_17,"Ollagüe",base.state_cl_02,base.cl
+city_cl_18,"San Pedro De Atacama",base.state_cl_02,base.cl
+city_cl_19,"Tocopilla",base.state_cl_02,base.cl
+city_cl_20,"María Elena",base.state_cl_02,base.cl
+city_cl_21,"Copiapó",base.state_cl_03,base.cl
+city_cl_22,"Caldera",base.state_cl_03,base.cl
+city_cl_23,"Tierra Amarilla",base.state_cl_03,base.cl
+city_cl_24,"Chañaral",base.state_cl_03,base.cl
+city_cl_25,"Diego De Almagro",base.state_cl_03,base.cl
+city_cl_26,"Vallenar",base.state_cl_03,base.cl
+city_cl_27,"Alto Del Carmen",base.state_cl_03,base.cl
+city_cl_28,"Freirina",base.state_cl_03,base.cl
+city_cl_29,"Huasco",base.state_cl_03,base.cl
+city_cl_30,"La Serena",base.state_cl_04,base.cl
+city_cl_31,"Coquimbo",base.state_cl_04,base.cl
+city_cl_32,"Andacollo",base.state_cl_04,base.cl
+city_cl_33,"La Higuera",base.state_cl_04,base.cl
+city_cl_34,"Paihuano",base.state_cl_04,base.cl
+city_cl_35,"Vicuña",base.state_cl_04,base.cl
+city_cl_36,"Illapel",base.state_cl_04,base.cl
+city_cl_37,"Canela",base.state_cl_04,base.cl
+city_cl_38,"Los Vilos",base.state_cl_04,base.cl
+city_cl_39,"Salamanca",base.state_cl_04,base.cl
+city_cl_40,"Ovalle",base.state_cl_04,base.cl
+city_cl_41,"Combarbalá",base.state_cl_04,base.cl
+city_cl_42,"Monte Patria",base.state_cl_04,base.cl
+city_cl_43,"Punitaqui",base.state_cl_04,base.cl
+city_cl_44,"Río Hurtado",base.state_cl_04,base.cl
+city_cl_45,"Valparaíso",base.state_cl_05,base.cl
+city_cl_46,"Casablanca",base.state_cl_05,base.cl
+city_cl_47,"Concón",base.state_cl_05,base.cl
+city_cl_48,"Juan Fernández",base.state_cl_05,base.cl
+city_cl_49,"Puchuncaví",base.state_cl_05,base.cl
+city_cl_50,"Quilpué",base.state_cl_05,base.cl
+city_cl_51,"Quintero",base.state_cl_05,base.cl
+city_cl_52,"Villa Alemana",base.state_cl_05,base.cl
+city_cl_53,"Viña Del Mar",base.state_cl_05,base.cl
+city_cl_54,"Isla De Pascua",base.state_cl_05,base.cl
+city_cl_55,"Los Andes",base.state_cl_05,base.cl
+city_cl_56,"Calle Larga",base.state_cl_05,base.cl
+city_cl_57,"Rinconada",base.state_cl_05,base.cl
+city_cl_58,"San Esteban",base.state_cl_05,base.cl
+city_cl_59,"La Ligua",base.state_cl_05,base.cl
+city_cl_60,"Cabildo",base.state_cl_05,base.cl
+city_cl_61,"Papudo",base.state_cl_05,base.cl
+city_cl_62,"Petorca",base.state_cl_05,base.cl
+city_cl_63,"Zapallar",base.state_cl_05,base.cl
+city_cl_64,"Quillota",base.state_cl_05,base.cl
+city_cl_65,"La Calera",base.state_cl_05,base.cl
+city_cl_66,"Hijuelas",base.state_cl_05,base.cl
+city_cl_67,"La Cruz",base.state_cl_05,base.cl
+city_cl_68,"Limache",base.state_cl_05,base.cl
+city_cl_69,"Nogales",base.state_cl_05,base.cl
+city_cl_70,"Olmué",base.state_cl_05,base.cl
+city_cl_71,"San Antonio",base.state_cl_05,base.cl
+city_cl_72,"Algarrobo",base.state_cl_05,base.cl
+city_cl_73,"Cartagena",base.state_cl_05,base.cl
+city_cl_74,"El Quisco",base.state_cl_05,base.cl
+city_cl_75,"El Tabo",base.state_cl_05,base.cl
+city_cl_76,"Santo Domingo",base.state_cl_05,base.cl
+city_cl_77,"San Felipe",base.state_cl_05,base.cl
+city_cl_78,"Catemu",base.state_cl_05,base.cl
+city_cl_79,"Llaillay",base.state_cl_05,base.cl
+city_cl_80,"Panquehue",base.state_cl_05,base.cl
+city_cl_81,"Putaendo",base.state_cl_05,base.cl
+city_cl_82,"Santa María",base.state_cl_05,base.cl
+city_cl_83,"Rancagua",base.state_cl_06,base.cl
+city_cl_84,"Codegua",base.state_cl_06,base.cl
+city_cl_85,"Coinco",base.state_cl_06,base.cl
+city_cl_86,"Coltauco",base.state_cl_06,base.cl
+city_cl_87,"Doñihue",base.state_cl_06,base.cl
+city_cl_88,"Graneros",base.state_cl_06,base.cl
+city_cl_89,"Las Cabras",base.state_cl_06,base.cl
+city_cl_90,"Machalí",base.state_cl_06,base.cl
+city_cl_91,"Malloa",base.state_cl_06,base.cl
+city_cl_92,"Mostazal",base.state_cl_06,base.cl
+city_cl_93,"Olivar",base.state_cl_06,base.cl
+city_cl_94,"Peumo",base.state_cl_06,base.cl
+city_cl_95,"Pichidegua",base.state_cl_06,base.cl
+city_cl_96,"Quinta De Tilcoco",base.state_cl_06,base.cl
+city_cl_97,"Rengo",base.state_cl_06,base.cl
+city_cl_98,"Requínoa",base.state_cl_06,base.cl
+city_cl_99,"San Vicente",base.state_cl_06,base.cl
+city_cl_100,"Pichilemu",base.state_cl_06,base.cl
+city_cl_101,"La Estrella",base.state_cl_06,base.cl
+city_cl_102,"Litueche",base.state_cl_06,base.cl
+city_cl_103,"Marchigüe",base.state_cl_06,base.cl
+city_cl_104,"Navidad",base.state_cl_06,base.cl
+city_cl_105,"Paredones",base.state_cl_06,base.cl
+city_cl_106,"San Fernando",base.state_cl_06,base.cl
+city_cl_107,"Chépica",base.state_cl_06,base.cl
+city_cl_108,"Chimbarongo",base.state_cl_06,base.cl
+city_cl_109,"Lolol",base.state_cl_06,base.cl
+city_cl_110,"Nancagua",base.state_cl_06,base.cl
+city_cl_111,"Palmilla",base.state_cl_06,base.cl
+city_cl_112,"Peralillo",base.state_cl_06,base.cl
+city_cl_113,"Placilla",base.state_cl_06,base.cl
+city_cl_114,"Pumanque",base.state_cl_06,base.cl
+city_cl_115,"Santa Cruz",base.state_cl_06,base.cl
+city_cl_116,"Talca",base.state_cl_07,base.cl
+city_cl_117,"Constitución",base.state_cl_07,base.cl
+city_cl_118,"Curepto",base.state_cl_07,base.cl
+city_cl_119,"Empedrado",base.state_cl_07,base.cl
+city_cl_120,"Maule",base.state_cl_07,base.cl
+city_cl_121,"Pelarco",base.state_cl_07,base.cl
+city_cl_122,"Pencahue",base.state_cl_07,base.cl
+city_cl_123,"Río Claro",base.state_cl_07,base.cl
+city_cl_124,"San Clemente",base.state_cl_07,base.cl
+city_cl_125,"San Rafael",base.state_cl_07,base.cl
+city_cl_126,"Cauquenes",base.state_cl_07,base.cl
+city_cl_127,"Chanco",base.state_cl_07,base.cl
+city_cl_128,"Pelluhue",base.state_cl_07,base.cl
+city_cl_129,"Curicó",base.state_cl_07,base.cl
+city_cl_130,"HualaÑé",base.state_cl_07,base.cl
+city_cl_131,"Licantén",base.state_cl_07,base.cl
+city_cl_132,"Molina",base.state_cl_07,base.cl
+city_cl_133,"Rauco",base.state_cl_07,base.cl
+city_cl_134,"Romeral",base.state_cl_07,base.cl
+city_cl_135,"Sagrada Familia",base.state_cl_07,base.cl
+city_cl_136,"Teno",base.state_cl_07,base.cl
+city_cl_137,"Vichuquén",base.state_cl_07,base.cl
+city_cl_138,"Linares",base.state_cl_07,base.cl
+city_cl_139,"Colbún",base.state_cl_07,base.cl
+city_cl_140,"Longaví",base.state_cl_07,base.cl
+city_cl_141,"Parral",base.state_cl_07,base.cl
+city_cl_142,"Retiro",base.state_cl_07,base.cl
+city_cl_143,"San Javier",base.state_cl_07,base.cl
+city_cl_144,"Villa Alegre",base.state_cl_07,base.cl
+city_cl_145,"Yerbas Buenas",base.state_cl_07,base.cl
+city_cl_146,"Concepción",base.state_cl_08,base.cl
+city_cl_147,"Coronel",base.state_cl_08,base.cl
+city_cl_148,"Chiguayante",base.state_cl_08,base.cl
+city_cl_149,"Florida",base.state_cl_08,base.cl
+city_cl_150,"Hualqui",base.state_cl_08,base.cl
+city_cl_151,"Lota",base.state_cl_08,base.cl
+city_cl_152,"Penco",base.state_cl_08,base.cl
+city_cl_153,"San Pedro De La Paz",base.state_cl_08,base.cl
+city_cl_154,"Santa Juana",base.state_cl_08,base.cl
+city_cl_155,"Talcahuano",base.state_cl_08,base.cl
+city_cl_156,"Tomé",base.state_cl_08,base.cl
+city_cl_157,"Hualpén",base.state_cl_08,base.cl
+city_cl_158,"Lebu",base.state_cl_08,base.cl
+city_cl_159,"Arauco",base.state_cl_08,base.cl
+city_cl_160,"Cañete",base.state_cl_08,base.cl
+city_cl_161,"Contulmo",base.state_cl_08,base.cl
+city_cl_162,"Curanilahue",base.state_cl_08,base.cl
+city_cl_163,"Los Álamos",base.state_cl_08,base.cl
+city_cl_164,"Tirúa",base.state_cl_08,base.cl
+city_cl_165,"Los Ángeles",base.state_cl_08,base.cl
+city_cl_166,"Antuco",base.state_cl_08,base.cl
+city_cl_167,"Cabrero",base.state_cl_08,base.cl
+city_cl_168,"Laja",base.state_cl_08,base.cl
+city_cl_169,"Mulchén",base.state_cl_08,base.cl
+city_cl_170,"Nacimiento",base.state_cl_08,base.cl
+city_cl_171,"Negrete",base.state_cl_08,base.cl
+city_cl_172,"Quilaco",base.state_cl_08,base.cl
+city_cl_173,"Quilleco",base.state_cl_08,base.cl
+city_cl_174,"San Rosendo",base.state_cl_08,base.cl
+city_cl_175,"Santa Bárbara",base.state_cl_08,base.cl
+city_cl_176,"Tucapel",base.state_cl_08,base.cl
+city_cl_177,"Yumbel",base.state_cl_08,base.cl
+city_cl_178,"Alto Biobío",base.state_cl_08,base.cl
+city_cl_179,"Chillán",base.state_cl_16,base.cl
+city_cl_180,"Bulnes",base.state_cl_16,base.cl
+city_cl_181,"Cobquecura",base.state_cl_16,base.cl
+city_cl_182,"Coelemu",base.state_cl_16,base.cl
+city_cl_183,"Coihueco",base.state_cl_16,base.cl
+city_cl_184,"Chillán Viejo",base.state_cl_16,base.cl
+city_cl_185,"El Carmen",base.state_cl_16,base.cl
+city_cl_186,"Ninhue",base.state_cl_16,base.cl
+city_cl_187,"Ñiquén",base.state_cl_16,base.cl
+city_cl_188,"Pemuco",base.state_cl_16,base.cl
+city_cl_189,"Pinto",base.state_cl_16,base.cl
+city_cl_190,"Portezuelo",base.state_cl_16,base.cl
+city_cl_191,"Quillón",base.state_cl_16,base.cl
+city_cl_192,"Quirihue",base.state_cl_16,base.cl
+city_cl_193,"Ránquil",base.state_cl_16,base.cl
+city_cl_194,"San Carlos",base.state_cl_16,base.cl
+city_cl_195,"San Fabián",base.state_cl_16,base.cl
+city_cl_196,"San Ignacio",base.state_cl_16,base.cl
+city_cl_197,"San Nicolás",base.state_cl_16,base.cl
+city_cl_198,"Treguaco",base.state_cl_16,base.cl
+city_cl_199,"Yungay",base.state_cl_16,base.cl
+city_cl_200,"Temuco",base.state_cl_09,base.cl
+city_cl_201,"Carahue",base.state_cl_09,base.cl
+city_cl_202,"Cunco",base.state_cl_09,base.cl
+city_cl_203,"Curarrehue",base.state_cl_09,base.cl
+city_cl_204,"Freire",base.state_cl_09,base.cl
+city_cl_205,"Galvarino",base.state_cl_09,base.cl
+city_cl_206,"Gorbea",base.state_cl_09,base.cl
+city_cl_207,"Lautaro",base.state_cl_09,base.cl
+city_cl_208,"Loncoch",base.state_cl_09,base.cl
+city_cl_209,"Melipeuco",base.state_cl_09,base.cl
+city_cl_210,"Nueva Imperial",base.state_cl_09,base.cl
+city_cl_211,"Padre Las Casas",base.state_cl_09,base.cl
+city_cl_212,"Perquenco",base.state_cl_09,base.cl
+city_cl_213,"Pitrufquén",base.state_cl_09,base.cl
+city_cl_214,"Pucón",base.state_cl_09,base.cl
+city_cl_215,"Saavedra",base.state_cl_09,base.cl
+city_cl_216,"Teodoro Schmidt",base.state_cl_09,base.cl
+city_cl_217,"Toltén",base.state_cl_09,base.cl
+city_cl_218,"Vilcún",base.state_cl_09,base.cl
+city_cl_219,"Villarrica",base.state_cl_09,base.cl
+city_cl_220,"Cholchol",base.state_cl_09,base.cl
+city_cl_221,"Angol",base.state_cl_09,base.cl
+city_cl_222,"Collipulli",base.state_cl_09,base.cl
+city_cl_223,"Curacautín",base.state_cl_09,base.cl
+city_cl_224,"Ercilla",base.state_cl_09,base.cl
+city_cl_225,"Lonquimay",base.state_cl_09,base.cl
+city_cl_226,"Los Sauces",base.state_cl_09,base.cl
+city_cl_227,"Lumaco",base.state_cl_09,base.cl
+city_cl_228,"Purén",base.state_cl_09,base.cl
+city_cl_229,"Renaico",base.state_cl_09,base.cl
+city_cl_230,"Traiguén",base.state_cl_09,base.cl
+city_cl_231,"Victoria",base.state_cl_09,base.cl
+city_cl_232,"Valdivia",base.state_cl_14,base.cl
+city_cl_233,"Corral",base.state_cl_14,base.cl
+city_cl_234,"Futrono",base.state_cl_14,base.cl
+city_cl_235,"La Unión",base.state_cl_14,base.cl
+city_cl_236,"Lago Ranco",base.state_cl_14,base.cl
+city_cl_237,"Lanco",base.state_cl_14,base.cl
+city_cl_238,"Los Lagos",base.state_cl_14,base.cl
+city_cl_239,"Máfil",base.state_cl_14,base.cl
+city_cl_240,"Mariquina",base.state_cl_14,base.cl
+city_cl_241,"Paillaco",base.state_cl_14,base.cl
+city_cl_242,"Panguipulli",base.state_cl_14,base.cl
+city_cl_243,"Río Bueno",base.state_cl_14,base.cl
+city_cl_244,"Puerto Montt",base.state_cl_10,base.cl
+city_cl_245,"Calbuco",base.state_cl_10,base.cl
+city_cl_246,"Cochamó",base.state_cl_10,base.cl
+city_cl_247,"Fresia",base.state_cl_10,base.cl
+city_cl_248,"Frutillar",base.state_cl_10,base.cl
+city_cl_249,"Los Muermos",base.state_cl_10,base.cl
+city_cl_250,"Llanquihue",base.state_cl_10,base.cl
+city_cl_251,"Maullín",base.state_cl_10,base.cl
+city_cl_252,"Puerto Varas",base.state_cl_10,base.cl
+city_cl_253,"Castro",base.state_cl_10,base.cl
+city_cl_254,"Ancud",base.state_cl_10,base.cl
+city_cl_255,"Chonchi",base.state_cl_10,base.cl
+city_cl_256,"Curaco De Vélez",base.state_cl_10,base.cl
+city_cl_257,"Dalcahue",base.state_cl_10,base.cl
+city_cl_258,"Puqueldón",base.state_cl_10,base.cl
+city_cl_259,"Queilén",base.state_cl_10,base.cl
+city_cl_260,"Quellón",base.state_cl_10,base.cl
+city_cl_261,"Quemchi",base.state_cl_10,base.cl
+city_cl_262,"Quinchao",base.state_cl_10,base.cl
+city_cl_263,"Osorno",base.state_cl_10,base.cl
+city_cl_264,"Puerto Octay",base.state_cl_10,base.cl
+city_cl_265,"Purranque",base.state_cl_10,base.cl
+city_cl_266,"Puyehue",base.state_cl_10,base.cl
+city_cl_267,"Río Negro",base.state_cl_10,base.cl
+city_cl_268,"San Juan De La Costa",base.state_cl_10,base.cl
+city_cl_269,"San Pablo",base.state_cl_10,base.cl
+city_cl_270,"Chaitén",base.state_cl_10,base.cl
+city_cl_271,"Futaleufú",base.state_cl_10,base.cl
+city_cl_272,"Hualaihué",base.state_cl_10,base.cl
+city_cl_273,"Palena",base.state_cl_10,base.cl
+city_cl_274,"Coyhaique",base.state_cl_11,base.cl
+city_cl_275,"Lago Verde",base.state_cl_11,base.cl
+city_cl_276,"Aysén",base.state_cl_11,base.cl
+city_cl_277,"Cisnes",base.state_cl_11,base.cl
+city_cl_278,"Guaitecas",base.state_cl_11,base.cl
+city_cl_279,"Cochrane",base.state_cl_11,base.cl
+city_cl_280,"O'Higgins",base.state_cl_11,base.cl
+city_cl_281,"Tortel",base.state_cl_11,base.cl
+city_cl_282,"Chile Chico",base.state_cl_11,base.cl
+city_cl_283,"Río Ibáñez",base.state_cl_11,base.cl
+city_cl_284,"Punta Arenas",base.state_cl_12,base.cl
+city_cl_285,"Laguna Blanca",base.state_cl_12,base.cl
+city_cl_286,"Río Verde",base.state_cl_12,base.cl
+city_cl_287,"San Gregorio",base.state_cl_12,base.cl
+city_cl_288,"Cabo De Hornos",base.state_cl_12,base.cl
+city_cl_289,"Antártica",base.state_cl_12,base.cl
+city_cl_290,"Porvenir",base.state_cl_12,base.cl
+city_cl_291,"Primavera",base.state_cl_12,base.cl
+city_cl_292,"Timaukel",base.state_cl_12,base.cl
+city_cl_293,"Natales",base.state_cl_12,base.cl
+city_cl_294,"Torres Del Paine",base.state_cl_12,base.cl
+city_cl_295,"Santiago",base.state_cl_13,base.cl
+city_cl_296,"Cerrillos",base.state_cl_13,base.cl
+city_cl_297,"Cerro Navia",base.state_cl_13,base.cl
+city_cl_298,"Conchalí",base.state_cl_13,base.cl
+city_cl_299,"El Bosque",base.state_cl_13,base.cl
+city_cl_300,"Estación Central",base.state_cl_13,base.cl
+city_cl_301,"Huechuraba",base.state_cl_13,base.cl
+city_cl_302,"Independencia",base.state_cl_13,base.cl
+city_cl_303,"La Cisterna",base.state_cl_13,base.cl
+city_cl_304,"La Florida",base.state_cl_13,base.cl
+city_cl_305,"La Granja",base.state_cl_13,base.cl
+city_cl_306,"La Pintana",base.state_cl_13,base.cl
+city_cl_307,"La Reina",base.state_cl_13,base.cl
+city_cl_308,"Las Condes",base.state_cl_13,base.cl
+city_cl_309,"Lo Barnechea",base.state_cl_13,base.cl
+city_cl_310,"Lo Espejo",base.state_cl_13,base.cl
+city_cl_311,"Lo Prado",base.state_cl_13,base.cl
+city_cl_312,"Macul",base.state_cl_13,base.cl
+city_cl_313,"Maipú",base.state_cl_13,base.cl
+city_cl_314,"Ñuñoa",base.state_cl_13,base.cl
+city_cl_315,"Pedro Aguirre Cerda",base.state_cl_13,base.cl
+city_cl_316,"Peñalolén",base.state_cl_13,base.cl
+city_cl_317,"Providencia",base.state_cl_13,base.cl
+city_cl_318,"Pudahuel",base.state_cl_13,base.cl
+city_cl_319,"Quilicura",base.state_cl_13,base.cl
+city_cl_320,"Quinta Normal",base.state_cl_13,base.cl
+city_cl_321,"Recoleta",base.state_cl_13,base.cl
+city_cl_322,"Renca",base.state_cl_13,base.cl
+city_cl_323,"San Joaquín",base.state_cl_13,base.cl
+city_cl_324,"San Miguel",base.state_cl_13,base.cl
+city_cl_325,"San Ramón",base.state_cl_13,base.cl
+city_cl_326,"Vitacura",base.state_cl_13,base.cl
+city_cl_327,"Puente Alto",base.state_cl_13,base.cl
+city_cl_328,"Pirque",base.state_cl_13,base.cl
+city_cl_329,"San José De Maipo",base.state_cl_13,base.cl
+city_cl_330,"Colina",base.state_cl_13,base.cl
+city_cl_331,"Lampa",base.state_cl_13,base.cl
+city_cl_332,"Til Til",base.state_cl_13,base.cl
+city_cl_333,"San Bernardo",base.state_cl_13,base.cl
+city_cl_334,"Buin",base.state_cl_13,base.cl
+city_cl_335,"Calera De Tango",base.state_cl_13,base.cl
+city_cl_336,"Paine",base.state_cl_13,base.cl
+city_cl_337,"Melipilla",base.state_cl_13,base.cl
+city_cl_338,"Alhué",base.state_cl_13,base.cl
+city_cl_339,"Curacaví",base.state_cl_13,base.cl
+city_cl_340,"María Pinto",base.state_cl_13,base.cl
+city_cl_341,"San Pedro",base.state_cl_13,base.cl
+city_cl_342,"Talagante",base.state_cl_13,base.cl
+city_cl_343,"El Monte",base.state_cl_13,base.cl
+city_cl_344,"Isla De Maipo",base.state_cl_13,base.cl
+city_cl_345,"Padre Hurtado",base.state_cl_13,base.cl
+city_cl_346,"Peñaflor",base.state_cl_13,base.cl

--- a/addons/l10n_cl/data/res_country.xml
+++ b/addons/l10n_cl/data/res_country.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="base.cl" model="res.country">
+        <field name="address_view_id" ref="cl_partner_address_form"/>
+        <field name="enforce_cities" eval="1"/>
+    </record>
+</odoo>

--- a/addons/l10n_cl/demo/partner_demo.xml
+++ b/addons/l10n_cl/demo/partner_demo.xml
@@ -4,7 +4,7 @@
     <record id="res_partner_bmya" model="res.partner">
         <field name="name">Blanco Martin &amp; Asociados EIRL</field>
         <field name="email">info@bmya.cl</field>
-        <field name="city">Las Condes</field>
+        <field name="city_id" ref="l10n_cl.city_cl_308"/>
         <field name="country_id" ref="base.cl"/>
         <field name="street">Apoquindo 6410</field>
         <field name="street2">Oficina 212, Santiago (RM)</field>
@@ -27,7 +27,7 @@
     <record id="res_partner_teksa" model="res.partner">
         <field name="name">Andes Innovación SpA</field>
         <field name="email">innovacion@andes.com</field>
-        <field name="city">Los Condes</field>
+        <field name="city_id" ref="l10n_cl.city_cl_308"/>
         <field name="country_id" ref="base.cl"/>
         <field name="street">Apoquindo 6988</field>
         <field name="street2">Santiago</field>

--- a/addons/l10n_cl/views/res_partner.xml
+++ b/addons/l10n_cl/views/res_partner.xml
@@ -1,25 +1,57 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
+    <record id="cl_partner_address_form" model="ir.ui.view">
+        <field name="name">partner.form.address.extended</field>
+        <field name="model">res.partner</field>
+        <field name="arch" type="xml">
+            <form>
+                <div class="o_address_format">
+                    <field name="country_enforce_cities" invisible="1"/>
+                    <field name="parent_id" invisible="1"/>
+                    <field name="type" invisible="1"/>
+                    <field name="street" placeholder="Street..." class="o_address_street"
+                           readonly="type == 'contact' and parent_id"/>
+                    <field name="street2" placeholder="Additional data address and city" class="o_address_street"
+                           readonly="type == 'contact' and parent_id"/>
+                    <field name="city_id"
+                           placeholder="Commune"
+                           class="o_address_city"
+                           domain="[('country_id', '=', country_id)]"
+                           invisible="not country_enforce_cities"
+                           readonly="type == 'contact' and parent_id"
+                           context="{'default_country_id': country_id, 'default_state_id': state_id, 'default_zipcode': zip}"/>
+                    <field name="city"
+                           placeholder="Commune"
+                           class="o_address_city"
+                           invisible="country_enforce_cities and (city_id or city in ('', False))"
+                           readonly="type == 'contact' and parent_id"/>
+                    <field name="state_id"
+                           class="o_address_state"
+                           placeholder="Region"
+                           readonly="type == 'contact' and parent_id"
+                           options="{'no_open': True, 'no_quick_create': True}"
+                           context="{'default_country_id': country_id}"/>
+                    <field name="zip" placeholder="ZIP" class="o_address_zip"
+                           readonly="type == 'contact' and parent_id"/>
+                    <field name="country_id"
+                           placeholder="Country"
+                           class="o_address_country"
+                           readonly="type == 'contact' and parent_id"
+                           options="{'no_open': True, 'no_create': True}"/>
+                </div>
+            </form>
+        </field>
+    </record>
 
     <record id="view_move_form" model="ir.ui.view">
         <field name="name">res.partner.placeholders.l10n_cl.form</field>
         <field name="inherit_id" ref="account.view_partner_property_form"/>
         <field name="model">res.partner</field>
         <field name="arch" type="xml">
-            <field name="street2" position="attributes">
-                <attribute name="placeholder">Additional data address and city</attribute>
-            </field>
-            <field name="city" position="attributes">
-                <attribute name="placeholder">Commune</attribute>
-            </field>
-            <field name="state_id" position="attributes">
-                <attribute name="placeholder">Region</attribute>
-            </field>
             <field name="vat" position="after">
-                <field name="l10n_cl_sii_taxpayer_type" invisible="'CL' not in fiscal_country_codes" readonly="parent_id"/>
+                <field name="l10n_cl_sii_taxpayer_type" placeholder="Taxpayer Type" invisible="'CL' not in fiscal_country_codes" readonly="parent_id"/>
                 <field name="l10n_cl_activity_description" placeholder="Activity Description" invisible="'CL' not in fiscal_country_codes"/>
             </field>
         </field>
     </record>
-
 </odoo>

--- a/addons/l10n_pe/__manifest__.py
+++ b/addons/l10n_pe/__manifest__.py
@@ -10,7 +10,7 @@
     'license': 'LGPL-3',
     'depends': [
         'base_vat',
-        'base_address_extended',
+        'portal_address_extended',
         'l10n_latam_base',
         'l10n_latam_invoice_document',
         'account_debit_note',

--- a/addons/l10n_pe/controllers/portal.py
+++ b/addons/l10n_pe/controllers/portal.py
@@ -12,29 +12,18 @@ class L10nPEPortalAccount(L10nLatamBasePortalAccount):
 
     def _prepare_address_form_values(self, partner_sudo, *args, **kwargs):
         rendering_values = super()._prepare_address_form_values(partner_sudo, *args, **kwargs)
-        if not self._is_peru_company():
-            return rendering_values
-
-        state = request.env['res.country.state'].browse(rendering_values['state_id'])
-        city = partner_sudo.city_id
-        ResCity = request.env['res.city'].sudo()
-        District = request.env['l10n_pe.res.city.district'].sudo()
-        rendering_values.update({
-            'state': state,
-            'state_cities': ResCity.search([('state_id', '=', state.id)]) if state else ResCity,
-            'city': city,
-            'city_districts': District.search([('city_id', '=', city.id)]) if city else District,
-        })
+        if self._is_peru_company():
+            city = partner_sudo.city_id
+            District = request.env['l10n_pe.res.city.district'].sudo()
+            rendering_values.update({
+                'city_districts': District.search([('city_id', '=', city.id)]) if city else District,
+            })
         return rendering_values
 
     def _get_mandatory_address_fields(self, country_sudo):
         mandatory_fields = super()._get_mandatory_address_fields(country_sudo)
-        if not self._is_peru_company():
-            return mandatory_fields
-
-        if country_sudo.code == 'PE':
-            mandatory_fields.update({'state_id', 'city_id', 'l10n_pe_district'})
-            mandatory_fields.remove('city')
+        if self._is_peru_company() and country_sudo.code == 'PE':
+            mandatory_fields.add('l10n_pe_district')
         return mandatory_fields
 
     def _l10n_get_default_identification_type_id(self):
@@ -42,17 +31,6 @@ class L10nPEPortalAccount(L10nLatamBasePortalAccount):
             (self.env.company.country_code == 'PE' and request.env.ref('l10n_pe.it_DNI'))
             or super()._l10n_get_default_identification_type_id()
         )
-
-    @route(
-        '/portal/state_infos/<model("res.country.state"):state>',
-        type='jsonrpc',
-        auth='public',
-        methods=['POST'],
-        website=True,
-    )
-    def state_infos(self, state, **kw):
-        states = request.env['res.city'].sudo().search([('state_id', '=', state.id)])
-        return {'cities': [(c.id, c.name, c.l10n_pe_code) for c in states]}
 
     @route(
         '/portal/city_infos/<model("res.city"):city>',

--- a/addons/l10n_pe/models/res_partner.py
+++ b/addons/l10n_pe/models/res_partner.py
@@ -27,6 +27,6 @@ class ResPartner(models.Model):
 
     def _get_frontend_writable_fields(self):
         frontend_writable_fields = super()._get_frontend_writable_fields()
-        frontend_writable_fields.update({'city_id', 'l10n_pe_district'})
+        frontend_writable_fields.add('l10n_pe_district')
 
         return frontend_writable_fields

--- a/addons/l10n_pe/static/src/interactions/address.js
+++ b/addons/l10n_pe/static/src/interactions/address.js
@@ -1,51 +1,18 @@
 import { patch } from '@web/core/utils/patch';
-import { patchDynamicContent } from '@web/public/utils';
 import { rpc } from '@web/core/network/rpc';
 import { CustomerAddress } from '@portal/interactions/address';
 
 patch(CustomerAddress.prototype, {
     setup() {
         super.setup();
-        patchDynamicContent(this.dynamicContent, {
-            'select[name="city_id"]': { 't-on-change': this.onChangeCity.bind(this) },
-        });
-
         this.isPeruvianCompany = this.countryCode === 'PE';
         if (this.isPeruvianCompany) {
-            this.elementState = this.addressForm.state_id;
-            this.elementCities = this.addressForm.city_id;
             this.elementDistricts = this.addressForm.l10n_pe_district;
         }
     },
 
-    _changeOption(selectElement, choices) {
-        // empty existing options, only keep the placeholder.
-        selectElement.options.length = 1;
-        if (choices.length) {
-            choices.forEach((item) => {
-                const option = new Option(item[1], item[0]);
-                option.setAttribute('data-code', item[2]);
-                selectElement.appendChild(option);
-            });
-        }
-    },
-
-    async onChangeState() {
-        await this.waitFor(super.onChangeState());
-        if (!this.isPeruvianCompany || this._getSelectedCountryCode() !== 'PE') return;
-
-        const stateId = this.elementState.value;
-        let choices = [];
-        if (stateId)  {
-            const data = await this.waitFor(rpc(`/portal/state_infos/${stateId}`, {}));
-            choices = data.cities;
-        }
-        this._changeOption(this.elementCities, choices);
-        // reset districts input as well
-        await this.onChangeCity();
-    },
-
     async onChangeCity() {
+        await super.onChangeCity();
         if (!this.isPeruvianCompany || this._getSelectedCountryCode() !== 'PE') return;
 
         const cityId = this.elementCities.value;
@@ -62,18 +29,9 @@ patch(CustomerAddress.prototype, {
         if (!this.isPeruvianCompany) return;
 
         if (this._getSelectedCountryCode() === 'PE') {
-            const cityInput = this.addressForm.city;
-            if (cityInput.value) {
-                cityInput.value = '';
-            }
-            this._hideInput('city');
-            this._showInput('city_id');
             this._showInput('l10n_pe_district');
         } else {
-            this._hideInput('city_id');
             this._hideInput('l10n_pe_district');
-            this._showInput('city');
-            this.elementCities.value = '';
             this.elementDistricts.value = '';
         }
     },

--- a/addons/l10n_pe/views/portal_address_templates.xml
+++ b/addons/l10n_pe/views/portal_address_templates.xml
@@ -2,26 +2,8 @@
 <odoo>
 
     <template id="address_form_fields" inherit_id="portal.address_form_fields">
-        <div id="div_state" position="after">
+        <div id="div_city_id" position="after">
             <t t-if="res_company.country_id.code == 'PE'">
-                <div
-                    id="div_city_id"
-                    class="col-lg-6 mb-3"
-                    t-att-style="(country and country.code != 'PE') and 'display:none;'"
-                >
-                    <label class="col-form-label" for="city_id">City</label>
-                    <select id="city_id" name="city_id" class="form-select" data-init="1">
-                        <option value="">City...</option>
-                        <option
-                            t-foreach="state_cities"
-                            t-as="city"
-                            t-att-value="city.id"
-                            t-att-selected="city.id == partner_sudo.city_id.id"
-                            t-out="city.name"
-                        />
-                    </select>
-                </div>
-
                 <div
                     id="div_district"
                     class="col-lg-6 mb-3"

--- a/addons/l10n_tw_edi_ecpay_website_sale/tests/test_l10n_tw_edi_website_sale.py
+++ b/addons/l10n_tw_edi_ecpay_website_sale/tests/test_l10n_tw_edi_website_sale.py
@@ -28,6 +28,7 @@ class TestUi(HttpCase):
             'phone': '+886 123 456 781',
         })
         website.company_id.account_fiscal_country_id = website.company_id.country_id = self.env.ref('base.tw')
+        website.company_id.country_id.enforce_cities = False
         self.env.ref('l10n_tw_edi_ecpay_website_sale.checkout_step_invoicing').website_id = website
         self.env.ref('l10n_tw_edi_ecpay_website_sale.checkout_step_invoicing').is_published = True
 

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -130,6 +130,9 @@ class TestPointOfSaleHttpCommon(AccountTestInvoicingHttpCommon):
             'name': 'Deco Addict',
         })
 
+        if 'enforce_cities' in cls.env['res.country']._fields:
+            cls.env.company.country_id.enforce_cities = False
+
         cash_journal = journal_obj.create({
             'name': 'Cash Test',
             'type': 'cash',

--- a/addons/portal/tests/test_portal.py
+++ b/addons/portal/tests/test_portal.py
@@ -96,6 +96,8 @@ class TestUsersHttp(HttpCase):
             'type': 'invoice',
             'parent_id': portal_user.commercial_partner_id.id,
         })
+        if 'enforce_cities' in self.env['res.country']._fields:
+            self.env.company.country_id.enforce_cities = False
         common_data = {
             'phone': '1234567890',
             'email': 'anonymous-user@example.com',

--- a/addons/portal/tests/test_tours.py
+++ b/addons/portal/tests/test_tours.py
@@ -20,6 +20,8 @@ class TestUi(HttpCaseWithUserDemo, HttpCaseWithUserPortal):
             "zip": "07002",
             "state_id": cls.env.ref("base.state_us_5").id,
         })
+        if 'enforce_cities' in cls.env['res.country']._fields:
+            cls.env.company.country_id.enforce_cities = False
 
     def test_01_portal_load_tour(self):
         self.start_tour("/", 'portal_load_homepage', login="portal")

--- a/addons/portal_address_extended/__init__.py
+++ b/addons/portal_address_extended/__init__.py
@@ -1,0 +1,4 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import controllers
+from . import models

--- a/addons/portal_address_extended/__manifest__.py
+++ b/addons/portal_address_extended/__manifest__.py
@@ -1,0 +1,25 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+{
+    'name': "Extended Addresses - Customer portal",
+    'summary': 'Add extra fields on addresses for Customer Portal',
+    'category': 'Hidden',
+    'description': """
+Extended Addresses Management (Customer Portal)
+===============================================
+
+This bridge module adds support for city dropdowns
+in the customer portal for the countries where cities are enforced.
+
+        """,
+    'data': [
+        'views/portal_address_templates.xml',
+    ],
+    'assets': {
+        'web.assets_frontend': [
+            'portal_address_extended/static/src/interactions/**/*',
+        ]
+    },
+    'depends': ['base_address_extended', 'portal'],
+    'author': 'Odoo S.A.',
+    'license': 'LGPL-3',
+}

--- a/addons/portal_address_extended/controllers/__init__.py
+++ b/addons/portal_address_extended/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import portal

--- a/addons/portal_address_extended/controllers/portal.py
+++ b/addons/portal_address_extended/controllers/portal.py
@@ -1,0 +1,48 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.http import request, route
+from odoo.addons.portal.controllers.portal import CustomerPortal
+
+
+class CustomerPortalExtended(CustomerPortal):
+
+    def _is_enforce_cities(self):
+        return request.env.company.country_id.enforce_cities
+
+    def _prepare_address_form_values(self, partner_sudo, *args, **kwargs):
+        rendering_values = super()._prepare_address_form_values(partner_sudo, *args, **kwargs)
+        if self._is_enforce_cities():
+            state_cities = request.env['res.city'].sudo().search([
+                ('country_id', '=', partner_sudo.country_id.id),
+            ])
+            rendering_values.setdefault('city', partner_sudo.city_id)
+            rendering_values.setdefault('state_cities', state_cities)
+        return rendering_values
+
+    def _get_mandatory_address_fields(self, country_sudo):
+        mandatory_fields = super()._get_mandatory_address_fields(country_sudo)
+        if self._is_enforce_cities() and country_sudo.enforce_cities:
+            mandatory_fields.add('city_id')
+            mandatory_fields.remove('city')
+        return mandatory_fields
+
+    def _parse_form_data(self, form_data):
+        address_values, extra_form_data = super()._parse_form_data(form_data)
+        country_id = address_values.get('country_id')
+        country_sudo = request.env['res.country'].browse(country_id)
+        if country_sudo.enforce_cities and self._is_enforce_cities() and form_data.get('city_id'):
+            if city := request.env['res.city'].sudo().browse(int(form_data['city_id'])):
+                address_values['city'] = city.name
+        return address_values, extra_form_data
+
+    @route(
+        '/my/address/state_info/<model("res.country.state"):state>',
+        type='jsonrpc',
+        auth='public',
+        methods=['POST'],
+        website=True,
+        readonly=True,
+    )
+    def portal_address_state_info(self, state, **kw):
+        cities = request.env['res.city'].sudo().search([('state_id', '=', state.id)])
+        return {'cities': [(city.id, city.name) for city in cities]}

--- a/addons/portal_address_extended/models/__init__.py
+++ b/addons/portal_address_extended/models/__init__.py
@@ -1,0 +1,1 @@
+from . import res_partner

--- a/addons/portal_address_extended/models/res_partner.py
+++ b/addons/portal_address_extended/models/res_partner.py
@@ -1,0 +1,13 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    def _get_frontend_writable_fields(self):
+        frontend_writable_fields = super()._get_frontend_writable_fields()
+        frontend_writable_fields.add('city_id')
+
+        return frontend_writable_fields

--- a/addons/portal_address_extended/views/portal_address_templates.xml
+++ b/addons/portal_address_extended/views/portal_address_templates.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="address_extended_form_fields" inherit_id="portal.address_form_fields">
+        <div id="div_state" position="after">
+            <input type="hidden" name="enforce_cities"
+                t-att-value="res_company.country_id.enforce_cities"/>
+            <div t-if="res_company.country_id.enforce_cities"
+                 id="div_city_id"
+                 class="col-lg-6 mb-2"
+                 t-att-style="not country and 'display:none;'" >
+                <label class="col-form-label label-optional" for="city_id">City</label>
+                <select id="o_city_id" name="city_id" class="form-select">
+                    <option value="">City...</option>
+                    <option t-foreach="state_cities"
+                            t-as="c"
+                            t-att-value="c.id"
+                            t-att-selected="c.id == (city.id if city else partner_sudo.city_id.id)"
+                            t-att-state-id="c.state_id.id"
+                            t-out="c.name"/>
+                </select>
+            </div>
+        </div>
+        <xpath expr="//select[@name='country_id']/option[not(@value='')]" position="attributes">
+            <attribute name="t-att-enforce-cities"
+                add="c.enforce_cities" />
+        </xpath>
+    </template>
+</odoo>

--- a/addons/website_sale/tests/common.py
+++ b/addons/website_sale/tests/common.py
@@ -62,6 +62,9 @@ class WebsiteSaleCommon(ProductCommon, DeliveryCommon):
                 'company_id': cls.env.company.id,
             })
 
+        if 'enforce_cities' in cls.env['res.country']._fields:
+            cls.env.company.country_id.enforce_cities = False
+
         cls.public_user = cls.website.user_id
         cls.public_partner = cls.public_user.partner_id
 

--- a/addons/website_sale/tests/test_delivery_ui.py
+++ b/addons/website_sale/tests/test_delivery_ui.py
@@ -18,6 +18,9 @@ class TestUi(HttpCase):
         })
         transfer_provider._transfer_ensure_pending_msg_is_set()
 
+        if 'enforce_cities' in self.env['res.country']._fields:
+            self.env.company.country_id.enforce_cities = False
+
         # Avoid Shipping/Billing address page
         self.env.ref('base.partner_admin').write({
             'street': '215 Vine St',


### PR DESCRIPTION
This commit introduces a new bridge module to centralize and simplify
the frontend address management logic when `enforce_cities=True`.

Before this commit:
---
- Several localization modules were overriding `base_address_extended` and its
  `address_form_fields` template to customize the address form.
- Each localization duplicated similar logic related to city selection.

In this commit:
---
- Add a new module `portal_address_extended` providing a generic frontend
  address template that supports selecting a city from the list of cities when
  `enforce_cities=True`.
- Enable enforce_cities support in Chile with added cities data.
- Adapt localization modules to rely on this common implementation.

---
If `enforce_cities=False`:
---
<img width="1826" height="941" alt="image" src="https://github.com/user-attachments/assets/47f667a7-cdbb-41e5-b9e2-3c62f16ce8ee" />

If `enforce_cities=True`:
---
`city selection` instead of `city text` field
<img width="1893" height="942" alt="image" src="https://github.com/user-attachments/assets/03f311f5-8e73-4ce6-897a-362af641f2ae" />


<img width="1821" height="942" alt="image" src="https://github.com/user-attachments/assets/695f2fc2-cde9-4a7d-9197-57edb3bf9160" />

---
Task-5098839

enterprise- odoo/enterprise#95885