### PR TITLE
[IMP] account, sale(_management): add section state widget and `collapse_*` logic in quotation templates

### DIFF
--- a/addons/account/static/src/components/account_merge_wizard_line_one2many/account_merge_wizard_line_one2many.js
+++ b/addons/account/static/src/components/account_merge_wizard_line_one2many/account_merge_wizard_line_one2many.js
@@ -23,7 +23,7 @@ export class AccountMergeWizardLinesRenderer extends SectionAndNoteListRenderer 
     }
 
     /** @override **/
-    getSectionColumns(columns) {
+    getSectionAndNoteColumns(columns) {
         const sectionCols = columns.filter(
             (col) =>
                 col.type === "field" && (col.name === this.titleField || col.name === "is_selected")

--- a/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.js
+++ b/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.js
@@ -125,6 +125,10 @@ export class SectionAndNoteListRenderer extends ListRenderer {
         return this.shouldCollapse(this.record, 'collapse_composition');
     }
 
+    get sectionColumns() {
+        return [...this.props.aggregatedFields, 'section_state'];
+    }
+
     async toggleCollapse(record, fieldName) {
         // We don't want to have 'collapse_prices' & 'collapse_composition' set to True at the same time
         const reverseFieldName = fieldName === 'collapse_prices' ? 'collapse_composition' : 'collapse_prices';
@@ -394,7 +398,7 @@ export class SectionAndNoteListRenderer extends ListRenderer {
     getColumns(record) {
         const columns = super.getColumns(record);
         if (this.isSectionOrNote(record)) {
-            return this.getSectionColumns(columns, record);
+            return this.getSectionAndNoteColumns(columns, record);
         }
         return columns;
     }
@@ -414,12 +418,12 @@ export class SectionAndNoteListRenderer extends ListRenderer {
         return super.getFormattedValue(column, record);
     }
 
-    getSectionColumns(columns, record) {
+    getSectionAndNoteColumns(columns, record) {
         const sectionCols = columns.filter(
             (col) =>
                 col.widget === "handle"
                 || col.name === this.titleField
-                || (this.isSection(record) && this.props.aggregatedFields.includes(col.name))
+                || (this.isSection(record) && this.sectionColumns.includes(col.name))
         );
         return sectionCols.map((col) => {
             if (col.name === this.titleField) {

--- a/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.xml
+++ b/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.xml
@@ -42,7 +42,7 @@
                                     onSelected="() => this.toggleCollapse(record, 'collapse_composition')"
                                     attrs="{ 'class': disableCompositionButton ? 'disabled' : '' }"
                                 >
-                                    <i class="me-1 fa fa-fw" t-att-class="hideComposition ? 'fa-eye' : 'fa-eye-slash'"/>
+                                    <i class="me-1 fa fa-fw" t-att-class="hideComposition ? 'fa-expand' : 'fa-compress'"/>
                                     <span t-if="hideComposition">Show Composition</span>
                                     <span t-else="">Hide Composition</span>
                                 </DropdownItem>

--- a/addons/account/static/src/components/section_state/section_state_icon.js
+++ b/addons/account/static/src/components/section_state/section_state_icon.js
@@ -1,0 +1,39 @@
+import { Component } from '@odoo/owl';
+import { registry } from '@web/core/registry';
+import { standardWidgetProps } from '@web/views/widgets/standard_widget_props';
+
+export const COLLAPSE_ICONS = {
+    collapse_composition: 'fa fa-compress',
+    collapse_prices: 'fa fa-eye-slash',
+}
+
+export class SectionStateIcon extends Component {
+    static template = 'account.SectionStateIcon';
+    static props = {
+        ...standardWidgetProps,
+        iconMapping: Object,
+    };
+
+    get iconClass() {
+        for (const [field, icon] of Object.entries(this.props.iconMapping)) {
+            if (this.props.record.data[field]) {
+                return icon;
+            }
+        }
+
+        return '';
+    }
+}
+
+export const sectionStateIcon = {
+    component: SectionStateIcon,
+    extractProps: ({ options }) => ({
+        iconMapping: {
+            ...COLLAPSE_ICONS,
+            ...options,
+        },
+    }),
+    listViewWidth: 20,
+};
+
+registry.category('view_widgets').add('section_state', sectionStateIcon);

--- a/addons/account/static/src/components/section_state/section_state_icon.xml
+++ b/addons/account/static/src/components/section_state/section_state_icon.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<templates>
+
+    <t t-name="account.SectionStateIcon">
+        <t t-if="['line_section', 'line_subsection'].includes(props.record.data.display_type)">
+            <i
+                class="ms-1 mt-1 text-muted"
+                t-att-class="iconClass"
+                aria-hidden="true"
+            />
+        </t>
+    </t>
+
+</templates>

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1225,6 +1225,7 @@
                                         <field name="price_total"
                                                column_invisible="parent.move_type in ['in_invoice', 'in_refund', 'in_receipt'] or parent.company_price_include == 'tax_excluded'"
                                                string="Amount"/>
+                                        <widget name="section_state"/>
                                         <!-- Others fields -->
                                         <field name="partner_id" column_invisible="True"/>
                                         <field name="currency_id" column_invisible="True"/>

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -778,6 +778,7 @@
                                     invisible="is_downpayment"
                                     optional="hide"
                                 />
+                                <widget name="section_state"/>
                             </list>
                             <kanban class="o_kanban_mobile">
                                 <field name="display_type"/>

--- a/addons/sale_management/models/sale_order_template.py
+++ b/addons/sale_management/models/sale_order_template.py
@@ -142,7 +142,7 @@ class SaleOrderTemplate(models.Model):
         ).product_variant_id
         demo_template.sale_order_template_line_ids = [
             Command.create({
-                'name': "Regular Section",
+                'name': self.env._("Regular Section"),
                 'display_type': 'line_section',
                 'product_uom_qty': 0,
             }),
@@ -153,7 +153,7 @@ class SaleOrderTemplate(models.Model):
                 'product_id': self.env.ref('product.monitor_stand').id,
             }),
             Command.create({
-                'name': "Hidden Composition Section",
+                'name': self.env._("Hidden Composition Section"),
                 'display_type': 'line_section',
                 'collapse_composition': True,
                 'product_uom_qty': 0,
@@ -166,7 +166,7 @@ class SaleOrderTemplate(models.Model):
                 'product_uom_qty': 8,
             }),
             Command.create({
-                'name': "Hidden Prices Section",
+                'name': self.env._("Hidden Prices Section"),
                 'display_type': 'line_section',
                 'collapse_prices': True,
                 'product_uom_qty': 0,
@@ -179,7 +179,7 @@ class SaleOrderTemplate(models.Model):
                 'product_uom_qty': 8,
             }),
             Command.create({
-                'name': "Optional Section",
+                'name': self.env._("Optional Section"),
                 'display_type': 'line_section',
                 'is_optional': True,
                 'product_uom_qty': 0,
@@ -189,7 +189,7 @@ class SaleOrderTemplate(models.Model):
                 'product_uom_qty': 0,
             }),
             Command.create({
-                'name': "Subsection",
+                'name': self.env._("Subsection"),
                 'display_type': 'line_subsection',
                 'product_uom_qty': 0,
             }),

--- a/addons/sale_management/models/sale_order_template.py
+++ b/addons/sale_management/models/sale_order_template.py
@@ -142,11 +142,34 @@ class SaleOrderTemplate(models.Model):
         ).product_variant_id
         demo_template.sale_order_template_line_ids = [
             Command.create({
+                'name': "Regular Section",
+                'display_type': 'line_section',
+                'product_uom_qty': 0,
+            }),
+            Command.create({
+                'product_id': self.env.ref('product.product_template_dining_table').id,
+            }),
+            Command.create({
+                'product_id': self.env.ref('product.monitor_stand').id,
+            }),
+            Command.create({
+                'name': "Hidden Composition Section",
+                'display_type': 'line_section',
+                'collapse_composition': True,
+                'product_uom_qty': 0,
+            }),
+            Command.create({
                 'product_id': self.env.ref('product.consu_delivery_02').id,
             }),
             Command.create({
                 'product_id': self.env.ref('product.product_delivery_01').id,
                 'product_uom_qty': 8,
+            }),
+            Command.create({
+                'name': "Hidden Prices Section",
+                'display_type': 'line_section',
+                'collapse_prices': True,
+                'product_uom_qty': 0,
             }),
             Command.create({
                 'product_id': acoustic_bloc_screen_product.id,
@@ -156,7 +179,7 @@ class SaleOrderTemplate(models.Model):
                 'product_uom_qty': 8,
             }),
             Command.create({
-                'name': "Optional Products Section",
+                'name': "Optional Section",
                 'display_type': 'line_section',
                 'is_optional': True,
                 'product_uom_qty': 0,
@@ -166,7 +189,8 @@ class SaleOrderTemplate(models.Model):
                 'product_uom_qty': 0,
             }),
             Command.create({
-                'product_id': self.env.ref('product.product_product_7').id,
+                'name': "Subsection",
+                'display_type': 'line_subsection',
                 'product_uom_qty': 0,
             }),
             Command.create({

--- a/addons/sale_management/models/sale_order_template_line.py
+++ b/addons/sale_management/models/sale_order_template_line.py
@@ -70,6 +70,8 @@ class SaleOrderTemplateLine(models.Model):
         copy=True,
         default=False,
     )
+    collapse_composition = fields.Boolean()
+    collapse_prices = fields.Boolean()
 
     #=== COMPUTE METHODS ===#
 
@@ -133,11 +135,13 @@ class SaleOrderTemplateLine(models.Model):
         """
         self.ensure_one()
         vals = {
+            'collapse_composition': self.collapse_composition,
+            'collapse_prices': self.collapse_prices,
             'display_type': self.display_type,
+            'is_optional': self.is_optional,
             'product_id': self.product_id.id,
             'product_uom_qty': self.product_uom_qty,
             'product_uom_id': self.product_uom_id.id,
-            'is_optional': self.is_optional,
             'sequence': self.sequence,
         }
         if self.name:

--- a/addons/sale_management/static/src/fields/sale_order_line_field/sale_order_line_field.js
+++ b/addons/sale_management/static/src/fields/sale_order_line_field/sale_order_line_field.js
@@ -87,7 +87,7 @@ patch(SaleOrderLineListRenderer.prototype, {
 
     getRowClass(record) {
         let rowClasses = super.getRowClass(record);
-        if (this.shouldCollapse(record, 'is_optional', true)) {
+        if (this.shouldCollapse(record, 'is_optional')) {
             rowClasses += ' text-primary';
         }
         return rowClasses;

--- a/addons/sale_management/static/src/fields/sale_order_line_field/sale_order_line_field.xml
+++ b/addons/sale_management/static/src/fields/sale_order_line_field/sale_order_line_field.xml
@@ -7,7 +7,7 @@
                 onSelected="() => this.toggleIsOptional(record)"
                 attrs="{ 'class': disableOptionalButton ? 'disabled' : '' }"
             >
-                <i class="me-1 fa fa-fw fa-list"/>
+                <i class="me-1 fa fa-fw fa-dot-circle-o"/>
                 <span t-if="record.data.is_optional">Unset Optional</span>
                 <span t-else="">Set Optional</span>
             </DropdownItem>

--- a/addons/sale_management/static/src/fields/sale_order_template_line_field/sale_order_template_line_field.js
+++ b/addons/sale_management/static/src/fields/sale_order_template_line_field/sale_order_template_line_field.js
@@ -64,7 +64,7 @@ export class SaleOrderTemplateLineListRenderer extends SectionAndNoteListRendere
 
     getRowClass(record) {
         let rowClasses = super.getRowClass(record);
-        if (this.shouldCollapse(record, 'is_optional', true)) {
+        if (this.shouldCollapse(record, 'is_optional')) {
             rowClasses += ' text-primary';
         }
         return rowClasses;

--- a/addons/sale_management/static/src/fields/sale_order_template_line_field/sale_order_template_line_field.xml
+++ b/addons/sale_management/static/src/fields/sale_order_template_line_field/sale_order_template_line_field.xml
@@ -11,7 +11,7 @@
                 onSelected="() => this.toggleIsOptional(record)"
                 attrs="{ 'class': disableOptionalButton ? 'disabled' : '' }"
             >
-                <i class="me-1 fa fa-fw fa-list"/>
+                <i class="me-1 fa fa-fw fa-dot-circle-o"/>
                 <span t-if="record.data.is_optional">Unset Optional</span>
                 <span t-else="">Set Optional</span>
             </DropdownItem>

--- a/addons/sale_management/views/sale_order_template_views.xml
+++ b/addons/sale_management/views/sale_order_template_views.xml
@@ -58,7 +58,7 @@
                         <field
                             name="sale_order_template_line_ids"
                             widget="so_template_line_o2m"
-                            options="{ 'subsections': True }"
+                            options="{'subsections': True, 'hide_prices': True, 'hide_composition': True}"
                         >
                             <form string="Quotation Template Lines">
                                 <!--
@@ -96,6 +96,8 @@
                                 </control>
                                 <field name="display_type" column_invisible="True"/>
                                 <field name="is_optional" column_invisible="True"/>
+                                <field name="collapse_prices" column_invisible="True"/>
+                                <field name="collapse_composition" column_invisible="True"/>
                                 <field name="sequence" widget="handle"/>
                                 <field name="product_id"/>
                                 <field name="name"/>

--- a/addons/sale_management/views/sale_order_template_views.xml
+++ b/addons/sale_management/views/sale_order_template_views.xml
@@ -106,6 +106,10 @@
                                     name="product_uom_id"
                                     groups="uom.group_uom"
                                     required="not display_type"/>
+                                <widget
+                                    name="section_state"
+                                    options="{'is_optional': 'fa fa-dot-circle-o'}"
+                                />
                             </list>
                         </field>
                     </page>

--- a/addons/sale_management/views/sale_order_views.xml
+++ b/addons/sale_management/views/sale_order_views.xml
@@ -23,9 +23,14 @@
                     />
                 </group>
             </xpath>
+
             <xpath expr="//list/field[@name='linked_virtual_id']" position="after">
                 <field name="is_optional" column_invisible="True"/>
             </xpath>
+
+            <widget name="section_state" position="attributes">
+                <attribute name="options">{'is_optional': 'fa fa-dot-circle-o'}</attribute>
+            </widget>
         </field>
     </record>
 


### PR DESCRIPTION
This PR introduces two improvements to sections in Sale Orders, Quotations, and Invoices:

1. **Section State Widget**
   - Adds a new widget to display the state of sections in invoices, sale orders, and quotation templates.
   - Shows whether a section is:
       - Hidden → fa-compress
       - Prices hidden → fa-eye-slash
       - Optional → fa-dot-circle-o
   - Helps identify section states when muted columns alone are not enough.

2. **Collapse_* Logic in Quotation Templates**
   - Supports Hide/Show Composition and Hide/Show Prices actions in Quotation templates, similar to Sale Orders.
   - These settings are applied when a Quotation template is selected in the Sale Order form, ensuring consistency.
   - Improves readability and control over displayed sections in templates and orders.

task-5129152


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
