### PR TITLE
[FIX] project_mrp:  allow project user to access bom and bom line

### DIFF
--- a/addons/project_mrp/__manifest__.py
+++ b/addons/project_mrp/__manifest__.py
@@ -8,6 +8,7 @@
     'category': 'Services/Project',
     'depends': ['mrp', 'project'],
     'data': [
+        'security/ir.model.access.csv',
         'views/mrp_bom_views.xml',
         'views/mrp_production_views.xml',
         'views/project_project_views.xml',

--- a/addons/project_mrp/security/ir.model.access.csv
+++ b/addons/project_mrp/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_mrp_bom_project_user,mrp.bom,mrp.model_mrp_bom,project.group_project_user,1,0,0,0
+access_mrp_bom_line_project_user,mrp.bom.line,mrp.model_mrp_bom_line,project.group_project_user,1,0,0,0


### PR DESCRIPTION
**Steps to reproduce:**
  - Install mrp, industry_fsm_repair, and industry_fsm_sale
  - Create a user with only fsm access rights
  - Create a sale order with both service and goods products using the above user
  - Confirm the sale
  - Log in as the fsm user
    - Go to fsm app > open task > open pickup > open stock move

**Issue:**
  fsm users with no BOM access encounter errors when opening stock moves from fsm tasks.

**Cause:**
  lack of bom access for fsm-only user.

**Fix:**
  This commit grants bom and bom line access to the project user.


task-5077522
