### PR TITLE
[FIX] survey: fix table conflict with matrix question in survey

### DIFF
--- a/addons/survey/static/src/js/survey_form.js
+++ b/addons/survey/static/src/js/survey_form.js
@@ -666,7 +666,7 @@ publicWidget.registry.SurveyFormWidget = publicWidget.Widget.extend(SurveyPreloa
                     break;
                 case 'matrix':
                     if (questionRequired) {
-                        const subQuestionsIds = $questionWrapper.find('table').data('subQuestions');
+                        const subQuestionsIds = $questionWrapper.find('table.o_survey_question_matrix').data('subQuestions');
                         // Highlight unanswered rows' header
                         const questionBodySelector = `div[id="${questionId}"] > .o_survey_question_matrix > tbody`;
                         subQuestionsIds.forEach((subQuestionId) => {


### PR DESCRIPTION
A conflict occurs if a matrix question is set to "Mandatory answer" (questionRequired = True) and a table is also added to its description.

The issue is that when the system evaluates a required matrix, it gets the subQuestionsIds by looking for the first table within the question's wrapper. If a table exists in the description, the system incorrectly tries to retrieve the IDs from that table. This action throws a traceback because the descriptive table does not contain any sub-question data.

This commit fixes the issue by being more specific when looking for the table containing the subQuestionsIds. It adds a specific class to this table and uses it in the selector. An attribute selector, like 'table[data-sub-questions]', could also have been used as an alternative.

opw-4931881