### PR TITLE
[FIX] web: BottomSheet: fix switch view layout for long text

### DIFF
--- a/addons/web/static/src/search/control_panel/control_panel.scss
+++ b/addons/web/static/src/search/control_panel/control_panel.scss
@@ -202,10 +202,16 @@
         display: grid;
         justify-items: center;
         gap: map-get($spacers, 2);
-        padding: map-get($spacers, 3);
+        padding: map-get($spacers, 3) map-get($spacers, 2);
 
         &.selected::before {
             content: none !important;
+        }
+
+        > span {
+            @include text-truncate();
+            max-width: 100%;
+            margin-left: 0 !important; // Counter BS rule ms-1
         }
     }
 }


### PR DESCRIPTION
This commit adds some CSS rules to have a better layout when there are long view title in some language (e.g.: in French: "Tableau croisé dynamique")

task-5139101

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
