### PR TITLE
[IMP] l10n_be : add default rounding method for cash

### DIFF
--- a/addons/account/models/account_cash_rounding.py
+++ b/addons/account/models/account_cash_rounding.py
@@ -22,10 +22,10 @@ class AccountCashRounding(models.Model):
     strategy = fields.Selection([('biggest_tax', 'Modify tax amount'), ('add_invoice_line', 'Add a rounding line')],
         string='Rounding Strategy', default='add_invoice_line', required=True,
         help='Specify which way will be used to round the invoice amount to the rounding precision')
+    company_id = fields.Many2one('res.company', string='Company', required=True, readonly=True, default=lambda self: self.env.company, ondelete='cascade')
     profit_account_id = fields.Many2one(
         'account.account',
         string='Profit Account',
-        company_dependent=True,
         check_company=True,
         domain="[('account_type', 'not in', ('asset_receivable', 'liability_payable'))]",
         ondelete='restrict',
@@ -33,7 +33,6 @@ class AccountCashRounding(models.Model):
     loss_account_id = fields.Many2one(
         'account.account',
         string='Loss Account',
-        company_dependent=True,
         check_company=True,
         domain="[('account_type', 'not in', ('asset_receivable', 'liability_payable'))]",
         ondelete='restrict',

--- a/addons/account/security/account_security.xml
+++ b/addons/account/security/account_security.xml
@@ -173,6 +173,12 @@
         <field name="domain_force">[('company_id', 'parent_of', company_ids)]</field>
     </record>
 
+    <record id="account_cash_rounding_comp_rule" model="ir.rule">
+        <field name="name">Account cash rounding multi-company</field>
+        <field name="model_id" ref="model_account_cash_rounding" />
+        <field name="domain_force">[('company_id', 'in', company_ids)]</field>
+    </record>
+
     <record id="tax_rep_comp_rule" model="ir.rule">
         <field name="name">Tax Repartition multi-company</field>
         <field name="model_id" ref="model_account_tax_repartition_line"/>

--- a/addons/l10n_be/models/template_be_asso.py
+++ b/addons/l10n_be/models/template_be_asso.py
@@ -7,6 +7,23 @@ from odoo.addons.account.models.chart_template import template
 class AccountChartTemplate(models.AbstractModel):
     _inherit = 'account.chart.template'
 
+    @template('be_asso', 'account.cash.rounding')
+    def _get_be_asso_account_cash_rounding(self):
+        return {
+            'cash_rounding_be_asso_05': {
+                'name': "Round to 0.05",
+                'name@fr': "Arrondi à 0.05",
+                'name@nl': "Afronding tot 0.05",
+                'name@de': "Rundung auf 0,05",
+                'rounding': 0.05,
+                'strategy': 'add_invoice_line',
+                'company_id': self.env.company.id,
+                'rounding_method': 'HALF-UP',
+                'profit_account_id': 'a743',
+                'loss_account_id': 'a644',
+            },
+        }
+
     @template('be_asso')
     def _get_be_asso_template_data(self):
         return {

--- a/addons/l10n_be/models/template_be_comp.py
+++ b/addons/l10n_be/models/template_be_comp.py
@@ -7,6 +7,23 @@ from odoo.addons.account.models.chart_template import template
 class AccountChartTemplate(models.AbstractModel):
     _inherit = 'account.chart.template'
 
+    @template('be_comp', 'account.cash.rounding')
+    def _get_be_comp_account_cash_rounding(self):
+        return {
+            'cash_rounding_be_comp_05': {
+                'name': "Round to 0.05",
+                'name@fr': "Arrondi à 0.05",
+                'name@nl': "Afronding tot 0.05",
+                'name@de': "Rundung auf 0,05",
+                'rounding': 0.05,
+                'strategy': 'add_invoice_line',
+                'company_id': self.env.company.id,
+                'rounding_method': 'HALF-UP',
+                'profit_account_id': 'a743',
+                'loss_account_id': 'a643',
+            },
+        }
+
     @template('be_comp')
     def _get_be_comp_template_data(self):
         return {

--- a/addons/l10n_be_pos/__init__.py
+++ b/addons/l10n_be_pos/__init__.py
@@ -1,0 +1,4 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+
+from . import models

--- a/addons/l10n_be_pos/__manifest__.py
+++ b/addons/l10n_be_pos/__manifest__.py
@@ -1,0 +1,13 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+
+{
+    'name': 'BE POS Localization',
+    'category': 'Sales/Point of Sale',
+    'sequence': 6,
+    'summary': 'Link module between point_of_sale and l10n_be',
+    'depends': ['point_of_sale', 'l10n_be', 'account'],
+    'auto_install': True,
+    'author': 'Odoo S.A.',
+    'license': 'LGPL-3',
+}

--- a/addons/l10n_be_pos/models/__init__.py
+++ b/addons/l10n_be_pos/models/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import pos_config

--- a/addons/l10n_be_pos/models/pos_config.py
+++ b/addons/l10n_be_pos/models/pos_config.py
@@ -1,0 +1,23 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models
+
+
+class PosConfig(models.Model):
+    _inherit = 'pos.config'
+
+    @api.model
+    def create(self, vals_list):
+        for val in vals_list:
+            company_id = self.env['res.company'].browse(val.get('company_id'))
+            if company_id.exists() and company_id.country_id.code == 'BE':
+                rounding_method = self.env['account.cash.rounding'].search([
+                    ('company_id', '=', company_id.id),
+                    ('name', '=', 'Round to 0.05'),
+                    ], limit=1)
+                if rounding_method:
+                    val['cash_rounding'] = True
+                    val['rounding_method'] = rounding_method.id
+                    val['only_round_cash_method'] = True
+
+        return super().create(vals_list)

--- a/addons/l10n_hu_edi/__manifest__.py
+++ b/addons/l10n_hu_edi/__manifest__.py
@@ -13,7 +13,6 @@
     'data': [
         'security/ir.model.access.csv',
         'data/uom.uom.csv',
-        'data/account_cash_rounding.xml',
         'data/template_requests.xml',
         'data/template_invoice.xml',
         'data/ir_cron.xml',

--- a/addons/l10n_hu_edi/data/account_cash_rounding.xml
+++ b/addons/l10n_hu_edi/data/account_cash_rounding.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<odoo>
-    <record id="cash_rounding_1_huf" model="account.cash.rounding">
-        <field name="name">Rounding to 1.00</field>
-        <field name="name@hu">Kerekítés 1.00-ra</field>
-        <field name="rounding">1.0</field>
-        <field name="strategy">add_invoice_line</field>
-    </record>
-</odoo>

--- a/addons/l10n_hu_edi/models/res_company.py
+++ b/addons/l10n_hu_edi/models/res_company.py
@@ -68,7 +68,7 @@ class ResCompany(models.Model):
             # Set profit/loss accounts on cash rounding method
             profit_account = self.env['account.chart.template'].with_company(company).ref('l10n_hu_969', raise_if_not_found=False)
             loss_account = self.env['account.chart.template'].with_company(company).ref('l10n_hu_869', raise_if_not_found=False)
-            rounding_method = self.env.ref('l10n_hu_edi.cash_rounding_1_huf', raise_if_not_found=False)
+            rounding_method = self.env['account.chart.template'].with_company(company).ref('cash_rounding_1_huf', raise_if_not_found=False)
             if profit_account and loss_account and rounding_method:
                 rounding_method.with_company(company).write({
                     'profit_account_id': profit_account.id,

--- a/addons/l10n_hu_edi/models/template_hu.py
+++ b/addons/l10n_hu_edi/models/template_hu.py
@@ -15,3 +15,14 @@ class AccountChartTemplate(models.AbstractModel):
     def _get_hu_account_tax(self):
         data = self._parse_csv('hu', 'account.tax', module='l10n_hu_edi')
         return data
+
+    @template('hu', 'account.cash.rounding')
+    def _get_hu_account_rounding(self):
+        return {
+            'cash_rounding_1_huf': {
+                'name': "Rounding to 1.00",
+                'name@hu': "Kerekítés 1.00-ra",
+                'rounding': 1.0,
+                'strategy': 'add_invoice_line'
+            }
+        }

--- a/addons/l10n_hu_edi/tests/common.py
+++ b/addons/l10n_hu_edi/tests/common.py
@@ -275,7 +275,7 @@ class L10nHuEdiTestCommon(AccountTestInvoicingCommon):
             'invoice_date': self.today,
             'delivery_date': self.today,
             'l10n_hu_payment_mode': 'TRANSFER',
-            'invoice_cash_rounding_id': self.env.ref('l10n_hu_edi.cash_rounding_1_huf').id,
+            'invoice_cash_rounding_id': self.env['account.chart.template'].with_company(self.company).ref('cash_rounding_1_huf').id,
             'invoice_line_ids': [
                 Command.create({
                     'product_id': self.product_a.id,

--- a/addons/l10n_in/models/template_in.py
+++ b/addons/l10n_in/models/template_in.py
@@ -43,6 +43,7 @@ class AccountChartTemplate(models.AbstractModel):
     def _get_in_account_cash_rounding(self):
         return {
             'l10n_in.cash_rounding_in_half_up': {
+                'company_id': self.env.company.id,
                 'profit_account_id': 'p213202',
                 'loss_account_id': 'p213201',
             }


### PR DESCRIPTION
Add a new `l10n_be_pos` module which specifies a function to create a new account cash rounding if one with the same parameters doesn't already exist and on each new point of sale created will assign by default the rounding method created earlier

Task-5056857