### PR TITLE
[IMP] account_fleet: add bidirectional links between bills and services

### DIFF
--- a/addons/account_fleet/views/account_move_views.xml
+++ b/addons/account_fleet/views/account_move_views.xml
@@ -6,6 +6,11 @@
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <button name="action_show_services" type="object" class="oe_stat_button" icon="fa-wrench" groups="fleet.fleet_group_user" invisible="not service_count">
+                    <field name="service_count" widget="statinfo" string="Services"/>
+                </button>
+            </xpath>
             <xpath expr="//field[@name='journal_line_ids']//field[@name='account_id']" position="after">
                 <field name='need_vehicle' column_invisible="True"/>
                 <field name='vehicle_id' column_invisible="parent.move_type not in ('in_invoice', 'in_refund')" required="need_vehicle and parent.move_type in ('in_invoice', 'in_refund')" optional='hidden'/>

--- a/addons/account_fleet/views/fleet_vehicle_log_services_views.xml
+++ b/addons/account_fleet/views/fleet_vehicle_log_services_views.xml
@@ -23,6 +23,19 @@
                                 title="Service's Bill">Service's Bill</span>
                         </div>
                     </button>
+                    <button
+                        name="action_create_account_move"
+                        type="object"
+                        class="oe_stat_button"
+                        icon="fa-pencil-square-o"
+                        invisible="account_move_line_id or not id">
+                        <div class="o_field_widget o_stat_info">
+                            <div class="o_field_widget o_stat_info ms-1">
+                                <span class="o_stat_value">New</span>
+                                <span class="o_stat_text">Service's Bill</span>
+                            </div>
+                        </div>
+                    </button>
                 </div>
             </xpath>
             <xpath expr="//field[@name='amount']" position="attributes">


### PR DESCRIPTION
Feature 1:
Previously there was a button on services to show the vendor bill
associated with it, but there was no button to get from the bill to its
associated services. This commit adds the smart button in the bill.

Feature 2:
There was no way of creating a bill for an existing fleet service, the
only way to link a bill and a service was to create a bill with a line
that included the vehicle that needed service. Confirming that bill
would create a service and link it to the bill. To simplify the flow,
the service can be created manually and a smart button is now added to
the service form to create a bill and link it to the service.

Task ID: 5109353