### PR TITLE
[FIX] web: Respect 'no_open' option on x2many list views

### DIFF
--- a/addons/web/static/src/views/fields/x2many/x2many_field.js
+++ b/addons/web/static/src/views/fields/x2many/x2many_field.js
@@ -103,7 +103,7 @@ export class X2ManyField extends Component {
         };
         this.canOpenRecord =
             this.props.viewMode === "list"
-                ? !(this.archInfo.editable || this.props.editable)
+                ? !(this.archInfo.editable || this.props.editable || this.props.crudOptions['no_open'])
                 : true;
 
         const selectCreate = useSelectCreate({

--- a/doc/cla/individual/mohandgesm.md
+++ b/doc/cla/individual/mohandgesm.md
@@ -1,0 +1,11 @@
+Sudan, 2025-09-21
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Mohand-GesmElkhalig mohandgesm8420@gmail.com https://github.com/mohandgesm


### PR DESCRIPTION
This fixes a regression where the 'no_open' option on One2Many/Many2Many fields was ignored in the list view (sub-view) logic, allowing users to still open the records.

The issue occurred because the logic to determine if a record could be opened did not check for the explicit 'no_open' option.

**Example XML (invoice_line_ids of type o2many):**
```xml
<field name="invoice_line_ids" readonly="True" options="{'no_open':1}">
    <list string="Journal Items" default_order="sequence, id">
     <field name="name"/>
     </list>
  <field/>
```

**Fix:**
Modify x2many_field.js to include the check for this.props.crudOptions.no_open when determining this.canOpenRecord in list view mode.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
