### PR TITLE
[FIX] mail: traceback when switching messaging menu tab

### DIFF
--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -1,5 +1,5 @@
 import { AND, fields, Record } from "@mail/core/common/record";
-import { prettifyMessageContent } from "@mail/utils/common/format";
+import { cleanTerm, prettifyMessageContent } from "@mail/utils/common/format";
 import { assignDefined } from "@mail/utils/common/misc";
 import { rpc } from "@web/core/network/rpc";
 
@@ -239,6 +239,26 @@ export class Thread extends Record {
      * @type {number|'bottom'}
      */
     scrollTop = "bottom";
+    storeAsMenuThreads = fields.One("Store", {
+        compute() {
+            /** @type {import("models").Thread[]} */
+            const searchTerm = cleanTerm(this.store.discuss.searchTerm);
+            const visible =
+                this.displayToSelf ||
+                (this.needactionMessages.length > 0 && this.model !== "mail.box");
+            const matchesSearch = cleanTerm(this.displayName).includes(searchTerm);
+            if (!visible || !matchesSearch) {
+                return;
+            }
+            const tab = this.store.discuss.activeTab;
+            if (
+                tab === "notification" ||
+                this.store.tabToThreadType(tab).includes(this.channel_type)
+            ) {
+                return this.store;
+            }
+        },
+    });
     transientMessages = fields.Many("mail.message");
     /* The additional recipients are the recipients that are manually added
      * by the user by using the "To" field of the Chatter. */


### PR DESCRIPTION
Before this commit, a maximum call stack traceback occurred when accessing the chat tab of the messaging menu on iOS when many chats were present. On chrome and firefox, no traceback occurred, but the menu took a long time to open.

Threads shown in the messaging menu rely on the `menuThreads` store property, which had two issues:
- It was a computed field done on the many side of the relation, while relying on the inverse (thread) side would be much faster.
- The sort function was triggered for each thread inserted or removed from the relation. The sort function is not trivial, and accessing sort fields through the reactive proxy is very slow.

This commit fixes the issue by:
- Updating the `menuThreads` property to use an inverse instead of a complex compute.
- Debouncing the array sort to ensure it is executed only once when the relation is properly filled.

task-4794325

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
