### PR TITLE
[FIX] point_of_sale: handle online payment selection for new PaymentLine

### DIFF
--- a/addons/point_of_sale/static/src/app/customer_display/customer_display_adapter.js
+++ b/addons/point_of_sale/static/src/app/customer_display/customer_display_adapter.js
@@ -30,6 +30,7 @@ export class CustomerDisplayPosAdapter {
     }
 
     formatOrderData(order) {
+        this.currency = order.currency;
         this.data = {
             finalized: order.finalized,
             general_customer_note: order.general_customer_note,
@@ -65,7 +66,7 @@ export class CustomerDisplayPosAdapter {
     getPaymentData(payment) {
         return {
             name: payment.payment_method_id.name,
-            amount: formatCurrency(payment.amount, payment.pos_order_id.currency),
+            amount: formatCurrency(payment.amount, this.currency),
         };
     }
 }


### PR DESCRIPTION
Steps to Reproduce(On Runbot):
- Navigate to Pos>Configuration>Payment Method
- Create an 'Online Payment' method using 'Demo Payment' for a shop (e.g., bakery shop).
- Open a session for the bakery shop, select any product, and proceed to payment.
- Select the online payment method multiple times.

Error:
`TypeError: Cannot read properties of undefined (reading 'currency')`

After this commit:
- Users can select the payment method multiple times without a crash.

task-5122932
