### PR TITLE
[FIX] mail: return BlurManager instance to update blur properties in real-time

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_preview.js
+++ b/addons/mail/static/src/discuss/call/common/call_preview.js
@@ -83,6 +83,13 @@ export class CallPreview extends Component {
                     this.disableBlur();
                 }
             });
+            onChange(this.store.settings, ["edgeBlurAmount", "backgroundBlurAmount"], () => {
+                if (this.state.blurManager) {
+                    this.state.blurManager.edgeBlur = this.store.settings.edgeBlurAmount;
+                    this.state.blurManager.backgroundBlur =
+                        this.store.settings.backgroundBlurAmount;
+                }
+            });
             onWillDestroy(() => {
                 closeStream(this.state.audioStream);
                 closeStream(this.state.videoStream);
@@ -269,7 +276,7 @@ export class CallPreview extends Component {
         }
         try {
             this.state.blurManager = await this.rtc.applyBlurEffect(this.state.videoStream);
-            this.videoRef.el.srcObject = this.state.blurManager.stream;
+            this.videoRef.el.srcObject = await this.state.blurManager.stream;
         } catch (_e) {
             this.notification.add(_e.message, { type: "warning" });
             this.disableBlur();

--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -1763,17 +1763,13 @@ export class Rtc extends Record {
      * Applies blur effect to a video stream using BlurManager.
      *
      * @param {MediaStream} videoStream - input video stream.
-     * @returns {Promise<{stream: MediaStream, close: Function}>} - Blurred video stream and a function to close the blur manager.
+     * @returns {Promise<BlurManager>} - BlurManager instance.
      */
     async applyBlurEffect(videoStream) {
-        const blurManager = new BlurManager(videoStream, {
+        return new BlurManager(videoStream, {
             backgroundBlur: this.store.settings.backgroundBlurAmount,
             edgeBlur: this.store.settings.edgeBlurAmount,
         });
-        return {
-            stream: await blurManager.stream,
-            close: () => blurManager.close(),
-        };
     }
 
     /**
@@ -1989,7 +1985,7 @@ export class Rtc extends Record {
             this.blurManager = undefined;
             try {
                 this.blurManager = await this.applyBlurEffect(sourceStream);
-                const blurredStream = this.blurManager.stream;
+                const blurredStream = await this.blurManager.stream;
                 outputTrack = blurredStream.getVideoTracks()[0];
             } catch (_e) {
                 this.notification.add(_e.message, { type: "warning" });


### PR DESCRIPTION
**Current behavior before PR:**
- Before this commit, `applyBlurEffect` returned a partial object with only `stream` and `close` properties, preventing access to properties like `edgeBlur` and `backgroundBlur` needed for real-time adjustments during calls.

**Desired behavior after PR is merged:**

- This commit returns the `BlurManager` instance from `applyBlurEffect` and adds an `onChange` listener in `CallPreview`, enabling users to adjust blur characteristics in real-time during both preview and active calls.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
