### PR TITLE
[FIX] pos_loyalty: fix runbot coupon issue

### DIFF
--- a/addons/pos_loyalty/static/tests/tours/gift_card_program_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/gift_card_program_tour.js
@@ -213,10 +213,12 @@ registry.category("web_tour.tours").add("test_coupon_code_stays_set", {
             ProductScreen.clickDisplayedProduct("Gift Card"),
             PosLoyalty.createManualGiftCard("Card Name", 20),
             ProductScreen.clickDisplayedProduct("Gift Card"),
+            ProductScreen.selectedOrderlineHas("Gift Card", "1.00", "50"),
             Utils.refresh(),
             ProductScreen.clickPayButton(),
             PaymentScreen.clickPaymentMethod("Cash"),
             PaymentScreen.clickValidate(),
             ReceiptScreen.clickNextOrder(),
+            Chrome.endTour(),
         ].flat(),
 });


### PR DESCRIPTION
When the last tour of this step was ignored, the coupons did not have enough time to be generated, resulting in an error because we are trying to access them later on in the backend. We thus had an out of range error on the coupons list.

Another issue was that we refreshed the page too soon after clicking the gift card product, so it did not have time to add it to the order before refreshing the page.

We now use a the *endTour* function to make sure the coupons have time to be generated to avoid said error.
We also make sure that the gift card has been added to the order before refreshing the page.

runbot-232857