### PR TITLE
[FIX] point_of_sale: show error message when country is not set

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -524,6 +524,11 @@ class PosConfig(models.Model):
         if not self.env.is_admin() and {'is_header_or_footer', 'receipt_header', 'receipt_footer'} & values.keys():
             raise AccessError(_('Only administrators can edit receipt headers and footers'))
 
+    def _check_company_has_fiscal_country(self):
+        self.ensure_one()
+        if not self.company_id.account_fiscal_country_id:
+            raise ValidationError(_("The company must have a fiscal country set."))
+
     @api.model_create_multi
     def create(self, vals_list):
         if not self._default_warehouse_id():
@@ -792,6 +797,7 @@ class PosConfig(models.Model):
                 return res
         self._validate_fields(self._fields)
 
+        self._check_company_has_fiscal_country()
         return self._action_to_open_ui()
 
     def open_existing_session_cb(self):

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -6,6 +6,7 @@ from odoo.fields import Command
 from odoo.tests import Form
 from datetime import datetime, timedelta
 from odoo.addons.point_of_sale.tests.common import CommonPosTest
+from odoo.exceptions import ValidationError
 
 
 @odoo.tests.tagged('post_install', '-at_install')
@@ -1791,3 +1792,9 @@ class TestPointOfSaleFlow(CommonPosTest):
         order_ids = [oi[0] for oi in self.env['pos.order'].search_paid_order_ids(other_pos_config.id, [('partner_id.complete_name', 'ilike', self.partner.complete_name)], 80, 0)['ordersInfo']]
         self.assertNotIn(paid_order_1.id, order_ids)
         self.assertIn(paid_order_2.id, order_ids)
+
+    def test_open_ui_missing_country(self):
+        """ Test that a POS can not be opened if it has no country """
+        self.pos_config_usd.company_id.account_fiscal_country_id = False
+        with self.assertRaises(ValidationError, msg="The company must have a fiscal country set."):
+            self.pos_config_usd.open_ui()


### PR DESCRIPTION
Before this commit, if the fiscal country was not set on the company, it was still possible to open the PoS session, but the interface would fail to load due to an error in the round_base_lines_tax_details function, which requires the country.

With this commit, a clear error message is displayed when the country is not set, preventing the session from opening and avoiding the silent loading failure.

opw-5135750

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
