### PR TITLE
[IMP] hr_recruitment: show employees with rights in recruiter selection

### DIFF
--- a/addons/hr/models/hr_job.py
+++ b/addons/hr/models/hr_job.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models, _
+from odoo import api, fields, models
 from odoo.addons.html_editor.tools import handle_history_divergence
 
 
@@ -10,6 +10,12 @@ class HrJob(models.Model):
     _description = "Job Position"
     _inherit = ['mail.thread']
     _order = 'sequence'
+
+    def _recruiter_domain(self):
+        return [
+            ("user_id", "!=", False),
+            ("user_id.share", "=", False),
+        ]
 
     active = fields.Boolean(default=True)
     name = fields.Char(string='Job Position', required=True, index='trigram', translate=True)
@@ -23,18 +29,17 @@ class HrJob(models.Model):
     employee_ids = fields.One2many('hr.employee', 'job_id', string='Employees', groups='base.group_user')
     description = fields.Html(string='Job Description', sanitize_attributes=False)
     requirements = fields.Text('Requirements', groups="hr.group_hr_user")
-    user_id = fields.Many2one(
-        "res.users",
+    recruiter_id = fields.Many2one(
+        'hr.employee',
         "Recruiter",
-        domain="[('share', '=', False), ('company_ids', '=?', company_id)]",
-        default=lambda self: self.env.user,
+        domain=_recruiter_domain,
+        check_company=True,
+        default=lambda self: self.env.user.employee_id,
         groups="hr.group_hr_user",
         tracking=True,
         help="The Recruiter will be the default value for all Applicants in this job \
             position. The Recruiter is automatically added to all meetings with the Applicant.",
     )
-    # TODO (master): remove the field `allowed_user_ids`.
-    allowed_user_ids = fields.Many2many('res.users', compute='_compute_allowed_user_ids', readonly=True)
     department_id = fields.Many2one('hr.department', string='Department', check_company=True, tracking=True, index='btree_not_null')
     company_id = fields.Many2one('res.company', string='Company', default=lambda self: self.env.company, tracking=True)
     contract_type_id = fields.Many2one('hr.contract.type', string='Contract Type', tracking=True)
@@ -55,28 +60,6 @@ class HrJob(models.Model):
         for job in self:
             job.no_of_employee = result.get(job.id, 0)
             job.expected_employees = result.get(job.id, 0) + job.no_of_recruitment
-
-    @api.depends("company_id")
-    def _compute_allowed_user_ids(self):
-        company_ids = self.mapped("company_id.id")
-        domain = [("share", "=", False)]
-        if company_ids:
-            domain += [("company_ids", "in", company_ids)]
-
-        users_by_company = dict(
-            self.env["res.users"]._read_group(
-                domain=domain,
-                groupby=["company_id"],
-                aggregates=["id:recordset"],
-            ),
-        )
-
-        all_users = self.env["res.users"]
-        for users in users_by_company.values():
-            all_users |= users
-
-        for job in self:
-            job.allowed_user_ids = users_by_company.get(job.company_id, all_users)
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/hr/views/hr_job_views.xml
+++ b/addons/hr/views/hr_job_views.xml
@@ -22,7 +22,7 @@
                             <page string="Details" name="recruitment_page" invisible="1" groups="hr.group_hr_user">
                                 <group>
                                     <group name="hiring_process" string="Hiring Process" invisible="1">
-                                        <field name="user_id" widget="many2one_avatar_user"/>
+                                        <field name="recruiter_id" widget="many2one_avatar_employee"/>
                                         <label name="no_of_recruitment_label" for="no_of_recruitment"/>
                                         <div class="o_row" name="recruitment_target">
                                             <field name="no_of_recruitment" class="o_hr_narrow_field"/>

--- a/addons/hr_recruitment/data/hr_recruitment_demo.xml
+++ b/addons/hr_recruitment/data/hr_recruitment_demo.xml
@@ -97,7 +97,7 @@
         <field name="job_id" ref="hr.job_marketing"/>
         <field name="department_id" ref="hr.dep_sales"/>
         <field name="medium_id" ref="utm.utm_medium_direct"/>
-        <field name="user_id" ref="base.user_demo"/>
+        <field name="recruiter_id" ref="hr.employee_admin"/>
         <field name="priority">1</field>
         <field name="stage_id" ref="stage_job2"/>
         <field name="create_date" eval="DateTime.now() - relativedelta(days=29)"/>
@@ -113,7 +113,7 @@
         <field name="availability" eval="(DateTime.today() + relativedelta(months=3)).strftime('%Y-%m-%d')"/>
         <field name="job_id" ref="hr.job_marketing"/>
         <field name="department_id" ref="hr.dep_sales"/>
-        <field name="user_id" ref="base.user_demo"/>
+        <field name="recruiter_id" ref="hr.employee_admin"/>
         <field name="priority">1</field>
         <field name="stage_id" ref="stage_job1"/>
     </record>
@@ -129,7 +129,7 @@
         <field name="job_id" ref="hr.job_cto"/>
         <field name="department_id" ref="hr.dep_rd"/>
         <field name="medium_id" ref="utm.utm_medium_email"/>
-        <field name="user_id" ref="base.user_admin"/>
+        <field name="recruiter_id" ref="hr.employee_admin"/>
         <field name="stage_id" ref="stage_job1"/>
     </record>
 
@@ -143,7 +143,7 @@
         <field name="job_id" ref="hr.job_cto"/>
         <field name="department_id" ref="hr.dep_rd"/>
         <field name="medium_id" ref="utm.utm_medium_email"/>
-        <field name="user_id" ref="base.user_admin"/>
+        <field name="recruiter_id" ref="hr.employee_admin"/>
         <field name="priority">3</field>
         <field name="stage_id" ref="stage_job2"/>
         <field name="refuse_reason_id" ref="refuse_reason_8"></field>
@@ -158,7 +158,7 @@
         <field name="availability" eval="(DateTime.today() + timedelta(days=15)).strftime('%Y-%m-%d')"/>
         <field name="job_id" ref="hr.job_cto"/>
         <field name="department_id" ref="hr.dep_rd"/>
-        <field name="user_id" ref="base.user_admin"/>
+        <field name="recruiter_id" ref="hr.employee_admin"/>
         <field name="priority">3</field>
         <field name="stage_id" ref="stage_job4"/>
     </record>
@@ -173,7 +173,7 @@
         <field name="job_id" ref="hr.job_developer"/>
         <field name="department_id" ref="hr.dep_rd"/>
         <field name="medium_id" ref="utm.utm_medium_email"/>
-        <field name="user_id" ref="base.user_admin"/>
+        <field name="recruiter_id" ref="hr.employee_admin"/>
         <field name="priority">3</field>
         <field name="stage_id" ref="stage_job1"/>
     </record>
@@ -186,7 +186,7 @@
         <field name="categ_ids" eval="[(6,0,[ref('tag_applicant_it')])]"/>
         <field name="job_id" ref="hr.job_developer"/>
         <field name="department_id" ref="hr.dep_rd"/>
-        <field name="user_id" ref="base.user_admin"/>
+        <field name="recruiter_id" ref="hr.employee_admin"/>
         <field name="priority">0</field>
         <field name="stage_id" ref="stage_job2"/>
     </record>
@@ -200,7 +200,7 @@
         <field name="job_id" ref="hr.job_developer"/>
         <field name="department_id" ref="hr.dep_rd"/>
         <field name="medium_id" ref="utm.utm_medium_email"/>
-        <field name="user_id" ref="base.user_admin"/>
+        <field name="recruiter_id" ref="hr.employee_admin"/>
         <field name="priority">0</field>
         <field name="stage_id" ref="stage_job3"/>
     </record>
@@ -213,7 +213,7 @@
         <field name="categ_ids" eval="[(6,0,[ref('tag_applicant_it')])]"/>
         <field name="job_id" ref="hr.job_developer"/>
         <field name="department_id" ref="hr.dep_rd"/>
-        <field name="user_id" ref="base.user_admin"/>
+        <field name="recruiter_id" ref="hr.employee_admin"/>
         <field name="priority">0</field>
         <field name="stage_id" ref="stage_job1"/>
         <field name="refuse_reason_id" ref="refuse_reason_6"></field>
@@ -229,7 +229,7 @@
         <field name="availability" eval="(DateTime.today() + timedelta(days=15)).strftime('%Y-%m-%d')"/>
         <field name="job_id" ref="hr.job_trainee"/>
         <field name="department_id" ref="hr.dep_rd"/>
-        <field name="user_id" ref="base.user_demo"/>
+        <field name="recruiter_id" ref="hr.employee_admin"/>
         <field name="priority">2</field>
         <field name="stage_id" ref="stage_job4"/>
         <field name="partner_phone">6633225</field>
@@ -246,7 +246,7 @@
         <field name="availability" eval="(DateTime.today() + timedelta(days=15)).strftime('%Y-%m-%d')"/>
         <field name="job_id" ref="hr.job_trainee"/>
         <field name="department_id" ref="hr.dep_sales"/>
-        <field name="user_id" ref="base.user_demo"/>
+        <field name="recruiter_id" ref="hr.employee_admin"/>
         <field name="priority">2</field>
         <field name="stage_id" ref="stage_job3"/>
         <field name="partner_phone">6633225</field>
@@ -264,7 +264,7 @@
         <field name="categ_ids" eval="[(6,0,[ref('tag_applicant_it')])]"/>
         <field name="job_id" ref="hr.job_trainee"/>
         <field name="department_id" ref="hr.dep_administration"/>
-        <field name="user_id" ref="base.user_demo"/>
+        <field name="recruiter_id" ref="hr.employee_admin"/>
         <field name="priority">0</field>
         <field name="stage_id" ref="stage_job3"/>
     </record>
@@ -277,7 +277,7 @@
         <field name="categ_ids" eval="[Command.set([ref('tag_applicant_it')])]"/>
         <field name="job_id" ref="hr.job_trainee"/>
         <field name="department_id" ref="hr.dep_administration"/>
-        <field name="user_id" ref="base.user_demo"/>
+        <field name="recruiter_id" ref="hr.employee_admin"/>
         <field name="priority">0</field>
         <field name="stage_id" ref="stage_job3"/>
         <field name="refuse_reason_id" ref="refuse_reason_7"></field>
@@ -292,7 +292,7 @@
         <field name="categ_ids" eval="[Command.set([ref('tag_applicant_it')])]"/>
         <field name="job_id" ref="hr.job_trainee"/>
         <field name="department_id" ref="hr.dep_administration"/>
-        <field name="user_id" ref="base.user_demo"/>
+        <field name="recruiter_id" ref="hr.employee_admin"/>
         <field name="priority">0</field>
         <field name="stage_id" ref="stage_job3"/>
         <field name="refuse_reason_id" ref="refuse_reason_7"></field>
@@ -307,7 +307,7 @@
         <field name="categ_ids" eval="[Command.set([ref('tag_applicant_it')])]"/>
         <field name="job_id" ref="hr.job_trainee"/>
         <field name="department_id" ref="hr.dep_administration"/>
-        <field name="user_id" ref="base.user_demo"/>
+        <field name="recruiter_id" ref="hr.employee_admin"/>
         <field name="priority">0</field>
         <field name="stage_id" ref="stage_job3"/>
         <field name="refuse_reason_id" ref="refuse_reason_7"></field>
@@ -321,7 +321,7 @@
         <field name="categ_ids" eval="[(6,0,[ref('tag_applicant_manager')])]"/>
         <field name="job_id" ref="hr.job_marketing"/>
         <field name="department_id" ref="hr.dep_sales"/>
-        <field name="user_id" ref="base.user_admin"/>
+        <field name="recruiter_id" ref="hr.employee_admin"/>
         <field name="stage_id" ref="stage_job1"/>
     </record>
 
@@ -333,7 +333,7 @@
         <field name="availability" eval="(DateTime.today() + timedelta(days=15)).strftime('%Y-%m-%d')"/>
         <field name="job_id" ref="hr.job_marketing"/>
         <field name="department_id" ref="hr.dep_sales"/>
-        <field name="user_id" ref="base.user_admin"/>
+        <field name="recruiter_id" ref="hr.employee_admin"/>
         <field name="priority">3</field>
         <field name="stage_id" ref="stage_job3"/>
     </record>
@@ -346,7 +346,7 @@
         <field name="availability" eval="(DateTime.today() + timedelta(days=15)).strftime('%Y-%m-%d')"/>
         <field name="job_id" ref="hr.job_marketing"/>
         <field name="department_id" ref="hr.dep_sales"/>
-        <field name="user_id" ref="base.user_admin"/>
+        <field name="recruiter_id" ref="hr.employee_admin"/>
         <field name="priority">3</field>
         <field name="stage_id" ref="stage_job0"/>
         <field name="refuse_reason_id" ref="refuse_reason_5"></field>
@@ -361,7 +361,7 @@
         <field name="categ_ids" eval="[Command.set([ref('tag_applicant_it')])]"/>
         <field name="job_id" ref="hr.job_marketing"/>
         <field name="department_id" ref="hr.dep_administration"/>
-        <field name="user_id" ref="base.user_admin"/>
+        <field name="recruiter_id" ref="hr.employee_admin"/>
         <field name="priority">1</field>
         <field name="stage_id" ref="stage_job0"/>
         <field name="refuse_reason_id" ref="refuse_reason_7"></field>
@@ -376,7 +376,7 @@
         <field eval="(datetime.now()+relativedelta(months=-2)).strftime('%Y-%m-03 01:00:00')" name="create_date"/>
         <field name="job_id" ref="hr.job_marketing"/>
         <field name="department_id" ref="hr.dep_sales"/>
-        <field name="user_id" ref="base.user_admin"/>
+        <field name="recruiter_id" ref="hr.employee_admin"/>
         <field name="stage_id" ref="stage_job5"/>
         <field name="create_date" eval="DateTime.now() - relativedelta(days=61)"/>
         <field name="date_last_stage_update" eval="(DateTime.today() - timedelta(days=37)).strftime('%Y-%m-%d')"/>
@@ -390,7 +390,7 @@
         <field eval="(datetime.now()+relativedelta(months=-1)).strftime('%Y-%m-08 01:00:00')" name="create_date"/>
         <field name="job_id" ref="hr.job_developer"/>
         <field name="department_id" ref="hr.dep_rd"/>
-        <field name="user_id" ref="base.user_demo"/>
+        <field name="recruiter_id" ref="hr.employee_admin"/>
         <field name="stage_id" ref="stage_job5"/>
         <field name="create_date" eval="DateTime.now() - relativedelta(days=34)"/>
         <field name="date_last_stage_update" eval="(DateTime.today() - timedelta(days=7)).strftime('%Y-%m-%d')"/>
@@ -405,7 +405,7 @@
         <field name="availability" eval="(DateTime.today() + relativedelta(months=3)).strftime('%Y-%m-%d')"/>
         <field name="job_id" ref="hr.job_hrm"/>
         <field name="department_id" ref="hr.dep_administration"/>
-        <field name="user_id" ref="base.user_admin"/>
+        <field name="recruiter_id" ref="hr.employee_admin"/>
         <field name="priority">1</field>
         <field name="stage_id" ref="stage_job2"/>
     </record>
@@ -418,7 +418,7 @@
         <field name="availability" eval="(DateTime.today() + timedelta(days=15)).strftime('%Y-%m-%d')"/>
         <field name="job_id" ref="hr.job_hrm"/>
         <field name="department_id" ref="hr.dep_administration"/>
-        <field name="user_id" ref="base.user_admin"/>
+        <field name="recruiter_id" ref="hr.employee_admin"/>
         <field name="priority">1</field>
         <field name="stage_id" ref="stage_job2"/>
         <field name="create_date" eval="DateTime.now() - relativedelta(days=7)"/>
@@ -434,7 +434,7 @@
         <field name="availability" eval="(DateTime.today() + relativedelta(months=3)).strftime('%Y-%m-%d')"/>
         <field name="job_id" ref="hr.job_hrm"/>
         <field name="department_id" ref="hr.dep_administration"/>
-        <field name="user_id" ref="base.user_admin"/>
+        <field name="recruiter_id" ref="hr.employee_admin"/>
         <field name="priority">1</field>
         <field name="stage_id" ref="stage_job2"/>
         <field name="refuse_reason_id" ref="refuse_reason_1"></field>
@@ -450,7 +450,7 @@
         <field name="availability" eval="(DateTime.today() + relativedelta(months=3)).strftime('%Y-%m-%d')"/>
         <field name="job_id" ref="hr.job_hrm"/>
         <field name="department_id" ref="hr.dep_administration"/>
-        <field name="user_id" ref="base.user_admin"/>
+        <field name="recruiter_id" ref="hr.employee_admin"/>
         <field name="priority">3</field>
         <field name="stage_id" ref="stage_job2"/>
     </record>
@@ -464,7 +464,7 @@
         <field name="availability" eval="(DateTime.today() + relativedelta(months=3)).strftime('%Y-%m-%d')"/>
         <field name="job_id" ref="hr.job_hrm"/>
         <field name="department_id" ref="hr.dep_administration"/>
-        <field name="user_id" ref="base.user_admin"/>
+        <field name="recruiter_id" ref="hr.employee_admin"/>
         <field name="priority">2</field>
         <field name="stage_id" ref="stage_job0"/>
     </record>
@@ -478,7 +478,7 @@
         <field name="job_id" ref="hr.job_trainee"/>
         <field name="department_id" ref="hr.dep_rd"/>
         <field name="stage_id" ref="stage_job4"/>
-        <field name="user_id" ref="base.user_admin"/>
+        <field name="recruiter_id" ref="hr.employee_admin"/>
         <field name="create_date" eval="DateTime.now() - relativedelta(days=67)"/>
         <field name="date_last_stage_update" eval="(DateTime.today() - timedelta(days=45)).strftime('%Y-%m-%d')"/>
     </record>
@@ -492,7 +492,7 @@
         <field name="job_id" ref="hr.job_trainee"/>
         <field name="department_id" ref="hr.dep_rd"/>
         <field name="stage_id" ref="stage_job0"/>
-        <field name="user_id" ref="base.user_admin"/>
+        <field name="recruiter_id" ref="hr.employee_admin"/>
         <field name="create_date" eval="DateTime.now() - relativedelta(days=67)"/>
         <field name="date_last_stage_update" eval="(DateTime.today() - timedelta(days=45)).strftime('%Y-%m-%d')"/>
     </record>
@@ -506,7 +506,7 @@
         <field name="job_id" ref="hr.job_trainee"/>
         <field name="department_id" ref="hr.dep_rd"/>
         <field name="stage_id" ref="stage_job1"/>
-        <field name="user_id" ref="base.user_admin"/>
+        <field name="recruiter_id" ref="hr.employee_admin"/>
         <field name="create_date" eval="DateTime.now() - relativedelta(days=67)"/>
         <field name="date_last_stage_update" eval="(DateTime.today() - timedelta(days=45)).strftime('%Y-%m-%d')"/>
     </record>
@@ -520,7 +520,7 @@
         <field name="availability" eval="(DateTime.today() + relativedelta(months=3)).strftime('%Y-%m-%d')"/>
         <field name="job_id" ref="hr.job_developer"/>
         <field name="department_id" ref="hr.dep_rd"/>
-        <field name="user_id" ref="base.user_admin"/>
+        <field name="recruiter_id" ref="hr.employee_admin"/>
         <field name="stage_id" ref="stage_job4"/>
         <field name="salary_expected">11000.0</field>
         <field name="create_date" eval="DateTime.now() - relativedelta(days=13)"/>
@@ -536,7 +536,7 @@
         <field name="availability" eval="(DateTime.today() + relativedelta(months=3)).strftime('%Y-%m-%d')"/>
         <field name="job_id" ref="hr.job_consultant"/>
         <field name="department_id" ref="hr.dep_ps"/>
-        <field name="user_id" ref="base.user_admin"/>
+        <field name="recruiter_id" ref="hr.employee_admin"/>
         <field name="stage_id" ref="stage_job2"/>
         <field name="salary_expected">11000.0</field>
         <field name="create_date" eval="DateTime.now() - relativedelta(days=4)"/>
@@ -552,7 +552,7 @@
         <field name="availability" eval="(DateTime.today() + relativedelta(months=3)).strftime('%Y-%m-%d')"/>
         <field name="job_id" ref="hr.job_consultant"/>
         <field name="department_id" ref="hr.dep_ps"/>
-        <field name="user_id" ref="base.user_admin"/>
+        <field name="recruiter_id" ref="hr.employee_admin"/>
         <field name="stage_id" ref="stage_job2"/>
         <field name="salary_expected">21000.0</field>
         <field name="create_date" eval="DateTime.now() - relativedelta(days=4)"/>
@@ -568,7 +568,7 @@
         <field name="availability" eval="(DateTime.today() + relativedelta(months=3)).strftime('%Y-%m-%d')"/>
         <field name="job_id" ref="hr.job_consultant"/>
         <field name="department_id" ref="hr.dep_ps"/>
-        <field name="user_id" ref="base.user_admin"/>
+        <field name="recruiter_id" ref="hr.employee_admin"/>
         <field name="stage_id" ref="stage_job1"/>
         <field name="salary_expected">51000.0</field>
         <field name="create_date" eval="DateTime.now() - relativedelta(days=4)"/>
@@ -584,7 +584,7 @@
         <field name="availability" eval="(DateTime.today() + relativedelta(months=3)).strftime('%Y-%m-%d')"/>
         <field name="job_id" ref="hr.job_consultant"/>
         <field name="department_id" ref="hr.dep_ps"/>
-        <field name="user_id" ref="base.user_admin"/>
+        <field name="recruiter_id" ref="hr.employee_admin"/>
         <field name="stage_id" ref="stage_job4"/>
         <field name="salary_expected">71000.0</field>
         <field name="create_date" eval="DateTime.now() - relativedelta(days=4)"/>
@@ -600,7 +600,7 @@
         <field name="availability" eval="(DateTime.today() + relativedelta(months=3)).strftime('%Y-%m-%d')"/>
         <field name="job_id" ref="hr.job_consultant"/>
         <field name="department_id" ref="hr.dep_ps"/>
-        <field name="user_id" ref="base.user_admin"/>
+        <field name="recruiter_id" ref="hr.employee_admin"/>
         <field name="stage_id" ref="stage_job4"/>
         <field name="salary_expected">51123.0</field>
         <field name="create_date" eval="DateTime.now() - relativedelta(days=4)"/>
@@ -900,7 +900,7 @@
         <field name="partner_name">Cameron Ellis</field>
         <field name="email_from">cameron.ellis@example.com</field>
         <field name="partner_phone">654687987</field>
-        <field name="user_id" ref="base.user_admin"/>
+        <field name="recruiter_id" ref="hr.employee_admin"/>
         <field name="priority">0</field>
         <field name="talent_pool_ids" eval="[Command.link(ref('talent_pool_0'))]"></field>
     </record>
@@ -922,7 +922,7 @@
         <field name="partner_name">Ethan Carter</field>
         <field name="email_from">ethan.carter@example.com</field>
         <field name="partner_phone">987891</field>
-        <field name="user_id" ref="base.user_admin"/>
+        <field name="recruiter_id" ref="hr.employee_admin"/>
         <field name="priority">1</field>
         <field name="talent_pool_ids" eval="[Command.link(ref('talent_pool_0'))]"></field>
     </record>
@@ -944,7 +944,7 @@
         <field name="partner_name">Noah Bennett</field>
         <field name="email_from">noah.bennett@example.com</field>
         <field name="partner_phone">8951245111</field>
-        <field name="user_id" ref="base.user_admin"/>
+        <field name="recruiter_id" ref="hr.employee_admin"/>
         <field name="priority">3</field>
         <field name="talent_pool_ids" eval="[Command.link(ref('talent_pool_0'))]"></field>
     </record>

--- a/addons/hr_recruitment/data/mail_template_data.xml
+++ b/addons/hr_recruitment/data/mail_template_data.xml
@@ -34,11 +34,11 @@
     <br/><br/>
     Thank you,
     <div style="font-size: 11px; color: grey;">
-        <t t-if="object.user_id">
+        <t t-if="object.recruiter_id">
             -- <br/>
-            <strong t-out="object.user_id.name or ''">Mitchell Admin</strong><br/>
-            Email: <t t-out="object.user_id.email or ''">admin@yourcompany.example.com</t><br/>
-            Phone: <t t-out="object.user_id.phone or ''">+1 650-123-4567</t>
+            <strong t-out="object.recruiter_id.name or ''">Mitchell Admin</strong><br/>
+            Email: <t t-out="object.recruiter_id.work_email or ''">admin@yourcompany.example.com</t><br/>
+            Phone: <t t-out="object.recruiter_id.work_phone or ''">+1 650-123-4567</t>
         </t>
         <t t-else="">
             -- <br/>
@@ -76,11 +76,11 @@
                 t-attf-style="background-color: {{object.company_id.email_secondary_color or '#875A7B'}}; text-decoration: none; color: {{object.company_id.email_primary_color or '#FFFFFF'}}; padding: 8px 16px 8px 16px; border-radius: 5px;">Job Description</a>
         </div>
 
-        <t t-if="object.user_id">
+        <t t-if="object.recruiter_id and object.recruiter_id.user_id">
             You will soon be contacted by:<br/>
-            <strong t-out="object.user_id.name or ''">Mitchell Admin</strong><br/>
-            <span>Email: <t t-out="object.user_id.email or ''">admin@yourcompany.example.com</t></span><br/>
-            <span>Phone: <t t-out="object.user_id.phone or ''">+1 650-123-4567</t></span>
+            <strong t-out="object.recruiter_id.name or ''">Mitchell Admin</strong><br/>
+            <span>Email: <t t-out="object.recruiter_id.work_email or ''">admin@yourcompany.example.com</t></span><br/>
+            <span>Phone: <t t-out="object.recruiter_id.work_phone or ''">+1 650-123-4567</t></span>
             <br/><br/>
         </t>
         See you soon,
@@ -163,12 +163,12 @@
     </div>
 
     <hr width="97%" style="background-color: rgb(204,204,204); border: medium none; clear: both; display: block; font-size: 0px; min-height: 1px; line-height: 0; margin: 16px 0px 16px 0px;"/>
-    <t t-if="object.user_id">
+    <t t-if="object.recruiter_id and object.recruiter_id.user_id">
         <h3 style="color:#9A6C8E;"><strong>Your Contact:</strong></h3>
         <p>
-            <strong t-out="object.user_id.name or ''">Mitchell Admin</strong><br/>
-            <span>Email: <t t-out="object.user_id.email or ''">admin@yourcompany.example.com</t></span><br/>
-            <span>Phone: <t t-out="object.user_id.phone or ''">+1 650-123-4567</t></span>
+            <strong t-out="object.recruiter_id.name or ''">Mitchell Admin</strong><br/>
+            <span>Email: <t t-out="object.recruiter_id.work_email or ''">admin@yourcompany.example.com</t></span><br/>
+            <span>Phone: <t t-out="object.recruiter_id.work_phone or ''">+1 650-123-4567</t></span>
         </p>
         <hr width="97%" style="background-color: rgb(204,204,204); border: medium none; clear: both; display: block; font-size: 0px; min-height: 1px; line-height: 0; margin: 16px 0px 16px 0px;"/>
     </t>
@@ -232,11 +232,11 @@
         <br/><br/>
         Best<br/>
         <div style="font-size: 11px; color: grey;">
-            <t t-if="object.user_id">
+            <t t-if="object.recruiter_id and object.recruiter_id.user_id">
                 -- <br/>
-                <strong t-out="object.user_id.name or ''">Marc Demo</strong><br/>
-                Email: <t t-out="object.user_id.email or ''">mark.brown23@example.com</t><br/>
-                Phone: <t t-out="object.user_id.phone or ''">+1 650-123-4567</t>
+                <strong t-out="object.recruiter_id.name or ''">Marc Demo</strong><br/>
+                Email: <t t-out="object.recruiter_id.work_email or ''">mark.brown23@example.com</t><br/>
+                Phone: <t t-out="object.recruiter_id.work_phone or ''">+1 650-123-4567</t>
             </t>
             <t t-else="">
                 -- <br/>

--- a/addons/hr_recruitment/tests/test_recruitment_allowed_user_ids.py
+++ b/addons/hr_recruitment/tests/test_recruitment_allowed_user_ids.py
@@ -1,9 +1,9 @@
 from odoo.tests import tagged, TransactionCase
 
 
-@tagged('recruitment_allowed_user_ids')
+@tagged('recruitment_allowed_recruiters')
 @tagged('at_install', '-post_install')  # LEGACY at_install
-class TestRecruitmentAllowedUserIds(TransactionCase):
+class TestRecruitmentAllowedRecruiters(TransactionCase):
 
     def setUp(self):
         super().setUp()
@@ -13,7 +13,7 @@ class TestRecruitmentAllowedUserIds(TransactionCase):
         self.company_a = self.env['res.company'].create({'name': 'Company A'})
         self.company_b = self.env['res.company'].create({'name': 'Company BBS'})
 
-        # Internal user in company A
+        # Internal user + employee in company A
         self.user_a = self.env['res.users'].create({
             'name': 'User A',
             'login': 'usera@test.com',
@@ -21,9 +21,15 @@ class TestRecruitmentAllowedUserIds(TransactionCase):
             'share': False,
             'company_ids': [self.company_a.id],
             'company_id': self.company_a.id,
+            'group_ids': [self.env.ref('hr_recruitment.group_hr_recruitment_user').id]
+        })
+        self.employee_a = self.env['hr.employee'].create({
+            'name': self.user_a.name,
+            'user_id': self.user_a.id,
+            'company_id': self.company_a.id,
         })
 
-        # Internal user in company B
+        # Internal user + employee in company B
         self.user_b = self.env['res.users'].create({
             'name': 'User B',
             'login': 'userb@test.com',
@@ -31,41 +37,99 @@ class TestRecruitmentAllowedUserIds(TransactionCase):
             'share': False,
             'company_ids': [self.company_b.id],
             'company_id': self.company_b.id,
+            'group_ids': [self.env.ref('hr_recruitment.group_hr_recruitment_user').id]
+        })
+        self.employee_b = self.env['hr.employee'].create({
+            'name': self.user_b.name,
+            'user_id': self.user_b.id,
+            'company_id': self.company_b.id,
         })
 
-    def test_recruiter_user_id_with_company(self):
-        # Test job with company A - should allow user_a but not user_b
+        # Users with different access rights and their employees
+        self.dep_a = self.env['hr.department'].create({
+                'name': 'Research & Development at Company A',
+                'company_id': self.company_a.id,
+            })
+
+        # 1. Manager at Company B
+        self.manager_user_company_b = self.env['res.users'].create({
+            'name': 'Mannie the Manager',
+            'login': 'mannie',
+            'email': 'mannie@companyB.com',
+            'company_ids': [self.company_b.id],
+            'company_id': self.company_b.id,
+            'group_ids': [self.env.ref('hr_recruitment.group_hr_recruitment_manager').id]
+        })
+        self.manager_employee_company_b = self.env['hr.employee'].create({
+                    'name': self.manager_user_company_b.name,
+                    'user_id': self.manager_user_company_b.id,
+                    'company_id': self.company_b.id,
+                })
+
+        # 2. Recruitment Officer at Company A
+        self.officer_user_company_a = self.env['res.users'].create({
+            'name': 'Oliver the Officer',
+            'login': 'oliver',
+            'email': 'oliver@company.com',
+            'company_ids': [self.company_a.id],
+            'company_id': self.company_a.id,
+            'group_ids': [self.env.ref('hr_recruitment.group_hr_recruitment_user').id]
+        })
+        self.officer_employee_company_a = self.env['hr.employee'].create({
+                    'name': self.officer_user_company_a.name,
+                    'user_id': self.officer_user_company_a.id,
+                    'company_id': self.company_a.id,
+                })
+
+        # 3. Interviewer at Company A
+        self.interviewer_user_company_a = self.env['res.users'].create({
+            'name': 'Ian the Interviewer',
+            'login': 'ian',
+            'email': 'ian@company.com',
+            'company_ids': [self.company_a.id],
+            'company_id': self.company_a.id,
+            'group_ids': [self.env.ref('hr_recruitment.group_hr_recruitment_interviewer').id]
+        })
+
+        self.interviewer_employee_company_a = self.env['hr.employee'].create({
+            'name': self.interviewer_user_company_a.name,
+            'user_id': self.interviewer_user_company_a.id,
+            'company_id': self.company_a.id,
+        })
+
+    def test_recruiter_with_company(self):
+        # Test job with company A - should allow employee_a but not employee_b
         job_a = self.env['hr.job'].create({
             'name': 'Job Position Company A',
             'company_id': self.company_a.id,
         })
 
-        # user_a can be set as a recruiter
-        job_a.user_id = self.user_a
-        self.assertEqual(job_a.user_id, self.user_a)
+        # employee_a can be set as a recruiter
+        job_a.recruiter_id = self.employee_a
+        self.assertEqual(job_a.recruiter_id, self.employee_a)
 
-        # Validate that the domain defined on hr.job.user_id contains user_a, but excludes user_b
-        domain = [('share', '=', False), ('company_ids', '=?', self.company_a.id)]
-        allowed_users = self.env['res.users'].search(domain)
-        self.assertIn(self.user_a, allowed_users)
-        self.assertNotIn(self.user_b, allowed_users)
+        # Validate that the domain defined on hr.job.recruiter_id contains employee_a, but excludes employee_b
+        domain = job_a._recruiter_domain() + [('company_id', '=', job_a.company_id.id)]
+        allowed_recruiter_ids = self.env['hr.employee'].search(domain)
+        self.assertIn(self.employee_a, allowed_recruiter_ids)
+        self.assertNotIn(self.employee_b, allowed_recruiter_ids)
 
-    def test_recruiter_user_id_without_company(self):
-        # Test job without company - should allow both users
+    def test_applicant_access_rights(self):
         job = self.env['hr.job'].create({
-            'name': 'Job Position',
-            'company_id': False,
+            'name': "Job Position at Company A",
+            'company_id': self.company_a.id,
         })
 
-        # When company_id is False, users from *any* company are ok
-        domain = [('share', '=', False), ('company_ids', '=?', False)]
-        allowed_users = self.env['res.users'].search(domain)
-        self.assertIn(self.user_a, allowed_users)
-        self.assertIn(self.user_b, allowed_users)
+        applicant = self.env['hr.applicant'].create({
+            'partner_name': "Tito Applicantson",
+            'job_id': job.id,
+            'company_id': self.company_a.id,
+            'department_id': self.dep_a.id,
+        })
 
-        # Both users should be settable as recruiter
-        job.user_id = self.user_a
-        self.assertEqual(job.user_id, self.user_a)
+        domain = applicant._recruiter_domain() + [('company_id', '=', applicant.company_id.id)]
+        allowed_recruiter_ids = self.env['hr.employee'].search(domain)
 
-        job.user_id = self.user_b
-        self.assertEqual(job.user_id, self.user_b)
+        self.assertNotIn(self.manager_employee_company_b, allowed_recruiter_ids, "Manager of different company should not appear in recruiter dropdown.")
+        self.assertIn(self.officer_employee_company_a, allowed_recruiter_ids, "Officer should appear in recruiter dropdown.")
+        self.assertNotIn(self.interviewer_employee_company_a, allowed_recruiter_ids, "Access error: Interviewer should not appear in recruiter dropdown.")

--- a/addons/hr_recruitment/tests/test_recruitment_interviewer.py
+++ b/addons/hr_recruitment/tests/test_recruitment_interviewer.py
@@ -25,9 +25,13 @@ class TestRecruitmentInterviewer(MailCase):
             groups='base.group_user,hr_recruitment.group_hr_recruitment_manager',
             name='Recruitment Manager', email='mng@example.com')
 
