### PR TITLE
[FIX] analytic: fix traceback on group by in analytic accounts

### DIFF
--- a/addons/analytic/models/analytic_account.py
+++ b/addons/analytic/models/analytic_account.py
@@ -128,12 +128,12 @@ class AccountAnalyticAccount(models.Model):
     def _read_group_select(self, aggregate_spec, query):
         # flag balance/debit/credit as aggregatable, and manually sum the values
         # from the records in the group
-        if aggregate_spec in ('balance:sum', 'debit:sum', 'credit:sum'):
+        if aggregate_spec in ('balance:sum', 'debit:sum', 'credit:sum', 'debit:sum_currency', 'credit:sum_currency', 'balance:sum_currency'):
             return super()._read_group_select('id:recordset', query)
         return super()._read_group_select(aggregate_spec, query)
 
     def _read_group_postprocess_aggregate(self, aggregate_spec, raw_values):
-        if aggregate_spec in ('balance:sum', 'debit:sum', 'credit:sum'):
+        if aggregate_spec in ('balance:sum', 'debit:sum', 'credit:sum', 'debit:sum_currency', 'credit:sum_currency', 'balance:sum_currency'):
             field_name = aggregate_spec.split(':')[0]
             column = super()._read_group_postprocess_aggregate('id:recordset', raw_values)
             return (sum(records.mapped(field_name)) for records in column)


### PR DESCRIPTION
**Steps to reproduce:**
1. Install `accountant`
2. Go to  settings and enable `Analytic Accounting`
3. Navigate to Accounting > Configuration > Analytic Accounts
4. Apply Group by plan.

**Isuue:**
- Traceback
`ValueError: Cannot convert account.analytic.account.debit to SQL because it is not stored`

**Cause:**
- By this commit https://github.com/odoo/odoo/commit/98f746269bdec23e184e9efa83dc30057a458718 a new aggregator function sum_currency was introduced. https://github.com/odoo/odoo/blob/e6928b68bfb2b07e20d9fa49d30a70af0890bd75/addons/web/static/tests/_framework/mock_server/mock_model.js#L1342
in the case of account.analytic.account the non-stored computed fields debit, credit, and balance now receive extra aggregate requests (debit:sum_currency, credit:sum_currency, balance:sum_currency) during web_read_group.

**Solution:**
- Bypass SQL aggregation for the non-stored fields (debit, credit, balance). Instead of aggregating them in SQL, return the recordsets (id:recordset) for these fields and compute their sums in Python.

opw-5101209