### PR TITLE
[FIX] mrp_account: prevent crash when MO has no finished moves

### DIFF
--- a/addons/mrp_account/models/mrp_production.py
+++ b/addons/mrp_account/models/mrp_production.py
@@ -114,7 +114,11 @@ class MrpProduction(models.Model):
                 continue
 
             desc = _('%s - Labour', mo.name)
-            account = self.env['account.account'].browse(mo.move_finished_ids[0]._get_src_account(product_accounts))
+            if mo.move_finished_ids:
+                src_account_id = mo.move_finished_ids[0]._get_src_account(product_accounts)
+            else:
+                src_account_id = (product_accounts.get('production') or product_accounts.get('stock_input')).id
+            account = self.env['account.account'].browse(src_account_id)
             labour_amounts[account] -= workcenter_cost
             account_move = self.env['account.move'].sudo().create({
                 'journal_id': product_accounts['stock_journal'].id,


### PR DESCRIPTION
In some cases, a Manufacturing Order may not have any finished move lines. When posting labor costs from work orders, it tries to access the first finished move in order to retrieve its account. If no finished move exists, this leads to a traceback at MO validation.

This commit ensures a proper fallback account is used when no finished moves are linked to the MO, avoiding unexpected crashes.

opw-4858696
opw-5066266