### PR TITLE
[FIX] pos_self_order: prevent access error when reading order data

### DIFF
--- a/addons/pos_self_order/controllers/orders.py
+++ b/addons/pos_self_order/controllers/orders.py
@@ -239,6 +239,7 @@ class PosSelfOrderController(http.Controller):
             raise Unauthorized("Invalid access token")
         company = pos_config_sudo.company_id
         user = pos_config_sudo.self_ordering_default_user_id
+        request.update_env(user=user)
         return pos_config_sudo.sudo(False).with_company(company).with_user(user).with_context(allowed_company_ids=company.ids)
 
     def _verify_config_constraint(self, pos_config_sudo, check_active_session=True):


### PR DESCRIPTION
Before this commit, if a partner was added to the message_partner_ids, as reading the order triggered the compute function and it changed the uid to the public user due to a call to _check_sudo_commands. This caused an access error when trying to pay an order from the mobile.

opw-5128747

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
