### PR TITLE
[FIX] point_of_sale: support quantity in GS1 barcode

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -319,8 +319,18 @@ export class ProductScreen extends ControlButtonsMixin(Component) {
     async _parseElementsFromGS1(parsed_results) {
         const productBarcode = parsed_results.find((element) => element.type === "product");
         const lotBarcode = parsed_results.find((element) => element.type === "lot");
+        const qty = parsed_results.find((element) => element.type === "quantity");
         const product = await this._getProductByBarcode(productBarcode);
-        return { product, lotBarcode, customProductOptions: {} };
+        const customProductOptions = {};
+        if (
+            qty &&
+            product?.uom_id[0] &&
+            qty?.rule?.associated_uom_id &&
+            product.uom_id[0] == qty.rule.associated_uom_id[0]
+        ) {
+            customProductOptions.quantity = qty.value;
+        }
+        return { product, lotBarcode, customProductOptions };
     }
     /**
      * Add a product to the current order using the product identifier and lot number from parsed results.

--- a/addons/point_of_sale/static/tests/tours/BarcodeScanning.tour.js
+++ b/addons/point_of_sale/static/tests/tours/BarcodeScanning.tour.js
@@ -71,6 +71,12 @@ registry.category("web_tour.tours").add("GS1BarcodeScanningTour", {
             scan_barcode("0108431673020125100000001"),
             ProductScreen.selectedOrderlineHas("Product 1", 2),
 
+            // Add the product 1 with GS1 barcode and quantity
+            scan_barcode("0108431673020125305"),
+            ProductScreen.selectedOrderlineHas("Product 1", 7),
+            scan_barcode("01084316730201253010"),
+            ProductScreen.selectedOrderlineHas("Product 1", 17),
+
             // Add the Product 2 with normal barcode
             scan_barcode("08431673020126"),
             ProductScreen.selectedOrderlineHas("Product 2"),


### PR DESCRIPTION
Before this commit, the quantity encoded in a GS1 barcode was ignored when scanning. After this commit, the product will be added with the correct quantity extracted from the GS1 barcode.

opw-5126522

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
