### PR TITLE
[FIX] mail: fix race condition in emoji test

### DIFF
--- a/addons/mail/static/tests/emoji/emoji.test.js
+++ b/addons/mail/static/tests/emoji/emoji.test.js
@@ -30,7 +30,7 @@ test("emoji picker correctly handles translations with special characters", asyn
     await click("button[aria-label='Emojis']");
     await insertText("input[placeholder='Search emoji']", "ici");
     await contains(`.o-Emoji[title='Bouton "ici" japonais']`);
-    await insertText("input[placeholder='Search emoji']", "dollar");
+    await insertText("input[placeholder='Search emoji']", "dollar", { replace: true });
     await contains(`.o-Emoji[title*='Symbole du dollar']`);
 });
 
@@ -224,7 +224,7 @@ test("Emoji picker shows failure to load emojis", async () => {
     patchWithCleanup(odoo.loader.modules.get("@web/core/emoji_picker/emoji_data"), {
         getEmojis() {
             return [];
-        }
+        },
     });
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "" });


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/223564

PR above adapted test with emoji picker with translations by using the emoji picker search twice.

However `insertText()` is used a 2nd time without the `replace` option. As a result, the 2 search texts are concatenated, and produce a search term that should find no emoji. The test passes sometimes because of the asynchronous rendering and the 2nd emoji being visible on the 1st search.

This commit fixes the issue by using `replace: true` on 2nd insert of test, so that this is a fresh search that matches the emoji being searched.
