### PR TITLE
[IMP] mass_mailing: add conditional visibility on snippets

### DIFF
--- a/addons/mass_mailing/__manifest__.py
+++ b/addons/mass_mailing/__manifest__.py
@@ -117,10 +117,15 @@
             'web/static/src/scss/ui.scss',
             'web/static/src/scss/fontawesome_overridden.scss',
 
-            ('include', 'html_builder.assets_inside_builder_iframe'),
             ('include', 'mass_mailing.assets_mail_themes'),
             'mass_mailing/static/src/scss/mass_mailing_mail.scss',
             'mass_mailing/static/src/iframe_assets/**/*',
+        ],
+        # style assets used to view the mail content in Odoo, but not used
+        # during html conversion, specific to the builder
+        'mass_mailing.assets_inside_builder_iframe': [
+            ('include', 'html_builder.assets_inside_builder_iframe'),
+            'mass_mailing/static/src/builder/**/*.inside.scss'
         ],
         'mass_mailing.iframe_add_dialog': [
             'mass_mailing/static/src/builder/snippet_viewer/*.scss',

--- a/addons/mass_mailing/static/src/builder/options/snippet_visibility_option.inside.scss
+++ b/addons/mass_mailing/static/src/builder/options/snippet_visibility_option.inside.scss
@@ -1,0 +1,14 @@
+section[data-filter-domain]:not([data-filter-domain="[]"]) {
+    position: relative;
+    & > *:first-child::before {
+        right: 20px; // See Website for indicator values.
+        top: 0;
+        pointer-events: none;
+        opacity: 50%;
+        position: absolute;
+        font-family: "FontAwesome";
+        content: "\f070";
+        font-size: xx-large;
+        color: $o-we-color-accent;
+    }
+}

--- a/addons/mass_mailing/static/src/builder/options/snippet_visibility_option.js
+++ b/addons/mass_mailing/static/src/builder/options/snippet_visibility_option.js
@@ -1,0 +1,79 @@
+import { BaseOptionComponent, useDomState } from "@html_builder/core/utils";
+import { Domain } from "@web/core/domain";
+import { DomainSelectorDialog } from "@web/core/domain_selector_dialog/domain_selector_dialog";
+import { useService } from "@web/core/utils/hooks";
+
+/**
+ * Option Component to enable the user to filter some snippets to a specific subset of ids following
+ * a domain.
+ */
+export class SnippetVisibilityOption extends BaseOptionComponent {
+    static template = "mass_mailing.VisibilityOption";
+    static selector = "section";
+    static dependencies = ["mass_mailing.SnippetVisibility"];
+
+    setup() {
+        super.setup();
+        this.getModel = this.dependencies["mass_mailing.SnippetVisibility"].getModel;
+        this.treeProcessor = useService("tree_processor");
+        this.dialog = useService("dialog");
+        this.historyPlugin = this.env.editor.shared.history;
+        this.overlayButtonsPlugin = this.env.editor.shared.overlayButtons;
+
+        this.state = useDomState((editingElement) => {
+            const currentDomain = new Domain(
+                JSON.parse(editingElement.dataset.filterDomain || "[]")
+            );
+            this.parseTree(currentDomain);
+            return {
+                domain: currentDomain,
+            };
+        });
+    }
+
+    get stringifiedDomain() {
+        return JSON.stringify(this.state.domain.toJson());
+    }
+
+    /**
+     *
+     * @param {import("@web/core/tree_editor/condition_tree").Tree} tree
+     */
+    async parseTree(domain) {
+        const resModel = this.getModel();
+        const tree = await this.treeProcessor.treeFromDomain(resModel, domain, !this.env.debug);
+        // Extract subtrees connected by an `&`, Odoo Standard for domain facets
+        const trees = !tree.negate && tree.value === "&" ? tree.children : [tree];
+        this.state.facets = await Promise.all(
+            trees.map((tree) =>
+                this.treeProcessor.getDomainTreeDescription(resModel, tree, false, 2, 1)
+            )
+        );
+    }
+
+    onClickEditDomain() {
+        this.overlayButtonsPlugin.hideOverlayButtonsUi();
+        this.dialog.add(
+            DomainSelectorDialog,
+            {
+                resModel: this.getModel(),
+                domain: this.state.domain.toString(),
+                isDebugMode: !!this.env.debug,
+                onConfirm: (domain) => {
+                    const newDomain = new Domain(domain);
+                    this.state.domain = newDomain;
+                    this.env.getEditingElement().dataset.filterDomain = JSON.stringify(
+                        this.state.domain.toJson()
+                    );
+                    this.parseTree(newDomain);
+                    this.historyPlugin.addStep();
+                },
+            },
+            {
+                onClose: () => {
+                    this.overlayButtonsPlugin.showOverlayButtonsUi();
+                },
+            }
+        );
+    }
+}

--- a/addons/mass_mailing/static/src/builder/options/snippet_visibility_option.xml
+++ b/addons/mass_mailing/static/src/builder/options/snippet_visibility_option.xml
@@ -1,0 +1,27 @@
+<templates>
+    <t t-name="mass_mailing.VisibilityOption">
+        <BuilderRow label.translate="Visibility">
+            <BuilderSelect dataAttributeAction="'filterDomain'">
+                <BuilderSelectItem dataAttributeActionValue="''">Always Visible</BuilderSelectItem>
+                <BuilderSelectItem dataAttributeActionValue="this.stringifiedDomain" id="'show_domain_selector'">Conditionally</BuilderSelectItem>
+            </BuilderSelect>
+        </BuilderRow>
+        <BuilderContext t-if="this.isActiveItem('show_domain_selector')">
+            <BuilderRow level="1" label.translate="Domain" extraLabelClass="'align-self-end'">
+                <div class="d-flex flex-column">
+                    <div class="d-inline-flex align-items-center pt-1" t-foreach="this.state.facets || []" t-as="facet" t-key="facet_index">
+                        <span class="fa fa-filter pe-1"/>
+                        <span t-out="facet"/>
+                    </div>
+                </div>
+            </BuilderRow>
+            <!-- Trick to have the content of two rows on the same level -->
+            <BuilderRow label.translate=" ">
+                <button class="btn btn-secondary me-auto mt-1" t-on-click="this.onClickEditDomain">
+                    <t t-if="this.state.facets?.length">Add Conditions</t>
+                    <t t-else="">Edit Conditions</t>
+                </button>
+            </BuilderRow>
+        </BuilderContext>
+    </t>
+</templates>

--- a/addons/mass_mailing/static/src/builder/plugins/snippet_visibility_option_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/snippet_visibility_option_plugin.js
@@ -1,0 +1,41 @@
+import { Plugin } from "@html_editor/plugin";
+import { registry } from "@web/core/registry";
+import { SnippetVisibilityOption } from "../options/snippet_visibility_option";
+import { withSequence } from "@html_editor/utils/resource";
+import { effect } from "@web/core/utils/reactive";
+
+class SnippetVisibilityPlugin extends Plugin {
+    static id = "mass_mailing.SnippetVisibility";
+    static shared = ["getModel"];
+
+    resources = {
+        builder_options: [withSequence(Infinity, SnippetVisibilityOption)],
+    };
+    setup() {
+        this.mailingModelId = this.config.record.data.mailing_model_id.id;
+        effect(
+            (record) => {
+                if (this.isDestroyed) {
+                    return;
+                }
+                if (record.data.mailing_model_id.id !== this.mailingModelId) {
+                    this.mailingModelId = record.data.mailing_model_id.id;
+                    this.resetFilterDomains();
+                }
+            },
+            [this.config.record]
+        );
+    }
+
+    getModel() {
+        return this.config.record.data.mailing_model_real;
+    }
+
+    resetFilterDomains() {
+        const filteredElements = this.editable.querySelectorAll("[data-filter-domain]");
+        filteredElements.forEach((el) => el.removeAttribute("data-filter-domain"));
+        this.dispatchTo("trigger_dom_updated");
+    }
+}
+
+registry.category("mass_mailing-plugins").add(SnippetVisibilityPlugin.id, SnippetVisibilityPlugin);

--- a/addons/mass_mailing/static/src/fields/html_field/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/fields/html_field/mass_mailing_html_field.js
@@ -12,6 +12,7 @@ import { registry } from "@web/core/registry";
 import { Deferred } from "@web/core/utils/concurrency";
 import { effect } from "@web/core/utils/reactive";
 import { useChildRef, useService } from "@web/core/utils/hooks";
+import { Domain } from "@web/core/domain";
 
 export class MassMailingHtmlField extends HtmlField {
     static template = "mass_mailing.HtmlField";
@@ -220,6 +221,7 @@ export class MassMailingHtmlField extends HtmlField {
         delete config.Plugins;
         return {
             ...config,
+            record: this.props.record,
             mobileBreakpoint: "md",
             defaultImageMimetype: "image/jpeg",
             onEditorReady: () => this.commitChanges(),
@@ -318,6 +320,7 @@ export class MassMailingHtmlField extends HtmlField {
         );
         bundleControls["mass_mailing.assets_inside_builder_iframe"]?.toggle(false);
         processingContainer.append(processingEl);
+        this.preprocessFilterDomains(processingEl);
         const cssRules = getCSSRules(this.iframeRef.el.contentDocument);
         await toInline(processingEl, cssRules);
         const inlineValue = processingEl.innerHTML;
@@ -334,6 +337,24 @@ export class MassMailingHtmlField extends HtmlField {
             })
             .catch(() => (this.isDirty = true));
         this.props.record.model.bus.trigger("FIELD_IS_DIRTY", this.isDirty);
+    }
+    /**
+     * Processes the data-filter-domain to be converted to a t-if that will be interpreted on send
+     * by QWeb.
+     * TODO EGGMAIL: move in a convert_inline plugin when they are implemented.
+     * @param {HTMLElement} htmlEl
+     */
+    preprocessFilterDomains(htmlEl) {
+        htmlEl.querySelectorAll("[data-filter-domain]").forEach((el) => {
+            let domain;
+            try {
+                domain = new Domain(JSON.parse(el.dataset.filterDomain));
+            } catch {
+                el.setAttribute("t-if", "false");
+                return;
+            }
+            el.setAttribute("t-if", `object.filtered_domain(${domain.toString()})`);
+        });
     }
 }
 

--- a/addons/mass_mailing/static/src/iframe/mass_mailing_iframe.js
+++ b/addons/mass_mailing/static/src/iframe/mass_mailing_iframe.js
@@ -22,6 +22,10 @@ import { _t } from "@web/core/l10n/translation";
 import { localization } from "@web/core/l10n/localization";
 
 const IFRAME_VALUE_SELECTOR = ".o_mass_mailing_value";
+const MASS_MAILING_IFRAME_ASSETS = [
+    "mass_mailing.assets_iframe_style",
+    "mass_mailing.assets_inside_builder_iframe",
+];
 
 export class MassMailingIframe extends Component {
     static template = "mass_mailing.MassMailingIframe";
@@ -193,7 +197,7 @@ export class MassMailingIframe extends Component {
     }
 
     async setupIframe() {
-        await this.loadIframeAssets();
+        this.bundleControls = await this.loadIframeAssets();
         if (status(this) === "destroyed") {
             return;
         }
@@ -220,7 +224,10 @@ export class MassMailingIframe extends Component {
         this.iframeRef.el.contentWindow.addEventListener("beforeUnload", () => {
             this.iframeRef.el.removeAttribute("is-ready");
         });
-        this.iframeLoaded.resolve(this.iframeRef.el);
+        this.iframeLoaded.resolve({
+            iframe: this.iframeRef.el,
+            bundleControls: this.bundleControls,
+        });
         this.props.onIframeLoad?.(this.iframeLoaded);
         this.state.ready = true;
     }
@@ -262,14 +269,38 @@ export class MassMailingIframe extends Component {
         );
     }
 
+    /**
+     * @returns {Object} bundleControls { bundleName: activatorObject }
+     */
     async loadIframeAssets() {
-        await Promise.all([
-            loadBundle("mass_mailing.assets_iframe_style", {
-                targetDoc: this.iframeRef.el.contentDocument,
-                css: true,
-                js: false,
-            }),
-        ]);
+        const bundleEntryPromises = MASS_MAILING_IFRAME_ASSETS.map(async (bundle) => {
+            const targets = (
+                await loadBundle(bundle, {
+                    targetDoc: this.iframeRef.el.contentDocument,
+                    css: true,
+                    js: false,
+                })
+            ).map((bundleEvent) => bundleEvent.target);
+            const iframe = this.iframeRef.el;
+            return [
+                bundle,
+                {
+                    toggle(enable = false) {
+                        if (!iframe?.isConnected) {
+                            return;
+                        }
+                        for (const target of targets) {
+                            if (enable && !iframe.contentDocument.head.contains(target)) {
+                                iframe.contentDocument.head.appendChild(target);
+                            } else if (!enable && iframe.contentDocument.head.contains(target)) {
+                                target.remove();
+                            }
+                        }
+                    },
+                },
+            ];
+        });
+        return Object.fromEntries(await Promise.all(bundleEntryPromises));
     }
 
     onBlur(ev) {
@@ -289,7 +320,7 @@ export class MassMailingIframe extends Component {
     getBuilderProps() {
         return {
             overlayRef: this.overlayRef,
-            iframeLoaded: this.iframeLoaded,
+            iframeLoaded: this.iframeLoaded.then((iframeInfo) => iframeInfo.iframe),
             snippetsName: "mass_mailing.email_designer_snippets",
             config: this.props.config,
             isMobile: this.state.isMobile,


### PR DESCRIPTION
This commit adds an option in the new Mail Builder to enable users to only show
elements based on a domain on the recipients.

This option uses the DomainSelectorDialog so that the user has an easier time
working on it. The resModel is the model chosen by the user for the whole
mailing limiting the choice of fields to a limited list. The option populates a
data attribute: `data-filter-domain` that is supposed to contain a valid domain
notation. When processing the htmlField to be inlined, we process each elements
that contains the data attribute and set the `t-if` attribute accordingly.

If the domain stored isn't valid, the attribute is set to `false`. We prefer to
not show elements that could be reserved to a subset of a recipients.

If the domain is valid, then the attribute is set to
`object.filtered_domain([data-filter-domain])`. This enables us to easily create
QWeb conditions on the mailing that will be interpreted by the render mixin on
each recipients.

The resulting processed body is then returned to be fed to the rest of the
sending process.

task-4599334

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