+        cls.simple_employee = cls.simple_user.employee_id
+        cls.interviewer_employee = cls.interviewer_user.employee_id
+        cls.manager_employee = cls.manager_user.employee_id
+
         cls.job = cls.env['hr.job'].create({
             'name': 'super nice job',
-            'user_id': cls.manager_user.id,
+            'recruiter_id': cls.manager_employee.id,
         })
 
     def test_interviewer_group(self):
@@ -141,17 +145,19 @@ class TestRecruitmentInterviewer(MailCase):
         new_manager_user = new_test_user(self.env, 'thala',
             groups='base.group_user,hr_recruitment.group_hr_recruitment_manager',
             name='New Recruitment Manager', email='thala@example.com')
+        new_manager_employee = new_manager_user.employee_id
+
         ongoing_application = Application.create({
             'job_id': self.job.id,
-            'user_id': self.manager_user.id,
+            'recruiter_id': self.manager_employee.id,
             'application_status': 'ongoing',
         })
         hired_application = Application.create({
             'job_id': self.job.id,
-            'user_id': self.manager_user.id,
+            'recruiter_id': self.manager_employee.id,
             'date_closed': fields.Datetime.now(),
             'application_status': 'hired',
         })
-        self.job.write({'user_id': new_manager_user.id})
-        self.assertEqual(ongoing_application.user_id, new_manager_user)
-        self.assertEqual(hired_application.user_id, self.manager_user)
+        self.job.write({'recruiter_id': new_manager_employee.id})
+        self.assertEqual(ongoing_application.recruiter_id, new_manager_employee)
+        self.assertEqual(hired_application.recruiter_id, self.manager_employee)

