### PR TITLE
[FIX] hr_attendance, hr_holidays_attendance: update overtimes after reevaluating leave

### DIFF
--- a/addons/hr_attendance/models/__init__.py
+++ b/addons/hr_attendance/models/__init__.py
@@ -8,3 +8,4 @@ from . import hr_employee
 from . import hr_employee_public
 from . import res_company
 from . import res_users
+from . import resource_calendar_leaves

--- a/addons/hr_attendance/models/resource_calendar_leaves.py
+++ b/addons/hr_attendance/models/resource_calendar_leaves.py
@@ -1,0 +1,53 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from collections import defaultdict
+from datetime import timedelta
+
+from odoo import api, models
+
+
+class CalendarLeaves(models.Model):
+    _inherit = "resource.calendar.leaves"
+
+    def _get_employee_dates(self):
+        # returns the dict for each concerned employees, and fetches all employees concerned in case of a public holiday
+        employee_dates = defaultdict(set)
+        for leave in self:
+            if not leave.resource_id and leave.company_id.hr_attendance_overtime:
+                domain = []
+                if leave.calendar_id:
+                    domain.append(('resource_calendar_id', '=', leave.calendar_id.id))
+                if leave.company_id:
+                    domain.append(('company_id', '=', leave.company_id.id))
+                employees = self.env['hr.employee'].search(domain)
+                for emp in employees:
+                    for d in range((leave.date_to - leave.date_from).days + 1):
+                        employee_dates[emp].add(self.env['hr.attendance']._get_day_start_and_day(emp, leave.date_from + timedelta(days=d)))
+            if leave.resource_id.employee_id and leave.company_id.hr_attendance_overtime:
+                for d in range((leave.date_to - leave.date_from).days + 1):
+                    employee_dates[leave.resource_id.employee_id].add(self.env['hr.attendance']._get_day_start_and_day(leave.resource_id.employee_id, leave.date_from + timedelta(days=d)))
+        return employee_dates
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        res = super().create(vals_list)
+        employee_dates = res._get_employee_dates()
+        if employee_dates:
+            self.env['hr.attendance'].sudo()._update_overtime(employee_dates)
+        return res
+
+    def write(self, vals):
+        employee_dates = self._get_employee_dates()
+        res = super().write(vals)
+        for emp, dates in self._get_employee_dates().items():
+            employee_dates[emp].update(dates)
+        if employee_dates:
+            self.env['hr.attendance'].sudo()._update_overtime(employee_dates)
+        return res
+
+    def unlink(self):
+        employee_dates = self._get_employee_dates()
+        res = super().unlink()
+        if employee_dates:
+            self.env['hr.attendance'].sudo()._update_overtime(employee_dates)
+        return res

--- a/addons/hr_holidays/tests/test_company_leave.py
+++ b/addons/hr_holidays/tests/test_company_leave.py
@@ -302,7 +302,7 @@ class TestCompanyLeave(TransactionCase):
         })
         company_leave._compute_date_from_to()
 
-        with self.assertQueryCount(__system__=1856):  # 770 community
+        with self.assertQueryCount(__system__=1857):  # 770 community
             # Original query count: 1987
             # Without tracking/activity context keys: 5154
             company_leave.action_validate()

--- a/addons/hr_holidays_attendance/models/hr_leave.py
+++ b/addons/hr_holidays_attendance/models/hr_leave.py
@@ -84,24 +84,6 @@ class HRLeave(models.Model):
         self.sudo().overtime_id.unlink()
         return res
 
-    def _validate_leave_request(self):
-        super()._validate_leave_request()
-        self._update_leaves_overtime()
-
-    def _remove_resource_leave(self):
-        res = super()._remove_resource_leave()
-        self._update_leaves_overtime()
-        return res
-
-    def _update_leaves_overtime(self):
-        employee_dates = defaultdict(set)
-        for leave in self:
-            if leave.employee_id and leave.employee_company_id.hr_attendance_overtime:
-                for d in range((leave.date_to - leave.date_from).days + 1):
-                    employee_dates[leave.employee_id].add(self.env['hr.attendance']._get_day_start_and_day(leave.employee_id, leave.date_from + timedelta(days=d)))
-        if employee_dates:
-            self.env['hr.attendance'].sudo()._update_overtime(employee_dates)
-
     def unlink(self):
         # TODO master change to ondelete
         self.sudo().overtime_id.unlink()

--- a/addons/hr_work_entry_holidays/tests/test_performance.py
+++ b/addons/hr_work_entry_holidays/tests/test_performance.py
@@ -32,7 +32,7 @@ class TestWorkEntryHolidaysPerformance(TestWorkEntryHolidaysBase):
         self.richard_emp.generate_work_entries(date(2018, 1, 1), date(2018, 1, 2))
         leave = self.create_leave(datetime(2018, 1, 1, 7, 0), datetime(2018, 1, 1, 18, 0))
 
-        with self.assertQueryCount(__system__=114, admin=115):  # com 96/97
+        with self.assertQueryCount(__system__=115, admin=116):  # com 96/97
             leave.action_validate()
         leave.action_refuse()
 


### PR DESCRIPTION
When we re-evaluate leaves we update overtimes after switching to draft
but we do not update the overtimes again after the leave is switched
back to validated. This causes the overtimes from attendances that
overlap with the leave to be miscalculated as if the leave was not
validated.

To rectify this issue, we recalculate the overtimes for the affected
employees after every create/write/unlink of `resource.calendar.leaves`.

opw-4844447