### PR TITLE
[IMP] html_editor: enable drag-and-drop for table rows and columns

### DIFF
--- a/addons/html_editor/static/src/main/table/table_drag_drop.js
+++ b/addons/html_editor/static/src/main/table/table_drag_drop.js
@@ -1,0 +1,173 @@
+import { closestElement } from "@html_editor/utils/dom_traversal";
+import { getColumnIndex, getRowIndex } from "@html_editor/utils/table";
+import { Component, useRef, useExternalListener, onMounted, onWillUnmount } from "@odoo/owl";
+
+const OVERLAY_CLAMP_OFFSET = 5;
+
+export class TableDragDrop extends Component {
+    static template = "html_editor.TableDragDrop";
+    static props = {
+        type: String,
+        pointerPos: Object,
+        target: { validate: (el) => el.nodeType === Node.ELEMENT_NODE },
+        document: { validate: (p) => p.nodeType === Node.DOCUMENT_NODE },
+        editable: { validate: (p) => p.nodeType === Node.ELEMENT_NODE },
+        close: Function,
+        moveRow: Function,
+        moveColumn: Function,
+    };
+
+    setup() {
+        this.overlayRef = useRef("dragOverlay");
+        this.pointerPos = { ...this.props.pointerPos };
+        this.tableElement = closestElement(this.props.target, "table");
+        this.tableRect = this.tableElement.getBoundingClientRect();
+        const targetRect =
+            this.props.type === "row"
+                ? this.props.target.parentElement.getBoundingClientRect()
+                : this.props.target.getBoundingClientRect();
+        this.overlayRect = {
+            top: targetRect.top,
+            left: targetRect.left,
+            width: targetRect.width,
+            height: this.props.type === "row" ? targetRect.height : this.tableRect.height,
+        };
+        // Compute bounding rects of rows or column cells
+        this.itemRects =
+            this.props.type === "row"
+                ? [...this.tableElement.rows].map((r) => r.getBoundingClientRect())
+                : [...this.props.target.parentElement.cells].map((c) => c.getBoundingClientRect());
+
+        useExternalListener(this.props.document, "pointermove", this.onPointerMove);
+        useExternalListener(this.props.document, "pointerup", this.onPointerUp);
+        if (this.props.document !== document) {
+            // Listen outside the iframe.
+            useExternalListener(document, "pointermove", this.onPointerMove);
+            useExternalListener(document, "pointerup", this.onPointerUp);
+        }
+
+        onMounted(() => {
+            this.props.editable.classList.add("o-we-table-dragging");
+            if (this.overlayRef.el) {
+                Object.assign(this.overlayRef.el.style, {
+                    top: `${this.overlayRect.top}px`,
+                    left: `${this.overlayRect.left}px`,
+                    width: `${this.overlayRect.width}px`,
+                    height: `${this.overlayRect.height}px`,
+                });
+            }
+        });
+
+        onWillUnmount(() => {
+            this.props.editable.classList.remove("o-we-table-dragging");
+            this.clearBorderHighlights();
+        });
+    }
+
+    clearBorderHighlights() {
+        // Determine which highlight classes to remove.
+        const highlightClasses = [
+            "tr-highlight-top",
+            "tr-highlight-bottom",
+            "td-highlight-left",
+            "td-highlight-right",
+        ];
+        const highlightedElements = this.tableElement.querySelectorAll(
+            highlightClasses.map((cls) => `.${cls}`).join(", ")
+        );
+        // Remove the highlight classes.
+        highlightedElements.forEach((el) => el.classList.remove(...highlightClasses));
+    }
+
+    getInsertPosition() {
+        // Calculate overlay middle(vertical for row, horizontal for column)
+        const overlayMiddle =
+            this.props.type === "row"
+                ? this.overlayRect.top + this.overlayRect.height / 2
+                : this.overlayRect.left + this.overlayRect.width / 2;
+        // Index of target row/column where overlay is currently positioned
+        const targetIndex = this.itemRects.findIndex((rect) =>
+            this.props.type === "row"
+                ? rect.top <= overlayMiddle && overlayMiddle <= rect.bottom
+                : rect.left <= overlayMiddle && overlayMiddle <= rect.right
+        );
+        // Calculate the middle of the target row/column
+        const targetMiddle =
+            this.props.type === "row"
+                ? this.itemRects[targetIndex].top + this.itemRects[targetIndex].height / 2
+                : this.itemRects[targetIndex].left + this.itemRects[targetIndex].width / 2;
+
+        // Determine whether to insert before or after the target
+        // Insert before if overlay middle is left, else after
+        return { targetIndex, insertBefore: overlayMiddle < targetMiddle };
+    }
+
+    onPointerMove(ev) {
+        // Calculate min and max positions for overlay to
+        // prevent it from going outside the table bounds
+        const min =
+            this.props.type === "row"
+                ? this.tableRect.top - this.overlayRect.height / 2 + OVERLAY_CLAMP_OFFSET
+                : this.tableRect.left - this.overlayRect.width / 2 + OVERLAY_CLAMP_OFFSET;
+        const max =
+            this.props.type === "row"
+                ? this.tableRect.bottom - this.overlayRect.height / 2 - OVERLAY_CLAMP_OFFSET
+                : this.tableRect.right - this.overlayRect.width / 2 - OVERLAY_CLAMP_OFFSET;
+        // Update overlay position on pointer movement, clamped within min/max
+        if (this.props.type === "row") {
+            this.overlayRect.top = Math.min(
+                max,
+                Math.max(min, this.overlayRect.top + ev.clientY - this.pointerPos.y)
+            );
+        } else {
+            this.overlayRect.left = Math.min(
+                max,
+                Math.max(min, this.overlayRect.left + ev.clientX - this.pointerPos.x)
+            );
+        }
+        this.clearBorderHighlights();
+        const { targetIndex, insertBefore } = this.getInsertPosition();
+        // Highlight the target row or column
+        if (this.props.type === "row") {
+            const targetRow = this.tableElement.rows[targetIndex];
+            targetRow.classList.add(insertBefore ? "tr-highlight-top" : "tr-highlight-bottom");
+        } else {
+            [...this.tableElement.rows].forEach((row) => {
+                const targetCell = row.cells[targetIndex];
+                targetCell.classList.add(insertBefore ? "td-highlight-left" : "td-highlight-right");
+            });
+        }
+        // Apply updated overlay position to the overlay element
+        const overlayStyle = this.overlayRef.el.style;
+        overlayStyle.top = `${this.overlayRect.top}px`;
+        overlayStyle.left = `${this.overlayRect.left}px`;
+        // Update stored pointer position for next move
+        this.pointerPos.x = ev.clientX;
+        this.pointerPos.y = ev.clientY;
+    }
+
+    onPointerUp() {
+        this.clearBorderHighlights();
+
+        let { targetIndex, insertBefore } = this.getInsertPosition();
+        const draggedIndex =
+            this.props.type === "row"
+                ? getRowIndex(this.props.target.parentElement)
+                : getColumnIndex(this.props.target);
+        if (draggedIndex > targetIndex && !insertBefore) {
+            // Moving upward or leftward
+            targetIndex += 1;
+        } else if (draggedIndex < targetIndex && insertBefore) {
+            // Moving downward or rightward
+            targetIndex -= 1;
+        }
+
+        if (this.props.type === "row") {
+            this.props.moveRow(targetIndex, this.props.target.parentElement);
+        } else {
+            this.props.moveColumn(targetIndex, this.props.target);
+        }
+        // Close overlay after drop
+        this.props.close();
+    }
+}