--- a/addons/hr_recruitment/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment/views/hr_applicant_views.xml
@@ -38,7 +38,7 @@
                 <field name="kanban_state" widget="state_selection" string="State" optional="hide"/> 
                 <field name="priority" widget="priority" nolabel="1" optional="show"/>
                 <field name="categ_ids" widget="many2many_tags" options="{'color_field': 'color', 'on_tag_click': 'edit_color'}" optional="show"/>
-                <field name="user_id" widget="many2one_avatar_user" optional="show"/>
+                <field name="recruiter_id" widget="many2one_avatar_employee" optional="show"/>
                 <field name="is_rotting" column_invisible="True"/>
                 <field name="rotting_days" column_invisible="True"/>
                 <field name="type_id" column_invisible="True"/>
@@ -162,7 +162,7 @@
                         <field name="priority" widget="priority"/>
                         <field name="job_id" invisible="is_pool_applicant" placeholder="Spontaneous application"/>
                         <field name="talent_pool_ids" widget="many2many_tags" options="{'color_field': 'color', 'on_tag_click': 'edit_color'}" invisible="not is_pool_applicant"/>
-                        <field name="user_id" widget="many2one_avatar_user" placeholder="Unassigned"/>
+                        <field name="recruiter_id" widget="many2one_avatar_employee" placeholder="Unassigned"/>
                         <field name="interviewer_ids" options="{'no_create': True}" widget="many2many_avatar_user" invisible="is_pool_applicant" placeholder="Who can access applicants" />
                         <field name="date_closed" invisible="not date_closed" />
                         <field name="categ_ids" placeholder="e.g. Trainee" widget="many2many_tags" options="{'color_field': 'color', 'on_tag_click': 'edit_color', 'no_create_edit': True}"/>
