### PR TITLE
[FIX] l10n_fr_pos_cert: consider only pos.order records with l10n_fr_secure_sequence_number

### DIFF
--- a/addons/l10n_fr_pos_cert/models/pos.py
+++ b/addons/l10n_fr_pos_cert/models/pos.py
@@ -63,7 +63,9 @@ class pos_order(models.Model):
             orders_by_company[order.company_id.id].append(order)
 
         for company_id, orders in orders_by_company.items():
-            prev_seq = [o.l10n_fr_secure_sequence_number - 1 for o in orders]
+            # Since sequence number can't be zero, we don't consider
+            # it as a posible previous sequence number
+            prev_seq = [o.l10n_fr_secure_sequence_number - 1 for o in orders if o.l10n_fr_secure_sequence_number > 1]
             prev_orders = self.search([
                 ('state', 'in', ['paid', 'done', 'invoiced']),
                 ('company_id', '=', company_id),


### PR DESCRIPTION
## Description of the issue/feature this PR addresses:

When obtaining the previous order for pos.order records, all orders with l10n_fr_secure_sequence_number == NULL will be recognised as the previous order for those where l10n_fr_secure_sequence_number == 1, as if their sequence value was zero.

## Current behavior before PR:

Since there can be more than one orders without sequence number, this behaviour will trigger an UserError exception, as the ORM will mistakenly deduce that there are multiple previous orders for a single one, which is not necessarily correct.

### Examples:

upg-3170341

```sql
lare_3170341=> SELECT count(id) FROM pos_order WHERE l10n_fr_secure_sequence_number IS NULL;
 count
-------
 67281
(1 row)
```

```python
# Debugging standard codebase with a Python debugger
...
match = prev_map.get(order.l10n_fr_secure_sequence_number - 1, [])    # len(match) == 67281
if len(match) > 1:
    raise UserError(_('An error occurred when computing the inalterability...'))
...
```

upg-3170341

```sql
lare_3167621=> SELECT count(id) FROM pos_order WHERE l10n_fr_secure_sequence_number IS NULL;
 count
-------
   294
(1 row)
```

```python
# Debugging standard codebase with a Python debugger
...
match = prev_map.get(order.l10n_fr_secure_sequence_number - 1, [])    # len(match) == 294
if len(match) > 1:
    raise UserError(_('An error occurred when computing the inalterability...'))
...
```

---

Traceback group: https://upgrade.odoo.com/odoo/tbg/1869

```
2025-09-30 07:48:30,945 329 INFO db_3167621 odoo.modules.loading: Loading module l10n_fr_pos_cert (110/131) 
2025-09-30 07:48:31,375 329 INFO db_3167621 odoo.modules.registry: module l10n_fr_pos_cert: creating or updating database tables 
2025-09-30 07:48:31,432 329 INFO db_3167621 odoo.models: Prepare computation of pos.order.previous_order_id 
2025-09-30 07:48:31,597 329 WARNING db_3167621 odoo.modules.loading: Transient module states were reset 
2025-09-30 07:48:31,597 329 ERROR db_3167621 odoo.modules.registry: Failed to load registry 
2025-09-30 07:48:31,597 329 CRITICAL db_3167621 odoo.service.server: Failed to initialize database `db_3167621`. 
Traceback (most recent call last):
  File "/home/odoo/src/odoo/18.0/odoo/service/server.py", line 1361, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "<decorator-gen-13>", line 2, in new
  File "/home/odoo/src/odoo/18.0/odoo/tools/func.py", line 97, in locked
    return func(inst, *args, **kwargs)
  File "/home/odoo/src/odoo/18.0/odoo/modules/registry.py", line 129, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/home/odoo/src/odoo/18.0/odoo/modules/loading.py", line 485, in load_modules
    processed_modules += load_marked_modules(env, graph,
  File "/home/odoo/src/odoo/18.0/odoo/modules/loading.py", line 365, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/home/odoo/src/odoo/18.0/odoo/modules/loading.py", line 206, in load_module_graph
    registry.init_models(env.cr, model_names, {'module': package.name}, new_install)
  File "/home/odoo/src/odoo/18.0/odoo/modules/registry.py", line 618, in init_models
    func()
  File "/home/odoo/src/odoo/18.0/odoo/addons/base/models/ir_model.py", line 2007, in _reflect_relation
    self.env.invalidate_all()
  File "/home/odoo/src/odoo/18.0/odoo/api.py", line 839, in invalidate_all
    self.flush_all()
  File "/home/odoo/src/odoo/18.0/odoo/api.py", line 857, in flush_all
    self._recompute_all()
  File "/home/odoo/src/odoo/18.0/odoo/api.py", line 850, in _recompute_all
    self[field.model_name]._recompute_field(field)
  File "/home/odoo/src/odoo/18.0/odoo/models.py", line 7359, in _recompute_field
    field.recompute(records)
  File "/home/odoo/src/odoo/18.0/odoo/fields.py", line 1463, in recompute
    apply_except_missing(self.compute_value, recs)
  File "/home/odoo/src/odoo/18.0/odoo/fields.py", line 1436, in apply_except_missing
    func(records)
  File "/home/odoo/src/odoo/18.0/odoo/fields.py", line 1485, in compute_value
    records._compute_field_value(self)
  File "/home/odoo/src/odoo/18.0/addons/mail/models/mail_thread.py", line 427, in _compute_field_value
    return super()._compute_field_value(field)
  File "/home/odoo/src/odoo/18.0/odoo/models.py", line 5296, in _compute_field_value
    fields.determine(field.compute, self)
  File "/home/odoo/src/odoo/18.0/odoo/fields.py", line 110, in determine
    return needle(*args)
  File "/home/odoo/src/odoo/18.0/addons/l10n_fr_pos_cert/models/pos.py", line 79, in _compute_previous_order
    raise UserError(_('An error occurred when computing the inalterability. Impossible to get the unique previous posted point of sale order.'))
odoo.exceptions.UserError: Une erreur s'est produite lors de la vérification de l'inaltérabilité. Impossible de récupérer la dernière commande de caisse unique et comptabilisée.
```

## Desired behavior after PR is merged:

The method `pos.order._compute_previous_order` already only checks orders with a sequence number != NULL, so to address this issue, we will use the same condition to retrieve only orders with a valid sequence. This will result in no more exceptions created by incorrect data.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
