### PR TITLE
[IMP] mail,*:powerbox for composer suggestion

### DIFF
--- a/addons/html_editor/static/src/main/powerbox/powerbox.xml
+++ b/addons/html_editor/static/src/main/powerbox/powerbox.xml
@@ -11,13 +11,16 @@
                     t-on-mouseenter="() => this.onMouseEnter(command_index)"
                     t-on-mousedown="(ev) => ev.preventDefault()"
                     t-on-click="() => this.props.applyCommand(command)">
-                    <div class="border rounded">
-                        <i class="o-we-command-img d-flex align-items-center justify-content-center fa" t-att-class="command.icon"/>
-                    </div>
-                    <div class="ms-3">
-                        <div class="o-we-command-name" t-esc="command.title"/>
-                        <div class="o-we-command-description" t-esc="command.description"/>
-                    </div>
+                    <t t-if="command.template" t-call="{{command.template}}" t-call-context="command.props"/>
+                    <t t-else="">
+                        <div class="border rounded">
+                            <i class="o-we-command-img d-flex align-items-center justify-content-center fa" t-att-class="command.icon"/>
+                        </div>
+                        <div class="ms-3">
+                            <div class="o-we-command-name" t-esc="command.title"/>
+                            <div class="o-we-command-description" t-esc="command.description"/>
+                        </div>
+                    </t>
                 </div>
             </t>
         </div>

