### PR TITLE
[REF] pos_self_order: simplify payment method filtering

### DIFF
--- a/addons/pos_online_payment_self_order/models/pos_config.py
+++ b/addons/pos_online_payment_self_order/models/pos_config.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from typing import Dict
 from odoo import models, fields, api, _
 from odoo.exceptions import ValidationError
 
@@ -16,14 +15,8 @@ class PosConfig(models.Model):
             if config.self_ordering_mode == 'mobile' and config.self_ordering_service_mode == 'each' and config.self_order_online_payment_method_id and not config.self_order_online_payment_method_id._get_online_payment_providers(config.id, error_if_invalid=True):
                 raise ValidationError(_("The online payment method used for self-order in a POS config must have at least one published payment provider supporting the currency of that POS config."))
 
-    def _get_self_ordering_data(self):
-        res = super()._get_self_ordering_data()
-        payment_methods = self._get_self_ordering_payment_methods_data(self.self_order_online_payment_method_id)
-        res['pos_payment_methods'] += payment_methods
-        return res
-
     def has_valid_self_payment_method(self):
         res = super().has_valid_self_payment_method()
         if self.self_ordering_mode == 'mobile':
             return res or bool(self.self_order_online_payment_method_id)
-        return res or any(pm.is_online_payment for pm in self.payment_method_ids)
+        return res

--- a/addons/pos_online_payment_self_order/models/pos_payment_method.py
+++ b/addons/pos_online_payment_self_order/models/pos_payment_method.py
@@ -7,9 +7,18 @@ class PosPaymentMethod(models.Model):
 
     @api.model
     def _load_pos_self_data_domain(self, data, config):
+        super_domain = super()._load_pos_self_data_domain(data, config)
+
+        online_payment_domain = None
         if config.self_ordering_mode == 'kiosk':
-            domain = super()._load_pos_self_data_domain(data, config)
-            domain = Domain.OR([[('is_online_payment', '=', True), ('id', 'in', config.payment_method_ids.ids)], domain])
-            return domain
-        else:
-            return [('is_online_payment', '=', True)]
+            online_payment_domain = Domain.AND([
+                Domain('is_online_payment', '=', True),
+                Domain('id', 'in', config.payment_method_ids.ids)
+            ])
+        elif config.self_order_online_payment_method_id:
+            online_payment_domain = Domain('id', '=', config.self_order_online_payment_method_id.id)
+
+        if not online_payment_domain:
+            return super_domain
+
+        return Domain.OR([online_payment_domain, super_domain])

--- a/addons/pos_online_payment_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_online_payment_self_order/static/src/app/services/self_order_service.js
@@ -51,15 +51,4 @@ patch(SelfOrder.prototype, {
         const exit = encodeURIComponent(exitRouteUrl);
         return `${baseUrl}/pos/pay/${order_id}?access_token=${order_access_token}&exit_route=${exit}`;
     },
-    filterPaymentMethods(pms) {
-        const pm = super.filterPaymentMethods(...arguments);
-        const pmIds = this.config.payment_method_ids.map((o) => o.id);
-        const online_pms = pms.filter(
-            (rec) =>
-                rec.is_online_payment &&
-                (this.config.self_order_online_payment_method_id?.id === rec.id ||
-                    (this.config.self_ordering_mode === "kiosk" && pmIds.includes(rec.id)))
-        );
-        return [...new Set([...pm, ...online_pms])];
-    },
 });

--- a/addons/pos_online_payment_self_order/tests/__init__.py
+++ b/addons/pos_online_payment_self_order/tests/__init__.py
@@ -3,3 +3,4 @@
 
 from . import test_self_order_frontend
 from . import test_self_order_mobile
+from . import test_self_order_payment_method

