### PR TITLE
[FIX] http: Headers proxy compat for Trixie

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1699,6 +1699,8 @@ class Response(Proxy):
             elif isinstance(arg, werkzeug.wrappers.Response):
                 response = _Response.load(arg)
         if response is None:
+            if isinstance(kwargs.get('headers'), Headers):
+                kwargs['headers'] = kwargs['headers']._wrapped__
             response = _Response(*args, **kwargs)
 
         super().__init__(response)


### PR DESCRIPTION
Support the possibility to pass a wrapped `Headers` to the constructor of the wrapped `Response`

This is related to
https://github.com/odoo/odoo/commit/6c8a90ecba45fb99addf1b86fe237fd626fba650#diff-77bd6b19c39e211959885024bcad914655ff84cfc10c16633687d014e50aa69aR383 which passes a wrapped `Headers`
to the constructor of the wrapped `Response`.

The issue is that the wrapped `Headers` was passed to the original `werkzeug.wrappers.Response`, and then, internally in `werkzeug`, method which are implemented on the original `Headers` are not proxied on the wrapped `Headers`.

```py
Exception during request handling.
Traceback (most recent call last):
  File "/data/build/odoo/odoo/http.py", line 2798, in __call__
    response = request._serve_db()
  File "/data/build/odoo/odoo/http.py", line 2261, in _serve_db
    raise self._update_served_exception(exc)
  File "/data/build/odoo/odoo/http.py", line 2253, in _serve_db
    return service_model.retrying(serve_func, env=self.env)
           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/build/odoo/odoo/service/model.py", line 184, in retrying
    result = func()
  File "/data/build/odoo/odoo/http.py", line 2327, in _serve_ir_http
    self.registry['ir.http']._post_dispatch(response)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/data/build/odoo/addons/website/models/ir_http.py", line 269, in _post_dispatch
    super()._post_dispatch(response)
    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/data/build/odoo/addons/utm/models/ir_http.py", line 26, in _post_dispatch
    super()._post_dispatch(response)
    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/data/build/odoo/odoo/addons/base/models/ir_http.py", line 364, in _post_dispatch
    request.dispatcher.post_dispatch(response)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/data/build/odoo/odoo/http.py", line 2404, in post_dispatch
    root.set_csp(response)
    ~~~~~~~~~~~~^^^^^^^^^^
  File "/data/build/odoo/odoo/http.py", line 2746, in set_csp
    if 'Content-Security-Policy' in headers:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/build/odoo/odoo/tools/facade.py", line 79, in wrap_func
    result = func(self._wrapped__, *args, **kwargs)
  File "/usr/lib/python3/dist-packages/werkzeug/datastructures/headers.py", line 328, in __contains__
    self._get_key(key)
    ^^^^^^^^^^^^^
AttributeError: 'Headers' object has no attribute '_get_key'. Did you mean: '_del_key'?
```

The exception did not occur before Trixie, because the implementation of `__contains__` was not using the method `_get_key` of `werkzeug.datastructures.Headers` werkzeug < 3.1.0
```py
    def __contains__(self, key):
        """Check if a key is present."""
        try:
            self.__getitem__(key, _get_mode=True)
        except KeyError:
            return False
        return True
```
werkzeug >= 3.1.0
```py
    def __contains__(self, key: str) -> bool:
        """Check if a key is present."""
        try:
            self._get_key(key)
        except KeyError:
            return False

        return True
```

https://runbot.odoo.com/odoo/runbot.build.error/233070
