### PR TITLE
[IMP] pos_self_order: add required badge indication for attributes

### DIFF
--- a/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.xml
+++ b/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.xml
@@ -2,7 +2,10 @@
 <templates id="template" xml:space="preserve">
     <t t-name="pos_self_order.AttributeSelection">
          <t t-foreach="props.productTemplate.attribute_line_ids" t-as="attribute" t-key="attribute.id">
-             <h2 class="text-start py-3 m-0" t-out="attribute.attribute_id.name" t-att-id="attribute.attribute_id.id"/>
+             <h2 class="text-start py-3 m-0 d-flex align-items-center" t-att-id="attribute.attribute_id.id">
+                 <t t-out="attribute.attribute_id.name"/>
+                 <span t-if="attribute.attribute_id.display_type !== 'multi'" class="badge smaller rounded-pill bg-danger text-white ms-2">Required</span>
+             </h2>
              <div class="self_order_attribute_selection row pb-3">
                 <t t-foreach="availableAttributeValue(attribute)" t-as="value" t-key="value.id">
                     <t t-set="valueSelected" t-value="isValueSelected(attribute,value)"/>

--- a/addons/pos_self_order/static/tests/tours/self_order_attribute_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_attribute_tour.js
@@ -99,6 +99,14 @@ registry.category("web_tour.tours").add("test_self_order_multi_check_attribute_w
         [
             Utils.clickBtn("Order Now"),
             ProductPage.clickProduct("Desk Organizer"),
+            {
+                content: "Check required badge for Fabric attribute",
+                trigger: "h2:contains('Fabric') .badge:contains('Required')",
+            },
+            {
+                content: "Check no required badge for Add-ons attribute",
+                trigger: "h2:contains('Add-ons'):not(:has(.badge))",
+            },
             ProductPage.setupAttribute(
                 [
                     { name: "Fabric", value: "Leather" },


### PR DESCRIPTION
PURPOSE:
---------
- Help users to easily identify which attributes are required in the POS self-order attribute selection page.

Before this commit:
------
- Required attributes had no badge or clear visual indication.

After this commit:
----------
- Added a Required badge next to attribute names so users can quickly identify and select them.

Task-5079571
