### PR TITLE
[FIX] html_editor: handle color removal on special classes

### DIFF
--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -7,6 +7,7 @@ import {
     TEXT_CLASSES_REGEX,
     BG_CLASSES_REGEX,
     RGBA_REGEX,
+    hasTextColorClass,
 } from "@html_editor/utils/color";
 import { fillEmpty, unwrapContents } from "@html_editor/utils/dom";
 import {
@@ -275,7 +276,8 @@ export class ColorPlugin extends Plugin {
                         node,
                         '[style*="color"], [style*="background-color"], [style*="background-image"]'
                     ) ||
-                    closestElement(node, "span");
+                    closestElement(node, "span") ||
+                    closestElement(node, (node) => hasTextColorClass(node, mode));
 
                 const faNodes = font?.querySelectorAll(".fa");
                 if (faNodes && Array.from(faNodes).some((faNode) => faNode.contains(node))) {
@@ -294,7 +296,10 @@ export class ColorPlugin extends Plugin {
                 if (
                     font &&
                     font.nodeName !== "T" &&
-                    (font.nodeName !== "SPAN" || font.style[mode] || font.style.backgroundImage) &&
+                    (font.nodeName !== "SPAN" ||
+                        font.style[mode] ||
+                        font.style.backgroundImage ||
+                        hasTextColorClass(font, mode)) &&
                     (isColorGradient(color) ||
                         color === "" ||
                         !hasInlineGradient ||

--- a/addons/html_editor/static/src/utils/color.js
+++ b/addons/html_editor/static/src/utils/color.js
@@ -1,4 +1,5 @@
 import { closestElement } from "@html_editor/utils/dom_traversal";
+import { isElement } from "./dom_info";
 
 export const COLOR_PALETTE_COMPATIBILITY_COLOR_NAMES = [
     "primary",
@@ -228,6 +229,26 @@ export const TEXT_CLASSES_REGEX =
 export const BG_CLASSES_REGEX = /\bbg-[^\s]*\b/;
 
 /**
+ * Returns true if the given element has a visible color applied
+ * by `TEXT_CLASSES_REGEX` or `BG_CLASSES_REGEX`
+ *
+ * @param {Element} element
+ * @param {string} mode 'color' or 'backgroundColor'
+ * @returns {boolean}
+ */
+export function hasTextColorClass(element, mode) {
+    if (!element || !isElement(element)) {
+        return false;
+    }
+    const classRegex = mode === "color" ? TEXT_CLASSES_REGEX : BG_CLASSES_REGEX;
+    const parent = element.parentNode;
+    return (
+        classRegex.test(element.className) &&
+        (!parent || getComputedStyle(element)[mode] !== getComputedStyle(parent)[mode])
+    );
+}
+
+/**
  * Returns true if the given element has a visible color (fore- or
  * -background depending on the given mode).
  *
@@ -238,7 +259,6 @@ export const BG_CLASSES_REGEX = /\bbg-[^\s]*\b/;
 export function hasColor(element, mode) {
     const style = element.style;
     const parent = element.parentNode;
-    const classRegex = mode === "color" ? TEXT_CLASSES_REGEX : BG_CLASSES_REGEX;
     if (element.classList.contains("btn")) {
         // Ignore style applied on buttons from color detection
         return false;
@@ -258,8 +278,7 @@ export function hasColor(element, mode) {
         (style[mode] &&
             style[mode] !== "inherit" &&
             (!parent || style[mode] !== parent.style[mode])) ||
-        (classRegex.test(element.className) &&
-            (!parent || getComputedStyle(element)[mode] !== getComputedStyle(parent)[mode]))
+        hasTextColorClass(element, mode)
     );
 }
 

--- a/addons/html_editor/static/tests/color.test.js
+++ b/addons/html_editor/static/tests/color.test.js
@@ -634,3 +634,19 @@ test("should remove remove color from `td`", async () => {
         `),
     });
 });
+
+test("should be able to remove color applied by 'text-*' classes (1)", async () => {
+    await testEditor({
+        contentBefore: '<p><span class="text-muted">[a]</span></p>',
+        stepFunction: setColor("", "color"),
+        contentAfter: "<p>[a]</p>",
+    });
+});
+
+test.todo("should be able to remove color applied by 'text-*' classes (2)", async () => {
+    await testEditor({
+        contentBefore: '<p><a href="#" class="text-muted">[a]</a></p>',
+        stepFunction: setColor("", "color"),
+        contentAfter: '<p><a href="#">[a]</a></p>',
+    });
+});


### PR DESCRIPTION
Problem:
On website > shop > product page, when trying to edit the link of "Terms and conditions", a traceback occurs.

Cause:
When applying changes on "Terms and conditions" in `shop/product`, `ColorPlugin.removeAllColor()` is called on the `a` element. Its color was applied by the `text-muted` class.
This case in color removal was not properly handled.

Solution:
In `getFonts`, consider elements that have those special classes (e.g., `text-muted`) when processing color removal.

Steps to reproduce:
1. Open website/shop.
2. Open any product page.
3. Open the editor.
4. Select the "Terms and conditions" text.
5. Click edit in the link popover.
6. Click apply.
7. Traceback occurs.

opw-5130016

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
