### PR TITLE
[FIX] website: stabilize showcase background video in Chrome

### DIFF
--- a/addons/website/static/src/interactions/video/background_video.js
+++ b/addons/website/static/src/interactions/video/background_video.js
@@ -67,7 +67,15 @@ export class BackgroundVideo extends Interaction {
         const wrapperHeight = this.el.clientHeight;
         const relativeRatio = (wrapperWidth / wrapperHeight) / (16 / 9);
 
-        if (relativeRatio >= 1.0) {
+        if (this.el.closest(".s_ecomm_categories_showcase_block")) {
+            // Chrome-only: percentage sizing makes the video in "Categories
+            // Showcase" snippet jitter on hover, so force pixel values while
+            // keeping the ratio.
+            const iframeHeight = Math.round(relativeRatio >= 1 ? wrapperWidth * (9 / 16) : wrapperHeight);
+            const iframeWidth = Math.round(relativeRatio >= 1 ? wrapperWidth : wrapperHeight * (16 / 9));
+            this.iframeEl.style.height = `${iframeHeight}px`;
+            this.iframeEl.style.width = `${iframeWidth}px`;
+        } else if (relativeRatio >= 1.0) {
             this.iframeEl.style.width = "100%";
             this.iframeEl.style.height = (relativeRatio * 100) + "%";
             this.iframeEl.style.insetInlineStart = "0";

--- a/addons/website/static/src/snippets/s_ecomm_categories_showcase/000.scss
+++ b/addons/website/static/src/snippets/s_ecomm_categories_showcase/000.scss
@@ -25,6 +25,12 @@
             margin: 0;
             z-index: 2;
         }
+
+        .o_bg_video_container iframe {
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+        }
     }
 
     .s_ecomm_categories_showcase_content {


### PR DESCRIPTION
**[FIX] website: stabilize showcase background video in Chrome**

Steps to reproduce:

- Drop the "s_ecomm_categories_showcase" snippet.
- Change its background to a video.
- Hover between the different blocks.
- Bug: the video flicker on hover.

Before this commit Chrome kept resizing the iframe, making the video
flicker on hover.

After this commit we freeze the iframe sizing in pixels so Chrome
keeps the video stable.

task-5104176