### PR TITLE
[IMP] hr_work_entry*: add source field to work entries

### DIFF
--- a/addons/hr_work_entry/models/hr_employee.py
+++ b/addons/hr_work_entry/models/hr_employee.py
@@ -8,7 +8,7 @@ class HrEmployee(models.Model):
     _inherit = 'hr.employee'
 
     has_work_entries = fields.Boolean(compute='_compute_has_work_entries', groups="base.group_system,hr.group_hr_user")
-    work_entry_source = fields.Selection(readonly=False, related="version_id.work_entry_source", inherited=True, groups="hr.group_hr_manager")
+    work_entry_source = fields.Selection(readonly=False, related="version_id.work_entry_source", inherited=True, groups="base.group_system,hr.group_hr_manager")
     work_entry_source_calendar_invalid = fields.Boolean(related="version_id.work_entry_source_calendar_invalid", inherited=True, groups="hr.group_hr_manager")
 
     def _compute_has_work_entries(self):

--- a/addons/hr_work_entry/models/hr_version.py
+++ b/addons/hr_work_entry/models/hr_version.py
@@ -30,7 +30,7 @@ class HrVersion(models.Model):
         Working Schedule: Work entries will be generated from the working hours below.
         Attendances: Work entries will be generated from the employee's attendances. (requires Attendance app)
         Planning: Work entries will be generated from the employee's planning. (requires Planning app)
-    ''', groups="hr.group_hr_manager")
+    ''', groups="base.group_system,hr.group_hr_manager")
     work_entry_source_calendar_invalid = fields.Boolean(
         compute='_compute_work_entry_source_calendar_invalid',
         groups="hr.group_hr_manager",
@@ -311,7 +311,8 @@ class HrVersion(models.Model):
                 leaves_over_interval = [l for l in leaves_over_attendances if l[0] >= interval[0] and l[1] <= interval[1]]
                 for leave_interval in [(l[0], l[1], interval[2]) for l in leaves_over_interval]:
                     leave_entry_type = version._get_interval_leave_work_entry_type(leave_interval, leaves, bypassing_work_entry_type_codes)
-                    interval_leaves = [leave for leave in leaves if leave[2].work_entry_type_id.id == leave_entry_type.id]
+                    # leaves don't have work_entry_type_id set if you create them before having hr_work_entry_installed
+                    interval_leaves = [leave for leave in leaves if not leave[2].work_entry_type_id or leave[2].work_entry_type_id.id == leave_entry_type.id]
                     interval_start = leave_interval[0].astimezone(pytz.utc).replace(tzinfo=None)
                     interval_stop = leave_interval[1].astimezone(pytz.utc).replace(tzinfo=None)
                     version_vals += [dict([

--- a/addons/hr_work_entry/models/hr_work_entry.py
+++ b/addons/hr_work_entry/models/hr_work_entry.py
@@ -24,6 +24,7 @@ class HrWorkEntry(models.Model):
     employee_id = fields.Many2one('hr.employee', required=True, domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]", index=True)
     version_id = fields.Many2one('hr.version', string="Employee Record", required=True)
     work_entry_source = fields.Selection(related='version_id.work_entry_source')
+    resource_calendar_id = fields.Many2one(related='version_id.resource_calendar_id')
     date = fields.Date(required=True)
     duration = fields.Float(string="Duration", default=8)
     work_entry_type_id = fields.Many2one('hr.work.entry.type', index=True, default=lambda self: self.env['hr.work.entry.type'].search([], limit=1), domain="['|', ('country_id', '=', False), ('country_id', '=', country_id)]")
@@ -31,6 +32,8 @@ class HrWorkEntry(models.Model):
     code = fields.Char(related='work_entry_type_id.code')
     external_code = fields.Char(related='work_entry_type_id.external_code')
     color = fields.Integer(related='work_entry_type_id.color', readonly=True)
+    is_leave = fields.Boolean(related='work_entry_type_id.is_leave')
+    is_manual = fields.Boolean(help="Marks if the work entry came from manual creation or split")
     state = fields.Selection([
         ('draft', 'New'),
         ('conflict', 'In Conflict'),
@@ -128,6 +131,7 @@ class HrWorkEntry(models.Model):
                 )
             )
         self.duration -= split_duration
+        self.is_manual = True
         split_work_entry = self.copy()
         split_work_entry.write(vals)
         return split_work_entry.id

--- a/addons/hr_work_entry/models/hr_work_entry_type.py
+++ b/addons/hr_work_entry/models/hr_work_entry_type.py
@@ -24,7 +24,7 @@ class HrWorkEntryType(models.Model):
     )
     country_code = fields.Char(related='country_id.code')
     is_leave = fields.Boolean(
-        default=False, string="Time Off", help="Allow the work entry type to be linked with time off types.")
+        default=False, string="Is Time Off", help="Allow the work entry type to be linked with time off types.")
     is_work = fields.Boolean(
         compute='_compute_is_work', inverse='_inverse_is_work', string="Working Time", readonly=False,
         help="If checked, the work entry is counted as work time in the working schedule")

--- a/addons/hr_work_entry/security/ir.model.access.csv
+++ b/addons/hr_work_entry/security/ir.model.access.csv
@@ -1,5 +1,5 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_hr_work_entry_officer,access_hr_work_entry_officer,model_hr_work_entry,hr.group_hr_user,1,1,1,0
+access_hr_work_entry_officer,access_hr_work_entry_officer,model_hr_work_entry,hr.group_hr_manager,1,1,1,0
 access_hr_work_entry_system,access_hr_work_entry_system,model_hr_work_entry,base.group_system,1,1,1,1
 access_hr_work_entry_type_officer,access_hr_work_entry_type_officer,model_hr_work_entry_type,hr.group_hr_user,1,0,0,0
 access_hr_work_entry_type_manager,access_hr_work_entry_type_manager,model_hr_work_entry_type,hr.group_hr_manager,1,1,1,1

--- a/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_calendar_controller.js
+++ b/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_calendar_controller.js
@@ -47,6 +47,7 @@ export class WorkEntryCalendarController extends CalendarController {
                     default_work_entry_type_id: record.rawRecord.work_entry_type_id?.[0],
                     default_employee_id: record.rawRecord.employee_id?.[0],
                     default_date: record.rawRecord.date,
+                    default_is_manual: true,
                 },
                 canExpand: false,
             },

--- a/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_multi_selection_buttons.js
+++ b/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_multi_selection_buttons.js
@@ -38,6 +38,10 @@ export class WorkEntryCalendarMultiSelectionButtons extends MultiSelectionButton
         props.onQuickReplace = (values) => {
             this.props.reactive.onQuickReplace(values);
         }
+        props.multiCreateRecordProps.context = {
+            default_is_manual: true,
+            default_employee_id: this.actionService.currentController.currentState.active_id,
+        }
         return props;
     }
 
