### PR TITLE
[FIX] website: apply opacity to highlights correctly

### DIFF
--- a/addons/website/static/tests/builder/website_builder/highlight.test.js
+++ b/addons/website/static/tests/builder/website_builder/highlight.test.js
@@ -10,7 +10,7 @@ import { contains } from "@web/../tests/web_test_helpers";
 import { closestElement } from "@html_editor/utils/dom_traversal";
 import { Plugin } from "@html_editor/plugin";
 import { highlightIdToName } from "@website/builder/plugins/highlight/highlight_configurator";
-import { textHighlightFactory } from "@website/js/highlight_utils";
+import { textHighlightFactory, makeHighlightSvg } from "@website/js/highlight_utils";
 
 defineMailModels();
 
@@ -191,4 +191,19 @@ test("each highlight has a name", () => {
     highlightWithAName.sort();
     highlightWithAPath.sort();
     expect(highlightWithAPath).toEqual(highlightWithAName);
+});
+
+test(`Fill highlights don't have the 'stroke' attribute`, () => {
+    const params = {
+        width: 50,
+        height: 50,
+        numberOfCharPerWidth: () => 1,
+    };
+    const strokeSvg = makeHighlightSvg("freehand_1", params);
+    const fillSvg = makeHighlightSvg("freehand_3", params);
+
+    expect(strokeSvg.querySelector("path")).toHaveAttribute("stroke");
+    expect(strokeSvg.querySelector("path")).not.toHaveAttribute("fill");
+    expect(fillSvg.querySelector("path")).toHaveAttribute("fill");
+    expect(fillSvg.querySelector("path")).not.toHaveAttribute("stroke");
 });


### PR DESCRIPTION
We can use custom colors on highlights using the inline text editor,
and when the highlight isn't a line (e.g., has a filling inside) and we
set its color to have a different opacity than 100%, we can see the
stroke and the filling overlap, and the semi-transparent colors
blend together, creating a darker appearance along the edges.

To see the issue:
- Open the website and start editing
- Select any text and apply a highlight with a filling, for example,
freehand_3
- Click on Color, open the "Custom" tab, and slide the opacity slider
down

-> Observe the darker appearance along the edges of the highlight,
which happens because the highlight svg has both `fill` and `stroke`.

task-5104135
