### PR TITLE
[FIX] core: Add warning for contraint using PG18 suffix

### DIFF
--- a/addons/mail/models/mail_message_link_preview.py
+++ b/addons/mail/models/mail_message_link_preview.py
@@ -19,8 +19,6 @@ class MessageMailLinkPreview(models.Model):
     author_id = fields.Many2one(related="message_id.author_id")
 
     _unique_message_link_preview = models.UniqueIndex("(message_id, link_preview_id)")
-    _message_id_not_null = models.Constraint("CHECK(message_id IS NOT NULL)")
-    _link_preview_id_not_null = models.Constraint("CHECK(link_preview_id IS NOT NULL)")
 
     def _bus_channel(self):
         return self.message_id._bus_channel()

--- a/odoo/orm/table_objects.py
+++ b/odoo/orm/table_objects.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import typing
+import warnings
 
 from odoo.tools import sql
 
@@ -105,6 +106,16 @@ class Constraint(TableObject):
 
     def get_definition(self, registry: Registry):
         return self._definition
+
+    def __set_name__(self, owner, name):
+        if name.endswith('_not_null'):
+            warnings.warn(
+                f'The Constraint "{name}" ends with _not_null. In PostgreSQL 18, '
+                'this suffix is used automatically for NOT NULL column (required).'
+                'To avoid any name clashing, please change the Constraint name.',
+                stacklevel=1,
+            )
+        return super().__set_name__(owner, name)
 
     def apply_to_database(self, model: BaseModel):
         cr = model.env.cr


### PR DESCRIPTION
Since PostgreSQL 18, PostgreSQL automatically adds a real constraint for `NOT NULL` columns using the suffix `_not_null` (see https://postgr.es/c/14e87ffa5).

To avoid name clashing and ensure the database can be restored/upgraded in PG18, we add a warning if a user defines a `models.Constraint` object that uses this reserved suffix.

https://github.com/odoo/enterprise/pull/95909
https://github.com/odoo/upgrade/pull/8521