### PR TITLE
[REM] core: profiler SyncCollector

### DIFF
--- a/odoo/addons/base/models/ir_profile.py
+++ b/odoo/addons/base/models/ir_profile.py
@@ -39,7 +39,6 @@ class IrProfile(models.Model):
     sql = fields.Text('Sql', prefetch=False)
     sql_count = fields.Integer('Queries Count')
     traces_async = fields.Text('Traces Async', prefetch=False)
-    traces_sync = fields.Text('Traces Sync', prefetch=False)
     others = fields.Text('others', prefetch=False)
     qweb = fields.Text('Qweb', prefetch=False)
     entry_count = fields.Integer('Entry count')


### PR DESCRIPTION
The synchronous profiler has a huge overhead and is not really useful for profiling. It is also not available from the web interface.

https://github.com/odoo/documentation/pull/14774
https://github.com/odoo/upgrade/pull/8548

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