--- a/addons/html_editor/static/src/main/table/table_drag_drop.scss
+++ b/addons/html_editor/static/src/main/table/table_drag_drop.scss
@@ -1,0 +1,25 @@
+.o-we-table-drag-drop {
+    position: fixed;
+    background-color: rgba(117, 167, 249, 0.5);
+    cursor: grabbing;
+}
+
+.o-we-table-dragging {
+    cursor: grabbing;
+}
+
+.tr-highlight-top {
+    border-top: 2px solid rgba(0, 136, 255, 0.508) !important;
+}
+
+.tr-highlight-bottom {
+    border-bottom: 2px solid rgba(0, 136, 255, 0.508) !important;
+}
+
+.td-highlight-left {
+    border-left: 2px solid rgba(0, 136, 255, 0.508) !important;
+}
+
+.td-highlight-right {
+    border-right: 2px solid rgba(0, 136, 255, 0.508) !important;
+}

--- a/addons/html_editor/static/src/main/table/table_drag_drop.xml
+++ b/addons/html_editor/static/src/main/table/table_drag_drop.xml
@@ -1,0 +1,5 @@
+<templates xml:space="preserve">
+  <t t-name="html_editor.TableDragDrop">
+    <div t-ref="dragOverlay" class="o-we-table-drag-drop"></div>
+  </t>
+</templates>

