### PR TITLE
[FIX] mail: allow using `@everyone` without mentioning specific users

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -1002,7 +1002,7 @@ class DiscussChannel(models.Model):
         # sudo: discuss.channel - write to discuss.channel is not accessible for most users
         self.sudo().last_interest_dt = fields.Datetime.now()
         if "everyone" in kwargs.pop("special_mentions", []):
-            partner_ids = list(OrderedSet(partner_ids + self.channel_member_ids.partner_id.ids))
+            partner_ids = list(OrderedSet((partner_ids or []) + self.channel_member_ids.partner_id.ids))
         if partner_ids:
             kwargs["partner_ids"] = self._get_allowed_message_partner_ids(partner_ids)
         # mail_post_autofollow=False is necessary to prevent adding followers

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -291,6 +291,16 @@ class TestChannelInternals(MailCommon, HttpCase):
                 message_type='comment', subtype_xmlid='mail.mt_comment')
         self.assertSentEmail(self.test_channel.env.user.partner_id, [self.test_partner])
 
+    @mute_logger("odoo.models.unlink")
+    def test_channel_special_mention(self):
+        """ Posting a message on a channel should support special mention """
+        self.test_channel._add_members(users=self.user_employee | self.user_employee_nomail)
+        with self.mock_mail_gateway():
+            new_msg = self.test_channel.message_post(
+                body="Test", special_mentions=["everyone"],
+                message_type="comment", subtype_xmlid="mail.mt_comment")
+        self.assertEqual(new_msg.partner_ids, self.test_channel.channel_member_ids.partner_id)
+
     @mute_logger('odoo.models.unlink')
     def test_channel_user_synchronize(self):
         """Archiving / deleting a user should automatically unsubscribe related partner from group restricted channels"""


### PR DESCRIPTION
**Before this commit:**

Since [1] if a user wrote a message with only `@everyone` and did not mention any
individual user, the message failed to send. This happened because the
system tried to combine the list of mentioned users with the list of
channel members, but the mentioned users list was None and caused an
error.

**After this commit:**

`@everyone` can be used on its own without also tagging specific users.
When no other users are mentioned, the system simply treats it as an
empty list and continues normally, allowing the message to be sent to
everyone in the channel.

[1]: https://github.com/odoo/odoo/pull/219637
Task-5136984

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
