### PR TITLE
[FIX] hr_holidays: resolve Missing Record traceback

### DIFF
--- a/addons/hr_holidays/static/src/views/calendar/calendar_model.js
+++ b/addons/hr_holidays/static/src/views/calendar/calendar_model.js
@@ -107,7 +107,11 @@ export class TimeOffCalendarModel extends CalendarModel {
     }
 
     get employeeId() {
-        return (this.meta.context.employee_id && this.meta.context.employee_id[0]) || this.meta.context.active_id || null;
+        return (
+            (this.meta.context.employee_id && this.meta.context.employee_id[0]) ||
+            (this.meta.context.active_model === "hr.employee" && this.meta.context.active_id) ||
+            null
+        );
     }
 
     fetchRecords(data) {


### PR DESCRIPTION
**Steps to reproduce (without demo data):**
 - Install hr_holidays
 - Go to "My Profile"
 - Open "Time Off"

**Issue:**
  Accessing Time Off from a user profile triggers a `Missing Record` error.

**Cause:**
   The system was passing the user’s active_id to the employee record incorrectly.

**Fix:**
  Now, when the context's active_model is 'hr.employee', the correct active_id is applied.

**Commit issue:**https://github.com/odoo/odoo/pull/225839
