### PR TITLE
[FIX] microsoft_calendar: prevent duplicate events

### DIFF
--- a/addons/microsoft_calendar/models/calendar.py
+++ b/addons/microsoft_calendar/models/calendar.py
@@ -488,12 +488,16 @@ class Meeting(models.Model):
             return 'organizer'
         return ATTENDEE_CONVERTER_O2M.get(attendee.state, 'None')
 
+    def _get_microsoft_transaction_id(self):
+        return f"{self.id}-{self.create_date.timestamp()}-{self.write_uid.id}"
+
     def _microsoft_values(self, fields_to_sync, initial_values={}):
         values = dict(initial_values)
         if not fields_to_sync:
             return values
 
-        microsoft_guid = self.env['ir.config_parameter'].sudo().get_param('microsoft_calendar.microsoft_guid', False)
+        # Transaction ID is used to prevent duplicate events in case of retry
+        values["transactionId"] = self._get_microsoft_transaction_id()
 
         if self.microsoft_recurrence_master_id and 'type' not in values:
             values['seriesMasterId'] = self.microsoft_recurrence_master_id

--- a/addons/microsoft_calendar/tests/test_update_events.py
+++ b/addons/microsoft_calendar/tests/test_update_events.py
@@ -69,7 +69,10 @@ class TestUpdateEvents(TestCommon):
         self.assertTrue(res)
         mock_patch.assert_called_once_with(
             self.simple_event.ms_organizer_event_id,
-            {"subject": "my new simple event"},
+            {
+                "transactionId": self.simple_event._get_microsoft_transaction_id(),
+                "subject": "my new simple event"
+            },
             token=mock_get_token(self.organizer_user),
             timeout=ANY,
         )
@@ -93,7 +96,10 @@ class TestUpdateEvents(TestCommon):
         self.assertTrue(res)
         mock_patch.assert_called_once_with(
             self.simple_event.ms_organizer_event_id,
-            {"subject": "my new simple event"},
+            {
+                "transactionId": self.simple_event._get_microsoft_transaction_id(),
+                "subject": "my new simple event"
+            },
             token=mock_get_token(self.organizer_user),
             timeout=ANY,
         )


### PR DESCRIPTION
When inserting an event into Outlook after a commit, if the insertion fails due to a timeout, the microsoft_id is never stored in the Odoo record. As a result, synchronization does not occur correctly. On the next sync, a new event is created in Outlook. Since the original event is not linked to the Odoo entry, it is also re-synchronized back into Odoo, resulting in duplicate events in both systems.

Steps to reproduce:
- This is difficult to reproduce consistently, as it depends on Outlook’s response time.
- Locally, it can be reproduced by forcing an error right after the Outlook insertion but before updating the Odoo record (between these lines: https://github.com/odoo/odoo/blob/34d0ae0ccb965e340d31bdbd7a7436af98e6dd48/addons/microsoft_calendar/models/microsoft_sync.py#L474-L475).

Fix approach:
This solution leverages the transactionId property provided by Microsoft (see: https://learn.microsoft.com/en-us/graph/api/resources/event?view=graph-rest-1.0#properties).

This ensures that even if a timeout occurs, a retry will trigger a sync from Microsoft to Odoo, and thanks to the transaction ID, the Microsoft event can be correctly matched with the Odoo event — preventing duplicates.

opw-5031073
opw-5105449