### PR TITLE
[FIX] html_editor: properly change color when there's an icon

### DIFF
--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -276,7 +276,9 @@ export class ColorPlugin extends Plugin {
                         '[style*="color"], [style*="background-color"], [style*="background-image"]'
                     ) ||
                     closestElement(node, "span");
-                if (font && font.querySelector(".fa")) {
+
+                const faNodes = font?.querySelectorAll(".fa");
+                if (faNodes && Array.from(faNodes).some((faNode) => faNode.contains(node))) {
                     return font;
                 }
                 const children = font && descendants(font);

--- a/addons/html_editor/static/tests/color.test.js
+++ b/addons/html_editor/static/tests/color.test.js
@@ -594,6 +594,27 @@ test("should be able to remove color of an icon", async () => {
     });
 });
 
+test("doesn't change the color of the whole section when there's an icon next to the selection", async () => {
+    await testEditor({
+        contentBefore: `
+        <section style="color: rgb(255, 0, 0);">
+            <p>a[bc]d</p>
+            \ufeff<span class="fa fa-glass" contenteditable="false">\u200b</span>\ufeff
+        </section>`,
+        stepFunction: setColor("rgb(0, 0, 255)", "color"),
+        contentAfterEdit: `
+        <section style="color: rgb(255, 0, 0);">
+            <p>a<font style="color: rgb(0, 0, 255);">[bc]</font>d</p>
+            \ufeff<span class="fa fa-glass" contenteditable="false">\u200b</span>\ufeff
+        </section>`,
+        contentAfter: `
+        <section style="color: rgb(255, 0, 0);">
+            <p>a<font style="color: rgb(0, 0, 255);">[bc]</font>d</p>
+            <span class="fa fa-glass"></span>
+        </section>`,
+    });
+});
+
 test("should remove remove color from `td`", async () => {
     await testEditor({
         contentBefore: unformat(`


### PR DESCRIPTION
After this [commit], we'd have an issue when we tried to change a color and there was an `fa` icon next to our selection. Instead of changing the color of only the selection it would change it for the closest element with `color`, `background-color`, or `background-image` style properties.
To reproduce the bug:
- Set selection on an element that has a color style property on its parent, and the parent has .fa icon but not directly on our element
- Try to change its color

=> Color of the whole parent changes

task-5107147

[commit]: https://github.com/odoo/odoo/commit/927f4b973932d14961c148e13473017651a60dc0