### PR TITLE
[FIX] stock: fix unreserve for 2-step delivery

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1781,7 +1781,8 @@ Please change the quantity done or the rounding precision of your unit of measur
                         need = move.product_qty - sum(move.move_line_ids.mapped('quantity_product_uom')) - sum(taken_quantities.values())
                         move_line_vals, taken_quantity = move._update_reserved_quantity_vals(min(quantity, need), location_id, None, lot_id, package_id, owner_id, strict=True)
                         all_move_line_vals += move_line_vals
-                        taken_quantities[need, location_id, lot_id, package_id, owner_id] = taken_quantity
+                        if move_line_vals:  # Only subtract for new lines (updates are already reflected in sum(move_line_ids))
+                            taken_quantities[need, location_id, lot_id, package_id, owner_id] = taken_quantity
                     if all_move_line_vals:
                         self.env['stock.move.line'].create(all_move_line_vals)
 

--- a/addons/stock/tests/test_move2.py
+++ b/addons/stock/tests/test_move2.py
@@ -3930,3 +3930,101 @@ class TestAutoAssign(TestStockCommon):
         move.lot_ids = [(4, lot2.id)]
         move.lot_ids = [(4, lot3.id)]
         self.assertEqual(move.quantity, 3.0/12.0)
+
+
+class TestPickShipBackorder(TestStockCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.picking_type_out = cls.env["stock.picking.type"].search(
+            [("code", "=", "outgoing")], limit=1
+        )
+        cls.picking_type_out.use_create_lots = True
+        cls.picking_type_out.write({"sequence_code": "WH/OUT"})
+
+        cls.product_lot = cls.env["product.product"].create(
+            {
+                "name": "Lot Product",
+                "type": "product",
+                "tracking": "lot",
+                "uom_id": cls.env.ref("uom.product_uom_unit").id,
+                "uom_po_id": cls.env.ref("uom.product_uom_unit").id,
+            }
+        )
+
+        cls.lot1 = cls.env["stock.lot"].create(
+            {
+                "name": "LOT001",
+                "product_id": cls.product_lot.id,
+            }
+        )
+        cls.lot2 = cls.env["stock.lot"].create(
+            {
+                "name": "LOT002",
+                "product_id": cls.product_lot.id,
+            }
+        )
+
+        cls.stock_location = cls.env.ref("stock.stock_location_stock")
+
+        cls.env["stock.quant"]._update_available_quantity(
+            cls.product_lot, cls.stock_location, 5.0, lot_id=cls.lot1
+        )
+        cls.env["stock.quant"]._update_available_quantity(
+            cls.product_lot, cls.stock_location, 5.0, lot_id=cls.lot2
+        )
+
+    def test_pick_assign_and_backorder(self):
+        cust = self.env.ref("stock.stock_location_customers")
+        pg = self.env["procurement.group"].create({"name": "sale order"})
+        warehouse = self.env["stock.warehouse"].search([], limit=1)
+        warehouse.delivery_steps = "pick_ship"
+        self.env["procurement.group"].run(
+            [
+                pg.Procurement(
+                    self.product_lot,
+                    10.0,
+                    self.product_lot.uom_id,
+                    cust,
+                    "sale_order",
+                    "sale_order",
+                    warehouse.company_id,
+                    {"warehouse_id": warehouse, "group_id": pg},
+                )
+            ]
+        )
+        picking = pg.stock_move_ids.picking_id[1]
+
+        picking.action_confirm()
+        picking.action_assign()
+
+        move_line_obj = picking.move_ids.move_line_ids
+
+        pack = self.env["stock.quant.package"].create({"name": "Test Package"})
+        move_line_obj[0].write({"quantity": 2.0, "lot_id": self.lot1})
+        move_line_obj[1].write({"quantity": 2.0, "lot_id": self.lot2})
+        picking.move_ids.move_line_ids = [
+            Command.create(
+                {
+                    "picking_id": picking.id,
+                    "move_id": picking.move_ids[0].id,
+                    "product_id": self.product_lot.id,
+                    "lot_id": self.lot1.id,
+                    "quantity": 3.0,
+                    "result_package_id": pack.id,
+                }
+            )
+        ]
+
+        picking.picking_type_id.create_backorder = "always"
+        picking.button_validate()
+
+        backorder = self.env["stock.picking"].search(
+            [("backorder_id", "=", picking.id)]
+        )
+
+        self.assertTrue(backorder, "Backorder should exist")
+
+        backorder.action_assign()
+        backorder.button_validate()
+        self.assertEqual(backorder.state, "done")


### PR DESCRIPTION
# Problem

Unreserve issue preventing users from validating a delivery order with 2-step delivery warehouse configuration. Introduced in the following commit: https://github.com/odoo/odoo/commit/13567aa27250f5798bbe42648eeac82241dbb780

# Steps to reproduce on the runbot:

- Activate packages
- Edit the warehouse to deliver in 2-steps
- Create a product tracked by lot
- Create two lots with 5 qty each
- Create a sale order with 10 qty and confirm
- Check the delivery order and assign: 
=> 2 units to lot1 and create a pkg for it
=> 1 units to lot1 without pkg
=> 3 to lot2 without package
- Validate the delivery and create a backorder
- go to pick backorder and try to validate
- Unreserve issue pops up
- For further details, check: [#225948](https://github.com/odoo/odoo/issues/225948)

# Solution:

Conditional subtracting limited to new lines only.

Task ID: opw-5086289


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
