### PR TITLE
[IMP] Employee: Add domain on contract type by country

### DIFF
--- a/addons/hr/models/hr_contract_type.py
+++ b/addons/hr/models/hr_contract_type.py
@@ -7,7 +7,7 @@ from odoo import api, fields, models
 class HrContractType(models.Model):
     _name = 'hr.contract.type'
     _description = 'Contract Type'
-    _order = 'sequence'
+    _order = 'name'
 
     name = fields.Char(required=True, translate=True)
     code = fields.Char(compute='_compute_code', store=True, readonly=False)

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -268,6 +268,11 @@ class HrEmployee(models.Model):
         'A user cannot be linked to multiple employees in the same company.',
     )
 
+    has_country_contract_type = fields.Boolean(
+        compute='_compute_has_country_contract_type',
+        groups="hr.group_hr_user",
+    )
+
     def _prepare_create_values(self, vals_list):
         result = super()._prepare_create_values(vals_list)
         new_vals_list = []
@@ -597,6 +602,18 @@ class HrEmployee(models.Model):
             # To not trigger computed properties if still the same version
             if employee.current_version_id != new_current_version:
                 employee.current_version_id = new_current_version
+
+    @api.depends('company_country_id')
+    def _compute_has_country_contract_type(self):
+        count_contract_type_by_country = dict(self.env['hr.contract.type']._read_group(
+            domain=[],
+            groupby=['country_id'],
+            aggregates=['__count']
+        ))
+        for employee in self:
+            employee.has_country_contract_type = bool(
+                count_contract_type_by_country.get(employee.company_country_id)
+            )
 
     def _cron_update_current_version_id(self):
         self.search([])._compute_current_version_id()

--- a/addons/hr/views/hr_contract_type_views.xml
+++ b/addons/hr/views/hr_contract_type_views.xml
@@ -4,7 +4,7 @@
         <record id="hr_contract_type_view_tree" model="ir.ui.view">
             <field name="model">hr.contract.type</field>
             <field name="arch" type="xml">
-                <list string="Contract Types" editable="bottom">
+                <list string="Contract Types" editable="bottom" default_order="name">
                     <field name="sequence" widget="handle"/>
                     <field name="name"/>
                     <field name="code" column_invisible="1"/>
@@ -29,12 +29,12 @@
         </record>
 
         <record id="hr_contract_type_action" model="ir.actions.act_window">
-            <field name="name">Employment Types</field>
+            <field name="name">Contract Types</field>
             <field name="res_model">hr.contract.type</field>
             <field name="view_mode">list</field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">
-                    Create a new employment type
+                    Create a new contract type
                 </p>
             </field>
         </record>

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -379,7 +379,10 @@
                                             <field name="wage" class="oe_inline o_hr_narrow_field" nolabel="1"/>
                                         </div>
                                         <field name="employee_type"/>
-                                        <field name="contract_type_id" string="Contract Type" placeholder="Contract Type"/>
+                                        <field name="contract_type_id" string="Contract Type" placeholder="Contract Type"
+                                               invisible="not has_country_contract_type" domain="[('country_id', '=', company_country_id)]"/>
+                                        <field name="contract_type_id" string="Contract Type" placeholder="Contract Type"
+                                               invisible="has_country_contract_type" domain="[('country_id', '=', False)]"/>
                                         <field name="structure_type_id" string="Pay Category" placeholder="Pay Category"
                                                 domain="['|', ('country_id', '=', False), ('country_id', '=', company_country_id)]"/>
 


### PR DESCRIPTION
- Applied a domain on contract type based on the employee's country of birth, ensuring it matches the country defined on the contract type.
- Renamed the hr_contract_type_action record from (Employment Types) to (Contract Types).

task-5118865

