### PR TITLE
[IMP] account: self billing improvements

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -637,6 +637,7 @@ class AccountMove(models.Model):
     invoice_source_email = fields.Char(string='Source Email', tracking=True)
     invoice_partner_display_name = fields.Char(compute='_compute_invoice_partner_display_info', store=True)
     is_manually_modified = fields.Boolean()
+    is_self_billing = fields.Boolean(related='journal_id.is_self_billing')
 
     # === Fiduciary mode fields === #
     quick_edit_mode = fields.Boolean(compute='_compute_quick_edit_mode')

--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field_o2m.js
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field_o2m.js
@@ -24,7 +24,7 @@ export class ProductLabelSectionAndNoteListRender extends SectionAndNoteListRend
                  */
                 column["optional"] = ["in_invoice", "in_refund", "in_receipt"].includes(
                     this.props.list.evalContext.parent.move_type
-                )
+                ) && !this.props.list.evalContext.parent.is_self_billing
                     ? "hide"
                     : "show";
             }

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -958,7 +958,7 @@
                             <span class="o_form_label">
                                 <field
                                     name="move_type"
-                                    invisible="move_type == 'entry'"
+                                    invisible="move_type == 'entry' or is_self_billing"
                                     widget="receipt_selector"
                                     options="{'horizontal': true}"
                                     nolabel="1"


### PR DESCRIPTION
Before this commit: For Bill with self billing journal selected, "Bill/Receipt" choice was displayed and "Product" field was optional hide.

After this commit: For Bill with self billing journal selected, "Bill/Receipt" choice is hidden as it will be always a bill and "Product" field is set optional show.

task-5125965