### PR TITLE
[FIX] pos_online_payment*: update payment screen after online payment paid

### DIFF
--- a/addons/pos_online_payment/static/src/app/services/pos_store.js
+++ b/addons/pos_online_payment/static/src/app/services/pos_store.js
@@ -10,11 +10,6 @@ patch(PosStore.prototype, {
             // Therefore, no sensitive information is sent through it, only a
             // notification to invite the local browser to do a safe RPC to
             // the server to check the new state of the order.
-            const order = this.models["pos.order"].find((o) => o.id == id);
-            const updatedOrder = await this.data.read("pos.order", [id])[0];
-            if (updatedOrder) {
-                order.state = updatedOrder.state;
-            }
             if (this.getOrder()?.id === id) {
                 this.updateOnlinePaymentsDataWithServer(this.getOrder(), false);
             }

--- a/addons/pos_online_payment_self_order/models/pos_order.py
+++ b/addons/pos_online_payment_self_order/models/pos_order.py
@@ -68,7 +68,6 @@ class PosOrder(models.Model):
         return res
 
     def _send_notification_online_payment_status(self, status):
-        self.config_id.notify_synchronisation(self.config_id.current_session_id.id, 0)
         self.config_id._notify("ONLINE_PAYMENT_STATUS", {
             'status': status,  # progress, success, fail
             'data': {


### PR DESCRIPTION
*: pos_online_payment_self_order

Before this commit:
===============
- When paying with a QR code, the screen kept showing the QR code even after
the payment was completed.
- Closing the QR popup manually and performing another action resulted in
a `Finalize order` error.
- This happened because the WebSocket handler flow were not updating
the order state properly.

After this commit:
===============
- Ensure the frontend refreshes payment status directly from the server
when the current order is updated.
- Remove unnecessary synchronization calls to prevent stale state.
- The order is now correctly marked as paid, and no finalize error occurs
after closing the QR popup.

Issue:
===============
- The frontend WebSocket handler for `ONLINE_PAYMENTS_NOTIFICATION`
was fetching the full `pos.order` unnecessarily, because the order state is
already updated by another WebSocket flow.
- `notify_synchronisation` in the self order flow was redundant, as updates
are already handled in the `pos_self_order` module’s `pos.order` file.

Task - 5107009