### PR TITLE
[IMP] website_sale: Single RPC call on address change

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1459,7 +1459,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         address.update(country_id=country.id, state_id=state_id)
 
     @route('/shop/update_address', type='jsonrpc', auth='public', website=True)
-    def shop_update_address(self, partner_id, address_type='billing', **kw):
+    def shop_update_address(self, partner_id, address_type='billing', use_delivery_as_billing=False, **kw):
         partner_id = int(partner_id)
 
         if not (order_sudo := request.cart):
@@ -1480,11 +1480,11 @@ class WebsiteSale(payment_portal.PaymentPortal):
 
         partner_fnames = set()
         if (
-            address_type == 'billing'
+            (use_delivery_as_billing or address_type == 'billing')
             and partner_sudo != order_sudo.partner_invoice_id
         ):
             partner_fnames.add('partner_invoice_id')
-        elif (
+        if (
             address_type == 'delivery'
             and partner_sudo != order_sudo.partner_shipping_id
         ):

--- a/addons/website_sale/tests/test_address.py
+++ b/addons/website_sale/tests/test_address.py
@@ -660,6 +660,37 @@ class TestCheckoutAddress(WebsiteSaleCommon):
             "Tax should no longer change after order confirmation",
         )
 
+    def test_shop_update_address_with_use_delivery_as_billing(self):
+        user = self.user_portal
+        user_partner = user.partner_id
+
+        so = self._create_so(partner_id=user_partner.id)
+
+        user_address = self.env['res.partner'].create([
+            {
+                'name': 'Test Address',
+                'street': '215 Vine St',
+                'city': 'Scranton',
+                'zip': '18503',
+                'country_id': self.country_us.id,
+                'state_id': self.country_us_state_id,
+                'phone': '+1 555-555-5555',
+                'email': 'admin@yourcompany.example.com',
+                'parent_id': user_partner.id,
+                'type': 'other',
+            }
+        ])
+
+        website = self.website.with_user(user)
+        with MockRequest(website.env, website=website, sale_order_id=so.id):
+            self.WebsiteSaleController.shop_update_address(
+                partner_id=user_address.id,
+                address_type='delivery',
+                use_delivery_as_billing=True
+            )
+            self.assertEqual(so.partner_shipping_id, user_address)
+            self.assertEqual(so.partner_invoice_id, user_address)
+
     def test_imported_user_with_trailing_name_can_checkout(self):
         """Ensure that an imported user with trailing spaces in their name can complete checkout without error."""
         imported_user = self.env['res.users'].create({


### PR DESCRIPTION
**Purpose:**
When changing the address on the checkout page with use_same_as_billing_address checked, two RPC calls are made to set partners on the order, which is not efficient.

**Specification:**
Adapt the /shop/update_address and changeAddress controllers to make a single RPC call to set both addresses at once.

Task-5072845

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
