### PR TITLE
[FIX] point_of_sale: make +10/+50 buttons give correct amount

### DIFF
--- a/addons/point_of_sale/static/src/app/services/number_buffer_service.js
+++ b/addons/point_of_sale/static/src/app/services/number_buffer_service.js
@@ -295,8 +295,12 @@ class NumberBuffer extends EventBus {
         } else if (input[0] === "+" && !isNaN(parseFloat(input))) {
             // when input is like '+10', '+50', etc
             const inputValue = oParseFloat(input.slice(1));
-            const currentBufferValue = this.state.buffer ? oParseFloat(this.state.buffer) : 0;
-            this.state.buffer = (inputValue + currentBufferValue).toString();
+            const currentBufferValue = this.state.buffer
+                ? oParseFloat(this.state.buffer.replace(".", this.decimalPoint))
+                : 0;
+            this.state.buffer = (inputValue + currentBufferValue)
+                .toString()
+                .replace(".", this.decimalPoint);
         } else if (!isNaN(parseInt(input, 10))) {
             if (this.state.toStartOver) {
                 // when we want to erase the current buffer for a new value

--- a/addons/point_of_sale/static/tests/pos/tours/payment_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/payment_screen_tour.js
@@ -253,3 +253,17 @@ registry.category("web_tour.tours").add("PaymentScreenInvoiceOrder", {
             PaymentScreen.clickValidate(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_add_money_button_with_different_decimal_separator", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Ouvrir la caisse"),
+            ProductScreen.addOrderline("Whiteboard Pen", "1"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickNumpad("+50"),
+            PaymentScreen.fillPaymentLineAmountMobile("Bank", "53,20"),
+            PaymentScreen.changeIs("50"),
+        ].flat(),
+});

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -2885,6 +2885,15 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('test_preset_customer_selection')
 
+    def test_add_money_button_with_different_decimal_separator(self):
+        """
+        Tests that the buttons such as +10 or +50 work even in languages such as
+        french that have ',' as a decimal separator.
+        """
+        self.env['res.lang']._activate_lang('fr_BE')
+        self.pos_user.write({'lang': 'fr_BE'})
+        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'test_add_money_button_with_different_decimal_separator', login="pos_user")
+
 
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):


### PR DESCRIPTION
**Steps to reproduce:**
- Set your database in a language with a "," as a decimal separator, such as French
- Make a purchase, chose a payment method
- Before paying, click any +10/20/50 button
- The price will be multiplied by 100, then add the desired amount

**Why the fix:**
There were two places where the decimal separator was causing issues.

First when we try to get the current price, *currentBufferValue*, we try to get it when it's in float state, but as we have a language with a decimal separator set as "," the "." in this float will be ignored, and we will take the decimal as units as well, explaining the *100 amount, because the decimals become whole numbers.

Secondly, when we try to make the addition of the two and convert it to string again, the *toString* method will convert it with a default "." not taking the current decimal separator into account. Once again, the "." will be ignored later on, leading to an even more over the top number.

We now convert the numbers and the strings using the correct decimal separator.

opw-5126224