### PR TITLE
[FIX] account: UX of trusted bank accounts

### DIFF
--- a/addons/account/models/res_partner_bank.py
+++ b/addons/account/models/res_partner_bank.py
@@ -360,16 +360,3 @@ class ResPartnerBank(models.Model):
         # `acc_number` variable instead.
         default_acc_number = self.env.context.get('default_acc_number', False) or self.env.context.get('default_name', False)
         return super(ResPartnerBank, self.with_context(default_acc_number=default_acc_number)).default_get(fields)
-
-    @api.depends('allow_out_payment', 'acc_number', 'bank_id')
-    @api.depends_context('display_account_trust')
-    def _compute_display_name(self):
-        super()._compute_display_name()
-        if self.env.context.get('display_account_trust'):
-            for acc in self:
-                trusted_label = _('trusted') if acc.allow_out_payment else _('untrusted')
-                if acc.bank_id:
-                    name = f'{acc.acc_number} - {acc.bank_id.name} ({trusted_label})'
-                else:
-                    name = f'{acc.acc_number} ({trusted_label})'
-                acc.display_name = name

--- a/addons/account/static/src/components/manyone_banks/many2one_banks.js
+++ b/addons/account/static/src/components/manyone_banks/many2one_banks.js
@@ -1,0 +1,77 @@
+import { _t } from "@web/core/l10n/translation";
+import { markup } from "@odoo/owl";
+import { registry } from "@web/core/registry";
+import { extractData, Many2One } from "@web/views/fields/many2one/many2one";
+import { buildM2OFieldDescription, Many2OneField } from "@web/views/fields/many2one/many2one_field";
+import { Many2XAutocomplete } from "@web/views/fields/relational_utils";
+
+/**
+ * These classes and widget `many2one_bank` are meant to be
+ * used only with res.partner.bank
+ */
+
+export class Many2XAutocompleteBank extends Many2XAutocomplete {
+    buildRecordSuggestion(request, record) {
+        const recordSuggestion = super.buildRecordSuggestion(request, record);
+        const icon = record.allow_out_payment ? "fa-shield" : "fa-exclamation-circle";
+        const colorClass = record.allow_out_payment ? "text-success" : "text-danger";
+        const title = record.allow_out_payment ? _t("Trusted") : _t("Untrusted");
+        recordSuggestion.label = markup`<i class="me-1 fa ${icon} ${colorClass}" title="${title}"></i> ${recordSuggestion.label}`;
+        return recordSuggestion;
+    }
+
+    get searchSpecification() {
+        return {
+            ...super.searchSpecification,
+            allow_out_payment: {},
+        };
+    }
+}
+
+function extractDataBank(record) {
+    return {
+        ...extractData(record),
+        allow_out_payment: record.allow_out_payment,
+    };
+}
+
+export class Many2OneBank extends Many2One {
+    static template = "account.Many2OneBank";
+    static components = {
+        ...Many2One.components,
+        Many2XAutocomplete: Many2XAutocompleteBank,
+    };
+
+    get many2XAutocompleteProps() {
+        return {
+            ...super.many2XAutocompleteProps,
+            update: (records) => {
+                const bankRecordData = records && records[0] ? extractDataBank(records[0]) : false;
+                this.update(bankRecordData);
+            },
+        };
+    }
+}
+
+
+export class Many2OneBankField extends Many2OneField {
+    static components = {
+        ...Many2OneField.components,
+        Many2One: Many2OneBank,
+    };
+
+    get m2oProps() {
+        const props = super.m2oProps;
+        props.cssClass = `${props.cssClass ?? ''} d-flex`;
+        return props;
+    }
+}
+
+export const many2OneBankField = {
+    ...buildM2OFieldDescription(Many2OneBankField),
+    relatedFields: [
+        { name: "allow_out_payment", type: "bool" },
+    ],
+};
+
+registry.category("fields").add("many2one_bank", many2OneBankField);

--- a/addons/account/static/src/components/manyone_banks/many2one_banks.xml
+++ b/addons/account/static/src/components/manyone_banks/many2one_banks.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="account.Many2OneBank" t-inherit="web.Many2One">
+        <xpath expr="//t[@t-if='props.readonly']" position="before">
+            <t t-if="this.props.value.id">
+                <i t-if="this.props.value.allow_out_payment" class="me-1 fa fa-shield text-success align-self-center" title="Trusted"/>
+                <i t-else="" class="me-1 fa fa-exclamation-circle text-danger align-self-center" title="Untrusted"/>
+            </t>
+        </xpath>
+    </t>
+</templates>

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -733,7 +733,7 @@
                                     or move_type not in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt')
                                     or invoice_has_outstanding
                                 )"
-                                context="{'dont_redirect_to_payments': True, 'display_account_trust': True}"
+                                context="{'dont_redirect_to_payments': True}"
                                 string="Pay" data-hotkey="g"
                                 groups="account.group_account_invoice"/>
                         <!-- Register Payment (only invoices / receipts, with outstanding payments) -->
