### PR TITLE
[FIX] website_payment: prevent company inconsistencies on provider copy

### DIFF
--- a/addons/website_payment/models/payment_provider.py
+++ b/addons/website_payment/models/payment_provider.py
@@ -15,6 +15,7 @@ class PaymentProvider(models.Model):
     website_id = fields.Many2one(
         "website",
         check_company=True,
+        copy=False,  # handled in `copy` override to prevent company inconsistencies
         ondelete="restrict",
     )
 
@@ -60,4 +61,8 @@ class PaymentProvider(models.Model):
         res = super().copy(default=default)
         if self._context.get('stripe_connect_onboarding'):
             res.website_id = False
+        elif not default or 'website_id' not in default:
+            for src, copy in zip(self, res):
+                if src.website_id and src.company_id in copy.company_id.parent_ids:
+                    copy.website_id = src.website_id
         return res


### PR DESCRIPTION
Versions
--------
- saas-18.4+

Steps
-----
1. Specify a website for a payment provider;
2. create a new (non-branch) company.

Issue
-----
> Uh-oh! You’ve got some company inconsistencies here

Cause
-----
As of commit 0d3228e10d04a, payment providers get automatically duplicated when creating a new company. This leads to company inconsistencies when the provider has a website specified, as the website's company doesn't match copied provider's company.

Solution
--------
Disable automatic copying of the `website_id` field, and instead, handle it manually in the `copy` override, assigning the `website_id` field iff the new provider belongs to the same company or a branch company.

opw-5119731