### PR TITLE
[FIX] portal: Prevent rating cards showing through

### DIFF
--- a/addons/portal/static/src/chatter/scss/shadow.scss
+++ b/addons/portal/static/src/chatter/scss/shadow.scss
@@ -21,5 +21,5 @@
 }
 
 .o-portal-Chatter .o-mail-Chatter-top {
-    background-color: inherit;
+    background-color: var(--body-bg);
 }


### PR DESCRIPTION
To reproduce:
=============
1- Enable product reviews on the website
2- Add a few reviews
3- Switch to mobile view
-> Scroll to see the behavior

Why:
====
This commit did the problem
https://github.com/odoo/odoo/commit/f13ee41a4a62f7fedbddc4245e52ee8e9dce9e0e Specifically this change:
https://github.com/odoo/odoo/commit/f13ee41a4a62f7fedbddc4245e52ee8e9dce9e0e#diff-6e5197b652583a0032baba5d873fb639b7567600f54b58acce137945ca072b03L23-R24 So the value of the background-color for the portal Chatter is no longer getting background-color of the body.

Solution:
=========
Apply the body background-color to the sticky part.

opw-5098372
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