@@ -745,7 +745,7 @@
                                     or move_type not in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt')
                                     or not invoice_has_outstanding
                                 )"
-                                context="{'dont_redirect_to_payments': True, 'display_account_trust': True}"
+                                context="{'dont_redirect_to_payments': True}"
                                 string="Pay" data-hotkey="g"
                                 groups="account.group_account_invoice"/>
                         <!-- Preview (only customer invoices) -->
@@ -1041,7 +1041,8 @@
                                        readonly="inalterable_hash != False"
                                        placeholder="Use Bill Reference"/>
                                 <field name="partner_bank_id"
-                                       context="{'default_partner_id': bank_partner_id, 'display_account_trust': True}"
+                                       widget="many2one_bank"
+                                       context="{'default_partner_id': bank_partner_id}"
                                        domain="[('partner_id', '=', bank_partner_id)]"
                                        invisible="move_type not in ('in_invoice', 'in_refund', 'in_receipt')"
                                        readonly="is_move_sent and state != 'draft'"/>
@@ -1468,7 +1469,8 @@
                                         <field name="invoice_user_id" domain="[('share', '=', False)]" widget="many2one_avatar_user"/>
                                         <field name="invoice_origin" string="Source Document" force_save="1" invisible="1"/>
                                         <field name="partner_bank_id"
-                                               context="{'default_partner_id': bank_partner_id, 'display_account_trust': True}"
+                                               widget="many2one_bank"
+                                               context="{'default_partner_id': bank_partner_id}"
                                                domain="[('partner_id.ref_company_ids', 'parent_of', company_id)]"
                                                readonly="is_move_sent and state != 'draft'"/>
                                         <field name="payment_reference"
@@ -1958,7 +1960,7 @@
             <field name="view_id" ref="view_out_credit_note_tree"/>
             <field name="search_view_id" ref="view_account_invoice_filter"/>
             <field name="domain">[('move_type', 'in', ['out_invoice', 'out_refund'])]</field>
-            <field name="context">{'search_default_out_refund': 1, 'default_move_type': 'out_refund', 'display_account_trust': True}</field>
+            <field name="context">{'search_default_out_refund': 1, 'default_move_type': 'out_refund'}</field>
             <field name="help" type="html">
               <p class="o_view_nocontent_smiling_face">
                 Create a credit note
@@ -1977,7 +1979,7 @@
             <field name="view_id" ref="view_in_invoice_bill_tree"/>
             <field name="search_view_id" ref="view_account_bill_filter"/>
             <field name="domain">[('move_type', 'in', ['in_invoice', 'in_refund', 'in_receipt'])]</field>
-            <field name="context">{'default_move_type': 'in_invoice', 'display_account_trust': True}</field>
+            <field name="context">{'default_move_type': 'in_invoice'}</field>
             <field name="help" type="html">
                 <!-- An owl component should be displayed instead -->
                 <p class="o_view_nocontent_smiling_face">
@@ -1997,7 +1999,7 @@
             <field name="view_id" ref="view_in_invoice_bill_tree"/>
             <field name="search_view_id" ref="view_account_bill_filter"/>
             <field name="domain">[('move_type', 'in', ['in_invoice', 'in_refund', 'in_receipt'])]</field>
-            <field name="context">{'search_default_in_invoice': 1, 'default_move_type': 'in_invoice', 'display_account_trust': True}</field>
+            <field name="context">{'search_default_in_invoice': 1, 'default_move_type': 'in_invoice'}</field>
             <field name="help" type="html">
                 <!-- An owl component should be displayed instead -->
                 <p class="o_view_nocontent_smiling_face">
@@ -2116,7 +2118,7 @@ if records:
             <field name="view_id" ref="view_out_credit_note_tree"/>
             <field name="search_view_id" ref="view_account_invoice_filter"/>
             <field name="domain">[('move_type', 'in', ['out_invoice', 'out_refund'])]</field>
-            <field name="context">{'search_default_out_refund': 1, 'default_move_type': 'out_refund', 'display_account_trust': True}</field>
+            <field name="context">{'search_default_out_refund': 1, 'default_move_type': 'out_refund'}</field>
             <field name="help" type="html">
               <p class="o_view_nocontent_smiling_face">
                 Create a credit note

--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -283,19 +283,22 @@
                                        readonly="state != 'draft'"/>
 
                                 <field name="partner_bank_id" string="Customer Bank Account"
-                                      context="{'default_partner_id': partner_id, 'display_account_trust': True}"
+                                        widget="many2one_bank"
+                                        context="{'default_partner_id': partner_id}"
                                         invisible="not show_partner_bank_account or partner_type != 'customer' or payment_type == 'inbound'"
                                         required="require_partner_bank_account"/>
 
                                 <field name="partner_bank_id" string="Vendor Bank Account"
