### PR TITLE
[FIX] website, html_builder: run after-save handlers if aborted

### DIFF
--- a/addons/html_builder/static/src/core/save_plugin.js
+++ b/addons/html_builder/static/src/core/save_plugin.js
@@ -52,14 +52,14 @@ export class SavePlugin extends Plugin {
         this.savableSelector = this.getResource("savable_selectors").join(", ");
     }
 
-    async save({ alwaysSkipAfterSaveHandlers = true } = {}) {
-        let success;
+    async save({ shouldSkipAfterSaveHandlers = async () => true } = {}) {
+        let skipAfterSaveHandlers;
         try {
             await Promise.all(this.getResource("before_save_handlers").map((handler) => handler()));
             await this._save();
-            success = true;
+            skipAfterSaveHandlers = await shouldSkipAfterSaveHandlers();
         } finally {
-            if (!(alwaysSkipAfterSaveHandlers || success)) {
+            if (!skipAfterSaveHandlers) {
                 this.getResource("after_save_handlers").forEach((handler) => handler());
             }
         }

--- a/addons/mail/static/tests/mail_test_helpers.js
+++ b/addons/mail/static/tests/mail_test_helpers.js
@@ -77,6 +77,7 @@ import { ResRole } from "./mock_server/mock_models/res_role";
 import { ResUsers } from "./mock_server/mock_models/res_users";
 import { ResUsersSettings } from "./mock_server/mock_models/res_users_settings";
 import { ResUsersSettingsVolumes } from "./mock_server/mock_models/res_users_settings_volumes";
+import { Rtc } from "@mail/discuss/call/common/rtc_service";
 
 export * from "./mail_test_helpers_contains";
 
@@ -309,6 +310,12 @@ let discussAsTabId = 0;
  * }} [options]
  */
 export async function start(options) {
+    patchWithCleanup(Rtc.prototype, {
+        start() {
+            super.start();
+            after(() => this.clear());
+        },
+    });
     if (!MockServer.current) {
         await startServer();
     }

--- a/addons/website/static/src/builder/plugins/customize_website_plugin.js
+++ b/addons/website/static/src/builder/plugins/customize_website_plugin.js
@@ -431,19 +431,25 @@ export class AddLanguageAction extends BuilderAction {
         if (!save) {
             return;
         }
-        this.config.builderSidebar.toggle(false);
-        await this.dependencies.savePlugin.save(/* not in translation */);
-        await this.services.action.doAction("base.action_view_base_language_install", {
-            additionalContext: {
-                params: {
-                    website_id: websiteId,
-                    url_return: "[lang]",
+        await this.config.builderSidebar.withHiddenSidebar(() =>
+            this.dependencies.savePlugin.save({
+                shouldSkipAfterSaveHandlers: async () => {
+                    await this.services.action.doAction("base.action_view_base_language_install", {
+                        additionalContext: {
+                            params: {
+                                website_id: websiteId,
+                                url_return: "[lang]",
+                            },
+                        },
+                        // The `noReload` in the params of the close callback
+                        // are the only way we have to know whether the modal
+                        // dialog has been cancelled
+                        onClose: (closeParams) => def.resolve(!!closeParams?.noReload),
+                    });
+                    return await def;
                 },
-            },
-            onClose: def.resolve,
-        });
-        await def;
-        this.config.builderSidebar.toggle(true);
+            })
+        );
     }
 }
 

--- a/addons/website/static/src/builder/website_builder.js
+++ b/addons/website/static/src/builder/website_builder.js
@@ -98,7 +98,7 @@ export class WebsiteBuilder extends Component {
         if (!this.editor) {
             return;
         }
-        if (!this.isSaving && this.editor.shared.history.canUndo()) {
+        if (this.editor.shared.history.canUndo()) {
             event.preventDefault();
             event.returnValue = "Unsaved changes";
         }
@@ -127,15 +127,14 @@ export class WebsiteBuilder extends Component {
     }
 
     async save() {
-        this.editor.shared.operation.next(this._save.bind(this), { withLoadingEffect: false });
-    }
-
-    async _save() {
-        this.isSaving = true;
         // TODO: handle the urgent save and the fail of the save operation
-        await this.editor.shared.savePlugin.save({ alwaysSkipAfterSaveHandlers: false });
-        this.props.builderProps.closeEditor();
-        this.isSaving = false;
+        await this.editor.shared.operation.next(
+            async () => {
+                await this.editor.shared.savePlugin.save();
+                this.props.builderProps.closeEditor();
+            },
+            { withLoadingEffect: false }
+        );
     }
 
     get builderProps() {

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -213,6 +213,15 @@ export class WebsiteBuilderClientAction extends Component {
                 initialTarget: this.target,
                 initialTab: this.initialTab || this.translation ? "customize" : "blocks",
                 builderSidebar: {
+                    withHiddenSidebar: async (cb) => {
+                        try {
+                            this.state.showSidebar = false;
+                            return await cb();
+                        } finally {
+                            this.state.showSidebar = true;
+                        }
+                    },
+                    // TODO: remove `toggle` in master
                     toggle: (show) => {
                         this.state.showSidebar = show ?? !this.state.showSidebar;
                     },


### PR DESCRIPTION
### [FIX] mail: clean the "beforeunload" listener in tests

Some tests trigger a call to the function `Rtc.joinCall` which adds a
listener on `beforeunload` event that cancels the event. Some of these
tests do not trigger a later call to `Rpc.clear`, thus the listener
stays registered. This could mess with other unrelated tests that check
their own handlers of `beforeunload` are correct.

This commit adds a cleanup on the helper used by the problematic tests.

task-5138313

### [FIX] website, html_builder: run after-save handlers if aborted

Usually, running the after save handlers is not needed after the save
because we are about to close or reload the builder. Thus they are not
run as an optimization. But there are a few cases where they are needed:
- The saving of the page failed. This case was correctly handled only
  when clicking on the save button or adding a module
- When adding a language, but cancelling the dialog to choose the
  language

This commit changes the save function of the save plugin, to take a
async callback to determine whether the after-save handlers should run.
The callback is async to be able to wait for the language choice dialog.
If the callback returns `true`, then the after-save handlers are run.

Steps to reproduce:
- Open website builder
- Open "Theme" tab
- Click "Add Language"
- Confirm the first dialog (about save)
- Cancel the second dialog (language choice)
- Bug: the save button stays disabled with the spinning wheel next to it

task-5138313