@@ -266,7 +266,7 @@
                 <field name="job_id"/>
                 <field name="department_id" operator="child_of"/>
                 <field name="company_id" groups="base.group_multi_company"/>
-                <field name="user_id"/>
+                <field name="recruiter_id"/>
                 <field name="stage_id" domain="[]"/>
                 <field name="categ_ids"/>
                 <field name="refuse_reason_id"/>
@@ -275,8 +275,8 @@
                 <field name="activity_user_id" string="Activities of"/>
                 <field name="activity_type_id" string="Activity type"/>
                 <field name="attachment_ids" filter_domain="[('attachment_ids', 'any', [('index_content', 'ilike', self), ('res_model', '=', 'hr.applicant')])]" string="Resume's content"/>
-                <filter string="My Applications" name="my_applications" domain="[('user_id', '=', uid)]"/>
-                <filter string="Unassigned" name="unassigned" domain="[('user_id', '=', False)]"/>
+                <filter string="My Applications" name="my_applications" domain="[('recruiter_id.user_id', '=', uid)]"/>
+                <filter string="Unassigned" name="unassigned" domain="[('recruiter_id', '=', False)]"/>
                 <separator/>
                 <filter string="Applicants" name="applicants" domain="[('talent_pool_ids', '=', False)]"/>
                 <filter string="Talents" name="talents" domain="[('talent_pool_ids', '!=', False)]"/>
