### PR TITLE
[FIX] tools/pdf: add correct delimiters for NameObject in PyPDF2

### DIFF
--- a/odoo/tools/pdf/__init__.py
+++ b/odoo/tools/pdf/__init__.py
@@ -115,6 +115,13 @@ def _unwrapping_get(self, key, default=None):
 
 DictionaryObject.get = _unwrapping_get
 
+# Make sure all the correct delimiters are included
+# https://github.com/py-pdf/pypdf/commit/8c542f331828c5839fda48442d89b8ac5d3984ac
+NameObject.renumber_table.update({
+    **{chr(i): f"#{i:02X}".encode() for i in b"#()<>[]{}/%"},
+    **{chr(i): f"#{i:02X}".encode() for i in range(33)},
+})
+
 
 if hasattr(PdfWriter, 'write_stream'):
     # >= 2.x has a utility `write` which can open a path, so `write_stream` could be called directly


### PR DESCRIPTION
Patch the following commit locally:
https://github.com/py-pdf/pypdf/commit/8c542f331828c5839fda48442d89b8ac5d3984ac

Issue:
A PDF files contain `/FontName /TimesNewRomanGreek#5Bbold#5D`. While this is a valid font descriptor, it gets converted to `/FontName /TimesNewRomanGreek[bold]` in `NameObject.read_from_stream` through `unhexlify` (see the complete call stack below)
The converted value is not longer valid as `[` marks the start of a `ArrayObject`. The character should have been escaped back to `#5B` before being written in a new document.

```python
  /home/odoo/git/odoo/odoo/addons/account/models/ir_actions_report.py(37)_render_qweb_pdf_prepare_streams()
-> stream = pdf.add_banner(stream, record.name or '', logo=True)
  /home/odoo/git/odoo/odoo/odoo/tools/pdf/__init__.py(288)add_banner()
-> new_pdf.write(output)
  /home/odoo/git/odoo/.env3.11/lib/python3.11/site-packages/PyPDF2/_writer.py(935)write()
-> self.write_stream(stream)
  /home/odoo/git/odoo/odoo/odoo/tools/pdf/__init__.py(127)write_stream()
-> super().write_stream(*args, **kwargs)
  /home/odoo/git/odoo/.env3.11/lib/python3.11/site-packages/PyPDF2/_writer.py(908)write_stream()
-> self._sweep_indirect_references(self._root)
  /home/odoo/git/odoo/.env3.11/lib/python3.11/site-packages/PyPDF2/_writer.py(1057)_sweep_indirect_references()
-> data = self._resolve_indirect_object(data)
  /home/odoo/git/odoo/.env3.11/lib/python3.11/site-packages/PyPDF2/_writer.py(1102)_resolve_indirect_object()
-> real_obj = data.pdf.get_object(data)
  /home/odoo/git/odoo/.env3.11/lib/python3.11/site-packages/PyPDF2/_reader.py(1256)get_object()
-> retval = read_object(self.stream, self)  # type: ignore
  /home/odoo/git/odoo/.env3.11/lib/python3.11/site-packages/PyPDF2/generic/_data_structures.py(841)read_object()
-> return DictionaryObject.read_from_stream(stream, pdf, forced_encoding)
  /home/odoo/git/odoo/.env3.11/lib/python3.11/site-packages/PyPDF2/generic/_data_structures.py(270)read_from_stream()
-> value = read_object(stream, pdf, forced_encoding)
  /home/odoo/git/odoo/.env3.11/lib/python3.11/site-packages/PyPDF2/generic/_data_structures.py(834)read_object()
-> return NameObject.read_from_stream(stream, pdf)
  /home/odoo/git/odoo/.env3.11/lib/python3.11/site-packages/PyPDF2/generic/_base.py(469)read_from_stream()
-> name = NameObject.unnumber(name)
> /home/odoo/git/odoo/.env3.11/lib/python3.11/site-packages/PyPDF2/generic/_base.py(450)unnumber()
-> while i >= 0:
```

opw-4991601