### PR TITLE
[IMP] l10n_sa_{edi}: allow backdating invoices

### DIFF
--- a/addons/l10n_sa/__manifest__.py
+++ b/addons/l10n_sa/__manifest__.py
@@ -28,6 +28,7 @@ Activates:
         'data/account_data.xml',
         'data/account_tax_report_data.xml',
         'data/report_paperformat_data.xml',
+        'views/account_move_views.xml',
         'views/report_invoice.xml',
         'views/report_templates_views.xml'
     ],

--- a/addons/l10n_sa/i18n/l10n_sa.pot
+++ b/addons/l10n_sa/i18n/l10n_sa.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.0\n"
+"Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-28 10:17+0000\n"
-"PO-Revision-Date: 2025-10-28 10:17+0000\n"
+"POT-Creation-Date: 2025-11-12 12:50+0000\n"
+"PO-Revision-Date: 2025-11-12 12:50+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -221,42 +221,9 @@ msgid "Account Chart Template"
 msgstr ""
 
 #. module: l10n_sa
-#: model_terms:res.company,invoice_terms_html:l10n_sa.demo_company_sa
-msgid ""
-"All our contractual relations will be governed exclusively by Saudi Arabia "
-"law."
-msgstr ""
-
-#. module: l10n_sa
 #: model:account.report.column,name:l10n_sa.tax_report_vat_filing_balance
 #: model:account.report.column,name:l10n_sa.tax_report_withholding_tax_balance
 msgid "Balance"
-msgstr ""
-
-#. module: l10n_sa
-#: model_terms:res.company,invoice_terms_html:l10n_sa.demo_company_sa
-msgid ""
-"Below text serves as a suggestion and doesn’t engage Odoo S.A. "
-"responsibility."
-msgstr ""
-
-#. module: l10n_sa
-#: model_terms:res.company,invoice_terms_html:l10n_sa.demo_company_sa
-msgid ""
-"Certain countries apply withholding at source on the amount of invoices, in "
-"accordance with their internal legislation. Any withholding at source will "
-"be paid by the client to the tax authorities. Under no circumstances can SA "
-"Company become involved in costs related to a country's legislation. The "
-"amount of the invoice will therefore be due to SA Company in its entirety "
-"and does not include any costs relating to the legislation of the country in"
-" which the client is located."
-msgstr ""
-
-#. module: l10n_sa
-#: model:ir.model.fields,field_description:l10n_sa.field_account_bank_statement_line__l10n_sa_confirmation_datetime
-#: model:ir.model.fields,field_description:l10n_sa.field_account_move__l10n_sa_confirmation_datetime
-#: model:ir.model.fields,field_description:l10n_sa.field_account_payment__l10n_sa_confirmation_datetime
-msgid "Confirmation Date"
 msgstr ""
 
 #. module: l10n_sa
@@ -264,24 +231,8 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_sa.field_account_move__l10n_sa_confirmation_datetime
 #: model:ir.model.fields,help:l10n_sa.field_account_payment__l10n_sa_confirmation_datetime
 msgid ""
-"Date when the invoice is confirmed and posted.\n"
-"                                                    In other words, it is the date on which the invoice is generated as final document (after securing all internal approvals)."
-msgstr ""
-
-#. module: l10n_sa
-#: model_terms:res.company,invoice_terms_html:l10n_sa.demo_company_sa
-msgid ""
-"If a payment is still outstanding more than sixty (60) days after the due "
-"payment date, SA Company reserves the right to call on the services of a "
-"debt recovery company. All legal expenses will be payable by the client."
-msgstr ""
-
-#. module: l10n_sa
-#: model_terms:res.company,invoice_terms_html:l10n_sa.demo_company_sa
-msgid ""
-"In order for it to be admissible, SA Company must be notified of any claim "
-"by means of a letter sent by recorded delivery to its registered office "
-"within 8 days of the delivery of the goods or the provision of the services."
+"Date on which the invoice is generated as final document (after securing all"
+" internal approvals)."
 msgstr ""
 
 #. module: l10n_sa
@@ -297,42 +248,6 @@ msgstr ""
 #. module: l10n_sa
 #: model:account.report.line,name:l10n_sa.tax_report_line_net_vat_due_or_reclaimed_for_the_period
 msgid "Net VAT due (or reclaimed) for the period"
