### PR TITLE
[FIX] {test_,}mail: change scheduler summary and note according activity type

### DIFF
--- a/addons/mail/wizard/mail_activity_schedule.py
+++ b/addons/mail/wizard/mail_activity_schedule.py
@@ -167,14 +167,12 @@ class MailActivitySchedule(models.TransientModel):
     @api.depends('activity_type_id')
     def _compute_summary(self):
         for scheduler in self:
-            if scheduler.activity_type_id.summary:
-                scheduler.summary = scheduler.activity_type_id.summary
+            scheduler.summary = scheduler.activity_type_id.summary
 
     @api.depends('activity_type_id')
     def _compute_note(self):
         for scheduler in self:
-            if scheduler.activity_type_id.default_note:
-                scheduler.note = scheduler.activity_type_id.default_note
+            scheduler.note = scheduler.activity_type_id.default_note
 
     @api.depends('activity_type_id')
     def _compute_activity_user_id(self):

--- a/addons/test_mail/tests/test_mail_activity_plan.py
+++ b/addons/test_mail/tests/test_mail_activity_plan.py
@@ -166,6 +166,29 @@ class TestActivitySchedule(ActivityScheduleCase):
         self.assertEqual(len(self.test_records[3].activity_ids), 0)
         self.assertEqual(len(self.test_records[4].activity_ids), 0)
 
+    @users('admin')
+    def test_activity_type_changes_summary_and_note(self):
+        """Check that changing activity type updates summary and note fields correctly."""
+        activity_type_call = self.activity_type_call
+        activity_type_call.write({
+            'summary': 'test summary',
+            'default_note': 'test note'
+        })
+        # To-Do activity type doesn't have any default summary and note
+        activity_type_todo = self.activity_type_todo
+
+        test_record = self.test_records[0].with_env(self.env)
+
+        form = self._instantiate_activity_schedule_wizard(test_record)
+        form.activity_type_id = activity_type_call
+        self.assertEqual(form.activity_type_id, activity_type_call)
+        self.assertEqual(form.summary, activity_type_call.summary)
+        self.assertEqual(form.note, activity_type_call.default_note)
+        form.activity_type_id = activity_type_todo
+        # activity summary and note changed due change of activity type as To-Do Activity doesn't have default summary and note
+        self.assertEqual(form.summary, activity_type_todo.summary)
+        self.assertEqual(form.note, activity_type_todo.default_note)
+
     @users('employee')
     def test_plan_mode(self):
         """ Test the plan_mode that allows to preselect a compatible plan. """


### PR DESCRIPTION
Steps to reproduce:
--------------------------
1. Install Discuss Module
2. Create two activity types: one with a default summary and default note, and another with both fields empty.
3. Go to any user's partner record and click on Activities from Chatter
4. Select the activity type with the default summary and note.
5. Now change it to the activity type with no summary and note.

Observation:
--------------------------
The scheduler still shows the previous summary and note after changing to an activity type without defaults.

Issue:
--------------------------
The compute methods only update the summary and note if the new activity type has them. As a result, fields are not cleared when the new type has empty values https://github.com/odoo/odoo/blob/b2c1af2e60968ee745e0a1238602aafe12f486b0/addons/mail/wizard/mail_activity_schedule.py#L167-L177

Solution:
--------------------------
Remove the condition that blocks updating the summary and note. Now, the scheduler updates correctly even when the new activity type has no summary or note.

opw-5106771