### PR TITLE
[IMP] website_sale: show detailed tax breakdown

### DIFF
--- a/addons/l10n_br_website_sale/views/templates.xml
+++ b/addons/l10n_br_website_sale/views/templates.xml
@@ -5,11 +5,13 @@
         <tr name="o_order_total_untaxed" position="attributes">
             <attribute name="t-attf-class" add="#{'d-none' if website.company_id.country_code == 'BR' else ''}" separator=" "/>
         </tr>
-        <tr name="o_order_total_taxes" position="attributes">
-            <attribute name="t-attf-class" add="#{'d-none' if website.company_id.country_code == 'BR' else ''}" separator=" "/>
-        </tr>
         <tr name="o_order_total" position="attributes">
             <attribute name="t-attf-class" add="#{'border-top' if website.company_id.country_code != 'BR' else ''}" separator=" "/>
+        </tr>
+    </template>
+    <template id="order_tax_lines" inherit_id="website_sale.order_tax_lines">
+        <tr name="o_order_total_taxes" position="attributes">
+            <attribute name="t-attf-class" add="#{'d-none' if website.company_id.country_code == 'BR' else ''}" separator=" "/>
         </tr>
     </template>
 

--- a/addons/sale/data/mail_template_data.xml
+++ b/addons/sale/data/mail_template_data.xml
@@ -293,8 +293,16 @@
                             </table>
                             <table width="100%" style="max-width: 590px; font-size: 14px; border-spacing: 0px; white-space: nowrap;" role="presentation">
                                 <tr>
-                                    <td style="width: 20%; padding-bottom: 8px;" align="left">Taxes:</td>
-                                    <td style="width: 80%; padding-bottom: 8px;" align="right" t-out="format_amount(object.amount_tax, object.currency_id) or ''">$ 0.00</td>
+                                    <t t-if="object.tax_totals and object.tax_totals['subtotals']">
+                                        <t t-foreach="object.tax_totals['subtotals']" t-as="line">
+                                            <t t-foreach="line['tax_groups']" t-as="tax_line">
+                                                <tr>
+                                                    <td style="width: 20%; padding-bottom: 8px;" align="left"><span t-out="tax_line['group_name']"/></td>
+                                                    <td style="width: 80%;" align="right" t-out="format_amount(tax_line['tax_amount_currency'], object.currency_id) or ''">$ 0.00</td>
+                                                </tr>
+                                            </t>
+                                        </t>
+                                    </t>
                                 </tr>
                                 <tr>
                                     <td style="width: 20%; padding-top: 4px; border-top: 1px solid #343a40; opacity: 0.9;" align="left"><strong>Total</strong></td>

