### PR TITLE
[FIX] hr: prevent error when opening preferences

### DIFF
--- a/addons/hr/tests/test_self_user_access.py
+++ b/addons/hr/tests/test_self_user_access.py
@@ -87,6 +87,20 @@ class TestSelfAccessPreferences(TestHrCommon):
         internal_user = new_test_user(self.env, login='mireille', groups='base.group_user', name='Mireille', email='mireille@example.com')
         self.env['hr.employee'].with_user(internal_user).search([]).read([])
 
+    def test_open_preferences_with_group_without_external_id(self):
+        """Test opening preferences when the user belongs to a group without an external ID."""
+        self.env['hr.employee'].create({
+            'name': 'John',
+            'user_id': self.env.user.id,
+        })
+        group = self.env['res.groups'].create({
+            'name': "Test Group",
+        })
+        self.env.user.group_ids = [Command.link(group.id)]
+        action = self.env.user.action_get()
+        self.assertEqual(action['type'], 'ir.actions.act_window')
+        self.assertEqual(action['display_name'], 'Change my Preferences')
+
 class TestSelfAccessRights(TestHrCommon):
 
     @classmethod


### PR DESCRIPTION
Currently an error occurs when user open their preferences.

**Steps to Reproduce:**

 - Install the `hr` module.
 - Go to `Groups`, create a group, and assign the `current user to it`.
 - Make sure this user has an `Employee record`.
 - Click on the `profile icon` in the top-right corner and select `My Preferences`.

`IndexError: list index out of range`

This commit adds a test for this [PR], as the issue is fixed here.

[PR]: https://github.com/odoo/odoo/pull/230210

sentry-6913468854

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
