### PR TITLE
[FIX] mrp_subcontracting,*: reserve dropshipped components in subcontracted MO

### DIFF
--- a/addons/mrp_subcontracting/models/mrp_production.py
+++ b/addons/mrp_subcontracting/models/mrp_production.py
@@ -94,6 +94,8 @@ class MrpProduction(models.Model):
             backorder.move_raw_ids.filtered(lambda m: m.additional).product_uom_qty = 0.0
 
             backorder.qty_producing = backorder.product_qty
+            # sudo needed for portal users
+            self.env['stock.quant'].sudo()._clean_reservations()
             backorder._set_qty_producing()
 
             self.product_qty = self.qty_producing

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -2248,7 +2248,7 @@ Please change the quantity done or the rounding precision of your unit of measur
     def _set_quantity_done_prepare_vals(self, qty):
         res = []
         for ml in self.move_line_ids:
-            ml_qty = ml.quantity
+            ml_qty = ml._origin.quantity or ml.quantity
             if float_is_zero(qty, precision_rounding=self.product_uom.rounding):
                 res.append((2, ml.id))
                 continue


### PR DESCRIPTION
*=stock

Issue Before This Commit:
=======================
During production entry in a subcontracting workflow, the system does not automatically reserve `component lots/serials` dropshipped by the `previous subcontractor`. A component line is created with an `empty lot/serial`, forcing the user to manually select the correct lot/serial. This can cause an incorrect lot to be used in production.

Steps to Reproduce:
=======================
- Install the `mrp_subcontracting_dropshipping` module.
- Create 2 lot-tracked products (product1, product2), set vendor in Purchase (Vendor1, Vendor2), and enable `Dropship  Subcontractor on Order` in Inventory
- Create BOM for product1 (component: product2 , subcontractor: vendor1) and for product2 (subcontractor: vendor2).
- Create and confirm a purchase order for product1 with Vendor1.
- After confirming, a second PO for the dropshipped + subcontracted product2   is generated; confirm it → go to Dropship, set the quantity producing for product2 assign a lot, and validate the picking.
- Go to source PO (first PO) → Receipt → in the subcontracting MO wizard, change the quantity producing for the product1. A component line is created with an empty lot;
- `Observation`: it does not automatically assign the component product2's lot that was already dropshipped from Vendor2 to Vendor1.

Cause of the issue:
=======================
The `_set_quantity_done_prepare_vals method`, which generates component lines based on `qty_producing` in the Subcontracting MO wizard, ignores dropshipped component lots/serials. Additionally, When a MO is split, previously reserved
quants not linked to move lines remain reserved. As a result, `qty_producing` can create new lines with empty lots instead of using the already dropshipped ones, forcing the user to manually select them.

With This Commit:
=======================
The `_set_quantity_done_prepare_vals` method now correctly accounts for component lots/serials dropshipped by the previous subcontractor. When `qty_producing` is changed in the Subcontracting MO wizard, it automatically assigns the already dropshipped component lots/serials to the component lines through the `_prepare_tracked_move_lines` method. And `_clean_reservations` is called  to release quants that are no longer linked to any move lines, preventing the creation of new lines with empty lots and eliminating the need for manual selection and preventing incorrect lots from being used in production

opw-5116273