### PR TITLE
[IMP] web_editor: disable image filters when WebGL missing

### DIFF
--- a/addons/web_editor/static/src/js/editor/image_processing.js
+++ b/addons/web_editor/static/src/js/editor/image_processing.js
@@ -20,6 +20,24 @@ const modifierFields = [
 ];
 export const isGif = (mimetype) => mimetype === 'image/gif';
 
+let _isWebGLEnabled;
+/**
+ * Cacheable check telling whether the current browser can allocate a WebGL context.
+ */
+export function isWebGLEnabled() {
+    if (_isWebGLEnabled !== undefined) {
+        return _isWebGLEnabled;
+    }
+    try {
+        const canvas = document.createElement("canvas");
+        _isWebGLEnabled = !!(window.WebGLRenderingContext
+            && (canvas.getContext("webgl") || canvas.getContext("experimental-webgl")));
+    } catch {
+        _isWebGLEnabled = false;
+    }
+    return _isWebGLEnabled;
+}
+
 // webgl color filters
 const _applyAll = (result, filter, filters) => {
     filters.forEach(f => {
@@ -322,7 +340,8 @@ export async function applyModifications(img, dataOptions = {}) {
     }
 
     // GL filter
-    if (glFilter) {
+    const canUseWebGL = glFilter && isWebGLEnabled() && window.WebGLImageFilter;
+    if (canUseWebGL) {
         const glf = new window.WebGLImageFilter();
         const cv = document.createElement('canvas');
         cv.width = result.width;

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -3254,6 +3254,11 @@ var SnippetsMenu = Widget.extend({
             iframeEl.dataset.oSrcOnDrop = iframeEl.getAttribute("src");
             iframeEl.removeAttribute("src");
         }
+
+        const filterSelectEl = $html.find("we-select").has("we-button[data-gl-filter]")[0];
+        if (filterSelectEl) {
+            filterSelectEl.dataset.name = "glfilter_select_opt";
+        }
     },
     /**
      * Creates a snippet editor to associated to the given snippet. If the given

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -30,6 +30,7 @@ import {
     createDataURL,
     isGif,
     getDataURLBinarySize,
+    isWebGLEnabled,
 } from "@web_editor/js/editor/image_processing";
 import * as OdooEditorLib from "@web_editor/js/editor/odoo-editor/src/OdooEditor";
 import { pick } from "@web/core/utils/objects";
@@ -1117,6 +1118,10 @@ const SelectUserValueWidget = BaseSelectionUserValueWidget.extend({
      * @param {Event} ev
      */
     _shouldIgnoreClick(ev) {
+        if (this.el.dataset.disabled === "true") {
+            ev.preventDefault();
+            return true;
+        }
         return !!ev.target.closest('[role="button"]');
     },
     /**
@@ -6217,6 +6222,7 @@ const ImageHandlerOption = SnippetOptionWidget.extend({
         // loadImageInfo RPC that obtains the file size.
         // This does not update the target.
         await this._applyOptions(false);
+        this._updateFilterAvailability();
     },
 
     //--------------------------------------------------------------------------
@@ -6238,6 +6244,7 @@ const ImageHandlerOption = SnippetOptionWidget.extend({
             this.$weight.removeClass('d-none');
             this._relocateWeightEl();
         }
+        this._updateFilterAvailability();
     },
 
     //--------------------------------------------------------------------------
@@ -6364,6 +6371,31 @@ const ImageHandlerOption = SnippetOptionWidget.extend({
         // TODO: remove in saas-18.4 since XML is static and will be up to date
         const optQuality = uiFragment.querySelector('we-range[data-set-quality]');
         optQuality.setAttribute('data-name', 'quality_range_opt');
+    },
+    /**
+     * Toggle the WebGL filter widget based on browser support, restoring the expected dataset name
+     * when the DOM predates the snippet patch (e.g., legacy custom snippets).
+     *
+     * @private
+     */
+    _updateFilterAvailability() {
+        if (!this.el) {
+            return;
+        }
+        let filterWidgetEl = this.el.querySelector('we-select[data-name="glfilter_select_opt"]');
+        if (!filterWidgetEl) {
+            return;
+        }
+        const tooltipTargetEl = filterWidgetEl.querySelector("we-toggler");
+        if (!isWebGLEnabled()) {
+            filterWidgetEl.dataset.disabled = "true";
+            filterWidgetEl.setAttribute("aria-disabled", "true");
+            tooltipTargetEl.setAttribute("title", _t("WebGL is not enabled on your browser."));
+        } else {
+            delete filterWidgetEl.dataset.disabled;
+            filterWidgetEl.removeAttribute("aria-disabled");
+            tooltipTargetEl.removeAttribute("title");
+        }
     },
     /**
      * Returns a list of valid formats for a given image or an empty list if

--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -1119,6 +1119,13 @@
         we-select.o_we_user_value_widget {
             position: relative;
 
+            &[data-disabled] {
+                we-toggler {
+                    opacity: .5;
+                    cursor: not-allowed;
+                }
+            }
+
             &:not(.o_we_icon_select) we-toggler {
                 @include large-component();
             }


### PR DESCRIPTION
On recent versions of Chrome for Linux (v140+), the old SwiftShader software fallback for WebGL has been removed. As a result, new window.WebGLImageFilter() now throws if no GPU context is available, typically when WebGL is disabled or unsupported.

Since the application cannot enable WebGL from JavaScript, this commit improves the user experience by detecting the absence of a WebGL context early and disabling image filters in edit mode. Instead of raising a traceback, the editor now skips the filter feature and can optionally display a friendly message explaining that WebGL is required to use image filters.

This avoids runtime errors and ensures a more robust behavior on platforms where WebGL is unavailable.

task-5117584