-                                        context="{'default_partner_id': partner_id, 'display_account_trust': True}"
+                                        widget="many2one_bank"
+                                        context="{'default_partner_id': partner_id}"
                                         invisible="not show_partner_bank_account or partner_type != 'supplier' or payment_type == 'inbound'"
                                         required="require_partner_bank_account"/>
 
                                 <!-- This field should always be readonly but using readonly="1" overrides the other partner_bank_id
                                 fields readonly condition in the framework, preventing the modification of these fields -->
                                 <field name="partner_bank_id" string="Company Bank Account"
-                                        context="{'default_partner_id': partner_id, 'display_account_trust': True}"
+                                        widget="many2one_bank"
+                                        context="{'default_partner_id': partner_id}"
                                         invisible="not show_partner_bank_account or payment_type == 'outbound'"
                                         required="require_partner_bank_account"/>
                             </group>
@@ -348,7 +351,6 @@
                 'default_partner_type': 'customer',
                 'search_default_inbound_filter': 1,
                 'default_move_journal_types': ('bank', 'cash'),
-                'display_account_trust': True,
             }</field>
             <field name="view_id" ref="view_account_payment_tree"/>
             <field name="help" type="html">
@@ -370,7 +372,6 @@
                 'default_partner_type': 'supplier',
                 'search_default_outbound_filter': 1,
                 'default_move_journal_types': ('bank', 'cash'),
-                'display_account_trust': True,
             }</field>
             <field name="view_id" ref="view_account_supplier_payment_tree"/>
             <field name="help" type="html">
@@ -386,7 +387,7 @@
             <field name="name">Internal Transfers</field>
             <field name="res_model">account.payment</field>
             <field name="view_mode">list,kanban,form,graph</field>
-            <field name="context">{'default_payment_type': 'outbound', 'search_default_transfers_filter': 1, 'display_account_trust': True}</field>
+            <field name="context">{'default_payment_type': 'outbound', 'search_default_transfers_filter': 1}</field>
             <field name="domain">[]</field>
             <field name="view_id" ref="view_account_supplier_payment_tree"/>
             <field name="help" type="html">

--- a/addons/account/views/res_partner_bank_views.xml
+++ b/addons/account/views/res_partner_bank_views.xml
@@ -1,6 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data>
+        <record id="view_partner_bank_kanban_account" model="ir.ui.view">
+            <field name="name">res.partner.bank.kanban.account</field>
+            <field name="model">res.partner.bank</field>
+            <field name="arch" type="xml">
+                <kanban class="o_kanban_mobile">
+                    <field name="allow_out_payment"/>
+                    <templates>
+                        <t t-name="card">
+                            <t t-value="record.allow_out_payment.raw_value" t-set="trusted"/>
+                            <div class="d-flex">
+                                <i class="fa me-1 align-self-center" 
+                                   t-att-class="{
+                                        'fa-shield text-success': trusted,
+                                        'fa-exclamation-circle text-danger': !trusted,
+                                   }"/>
+                                <field name="display_name"/>
+                            </div>
+                        </t>
+                    </templates>
+                </kanban>
+            </field>
+        </record>
+
         <record id="view_partner_bank_form_inherit_account" model="ir.ui.view">
             <field name="name">res.partner.bank.form.inherit.account</field>
             <field name="model">res.partner.bank</field>

--- a/addons/account/wizard/account_payment_register_views.xml
+++ b/addons/account/wizard/account_payment_register_views.xml
@@ -65,7 +65,8 @@
                                    readonly="payment_type == 'inbound'"
                                    required="require_partner_bank_account and can_edit_wizard and (not can_group_payments or not group_payment)"
                                    placeholder="Account Number"
-                                   context="{'display_account_trust': True, 'default_partner_id': partner_id}"/>
+                                   widget="many2one_bank"
+                                   context="{'default_partner_id': partner_id}"/>
                             <field name="group_payment"
                                    invisible="not can_group_payments"/>
                             <label for="payment_difference" invisible="not show_payment_difference"/>

--- a/addons/web/static/src/views/fields/many2one/many2one.js
+++ b/addons/web/static/src/views/fields/many2one/many2one.js
@@ -14,7 +14,7 @@ import { Many2XAutocomplete, useOpenMany2XRecord } from "../relational_utils";
 // UTILS
 ///////////////////////////////////////////////////////////////////////////////
 
-function extractData(record) {
+export function extractData(record) {
     let name;
     if ("display_name" in record) {
         name = record.display_name;


### PR DESCRIPTION
This commit fixes the UI indicator of trusted/untrusted bank accounts
in many2one widget.
For trusted bank accounts, they are indicated with a green shield.
Untrusted bank accounts are indicated with a red exclamation circle.

This is a followup of the work done in this PR:
https://github.com/odoo/odoo/pull/229298

task-5117800




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
