### PR TITLE
[FIX] delivery: resequence providers ir.module.module views

### DIFF
--- a/addons/delivery/views/ir_module_module_views.xml
+++ b/addons/delivery/views/ir_module_module_views.xml
@@ -6,6 +6,7 @@
         <field name="model">ir.module.module</field>
         <field name="inherit_id" ref="base.module_tree"/>
         <field name="mode">primary</field>
+        <field name="priority">20</field>
         <field name="arch" type="xml">
             <field name="name" position="attributes">
                 <attribute name="column_invisible">1</attribute>
@@ -27,6 +28,7 @@
         <field name="model">ir.module.module</field>
         <field name="inherit_id" ref="base.module_view_kanban"/>
         <field name="mode">primary</field>
+        <field name="priority">20</field>
         <field name="arch" type="xml">
             <button name="button_immediate_install" position="after">
                 <button


### PR DESCRIPTION
This commit* introduced a new views for delivery provider modules, list and kanban. The new views are meant to target only this particular delivery provider view. But, since the priority of the list view is not defined, the default order (with the name) makes it used before the classic list view for modules in Apps. This has the effect to hide a few fields (name, author, website and version).

This commit adds a priority to this list view such that it is not used by default to list ir.module.module records. A priority is also defined on the kanban view to avoid this issue to affect kanban view if anyone ever changes its name.

*: https://github.com/odoo/odoo/commit/b798db1b2faa0e437baa4fc524821ec324136aff