### PR TITLE
[IMP] base: allow changing the login field

### DIFF
--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -6,12 +6,17 @@
             <field name="model">change.password.own</field>
             <field name="arch" type="xml">
                 <form string="Change Password">
-                    <group>
-                        <field name="new_password" password="True" required="1"/>
-                        <field name="confirm_password" password="True" required="1"/>
+                    <group invisible="mode != 'password'">
+                        <field name="new_password" password="True" required="mode == 'password'"/>
+                        <field name="confirm_password" password="True" required="mode == 'password'"/>
+                    </group>
+                    <group invisible="mode != 'login'">
+                        <field name="user_login" readonly="1"/>
+                        <field name="new_login" required="mode == 'login'"/>
                     </group>
                     <footer>
-                        <button string="Change Password" name="change_password" type="object" class="btn-primary" data-hotkey="q"/>
+                    <button string="Change Login" name="change_login" type="object" class="btn-primary" data-hotkey="q" invisible="mode != 'login'"/>
+                    <button string="Change Password" name="change_password" type="object" class="btn-primary" data-hotkey="q" invisible="mode != 'password'"/>
                         <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x" />
                     </footer>
                 </form>
@@ -26,7 +31,8 @@
                 <form string="Change Password">
                     <field mode="list" name="user_ids"/>
                     <footer>
-                        <button string="Change Password" name="change_password_button" type="object" class="btn-primary" data-hotkey="q"/>
+                        <button string="Change Login" name="change_login_button" type="object" class="btn-primary" data-hotkey="q" invisible="mode != 'login'"/>
+                        <button string="Change Password" name="change_password_button" type="object" class="btn-primary" data-hotkey="q" invisible="mode != 'password'"/>
                         <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x" />
                     </footer>
                 </form>
@@ -40,9 +46,18 @@
                 <list string="Users" editable="bottom" create="false" delete="false">
                     <field name="user_id" column_invisible="True"/> <!-- required field, needed when updating the password -->
                     <field name="user_login" force_save="1"/>
-                    <field name="new_passwd" password="True"/>
+                    <field name="new_login" column_invisible="parent.mode != 'login'"/>
+                    <field name="new_passwd" password="True" column_invisible="parent.mode != 'password'"/>
                 </list>
             </field>
+        </record>
+        <record id="change_login_wizard_action" model="ir.actions.act_window">
+            <field name="name">Change Login</field>
+            <field name="res_model">change.password.wizard</field>
+            <field name="view_mode">form</field>
+            <field name="target">new</field>
+            <field name="binding_model_id" ref="base.model_res_users"/>
+            <field name="context">{'default_mode': 'login'}</field>
         </record>
         <record id="change_password_wizard_action" model="ir.actions.act_window">
             <field name="name">Change Password</field>
@@ -194,7 +209,21 @@
                                 </group>
                             </page>
                             <page string="Security" name="page_security" invisible="not id">
-                                <div name="auth" class="d-flex">
+                                <div name="login_auth" class="d-flex">
+                                    <div class="col-7 col-sm-6 col-lg-3 d-flex flex-column">
+                                        <span class="o_form_label">
+                                            Change Login
+                                        </span>
+                                        <span class="text-muted">
+                                            Change credentials if outdated.
+                                        </span>
+                                    </div>
+                                    <button invisible="id != uid" name="preference_change_login" type="object"
+                                        string="Change login" class="btn btn-secondary h-100 my-auto"/>
+                                    <button invisible="id == uid" name="action_change_login_wizard" type="object"
+                                        string="Change login" class="btn btn-secondary h-100 my-auto"/>
+                                </div>
+                                <div name="auth" class="d-flex mt-3">
                                     <div class="col-7 col-sm-6 col-lg-3 d-flex flex-column">
                                         <span class="o_form_label">
                                             Change Password


### PR DESCRIPTION
We want to allow users to modify their and other users' login from the user view. For this purpose we introduce a "mode" field on the password change wizard to allow using it to either pick a new login or password, as the logic is similar. in that changing either invalidates the session, and both should require the current password to modify from the UI.

task-5130854
