### PR TITLE
[FIX] mrp_subcontracting: portal access rights

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1786,7 +1786,8 @@ class MrpProduction(models.Model):
             if finish_moves:
                 production._log_downside_manufactured_quantity({finish_move: (production.product_uom_qty, 0.0) for finish_move in finish_moves}, cancel=True)
 
-        self.workorder_ids.filtered(lambda x: x.state not in ['done', 'cancel']).action_cancel()
+        if self._has_workorders():
+            self.workorder_ids.filtered(lambda x: x.state not in ['done', 'cancel']).action_cancel()
         finish_moves = self.move_finished_ids.filtered(lambda x: x.state not in ('done', 'cancel'))
         raw_moves = self.move_raw_ids.filtered(lambda x: x.state not in ('done', 'cancel'))
         (finish_moves | raw_moves).with_context(skip_mo_check=True)._action_cancel()
@@ -1810,7 +1811,9 @@ class MrpProduction(models.Model):
         # However, if the user clicks on 'Cancel', it is expected that the MO is either done or
         # canceled. If the MO is still in progress at this point, it means that the move raws
         # are either all done or a mix of done / canceled => the MO should be done.
-        self.filtered(lambda p: p.state not in ['done', 'cancel'] and p.bom_id.consumption == 'flexible').write({'state': 'done'})
+        mos_to_mark_as_done = self.filtered(lambda p: p.state not in ['done', 'cancel'] and p.bom_id.consumption == 'flexible')
+        if mos_to_mark_as_done:
+            mos_to_mark_as_done.write({'state': 'done'})
 
         return True
 

--- a/addons/mrp_subcontracting/__manifest__.py
+++ b/addons/mrp_subcontracting/__manifest__.py
@@ -136,6 +136,7 @@
             'stock/static/src/widgets/*',
             'stock/static/src/fields/*',
             'mrp_subcontracting/static/src/components/subcontracting_production_form_controller.js',
+            'mrp_subcontracting/static/src/components/subcontracting_production_list_controller.js',
         ],
     },
     'uninstall_hook': 'uninstall_hook',

--- a/addons/mrp_subcontracting/models/mrp_production.py
+++ b/addons/mrp_subcontracting/models/mrp_production.py
@@ -70,7 +70,7 @@ class MrpProduction(models.Model):
                     'mo_id': mo.id,
                     'product_qty': vals['product_qty'],
                 }]).change_prod_qty()
-                mo.action_assign()
+                mo.sudo().action_assign()
 
         res = super().write(vals)
 

--- a/addons/mrp_subcontracting/models/stock_move.py
+++ b/addons/mrp_subcontracting/models/stock_move.py
@@ -282,7 +282,7 @@ class StockMove(models.Model):
                     production_to_keep.lot_producing_ids = False
                     orphan_productions = orphan_productions[:-1]
                 if orphan_productions:
-                    orphan_productions.with_context(skip_activity=True).unlink()
+                    orphan_productions.sudo().with_context(skip_activity=True).unlink()
                     productions -= orphan_productions
 
                 mos_to_assign.sudo().action_assign()

--- a/addons/mrp_subcontracting/security/ir.model.access.csv
+++ b/addons/mrp_subcontracting/security/ir.model.access.csv
@@ -15,3 +15,5 @@ access_subcontracting_portal_product,subcontracting.portal.product,product.model
 access_subcontracting_portal_product_template,subcontracting.portal.product.template,product.model_product_template,base.group_portal,1,0,0,0
 access_subcontracting_portal_uom,subcontracting.portal.uom,uom.model_uom_uom,base.group_portal,1,0,0,0
 access_subcontracting_portal_barcode_nomenclature_stock_user,subcontracting.portal.barcode.nomenclature,barcodes.model_barcode_nomenclature,base.group_portal,1,0,0,0
+access_subcontracting_portal_sequence,subcontracting.portal.sequence,base.model_ir_sequence,base.group_portal,1,1,0,0
+access_subcontracting_portal_mrp_production_serials,subcontracting.portal.mrp.production.serials,mrp.model_mrp_production_serials,base.group_portal,1,1,1,0

--- a/addons/mrp_subcontracting/views/subcontracting_portal_views.xml
+++ b/addons/mrp_subcontracting/views/subcontracting_portal_views.xml
@@ -21,7 +21,7 @@
                     </group>
                     <notebook>
                         <page string="Operations" name="operations">
-                            <field name="move_ids" mode="list">
+                            <field name="move_ids" mode="list" context="{'default_picking_id': id, 'default_picking_type_id': picking_type_id, 'default_company_id': company_id, 'default_date': scheduled_date}">
                                 <list no_open="1">
                                     <field name="id" readonly="1" column_invisible="True"/>
                                     <field name="product_id" readonly="1"/>

--- a/addons/mrp_subcontracting/wizard/mrp_production_serial_numbers.py
+++ b/addons/mrp_subcontracting/wizard/mrp_production_serial_numbers.py
@@ -23,6 +23,11 @@ class MrpProductionSerials(models.TransientModel):
         for lot_name in lots:
             if lot_name in existing_lot_names:
                 continue
+            if self.lot_name == self.production_id.product_id.serial_prefix_format + self.production_id.product_id.next_serial:
+                if self.production_id.product_id.lot_sequence_id:
+                    lot_name = self.production_id.product_id.lot_sequence_id.next_by_id()
+                else:
+                    lot_name = self.env['ir.sequence'].next_by_code('stock.lot.serial')
             new_lots.append({
                 'name': lot_name,
                 'product_id': self.production_id.product_id.id


### PR DESCRIPTION
Make sure that portal subcontractors can do what they need to:
- create new serial numbers and assign them to SMLs
	-> new ACL for sequences (READ and WRITE)
	-> new ACL for mrp.production.serials to open the wizard
- see SML serials in the Detailed Operations popup
	-> add context to portal view
- open the MO list view for registering components for multiple MOs
	-> add the missing js file in the manifest
- save the changes on the DB
	-> call `_has_workorders` before doing some workorder operations
	-> add sudo for MO unlink because a portal user doesn't have DELETE ACL
	-> add sudo for MO assign when using lots/serials
	-> skip writing the state field if there's no record to write
- correctly increment sequence
	-> added the changes from https://github.com/odoo/odoo/pull/227095 to the subcontracting serial wizard

task 5107873

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
