### PR TITLE
[FIX] project: show revenues for archived products

### DIFF
--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -836,7 +836,7 @@ class Project(models.Model):
         if self.allow_milestones:
             panel_data['milestones'] = self._get_milestones()
         if show_profitability:
-            profitability_items = self._get_profitability_items()
+            profitability_items = self.with_context(active_test=False)._get_profitability_items()
             if self._get_profitability_sequence_per_invoice_type() and profitability_items and 'revenues' in profitability_items and 'costs' in profitability_items:  # sort the data values
                 profitability_items['revenues']['data'] = sorted(profitability_items['revenues']['data'], key=lambda k: k['sequence'])
                 profitability_items['costs']['data'] = sorted(profitability_items['costs']['data'], key=lambda k: k['sequence'])


### PR DESCRIPTION
**Steps to reproduce:**
1. Install the Sale, Project, and Timesheet modules.
2. Create a service-based product with `invoicing policy > Prepaid`, linked to `Create on Order > Project and Task`. Add a project template.
3. Create a sale order with that product.
4. Go to the created project and check the project status.

**Observed behavior:**
* Revenue is visible in project status while the product is active.
* Once the product is archived, its revenue disappears.

**Root cause:**
Archived products were not considered when calculating revenue.

**Solution:**
Backport the fix from v18 to include archived products in revenue calculations.
v18 pr : https://github.com/odoo/odoo/pull/129089
added test for product archive case.

opw-5070289