### PR TITLE
[FIX] base,hr: show login in user form

### DIFF
--- a/addons/hr/views/res_users.xml
+++ b/addons/hr/views/res_users.xml
@@ -188,14 +188,20 @@
                 </xpath>
                 <!-- Must be replaced by work_email when the user has an employee_id. -->
                 <xpath expr="//h5[@name='h5_email']" position="attributes">
-                    <attribute name="invisible">not id or employee_id</attribute>
+                    <attribute name="invisible">employee_id or login == email</attribute>
                 </xpath>
                 <!-- Must be replaced by work_phone when the user has an employee_id. -->
                 <xpath expr="//h5[@name='h5_phone']" position="attributes">
                     <attribute name="invisible">employee_id</attribute>
                 </xpath>
+                <xpath expr="//h5[@name='h5_login']/i[hasclass('fa-envelope')]" position="attributes">
+                    <attribute name="invisible">(not employee_id and login != email) or (employee_id and login != work_email)</attribute>
+                </xpath>
+                <xpath expr="//h5[@name='h5_login']/i[hasclass('fa-key')]" position="attributes">
+                    <attribute name="invisible">(not employee_id and login == email) or (employee_id and login == work_email)</attribute>
+                </xpath>
                 <xpath expr="//div[hasclass('oe_title')]" position="inside">
-                    <h5 class="d-flex align-items-baseline mb-0" invisible="not id or not employee_id">
+                    <h5 class="d-flex align-items-baseline mb-0" invisible="not employee_id or login == work_email">
                         <i class="fa fa-envelope fa-fw me-1 text-primary" title="Work Email"/>
                         <field name="email_domain_placeholder" invisible="1" />
                         <field name="work_email" widget="email" string="Work Email" class="w-75" options="{'placeholder_field': 'email_domain_placeholder'}"/>

--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -132,14 +132,14 @@
                                 <h1 class="mb-0 w-sm-75">
                                     <field name="name" placeholder="e.g. John Doe" required="1"/>
                                 </h1>
-                                <!-- Must replace the login when the user is created. -->
-                                <h5 name="h5_email" class="d-flex align-items-baseline mb-0" invisible="not id">
+                                <h5 name="h5_login" class="d-flex align-items-baseline mb-0">
+                                    <i class="fa fa-fw fa-envelope text-primary" title="Login / Email" invisible="login != email"/>
+                                    <i class="fa fa-fw fa-key text-primary" title="Login" invisible="login == email"/>
+                                    <field name="login" placeholder="Login" class="w-75"/>
+                                </h5>
+                                <h5 name="h5_email" class="d-flex align-items-baseline mb-0" invisible="login == email">
                                     <i class="fa fa-fw fa-envelope text-primary" title="Email"/>
                                     <field name="email" placeholder="Email" class="w-75"/>
-                                </h5>
-                                <h5 class="d-flex align-items-baseline mb-0" invisible="id">
-                                    <i class="fa fa-fw fa-envelope text-primary" title="Email"/>
-                                    <field name="login" placeholder="Email" class="w-75"/>
                                 </h5>
                                 <h5 name="h5_phone" class="d-flex align-items-baseline mb-0">
                                     <i class="fa fa-fw fa-phone text-primary" title="Email"/>


### PR DESCRIPTION
We want to allow users to edit the login even after the user is created.
However as the email is usually the same as the login we don't want to
be too noisy by having duplicate values.

If the email and login field are the same: only show the login field

If the user goes to the user form and modifies the "email" (actually
login) both fields will appear and they will be able to modify each
independently.

Same logic is applied to hr with user.work_email replacing user.email

task-5130854