### PR TITLE
[REV] web: revert "too many data in graph"

### DIFF
--- a/addons/web/static/src/views/graph/graph_renderer.js
+++ b/addons/web/static/src/views/graph/graph_renderer.js
@@ -598,10 +598,6 @@ export class GraphRenderer extends Component {
         return { x: xAxe, y: yAxe };
     }
 
-    loadAll() {
-        return this.model.forceLoadAll();
-    }
-
     /**
      * This function extracts the information from the data points in
      * tooltipModel.dataPoints (corresponding to datapoints over a given

--- a/addons/web/static/src/views/graph/graph_renderer.xml
+++ b/addons/web/static/src/views/graph/graph_renderer.xml
@@ -31,14 +31,6 @@
 
     <t t-name="web.GraphRenderer">
         <div t-att-class="'o_graph_renderer o_renderer h-100 d-flex flex-column border-top ' + props.class" t-ref="root">
-            <t t-if="model.data.exceeds">
-                <div class="alert alert-info text-center o_graph_alert m-3 mb-2" role="status">
-                    There are too many data. The graph only shows a sample. Use the filters to refine the scope.
-                    <a class="o_graph_load_all_btn" href="#" t-on-click="() => this.loadAll()">
-                        Load everything anyway.
-                    </a>
-                </div>
-            </t>
             <div class="d-flex d-print-none gap-1 flex-shrink-0 mt-2 mx-3 mb-3 overflow-x-auto">
                 <t t-call="{{ props.buttonTemplate }}"/>
             </div>

--- a/addons/web/static/tests/views/graph/graph_view.test.js
+++ b/addons/web/static/tests/views/graph/graph_view.test.js
@@ -50,7 +50,6 @@ import { DEFAULT_BG, getBorderWhite, getColors, lightenColor } from "@web/core/c
 import { Domain } from "@web/core/domain";
 import { SampleServer } from "@web/model/sample_server";
 import { GraphArchParser } from "@web/views/graph/graph_arch_parser";
-import { GraphModel } from "@web/views/graph/graph_model";
 import { GraphRenderer } from "@web/views/graph/graph_renderer";
 import { WebClient } from "@web/webclient/webclient";
 
@@ -2916,68 +2915,6 @@ test("display the field's falsy_value_label for false group, if defined", async 
     });
 
     checkLabels(view, ["xphone", "xpad", "I'm the false group"]);
-});
-
-test("limit dataset amount", async () => {
-    class Project extends models.Model {
-        id = fields.Integer();
-        name = fields.Char();
-    }
-    class Stage extends models.Model {
-        id = fields.Integer();
-        name = fields.Char();
-    }
-    class Task extends models.Model {
-        id = fields.Integer();
-        name = fields.Char();
-        project_id = fields.Many2one({ relation: "project" });
-        stage_id = fields.Many2one({ relation: "stage" });
-    }
-    defineModels([Project, Stage, Task]);
-
-    for (let i = 1; i <= 600; i++) {
-        Project._records.push({
-            id: i,
-            name: `Project ${i}`,
-        });
-        Stage._records.push({
-            id: i,
-            name: `Stage ${i}`,
-        });
-        Task._records.push({
-            id: i,
-            project_id: i,
-            stage_id: i,
-            name: `Task ${i}`,
-        });
-    }
-
-    const view = await mountView({
-        type: "graph",
-        resModel: "task",
-        arch: `
-            <graph>
-                <field name="project_id"/>
-                <field name="stage_id"/>
-            </graph>
-        `,
-    });
-    const model = getGraphModel(view);
-    expect(model.data.exceeds).toBe(true);
-    expect(model.data.datasets).toHaveLength(80);
-    expect(model.data.labels).toHaveLength(80);
-    expect(`.o_graph_alert`).toHaveCount(1);
-
-    patchWithCleanup(GraphModel.prototype, {
-        notify() {
-            expect.step("rerender");
-        },
-    });
-    await contains(`.o_graph_load_all_btn`).click();
-    expect.verifySteps(["rerender"]);
-    expect(model.data.exceeds).toBe(false);
-    expect(model.data.datasets).toHaveLength(600);
-    expect(model.data.labels).toHaveLength(600);
 });
 
 test.tags("desktop");


### PR DESCRIPTION
This reverts the changes introduced in https://github.com/odoo/odoo/pull/192892

Since the control panel no longer waits for all data to be loaded, filters can now be applied immediately, without needing to wait for large datasets to finish loading.

task-5134538
