### PR TITLE
[IMP] project_timesheet_holidays: disable timesheet creation from work type leave

### DIFF
--- a/addons/project_timesheet_holidays/models/hr_holidays.py
+++ b/addons/project_timesheet_holidays/models/hr_holidays.py
@@ -22,10 +22,10 @@ class HolidaysType(models.Model):
                 "('project_id', '!=', False),"
                 "('company_id', 'in', [False, company_id])]")
 
-    @api.depends('timesheet_task_id', 'timesheet_project_id')
+    @api.depends('timesheet_task_id', 'timesheet_project_id', 'time_type')
     def _compute_timesheet_generate(self):
         for leave_type in self:
-            leave_type.timesheet_generate = not leave_type.company_id or (leave_type.timesheet_task_id and leave_type.timesheet_project_id)
+            leave_type.timesheet_generate = leave_type.time_type != 'other' and (not leave_type.company_id or (leave_type.timesheet_task_id and leave_type.timesheet_project_id))
 
     @api.depends('company_id')
     def _compute_timesheet_project_id(self):

--- a/addons/project_timesheet_holidays/tests/test_timesheet_holidays.py
+++ b/addons/project_timesheet_holidays/tests/test_timesheet_holidays.py
@@ -54,7 +54,7 @@ class TestTimesheetHolidays(TestCommonTimesheet):
         self.internal_task_leaves = self.env.company.leave_timesheet_task_id
 
         self.hr_leave_type_with_ts = self.env['hr.leave.type'].create({
-            'name': 'Time Off Type with timesheet generation',
+            'name': 'Time Off Type with timesheet generation (absence)',
             'requires_allocation': 'no',
             'timesheet_generate': True,
             'timesheet_project_id': self.internal_project.id,
@@ -68,6 +68,14 @@ class TestTimesheetHolidays(TestCommonTimesheet):
             'timesheet_generate': True,
             'timesheet_project_id': self.internal_project.id,
             'timesheet_task_id': self.internal_task_leaves.id,
+        })
+
+        self.hr_leave_type_worked = self.env['hr.leave.type'].create({
+            'name': 'Time Off Type (worked time)',
+            'requires_allocation': 'no',
+            'timesheet_project_id': self.internal_project.id,
+            'timesheet_task_id': self.internal_task_leaves.id,
+            'time_type': 'other',
         })
 
         self.hr_leave_type_no_ts = self.env['hr.leave.type'].create({
@@ -144,6 +152,19 @@ class TestTimesheetHolidays(TestCommonTimesheet):
         # The leave type and timesheet are linked to the same project and task of the employee company as the company is not set
         self.assertEqual(holiday.timesheet_ids.project_id.id, company.internal_project_id.id)
         self.assertEqual(holiday.timesheet_ids.task_id.id, company.leave_timesheet_task_id.id)
+
+    def test_validate_worked_leave(self):
+        # employee creates a leave request of worked time type
+        holiday = self.Requests.with_user(self.user_employee).create({
+            'name': 'Time Off 3',
+            'employee_id': self.empl_employee.id,
+            'holiday_status_id': self.hr_leave_type_worked.id,
+            'request_date_from': self.leave_start_datetime,
+            'request_date_to': self.leave_end_datetime,
+        })
+        holiday.with_user(SUPERUSER_ID).action_validate()
+
+        self.assertEqual(len(holiday.timesheet_ids), 0, 'No timesheet should be created for a leave of worked time type')
 
     def test_validate_without_timesheet(self):
         # employee creates a leave request


### PR DESCRIPTION
When a leave using a work leave type is approved, now it should not create a timesheet.

task-5097482

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
