### PR TITLE
[FIX] sale_project: fix project creation issue via sale order

### DIFF
--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -345,7 +345,6 @@
             <field name="view_mode">form</field>
             <field name="view_id" ref="project_project_view_form_simplified_footer"/>
             <field name="target">new</field>
-            <field name="context">{"default_allow_billable": 0}</field>
         </record>
 
         <record model="ir.ui.view" id="view_project_kanban">

--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -193,6 +193,7 @@ class SaleOrder(models.Model):
                 'generate_milestone': default_sale_line.product_id.service_policy == 'delivered_milestones',
                 'default_name': self.name,
                 'default_allow_milestones': 'delivered_milestones' in self.order_line.product_id.mapped('service_policy'),
+                'sale_company_id': self.company_id.id,
             },
         }
 

--- a/addons/sale_project/views/project_views.xml
+++ b/addons/sale_project/views/project_views.xml
@@ -87,21 +87,19 @@
     </record>
 
     <record id="project.open_view_project_all_config" model="ir.actions.act_window">
-        <field name="context">{'default_allow_billable': True, 'sale_show_partner_name': True, 'display_milestone_deadline': True}</field>
+        <field name="context">{'sale_show_partner_name': True, 'display_milestone_deadline': True}</field>
     </record>
     <record id="project.open_view_project_all_config_group_stage" model="ir.actions.act_window">
         <field name="context">{
-            'default_allow_billable': True,
             'sale_show_partner_name': True,
             'display_milestone_deadline': True
         }</field>
     </record>
     <record id="project.open_view_project_all" model="ir.actions.act_window">
-        <field name="context">{'default_allow_billable': True, 'sale_show_partner_name': True, 'display_milestone_deadline': True}</field>
+        <field name="context">{'sale_show_partner_name': True, 'display_milestone_deadline': True}</field>
     </record>
     <record id="project.open_view_project_all_group_stage" model="ir.actions.act_window">
         <field name="context">{
-            'default_allow_billable': True,
             'sale_show_partner_name': True,
             'display_milestone_deadline': True
         }</field>

--- a/addons/sale_project/wizard/project_template_create_wizard.xml
+++ b/addons/sale_project/wizard/project_template_create_wizard.xml
@@ -34,7 +34,12 @@
                     name="template_id"
                     string="Project Template"
                     placeholder="New project"
-                    domain="[('is_template', '=', True)]"
+                    domain="[
+                        ('is_template', '=', True),
+                        '|',
+                        ('company_id', '=', context.get('sale_company_id')),
+                        ('company_id', '=', False),
+                    ]"
                     context="{'default_is_template': True}"
                 />
             </field>

--- a/addons/sale_project/wizard/project_template_create_wizard.xml
+++ b/addons/sale_project/wizard/project_template_create_wizard.xml
@@ -36,9 +36,7 @@
                     placeholder="New project"
                     domain="[
                         ('is_template', '=', True),
-                        '|',
-                        ('company_id', '=', context.get('sale_company_id')),
-                        ('company_id', '=', False),
+                        '|', ('company_id', '=?', context.get('sale_company_id')), ('company_id', '=', False),
                     ]"
                     context="{'default_is_template': True}"
                 />


### PR DESCRIPTION
Fix 1 : project, sale_timesheet: remove default_allow_billable context in Create a Project
---------------------
**Issue:**
  When a project is created from the sale app, it is not billable by default, and the sale order / sale order line are not set.

**Fix:**
 Remove default_allow_billable = False in the Create a Project

**Note:**
  default_allow_billable = True already exists in action_view_project_ids, but that default context is replaced when opening the project directly from the view. This happens because default_allow_billable = False is set in the Create a Project
  action.

Fix 2: sale_project: show only relevant project templates per company
----------------
**Steps:**
   - Install sale_project
   - Create two companies (A, B)
   - Create three project templates:
	 - Template A (company A)
	 - Template B (company B)
	 - Template C (no company → visible to all)
   - Create a sale order for company A with a service product
   - Confirm the sale order
   - Create a project and try to select a template

**Issue:**
   All project templates were visible even if the sale order had a company set.

**Fix:**
   Added a filter (domain) on the project template field so only templates for the sale order’s company or templates with   no company are shown. Users cannot select templates from other companies.

task-5074893
