### PR TITLE
[IMP] hr_holidays: round duration values in leave allocation

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -149,7 +149,7 @@ class HrLeaveAllocation(models.Model):
             return _(
                 '%(name)s (%(duration)s hour(s))',
                 name=self.holiday_status_id.name,
-                duration=self.number_of_days * self.employee_id._get_hours_per_day(self.date_from),
+                duration=float_round(self.number_of_days * self.employee_id._get_hours_per_day(self.date_from), precision_digits=2),
             )
         return _(
             '%(name)s (%(duration)s day(s))',

--- a/addons/hr_holidays/wizard/hr_leave_allocation_generate_multi_wizard.py
+++ b/addons/hr_holidays/wizard/hr_leave_allocation_generate_multi_wizard.py
@@ -5,6 +5,7 @@ from odoo.exceptions import AccessError
 from odoo.fields import Domain
 
 from odoo.addons.resource.models.utils import HOURS_PER_DAY
+from odoo.tools.float_utils import float_round
 
 
 class HrLeaveAllocationGenerateMultiWizard(models.TransientModel):
@@ -60,7 +61,7 @@ class HrLeaveAllocationGenerateMultiWizard(models.TransientModel):
         return self.env._(
             '%(name)s (%(duration)s %(request_unit)s(s))',
             name=self.holiday_status_id.name,
-            duration=self.duration,
+            duration=float_round(self.duration, precision_digits=2),
             request_unit=self.request_unit
         )
 


### PR DESCRIPTION
**Issue**
Currently, leave allocation title calculation can result in excessive decimal places. Added rounding precision by limiting decimal places to 2

Task ID: 5078791

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
