### PR TITLE
[IMP] (website_)payment, sale: move onboarding logic to res.company

### DIFF
--- a/addons/payment/data/ir_actions_server_data.xml
+++ b/addons/payment/data/ir_actions_server_data.xml
@@ -6,7 +6,7 @@
         <field name="model_id" ref="payment.model_payment_provider"/>
         <field name="state">code</field>
         <field name="code">
-action = env['res.config.settings'].sudo().create({})._start_payment_onboarding()
+action = env.company._start_payment_onboarding()
         </field>
     </record>
 

--- a/addons/payment/models/res_company.py
+++ b/addons/payment/models/res_company.py
@@ -1,10 +1,32 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, models
+from odoo import api, fields, models
 
 
 class ResCompany(models.Model):
     _inherit = 'res.company'
+
+    onboarding_payment_module = fields.Selection(
+        string="Onboarding Payment Module",
+        selection=[
+            ('mercado_pago', "Mercado Pago"),
+            ('razorpay', "Razorpay"),
+            ('stripe', "Stripe"),
+        ],
+        compute='_compute_onboarding_payment_module',
+    )
+
+    @api.depends('currency_id', 'country_id')
+    def _compute_onboarding_payment_module(self):
+        for company in self:
+            if company.currency_id.name == 'INR':
+                company.onboarding_payment_module = 'razorpay'
+            elif company.country_id.is_stripe_supported_country:
+                company.onboarding_payment_module = 'stripe'
+            elif company.country_id.is_mercado_pago_supported_country:
+                company.onboarding_payment_module = 'mercado_pago'
+            else:
+                company.onboarding_payment_module = None
 
     @api.model_create_multi
     def create(self, vals_list):
@@ -22,3 +44,36 @@ class ResCompany(models.Model):
                 provider_sudo.copy({'company_id': company.id})
 
         return companies
+
+    def _start_payment_onboarding(self, menu_id=None):
+        """Install the onboarding module, configure the provider and run the onboarding action.
+
+        Note: `self.ensure_one()`
+
+        :param int menu_id: The menu from which the onboarding is started, as an `ir.ui.menu` id.
+        :return: The action returned by `action_start_onboarding`.
+        :rtype: dict
+        """
+        self.ensure_one()
+        if not self.onboarding_payment_module:
+            return False
+
+        # Install the onboarding module if needed.
+        onboarding_module = self.env['ir.module.module'].sudo().search(
+            [('name', '=', f'payment_{self.onboarding_payment_module}')]
+        )  # In sudo mode to search the onboarding module
+        onboarding_module.filtered(lambda m: m.state == 'uninstalled').button_immediate_install()
+
+        # Create a new env including the freshly installed module.
+        new_env = api.Environment(self.env.cr, self.env.uid, self.env.context)
+
+        # Configure the provider.
+        provider_code = self.onboarding_payment_module
+        provider = new_env['payment.provider'].search([
+            ('code', '=', provider_code),
+            *self.env['payment.provider']._check_company_domain(self),
+        ], limit=1)
+        if not provider:
+            return False
+
+        return provider.action_start_onboarding(menu_id=menu_id)

--- a/addons/payment/views/payment_form_templates.xml
+++ b/addons/payment/views/payment_form_templates.xml
@@ -417,7 +417,7 @@
                 </p>
                 <t
                     t-set="onboarding_provider"
-                    t-value="request.env['res.config.settings'].sudo().new({}).onboarding_payment_module"
+                    t-value="request.env.company.onboarding_payment_module"
                 />
                 <a
                     t-if="onboarding_provider and not providers_sudo"

--- a/addons/payment/wizards/res_config_settings.py
+++ b/addons/payment/wizards/res_config_settings.py
@@ -15,15 +15,7 @@ class ResConfigSettings(models.TransientModel):
     has_enabled_provider = fields.Boolean(
         string="Has Enabled Provider", compute='_compute_has_enabled_provider'
     )
