### PR TITLE
[FIX] website: add missing pricelist description classes

### DIFF
--- a/addons/website/static/src/js/editor/shared_options/pricelist.js
+++ b/addons/website/static/src/js/editor/shared_options/pricelist.js
@@ -23,7 +23,20 @@ options.registry.Pricelist = options.Class.extend({
                     description.classList.remove("d-none");
                 } else {
                     const descriptionEl = document.createElement("p");
-                    descriptionEl.classList.add(params.descriptionClass, "d-block", "pe-5", "text-muted", "o_default_snippet_text");
+                    descriptionEl.classList.add(
+                        params.descriptionClass,
+                        "d-block",
+                        "mt-2",
+                        "pe-5",
+                        "text-muted",
+                        "o_default_snippet_text"
+                    );
+                    if (params.descriptionExtraClass) {
+                        descriptionEl.classList.add(params.descriptionExtraClass);
+                    } else if (this.$target[0].matches(".s_pricelist_boxed, .s_pricelist_cafe")) {
+                        // TODO: remove in master where DB will have the class thanks to the XML.
+                        descriptionEl.classList.add("o_small")
+                    }
                     descriptionEl.textContent = _t("Add a description here");
                     el.appendChild(descriptionEl);
                 }

--- a/addons/website/views/snippets/s_pricelist_boxed.xml
+++ b/addons/website/views/snippets/s_pricelist_boxed.xml
@@ -95,7 +95,7 @@
     </xpath>
     <xpath expr="." position="inside">
         <div data-js="Pricelist" data-selector=".s_pricelist_boxed">
-            <we-checkbox string="Descriptions" data-toggle-description="true" data-items-class="s_pricelist_boxed_item" data-description-class="s_pricelist_boxed_item_description" data-no-preview="true"/>
+            <we-checkbox string="Descriptions" data-toggle-description="true" data-items-class="s_pricelist_boxed_item" data-description-class="s_pricelist_boxed_item_description" data-description-extra-class="o_small" data-no-preview="true"/>
             <t t-call="website.snippet_options_border_line_widgets">
                 <t t-set="label">Separator</t>
                 <t t-set="direction" t-value="'top'"/>

--- a/addons/website/views/snippets/s_pricelist_cafe.xml
+++ b/addons/website/views/snippets/s_pricelist_cafe.xml
@@ -102,7 +102,7 @@
     <!-- Toggle descriptions -->
     <xpath expr="." position="inside">
         <div data-js="Pricelist" data-selector=".s_pricelist_cafe">
-            <we-checkbox string="Descriptions" data-toggle-description="true" data-items-class="s_pricelist_cafe_item" data-description-class="s_pricelist_cafe_item_description" data-no-preview="true"/>
+            <we-checkbox string="Descriptions" data-toggle-description="true" data-items-class="s_pricelist_cafe_item" data-description-class="s_pricelist_cafe_item_description" data-description-extra-class="o_small" data-no-preview="true"/>
             <t t-call="website.snippet_options_border_line_widgets">
                 <t t-set="label">Separator</t>
                 <t t-set="direction" t-value="'top'"/>


### PR DESCRIPTION
New description paragraphs generated by the builder for the "pricelist" snippets were missing two expected classes.

- "mt-2" was never applied, so all pricelist variants lacked the vertical spacing below product titles.
- The boxed and cafe snippets also needed the `o_small` class to keep their text size consistent.

Steps to see the missing "o_small":

1. Drop an "s_pricelist_boxed" or "Pricelist Cafe" snippet on a page.
2. Use Backspace to delete the text already present in one of the descriptions.
3. Toggle the "Descriptions" option off and on; the regenerated paragraph appears larger than expected because `o_small` is absent.

task-5117864