--- a/addons/html_editor/static/src/main/table/table_menu.js
+++ b/addons/html_editor/static/src/main/table/table_menu.js
@@ -1,4 +1,5 @@
 import { closestElement } from "@html_editor/utils/dom_traversal";
+import { getColumnIndex, getRowIndex } from "@html_editor/utils/table";
 import { Component } from "@odoo/owl";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
@@ -78,13 +79,13 @@ export class TableMenu extends Component {
                 name: "move_left",
                 icon: "fa-chevron-left disabled",
                 text: ltr ? _t("Move left") : _t("Move right"),
-                action: this.props.moveColumn.bind(this, "left"),
+                action: (target) => this.props.moveColumn(getColumnIndex(target) - 1, target),
             },
             !this.isLast && {
                 name: "move_right",
                 icon: "fa-chevron-right",
                 text: ltr ? _t("Move right") : _t("Move left"),
-                action: this.props.moveColumn.bind(this, "right"),
+                action: (target) => this.props.moveColumn(getColumnIndex(target) + 1, target),
             },
             {
                 name: "insert_left",
@@ -147,13 +148,15 @@ export class TableMenu extends Component {
                 name: "move_up",
                 icon: "fa-chevron-up",
                 text: _t("Move up"),
-                action: (target) => this.props.moveRow("up", target.parentElement),
+                action: (target) =>
+                    this.props.moveRow(getRowIndex(target.parentElement) - 1, target.parentElement),
             },
             !this.isLast && {
                 name: "move_down",
                 icon: "fa-chevron-down",
                 text: _t("Move down"),
-                action: (target) => this.props.moveRow("down", target.parentElement),
+                action: (target) =>
+                    this.props.moveRow(getRowIndex(target.parentElement) + 1, target.parentElement),
             },
             !this.isTableHeader && {
                 name: "insert_above",

--- a/addons/html_editor/static/src/main/table/table_menu.xml
+++ b/addons/html_editor/static/src/main/table/table_menu.xml
@@ -12,9 +12,12 @@
                 <div t-on-pointerdown.stop="() => {}">
                     <t t-foreach="items" t-as="item" t-key="item_index">
                         <DropdownItem onSelected="() => this.onSelected(item)">
-                            <div class="user-select-none" t-att-name="item.name">
-                                <span t-if="item.icon" class="me-2 fa" t-att-class="item.icon"/>
-                                <span t-esc="item.text"/>
+                            <div class="user-select-none d-flex align-items-center" t-att-name="item.name">
+                                <span t-if="item.icon"
+                                    class="fa text-center"
+                                    style="width:16px;"
+                                    t-att-class="item.icon"/>
+                                <span class="ms-2" t-esc="item.text"/>
                             </div>
                         </DropdownItem>
                     </t>

--- a/addons/html_editor/static/src/main/table/table_menu.xml
+++ b/addons/html_editor/static/src/main/table/table_menu.xml
@@ -1,7 +1,13 @@
 <templates xml:space="preserve">
     <t t-name="html_editor.TableMenu">
         <Dropdown menuClass="'m-0'" position="props.type === 'column' ? 'bottom' : 'right'" state="props.dropdownState" bottomSheet="false">
-            <button t-att-data-type="props.type" class="o-we-table-menu oi" t-attf-class="oi-ellipsis-{{props.type === 'column' ? 'h w-100' : 'v h-100 px-0'}}" />
+            <button
+                t-ref="menuRef"
+                t-att-data-type="props.type"
+                class="o-we-table-menu oi"
+                t-attf-class="oi-ellipsis-{{ props.type === 'column' ? 'h w-100' : 'v h-100 px-0' }}"
+                title="Click to open options&#10;Drag to move"
+            />
             <t t-set-slot="content">
                 <div t-on-pointerdown.stop="() => {}">
                     <t t-foreach="items" t-as="item" t-key="item_index">
@@ -12,7 +18,7 @@
                             </div>
                         </DropdownItem>
                     </t>
-                 </div>
+                </div>
             </t>
         </Dropdown>
     </t>

--- a/addons/html_editor/static/src/main/table/table_ui_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_ui_plugin.js
@@ -5,6 +5,7 @@ import { _t } from "@web/core/l10n/translation";
 import { TableMenu } from "./table_menu";
 import { TablePicker } from "./table_picker";
 import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
+import { TableDragDrop } from "./table_drag_drop";
 
 /**
  * This plugin only contains the table ui feature (table picker, menus, ...).
@@ -66,6 +67,8 @@ export class TableUIPlugin extends Plugin {
                 position: "left-fit",
             },
         });
+        /** @type {import("@html_editor/core/overlay_plugin").Overlay} */
+        this.tableDragDropOverlay = this.dependencies.overlay.createOverlay(TableDragDrop);
         this.addDomListener(this.document, "pointermove", this.onMouseMove);
         const closeMenus = () => {
             if (this.isMenuOpened) {
@@ -172,8 +175,11 @@ export class TableUIPlugin extends Plugin {
                 props: {
                     type: "row",
                     overlay: this.rowMenu,
+                    tableDragDropOverlay: this.tableDragDropOverlay,
                     target: td,
                     dropdownState: this.createDropdownState(this.colMenu),
+                    document: this.document,
+                    editable: this.editable,
                     ...tableMethods,
                 },
             });
@@ -185,8 +191,11 @@ export class TableUIPlugin extends Plugin {
                     type: "column",
                     overlay: this.colMenu,
                     target: td,
+                    tableDragDropOverlay: this.tableDragDropOverlay,
                     dropdownState: this.createDropdownState(this.rowMenu),
                     direction: this.config.direction || "ltr",
+                    document: this.document,
+                    editable: this.editable,
                     ...tableMethods,
                 },
             });

--- a/addons/html_editor/static/tests/table/table_drag_drop.test.js
+++ b/addons/html_editor/static/tests/table/table_drag_drop.test.js
@@ -1,0 +1,560 @@
+import { expect, test } from "@odoo/hoot";
+import { setupEditor } from "../_helpers/editor";
+import { unformat } from "../_helpers/format";
+import { expectElementCount } from "../_helpers/ui_expectations";
+import { hover, manuallyDispatchProgrammaticEvent, waitFor } from "@odoo/hoot-dom";
+import { getContent } from "../_helpers/selection";
+import { redo, undo } from "../_helpers/user_actions";
+import { delay } from "@web/core/utils/concurrency";
+
+test("should move first column after second column on drag and drop", async () => {
+    const { el } = await setupEditor(
+        unformat(`
+            <p><br></p>
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr>
+                        <td class="a">[]1</td>
+                        <td class="b">2</td>
+                        <td class="c">3</td>
+                    </tr>
+                    <tr>
+                        <td class="d">4</td>
+                        <td class="e">5</td>
+                        <td class="f">6</td>
+                    </tr>
+                </tbody>
+            </table>
+        `)
+    );
+    await expectElementCount(".o-we-table-menu", 0);
+    // Hover over first cell to trigger column menu
+    await hover(el.querySelector("td.a"));
+    await waitFor("[data-type='column'].o-we-table-menu");
+    const colMenu = document.querySelector("[data-type='column'].o-we-table-menu");
+    const colMenuRect = colMenu.getBoundingClientRect();
+    // Start long press on column menu
+    await manuallyDispatchProgrammaticEvent(colMenu, "pointerdown", {
+        clientX: colMenuRect.x + colMenuRect.width / 2,
+        clientY: colMenuRect.y,
+    });
+    // Table drag-drop overlay activates after a 200ms long press.
+    // Wait 300ms to ensure reliability in tests.
+    await delay(300);
+    await expectElementCount(".o-we-table-drag-drop", 1);
+    const targetCell = el.querySelector("td.b");
+    const targetCellRect = targetCell.getBoundingClientRect();
+    // Drag overlay to the right of second column
+    await manuallyDispatchProgrammaticEvent(targetCell, "pointermove", {
+        clientX: targetCellRect.x + targetCellRect.width * 0.75,
+        clientY: targetCellRect.y,
+    });
+    expect(getContent(el)).toBe(
+        unformat(`
+            <p><br></p>
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr>
+                        <td class="a">[]1</td>
+                        <td class="b td-highlight-right">2</td>
+                        <td class="c">3</td>
+                    </tr>
+                    <tr>
+                        <td class="d">4</td>
+                        <td class="e td-highlight-right">5</td>
+                        <td class="f">6</td>
+                    </tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
+        `)
+    );
+    // Release pointer to drop the first column after the second column.
+    await manuallyDispatchProgrammaticEvent(targetCell, "pointerup", {
+        clientX: targetCellRect.x + targetCellRect.width * 0.75,
+        clientY: targetCellRect.y,
+    });
+    await expectElementCount(".o-we-table-drag-drop", 0);
+    expect(getContent(el)).toBe(
+        unformat(`
+            <p><br></p>
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr>
+                        <td class="b">2</td>
+                        <td class="a">[]1</td>
+                        <td class="c">3</td>
+                    </tr>
+                    <tr>
+                        <td class="e">5</td>
+                        <td class="d">4</td>
+                        <td class="f">6</td>
+                    </tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
+        `)
+    );
+});
+
+test("should move third column before first column on drag and drop", async () => {
+    const { el } = await setupEditor(
+        unformat(`
+            <p><br></p>
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr>
+                        <td class="a">1</td>
+                        <td class="b">2</td>
+                        <td class="c">[]3</td>
+                    </tr>
+                    <tr>
+                        <td class="d">4</td>
+                        <td class="e">5</td>
+                        <td class="f">6</td>
+                    </tr>
+                </tbody>
+            </table>
+        `)
+    );
+    await expectElementCount(".o-we-table-menu", 0);
+    // Hover over third column header cell to trigger column menu
+    await hover(el.querySelector("td.c"));
+    await waitFor("[data-type='column'].o-we-table-menu");
+    const colMenu = document.querySelector("[data-type='column'].o-we-table-menu");
+    const colMenuRect = colMenu.getBoundingClientRect();
+    // Start long press drag on third column
+    await manuallyDispatchProgrammaticEvent(colMenu, "pointerdown", {
+        clientX: colMenuRect.x + colMenuRect.width / 2,
+        clientY: colMenuRect.y,
+    });
+    // Table drag-drop overlay activates after a 200ms long press.
+    // Wait 300ms to ensure reliability in tests.
+    await delay(300);
+    await expectElementCount(".o-we-table-drag-drop", 1);
+    const targetCell = el.querySelector("td.a");
+    const targetCellRect = targetCell.getBoundingClientRect();
+    // Drag overlay to the left of first column
+    await manuallyDispatchProgrammaticEvent(targetCell, "pointermove", {
+        clientX: targetCellRect.x - targetCellRect.width * 0.75,
+        clientY: targetCellRect.y,
+    });
+    expect(getContent(el)).toBe(
+        unformat(`
+            <p><br></p>
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr>
+                        <td class="a td-highlight-left">1</td>
+                        <td class="b">2</td>
+                        <td class="c">[]3</td>
+                    </tr>
+                    <tr>
+                        <td class="d td-highlight-left">4</td>
+                        <td class="e">5</td>
+                        <td class="f">6</td>
+                    </tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
+        `)
+    );
+    // Release pointer to drop the third column before the first column
+    await manuallyDispatchProgrammaticEvent(targetCell, "pointerup", {
+        clientX: targetCellRect.x - targetCellRect.width * 0.75,
+        clientY: targetCellRect.y,
+    });
+    await expectElementCount(".o-we-table-drag-drop", 0);
+    expect(getContent(el)).toBe(
+        unformat(`
+            <p><br></p>
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr>
+                        <td class="c">[]3</td>
+                        <td class="a">1</td>
+                        <td class="b">2</td>
+                    </tr>
+                    <tr>
+                        <td class="f">6</td>
+                        <td class="d">4</td>
+                        <td class="e">5</td>
+                    </tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
+        `)
+    );
+});
+
+test("undo/redo should work correctly after dragging and dropping a column", async () => {
+    const { el, editor } = await setupEditor(
+        unformat(`
+            <p><br></p>
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr>
+                        <td class="a">[]1</td>
+                        <td class="b">2</td>
+                        <td class="c">3</td>
+                    </tr>
+                </tbody>
+            </table>
+        `)
+    );
+    await expectElementCount(".o-we-table-menu", 0);
+    // Hover over first cell to trigger column menu
+    await hover(el.querySelector("td.a"));
+    await waitFor("[data-type='column'].o-we-table-menu");
+    const colMenu = document.querySelector("[data-type='column'].o-we-table-menu");
+    const colMenuRect = colMenu.getBoundingClientRect();
+    // Start long press drag on first column
+    await manuallyDispatchProgrammaticEvent(colMenu, "pointerdown", {
+        clientX: colMenuRect.x + colMenuRect.width / 2,
+        clientY: colMenuRect.y,
+    });
+    // Table drag-drop overlay activates after a 200ms long press.
+    // Wait 300ms to ensure reliability in tests.
+    await delay(300);
+    await expectElementCount(".o-we-table-drag-drop", 1);
+    const targetCell = el.querySelector("td.c");
+    const targetCellRect = targetCell.getBoundingClientRect();
+    // Drag overlay to the right of last column
+    await manuallyDispatchProgrammaticEvent(targetCell, "pointermove", {
+        clientX: targetCellRect.x + targetCellRect.width * 0.75,
+        clientY: targetCellRect.y,
+    });
+    // Release pointer to drop the first column after the third column
+    await manuallyDispatchProgrammaticEvent(targetCell, "pointerup", {
+        clientX: targetCellRect.x + targetCellRect.width * 0.75,
+        clientY: targetCellRect.y,
+    });
+    await expectElementCount(".o-we-table-drag-drop", 0);
+    expect(getContent(el)).toBe(
+        unformat(`
+            <p><br></p>
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr>
+                        <td class="b">2</td>
+                        <td class="c">3</td>
+                        <td class="a">[]1</td>
+                    </tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
+        `)
+    );
+    // Undo the drag and drop
+    undo(editor);
+    expect(getContent(el)).toBe(
+        unformat(`
+            <p><br></p>
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr>
+                        <td class="a">[]1</td>
+                        <td class="b">2</td>
+                        <td class="c">3</td>
+                    </tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
+        `)
+    );
+    // Redo the drag and drop
+    redo(editor);
+    expect(getContent(el)).toBe(
+        unformat(`
+            <p><br></p>
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr>
+                        <td class="b">2</td>
+                        <td class="c">3</td>
+                        <td class="a">[]1</td>
+                    </tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
+        `)
+    );
+});
+
+test("should move first header row to last position on drag and drop", async () => {
+    const { el } = await setupEditor(
+        unformat(`
+            <p><br></p>
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr>
+                        <th class="a o_table_header">[]1</th>
+                        <th class="b o_table_header">2</th>
+                    </tr>
+                    <tr>
+                        <td class="c">3</td>
+                        <td class="d">4</td>
+                    </tr>
+                    <tr>
+                        <td class="e">5</td>
+                        <td class="f">6</td>
+                    </tr>
+                </tbody>
+            </table>
+        `)
+    );
+    await expectElementCount(".o-we-table-menu", 0);
+    // Hover over the first row to trigger row menu
+    await hover(el.querySelector("th.a"));
+    await waitFor("[data-type='row'].o-we-table-menu");
+    const rowMenu = document.querySelector("[data-type='row'].o-we-table-menu");
+    const rowMenuRect = rowMenu.getBoundingClientRect();
+    // Start long press drag on first header row
+    await manuallyDispatchProgrammaticEvent(rowMenu, "pointerdown", {
+        clientX: rowMenuRect.x,
+        clientY: rowMenuRect.y + rowMenuRect.height / 2,
+    });
+    // Table drag-drop overlay activates after a 200ms long press.
+    // Wait 300ms to ensure reliability in tests.
+    await delay(300);
+    await expectElementCount(".o-we-table-drag-drop", 1);
+    const targetRow = el.querySelector("tr:last-child");
+    const targetRowRect = targetRow.getBoundingClientRect();
+    // Drag overlay to the position of last row
+    await manuallyDispatchProgrammaticEvent(targetRow, "pointermove", {
+        clientX: targetRowRect.x,
+        clientY: targetRowRect.y + targetRowRect.height * 0.75,
+    });
+    expect(getContent(el)).toBe(
+        unformat(`
+            <p><br></p>
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr>
+                        <th class="a o_table_header">[]1</th>
+                        <th class="b o_table_header">2</th>
+                    </tr>
+                    <tr>
+                        <td class="c">3</td>
+                        <td class="d">4</td>
+                    </tr>
+                    <tr class="tr-highlight-bottom">
+                        <td class="e">5</td>
+                        <td class="f">6</td>
+                    </tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
+        `)
+    );
+    // Release pointer to drop the first row at last position
+    await manuallyDispatchProgrammaticEvent(targetRow, "pointerup", {
+        clientX: targetRowRect.x,
+        clientY: targetRowRect.y + targetRowRect.height * 0.75,
+    });
+    await expectElementCount(".o-we-table-drag-drop", 0);
+    expect(getContent(el)).toBe(
+        unformat(`
+            <p><br></p>
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr>
+                        <th class="o_table_header">3</th>
+                        <th class="o_table_header">4</th>
+                    </tr>
+                    <tr class="">
+                        <td class="e">5</td>
+                        <td class="f">6</td>
+                    </tr>
+                    <tr>
+                        <td>[]1</td>
+                        <td>2</td>
+                    </tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
+        `)
+    );
+});
+
+test("should move last row above the first header row on drag and drop", async () => {
+    const { el } = await setupEditor(
+        unformat(`
+            <p><br></p>
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr>
+                        <th class="a o_table_header">1</th>
+                        <th class="b o_table_header">2</th>
+                    </tr>
+                    <tr>
+                        <td class="c">3</td>
+                        <td class="d">4</td>
+                    </tr>
+                    <tr>
+                        <td class="e">[]5</td>
+                        <td class="f">6</td>
+                    </tr>
+                </tbody>
+            </table>
+        `)
+    );
+    await expectElementCount(".o-we-table-menu", 0);
+    // Hover over the last row to trigger row menu
+    await hover(el.querySelector("td.e"));
+    await waitFor("[data-type='row'].o-we-table-menu");
+    const rowMenu = document.querySelector("[data-type='row'].o-we-table-menu");
+    const rowMenuRect = rowMenu.getBoundingClientRect();
+    // Start long press drag on the last row
+    await manuallyDispatchProgrammaticEvent(rowMenu, "pointerdown", {
+        clientX: rowMenuRect.x,
+        clientY: rowMenuRect.y + rowMenuRect.height / 2,
+    });
+    // Table drag-drop overlay activates after a 200ms long press.
+    // Wait 300ms to ensure reliability in tests.
+    await delay(300);
+    await expectElementCount(".o-we-table-drag-drop", 1);
+    const targetRow = el.querySelector("tr:first-child"); // first header row
+    const targetRowRect = targetRow.getBoundingClientRect();
+    // Drag overlay above the first header row
+    await manuallyDispatchProgrammaticEvent(targetRow, "pointermove", {
+        clientX: targetRowRect.x,
+        clientY: targetRowRect.y - targetRowRect.height * 0.75,
+    });
+    expect(getContent(el)).toBe(
+        unformat(`
+            <p><br></p>
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr class="tr-highlight-top">
+                        <th class="a o_table_header">1</th>
+                        <th class="b o_table_header">2</th>
+                    </tr>
+                    <tr>
+                        <td class="c">3</td>
+                        <td class="d">4</td>
+                    </tr>
+                    <tr>
+                        <td class="e">[]5</td>
+                        <td class="f">6</td>
+                    </tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
+        `)
+    );
+    // Release pointer to drop the last row above the header row
+    await manuallyDispatchProgrammaticEvent(targetRow, "pointerup", {
+        clientX: targetRowRect.x,
+        clientY: targetRowRect.y - targetRowRect.height * 0.75,
+    });
+    await expectElementCount(".o-we-table-drag-drop", 0);
+    expect(getContent(el)).toBe(
+        unformat(`
+            <p><br></p>
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr>
+                        <th class="o_table_header">[]5</th>
+                        <th class="o_table_header">6</th>
+                    </tr>
+                    <tr class="">
+                        <td>1</td>
+                        <td>2</td>
+                    </tr>
+                    <tr>
+                        <td class="c">3</td>
+                        <td class="d">4</td>
+                    </tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
+        `)
+    );
+});
+
+test("undo/redo should work correctly after dragging and dropping a row", async () => {
+    const { el, editor } = await setupEditor(
+        unformat(`
+            <p><br></p>
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr><td class="a">[]1</td></tr>
+                    <tr><td class="b">2</td></tr>
+                    <tr><td class="c">3</td></tr>
+                </tbody>
+            </table>
+        `)
+    );
+    await expectElementCount(".o-we-table-menu", 0);
+    // Hover over the first row to trigger the row menu
+    await hover(el.querySelector("td.a"));
+    await waitFor("[data-type='row'].o-we-table-menu");
+    const rowMenu = document.querySelector("[data-type='row'].o-we-table-menu");
+    const rowMenuRect = rowMenu.getBoundingClientRect();
+    // Start long press drag on the first row
+    await manuallyDispatchProgrammaticEvent(rowMenu, "pointerdown", {
+        clientX: rowMenuRect.x,
+        clientY: rowMenuRect.y + rowMenuRect.height / 2,
+    });
+    // Table drag-drop overlay activates after a 200ms long press.
+    // Wait 300ms to ensure reliability in tests.
+    await delay(300);
+    await expectElementCount(".o-we-table-drag-drop", 1);
+    const targetRow = el.querySelector("tr:last-child"); // Drop position (last row)
+    const targetRowRect = targetRow.getBoundingClientRect();
+    // Drag overlay to the position of the last row
+    await manuallyDispatchProgrammaticEvent(targetRow, "pointermove", {
+        clientX: targetRowRect.x,
+        clientY: targetRowRect.y + targetRowRect.height * 0.75,
+    });
+    // Release pointer to drop the first row at last position
+    await manuallyDispatchProgrammaticEvent(targetRow, "pointerup", {
+        clientX: targetRowRect.x,
+        clientY: targetRowRect.y + targetRowRect.height * 0.75,
+    });
+    await expectElementCount(".o-we-table-drag-drop", 0);
+    expect(getContent(el)).toBe(
+        unformat(`
+            <p><br></p>
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr><td class="b">2</td></tr>
+                    <tr class=""><td class="c">3</td></tr>
+                    <tr><td class="a">[]1</td></tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
+        `)
+    );
+    // Undo the drag and drop
+    undo(editor);
+    expect(getContent(el)).toBe(
+        unformat(`
+            <p><br></p>
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr><td class="a">[]1</td></tr>
+                    <tr><td class="b">2</td></tr>
+                    <tr><td class="c">3</td></tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
+        `)
+    );
+    // Redo the drag and drop
+    redo(editor);
+    expect(getContent(el)).toBe(
+        unformat(`
+            <p><br></p>
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr><td class="b">2</td></tr>
+                    <tr><td class="c">3</td></tr>
+                    <tr><td class="a">[]1</td></tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
+        `)
+    );
+});

--- a/addons/html_editor/static/tests/table/ui.test.js
+++ b/addons/html_editor/static/tests/table/ui.test.js
@@ -1179,6 +1179,57 @@ test("move header row below operation", async () => {
     );
 });
 