-    onboarding_payment_module = fields.Selection(
-        string="Onboarding Payment Module",
-        selection=[
-            ('mercado_pago', "Mercado Pago"),
-            ('razorpay', "Razorpay"),
-            ('stripe', "Stripe"),
-        ],
-        compute='_compute_onboarding_payment_module',
-    )
+    onboarding_payment_module = fields.Selection(related='company_id.onboarding_payment_module')
 
     # === COMPUTE METHODS === #
 
@@ -59,18 +51,6 @@ class ResConfigSettings(models.TransientModel):
         else:
             return company_domain & Domain('state', '!=', 'disabled')
 
-    @api.depends('company_id.currency_id', 'company_id.country_id.is_stripe_supported_country')
-    def _compute_onboarding_payment_module(self):
-        for config in self:
-            if config.company_id.currency_id.name == 'INR':
-                config.onboarding_payment_module = 'razorpay'
-            elif config.company_id.country_id.is_stripe_supported_country:
-                config.onboarding_payment_module = 'stripe'
-            elif config.company_id.country_id.is_mercado_pago_supported_country:
-                config.onboarding_payment_module = 'mercado_pago'
-            else:
-                config.onboarding_payment_module = None
-
     # === ACTION METHODS === #
 
     def action_view_active_provider(self):
@@ -82,33 +62,3 @@ class ResConfigSettings(models.TransientModel):
             'views': [[False, 'form']],
             'res_id': provider.id,
         }
-
-    def _start_payment_onboarding(self, menu_id=None):
-        """Install the onboarding module, configure the provider and run the onboarding action.
-
-        :param int menu_id: The menu from which the onboarding is started, as an `ir.ui.menu` id.
-        :return: The action returned by `action_start_onboarding`.
-        :rtype: dict
-        """
-        self.ensure_one()
-        if not self.onboarding_payment_module:
-            return False
-
-        # Install the onboarding module if needed.
-        onboarding_module = self.env['ir.module.module'].search(
-            [('name', '=', f'payment_{self.onboarding_payment_module}')]
-        )
-        self._install_modules(onboarding_module)
-        # Create a new env including the freshly installed module.
-        new_env = api.Environment(self.env.cr, self.env.uid, self.env.context)
-
-        # Configure the provider.
-        provider_code = self.onboarding_payment_module
-        provider = new_env['payment.provider'].search([
-            ('code', '=', provider_code),
-            *self.env['payment.provider']._check_company_domain(self.env.company),
-        ], limit=1)
-        if not provider:
-            return False
-
-        return provider.action_start_onboarding(menu_id=menu_id)

--- a/addons/sale/wizard/res_config_settings.py
+++ b/addons/sale/wizard/res_config_settings.py
@@ -130,4 +130,4 @@ class ResConfigSettings(models.TransientModel):
     # Unique name to avoid colliding with `website_payment`.
     def action_sale_start_payment_onboarding(self):
         menu = self.env.ref('sale.menu_sale_general_settings', raise_if_not_found=False)
-        return self._start_payment_onboarding(menu and menu.id)
+        return self.company_id._start_payment_onboarding(menu and menu.id)

--- a/addons/website_payment/models/res_config_settings.py
+++ b/addons/website_payment/models/res_config_settings.py
@@ -30,4 +30,4 @@ class ResConfigSettings(models.TransientModel):
     # Unique name to avoid colliding with `sale`.
     def action_w_payment_start_payment_onboarding(self):
         menu = self.env.ref('website.menu_website_website_settings', raise_if_not_found=False)
-        return self._start_payment_onboarding(menu and menu.id)
+        return self.company_id._start_payment_onboarding(menu and menu.id)


### PR DESCRIPTION
The onboarding logic was originally implemented in `res.config.settings`, but this transient model does not support all onboarding entry points. Specifically, when the 'Activate <provider>' button was used in frontend payment forms, such as the portal or checkout, the transient settings record could not be relied upon. To work around this limitation, a temporary settings record had to be generated from a QWeb template, which added unnecessary complexity and risk of errors.

To resolve this issue, the onboarding logic is moved to `res.company`. The company record is persistent and accessible in both backend and frontend contexts. As a result, the 'Activate <provider>' button now reliably triggers the onboarding process in all scenarios, without requiring temporary records.

task-5081953