### PR TITLE
[FIX] point_of_sale: improve customer display popup

### DIFF
--- a/addons/point_of_sale/static/src/app/components/navbar/navbar.js
+++ b/addons/point_of_sale/static/src/app/components/navbar/navbar.js
@@ -150,14 +150,10 @@ export class Navbar extends Component {
                 this.pos.config.id
             }/${getDeviceUuid()}`;
 
-            if (this.ui.isSmall) {
-                this.dialog.add(QrCodeCustomerDisplay, {
-                    customerDisplayURL: `${this.pos.session._base_url}${customer_display_url}`,
-                });
-                return;
-            }
-            window.open(customer_display_url, "newWindow", "width=800,height=600,left=200,top=200");
-            this.notification.add(_t("PoS Customer Display opened in a new window"));
+            this.dialog.add(QrCodeCustomerDisplay, {
+                customerDisplayURL: `${this.pos.session._base_url}${customer_display_url}`,
+            });
+            return;
         }
     }
 

--- a/addons/point_of_sale/static/src/app/customer_display/customer_display_qr_code_popup.js
+++ b/addons/point_of_sale/static/src/app/customer_display/customer_display_qr_code_popup.js
@@ -1,14 +1,59 @@
-import { Component } from "@odoo/owl";
+import { Component, xml } from "@odoo/owl";
 import { Dialog } from "@web/core/dialog/dialog";
 import { generateQRCodeDataUrl } from "@point_of_sale/utils";
 import { CopyButton } from "@web/core/copy_button/copy_button";
+import { useService } from "@web/core/utils/hooks";
+import { _t } from "@web/core/l10n/translation";
 
 export class QrCodeCustomerDisplay extends Component {
     static template = "point_of_sale.QrCodeCustomerDisplay";
     static components = { Dialog, CopyButton };
     static props = ["close", "customerDisplayURL"];
 
+    setup() {
+        this.ui = useService("ui");
+        this.notification = useService("notification");
+        this.dialogService = useService("dialog");
+    }
+
     getQrCode() {
         return generateQRCodeDataUrl(this.props.customerDisplayURL);
+    }
+
+    openOnThisDevice() {
+        window.open(
+            this.props.customerDisplayURL,
+            "newWindow",
+            "width=800,height=600,left=200,top=200"
+        );
+        this.notification.add(_t("PoS Customer Display opened in a new window"));
+    }
+
+    showQr() {
+        const qr = this.getQrCode();
+        this.dialogService.add(QrDialog, {
+            qrData: qr,
+            parentClose: this.props.close,
+        });
+    }
+}
+
+class QrDialog extends Component {
+    static props = ["close", "qrData", "parentClose"];
+    static components = { Dialog };
+    static template = xml`
+        <Dialog header="false" footer="false" size="'sm'">
+            <div class="d-flex flex-column align-items-center">
+                <img id="CustomerDisplayqrCode" t-att-src="props.qrData" alt="Customer QR Code" class="img-fluid mb-3 square w-100"/>
+                <button t-on-click="close" class="button btn btn-secondary h1 mb-3 rounded-3">
+                    Close
+                </button>
+            </div>
+        </Dialog>
+    `;
+
+    close() {
+        this.props.close();
+        this.props.parentClose();
     }
 }

--- a/addons/point_of_sale/static/src/app/customer_display/customer_display_qr_code_popup.scss
+++ b/addons/point_of_sale/static/src/app/customer_display/customer_display_qr_code_popup.scss
@@ -1,0 +1,7 @@
+.popup-text {
+  font-size: 125%;
+}
+
+.button {
+  max-width: 200px;
+}

--- a/addons/point_of_sale/static/src/app/customer_display/customer_display_qr_code_popup.xml
+++ b/addons/point_of_sale/static/src/app/customer_display/customer_display_qr_code_popup.xml
@@ -2,15 +2,43 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="point_of_sale.QrCodeCustomerDisplay">
-        <Dialog title.translate="Open Customer Display" footer="false">
-            <div class="text-center">
-                <img id="CustomerDisplayqrCode" t-att-src="getQrCode()" alt="Customer QR Code"
-                    class="img-fluid mb-3" style="max-width: 200px; width: 50%;" />
+        <Dialog header="false" footer="false" size="'md'">
+            <div class="container">
+                <div class="align-items-center d-inline-flex justify-content-between w-100">
+                    <t t-if="this.ui.isSmall">
+                        <div class="text-center position-relative pt-5 w-100">
+                            <p class="popup-text w-100 position-absolute top-0 start-50 translate-middle-x">Scan QR</p>
+                            <img id="CustomerDisplayqrCode" t-att-src="getQrCode()" alt="Customer QR Code"
+                                class="img-fluid mb-3 square w-100"/>
 
-                <div class="small mb-3">
-                    <t t-set="customerDisplayURL" t-value="props.customerDisplayURL"/>
-                    <a t-att-href="customerDisplayURL" target="_blank" t-esc="customerDisplayURL" />
-                    <CopyButton content="customerDisplayURL" className="'ms-2 btn-primary'" successText.translate="Link copied to clipboard" icon="'fa-clone'"/>
+                            <div class="small mb-3">
+                                <t t-set="customerDisplayURL" t-value="props.customerDisplayURL"/>
+                                <a t-att-href="customerDisplayURL" target="_blank" t-esc="customerDisplayURL" />
+                                <CopyButton content="customerDisplayURL" className="'ms-2 btn-primary'" successText.translate="Link copied to clipboard" icon="'fa-clone'"/>
+                            </div>
+                        </div>
+                    </t>
+                    <t t-if="!this.ui.isSmall">
+                        <div class="w-100 d-flex flex-column gap-3">
+                            <div>
+                                <h2>Open Customer Display</h2>
+                            </div>
+                            <p class="popup-text w-100">You can either use it on this device or scan the QR code to display it on another device</p>
+                            <div class="d-flex justify-content-between">
+                                <div class="d-flex gap-3 flex-grow-1">
+                                    <button t-on-click="openOnThisDevice" class="button btn btn-primary h1 mb-3 rounded-3">
+                                        This device 
+                                    </button>
+                                    <button t-on-click="showQr" class="button btn btn-secondary h1 mb-3 rounded-3">
+                                        Display QR
+                                    </button>
+                                </div>
+                                <button t-on-click="() => this.props.close()" class="button btn btn-secondary h1 mb-3 rounded-3">
+                                    Close
+                                </button>
+                            </div>
+                        </div>
+                    </t>
                 </div>
             </div>
         </Dialog>

--- a/addons/point_of_sale/static/tests/pos/tours/customer_display_popup_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/customer_display_popup_tour.js
@@ -1,0 +1,19 @@
+import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
+import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("customer_display_shows_qr_popup", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            Chrome.waitForMenuButtons(),
+            Chrome.clickMenuButton(),
+            Chrome.waitForMenuOptionsToOpen(),
+            Chrome.ClickOnCustomerDisplayButton(),
+            Chrome.CustomerDisplayHasThisDeviceButton(),
+            Chrome.CustomerDisplayHasQRButton(),
+            Chrome.ClickCustomerDisplayQRButton(),
+            Chrome.CustomerDisplayQRIsDisplayed(),
+        ].flat(),
+});

--- a/addons/point_of_sale/static/tests/pos/tours/utils/chrome_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/chrome_util.js
@@ -253,6 +253,46 @@ export function clickOnScanButton() {
         run: "click",
     };
 }
+
+export function ClickOnCustomerDisplayButton() {
+    return {
+        content: "Click on the customer display button inside the burger menu",
+        trigger: "span i.fa-desktop",
+        run: "click",
+    };
+}
+export function CustomerDisplayHasThisDeviceButton() {
+    return {
+        content: "Check that the customer display popup has a 'This device' button",
+        trigger: ".o_dialog .modal-body .container .btn-primary:contains('This device')",
+    };
+}
+export function CustomerDisplayHasQRButton() {
+    return {
+        content: "Check that the customer display popup has a 'Display QR' button",
+        trigger: ".o_dialog .modal-body .container .btn-secondary:contains('Display QR')",
+    };
+}
+export function ClickCustomerDisplayThisDeviceButton() {
+    return {
+        content: "Check that the customer display popup has a 'This device' button",
+        trigger: ".btn-primary:contains('This device')",
+        run: "click",
+    };
+}
+export function ClickCustomerDisplayQRButton() {
+    return {
+        content: "Check that the customer display popup has a 'Display QR' button",
+        trigger: ".btn-secondary:contains('Display QR')",
+        run: "click",
+    };
+}
+export function CustomerDisplayQRIsDisplayed() {
+    return {
+        content: "Check that the QR code is displayed on screen",
+        trigger: ".o-overlay-item .modal .modal-body img.square",
+    };
+}
 export function freezeDateTime(millis) {
     return [
         {

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1350,6 +1350,9 @@ class TestUi(TestPointOfSaleHttpCommon):
         order = self.env['pos.order'].search([])
         self.assertTrue(order[0].name == order[1].name + " REFUND")
 
+    def test_customer_display_popup(self):
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'customer_display_shows_qr_popup', login="pos_user")
+
     def test_lot_refund(self):
 
         self.product1 = self.env['product.product'].create({
@@ -3250,6 +3253,10 @@ class MobileTestUi(TestUi):
     browser_size = '375x667'
     touch_enabled = True
     allow_inherited_tests_method = True
+
+    # Skip customer display web tests on mobile
+    def test_customer_display_popup(self):
+        return
 
 
 class TestTaxCommonPOS(TestPointOfSaleHttpCommon, TestTaxCommon):


### PR DESCRIPTION
Changed to open the QR code popup on the desktop as well. Before it was opening directly in a new window and it was hard to open it on a separate device.
The QR popup will:
- on desktop: will show a button to open the customer display on the same device, or to scan the qr
- on mobile: will show only the qr code to scan

task-5129241

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
