### PR TITLE
[IMP] payment: prevent deletion of payment methods linked to providers

### DIFF
--- a/addons/payment/data/payment_method_data.xml
+++ b/addons/payment/data/payment_method_data.xml
@@ -2306,11 +2306,15 @@
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
+                         ref('base.de'),
+                         ref('base.fi'),
+                         ref('base.fr'),
                          ref('base.uk'),
                      ])]"
         />
         <field name="supported_currency_ids"
                eval="[Command.set([
+                         ref('base.EUR'),
                          ref('base.GBP'),
                      ])]"
         />

--- a/addons/payment/models/payment_method.py
+++ b/addons/payment/models/payment_method.py
@@ -225,6 +225,11 @@ class PaymentMethod(models.Model):
         if payment_method_unknown in self:
             raise UserError(_("You cannot delete the default payment method."))
 
+    @api.ondelete(at_uninstall=False)
+    def _unlink_if_not_linked_to_providers(self):
+        if any(record.provider_ids for record in self):
+            raise UserError(_("You cannot delete a payment method linked to a provider."))
+
     # === BUSINESS METHODS === #
 
     def _get_compatible_payment_methods(

--- a/addons/payment/tests/test_payment_method.py
+++ b/addons/payment/tests/test_payment_method.py
@@ -43,6 +43,25 @@ class TestPaymentMethod(PaymentCommon):
         self._assert_does_not_raise(ValidationError, brand_payment_method.action_unarchive)
         self.assertTrue(brand_payment_method.active)
 
+    def test_unlink_not_allowed_when_linked_to_providers(self):
+        """Test that the payment method cannot be deleted if it is linked to providers."""
+        payment_method_with_provider = self.env['payment.method'].create({
+            'name': "Dummy Method",
+            'code': 'dummymethod',
+            'provider_ids': self.provider.ids,
+        })  # self.payment_method is already checked by _unlink_if_not_default_payment_method.
+        with self.assertRaises(UserError):
+            payment_method_with_provider.unlink()
+
+    def test_unlink_allowed_when_not_linked_providers(self):
+        """Test that the payment method can be deleted if it is not linked to providers."""
+        payment_method_without_provider = self.env['payment.method'].create({
+            'name': "Dummy Method",
+            'code': 'dummymethod',
+            'provider_ids': [],
+        })  # self.payment_method is already checked by _unlink_if_not_default_payment_method.
+        self._assert_does_not_raise(UserError, payment_method_without_provider.unlink)
+
     def test_payment_method_compatible_when_provider_is_enabled(self):
         """ Test that a payment method is available when it is supported by an enabled provider. """
         compatible_payment_methods = self.env['payment.method']._get_compatible_payment_methods(


### PR DESCRIPTION
**Purpose:**
Prevent deletion of payment methods

**Specification:**
- Forbid deletion of payment methods linked to providers.
- Open banking payment method: add FR, DE, and FI to the list of supported countries, and EUR to the currencies. https://docs.adyen.com/payment-methods/pay-by-bank-europe/

Task-5082049

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
