### PR TITLE
[FIX] point_of_sale: fix generic tour

### DIFF
--- a/addons/point_of_sale/static/tests/pos/tours/generic_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/generic_tour.js
@@ -9,7 +9,7 @@ import { registry } from "@web/core/registry";
 registry.category("web_tour.tours").add("generic_localization_tour", {
     steps: () =>
         [
-            Chrome.startPoS(),
+            Chrome.startPoS().map((step) => ({ ...step, timeout: 20000 })),
             Dialog.confirm("Open Register"),
             ProductScreen.clickPartnerButton(),
             ProductScreen.clickCustomer("AAAA Generic Partner"),


### PR DESCRIPTION
Loading the PoS with all the localizations installed can take up to 15s
to load, so we increase the timeout of the first step of the generic
tour to 20s to make sure it doesn't fail.

runbot-233059