### PR TITLE
[IMP] l10n_tr_nilvera_einvoice: improve e-invoice name handling before sending

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice/i18n/l10n_tr_nilvera_einvoice.pot
+++ b/addons/l10n_tr_nilvera_einvoice/i18n/l10n_tr_nilvera_einvoice.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server saas~18.4+e\n"
+"Project-Id-Version: Odoo Server 19.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-09 06:42+0000\n"
-"PO-Revision-Date: 2025-09-09 06:42+0000\n"
+"POT-Creation-Date: 2025-10-15 12:43+0000\n"
+"PO-Revision-Date: 2025-10-15 12:43+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -48,12 +48,6 @@ msgstr ""
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
-msgid "Check Street 2 on Partner(s)"
-msgstr ""
-
-#. module: l10n_tr_nilvera_einvoice
-#. odoo-python
-#: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
 msgid "Check Tax ID, City, Street, State, and Country or Company(s)"
 msgstr ""
 
@@ -73,6 +67,12 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
 msgid "Check e-Invoice Format or Nilvera Status on Partner(s)"
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
+msgid "Check name on Invoice(s)"
 msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice
@@ -356,12 +356,6 @@ msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
-#: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
-msgid "The following partner(s) must have Street 2 empty"
-msgstr ""
-
-#. module: l10n_tr_nilvera_einvoice
-#. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move.py:0
 msgid "The invoice couldn't be sent due to the following errors:\n"
 msgstr ""
@@ -376,6 +370,15 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move.py:0
 msgid "The invoice has been successfully sent to Nilvera."
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
+msgid ""
+"The invoice name must follow the format when sending to Nilvera: 3 "
+"alphanumeric characters, followed by the year, and then a sequential number."
+" Example: INV/2025/000001"
 msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice

--- a/addons/l10n_tr_nilvera_einvoice/i18n/tr.po
+++ b/addons/l10n_tr_nilvera_einvoice/i18n/tr.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server saas~18.4+e\n"
+"Project-Id-Version: Odoo Server 19.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-09 06:43+0000\n"
-"PO-Revision-Date: 2025-09-09 06:43+0000\n"
+"POT-Creation-Date: 2025-10-15 12:44+0000\n"
+"PO-Revision-Date: 2025-10-15 12:44+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -48,20 +48,16 @@ msgstr ""
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
-msgid "Check Street 2 on Partner(s)"
-msgstr "Ortak(lar) üzerindeki 2. Adres Satırını Kontrol Edin"
-
-#. module: l10n_tr_nilvera_einvoice
-#. odoo-python
-#: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
 msgid "Check Tax ID, City, Street, State, and Country or Company(s)"
-msgstr "Vergi Numarası, Şehir, Adres, Eyalet ve Ülke veya Şirket(ler)i Kontrol Edin"
+msgstr ""
+"Vergi Numarası, Şehir, Adres, Eyalet ve Ülke veya Şirket(ler)i Kontrol Edin"
 
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
 msgid "Check Tax ID, City, Street, State, and Country or Partner(s)"
-msgstr "Vergi Numarası, Şehir, Adres, Eyalet ve Ülke veya Ortak(lar)ı Kontrol Edin"
+msgstr ""
+"Vergi Numarası, Şehir, Adres, Eyalet ve Ülke veya Ortak(lar)ı Kontrol Edin"
 
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
@@ -72,20 +68,15 @@ msgstr "Fatura(lar)daki Verileri Kontrol Edin"
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
-msgid "Check data on Partner(s)"
-msgstr "Ortak(lar) üzerindeki verileri kontrol edin"
-
-#. module: l10n_tr_nilvera_einvoice
-#. odoo-python
-#: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
-msgid "Check reference on Partner(s)"
-msgstr "Ortak(lar) üzerindeki referansı kontrol edin"
-
-#. module: l10n_tr_nilvera_einvoice
-#. odoo-python
-#: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
 msgid "Check e-Invoice Format or Nilvera Status on Partner(s)"
