### PR TITLE
[FIX] html_editor: prevent infinite loop in removeAllColor on table

### DIFF
--- a/addons/html_editor/static/tests/color.test.js
+++ b/addons/html_editor/static/tests/color.test.js
@@ -593,3 +593,23 @@ test("should be able to remove color of an icon", async () => {
         contentAfter: '<p>[<span class="fa fa-glass"></span>]</p>',
     });
 });
+
+test("should remove remove color from `td`", async () => {
+    await testEditor({
+        contentBefore: unformat(`
+                <table style="color: red;" class="o_selected_table"><tbody>
+                    <tr><td class="o_selected_td">[ab]</td></tr>
+                    <tr><td>ab</td></tr>
+                </tbody></table>
+            `),
+        stepFunction: setColor("", "color"),
+        contentAfter: unformat(`
+            <table>
+                <tbody>
+                    <tr><td>[ab]</td></tr>
+                    <tr><td style="color: red;">ab</td></tr>
+                </tbody>
+            </table>
+        `),
+    });
+});

--- a/addons/html_editor/static/tests/normalize.test.js
+++ b/addons/html_editor/static/tests/normalize.test.js
@@ -1,10 +1,49 @@
 import { test } from "@odoo/hoot";
 import { testEditor } from "./_helpers/editor";
+import { unformat } from "./_helpers/format";
 
 test("should remove empty class attribute", async () => {
     // content after is compared after cleaning up DOM
     await testEditor({
         contentBefore: '<div class=""></div>',
         contentAfter: "<div><br></div>",
+    });
+});
+
+test("should remove `style.color` from table and apply it to tds", async () => {
+    await testEditor({
+        contentBefore: unformat(`
+                <table style="color: red;" class="o_selected_table"><tbody>
+                    <tr><td class="o_selected_td">ab</td></tr>
+                    <tr><td>ab</td></tr>
+                </tbody></table>
+            `),
+        contentBeforeEdit: unformat(`
+            <table style="" class="o_selected_table">
+                <tbody>
+                    <tr><td class="o_selected_td" style="color: red;">ab</td></tr>
+                    <tr><td style="color: red;">ab</td></tr>
+                </tbody>
+            </table>
+        `),
+    });
+});
+
+test("should remove `style.color` from table and apply it to td without `style.color`", async () => {
+    await testEditor({
+        contentBefore: unformat(`
+                <table style="color: red;"><tbody>
+                    <tr><td>ab</td></tr>
+                    <tr><td style="color: green;">ab</td></tr>
+                </tbody></table>
+            `),
+        contentBeforeEdit: unformat(`
+            <table style="">
+                <tbody>
+                    <tr><td style="color: red;">ab</td></tr>
+                    <tr><td style="color: green;">ab</td></tr>
+                </tbody>
+            </table>
+        `),
     });
 });


### PR DESCRIPTION
Problem:
When having a `table` with `color` and selecting a cell to remove format, we get a traceback: "Infinite Loop in removeAllColor()."

Cause:
The color is applied on `table`, but we only process `td` for color removal. As the color remains on `table`, each attempt to remove it keeps reapplying, leading to an infinite loop.

Solution:
When removing color, also remove it from the `table`. Then apply the color to all child `td`. This ensures `td` colors are later removed automatically if selected, avoiding the loop.

Steps to reproduce:
1. Add a `color` property to a `table` and `td`.
2. Select the `td`.
3. Click "remove format" from the toolbar.
4. Observe traceback.

opw-5112088

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
