### PR TITLE
[FIX] stock: only reserve from company's locations

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -800,11 +800,13 @@ class StockQuant(models.Model):
                 domain = expression.AND([[('package_id', '=', package_id.id)], domain])
             if owner_id:
                 domain = expression.AND([[('owner_id', '=', owner_id.id)], domain])
+            domain = expression.AND([['|', ('company_id', 'child_of', self.env.companies.ids), ('company_id', '=', False)], domain])
             domain = expression.AND([[('location_id', 'child_of', location_id.id)], domain])
         else:
             domain = expression.AND([['|', ('lot_id', '=', lot_id.id), ('lot_id', '=', False)] if lot_id else [('lot_id', '=', False)], domain])
             domain = expression.AND([[('package_id', '=', package_id and package_id.id or False)], domain])
             domain = expression.AND([[('owner_id', '=', owner_id and owner_id.id or False)], domain])
+            domain = expression.AND([['|', ('company_id', 'in', self.env.companies.ids), ('company_id', '=', False)], domain])
             domain = expression.AND([[('location_id', '=', location_id.id)], domain])
         if self.env.context.get('with_expiration'):
             domain = expression.AND([['|', ('expiration_date', '>=', self.env.context['with_expiration']), ('expiration_date', '=', False)], domain])


### PR DESCRIPTION
Current Behavior:
When reserving product quants for a picking, quants will be selected from
children locations of the selected location, even if they are from a
company not accessible to the current user.
In Odoo 18 and Odoo 19, this also causes an Access Error to occur when
trying to view the product's On-Hand Quantity while in the picking's
company.

Expected Behavior:
Quants should only be reserved from locations in companies the current
user has enabled.

Steps to reproduce:
1. Enable Locations in Inventory
2. Create a Location with no Company set, then set it as the parent of
   the Stock locations in Companies X and Y
2. Create a new Stored Product and add a Quant for it in Company X
3. Create a Quotation in Company Y including the product and confirm it
4. In the Delivery connected to the Sale Order, set the Source Location
   to the created parent Location, then select Check Availability

Fix:
Modify the gather domain to only include records from active companies.

opw-5096469