### PR TITLE
[FIX] l10n_dk_nemhandel: Add neutralize script

### DIFF
--- a/addons/account_edi_proxy_client/data/neutralize.sql
+++ b/addons/account_edi_proxy_client/data/neutralize.sql
@@ -2,7 +2,7 @@
 -- for malaysian edi, this script can cause issue as you could have both a demo and prod user, in which case it breaks the unique constrain. Another neutralize in the malaysian module disable the clients instead.
 UPDATE account_edi_proxy_client_user
 SET edi_mode = CASE
-                    WHEN proxy_type IN ('l10n_it_edi', 'peppol') THEN 'demo'
+                    WHEN proxy_type IN ('l10n_it_edi', 'peppol', 'l10n_dk_nemhandel') THEN 'demo'
                     ELSE 'test'
                END
 WHERE proxy_type != 'l10n_my_edi';

--- a/addons/l10n_dk_nemhandel/data/neutralize.sql
+++ b/addons/l10n_dk_nemhandel/data/neutralize.sql
@@ -1,0 +1,3 @@
+UPDATE ir_config_parameter
+SET value = 'test'
+WHERE key = 'l10n_dk_nemhandel.edi.mode';


### PR DESCRIPTION
To avoid sending/registering on production, add a neutralize script. 
The existing proxy client are put in demo mode.
The new connections will be registered on the test server.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
