### PR TITLE
[FIX] website: remove sidebar padding when header is hidden

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1505,7 +1505,7 @@ header {
 
 @if o-website-value('header-template') == 'sidebar' {
     @include media-breakpoint-up(lg) {
-        #wrapwrap {
+        #wrapwrap:has(> header) {
             // Two different website options might add padding:
             // - The sidebar header template
             // - The website layout template when different than 'full'

--- a/addons/website/static/tests/tours/hide_sidebar_header.js
+++ b/addons/website/static/tests/tours/hide_sidebar_header.js
@@ -1,0 +1,57 @@
+import { clickOnSave, registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
+
+registerWebsitePreviewTour(
+    "hide_sidebar_header",
+    {
+        url: "/",
+        edition: true,
+    },
+    () => [
+        {
+            content: "Click on the header",
+            trigger: ":iframe #o_main_nav",
+            run: "click",
+        },
+        {
+            content: "Click on header template",
+            trigger: ".o_we_user_value_widget:has(we-title:contains(Template)) we-toggler",
+            run: "click",
+        },
+        {
+            content: "Change header template to 'Sidebar'",
+            trigger: ".o_we_user_value_widget[title='Sidebar']",
+            run: "click",
+        },
+        {
+            content: "Ensure the header is 'Sidebar'",
+            trigger: ":iframe #wrapwrap>header.o_header_sidebar",
+            timeout: 10000,
+        },
+        {
+            content: "Go to the theme tab",
+            trigger: ".o_we_customize_theme_btn",
+            run: "click",
+        },
+        {
+            content: "Toggle 'Show Header' off",
+            trigger: ".o_we_user_value_widget:has(we-title:contains(Show Header)) we-checkbox",
+            run: "click",
+        },
+        {
+            content: "Ensure the header has been hidden",
+            trigger: ":iframe #wrapwrap:not(:has(:scope > header))",
+            timeout: 10000,
+        },
+        {
+            content: "Check that there's no header padding on the #wrapwrap",
+            trigger: ":iframe #wrapwrap",
+            run() {
+                const style = getComputedStyle(this.anchor);
+                if (style.paddingLeft !== "0px") {
+                    throw new Error("There shouldn't be padding for the header");
+                }
+            },
+        },
+        ...clickOnSave(),
+    ]
+);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -756,3 +756,6 @@ class TestUi(odoo.tests.HttpCase):
 
     def test_popup_visibility_option(self):
         self.start_tour("/", "website_popup_visibility_option", login="admin")
+
+    def test_hiding_sidebar_header(self):
+        self.start_tour("/", "hide_sidebar_header", login="admin")


### PR DESCRIPTION
Steps to reproduce the issue:
- In edit mode, change the header template to use the "Sidebar" header (=> since it is a sidebar, the page content is shifted to the right)
- Go to the theme tab and toggle the "Show Header" option so the header is removed

=> Bug: the page content is still shifted as if the sidebar were still present.

This happens because the page still has padding-left for the header, although there's no header.

task-5131064