### PR TITLE
[FIX] spreadsheet_dashboard_sale: prevent error on opening dashboard

### DIFF
--- a/addons/spreadsheet_dashboard_sale/data/files/product_dashboard.json
+++ b/addons/spreadsheet_dashboard_sale/data/files/product_dashboard.json
@@ -263,7 +263,7 @@
                   "context": {
                     "group_by": []
                   },
-                  "domain": "[\"&\", (\"state\", \"!=\", \"cancel\"), \"&\", (\"state\", \"not in\", (\"draft\", \"cancel\", \"sent\")), (\"product_tmpl_id.recurring_invoice\", \"!=\", True)]",
+                  "domain": "[\"&\", (\"state\", \"!=\", \"cancel\"), (\"state\", \"not in\", (\"draft\", \"cancel\", \"sent\"))]",
                   "groupBy": ["categ_id"],
                   "orderBy": []
                 },

--- a/addons/spreadsheet_dashboard_sale/data/files/sales_dashboard.json
+++ b/addons/spreadsheet_dashboard_sale/data/files/sales_dashboard.json
@@ -497,7 +497,7 @@
                   "context": {
                     "group_by": []
                   },
-                  "domain": "[\"&\", (\"state\", \"!=\", \"cancel\"), \"&\", (\"state\", \"not in\", (\"draft\", \"cancel\", \"sent\")), (\"product_tmpl_id.recurring_invoice\", \"!=\", True)]",
+                  "domain": "[\"&\", (\"state\", \"!=\", \"cancel\"), (\"state\", \"not in\", (\"draft\", \"cancel\", \"sent\"))]",
                   "groupBy": ["country_id"],
                   "orderBy": []
                 },
@@ -559,7 +559,7 @@
                   "context": {
                     "group_by": []
                   },
-                  "domain": "[\"&\", (\"state\", \"!=\", \"cancel\"), \"&\", (\"state\", \"not in\", (\"draft\", \"cancel\", \"sent\")), (\"product_tmpl_id.recurring_invoice\", \"!=\", True)]",
+                  "domain": "[\"&\", (\"state\", \"!=\", \"cancel\"), (\"state\", \"not in\", (\"draft\", \"cancel\", \"sent\"))]",
                   "groupBy": ["categ_id"],
                   "orderBy": []
                 },


### PR DESCRIPTION
The system will crash when the user opens the dashboard module.

**Steps to produce:**
- Install the `Sales` module with demo data.
- Open the dashboard module.

**Error:**
```py
KeyError: 'recurring_invoice'
ValueError: Invalid field product.template.recurring_invoice in condition ('recurring_invoice', '!=', True)
```

**Cause:**
- From this [PR], the field `recurring_invoice` is being used in the `spreadsheet_dashboard_sale` module. However, this field is actually defined in the `sale_subscription` module. Since `spreadsheet_dashboard_sale` does not currently listed `sale_subscription`in its `depends`.

**Solution:**
- In this PR, I have removed the reference from the domain from `spreadsheet_dashboard_sale` module.

[PR]: https://github.com/odoo/odoo/pull/225542

**sentry-6912254481**