@@ -316,7 +316,7 @@
                 <group>
                     <filter string="Job" name="job" domain="[]" context="{'group_by': 'job_id'}"/>
                     <filter string="Stage" name="stage" domain="[]" context="{'group_by': 'stage_id'}"/>
-                    <filter string="Responsible" name="responsible" domain="[]"  context="{'group_by': 'user_id'}"/>
+                    <filter string="Responsible" name="responsible" domain="[]"  context="{'group_by': 'recruiter_id'}"/>
                     <filter string="Talent Pool" name="talent_pool" domain="[]" context="{'group_by': 'talent_pool_ids'}"/>
                     <filter string="Creation Date" name="creation_date" context="{'group_by': 'create_date'}"/>
                     <filter string="Hiring Date" name="hired_date" context="{'group_by': 'date_closed'}"/>
@@ -338,7 +338,7 @@
                 string="Applicants"
                 mode="month"
                 date_start="activity_date_deadline"
-                color="user_id"
+                color="recruiter_id"
                 event_limit="5"
                 hide_time="true"
                 quick_create="0"
@@ -346,7 +346,7 @@
                 <field name="partner_name"/>
                 <field name="job_id"/>
                 <field name="priority" widget="priority"/>
-                <field name="user_id" filters="1" invisible="1"/>
+                <field name="recruiter_id" filters="1" invisible="1"/>
                 <field name="activity_summary"/>
             </calendar>
         </field>
