### PR TITLE
[FIX] im_livechat: add missing im_status field in mock server

### DIFF
--- a/addons/im_livechat/static/tests/mock_server/mock_models/discuss_channel_member.js
+++ b/addons/im_livechat/static/tests/mock_server/mock_models/discuss_channel_member.js
@@ -12,7 +12,14 @@ export class DiscussChannelMember extends mailModels.DiscussChannelMember {
         const [member] = this.browse(ids);
         const [channel] = DiscussChannel.browse(member.channel_id);
         if (channel.channel_type === "livechat") {
-            return ["active", "avatar_128", "country", "is_public", "user_livechat_username"];
+            return [
+                "active",
+                "avatar_128",
+                "country",
+                "im_status",
+                "is_public",
+                "user_livechat_username",
+            ];
         }
         return super._get_store_partner_fields(...arguments);
     }


### PR DESCRIPTION
**Description of the issue this PR addresses:**

Add missing im_status field in mock server 

**Current behavior before PR:**

Previously, the `im_status` field was available on the server side, 
but it was missing in the mock server implementation used in tests.

**Desired behavior after PR is merged:**

This PR updates the mock `DiscussChannelMember` model to include `im_status` 
in the list of stored partner fields, ensuring that test scenarios accurately 
reflect server behavior.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
