### PR TITLE
[FIX] stock: correct location domain for quantities computations in strict mode

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -316,7 +316,7 @@ class Product(models.Model):
         if self.env.context.get('strict'):
             loc_domain = [('location_id', 'in', locations.ids)]
             dest_loc_domain = [('location_dest_id', 'in', locations.ids)]
-            dest_loc_domain_out = [('location_dest_id', 'in', locations.ids)]
+            dest_loc_domain_out = [('location_dest_id', 'not in', locations.ids)]
         elif locations:
             paths_domain = expression.OR([[('parent_path', '=like', loc.parent_path + '%')] for loc in locations])
             loc_domain = [('location_id', 'any', paths_domain)]

--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -2250,6 +2250,39 @@ class StockMove(TransactionCase):
         self.assertAlmostEqual(self.product.qty_available, 2.0)  # 14 - a dozen
         self.assertAlmostEqual(product_in_past.qty_available, 0)
 
+    def test_past_availability_in_strict_mode(self):
+        """
+        Test the quantity is correct when looking in the past in strict mode.
+        """
+        today = fields.Date.today()
+        self.env["stock.quant"]._update_available_quantity(self.product, self.stock_location, 10.0)
+        moves = self.env['stock.move'].create([
+            {
+                'name': 'A move in of 3 x product',
+                'location_id': self.customer_location.id,
+                'location_dest_id': self.stock_location.id,
+                'product_id': self.product.id,
+                'product_uom_qty': 3.0,
+            },
+            {
+                'name': 'A move out of 2 x product',
+                'location_id': self.stock_location.id,
+                'location_dest_id': self.customer_location.id,
+                'product_id': self.product.id,
+                'product_uom_qty': 2.0,
+            },
+        ])
+        moves._action_confirm()
+        moves._action_assign()
+        moves.picked = True
+        moves._action_done()
+        moves[0].date = fields.Date.add(today, days=-7)
+        moves[1].date = fields.Date.add(today, days=-5)
+        product = self.product.with_context(strict=True, location=self.stock_location.id)
+        self.assertAlmostEqual(product.with_context(to_date=fields.Date.add(today, days=-8)).qty_available, 10.0)
+        self.assertAlmostEqual(product.with_context(to_date=fields.Date.add(today, days=-6)).qty_available, 13.0)
+        self.assertAlmostEqual(product.with_context(to_date=fields.Date.add(today, days=-4)).qty_available, 11.0)
+
     def test_product_tree_views(self):
         """Test to make sure that there are no ACLs errors in users with basic permissions."""
         self.env["stock.quant"]._update_available_quantity(self.product, self.stock_location, 3.0)


### PR DESCRIPTION
### Issue:

Commit ba54310a11d2b702753d4b9b028a62dd00a91467 has altered the location domain for quantities computations. However, the `dest_loc_domain_out` has not been correctly replaced:
https://github.com/odoo/odoo/blob/f173c738b1adcf85a80eb641ad307b7cccf17294/addons/stock/models/product.py#L319 Since the returned value used to be negated and is not anymore. This results in out moves being ignored by the `_compute_quantities` in `strict` mode.

opw-4997982
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
