### PR TITLE
[IMP] mass_mailing(_themes): increment mass_mailing snippets vxml

### DIFF
--- a/addons/mass_mailing/static/src/builder/mass_mailing_builder.js
+++ b/addons/mass_mailing/static/src/builder/mass_mailing_builder.js
@@ -4,10 +4,26 @@ import { CORE_PLUGINS } from "@html_builder/core/core_plugins";
 import { removePlugins } from "@html_builder/utils/utils";
 import { DYNAMIC_PLACEHOLDER_PLUGINS } from "@html_editor/backend/plugin_sets";
 import { registry } from "@web/core/registry";
+import { CustomizeTab } from "@html_builder/sidebar/customize_tab";
+import { OptionsContainerWithSnippetVersionControl } from "./options/options_container";
+
+class CustomizeTabWithSnippetVersionControl extends CustomizeTab {
+    static components = {
+        ...CustomizeTab.components,
+        OptionsContainer: OptionsContainerWithSnippetVersionControl,
+    };
+}
+
+class BuilderWithSnippetVersionControl extends Builder {
+    static components = {
+        ...Builder.components,
+        CustomizeTab: CustomizeTabWithSnippetVersionControl,
+    };
+}
 
 export class MassMailingBuilder extends Component {
     static template = "mass_mailing.MassMailingBuilder";
-    static components = { Builder };
+    static components = { Builder: BuilderWithSnippetVersionControl };
     static props = {
         builderProps: { type: Object },
         toggleCodeView: { type: Function, optional: true },

--- a/addons/mass_mailing/static/src/builder/options/options_container.js
+++ b/addons/mass_mailing/static/src/builder/options/options_container.js
@@ -1,0 +1,24 @@
+import { OptionsContainer } from "@html_builder/sidebar/option_container";
+import { useState } from "@odoo/owl";
+
+export class OptionsContainerWithSnippetVersionControl extends OptionsContainer {
+    static template = "mass_mailing.OptionsContainer";
+    setup() {
+        super.setup();
+        this.versionState = useState({
+            isUpToDate: this.env.editor.shared.versionControl.hasAccessToOutdatedEl(
+                this.props.editingElement
+            ),
+        });
+    }
+    // Version control
+    replaceElementWithNewVersion() {
+        this.callOperation(() => {
+            this.env.editor.shared.versionControl.replaceWithNewVersion(this.props.editingElement);
+        });
+    }
+    accessOutdated() {
+        this.env.editor.shared.versionControl.giveAccessToOutdatedEl(this.props.editingElement);
+        this.versionState.isUpToDate = true;
+    }
+}

--- a/addons/mass_mailing/static/src/builder/options/options_container.scss
+++ b/addons/mass_mailing/static/src/builder/options/options_container.scss
@@ -1,0 +1,11 @@
+.options-container {
+        .o_we_version_control {
+        background-color: $o-we-color-info;
+
+        div.title {
+            margin-bottom: $o-we-sidebar-content-field-label-spacing;
+            text-transform: uppercase;
+            font-weight: bold;
+        }
+    }
+}

--- a/addons/mass_mailing/static/src/builder/options/options_container.xml
+++ b/addons/mass_mailing/static/src/builder/options/options_container.xml
@@ -1,0 +1,24 @@
+<templates xml:space="preserve">
+    <t t-name="mass_mailing.OptionsContainer" t-inherit="html_builder.OptionsContainer">
+        <xpath expr="//div[@t-ref='content']" position="replace">
+            <t t-if="versionState.isUpToDate">
+                <div class="we-bg-options-container pb-3" t-ref="content">
+                    <t t-foreach="props.options" t-as="OptionClass" t-key="OptionClass.name + '-' + OptionClass.template">
+                        <BuilderContext applyTo="OptionClass.applyTo" t-if="hasAccess(OptionClass.groups)">
+                            <t t-component="OptionClass"></t>
+                        </BuilderContext>
+                    </t>
+                </div>
+            </t>
+            <t t-else="">
+                <div class="o_we_version_control d-flex flex-column p-3 pt-4 align-items-center text-center text-white">
+                    <div class="title">This block is outdated.</div>
+                    <div>You might not be able to customize it anymore.</div>
+                    <button type="button" class="btn btn-primary py-2 my-4 border-0" t-on-click="() => this.replaceElementWithNewVersion()">REPLACE BY NEW VERSION</button>
+                    <div>You can still access the block options but it might be ineffective.</div>
+                    <button type="button" class="btn btn-primary py-2 my-4 border-0" t-on-click="() => this.accessOutdated()">ACCESS OPTIONS ANYWAY</button>
+                </div>
+            </t>
+        </xpath>
+    </t>
+</templates>

--- a/addons/mass_mailing/static/src/builder/plugins/alert_option_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/alert_option_plugin.js
@@ -13,7 +13,7 @@ export class AlertOption extends BaseOptionComponent {
 export class BorderOption extends BaseOptionComponent {
     static template = "mass_mailing.BorderOption";
     static selector = ".s_mail_alert .s_alert";
-    static components = {BorderConfigurator}
+    static components = { BorderConfigurator };
 }
 
 class AlertOptionPlugin extends Plugin {

--- a/addons/mass_mailing/static/src/builder/plugins/background_option_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/background_option_plugin.js
@@ -3,14 +3,19 @@ import { Plugin } from "@html_editor/plugin";
 import { registry } from "@web/core/registry";
 
 export class MailingBackgroundOption extends BackgroundOption {
-    static template = "mass_mailing.BackgroundOption";
     static selector =
         ".s_masonry_block > .container > .row > div:not(:has(.row)), .s_cover > .container > .row > div, .s_reviews_wall";
+    static props = {
+        ...BackgroundOption.props,
+        withColors: { type: Boolean, optional: true },
+        withImages: { type: Boolean, optional: true },
+        withColorCombinations: { type: Boolean, optional: true },
+    };
     static defaultProps = {
         withImages: true,
         withColors: false,
         withColorCombinations: false,
-    }
+    };
 }
 
 class BackgroundOptionPlugin extends Plugin {

--- a/addons/mass_mailing/static/src/builder/plugins/border_option_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/border_option_plugin.js
@@ -7,7 +7,8 @@ import { registry } from "@web/core/registry";
 
 export class BorderOption1 extends BaseOptionComponent {
     static template = "mass_mailing.BorderOption";
-    static selector = ".s_three_columns .row > div, .s_comparisons .row > div, .s_mail_block_event .row > div";
+    static selector =
+        ".s_three_columns .row > div, .s_comparisons .row > div, .s_mail_block_event .row > div";
     static applyTo = ".card";
     static components = { BorderConfigurator };
 }

--- a/addons/mass_mailing/static/src/builder/plugins/colorpicker_option_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/colorpicker_option_plugin.js
@@ -16,7 +16,8 @@ export class ColorPickerOption extends BaseOptionComponent {
 
 export class ColorPickerOption2 extends BaseOptionComponent {
     static template = "mass_mailing.ColorPickerOption";
-    static selector = ".s_three_columns .row > div, .s_comparisons .row > div, .s_mail_block_event .row > div";
+    static selector =
+        ".s_three_columns .row > div, .s_comparisons .row > div, .s_mail_block_event .row > div";
     static applyTo = ".card-body";
 }
 

--- a/addons/mass_mailing/static/src/builder/plugins/design_tab_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/design_tab_plugin.js
@@ -71,7 +71,7 @@ class DesignTabPlugin extends Plugin {
     getDesignOptionBlock(id, options) {
         const Option = class extends BaseOptionComponent {
             static selector = "*";
-        }
+        };
         Object.assign(Option, options);
 
         return {

--- a/addons/mass_mailing/static/src/builder/plugins/image_tool_options_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/image_tool_options_plugin.js
@@ -1,6 +1,9 @@
 import { BaseOptionComponent } from "@html_builder/core/utils";
 import { BorderConfigurator } from "@html_builder/plugins/border_configurator_option";
-import { CropImageAction, ImageAndFaOption } from "@html_builder/plugins/image/image_tool_option_plugin";
+import {
+    CropImageAction,
+    ImageAndFaOption,
+} from "@html_builder/plugins/image/image_tool_option_plugin";
 import { IMAGE_TOOL } from "@html_builder/utils/option_sequence";
 import { Plugin } from "@html_editor/plugin";
 import { closestElement } from "@html_editor/utils/dom_traversal";
@@ -15,8 +18,8 @@ export class FontAwesomeOption extends BaseOptionComponent {
 }
 
 patch(ImageAndFaOption, {
-    components: {...ImageAndFaOption.components, BorderConfigurator},
-})
+    components: { ...ImageAndFaOption.components, BorderConfigurator },
+});
 
 class ImageToolOptionPlugin extends Plugin {
     static id = "mass_mailing.ImageToolOption";

--- a/addons/mass_mailing/static/src/builder/plugins/layout_column_option_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/layout_column_option_plugin.js
@@ -9,8 +9,7 @@ import { closestElement } from "@html_editor/utils/dom_traversal";
 export class MassMailingLayoutColumnOption extends LayoutColumnOption {
     static selector = ".o_mail_snippet_general";
     static exclude = ".s_reviews_wall";
-    static applyTo =
-        ":scope > *:has(> .row:not(.s_nb_column_fixed)), * > .s_allow_columns";
+    static applyTo = ":scope > *:has(> .row:not(.s_nb_column_fixed)), * > .s_allow_columns";
 }
 
 class MassMailingLayoutColumnPlugin extends Plugin {

--- a/addons/mass_mailing/static/src/builder/plugins/pricelist_boxed_option_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/pricelist_boxed_option_plugin.js
@@ -6,17 +6,13 @@ import { registry } from "@web/core/registry";
 
 export class MassMailingAddProductOption extends BaseAddProductOption {
     static selector = ".s_pricelist_boxed_section:has(> .container)";
-    static defaultProps = {
-        productSelector: ".container",
-    };
+    productSelector = ".container";
 }
 
 export class PricelistBoxedOptionPlugin extends Plugin {
     static id = "mass_mailing.PricelistBoxedOptionPlugin";
     resources = {
-        builder_options: [
-            withSequence(BEGIN, MassMailingAddProductOption),
-        ],
+        builder_options: [withSequence(BEGIN, MassMailingAddProductOption)],
     };
 }
 

--- a/addons/mass_mailing/static/src/builder/plugins/reviews_wall_option_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/reviews_wall_option_plugin.js
@@ -16,10 +16,7 @@ export class MassMailingLayoutColumnOption extends LayoutColumnOption {
 class ReviewsWallOptionPlugin extends Plugin {
     static id = "mass_mailing.ReviewsWallOptionPlugin";
     resources = {
-        builder_options: [
-            CustomerTestimonialsBlockquote,
-            MassMailingLayoutColumnOption,
-        ],
+        builder_options: [CustomerTestimonialsBlockquote, MassMailingLayoutColumnOption],
     };
 }
 

--- a/addons/mass_mailing/static/src/builder/plugins/version_control_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/version_control_plugin.js
@@ -1,0 +1,41 @@
+import { Plugin } from "@html_editor/plugin";
+import { registry } from "@web/core/registry";
+
+export class VersionControlPlugin extends Plugin {
+    static id = "versionControl";
+    static dependencies = ["builderOptions"];
+    accessPerOutdatedEl = new WeakMap();
+    static shared = ["hasAccessToOutdatedEl", "giveAccessToOutdatedEl", "replaceWithNewVersion"];
+
+    hasAccessToOutdatedEl(el) {
+        if (!el.dataset.snippet) {
+            return true;
+        }
+        if (this.accessPerOutdatedEl.has(el)) {
+            return this.accessPerOutdatedEl.get(el);
+        }
+        const snippetKey = el.dataset.snippet;
+        const snippet = this.config.snippetModel.getOriginalSnippet(snippetKey);
+        let isUpToDate = true;
+        if (snippet) {
+            const { vxml: originalVxml } = snippet.content.dataset;
+            const { vxml: elVxml } = el.dataset;
+            isUpToDate = originalVxml === elVxml;
+        }
+        this.accessPerOutdatedEl.set(el, isUpToDate);
+        return isUpToDate;
+    }
+    giveAccessToOutdatedEl(el) {
+        this.accessPerOutdatedEl.set(el, true);
+    }
+    replaceWithNewVersion(el) {
+        const snippetKey = el.dataset.snippet;
+        const snippet = this.config.snippetModel.getOriginalSnippet(snippetKey);
+        const cloneEl = snippet.content.cloneNode(true);
+        el.after(cloneEl);
+        el.remove();
+        this.dependencies.builderOptions.setNextTarget(cloneEl);
+    }
+}
+
+registry.category("mass_mailing-plugins").add(VersionControlPlugin.id, VersionControlPlugin);

--- a/addons/mass_mailing/static/src/fields/html_field/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/fields/html_field/mass_mailing_html_field.js
@@ -139,15 +139,15 @@ export class MassMailingHtmlField extends HtmlField {
         const state = toRaw(this.state);
         const getThemeName = () => {
             const value = record.data[this.props.name];
-            if (!value) {
+            if (!value || !value.toString()) {
                 return;
             }
             const fragment = parseHTML(document, value);
             const layout = fragment.querySelector(".o_layout");
             if (!layout) {
-                return;
+                return "unknown";
             }
-            return this.themeService.getThemeName(layout.classList);
+            return this.themeService.getThemeName(layout.classList) || "unknown";
         };
         const activeTheme = getThemeName();
         if (state.activeTheme !== activeTheme) {
@@ -162,8 +162,8 @@ export class MassMailingHtmlField extends HtmlField {
         // dependencies to that effect, so it is used raw.
         const state = toRaw(this.state);
         if (!state.activeTheme && !state.showThemeSelector && !props.readonly) {
-            // Show the ThemeSelector when the theme is unknown and the content can be
-            // changed (invalid value).
+            // Show the ThemeSelector when the theme is undefined and the content can be
+            // changed.
             state.showThemeSelector = true;
         } else if ((state.activeTheme && state.showThemeSelector) || props.readonly) {
             state.showThemeSelector = false;

--- a/addons/mass_mailing/static/src/fields/html_field/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/fields/html_field/mass_mailing_html_field.js
@@ -305,7 +305,7 @@ export class MassMailingHtmlField extends HtmlField {
                 return;
             }
         }
-        if (this.editor?.isDestroyed) {
+        if (!this.state.showCodeView && this.editor?.isDestroyed) {
             return;
         }
         return super._commitChanges({ urgent });

--- a/addons/mass_mailing/static/src/themes/theme_selector/theme_selector.xml
+++ b/addons/mass_mailing/static/src/themes/theme_selector/theme_selector.xml
@@ -16,12 +16,12 @@
                 </div>
             </div>
             <div class="d-inline-block w-100">
-                <a t-foreach="themes.values()" t-as="theme" t-key="theme_index" role="menuitem" href="#" class="dropdown-item px-4"
+                <div t-foreach="themes.values()" t-as="theme" t-key="theme_index" role="menuitem" class="cursor-pointer dropdown-item px-4"
                     t-on-click="() => this.onSelectTheme(theme)" t-att-data-name="theme.name">
                     <div class="o_thumb small mb-2" t-attf-style="background-image: url(#{theme.imgPath}_small.png)"/>
                     <div class="o_thumb large mb-2" t-attf-style="background-image: url(#{theme.imgPath}_large.png)"/>
                     <h5 class="text-capitalize text-truncate" t-out="theme.title"/>
-                </a>
+                </div>
             </div>
         </div>
     </div>

--- a/addons/mass_mailing/static/tests/mass_mailing_html_field.test.js
+++ b/addons/mass_mailing/static/tests/mass_mailing_html_field.test.js
@@ -225,7 +225,11 @@ describe("field HTML", () => {
             arch: mailViewArch,
         });
         expect(queryOne(".o_mass_mailing_iframe_wrapper iframe")).toHaveClass("d-none");
-        await click(waitFor(".o_mailing_template_preview_wrapper a:contains(Start From Scratch)"));
+        await click(
+            waitFor(
+                ".o_mailing_template_preview_wrapper div[role='menuitem']:contains(Start From Scratch)"
+            )
+        );
         await waitFor(".o_mass_mailing_iframe_wrapper iframe:not(.d-none)");
         expect(await waitFor(":iframe .o_layout", { timeout: 3000 })).toHaveClass("o_empty_theme");
         await clickSave();
@@ -301,7 +305,7 @@ describe("field HTML", () => {
             resId: 1,
             arch: mailViewArch,
         });
-        await click(waitFor(".o_mailing_template_preview_wrapper a[data-name='default']"));
+        await click(waitFor(".o_mailing_template_preview_wrapper [data-name='default']"));
         await waitFor(".o_mass_mailing_iframe_wrapper iframe:not(.d-none)");
         expect(await waitFor(":iframe .o_layout", { timeout: 3000 })).toHaveClass(
             "o_default_theme"
@@ -378,7 +382,7 @@ describe("field HTML: with loaded assets", () => {
             resId: 1,
             arch: mailViewArch,
         });
-        await click(waitFor(".o_mailing_template_preview_wrapper a[data-name='default']"));
+        await click(waitFor(".o_mailing_template_preview_wrapper [data-name='default']"));
         await waitFor(".o_mass_mailing_iframe_wrapper iframe:not(.d-none)");
         const { bundleControls } = await htmlField.ensureIframeLoaded();
 

--- a/addons/mass_mailing/views/snippets/mass_mailing_columns_snippets.xml
+++ b/addons/mass_mailing/views/snippets/mass_mailing_columns_snippets.xml
@@ -1,6 +1,6 @@
 <odoo>
 <template id="s_three_columns" name="Columns">
-    <section class="s_three_columns o_mail_snippet_general o_cc o_cc2 pt32 pb32">
+    <section class="s_three_columns o_mail_snippet_general o_cc o_cc2 pt32 pb32" data-vxml="001">
         <div class="container">
             <div class="row d-flex align-items-stretch">
                 <div class="col-md-4 o_mail_no_colorpicker pt16 pb16 col-12">
@@ -42,7 +42,7 @@
 </template>
 
 <template name="Big Boxes" id="s_color_blocks_2">
-    <section class="s_mail_color_blocks_2 o_mail_snippet_general">
+    <section class="s_mail_color_blocks_2 o_mail_snippet_general" data-vxml="001">
         <div class="container mx-auto my-auto">
             <div class="row">
                 <div class="col-md-6 o_cc o_cc4 pb24 pt24 col-12">
@@ -61,7 +61,7 @@
 </template>
 
 <template name="Media List" id="s_media_list">
-    <section class="s_media_list pt32 pb32 o_colored_level o_cc o_cc2 o_mail_snippet_general" data-vcss="001">
+    <section class="s_media_list pt32 pb32 o_colored_level o_cc o_cc2 o_mail_snippet_general" data-vcss="001" data-vxml="001">
         <div class="container">
             <div class="row s_nb_column_fixed">
                 <div class="col-md-12 s_media_list_item pt16 pb16 col-12" data-name="Media item">
@@ -72,7 +72,7 @@
                         <div class="col-md-8 s_media_list_body ps-md-4 col-12">
                             <h2>Media heading</h2>
                             <p>Use this snippet to build various types of components that feature a left- or right-aligned image alongside textual content. Duplicate the element to create a list that fits your needs.</p>
-                            <a href="#">Discover more <span class="fa fa-long-arrow-right align-middle ms-1"/></a>
+                            <p><a href="#">Discover more <span class="fa fa-long-arrow-right align-middle ms-1"/></a></p>
                         </div>
                     </div>
                 </div>
@@ -95,7 +95,7 @@
                         <div class="col-md-8 s_media_list_body ps-md-4 col-12">
                             <h2>Post heading</h2>
                             <p>Use this component for creating a list of featured elements to which you want to bring attention.</p>
-                            <a href="#">Continue reading <span class="fa fa-long-arrow-right align-middle ms-1"/></a>
+                            <p><a href="#">Continue reading <span class="fa fa-long-arrow-right align-middle ms-1"/></a></p>
                         </div>
                     </div>
                 </div>
@@ -105,7 +105,7 @@
 </template>
 
 <template id="s_attributes_horizontal" name="Horizontal Attributes">
-    <section class="s_attributes_horizontal pt24 pb24 o_mail_snippet_general">
+    <section class="s_attributes_horizontal pt24 pb24 o_mail_snippet_general" data-vxml="001">
         <div class="container">
             <div class="row">
                 <div class="s_attributes_horizontal_col col-md-4 pt24 pb24 col-12" data-name="Column">
@@ -177,7 +177,7 @@
 </template>
 
 <template id="s_numbers" name="Numbers">
-    <section class="s_numbers o_mail_snippet_general o_cc o_cc1">
+    <section class="s_numbers o_mail_snippet_general o_cc o_cc1" data-vxml="001">
         <div class="container">
             <div class="row">
                 <div class="col-md-4 pt24 pb24 o_cc o_cc2 col-12" style="text-align: center;">
@@ -198,7 +198,7 @@
 </template>
 
 <template id="s_event" name="Event">
-    <section class="s_mail_block_event o_mail_snippet_general bg-100">
+    <section class="s_mail_block_event o_mail_snippet_general bg-100" data-vxml="001">
         <div class="container">
             <div class="row align-items-center">
                 <div class="o_mail_no_colorpicker col-md-6 pt32 pb32 col-12">
@@ -242,7 +242,7 @@
 </template>
 
 <template id="s_product_list" name="Items">
-    <section class="s_mail_product_list o_mail_snippet_general">
+    <section class="s_mail_product_list o_mail_snippet_general" data-vxml="001">
         <div class="container pt16">
             <h2><span class="h3-fs">Our finest selection</span></h2>
             <div class="row">
@@ -276,7 +276,7 @@
 </template>
 
 <template id="s_features_grid" name="Features Grid">
-    <section class="s_mail_features_grid o_mail_snippet_general pt48 pb24">
+    <section class="s_mail_features_grid o_mail_snippet_general pt48 pb24" data-vxml="001">
         <div class="container">
             <div class="row">
                 <div class="col-md-6 o_cc col-12">

--- a/addons/mass_mailing/views/snippets/mass_mailing_footer_snippets.xml
+++ b/addons/mass_mailing/views/snippets/mass_mailing_footer_snippets.xml
@@ -1,6 +1,6 @@
 <odoo>
 <template id="s_mail_block_footer_social">
-    <section class="s_footer_social o_mail_block_footer_social o_mail_footer_social_center o_mail_snippet_general bg-900 pt16" data-name="Footer Center">
+    <section class="s_footer_social o_mail_block_footer_social o_mail_footer_social_center o_mail_snippet_general bg-900 pt16" data-name="Footer Center" data-vxml="001">
         <div class="container">
             <div class="row">
                 <div class="col-md o_mail_footer_social col" style="text-align: center;">
@@ -28,7 +28,7 @@
 </template>
 
 <template id="s_mail_block_footer_social_left" name="Footer Left">
-    <section class="s_footer_social o_mail_block_footer_social o_mail_footer_social_left o_mail_snippet_general pt16" data-name="Footer Left">
+    <section class="s_footer_social o_mail_block_footer_social o_mail_footer_social_left o_mail_snippet_general pt16" data-name="Footer Left" data-vxml="001">
         <div class="container">
             <div class="row">
                 <div class="col-md-6 o_mail_footer_description col-12">

--- a/addons/mass_mailing/views/snippets/mass_mailing_headers_snippets.xml
+++ b/addons/mass_mailing/views/snippets/mass_mailing_headers_snippets.xml
@@ -1,6 +1,6 @@
 <odoo>
 <template id="s_mail_block_header_social" name="Left Logo">
-    <section class="s_header_social o_mail_block_header_social o_mail_snippet_general pt16 pb16" data-name="Left Logo">
+    <section class="s_header_social o_mail_block_header_social o_mail_snippet_general pt16 pb16" data-name="Left Logo" data-vxml="001">
         <div class="container">
             <div class="row">
                 <div class="col-md-4 pt16 pb16">
@@ -20,7 +20,7 @@
 </template>
 
 <template id="s_mail_block_header_logo" name="Centered Logo">
-    <section class="s_header_logo o_mail_block_header_logo o_mail_snippet_general" data-name="Centered Logo">
+    <section class="s_header_logo o_mail_block_header_logo o_mail_snippet_general" data-name="Centered Logo" data-vxml="001">
         <div class="container">
             <div class="row">
                 <div class="col-md-3"/>

--- a/addons/mass_mailing/views/snippets/mass_mailing_headings_snippets.xml
+++ b/addons/mass_mailing/views/snippets/mass_mailing_headings_snippets.xml
@@ -1,6 +1,6 @@
 <odoo>
 <template id="s_title" name="Title">
-    <section class="s_title o_mail_snippet_general pt16 pb16">
+    <section class="s_title o_mail_snippet_general pt16 pb16" data-vxml="001">
         <div class="container s_allow_columns">
             <h1 style="text-align:center">Your Title</h1>
         </div>

--- a/addons/mass_mailing/views/snippets/mass_mailing_images_snippets.xml
+++ b/addons/mass_mailing/views/snippets/mass_mailing_images_snippets.xml
@@ -1,6 +1,6 @@
 <odoo>
 <template id="s_cover" name="Cover">
-    <section class="s_cover o_mail_snippet_general">
+    <section class="s_cover o_mail_snippet_general" data-vxml="001">
         <div class="container">
             <div class="row">
                 <div class="col-md-12 oe_img_bg pt56 pb48 col-12" style="background-image: url('/web/image/mass_mailing.s_cover_default_image'); background-position: 50% 84.7081%;">
@@ -14,7 +14,7 @@
 </template>
 
 <template id="s_image_text" name="Image - Text">
-    <section class="s_text_image o_mail_snippet_general pt32 pb32">
+    <section class="s_text_image o_mail_snippet_general pt32 pb32" data-vxml="001">
         <div class="container">
             <div class="row align-items-center">
                 <div class="col-md-6 pt16 pb16 col-12">
@@ -34,7 +34,7 @@
 </template>
 
 <template id="s_text_image" name="Text - Image">
-    <section class="s_text_image o_mail_snippet_general pt80 pb80">
+    <section class="s_text_image o_mail_snippet_general pt80 pb80" data-vxml="001">
         <div class="container">
             <div class="row align-items-center">
                 <div class="col-md-5 col-12 pt16 pb16">
@@ -54,7 +54,7 @@
 </template>
 
 <template id="s_picture" name="Picture">
-    <section class="s_picture o_mail_snippet_general pt48 pb24 o_cc o_cc2" style="padding-left: 15px; padding-right: 15px;">
+    <section class="s_picture o_mail_snippet_general pt48 pb24 o_cc o_cc2" style="padding-left: 15px; padding-right: 15px;" data-vxml="001">
         <div class="container s_allow_columns">
             <h2 style="text-align: center;">Step Up Your Game</h2>
             <p style="text-align: center;">Experience unparalleled comfort, cutting-edge design, and performance-enhancing<br/>technology with this latest innovation, crafted to elevate every athlete's journey.</p>

--- a/addons/mass_mailing/views/snippets/mass_mailing_inner_snippets.xml
+++ b/addons/mass_mailing/views/snippets/mass_mailing_inner_snippets.xml
@@ -1,6 +1,6 @@
 <odoo>
 <template id="s_text_highlight" name="Text Highlight">
-    <div class="s_text_highlight s_mail_text_highlight o_mail_snippet_general o_cc o_cc3 pt32 pb32 text-center mx-auto w-100" style="border-radius: 6px;">
+    <div class="s_text_highlight s_mail_text_highlight o_mail_snippet_general o_cc o_cc3 pt32 pb32 text-center mx-auto w-100" style="border-radius: 6px;" data-vxml="001">
         <h3><font class="text-white">Text Highlight</font></h3>
         <p><font class="text-white">Put the focus on what you have to say!</font></p>
     </div>
@@ -8,7 +8,7 @@
 
 
 <template id="s_rating" name="Rating">
-    <div class="s_rating o_mail_snippet_general pt16 pb16" style="padding: 0 15px;" data-vcss="001" data-icon="fa-star">
+    <div class="s_rating o_mail_snippet_general pt16 pb16" style="padding: 0 15px;" data-vcss="001" data-vxml="001" data-icon="fa-star">
         <h3 class="s_rating_title">Quality</h3>
         <div class="s_rating_icons o_not_editable">
             <span class="s_rating_active_icons">
@@ -25,7 +25,7 @@
 </template>
 
 <template id="s_hr" name="Separator">
-    <div class="s_hr o_mail_snippet_general pt16 pb16 o_not_editable">
+    <div class="s_hr o_mail_snippet_general pt16 pb16 o_not_editable" data-vxml="001">
         <hr class="w-100 mx-auto"/>
     </div>
 </template>
@@ -35,7 +35,7 @@
 </template>
 
 <template id="s_alert" name="Alert">
-    <div class="s_mail_alert o_mail_snippet_general pt16 pb16 mx-auto" data-name="Alert">
+    <div class="s_mail_alert o_mail_snippet_general pt16 pb16 mx-auto" data-name="Alert" data-vxml="001">
         <div class="container">
             <div class="row">
                 <div class="col-md-12 col-12">

--- a/addons/mass_mailing/views/snippets/mass_mailing_marketing_snippets.xml
+++ b/addons/mass_mailing/views/snippets/mass_mailing_marketing_snippets.xml
@@ -1,6 +1,6 @@
 <odoo>
 <template id="s_comparisons" name="Comparisons">
-    <section class="s_comparisons pt48 pb48 o_mail_snippet_general" data-vcss="001">
+    <section class="s_comparisons pt48 pb48 o_mail_snippet_general" data-vcss="001" data-vxml="001">
         <div class="container">
             <div class="row gap-4 gap-md-0">
                 <div class="col-12 col-md-6" data-name="Plan">
@@ -61,7 +61,7 @@
 </template>
 
 <template name="Showcase" id="s_showcase">
-    <section class="s_showcase o_mail_snippet_general pt48 pb48">
+    <section class="s_showcase o_mail_snippet_general pt48 pb48" data-vxml="001">
         <div class="container">
             <div class="row s_nb_column_fixed">
                 <div class="col-12 pb32 oe_unmovable">
@@ -119,7 +119,7 @@
 </template>
 
 <template id="s_call_to_action" name="Call to Action">
-    <section class="s_call_to_action o_mail_snippet_general o_cc o_cc3 pt48 pb24">
+    <section class="s_call_to_action o_mail_snippet_general o_cc o_cc3 pt48 pb24" data-vxml="001">
         <div class="container">
             <div class="row">
                 <div class="col-md-9 col-9">
@@ -137,7 +137,7 @@
 </template>
 
 <template id="s_coupon_code" name="Promo Code">
-    <section class="s_discount2 o_mail_block_discount2 o_mail_snippet_general pt32 pb32" style="padding-left: 15px; padding-right: 15px;">
+    <section class="s_discount2 o_mail_block_discount2 o_mail_snippet_general pt32 pb32" style="padding-left: 15px; padding-right: 15px;" data-vxml="001">
         <h2 style="text-align: center;"><span><font style="font-weight: bolder;">GET $20 OFF</font></span></h2>
         <p style="text-align: center;">
             Here's your coupon code - but hurry! Ends 9/28

--- a/addons/mass_mailing/views/snippets/mass_mailing_masonry_snippets.xml
+++ b/addons/mass_mailing/views/snippets/mass_mailing_masonry_snippets.xml
@@ -3,7 +3,7 @@
 
 <!-- Template -->
 <template id="s_masonry_block" name="Masonry">
-    <section class="s_masonry_block o_mail_snippet_general" data-vcss="001" data-template-name="default_template">
+    <section class="s_masonry_block o_mail_snippet_general" data-vcss="001" data-vxml="001" data-template-name="default_template">
         <div class="container text-white">
             <t t-call="mass_mailing.s_masonry_block_default_template"/>
         </div>

--- a/addons/mass_mailing/views/snippets/mass_mailing_people_snippets.xml
+++ b/addons/mass_mailing/views/snippets/mass_mailing_people_snippets.xml
@@ -1,6 +1,6 @@
 <odoo>
 <template id="s_company_team" name="Team">
-    <section class="s_company_team o_mail_snippet_general">
+    <section class="s_company_team o_mail_snippet_general" data-vxml="001">
         <div class="container">
             <div class="ms-3">
                 <h3>Meet our team</h3>
@@ -233,7 +233,7 @@
 </template>
 
 <template id="s_references" name="References">
-    <section class="s_references o_mail_snippet_general pt32 pb32">
+    <section class="s_references o_mail_snippet_general pt32 pb32" data-vxml="001">
         <div class="container">
             <h2 style="text-align: center;">Our References</h2>
             <p style="text-align: center;">We are in good company.</p>

--- a/addons/mass_mailing/views/snippets/mass_mailing_text_snippets.xml
+++ b/addons/mass_mailing/views/snippets/mass_mailing_text_snippets.xml
@@ -1,6 +1,6 @@
 <odoo>
 <template id="s_text_block" name="Text">
-    <section class="s_text_block o_mail_snippet_general pt24 pb24" style="padding-left: 15px; padding-right: 15px;">
+    <section class="s_text_block o_mail_snippet_general pt24 pb24" style="padding-left: 15px; padding-right: 15px;" data-vxml="001">
         <div class="container s_allow_columns">
             <p>Great stories have a <strong>personality</strong>. Consider telling a great story that provides personality. Writing a story with personality for potential clients will assist with making a relationship connection. This shows up in small quirks like word choices or phrases. Write from your point of view, not from someone else's experience.</p>
             <p>Great stories are <strong>for everyone</strong> even when only written <strong>for just one person</strong>. If you try to write with a wide, general audience in mind, your story will sound fake and lack emotion. No one will be interested. Write for one person. If it's genuine for the one, it's genuine for the rest.</p>

--- a/addons/mass_mailing/views/themes_templates.xml
+++ b/addons/mass_mailing/views/themes_templates.xml
@@ -25,7 +25,7 @@
                 --separator-border-color: #ced4da !important;
             }
         </style>
-        <section class="s_header_logo o_mail_block_header_logo o_mail_snippet_general pt16 pb16" data-snippet="s_header_logo" data-name="Centered Logo">
+        <section class="s_header_logo o_mail_block_header_logo o_mail_snippet_general pt16 pb16" data-snippet="s_header_logo" data-name="Centered Logo" data-vxml="001">
             <div class="container">
                 <div class="row">
                     <div class="col-md-4"/>
@@ -38,7 +38,7 @@
                 </div>
             </div>
         </section>
-        <section class="s_text_block o_mail_snippet_general pt40 pb16" style="padding-left: 15px; padding-right: 15px;" data-snippet="s_text_block" data-name="Text">
+        <section class="s_text_block o_mail_snippet_general pt40 pb16" style="padding-left: 15px; padding-right: 15px;" data-snippet="s_text_block" data-name="Text" data-vxml="001">
             <div class="container s_allow_columns">
                 <h2>Thank you for joining us!</h2>
                 <p><br/>We want to take this opportunity to welcome you to our ever-growing community!
@@ -52,7 +52,7 @@
                 </p>
             </div>
         </section>
-        <div class="s_hr pt16 pb16" data-snippet="s_hr" data-name="Separator">
+        <div class="s_hr pt16 pb16" data-snippet="s_hr" data-name="Separator" data-vxml="001">
             <hr class="s_hr_1px s_hr_solid"/>
         </div>
         <t t-call="mass_mailing.s_mail_block_footer_social_left"/>

--- a/addons/mass_mailing_themes/views/mass_mailing_themes_templates.xml
+++ b/addons/mass_mailing_themes/views/mass_mailing_themes_templates.xml
@@ -50,7 +50,7 @@
         </style>
         <t t-set="now" t-value="datetime.datetime.now()"/>
         <t t-set="website_url_or_none" t-value="(company_id.website) or '#'"/>
-        <section class="s_header_social o_mail_block_header_social o_mail_snippet_general pt16 pb16" data-snippet="s_mail_block_header_social" style="background-color: rgb(26, 36, 54) !important;" data-name="Header Social">
+        <section class="s_header_social o_mail_block_header_social o_mail_snippet_general pt16 pb16" data-vxml="001" data-snippet="s_mail_block_header_social" style="background-color: rgb(26, 36, 54) !important;" data-name="Header Social">
             <div class="container">
                 <div class="row">
                     <div class="col-md-4">
@@ -78,7 +78,7 @@
                 </div>
             </div>
         </section>
-        <section class="s_text_block o_mail_snippet_general pb16 pt32" style="background-color: rgb(43, 59, 88) !important; padding-left: 15px; padding-right: 15px;" data-snippet="s_text_block" data-name="Text">
+        <section class="s_text_block o_mail_snippet_general pb16 pt32" data-vxml="001" style="background-color: rgb(43, 59, 88) !important; padding-left: 15px; padding-right: 15px;" data-snippet="s_text_block" data-name="Text">
             <div class="container s_allow_columns">
                 <p><font style="color: rgb(255, 255, 255);">Hi there!</font></p>
                 <p><font style="color: rgb(255, 255, 255);">The next edition of <span style="font-weight: bolder;">Odoo Experience Online</span> is coming soon!
@@ -86,7 +86,7 @@
                 </p>
             </div>
         </section>
-        <section class="s_media_list o_mail_snippet_general o_cc o_cc2 pb16 pt0" style="background-color: rgb(43, 59, 88) !important; padding-left: 15px; padding-right: 15px;" data-snippet="s_media_list" data-vcss="001" data-name="Media List">
+        <section class="s_media_list o_mail_snippet_general o_cc o_cc2 pb16 pt0" style="background-color: rgb(43, 59, 88) !important; padding-left: 15px; padding-right: 15px;" data-snippet="s_media_list" data-vcss="001" data-vxml="001" data-name="Media List">
             <div class="container">
                 <div class="row s_nb_column_fixed">
                     <div class="col-md-12 s_media_list_item pt0 pb0" data-name="Media item">
@@ -97,7 +97,7 @@
                             <div class="col-md-7 s_media_list_body">
                                 <h3>Get 6-months' worth of knowledge<br/>in just 2 days</h3>
                                 <p>Learn through workshops, product demos, and inspiring talks from Odoo Experts and Partners.</p>
-                                <a class="btn btn-primary" t-att-href="website_url_or_none">See what we've got planned</a>
+                                <p><a class="btn btn-primary" t-att-href="website_url_or_none">See what we've got planned</a></p>
                             </div>
                         </div>
                     </div>
@@ -109,7 +109,7 @@
                             <div class="col-md-7 s_media_list_body">
                                 <h3>Meet (other) awesome members<br/>of the community</h3>
                                 <p>Create your very own chat room or join an existing one that sparks your interest.</p>
-                                <a class="btn btn-primary" t-att-href="website_url_or_none">Go to the chatrooms</a>
+                                <p><a class="btn btn-primary" t-att-href="website_url_or_none">Go to the chatrooms</a></p>
                             </div>
                         </div>
                     </div>
@@ -121,14 +121,14 @@
                             <div class="col-md-7 s_media_list_body">
                                 <h3>An interactive, fun<br/>and comprehensive experience</h3>
                                 <p>Experience everything from a virtual exhibitor's hall to multiple interactive presentations and demos.</p>
-                                <a class="btn btn-primary" t-att-href="website_url_or_none">Find out more</a>
+                                <p><a class="btn btn-primary" t-att-href="website_url_or_none">Find out more</a></p>
                             </div>
                         </div>
                     </div>
                 </div>
             </div>
         </section>
-        <section class="s_call_to_action o_mail_snippet_general o_cc o_cc3 pt40 pb40" style="background-color: rgb(26, 36, 54) !important;" data-snippet="s_call_to_action" data-name="Call to Action">
+        <section class="s_call_to_action o_mail_snippet_general o_cc o_cc3 pt40 pb40" data-vxml="001" style="background-color: rgb(26, 36, 54) !important;" data-snippet="s_call_to_action" data-name="Call to Action">
             <div class="container">
                 <div class="row">
                     <div class="col-md-12" style="border-color: rgb(56, 62, 69) !important;">
@@ -136,12 +136,12 @@
                         <p style="text-align: center;"><font style="color: rgb(255, 255, 255);">Zero, zilch, nada! Odoo Experience is free for everyone!</font></p>
                     </div>
                     <div class="col-md-12" style="text-align: center;">
-                        <a class="btn btn-primary btn-lg" t-att-href="website_url_or_none">Register now!</a>
+                        <p><a class="btn btn-primary btn-lg" t-att-href="website_url_or_none">Register now!</a></p>
                     </div>
                 </div>
             </div>
         </section>
-        <section class="s_footer_social o_mail_block_footer_social o_mail_footer_social_center o_mail_snippet_general bg-200 pt16 pb16" data-snippet="s_mail_block_footer_social" data-name="Footer Center">
+        <section class="s_footer_social o_mail_block_footer_social o_mail_footer_social_center o_mail_snippet_general bg-200 pt16 pb16" data-vxml="001" data-snippet="s_mail_block_footer_social" data-name="Footer Center">
             <div class="container">
                 <div class="row">
                     <div class="col-md-12 o_mail_footer_links pt8 pb8" style="text-align: center;">
@@ -187,7 +187,7 @@
         </style>
         <t t-set="now" t-value="datetime.datetime.now()"/>
         <t t-set="website_url_or_none" t-value="(company_id.website) or '#'"/>
-        <section class="s_header_social o_mail_block_header_social o_mail_snippet_general pt40 pb32" data-snippet="s_mail_block_header_social" data-name="Header Social">
+        <section class="s_header_social o_mail_block_header_social o_mail_snippet_general pt40 pb32" data-vxml="001" data-snippet="s_mail_block_header_social" data-name="Header Social">
             <div class="container">
                 <div class="row">
                     <div class="col-md-4">
@@ -223,7 +223,7 @@
         <div class="s_hr o_mail_snippet_general pt0 pb0" data-snippet="s_hr" data-name="Separator">
             <hr class="s_hr_1px s_hr_solid"/>
         </div>
-        <section class="s_text_image o_mail_snippet_general" data-snippet="s_text_image" data-name="Text - Image">
+        <section class="s_text_image o_mail_snippet_general" data-vxml="001" data-snippet="s_text_image" data-name="Text - Image">
             <div class="container">
                 <div class="row align-items-center">
                     <div class="col-md-7 pt16 pb16">
@@ -238,10 +238,10 @@
                 </div>
             </div>
         </section>
-        <div class="s_hr o_mail_snippet_general pt0 pb16" data-snippet="s_hr" data-name="Separator">
+        <div class="s_hr o_mail_snippet_general pt0 pb16" data-vxml="001" data-snippet="s_hr" data-name="Separator">
             <hr class="s_hr_1px s_hr_solid"/>
         </div>
-        <section class="s_media_list o_mail_snippet_general o_cc o_cc2 pb0 pt0 bg-white" style="padding-left: 15px; padding-right: 15px;" data-snippet="s_media_list" data-vcss="001" data-name="Media List">
+        <section class="s_media_list o_mail_snippet_general o_cc o_cc2 pb0 pt0 bg-white" style="padding-left: 15px; padding-right: 15px;" data-snippet="s_media_list" data-vxml="001" data-vcss="001" data-name="Media List">
             <div class="container">
                 <div class="row s_nb_column_fixed o_mail_no_colorpicker">
                     <div class="col-md-12 s_media_list_item pb0 pt0" data-name="Media item">
@@ -252,9 +252,9 @@
                             <div class="col-md-8 s_media_list_body">
                                 <h3>The future of smartphone video production</h3>
                                 <p>Modern smartphones have all the built-in tech equal to a majority of the current professional cameras.</p>
-                                <a class="btn btn-primary" t-att-href="website_url_or_none"><span class="fa fa-play" />&amp;nbsp;&amp;nbsp;WATCH VIDEO</a>
+                                <p><a class="btn btn-primary" t-att-href="website_url_or_none"><span class="fa fa-play" />&amp;nbsp;&amp;nbsp;WATCH VIDEO</a>
                                 &amp;nbsp;&amp;nbsp;&amp;nbsp;&amp;nbsp;
-                                <a class="btn btn-link" href="#">READ MORE</a>
+                                <a class="btn btn-link" href="#">READ MORE</a></p>
                             </div>
                         </div>
                     </div>
@@ -275,7 +275,7 @@
                             <div class="col-md-8 s_media_list_body pt16 pb16">
                                 <h3>5 Ways Drones Can Better Your Live Events</h3>
                                 <p>One clever use of drones is for delivering gifts — but another that's becoming popular for event safety purposes.</p>
-                                <a class="btn btn-primary" t-att-href="website_url_or_none">READ MORE</a>
+                                <p><a class="btn btn-primary" t-att-href="website_url_or_none">READ MORE</a></p>
                             </div>
                         </div>
                     </div>
@@ -296,17 +296,17 @@
                             <div class="col-md-8 s_media_list_body">
                                 <h3>How to Code a Website Without Experience</h3>
                                 <p>Anyone with an ounce of business acumen knows that any business that wants to succeed needs a website.</p>
-                                <a class="btn btn-primary" t-att-href="website_url_or_none">READ MORE</a>
+                                <p><a class="btn btn-primary" t-att-href="website_url_or_none">READ MORE</a></p>
                             </div>
                         </div>
                     </div>
                 </div>
             </div>
         </section>
-        <div class="s_hr o_mail_snippet_general pt16 pb0" data-snippet="s_hr" data-name="Separator">
+        <div class="s_hr o_mail_snippet_general pt16 pb0" data-vxml="001" data-snippet="s_hr" data-name="Separator">
             <hr class="s_hr_1px s_hr_solid"/>
         </div>
-        <section class="s_footer_social o_mail_block_footer_social o_mail_footer_social_center o_mail_snippet_general pt16 pb16" data-snippet="s_mail_block_footer_social" data-name="Footer Social Center">
+        <section class="s_footer_social o_mail_block_footer_social o_mail_footer_social_center o_mail_snippet_general pt16 pb16" data-snippet="s_mail_block_footer_social" data-vxml="001" data-name="Footer Social Center">
             <div class="container">
                 <div class="row">
                     <div class="col-md-12 o_mail_footer_links pt8 pb8" style="text-align: center;">
@@ -355,7 +355,7 @@
         <t t-set="now" t-value="datetime.datetime.now()"/>
         <t t-set="future_date" t-value="(datetime.date.today() + datetime.timedelta(days=30))"/>
         <t t-set="website_url_or_none" t-value="(company_id.website) or '#'"/>
-        <section class="s_header_logo o_mail_block_header_logo o_mail_snippet_general" data-snippet="s_mail_block_header_logo" data-name="Centered Logo" style="background-color: rgb(36, 37, 48) !important;">
+        <section class="s_header_logo o_mail_block_header_logo o_mail_snippet_general" data-snippet="s_mail_block_header_logo" data-name="Centered Logo" data-vxml="001" style="background-color: rgb(36, 37, 48) !important;">
             <div class="container">
                 <div class="row">
                     <div class="col-md-4" style="text-align: center;">
@@ -374,25 +374,25 @@
                 </div>
             </div>
         </section>
-        <section class="s_cover o_mail_snippet_general" data-snippet="s_cover" data-name="Cover" style="background-color: rgb(36, 37, 48) !important;">
+        <section class="s_cover o_mail_snippet_general" data-vxml="001" data-snippet="s_cover" data-name="Cover" style="background-color: rgb(36, 37, 48) !important;">
             <img src="/mass_mailing_themes/static/src/img/theme_coupon/vip_banner_part1.png" alt="Cover" class="img-fluid w-100 mx-auto"/>
         </section>
-        <div class="s_hr o_mail_snippet_general pt0 pb16" data-snippet="s_hr" data-name="Separator" style="background-color: rgb(36, 37, 48) !important;">
+        <div class="s_hr o_mail_snippet_general pt0 pb16" data-vxml="001" data-snippet="s_hr" data-name="Separator" style="background-color: rgb(36, 37, 48) !important;">
             <hr class="s_hr_1px s_hr_solid"/>
         </div>
-        <div class="s_title o_mail_snippet_general pb8 pt8" data-snippet="s_title" data-name="Title" style="background-color: rgb(36, 37, 48) !important;">
+        <div class="s_title o_mail_snippet_general pb8 pt8" data-vxml="001" data-snippet="s_title" data-name="Title" style="background-color: rgb(36, 37, 48) !important;">
             <div class="container s_allow_columns">
                 <h1 style="text-align:center;"><font class="text-white">$100 OFF</font></h1>
                 <h2 style="text-align:center;"><font class="text-white">VIP members only</font></h2>
             </div>
         </div>
-        <div class="s_hr o_mail_snippet_general pt16 pb0" data-snippet="s_hr" data-name="Separator" style="background-color: rgb(36, 37, 48) !important;">
+        <div class="s_hr o_mail_snippet_general pt16 pb0" data-vxml="001" data-snippet="s_hr" data-name="Separator" style="background-color: rgb(36, 37, 48) !important;">
             <hr class="s_hr_1px s_hr_solid"/>
         </div>
-        <section class="s_cover o_mail_snippet_general" data-snippet="s_cover" data-name="Cover" style="background-color: rgb(36, 37, 48) !important;">
+        <section class="s_cover o_mail_snippet_general" data-vxml="001" data-snippet="s_cover" data-name="Cover" style="background-color: rgb(36, 37, 48) !important;">
             <img src="/mass_mailing_themes/static/src/img/theme_coupon/vip_banner_part2.png" alt="Cover" class="img-fluid w-100 mx-auto"/>
         </section>
-        <section class="s_discount2 o_mail_block_discount2 o_mail_snippet_general pt32 pb32" data-snippet="s_coupon_code" data-name="Promo Code" style="background-color: rgb(36, 37, 48) !important; text-align: center; padding-left: 15px; padding-right: 15px;">
+        <section class="s_discount2 o_mail_block_discount2 o_mail_snippet_general pt32 pb32" data-vxml="001" data-snippet="s_coupon_code" data-name="Promo Code" style="background-color: rgb(36, 37, 48) !important; text-align: center; padding-left: 15px; padding-right: 15px;">
             <p style="text-align: center;"><font class="text-white">Here's your coupon code*:</font></p>
             <table cellpadding="0" cellspacing="0" align="center" class="border" style="background-color: rgb(36, 37, 48) !important; border-collapse: collapse; border-color: rgb(198, 150, 120) !important;">
                 <tr>
@@ -407,7 +407,7 @@
                 <a class="btn btn-primary btn-lg" t-att-href="website_url_or_none">Redeem it now</a>
             </p>
         </section>
-        <section class="s_call_to_action o_mail_snippet_general o_cc o_cc3 pt24 pb24" data-snippet="s_call_to_action" data-name="Call to Action" style="background-color: rgb(36, 37, 48) !important;">
+        <section class="s_call_to_action o_mail_snippet_general o_cc o_cc3 pt24 pb24" data-vxml="001" data-snippet="s_call_to_action" data-name="Call to Action" style="background-color: rgb(36, 37, 48) !important;">
             <div class="container">
                 <div class="row">
                     <div class="col-md-10 offset-md-1 border pt24 pb16" style="border-width: 2px !important; border-color: rgb(198, 150, 120) !important;">
@@ -420,7 +420,7 @@
                 </div>
             </div>
         </section>
-        <section class="s_footer_social o_mail_block_footer_social o_mail_footer_social_center o_mail_snippet_general pt16 pb16" data-snippet="s_mail_block_footer_social" data-name="Footer Center" style="background-color: rgb(36, 37, 48) !important;">
+        <section class="s_footer_social o_mail_block_footer_social o_mail_footer_social_center o_mail_snippet_general pt16 pb16" data-vxml="001" data-snippet="s_mail_block_footer_social" data-name="Footer Center" style="background-color: rgb(36, 37, 48) !important;">
             <div class="container">
                 <div class="row">
                     <div class="col-md-12" style="text-align: center;" t-translation="off">
@@ -481,7 +481,7 @@
             }
         </style>
         <t t-set="now" t-value="datetime.datetime.now()"/>
-        <section class="s_header_logo o_mail_block_header_logo o_mail_snippet_general bg-white pt32 pb16" data-snippet="s_mail_block_header_logo" data-name="Centered Logo">
+        <section class="s_header_logo o_mail_block_header_logo o_mail_snippet_general bg-white pt32 pb16" data-vxml="001" data-snippet="s_mail_block_header_logo" data-name="Centered Logo">
             <div class="container">
                 <div class="row">
                     <div class="col-md-3">
@@ -501,10 +501,10 @@
                 </div>
             </div>
         </section>
-        <div class="s_hr o_mail_snippet_general pb32" data-snippet="s_hr" data-name="Separator">
+        <div class="s_hr o_mail_snippet_general pb32" data-vxml="001" data-snippet="s_hr" data-name="Separator">
             <hr class="s_hr_1px s_hr_solid"/>
         </div>
-        <section class="s_text_image o_mail_snippet_general" data-snippet="s_text_image" data-name="Image - Text">
+        <section class="s_text_image o_mail_snippet_general" data-vxml="001" data-snippet="s_text_image" data-name="Image - Text">
             <div class="container">
                 <div class="row align-items-center">
                     <div class="col-md-8 px-0">
@@ -512,7 +512,7 @@
                     </div>
                     <div class="col-md-4 o_cc pt0 pb0">
                         <h2 style="text-align: center;">IN THIS ISSUE</h2>
-                        <div class="s_hr o_mail_snippet_general pt16 pb16" data-snippet="s_hr" data-name="Separator">
+                        <div class="s_hr o_mail_snippet_general pt16 pb16" data-vxml="001" data-snippet="s_hr" data-name="Separator">
                             <hr class="s_hr_1px s_hr_solid"/>
                         </div>
                         <p>
@@ -545,17 +545,17 @@
                 </div>
             </div>
         </section>
-        <div class="s_hr o_mail_snippet_general pt32 pb32" data-snippet="s_hr" data-name="Separator">
+        <div class="s_hr o_mail_snippet_general pt32 pb32" data-vxml="001" data-snippet="s_hr" data-name="Separator">
             <hr class="s_hr_1px s_hr_solid"/>
         </div>
-        <section class="s_mail_product_list o_mail_snippet_general pt0" data-snippet="s_product_list" data-name="Items">
+        <section class="s_mail_product_list o_mail_snippet_general pt0" data-vxml="001" data-snippet="s_product_list" data-name="Items">
             <div class="container">
                 <div class="row">
                     <div class="col-md-6 o_cc">
                         <h3><font style="background-color: rgb(231, 148, 57);">TRAVEL</font></h3>
-                        <a href="#">
+                        <p class="md-0"><a href="#">
                             <img class="img-fluid o_we_custom_image" src="/mass_mailing_themes/static/src/img/theme_magazine/s_default_image_product_2.jpg" alt="Man on a rock looking at mountains in the distance" style="width: 100% !important; padding: 15px 0px;"/>
-                        </a>
+                        </a></p>
                         <h2 style="text-align: left;">Destinations for an eco-holiday</h2>
                         <p style="text-align: left;">Bitten by the travel bug but looking to travel consciously? Eco-travel is the way forward.</p>
                         <p style="text-align: right;">
@@ -566,9 +566,9 @@
                     </div>
                     <div class="col-md-6 o_cc">
                         <h3><font style="background-color: rgb(231, 99, 99);">LIFESTYLE</font></h3>
-                        <a href="#">
+                        <p class="md-0"><a href="#">
                             <img class="img-fluid o_we_custom_image" src="/mass_mailing_themes/static/src/img/theme_magazine/s_default_image_product_1.jpg" alt="Woman having breakfast in bed" style="width: 100% !important; padding: 15px 0px;"/>
-                        </a>
+                        </a></p>
                         <h2 style="text-align: left;">Top 5 energy-boosting morning routines</h2>
                         <p style="text-align: left;">Imagine waking up with more energy, more flexibility, with less stress and fewer instances of anxiously rushing out the door.</p>
                         <p style="text-align: right;">
@@ -580,10 +580,10 @@
                 </div>
             </div>
         </section>
-        <div class="s_hr o_mail_snippet_general pt16 pb32" data-snippet="s_hr" data-name="Separator">
+        <div class="s_hr o_mail_snippet_general pt16 pb32" data-vxml="001" data-snippet="s_hr" data-name="Separator">
             <hr class="s_hr_1px s_hr_solid"/>
         </div>
-        <section class="s_text_image o_mail_snippet_general" data-snippet="s_text_image" data-name="Text - Image">
+        <section class="s_text_image o_mail_snippet_general" data-vxml="001" data-snippet="s_text_image" data-name="Text - Image">
             <div class="container">
                 <div class="row align-items-center">
                     <div class="col-md-6 o_cc pt16 pb16">
@@ -602,10 +602,10 @@
                 </div>
             </div>
         </section>
-        <div class="s_hr o_mail_snippet_general pt32 pb16" data-snippet="s_hr" data-name="Separator">
+        <div class="s_hr o_mail_snippet_general pt32 pb16" data-vxml="001"  data-snippet="s_hr" data-name="Separator">
             <hr class="s_hr_1px s_hr_solid"/>
         </div>
-        <section class="s_footer_social o_mail_block_footer_social o_mail_footer_social_center o_mail_snippet_general pt16 pb16" data-snippet="s_mail_block_footer_social" data-name="Footer Center">
+        <section class="s_footer_social o_mail_block_footer_social o_mail_footer_social_center o_mail_snippet_general pt16 pb16" data-vxml="001"  data-snippet="s_mail_block_footer_social" data-name="Footer Center">
             <div class="container">
                 <div class="row">
                     <div class="col-md-12" style="text-align: center;" t-translation="off">
@@ -667,7 +667,7 @@
         </style>
         <t t-set="now" t-value="datetime.datetime.now()"/>
         <t t-set="future_date" t-value="(datetime.date.today() + datetime.timedelta(days=30))"/>
-        <section class="s_header_logo o_mail_block_header_logo o_mail_snippet_general pt16 pb16 bg-200" data-snippet="s_mail_block_header_logo" data-name="Header Logo">
+        <section class="s_header_logo o_mail_block_header_logo o_mail_snippet_general pt16 pb16 bg-200" data-vxml="001"  data-snippet="s_mail_block_header_logo" data-name="Header Logo">
             <div class="container">
                 <div class="row">
                     <div class="col-md-4"></div>
@@ -680,15 +680,15 @@
                 </div>
             </div>
         </section>
-        <section class="s_title o_mail_snippet_general pt32 pb16" data-snippet="s_title" data-name="Title">
+        <section class="s_title o_mail_snippet_general pt32 pb16" data-vxml="001"  data-snippet="s_title" data-name="Title">
             <div class="container s_allow_columns">
                 <h1 style="text-align: center;">WE'RE MOVING</h1>
             </div>
         </section>
-        <section class="s_cover o_mail_snippet_general pt0" data-snippet="s_cover" data-name="Cover">
+        <section class="s_cover o_mail_snippet_general pt0" data-vxml="001"  data-snippet="s_cover" data-name="Cover">
             <img src="/mass_mailing_themes/static/src/img/theme_bignews/s_default_image_cover.jpg" alt="Cover image" class="img-fluid w-100 mx-auto" style="padding: 15px;"/>
         </section>
-        <section class="s_text_block o_mail_snippet_general pt32 pb32" data-snippet="s_text_block" data-name="Text" style="padding-left: 15px; padding-right: 15px;">
+        <section class="s_text_block o_mail_snippet_general pt32 pb32" data-vxml="001"  data-snippet="s_text_block" data-name="Text" style="padding-left: 15px; padding-right: 15px;">
             <div class="container s_allow_columns">
                 <h2>BEGINNING <t t-out="future_date.strftime('%B %d').upper()" /></h2>
                 <p>We are proud to announce that due to our remarkable growth in the Springfield area, we are moving to a new location on July 1.
@@ -705,7 +705,7 @@
                 </p>
             </div>
         </section>
-        <section class="s_footer_social o_mail_block_footer_social o_mail_footer_social_center o_mail_snippet_general bg-200 pt16 pb16" data-snippet="s_mail_block_footer_social" data-name="Footer Center">
+        <section class="s_footer_social o_mail_block_footer_social o_mail_footer_social_center o_mail_snippet_general bg-200 pt16 pb16" data-vxml="001"  data-snippet="s_mail_block_footer_social" data-name="Footer Center">
             <div class="container">
                 <div class="row">
                     <div class="col-md-12" style="text-align: center;" t-translation="off">
@@ -763,7 +763,7 @@
         </style>
         <t t-set="now" t-value="datetime.datetime.now()"/>
         <t t-set="website_url_or_none" t-value="(company_id.website) or '#'"/>
-        <section class="s_header_text_social o_mail_block_header_text_social o_mail_snippet_general pt16 pb16" data-snippet="s_mail_block_header_text_social" data-name="Left Text">
+        <section class="s_header_text_social o_mail_block_header_text_social o_mail_snippet_general pt16 pb16" data-vxml="001" data-snippet="s_mail_block_header_text_social" data-name="Left Text">
             <div class="container">
                 <div class="row">
                     <div class="col-md-4 pt16 pb16">
@@ -784,9 +784,9 @@
         <section class="s_title o_mail_snippet_general pt72 pb80" data-snippet="s_title" data-name="Title" style="background-color: rgb(255, 187, 0) !important;">
             <div class="container s_allow_columns">
                 <h1 style="text-align:center">
-                        <font style="font-size: 62px; background-color: rgb(255, 255, 255);">&amp;nbsp;10% OFF&amp;nbsp;</font>
+                    <font style="font-size: 62px; background-color: rgb(255, 255, 255);">&amp;nbsp;10% OFF&amp;nbsp;</font>
                     <br/>
-                        <font style="font-size: 62px; background-color: rgb(255, 255, 255);">&amp;nbsp;SALES&amp;nbsp;</font>
+                    <font style="font-size: 62px; background-color: rgb(255, 255, 255);">&amp;nbsp;SALES&amp;nbsp;</font>
                 </h1>
             </div>
         </section>
@@ -806,29 +806,29 @@
                 <a role="button" class="btn btn-primary btn-lg" t-att-href="website_url_or_none">Visit the website</a>
             </p>
         </section>
-        <div class="s_hr pt16 pb16" data-snippet="s_hr" data-name="Separator">
+        <div class="s_hr pt16 pb16" data-vxml="001" data-snippet="s_hr" data-name="Separator">
             <hr class="s_hr_1px s_hr_solid"/>
         </div>
-        <section class="s_features o_mail_snippet_general" data-snippet="s_features" data-name="Features">
+        <section class="s_features o_mail_snippet_general" data-vxml="001" data-snippet="s_features" data-name="Features">
             <div class="container">
                 <div class="row">
                     <div class="col-md-4 pt16 pb16" style="text-align:center;">
-                        <img alt="Customer Service" src="/mass_mailing_themes/static/src/img/theme_promotion/s_default_image_product_1.jpg" class="img-fluid o_we_custom_image mx-auto d-block" style="width: 100px;"/>
+                        <p class="md-0"><img alt="Customer Service" src="/mass_mailing_themes/static/src/img/theme_promotion/s_default_image_product_1.jpg" class="img-fluid o_we_custom_image mx-auto d-block" style="width: 100px;"/></p>
                         <h3>24/7 <br/>Customer Service</h3>
                     </div>
                     <div class="col-md-4 pt16 pb16" style="text-align:center;">
-                        <img alt="Free Delivery" src="/mass_mailing_themes/static/src/img/theme_promotion/s_default_image_product_2.jpg" class="img-fluid o_we_custom_image mx-auto d-block" style="width: 100px;"/>
+                        <p class="md-0"><img alt="Free Delivery" src="/mass_mailing_themes/static/src/img/theme_promotion/s_default_image_product_2.jpg" class="img-fluid o_we_custom_image mx-auto d-block" style="width: 100px;"/></p>
                         <h3 style="text-align:center;">Free delivery*</h3>
                         <p style="text-align:center;">*For orders over $39.</p>
                     </div>
                     <div class="col-md-4 pt16 pb16" style="text-align:center;">
-                        <img alt="Easy Returns" src="/mass_mailing_themes/static/src/img/theme_promotion/s_default_image_product_3.jpg" class="img-fluid o_we_custom_image mx-auto d-block" style="width: 100px;"/>
+                        <p class="md-0"><img alt="Easy Returns" src="/mass_mailing_themes/static/src/img/theme_promotion/s_default_image_product_3.jpg" class="img-fluid o_we_custom_image mx-auto d-block" style="width: 100px;"/></p>
                         <h3 style="text-align:center;">Easy Returns</h3>
                     </div>
                 </div>
             </div>
         </section>
-        <section class="s_footer_social o_mail_block_footer_social o_mail_footer_social_left o_mail_snippet_general pt16 pb16" data-snippet="s_mail_block_footer_social_left" data-name="Footer Left" style="background-color: rgb(255, 187, 0) !important;">
+        <section class="s_footer_social o_mail_block_footer_social o_mail_footer_social_left o_mail_snippet_general pt16 pb16" data-vxml="001" data-snippet="s_mail_block_footer_social_left" data-name="Footer Left" style="background-color: rgb(255, 187, 0) !important;">
             <div class="container">
                 <div class="row">
                     <div class="col-md-6">
@@ -901,7 +901,7 @@
                 }
             }
         </style>
-        <section class="s_header_social o_mail_block_header_social o_mail_snippet_general" style="background-color: rgb(238, 233, 226) !important;" data-snippet="s_mail_block_header_social" data-name="Left Logo">
+        <section class="s_header_social o_mail_block_header_social o_mail_snippet_general" style="background-color: rgb(238, 233, 226) !important;" data-vxml="001" data-snippet="s_mail_block_header_social" data-name="Left Logo">
             <div class="container">
                 <div class="row">
                     <div class="col-md-8 pt16 pb16">
@@ -910,35 +910,35 @@
                         </a>
                     </div>
                     <div class="col-md-4 o_mail_header_social" style="text-align: right">
-                            <a aria-label="Facebook" title="Facebook" target="_blank" href="https://www.facebook.com/Odoo">
-                                <span class="fa fa-facebook" style="color: rgb(84, 52, 39) !important; background-color: rgb(211, 197, 177) !important;"></span>
-                            </a>&amp;nbsp;&amp;nbsp;
-                            <a style="margin-left:10px" aria-label="X" title="X" target="_blank" href="https://twitter.com/Odoo">
-                                <span class="fa fa-twitter" style="color: rgb(84, 52, 39) !important; background-color: rgb(211, 197, 177) !important;"></span>
-                            </a>&amp;nbsp;&amp;nbsp;
-                            <a style="margin-left:10px" aria-label="Instagram" title="Instagram" target="_blank" href="https://www.instagram.com/explore/tags/odoo/">
-                                <span class="fa fa-instagram" style="color: rgb(84, 52, 39) !important; background-color: rgb(211, 197, 177) !important;"></span>
-                            </a>
+                        <a aria-label="Facebook" title="Facebook" target="_blank" href="https://www.facebook.com/Odoo">
+                            <span class="fa fa-facebook" style="color: rgb(84, 52, 39) !important; background-color: rgb(211, 197, 177) !important;"></span>
+                        </a>&amp;nbsp;&amp;nbsp;
+                        <a style="margin-left:10px" aria-label="X" title="X" target="_blank" href="https://twitter.com/Odoo">
+                            <span class="fa fa-twitter" style="color: rgb(84, 52, 39) !important; background-color: rgb(211, 197, 177) !important;"></span>
+                        </a>&amp;nbsp;&amp;nbsp;
+                        <a style="margin-left:10px" aria-label="Instagram" title="Instagram" target="_blank" href="https://www.instagram.com/explore/tags/odoo/">
+                            <span class="fa fa-instagram" style="color: rgb(84, 52, 39) !important; background-color: rgb(211, 197, 177) !important;"></span>
+                        </a>
                     </div>
                 </div>
             </div>
         </section>
-        <section class="s_title o_mail_snippet_general pt16 pb16" data-snippet="s_title" data-name="Title">
+        <section class="s_title o_mail_snippet_general pt16 pb16" data-vxml="001" data-snippet="s_title" data-name="Title">
             <div class="container s_allow_columns">
                 <h1 class="text-center">Company News</h1>
                 <h2 class="text-center">28 Jan 2022</h2>
             </div>
         </section>
-        <div class="s_hr o_mail_snippet_general pt16 pb0" style="background-color: rgb(238, 233, 226) !important;" data-snippet="s_hr" data-name="Separator">
+        <div class="s_hr o_mail_snippet_general pt16 pb0" style="background-color: rgb(238, 233, 226) !important;" data-vxml="001" data-snippet="s_hr" data-name="Separator">
             <hr class="s_hr_1px s_hr_solid" style="border-color: rgba(0,0,0,0)"/>
         </div>
-        <section class="s_cover o_mail_snippet_general" data-snippet="s_cover" data-name="Cover">
+        <section class="s_cover o_mail_snippet_general" data-vxml="001" data-snippet="s_cover" data-name="Cover">
             <img src="/mass_mailing_themes/static/src/img/theme_coffeebreak/s_default_image_block_banner.jpg" alt="Cover image" class="img-fluid w-100 mx-auto"/>
         </section>
-        <div class="s_hr o_mail_snippet_general pt16 pb0" style="background-color: rgb(238, 233, 226) !important;" data-snippet="s_hr" data-name="Separator">
+        <div class="s_hr o_mail_snippet_general pt16 pb0" style="background-color: rgb(238, 233, 226) !important;" data-vxml="001" data-snippet="s_hr" data-name="Separator">
             <hr class="s_hr_1px s_hr_solid" style="border-color: rgba(0,0,0,0)"/>
         </div>
-        <section class="s_text_block o_mail_snippet_general pt40 pb40 px-3" data-snippet="s_text_block" data-name="Text">
+        <section class="s_text_block o_mail_snippet_general pt40 pb40 px-3" data-vxml="001" data-snippet="s_text_block" data-name="Text">
             <div class="container s_allow_columns">
                 <div class="row">
                     <div class="col-md-5 offset-md-1">
@@ -957,15 +957,17 @@
                 </div>
             </div>
         </section>
-        <div class="s_hr o_mail_snippet_general pt16 pb0" style="background-color: rgb(238, 233, 226) !important;" data-snippet="s_hr" data-name="Separator">
+        <div class="s_hr o_mail_snippet_general pt16 pb0" style="background-color: rgb(238, 233, 226) !important;" data-vxml="001" data-snippet="s_hr" data-name="Separator">
             <hr class="s_hr_1px s_hr_solid" style="border-color: rgba(0,0,0,0)"/>
         </div>
-        <section class="s_text_image o_mail_snippet_general pt32 pb32" data-snippet="s_image_text" data-name="Image - Text">
+        <section class="s_text_image o_mail_snippet_general pt32 pb32" data-vxml="001" data-snippet="s_image_text" data-name="Image - Text">
             <div class="container">
                 <div class="row align-items-center">
                     <div class="col-md-10 offset-md-1 px-0">
                         <h3>NEW PEOPLE</h3>
-                        <img src="/mass_mailing_themes/static/src/img/theme_coffeebreak/s_default_image_block_image_text.jpg" class="img w-100"/>
+                        <p class="md-0">
+                            <img src="/mass_mailing_themes/static/src/img/theme_coffeebreak/s_default_image_block_image_text.jpg" class="img w-100"/>
+                        </p>
                     </div>
                 </div>
                 <div class="row">
@@ -979,10 +981,10 @@
                 </div>
             </div>
         </section>
-        <div class="s_hr o_mail_snippet_general pt16 pb0" style="background-color: rgb(238, 233, 226) !important;" data-snippet="s_hr" data-name="Separator">
+        <div class="s_hr o_mail_snippet_general pt16 pb0" style="background-color: rgb(238, 233, 226) !important;" data-vxml="001" data-snippet="s_hr" data-name="Separator">
             <hr class="s_hr_1px s_hr_solid" style="border-color: rgba(0,0,0,0)"/>
         </div>
-        <section class="s_text_block o_mail_snippet_general pt40 pb32" data-snippet="s_text_block" data-name="Text">
+        <section class="s_text_block o_mail_snippet_general pt40 pb32" data-vxml="001" data-snippet="s_text_block" data-name="Text">
             <div class="container s_allow_columns">
                 <div class="row">
                     <div class="offset-md-1 col-md-10">
@@ -1011,10 +1013,10 @@
                 </div>
             </div>
         </section>
-        <div class="s_hr o_mail_snippet_general pt16 pb0" style="background-color: rgb(238, 233, 226) !important;" data-snippet="s_hr" data-name="Separator">
+        <div class="s_hr o_mail_snippet_general pt16 pb0" style="background-color: rgb(238, 233, 226) !important;" data-vxml="001" data-snippet="s_hr" data-name="Separator">
             <hr class="s_hr_1px s_hr_solid" style="border-color: rgba(0,0,0,0)"/>
         </div>
-        <section class="s_footer_social o_mail_block_footer_social o_mail_footer_social_center o_mail_snippet_general o_cc o_cc5 pt24 pb24" style="background-color: rgb(84, 52, 39) !important;" data-snippet="s_mail_block_footer_social" data-name="Footer Center">
+        <section class="s_footer_social o_mail_block_footer_social o_mail_footer_social_center o_mail_snippet_general o_cc o_cc5 pt24 pb24" style="background-color: rgb(84, 52, 39) !important;" data-vxml="001" data-snippet="s_mail_block_footer_social" data-name="Footer Center">
             <div class="container">
                 <div class="row">
                     <div class="col-10 offset-md-1">
@@ -1060,20 +1062,20 @@
                 --btn-secondary-border-color: #CE0000;
             }
         </style>
-        <section class="o_snippet_view_in_browser o_mail_snippet_general pt16 pb0" style="text-align: left; padding-left: 15px; padding-right: 15px;" data-snippet="s_mail_block_header_view" data-name="View Online">
+        <section class="o_snippet_view_in_browser o_mail_snippet_general pt16 pb0" style="text-align: left; padding-left: 15px; padding-right: 15px;" data-vxml="001" data-snippet="s_mail_block_header_view" data-name="View Online">
             <p><a href="/view" class="" target="_blank" data-bs-original-title="" title="">View Online</a> - <font style="color: rgb(183, 191, 199);"><span style="font-size: 12.25px" t-out="datetime.datetime.now().strftime('%B %d %Y')"/></font></p>
         </section>
-        <section class="s_title o_mail_snippet_general pt32 pb32" data-snippet="s_title" data-name="Title" style="background-color: rgb(255, 255, 255) !important;">
+        <section class="s_title o_mail_snippet_general pt32 pb32" data-vxml="001" data-snippet="s_title" data-name="Title" style="background-color: rgb(255, 255, 255) !important;">
             <div class="container s_allow_columns">
                 <h1 style="text-align:center" class="">Weekly Musings</h1>
             </div>
         </section>
-        <section class="s_title o_mail_snippet_general px-3 pb0 pt0" data-snippet="s_title" data-name="Title">
+        <section class="s_title o_mail_snippet_general px-3 pb0 pt0" data-vxml="001" data-snippet="s_title" data-name="Title">
             <div class="container s_allow_columns">
                     <h2 style="" class="">The story of Odoo</h2>
             </div>
         </section>
-        <section class="s_header_social o_mail_block_header_social o_mail_snippet_general bg-white px-3 pt24 pb24" style="" data-snippet="s_mail_block_header_social" data-name="Left Logo">
+        <section class="s_header_social o_mail_block_header_social o_mail_snippet_general bg-white px-3 pt24 pb24" style="" data-vxml="001" data-snippet="s_mail_block_header_social" data-name="Left Logo">
             <div class="container" style="">
                 <div class="col-md-12 o_mail_header_social" style="background-color: rgb(255, 255, 255) !important; text-align: left;">
                     <a aria-label="Facebook" target="_blank" href="https://www.facebook.com/Odoo" data-original-title="Facebook" rel="noreferrer">
@@ -1088,17 +1090,17 @@
                 </div>
             </div>
         </section>
-        <section class="s_text_block o_mail_snippet_general px-3 pb24" data-snippet="s_text_block" data-name="Text">
+        <section class="s_text_block o_mail_snippet_general px-3 pb24" data-vxml="001" data-snippet="s_text_block" data-name="Text">
             <div class="container s_allow_columns">
                 <p style="font-size: 14px;" class="small text-muted">Musings on the week from <a style="font-size: 14px;" href="https://twitter.com/fpodoo?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Eauthor">@fpodoo</a></p>
             </div>
         </section>
-        <section class="s_title o_mail_snippet_general px-3 pb0 pt0" data-snippet="s_title" data-name="Title">
+        <section class="s_title o_mail_snippet_general px-3 pb0 pt0" data-vxml="001" data-snippet="s_title" data-name="Title">
             <div class="container s_allow_columns">
                 <h3>Making companies a better place, one app at a time</h3>
             </div>
         </section>
-        <section class="s_text_block o_mail_snippet_general px-3 pt16 pb24 " data-snippet="s_text_block" data-name="Text">
+        <section class="s_text_block o_mail_snippet_general px-3 pt16 pb24 " data-vxml="001" data-snippet="s_text_block" data-name="Text">
             <div class="container s_allow_columns">
                 <p>I needed to change the world. I wanted to... You know how it is when you are young; you have big dreams, a lot of energy and naive stupidity. My dream was to lead the enterprise management market with a fully open source software (I also wanted to get 100 employees before 30 years old with a self-financed company but I failed this one by only a few months).</p>
                 <p>To fuel my motivation, I had to pick someone to fight against. In business, it's like a playground. When you arrive in a new school, if you want to quickly become the leader, you must choose the class bully, the older guy who terrorizes small boys, and kick his butt in front of everyone. That was my strategy with SAP, the enterprise software giant.</p>
@@ -1109,15 +1111,15 @@
                 <p>In 2010, we had a 100+ employees selling services on OpenERP and a powerful but ugly product. This is what happens when delivering services to customers distracts you from building an exceptional product. It was time to do a pivot in the business model.</p>
             </div>
         </section>
-        <section class="s_cover o_mail_snippet_general" data-snippet="s_cover" data-name="Cover">
+        <section class="s_cover o_mail_snippet_general" data-vxml="001" data-snippet="s_cover" data-name="Cover">
             <img src="/mass_mailing_themes/static/src/img/theme_newsletter/s_default_image_block_banner.jpg" alt="Cover image" class="img-fluid w-100 mx-auto"/>
         </section>
-        <section class="s_title o_mail_snippet_general px-3 pb0 pt0" data-snippet="s_title" data-name="Title">
+        <section class="s_title o_mail_snippet_general px-3 pb0 pt0" data-vxml="001" data-snippet="s_title" data-name="Title">
             <div class="container s_allow_columns">
                 <h3>The Pivot</h3>
             </div>
         </section>
-        <section class="s_text_block o_mail_snippet_general px-3 pt16 pb24" data-snippet="s_text_block" data-name="Text">
+        <section class="s_text_block o_mail_snippet_general px-3 pt16 pb24" data-vxml="001" data-snippet="s_text_block" data-name="Text">
             <div class="container s_allow_columns">
                 <p>We wanted to switch from a service company to a software publisher company. This would allow us to increase our efforts in our research and development activities. As a result, <a href="https://accounts.openerp.com/blog/OpenERP-Blog-Post-1/post/Open-Source-Free-as-in-Freedom-not-free-as-in-Free-services-119" target="_blank">we changed our business model</a> and decided to stop our services for customers and focus on building a strong partner network and maintenance offer. This would cost money, so I had to raise a few million euros.</p>
                 <p>After a few months of pitching investors, I got roughly 10 LOI from different VCs. We chose Sofinnova Partners, the biggest European VC, and Xavier Niel the founder of Iliad, the only company in France funded in the past 10 years to have reached the 1 billion EUR valuation.</p>
@@ -1126,15 +1128,15 @@
                 <p>We changed the deal and I got the 3 million EUR. It allowed me to recruit a rocking management team.</p>
             </div>
         </section>
-        <section class="s_cover o_mail_snippet_general pb24" data-snippet="s_cover" data-name="Cover">
+        <section class="s_cover o_mail_snippet_general pb24" data-vxml="001" data-snippet="s_cover" data-name="Cover">
             <img src="/mass_mailing_themes/static/src/img/theme_newsletter/s_default_image_block_banner_2.jpg" alt="Cover image" class="img-fluid w-100 mx-auto"/>
         </section>
-        <section class="s_title o_mail_snippet_general px-3 pb0 pt0" data-snippet="s_title" data-name="Title">
+        <section class="s_title o_mail_snippet_general px-3 pb0 pt0" data-vxml="001" data-snippet="s_title" data-name="Title">
             <div class="container s_allow_columns">
                 <h3>Being a Mature Company</h3>
             </div>
         </section>
-        <section class="s_text_block o_mail_snippet_general px-3 pt16 pb24" data-snippet="s_text_block" data-name="Text">
+        <section class="s_text_block o_mail_snippet_general px-3 pt16 pb24" data-vxml="001" data-snippet="s_text_block" data-name="Text">
             <div class="container s_allow_columns">
                 <p>With this money in our bank account, we boosted two departments: R&amp;D and Sales. We burned 2 million EUR in 18 months, mostly in salaries. The company started to grow even faster. We developed a partner network of 500 partners in 100 countries and we started to sign contracts with 6 zeros.</p>
                 <p>Then, things became different. You know, tedious things like handling human resources, board meetings, dealing with big customer contracts, traveling to launch international subsidiaries. We did boring stuff like budgets, career paths, management meetings, etc.</p>
@@ -1143,12 +1145,12 @@
                 <p>As usual, I should have listened to my wife. She is way more lucid than I am. Every week I complained to her "It's not good enough, we should grow faster, what am I missing?" and she used to reply: "But you already are the fastest growing company in Belgium!" (Deloitte awarded us as <a href="https://accounts.openerp.com/blog/OpenERP-Blog-1/post/Three-Awards-for-OpenERP-in-2013-139" target="_blank">the fastest growing company of Belgium</a> with 1549% growth of the turnover between 2007 and 2011).</p>
             </div>
         </section>
-        <section class="s_title o_mail_snippet_general px-3 pb0 pt0" data-snippet="s_title" data-name="Title">
+        <section class="s_title o_mail_snippet_general px-3 pb0 pt0" data-vxml="001" data-snippet="s_title" data-name="Title">
             <div class="container s_allow_columns">
                 <h3>Changing the World</h3>
             </div>
         </section>
-        <section class="s_text_block o_mail_snippet_general px-3 pt16 pb24" data-snippet="s_text_block" data-name="Text">
+        <section class="s_text_block o_mail_snippet_general px-3 pt16 pb24" data-vxml="001" data-snippet="s_text_block" data-name="Text">
             <div class="container s_allow_columns">
                 <p>Then the dream started to become reality. We started to get clues that what we did would change the world:</p>
                 <ul>
@@ -1162,26 +1164,26 @@
                 <p>Something is happening... And it's big!</p>
             </div>
         </section>
-        <section class="s_title o_mail_snippet_general px-3 pb0 pt0" data-snippet="s_title" data-name="Title">
+        <section class="s_title o_mail_snippet_general px-3 pb0 pt0" data-vxml="001" data-snippet="s_title" data-name="Title">
             <div class="container s_allow_columns">
                 <h3>New Financing in 2014</h3>
             </div>
         </section>
-        <section class="s_text_block o_mail_snippet_general px-3 pt16 pb24" data-snippet="s_text_block" data-name="Text">
+        <section class="s_text_block o_mail_snippet_general px-3 pt16 pb24" data-vxml="001" data-snippet="s_text_block" data-name="Text">
             <div class="container s_allow_columns">
                 <p>After years of rapid growth, we achieved another amazing goal - we secured a new round of 10 Million USD of financing, jointly provided by leading venture capital firms XAnge (France), SRIW (Belgium), Sofinnova (France), and the management team.</p>
                 <p>The new financing will support the acceleration of the outstanding growth the company has seen over the last years, enabling the doubling of the commercial force and increased R&amp;D staff - already 100+ people strong. </p>
             </div>
         </section>
-        <section class="s_cover o_mail_snippet_general pb24" data-snippet="s_cover" data-name="Cover">
+        <section class="s_cover o_mail_snippet_general pb24" data-vxml="001" data-snippet="s_cover" data-name="Cover">
             <img src="/mass_mailing_themes/static/src/img/theme_newsletter/s_default_image_block_banner_3.jpg" alt="Cover image" class="img-fluid w-100 mx-auto"/>
         </section>
-        <section class="s_title o_mail_snippet_general px-3 pb0 pt0" data-snippet="s_title" data-name="Title">
+        <section class="s_title o_mail_snippet_general px-3 pb0 pt0" data-vxml="001" data-snippet="s_title" data-name="Title">
             <div class="container s_allow_columns">
                 <h3>The Rise of Odoo</h3>
             </div>
         </section>
-        <section class="s_text_block o_mail_snippet_general px-3 pt16" data-snippet="s_text_block" data-name="Text">
+        <section class="s_text_block o_mail_snippet_general px-3 pt16" data-vxml="001" data-snippet="s_text_block" data-name="Text">
             <div class="container s_allow_columns">
                 <p>After having disrupted the ERP market, OpenERP moved far beyond the boundaries of traditional ERP players. The integration of business activities is no longer restricted to sales, accounting, inventory and procurements. In June 2014, we released version 8 with awesome CMS &amp; eCommerce, a Point of Sale, an integrated Business Intelligence engine and much more (3000+ modules).</p>
                 <p>Our exceptional technology allowed us to move to newer markets (CMS &amp; eCommerce) and propose a product that disrupts existing open source players (Wordpress, Magento, etc). The OpenERP CMS is so good that even top competitors admitted it publicly when we released the beta version.</p>
@@ -1191,7 +1193,7 @@
                 <p>And a new story just started...</p>
             </div>
         </section>
-        <section class="s_text_block o_mail_snippet_general pb16 px-3" data-snippet="s_text_block" data-name="Text">
+        <section class="s_text_block o_mail_snippet_general pb16 px-3" data-vxml="001" data-snippet="s_text_block" data-name="Text">
             <div class="container s_allow_columns">
                 <img src="/mass_mailing_themes/static/src/img/theme_newsletter/FPsignature.gif" style="width: 125px" alt=""/>
                 <p style="text-align:center;" class="pt32">
@@ -1199,7 +1201,7 @@
                 </p>
             </div>
         </section>
-        <section class="s_footer_social o_mail_block_footer_social o_mail_footer_social_center o_mail_snippet_general o_cc o_cc1 pt0 pb0" data-snippet="s_mail_block_footer_social" data-name="Footer Center">
+        <section class="s_footer_social o_mail_block_footer_social o_mail_footer_social_center o_mail_snippet_general o_cc o_cc1 pt0 pb0" data-vxml="001" data-snippet="s_mail_block_footer_social" data-name="Footer Center">
             <div class="container">
                 <div class="col-md-12 o_mail_footer_social pt0 pb0" style="text-align: center;">
                     <a aria-label="Facebook" target="_blank" href="https://www.facebook.com/Odoo" data-original-title="Facebook" rel="noreferrer">
@@ -1214,10 +1216,10 @@
                 </div>
             </div>
         </section>
-        <div class="s_hr o_mail_snippet_general pt16 pb16" data-snippet="s_hr" data-name="Separator">
+        <div class="s_hr o_mail_snippet_general pt16 pb16" data-vxml="001" data-snippet="s_hr" data-name="Separator">
             <hr class="s_hr_1px s_hr_solid" style="border-top-color: rgb(108, 117, 125) !important;"/>
         </div>
-        <section class="s_footer_social o_mail_block_footer_social o_mail_footer_social_center o_mail_snippet_general o_cc o_cc1 pt0 pb0" data-snippet="s_mail_block_footer_social" data-name="Footer Center">
+        <section class="s_footer_social o_mail_block_footer_social o_mail_footer_social_center o_mail_snippet_general o_cc o_cc1 pt0 pb0" data-vxml="001" data-snippet="s_mail_block_footer_social" data-name="Footer Center">
             <div class="container" style="text-align: center; color:rgb(183, 191, 199) !important;">
                 <span style="font-size: 12px;"><font style="color: rgb(183, 191, 199);">8000 Marina Blvd, Suite 300</font></span>
                 <br/>
@@ -1245,9 +1247,9 @@
                 --link-color: #35979c;
             }
         </style>
-        <section class="s_text_block o_mail_snippet_general pt40 px-3 pb0" data-snippet="s_text_block" data-name="Text">
+        <section class="s_text_block o_mail_snippet_general pt40 px-3 pb0" data-vxml="001" data-snippet="s_text_block" data-name="Text">
             <div class="container s_allow_columns">
-                <div class="s_title o_mail_snippet_general pb0 pt0" data-snippet="s_title" data-name="Title">
+                <div class="s_title o_mail_snippet_general pb0 pt0" data-vxml="001" data-snippet="s_title" data-name="Title">
                     <div class="container s_allow_columns">
                         <h1>We're almost there!</h1>
                     </div>
@@ -1255,7 +1257,7 @@
                 <p>Odoo invites you on <span class="font-weight: bolder">[date]</span> at <span class="font-weight: bolder">[time]</span> for their infamous roadshow in <span class="font-weight: bolder">[city]</span>: an event that combines learning and networking in a casual afterwork-like atmosphere.</p>
             </div>
         </section>
-        <section class="s_text_block o_mail_snippet_general px-3 pt8 pb0" data-snippet="s_text_block" data-name="Text">
+        <section class="s_text_block o_mail_snippet_general px-3 pt8 pb0" data-vxml="001" data-snippet="s_text_block" data-name="Text">
             <div class="container s_allow_columns">
                 <p>Registration is free, but mandatory:</p>
                 <p style="text-align: center;">
@@ -1268,22 +1270,22 @@
                 </p>
             </div>
         </section>
-        <section class="s_text_block o_mail_snippet_general px-3 pt0 pb0" data-snippet="s_text_block" data-name="Text">
+        <section class="s_text_block o_mail_snippet_general px-3 pt0 pb0" data-vxml="001" data-snippet="s_text_block" data-name="Text">
             <div class="container s_allow_columns">
                 <p>Discover Odoo, the all-in-one management platform, and its apps designed to improve employees' daily tasks. From sales and deliveries, to logistics, marketing and accounting ; learn what are the best available options to digitize your company.</p>
             </div>
         </section>
-        <section class="s_text_block o_mail_snippet_general px-3 pt0 pb0" data-snippet="s_text_block" data-name="Text">
+        <section class="s_text_block o_mail_snippet_general px-3 pt0 pb0" data-vxml="001" data-snippet="s_text_block" data-name="Text">
             <div class="container s_allow_columns">
                 <p>[speaker] and [speaker] will rely on a unique demo concept in which YOU lead the demo and choose what you wish to see. They'll show how to tackle the challenge using the best tools, live. You will be amazed!</p>
             </div>
         </section>
-        <section class="s_text_block o_mail_snippet_general px-3 pt0 pb0" data-snippet="s_text_block" data-name="Text">
+        <section class="s_text_block o_mail_snippet_general px-3 pt0 pb0" data-vxml="001" data-snippet="s_text_block" data-name="Text">
             <div class="container s_allow_columns">
                 <p>You may then take part in round table discussions with experts who will give you their tips and tricks to help digitize companies. We'll wrap up the event with a networking session including a walking dinner.</p>
             </div>
         </section>
-        <section class="s_title o_mail_snippet_general pb0 pt8" data-snippet="s_title" data-name="Title">
+        <section class="s_title o_mail_snippet_general pb0 pt8" data-vxml="001" data-snippet="s_title" data-name="Title">
             <div class="container s_allow_columns">
                 <div class="row">
                     <div class="offset-md-2 col-md-8">
@@ -1292,10 +1294,10 @@
                 </div>
             </div>
         </section>
-        <div class="s_hr o_mail_snippet_general pb16 pt4" data-snippet="s_hr" data-name="Separator">
+        <div class="s_hr o_mail_snippet_general pb16 pt4" data-vxml="001" data-snippet="s_hr" data-name="Separator">
             <hr class="s_hr_1px s_hr_solid w-50"/>
         </div>
-        <section class="s_text_block o_mail_snippet_general px-3 pt8 pb32" data-snippet="s_text_block" data-name="Text">
+        <section class="s_text_block o_mail_snippet_general px-3 pt8 pb32" data-vxml="001" data-snippet="s_text_block" data-name="Text">
             <div class="container s_allow_columns">
                 <table class="mx-auto">
                     <tr style="vertical-align:top">
@@ -1341,7 +1343,7 @@
                 </table>
             </div>
         </section>
-        <section class="s_text_block o_mail_snippet_general px-3 pt0 pb4" data-snippet="s_text_block" data-name="Text">
+        <section class="s_text_block o_mail_snippet_general px-3 pt0 pb4" data-vxml="001" data-snippet="s_text_block" data-name="Text">
             <div class="container s_allow_columns">
                 <p>For more information, check the event page : <a href="#" target="_blank" rel="noreferrer">[link]</a>.</p>
                 <p>We're on the starting blocks to prepare an incredible event for you!
@@ -1370,9 +1372,9 @@
                 --link-color: #35979c;
             }
         </style>
-        <section class="s_text_block o_mail_snippet_general px-3 pt40 pb0" data-snippet="s_text_block" data-name="Text">
+        <section class="s_text_block o_mail_snippet_general px-3 pt40 pb0" data-vxml="001" data-snippet="s_text_block" data-name="Text">
             <div class="container s_allow_columns">
-                <div class="s_title o_mail_snippet_general pb0 pt0" data-snippet="s_title" data-name="Title">
+                <div class="s_title o_mail_snippet_general pb0 pt0" data-vxml="001" data-snippet="s_title" data-name="Title">
                     <div class="container s_allow_columns">
                         <h1>Yesterday's event at [venue] in [city] was incredible!</h1>
                     </div>
@@ -1385,20 +1387,20 @@
                 <p>Don't hesitate to send us more!</p>
             </div>
         </section>
-        <section class="s_text_block o_mail_snippet_general px-3 pt8 pb0" data-snippet="s_text_block" data-name="Text">
+        <section class="s_text_block o_mail_snippet_general px-3 pt8 pb0" data-vxml="001" data-snippet="s_text_block" data-name="Text">
             <div class="container s_allow_columns">
                 <p>You had the chance to discover Odoo during a full 3 hours, how great is that?
                     <br/>Now that you've seen Odoo in action and asked some questions, you likely need more information to move forward in your project and to work with us. You'll find additional points just below.
                 </p>
             </div>
         </section>
-        <section class="s_title o_mail_snippet_general pb0 pt0" data-snippet="s_title" data-name="Title">
+        <section class="s_title o_mail_snippet_general pb0 pt0" data-vxml="001" data-snippet="s_title" data-name="Title">
             <div class="container s_allow_columns">
                 <h3>Do you wish to use Odoo?</h3>
                 <p>If you wish to evaluate Odoo while taking into account your company's specific needs, you can book a free appointment with one of our <a href="https://odoo.com/r/meeting" target="_blank">Odoo Experts</a> or <a href="https://odoo.com/page/tour" target="_blank">watch our videos about the product</a>.</p>
             </div>
         </section>
-        <section class="s_text_block o_mail_snippet_general px-3 pt8 pb0" data-snippet="s_text_block" data-name="Text">
+        <section class="s_text_block o_mail_snippet_general px-3 pt8 pb0" data-vxml="001" data-snippet="s_text_block" data-name="Text">
             <div class="container s_allow_columns">
                 <p>Here are the links to our sponsors' websites if you wish to meet them:</p>
                 <ul>
@@ -1410,19 +1412,19 @@
                 <p>You may test Odoo for free by clicking <a href="https://odoo.com/trial" target="_blank">here</a>.</p>
             </div>
         </section>
-        <section class="s_title o_mail_snippet_general pb0 pt0" data-snippet="s_title" data-name="Title">
+        <section class="s_title o_mail_snippet_general pb0 pt0" data-vxml="001" data-snippet="s_title" data-name="Title">
             <div class="container s_allow_columns">
                 <h3>Do you wish to become a partner?</h3>
                 <p>If you wish to become a partner and offer your services in [country], take a look at <a href="https://odoo.com/r/meeting" target="_blank">this page</a>.</p>
                 <p>Learn more about our pricing <a href="https://odoo.com/r/meeting" target="_blank">here</a>.</p>
             </div>
         </section>
-        <section class="s_text_block o_mail_snippet_general px-3 pt8 pb0" data-snippet="s_text_block" data-name="Text">
+        <section class="s_text_block o_mail_snippet_general px-3 pt8 pb0" data-vxml="001" data-snippet="s_text_block" data-name="Text">
             <div class="container s_allow_columns">
                 <p>You may then take part in round table discussions with experts who will give you their tips and tricks to help digitize companies. We'll wrap up the event with a networking session including a walking dinner.</p>
             </div>
         </section>
-        <section class="s_text_block o_mail_snippet_general px-3 pt8 pb0" data-snippet="s_text_block" data-name="Text">
+        <section class="s_text_block o_mail_snippet_general px-3 pt8 pb0" data-vxml="001" data-snippet="s_text_block" data-name="Text">
             <div class="container s_allow_columns">
                 <p>Thank you, once again, for your attendance at yesterday's event.</p>
                 <p>--</p>
@@ -1459,7 +1461,7 @@
                 --separator-border-top-width: 2px;
             }
         </style>
-        <section class="s_header_logo o_mail_block_header_logo o_mail_snippet_general" data-snippet="s_mail_block_header_logo" data-name="Centered Logo" style="background-color: rgb(220, 234, 255);">
+        <section class="s_header_logo o_mail_block_header_logo o_mail_snippet_general" data-vxml="001" data-snippet="s_mail_block_header_logo" data-name="Centered Logo" style="background-color: rgb(220, 234, 255);">
             <div class="container">
                 <div class="row">
                     <div class="col-md-4"></div>
@@ -1472,10 +1474,10 @@
                 </div>
             </div>
         </section>
-        <section class="s_picture o_mail_snippet_general pt48 px-3 o_cc o_cc2 pb0" data-snippet="s_picture" data-name="Picture" placeholder="Type &quot;/&quot; for commands" style="background-color: rgb(67, 128, 219);">
+        <section class="s_picture o_mail_snippet_general pt48 px-3 o_cc o_cc2 pb0" data-vxml="001" data-snippet="s_picture" data-name="Picture" placeholder="Type &quot;/&quot; for commands" style="background-color: rgb(67, 128, 219);">
             <img class="img-fluid o_we_custom_image" src="/html_editor/image_shape/mass_mailing_themes.s_default_image_block_image/html_builder/composition/composition_organic_line.svg?c1=%23FF9800" data-shape="html_builder/composition/composition_organic_line" data-file-name="picture-composition_organic_line.svg" data-shape-colors="#FF9800;;;;" data-format-mimetype="image/jpeg"/>
         </section>
-        <section class="s_title o_mail_snippet_general pt32 pb0" data-snippet="s_title" data-name="Title" style="background-color: rgb(67, 128, 219);">
+        <section class="s_title o_mail_snippet_general pt32 pb0" data-vxml="001" data-snippet="s_title" data-name="Title" style="background-color: rgb(67, 128, 219);">
             <div class="container s_allow_columns">
                 <div class="row">
                     <div class="col-md-10 offset-md-1 pb32">
@@ -1484,13 +1486,13 @@
                 </div>
             </div>
         </section>
-        <section class="s_mail_block_event o_mail_snippet_general bg-white o_colored_level" data-snippet="s_event" data-name="Event" contenteditable="false">
+        <section class="s_mail_block_event o_mail_snippet_general bg-white o_colored_level" data-vxml="001" data-snippet="s_event" data-name="Event" contenteditable="false">
             <div class="container" contenteditable="true">
                 <div class="row align-items-center">
                     <div class="o_mail_no_colorpicker pt32 pb0 o_colored_level col-md-10 offset-md-1" style="padding-left: 0px; padding-right: 0px;">
                         <div class="card bg-white h-100 border" style="border-radius: 5px !important; border-color: rgb(233, 236, 239) !important; border-width: 0px !important;">
                             <div class="card-body">
-                                <div class="s_title o_mail_snippet_general pb0 pt0 o_colored_level" data-snippet="s_title" data-name="Title">
+                                <div class="s_title o_mail_snippet_general pb0 pt0 o_colored_level" data-vxml="001" data-snippet="s_title" data-name="Title">
                                     <div class="container">
                                         <div class="row">
                                             <div class="o_colored_level col-md-12 o_draggable">
@@ -1517,7 +1519,7 @@
                 </div>
             </div>
         </section>
-        <section class="s_text_block o_mail_snippet_general" data-snippet="s_text_block" data-name="Text">
+        <section class="s_text_block o_mail_snippet_general" data-vxml="001" data-snippet="s_text_block" data-name="Text">
             <div class="container s_allow_columns">
                 <div class="row">
                     <div class="offset-md-1 col-md-10">
@@ -1526,7 +1528,7 @@
                 </div>
             </div>
         </section>
-        <section class="s_cover o_mail_snippet_general" data-snippet="s_cover" data-name="Cover" style="background-color: rgb(220, 234, 255);">
+        <section class="s_cover o_mail_snippet_general" data-vxml="001" data-snippet="s_cover" data-name="Cover" style="background-color: rgb(220, 234, 255);">
             <div class="container">
                 <div class="row">
                     <div class="oe_img_bg o_bg_img_center pb88 pt104 col-md-12" data-original-src="/mass_mailing_themes/static/src/img/theme_training/see_you_soon.svg" style="background-image: url('/mass_mailing_themes/static/src/img/theme_training/see_you_soon.svg');">
@@ -1536,7 +1538,7 @@
                 </div>
             </div>
         </section>
-        <section class="s_text_block o_mail_snippet_general px-3 pt16 pb0" data-snippet="s_text_block" data-name="Text" style="background-color: rgb(220, 234, 255);">
+        <section class="s_text_block o_mail_snippet_general px-3 pt16 pb0" data-vxml="001" data-snippet="s_text_block" data-name="Text" style="background-color: rgb(220, 234, 255);">
             <div class="container s_allow_columns">
                 <p style="text-align: center">
                     <span style="font-size: 10px;">
@@ -1544,12 +1546,12 @@
                         </font>
                     </span>
                 </p>
-                <div class="s_hr o_mail_snippet_general pt0 pb16" data-snippet="s_hr" data-name="Separator">
+                <div class="s_hr o_mail_snippet_general pt0 pb16" data-vxml="001" data-snippet="s_hr" data-name="Separator">
                     <hr class="s_hr_1px s_hr_solid w-50" contenteditable="false"/>
                 </div>
             </div>
         </section>
-        <section class="s_footer_social o_mail_block_footer_social o_mail_footer_social_center o_mail_snippet_general" data-snippet="s_mail_block_footer_social" data-name="Footer Center" style="background-color: rgb(220, 234, 255); text-align: center;">
+        <section class="s_footer_social o_mail_block_footer_social o_mail_footer_social_center o_mail_snippet_general" data-vxml="001" data-snippet="s_mail_block_footer_social" data-name="Footer Center" style="background-color: rgb(220, 234, 255); text-align: center;">
             <div class="container">
                 <div class="row">
                     <div class="col-md o_mail_footer_social pt8 pb8">


### PR DESCRIPTION
This work's purpose is to prepare `mass_mailing` for the upcoming migration to Odoo 19.0.
Existing mail content produced with the old editor is not upgraded, and users who end up editing such content must be informed if a snippet is not up to date.

contents:
- ensure that existing mail content with an obsolete mail HTML structure is properly displayed, even if the editor will not work at all, instead of showing the Theme Selector if no authorized theme is detected.
- ensure that a user editing an obsolete snippet is informed and can change it to the new version
- various crash fixes

See commits messages for further detail.

task-5134263
