### PR TITLE
[FIX] account: UX of trusted bank accounts

### DIFF
--- a/addons/account/static/src/components/many2many_tags_banks/many2many_tags_banks.xml
+++ b/addons/account/static/src/components/many2many_tags_banks/many2many_tags_banks.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="FieldMany2ManyTagsBanksTagsList" t-inherit="web.TagsList" t-inherit-mode="primary">
-        <xpath expr="//div[hasclass('o_tag_badge_text')]" position="after">
-            <i t-if="tag.allowOutPayment" class="ms-1 fa fa-unlock"/>
+        <xpath expr="//div[hasclass('o_tag_badge_text')]" position="before">
+            <span class="me-1">
+                <i t-if="tag.allowOutPayment" class="fa fa-shield text-success" data-tooltip="Trusted"/>
+                <i t-else="" class="fa fa-exclamation-circle text-danger" data-tooltip="Untrusted"/>
+            </span>
         </xpath>
     </t>
 


### PR DESCRIPTION
This commit fixes the UI indicator of trusted/untrusted bank accounts.
For trusted bank accounts, they are indicated with a green shield.
Untrusted bank accounts are indicated with a red exclamation circle.

task-5117800



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
