### PR TITLE
[IMP] payment: dynamic payment button label

### DIFF
--- a/addons/delivery/static/src/interactions/payment_form.js
+++ b/addons/delivery/static/src/interactions/payment_form.js
@@ -1,3 +1,4 @@
+import { _t } from '@web/core/l10n/translation';
 import { patch } from '@web/core/utils/patch';
 
 import { PaymentForm } from '@payment/interactions/payment_form';
@@ -5,15 +6,15 @@ import { PaymentForm } from '@payment/interactions/payment_form';
 patch(PaymentForm.prototype, {
 
     /**
-     * Configure 'cash_on_delivery' as a pay later method.
+     * Determine the label for the submit button based on the selected payment method.
      *
      * @override
      */
-    _isPayLaterPaymentMethod(paymentMethodCode) {
-        return (
-            paymentMethodCode === 'cash_on_delivery'
-            || super._isPayLaterPaymentMethod(...arguments)
-        );
+    _getSubmitButtonLabel(paymentMethodCode) {
+        if (paymentMethodCode === 'cash_on_delivery') {
+            return _t('Confirm');
+        }
+        return  super._getSubmitButtonLabel(paymentMethodCode);
     }
 
 });

--- a/addons/payment/static/src/interactions/payment_form.js
+++ b/addons/payment/static/src/interactions/payment_form.js
@@ -283,9 +283,7 @@ export class PaymentForm extends Interaction {
      * @return {void}
      */
     _adaptSubmitButtonLabel(paymentMethodCode) {
-        const buttonLabel = this._isPayLaterPaymentMethod(paymentMethodCode)
-            ? _t("Confirm")
-            : this.defaultSubmitButtonLabel;
+        const buttonLabel = this._getSubmitButtonLabel(paymentMethodCode);
         for (const btn of document.querySelectorAll('button[name="o_payment_submit_button"]')) {
             if (btn.textContent !== buttonLabel) {
                 btn.textContent = buttonLabel;
@@ -294,16 +292,16 @@ export class PaymentForm extends Interaction {
     }
 
     /**
-     * Check whether the given payment method expects immediate payment.
+     * Get the appropriate submit button label based on the payment method.
      *
-     * Override this method to change the submit button label from the default label to "Confirm".
+     * Override this method to change the submit button label from the default label to a custom one.
      *
      * @private
      * @param {string} paymentMethodCode - The code of the selected payment method, if any.
-     * @return {boolean}
+     * @return {string} -the correct button label
      */
-    _isPayLaterPaymentMethod(paymentMethodCode) {
-        return false;
+    _getSubmitButtonLabel(paymentMethodCode) {
+        return this.defaultSubmitButtonLabel;
     }
 
     /**

--- a/addons/website_sale_collect/static/src/interactions/payment_form.js
+++ b/addons/website_sale_collect/static/src/interactions/payment_form.js
@@ -1,3 +1,4 @@
+import { _t } from '@web/core/l10n/translation';
 import { patch } from '@web/core/utils/patch';
 
 import { PaymentForm } from '@payment/interactions/payment_form';
@@ -5,12 +6,15 @@ import { PaymentForm } from '@payment/interactions/payment_form';
 patch(PaymentForm.prototype, {
 
     /**
-     * Configure 'pay_on_site' as a pay later method.
+     * Determine the label for the submit button based on the selected payment method.
      *
      * @override
      */
-    _isPayLaterPaymentMethod(paymentMethodCode) {
-        return paymentMethodCode === 'pay_on_site' || super._isPayLaterPaymentMethod(...arguments);
+    _getSubmitButtonLabel(paymentMethodCode) {
+        if (paymentMethodCode === 'pay_on_site') {
+            return _t('Confirm');
+        }
+        return  super._getSubmitButtonLabel(paymentMethodCode);
     }
 
 });


### PR DESCRIPTION
Update the payment module to allow other modules to provide
custom labels for the payment button dynamically.
Previously, modules returned only the payment method code, but
now they return the exact label to be displayed on the submit button.

task-5005916

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
