### PR TITLE
[FIX] product: pricelist rules not saved

### DIFF
--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -65,6 +65,7 @@ class ProductProduct(models.Model):
         comodel_name='product.pricelist.item',
         inverse_name='product_id',
         compute='_compute_pricelist_rule_ids',
+        inverse='_inverse_pricelist_rule_ids',
         readonly=False,
     )
 
@@ -138,14 +139,26 @@ class ProductProduct(models.Model):
             else:
                 record[variant_field] = record[template_field]
 
-    @api.depends('product_tmpl_id')
+    @api.depends('product_tmpl_id.pricelist_rule_ids')
     def _compute_pricelist_rule_ids(self):
         for product in self:
             if not product.id:
                 product.pricelist_rule_ids = False
                 continue
             product.pricelist_rule_ids = product.product_tmpl_id.pricelist_rule_ids.filtered(
-                lambda rule: not rule.product_id or rule.product_id == product.id
+                lambda rule: rule.product_id <= product,
+            )
+
+    def _inverse_pricelist_rule_ids(self):
+        for product in self:
+            template = product.product_tmpl_id
+            template.pricelist_rule_ids = (
+                product.pricelist_rule_ids
+                # We have to manually keep the rules the current variant
+                # wasn't aware of because they targeted other variants.
+                | template.pricelist_rule_ids.filtered(
+                    lambda rule: rule.product_id and rule.product_id != product
+                )
             )
 
     @api.depends("product_tmpl_id.write_date")

--- a/addons/product/tests/common.py
+++ b/addons/product/tests/common.py
@@ -138,3 +138,22 @@ class ProductVariantsCommon(ProductCommon):
                 ])],
             })]
         })
+
+        cls.product_sofa_red = cls.product_template_sofa.product_variant_ids.filtered(
+            lambda pp:
+                pp.product_template_attribute_value_ids.product_attribute_value_id
+                ==
+                cls.color_attribute_red
+        )
+        cls.product_sofa_blue = cls.product_template_sofa.product_variant_ids.filtered(
+            lambda pp:
+                pp.product_template_attribute_value_ids.product_attribute_value_id
+                ==
+                cls.color_attribute_blue
+        )
+        cls.product_sofa_green = cls.product_template_sofa.product_variant_ids.filtered(
+            lambda pp:
+                pp.product_template_attribute_value_ids.product_attribute_value_id
+                ==
+                cls.color_attribute_green
+        )


### PR DESCRIPTION
steps to reproduce:
-------------------
1. Install sales
2. Enable Product Variants and Pricelists under Sales > Configuration
3. Open a product variant and create a pricelist rule
4. Save it

issue:
-----
The pricelist rules are not saved.

cause:
------
The field `pricelist_rule_ids` on `product.product` is a non-stored One2many. https://github.com/odoo/odoo/blob/b1041951d436b4b6adc90d8b8dd7b8c88cc69a46/addons/product/models/product_product.py#L62-L68 In the ORM, such fields are handled in the else part of [write_real()](https://github.com/odoo/odoo/blob/b1041951d436b4b6adc90d8b8dd7b8c88cc69a46/odoo/orm/fields_relational.py#L1033-L1049), Since this field is non-stored, it has no corresponding column in the database to persist changes. As a result, any updates made to it are lost after saving.

solution:
---------
Add an inverse method to make the field writable.

opw-5097909

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
