### PR TITLE
[FIX] mass_mailing: inline placeholder element

### DIFF
--- a/addons/html_editor/__manifest__.py
+++ b/addons/html_editor/__manifest__.py
@@ -76,6 +76,7 @@ This addon provides an extensible, maintainable editor.
             'html_editor/static/src/others/embedded_component_utils.js',
             'html_editor/static/src/others/embedded_components/core/**/*',
             'html_editor/static/src/utils/**/*',
+            'html_editor/static/src/others/qweb_plugin.scss',
         ],
         "web.assets_web_dark": [
             'html_editor/static/src/**/*.dark.scss',

--- a/addons/mass_mailing/static/src/fields/html_field/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/fields/html_field/mass_mailing_html_field.js
@@ -1,6 +1,6 @@
+import { DYNAMIC_PLACEHOLDER_PLUGINS } from "@html_editor/backend/plugin_sets";
 import { htmlField, HtmlField } from "@html_editor/fields/html_field";
 import { LocalOverlayContainer } from "@html_editor/local_overlay_container";
-import { DynamicPlaceholderPlugin } from "@html_editor/others/dynamic_placeholder_plugin";
 import { MAIN_PLUGINS as MAIN_EDITOR_PLUGINS } from "@html_editor/plugin_sets";
 import { normalizeHTML, parseHTML } from "@html_editor/utils/html";
 import { MassMailingIframe } from "@mass_mailing/iframe/mass_mailing_iframe";
@@ -234,7 +234,7 @@ export class MassMailingHtmlField extends HtmlField {
         return {
             ...config,
             onEditorReady: () => this.commitChanges(),
-            Plugins: [...MAIN_EDITOR_PLUGINS, DynamicPlaceholderPlugin],
+            Plugins: [...MAIN_EDITOR_PLUGINS, ...DYNAMIC_PLACEHOLDER_PLUGINS],
         };
     }
 

--- a/addons/mass_mailing/static/tests/mass_mailing_html_field.test.js
+++ b/addons/mass_mailing/static/tests/mass_mailing_html_field.test.js
@@ -33,6 +33,22 @@ class Mailing extends models.Model {
             display_name: "Belgian Event promotion",
             mailing_model_id: 1,
         },
+        {
+            id: 2,
+            display_name: "Sent Belgian Event promotion",
+            mailing_model_id: 1,
+            body_arch: `
+                <div data_name="Mailing" class="o_layout oe_unremovable oe_unmovable o_empty_theme">
+                    <div class="container o_mail_wrapper o_mail_regular oe_unremovable">
+                        <div class="row">
+                            <div class="col o_mail_no_options o_mail_wrapper_td bg-white oe_structure o_editable oe_empty" data-editor-message-default="true" data-editor-message="DRAG BUILDING BLOCKS HERE" contenteditable="true">
+                                This element <t t-out="'should be inline'"/>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            `,
+        },
     ];
 }
 
@@ -81,6 +97,19 @@ const mailViewArch = `
 </form>
 `;
 
+const readonlyMailViewArch = `
+<form>
+    <field name="mailing_model_name" invisible="1"/>
+    <field name="mailing_model_id" invisible="1"/>
+    <field name="body_html" invisible="1"/>
+    <field name="body_arch" class="o_mail_body_mailing" widget="mass_mailing_html"
+        options="{
+            'inline_field': 'body_html',
+            'dynamic_placeholder': true,
+        }" readonly="true"/>
+</form>
+`;
+
 describe.current.tags("desktop");
 describe("field HTML", () => {
     beforeEach(() => {
@@ -107,5 +136,21 @@ describe("field HTML", () => {
         expect(await waitFor(":iframe .o_layout", { timeout: 3000 })).toHaveClass("o_empty_theme");
         await clickSave();
         await expect.waitForSteps(["web_save mail body"]);
+    });
+    test("t-out field in uneditable mode inline", async () => {
+        await mountView({
+            type: "form",
+            resModel: "mailing.mailing",
+            resId: 2,
+            arch: readonlyMailViewArch,
+        });
+        await waitFor(".o_mass_mailing_iframe_wrapper iframe:not(.d-none)");
+        const tElement = await waitFor(":iframe t", { timeout: 3000 });
+
+        // assert that we are in readonly mode (sanity check)
+        expect(":iframe .o_mass_mailing_value.o_readonly").toHaveCount(1);
+
+        // assert that tElement style has inline attibute
+        expect(tElement).toHaveAttribute("data-oe-t-inline", "true");
     });
 });


### PR DESCRIPTION
In editable fields, the Html Editor currently adds the data-oe-t-inline
attribute to items that are identified as needing to be displayed inline

However, this attribute is added by the editor and removed on save.

As a result, if the editable body is ever set to readonly(for example:
a mailing that is sent no longer allows users to edit its body), then
the inline property appears to be lost: an inline dynamic attribute
suddenly looks like it's on its own line.

Steps to reproduce:

- Create a mailing
- Add a dynamic attribute in the middle of a line
- Send the mailing
- You will see a carriage return directly before and after the dynamic
  attribute

Fix:
The mass_mailing html field now applies the current inlining logic to
readonly HTML.

--

https://github.com/odoo/odoo/pull/229049 deleted several duplicated styles exclusive to the HTML
builder from html_editor:common.scss, which were also
present in qweb_plugin.scss.

However, the mass_mailing html editor does not take into account this
file to determine styles within the editor iframe (nor does it use any
plugin in readonly mode.)

To fix this, the missing styles are duplicated into mass_mailing, to be
used in both editable and readonly modes.

task-4852246