### PR TITLE
[REM] mail: redundant check constraint on mail channels

### DIFF
--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -79,7 +79,6 @@ class Channel(models.Model):
     invitation_url = fields.Char('Invitation URL', compute='_compute_invitation_url')
 
     _sql_constraints = [
-        ('channel_type_not_null', 'CHECK(channel_type IS NOT NULL)', 'The channel type cannot be empty'),
         ('uuid_unique', 'UNIQUE(uuid)', 'The channel UUID must be unique'),
         ('group_public_id_check',
          "CHECK (channel_type = 'channel' OR group_public_id IS NULL)",


### PR DESCRIPTION
The field is `required=True`, which automatically sets it `NOT NULL` (if possible). The constraint does not do anything useful.

Furthermore, pg18 promoted `NOT NULL` to "real" named constraints[1], and the constraint was created following the pattern pg uses, so trying to migrate a database to pg18 (either upgrading a cluster from 17 to 18 or restoring a db on a pg18) the restoration fails with

    duplicate key value violates unique constraint "pg_constraint_conrelid_contypid_conname_index"

The easiest fix is to delete the constraint in the upstream DB if possible (I didn't find a way to filter out constraints from pg_dump or pg_restore, though it should be possible to filter it out from a "plain" dump by hand).

AFAIK Odoo does not generally drop constraints so I don't think this will fix existing databases, but it at least makes future databases compatible with pg18.

[1]: https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=a379061a22a8fdf421e1a457cc6af8503def6252