@@ -388,10 +388,10 @@
                 <field name="stage_id" options='{"group_by_tooltip": {"requirements": "Requirements"}}'/>
                 <field name="date_closed"/>
                 <field name="color"/>
-                <field name="user_id"/>
+                <field name="recruiter_id"/>
                 <field name="active"/>
                 <field name="application_status" />
-                <field name="company_id" invisible="1"/> <!-- We need to keep this field as it is used in the domain of user_id in the model -->
+                <field name="company_id" invisible="1"/> <!-- We need to keep this field as it is used in the domain of recruiter in the model -->
                 <progressbar field="kanban_state" colors='{"done": "success", "waiting": "warning", "blocked": "danger"}'/>
                 <templates>
                     <t t-name="menu">
@@ -422,7 +422,7 @@
                                     <field name="attachment_number"/>
                                 </a>
                                 <field name="kanban_state" class="mx-1" widget="hr_applicant_state_selection"/>
-                                <field name="user_id" widget="many2one_avatar_user"/>
+                                <field name="recruiter_id" widget="many2one_avatar_employee"/>
                             </div>
                         </footer>
                     </t>
@@ -438,7 +438,7 @@
             <activity string="Applicants">
                 <templates>
                     <div t-name="activity-box" class="o_hr_applicant_view_activity">
