### PR TITLE
[FIX] spreadsheet: do not dispatch undefined field matching

### DIFF
--- a/addons/spreadsheet/static/src/global_filters/plugins/global_filters_ui_plugin.js
+++ b/addons/spreadsheet/static/src/global_filters/plugins/global_filters_ui_plugin.js
@@ -37,11 +37,9 @@ export class GlobalFiltersUIPlugin extends OdooUIPlugin {
                         if (dataSourceId === cmd.dataSourceId) {
                             filterFieldMatching[dataSourceId] = cmd.fieldMatchings[filterId];
                         } else {
-                            filterFieldMatching[dataSourceId] = matcher.getFieldMatching(
-                                this.getters,
-                                dataSourceId,
-                                filterId
-                            );
+                            filterFieldMatching[dataSourceId] =
+                                matcher.getFieldMatching(this.getters, dataSourceId, filterId) ||
+                                {};
                         }
                     }
                     this.dispatch("EDIT_GLOBAL_FILTER", {


### PR DESCRIPTION
Steps to reproduce (in enterprise):
1. Open the Sales dashboard
2. Edit the first list
3. Try to set the "Medium" field matching => Traceback

The test is in enterprise as the issue is triggered only by editing the spreadsheet.

Task: 5101093

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
