### PR TITLE
[FIX] pos_self_order: fix stuck prep display

### DIFF
--- a/addons/pos_online_payment_self_order/static/src/overrides/services/pos_store.js
+++ b/addons/pos_online_payment_self_order/static/src/overrides/services/pos_store.js
@@ -37,8 +37,8 @@ patch(PosStore.prototype, {
                 orderId,
             ]);
             const order = result["pos.order"][0];
-            await this.printReceipt({ order });
             await this.sendOrderInPreparation(order, { bypassPdis: true });
+            await this.printReceipt({ order });
         } catch {
             logPosMessage(
                 "Store",


### PR DESCRIPTION
When ordering from a self order and paying online, the ticket would be
printed at the cashier. If the config doesn't use any physical printer
it will fallback on webprint. In this case the cashier would need to
print via the popup on his screen. But as we are awaiting the printing
to be done, the receipt screen is not updated until the cashier has
closed the popup.

Steps to reproduce:
-------------------
* Setup a PoS to use self order and online payment.
* Make sure the PoS doesn't have any printer setup.
* Setup a preparation display for the PoS.
* Make sure the PoS is not a restaurant.
* Open the PoS, the kiosk and the preparation display on different pages
* Make an order on the kiosk and pay for it.
* Go to the PoS, you should see a popup trying to print the ticket.
> Observation: The preparation display is not updated until the printing
  popup is processed.

Why the fix:
------------
To make sure the preparation display is always up to date, we send the
order first to the prepartion display and then to the cashier. So that
if no one is at the cashier the preparation display is still updated.

opw-5111555