### PR TITLE
[IMP] Some UI improvements

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/product_configurator_popup/product_configurator_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/product_configurator_popup/product_configurator_popup.xml
@@ -3,7 +3,7 @@
 
     <t t-name="point_of_sale.RadioProductAttribute">
         <div class="configurator_radio" t-ref="root">
-            <div class="d-flex flex-wrap gap-3">
+            <div class="d-flex flex-wrap gap-3 align-items-center">
                 <t t-foreach="props.attribute.values()" t-as="value" t-key="value.id">
                     <div class="attribute-name-cell form-check">
                         <input 
@@ -24,7 +24,7 @@
                         </label>
                     </div>
                     <div t-if="value.id == props.selected.id and value.is_custom" class="custom-value-cell">
-                        <input type="text" t-att-value="props.customValue" t-on-change="(e) => props.setCustomValue(e.target.value)" class="custom_value form-control form-control-lg mt-2" />
+                        <input type="text" t-att-value="props.customValue" t-on-change="(e) => props.setCustomValue(e.target.value)" class="custom_value form-control form-control-lg" />
                     </div>
                 </t>
             </div>

--- a/addons/point_of_sale/views/pos_payment_views.xml
+++ b/addons/point_of_sale/views/pos_payment_views.xml
@@ -9,7 +9,8 @@
                     <group>
                         <field name="session_id" readonly="0"/>
                         <field name="pos_order_id"/>
-                        <field name="amount" readonly="0"/>
+                        <field name="amount" readonly="0" widget="monetary"/>
+                        <field name="currency_id"/>
                         <field name="payment_method_id"/>
                         <field name="payment_method_payment_mode" invisible="not payment_method_payment_mode"/>
                         <field name="card_type" invisible="not card_type or not card_no"/>


### PR DESCRIPTION
Before this commit:
    1. The currency symbol was not visible in the monetary field in the payment form view.
    2. The custom text box in a customizable item was not aligned with the other choices.

After this commit:
    1. Now, the currency symbol is visible.
    2. Now, the text box is aligned with other choices.

Task id : 5106355

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
