### PR TITLE
[FIX] website_event_track: fix bus event name after refactoring

### DIFF
--- a/addons/website_event_track/static/src/interactions/event_track_reminder.js
+++ b/addons/website_event_track/static/src/interactions/event_track_reminder.js
@@ -1,7 +1,6 @@
 import { _t } from "@web/core/l10n/translation";
 import { renderToElement } from "@web/core/utils/render";
 import { rpc } from "@web/core/network/rpc";
-import { Component } from "@odoo/owl";
 import { Interaction } from "@web/public/interaction";
 import { registry } from "@web/core/registry";
 import { session } from "@web/session";
@@ -72,7 +71,7 @@ export class WebsiteEventTrackReminder extends Interaction {
                 this.reminderOn = reminderOnValue;
                 if (this.reminderOn) {
                     this.favoriteAddedConfirmation = _t("Track successfully added to your favorites.");
-                    Component.env.bus.trigger("open_notification_request", [
+                    this.env.bus.trigger("NOTIFICATION:REQUEST-OPEN", [
                         "add_track_to_favorite",
                         {
                             title: _t("Allow push notifications?"),


### PR DESCRIPTION
After the refactoring in this [PR], the event name was changed from 'open_notification_request' to 'NOTIFICATION:REQUEST-OPEN'.

This commit updates the event trigger to use the new name and replaces 'Component.env.bus' with 'this.env.bus' for more interaction friendly pattern.

[PR]: https://github.com/odoo/enterprise/pull/94333





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
