### PR TITLE
[FIX] mail: fix race condition with Enter in channel public tour

### DIFF
--- a/addons/mail/static/tests/tours/discuss_channel_public_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_public_tour.js
@@ -88,11 +88,7 @@ registry.category("web_tour.tours").add("discuss_channel_public_tour.js", {
                 }
             },
         },
-        { trigger: ".o-mail-Composer-input", run: "click" }, // focus
-        {
-            trigger: ".o-mail-Composer:has(button[title='Send']:enabled) .o-mail-Composer-input",
-            run: "press Enter",
-        },
+        { trigger: ".o-mail-Composer button[title='Send']:enabled", run: "click" },
         {
             trigger: `${messageSelector}[data-persistent]`,
         },


### PR DESCRIPTION
Pressing Enter is prone to race conditions as it requires the proper element to have the focus at the right time.

Clicking on the button directly when it is enabled should be preferred.

https://runbot.odoo.com/odoo/runbot.build.error/233169