### PR TITLE
[FIX] website_sale: auth_signup_uninvited usable again


### DIFF
--- a/addons/website_sale/models/res_config_settings.py
+++ b/addons/website_sale/models/res_config_settings.py
@@ -99,12 +99,13 @@ class ResConfigSettings(models.TransientModel):
         for record in self:
             if not record.website_id:
                 continue
-            record.website_id.account_on_checkout = record.account_on_checkout
             # account_on_checkout implies different values for `auth_signup_uninvited`
-            if record.account_on_checkout in ['optional', 'mandatory']:
-                record.website_id.auth_signup_uninvited = 'b2c'
-            else:
-                record.website_id.auth_signup_uninvited = 'b2b'
+            if record.website_id.account_on_checkout != record.account_on_checkout:
+                if self.account_on_checkout in ['optional', 'mandatory']:
+                    record.website_id.auth_signup_uninvited = 'b2c'
+                else:
+                    record.website_id.auth_signup_uninvited = 'b2b'
+            record.website_id.account_on_checkout = record.account_on_checkout
 
     # === CRUD METHODS === #
 

--- a/addons/website_sale/tests/__init__.py
+++ b/addons/website_sale/tests/__init__.py
@@ -33,6 +33,7 @@ from . import test_website_sale_product_filters
 from . import test_website_sale_product_page
 from . import test_website_sale_product_template
 from . import test_website_sale_reorder_from_portal
+from . import test_website_sale_settings
 from . import test_website_sale_shop_redirects
 from . import test_website_sale_show_compare_list_price
 from . import test_website_sale_snippets

--- a/addons/website_sale/tests/test_website_sale_settings.py
+++ b/addons/website_sale/tests/test_website_sale_settings.py
@@ -1,0 +1,33 @@
+from odoo.tests import tagged
+from odoo.addons.base.tests.common import BaseCommon
+
+
+@tagged('post_install', '-at_install')
+class TestWebsiteSaleSettings(BaseCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env['res.company'].create({
+            'name': 'Test Company',
+        })
+        cls.website = cls.env['website'].create({
+            'name': 'Test Website',
+            'company_id': cls.company.id,
+            'account_on_checkout': 'mandatory',
+            'auth_signup_uninvited': 'b2b',
+        })
+
+    def test_settings_account_on_checkout(self):
+        # only change auth_signup_uninvited if account_on_checkout was changed
+        config = self.env['res.config.settings'].with_company(self.company)
+        config.create({'account_on_checkout': 'mandatory'}).execute()
+        self.assertEqual(self.website.auth_signup_uninvited, 'b2b')
+        config.create({'account_on_checkout': 'optional'}).execute()
+        self.assertEqual(self.website.auth_signup_uninvited, 'b2c')
+        config.create({'account_on_checkout': 'disabled'}).execute()
+        self.assertEqual(self.website.auth_signup_uninvited, 'b2b')
+        config.create({'auth_signup_uninvited': 'b2c', 'account_on_checkout': 'disabled'}).execute()
+        self.assertEqual(self.website.auth_signup_uninvited, 'b2c')
+        config.create({'auth_signup_uninvited': 'b2b', 'account_on_checkout': 'mandatory'}).execute()
+        self.assertEqual(self.website.auth_signup_uninvited, 'b2c')


### PR DESCRIPTION
Scenario:

- install website_sale
- try to change auth_signup_uninvited (Customer Account) setting to
  another value
- save

Result: the option can never be changed and is always reset to the same
value.

Cause: there is code on the inverse method of account_on_checkout that
sets auth_signup_uninvited.

Before 19.0 version, the inverse method of account_on_checkout was
called before the inverse method of auth_signup_uninvited, so:

- account_on_checkout inverse would set auth_signup_uninvited
- auth_signup_uninvited would then set auth_signup_uninvited

=> so the code in _inverse_account_on_checkout was just dead code.

In 19.0 the inverse methods are executed in the other order, and now the
inverse method _inverse_auth_signup_uninvited is dead code and
_inverse_account_on_checkout is the only methods that sets
the value of auth_signup_uninvited.

Fix: this fix proposes to only set auth_signup_uninvited if the value of
account_on_checkout has changed.

opw-5104120
opw-5109360
opw-5117550
opw-5119586

closes #229358