### PR TITLE
[FIX] website_sale: add cart redirection after ecommerce_access login

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -233,7 +233,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
     ], type='http', auth="public", website=True, sitemap=sitemap_shop)
     def shop(self, page=0, category=None, search='', min_price=0.0, max_price=0.0, ppg=False, **post):
         if not request.website.has_ecommerce_access():
-            return request.redirect('/web/login')
+            return request.redirect(f'/web/login?redirect={request.httprequest.path}')
         try:
             min_price = float(min_price)
         except ValueError:
@@ -460,7 +460,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
     @route(['/shop/<model("product.template"):product>'], type='http', auth="public", website=True, sitemap=sitemap_products, readonly=True)
     def product(self, product, category='', search='', **kwargs):
         if not request.website.has_ecommerce_access():
-            return request.redirect('/web/login')
+            return request.redirect(f'/web/login?redirect={request.httprequest.path}')
 
         return request.render("website_sale.product", self._prepare_product_values(product, category, search, **kwargs))
 
@@ -757,7 +757,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         revive: Revival method when abandoned cart. Can be 'merge' or 'squash'
         """
         if not request.website.has_ecommerce_access():
-            return request.redirect('/web/login')
+            return request.redirect('/web/login?redirect=/shop/cart')
 
         order = request.website.sale_get_order()
         if order and order.state != 'draft':

--- a/addons/website_sale/tests/test_ecommerce_access.py
+++ b/addons/website_sale/tests/test_ecommerce_access.py
@@ -40,3 +40,27 @@ class TestEcommerceAccess(HttpCaseWithUserDemo, WebsiteSaleCommon):
         self.menu.with_user(self.public_user).sudo()._compute_visible()
         # Check if menu is hidden for public user when ecommerce is restricted
         self.assertFalse(self.menu.is_visible)
+
+    def test_ecommerce_access_shop_cart_redirection(self):
+        self.website.ecommerce_access = 'logged_in'
+        self.authenticate(None, None)
+        response = self.url_open('/shop/cart', allow_redirects=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertURLEqual(response.url, '/web/login?redirect=/shop/cart')
+
+        public_category = self.env['product.public.category'].create({
+            'name': 'Test Category',
+        })
+        category_slug = self.env["ir.http"]._slug(public_category)
+        response = self.url_open(f'/shop/category/{category_slug}/page/1', allow_redirects=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertURLEqual(response.url, f'/web/login?redirect=/shop/category/{category_slug}/page/1')
+
+        public_product_template = self.env['product.template'].create({
+            'name': 'Test Template',
+            'website_published': True
+        })
+        product_slug = self.env["ir.http"]._slug(public_product_template)
+        response = self.url_open(f'/shop/{product_slug}', allow_redirects=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertURLEqual(response.url, f'/web/login?redirect=/shop/{product_slug}')


### PR DESCRIPTION
**Steps to reproduce:**
- Install eCommerce and Appointment
- Set `Ecommerce Access` to `Logged in users` in Settings > Website
- Go to the website without logging in
- Create an appointment
- Proceed to make the payment
- You will get redirected to the sign-in page due to the setting
- After logging-in the system doesn't redirect back to the checkout form

**Issue:**
When the user is not logged and the setting is applied, the user is directly sent to the login page without further redirection.

**Fix:**
Added redirect param to the original url target.

opw-4965735

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
