### PR TITLE
[IMP] web: add offline UI support

### DIFF
--- a/addons/web/models/ir_ui_view.py
+++ b/addons/web/models/ir_ui_view.py
@@ -13,6 +13,7 @@ class IrUiView(models.Model):
                 'display_name': display_name,
                 'icon': _view_info[type_]['icon'],
                 'multi_record': _view_info[type_].get('multi_record', True),
+                'available_offline': _view_info[type_].get('available_offline', False),
             }
             for (type_, display_name)
             in self.fields_get(['type'], ['selection'])['type']['selection']
@@ -21,11 +22,11 @@ class IrUiView(models.Model):
 
     def _get_view_info(self):
         return {
-            'list': {'icon': 'oi oi-view-list'},
-            'form': {'icon': 'fa fa-address-card', 'multi_record': False},
+            'list': {'icon': 'oi oi-view-list', 'available_offline': True},
+            'form': {'icon': 'fa fa-address-card', 'multi_record': False, 'available_offline': True},
             'graph': {'icon': 'fa fa-area-chart'},
             'pivot': {'icon': 'oi oi-view-pivot'},
-            'kanban': {'icon': 'oi oi-view-kanban'},
+            'kanban': {'icon': 'oi oi-view-kanban', 'available_offline': True},
             'calendar': {'icon': 'fa fa-calendar'},
             'search': {'icon': 'oi oi-search'},
         }

