### PR TITLE
[FIX] pos_qfpay: fix undeterministic error in test

### DIFF
--- a/addons/pos_qfpay/static/tests/tours/qfpay_tour.js
+++ b/addons/pos_qfpay/static/tests/tours/qfpay_tour.js
@@ -10,6 +10,8 @@ import { registry } from "@web/core/registry";
 import { QFPay } from "@pos_qfpay/app/qfpay";
 import { mockQFPayWebhook } from "@pos_qfpay/../tests/tours/utils/common";
 
+const { DateTime } = luxon;
+
 // Patch QFPay to validate the request that would be sent to the terminal
 patch(QFPay.prototype, {
     makeQFPayRequest: async function (endpoint, payload) {
@@ -48,6 +50,10 @@ let paymentUuid = "";
 registry.category("web_tour.tours").add("qfpay_order_and_refund", {
     steps: () =>
         [
+            // Refund have to be made on the same day before 23:00 HKT.
+            Chrome.freezeDateTime(
+                DateTime.now().setZone("Asia/Hong_Kong").set({ hour: 12 }).toMillis()
+            ),
             Chrome.startPoS(),
             Dialog.confirm("Open Register"),
 


### PR DESCRIPTION
Refund cannot be processed after 11PM and are leading to errors whenever the test happens to run between 11PM and midnight.

runbot build error: 232599

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
