### PR TITLE
[FIX] pos_loyalty: recalculate loyalty points after page refresh

### DIFF
--- a/addons/pos_loyalty/static/src/app/services/pos_store.js
+++ b/addons/pos_loyalty/static/src/app/services/pos_store.js
@@ -27,6 +27,7 @@ patch(PosStore.prototype, {
         this.couponByLineUuidCache = {};
         this.rewardProductByLineUuidCache = {};
         await super.setup(...arguments);
+        await this.updateOrder(this.getOrder());
     },
     async afterProcessServerData() {
         // Remove reward lines that have no reward anymore (could happen if the program got archived)

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
@@ -8,6 +8,7 @@ import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
 import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
 import * as PaymentScreen from "@point_of_sale/../tests/pos/tours/utils/payment_screen_util";
 import * as Notification from "@point_of_sale/../tests/generic_helpers/notification_util";
+import * as Utils from "@point_of_sale/../tests/generic_helpers/utils";
 import { registry } from "@web/core/registry";
 import { scan_barcode } from "@point_of_sale/../tests/generic_helpers/utils";
 
@@ -236,10 +237,10 @@ registry.category("web_tour.tours").add("PosLoyaltyTour6", {
             PaymentScreen.clickPaymentMethod("Cash"),
             PaymentScreen.clickValidate(),
             ReceiptScreen.isShown(),
-            {
-                content: "Loyalty Points is visible on the receipt",
-                trigger: ".pos-receipt .loyalty",
-            },
+            PosLoyalty.isLoyaltyPointsAvailable(),
+            Utils.refresh(),
+            ReceiptScreen.isShown(),
+            PosLoyalty.isLoyaltyPointsAvailable(),
         ].flat(),
 });
 

--- a/addons/pos_loyalty/static/tests/tours/utils/pos_loyalty_util.js
+++ b/addons/pos_loyalty/static/tests/tours/utils/pos_loyalty_util.js
@@ -208,3 +208,10 @@ export function checkPartnerPoints(name, points) {
         },
     ];
 }
+
+export function isLoyaltyPointsAvailable() {
+    return {
+        content: "Loyalty Points are visible on the receipt",
+        trigger: ".pos-receipt .loyalty",
+    };
+}


### PR DESCRIPTION
Before this commit:
---------
- Loyalty points are not recalculated when the receipt screen is refreshed.

After this commit:
----------
- Ensures that loyalty points are properly recalculated when the receipt screen is refreshed, preventing inconsistencies in displayed points.

task-5106892
