### PR TITLE
[FIX] loading: reset transaction with default env

### DIFF
--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -538,7 +538,7 @@ def load_modules(
                 registry = Registry.new(
                     cr.dbname, update_module=update_module
                 )
-                cr.reset()
+                cr.transaction.reset()
                 registry.check_tables_exist(cr)
                 cr.commit()
                 return


### PR DESCRIPTION
When loading, keep the default environment for flushing. `cr.reset()` will remove the deafult environment from the transaction which we want to keep.

(runbot.build.error/232851)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
