### PR TITLE
[FIX] web,*: no default OK button in Dialog

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/number_popup/number_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/number_popup/number_popup.xml
@@ -13,10 +13,10 @@
             <Numpad buttons="props.buttons"/>
             <t t-set-slot="footer">
                 <div class="d-flex flex-grow-1 justify-content-center">
-                    <button t-att-disabled="!props.isValid(state.buffer)" class="btn btn-primary btn-lg lh-lg o-default-button me-2" tabindex="1" t-on-click="confirm">
+                    <button t-att-disabled="!props.isValid(state.buffer)" class="btn btn-primary btn-lg lh-lg me-2" tabindex="1" t-on-click="confirm">
                         <t t-esc="confirmButtonLabel"/>
                     </button>
-                    <button class="btn btn-secondary btn-lg lh-lg o-default-button" tabindex="1" t-on-click="cancel">
+                    <button class="btn btn-secondary btn-lg lh-lg" tabindex="1" t-on-click="cancel">
                         Discard
                     </button>
                 </div>

--- a/addons/point_of_sale/static/src/app/components/popups/optional_products_popup/optional_products_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/optional_products_popup/optional_products_popup.xml
@@ -66,8 +66,8 @@
 
             <t t-set-slot="footer">
                 <div class="d-flex flex-row gap-2 w-100">
-                    <button class="btn btn-primary btn-lg lh-lg w-50 o-default-button" t-on-click="confirm" t-att-disabled="buttonDisabled">Add</button>
-                    <button class="btn btn-secondary btn-lg lh-lg w-50 o-default-button" t-on-click="cancel">Discard</button>
+                    <button class="btn btn-primary btn-lg lh-lg w-50" t-on-click="confirm" t-att-disabled="buttonDisabled">Add</button>
+                    <button class="btn btn-secondary btn-lg lh-lg w-50" t-on-click="cancel">Discard</button>
                 </div>
             </t>
         </Dialog>

--- a/addons/point_of_sale/static/src/app/components/popups/product_configurator_popup/product_configurator_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/product_configurator_popup/product_configurator_popup.xml
@@ -226,12 +226,12 @@
             <t t-set-slot="footer">
                 <div class="d-flex flex-row gap-2 w-100">
                     <button
-                            class="btn btn-primary btn-lg lh-lg w-50 o-default-button"
+                            class="btn btn-primary btn-lg lh-lg w-50"
                             t-att-class="{'disabled': isArchivedCombination() or !this.isValidCombination()}"
                             t-on-click="confirm">
                             Add
                         </button>
-                    <button class="btn btn-secondary btn-lg lh-lg w-50 o-default-button" t-on-click="props.close">Discard</button>
+                    <button class="btn btn-secondary btn-lg lh-lg w-50" t-on-click="props.close">Discard</button>
                 </div>
             </t>
         </Dialog>

--- a/addons/point_of_sale/static/src/app/components/popups/text_input_popup/text_input_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/text_input_popup/text_input_popup.xml
@@ -13,8 +13,8 @@
             </t>
             <textarea t-att-rows="props.rows" class="form-control form-control-lg mx-auto" type="text" t-model="state.inputValue" t-ref="input" t-att-placeholder="props.placeholder" t-on-keydown="onKeydown" />
             <t t-set-slot="footer">
-                <button class="btn btn-primary btn-lg lh-lg o-default-button" t-on-click="confirm">Apply</button>
-                <button class="btn btn-secondary btn-lg lh-lg o-default-button" t-on-click="close">Discard</button>
+                <button class="btn btn-primary btn-lg lh-lg" t-on-click="confirm">Apply</button>
+                <button class="btn btn-secondary btn-lg lh-lg" t-on-click="close">Discard</button>
             </t>
         </Dialog>
     </t>

--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.xml
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.xml
@@ -63,7 +63,7 @@
                         title="Add a customer">
                     New 
                     </button>