--- a/addons/pos_online_payment_self_order/tests/test_self_order_payment_method.py
+++ b/addons/pos_online_payment_self_order/tests/test_self_order_payment_method.py
@@ -1,0 +1,57 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import odoo.tests
+from odoo import Command
+from odoo.addons.pos_self_order.tests.self_order_common_test import SelfOrderCommonTest
+from odoo.addons.pos_online_payment.tests.online_payment_common import OnlinePaymentCommon
+
+
+@odoo.tests.tagged("post_install", "-at_install")
+class TestSelfOrderOnlinePaymentMethod(SelfOrderCommonTest, OnlinePaymentCommon):
+    def setUp(self):
+        super().setUp()
+        self.online_payment_method = self.env["pos.payment.method"].create({
+            "name": "Online",
+            "journal_id": self.bank_journal.id,
+            "is_online_payment": True,
+            "online_payment_provider_ids": [Command.set([self.dummy_provider.id])],
+        })
+
+        self.pos_config.write(
+            {
+                "self_order_online_payment_method_id": self.online_payment_method.id,
+                "payment_method_ids": [Command.set([self.online_payment_method.id])],
+            }
+        )
+
+    def test_self_order_kiosk_loads_online_payment_method(self):
+        self.pos_config.write({"self_ordering_mode": "kiosk"})
+
+        payment_methods_to_load = self.pos_config.payment_method_ids._load_pos_self_data_search_read({}, self.pos_config)
+
+        self.assertEqual(len(payment_methods_to_load), 1)
+        self.assertEqual(payment_methods_to_load[0]["id"], self.online_payment_method.id)
+        self.assertTrue(self.pos_config.has_valid_self_payment_method())
+
+    def test_self_order_mobile_loads_online_payment_method_from_config(self):
+        self.pos_config.write({
+            "self_ordering_mode": "mobile",
+            "payment_method_ids": [Command.set([])],
+        })
+
+        payment_methods_to_load = self.pos_config.payment_method_ids._load_pos_self_data_search_read({}, self.pos_config)
+
+        self.assertEqual(len(payment_methods_to_load), 1)
+        self.assertEqual(payment_methods_to_load[0]["id"], self.online_payment_method.id)
+        self.assertTrue(self.pos_config.has_valid_self_payment_method())
+
+    def test_self_order_kiosk_does_not_load_online_payment_method_from_config(self):
+        self.pos_config.write({
+            "self_ordering_mode": "kiosk",
+            "payment_method_ids": [Command.set([])],
+        })
+
+        payment_methods_to_load = self.pos_config.payment_method_ids._load_pos_self_data_search_read({}, self.pos_config)
+
+        self.assertEqual(len(payment_methods_to_load), 0)
+        self.assertFalse(self.pos_config.has_valid_self_payment_method())

--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -390,9 +390,8 @@ class PosConfig(models.Model):
     def has_valid_self_payment_method(self):
         """ Checks if the POS config has a valid payment method (terminal or online). """
         self.ensure_one()
-        if self.self_ordering_mode == 'mobile':
-            return False
-        return any(pm.use_payment_terminal in self._supported_kiosk_payment_terminal() for pm in self.payment_method_ids)
+        domain = self.payment_method_ids._load_pos_self_data_domain({}, self)
+        return bool(self.payment_method_ids.filtered_domain(domain))
 
     @api.model
     def load_onboarding_kiosk_scenario(self):

--- a/addons/pos_self_order/models/pos_payment_method.py
+++ b/addons/pos_self_order/models/pos_payment_method.py
@@ -11,6 +11,6 @@ class PosPaymentMethod(models.Model):
     @api.model
     def _load_pos_self_data_domain(self, data, config):
         if config.self_ordering_mode == 'kiosk':
-            return [('use_payment_terminal', 'in', ['adyen', 'stripe']), ('id', 'in', data['pos.config'][0]['payment_method_ids']) ]
+            return [('use_payment_terminal', 'in', config._supported_kiosk_payment_terminal()), ('id', 'in', config.payment_method_ids.ids)]
         else:
-            [('id', '=', False)]
+            return [('id', '=', False)]