--- a/addons/html_editor/static/src/main/powerbox/powerbox_plugin.js
+++ b/addons/html_editor/static/src/main/powerbox/powerbox_plugin.js
@@ -239,11 +239,13 @@ export class PowerboxPlugin extends Plugin {
                 break;
             case "ArrowUp": {
                 ev.preventDefault();
+                ev.stopImmediatePropagation();
                 this.state.currentIndex = rotate(this.state.currentIndex, this.state.commands, -1);
                 break;
             }
             case "ArrowDown": {
                 ev.preventDefault();
+                ev.stopImmediatePropagation();
                 this.state.currentIndex = rotate(this.state.currentIndex, this.state.commands, 1);
                 break;
             }

--- a/addons/mail/static/src/core/common/chat_window.js
+++ b/addons/mail/static/src/core/common/chat_window.js
@@ -110,7 +110,11 @@ export class ChatWindow extends Component {
             ev.stopPropagation();
             return;
         }
-        if (ev.target.closest(".o-dropdown") || ev.target.closest(".o-dropdown--menu")) {
+        if (
+            ev.target.closest(".o-dropdown") ||
+            ev.target.closest(".o-dropdown--menu") ||
+            document.querySelector(".o-we-powerbox")
+        ) {
             return;
         }
         ev.stopPropagation(); // not letting home menu steal my CTRL-C

--- a/addons/mail/static/src/core/common/composer.scss
+++ b/addons/mail/static/src/core/common/composer.scss
@@ -233,3 +233,9 @@
 .o-mail-Composer-suggestionList:has(.o-open) {
     border: $border-width solid $border-color;
 }
+
+.o-mail-Composer-suggestionImg {
+    height: 35px;
+    width: 35px;
+    background-color: $o-gray-100;
+}

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -131,7 +131,7 @@
             </div>
         </div>
     </div>
-    <NavigableList t-if="suggestion" class="'o-mail-Composer-suggestionList'" t-props="navigableListProps"/>
+    <NavigableList t-if="suggestion and !composerService.htmlEnabled" class="'o-mail-Composer-suggestionList'" t-props="navigableListProps"/>
 </t>
 
 <t t-name="mail.Composer.sendButton">
@@ -194,7 +194,7 @@
 
     <t t-name="mail.Composer.suggestionPartner">
         <t t-set="partner" t-value="option.partner"/>
-        <ImStatus t-if="partner" persona="partner"/>
+        <ImStatus t-if="option.showImStatus and partner" persona="partner"/>
         <strong class="px-2 py-1 align-self-center flex-shrink-0 text-truncate">
             <t t-esc="partner.name"/>
         </strong>

--- a/addons/mail/static/src/core/common/plugin/mail_suggestion_canned_response_plugin.js
+++ b/addons/mail/static/src/core/common/plugin/mail_suggestion_canned_response_plugin.js
@@ -1,0 +1,27 @@
+import { Plugin } from "@html_editor/plugin";
+
+export class MailSuggestionCannedResponsePlugin extends Plugin {
+    static id = "mail_suggestion_canned_response";
+    static dependencies = ["mail_suggestion"];
+    resources = {
+        mail_suggestion_type_formatters: {
+            type: "mail.canned.response",
+            formatter: (useSuggestion) => {
+                const suggestions = useSuggestion.state.items.suggestions;
+                return suggestions.map((suggestion) => ({
+                    commandId: suggestion.id,
+                    template: "mail.Composer.suggestionCannedResponse",
+                    props: {
+                        option: { source: suggestion.source, label: suggestion.substitution },
+                    },
+                    run: () => {
+                        useSuggestion.insert({
+                            cannedResponse: suggestion,
+                            label: suggestion.substitution,
+                        });
+                    },
+                }));
+            },
+        },
+    };
+}

--- a/addons/mail/static/src/core/common/plugin/mail_suggestion_channel_command_plugin.js
+++ b/addons/mail/static/src/core/common/plugin/mail_suggestion_channel_command_plugin.js
@@ -1,0 +1,26 @@
+import { Plugin } from "@html_editor/plugin";
+
+export class MailSuggestionChannelCommandPlugin extends Plugin {
+    static id = "mail_suggestion_channel_command";
+    static dependencies = ["mail_suggestion"];
+    resources = {
+        mail_suggestion_type_formatters: {
+            type: "ChannelCommand",
+            formatter: (useSuggestion) => {
+                const suggestions = useSuggestion.state.items.suggestions;
+                return suggestions.map((suggestion) => ({
+                    commandId: suggestion.id,
+                    icon: suggestion.icon,
+                    title: suggestion.name,
+                    description: suggestion.help,
+                    run: () => {
+                        useSuggestion.insert({
+                            channelCommand: suggestion,
+                            label: suggestion.name,
+                        });
+                    },
+                }));
+            },
+        },
+    };
+}

--- a/addons/mail/static/src/core/common/plugin/mail_suggestion_emoji_plugin.js
+++ b/addons/mail/static/src/core/common/plugin/mail_suggestion_emoji_plugin.js
@@ -1,0 +1,27 @@
+import { Plugin } from "@html_editor/plugin";
+
+export class MailSuggestionEmojiPlugin extends Plugin {
+    static id = "mail_suggestion_emoji";
+    static dependencies = ["mail_suggestion"];
+    resources = {
+        mail_suggestion_type_formatters: {
+            type: "emoji",
+            formatter: (useSuggestion) => {
+                const suggestions = useSuggestion.state.items.suggestions;
+                return suggestions.map((suggestion) => ({
+                    commandId: suggestion.id,
+                    template: "mail.Composer.suggestionEmoji",
+                    props: {
+                        option: { emoji: suggestion },
+                    },
+                    run: () => {
+                        useSuggestion.insert({
+                            emoji: suggestion,
+                            label: suggestion.codepoints,
+                        });
+                    },
+                }));
+            },
+        },
+    };
+}

--- a/addons/mail/static/src/core/common/plugin/mail_suggestion_partner_plugin.js
+++ b/addons/mail/static/src/core/common/plugin/mail_suggestion_partner_plugin.js
@@ -1,0 +1,58 @@
+import { Plugin } from "@html_editor/plugin";
+
+export class MailSuggestionPartnerPlugin extends Plugin {
+    static id = "mail_suggestion_partner";
+    static dependencies = ["mail_suggestion"];
+    resources = {
+        mail_suggestion_type_formatters: {
+            type: "Partner",
+            formatter: (useSuggestion) => {
+                const suggestions = useSuggestion.state.items.suggestions;
+                return suggestions.map((suggestion) => {
+                    if (suggestion.isSpecial) {
+                        return {
+                            commandId: suggestion.id,
+                            template: "mail.Composer.suggestionSpecial",
+                            props: {
+                                option: { ...suggestion },
+                            },
+                            run: () => {
+                                useSuggestion.insert({
+                                    ...suggestion,
+                                });
+                            },
+                        };
+                    } else if (suggestion.Model.getName() === "res.role") {
+                        return {
+                            commandId: suggestion.id,
+                            template: "mail.Composer.suggestionRole",
+                            props: {
+                                option: { label: suggestion.name, thread: suggestion.thread },
+                            },
+                            run: () => {
+                                useSuggestion.insert({
+                                    role: suggestion,
+                                    label: suggestion.name,
+                                });
+                            },
+                        };
+                    } else {
+                        return {
+                            commandId: suggestion.id,
+                            template: "mail.Composer.suggestionPartner",
+                            props: {
+                                option: { partner: suggestion, showImStatus: false },
+                            },
+                            run: () => {
+                                useSuggestion.insert({
+                                    partner: suggestion,
+                                    label: suggestion.name,
+                                });
+                            },
+                        };
+                    }
+                });
+            },
+        },
+    };
+}

--- a/addons/mail/static/src/core/common/plugin/mail_suggestion_plugin.js
+++ b/addons/mail/static/src/core/common/plugin/mail_suggestion_plugin.js
@@ -1,0 +1,28 @@
+import { Plugin } from "@html_editor/plugin";
+
+export class MailSuggestionPlugin extends Plugin {
+    static id = "mail_suggestion";
+    static dependencies = ["powerbox"];
+    static shared = ["openSuggestionPowerbox"];
+
+    openSuggestionPowerbox(useSuggestion) {
+        const commands = this.formatPowerboxCommands(useSuggestion);
+        if (!commands || commands.length === 0) {
+            return;
+        }
+        this.dependencies.powerbox.openPowerbox({
+            commands,
+        });
+    }
+
+    formatPowerboxCommands(useSuggestion) {
+        const mailSuggestionTypeFormatters = this.getResource("mail_suggestion_type_formatters");
+        const mailSuggestionTypeFormatterDict = Object.fromEntries(
+            mailSuggestionTypeFormatters.map((typeFormatter) => [
+                typeFormatter.type,
+                typeFormatter.formatter,
+            ])
+        );
+        return mailSuggestionTypeFormatterDict[useSuggestion.state.items.type]?.(useSuggestion);
+    }
+}

--- a/addons/mail/static/src/core/common/plugin/mail_suggestion_thread_plugin.js
+++ b/addons/mail/static/src/core/common/plugin/mail_suggestion_thread_plugin.js
@@ -1,0 +1,27 @@
+import { Plugin } from "@html_editor/plugin";
+
+export class MailSuggestionThreadPlugin extends Plugin {
+    static id = "mail_suggestion_thread";
+    static dependencies = ["mail_suggestion"];
+    resources = {
+        mail_suggestion_type_formatters: {
+            type: "Thread",
+            formatter: (useSuggestion) => {
+                const suggestions = useSuggestion.state.items.suggestions;
+                return suggestions.map((suggestion) => ({
+                    commandId: suggestion.id,
+                    template: "mail.Composer.suggestionThread",
+                    props: {
+                        option: { thread: suggestion },
+                    },
+                    run: () => {
+                        useSuggestion.insert({
+                            thread: suggestion,
+                            label: suggestion.fullNameWithParent,
+                        });
+                    },
+                }));
+            },
+        },
+    };
+}

--- a/addons/mail/static/src/core/common/plugin/plugin_sets.js
+++ b/addons/mail/static/src/core/common/plugin/plugin_sets.js
@@ -5,25 +5,31 @@ import { InlineCodePlugin } from "@html_editor/main/inline_code";
 import { TabulationPlugin } from "@html_editor/main/tabulation_plugin";
 import { HintPlugin } from "@html_editor/main/hint_plugin";
 import { MailComposerPlugin } from "@mail/core/common/plugin/mail_composer_plugin";
+import { MailSuggestionPlugin } from "@mail/core/common/plugin/mail_suggestion_plugin";
+import { MailSuggestionPartnerPlugin } from "@mail/core/common/plugin/mail_suggestion_partner_plugin";
+import { MailSuggestionEmojiPlugin } from "@mail/core/common/plugin/mail_suggestion_emoji_plugin";
+import { MailSuggestionCannedResponsePlugin } from "@mail/core/common/plugin/mail_suggestion_canned_response_plugin";
+import { MailSuggestionChannelCommandPlugin } from "@mail/core/common/plugin/mail_suggestion_channel_command_plugin";
+import { MailSuggestionThreadPlugin } from "@mail/core/common/plugin/mail_suggestion_thread_plugin";
 import { ChatGPTTranslatePlugin } from "@html_editor/main/chatgpt/chatgpt_translate_plugin";
+import { PowerboxPlugin } from "@html_editor/main/powerbox/powerbox_plugin";
 
-export const MAIL_PLUGINS = [
+export const MAIL_CORE_PLUGINS = [
     ...CORE_PLUGINS,
     ChatGPTTranslatePlugin,
     HintPlugin,
     InlineCodePlugin,
     MailComposerPlugin,
+    MailSuggestionCannedResponsePlugin,
+    MailSuggestionChannelCommandPlugin,
+    MailSuggestionEmojiPlugin,
+    MailSuggestionPartnerPlugin,
+    MailSuggestionPlugin,
+    MailSuggestionThreadPlugin,
+    PowerboxPlugin,
     ShortCutPlugin,
     TabulationPlugin,
-    ToolbarPlugin,
 ];
 
-export const MAIL_SMALL_UI_PLUGINS = [
-    ...CORE_PLUGINS,
-    ChatGPTTranslatePlugin,
-    HintPlugin,
-    InlineCodePlugin,
-    MailComposerPlugin,
-    ShortCutPlugin,
-    TabulationPlugin,
-];
+export const MAIL_PLUGINS = [...CORE_PLUGINS, ...MAIL_CORE_PLUGINS, ToolbarPlugin];
+export const MAIL_SMALL_UI_PLUGINS = MAIL_PLUGINS;

--- a/addons/mail/static/src/discuss/core/common/channel_commands.js
+++ b/addons/mail/static/src/discuss/core/common/channel_commands.js
@@ -5,14 +5,17 @@ const commandRegistry = registry.category("discuss.channel_commands");
 
 commandRegistry
     .add("help", {
+        icon: "fa-info",
         help: _t("Show a helper message"),
         methodName: "execute_command_help",
     })
     .add("leave", {
+        icon: "fa-sign-out",
         help: _t("Leave this channel"),
         methodName: "execute_command_leave",
     })
     .add("who", {
+        icon: "oi oi-users",
         channel_types: ["channel", "chat", "group"],
         help: _t("List users in the current channel"),
         methodName: "execute_command_who",

--- a/addons/mail/static/src/discuss/core/common/suggestion_service_patch.js
+++ b/addons/mail/static/src/discuss/core/common/suggestion_service_patch.js
@@ -77,6 +77,7 @@ const suggestionServicePatch = {
             .map(([name, command]) => ({
                 channel_types: command.channel_types,
                 help: command.help,
+                icon: command.icon,
                 id: command.id,
                 name,
             }));

--- a/addons/mail/static/tests/composer/composer.test.js
+++ b/addons/mail/static/tests/composer/composer.test.js
@@ -1100,8 +1100,8 @@ test('display canned response suggestions on typing "::"', async () => {
         editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
     };
     await htmlInsertText(editor, "::");
-    await contains(".o-mail-Composer-suggestionList .o-open");
-    await contains(".o-mail-NavigableList-item", { text: "helloHello! How are you?" });
+    await contains(".o-we-powerbox");
+    await contains(".o-we-command", { text: "helloHello! How are you?" });
 });
 
 test("[text composer] select a canned response suggestion", async () => {
@@ -1153,7 +1153,7 @@ test("select a canned response suggestion", async () => {
         editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
     };
     await htmlInsertText(editor, "::");
-    await click(".o-mail-Composer-suggestion");
+    await click(".o-we-command");
     await contains(".o-mail-Composer-html.odoo-editor-editable", { text: "Hello! How are you?" });
 });
 
@@ -1209,7 +1209,7 @@ test("select a canned response suggestion with some text", async () => {
     await htmlInsertText(editor, "bluhbluh ");
     await contains(".o-mail-Composer-html.odoo-editor-editable", { text: "bluhbluh" });
     await htmlInsertText(editor, "::");
-    await click(".o-mail-Composer-suggestion");
+    await click(".o-we-command");
     await contains(".o-mail-Composer-html.odoo-editor-editable", {
         text: "bluhbluh\u00A0Hello! How are you?",
     });
@@ -1451,16 +1451,16 @@ test("can quickly add emoji with ':' keyword", async () => {
         editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
     };
     await htmlInsertText(editor, ":sweat");
-    await contains(".o-mail-Composer-suggestionList .o-open");
-    await contains(".o-mail-NavigableList-item", { text: "😅:sweat_smile:" });
-    await click(".o-mail-NavigableList-item", { text: "😅:sweat_smile:" });
+    await contains(".o-we-powerbox");
+    await contains(".o-we-command", { text: "😅:sweat_smile:" });
+    await click(".o-we-command", { text: "😅:sweat_smile:" });
     await contains(".o-mail-Composer-html.odoo-editor-editable", { text: "😅" });
-    await contains(".o-mail-Composer-suggestionList .o-open", { count: 0 });
+    await contains(".o-we-powerbox", { count: 0 });
     await htmlInsertText(editor, " :sw");
-    await contains(".o-mail-Composer-suggestionList .o-open");
-    await contains(".o-mail-NavigableList-item", { text: "😅:sweat_smile:" });
+    await contains(".o-we-powerbox");
+    await contains(".o-we-command", { text: "😅:sweat_smile:" });
     await htmlInsertText(editor, ":s", { replace: true });
-    await contains(".o-mail-Composer-suggestionList .o-open", { count: 0 });
+    await contains(".o-we-powerbox", { count: 0 });
 });
 
 test("composer reply-to message is restored on thread change", async () => {

--- a/addons/mail/static/tests/discuss/core/suggestion.test.js
+++ b/addons/mail/static/tests/discuss/core/suggestion.test.js
@@ -4,6 +4,7 @@ import {
     click,
     contains,
     defineMailModels,
+    focus,
     insertText,
     openDiscuss,
     start,
@@ -53,15 +54,13 @@ test("display command suggestions on typing '/'", async () => {
     const composerService = getService("mail.composer");
     composerService.setHtmlComposer();
     await openDiscuss(channelId);
-    await contains(".o-mail-Composer-suggestionList");
-    await contains(".o-mail-Composer-suggestionList .o-open", { count: 0 });
     await focus(".o-mail-Composer-html.odoo-editor-editable");
     const editor = {
         document,
         editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
     };
     await htmlInsertText(editor, "/");
-    await contains(".o-mail-Composer-suggestionList .o-open");
+    await contains(".o-we-powerbox");
 });
 
 test("[text composer] use a command for a specific channel type", async () => {
@@ -85,15 +84,13 @@ test("use a command for a specific channel type", async () => {
     const composerService = getService("mail.composer");
     composerService.setHtmlComposer();
     await openDiscuss(channelId);
-    await contains(".o-mail-Composer-suggestionList");
-    await contains(".o-mail-Composer-suggestionList .o-open", { count: 0 });
     await focus(".o-mail-Composer-html.odoo-editor-editable");
     const editor = {
         document,
         editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
     };
     await htmlInsertText(editor, "/");
-    await click(".o-mail-Composer-suggestion strong", { text: "who" });
+    await click(".o-we-command .o-we-command-name", { text: "who" });
     await contains(".o-mail-Composer-html.odoo-editor-editable", { text: "/who" });
 });
 
@@ -126,8 +123,6 @@ test("command suggestion should only open if command is the first character", as
     const composerService = getService("mail.composer");
     composerService.setHtmlComposer();
     await openDiscuss(channelId);
-    await contains(".o-mail-Composer-suggestionList");
-    await contains(".o-mail-Composer-suggestionList .o-open", { count: 0 });
     await focus(".o-mail-Composer-html.odoo-editor-editable");
     const editor = {
         document,
@@ -137,7 +132,7 @@ test("command suggestion should only open if command is the first character", as
     await contains(".o-mail-Composer-html.odoo-editor-editable", { text: "bluhbluh" });
     await htmlInsertText(editor, "/");
     // weak test, no guarantee that we waited long enough for the potential list to open
-    await contains(".o-mail-Composer-suggestionList .o-open", { count: 0 });
+    await contains(".o-we-powerbox .o-we-command", { count: 0 });
 });
 
 test("Sort partner suggestions by recent chats", async () => {
@@ -272,19 +267,17 @@ test("command suggestion are shown after deleting a character", async () => {
     const composerService = getService("mail.composer");
     composerService.setHtmlComposer();
     await openDiscuss(channelId);
-    await contains(".o-mail-Composer-suggestionList");
-    await contains(".o-mail-Composer-suggestionList .o-open", { count: 0 });
     await focus(".o-mail-Composer-html.odoo-editor-editable");
     const editor = {
         document,
         editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
     };
     await htmlInsertText(editor, "/he");
-    await contains(".o-mail-Composer-suggestion strong", { text: "help" });
+    await contains(".o-we-command .o-we-command-name", { text: "help" });
     await htmlInsertText(editor, "e");
-    await contains(".o-mail-Composer-suggestion strong", { count: 0, text: "help" });
+    await contains(".o-we-command .o-we-command-name", { count: 0, text: "help" });
     await press("Backspace");
-    await contains(".o-mail-Composer-suggestion strong", { text: "help" });
+    await contains(".o-we-command .o-we-command-name", { text: "help" });
 });
 
 test("mention suggestion displays OdooBot before archived partners", async () => {

--- a/addons/mail/static/tests/suggestion/suggestion.test.js
+++ b/addons/mail/static/tests/suggestion/suggestion.test.js
@@ -94,7 +94,7 @@ test("display partner mention suggestions on typing '@'", async () => {
     };
     await focus(".o-mail-Composer-html.odoo-editor-editable");
     await htmlInsertText(editor, "@");
-    await contains(".o-mail-Composer-suggestion strong", { count: 3 });
+    await contains(".o-we-command strong", { count: 3 });
 });
 
 test("[text composer] can @user in restricted (group_public_id) channels", async () => {
@@ -159,7 +159,7 @@ test("can @user in restricted (group_public_id) channels", async () => {
     };
     await focus(".o-mail-Composer-html.odoo-editor-editable");
     await htmlInsertText(editor, "@");
-    await contains(".o-mail-Composer-suggestion strong", { count: 2 });
+    await contains(".o-we-command strong", { count: 2 });
 });
 
 test("[text composer] post a first message then display partner mention suggestions on typing '@'", async () => {
@@ -225,7 +225,7 @@ test("post a first message then display partner mention suggestions on typing '@
     await press("Enter");
     await contains(".o-mail-Message");
     await htmlInsertText(editor, "@");
-    await contains(".o-mail-Composer-suggestion strong", { count: 3 });
+    await contains(".o-we-command strong", { count: 3 });
 });
 
 test('[text composer] display partner mention suggestions on typing "@" in chatter', async () => {
@@ -251,7 +251,7 @@ test('display partner mention suggestions on typing "@" in chatter', async () =>
         editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
     };
     await htmlInsertText(editor, "@");
-    await contains(".o-mail-Composer-suggestion strong", { text: "Mitchell Admin" });
+    await contains(".o-we-command strong", { text: "Mitchell Admin" });
 });
 
 test("[text composer] Do not fetch if search more specific and fetch had no result", async () => {
@@ -291,11 +291,11 @@ test("Do not fetch if search more specific and fetch had no result", async () =>
     };
     await focus(".o-mail-Composer-html.odoo-editor-editable");
     await htmlInsertText(editor, "@");
-    await contains(".o-mail-Composer-suggestion", { count: 3 }); // Mitchell Admin, Hermit, Public user
-    await contains(".o-mail-Composer-suggestion", { text: "Mitchell Admin" });
+    await contains(".o-we-command", { count: 3 }); // Mitchell Admin, Hermit, Public user
+    await contains(".o-we-command", { text: "Mitchell Admin" });
     await expect.waitForSteps(["get_mention_suggestions"]);
     await htmlInsertText(editor, "x");
-    await contains(".o-mail-Composer-suggestion", { count: 0 });
+    await contains(".o-we-command", { count: 0 });
     await expect.waitForSteps(["get_mention_suggestions"]);
     await htmlInsertText(editor, "x");
     await expect.waitForSteps([]);
@@ -345,7 +345,7 @@ test("show other channel member in @ mention", async () => {
     };
     await focus(".o-mail-Composer-html.odoo-editor-editable");
     await htmlInsertText(editor, "@");
-    await contains(".o-mail-Composer-suggestion strong", { text: "TestPartner" });
+    await contains(".o-we-command strong", { text: "TestPartner" });
 });
 
 test("[text composer] select @ mention insert mention text in composer", async () => {
@@ -393,7 +393,7 @@ test("select @ mention insert mention text in composer", async () => {
     };
     await focus(".o-mail-Composer-html.odoo-editor-editable");
     await htmlInsertText(editor, "@");
-    await click(".o-mail-Composer-suggestion strong", { text: "TestPartner" });
+    await click(".o-we-command strong", { text: "TestPartner" });
     await contains(".o-mail-Composer-html.odoo-editor-editable", { text: "@TestPartner" });
 });
 
@@ -442,8 +442,8 @@ test("select @ mention closes suggestions", async () => {
     };
     await focus(".o-mail-Composer-html.odoo-editor-editable");
     await htmlInsertText(editor, "@");
-    await click(".o-mail-Composer-suggestion strong", { text: "TestPartner" });
-    await contains(".o-mail-Composer-suggestion strong", { count: 0 });
+    await click(".o-we-command strong", { text: "TestPartner" });
+    await contains(".o-we-command strong", { count: 0 });
 });
 
 test('[text composer] display channel mention suggestions on typing "#"', async () => {
@@ -477,10 +477,8 @@ test('display channel mention suggestions on typing "#"', async () => {
         editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
     };
     await focus(".o-mail-Composer-html.odoo-editor-editable");
-    await contains(".o-mail-Composer-suggestionList");
-    await contains(".o-mail-Composer-suggestionList .o-open", { count: 0 });
     await htmlInsertText(editor, "#");
-    await contains(".o-mail-Composer-suggestionList .o-open");
+    await contains(".o-we-powerbox .o-we-command");
 });
 
 test("[text composer] mention a channel", async () => {
@@ -516,11 +514,9 @@ test("mention a channel", async () => {
         editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
     };
     await focus(".o-mail-Composer-html.odoo-editor-editable");
-    await contains(".o-mail-Composer-suggestionList");
-    await contains(".o-mail-Composer-suggestionList .o-open", { count: 0 });
     await contains(".o-mail-Composer-html.odoo-editor-editable", { text: "" });
     await htmlInsertText(editor, "#");
-    await click(".o-mail-Composer-suggestion");
+    await click(".o-we-command");
     await contains(".o-mail-Composer-html.odoo-editor-editable", { text: "#General" });
 });
 
@@ -578,17 +574,16 @@ test("mention a channel thread", async () => {
         editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
     };
     await focus(".o-mail-Composer-html.odoo-editor-editable");
-    await contains(".o-mail-Composer-suggestionList");
-    await contains(".o-mail-Composer-suggestionList .o-open", { count: 0 });
     await contains(".o-mail-Composer-html.odoo-editor-editable", { text: "" });
     await htmlInsertText(editor, "#");
-    await contains(".o-mail-Composer-suggestion", { count: 2 });
-    await contains(".o-mail-Composer-suggestion:eq(0):has(i.fa-hashtag)", { text: "General" });
-    await contains(".o-mail-Composer-suggestion:eq(1):has(i.fa-comments-o)", {
+    await contains(".o-we-command", { count: 2 });
+    await contains(".o-we-command:eq(0)", { text: "General" });
+    await contains(".o-we-command:eq(1)", {
         text: "GeneralThreadOne",
     });
-    await click(".o-mail-Composer-suggestion:eq(1)");
+    await click(".o-we-command:eq(1)");
     await contains(".o-mail-Composer-html.odoo-editor-editable", { text: "#General > ThreadOne" });
+    await contains(".o-we-powerbox .o-we-command", { count: 0 });
     await press("Enter");
     await contains(".o-mail-Message a.o_channel_redirect:has(i.fa-comments-o)", {
         text: "General > ThreadOne",
@@ -670,11 +665,11 @@ test("Suggestions are shown after delimiter was used in text (@)", async () => {
     };
     await focus(".o-mail-Composer-html.odoo-editor-editable");
     await htmlInsertText(editor, "@");
-    await contains(".o-mail-Composer-suggestion");
+    await contains(".o-we-command");
     await htmlInsertText(editor, "NonExistingUser");
-    await contains(".o-mail-Composer-suggestion strong", { count: 0 });
+    await contains(".o-we-command strong", { count: 0 });
     await htmlInsertText(editor, " @");
-    await contains(".o-mail-Composer-suggestion strong", { text: "Mitchell Admin" });
+    await contains(".o-we-command strong", { text: "Mitchell Admin" });
 });
 
 test("[text composer] Suggestions are shown after delimiter was used in text (#)", async () => {
@@ -705,11 +700,11 @@ test("Suggestions are shown after delimiter was used in text (#)", async () => {
     };
     await focus(".o-mail-Composer-html.odoo-editor-editable");
     await htmlInsertText(editor, "#");
-    await contains(".o-mail-Composer-suggestion");
+    await contains(".o-we-command");
     await htmlInsertText(editor, "NonExistingChannel");
-    await contains(".o-mail-Composer-suggestion strong", { count: 0 });
+    await contains(".o-we-command strong", { count: 0 });
     await htmlInsertText(editor, " #");
-    await contains(".o-mail-Composer-suggestion strong", { text: "General" });
+    await contains(".o-we-command strong", { text: "General" });
 });
 
 test("[text composer] display partner mention when typing more than 2 words if they match", async () => {
@@ -769,12 +764,12 @@ test("display partner mention when typing more than 2 words if they match", asyn
     };
     await focus(".o-mail-Composer-html.odoo-editor-editable");
     await htmlInsertText(editor, "@My ");
-    await contains(".o-mail-Composer-suggestion strong", { count: 3 });
+    await contains(".o-we-command strong", { count: 3 });
     await htmlInsertText(editor, "Test ");
-    await contains(".o-mail-Composer-suggestion strong", { count: 2 });
+    await contains(".o-we-command strong", { count: 2 });
     await htmlInsertText(editor, "Partner");
-    await contains(".o-mail-Composer-suggestion");
-    await contains(".o-mail-Composer-suggestion strong", { text: "My Test Partner" });
+    await contains(".o-we-command");
+    await contains(".o-we-command strong", { text: "My Test Partner" });
 });
 
 test("[text composer] Internal user should be displayed first", async () => {
@@ -846,10 +841,19 @@ test("Internal user should be displayed first", async () => {
     };
     await focus(".o-mail-Composer-html.odoo-editor-editable");
     await htmlInsertText(editor, "@Person ");
-    await contains(":nth-child(1 of .o-mail-Composer-suggestion) strong", { text: "Person D" });
-    await contains(":nth-child(2 of .o-mail-Composer-suggestion) strong", { text: "Person C" });
-    await contains(":nth-child(3 of .o-mail-Composer-suggestion) strong", { text: "Person B" });
-    await contains(":nth-child(4 of .o-mail-Composer-suggestion) strong", { text: "Person A" });
+    await contains(".o-we-command", {
+        text: "Person D",
+        before: [".o-we-command", { text: "Person C" }],
+    });
+    await contains(".o-we-command", {
+        text: "Person C",
+        before: [".o-we-command", { text: "Person B" }],
+    });
+    await contains(".o-we-command", {
+        text: "Person B",
+        before: [".o-we-command", { text: "Person A" }],
+    });
+    await contains(".o-we-command", { text: "Person A" });
 });
 
 test("[text composer] Current user that is a follower should be considered as such", async () => {
@@ -910,14 +914,14 @@ test("Current user that is a follower should be considered as such", async () =>
     };
     await focus(".o-mail-Composer-html.odoo-editor-editable");
     await htmlInsertText(editor, "@");
-    await contains(".o-mail-Composer-suggestion", { count: 5 });
-    await contains(".o-mail-Composer-suggestion", {
+    await contains(".o-we-command", { count: 5 });
+    await contains(".o-we-command", {
         text: "Mitchell Admin",
-        before: [".o-mail-Composer-suggestion", { text: "Person B(b@test.com)" }],
+        before: [".o-we-command", { text: "Person B" }],
     });
-    await contains(".o-mail-Composer-suggestion", {
-        text: "Person B(b@test.com)",
-        before: [".o-mail-Composer-suggestion", { text: "Person A(a@test.com)" }],
+    await contains(".o-we-command", {
+        text: "Person B",
+        before: [".o-we-command", { text: "Person A" }],
     });
 });
 
@@ -957,12 +961,11 @@ test("Mention with @everyone", async () => {
         editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
     };
     await focus(".o-mail-Composer-html.odoo-editor-editable");
-    await contains(".o-mail-Composer-suggestionList");
-    await contains(".o-mail-Composer-suggestionList .o-open", { count: 0 });
     await contains(".o-mail-Composer-html.odoo-editor-editable", { text: "" });
     await htmlInsertText(editor, "@ever");
-    await click(".o-mail-Composer-suggestion");
+    await click(".o-we-command");
     await contains(".o-mail-Composer-html.odoo-editor-editable", { text: "@everyone" });
+    await contains(".o-we-powerbox .o-we-command", { count: 0 });
     await press("Enter");
     await contains(".o-mail-Message-bubble.o-orange");
     await contains(".o-mail-Message a:contains('@everyone')");
@@ -1002,14 +1005,14 @@ test("Suggestions that begin with the search term should have priority", async (
     };
     await focus(".o-mail-Composer-html.odoo-editor-editable");
     await htmlInsertText(editor, "@");
-    await contains(".o-mail-Composer-suggestion", {
+    await contains(".o-we-command", {
         text: "Best Partner",
-        before: [".o-mail-Composer-suggestion", { text: "Party Partner" }],
+        before: [".o-we-command", { text: "Party Partner" }],
     });
     await htmlInsertText(editor, "part");
-    await contains(".o-mail-Composer-suggestion", {
+    await contains(".o-we-command", {
         text: "Party Partner",
-        before: [".o-mail-Composer-suggestion", { text: "Best Partner" }],
+        before: [".o-we-command", { text: "Best Partner" }],
     });
 });
 
@@ -1102,12 +1105,11 @@ test("Mention with @-role", async () => {
         editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
     };
     await focus(".o-mail-Composer-html.odoo-editor-editable");
-    await contains(".o-mail-Composer-suggestionList");
-    await contains(".o-mail-Composer-suggestionList .o-open", { count: 0 });
     await contains(".o-mail-Composer-html.odoo-editor-editable", { text: "" });
     await htmlInsertText(editor, "@discuss");
-    await click(".o-mail-Composer-suggestion");
+    await click(".o-we-command");
     await contains(".o-mail-Composer-html.odoo-editor-editable", { text: "@rd-Discuss" });
+    await contains(".o-we-powerbox .o-we-command", { count: 0 });
     await press("Enter");
     await contains(".o-mail-Message a.o-discuss-mention", {
         text: "@rd-Discuss",
@@ -1198,12 +1200,11 @@ test("Mention with @-role send correct role id", async () => {
         editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
     };
     await focus(".o-mail-Composer-html.odoo-editor-editable");
-    await contains(".o-mail-Composer-suggestionList");
-    await contains(".o-mail-Composer-suggestionList .o-open", { count: 0 });
     await contains(".o-mail-Composer-html.odoo-editor-editable", { text: "" });
     await htmlInsertText(editor, "@discuss");
-    await click(".o-mail-Composer-suggestion");
+    await click(".o-we-command");
     await contains(".o-mail-Composer-html.odoo-editor-editable", { text: "@rd-Discuss" });
+    await contains(".o-we-powerbox .o-we-command", { count: 0 });
     await press("Enter");
     await contains(".o-mail-Message a.o-discuss-mention", { text: "@rd-Discuss" });
     await expect.waitForSteps(["message_post"]);
@@ -1303,8 +1304,6 @@ test("Mention with @-role trigger one RPC only", async () => {
         editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
     };
     await focus(".o-mail-Composer-html.odoo-editor-editable");
-    await contains(".o-mail-Composer-suggestionList");
-    await contains(".o-mail-Composer-suggestionList .o-open", { count: 0 });
     await contains(".o-mail-Message", { text: "message fetched" });
     await contains(".o-discuss-ChannelMember", { text: "Discuss guru" });
     await contains(".o-mail-Composer-html.odoo-editor-editable", { text: "" });
@@ -1315,8 +1314,8 @@ test("Mention with @-role trigger one RPC only", async () => {
         }
     });
     await htmlInsertText(editor, "@discuss");
-    await contains(".o-mail-Composer-suggestion strong", { text: "Discuss guru" });
-    await contains(".o-mail-Composer-suggestion strong", { text: "rd-Discuss" });
+    await contains(".o-we-command strong", { text: "Discuss guru" });
+    await contains(".o-we-command strong", { text: "rd-Discuss" });
     await expect.waitForSteps([
         "/web/dataset/call_kw/res.partner/get_mention_suggestions_from_channel",
     ]);


### PR DESCRIPTION
Use powerbox to display suggestions in HTML composer.
This improves the UX of these features.

Also, this commit introduce the MailSuggestionPlugin which can be
further extended to support suggestions in full composer fields,
replacing the mention list at this moment.
https://github.com/odoo/enterprise/pull/96841

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
