### PR TITLE
[IMP] payment: remove unused `_should_build_inline_form` method

### DIFF
--- a/addons/payment/models/payment_provider.py
+++ b/addons/payment/models/payment_provider.py
@@ -675,19 +675,6 @@ class PaymentProvider(models.Model):
         """
         return False
 
-    def _should_build_inline_form(self, is_validation=False):
-        """ Return whether the inline payment form should be instantiated.
-
-        For a provider to handle both direct payments and payments with redirection, it must
-        override this method and return whether the inline payment form should be instantiated (i.e.
-        if the payment should be direct) based on the operation (online payment or validation).
-
-        :param bool is_validation: Whether the operation is a validation.
-        :return: Whether the inline form should be instantiated.
-        :rtype: bool
-        """
-        return True
-
     def _get_validation_amount(self):
         """ Return the amount to use for validation operations.
 

--- a/addons/payment/views/payment_form_templates.xml
+++ b/addons/payment/views/payment_form_templates.xml
@@ -322,11 +322,7 @@
         </div>
         <!-- === Inline form === -->
         <div name="o_payment_inline_form" class="position-relative d-none">
-            <t t-if="inline_form_xml_id and provider_sudo._should_build_inline_form(
-                         is_validation=mode == 'validation'
-                     )"
-               t-call="{{inline_form_xml_id}}"
-            >
+            <t t-if="inline_form_xml_id" t-call="{{inline_form_xml_id}}">
                 <t t-set="provider_id" t-value="provider_sudo.id"/>
             </t>
             <div class="d-flex flex-column flex-sm-row align-md-items-center justify-content-between


### PR DESCRIPTION
Replaced by `mode` in payment forms and `_get_compatible_providers`.

task-4911075

See also:

- https://github.com/odoo/documentation/pull/14754
