### PR TITLE
[FIX] web: adapt kanban view for print

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_controller.scss
+++ b/addons/web/static/src/views/kanban/kanban_controller.scss
@@ -162,6 +162,7 @@
         overflow-wrap: break-word;
         word-wrap: break-word;
         word-break: break-word;
+        break-inside: avoid;
 
         &:first-of-type {
             margin-top: 1px;
@@ -181,6 +182,16 @@
             padding: var(--KanbanRecord-padding-v) var(--KanbanRecord-padding-h);
             border: $border-width solid $border-color;
             background-color: $o-view-background-color;
+
+            @include media-only(print) {
+                .o_field_background_image {
+                    height: auto;
+                }
+
+                div.o_field_widget.o_field_background_image > img {
+                    position: relative;
+                }
+            }
         }
 
         &:where(:not(.row)) {
@@ -200,6 +211,10 @@
             flex-flow: column;
             min-width: 0;
             height: 100%;
+
+            @include media-only(print) {
+                height: auto;
+            }
         }
 
         > footer, > main > footer {
@@ -220,9 +235,17 @@
                 --KanbanRecord__image-height: 100%;
                 --KanbanRecord__image-width: var(--KanbanRecord__image--fill-width);
 
+                @include media-only(print) {
+                    --KanbanRecord__image-height: auto;
+                }
+
                 .o_kanban_image_fill {
                     min-height: var(--KanbanRecord__image-fill-width);
                     max-height: var(--KanbanRecord__image-max-height, $o-kanban-image-fill-width * 1.5);
+
+                    @include media-only(print) {
+                        height: auto;
+                    }
                 }
 
                 > * {
@@ -231,6 +254,10 @@
                         margin-top: calc(var(--KanbanRecord-padding-v)* -1);
                         margin-bottom: calc(var(--KanbanRecord-padding-v)* -1);
                         margin-left: calc(var(--KanbanRecord-padding-h)* -1);
+                    }
+
+                    @include media-only(print) {
+                        height: auto;
                     }
                 }
             }


### PR DESCRIPTION
This commit fixes the kanban view print to better handle the page break. The issue was caused by the flex layout: when printing, heights often misbehave on the last row or at page breaks.

task-4630646

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
