### PR TITLE
[IMP] web: reduce entropy of allowed_company_ids

### DIFF
--- a/addons/web/static/src/core/user.js
+++ b/addons/web/static/src/core/user.js
@@ -3,7 +3,7 @@ import { pyToJsLocale } from "@web/core/l10n/utils/locales";
 import { rpc } from "@web/core/network/rpc";
 import { Cache } from "@web/core/utils/cache";
 import { session } from "@web/session";
-import { ensureArray } from "./utils/arrays";
+import { ensureArray, sortBy } from "./utils/arrays";
 import { cookie } from "@web/core/browser/cookie";
 import { EventBus } from "@odoo/owl";
 
@@ -65,6 +65,13 @@ export function _makeUser(session) {
         ) {
             activeCompanies = [defaultCompanyId];
         }
+        // Sort companies, except for the first one which has a different status, as the order of
+        // the others doesn't matter, and we want to reduce the entropy of the `allowed_company_ids`
+        // key in the context. This is important for the caches, as the stringified context is
+        // always present in the rpc cache keys.
+        activeCompanies = [activeCompanies[0]].concat(
+            sortBy(activeCompanies.slice(1), (c) => c.id)
+        );
 
         // update browser data
         cookie.set("cids", activeCompanies.map((c) => c.id).join("-"));

--- a/addons/web/static/tests/core/user.test.js
+++ b/addons/web/static/tests/core/user.test.js
@@ -54,8 +54,20 @@ test("extract allowed company ids from cookies", async () => {
     expect(user.activeCompany.id).toBe(3);
 });
 
+test("active companies are sorted", async () => {
+    serverState.companies = [
+        { id: 1, name: "Company 1", sequence: 1, parent_id: false, child_ids: [] },
+        { id: 2, name: "Company 2", sequence: 2, parent_id: false, child_ids: [] },
+        { id: 3, name: "Company 3", sequence: 3, parent_id: false, child_ids: [] },
+    ];
+
+    expect(user.activeCompanies.map((c) => c.id)).toEqual([1]);
+    user.activateCompanies([2, 3, 1]);
+    expect(user.activeCompanies.map((c) => c.id)).toEqual([2, 1, 3]);
+});
+
 test("activate company branches after access error", async () => {
-    cookie.set("cids", "1")
+    cookie.set("cids", "1");
     serverState.companies = [
         {
             id: 1,
@@ -85,4 +97,4 @@ test("activate company branches after access error", async () => {
     user.activateCompanies(activeCompanyIds);
     // Activating the first branch should activate all branches
     expect(cookie.get("cids")).toBe("1-2-3");
-})
+});

--- a/addons/web/static/tests/webclient/mobile/mobile_switch_company.test.js
+++ b/addons/web/static/tests/webclient/mobile/mobile_switch_company.test.js
@@ -195,7 +195,7 @@ test("multi company mode: log into a non selected company", async () => {
      *   [x] **Company 3**
      */
     await contains(".log_into:eq(1)").click();
-    expect(cookie.get("cids")).toEqual("2-3-1");
+    expect(cookie.get("cids")).toEqual("2-1-3"); // 1-3 in that order, they are sorted
 });
 
 test("multi company mode: log into an already selected company", async () => {

--- a/addons/web/static/tests/webclient/switch_company_menu.test.js
+++ b/addons/web/static/tests/webclient/switch_company_menu.test.js
@@ -248,7 +248,7 @@ test("multi company mode: log into a non selected company", async () => {
      */
     await contains(".log_into:eq(1)").click();
     expect(".dropdown-menu").toHaveCount(0, { message: "dropdown is directly closed" });
-    expect(cookie.get("cids")).toEqual("2-3-1");
+    expect(cookie.get("cids")).toEqual("2-1-3"); // 1-3 in that order, they are sorted
 });
 
 test("multi company mode: log into an already selected company", async () => {


### PR DESCRIPTION
The `allowed_company_ids` key encodes the ids of the companies the user is currently logged in. There's always a "main" company, the first one, which acts as default company. The order for the others is not relevant. Before this commit, those ids weren't sorted. This was a (small) problem for the rpc caches, because that list of ids is present in the context, which is stringified in the cache keys. So the same request but with `allowed_company_ids`, e.g., `[3,1,2]` and `[3,2,1]` would result in 2 different keys in the cache, and could thus lead to cache misses even though we already did the same request.

This commit thus sorts the ids (except for the one).

Task~5104126

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
