### PR TITLE
[IMP] hr_fleet: add cars history in public employee view

### DIFF
--- a/addons/hr_fleet/models/employee.py
+++ b/addons/hr_fleet/models/employee.py
@@ -86,4 +86,11 @@ class HrEmployee(models.Model):
 class HrEmployeePublic(models.Model):
     _inherit = 'hr.employee.public'
 
+    employee_cars_count = fields.Integer(compute="_compute_employee_cars_count", string="Cars", groups="fleet.fleet_group_user")
     mobility_card = fields.Char(readonly=True)
+
+    def action_open_employee_cars(self):
+        return self.env['hr.employee'].browse(self.ids).action_open_employee_cars()
+
+    def _compute_employee_cars_count(self):
+        self._compute_from_employee('employee_cars_count')

--- a/addons/hr_fleet/views/employee_views.xml
+++ b/addons/hr_fleet/views/employee_views.xml
@@ -34,4 +34,20 @@
         </field>
     </record>
 
+    <!-- Employee Public -->
+    <record id="hr_employee_public_view_form" model="ir.ui.view">
+        <field name="name">hr.employee.public.form.inherit.hr.fleet</field>
+        <field name="model">hr.employee.public</field>
+        <field name="inherit_id" ref="hr.hr_employee_public_view_form" />
+        <field name="arch" type="xml">
+            <div name="button_box" position="inside">
+                <button name="action_open_employee_cars" type="object"
+                        class="oe_stat_button" icon="fa-car" groups="fleet.fleet_group_user"
+                        invisible="employee_cars_count == 0 or not is_user">
+                    <field name="employee_cars_count" widget="statinfo" string="Cars History" />
+                </button>
+            </div>
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
**Issue**
Previously, the "Cars History" smart button was only visible on the officer employee profile but not on the public employee profile basically preventing employees with only fleet management rights from accessing their own vehicle assignment history when viewing their public profile.

Task ID: 5139446

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