-                        <field name="user_id" widget="many2one_avatar_user"/>
+                        <field name="recruiter_id" widget="many2one_avatar_employee"/>
                         <div class="flex-grow-1 ms-1">
                             <field name="partner_name" muted="1" display="full" class="o_text_block"/>
                         </div>
@@ -614,10 +614,10 @@
             <search string="Recruitment Analysis">
                 <field name="job_id"/>
                 <field name="department_id" operator="child_of"/>
-                <field name="user_id"/>
+                <field name="recruiter_id"/>
                 <filter string="Creation Date" name="year" date="create_date" default_period="year"/>
                 <separator/>
-                <filter string="Unassigned" name="unassigned" domain="[('user_id', '=', False)]"/>
+                <filter string="Unassigned" name="unassigned" domain="[('recruiter_id', '=', False)]"/>
                 <separator/>
                 <filter string="New" name="new" domain="[('stage_id.sequence', '=', 1)]"/>
                 <separator/>
@@ -634,7 +634,7 @@
                     <field name="date_closed"/>
                 </group>
                 <group>
-                    <filter string="Responsible" name='User' context="{'group_by':'user_id'}"/>
+                    <filter string="Responsible" name='Recruiter' context="{'group_by':'recruiter_id'}"/>
                     <filter string="Company" name="company" context="{'group_by':'company_id'}" groups="base.group_multi_company"/>
                     <filter string="Jobs" name="job" context="{'group_by':'job_id'}"/>
                     <filter string="Department" name="department" context="{'group_by':'department_id'}"/>
@@ -713,7 +713,7 @@
         <field name="model_id">hr.applicant</field>
         <field name="user_ids" eval="False"/>
         <field name="action_id" ref="hr_applicant_action_analysis"/>
-        <field name="context">{'group_by': ['create_date:month', 'user_id']}</field>
+        <field name="context">{'group_by': ['create_date:month', 'recruiter_id']}</field>
     </record>
     <record id="hr_applicant_filter_job" model="ir.filters">
         <field name="name">By Job</field>

--- a/addons/hr_recruitment/views/hr_job_views.xml
+++ b/addons/hr_recruitment/views/hr_job_views.xml
@@ -80,19 +80,19 @@
                                         </div>
                                         <div groups="hr_recruitment.group_hr_recruitment_interviewer,hr.group_hr_user">
                                             <div groups="!base.group_multi_company">
-                                                    <field name="user_id" widget="many2one_avatar_user" class="text-muted"
+                                                    <field name="recruiter_id" widget="many2one_avatar_employee" class="text-muted"
                                                         options="{'display_avatar_name': True}"/>
                                                 </div>
                                                 <div groups="base.group_multi_company">
                                                     <t t-if="record.company_id.raw_value != 0">
                                                         <div class="d-flex flex-row">
-                                                            <field name="user_id" widget="many2one_avatar_user"
+                                                            <field name="recruiter_id" widget="many2one_avatar_employee"
                                                                 options="{'display_avatar_name': False}"/>
                                                             <field class="ms-1 text-muted" name="company_id" />
                                                         </div>
                                                     </t>
                                                     <t t-else="">
-                                                        <field name="user_id" widget="many2one_avatar_user" class="text-muted"
+                                                        <field name="recruiter_id" widget="many2one_avatar_employee" class="text-muted"
                                                             options="{'display_avatar_name': True}"/>
                                                     </t>
                                                 </div>
@@ -179,7 +179,7 @@
                                         <div class="col-1 me-1" style="max-width: 1.5rem;"
                                             groups="hr_recruitment.group_hr_recruitment_interviewer">
                                             <div class="d-flex flex-row justify-content-center">
-                                                <field name="user_id" widget="many2one_avatar_user"
+                                                <field name="recruiter_id" widget="many2one_avatar_employee"
                                                     options="{'display_avatar_name': False}"/>
                                             </div>
                                         </div>
@@ -189,11 +189,11 @@
                                                     <field name="company_id"/>
                                                 </t>
                                                 <t t-else="">
-                                                    <field name="user_id"/>
+                                                    <field name="recruiter_id"/>
                                                 </t>
                                             </div>
                                             <div groups="!base.group_multi_company">
-                                                <field name="user_id"/>
+                                                <field name="recruiter_id"/>
                                             </div>
                                         </div>
                                     </div>
@@ -226,7 +226,7 @@
         <field name="inherit_id" ref="hr.view_job_filter"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='department_id']" position="after">
-                <filter string="My Favorites" name="my_favorite_jobs" domain="[('favorite_user_ids', 'in', uid)]"/>
+                <filter string="My Favorites" name="my_favorite_jobs" domain="[('favorite_recruiter_ids.user_id', 'in', uid)]"/>
                 <separator/>
             </xpath>
         </field>
@@ -351,7 +351,7 @@
                     groups="hr_recruitment.group_hr_recruitment_interviewer"
                     icon="fa-pencil"
                     name="%(action_hr_job_applications)d"
-                    context="{'default_user_id': user_id, 'active_test': False}"
+                    context="{'default_recruiter': recruiter_id, 'active_test': False}"
                     type="action">
                     <field name="all_application_count" widget="statinfo" string="Applications"/>
                 </button>
@@ -417,7 +417,7 @@
                     <field name="company_id" groups="base.group_multi_company" icon="fa-building" enable_counters="1"/>
                     <field name="department_id" icon="fa-users" enable_counters="1"/>
                 </searchpanel>
-                <filter string="My Job Positions" name="my_positions" domain="[('user_id', '=', uid)]"/>
+                <filter string="My Job Positions" name="my_positions" domain="[('recruiter_id.user_id', '=', uid)]"/>
             </xpath>
         </field>
     </record>
@@ -443,7 +443,7 @@
                 <field name="alias_name" column_invisible="True"/>
                 <field name="alias_id" invisible="not alias_name" optional="hide"
                     groups="hr_recruitment.group_hr_recruitment_interviewer"/>
-                <field name="user_id" widget="many2one_avatar_user" optional="show"
+                <field name="recruiter_id" widget="many2one_avatar_employee" optional="show"
                     groups="hr_recruitment.group_hr_recruitment_interviewer,hr.group_hr_user"/>
             </field>
             <list position="attributes">

