### PR TITLE
[FIX] google_calendar: replace self._context with self.env.context

### DIFF
--- a/addons/google_calendar/utils/google_calendar.py
+++ b/addons/google_calendar/utils/google_calendar.py
@@ -82,7 +82,7 @@ class GoogleCalendarService():
 
     @requires_auth_token
     def patch(self, event_id, values, token=None, timeout=TIMEOUT):
-        send_updates = self.google_service._context.get('send_updates', True)
+        send_updates = self.google_service.env.context.get('send_updates', True)
         url = "/calendar/v3/calendars/primary/events/%s?sendUpdates=%s&conferenceDataVersion=1" % (event_id, "all" if send_updates else "none")
         headers = {'Content-type': 'application/json', 'Authorization': 'Bearer %s' % token}
         self.google_service._do_request(url, json.dumps(values), headers, method='PATCH', timeout=timeout)


### PR DESCRIPTION
after this PR: https://github.com/odoo/odoo/pull/193636 self._context usage has been deprecated in favor of self.env.context.

This commit updates google_calendar accordingly.

<img width="1916" height="447" alt="image" src="https://github.com/user-attachments/assets/622de21e-7c4c-4efc-8cff-045704934f04" />





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