--- a/addons/website_sale/controllers/delivery.py
+++ b/addons/website_sale/controllers/delivery.py
@@ -68,6 +68,12 @@ class Delivery(WebsiteSale):
         """
         Monetary = request.env['ir.qweb.field.monetary']
         currency = order.currency_id
+        rendered_tax_lines = request.env['ir.ui.view']._render_template(
+            'website_sale.order_tax_lines',
+            {
+                'website_sale_order': order,
+            }
+        )
         return {
             'success': True,
             'is_free_delivery': not bool(order.amount_delivery),
@@ -78,9 +84,7 @@ class Delivery(WebsiteSale):
             'amount_untaxed': Monetary.value_to_html(
                 order.amount_untaxed, {'display_currency': currency}
             ),
-            'amount_tax': Monetary.value_to_html(
-                order.amount_tax, {'display_currency': currency}
-            ),
+            'amount_tax_lines': rendered_tax_lines,
             'amount_total': Monetary.value_to_html(
                 order.amount_total, {'display_currency': currency}
             ),

--- a/addons/website_sale/data/mail_template_data.xml
+++ b/addons/website_sale/data/mail_template_data.xml
@@ -189,8 +189,16 @@
                                 <td style="padding-top: 4px; text-align: right; color: #495057;" width="100px" align="right"><t t-out="format_amount(object.amount_untaxed, object.currency_id) or ''">-</t></td>
                             </tr>
                             <tr>
-                                <td style="padding: 4px 0 8px 0; color: #495057;">Taxes</td>
-                                <td style="padding: 4px 0 8px 0; text-align: right; color: #495057;" width="100px" align="right"><t t-out="format_amount(object.amount_tax, object.currency_id) or ''">-</t></td>
+                                <t t-if="object.tax_totals and object.tax_totals['subtotals']">
+                                        <t t-foreach="object.tax_totals['subtotals']" t-as="line">
+                                            <t t-foreach="line['tax_groups']" t-as="tax_line">
+                                                <tr>
+                                                    <td style="padding: 4px 0 8px 0; color: #495057;"><span t-out="tax_line['group_name']"/></td>
+                                                    <td style="padding: 4px 0 8px 0; text-align: right; color: #495057;" width="100px" align="right" t-out="format_amount(tax_line['tax_amount_currency'], object.currency_id) or ''">$ 0.00</td>
+                                                </tr>
+                                            </t>
+                                        </t>
+                                    </t>
                             </tr>
                             <tr>
                                 <td style="padding-top: 8px; border-top: 1px solid #343a40;"><strong>Total</strong></td>

--- a/addons/website_sale/static/src/interactions/checkout.js
+++ b/addons/website_sale/static/src/interactions/checkout.js
@@ -357,7 +357,7 @@ export class Checkout extends Interaction {
         const amountUntaxed = targetEl.querySelector(
             'tr[name="o_order_total_untaxed"] .monetary_field'
         );
-        const amountTax = targetEl.querySelector('tr[name="o_order_total_taxes"] .monetary_field');
+        const amountTax = targetEl.querySelector('#order_tax_lines_container');
         const amountTotal = targetEl.parentElement.querySelectorAll(
             'tr[name="o_order_total"] .monetary_field, #amount_total_summary.monetary_field'
         );
@@ -370,7 +370,8 @@ export class Checkout extends Interaction {
 
         amountDelivery.innerHTML = result.amount_delivery;
         amountUntaxed.innerHTML = result.amount_untaxed;
-        amountTax.innerHTML = result.amount_tax;
+
+        amountTax.outerHTML = result.amount_tax_lines;
         amountTotal.forEach(total => total.innerHTML = result.amount_total);
     }
 

--- a/addons/website_sale/templates/checkout/checkout_templates.xml
+++ b/addons/website_sale/templates/checkout/checkout_templates.xml
@@ -450,15 +450,7 @@
                               t-options="{'widget': 'monetary', 'display_currency': website_sale_order.currency_id}"/>
                     </td>
                 </tr>
-                <tr name="o_order_total_taxes">
-                    <td colspan="2" class="text-muted border-0 p-0 pe-3 pb-2">Taxes</td>
-                    <td class="text-end border-0 p-0 ps-3 pb-2">
-                        <span t-field="website_sale_order.amount_tax"
-                              class="monetary_field"
-                              style="white-space: nowrap;"
-                              t-options="{'widget': 'monetary', 'display_currency': website_sale_order.currency_id}"/>
-                    </td>
-                </tr>
+                <t t-call="website_sale.order_tax_lines"/>
                 <tr name="o_order_total" class="border-top">
                     <td colspan="2" class="border-0 ps-0 pt-2"><strong>Total</strong></td>
                     <td class="text-end border-0 px-0 pt-2">
@@ -490,6 +482,29 @@
                 </td>
             </tr>
         </xpath>
+    </template>
+
+    <template id="order_tax_lines">
+        <tbody id="order_tax_lines_container">
+            <t t-if="website_sale_order.tax_totals and website_sale_order.tax_totals['subtotals']">
+                <t t-foreach="website_sale_order.tax_totals['subtotals']" t-as="line">
+                    <t t-foreach="line['tax_groups']" t-as="tax_line">
+                        <tr name="o_order_total_taxes">
+                            <td colspan="2" class="text-muted border-0 p-0 pe-3 pb-2">
+                                <t t-out="tax_line['group_name']"/>
+                            </td>
+                            <td class="text-end border-0 p-0 ps-3 pb-2">
+                                <span t-out="tax_line['tax_amount_currency']"
+                                        class="monetary_field"
+                                        style="white-space: nowrap;"
+                                        t-options="{'widget': 'monetary', 'display_currency': website_sale_order.currency_id}"
+                                />
+                            </td>
+                        </tr>
+                    </t>
+                </t>
+            </t>
+        </tbody>
     </template>
 
 </odoo>


### PR DESCRIPTION
Currently, the checkout summary only displays the aggregated tax amount. This makes it unclear to the customer which tax rates are applied.

With this commit, the template `website_sale.total` is improved to render a tax breakdown by group. Each tax group is shown with its label and calculated amount, aligned consistently with the order summary table.

See also:
- https://github.com/odoo/enterprise/pull/100876

task-4805599

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