-msgstr ""
-
-#. module: l10n_sa
-#: model_terms:res.company,invoice_terms_html:l10n_sa.demo_company_sa
-msgid ""
-"Our invoices are payable within 21 working days, unless another payment "
-"timeframe is indicated on either the invoice or the order. In the event of "
-"non-payment by the due date, SA Company reserves the right to request a "
-"fixed interest payment amounting to 10% of the sum remaining due. SA Company"
-" will be authorized to suspend any provision of services without prior "
-"warning in the event of late payment."
-msgstr ""
-
-#. module: l10n_sa
-#: model_terms:res.company,invoice_terms_html:l10n_sa.demo_company_sa
-msgid ""
-"SA Company undertakes to do its best to supply performant services in due "
-"time in accordance with the agreed timeframes. However, none of its "
-"obligations can be considered as being an obligation to achieve results. SA "
-"Company cannot under any circumstances, be required by the client to appear "
-"as a third party in the context of any claim for damages filed against the "
-"client by an end consumer."
-msgstr ""
-
-#. module: l10n_sa
-#: model_terms:res.company,invoice_terms_html:l10n_sa.demo_company_sa
-msgid "STANDARD TERMS AND CONDITIONS OF SALE"
-msgstr ""
-
-#. module: l10n_sa
-#: model_terms:res.company,invoice_terms_html:l10n_sa.demo_company_sa
-msgid ""
-"The client explicitly waives its own standard terms and conditions, even if "
-"these were drawn up after these standard terms and conditions of sale. In "
-"order to be valid, any derogation must be expressly agreed to in advance in "
-"writing."
 msgstr ""
 
 #. module: l10n_sa
@@ -526,8 +441,10 @@ msgid "Withholding Tax on Purchased Services (Tax)"
 msgstr ""
 
 #. module: l10n_sa
-#: model_terms:res.company,invoice_terms_html:l10n_sa.demo_company_sa
-msgid "You should update this document to reflect your T&amp;C."
+#: model:ir.model.fields,field_description:l10n_sa.field_account_bank_statement_line__l10n_sa_confirmation_datetime
+#: model:ir.model.fields,field_description:l10n_sa.field_account_move__l10n_sa_confirmation_datetime
+#: model:ir.model.fields,field_description:l10n_sa.field_account_payment__l10n_sa_confirmation_datetime
+msgid "ZATCA Issue Date"
 msgstr ""
 
 #. module: l10n_sa

--- a/addons/l10n_sa/models/account_move.py
+++ b/addons/l10n_sa/models/account_move.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import base64
-
+from datetime import datetime
 from odoo import api, fields, models
 from odoo.tools import float_repr, format_datetime
 
@@ -10,11 +10,10 @@ class AccountMove(models.Model):
     _inherit = 'account.move'
 
     l10n_sa_qr_code_str = fields.Char(string='Zatka QR Code', compute='_compute_qr_code_str')
-    l10n_sa_confirmation_datetime = fields.Datetime(string='Confirmation Date',
+    l10n_sa_confirmation_datetime = fields.Datetime(string='ZATCA Issue Date',
                                                     readonly=True,
                                                     copy=False,
-                                                    help="""Date when the invoice is confirmed and posted.
-                                                    In other words, it is the date on which the invoice is generated as final document (after securing all internal approvals).""")
+                                                    help="""Date on which the invoice is generated as final document (after securing all internal approvals).""")
 
     @api.depends('country_code', 'move_type')
     def _compute_show_delivery_date(self):
@@ -23,6 +22,9 @@ class AccountMove(models.Model):
         for move in self:
             if move.country_code == 'SA':
                 move.show_delivery_date = move.is_sale_document()
+
+    def _l10n_sa_reset_confirmation_datetime(self):
+        self.filtered(lambda m: m.country_code == 'SA').l10n_sa_confirmation_datetime = False
 
     @api.depends('amount_total_signed', 'amount_tax_signed', 'l10n_sa_confirmation_datetime', 'company_id', 'company_id.vat')
     def _compute_qr_code_str(self):
@@ -54,10 +56,9 @@ class AccountMove(models.Model):
         res = super()._post(soft)
         for move in self:
             if move.country_code == 'SA' and move.is_sale_document():
+                vals = {}
                 if not move.l10n_sa_confirmation_datetime:
-                    vals = {'l10n_sa_confirmation_datetime': fields.Datetime.now()}
-                else:
-                    vals = {}
+                    vals['l10n_sa_confirmation_datetime'] = datetime.combine(move.invoice_date, fields.Datetime.now().time())
                 if not move.delivery_date:
                     vals['delivery_date'] = move.invoice_date
                 if vals:
@@ -68,16 +69,18 @@ class AccountMove(models.Model):
         self.ensure_one()
         return format_datetime(self.env, self.l10n_sa_confirmation_datetime, tz='Asia/Riyadh', dt_format='Y-MM-dd\nHH:mm:ss')
 
-    def _l10n_sa_reset_confirmation_datetime(self):
-        self.filtered(lambda m: m.country_code == 'SA').l10n_sa_confirmation_datetime = False
-
-    def button_draft(self):
-        self._l10n_sa_reset_confirmation_datetime()
-        super().button_draft()
-
     def _get_l10n_sa_totals(self):
         self.ensure_one()
         return {
             'total_amount': self.amount_total_signed,
             'total_tax': self.amount_tax_signed,
         }
