### PR TITLE
[FIX] website: load a relative URL instead of an absolute in the SEO cover image

### DIFF
--- a/addons/website/static/src/components/dialog/seo.js
+++ b/addons/website/static/src/components/dialog/seo.js
@@ -960,7 +960,7 @@ export class OptimizeSEODialog extends Component {
         const imageEls = this.pageDocumentElement.querySelectorAll('#wrap img');
         return [...new Set(Array.from(imageEls)
             .filter(img => img.naturalHeight > 200 && img.naturalWidth > 200)
-            .map(({ src }) => (src))
+            .map(img => img.getAttribute("src"))
         )];
     }
 


### PR DESCRIPTION


Currently an error is generated when a user selects existing images inside the cover image of SEO.

Steps to produce:
- Install the `Ecommerce` module with demo data
- Add existing image inside `website_meta_og_img`
  (Website > Editor > Site > Optimize   SEO > Cover Image)
-Set a domain on the website
- Go to the shop page and get a 500 error

Error: `ValueError: Extra URL must use same scheme and host as base, and begin with base path`

This is because in 19 with commit https://github.com/odoo/odoo/commit/977e62d91f3e8235e251e9d21b08f53db1856c6b, Werkzeug `url_join` is
replaced by odoo `urljoin`,  which requires that the path that is appended
has no host or the same host. Since the current code loads the scheme and host
of the existing image, if the URL is different than the saved one (because
of the domain or another reason), we get an error.

This commit will fix the above issue by loading the relative URL instead of an absolute one.

sentry-6912373261