-msgstr "Ortak(lar) üzerindeki e-Fatura Formatını veya Nilvera Durumunu Kontrol Edin"
+msgstr ""
+"Ortak(lar) üzerindeki e-Fatura Formatını veya Nilvera Durumunu Kontrol Edin"
+
+#. module: l10n_tr_nilvera_einvoice
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
+msgid "Check name on Invoice(s)"
+msgstr "Fatura(ları) ismi kontrol edin"
 
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
@@ -185,11 +176,6 @@ msgid "Nilvera Document UUID"
 msgstr "Nilvera Belge UUID'si"
 
 #. module: l10n_tr_nilvera_einvoice
-#: model_terms:ir.ui.view,arch_db:l10n_tr_nilvera_einvoice.account_journal_dashboard_kanban_view
-msgid "Sync Nilvera Invoices"
-msgstr "Nilvera Faturalarını Senkronize Et"
-
-#. module: l10n_tr_nilvera_einvoice
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice.field_account_bank_statement_line__l10n_tr_nilvera_send_status
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice.field_account_move__l10n_tr_nilvera_send_status
 #: model_terms:ir.ui.view,arch_db:l10n_tr_nilvera_einvoice.account_nilvera_view_account_invoice_filter
@@ -210,7 +196,9 @@ msgstr "Nilvera belgesi başarıyla alındı"
 msgid ""
 "Nilvera portal cannot process negative quantity nor negative price on "
 "invoice lines"
-msgstr "Nilvera portalı, fatura satırlarında negatif miktar veya negatif fiyat işleyemez."
+msgstr ""
+"Nilvera portalı, fatura satırlarında negatif miktar veya negatif fiyat "
+"işleyemez."
 
 #. module: l10n_tr_nilvera_einvoice
 #: model:ir.actions.server,name:l10n_tr_nilvera_einvoice.ir_cron_nilvera_get_new_einvoice_sale_documents_ir_actions_server
@@ -264,8 +252,8 @@ msgid ""
 "Please ensure that your company contact has either the 'MERSISNO' or "
 "'TICARETSICILNO' tag with a value assigned."
 msgstr ""
-"Lütfen şirket kontaktınızda 'MERSISNO' veya "
-"'TICARETSICILNO' etiketinin değerle birlikte ekli olduğundan emin olun."
+"Lütfen şirket kontaktınızda 'MERSISNO' veya 'TICARETSICILNO' etiketinin "
+"değerle birlikte ekli olduğundan emin olun."
 
 #. module: l10n_tr_nilvera_einvoice
 #: model:res.partner.category,name:l10n_tr_nilvera_einvoice.res_partner_category_sayacno
@@ -346,8 +334,8 @@ msgid ""
 "The following company(s) either do not have their country set as Türkiye or "
 "are missing at least one of these fields: Tax ID, Street, City, or State"
 msgstr ""
-"Aşağıdaki şirket(ler)in ya ülkesi Türkiye olarak ayarlanmamış ya da "
-"şu alanlardan en az biri eksik: Vergi Numarası, Adres, Şehir veya İl"
+"Aşağıdaki şirket(ler)in ya ülkesi Türkiye olarak ayarlanmamış ya da şu "
+"alanlardan en az biri eksik: Vergi Numarası, Adres, Şehir veya İl"
 
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
@@ -355,6 +343,7 @@ msgstr ""
 msgid ""
 "The following company(s) must have the reference field set to the tax office"
 " name."
+msgstr ""
 "Aşağıdaki şirket(ler)in referans alanı vergi dairesi adı olarak "
 "ayarlanmalıdır."
 
