### PR TITLE
[IMP] event_crm: propagate company name from event registration to lead

### DIFF
--- a/addons/event_crm/models/event_registration.py
+++ b/addons/event_crm/models/event_registration.py
@@ -236,6 +236,7 @@ class EventRegistration(models.Model):
                     valid_partner = self.env['res.partner']
 
         registration_phone = sorted_self._find_first_notnull('phone')
+        registration_company = sorted_self._find_first_notnull('company_name')
         if valid_partner:
             contact_vals = self.env['crm.lead']._prepare_values_from_partner(valid_partner)
             # force email_from / phone only if not set on partner because those fields are now synchronized automatically
@@ -243,11 +244,14 @@ class EventRegistration(models.Model):
                 contact_vals['email_from'] = sorted_self._find_first_notnull('email')
             if not valid_partner.phone:
                 contact_vals['phone'] = registration_phone
+            if not valid_partner.company_name:
+                contact_vals['partner_name'] = registration_company
         else:
             # don't force email_from + partner_id because those fields are now synchronized automatically
             contact_vals = {
                 'contact_name': sorted_self._find_first_notnull('name'),
                 'email_from': sorted_self._find_first_notnull('email'),
+                'partner_name': registration_company,
                 'phone': registration_phone,
                 'lang_id': False,
             }

--- a/addons/event_crm/tests/common.py
+++ b/addons/event_crm/tests/common.py
@@ -81,13 +81,14 @@ class EventCrmCase(TestCrmCommon, EventCase):
 
         if partner is None:
             partner = self.env['res.partner']
+        registration_company = registrations._find_first_notnull('company_name')
         expected_reg_name = partner.name or registrations._find_first_notnull('name') or registrations._find_first_notnull('email')
         if partner:
             expected_contact_name = partner.name if not partner.is_company else False
-            expected_partner_name = partner.name if partner.is_company else False
+            expected_partner_name = (partner.is_company and partner.name) or partner.company_name or registration_company
         else:
             expected_contact_name = registrations._find_first_notnull('name')
-            expected_partner_name = False
+            expected_partner_name = registration_company
 
         # event information
         self.assertEqual(lead.event_id, event)

--- a/addons/event_crm/views/event_lead_rule_views.xml
+++ b/addons/event_crm/views/event_lead_rule_views.xml
@@ -36,7 +36,7 @@
         <field name="arch" type="xml">
             <form string="Lead Generation Rule">
                 <header>
-                    <button class="btn btn-primary" name="action_execute_rule" type="object" string="Execute Rule" help="Execute this rule for all ongoing and future events."/>
+                    <button class="btn btn-primary" name="action_execute_rule" type="object" string="Run Rule" help="Execute this rule for all ongoing and future events."/>
                 </header>
                 <sheet>
                     <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>


### PR DESCRIPTION
When an event registration includes a question of type Company(company_name),
the provided value was not being set on the generated lead.

As a result, the lead’s partner_name (company name) remained empty, even though
the attendee supplied the information.

This PR ensures that the company name from the registration is propagated to the
generated lead.

Task-5106882
