### PR TITLE
[FIX] base_import: allow file upload on product import for studio fields

### DIFF
--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -1509,7 +1509,7 @@ class Import(models.TransientModel):
             if any(name + '/' in import_field and name == import_field.split('/')[prefix.count('/')] for import_field in import_fields):
                 # Recursive call with the relational as new model and add the field name to the prefix
                 binary_filenames = self._extract_binary_filenames(import_fields, data, field.comodel_name, name + '/', binary_filenames)
-            elif field.type == 'binary' and field.attachment and any(f in name for f in IMAGE_FIELDS) and name in import_fields:
+            elif field.type == 'binary' and field.attachment and name in import_fields:
                 index = import_fields.index(name)
                 for line in data:
                     filename = None


### PR DESCRIPTION
## Versions
18.0 > 18.3
Solved from 18.4 thanks to e0e46b5c15d53d7aab69a9c4bf39d9b2a412efc6

## Issue
Importing products (with file fields) from XLSX file triggers an error or does not update when uploading related PDF files.

## Steps to reproduce

https://github.com/user-attachments/assets/7f4c1faf-de8c-4923-a50e-cce77071679d

*Requires Studio app*
- Go to any product's backend page and open Studio customization:
  - Add a "File" field to the product page and link it to a "PDF Viewer" widget;
  - Keep the field name ("New File");
  - Save and close.
- Go to the products' list view in debug mode and select a product (e.g. Acoustic Bloc Screens) to export (via "Actions"):
  - Check the "import-compatible" checkbox;
  - Remove all fields to export;
  - Look for "file" in available fields:
    - Add the "New File (x_studio_binary_field_xxx_xxxxxxxxx)" field;
    - Add its related "Filename for x_studio_binary_field_xxx_xxxxxxxxx (x_studio_binary_field_xxx_xxxxxxxxx_filename)".
  - Export in XLSX format.
- In your computer's file explorer:
  - Download or create a PDF file and copy its name;
  - Open the XLSX file and paste the PDF filename in the 2 empty columns;
  - Save and close the file.
- In the products' main view click "Import records" action button:
  - Click "Upload Data File" and select the XLSX product file.
  - Click "Upload your files" in the "Files to import" section on the left and select the PDF file.
  - Click "Test" or "Import"

## Cause
This upload feature has been described in task 4077715. This specific lines seems to be based on another one a bit further in the code: https://github.com/odoo/odoo/blob/e42f5bee59daa0e270ae4803cc827009974da232/addons/base_import/models/base_import.py#L1289

## Fix
Allow all files base 64 conversion by removing a restriction on images only.

opw-4931579