### PR TITLE
[IMP] mail, web: native-like "back" navigation on mobile browser

### DIFF
--- a/addons/mail/static/src/core/common/chat_window.js
+++ b/addons/mail/static/src/core/common/chat_window.js
@@ -14,7 +14,7 @@ import { Component, toRaw, useChildSubEnv, useRef, useState, useSubEnv } from "@
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { localization } from "@web/core/l10n/localization";
 import { _t } from "@web/core/l10n/translation";
-import { useService } from "@web/core/utils/hooks";
+import { useBackButton, useService } from "@web/core/utils/hooks";
 import { Typing } from "@mail/discuss/typing/common/typing";
 import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
 import { isMobileOS } from "@web/core/browser/feature_detection";
@@ -62,6 +62,7 @@ export class ChatWindow extends Component {
             closeActionPanel: () => this.threadActions.activeAction?.actionPanelClose(),
             messageHighlight: this.messageHighlight,
         });
+        useBackButton(() => this.close());
     }
 
     get hasActionsMenu() {

--- a/addons/mail/static/src/discuss/core/common/action_panel.js
+++ b/addons/mail/static/src/discuss/core/common/action_panel.js
@@ -1,7 +1,7 @@
 import { attClassObjectToString } from "@mail/utils/common/format";
 import { Component, useSubEnv } from "@odoo/owl";
 import { ResizablePanel } from "@web/core/resizable_panel/resizable_panel";
-import { useForwardRefToParent, useService } from "@web/core/utils/hooks";
+import { useBackButton, useForwardRefToParent, useService } from "@web/core/utils/hooks";
 
 /**
  * @typedef {Object} Props
@@ -29,6 +29,7 @@ export class ActionPanel extends Component {
         this.ui = useService("ui");
         useForwardRefToParent("contentRef");
         useSubEnv({ inDiscussActionPanel: true });
+        useBackButton(() => this.env.closeActionPanel());
     }
 
     get classNames() {

--- a/addons/mail/static/src/discuss/core/common/message_seen_indicator.js
+++ b/addons/mail/static/src/discuss/core/common/message_seen_indicator.js
@@ -1,7 +1,7 @@
 import { Component, useExternalListener, useRef } from "@odoo/owl";
 import { Dialog } from "@web/core/dialog/dialog";
 import { _t } from "@web/core/l10n/translation";
-import { useService } from "@web/core/utils/hooks";
+import { useBackButton, useService } from "@web/core/utils/hooks";
 import { browser } from "@web/core/browser/browser";
 
 class MessageSeenIndicatorDialog extends Component {
@@ -22,6 +22,7 @@ class MessageSeenIndicatorDialog extends Component {
             },
             true
         );
+        useBackButton(() => this.props.close());
     }
 }
 

--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -128,7 +128,6 @@
             ("include", "web._assets_bootstrap_backend"),
             ('include', 'web._assets_core'),
             "point_of_sale/static/src/app/services/offline_service.js",
-            ("remove", "web/static/src/core/browser/router.js"),
             ("remove", "web/static/src/core/debug/**/*"),
             ('include', 'web.icons_fonts'),
             "web/static/src/views/fields/formatters.js",

--- a/addons/web/static/src/core/bottom_sheet/bottom_sheet.js
+++ b/addons/web/static/src/core/bottom_sheet/bottom_sheet.js
@@ -3,9 +3,9 @@
  *
  * @class
  */
-import { Component, useState, useRef, onMounted, useExternalListener } from "@odoo/owl";
+import { Component, useState, useRef, onMounted } from "@odoo/owl";
 import { useHotkey } from "@web/core/hotkeys/hotkey_hook";
-import { useForwardRefToParent } from "@web/core/utils/hooks";
+import { useBackButton, useForwardRefToParent } from "@web/core/utils/hooks";
 import { useThrottleForAnimation } from "@web/core/utils/timing";
 import { compensateScrollbar } from "@web/core/utils/scrolling";
 import { getViewportDimensions, useViewportChange } from "@web/core/utils/dvu";
@@ -73,17 +73,10 @@ export class BottomSheet extends Component {
         // Handle "ESC" key press.
         useHotkey("escape", () => this.slideOut());
 
-        // Handle mobile "back" gesture and "back" navigation button.
-        // Push a history state when the BottomSheet opens, intercept the browser's
-        // history events, prevents navigation by pushing another state and closes the sheet.
-        window.history.pushState({ bottomSheet: true }, "");
-        this.handlePopState = () => {
-            if (this.state.isPositionedReady && !this.state.isDismissing) {
-                window.history.pushState({ bottomSheet: true }, "");
-                this.slideOut();
-            }
-        };
-        useExternalListener(window, "popstate", this.handlePopState);
+        useBackButton(
+            () => this.slideOut(),
+            () => this.state.isPositionedReady && !this.state.isDismissing
+        );
 
         onMounted(() => {
             const isReduced =

--- a/addons/web/static/src/core/file_viewer/file_viewer.js
+++ b/addons/web/static/src/core/file_viewer/file_viewer.js
@@ -1,6 +1,6 @@
 import { Component, useEffect, useRef, useState } from "@odoo/owl";
 import { hasTouch } from "@web/core/browser/feature_detection";
-import { useAutofocus, useService } from "@web/core/utils/hooks";
+import { useAutofocus, useBackButton, useService } from "@web/core/utils/hooks";
 import { clamp } from "@web/core/utils/numbers";
 import { hidePDFJSButtons } from "@web/core/utils/pdfjs";
 
@@ -77,6 +77,7 @@ export class FileViewer extends Component {
             },
             () => [this.iframeViewerPdfRef.el]
         );
+        useBackButton(() => this.close());
     }
 
     onImageLoaded() {

--- a/addons/web/static/src/core/popover/popover.js
+++ b/addons/web/static/src/core/popover/popover.js
@@ -5,7 +5,7 @@ import { usePosition } from "@web/core/position/position_hook";
 import { reverseForRTL } from "@web/core/position/utils";
 import { useActiveElement } from "@web/core/ui/ui_service";
 import { mergeClasses } from "@web/core/utils/classname";
-import { useForwardRefToParent } from "@web/core/utils/hooks";
+import { useBackButton, useForwardRefToParent } from "@web/core/utils/hooks";
 
 /**
  * @param {EventTarget} target
@@ -155,6 +155,11 @@ export class Popover extends Component {
         } else {
             this.props.close();
         }
+
+        useBackButton(
+            () => this.props.close(),
+            () => this.props.target.isConnected
+        );
     }
 
     get defaultClassObj() {


### PR DESCRIPTION
Enterprise PR: https://github.com/odoo/enterprise/pull/102809

This commit expands the `useBackButton` hook to manage mobile "back" gesture and "back" navigation button.
This allows modal-like components to be closed via "back" gesture, replacing the unwanted behavior of navigating back.


fixes task-5041807
fixes task-4563827