### PR TITLE
[IMP] iot_drivers: network quality check on receipts

### DIFF
--- a/addons/iot_drivers/controllers/driver.py
+++ b/addons/iot_drivers/controllers/driver.py
@@ -29,6 +29,10 @@ class DriverController(http.Controller):
         We specify in data from which session_id that action is called
         And call the action of specific device
         """
+        if device_identifier == "test_protocol":
+            # Special case for testing if a protocol is working
+            return True
+
         # If device_identifier is a type of device, we take the first device of this type
         # required for longpolling with community db
         if device_identifier in DEVICE_TYPES:

--- a/addons/iot_drivers/tools/helpers.py
+++ b/addons/iot_drivers/tools/helpers.py
@@ -6,6 +6,7 @@ from functools import cache, wraps
 from importlib import util
 import inspect
 import io
+from ipaddress import ip_address
 import logging
 import netifaces
 from pathlib import Path
@@ -23,7 +24,15 @@ import zipfile
 from werkzeug.exceptions import Locked
 
 from odoo import http, release, service
-from odoo.addons.iot_drivers.tools.system import IOT_CHAR, IOT_RPI_CHAR, IOT_WINDOWS_CHAR, IS_RPI, IS_TEST, IS_WINDOWS
+from odoo.addons.iot_drivers.tools.system import (
+    IOT_CHAR,
+    IOT_RPI_CHAR,
+    IOT_WINDOWS_CHAR,
+    IS_RPI,
+    IS_TEST,
+    IS_WINDOWS,
+    mtr,
+)
 from odoo.tools.func import reset_cached_properties
 from odoo.tools.misc import file_path
 
@@ -640,3 +649,34 @@ def toggle_remote_connection(token=""):
         )
         return True
     return False
+
+
+def check_network(host=None):
+    host = host or get_gateway()
+    if not host:
+        return None
+
+    host = socket.gethostbyname(host)
+    packet_loss, avg_latency = mtr(host)
+    thresholds = {"fast": 5, "normal": 20} if ip_address(host).is_private else {"fast": 50, "normal": 150}
+
+    if packet_loss is None or packet_loss >= 50 or avg_latency is None:
+        return "unreachable"
+    if avg_latency < thresholds["fast"] and packet_loss < 1:
+        return "fast"
+    if avg_latency < thresholds["normal"] and packet_loss < 5:
+        return "normal"
+    return "slow"
+
+
+def get_gateway():
+    """Get the router IP address (default gateway)
+
+    :return: The IP address of the default gateway or None if it can't be determined
+    """
+    gws = netifaces.gateways()
+    default = gws.get("default", {})
+    gw = default.get(netifaces.AF_INET)
+    if gw:
+        return gw[0]
+    return None

--- a/addons/iot_drivers/tools/system.py
+++ b/addons/iot_drivers/tools/system.py
@@ -1,5 +1,6 @@
 """Operating system-related utilities for the IoT"""
 
+import subprocess
 from platform import system, release
 
 IOT_SYSTEM = system()
@@ -26,3 +27,30 @@ else:
     def rpi_only(_):
         """No-op decorator for non raspberry pi systems."""
         return lambda *args, **kwargs: None
+
+
+def mtr(host):
+    """Run mtr command to the given host to get both
+    packet loss (%) and average latency (ms).
+
+    Note: we use ``-4`` in order to force IPv4, to avoid
+    empty results on IPv6 networks.
+
+    :param host: The host to ping.
+    :return: A tuple of (packet_loss, avg_latency) or (None, None) if the command failed.
+    """
+    if IS_WINDOWS:
+        return None, None
+
+    # sudo is required for probe interval < 1s, which almost divides execution time by 2
+    command = ["sudo", "mtr", "-r", "-C", "--no-dns", "-c", "3", "-i", "0.2", "-4", "-G", "1", host]
+    p = subprocess.run(command, stdout=subprocess.PIPE, text=True, check=False)
+    if p.returncode != 0:
+        return None, None
+
+    output = p.stdout.strip()
+    last_line = output.splitlines()[-1].split(",")
+    try:
+        return float(last_line[6]), float(last_line[10])
+    except (IndexError, ValueError):
+        return None, None

--- a/addons/iot_drivers/webrtc_client.py
+++ b/addons/iot_drivers/webrtc_client.py
@@ -7,6 +7,7 @@ import time
 from aiortc import RTCDataChannel, RTCPeerConnection, RTCSessionDescription
 
 from odoo.addons.iot_drivers import main
+from odoo.addons.iot_drivers.tools import helpers
 
 _logger = logging.getLogger(__name__)
 
@@ -71,6 +72,13 @@ class WebRtcClient(Thread):
                             'time': time.time(),
                             'status': 'disconnected',
                         })
+                elif message_type == "test_protocol":
+                    self.send({
+                        'owner': message['session_id'],
+                        'device_identifier': helpers.get_identifier(),
+                        'time': time.time(),
+                        'status': 'success',
+                    })
 
             @channel.on("close")
             def on_close():

--- a/addons/iot_drivers/websocket_client.py
+++ b/addons/iot_drivers/websocket_client.py
@@ -115,6 +115,17 @@ class WebsocketClient(Thread):
                         'status': 'success',
                         'result': {'enabled': helpers.is_ngrok_enabled()}
                     })
+                case "test_connection":
+                    send_to_controller({
+                        'session_id': payload['session_id'],
+                        'iot_box_identifier': helpers.get_identifier(),
+                        'device_identifier': helpers.get_identifier(),
+                        'status': 'success',
+                        'result': {
+                            'lan_quality': helpers.check_network(),
+                            'wan_quality': helpers.check_network("www.odoo.com"),
+                        }
+                    })
                 case _:
                     continue
 


### PR DESCRIPTION
In order to ease network checks for consultants, we added a quick latency and packet loss check, formatting the output as "slow"/"normal"/ "fast" or "unreachable".

We also add a way to test each protocol (webrtc, longpolling, websocket) and to check latency/packet lost, in order to add a `Test` button on the IoT Box record.

Enterprise PR: odoo/enterprise#96298
Task: 5130809
