### PR TITLE
[FIX] account: displays correct number to reconcile

### DIFF
--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -453,7 +453,6 @@ class account_journal(models.Model):
                AND st_line.company_id IN %s
                AND NOT st_line.is_reconciled
                AND st_line_move.checked IS TRUE
-               AND st_line_move.state = 'posted'
           GROUP BY st_line.journal_id
         """, [tuple(bank_cash_journals.ids), tuple(self.env.companies.ids)])
         number_to_reconcile = {


### PR DESCRIPTION
Steps to reproduce:
- go to daschboard > N to reconcile
- validate the first entry
- back to dashboard you will N-1 to reconcile
- Reset to to draft the journal entry associated with the reconciliation
- Reset the bank reconciliation

Issue
Back to the dashboard you will see N-1 to reconcile but when clicking on it you will have 8 entries to reconcile

Cause:
We filter out non posted entries. In Odoo, draft entrie can be reconciled.

opw-5102016