### PR TITLE
[IMP] iot_drivers: add qr code printing

### DIFF
--- a/addons/iot_drivers/static/src/app/status.js
+++ b/addons/iot_drivers/static/src/app/status.js
@@ -127,6 +127,10 @@ class StatusPage extends Component {
                                 <td class="col-3"><i class="me-1 fa fa-fw fa-id-card"/>Identifier</td>
                                 <td class="col-3" t-out="state.data.identifier"/>
                             </tr>
+                            <tr>
+                                <td class="col-3"><i class="me-1 fa fa-fw fa-address-book"/>Mac Address</td>
+                                <td class="col-3" t-out="state.data.mac_address"/>
+                            </tr>
                             <tr t-if="state.data.server_status">
                                 <td class="col-3"><i class="me-1 fa fa-fw fa-database"/>Database</td>
                                 <td class="col-3" t-out="state.data.server_status"/>


### PR DESCRIPTION
This PR adds a qr code to the status print receipt on receipt printers. This allows to scan the qr code to easily reach the iot box homepage. It also adds the mac address to the status receipt and the status page.

<img width="474" height="744" alt="image" src="https://github.com/user-attachments/assets/9bcd7adb-0342-42fa-854b-66e0ee5206a2" />

