### PR TITLE
[FIX] resource: also skip unavailable intervals for flexible resources

### DIFF
--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -547,7 +547,7 @@ class ResourceCalendar(models.Model):
         resources_work_intervals = self._work_intervals_batch(start_dt, end_dt, resources, domain, tz)
         result = {}
         for resource in resources_list:
-            if resource and resource._is_fully_flexible():
+            if resource and (resource._is_fully_flexible() or resource._is_flexible()):
                 continue
             work_intervals = [(start, stop) for start, stop, meta in resources_work_intervals[resource.id]]
             # start + flatten(intervals) + end


### PR DESCRIPTION
Steps to reproduce:
1. Create a resource with a "Working Time" calendar set with flexible hours
2. Create an appointment with this resource
3. Go to the website and try to book an appointment with this resource
4. Error 404 not found.

When booking appointments with resources that have flexible calendars, the system returns a 404 error during slot validation.

The issue occurs in `_check_appointment_is_valid_slot` (appointment controller) which validates that a slot is still available before allowing booking. This validation calls `_unavailable_intervals_batch` (resource.calendar) to check resource availability.

For flexible resources, `_unavailable_intervals_batch` generates inverted time intervals (e.g., start=18:30, end=18:00) which causes the overlap check to fail incorrectly, making valid slots appear unavailable.

This regression was introduced when the distinction between "fully flexible" (no calendar) and "flexible" (calendar with flexible_hours=True) was added. The check was only applied for fully flexible resources, leaving regular flexible resources broken.

Solution: Skip unavailable interval computation for both `_is_fully_flexible()` and `_is_flexible()` resources, since flexible resources by definition have no fixed unavailable periods.

opw-5026825

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
