### PR TITLE
[IMP] pos_self_order : unavailable product not displayed

### DIFF
--- a/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.js
+++ b/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.js
@@ -154,7 +154,16 @@ export class ProductListPage extends Component {
     }
 
     getProducts(category) {
-        return category.associatedProducts || this.selfOrder.productByCategIds[category.id] || [];
+        const products =
+            category.associatedProducts || this.selfOrder.productByCategIds[category.id] || [];
+
+        if (!products.length) {
+            return [];
+        }
+
+        return products.filter(
+            (product) => product.self_order_available && this.isProductAvailable(product)
+        );
     }
 
     toggleSubCategoryPanel() {

--- a/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.xml
@@ -57,17 +57,12 @@
                          <t t-set="productList" t-value="getProducts(category)"/>
                          <div class="product_list grid" t-att-class="{'pt-sm-3 pt-lg-4': selfOrder.kioskMode, 'pb-2': !selfOrder.kioskMode}">
                             <div t-foreach="productList" t-as="product" t-key="product.id" class="o_self_product_box g-col-12 g-col-md-6 g-col-lg-3 rounded-4 p-3 p-lg-0 shadow-sm shadow-lg-none" t-att-class="{'g-col-kiosk-p-4': productList.length &lt;= 9 , 'g-col-kiosk-p-3': productList.length &gt; 9 }">
-                                <t t-set="not_available" t-value="!product.self_order_available || !isProductAvailable(product)" />
-                                <article t-on-click="(evt) => this.selectProduct(product, evt.target)" class="position-relative d-flex flex-row-reverse flex-lg-column align-items-start cursor-pointer" t-att-class="{'opacity-50' : not_available}">
+                                <article t-on-click="(evt) => this.selectProduct(product, evt.target)" class="position-relative d-flex flex-row-reverse flex-lg-column align-items-start cursor-pointer">
                                     <div class="product_img ratio ratio-1x1 w-lg-100 flex-shrink-0 ms-2 ms-lg-0">
                                         <img class="object-fit-cover rounded-4" t-attf-src="/web/image/product.template/#{product.id}/image_512?unique=#{product.write_date}" loading="lazy"/>
                                     </div>
                                     <div class="d-flex flex-column w-100 mt-lg-2 mt-kiosk-p-3 gap-lg-1 text-lg-center align-items-lg-center">
                                         <ProductNameWidget product="product"/>
-                                        <div t-if="not_available" class="badge my-1 rounded-pill text-bg-danger w-auto me-auto mx-lg-auto">
-                                            <t t-if="!product.self_order_available">Out of stock</t>
-                                            <t t-else="">Unavailable</t>
-                                        </div>
                                         <span t-esc="selfOrder.formatMonetary(selfOrder.getProductDisplayPrice(product))" class="o-so-tabular-nums fs-4 fw-bold text-primary"/>
                                         <div class="product_descr d-lg-none mt-1 text-ellipsis text-muted small" t-if="product.public_description" t-out="product.productDescriptionMarkup"/>
                                     </div>

--- a/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
@@ -214,9 +214,9 @@ registry.category("web_tour.tours").add("test_self_order_kiosk_product_availabil
         Utils.clickBtn("Order Now"),
         LandingPage.selectLocation("Test-In"),
         ProductPage.clickCategory("Category 2"),
-        // Mark 'Combo Product 5' as unavailable and verify it shows as out of stock
+        // Mark 'Combo Product 5' as unavailable and verify does not show in the product list
         Utils.setProductAvailability("Combo Product 5", false),
-        ProductPage.checkProductOutOfStock("Combo Product 5"),
+        Utils.negateStep(ProductPage.isProductDisplayed("Combo Product 5")),
         ProductPage.clickProduct("Office Combo"),
         ProductPage.clickComboProduct("Combo Product 4"),
         Utils.clickBtn("Add to cart"),

--- a/addons/pos_self_order/static/tests/tours/self_order_mobile_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_mobile_tour.js
@@ -5,6 +5,7 @@ import * as LandingPage from "@pos_self_order/../tests/tours/utils/landing_page_
 import * as ProductPage from "@pos_self_order/../tests/tours/utils/product_page_util";
 import * as ConfirmationPage from "@pos_self_order/../tests/tours/utils/confirmation_page_util";
 import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
+import { negateStep } from "@point_of_sale/../tests/generic_helpers/utils";
 
 registry.category("web_tour.tours").add("self_mobile_each_table_takeaway_in", {
     steps: () => [
@@ -301,9 +302,9 @@ registry.category("web_tour.tours").add("test_self_order_product_availability", 
         Utils.checkIsNoBtn("My Order"),
         Utils.clickBtn("Order Now"),
         LandingPage.selectLocation("Test-In"),
-        // Mark 'Combo Product 5' as unavailable and verify it shows as out of stock
+        // Mark 'Combo Product 5' as unavailable and verify it is not displayed
         Utils.setProductAvailability("Combo Product 5", false),
-        ProductPage.checkProductOutOfStock("Combo Product 5"),
+        negateStep(ProductPage.isProductDisplayed("Combo Product 5")),
         ProductPage.clickProduct("Office Combo"),
         ProductPage.clickComboProduct("Combo Product 4"),
         Utils.clickBtn("Add to cart"),

--- a/addons/pos_self_order/static/tests/tours/utils/product_page_util.js
+++ b/addons/pos_self_order/static/tests/tours/utils/product_page_util.js
@@ -179,9 +179,9 @@ export function setupCombo(products, addToCart = true) {
     return steps;
 }
 
-export function checkProductOutOfStock(productName) {
+export function isProductDisplayed(productName) {
     return {
-        content: `Check if '${productName}' is marked as out of stock`,
-        trigger: `.o_self_product_box:has(span:contains('${productName}')):has(div:contains('Out of stock'))`,
+        content: `Check if product '${productName}' is displayed`,
+        trigger: `.o_self_product_box span:contains("${productName}")`,
     };
 }

--- a/addons/pos_self_order/views/pos_preset_view.xml
+++ b/addons/pos_self_order/views/pos_preset_view.xml
@@ -20,4 +20,15 @@
             </xpath>
         </field>
     </record>
+
+    <record id="view_pos_preset_tree" model="ir.ui.view">
+        <field name="name">pos.preset.list</field>
+        <field name="model">pos.preset</field>
+        <field name="inherit_id" ref="point_of_sale.view_pos_preset_tree"/>
+        <field name="arch" type="xml">
+            <field name="color" position="before">
+                <field name="available_in_self"/>
+            </field>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
Before this commit :

1. In the presets list view, the "available in self" setting was not available as a filter.
2. In the self, when products were not available, they were always displayed with an “out of stock” notice and reduced opacity.

After this commit :
1. "Available in self" filter is now available in the presets list view
2. Now, when a product is not available, it is not shown in the products selection page.

task-id: 5130687

note : fyi, preset popup part from the spec has been moved to this pr : https://github.com/odoo/odoo/pull/243180

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