@@ -62,6 +66,7 @@ export class WorkEntryCalendarMultiSelectionButtons extends MultiSelectionButton
             employee_id: this.actionService.currentController.currentState.active_id,
             duration: -1,
             work_entry_type_id: workEntryTypeId,
+            is_manual: true,
         };
     }
 

--- a/addons/hr_work_entry/views/hr_employee_views.xml
+++ b/addons/hr_work_entry/views/hr_employee_views.xml
@@ -9,7 +9,7 @@
             <button name="action_open_versions" position="before">
                 <field name="has_work_entries" invisible="1"/>
                 <button invisible="not has_work_entries" type="object" class="oe_stat_button" id="open_work_entries"
-                    icon="fa-calendar" name="action_open_work_entries">
+                    icon="fa-calendar" name="action_open_work_entries" groups="hr.group_hr_manager">
                     <div class="o_stat_info">
                             <span class="o_stat_text">
                             Work Entries

--- a/addons/hr_work_entry/views/hr_work_entry_views.xml
+++ b/addons/hr_work_entry/views/hr_work_entry_views.xml
@@ -41,6 +41,7 @@
                 <field name="employee_id" invisible="1"/>
                 <field name="color" invisible="1"/>
                 <field name="display_code" invisible="1"/>
+                <field name="is_manual" invisible="1"/>
             </form>
         </field>
     </record>
@@ -99,7 +100,7 @@
                         <group>
                             <field name="date" readonly="state != 'draft'"/>
                             <label for="duration"/>
-                            <div class="o_row mw-50 mw-sm-25">
+                            <div class="o_row mw-50 mw-sm-25" name="duration">
                                 <field name="duration"
                                     nolabel="1"
                                     widget="float_time"
@@ -107,6 +108,9 @@
                                     readonly="state != 'draft'"/>
                                 <span>Hours</span>
                             </div>
+                            <field name="resource_calendar_id" string="Source" invisible="is_manual or work_entry_source != 'calendar' or is_leave" readonly="1"/>
+                            <span class="text-muted fw-medium" invisible="not is_manual">Source</span>
+                            <span class="o_row mw-50 mw-sm-25" invisible="not is_manual">Manual</span>
                             <field name="company_id" invisible="1"/>
                         </group>
                     </group>

--- a/addons/hr_work_entry_holidays/models/hr_leave.py
+++ b/addons/hr_work_entry_holidays/models/hr_leave.py
@@ -43,7 +43,7 @@ class HrLeave(models.Model):
             for contract in contracts:
                 # Generate only if it has aleady been generated
                 if leave.date_to >= contract.date_generated_from and leave.date_from <= contract.date_generated_to:
-                    work_entries_vals_list += contracts._get_work_entries_values(leave.date_from, leave.date_to)
+                    work_entries_vals_list += contract._get_work_entries_values(leave.date_from, leave.date_to)
 
         work_entries_vals_list = self.env['hr.version']._generate_work_entries_postprocess(work_entries_vals_list)
         new_leave_work_entries = self.env['hr.work.entry'].create(work_entries_vals_list)


### PR DESCRIPTION
- added Source field in `hr_work_entry_view_form` which takes value from:
    - `resource_calendar_id` if the work entry has been generated from the working schedule
    - `leave_id` if the work entry has been generated from a time off
    - `planning_slot_id` if the work entry has been generated from a planning
    - `attendance_id` if the work entry has been generated from attendance
    - Manual if the work entry has been generated manually
- removed the expand button in the `hr_work_entry` pop up
- added inherited views for `hr_work_entry_view_form` in `hr_work_entry_attendance` and `hr_work_entry_planning` to show corresponding fields
- changed access of the work entries smart button to be only `group_hr_manager` and then change to `group_hr_payroll_user` when payroll is installed
- removed access to work entries from `group_hr_manager` when payroll is installed

Enterprise PR: odoo/enterprise#95964

task-5118852