### PR TITLE
[FIX] l10n_cz: prevent invoice date change after updating partner address

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -306,7 +306,7 @@ class AccountMove(models.Model):
     made_sequence_gap = fields.Boolean(compute='_compute_made_sequence_gap', store=True)  # store wether this is the first move breaking the natural sequencing
     show_name_warning = fields.Boolean(store=False)
     type_name = fields.Char('Type Name', compute='_compute_type_name')
-    country_code = fields.Char(related='company_id.account_fiscal_country_id.code', readonly=True)
+    country_code = fields.Char(related='company_id.account_fiscal_country_id.code', readonly=True, depends=['company_id'])
     company_price_include = fields.Selection(related='company_id.account_price_include', readonly=True)
     attachment_ids = fields.One2many('ir.attachment', 'res_id', domain=[('res_model', '=', 'account.move')], string='Attachments')
     audit_trail_message_ids = fields.One2many(

--- a/addons/account/tests/test_account_move_entry.py
+++ b/addons/account/tests/test_account_move_entry.py
@@ -1243,3 +1243,49 @@ class TestAccountMove(AccountTestInvoicingCommon):
         move_duplicate = move.copy()
         self.assertTrue(move_duplicate)
         self.assertFalse(move_duplicate.partner_id)
+
+    def test_no_recompute_when_company_address_changes(self):
+        """
+        Ensure that changing the company partner address does NOT trigger
+        any recomputation on account.move or account.move.line fields
+        """
+        # Prepare patching
+        protected_models = ['account.move', 'account.move.line']
+        original_recompute = {model: self.env[model]._recompute_field for model in protected_models}
+        fields_recomputed = []
+
+        def mock_recompute(self, field, ids=None):
+            ids_to_compute = self.env.transaction.tocompute.get(field, ())
+            ids = ids_to_compute if ids is None else [id_ for id_ in ids if id_ in ids_to_compute]
+            if field.store and (
+                (self._name == 'account.move' and invoice.id in ids)
+                or (self._name == 'account.move.line' and set(invoice.line_ids.ids) & set(ids))
+            ):
+                fields_recomputed.append(str(field))
+            original_recompute[self._name](field, ids)
+
+        # Setup data
+        invoice = self.env['account.move'].create({
+            'move_type': 'entry',
+            'partner_id': self.partner_a.id,
+            'date': fields.Date.from_string('2019-01-01'),
+            'currency_id': self.other_currency.id,
+            'line_ids': [
+                Command.create(self.entry_line_vals_1),
+                Command.create(self.entry_line_vals_2),
+            ],
+        })
+        self.env.flush_all()
+
+        # Check
+        for model in protected_models:
+            self.patch(self.env.registry[model], '_recompute_field', mock_recompute)
+
+        invoice.company_id.partner_id.write({
+            'street': 'New Street',
+            'zip': '12345',
+            'country_id': invoice.company_id.partner_id.country_id.id,
+            'vat': '12345678',
+        })
+        self.env.flush_all()
+        self.assertEqual(fields_recomputed, [])


### PR DESCRIPTION
**Steps to reproduce**

1.Install Accounting, Contacts, and l10n_cz.
2.Create an invoice with a future `invoice date` and confirm it. 
3.Go to Contacts → open the company (res.partner). 
4.Modify any address field (street, zip, etc.) and save. 
5.Return to the invoice → in the chatter, the `date` field has change unexpectedly

> Note: The `date` field is not shown in invoice default form view. Add it manually for clearer reproduction.

**Issue**
- The confirmed invoice `date` changes when updating the company partner’s address.

**Cause**

https://github.com/odoo/odoo/blob/7a1b27e5985b3b16768bea450c51226ae3659c76/addons/l10n_cz/models/account_move.py#L20-L24


- When creating an invoice, the `date` field is correctly set based on the 
`taxable_supply_date` while the invoice is in the draft state. After 
confirming (posting) the invoice, it moves to the `posted` state.

- However, when updating the partner address, the `_compute_date` method 
is triggered again, which calls `super()` and recomputes the `date` field 
using the standard logic. Since the invoice is already in the `posted` 
state, the CZ-specific condition is not satisfied, and the `date` gets 
updated incorrectly.

 **Solution**

- Update `_compute_date` to only call super() for invoices in draft state.
- This prevents unwanted recomputation of the `date` on post invoices.

opw - 5086961

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
