### PR TITLE
[FIX] mail: mention links should not be editable

### DIFF
--- a/addons/im_livechat/static/src/embed/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/embed/common/thread_model_patch.js
@@ -1,11 +1,11 @@
 import { fields } from "@mail/core/common/record";
 import { Thread } from "@mail/core/common/thread_model";
 import "@mail/discuss/core/common/thread_model_patch";
+import { generateEmojisOnHtml } from "@mail/utils/common/format";
 
 import { patch } from "@web/core/utils/patch";
 import { _t } from "@web/core/l10n/translation";
 import { Deferred } from "@web/core/utils/concurrency";
-import { prettifyMessageContent } from "@mail/utils/common/format";
 
 /** @type {typeof Thread} */
 const threadStaticPatch = {
@@ -127,7 +127,7 @@ patch(Thread.prototype, {
             }
             const temporaryMsg = this.store["mail.message"].insert({
                 author_id: this.store.self,
-                body: await prettifyMessageContent(body, { allowEmojiLoading: false }),
+                body: await generateEmojisOnHtml(body, { allowEmojiLoading: false }),
                 id: this.store.getNextTemporaryId(),
                 model: "discuss.channel",
                 res_id: this.id,

--- a/addons/mail/static/src/core/common/composer_model.js
+++ b/addons/mail/static/src/core/common/composer_model.js
@@ -1,5 +1,9 @@
 import { fields, OR, Record } from "@mail/core/common/record";
-import { convertBrToLineBreak, prettifyMessageText } from "@mail/utils/common/format";
+import {
+    convertBrToLineBreak,
+    getNonEditableMentions,
+    prettifyMessageText,
+} from "@mail/utils/common/format";
 import { markup } from "@odoo/owl";
 import { isHtmlEmpty } from "@web/core/utils/html";
 
@@ -65,7 +69,10 @@ export class Composer extends Record {
     composerHtml = fields.Html(markup("<div class='o-paragraph'><br></div>"), {
         compute() {
             if (this.syncHtmlWithMessage) {
-                return this.message.body || markup("<div class='o-paragraph'><br></div>");
+                return (
+                    getNonEditableMentions(this.message.body) ||
+                    markup("<div class='o-paragraph'><br></div>")
+                );
             }
             return this.composerHtml;
         },

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -5,9 +5,9 @@ import {
     EMOJI_REGEX,
     convertBrToLineBreak,
     decorateEmojis,
+    generateEmojisOnHtml,
     getNonEditableMentions,
     htmlToTextContentInline,
-    prettifyMessageContent,
 } from "@mail/utils/common/format";
 
 import { browser } from "@web/core/browser/browser";
@@ -549,7 +549,7 @@ export class Message extends Record {
             attachment_tokens: attachments
                 .concat(this.attachment_ids)
                 .map((attachment) => attachment.ownership_token),
-            body: await prettifyMessageContent(body, { validMentions }),
+            body: await generateEmojisOnHtml(body),
             partner_ids: validMentions?.partners?.map((partner) => partner.id),
             role_ids: validMentions?.roles?.map((role) => role.id),
         };

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -5,6 +5,7 @@ import {
     EMOJI_REGEX,
     convertBrToLineBreak,
     decorateEmojis,
+    getNonEditableMentions,
     htmlToTextContentInline,
     prettifyMessageContent,
 } from "@mail/utils/common/format";
@@ -573,7 +574,7 @@ export class Message extends Record {
         }
         this.composer = {
             mentionedPartners: this.partner_ids,
-            composerHtml: this.body,
+            composerHtml: getNonEditableMentions(this.body),
             selection: {
                 start: text.length,
                 end: text.length,

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -1,6 +1,6 @@
 import { Store as BaseStore, fields, makeStore, storeInsertFns } from "@mail/core/common/record";
 import { threadCompareRegistry } from "@mail/core/common/thread_compare";
-import { cleanTerm, generateEmojisOnHtml, prettifyMessageContent } from "@mail/utils/common/format";
+import { cleanTerm, generateEmojisOnHtml, prettifyMessageText } from "@mail/utils/common/format";
 
 import { reactive } from "@odoo/owl";
 
@@ -733,7 +733,7 @@ export class Store extends BaseStore {
             ...thread.getFetchParams(),
             fetch_params: {
                 is_notification,
-                search_term: await prettifyMessageContent(searchTerm), // formatted like message_post
+                search_term: await prettifyMessageText(searchTerm), // formatted like message_post
                 before,
             },
         });

--- a/addons/mail/static/src/discuss/core/common/message_actions.js
+++ b/addons/mail/static/src/discuss/core/common/message_actions.js
@@ -1,11 +1,9 @@
-import { messageActionsRegistry, registerMessageAction } from "@mail/core/common/message_actions";
+import { registerMessageAction } from "@mail/core/common/message_actions";
 
 import { toRaw } from "@odoo/owl";
 
 import { _t } from "@web/core/l10n/translation";
 import { rpc } from "@web/core/network/rpc";
-import { createDocumentFragmentFromContent } from "@web/core/utils/html";
-import { patch } from "@web/core/utils/patch";
 
 registerMessageAction("set-new-message-separator", {
     condition: ({ message, thread }) =>
@@ -30,22 +28,4 @@ registerMessageAction("set-new-message-separator", {
         });
     },
     sequence: 70,
-});
-
-const editAction = messageActionsRegistry.get("edit");
-
-patch(editAction, {
-    onSelected({ message, store }) {
-        const doc = createDocumentFragmentFromContent(message.body);
-        const mentionedChannelElements = doc.querySelectorAll(".o_channel_redirect");
-        message.mentionedChannelPromises = Array.from(mentionedChannelElements)
-            .filter((el) => el.dataset.oeModel === "discuss.channel")
-            .map(async (el) =>
-                store.Thread.getOrFetch({
-                    id: el.dataset.oeId,
-                    model: el.dataset.oeModel,
-                })
-            );
-        return super.onSelected(...arguments);
-    },
 });

--- a/addons/mail/static/src/discuss/core/common/message_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/message_model_patch.js
@@ -45,7 +45,7 @@ const messagePatch = {
                 return this.id < this.thread.lastSelfMessageSeenByEveryone.id;
             },
         });
-        /** @type {Promise<Thread>[]} */
+        /** @type {Promise<Thread>[]} @deprecated */
         this.mentionedChannelPromises = [];
         this.threadAsFirstUnread = fields.One("Thread", { inverse: "firstUnreadMessage" });
     },
@@ -63,12 +63,8 @@ const messagePatch = {
         attachments = [],
         { mentionedChannels = [], mentionedPartners = [], mentionedRoles = [] } = {}
     ) {
-        const validChannels = (await Promise.all(this.mentionedChannelPromises)).filter(
-            (channel) => channel !== undefined
-        );
-        const allChannels = this.store.Thread.insert([...validChannels, ...mentionedChannels]);
         return await super.edit(body, attachments, {
-            mentionedChannels: allChannels,
+            mentionedChannels,
             mentionedPartners,
             mentionedRoles,
         });

--- a/addons/mail/static/src/utils/common/format.js
+++ b/addons/mail/static/src/utils/common/format.js
@@ -25,9 +25,13 @@ const messageUrlRegExp = new RegExp(`^${escapeRegExp(getOrigin())}/mail/message/
  * @param {string|ReturnType<markup>} rawBody
  * @param {Object} validMentions
  * @param {import("models").Persona[]} validMentions.partners
- * @returns {string|ReturnType<markup>}
+ * @returns {Promise<string|ReturnType<markup>>}
  */
 export function prettifyMessageText(rawBody, { validMentions = [] } = {}) {
+    if (rawBody instanceof markup().constructor) {
+        // markup is already "pretty"
+        return rawBody;
+    }
     let body = htmlTrim(rawBody);
     body = htmlReplace(body, /(\r|\n){2,}/g, () => markup`<br/><br/>`);
     body = htmlReplace(body, /(\r|\n)/g, () => markup`<br/>`);
@@ -250,7 +254,7 @@ function generateMentionsLinks(
 /**
  * @private
  * @param {string|ReturnType<markup>} htmlString
- * @returns {ReturnType<markup>}
+ * @returns {Promise<ReturnType<markup>>}
  */
 async function _generateEmojisOnHtml(htmlString) {
     const { emojis } = await loadEmoji();

--- a/addons/mail/static/src/utils/common/format.js
+++ b/addons/mail/static/src/utils/common/format.js
@@ -281,6 +281,10 @@ export function getNonEditableMentions(body) {
     for (const mention of doc.body.querySelectorAll(".o_channel_redirect")) {
         mention.setAttribute("contenteditable", false);
     }
+    // for special mentions
+    for (const mention of doc.body.querySelectorAll(".o-discuss-mention")) {
+        mention.setAttribute("contenteditable", false);
+    }
     return markup(doc.body.innerHTML);
 }
 

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -1,4 +1,8 @@
-import { tripleClick } from "@html_editor/../tests/_helpers/user_actions";
+import { setSelection } from "@html_editor/../tests/_helpers/selection";
+import {
+    insertText as htmlInsertText,
+    tripleClick,
+} from "@html_editor/../tests/_helpers/user_actions";
 
 import {
     click,
@@ -511,7 +515,7 @@ test("Scroll bar to the top when edit starts", async () => {
     await contains(".o-mail-Message .o-mail-Composer-input", { scroll: 0 });
 });
 
-test("mentions are kept when editing message", async () => {
+test("[text composer] mentions and special mentions are kept when editing message", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({
         name: "general",
@@ -519,7 +523,7 @@ test("mentions are kept when editing message", async () => {
     });
     pyEnv["mail.message"].create({
         author_id: serverState.partnerId,
-        body: "Hello @Mitchell Admin",
+        body: '<div>Hello <a class="o_mail_redirect" target="_blank">@Mitchell Admin</a> and <a href="#" class="o-discuss-mention">@everyone</a></div>',
         model: "discuss.channel",
         partner_ids: [serverState.partnerId],
         res_id: channelId,
@@ -527,14 +531,77 @@ test("mentions are kept when editing message", async () => {
     });
     await start();
     await openDiscuss(channelId);
-    await click(".o-mail-Message [title='Edit']");
-    await insertText(".o-mail-Message .o-mail-Composer-input", "Hi @Mitchell Admin", {
-        replace: true,
+    await contains(".o-mail-Message", {
+        text: "Hello @Mitchell Admin and @everyone",
+        contains: [
+            ["a.o_mail_redirect", { text: "@Mitchell Admin" }],
+            ["a.o-discuss-mention", { text: "@everyone" }],
+        ],
     });
+    await click(".o-mail-Message [title='Edit']");
+    await insertText(".o-mail-Message .o-mail-Composer-input", " abc");
     await click(".o-mail-Message button", { text: "save" });
     await contains(".o-mail-Message", {
-        text: "Hi @Mitchell Admin (edited)",
-        contains: ["a.o_mail_redirect", { text: "@Mitchell Admin" }],
+        text: "Hello @Mitchell Admin and @everyone abc (edited)",
+        contains: [
+            ["a.o_mail_redirect", { text: "@Mitchell Admin" }],
+            ["a.o-discuss-mention", { text: "@everyone" }],
+        ],
+    });
+});
+
+test.tags("html composer");
+test("mentions and special mentions are kept when editing message", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "general",
+        channel_type: "channel",
+    });
+    await start();
+    pyEnv["mail.message"].create({
+        author_id: serverState.partnerId,
+        body: '<div>Hello <a class="o_mail_redirect" target="_blank">@Mitchell Admin</a> and <a href="#" class="o-discuss-mention">@everyone</a></div>',
+        model: "discuss.channel",
+        partner_ids: [serverState.partnerId],
+        res_id: channelId,
+        message_type: "comment",
+    });
+    const composerService = getService("mail.composer");
+    composerService.setHtmlComposer();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Message", {
+        text: "Hello @Mitchell Admin and @everyone",
+        contains: [
+            ["a.o_mail_redirect", { text: "@Mitchell Admin" }],
+            ["a.o-discuss-mention", { text: "@everyone" }],
+        ],
+    });
+    await click(".o-mail-Message [title='Edit']");
+    await contains(".o-mail-Message .o-mail-Composer-html", {
+        text: "Hello @Mitchell Admin and @everyone",
+        contains: [
+            ["a.o_mail_redirect[contenteditable=false]", { text: "@Mitchell Admin" }],
+            ["a.o-discuss-mention[contenteditable=false]", { text: "@everyone" }],
+        ],
+    });
+    const editor = {
+        document,
+        editable: document.querySelector(
+            ".o-mail-Message .o-mail-Composer-html.odoo-editor-editable"
+        ),
+    };
+    setSelection({
+        anchorNode: editor.editable.querySelector("div.o-paragraph"),
+        anchorOffset: 4 /* at the end = after 4 nodes: "Hello" <first mention> "and" <second mention> */,
+    });
+    await htmlInsertText(editor, " abc");
+    await click(".o-mail-Message button", { text: "save" });
+    await contains(".o-mail-Message", {
+        text: "Hello @Mitchell Admin and @everyone abc (edited)",
+        contains: [
+            ["a.o_mail_redirect", { text: "@Mitchell Admin" }],
+            ["a.o-discuss-mention", { text: "@everyone" }],
+        ],
     });
 });
 


### PR DESCRIPTION
This fixes the issue that when editing a message with mentions, the mentions were editable and could be partially deleted.

This is fixed by preprocessing the message body when loading it for edition, addding contenteditable="false" and draggable="false" to the mention links.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
