### PR TITLE
[FIX] hr_timesheet: create timesheet without access to internal project

### DIFF
--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -30,7 +30,7 @@ class AccountAnalyticLine(models.Model):
         )
         if not last_timesheets:
             internal_project = self.env.company.internal_project_id
-            return internal_project.active and internal_project.allow_timesheets and internal_project.id
+            return internal_project.has_access('read') and internal_project.active and internal_project.allow_timesheets and internal_project.id
         return mode([t.project_id.id for t in last_timesheets])
 
     @api.model

--- a/addons/hr_timesheet/tests/test_timesheet.py
+++ b/addons/hr_timesheet/tests/test_timesheet.py
@@ -309,6 +309,16 @@ class TestTimesheet(TestCommonTimesheet):
                 'project_id': False
             })
 
+    def test_favorite_project_id(self):
+        """ Test that user without previous timesheets and without
+        access to the internal project has no favorite project. """
+
+        # make internal project accessible to invited internal users only
+        self.env.company.internal_project_id.privacy_visibility = 'followers'
+
+        favorite_project = self.env['account.analytic.line'].with_user(self.user_employee)._get_favorite_project_id()
+        self.assertFalse(favorite_project, "A user without timesheet and without access to the internal project should have no favorite project.")
+
     def test_recompute_amount_for_multiple_timesheets(self):
         """ Check that amount is recomputed correctly when setting unit_amount for multiple timesheets at once. """
         Timesheet = self.env['account.analytic.line']


### PR DESCRIPTION
To reproduce:
=============
- make the internal project of the company for invited internal users only
- with internal user that doesn't have access to the internal project, and no previous timesheet created, try to create a timesheet
- you get a traceback

Problem:
========
when not having a previous timesheet, in the default value we set project_id based on the internal project of the company.
But if the user doesn't have access to this project, it raises an access error.

Solution:
=========
check if the user has access to the internal project of the company, if not, use `False` as default value.

opw-5119839

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