+test("should revert a converted header row back to normal after undo", async () => {
+    const { el, editor } = await setupEditor(
+        unformat(`
+        <table>
+            <tbody>
+                <tr><td class="a">1[]</td><td>2</td></tr>
+                <tr><td>3</td><td>4</td></tr>
+            </tbody>
+        </table>`)
+    );
+    await expectElementCount(".o-we-table-menu", 0);
+
+    // hover on th to show row ui
+    await hover(el.querySelector("td.a"));
+    await waitFor("[data-type='row'].o-we-table-menu");
+
+    // click on it to open dropdown
+    await click("[data-type='row'].o-we-table-menu");
+    await waitFor("div[name='make_header']");
+
+    // convert row into header
+    await click("div[name='make_header']");
+    await animationFrame();
+    expect(getContent(el)).toBe(
+        unformat(`
+            <p data-selection-placeholder=""><br></p>
+            <table>
+                <tbody>
+                    <tr><th class="o_table_header">1[]</th><th class="o_table_header">2</th></tr>
+                    <tr><td>3</td><td>4</td></tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder=""><br></p>
+        `)
+    );
+
+    undo(editor);
+    expect(getContent(el)).toBe(
+        unformat(`
+            <p data-selection-placeholder=""><br></p>
+            <table>
+                <tbody>
+                    <tr><td class="a">1[]</td><td>2</td></tr>
+                    <tr><td>3</td><td>4</td></tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder=""><br></p>
+        `)
+    );
+});
+
 test("preserve table rows width on move row below operation", async () => {
     const { el } = await setupEditor(
         unformat(`


### PR DESCRIPTION
### Purpose of this PR:

- Added an optional `timeout` attribute to the `expectElementCount` helper.
- By default, `waitFor` and `waitForNone` use a 200 ms timeout, but this parameter allows tests to wait longer when needed.
- Implement long-press detection on table menu overlay for rows and columns.
- Highlight the selected row or column during long press.
- Allow users to drag and drop rows or columns to the desired position.
- Maintain single-click behavior to open the existing table menu.
- Ensure DOM updates preserve table layout and cell widths.
- Track each move as a step for undo/redo functionality.
- Some Font Awesome icons have inconsistent intrinsic widths, causing text to appear misaligned in thetable dropdown. This ensures all icons render inside a fixed-width box and are horizontally centered using `text-center` utility.

task-5103768

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