--- a/addons/hr_recruitment_skills/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment_skills/views/hr_applicant_views.xml
@@ -62,7 +62,7 @@
         <field name="model">hr.applicant</field>
         <field name="inherit_id" ref="hr_recruitment.hr_applicant_view_search"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='user_id']" position="after">
+            <xpath expr="//field[@name='recruiter_id']" position="after">
                 <field name="applicant_skill_ids"/>
             </xpath>
             <filter name="stage" position="after">

--- a/addons/hr_recruitment_survey/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment_survey/views/hr_applicant_views.xml
@@ -53,7 +53,7 @@
         <field name="model">hr.applicant</field>
         <field name="inherit_id" ref="hr_recruitment.hr_kanban_view_applicant"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='user_id']" position="before">
+            <xpath expr="//field[@name='recruiter_id']" position="before">
                 <field name="survey_id"/>
             </xpath>
         </field>

--- a/addons/hr_skills/data/hr_job_skill_demo.xml
+++ b/addons/hr_skills/data/hr_job_skill_demo.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0"?>
 <odoo noupdate="1">
     <record id="hr.job_developer" model="hr.job">
-        <field name="user_id" ref="base.user_admin" />
+        <field name="recruiter_id" ref="hr.employee_admin" />
     </record>
     <record id="hr.job_cto" model="hr.job">
-        <field name="user_id" ref="base.user_admin" />
+        <field name="recruiter_id" ref="hr.employee_admin" />
     </record>
     <record id="hr.job_consultant" model="hr.job">
-        <field name="user_id" ref="base.user_demo" />
+        <field name="recruiter_id" ref="hr.employee_admin" />
     </record>
     <record id="hr.job_hrm" model="hr.job">
-        <field name="user_id" ref="base.user_admin" />
+        <field name="recruiter_id" ref="hr.employee_admin" />
     </record>
     <record id="hr.job_marketing" model="hr.job">
-        <field name="user_id" ref="base.user_demo" />
+        <field name="recruiter_id" ref="hr.employee_admin" />
     </record>
     <record id="hr.job_trainee" model="hr.job">
-        <field name="user_id" ref="base.user_admin" />
+        <field name="recruiter_id" ref="hr.employee_admin" />
     </record>
 </odoo>

--- a/addons/hr_skills/models/hr_employee.py
+++ b/addons/hr_skills/models/hr_employee.py
@@ -86,7 +86,7 @@ class HrEmployee(models.Model):
                     [
                         Domain("user_id", "!=", False),
                         Domain("parent_id.user_id", "!=", False),
-                        Domain("job_id.user_id", "!=", False),
+                        Domain("job_id.recruiter_id.user_id", "!=", False),
                     ],
                 ),
             ],
@@ -120,7 +120,7 @@ class HrEmployee(models.Model):
 
         for employee in employees:
             job_id = employee.job_id
-            responsible = employee.user_id or employee.parent_id.user_id or job_id.user_id
+            responsible = employee.user_id or employee.parent_id.user_id or job_id.recruiter_id.user_id
             if job_id not in job_skill_level_mapping or not responsible:
                 continue
 

--- a/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
+++ b/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
@@ -630,7 +630,7 @@
                                     Your application has been posted successfully,<br class="mb-2"/>
                                     We usually respond within 3 days...
                                 </p>
-                                <img class="img-fluid o_we_custom_image" t-attf-style="width:{{ '50%' if (job_sudo and job_sudo.user_id) else '25%' }} !important;" src="/website_hr_recruitment/static/src/img/job_congratulations.svg" alt="Congratulations!"/>
+                                <img class="img-fluid o_we_custom_image" t-attf-style="width:{{ '50%' if (job_sudo and job_sudo.recruiter_id) else '25%' }} !important;" src="/website_hr_recruitment/static/src/img/job_congratulations.svg" alt="Congratulations!"/>
                                 <div class="row" id="o_recruitment_thank_cta">
                                     <div class="col-lg-12 text-center mt32 mb48">
                                         <p>
@@ -642,7 +642,7 @@
                                 </div>
                             </div>
                             <!-- HR Recruiter Block -->
-                            <t t-if="job_sudo and job_sudo.user_id">
+                            <t t-if="job_sudo and job_sudo.recruiter_id">
                                 <div class="col-lg-4 align-self-center ps-4 o_cc o_cc2 rounded">
                                     <section class="s_text_block pt24" data-snippet="s_text_block" data-name="Text">
                                         <div class="container">
@@ -655,17 +655,17 @@
                                                 <div class="o_jobs_hr_recruiter col-10 o_cc o_cc1 mt24 p-4 border border-primary rounded shadow">
                                                     <div class="row align-items-center">
                                                         <div class="col-lg-5 pb16 o_not_editable">
-                                                            <img t-att-src="image_data_uri(job_sudo.user_id.avatar_256)" class="img-fluid" loading="lazy"/>
+                                                            <img t-att-src="image_data_uri(job_sudo.recruiter_id.avatar_256)" class="img-fluid" loading="lazy"/>
                                                         </div>
                                                         <div class="col-lg-7 px-1">
-                                                            <h2 class="text-truncate" t-field="job_sudo.user_id.name"/>
-                                                            <p class="fw-light text-truncate" t-field="job_sudo.user_id.job_title"/>
+                                                            <h2 class="text-truncate" t-field="job_sudo.recruiter_id.name"/>
+                                                            <p class="fw-light text-truncate" t-field="job_sudo.recruiter_id.job_title"/>
                                                         </div>
                                                     </div>
                                                     <div class="row">
                                                         <ul class="list-unstyled mb-0">
-                                                            <li t-if="job_sudo.user_id.work_phone"><i class="fa fa-phone fa-fw me-2"></i><span class="o_force_ltr" t-field="job_sudo.user_id.work_phone"/></li>
-                                                            <li class="d-inline-flex align-items-baseline"><i class="fa fa-envelope fa-fw me-2"></i><span><a class="text-break" t-attf-href="mailto:#{job_sudo.user_id.email}" t-field="job_sudo.user_id.email"/></span></li>
+                                                            <li t-if="job_sudo.recruiter_id.work_phone"><i class="fa fa-phone fa-fw me-2"></i><span class="o_force_ltr" t-field="job_sudo.recruiter_id.work_phone"/></li>
+                                                            <li class="d-inline-flex align-items-baseline"><i class="fa fa-envelope fa-fw me-2"></i><span><a class="text-break" t-attf-href="mailto:#{job_sudo.recruiter_id.work_email}" t-field="job_sudo.recruiter_id.work_email"/></span></li>
                                                         </ul>
                                                     </div>
                                                 </div>


### PR DESCRIPTION
#### Issue
In Recruitment → Job Position form, the Recruiter dropdown lists all company
users, including those without recruiter rights.

#### Fix
- Replace the `user_id` field in `hr.applicant`, `hr_recruitment_reports`, and
  `hr.job` with `recruiter` for clarity, using `hr.employee` instead of
  `res.users`.
- Restrict the dropdown to employees whose linked users have the correct
  recruiter access rights (Recruitment Officer or Administrator).
- Update SQL queries accordingly.

task-5083125