### PR TITLE
[FIX] website_sale: correct mobile padding

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -4340,7 +4340,7 @@
     <template id="carousel_product_indicators_left" inherit_id="website_sale.shop_product_carousel" name="Carousel Product Indicators Left">
         <xpath expr="//div[hasclass('o_carousel_product_outer')]" position="before">
             <t t-call="website_sale.carousel_product_indicators">
-                <t t-set="indicators_list_class" t-value="'d-flex d-lg-block pe-2'"/>
+                <t t-set="indicators_list_class" t-value="'d-flex d-lg-block pe-lg-2'"/>
             </t>
         </xpath>
         <xpath expr="//div[@id='o-carousel-product']" position="attributes">


### PR DESCRIPTION
This PR removes unnecessary mobile padding that misaligns the carousel indicators.

task-5126294






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
