### PR TITLE
[FIX] base: ir_qweb_field: Handle One2Many html converter

### DIFF
--- a/odoo/addons/base/models/ir_qweb_fields.py
+++ b/odoo/addons/base/models/ir_qweb_fields.py
@@ -357,6 +357,19 @@ class ManyToManyConverter(models.AbstractModel):
         return nl2br(escape(text))
 
 
+class OneToManyConverter(models.AbstractModel):
+    _name = 'ir.qweb.field.one2many'
+    _description = 'Qweb field one2many'
+    _inherit = 'ir.qweb.field'
+
+    @api.model
+    def value_to_html(self, value, options):
+        if not value:
+            return False
+        text = ', '.join(value.sudo().mapped('display_name'))
+        return nl2br(escape(text))
+
+
 class HTMLConverter(models.AbstractModel):
     _name = 'ir.qweb.field.html'
     _description = 'Qweb Field HTML'

--- a/odoo/addons/base/tests/test_qweb_field.py
+++ b/odoo/addons/base/tests/test_qweb_field.py
@@ -86,3 +86,53 @@ class TestQwebFieldContact(common.TransactionCase):
         self.assertIn(self.partner.website, result)
         self.assertNotIn(self.partner.phone, result)
         self.assertIn('itemprop="telephone"', result, "Empty telephone itemprop should be added to prevent issue with iOS Safari")
+
+
+class TestQwebFieldOne2Many(common.TransactionCase):
+    def value_to_html(self, value, options=None):
+        options = options or {}
+        return self.env['ir.qweb.field.one2many'].value_to_html(value, options)
+
+    def test_one2many_empty(self):
+        partner = self.env['res.partner'].create({'name': 'Test Parent'})
+        self.assertFalse(self.value_to_html(partner.child_ids))
+
+    def test_one2many_with_values(self):
+        parent = self.env['res.partner'].create({'name': 'Parent'})
+        self.env['res.partner'].create({'name': 'Child', 'parent_id': parent.id})
+        self.assertEqual(self.value_to_html(parent.child_ids), "Parent, Child")
+
+
+class TestQwebFieldMany2Many(common.TransactionCase):
+    def value_to_html(self, value, options=None):
+        options = options or {}
+        return self.env['ir.qweb.field.many2many'].value_to_html(value, options)
+
+    def test_many2many_empty(self):
+        user = self.env['res.users'].create({'name': 'UserTest', 'login': 'usertest@example.com', 'groups_id': None})
+        self.assertFalse(self.value_to_html(user.groups_id))
+
+    def test_many2many_with_values(self):
+        user = self.env['res.users'].create({
+            'name': 'User2',
+            'login': 'user2@example.com',
+        })
+        self.assertEqual(
+            self.value_to_html(user.groups_id[:2]),
+            'Technical / Access to export feature, Extra Rights / Contact Creation'
+        )
+
+
+class TestQwebFieldMany2One(common.TransactionCase):
+    def value_to_html(self, value, options=None):
+        options = options or {}
+        return self.env['ir.qweb.field.many2one'].value_to_html(value, options)
+
+    def test_many2one_empty(self):
+        partner = self.env['res.partner'].create({'name': 'Lonely'})
+        self.assertFalse(self.value_to_html(partner.parent_id))
+
+    def test_many2one_with_value(self):
+        parent = self.env['res.partner'].create({'name': 'BigBoss'})
+        child = self.env['res.partner'].create({'name': 'Minion', 'parent_id': parent.id})
+        self.assertEqual(self.value_to_html(child.parent_id), 'BigBoss')


### PR DESCRIPTION
For now, `One2Many` fields are not displayed correctly in reports.
This is because for other types of fields (`ManyToMany`, `ManyToOne`, etc.), there are Converter classes (`ManyToManyConverter`) `ir.qweb.field.many2many` that implement `value_to_html`.
However, for `OneToMany` fields, no implementation is present.

This commit adds a `OneToManyConverter`, which is essentially the same as the `ManyToMany `one.

opw-5098466