### PR TITLE
[FIX] api_doc: ConstantMapping is not json-serializable

### DIFF
--- a/addons/api_doc/controllers/api_doc.py
+++ b/addons/api_doc/controllers/api_doc.py
@@ -561,7 +561,7 @@ class Param:
             # ignore the default value when it is not json serializable
             try:
                 json.dumps(self.default)
-            except ValueError:
+            except (ValueError, TypeError):
                 d.pop('default')
         return d
 


### PR DESCRIPTION
There is the following public method on the ir.ui.view model:

    def distribute_branding(self, e, branding=None, parent_xpath='',
                            index_map=ConstantMapping(1)):

The default value for `index_map`: `ConstantMapping`, is not json-serializable. Trying to `json.dumps` it raises a TypeError. We want to ignore the default value in this case.

Reported-by: Sunhyeok Sam <suju@odoo.com>

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
