### PR TITLE
[FIX] mrp: allow accessing MO overview when no BoM is linked

### DIFF
--- a/addons/mrp/report/mrp_report_mo_overview.py
+++ b/addons/mrp/report/mrp_report_mo_overview.py
@@ -689,8 +689,11 @@ class ReportMoOverview(models.AbstractModel):
         free_qty = max(0, product.uom_id._compute_quantity(product.free_qty, move_raw.product_uom))
         available_qty = reserved_quantity + free_qty + total_ordered
         missing_quantity = quantity - available_qty
-        qty_in_bom_uom = production.product_uom_id._compute_quantity(production.product_qty, production.bom_id.product_uom_id)
-        bom_missing_quantity = qty_in_bom_uom * move_raw.bom_line_id.product_qty - (reserved_quantity + free_qty + total_ordered)
+        if move_raw.bom_line_id:
+            qty_in_bom_uom = production.product_uom_id._compute_quantity(production.product_qty, production.bom_id.product_uom_id)
+            bom_missing_quantity = qty_in_bom_uom * move_raw.bom_line_id.product_qty - (reserved_quantity + free_qty + total_ordered)
+        else:
+            bom_missing_quantity = 0
 
         if product.is_storable and production.state not in ('done', 'cancel')\
            and float_compare(missing_quantity, 0, precision_rounding=move_raw.product_uom.rounding) > 0:

--- a/addons/mrp/tests/test_stock_report.py
+++ b/addons/mrp/tests/test_stock_report.py
@@ -664,3 +664,20 @@ class TestMrpStockReports(TestReportsCommon):
         overview_values = self.env['report.mrp.report_mo_overview'].get_report_values(mo.id)
         self.assertEqual(overview_values['data']['components'][0]['summary']['bom_cost'], 120)
         self.assertEqual(overview_values['data']['components'][0]['summary']['mo_cost'], 120)
+
+        # Test without BoM
+        mo_no_bom = self.env['mrp.production'].create({
+            'name': 'MO without BoM',
+            'product_id': self.product.id,
+            'product_uom_id': self.env.ref('uom.product_uom_dozen').id,
+            'product_qty': 1.0,
+            'bom_id': False,
+            'move_raw_ids': [Command.create({
+                'product_id': self.product1.id,
+                'product_uom_qty': 12.0,
+            })],
+        })
+        mo_no_bom.action_confirm()
+        overview_values_no_bom = self.env['report.mrp.report_mo_overview'].get_report_values(mo_no_bom.id)
+        self.assertEqual(overview_values_no_bom['data']['components'][0]['summary']['bom_cost'], 120)
+        self.assertEqual(overview_values_no_bom['data']['components'][0]['summary']['mo_cost'], 120)


### PR DESCRIPTION
Steps to reproduce:
- Create a storable product “P1”
- Create a manufacturing order to produce one unit of P1:
  - add any component
- Mark the MO as done
- Try to open the MO overview

Issue:
An error is raised because the MO has no BoM.
But in the function we try to compute the missing quantity in the BoM's UoM, but since no BoM is linked, there is no UoM available.

Error message:
"The unit of measure Unit defined on the order line doesn't belong to the same category as the unit of measure %(product_unit)s defined on the product. Please correct the unit of measure defined on the order line or on the product. They should belong to the same category."

Fix:
Skip the computation of missing BoM quantities when no BoM is linked, allowing the MO overview to be opened without error.

opw-5112132
Opw-5105544
Opw-5119897
