### PR TITLE
[FIX] base: stability improvements during module uninstallation

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -2543,6 +2543,10 @@ class IrModelData(models.Model):
         # of records being cascade-deleted or tables being dropped just above
         for data in self.browse(undeletable_ids).exists():
             record = self.env[data.model].browse(data.res_id)
+            table_name = record._table
+            if not tools.table_exists(self._cr, table_name):
+                _logger.debug("Skipping record %s because table %s does not exist", data, table_name)
+                continue
             try:
                 with self.env.cr.savepoint():
                     if record.exists():

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -1783,10 +1783,23 @@ class IrModelFieldsSelection(models.Model):
         self.ensure_one()
         Model = self.env[self.field_id.model]
         Model.flush_model([self.field_id.name])
-        query = 'SELECT id FROM "{table}" WHERE "{field}"=%s'.format(
-            table=Model._table, field=self.field_id.name,
-        )
-        self.env.cr.execute(query, [self.value])
+        # Detect column type
+        self.env.cr.execute("""
+            SELECT data_type 
+            FROM information_schema.columns 
+            WHERE table_name=%s AND column_name=%s
+        """, (Model._table, self.field_id.name))
+        col_type = self.env.cr.fetchone()[0]
+        # Choose comparison depending on data type
+        if col_type in ("json", "jsonb"):
+            operator = "%s::jsonb"
+            value = Json(self.value)
+        else:
+            operator = "%s"
+            value = self.value
+        query = 'SELECT id FROM "{table}" WHERE "{field}" = ' + operator
+        query = query.format(table=Model._table, field=self.field_id.name)
+        self.env.cr.execute(query, [value])
         return Model.browse(r[0] for r in self.env.cr.fetchall())
 
 
@@ -2544,7 +2557,7 @@ class IrModelData(models.Model):
         for data in self.browse(undeletable_ids).exists():
             record = self.env[data.model].browse(data.res_id)
             table_name = record._table
-            if not tools.table_exists(self._cr, table_name):
+            if not sql.table_exists(self.env.cr, table_name):
                 _logger.debug("Skipping record %s because table %s does not exist", data, table_name)
                 continue
             try:


### PR DESCRIPTION
This PR contains two independent but related fixes addressing crashes that may occur while uninstalling modules in databases where `ir.model.data`, `ir.model.fields.selection` and JSON-backed fields are involved.

1. Prevent crash when comparing JSON fields in selection ondelete logic - commit [6d1ae58](https://github.com/odoo/odoo/pull/229447/commits/6d1ae5828db0b86e6d00367b3cf6a0fa1d0297cb)

- During `_process_ondelete`, odoo deletes records referencing a given selection value by running a raw SQL filter: `WHERE "<field>" = %s`
- If the field is of type `json/jsonb`, PostgreSQL refuses to compare JSON against plain strings and raises: 
```
ERROR: invalid input syntax for type json
DETAIL: Token "snailmail" is invalid.
```
- Fix: Detect when the column is `json/jsonb` and wrap the comparison value in `Json(...)` so that PostgreSQL performs a proper cast. This prevents uninstall crashes on databases using JSON-backed selection fields such as `res_partner.invoice_sending_method`.

2. Prevent crash when validating undeletable `ir.model.data` records - commit [8def242](https://github.com/odoo/odoo/pull/229447/commits/8def24213fe448d2ade3138cde8ecd704f681acd)

- A previous change (#72802) added a final safety pass where undeletable XMLIDs are re-evaluated via `.exists()` in case their target records became deletable later. However, if the underlying table has already been dropped earlier in the uninstall, `.exists()` raises: `ERROR: relation "<table>" does not exist`.
- Fix: Before performing `record.exists()`, check whether the table still exists using `sql.table_exists()`. If not, consider the XMLID orphaned and clean it up silently instead of crashing.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
