### PR TITLE
[FIX] purchase_stock: add UoM conversion for bill's quantity in cost computation

### DIFF
--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -159,11 +159,13 @@ class StockMove(models.Model):
             if aml.move_id.state != 'posted':
                 continue
             aml_ids.add(aml.id)
+
+            aml_converted_quantity = aml.product_uom_id._compute_quantity(aml.quantity, aml.product_id.uom_id)
             if aml.move_type == 'in_invoice':
-                aml_quantity += aml.quantity
+                aml_quantity += aml_converted_quantity
                 value += aml.price_subtotal
             elif aml.move_type == 'in_refund':
-                aml_quantity -= aml.quantity
+                aml_quantity -= aml_converted_quantity
                 value -= aml.price_subtotal
 
         if aml_quantity <= 0:


### PR DESCRIPTION
## Issue:
When purchasing a product using AVCO (Average Cost) of FIFO, the product's cost is computed incorrectly after importing a vendor bill if the purchase is in a different Unit of Measure than the product's default
Specifically, quantities from the bill are not properly converted to the product's UoM, which leads to incorrect cost assignment

## Cause:
When you use AVCO or FIFO on a product and you buy it in another UoM, the quantity get from the bill isn't converted in `_get_value_from_account_move()`
The method `_get_value_data()` first checks the Invoices/Bills and then the SO/PO lines for any remaining quantities
Because the bill quantity isn't converted, part of the cost is incorrectly attributed to the Purchase Order as well: https://github.com/odoo/odoo/blob/6a901395b9bb7e037bd4dfa71d298ae5a9fbf7d0/addons/stock_account/models/stock_move.py#L276-L290
This leads to quantity and cost being partially assigned incorrectly

## Steps to reproduce:
- Enable Unit of Measure in Settings
- Create an AVCO (or FIFO) product with tracked quantities
- On the product form, go to Purchase Tab and add a vendor line (Vendor: Vendor, Unit: Pack of 6, Unit Price: 10)
- Create a Purchase Order and receive the product
- On the product page, the cost changed accordingly
- Upload a Bill for the PO and confirm
- The cost of the product is wrong and the move analysis too

opw-5091629