### PR TITLE
[IMP] sale_project: custom milestone percentage from project template

### DIFF
--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -1012,6 +1012,10 @@ class ProjectProject(models.Model):
     def action_get_list_view(self):
         action = self.env['ir.actions.act_window']._for_xml_id('project.project_milestone_action')
         action['display_name'] = _("%(name)s's Milestones", name=self.name)
+        context = action.get('context', '{}').replace('active_id', str(self.id))
+        context = ast.literal_eval(context)
+        context.update({'is_project_template': self.is_template})
+        action['context'] = context
         return action
 
     def action_open_project_form(self):

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -452,7 +452,7 @@
                                         <div role="menuitem">
                                             <a name="action_view_tasks" type="object">Tasks</a>
                                         </div>
-                                        <div role="menuitem" groups="project.group_project_milestone" t-if="record.allow_milestones.raw_value and !record.is_template.raw_value">
+                                        <div role="menuitem" groups="project.group_project_milestone" t-if="record.allow_milestones.raw_value">
                                             <a name="action_get_list_view" type="object">Milestones</a>
                                         </div>
                                     </div>

--- a/addons/sale_project/models/project_milestone.py
+++ b/addons/sale_project/models/project_milestone.py
@@ -30,7 +30,7 @@ class ProjectMilestone(models.Model):
     sale_line_id = fields.Many2one('sale.order.line', 'Sales Order Item', default=_default_sale_line_id, help='Sales Order Item that will be updated once the milestone is reached.',
         index='btree_not_null',
         domain="[('order_partner_id', '=?', project_partner_id), ('qty_delivered_method', '=', 'milestones')]")
-    quantity_percentage = fields.Float('Quantity (%)', compute="_compute_quantity_percentage", store=True, help='Percentage of the ordered quantity that will automatically be delivered once the milestone is reached.')
+    quantity_percentage = fields.Float('Quantity (%)', compute="_compute_quantity_percentage", copy=True, readonly=False, store=True, help='Percentage of the ordered quantity that will automatically be delivered once the milestone is reached.')
 
     sale_line_display_name = fields.Char("Sale Line Display Name", related='sale_line_id.display_name', export_string_translation=False)
     product_uom_id = fields.Many2one(related="sale_line_id.product_uom_id", export_string_translation=False)

--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -359,12 +359,11 @@
             <xpath expr="//field[@name='name']" position="after">
                 <field name="project_partner_id" column_invisible="True"/>
                 <field name="allow_billable" column_invisible="True"/>
-                <field name="sale_line_id" options="{'no_open': True}" placeholder="Non-billable" readonly="1" groups="!sales_team.group_sale_salesman"/>
-                <field name="sale_line_id" options="{'no_create': True}" placeholder="Non-billable" groups="sales_team.group_sale_salesman"/>
-                <field name="quantity_percentage" string="Quantity (%)" widget="percentage" readonly="not sale_line_id" groups="!sales_team.group_sale_salesman"/>
-                <field name="quantity_percentage" string="Quantity (%)" widget="percentage" readonly="not sale_line_id" groups="sales_team.group_sale_salesman"/>
-                <field name="product_uom_qty" optional="hide" groups="!sales_team.group_sale_salesman" readonly="1"/>
-                <field name="product_uom_qty" optional="hide" groups="sales_team.group_sale_salesman"/>
+                <field name="sale_line_id" options="{'no_open': True}" placeholder="Non-billable" column_invisible="context.get('is_project_template')" readonly="1" groups="!sales_team.group_sale_salesman"/>
+                <field name="sale_line_id" options="{'no_create': True}" placeholder="Non-billable" column_invisible="context.get('is_project_template')" groups="sales_team.group_sale_salesman"/>
+                <field name="quantity_percentage" string="Quantity (%)" widget="percentage"/>
+                <field name="product_uom_qty" optional="hide" column_invisible="context.get('is_project_template')" groups="!sales_team.group_sale_salesman" readonly="1"/>
+                <field name="product_uom_qty" optional="hide" column_invisible="context.get('is_project_template')" groups="sales_team.group_sale_salesman"/>
             </xpath>
             <xpath expr="//button[@name='action_view_tasks']" position="after">
                 <button name="action_view_sale_order" type="object" string="View Sales Order"


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

### Current behavior before PR:

The milestone can't be edited, and the `quantity` percentage is only evenly distributed when it is linked to a sales order

### Desired behavior after PR is merged:

- ability to add a custom milestone percentage in project templates
- keep the even distribution if no customization is set to the milestone quantity
- Make the milestones page accessible in the project template page to edit them
- Adjust the test so it can check the new quality calculation

---

Task-4102768