### PR TITLE
[FIX] website: fix categories showcase hover effect

### DIFF
--- a/addons/website/static/src/snippets/s_ecomm_categories_showcase/000.scss
+++ b/addons/website/static/src/snippets/s_ecomm_categories_showcase/000.scss
@@ -72,7 +72,7 @@
             flex: var(--ecomm-categories-showcase-flex-base);
         }
 
-        .s_ecomm_categories_showcase_wrapper:hover .s_ecomm_categories_showcase_block:hover
+        .s_ecomm_categories_showcase_wrapper:hover .s_ecomm_categories_showcase_block:hover,
         .s_ecomm_categories_showcase_wrapper .s_ecomm_categories_showcase_block:focus-within {
             flex: 3;
         }


### PR DESCRIPTION
Since commit [1], the hover effect on the "categories showcase" snippet is no longer working. Nothing happens when it’s hovered with the mouse.

This is caused by a missing comma in the CSS rule that handles the effect.

[1]: https://github.com/odoo/odoo/commit/dea725a4e45b584689813bdbf09e51070a3c55d3