### PR TITLE
[FIX] bus: fix notify test

### DIFF
--- a/addons/bus/tests/test_notify.py
+++ b/addons/bus/tests/test_notify.py
@@ -79,10 +79,10 @@ class NotifyTests(TransactionCase):
                 while not stop_event.is_set():
                     if sel.select(timeout=5):
                         conn.poll()
-                        channels = json.loads(conn.notifies.pop().payload)
-                        _logger.info("[TEST_NOTIFY] 3. channels received: %s", channels)
-                        if notify_channels := [c for c in channels if c[0] == self.env.cr.dbname]:
-                            channels = notify_channels
+                        channels_received = json.loads(conn.notifies.pop().payload)
+                        _logger.info("[TEST_NOTIFY] 3. channels received: %s", channels_received)
+                        channels = [c for c in channels_received if c[0] == self.env.cr.dbname]
+                        if channels:
                             break
                 _logger.info("[TEST_NOTIFY] 4. exiting listen loop")
 


### PR DESCRIPTION
In [1], logs were added to the `test_postcommit` test in order to better understand why it sometimes fails. However, this commit changed the test behavior: we only care about notify coming from the DB executing the test, but the `channel` variable is filled regardless of the DB the notification comes from.

[1]: https://github.com/odoo/odoo/pull/229106

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
