### PR TITLE
[FIX] iot_drivers: webrtc times out on long actions

### DIFF
--- a/addons/iot_drivers/webrtc_client.py
+++ b/addons/iot_drivers/webrtc_client.py
@@ -40,7 +40,7 @@ class WebRtcClient(Thread):
             self.connections.add(channel)
 
             @channel.on("message")
-            def on_message(message_str: str):
+            async def on_message(message_str: str):
                 # Handle chunked message
                 if self.chunked_message_in_progress.get(channel) is not None:
                     if message_str == "chunked_end":
@@ -62,7 +62,7 @@ class WebRtcClient(Thread):
                     data["session_id"] = message["session_id"]
                     if device_identifier in main.iot_devices:
                         _logger.info("device '%s' action started with: %s", device_identifier, pprint.pformat(data))
-                        main.iot_devices[device_identifier].action(data)
+                        await self.event_loop.run_in_executor(None, lambda: main.iot_devices[device_identifier].action(data))
                     else:
                         # Notify that the device is not connected
                         self.send({


### PR DESCRIPTION
Before this commit, if an action took more than 5 seconds to execute, it would cause the WebRTC connection to disconnect. This was due to the action blocking the WebRTC thread for that connection, which internally is sending keep-alive messages to keep the connection active. The action prevents this from happening and so the connection gets automatically closed by the browser.

After this commit, we run the action inside a loop executor (essentially giving the action its own thread). This prevents the connection thread getting blocked and so the connection stays open as expected.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