@@ -390,12 +379,6 @@ msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
-#: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
-msgid "The following partner(s) must have Street 2 empty"
-msgstr "Aşağıdaki ortak(lar)ın 2. Adres Satırı boş olmalıdır"
-
-#. module: l10n_tr_nilvera_einvoice
-#. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move.py:0
 msgid "The invoice couldn't be sent due to the following errors:\n"
 msgstr "Fatura aşağıdaki hatalar nedeniyle gönderilemedi:\n"
@@ -411,6 +394,18 @@ msgstr "Fatura alıcıya gönderilemedi."
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move.py:0
 msgid "The invoice has been successfully sent to Nilvera."
 msgstr "Fatura Nilvera'ya başarıyla gönderildi."
+
+#. module: l10n_tr_nilvera_einvoice
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
+msgid ""
+"The invoice name must follow the format when sending to Nilvera: 3 "
+"alphanumeric characters, followed by the year, and then a sequential number."
+" Example: INV/2025/000001"
+msgstr ""
+"Fatura isim Nilvera'ya gönderirken şu formatta olmalıdır: 3 alfanümerik "
+"karakter, ardından yıl, ve ardından sıralı bir numara. Örnek: "
+"INV/2025/000001"
 
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python

--- a/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
@@ -46,10 +46,10 @@ class AccountEdiXmlUblTr(models.AbstractModel):
         if invoice._l10n_tr_nilvera_einvoice_check_negative_lines():
             raise UserError(self.env._("Nilvera portal cannot process negative quantity nor negative price on invoice lines"))
 
