### PR TITLE
[FIX] pos_self_order: load only required order fields

### DIFF
--- a/addons/pos_online_payment_self_order/models/pos_order.py
+++ b/addons/pos_online_payment_self_order/models/pos_order.py
@@ -86,3 +86,7 @@ class PosOrder(models.Model):
                 'pos.payment': self.payment_ids.read(self.payment_ids._load_pos_self_data_fields(self.config_id), load=False),
             }
         })
+
+    def _load_pos_self_data_fields(self, config):
+        result = super()._load_pos_self_data_fields(config)
+        return result + ['online_payment_method_id', 'next_online_payment_amount']

--- a/addons/pos_self_order/controllers/orders.py
+++ b/addons/pos_self_order/controllers/orders.py
@@ -163,8 +163,8 @@ class PosSelfOrderController(http.Controller):
             Domain([
                 ('access_token', '=', data['access_token']),
                 '|',
-                ('write_date', '>', data['write_date']),
-                ('state', '!=', data['state']),
+                ('write_date', '>', data.get('write_date')),
+                ('state', '!=', data.get('state')),
             ]) for data in order_access_tokens
         ]
 

--- a/addons/pos_self_order/models/pos_order.py
+++ b/addons/pos_self_order/models/pos_order.py
@@ -89,8 +89,14 @@ class PosOrder(models.Model):
             'payment_result': payment_result,
             'data': {
                 'pos.order': self.read(self._load_pos_self_data_fields(self.config_id), load=False),
-                'pos.order.line': self.lines.read(self._load_pos_self_data_fields(self.config_id), load=False),
+                'pos.order.line': self.lines.read(self.lines._load_pos_self_data_fields(self.config_id), load=False),
             }
         })
         if payment_result == 'Success':
             self._send_order()
+
+    def _load_pos_self_data_fields(self, config):
+        return ['id', 'uuid', 'name', 'display_name', 'access_token', 'last_order_preparation_change', 'date_order', 'amount_total', 'amount_paid', 'amount_return', 'user_id', 'amount_tax', 'lines', 'pricelist_id', 'company_id', 'country_code', 'sequence_number', 'session_id',
+                'config_id', 'currency_id', 'currency_rate', 'is_refund', 'has_refundable_lines', 'state', 'account_move', 'preset_id', 'floating_order_name', 'general_customer_note', 'internal_note', 'nb_print', 'pos_reference', 'fiscal_position_id', 'payment_ids', 'to_invoice',
+                'shipping_date', 'preset_time', 'is_invoiced', 'is_tipped', 'tip_amount', 'ticket_code', 'tracking_number', 'email', 'mobile', 'table_id', 'course_ids',
+                'table_stand_number', 'self_ordering_table_id', 'create_date', 'write_date', 'source', 'partner_id', 'customer_count']


### PR DESCRIPTION
Before this commit, updating an order in  a self as an anonymous user raised a traceback: "Failed to write field pos.order.message_partner_ids"

Steps to reproduce
- Open a self in an anonymous window and create an order.
- In the restaurant, pay the order.
- Back in self, an error notification is displayed, and the order is not updated.

The issue occurred because all fields were being loaded, including ones not writable for anonymous users.

After this commit, only the required field are loaded.

task-5126416






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