--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -285,23 +285,13 @@ export class SelfOrder extends Reactive {
         this.printKioskChanges(access_token);
     }
     hasPaymentMethod() {
-        return this.filterPaymentMethods(this.models["pos.payment.method"].getAll()).length > 0;
-    }
-
-    filterPaymentMethods(pms) {
-        //based on _load_pos_self_data_domain from pos_payment_method.py
-        return this.config.self_ordering_mode === "kiosk"
-            ? pms.filter((rec) => ["adyen", "stripe"].includes(rec.use_payment_terminal))
-            : [];
+        return this.models["pos.payment.method"].getAll().length > 0;
     }
 
     async confirmOrder() {
         const payAfter = this.config.self_ordering_pay_after; // each, meal
         const device = this.config.self_ordering_mode; // kiosk, mobile
         const service = this.selfService; // table, counter, delivery
-        const paymentMethods = this.filterPaymentMethods(
-            this.models["pos.payment.method"].getAll()
-        ); // Stripe, Adyen, Online
 
         let order = this.currentOrder;
         const orderHasChanges = Object.keys(order.changes).length > 0;
@@ -325,7 +315,7 @@ export class SelfOrder extends Reactive {
 
         // When no payment methods redirect to confirmation page
         // the client will be able to pay at counter
-        if (paymentMethods.length === 0) {
+        if (!this.hasPaymentMethod()) {
             let screenMode = "pay";
 
             if (orderHasChanges) {

--- a/addons/pos_self_order/static/tests/unit/components/order_widget.test.js
+++ b/addons/pos_self_order/static/tests/unit/components/order_widget.test.js
@@ -21,7 +21,7 @@ describe("order_widget", () => {
         store.router.activeSlot = "cart";
         expect(comp.buttonToShow).toMatchObject({ label: "Order", disabled: false });
         // With valid payment method
-        models["pos.payment.method"].getFirst().use_payment_terminal = "stripe";
+        models["pos.payment.method"].create({ use_payment_terminal: "stripe" });
         expect(comp.buttonToShow).toMatchObject({ label: "Pay", disabled: false });
     });
 

--- a/addons/pos_self_order/static/tests/unit/data/pos_payment_method.data.js
+++ b/addons/pos_self_order/static/tests/unit/data/pos_payment_method.data.js
@@ -1,0 +1,8 @@
+import { PosPaymentMethod } from "@point_of_sale/../tests/unit/data/pos_payment_method.data";
+import { patch } from "@web/core/utils/patch";
+
+patch(PosPaymentMethod.prototype, {
+    _load_pos_self_data_read(records) {
+        return records.filter((record) => record.use_payment_terminal);
+    },
+});

--- a/addons/pos_self_order/tests/__init__.py
+++ b/addons/pos_self_order/tests/__init__.py
@@ -12,3 +12,4 @@ from . import test_webmanifest
 from . import test_self_order_sequence
 from . import test_self_order_preset
 from . import test_self_order_controller
+from . import test_self_order_payment_method

--- a/addons/pos_self_order/tests/test_self_order_payment_method.py
+++ b/addons/pos_self_order/tests/test_self_order_payment_method.py
@@ -1,0 +1,40 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import odoo.tests
+from odoo import Command
+from odoo.addons.pos_self_order.tests.self_order_common_test import SelfOrderCommonTest
+
+
+@odoo.tests.tagged("post_install", "-at_install")
+class TestSelfOrderPaymentMethod(SelfOrderCommonTest):
+    def setUp(self):
+        super().setUp()
+        self.terminal_payment_method = self.env['pos.payment.method'].create({
+            'name': 'Terminal',
+            'journal_id': self.bank_journal.id,
+            'use_payment_terminal': 'stripe',
+        })
+
+        self.pos_config.write(
+            {
+                "payment_method_ids": [Command.link(self.terminal_payment_method.id)],
+            }
+        )
+
+    def test_self_order_kiosk_loads_terminal_payment_method(self):
+        self.pos_config.write({"self_ordering_mode": "kiosk"})
+
+        payment_methods_to_load = self.pos_config.payment_method_ids._load_pos_self_data_search_read({}, self.pos_config)
+
+        self.assertEqual(len(payment_methods_to_load), 1)
+        self.assertEqual(payment_methods_to_load[0]["id"], self.terminal_payment_method.id)
+        self.assertTrue(self.pos_config.has_valid_self_payment_method())
+
+    def test_self_order_non_kiosk_does_not_load_payment_method(self):
+        for ordering_mode in ["mobile", "consultation"]:
+            self.pos_config.write({"self_ordering_mode": ordering_mode})
+
+            payment_methods_to_load = self.pos_config.payment_method_ids._load_pos_self_data_search_read({}, self.pos_config)
+
+            self.assertEqual(len(payment_methods_to_load), 0)
+            self.assertFalse(self.pos_config.has_valid_self_payment_method())

--- a/addons/pos_self_order_pine_labs/models/pos_payment_method.py
+++ b/addons/pos_self_order_pine_labs/models/pos_payment_method.py
@@ -2,8 +2,7 @@
 
 import uuid
 
-from odoo import api, models
-from odoo.fields import Domain
+from odoo import models
 
 
 class PosPaymentMethod(models.Model):
@@ -23,10 +22,3 @@ class PosPaymentMethod(models.Model):
         payment_response = self.pine_labs_make_payment_request(data)
         payment_response['payment_ref_no'] = data['transactionNumber']
         return payment_response
-
-    @api.model
-    def _load_pos_self_data_domain(self, data, config):
-        domain = super()._load_pos_self_data_domain(data, config)
-        if data['pos.config'][0]['self_ordering_mode'] == 'kiosk':
-            domain = Domain.OR([[('use_payment_terminal', '=', 'pine_labs'), ('id', 'in', config.payment_method_ids.ids)], domain])
-        return domain

--- a/addons/pos_self_order_pine_labs/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order_pine_labs/static/src/app/services/self_order_service.js
@@ -21,14 +21,6 @@ patch(SelfOrder.prototype, {
         }
     },
 
-    filterPaymentMethods(pms) {
-        const filteredPaymentMethods = super.filterPaymentMethods(...arguments);
-        const pineLabsPaymentMethods = pms.filter(
-            (rec) => rec.use_payment_terminal === "pine_labs"
-        );
-        return [...new Set([...filteredPaymentMethods, ...pineLabsPaymentMethods])];
-    },
-
     handlePineLabsError(error, type) {
         this.paymentError = true;
         this.handleErrorNotification(error, type);

--- a/addons/pos_self_order_qfpay/models/pos_payment_method.py
+++ b/addons/pos_self_order_qfpay/models/pos_payment_method.py
@@ -1,17 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo import models, api, fields
-from odoo.fields import Domain
 
 
 class PosPaymentMethod(models.Model):
     _inherit = "pos.payment.method"
-
-    @api.model
-    def _load_pos_self_data_domain(self, data, config):
-        domain = super()._load_pos_self_data_domain(data, config)
-        if config.self_ordering_mode == 'kiosk':
-            domain = Domain.OR([[('use_payment_terminal', '=', 'qfpay'), ('id', 'in', config.payment_method_ids.ids)], domain])
-        return domain
 
     @api.model
     def _qfpay_handle_webhook(self, config, data, uuid):

--- a/addons/pos_self_order_qfpay/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order_qfpay/static/src/app/services/self_order_service.js
@@ -15,12 +15,6 @@ patch(SelfOrder.prototype, {
         }
     },
 
-    filterPaymentMethods(pms) {
-        const pm = super.filterPaymentMethods(...arguments);
-        const qfpay_pm = pms.filter((rec) => rec.use_payment_terminal === "qfpay");
-        return [...new Set([...pm, ...qfpay_pm])];
-    },
-
     handleQFPayError(error, type) {
         this.paymentError = true;
         this.handleErrorNotification(error, type);

--- a/addons/pos_self_order_razorpay/models/pos_payment_method.py
+++ b/addons/pos_self_order_razorpay/models/pos_payment_method.py
@@ -1,6 +1,5 @@
 import uuid
-from odoo import models, api
-from odoo.fields import Domain
+from odoo import models
 
 
 class PosPaymentMethod(models.Model):
@@ -15,10 +14,3 @@ class PosPaymentMethod(models.Model):
             'referenceId': f'{reference_prefix}/Order/{order.id}/{uuid.uuid4().hex}',
         }
         return self.razorpay_make_payment_request(data)
-
-    @api.model
-    def _load_pos_self_data_domain(self, data, config):
-        domain = super()._load_pos_self_data_domain(data, config)
-        if config.self_ordering_mode == 'kiosk':
-            domain = Domain.OR([[('use_payment_terminal', '=', 'razorpay')], domain])
-        return domain

--- a/addons/pos_self_order_razorpay/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order_razorpay/static/src/app/services/self_order_service.js
@@ -21,12 +21,6 @@ patch(SelfOrder.prototype, {
         }
     },
 
-    filterPaymentMethods(pms) {
-        const pm = super.filterPaymentMethods(...arguments);
-        const razorpay_pm = pms.filter((rec) => rec.use_payment_terminal === "razorpay");
-        return [...new Set([...pm, ...razorpay_pm])];
-    },
-
     handleRazorpayError(error, type) {
         this.paymentError = true;
         this.handleErrorNotification(error, type);


### PR DESCRIPTION
Before this commit, the payment methods that were available in self order were filtered in three places:
- On the server, by the domain used in `_load_pos_self_data_domain`
- On the server, in the `has_valid_self_payment_method` method (this is only called to check if an order should go to the preparation display)
- On the client, using the `filterPaymentMethods` method

This required any modules adding new self order payment methods to override all of these in order for the payment method to be available.

After this commit, we remove the client side filtering and instead do all of the filtering via the domain. The client simply displays all payment methods.

We also modify `has_valid_self_payment_method` to call `_load_pos_self_data_domain` instead of duplicating the filtering logic.

task-4882726

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
