### PR TITLE
[FIX] base_vat: fix zeep import on test_vat_numbers

### DIFF
--- a/addons/base_vat/tests/test_vat_numbers.py
+++ b/addons/base_vat/tests/test_vat_numbers.py
@@ -6,8 +6,8 @@ from unittest.mock import patch
 
 import stdnum.eu.vat
 from lxml import etree
-from zeep import Client, Transport
-from zeep.wsdl import Document
+from odoo.tools.zeep import Client, Transport
+from odoo.tools.zeep.wsdl import Document
 
 
 class TestStructure(TransactionCase):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
