### PR TITLE
[FIX] html_editor: snapshot step with unobserved nodes

### DIFF
--- a/addons/html_editor/static/src/core/history_plugin.js
+++ b/addons/html_editor/static/src/core/history_plugin.js
@@ -304,13 +304,15 @@ export class HistoryPlugin extends Plugin {
                 focusNode: undefined,
                 focusOffset: undefined,
             },
-            mutations: childNodes(this.editable).map((node) => ({
-                type: "add",
-                parentNodeId: "root",
-                nodeId: this.nodeMap.getId(node),
-                serializedNode: this.serializeNode(node),
-                nextNodeId: null,
-            })),
+            mutations: childNodes(this.editable)
+                .filter((node) => this.nodeMap.hasNode(node))
+                .map((node) => ({
+                    type: "add",
+                    parentNodeId: "root",
+                    nodeId: this.nodeMap.getId(node),
+                    serializedNode: this.serializeNode(node),
+                    nextNodeId: null,
+                })),
             id: this.steps[this.steps.length - 1]?.id || this.generateId(),
             previousStepId: undefined,
         };
@@ -1727,13 +1729,13 @@ export class HistoryPlugin extends Plugin {
 
     /**
      * @param {Tree} tree
-     * @returns {SerializedNode}
+     * @returns {SerializedNode|null}
      */
     serializeTree(tree) {
         const node = tree.node;
         const nodeId = this.nodeMap.getId(node);
         if (!nodeId) {
-            throw new Error("Missing nodeId for serialization");
+            return null;
         }
         const result = {
             nodeType: node.nodeType,


### PR DESCRIPTION
When creating a snapshot step, unobserved nodes (i.e. node inserted via `ignoreDOMMutations`) should not be included in the snapshot step.

This commit restores a previous behavior in which, on serialization, nodes that had no entry in the node map were ignored (instead of throwing an error).

Because of this thrown error, before this commit it was not possible to create a snapshot step if the editable contained unobserved nodes.

