### PR TITLE
[FIX] hr: traceback when archiving employee

### DIFF
--- a/addons/hr/models/hr_version.py
+++ b/addons/hr/models/hr_version.py
@@ -127,7 +127,7 @@ class HrVersion(models.Model):
 
     departure_reason_id = fields.Many2one("hr.departure.reason", string="Departure Reason",
                                           groups="hr.group_hr_user", copy=False, ondelete='restrict', tracking=True)
-    departure_description = fields.Html(string="Additional Information", groups="hr.group_hr_user", copy=False, tracking=True)
+    departure_description = fields.Html(string="Additional Information", groups="hr.group_hr_user", copy=False)
     departure_date = fields.Date(string="Departure Date", groups="hr.group_hr_user", copy=False, tracking=True)
 
     resource_calendar_id = fields.Many2one('resource.calendar', inverse='_inverse_resource_calendar_id', check_company=True, string="Working Hours", tracking=True)

--- a/addons/hr/tests/test_hr_version.py
+++ b/addons/hr/tests/test_hr_version.py
@@ -612,6 +612,7 @@ class TestHrVersion(TransactionCase):
             "currency_id",
             "date_end",
             "date_start",
+            "departure_description",
             "display_name",
             "id",
             "is_current",


### PR DESCRIPTION
Issue:
The tracking is not implemented for the html field, so when we archive an employee the tracking cannot work.

Purpose of this PR:
The tracking has been removed from the html field. The tracking is now replaced by a message in the chatter in the write method.

Steps to Reproduce on Runbot:
install hr
archive employee
set a `departure description`

Notes:
originally fixed by #140527
reintroduced by #223342

opw-5137695
