### PR TITLE
[IMP] web: center text in barcode dialog

### DIFF
--- a/addons/web/static/src/core/barcode/barcode_dialog.xml
+++ b/addons/web/static/src/core/barcode/barcode_dialog.xml
@@ -8,7 +8,7 @@
                  class="h-100 d-flex flex-column justify-content-center align-items-center gap-1">
                 <i class="fa fa-2x fa-camera text-muted"></i>
                 <strong>Unable to access camera</strong>
-                <span class="text-muted" t-out="state.errorMessage"/>
+                <span class="text-center text-muted" t-out="state.errorMessage"/>
             </div>
         </Dialog>
     </t>


### PR DESCRIPTION
This PR centers the text in the barcode dialog to improve the design and avoid sticking to the border.

task-5113549

PR-ent: https://github.com/odoo/enterprise/pull/96039




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
