### PR TITLE
[FIX] account: warning when batch send cron is disabled

### DIFF
--- a/addons/account/wizard/account_move_send_batch_wizard.py
+++ b/addons/account/wizard/account_move_send_batch_wizard.py
@@ -1,6 +1,7 @@
 from collections import Counter
 
 from odoo import _, api, Command, fields, models
+from odoo.exceptions import RedirectWarning, UserError
 
 
 class AccountMoveSendBatchWizard(models.TransientModel):
@@ -83,11 +84,27 @@ class AccountMoveSendBatchWizard(models.TransientModel):
             self.env['account.move.send']._generate_and_send_invoices(self.move_ids, allow_fallback_pdf=allow_fallback_pdf)
             return
 
+        account_move_send_cron = self.env.ref('account.ir_cron_account_move_send')
+        if not account_move_send_cron.sudo().active:
+            if self.env.user.has_group('base.group_system'):
+                raise RedirectWarning(
+                    _("Batch invoice sending is unavailable. Please, activate the cron to enable batch sending of invoices."),
+                    {
+                        'views': [(False, 'form')],
+                        'res_model': 'ir.cron',
+                        'type': 'ir.actions.act_window',
+                        'res_id': account_move_send_cron.id,
+                        'target': 'current',
+                    },
+                    _("Go to cron configuration"),
+                )
+            raise UserError(_("Batch invoice sending is unavailable. Please, contact your system administrator to activate the cron to enable batch sending of invoices."))
+
         self.move_ids.sending_data = {
             'author_user_id': self.env.user.id,
             'author_partner_id': self.env.user.partner_id.id,
         }
-        self.env.ref('account.ir_cron_account_move_send')._trigger()
+        account_move_send_cron._trigger()
         return {
             'type': 'ir.actions.client',
             'tag': 'display_notification',


### PR DESCRIPTION
This commit raises a RedirectWarning to the cron configuration to inform the user that the batch invoice cron must be enabled. Batch invoices cannot be sent if cron is disabled.

task-5122707

Current behavior before PR:
If batch invoice send is called and cron is disabled, then it will silently fail and not send.

Desired behavior after PR is merged:
If batch invoice send is called and cron is disabled, then it will raise a RedirectWarning to the cron configuration.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