+
+    def write(self, vals):
+        result = super().write(vals)
+        invoice_date = vals.get('invoice_date')
+        if not invoice_date:
+            return result
+        for move in self.filtered('l10n_sa_confirmation_datetime'):
+            move.l10n_sa_confirmation_datetime = datetime.combine(fields.Date.from_string(invoice_date), move.l10n_sa_confirmation_datetime.time())
+        return result

--- a/addons/l10n_sa/views/account_move_views.xml
+++ b/addons/l10n_sa/views/account_move_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_move_form" model="ir.ui.view">
+        <field name="name">account.move.form.inherit.l10n_sa</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//page[@id='other_tab']//field[@name='delivery_date']" position="after">
+                <field name="l10n_sa_confirmation_datetime" invisible="country_code != 'SA' or move_type not in ('out_invoice', 'out_refund')" />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/l10n_sa_edi/tests/test_edi_zatca.py
+++ b/addons/l10n_sa_edi/tests/test_edi_zatca.py
@@ -285,43 +285,43 @@ class TestEdiZatca(TestSaEdiCommon):
             final = final_wizard._create_invoices(sale_order)
             final.invoice_date_due = '2022-09-22'
 
-        # Test invoices
-        for move, test_file in [
-            (downpayment, "downpayment_invoice"),
-            (final, "final_invoice")
-        ]:
-            with self.subTest(move=move, test_file=test_file):
-                self._test_document_generation(
-                    test_file_path=f'l10n_sa_edi/tests/test_files/{test_file}.xml',
-                    expected_xpath=self.invoice_applied_xpath,
-                    freeze_time_at=freeze,
-                    move=move,
-                )
+            # Test invoices
+            for move, test_file in [
+                (downpayment, "downpayment_invoice"),
+                (final, "final_invoice")
+            ]:
+                with self.subTest(move=move, test_file=test_file):
+                    self._test_document_generation(
+                        test_file_path=f'l10n_sa_edi/tests/test_files/{test_file}.xml',
+                        expected_xpath=self.invoice_applied_xpath,
+                        freeze_time_at=freeze,
+                        move=move,
+                    )
 
-        # Test credit notes
-        for move, test_file in [
-            (downpayment, "downpayment_credit_note"),
-            (final, "final_credit_note")
-        ]:
-            with self.subTest(move=move, test_file=test_file):
-                # Create refund
-                wiz_context = {
-                    'active_model': 'account.move',
-                    'active_ids': [move.id],
-                    'default_journal_id': move.journal_id.id,
-                }
-                refund_wizard = self.env['account.move.reversal'].with_context(wiz_context).create({
-                    'reason': 'please reverse :c',
-                    'date': '2022-09-05',
-                })
-                refund_invoice = self.env['account.move'].browse(refund_wizard.reverse_moves()['res_id'])
-                refund_invoice.invoice_date_due = '2022-09-22'
-                self._test_document_generation(
-                    test_file_path=f'l10n_sa_edi/tests/test_files/{test_file}.xml',
-                    expected_xpath=self.credit_note_applied_xpath,
-                    freeze_time_at=freeze,
-                    move=refund_invoice,
-                )
+            # Test credit notes
+            for move, test_file in [
+                (downpayment, "downpayment_credit_note"),
+                (final, "final_credit_note")
+            ]:
+                with self.subTest(move=move, test_file=test_file):
+                    # Create refund
+                    wiz_context = {
+                        'active_model': 'account.move',
+                        'active_ids': [move.id],
+                        'default_journal_id': move.journal_id.id,
+                    }
+                    refund_wizard = self.env['account.move.reversal'].with_context(wiz_context).create({
+                        'reason': 'please reverse :c',
+                        'date': '2022-09-05',
+                    })
+                    refund_invoice = self.env['account.move'].browse(refund_wizard.reverse_moves()['res_id'])
+                    refund_invoice.invoice_date_due = '2022-09-22'
+                    self._test_document_generation(
+                        test_file_path=f'l10n_sa_edi/tests/test_files/{test_file}.xml',
+                        expected_xpath=self.credit_note_applied_xpath,
+                        freeze_time_at=freeze,
+                        move=refund_invoice,
+                    )
 
     @freeze_time('2022-09-05')
     def test_invoice_with_downpayment_individual_negative_zero(self):


### PR DESCRIPTION
Previously, `l10n_sa_confirmation_datetime` represented the time where the invoice was posted,
that meant that we could not backdate invoices, since it would cause disparity between
what zatca receives and what we consider in odoo (i.e. `invoice_date`)

This commit allows us to set the date component of `l10n_sa_confirmation_datetime` to the
`invoice_date` so we can safely backdate invoices.

task-5009969

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
