### PR TITLE
[IMP] hr: resized employee profile picture

### DIFF
--- a/addons/hr/views/hr_employee_public_views.xml
+++ b/addons/hr/views/hr_employee_public_views.xml
@@ -59,8 +59,8 @@
                             <!-- Used by other modules-->
                         </div>
                         <div class="row flex-column flex-sm-row align-items-center">
-                            <div class="o_employee_avatar ms-2 p-0 h-100 mw-25 align-self-start align-self-sm-center">
-                                <field name="image_1920" widget='image' class="m-0" options='{"size": [128,158], "zoom": true, "preview_image":"avatar_128"}'/>
+                            <div class="o_employee_avatar ms-3 p-0 h-100 mw-25 align-self-start align-self-sm-center">
+                                <field name="image_1920" widget='image' class="m-0" options='{"size": [175,175], "zoom": true, "preview_image":"avatar_128"}'/>
                                 <field name="show_hr_icon_display" invisible="1" />
                             </div>
                             <div class="align-self-start o_employee_form_header_info">

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -131,8 +131,8 @@
                             </button>
                         </div>
                         <div class="row flex-column flex-sm-row align-items-center">
-                            <div class="o_employee_avatar ms-2 p-0 h-100 mw-25 align-self-start align-self-sm-center">
-                                <field name="image_1920" widget='image' class="m-0" options='{"size": [128,158], "zoom": true, "preview_image":"avatar_128"}'/>
+                            <div class="o_employee_avatar ms-3 p-0 h-100 mw-25 align-self-start align-self-sm-center">
+                                <field name="image_1920" widget='image' class="m-0" options='{"size": [175,175], "zoom": true, "preview_image":"avatar_128"}'/>
                                 <field name="show_hr_icon_display" invisible="1" />
                             </div>
                             <div class="align-self-start o_employee_form_header_info">


### PR DESCRIPTION
Resized the profile picture to get rid of wasted space and make the image larger. According to the specs the new image should be of size 175*175 and the employee avatar becomes ms-3 instead of ms-2.

task - 5136093

