### PR TITLE
[IMP] point_of_sale : prevent cancel a paid/posted order

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1121,7 +1121,7 @@ class PosOrder(models.Model):
         invoice_receivable_lines = invoice.line_ids.filtered(lambda line: line.account_id == receivable_account and not line.reconciled)
         (payment_receivable_lines | invoice_receivable_lines).sudo().with_company(invoice.company_id).reconcile()
 
-    def action_pos_order_cancel(self):
+    def cancel_order_from_pos(self):
         if self.env.context.get('active_ids'):
             orders = self.browse(self.env.context.get('active_ids'))
             order_is_in_futur = any(order.preset_time and order.preset_time.date() > fields.Date.today() for order in orders)
@@ -1135,6 +1135,10 @@ class PosOrder(models.Model):
         return {
             'pos.order': self._load_pos_data_read(today_orders, self.config_id)
         }
+
+    def action_pos_order_cancel(self):
+        orders = self.browse(self.env.context.get('active_ids'))
+        orders.write({'state': 'cancel'})
 
     def _get_open_order(self, order):
         return self.env["pos.order"].search([('uuid', '=', order.get('uuid'))], limit=1, order='id desc')

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -585,7 +585,7 @@ export class PosStore extends WithLazyGetterTrap {
         }
 
         if (ids.size > 0) {
-            await this.data.callRelated("pos.order", "action_pos_order_cancel", [Array.from(ids)]);
+            await this.data.callRelated("pos.order", "cancel_order_from_pos", [Array.from(ids)]);
             return true;
         }
 

--- a/addons/point_of_sale/static/tests/unit/data/pos_order.data.js
+++ b/addons/point_of_sale/static/tests/unit/data/pos_order.data.js
@@ -21,7 +21,7 @@ export class PosOrder extends models.ServerModel {
         return [];
     }
 
-    action_pos_order_cancel(self) {
+    cancel_order_from_pos(self) {
         const records = this.browse(self);
         const orderIds = [];
 

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -1273,7 +1273,7 @@ class TestPointOfSaleFlow(CommonPosTest):
         refund_action = order.refund()
         refund = self.env['pos.order'].browse(refund_action['res_id'])
         self.assertEqual(order.lines[0].refunded_qty, 1)
-        refund.action_pos_order_cancel()
+        refund.cancel_order_from_pos()
         self.assertEqual(order.lines[0].refunded_qty, 0)
 
     def test_pos_order_refund_ship_delay_totalcost(self):
@@ -1438,7 +1438,7 @@ class TestPointOfSaleFlow(CommonPosTest):
             'preset_id': preset_takeaway.id,
             'preset_time': fields.Datetime.to_string(fields.Datetime.now() + timedelta(days=-2)),
         })
-        order.action_pos_order_cancel()
+        order.cancel_order_from_pos()
         self.assertEqual(order.state, 'cancel')
 
     def test_sum_only_pos_locations(self):

--- a/addons/point_of_sale/views/pos_order_view.xml
+++ b/addons/point_of_sale/views/pos_order_view.xml
@@ -460,8 +460,8 @@
         <field name="state">code</field>
         <field name="binding_view_types">list,kanban,form</field>
         <field name="code">
-if records:
-    action = records.action_pos_order_cancel()
+            if records:
+                action = records.action_pos_order_cancel()
         </field>
     </record>
 

--- a/addons/pos_self_order/models/pos_order.py
+++ b/addons/pos_self_order/models/pos_order.py
@@ -59,8 +59,8 @@ class PosOrder(models.Model):
         self._send_notification(order_ids)
         return result
 
-    def action_pos_order_cancel(self):
-        orders = super().action_pos_order_cancel()
+    def cancel_order_from_pos(self):
+        orders = super().cancel_order_from_pos()
         success_orders_ids = [o['id'] for o in orders['pos.order'] if o['state'] == 'cancel']
         orders_ids = self.browse(success_orders_ids)
         self._send_notification(orders_ids)

--- a/addons/pos_self_order/tests/test_self_order_controller.py
+++ b/addons/pos_self_order/tests/test_self_order_controller.py
@@ -96,7 +96,7 @@ class TestSelfOrderController(SelfOrderCommonTest):
         self.assertEqual(data['pos.order'][0]['id'], order1.id)
 
         # A cancelled order should be returned
-        order2.action_pos_order_cancel()
+        order2.cancel_order_from_pos()
         params['order_access_tokens'] = [{
             'access_token': order2.access_token,
             'state': 'paid',


### PR DESCRIPTION
Before this commit, when a paid or posted order was cancelled with the 'Cancel Order' button, nothing happened.

After this commit, An user error is raised to say that it is not allowed to cancel an unpaid or posted order.

Task-id : 5060443

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

