### PR TITLE
[FIX] sale: fix sale warning text

### DIFF
--- a/addons/sale/models/account_move.py
+++ b/addons/sale/models/account_move.py
@@ -56,7 +56,7 @@ class AccountMove(models.Model):
                 continue
             warnings = OrderedSet()
             if partner_msg := move.partner_id.sale_warn_msg:
-                warnings.add(move.partner_id.name + ' - ' + partner_msg)
+                warnings.add((move.partner_id.name or move.partner_id.display_name) + ' - ' + partner_msg)
             for product in move.invoice_line_ids.product_id:
                 if product_msg := product.sale_line_warn_msg:
                     warnings.add(product.display_name + ' - ' + product_msg)

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -812,7 +812,7 @@ class SaleOrder(models.Model):
         for order in self:
             warnings = OrderedSet()
             if partner_msg := order.partner_id.sale_warn_msg:
-                warnings.add(order.partner_id.name + ' - ' + partner_msg)
+                warnings.add((order.partner_id.name or order.partner_id.display_name) + ' - ' + partner_msg)
             for line in order.order_line:
                 if product_msg := line.sale_line_warn_msg:
                     warnings.add(line.product_id.display_name + ' - ' + product_msg)

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -683,7 +683,10 @@ class TestSaleOrder(SaleCommon):
         """Test warnings when partner/products with sale warnings are used."""
         partner_with_warning = self.env['res.partner'].create({
             'name': 'Test Partner', 'sale_warn_msg': 'Highly infectious disease'})
+        child_partner = self.env['res.partner'].create({
+            'type': 'invoice', 'parent_id': partner_with_warning.id, 'sale_warn_msg': 'Slightly infectious disease'})
         sale_order = self.env['sale.order'].create({'partner_id': partner_with_warning.id})
+        sale_order2 = self.env['sale.order'].create({'partner_id': child_partner.id})
 
         product_with_warning1 = self.env['product.product'].create({
             'name': 'Test Product 1', 'sale_line_warn_msg': 'Highly corrosive'})
@@ -703,12 +706,34 @@ class TestSaleOrder(SaleCommon):
                 'order_id': sale_order.id,
                 'product_id': product_with_warning1.id,
             },
+            {
+                'order_id': sale_order2.id,
+                'product_id': product_with_warning1.id,
+            },
+            {
+                'order_id': sale_order2.id,
+                'product_id': product_with_warning2.id,
+            },
+            # Warnings for duplicate products should not appear.
+            {
+                'order_id': sale_order2.id,
+                'product_id': product_with_warning1.id,
+            },
         ])
+
+        sale_order2.action_confirm()
+        sale_order2._create_invoices()
+        invoice = Form(sale_order2.invoice_ids[0])
 
         expected_warnings = ('Test Partner - Highly infectious disease',
                              'Test Product 1 - Highly corrosive',
                              'Test Product 2 - Toxic pollutant')
+        expected_warnings_for_sale_order2 = ('Test Partner, Invoice - Slightly infectious disease',
+                                             'Test Product 1 - Highly corrosive',
+                                             'Test Product 2 - Toxic pollutant')
         self.assertEqual(sale_order.sale_warning_text, '\n'.join(expected_warnings))
+        self.assertEqual(sale_order2.sale_warning_text, '\n'.join(expected_warnings_for_sale_order2))
+        self.assertEqual(invoice.sale_warning_text, '\n'.join(expected_warnings_for_sale_order2))
 
     def test_sale_order_unit_price_recompute_on_product_change(self):
         """Ensure price_unit is correctly recomputed when the product is


### PR DESCRIPTION
When creating a Sale Order or Invoice for a partner without a name, a traceback occurs.

Steps to reproduce the error:
- Install ``sale_management`` with demo data
- Enable ``Sale Warnings`` from settings
- Open ``Azure Interior`` Contact > In Contact, Add Contact > Type: invoice >
  Save & close
- Create a sale order with the newly created partner
AND 
- Create an invoice with the newly created partner

Traceback:
``TypeError: unsupported operand type(s) for +: 'bool' and 'str'``

https://github.com/odoo/odoo/blob/7a1b27e5985b3b16768bea450c51226ae3659c76/addons/sale/models/sale_order.py#L822

https://github.com/odoo/odoo/blob/7a1b27e5985b3b16768bea450c51226ae3659c76/addons/sale/models/account_move.py#L59

Here, ``partner_id.name`` is ``False``, which leads to string concatenation with
a boolean in sale warning messages and results in the above traceback.

sentry-6912482256

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
