### PR TITLE
[FIX] mail: prevent traceback closing non-mail fullscreen

### DIFF
--- a/addons/mail/static/src/core/common/mail_fullscreen.js
+++ b/addons/mail/static/src/core/common/mail_fullscreen.js
@@ -16,13 +16,14 @@ export class MailFullscreen extends Component {
 
 export const fullscreenService = {
     start(env) {
-        const state = reactive({ enter, exit, id: undefined });
+        const state = reactive({ enter, exit, id: undefined, closeOverlay: undefined });
         async function exit(id = state.id) {
-            if (id !== state.id) {
+            if (!id || id !== state.id) {
                 return;
             }
-            this.closeOverlay?.();
+            state.closeOverlay?.();
             state.id = undefined;
+            state.closeOverlay = undefined;
             const fullscreenElement =
                 document.webkitFullscreenElement || document.fullscreenElement;
             if (fullscreenElement) {
@@ -49,9 +50,9 @@ export const fullscreenService = {
             component,
             { keepBrowserHeader = false, props, rootId, id = DEFAULT_ID } = {}
         ) {
-            this.closeOverlay?.();
+            state.closeOverlay?.();
             state.id = id;
-            this.closeOverlay = env.services.overlay.add(
+            state.closeOverlay = env.services.overlay.add(
                 MailFullscreen,
                 { component, props },
                 { rootId }
@@ -77,7 +78,7 @@ export const fullscreenService = {
                 document.webkitFullscreenElement || document.fullscreenElement
             );
             if (!isFullscreen) {
-                exit();
+                state.exit();
             }
         });
         return state;


### PR DESCRIPTION
Versions
--------
- 19.0+

Steps
-----
1. Go to an eCommerce product page;
2. open the website editor;
3. add a YouTube video as extra media;
4. save changes;
5. open the video in fullscreen;
6. close the video.

Issue
-----
> `UncaughtPromiseError > TypeError`
> `Uncaught Promise > can't access property "closeOverlay", this is undefined`

Cause
-----
The `mail.fullscreen` service adds an event listener to `window` on start. This listener gets triggered on `fullscreenchange` events. Once triggered, there's a naked `exit()` call, hence when entering the `exit` function, `this` is not defined.

Solution
--------
- Explicitly store `closeOverlay` in `state`.
- Call `state.exit()` instead of `exit()`.
- Return from `exit` if `id` is undefined (i.e. non-mail fullscreen).

opw-5105959