--- a/addons/web/static/src/@types/services.d.ts
+++ b/addons/web/static/src/@types/services.d.ts
@@ -14,6 +14,7 @@ declare module "services" {
     import { nameService } from "@web/core/name_service";
     import { httpService } from "@web/core/network/http_service";
     import { notificationService } from "@web/core/notifications/notification_service";
+    import { offlineService } from "@web/core/offline/offline_service";
     import { ormService } from "@web/core/orm_service";
     import { overlayService } from "@web/core/overlay/overlay_service";
     import { popoverService } from "@web/core/popover/popover_service";
@@ -54,6 +55,7 @@ declare module "services" {
         menu: typeof menuService;
         name: typeof nameService;
         notification: typeof notificationService;
+        offline: typeof offlineService;
         orm: typeof ormService;
         overlay: typeof overlayService;
         popover: typeof popoverService;

--- a/addons/web/static/src/core/dialog/dialog.xml
+++ b/addons/web/static/src/core/dialog/dialog.xml
@@ -33,16 +33,16 @@
 
     <t t-name="web.Dialog.header">
         <t t-if="fullscreen">
-            <button class="btn oi oi-arrow-left oi-large" aria-label="Close" tabindex="-1" t-on-click="dismiss" />
+            <button class="btn oi oi-arrow-left oi-large" aria-label="Close" tabindex="-1" t-on-click="dismiss" data-available-offline=""/>
         </t>
         <h4 class="modal-title text-break flex-grow-1" t-att-class="{ 'me-auto': fullscreen, 'fs-5': props.size == 'sm' }">
             <t t-esc="props.title"/>
         </h4>
         <t t-if="onExpand">
-            <button type="button" class="fa fa-expand btn opacity-75 opacity-100-hover o_expand_button" aria-label="Expand" tabindex="-1" t-on-click="onExpand"/>
+            <button type="button" class="fa fa-expand btn opacity-75 opacity-100-hover o_expand_button" aria-label="Expand" tabindex="-1" t-on-click="onExpand" data-available-offline=""/>
         </t>
         <t t-if="!fullscreen">
-            <button type="button" class="btn-close" t-att-class="{'position-absolute top-0 end-0 mt-1 me-1': design == 'minimal' and !onExpand  }" aria-label="Close" tabindex="-1" t-on-click="dismiss"/>
+            <button type="button" class="btn-close" t-att-class="{'position-absolute top-0 end-0 mt-1 me-1': design == 'minimal' and !onExpand  }" aria-label="Close" tabindex="-1" t-on-click="dismiss" data-available-offline=""/>
         </t>
     </t>
 </templates>

--- a/addons/web/static/src/core/errors/error_dialogs.xml
+++ b/addons/web/static/src/core/errors/error_dialogs.xml
@@ -7,7 +7,7 @@
                 <p t-esc="message" class="text-prewrap"/>
             </div>
             <t t-set-slot="footer">
-                <button class="btn btn-primary o-default-button" t-on-click="props.close">Close</button>
+                <button class="btn btn-primary o-default-button" t-on-click="props.close" data-available-offline="">Close</button>
             </t>
         </Dialog>
     </t>
@@ -19,7 +19,7 @@
             </div>
             <t t-set-slot="footer">
                 <button class="btn btn-primary" t-on-click="onClick" t-esc="buttonText"/>
-                <button class="btn btn-secondary" t-on-click="props.close">Close</button>
+                <button class="btn btn-secondary" t-on-click="props.close" data-available-offline="">Close</button>
             </t>
         </Dialog>
     </t>
@@ -32,7 +32,7 @@
                 </p>
             </div>
             <t t-set-slot="footer">
-                <button class="btn btn-primary o-default-button" t-on-click="props.close">Close</button>
+                <button class="btn btn-primary o-default-button" t-on-click="props.close" data-available-offline="">Close</button>
             </t>
         </Dialog>
     </t>
@@ -45,7 +45,7 @@
                 </p>
             </div>
             <t t-set-slot="footer">
-                <button class="btn btn-primary o-default-button" t-on-click="onClick">Close</button>
+                <button class="btn btn-primary o-default-button" t-on-click="onClick" data-available-offline="">Close</button>
             </t>
         </Dialog>
     </t>
@@ -59,7 +59,7 @@
                 <details t-on-toggle="() => { state.showTraceback = !state.showTraceback }">
                     <summary t-esc="state.showTraceback ? this.constructor.hideTracebackButtonText : this.constructor.showTracebackButtonText" class="mb-1 link-info"/>
                     <div class="text-bg-100 clearfix mt-2 position-relative o_error_detail pb-2">
-                        <button class="btn position-absolute top-0 end-0 pt-2 btn-link link-body-emphasis" t-ref="copyButton" t-on-click="onClickClipboard">
+                        <button class="btn position-absolute top-0 end-0 pt-2 btn-link link-body-emphasis" t-ref="copyButton" t-on-click="onClickClipboard" data-available-offline="">
                             <span class="fa fa-clipboard"/>
                         </button>
                         <div class="ps-1 pt-1 ps-md-3 pt-md-3">
@@ -73,7 +73,7 @@
                 </details>
             </div>
             <t t-set-slot="footer">
-                <button class="btn btn-primary o-default-button" t-on-click="props.close">Close</button>
+                <button class="btn btn-primary o-default-button" t-on-click="props.close" data-available-offline="">Close</button>
             </t>
         </Dialog>
     </t>

--- a/addons/web/static/src/core/notifications/notification.xml
+++ b/addons/web/static/src/core/notifications/notification.xml
@@ -5,7 +5,7 @@
         <div t-on-mouseenter="freeze" t-on-mouseleave="refresh" t-attf-class="o_notification {{props.className}} d-flex mb-2 position-relative rounded shadow-lg" role="alert" aria-live="assertive" aria-atomic="true">
             <span t-attf-class="o_notification_bar bg-{{props.type}} rounded-start"/>
             <div class="w-100 py-2 ps-3 pe-5 border border-start-0 rounded-end text-break">
-                <button type="button" class="o_notification_close btn-close position-absolute top-0 end-0 mt-2 me-2" aria-label="Close" t-on-click="close"/>
+                <button type="button" class="o_notification_close btn-close position-absolute top-0 end-0 mt-2 me-2" aria-label="Close" t-on-click="close" data-available-offline=""/>
                 <div class="o_notification_body d-flex align-items-center">
                     <span class="me-auto o_notification_content w-100">
                         <!-- TODO-IPB: at the end, title has to be removed, but the change is too important to do all in once now -->

--- a/addons/web/static/src/core/offline/offline.scss
+++ b/addons/web/static/src/core/offline/offline.scss
@@ -1,0 +1,11 @@
+.o_disabled_offline {
+    cursor: not-allowed !important;
+    pointer-events: auto !important;
+    opacity: 0.5 !important;
+}
+
+// must override this rule https://github.com/odoo/odoo/blob/9e3b9bd085483ba0e0e956762fc0ad7d759eec73/addons/web/static/src/webclient/webclient.scss#L140
+.o_disabled_offline[type="action"],
+.o_disabled_offline[type="toggle"] {
+    cursor: not-allowed !important;
+}

--- a/addons/web/static/src/core/offline/offline_error.js
+++ b/addons/web/static/src/core/offline/offline_error.js
@@ -1,0 +1,26 @@
+import { UncaughtPromiseError } from "../errors/error_service";
+import { ConnectionLostError } from "../network/rpc";
+import { registry } from "../registry";
+
+const errorHandlerRegistry = registry.category("error_handlers");
+
+// -----------------------------------------------------------------------------
+// Lost connection errors
+// -----------------------------------------------------------------------------
+
+/**
+ * @param {OdooEnv} env
+ * @param {UncaughError} error
+ * @param {Error} originalError
+ * @returns {boolean}
+ */
+export function lostConnectionHandler(env, error, originalError) {
+    if (!(error instanceof UncaughtPromiseError)) {
+        return false;
+    }
+    if (originalError instanceof ConnectionLostError) {
+        env.services.offline.status.offline = true;
+        return true;
+    }
+}
+errorHandlerRegistry.add("lostConnectionHandler", lostConnectionHandler, { sequence: 98 });

--- a/addons/web/static/src/core/offline/offline_service.js
+++ b/addons/web/static/src/core/offline/offline_service.js
@@ -1,0 +1,96 @@
+import { reactive, useState } from "@odoo/owl";
+import { browser } from "@web/core/browser/browser";
+import { ConnectionLostError, rpc, rpcBus } from "@web/core/network/rpc";
+import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
+
+const SELECTORS_TO_DISABLE = [
+    "button:not([data-available-offline]):not([disabled])",
+    "input[type='checkbox']:not([disabled])",
+];
+
+function offlineUI() {
+    document.querySelectorAll(SELECTORS_TO_DISABLE.join(", ")).forEach((el) => {
+        el.setAttribute("disabled", "");
+        el.classList.add("o_disabled_offline");
+    });
+}
+
+function onlineUI() {
+    document.querySelectorAll(".o_disabled_offline").forEach((el) => {
+        el.removeAttribute("disabled");
+        el.classList.remove("o_disabled_offline");
+    });
+}
+
+export const offlineService = {
+    async start() {
+        let timeout;
+        let observer;
+
+        async function checkConnection() {
+            try {
+                await rpc("/web/webclient/version_info", {});
+            } catch {
+                status.offline = true;
+                return;
+            }
+            status.offline = false;
+        }
+
+        const status = reactive(
+            {
+                offline: false,
+            },
+            () => {
+                if (status.offline) {
+                    // Disable everything in the UI that isn't marked as available offline
+                    offlineUI();
+                    // Create an observer instance linked to the callback function to keep disabling
+                    // buttons that would appear in the DOM while being offline
+                    observer = new MutationObserver((mutationList) => {
+                        if (status.offline && mutationList.find((m) => m.addedNodes.length > 0)) {
+                            offlineUI();
+                        }
+                    });
+                    observer.observe(document.body, {
+                        childList: true, // listen for direct children being added/removed
+                        subtree: true, // also observe descendants (not just direct children)
+                    });
+
+                    // Repeatedly check if connection is back
+                    let delay = 2000;
+                    const _checkConnection = async () => {
+                        if (status.offline) {
+                            await checkConnection();
+                            // exponential backoff, with some jitter
+                            delay = delay * 1.5 + 500 * Math.random();
+                            timeout = browser.setTimeout(_checkConnection, delay);
+                        }
+                    };
+                    timeout = browser.setTimeout(_checkConnection, delay);
+                } else {
+                    onlineUI();
+                    observer?.disconnect();
+                    browser.clearTimeout(timeout);
+                }
+            }
+        );
+        status.offline; // activate the reactivity!
+
+        rpcBus.addEventListener("RPC:RESPONSE", (ev) => {
+            status.offline = ev.detail.error instanceof ConnectionLostError;
+        });
+
+        return {
+            status,
+            checkConnection,
+        };
+    },
+};
+
+registry.category("services").add("offline", offlineService);
+
+export function useOfflineStatus() {
+    return useState(useService("offline").status);
+}

--- a/addons/web/static/src/core/offline/offline_systray.js
+++ b/addons/web/static/src/core/offline/offline_systray.js
@@ -1,0 +1,21 @@
+import { Component, useEffect } from "@odoo/owl";
+import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
+import { useOfflineStatus } from "./offline_service";
+
+class OfflineSystray extends Component {
+    static template = "web.OfflineSystray";
+    static props = {};
+
+    setup() {
+        this.offlineService = useService("offline");
+        this.status = useOfflineStatus();
+        useEffect(this.env.redrawNavbar, () => [this.status.offline]);
+    }
+}
+
+const offlineSystrayItem = {
+    Component: OfflineSystray,
+};
+
+registry.category("systray").add("offline", offlineSystrayItem, { sequence: 1000 });

--- a/addons/web/static/src/core/offline/offline_systray.xml
+++ b/addons/web/static/src/core/offline/offline_systray.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="web.OfflineSystray">
+        <div t-if="status.offline" t-on-click="() => this.offlineService.checkConnection()">
+            <i t-if="env.isSmall"
+                class="fa fa-chain-broken o_nav_entry text-danger"
+                role="img"
+                aria-label="Working offline"
+                data-tooltip="Working offline"/>
+            <button t-else=""
+                class="o_nav_entry px-2 o_tag opacity-75 rounded-pill text-bg-danger"
+                data-available-offline=""
+                data-tooltip="Click to check connection">
+                <i class="fa fa-chain-broken me-1"></i> Working offline
+            </button>
+        </div>
+    </t>
+
+</templates>
+

--- a/addons/web/static/src/core/pager/pager.xml
+++ b/addons/web/static/src/core/pager/pager.xml
@@ -20,10 +20,14 @@
             </span>
             <span class="btn-group d-print-none" aria-atomic="true">
                 <!-- accesskeys not wanted in X2Many widgets -->
-                <button type="button" class="btn btn-secondary o_pager_previous px-2 rounded-start" aria-label="Previous" data-tooltip="Previous" tabindex="-1" t-att-data-hotkey="props.withAccessKey ? 'p' : false" t-att-disabled="state.isDisabled or isSinglePage" t-on-click.stop="() => this.navigate(-1)">
+                <button type="button" class="btn btn-secondary o_pager_previous px-2 rounded-start" aria-label="Previous" tabindex="-1"
+                    data-tooltip="Previous" t-att-data-hotkey="props.withAccessKey ? 'p' : false" data-available-offline=""
+                    t-att-disabled="state.isDisabled or isSinglePage"  t-on-click.stop="() => this.navigate(-1)">
                     <i class="oi oi-chevron-left"/>
                 </button>
-                <button type="button" class="btn btn-secondary o_pager_next px-2 rounded-end" aria-label="Next" data-tooltip="Next" tabindex="-1" t-att-data-hotkey="props.withAccessKey ? 'n' : false" t-att-disabled="state.isDisabled or isSinglePage" t-on-click.stop="() => this.navigate(1)">
+                <button type="button" class="btn btn-secondary o_pager_next px-2 rounded-end" aria-label="Next" tabindex="-1"
+                    data-tooltip="Next" t-att-data-hotkey="props.withAccessKey ? 'n' : false" data-available-offline=""
+                    t-att-disabled="state.isDisabled or isSinglePage" t-on-click.stop="() => this.navigate(1)">
                     <i class="oi oi-chevron-right"/>
                 </button>
             </span>

--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -142,9 +142,13 @@ export class Record extends DataPoint {
     }
 
     get isInEdition() {
+        if (this.model.offline.status.offline) {
+            return false;
+        }
         if (this.config.mode === "readonly") {
             return false;
         } else {
+            // FIXME: why the or ? if it's not in 'readonly' it's in 'edit', in which case the first is false ?
             return this.config.mode === "edit" || !this.resId;
         }
     }

--- a/addons/web/static/src/model/relational_model/relational_model.js
+++ b/addons/web/static/src/model/relational_model/relational_model.js
@@ -112,7 +112,7 @@ rpcBus.addEventListener("RPC:RESPONSE", (ev) => {
 });
 
 export class RelationalModel extends Model {
-    static services = ["action", "dialog", "notification", "orm"];
+    static services = ["action", "dialog", "notification", "orm", "offline"];
     static Record = RelationalRecord;
     static Group = Group;
     static DynamicRecordList = DynamicRecordList;
@@ -128,10 +128,11 @@ export class RelationalModel extends Model {
      * @param {RelationalModelParams} params
      * @param {Services} services
      */
-    setup(params, { action, dialog, notification }) {
+    setup(params, { action, dialog, notification, offline }) {
         this.action = action;
         this.dialog = dialog;
         this.notification = notification;
+        this.offline = offline;
 
         this.bus = new EventBus();
 
@@ -284,6 +285,7 @@ export class RelationalModel extends Model {
         }
         if (
             !this.isReady || // first load of the model
+            this.offline.status.offline || // use the cache if we are offline
             // monorecord, loading a different id, or creating a new record (onchange)
             (config.isMonoRecord && (this.root.config.resId !== config.resId || !config.resId))
         ) {

--- a/addons/web/static/src/search/action_menus/action_menus.js
+++ b/addons/web/static/src/search/action_menus/action_menus.js
@@ -55,7 +55,7 @@ export class ActionMenus extends Component {
     setup() {
         this.orm = useService("orm");
         this.actionService = useService("action");
-        this.state = useState({ printItems: []})
+        this.state = useState({ printItems: [] });
         onWillStart(async () => {
             this.actionItems = await this.getActionItems(this.props);
         });

--- a/addons/web/static/src/search/control_panel/control_panel.js
+++ b/addons/web/static/src/search/control_panel/control_panel.js
@@ -15,7 +15,6 @@ import { makeContext } from "@web/core/context";
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { Transition } from "@web/core/transition";
 import { Breadcrumbs } from "../breadcrumbs/breadcrumbs";
-import { SearchBar } from "../search_bar/search_bar";
 
 import { Component, useState, onMounted, useRef, useEffect } from "@odoo/owl";
 
@@ -91,7 +90,6 @@ export class ControlPanel extends Component {
     static template = "web.ControlPanel";
     static components = {
         Pager,
-        SearchBar,
         Dropdown,
         DropdownItem,
         Breadcrumbs,

--- a/addons/web/static/src/search/control_panel/control_panel.xml
+++ b/addons/web/static/src/search/control_panel/control_panel.xml
@@ -93,15 +93,19 @@
                     <t t-if="env.config.viewSwitcherEntries?.length > 1">
                         <div t-if="env.isSmall" class="o_cp_switch_buttons btn-group d-print-none">
                             <Dropdown menuClass="{o_cp_switch_buttons: true, o_custom_bottom_sheet: true }">
-                                <button class="btn btn-secondary">
+                                <button class="btn btn-secondary" data-available-offline="">
                                     <t t-set="activeView" t-value="env.config.viewSwitcherEntries.find((view) => view.active)"/>
                                     <i class="oi-fw" t-att-class="activeView.icon"/>
                                 </button>
                                 <t t-set-slot="content">
                                     <t t-foreach="env.config.viewSwitcherEntries" t-as="view" t-key="view.type">
-                                        <DropdownItem onSelected="() => this.switchView(view.type)" class="view.active ? 'selected' : ''">
-                                            <i class="oi-fw" t-att-class="view.icon"/>
-                                            <span class="ms-1" t-out="view.name"/>
+                                        <DropdownItem 
+                                            tag="'button'"
+                                            attrs="{ 'data-available-offline': view.availableOffline}"
+                                            onSelected="() => this.switchView(view.type)"
+                                            class="view.active ? 'selected' : ''">
+                                                <i class="oi-fw" t-att-class="view.icon"/>
+                                                <span class="ms-1" t-out="view.name"/>
                                         </DropdownItem>
                                     </t>
                                 </t>
@@ -111,6 +115,7 @@
                             <t t-foreach="env.config.viewSwitcherEntries" t-as="view" t-key="view.type">
                                 <button class="btn btn-secondary o_switch_view "
                                     t-attf-class="o_{{view.type}} {{view.active ? 'active' : ''}}"
+                                    t-att-data-available-offline="view.availableOffline"
                                     t-att-data-tooltip="view.name"
                                     t-custom-click="(ev, isMiddleClick) => this.switchView(view.type, isMiddleClick)"
                                     t-att-aria-label="view.name + ' View'"

--- a/addons/web/static/src/search/search_bar/search_bar.js
+++ b/addons/web/static/src/search/search_bar/search_bar.js
@@ -13,6 +13,7 @@ import { hasTouch } from "@web/core/browser/feature_detection";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { useNavigation } from "@web/core/navigation/navigation";
+import { useOfflineStatus } from "@web/core/offline/offline_service";
 
 const parsers = registry.category("parsers");
 
@@ -85,6 +86,8 @@ export class SearchBar extends Component {
         // derived state
         this.items = useState([]);
         this.subItems = {};
+
+        this.offlineStatus = useOfflineStatus();
 
         this.facetContainerRef = useRef("facetContainerRef");
         this.menuRef = useChildRef();

--- a/addons/web/static/src/search/search_bar/search_bar.xml
+++ b/addons/web/static/src/search/search_bar/search_bar.xml
@@ -86,7 +86,7 @@
     </t>
 
     <t t-name="web.SearchBar">
-        <div t-if="visibilityState.showSearchBar" class="o_cp_searchview d-flex input-group" role="search" t-ref="root">
+        <div t-if="visibilityState.showSearchBar and !offlineStatus.offline" class="o_cp_searchview d-flex input-group" role="search" t-ref="root">
             <Dropdown
                 state="inputDropdownState"
                 manual="true"

--- a/addons/web/static/src/views/fields/field.js
+++ b/addons/web/static/src/views/fields/field.js
@@ -1,4 +1,5 @@
 import { Domain } from "@web/core/domain";
+import { useOfflineStatus } from "@web/core/offline/offline_service";
 import { evaluateBooleanExpr, evaluateExpr } from "@web/core/py_js/py";
 import { registry } from "@web/core/registry";
 import { utils } from "@web/core/ui/ui_service";
@@ -355,6 +356,7 @@ export class Field extends Component {
     };
 
     setup() {
+        this.offlineStatus = useOfflineStatus();
         if (this.props.fieldInfo) {
             this.field = this.props.fieldInfo.field;
         } else {
@@ -409,7 +411,8 @@ export class Field extends Component {
 
     get fieldComponentProps() {
         const record = this.props.record;
-        let readonly = this.props.readonly || false;
+        // disable edition in offline mode
+        let readonly = this.props.readonly || this.offlineStatus.offline || false;
 
         let propsFromNode = {};
         if (this.props.fieldInfo) {

--- a/addons/web/static/src/views/fields/relational_utils.xml
+++ b/addons/web/static/src/views/fields/relational_utils.xml
@@ -63,7 +63,7 @@
         </t>
     </t>
     <t t-else="">
-        <button class="btn btn-primary o_form_button_cancel" t-on-click="() => this.props.close()" data-hotkey="j">Close</button>
+        <button class="btn btn-primary o_form_button_cancel" t-on-click="() => this.props.close()" data-hotkey="j" data-available-offline="">Close</button>
     </t>
 </t>
 

--- a/addons/web/static/src/views/form/button_box/button_box.xml
+++ b/addons/web/static/src/views/form/button_box/button_box.xml
@@ -6,7 +6,7 @@
         <t t-slot="{{ button_value }}" t-foreach="visibleButtons" t-as="button" t-key="button_value"/>
         <div t-if="additionalButtons.length" class="oe_stat_button btn position-relative p-0 border-0">
             <Dropdown position="!env.isSmall ? 'bottom-end' : ''" menuClass="'o-form-buttonbox p-0 border-0 ' + (!env.isSmall ? 'o_dropdown_more' : 'o-form-buttonbox-small')">
-                <button class="o_button_more btn d-flex justify-content-center align-items-center" t-att-class="!env.isSmall ? 'o-dropdown-caret btn-outline-secondary' : 'btn-secondary'">
+                <button class="o_button_more btn d-flex justify-content-center align-items-center" t-att-class="!env.isSmall ? 'o-dropdown-caret btn-outline-secondary' : 'btn-secondary'" data-available-offline="">
                     <span t-if="!env.isSmall">More</span>
                     <i t-else="" class="fa fa-fw fa-bolt lh-base" aria-hidden="true"/>
                 </button>

--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -45,6 +45,7 @@ import {
 } from "@odoo/owl";
 import { FetchRecordError } from "@web/model/relational_model/errors";
 import { effect } from "@web/core/utils/reactive";
+import { ConnectionLostError } from "@web/core/network/rpc";
 
 const viewRegistry = registry.category("views");
 
@@ -427,6 +428,9 @@ export class FormController extends Component {
     async onWillSaveRecord() {}
 
     async onSaveError(error, { discard, retry }, leaving) {
+        if (error instanceof ConnectionLostError) {
+            return false;
+        }
         const suggestedCompany = error.data?.context?.suggested_company;
         const activeCompanyIds = user.activeCompanies.map((c) => c.id);
         if (

--- a/addons/web/static/src/views/view_dialogs/form_view_dialog.xml
+++ b/addons/web/static/src/views/view_dialogs/form_view_dialog.xml
@@ -6,10 +6,10 @@
       <View t-props="viewProps"/>
       <t t-set-slot="footer">
         <t t-if="props.preventEdit and props.preventCreate">
-          <button class="btn btn-primary" t-on-click="() => props.close()">Close</button>
+          <button class="btn btn-primary" t-on-click="() => props.close()" data-available-offline="">Close</button>
         </t>
         <t t-else="">
-          <button class="btn btn-primary o-default-button" t-on-click="() => props.close()">Ok</button>
+          <button class="btn btn-primary o-default-button" t-on-click="() => props.close()" data-available-offline="">Ok</button>
         </t>
       </t>
     </Dialog>

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -674,6 +674,7 @@ export function makeActionManager(env, router = _router) {
                     name: v.display_name,
                     type: v.type,
                     multiRecord: v.multiRecord,
+                    availableOffline: v.availableOffline,
                 };
                 if (view.type === v.type) {
                     viewSwitcherEntry.active = true;
@@ -1218,8 +1219,13 @@ export function makeActionManager(env, router = _router) {
                 continue;
             }
             if (session.view_info[type]) {
-                const { icon, display_name, multi_record: multiRecord } = session.view_info[type];
-                views.push({ icon, display_name, multiRecord, type });
+                const {
+                    icon,
+                    display_name,
+                    multi_record: multiRecord,
+                    available_offline: availableOffline,
+                } = session.view_info[type];
+                views.push({ icon, display_name, multiRecord, type, availableOffline });
             } else {
                 unknown.push(type);
             }
@@ -1238,6 +1244,9 @@ export function makeActionManager(env, router = _router) {
         let view = (options.viewType && views.find((v) => v.type === options.viewType)) || views[0];
         if (env.isSmall) {
             view = _findView(views, view.multiRecord, action.mobile_view_mode) || view;
+        }
+        if (env.services.offline.status.offline && !view.availableOffline) {
+            view = views.find((v) => v.availableOffline);
         }
 
         const controller = _makeController({
@@ -1875,7 +1884,7 @@ export function makeActionManager(env, router = _router) {
 }
 
 export const actionService = {
-    dependencies: ["dialog", "effect", "localization", "notification", "title", "ui"],
+    dependencies: ["dialog", "effect", "localization", "notification", "offline", "title", "ui"],
     start(env) {
         return makeActionManager(env);
     },

--- a/addons/web/static/src/webclient/navbar/navbar.js
+++ b/addons/web/static/src/webclient/navbar/navbar.js
@@ -15,6 +15,7 @@ import {
     useRef,
     useState,
     onWillUnmount,
+    useChildSubEnv,
 } from "@odoo/owl";
 const systrayRegistry = registry.category("systray");
 
@@ -69,6 +70,9 @@ export class NavBar extends Component {
             },
             () => [adaptCounter]
         );
+
+        // allow systray items to trigger an adapt when their layout changes
+        useChildSubEnv({ redrawNavbar: renderAndAdapt });
 
         this.state = useState({
             isAllAppsMenuOpened: false,

--- a/addons/web/static/src/webclient/navbar/navbar.xml
+++ b/addons/web/static/src/webclient/navbar/navbar.xml
@@ -110,7 +110,7 @@
               <small class="d-flex align-items-center justify-content-between ms-2">
                   <a href="/odoo" class="btn btn-primary" t-on-click.prevent="onAllAppsBtnClick"><i class="oi oi-apps"></i><span class="px-2">All Apps</span></a>
               </small>
-              <button class="o_sidebar_close oi oi-close btn d-flex align-items-center h-100 bg-transparent border-0 fs-2 text-reset" aria-label="Close menu" title="Close menu" t-on-click.stop="_closeAppMenuSidebar"/>
+              <button class="o_sidebar_close oi oi-close btn d-flex align-items-center h-100 bg-transparent border-0 fs-2 text-reset" aria-label="Close menu" title="Close menu" t-on-click.stop="_closeAppMenuSidebar" data-available-offline=""/>
           </div>
           <nav class="o_burger_menu_content flex-grow-1 flex-shrink-1 overflow-auto o_burger_menu_app">
                 <div t-if="!state.isAllAppsMenuOpened and currentApp" class="d-flex align-items-center m-3 mb-0">
@@ -178,7 +178,7 @@
                     </t>
                     <t t-else="">
                         <Dropdown>
-                            <button t-att-data-hotkey="hotkey" t-att-data-menu-xmlid="section.xmlid">
+                            <button t-att-data-hotkey="hotkey" t-att-data-menu-xmlid="section.xmlid" data-available-offline="">
                                 <span t-esc="section.name" t-att-data-section="section.id" />
                             </button>
                             <t t-set-slot="content">

--- a/addons/web/static/tests/_framework/env_test_helpers.js
+++ b/addons/web/static/tests/_framework/env_test_helpers.js
@@ -106,6 +106,12 @@ export async function makeMockEnv(partialEnv, options) {
         currentEnv = env;
         startRouter();
         after(() => {
+            // Ideally: this should be done in a stop of the service !!!
+            // This is done to remove the observer that disables the buttons.
+            if (currentEnv.services.offline) {
+                currentEnv.services.offline.status.offline = false;
+            }
+
             currentEnv = null;
 
             // Ideally: should be done in a patch of the localization service, but this

--- a/addons/web/static/tests/core/offline/offline_error.test.js
+++ b/addons/web/static/tests/core/offline/offline_error.test.js
@@ -1,0 +1,18 @@
+import { ConnectionLostError } from "@web/core/network/rpc";
+
+import { animationFrame, expect, test } from "@odoo/hoot";
+import { makeMockEnv } from "@web/../tests/web_test_helpers";
+
+test("ConnectionLostError handler", async () => {
+    expect.errors(1);
+
+    const env = await makeMockEnv();
+    expect(env.services.offline.status.offline).toBe(false);
+    const error = new ConnectionLostError("/fake_url");
+    Promise.reject(error);
+    await animationFrame();
+    expect(env.services.offline.status.offline).toBe(true);
+    expect.verifyErrors([
+        `Error: Connection to "/fake_url" couldn't be established or was interrupted`,
+    ]);
+});

--- a/addons/web/static/tests/core/offline/offline_service.test.js
+++ b/addons/web/static/tests/core/offline/offline_service.test.js
@@ -1,0 +1,127 @@
+import { Component, xml } from "@odoo/owl";
+import { rpc } from "@web/core/network/rpc";
+
+import { advanceTime, animationFrame, expect, test } from "@odoo/hoot";
+import {
+    getService,
+    makeMockEnv,
+    mountWithCleanup,
+    onRpc,
+    patchWithCleanup,
+} from "@web/../tests/web_test_helpers";
+
+test("RPC:RESPONSE: rpc returning a status 502", async () => {
+    expect.errors(1);
+
+    onRpc("/rpc/offline", () => new Response("", { status: 502 }), { pure: true });
+
+    const env = await makeMockEnv();
+    expect(env.services.offline.status.offline).toBe(false);
+
+    rpc("/rpc/offline");
+    await animationFrame();
+    expect(env.services.offline.status.offline).toBe(true);
+
+    expect.verifyErrors([
+        `Error: Connection to "/rpc/offline" couldn't be established or was interrupted`,
+    ]);
+});
+
+test("RPC:RESPONSE: any succesfull rpc turns offline off", async () => {
+    onRpc("/rpc/thatworks", () => true);
+
+    const env = await makeMockEnv();
+    env.services.offline.status.offline = true;
+    expect(env.services.offline.status.offline).toBe(true);
+
+    await rpc("/rpc/thatworks");
+    expect(env.services.offline.status.offline).toBe(false);
+});
+
+test("offlineUI: disable interactive elements except [data-available-offline]", async () => {
+    class Root extends Component {
+        static template = xml`
+            <div>
+                <button type="button" class="button_to_disable"> Disable this button </button>
+                <button type="button" class="button_available_offline" data-available-offline=""> Don't disable this button </button>
+                <input type="checkbox" name="checkbox" class="checkbox_to_disable"/>
+            </div>
+        `;
+        static props = ["*"];
+    }
+
+    await mountWithCleanup(Root);
+    expect(`.button_to_disable`).not.toHaveAttribute("disabled");
+    expect(`.button_available_offline`).not.toHaveAttribute("disabled");
+    expect(`.checkbox_to_disable`).not.toHaveAttribute("disabled");
+
+    getService("offline").status.offline = true;
+    expect(`.button_to_disable`).toHaveAttribute("disabled");
+    expect(`.button_available_offline`).not.toHaveAttribute("disabled");
+    expect(`.checkbox_to_disable`).toHaveAttribute("disabled");
+    expect(`.button_to_disable`).toHaveClass("o_disabled_offline");
+    expect(`.button_available_offline`).not.toHaveClass("o_disabled_offline");
+    expect(`.checkbox_to_disable`).toHaveClass("o_disabled_offline");
+
+    getService("offline").status.offline = false;
+    expect(`.button_to_disable`).not.toHaveAttribute("disabled");
+    expect(`.button_available_offline`).not.toHaveAttribute("disabled");
+    expect(`.checkbox_to_disable`).not.toHaveAttribute("disabled");
+});
+
+test("offlineUI: don't disable already disabled elements", async () => {
+    class Root extends Component {
+        static template = xml`
+            <div>
+                <button type="button" class="button" disabled="disabled"> Disabled button </button>
+                <input type="checkbox" class="checkbox" disabled="disabled"/>
+            </div>
+        `;
+        static props = ["*"];
+    }
+
+    await mountWithCleanup(Root);
+    expect(`.button`).toHaveAttribute("disabled");
+    expect(`.checkbox`).toHaveAttribute("disabled");
+
+    getService("offline").status.offline = true;
+    expect(`.button`).toHaveAttribute("disabled");
+    expect(`.checkbox`).toHaveAttribute("disabled");
+    expect(`.button`).not.toHaveClass("o_disabled_offline");
+    expect(`.checkbox`).not.toHaveClass("o_disabled_offline");
+
+    getService("offline").status.offline = false;
+    expect(`.button`).toHaveAttribute("disabled");
+    expect(`.checkbox`).toHaveAttribute("disabled");
+});
+
+test("Repeatedly check connection when going offline", async () => {
+    patchWithCleanup(Math, {
+        random: () => 1, // no jitter
+    });
+
+    const values = [false, true]; // simulate the 'back online status' after 2 'version_info' calls
+    const mockVersionInfoRpc = () => {
+        expect.step("version_info");
+        const online = values.shift();
+        if (online) {
+            return new Response("true", { status: 200 });
+        } else {
+            return new Response("", { status: 502 });
+        }
+    };
+    onRpc("/web/webclient/version_info", mockVersionInfoRpc, { pure: true });
+
+    const env = await makeMockEnv();
+    expect(env.services.offline.status.offline).toBe(false);
+
+    // go offline
+    env.services.offline.status.offline = true;
+
+    expect(env.services.offline.status.offline).toBe(true);
+    await advanceTime(2000); // first version_info check
+    expect(env.services.offline.status.offline).toBe(true);
+    await advanceTime(3500); // second version_info check
+    expect(env.services.offline.status.offline).toBe(false);
+    expect.verifySteps(["version_info", "version_info"]);
+});

--- a/addons/web/static/tests/core/offline/offline_systray.test.js
+++ b/addons/web/static/tests/core/offline/offline_systray.test.js
@@ -1,0 +1,64 @@
+import { WebClient } from "@web/webclient/webclient";
+
+import { animationFrame, expect, test } from "@odoo/hoot";
+import { contains, getService, mountWithCleanup, onRpc } from "@web/../tests/web_test_helpers";
+
+test.tags("desktop");
+test("offline systray item: basic rendering (desktop)", async () => {
+    await mountWithCleanup(WebClient);
+    expect(`.o_menu_systray .o_nav_entry .fa-chain-broken`).toHaveCount(0);
+    getService("offline").status.offline = true;
+
+    await animationFrame();
+    expect(`.o_menu_systray .o_nav_entry .fa-chain-broken`).toHaveCount(1);
+    expect(`.o_menu_systray .o_nav_entry:first`).toHaveText("Working offline");
+
+    getService("offline").status.offline = false;
+    await animationFrame();
+    expect(`.o_menu_systray .o_nav_entry .fa-chain-broken`).toHaveCount(0);
+});
+
+test.tags("mobile");
+test("offline systray item: basic rendering (mobile)", async () => {
+    await mountWithCleanup(WebClient);
+    expect(`.o_menu_systray .o_nav_entry.fa-chain-broken`).toHaveCount(0);
+    getService("offline").status.offline = true;
+
+    await animationFrame();
+    expect(`.o_menu_systray .o_nav_entry.fa-chain-broken`).toHaveCount(1);
+    expect(`.o_menu_systray .o_nav_entry:first`).toHaveAttribute("data-tooltip", "Working offline");
+
+    getService("offline").status.offline = false;
+    await animationFrame();
+    expect(`.o_menu_systray .o_nav_entry.fa-chain-broken`).toHaveCount(0);
+});
+
+test.tags("desktop");
+test("offline systray item: click to check connection (desktop)", async () => {
+    onRpc("/web/webclient/version_info", async () => {
+        expect.step("version_info");
+        return true;
+    });
+    await mountWithCleanup(WebClient);
+    getService("offline").status.offline = true;
+
+    await contains(`.o_menu_systray .o_nav_entry .fa-chain-broken`).click();
+    expect.verifySteps(["version_info"]);
+    expect(getService("offline").status.offline).toBe(false);
+    expect(`.o_menu_systray .o_nav_entry .fa-chain-broken`).toHaveCount(0);
+});
+
+test.tags("mobile");
+test("offline systray item: click to check connection (mobile)", async () => {
+    onRpc("/web/webclient/version_info", async () => {
+        expect.step("version_info");
+        return true;
+    });
+    await mountWithCleanup(WebClient);
+    getService("offline").status.offline = true;
+
+    await contains(`.o_menu_systray .o_nav_entry.fa-chain-broken`).click();
+    expect.verifySteps(["version_info"]);
+    expect(getService("offline").status.offline).toBe(false);
+    expect(`.o_menu_systray .o_nav_entry .fa-chain-broken`).toHaveCount(0);
+});

--- a/addons/web/static/tests/model/record.test.js
+++ b/addons/web/static/tests/model/record.test.js
@@ -796,7 +796,7 @@ test(`don't duplicate a useRecordObserver effect when switching back and forth b
 
         setup() {
             this.orm = useService("orm");
-            const services = { orm: this.orm };
+            const services = { orm: this.orm, offline: useService("offline") };
             const model = new StandaloneRelationalModel(this.env, {}, services);
             model.load({ resId: 1, values: { foo: "abc" } });
             const record1 = model.root;

--- a/addons/web/static/tests/views/fields/badge_selection_field.test.js
+++ b/addons/web/static/tests/views/fields/badge_selection_field.test.js
@@ -86,9 +86,8 @@ test("[Offline] BadgeSelectionField widget on a many2one", async () => {
     expect(`div.o_field_selection_badge`).toHaveCount(1, {
         message: "should have rendered outer div",
     });
-    expect(`span.o_selection_badge`).toHaveCount(1);
-    expect(queryAllTexts(`span.o_selection_badge`)).toEqual(["xphone"]);
-    expect(`span.active`).toHaveCount(1);
+    expect(`div.o_field_selection_badge span`).toHaveCount(1);
+    expect(queryAllTexts(`div.o_field_selection_badge span`)).toEqual(["xphone"]);
 });
 
 test("BadgeSelectionField widget on a selection in a new record", async () => {

--- a/addons/web/static/tests/views/fields/many2many_checkboxes_field.test.js
+++ b/addons/web/static/tests/views/fields/many2many_checkboxes_field.test.js
@@ -95,7 +95,7 @@ test("[Offline] Many2ManyCheckBoxesField", async () => {
 
     expect("div.o_field_widget div.form-check input:eq(0)").toBeChecked();
 
-    expect("div.o_field_widget div.form-check input:disabled").toHaveCount(0);
+    expect("div.o_field_widget div.form-check input:disabled").toHaveCount(1);
 });
 test("Many2ManyCheckBoxesField (readonly)", async () => {
     Partner._records[0].timmy = [12];

--- a/addons/web/static/tests/views/fields/selection_field.test.js
+++ b/addons/web/static/tests/views/fields/selection_field.test.js
@@ -127,10 +127,10 @@ test("[Offline] SelectionField on many2one field", async () => {
                 <field name="product_id" widget="selection" />
             </form>`,
     });
-    expect(".o_select_menu").toHaveCount(1);
-    await contains(".o_field_widget[name='product_id'] input").click();
-    expect(queryAllTexts(".o_select_menu_item")).toEqual(["xphone"]);
-    expect(".o_field_widget[name='product_id'] input").toHaveValue("xphone");
+    expect(".o_field_widget[name='product_id'] span").toHaveCount(1, {
+        message: "field should be readonly",
+    });
+    expect(".o_field_widget[name='product_id']").toHaveText("xphone");
 });
 
 test("unset selection field with 0 as key", async () => {

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -255,6 +255,49 @@ test(`simple form rendering`, async () => {
     expect(`label.o_form_label_empty:contains(type_ids)`).toHaveCount(0);
 });
 
+test(`[Offline] form switches to readonly in offline mode`, async () => {
+    await mountView({
+        resModel: "partner",
+        type: "form",
+        arch: `
+            <form>
+                <field name="foo"/>
+                <field name="bar"/>
+                <field name="int_field" string="f3_description"/>
+                <field name="float_field"/>
+                <field name="child_ids">
+                    <list>
+                        <field name="foo"/>
+                        <field name="bar"/>
+                    </list>
+                </field>
+            </form>
+        `,
+        resId: 2,
+    });
+    expect(`.o_field_char[name="foo"] input`).toHaveCount(1);
+    expect(`.o_field_boolean[name="bar"] .o-checkbox input`).not.toHaveAttribute("disabled");
+    expect(`.o_field_integer[name="int_field"] input`).toHaveCount(1);
+    expect(`.o_field_float[name="float_field"] input`).toHaveCount(1);
+    expect(`.o_field_x2many_list_row_add`).toHaveCount(1);
+
+    getService("offline").status.offline = true;
+    await animationFrame();
+    expect(`.o_field_char[name="foo"] input`).toHaveCount(0);
+    expect(`.o_field_boolean[name="bar"] .o-checkbox input`).toHaveAttribute("disabled");
+    expect(`.o_field_integer[name="int_field"] input`).toHaveCount(0);
+    expect(`.o_field_float[name="float_field"] input`).toHaveCount(0);
+    expect(`.o_field_x2many_list_row_add`).toHaveCount(0);
+
+    getService("offline").status.offline = false;
+    await animationFrame();
+    expect(`.o_field_char[name="foo"] input`).toHaveCount(1);
+    expect(`.o_field_boolean[name="bar"] .o-checkbox input`).not.toHaveAttribute("disabled");
+    expect(`.o_field_integer[name="int_field"] input`).toHaveCount(1);
+    expect(`.o_field_float[name="float_field"] input`).toHaveCount(1);
+    expect(`.o_field_x2many_list_row_add`).toHaveCount(1);
+});
+
 test(`form rendering with class and style attributes`, async () => {
     await mountView({
         resModel: "partner",

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -552,6 +552,57 @@ test(`editable list with edit="0"`, async () => {
     expect.verifySteps(["switch to form - resId: 1 activeIds: 1,2,3,4"]);
 });
 
+test.tags("desktop");
+test(`[Offline] editable list`, async () => {
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `<list editable="top"><field name="foo"/></list>`,
+    });
+    expect(`tbody tr.o_data_row[data-id]`).toHaveCount(4);
+
+    expect(`.o_searchview`).toHaveCount(1);
+    await contains(`.o_data_cell`).click();
+    expect(`tbody tr.o_selected_row`).toHaveCount(1, { message: "should have editable row" });
+
+    getService("offline").status.offline = true;
+    await animationFrame();
+    expect(`.o_searchview`).toHaveCount(0);
+    await contains(`.o_data_cell`).click();
+    expect(`tbody tr.o_selected_row`).toHaveCount(0, { message: "should not have editable row" });
+});
+
+test.tags("desktop");
+test(`[Offline] list with priority widget`, async () => {
+    Foo._fields.priority = fields.Selection({
+        selection: [
+            [0, "Not Prioritary"],
+            [1, "Prioritary"],
+        ],
+        default: 0,
+    });
+
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `
+            <list>
+                <field name="priority" widget="priority"/>
+                <field name="foo"/>
+            </list>`,
+    });
+
+    expect(".o_field_widget[name=priority] .o_priority_star").not.toHaveClass("o_disabled");
+
+    getService("offline").status.offline = true;
+    await animationFrame();
+    expect(".o_field_widget[name=priority] .o_priority_star").toHaveClass("o_disabled");
+
+    getService("offline").status.offline = false;
+    await animationFrame();
+    expect(".o_field_widget[name=priority] .o_priority_star").not.toHaveClass("o_disabled");
+});
+
 test(`non-editable list with open_form_view`, async () => {
     await mountView({
         resModel: "foo",

--- a/addons/web/static/tests/web_test_helpers.js
+++ b/addons/web/static/tests/web_test_helpers.js
@@ -13,8 +13,8 @@ import { IrUiView } from "./_framework/mock_server/mock_models/ir_ui_view";
 import { ResCompany } from "./_framework/mock_server/mock_models/res_company";
 import { ResCountry } from "./_framework/mock_server/mock_models/res_country";
 import { ResCurrency } from "./_framework/mock_server/mock_models/res_currency";
-import { ResGroupsPrivilege } from "./_framework/mock_server/mock_models/res_groups_privilege";
 import { ResGroups } from "./_framework/mock_server/mock_models/res_groups";
+import { ResGroupsPrivilege } from "./_framework/mock_server/mock_models/res_groups_privilege";
 import { ResPartner } from "./_framework/mock_server/mock_models/res_partner";
 import { ResUsers } from "./_framework/mock_server/mock_models/res_users";
 import { ResUsersSettings } from "./_framework/mock_server/mock_models/res_users_settings";
@@ -42,7 +42,7 @@ export {
     findComponent,
     getDropdownMenu,
     mountWithCleanup,
-    waitUntilIdle,
+    waitUntilIdle
 } from "./_framework/component_test_helpers";
 export { contains, defineStyle, editAce, sortableDrag } from "./_framework/dom_test_helpers";
 export {
@@ -52,7 +52,7 @@ export {
     makeDialogMockEnv,
     makeMockEnv,
     mockService,
-    restoreRegistry,
+    restoreRegistry
 } from "./_framework/env_test_helpers";
 export {
     clickKanbanLoadMore,
@@ -74,7 +74,7 @@ export {
     toggleKanbanColumnActions,
     toggleKanbanRecordDropdown,
     validateKanbanColumn,
-    validateKanbanRecord,
+    validateKanbanRecord
 } from "./_framework/kanban_test_helpers";
 export { Command, registerInlineViewArchs } from "./_framework/mock_server/mock_model";
 export {
@@ -88,14 +88,14 @@ export {
     MockServer,
     onRpc,
     stepAllNetworkCalls,
-    withUser,
+    withUser
 } from "./_framework/mock_server/mock_server";
 export {
     getKwArgs,
     makeKwArgs,
     makeServerError,
     MockServerError,
-    unmakeKwArgs,
+    unmakeKwArgs
 } from "./_framework/mock_server/mock_server_utils";
 export { serverState } from "./_framework/mock_server_state.hoot";
 export { patchWithCleanup } from "./_framework/patch_test_helpers";
@@ -117,10 +117,7 @@ export {
     openAddCustomFilterDialog,
     pagerNext,
     pagerPrevious,
-    removeFacet,
-    saveFavorite,
-    saveAndEditFavorite,
-    selectGroup,
+    removeFacet, saveAndEditFavorite, saveFavorite, selectGroup,
     switchView,
     toggleActionMenu,
     toggleFavoriteMenu,
@@ -131,13 +128,12 @@ export {
     toggleMenuItemOption,
     toggleSaveFavorite,
     toggleSearchBarMenu,
-    validateSearch,
+    validateSearch
 } from "./_framework/search_test_helpers";
 export { swipeLeft, swipeRight } from "./_framework/touch_helpers";
 export {
-    installLanguages,
-    patchTranslations,
-    allowTranslations,
+    allowTranslations, installLanguages,
+    patchTranslations
 } from "./_framework/translation_test_helpers";
 export {
     clickButton,
@@ -146,15 +142,13 @@ export {
     clickFieldDropdownItem,
     clickModalButton,
     clickSave,
-    clickViewButton,
-    expectMarkup,
+    clickViewButton, editSelectMenu, expectMarkup,
     fieldInput,
     hideTab,
     mountView,
     mountViewInDialog,
     parseViewProps,
-    selectFieldDropdownItem,
-    editSelectMenu,
+    selectFieldDropdownItem
 } from "./_framework/view_test_helpers";
 export { mountWebClient, useTestClientAction } from "./_framework/webclient_test_helpers";
 

--- a/addons/web/static/tests/webclient/actions/error_handling.test.js
+++ b/addons/web/static/tests/webclient/actions/error_handling.test.js
@@ -145,8 +145,6 @@ test("connection lost when opening form view from kanban", async () => {
     });
     await contains(".o_kanban_record").click();
     expect(".o_kanban_view").toHaveCount(1);
-    expect(".o_notification").toHaveCount(1);
-    expect(".o_notification").toHaveText("Connection lost. Trying to reconnect...");
     expect.verifySteps([
         "/web/webclient/translations",
         "/web/webclient/load_menus",
@@ -204,8 +202,6 @@ test("connection lost when coming back to kanban from form", async () => {
     expect(".o_kanban_view").toHaveCount(1);
     expect(".o_kanban_view .o_kanban_renderer").toHaveCount(1);
     expect(".o_kanban_view .o_kanban_record:not(.o_kanban_ghost)").toHaveCount(2);
-    expect(".o_notification").toHaveCount(1);
-    expect(".o_notification").toHaveText("Connection lost. Trying to reconnect...");
     expect.verifySteps([
         "/web/webclient/load_menus",
         "/web/action/load",

--- a/addons/web/static/tests/webclient/clickbot.test.js
+++ b/addons/web/static/tests/webclient/clickbot.test.js
@@ -461,7 +461,7 @@ test("clickbot show rpc error when an error dialog is detected", async () => {
     const expectedModalHtml = /* xml */ `
         <header class="modal-header">
             <h4 class="modal-title text-break flex-grow-1">Oops!</h4>
-            <button type="button" class="btn-close position-absolute top-0 end-0 mt-1 me-1" aria-label="Close" tabindex="-1"></button>
+            <button type="button" class="btn-close position-absolute top-0 end-0 mt-1 me-1" aria-label="Close" tabindex="-1" data-available-offline=""></button>
         </header>
         <main class="modal-body">
             <div role="alert">
@@ -469,7 +469,7 @@ test("clickbot show rpc error when an error dialog is detected", async () => {
                 <details>
                     <summary class="mb-1 link-info">See technical details</summary>
                     <div class="text-bg-100 clearfix mt-2 position-relative o_error_detail pb-2">
-                        <button class="btn position-absolute top-0 end-0 pt-2 btn-link link-body-emphasis"><span class="fa fa-clipboard"></span></button>
+                        <button class="btn position-absolute top-0 end-0 pt-2 btn-link link-body-emphasis" data-available-offline=""><span class="fa fa-clipboard"></span></button>
                         <div class="ps-1 pt-1 ps-md-3 pt-md-3">
                             <p class="m-0"><b>Odoo Server Error</b></p>
                             <p class="d-block small text-info">ERROR INFO</p>
@@ -482,7 +482,7 @@ test("clickbot show rpc error when an error dialog is detected", async () => {
             </div>
         </main>
         <footer class="modal-footer d-empty-none justify-content-around justify-content-md-start flex-wrap gap-1 w-100">
-            <button class="btn btn-primary o-default-button">Close</button>
+            <button class="btn btn-primary o-default-button" data-available-offline="">Close</button>
         </footer>`
         .trim()
         .replaceAll(/>[\n\s]+</gm, "><");


### PR DESCRIPTION
This PR introduces the first offline features in the webclient.
For that matter, an "offline" service has been created. The service
exposes a reactive containing the offline state such that components
that want to render differently in offline can easily do so and be
automatically re-rendered when switching from/to offline mode.

A systray item has been added to indicate when we are offline.

By default, all buttons and checkboxes are disabled in offline. The
attribute `data-available-offline` can be set on those elements
that want to be available offline (e.g. breadcrumbs, menus...).

When offline, views that have an offline support (for now form,
list and kanban), take the priority over other views, as we know
the other views won't be able to fetch their data and render.

task~5106517