### PR TITLE
[REF] mail: remove support of _field_store_repr

### DIFF
--- a/addons/mail/tools/discuss.py
+++ b/addons/mail/tools/discuss.py
@@ -252,8 +252,6 @@ class Store:
             fields = [Store.Attr(key, value) for key, value in fields.items()]
         if not isinstance(fields, list):
             fields = [fields]
-        if hasattr(records, "_field_store_repr"):
-            return [f for field in fields for f in records._field_store_repr(field)]
         return fields
 
     def _get_records_data_list(self, records, fields):


### PR DESCRIPTION
_field_store_repr is too magic, better explicitly call a method which returns the list of fields to return instead of using a "magic" field name.

All occurences have been converted, remove support for the feature.

task-4855066