### PR TITLE
[FIX] payment: fix express checkout navigation

### DIFF
--- a/addons/payment/static/src/js/express_checkout_form.js
+++ b/addons/payment/static/src/js/express_checkout_form.js
@@ -20,11 +20,33 @@ publicWidget.registry.PaymentExpressCheckoutForm = publicWidget.Widget.extend({
         }
         // Monitor updates of the amount on eCommerce's cart pages.
         Component.env.bus.addEventListener('cart_amount_changed', (ev) => this._updateAmount(...ev.detail));
+        // Monitor when the page is restored from the bfcache.
+        window.addEventListener('pageshow', this._onNavigationBack);
+    },
+
+    /**
+     * @override
+     */
+    destroy() {
+        window.removeEventListener('pageshow', this._onNavigationBack);
+        this._super.apply(this, arguments);
     },
 
     //--------------------------------------------------------------------------
     // Private
     //--------------------------------------------------------------------------
+
+    /**
+     * Reload the page when the page is restored from the bfcache.
+     *
+     * @param {PageTransitionEvent} event - The pageshow event.
+     * @private
+     */
+    _onNavigationBack(event) {
+        if (event.persisted) {
+            window.location.reload();
+        }
+    },
 
     /**
      * Return all express checkout forms found on the page.


### PR DESCRIPTION
This error occurs when trying to make a payment again from the cart.

Steps to reproduce:
---
- Install the **website_sale** module (with demo)
- Activate **Demo** payment provider
- Go to Website > Shop > Add a **Warranty** product to Cart > View cart
- Pay with Demo > Pay
- Click the back button(chrome navbar)(Instantly)
- Now again Pay with Demo > Pay

Traceback:
---
`ValueError: Expected singleton: sale.order()`

At [1], this error occurs because **order_sudo** is empty. This
happens when there is no product in the cart — typically because, upon
clicking **Pay**, a sale order is created for the product, and when the
user navigates back, the cart is empty.

[1]- https://github.com/odoo/odoo/blob/125fc3028debb311e9f6ad25d8c46699b77525f0/addons/website_sale/controllers/main.py#L1307-L1312

sentry-5682671428