### PR TITLE
[FIX] mrp_subcontracting: delete unreferenced move lines

### DIFF
--- a/addons/mrp_subcontracting/models/mrp_production.py
+++ b/addons/mrp_subcontracting/models/mrp_production.py
@@ -37,7 +37,10 @@ class MrpProduction(models.Model):
             for line in production.move_line_raw_ids:
                 line_by_product[line.product_id] |= line
             for move in production.move_raw_ids:
-                move.move_line_ids = line_by_product.pop(move.product_id, self.env['stock.move.line'])
+                lines = line_by_product.pop(move.product_id, self.env['stock.move.line'])
+                lines_to_delete = move.move_line_ids - lines
+                move.move_line_ids = lines
+                lines_to_delete.unlink()
             for product_id, lines in line_by_product.items():
                 qty = sum(line.product_uom_id._compute_quantity(line.quantity, product_id.uom_id) for line in lines)
                 move = production._get_move_raw_values(product_id, qty, product_id.uom_id)


### PR DESCRIPTION
Issue
-----
Removing a line using the subcontracting wizard does not delete the line in DB, there is a "phantom" ML.

Steps to reproduce
-----
- Create a subcontracted product with 2 components
- Add one of each component in subcontractor's stock
- Create a PO for the finished product and confirm it
- Go to the production
- Open the "Record components" wizard
- Set quantity then remove the second line
- Confirm production (don't update consumption)
- Go to Inventory > Reporting > Moves History and remove the "Done" filter

> There is a pending move in the report

Cause
-----
When saving the wizard's changes, we call a write on the production's `move_line_raw_ids` field to remove delete the line. The field is a simple compute, so we go through its' inverse method

https://github.com/odoo/odoo/blob/be3a4283c383d187570f5a73f337030e6ae9d05c/addons/mrp_subcontracting/models/mrp_production.py#L34-L46

The problem is that we populate `line_by_product` using the values present in `move_line_raw_ids` from which we just removed the line. This means that when we do

`move.move_line_ids = line_by_product.pop(move.product_id, self.env['stock.move.line'])`

we replace the value of `move_line_ids` with only the remaining ones, which means we unlink the move line (*from the move*). Because the inverse field (`move_id` of the SML) is not set as `ondelete='cascade'`, the link is broken but the line remains in db.

https://github.com/odoo/odoo/blob/f173c738b1adcf85a80eb641ad307b7cccf17294/odoo/fields.py#L4311-L4322

We cannot change the field to `ondelete='cascade'` as such a change would not be stable.

Solution
-----
Keep reference of the lines to be removed in order to delete them once `move_line_ids` has been updated.

-----
Ticket:
opw-4817397
