### PR TITLE
[FIX] website: Google Cookie usage on websites url

### DIFF
--- a/addons/website/data/website_data.xml
+++ b/addons/website/data/website_data.xml
@@ -297,7 +297,7 @@
                                         <td>
                                             <p>
                                                 Understand how visitors engage with our website, via Google Analytics.
-                                                Learn more about <a href="https://developers.google.com/analytics/resources/concepts/gaConceptsCookies?hl=en">Analytics cookies and privacy information.</a>
+                                                Learn more about <a href="https://support.google.com/analytics/answer/11397207?hl=en">Analytics cookies and privacy information.</a>
                                             </p>
                                             <p>The website will still work if you reject or discard those cookies.</p>
                                         </td>


### PR DESCRIPTION
The previous URL for Google Cookie usage pointed to the legacy Universal Analytics page, which is no longer available since July 1, 2024.  

Steps to reproduce:
1. Go to Website Settings and enable the Cookies Bar.
2. Visit /cookie-policy on the website.
3. Click on the link "Analytics cookies and privacy information."
4. Observe that the page is no longer available.

This commit updates the link to point to the current Google Analytics 4 documentation, ensuring users can access the correct cookie policy information.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