-        # For now, we assume that the sequence is going to be in the format {prefix}/{year}/{invoice_number}.
-        # To send an invoice to Nlvera, the format needs to follow ABC2009123456789.
-        parts = invoice.name.split('/')
-        prefix, year, number = parts[0], parts[1], parts[2].zfill(9)
+        # Using _get_sequence_format_param to extract the invoice sequence components for various formats.
+        # To send an invoice to Nilvera, the format needs to follow ABC2009123456789.
+        _, parts = invoice._get_sequence_format_param(invoice.name)
+        prefix, year, number = parts['prefix1'][:3], parts['year'], str(parts['seq']).zfill(9)
         invoice_id = f"{prefix.upper()}{year}{number}"
 
         document_node.update({

--- a/addons/l10n_tr_nilvera_einvoice/models/account_move_send.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_move_send.py
@@ -1,5 +1,6 @@
 from io import BytesIO
 import logging
+import re
 
 from odoo import _, api, models
 
@@ -24,6 +25,16 @@ class AccountMoveSend(models.AbstractModel):
     # -------------------------------------------------------------------------
 
     def _get_alerts(self, moves, moves_data):
+        def _is_valid_nilvera_name(move):
+            _, parts = move._get_sequence_format_param(move.name)
+
+            return (
+                parts['year'] != 0
+                and parts['year_length'] == 4
+                and parts['seq'] != 0
+                and re.match(r'^[A-Za-z0-9]{3}[^A-Za-z0-9]?$', parts['prefix1'])
+            )
+
         alerts = super()._get_alerts(moves, moves_data)
 
         # Filter for moves that have 'tr_nilvera' in their EDI data
@@ -160,6 +171,17 @@ class AccountMoveSend(models.AbstractModel):
                 "message": _("Nilvera portal cannot process negative quantity nor negative price on invoice lines"),
                 "action_text": _("View Invoice(s)"),
                 "action": invalid_negative_lines._get_records_action(name=_("Check data on Invoice(s)")),
+            }
+
+        if moves_with_invalid_name := tr_nilvera_moves.filtered(lambda move: not _is_valid_nilvera_name(move)):
+            alerts['tr_moves_with_invalid_name'] = {
+                'level': 'danger',
+                'message': _(
+                    "The invoice name must follow the format when sending to Nilvera: 3 alphanumeric characters, "
+                    "followed by the year, and then a sequential number. Example: INV/2025/000001",
+                ),
+                'action_text': _("View Invoice(s)"),
+                'action': moves_with_invalid_name._get_records_action(name=_("Check name on Invoice(s)")),
             }
 
         return alerts

--- a/addons/l10n_tr_nilvera_einvoice/tests/__init__.py
+++ b/addons/l10n_tr_nilvera_einvoice/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_xml_ubl_tr
+from . import test_account_move_send

--- a/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_earchive.xml
+++ b/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_earchive.xml
@@ -3,7 +3,7 @@
   <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>TR1.2</cbc:CustomizationID>
   <cbc:ProfileID>EARSIVFATURA</cbc:ProfileID>
-  <cbc:ID>EIN998833000000000</cbc:ID>
+  <cbc:ID>EIN2025000000001</cbc:ID>
   <cbc:CopyIndicator>false</cbc:CopyIndicator>
   <cbc:UUID>___ignore___</cbc:UUID>
   <cbc:IssueDate>2025-03-03</cbc:IssueDate>
@@ -13,7 +13,7 @@
   <cbc:DocumentCurrencyCode>TRY</cbc:DocumentCurrencyCode>
   <cbc:LineCountNumeric>4</cbc:LineCountNumeric>
   <cac:OrderReference>
-    <cbc:ID>EIN/998833/0</cbc:ID>
+    <cbc:ID>EIN/2025/1</cbc:ID>
     <cbc:IssueDate>2025-03-03</cbc:IssueDate>
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>

--- a/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_earchive_multicurrency.xml
+++ b/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_earchive_multicurrency.xml
@@ -3,7 +3,7 @@
   <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>TR1.2</cbc:CustomizationID>
   <cbc:ProfileID>EARSIVFATURA</cbc:ProfileID>
-  <cbc:ID>EIN998833000000000</cbc:ID>
+  <cbc:ID>EIN2025000000001</cbc:ID>
   <cbc:CopyIndicator>false</cbc:CopyIndicator>
   <cbc:UUID>___ignore___</cbc:UUID>
   <cbc:IssueDate>2025-03-03</cbc:IssueDate>
@@ -16,7 +16,7 @@
   <cbc:PricingCurrencyCode>USD</cbc:PricingCurrencyCode>
   <cbc:LineCountNumeric>4</cbc:LineCountNumeric>
   <cac:OrderReference>
-    <cbc:ID>EIN/998833/0</cbc:ID>
+    <cbc:ID>EIN/2025/1</cbc:ID>
     <cbc:IssueDate>2025-03-03</cbc:IssueDate>
   </cac:OrderReference>
   <cac:AdditionalDocumentReference>

--- a/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_einvoice.xml
+++ b/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_einvoice.xml
@@ -3,7 +3,7 @@
   <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>TR1.2</cbc:CustomizationID>
   <cbc:ProfileID>TEMELFATURA</cbc:ProfileID>
-  <cbc:ID>EIN998833000000000</cbc:ID>
+  <cbc:ID>EIN2025000000001</cbc:ID>
   <cbc:CopyIndicator>false</cbc:CopyIndicator>
   <cbc:UUID>___ignore___</cbc:UUID>
   <cbc:IssueDate>2025-03-03</cbc:IssueDate>
@@ -13,7 +13,7 @@
   <cbc:DocumentCurrencyCode>TRY</cbc:DocumentCurrencyCode>
   <cbc:LineCountNumeric>4</cbc:LineCountNumeric>
   <cac:OrderReference>
-    <cbc:ID>EIN/998833/0</cbc:ID>
+    <cbc:ID>EIN/2025/1</cbc:ID>
     <cbc:IssueDate>2025-03-03</cbc:IssueDate>
   </cac:OrderReference>
   <cac:AccountingSupplierParty>

--- a/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_einvoice_multicurrency.xml
+++ b/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_einvoice_multicurrency.xml
@@ -3,7 +3,7 @@
   <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>TR1.2</cbc:CustomizationID>
   <cbc:ProfileID>TEMELFATURA</cbc:ProfileID>
-  <cbc:ID>EIN998833000000000</cbc:ID>
+  <cbc:ID>EIN2025000000001</cbc:ID>
   <cbc:CopyIndicator>false</cbc:CopyIndicator>
   <cbc:UUID>___ignore___</cbc:UUID>
   <cbc:IssueDate>2025-03-03</cbc:IssueDate>
@@ -16,7 +16,7 @@
   <cbc:PricingCurrencyCode>USD</cbc:PricingCurrencyCode>
   <cbc:LineCountNumeric>4</cbc:LineCountNumeric>
   <cac:OrderReference>
-    <cbc:ID>EIN/998833/0</cbc:ID>
+    <cbc:ID>EIN/2025/1</cbc:ID>
     <cbc:IssueDate>2025-03-03</cbc:IssueDate>
   </cac:OrderReference>
   <cac:AccountingSupplierParty>

--- a/addons/l10n_tr_nilvera_einvoice/tests/test_account_move_send.py
+++ b/addons/l10n_tr_nilvera_einvoice/tests/test_account_move_send.py
@@ -1,0 +1,46 @@
+from odoo.tests import tagged
+from odoo.addons.account.tests.test_account_move_send import TestAccountMoveSendCommon
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestTRAccountMoveSend(TestAccountMoveSendCommon):
+
+    @classmethod
+    @TestAccountMoveSendCommon.setup_country('tr')
+    def setUpClass(cls):
+        super().setUpClass()
+
+    def test_invoice_names_valid_for_nilvera(self):
+        valid_names = [
+            'INV-2025-00001',
+            'R01/2025/00001',
+            '123/2025/00001',
+            'res.2025.00001',
+            'RES2025/00001',
+        ]
+        invoices = self.env['account.move']
+        for name in valid_names:
+            invoice = self.init_invoice('out_invoice', invoice_date='2025-11-28', amounts=[1000])
+            invoice.name = name
+            invoice.action_post()
+            invoices |= invoice
+
+        wizard = self.create_send_and_print(invoices)
+        self.assertNotIn('tr_moves_with_invalid_name', wizard.alerts)
+
+    def test_invoice_names_invalid_for_nilvera(self):
+        invalid_names = [
+            'INV/2025/0',
+            'INV/25/1012',
+            'RESXYZ00001',
+            'res2025ABCDE',
+            'RES-XYZ-00001',
+            'INVOICE/2025/00010',
+        ]
+        for name in invalid_names:
+            invoice = self.init_invoice('out_invoice', invoice_date='2025-11-28', amounts=[1000])
+            invoice.name = name
+            invoice.action_post()
+
+            wizard = self.create_send_and_print(invoice)
+            self.assertIn('tr_moves_with_invalid_name', wizard.alerts)

--- a/addons/l10n_tr_nilvera_einvoice/tests/test_xml_ubl_tr.py
+++ b/addons/l10n_tr_nilvera_einvoice/tests/test_xml_ubl_tr.py
@@ -79,7 +79,7 @@ class TestUBLTR(AccountTestInvoicingCommon):
             'move_type': 'out_invoice',
             'company_id': self.company_data['company'].id,
             'partner_id': partner_id.id,
-            'name': 'EIN/998833/0',
+            'name': 'EIN/2025/1',
             'invoice_date': '2025-03-03',
             'narration': '3 products',
             'invoice_line_ids': [


### PR DESCRIPTION
Before this commit:
-  When sending an e-invoice through Nilvera, the invoice name used a hardcoded `.split('/')`, assuming `/` the only valid separator for fetching prefix, year and sequence.
- Invoice name was not validated, which could raise errors during XML generation

After this commit:
- The logic now supports various valid invoice name formats rather than relying only on `/` as a separator.
- Invoice name is validated before sending the e-invoice through Nilvera to ensure they comply with the GIB format, to prevent XML generation errors.

task-5117359