### PR TITLE
[IMP] crm_livechat: keep /lead creation visible in chat

### DIFF
--- a/addons/crm_livechat/__manifest__.py
+++ b/addons/crm_livechat/__manifest__.py
@@ -25,6 +25,9 @@
         'web.assets_backend': {
             'crm_livechat/static/src/core/**/*',
         },
+        'mail.assets_public': [
+            'crm_livechat/static/src/core/common/**/*',
+        ],
         'web.assets_unit_tests': [
             'crm_livechat/static/tests/**/*',
             ("remove", "crm_livechat/static/tests/tours/**/*"),
@@ -34,6 +37,9 @@
         ],
         'im_livechat.embed_assets_unit_tests_setup': [
             ('remove', 'crm_livechat/static/src/core/web/**/*'),
+        ],
+        'im_livechat.assets_embed_core': [
+            'crm_livechat/static/src/core/common/**/*',
         ],
     },
 }

--- a/addons/crm_livechat/models/discuss_channel.py
+++ b/addons/crm_livechat/models/discuss_channel.py
@@ -38,10 +38,13 @@ class DiscussChannel(models.Model):
                 i_start=Markup("<i>"),
                 i_end=Markup("</i>"),
             )
+            self.env.user._bus_send_transient_message(self, msg)
         else:
             lead = self._convert_visitor_to_lead(self.env.user.partner_id, key)
-            msg = _("Created a new lead: %s", lead._get_html_link())
-        self.env.user._bus_send_transient_message(self, msg)
+            msg = Markup(
+                '<div class="o_mail_notification" data-oe-type="create-lead">%s</div>',
+            ) % self.env._("created a new lead: %s", lead._get_html_link())
+            self.message_post(body=msg, subtype_xmlid="mail.mt_comment")
 
     def _convert_visitor_to_lead(self, partner, key):
         """ Create a lead from channel /lead command

--- a/addons/crm_livechat/static/src/core/common/message_model_patch.js
+++ b/addons/crm_livechat/static/src/core/common/message_model_patch.js
@@ -1,0 +1,12 @@
+import { Message } from "@mail/core/common/message_model";
+
+import { patch } from "@web/core/utils/patch";
+
+patch(Message.prototype, {
+    get notificationHidden() {
+        if (this.notificationType === "create-lead" && this.store.self_user?.share !== false) {
+            return true;
+        }
+        return super.notificationHidden;
+    },
+});

--- a/addons/crm_livechat/static/tests/create_lead.test.js
+++ b/addons/crm_livechat/static/tests/create_lead.test.js
@@ -10,6 +10,7 @@ import {
 } from "@mail/../tests/mail_test_helpers";
 
 import { describe, test } from "@odoo/hoot";
+import { mockDate } from "@odoo/hoot-mock";
 
 import { Command, serverState } from "@web/../tests/web_test_helpers";
 
@@ -17,6 +18,7 @@ describe.current.tags("desktop");
 defineCrmLivechatModels();
 
 test("can create a lead from the thread action after the conversation ends", async () => {
+    mockDate("2025-01-01 12:00:00", +1);
     const pyEnv = await startServer();
     const groupId = pyEnv["res.groups"].create({ name: "Sales Team" });
     serverState.groupSalesTeamId = groupId;
@@ -37,5 +39,7 @@ test("can create a lead from the thread action after the conversation ends", asy
     await click(".o-mail-DiscussContent-header button[title='Create Lead']");
     await insertText(".o-livechat-LivechatCommandDialog-form input", "testlead");
     await click(".o-mail-ActionPanel button", { text: "Create Lead" });
-    await contains(".o_mail_notification", { text: "Created a new lead: testlead" });
+    await contains(
+        `.o-mail-NotificationMessage:text('${serverState.partnerName} created a new lead: testlead1:00 PM')`
+    );
 });

--- a/addons/crm_livechat/static/tests/message.test.js
+++ b/addons/crm_livechat/static/tests/message.test.js
@@ -29,7 +29,7 @@ test("Can open lead from internal link", async () => {
     await insertText(".o-mail-Composer-input", "/lead My Lead");
     await click(".o-mail-Composer button[title='Send']:enabled");
     await contains(".o-mail-ChatWindow", { count: 0 });
-    await click('.o_mail_notification a[data-oe-model="crm.lead"]');
+    await click('.o-mail-NotificationMessage a[data-oe-model="crm.lead"]');
     await contains(".o-mail-ChatWindow-header", { text: "Visitor" });
     await contains(".o_form_view .o_last_breadcrumb_item span", { text: "My Lead" });
 });

--- a/addons/crm_livechat/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/crm_livechat/static/tests/mock_server/mock_models/discuss_channel.js
@@ -1,6 +1,6 @@
 import { DiscussChannel } from "@mail/../tests/mock_server/mock_models/discuss_channel";
 
-import { getKwArgs, serverState } from "@web/../tests/web_test_helpers";
+import { getKwArgs, makeKwArgs } from "@web/../tests/web_test_helpers";
 import { patch } from "@web/core/utils/patch";
 
 const discussChannelPatch = {
@@ -11,13 +11,13 @@ const discussChannelPatch = {
 
         const leadName = body.substring("/lead".length).trim();
         const leadId = this.env["crm.lead"].create({ name: leadName });
-        this.env["bus.bus"]._sendone(serverState.partnerId, "discuss.channel/transient_message", {
-            body: `
-                    <span class="o_mail_notification">
-                        Created a new lead: <a href="#" data-oe-model="crm.lead" data-oe-id="${leadId}">${leadName}</a>
-                    </span>`,
-            channel_id: ids[0],
-        });
+        this.message_post(
+            ids[0],
+            makeKwArgs({
+                body: `<div class="o_mail_notification">created a new lead: <a href="#" data-oe-model="crm.lead" data-oe-id="${leadId}">${leadName}</a></div>`,
+                subtype_xmlid: "mail.mt_comment",
+            })
+        );
         return true;
     },
 };


### PR DESCRIPTION
**purpose of this PR:**

when a lead is created from a livechat, post a message in the chat with a link for permanently. before this msg was sent as a transient bus notification, so it was not visible after chat refresh.
Additionally, the message type has been changed from **comment** to **notification**.

[enterprise](https://github.com/odoo/enterprise/pull/96246)

task - [4241782](https://www.odoo.com/odoo/project/1519/tasks/4241782)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
