### PR TITLE
[IMP] hr_attendance: add SA overtime ruleset data

### DIFF
--- a/addons/hr_attendance/__manifest__.py
+++ b/addons/hr_attendance/__manifest__.py
@@ -20,6 +20,7 @@ actions(Check in/Check out) performed by them.
         'data/hr_attendance_data.xml',
         'security/hr_attendance_security.xml',
         'security/ir.model.access.csv',
+        'data/hr_attendance_overtime_ruleset_data.xml',
         'views/hr_attendance_view.xml',
         'views/hr_department_view.xml',
         'views/hr_employee_view.xml',

--- a/addons/hr_attendance/data/hr_attendance_overtime_ruleset_data.xml
+++ b/addons/hr_attendance/data/hr_attendance_overtime_ruleset_data.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <data>
+<!-- SA : Saudi Arabia -->
+        <record id="l10n_sa_overtime_ruleset" model="hr.attendance.overtime.ruleset">
+            <field name="name">Saudi Overtime Ruleset</field>
+            <field name="rate_combination_mode">sum</field>
+            <field name="country_id" ref="base.sa"/>
+        </record>
+        <record id="l10n_sa_workdays_overtime_rule" model="hr.attendance.overtime.rule">
+            <field name="name">Workdays Overtime</field>
+            <field name="ruleset_id" ref="l10n_sa_overtime_ruleset"/>
+            <field name="base_off">quantity</field>
+            <field name="quantity_period">day</field>
+            <field name="expected_hours_from_contract" eval="True"/>
+        </record>
+    </data>
+</odoo>

--- a/addons/hr_attendance/security/hr_attendance_security.xml
+++ b/addons/hr_attendance/security/hr_attendance_security.xml
@@ -85,5 +85,12 @@
             <field name="perm_unlink" eval="0"/>
             <field name="perm_read" eval="1"/>
         </record>
+
+        <!-- Overtime Ruleset -->
+        <record id="hr_attendance_overtime_ruleset_rule_multi_company" model="ir.rule">
+            <field name="name">Overtime Ruleset: Multi Company</field>
+            <field name="model_id" ref="model_hr_attendance_overtime_ruleset"/>
+            <field name="domain_force">[('country_id', 'in', user.env.companies.mapped('country_id').ids + [False])]</field>
+        </record>
     </data>
 </odoo>

--- a/addons/hr_work_entry/data/hr_work_entry_type_data.xml
+++ b/addons/hr_work_entry/data/hr_work_entry_type_data.xml
@@ -1401,6 +1401,15 @@
         <field name="is_leave" eval="True"/>
         <field name="country_id" ref="base.sa"/>
     </record>
+    <record id="l10n_sa_work_entry_type_overtime" model="hr.work.entry.type">
+        <field name="name">Overtime</field>
+        <field name="code">SAOVERTIME</field>
+        <field name="color">4</field>
+        <field name="is_leave" eval="False"/>
+        <field name="is_extra_hours" eval="True"/>
+        <field name="amount_rate">1.5</field>
+        <field name="country_id" ref="base.sa"/>
+    </record>
 
 <!-- SK : Slovakia -->
     <record id="l10n_sk_work_entry_type_sick_25" model="hr.work.entry.type">


### PR DESCRIPTION
- add rule for multi campany where each company sees the overtime ruleset assign to its country
- Introduce a default overtime ruleset tailored for Saudi Arabian companies.
- Add a corresponding work entry type to ensure proper association with the ruleset’s rules through the appropriate bridge module.

Task: 5102385

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
