### PR TITLE
[FIX] google_gmail, microsoft_outlook: fix error message

### DIFF
--- a/addons/google_gmail/models/google_gmail_mixin.py
+++ b/addons/google_gmail/models/google_gmail_mixin.py
@@ -8,9 +8,10 @@ import requests
 
 from werkzeug.urls import url_encode
 
-from odoo import _, fields, models, tools
+from odoo import _, fields, models, tools, release
 from odoo.exceptions import AccessError, UserError
 from odoo.tools.urls import urljoin as url_join
+from odoo.addons.google_gmail.tools import get_iap_error_message
 
 GMAIL_TOKEN_REQUEST_TIMEOUT = 5
 
@@ -26,6 +27,8 @@ class GoogleGmailMixin(models.AbstractModel):
 
     _description = 'Google Gmail Mixin'
 
+    # The scope `https://mail.google.com/` is needed for SMTP and IMAP
+    # https://developers.google.com/workspace/gmail/imap/xoauth2-protocol
     _SERVICE_SCOPE = 'https://mail.google.com/ https://www.googleapis.com/auth/userinfo.email'
     _DEFAULT_GMAIL_IAP_ENDPOINT = 'https://gmail.api.odoo.com'
 
@@ -85,6 +88,9 @@ class GoogleGmailMixin(models.AbstractModel):
         is_configured = google_gmail_client_id and google_gmail_client_secret
 
         if not is_configured:  # use IAP (see '/google_gmail/iap_confirm')
+            if release.version_info[-1] != 'e':
+                raise UserError(_('Please configure your Gmail credentials.'))
+
             gmail_iap_endpoint = self.env['ir.config_parameter'].sudo().get_param(
                 'mail.server.gmail.iap.endpoint',
                 self._DEFAULT_GMAIL_IAP_ENDPOINT,
@@ -225,11 +231,7 @@ class GoogleGmailMixin(models.AbstractModel):
         return response
 
     def _raise_iap_error(self, error):
-        errors = {
-            "not_configured": _("Gmail is not configured on IAP."),
-            "no_subscription": _("You don't have an active subscription."),
-        }
-        raise UserError(_('An error occurred: %s.', errors.get(error, error)))
+        raise UserError(get_iap_error_message(self.env, error))
 
     def _generate_oauth2_string(self, user, refresh_token):
         """Generate a OAuth2 string which can be used for authentication.

--- a/addons/google_gmail/tools.py
+++ b/addons/google_gmail/tools.py
@@ -1,0 +1,6 @@
+def get_iap_error_message(env, error):
+    errors = {
+        "not_configured": env._("Something went wrong. Try again later"),
+        "no_subscription": env._("You don't have an active subscription"),
+    }
+    return errors.get(error, error)


### PR DESCRIPTION
Bug
===
When both module are installed, one overwrite the error messages of the
other, because the methods have the same name.

For database without enterprise, they won't have a subscription. We
don't want to try reaching IAP in that case, and so we show a generic
error message. For simplicity, we didn't make a bridge module just for
that error, and we just check the version.

Task-5113992