-                    <button class="btn btn-secondary btn-lg lh-lg o-default-button flex-fill" t-on-click="() => this.clickPartner(this.props.partner)">Discard</button>
+                    <button class="btn btn-secondary btn-lg lh-lg flex-fill" t-on-click="() => this.clickPartner(this.props.partner)">Discard</button>
                 </div>
             </t>
         </Dialog>

--- a/addons/point_of_sale/static/tests/pos/tours/pos_combo_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/pos_combo_tour.js
@@ -24,8 +24,7 @@ registry.category("web_tour.tours").add("ProductComboPriceTaxIncludedTour", {
             Dialog.is("Attribute selection"),
             {
                 content: "dialog discard",
-                trigger:
-                    ".modal-footer .o-default-button:contains(/^Add$/) + .o-default-button:contains(/^Discard$/)",
+                trigger: ".modal-footer .btn:contains(/^Add$/) + .btn:contains(/^Discard$/)",
                 run: "click",
             },
             combo.select("Combo Product 5"),

--- a/addons/pos_event/static/src/app/components/popup/event_configurator_popup/event_configurator_popup.xml
+++ b/addons/pos_event/static/src/app/components/popup/event_configurator_popup/event_configurator_popup.xml
@@ -34,8 +34,8 @@
                 </t>
             </div>
             <t t-set-slot="footer">
-                <button class="btn btn-secondary o-default-button" t-on-click="cancel">Cancel</button>
-                <button class="btn btn-primary o-default-button" t-on-click="confirm">Confirm</button>
+                <button class="btn btn-secondary" t-on-click="cancel">Cancel</button>
+                <button class="btn btn-primary" t-on-click="confirm">Confirm</button>
             </t>
         </Dialog>
     </t>

--- a/addons/pos_event/static/src/app/components/popup/event_registration_popup/event_registration_popup.xml
+++ b/addons/pos_event/static/src/app/components/popup/event_registration_popup/event_registration_popup.xml
@@ -42,8 +42,8 @@
                 </t>
             </div>
             <t t-set-slot="footer">
-                <button class="btn btn-secondary o-default-button" t-on-click="close">Cancel</button>
-                <button class="btn btn-primary o-default-button" t-on-click="confirm">Confirm</button>
+                <button class="btn btn-secondary" t-on-click="close">Cancel</button>
+                <button class="btn btn-primary" t-on-click="confirm">Confirm</button>
             </t>
         </Dialog>
     </t>

--- a/addons/pos_event/static/src/app/components/popup/event_slot_selection_popup/event_slot_selection_popup.xml
+++ b/addons/pos_event/static/src/app/components/popup/event_slot_selection_popup/event_slot_selection_popup.xml
@@ -24,8 +24,8 @@
                 </div>
             </div>
             <t t-set-slot="footer">
-                <button class="btn btn-secondary o-default-button" t-on-click="cancel">Cancel</button>
-                <button class="btn btn-primary o-default-button" t-on-click="confirm">Confirm</button>
+                <button class="btn btn-secondary" t-on-click="cancel">Cancel</button>
+                <button class="btn btn-primary" t-on-click="confirm">Confirm</button>
             </t>
         </Dialog>
     </t>

--- a/addons/pos_loyalty/static/src/app/components/popups/manage_giftcard_popup/manage_giftcard_popup.xml
+++ b/addons/pos_loyalty/static/src/app/components/popups/manage_giftcard_popup/manage_giftcard_popup.xml
@@ -49,7 +49,7 @@
                     onChange.bind="onExpDateChange" />
             </div>
             <t t-set-slot="footer">
-                <button class="btn btn-primary o-default-button" t-on-click="addBalance" t-att-disabled="state.loading">
+                <button class="btn btn-primary" t-on-click="addBalance" t-att-disabled="state.loading">
                     <t t-if="state.lockGiftCardFields">
                         Add existing Gift Card
                     </t>

--- a/addons/pos_restaurant/static/src/app/components/popup/edit_order_name_popup/edit_order_name_popup.xml
+++ b/addons/pos_restaurant/static/src/app/components/popup/edit_order_name_popup/edit_order_name_popup.xml
@@ -22,7 +22,7 @@
                 <textarea t-att-rows="props.rows" class="h-100 flex-grow-1 form-control form-control-lg mx-auto" type="text" t-model="state.inputValue" t-ref="input" t-att-placeholder="props.placeholder" t-on-keydown="onKeydown" />
             </div>
         </xpath>
-        <xpath expr="//button[hasclass('o-default-button', 'btn-primary')]" position="attributes">
+        <xpath expr="//button[hasclass('btn-primary')]" position="attributes">
             <attribute name="t-attf-class">{{state.inputValue ? '' : 'disabled'}}</attribute>
         </xpath>
     </t>

--- a/addons/web/static/src/core/dialog/dialog.xml
+++ b/addons/web/static/src/core/dialog/dialog.xml
@@ -21,12 +21,8 @@
                         <main class="modal-body" t-attf-class="{{ props.bodyClass }} {{ !props.withBodyPadding ? 'p-0': '' }}">
                             <t t-slot="default" close="() => this.data.close()" />
                         </main>
-                        <footer t-if="props.footer" class="modal-footer justify-content-around justify-content-md-start flex-wrap gap-1 w-100">
-                            <t t-slot="footer" close="() => this.data.close()">
-                                <button class="btn btn-primary o-default-button" t-on-click="() => this.data.close()">
-                                    <t>Ok</t>
-                                </button>
-                            </t>
+                        <footer t-if="props.footer" class="modal-footer d-empty-none justify-content-around justify-content-md-start flex-wrap gap-1 w-100">
+                            <t t-slot="footer" close="() => this.data.close()"/>
                         </footer>
                     </div>
                 </div>
@@ -36,7 +32,7 @@
 
     <t t-name="web.Dialog.header">
         <t t-if="fullscreen">
-            <button class="btn oi oi-arrow-left" aria-label="Close" t-on-click="dismiss" />
+            <button class="btn oi oi-arrow-left" aria-label="Close" tabindex="-1" t-on-click="dismiss" />
         </t>
         <h4 class="modal-title text-break flex-grow-1" t-att-class="{ 'me-auto': fullscreen }">
             <t t-esc="props.title"/>

--- a/addons/web/static/src/core/utils/ui.js
+++ b/addons/web/static/src/core/utils/ui.js
@@ -118,7 +118,7 @@ export function touching(elements, targetRect) {
 //  - redefine this selector in tests env with ":not(#qunit *)" ?
 
 // Following selector is based on this spec: https://html.spec.whatwg.org/multipage/interaction.html#dom-tabindex
-const TABABLE_SELECTOR = [
+const FOCUSABLE_SELECTORS = [
     "[tabindex]",
     "a",
     "area",
@@ -130,9 +130,17 @@ const TABABLE_SELECTOR = [
     "select",
     "textarea",
     "details > summary:nth-child(1)",
-]
-    .map((sel) => `${sel}:not([tabindex="-1"]):not(:disabled)`)
-    .join(",");
+].map((sel) => `${sel}:not(:disabled)`);
+const TABABLE_SELECTORS = FOCUSABLE_SELECTORS.map((sel) => `${sel}:not([tabindex="-1"])`);
+
+/**
+ * Check if an element is focusable
+ *
+ * @param {HTMLElement} element
+ */
+export function isFocusable(el) {
+    return el.matches(FOCUSABLE_SELECTORS.join(",")) && isVisible(el) && !el.closest("[inert]");
+}
 
 /**
  * Returns all focusable elements in the given container.
@@ -140,7 +148,7 @@ const TABABLE_SELECTOR = [
  * @param {HTMLElement} [container=document.body]
  */
 export function getTabableElements(container = document.body) {
-    const elements = [...container.querySelectorAll(TABABLE_SELECTOR)].filter(
+    const elements = [...container.querySelectorAll(TABABLE_SELECTORS.join(","))].filter(
         (el) => isVisible(el) && !el.closest("[inert]")
     );
     /** @type {Record<number, HTMLElement[]>} */

--- a/addons/web/static/tests/core/dialog_service.test.js
+++ b/addons/web/static/tests/core/dialog_service.test.js
@@ -1,4 +1,4 @@
-import { test, expect, beforeEach, describe } from "@odoo/hoot";
+import { test, expect, beforeEach } from "@odoo/hoot";
 import { click, press, queryAll, queryAllTexts, queryOne } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import { getService, mountWithCleanup } from "@web/../tests/web_test_helpers";
@@ -7,8 +7,6 @@ import { Component, xml } from "@odoo/owl";
 import { usePopover } from "@web/core/popover/popover_hook";
 import { useAutofocus } from "@web/core/utils/hooks";
 import { MainComponentsContainer } from "@web/core/main_components_container";
-
-describe.current.tags("desktop");
 
 beforeEach(async () => {
     await mountWithCleanup(MainComponentsContainer);
@@ -25,7 +23,7 @@ test("Simple rendering with a single dialog", async () => {
     await animationFrame();
     expect(".o_dialog").toHaveCount(1);
     expect("header .modal-title").toHaveText("Welcome");
-    await click(".o_dialog footer button");
+    await click(".o_dialog button");
     await animationFrame();
     expect(".o_dialog").toHaveCount(0);
 });
@@ -68,7 +66,7 @@ test("rendering with two dialogs", async () => {
     await animationFrame();
     expect(".o_dialog").toHaveCount(2);
     expect(queryAllTexts("header .modal-title")).toEqual(["Hello", "Sauron"]);
-    await click(".o_dialog footer button");
+    await click(".o_dialog button");
     await animationFrame();
     expect(".o_dialog").toHaveCount(1);
     expect("header .modal-title").toHaveText("Sauron");
@@ -174,7 +172,7 @@ test("Interactions between multiple dialogs", async () => {
     expect(res.active).toEqual([false, true]);
     expect(res.names).toEqual(["Hello", "Sauron"]);
 
-    await click(".o_dialog:not(.o_inactive_modal) footer button");
+    await click(".o_dialog:not(.o_inactive_modal) button");
     await animationFrame();
 
     expect(".o_dialog").toHaveCount(1);
@@ -182,7 +180,7 @@ test("Interactions between multiple dialogs", async () => {
     expect(res.active).toEqual([true]);
     expect(res.names).toEqual(["Hello"]);
 
-    await click("footer button");
+    await click(".o_dialog:not(.o_inactive_modal) button");
     await animationFrame();
     expect(".o_dialog").toHaveCount(0);
 });

--- a/addons/web/static/tests/core/dropdown/dropdown.test.js
+++ b/addons/web/static/tests/core/dropdown/dropdown.test.js
@@ -787,7 +787,11 @@ test("don't close dropdown outside the active element", async () => {
     expect(".modal-dialog").toHaveCount(1);
     expect(DROPDOWN_MENU).toHaveCount(1);
 
-    await click(".modal-dialog .btn-primary");
+    if (getMockEnv().isSmall) {
+        await click(".modal-dialog .oi-arrow-left");
+    } else {
+        await click(".modal-dialog .btn-close");
+    }
     await animationFrame();
     expect(".modal-dialog").toHaveCount(0);
     expect(DROPDOWN_MENU).toHaveCount(1);

--- a/addons/web/static/tests/core/ui_service.test.js
+++ b/addons/web/static/tests/core/ui_service.test.js
@@ -157,6 +157,29 @@ test("do not become UI active element if no element to focus", async () => {
     expect(getService("ui").activeElement).toBe(document);
 });
 
+test("become UI active element if no element to focus but the container is focusable", async () => {
+    class MyComponent extends Component {
+        static template = xml`
+            <div>
+                <h1>My Component</h1>
+                <input type="text" placeholder="outerUIActiveElement"/>
+                <div id="idActiveElement" t-ref="delegatedRef" tabindex="-1">
+                    <div>
+                        <span> No focus element </span>
+                    </div>
+                </div>
+            </div>
+        `;
+        static props = ["*"];
+        setup() {
+            useActiveElement("delegatedRef");
+        }
+    }
+
+    await mountWithCleanup(MyComponent);
+    expect(getService("ui").activeElement).toBe(queryOne("#idActiveElement"));
+});
+
 test("UI active element: trap focus - first or last tabable changes", async () => {
     class MyComponent extends Component {
         static template = xml`

--- a/addons/web/static/tests/webclient/actions/client_action.test.js
+++ b/addons/web/static/tests/webclient/actions/client_action.test.js
@@ -116,7 +116,7 @@ test("can display client actions in Dialog and close the dialog", async () => {
 
     expect(".modal .test_client_action").toHaveCount(1);
     expect(".modal-title").toHaveText("Dialog Test");
-    await contains(".modal footer .btn.btn-primary").click();
+    await contains(".modal .btn-close").click();
     expect(".modal .test_client_action").toHaveCount(0);
 });
 

--- a/addons/web/static/tests/webclient/clickbot.test.js
+++ b/addons/web/static/tests/webclient/clickbot.test.js
@@ -457,7 +457,7 @@ test("clickbot show rpc error when an error dialog is detected", async () => {
                 <button class="btn btn-link p-0">See technical details</button>
             </div>
         </main>
-        <footer class="modal-footer justify-content-around justify-content-md-start flex-wrap gap-1 w-100">
+        <footer class="modal-footer d-empty-none justify-content-around justify-content-md-start flex-wrap gap-1 w-100">
             <button class="btn btn-primary o-default-button">Close</button>
         </footer>`
         .trim()

--- a/addons/web_tour/static/tests/tour_interactive.test.js
+++ b/addons/web_tour/static/tests/tour_interactive.test.js
@@ -180,7 +180,7 @@ test("pointer is added on top of overlay's stack", async () => {
     registry.category("web_tour.tours").add("tour1", {
         steps: () => [
             { trigger: ".modal .a", run: "click" },
-            { trigger: ".btn-primary", run: "click" },
+            { trigger: ".modal .btn-close", run: "click" },
         ],
     });
     class DummyDialog extends Component {
@@ -214,7 +214,7 @@ test("pointer is added on top of overlay's stack", async () => {
     await animationFrame();
     expect(".o_tour_pointer").toHaveCount(1);
 
-    await click(".btn-primary");
+    await click(".modal .btn-close");
     await animationFrame();
     expect(".o_tour_pointer").toHaveCount(0);
 });


### PR DESCRIPTION
*: point_of_sale, pos_*

Since the commit [1] simplifying the method to hide the base Dialog's
default button (aka. the "Ok" button) and the cleanup of the
ControlPanel's buttons, this "Ok" is displayed on some dialog (like
containing a list view) with no real purpose.

While this behavior/appearance was actually willingfull and more
deterministic than the previous one, it showed us that those default
buttons didn't provide a meaningful user experience and are more
disturbing than anything else.

This commit removes the Dialog's default "Ok" button.

But, this removal has a side-effect: dialog's without any "tabbable"
element (input, button...) doesn't get the focus anymore... and can't be
closed via keyboard navigation.

To circumvent this issue, this commit also adapts the `useActiveElement`
hook to focus the referenced element itself it is focusable and it
doesn't contain any "tabable" element.

task-5082826

[1]: https://github.com/odoo/odoo/commit/1cf179bbf1c49a6d69588911c2a3d98dbeadd3d9