### PR TITLE
[REF] mail: make discuss.channel inherit mail.thread (JS)

### DIFF
--- a/addons/account/static/src/components/mail_attachments/mail_attachments_selector.js
+++ b/addons/account/static/src/components/mail_attachments/mail_attachments_selector.js
@@ -25,7 +25,7 @@ export class MailAttachments extends Component {
 
     async onFileUploaded({ name, data, type }) {
         const resIds = JSON.parse(this.props.record.data.res_ids);
-        const thread = await this.mailStore.Thread.insert({
+        const thread = await this.mailStore["mail.thread"].insert({
             model: this.props.record.data.model,
             id: resIds[0],
         });

--- a/addons/hr_holidays/static/src/core/common/@types/models.d.ts
+++ b/addons/hr_holidays/static/src/core/common/@types/models.d.ts
@@ -1,6 +1,6 @@
 declare module "models" {
     export interface HrEmployee {
-        leave_date_to: luxon.DateTime;
+        leave_date_to: import("luxon").DateTime;
     }
     export interface ResUsers {
         leave_date_to: string;

--- a/addons/im_livechat/static/src/core/common/@types/models.d.ts
+++ b/addons/im_livechat/static/src/core/common/@types/models.d.ts
@@ -25,6 +25,14 @@ declare module "models" {
     export interface DataResponse {
         chatbot_step: ChatbotStep;
     }
+    export interface DiscussChannel {
+        composerHidden: Readonly<boolean>;
+        livechat_conversation_tag_ids: LivechatConversationTag[];
+        livechat_end_dt: import("luxon").DateTime;
+        livechat_operator_id: ResPartner;
+        livechatVisitorMember: ChannelMember;
+        open_chat_window: true|undefined;
+    }
     export interface Message {
         chatbotStep: ChatbotStep;
     }
@@ -46,7 +54,7 @@ declare module "models" {
     export interface Thread {
         composerHidden: Readonly<boolean>;
         livechat_conversation_tag_ids: LivechatConversationTag[];
-        livechat_end_dt: luxon.DateTime;
+        livechat_end_dt: import("luxon").DateTime;
         livechat_operator_id: ResPartner;
         livechatVisitorMember: ChannelMember;
         open_chat_window: true|undefined;

--- a/addons/im_livechat/static/src/core/common/chatbot_model.js
+++ b/addons/im_livechat/static/src/core/common/chatbot_model.js
@@ -24,7 +24,7 @@ export class Chatbot extends Record {
         },
     });
     steps = fields.Many("ChatbotStep");
-    thread = fields.One("Thread", {
+    thread = fields.One("mail.thread", {
         inverse: "chatbot",
         onDelete() {
             this.delete();

--- a/addons/im_livechat/static/src/core/public_web/@types/models.d.ts
+++ b/addons/im_livechat/static/src/core/public_web/@types/models.d.ts
@@ -6,6 +6,11 @@ declare module "models" {
     export interface DiscussAppCategory {
         livechat_channel_id: LivechatChannel;
     }
+    export interface DiscussChannel {
+        appAsLivechats: DiscussApp;
+        country_id: Country;
+        livechat_channel_id: LivechatChannel;
+    }
     export interface LivechatChannel {
         appCategory: DiscussAppCategory;
         threads: Thread[];

--- a/addons/im_livechat/static/src/core/public_web/discuss_app_model_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/discuss_app_model_patch.js
@@ -20,6 +20,6 @@ patch(DiscussApp.prototype, {
             },
             eager: true,
         });
-        this.livechats = fields.Many("Thread", { inverse: "appAsLivechats" });
+        this.livechats = fields.Many("mail.thread", { inverse: "appAsLivechats" });
     },
 });

--- a/addons/im_livechat/static/src/core/public_web/livechat_channel_model_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/livechat_channel_model_patch.js
@@ -20,7 +20,7 @@ const livechatChannelPatch = {
             eager: true,
             inverse: "livechat_channel_id",
         });
-        this.threads = fields.Many("Thread", { inverse: "livechat_channel_id" });
+        this.threads = fields.Many("mail.thread", { inverse: "livechat_channel_id" });
     },
 };
 patch(LivechatChannel.prototype, livechatChannelPatch);

--- a/addons/im_livechat/static/src/core/public_web/messaging_menu_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/messaging_menu_patch.js
@@ -9,7 +9,7 @@ patch(MessagingMenu.prototype, {
      */
     get _tabs() {
         const items = super._tabs;
-        const hasLivechats = Object.values(this.store.Thread.records).some(
+        const hasLivechats = Object.values(this.store["mail.thread"].records).some(
             (thread) => thread.channel?.channel_type === "livechat"
         );
         if (hasLivechats) {

--- a/addons/im_livechat/static/src/core/web/@types/models.d.ts
+++ b/addons/im_livechat/static/src/core/web/@types/models.d.ts
@@ -1,4 +1,13 @@
 declare module "models" {
+    export interface DiscussChannel {
+        hasFetchedLivechatSessionData: boolean;
+        livechat_expertise_ids: LivechatExpertise[];
+        livechat_note: ReturnType<import("@odoo/owl").markup>|string;
+        livechat_outcome: "no_answer"|"no_agent"|"no_failure"|"escalated"|undefined;
+        livechat_status: "in_progress"|"waiting"|"need_help"|undefined;
+        livechatNoteText: string|undefined;
+        livechatStatusLabel: Readonly<string>;
+    }
     export interface LivechatChannel {
         join: (param0: { notify: boolean }) => Promise<void>;
         joinTitle: Readonly<string>;

--- a/addons/im_livechat/static/src/embed/common/@types/models.d.ts
+++ b/addons/im_livechat/static/src/embed/common/@types/models.d.ts
@@ -1,4 +1,17 @@
 declare module "models" {
+    export interface DiscussChannel {
+        _prevComposerDisabled: boolean;
+        _toggleChatbot: boolean;
+        chatbot: Chatbot;
+        chatbotTypingMessage: Message;
+        hasWelcomeMessage: Readonly<boolean>;
+        isLastMessageFromCustomer: Readonly<boolean>;
+        livechat_operator_id: ResPartner;
+        livechatWelcomeMessage: Message;
+        readyToSwapDeferred: Deferred;
+        requested_by_operator: boolean;
+        storeAsActiveLivechats: Store;
+    }
     export interface Message {
         disableChatbotAnswers: boolean;
     }
@@ -9,6 +22,7 @@ declare module "models" {
         livechat_rule: LivechatChannelRule;
     }
     export interface Thread {
+        _prevComposerDisabled: boolean;
         _toggleChatbot: boolean;
         chatbot: Chatbot;
         chatbotTypingMessage: Message;

--- a/addons/im_livechat/static/src/embed/common/autopopup_service.js
+++ b/addons/im_livechat/static/src/embed/common/autopopup_service.js
@@ -13,19 +13,19 @@ export class AutopopupService {
      * ui: typeof import("@web/core/ui/ui_service").uiService.start,
      * }} services
      */
-    constructor(env, { "im_livechat.livechat": livechatService, "mail.store": storeService, ui }) {
-        this.storeService = storeService;
+    constructor(env, { "im_livechat.livechat": livechatService, "mail.store": store, ui }) {
+        this.store = store;
         this.livechatService = livechatService;
         this.ui = ui;
 
-        storeService.isReady.then(() => { 
+        store.isReady.then(() => {
             browser.setTimeout(async () => {
-                await storeService.chatHub.initPromise;
+                await store.chatHub.initPromise;
                 if (this.allowAutoPopup) {
                     expirableStorage.setItem(AutopopupService.STORAGE_KEY, true);
                     livechatService.open();
                 }
-            }, storeService.livechat_rule?.auto_popup_timer * 1000);
+            }, store.livechat_rule?.auto_popup_timer * 1000);
         });
     }
 
@@ -33,9 +33,9 @@ export class AutopopupService {
         return Boolean(
             !expirableStorage.getItem(AutopopupService.STORAGE_KEY) &&
                 !this.ui.isSmall &&
-                this.storeService.livechat_rule?.action === "auto_popup" &&
-                this.storeService.livechat_available &&
-                this.storeService.activeLivechats.length === 0
+                this.store.livechat_rule?.action === "auto_popup" &&
+                this.store.livechat_available &&
+                this.store.activeLivechats.length === 0
         );
     }
 }

--- a/addons/im_livechat/static/src/embed/common/history_service.js
+++ b/addons/im_livechat/static/src/embed/common/history_service.js
@@ -11,13 +11,13 @@ export class HistoryService {
         /** @type {ReturnType<typeof import("@bus/services/bus_service").busService.start>} */
         this.busService = services.bus_service;
         /** @type {import("models").Store} */
-        this.storeService = services["mail.store"];
+        this.store = services["mail.store"];
     }
 
     setup() {
         this.updateHistory();
         this.busService.subscribe("im_livechat.history_command", async (payload) => {
-            const thread = await this.storeService.Thread.getOrFetch({
+            const thread = await this.store["mail.thread"].getOrFetch({
                 id: payload.id,
                 model: "discuss.channel",
             });

--- a/addons/im_livechat/static/src/embed/common/livechat_service.js
+++ b/addons/im_livechat/static/src/embed/common/livechat_service.js
@@ -54,7 +54,7 @@ export class LivechatService {
      * @returns {Promise<import("models").Thread|undefined>}
      */
     async open(options = {}) {
-        const thread = await this._createThread({ persist: false, options});
+        const thread = await this._createThread({ persist: false, options });
         await thread?.openChatWindow({ focus: true });
         return thread;
     }
@@ -116,7 +116,9 @@ export class LivechatService {
             {
                 channel_id: options.channel_id ?? this.options.channel_id,
                 previous_operator_id: expirableStorage.getItem(OPERATOR_STORAGE_KEY),
-                chatbot_script_id: originThread?.chatbot?.script.id ?? this.store.livechat_rule?.chatbot_script_id?.id,
+                chatbot_script_id:
+                    originThread?.chatbot?.script.id ??
+                    this.store.livechat_rule?.chatbot_script_id?.id,
                 persisted: options.persist ?? persist,
                 ...this.getSessionExtraParams(originThread, options),
             },
@@ -127,7 +129,7 @@ export class LivechatService {
             return;
         }
         this.store.insert(store_data);
-        const thread = this.store.Thread.get({ id: channel_id, model: "discuss.channel" });
+        const thread = this.store["mail.thread"].get({ id: channel_id, model: "discuss.channel" });
         const ONE_DAY_TTL = 60 * 60 * 24;
         expirableStorage.setItem(
             "im_livechat_previous_operator",

--- a/addons/im_livechat/static/src/embed/common/store_service_patch.js
+++ b/addons/im_livechat/static/src/embed/common/store_service_patch.js
@@ -9,7 +9,7 @@ export const GUEST_TOKEN_STORAGE_KEY = "im_livechat_guest_token";
 const StorePatch = {
     setup() {
         super.setup(...arguments);
-        this.activeLivechats = fields.Many("Thread", { inverse: "storeAsActiveLivechats" });
+        this.activeLivechats = fields.Many("mail.thread", { inverse: "storeAsActiveLivechats" });
         expirableStorage.onChange(GUEST_TOKEN_STORAGE_KEY, (value) => (this.guest_token = value));
         this.guest_token = fields.Attr(null, {
             compute() {

--- a/addons/im_livechat/static/src/views/livechat_form_renderer.js
+++ b/addons/im_livechat/static/src/views/livechat_form_renderer.js
@@ -30,7 +30,7 @@ export class LivechatSessionFormRenderer extends FormRenderer {
      * @param {Props} props
      */
     async getChannel(props) {
-        this.thread = await this.store.Thread.getOrFetch({
+        this.thread = await this.store["mail.thread"].getOrFetch({
             model: "discuss.channel",
             id: props.record.resId,
         });

--- a/addons/im_livechat/static/src/views/livechat_view_controller_mixin.js
+++ b/addons/im_livechat/static/src/views/livechat_view_controller_mixin.js
@@ -10,7 +10,7 @@ export const LivechatViewControllerMixin = (ViewController) =>
 
         async openRecord(record) {
             if (this.ui.isSmall) {
-                const thread = await this.store.Thread.getOrFetch({
+                const thread = await this.store["mail.thread"].getOrFetch({
                     model: "discuss.channel",
                     id: record.resId,
                 });

--- a/addons/im_livechat/static/tests/embed/feedback_panel.test.js
+++ b/addons/im_livechat/static/tests/embed/feedback_panel.test.js
@@ -68,7 +68,7 @@ test("Last operator leaving ends the livechat", async () => {
     // simulate operator leaving
     await withUser(operatorUserId, () =>
         getService("orm").call("discuss.channel", "action_unfollow", [
-            [Object.values(getService("mail.store").Thread.records).at(-1).id],
+            [Object.values(getService("mail.store")["mail.thread"].records).at(-1).id],
         ])
     );
     await contains("span", { text: "This livechat conversation has ended" });

--- a/addons/im_livechat/static/tests/embed/history_command.test.js
+++ b/addons/im_livechat/static/tests/embed/history_command.test.js
@@ -29,7 +29,7 @@ test("Handle livechat history command", async () => {
     await contains(".o-mail-Composer-input").edit("Hello World!", { confirm: false });
     await press("Enter");
     await waitFor(".o-mail-Message:contains(Hello World!)");
-    const thread = Object.values(getService("mail.store").Thread.records).at(-1);
+    const thread = Object.values(getService("mail.store")["mail.thread"].records).at(-1);
     const guestId = pyEnv.cookie.get("dgid");
     const [guest] = pyEnv["mail.guest"].read(guestId);
     pyEnv["bus.bus"]._sendone(guest, "im_livechat.history_command", {

--- a/addons/im_livechat/static/tests/embed/livechat_session.test.js
+++ b/addons/im_livechat/static/tests/embed/livechat_session.test.js
@@ -75,8 +75,9 @@ test("Seen message is saved on the server", async () => {
     triggerHotkey("Enter");
     await contains(".o-mail-Message", { text: "Hello, I need help!" });
     await waitUntilSubscribe();
-    const initialSeenMessageId = Object.values(getService("mail.store").Thread.records).at(-1)
-        .self_member_id.seen_message_id?.id;
+    const initialSeenMessageId = Object.values(getService("mail.store")["mail.thread"].records).at(
+        -1
+    ).self_member_id.seen_message_id?.id;
     queryFirst(".o-mail-Composer-input").blur();
     await withUser(userId, () =>
         rpc("/mail/message/post", {
@@ -85,7 +86,7 @@ test("Seen message is saved on the server", async () => {
                 message_type: "comment",
                 subtype_xmlid: "mail.mt_comment",
             },
-            thread_id: Object.values(getService("mail.store").Thread.records).at(-1).id,
+            thread_id: Object.values(getService("mail.store")["mail.thread"].records).at(-1).id,
             thread_model: "discuss.channel",
         })
     );
@@ -96,11 +97,15 @@ test("Seen message is saved on the server", async () => {
     const guestId = pyEnv.cookie.get("dgid");
     const [member] = pyEnv["discuss.channel.member"].search_read([
         ["guest_id", "=", guestId],
-        ["channel_id", "=", Object.values(getService("mail.store").Thread.records).at(-1).id],
+        [
+            "channel_id",
+            "=",
+            Object.values(getService("mail.store")["mail.thread"].records).at(-1).id,
+        ],
     ]);
     expect(initialSeenMessageId).not.toBe(member.seen_message_id[0]);
     expect(
-        Object.values(getService("mail.store").Thread.records).at(-1).self_member_id.seen_message_id
-            .id
+        Object.values(getService("mail.store")["mail.thread"].records).at(-1).self_member_id
+            .seen_message_id.id
     ).toBe(member.seen_message_id[0]);
 });

--- a/addons/mail/static/src/chatter/web/@types/models.d.ts
+++ b/addons/mail/static/src/chatter/web/@types/models.d.ts
@@ -3,6 +3,9 @@ declare module "models" {
 
     export interface ScheduledMessage extends ScheduledMessageClass {}
 
+    export interface DiscussChannel {
+        scheduledMessages: ScheduledMessage[];
+    }
     export interface Store {
         "mail.scheduled.message": StaticMailRecord<ScheduledMessage, typeof ScheduledMessageClass>;
     }

--- a/addons/mail/static/src/chatter/web/chatter_patch.js
+++ b/addons/mail/static/src/chatter/web/chatter_patch.js
@@ -95,7 +95,10 @@ patch(Chatter.prototype, {
         });
         this.messageSearch = useMessageSearch();
         this.attachmentUploader = useAttachmentUploader(
-            this.store.Thread.insert({ model: this.props.threadModel, id: this.props.threadId })
+            this.store["mail.thread"].insert({
+                model: this.props.threadModel,
+                id: this.props.threadId,
+            })
         );
         this.unfollowHover = useHover("unfollow");
         this.followerListDropdown = useDropdownState();

--- a/addons/mail/static/src/chatter/web/form_renderer.js
+++ b/addons/mail/static/src/chatter/web/form_renderer.js
@@ -40,7 +40,7 @@ patch(FormRenderer.prototype, {
         if (!this.mailStore || !this.props.record.resId) {
             return false;
         }
-        this.messagingState.thread = this.mailStore.Thread.insert({
+        this.messagingState.thread = this.mailStore["mail.thread"].insert({
             id: this.props.record.resId,
             model: this.props.record.resModel,
         });

--- a/addons/mail/static/src/chatter/web/mail_composer_form.js
+++ b/addons/mail/static/src/chatter/web/mail_composer_form.js
@@ -46,7 +46,7 @@ export class MailComposerFormRenderer extends formView.Renderer {
 
         const getActiveMailThreads = () =>
             JSON.parse(this.props.record.data.res_ids).map((resId) => {
-                const thread = this.mailStore.Thread.insert({
+                const thread = this.mailStore["mail.thread"].insert({
                     model: this.props.record.data.model,
                     id: resId,
                 });

--- a/addons/mail/static/src/chatter/web/scheduled_message_model.js
+++ b/addons/mail/static/src/chatter/web/scheduled_message_model.js
@@ -29,7 +29,7 @@ export class ScheduledMessage extends Record {
             return htmlToTextContentInline(this.body);
         },
     });
-    thread = fields.One("Thread");
+    thread = fields.One("mail.thread");
     // Editors of the records can delete scheduled messages
     get deletable() {
         return this.store.self.main_user_id?.is_admin || this.thread.hasWriteAccess;

--- a/addons/mail/static/src/chatter/web_portal/chatter.js
+++ b/addons/mail/static/src/chatter/web_portal/chatter.js
@@ -72,7 +72,7 @@ export class Chatter extends Component {
     }
 
     changeThread(threadModel, threadId) {
-        this.state.thread = this.store.Thread.insert({ model: threadModel, id: threadId });
+        this.state.thread = this.store["mail.thread"].insert({ model: threadModel, id: threadId });
         if (threadId === false) {
             if (this.state.thread.messages.length === 0) {
                 this.state.thread.messages.push({

--- a/addons/mail/static/src/core/common/@types/models.d.ts
+++ b/addons/mail/static/src/core/common/@types/models.d.ts
@@ -80,6 +80,7 @@ declare module "models" {
         "mail.message.subtype": StaticMailRecord<MailMessageSubtype, typeof MailMessageSubtypeClass>;
         "mail.notification": StaticMailRecord<Notification, typeof NotificationClass>;
         "mail.template": StaticMailRecord<MailTemplate, typeof MailTemplateClass>;
+        "mail.thread": StaticMailRecord<Thread, typeof ThreadClass>;
         MessageReactions: StaticMailRecord<MessageReactions, typeof MessageReactionsClass>;
         "res.company": StaticMailRecord<ResCompany, typeof ResCompanyClass>;
         "res.country": StaticMailRecord<Country, typeof CountryClass>;
@@ -90,7 +91,6 @@ declare module "models" {
         "res.role": StaticMailRecord<ResRole, typeof ResRoleClass>;
         "res.users": StaticMailRecord<ResUsers, typeof ResUsersClass>;
         Settings: StaticMailRecord<Settings, typeof SettingsClass>;
-        Thread: StaticMailRecord<Thread, typeof ThreadClass>;
         Volume: StaticMailRecord<Volume, typeof VolumeClass>;
     }
 
@@ -113,6 +113,7 @@ declare module "models" {
         "mail.message.subtype": MailMessageSubtype;
         "mail.notification": Notification;
         "mail.template": MailTemplate;
+        "mail.thread": Thread;
         MessageReactions: MessageReactions;
         "res.company": ResCompany;
         "res.country": Country;
@@ -123,7 +124,6 @@ declare module "models" {
         "res.role": ResRole;
         "res.users": ResUsers;
         Settings: Settings;
-        Thread: Thread;
         Volume: Volume;
     }
 }

--- a/addons/mail/static/src/core/common/attachment_model.js
+++ b/addons/mail/static/src/core/common/attachment_model.js
@@ -22,7 +22,7 @@ export class Attachment extends FileModelMixin(Record) {
     }
 
     composer = fields.One("Composer", { inverse: "attachments" });
-    thread = fields.One("Thread", { inverse: "attachments" });
+    thread = fields.One("mail.thread", { inverse: "attachments" });
     /** @type {string} */
     raw_access_token;
     res_name;

--- a/addons/mail/static/src/core/common/attachment_view.js
+++ b/addons/mail/static/src/core/common/attachment_view.js
@@ -58,7 +58,7 @@ class AbstractAttachmentView extends Component {
     }
 
     updateFromProps(props) {
-        this.state.thread = this.store.Thread.insert({
+        this.state.thread = this.store["mail.thread"].insert({
             id: props.threadId,
             model: props.threadModel,
         });

--- a/addons/mail/static/src/core/common/chat_hub_model.js
+++ b/addons/mail/static/src/core/common/chat_hub_model.js
@@ -95,7 +95,7 @@ export class ChatHub extends Record {
     async _load(str) {
         /** @type {{ opened: Object[], folded: Object[] }} */
         const { opened = [], folded = [] } = JSON.parse(str);
-        const getThread = (data) => this.store.Thread.getOrFetch(data, ["display_name"]);
+        const getThread = (data) => this.store["mail.thread"].getOrFetch(data, ["display_name"]);
         const openPromises = opened.map(getThread);
         const foldPromises = folded.map(getThread);
         this.preFirstFetchPromise.resolve();

--- a/addons/mail/static/src/core/common/chat_window_model.js
+++ b/addons/mail/static/src/core/common/chat_window_model.js
@@ -7,7 +7,7 @@ export class ChatWindow extends Record {
 
     actionsDisabled = false;
     bypassCompact = false;
-    thread = fields.One("Thread", { inverse: "chat_window" });
+    thread = fields.One("mail.thread", { inverse: "chat_window" });
     autofocus = 0;
     jumpToNewMessage = 0;
     hidden = false;

--- a/addons/mail/static/src/core/common/composer_model.js
+++ b/addons/mail/static/src/core/common/composer_model.js
@@ -45,7 +45,7 @@ export class Composer extends Record {
     message = fields.One("mail.message");
     mentionedPartners = fields.Many("res.partner");
     mentionedRoles = fields.Many("res.role");
-    mentionedChannels = fields.Many("Thread");
+    mentionedChannels = fields.Many("mail.thread");
     cannedResponses = fields.Many("mail.canned.response");
     isDirty = false;
     composerText = fields.Attr("", {
@@ -90,7 +90,7 @@ export class Composer extends Record {
             }
         },
     });
-    thread = fields.One("Thread");
+    thread = fields.One("mail.thread");
     /** @type {{ start: number, end: number, direction: "forward" | "backward" | "none"}}*/
     selection = {
         start: 0,

--- a/addons/mail/static/src/core/common/data_response_model.js
+++ b/addons/mail/static/src/core/common/data_response_model.js
@@ -54,8 +54,8 @@ export class DataResponse extends Record {
      * other fields can be added if necessary.
      */
     attachments = fields.Many("ir.attachment");
-    channel = fields.One("Thread");
-    channels = fields.Many("Thread");
+    channel = fields.One("mail.thread");
+    channels = fields.Many("mail.thread");
     /** @type {number} */
     count;
     message = fields.One("mail.message");

--- a/addons/mail/static/src/core/common/failure_model.js
+++ b/addons/mail/static/src/core/common/failure_model.js
@@ -7,6 +7,8 @@ export class Failure extends Record {
     static nextId = markRaw({ value: 1 });
     static id = "id";
 
+    /** @type {number} */
+    id;
     notifications = fields.Many("mail.notification", {
         /** @this {import("models").Failure} */
         onUpdate() {

--- a/addons/mail/static/src/core/common/follower_model.js
+++ b/addons/mail/static/src/core/common/follower_model.js
@@ -5,7 +5,7 @@ export class Follower extends Record {
     static _name = "mail.followers";
     static id = "id";
 
-    thread = fields.One("Thread");
+    thread = fields.One("mail.thread");
     /** @type {number} */
     id;
     /** @type {boolean} */

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -261,7 +261,7 @@ export class Message extends Component {
             "pt-1": !this.props.asCard && !this.props.squashed,
             "o-pt-0_5": !this.props.asCard && this.props.squashed,
             "o-selfAuthored": this.message.isSelfAuthored && !this.env.messageCard,
-            "o-selected": this.props.thread?.composer.replyToMessage?.eq(this.props.message),
+            "o-selected": this.props.thread?.composer?.replyToMessage?.eq(this.props.message),
             "o-squashed": this.props.squashed,
             "mt-1":
                 !this.props.squashed &&
@@ -269,7 +269,7 @@ export class Message extends Component {
                 !this.env.messageCard &&
                 !this.props.asCard,
             "px-1": this.props.isInChatWindow,
-            "opacity-50": this.props.thread?.composer.replyToMessage?.notEq(this.props.message),
+            "opacity-50": this.props.thread?.composer?.replyToMessage?.notEq(this.props.message),
             "o-actionMenuMobileOpen": this.ui.isSmall && this.optionsDropdown.isOpen,
             "o-editing": this.isEditing,
         };

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -126,16 +126,16 @@ export class Message extends Record {
     notification_ids = fields.Many("mail.notification", { inverse: "mail_message_id" });
     partner_ids = fields.Many("res.partner");
     subtype_id = fields.One("mail.message.subtype");
-    thread = fields.One("Thread");
-    threadAsNeedaction = fields.One("Thread", {
+    thread = fields.One("mail.thread");
+    threadAsNeedaction = fields.One("mail.thread", {
         compute() {
             if (this.needaction) {
                 return this.thread;
             }
         },
     });
-    threadAsNewest = fields.One("Thread");
-    threadAsInEdition = fields.One("Thread", {
+    threadAsNewest = fields.One("mail.thread");
+    threadAsInEdition = fields.One("mail.thread", {
         compute() {
             if (this.composer) {
                 return this.thread;
@@ -585,7 +585,10 @@ export class Message extends Record {
                 Array.from(
                     doc.querySelectorAll(".o_channel_redirect[data-oe-model='discuss.channel']")
                 ).map(async (el) =>
-                    this.store.Thread.getOrFetch({ id: el.dataset.oeId, model: "discuss.channel" })
+                    this.store["mail.thread"].getOrFetch({
+                        id: el.dataset.oeId,
+                        model: "discuss.channel",
+                    })
                 )
             )
         ).filter((channel) => channel?.exists());

--- a/addons/mail/static/src/core/common/res_groups_model.js
+++ b/addons/mail/static/src/core/common/res_groups_model.js
@@ -5,6 +5,8 @@ export class ResGroups extends Record {
     static id = "id";
     /** @type {string} */
     full_name;
+    /** @type {number} */
+    id;
     partners = fields.Many("res.partner", { inverse: "group_ids" });
     privilege_id = fields.One("res.groups.privilege");
 }

--- a/addons/mail/static/src/core/common/res_partner_model.js
+++ b/addons/mail/static/src/core/common/res_partner_model.js
@@ -112,7 +112,7 @@ export class ResPartner extends Record {
     }
 
     searchChat() {
-        return Object.values(this.store.Thread.records).find(
+        return Object.values(this.store["mail.thread"].records).find(
             (thread) =>
                 thread.channel?.channel_type === "chat" && thread.correspondent?.persona.eq(this)
         );

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -26,12 +26,7 @@ let prevLastMessageId = null;
 let temporaryIdOffset = 0.01;
 
 export const pyToJsModels = {
-    "discuss.channel": "Thread",
     "mail.thread": "Thread",
-};
-
-export const addFieldsByPyModel = {
-    "discuss.channel": { model: "discuss.channel" },
 };
 
 patch(storeInsertFns, {
@@ -51,12 +46,6 @@ patch(storeInsertFns, {
             );
         }
         return pyToJsModels[pyOrJsModelName] || pyOrJsModelName;
-    },
-    getExtraFieldsFromModel(store, pyOrJsModelName) {
-        if (!(store instanceof Store)) {
-            return super.getExtraFieldsFromModel(...arguments);
-        }
-        return addFieldsByPyModel[pyOrJsModelName];
     },
 });
 

--- a/addons/mail/static/src/core/common/suggestion_service.js
+++ b/addons/mail/static/src/core/common/suggestion_service.js
@@ -308,7 +308,7 @@ export class SuggestionService {
     }
 
     searchChannelSuggestions(cleanedSearchTerm) {
-        const suggestionList = Object.values(this.store.Thread.records).filter(
+        const suggestionList = Object.values(this.store["mail.thread"].records).filter(
             (thread) =>
                 thread.channel?.channel_type === "channel" &&
                 thread.displayName &&

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -17,6 +17,7 @@ import { Deferred } from "@web/core/utils/concurrency";
 
 export class Thread extends Record {
     static id = AND("model", "id");
+    static _name = "mail.thread";
     /**
      * @param {string} localId
      * @returns {string}
@@ -404,7 +405,7 @@ export class Thread extends Record {
     }
 
     async checkReadAccess() {
-        await this.store.Thread.getOrFetch(this, ["hasReadAccess"]);
+        await this.store["mail.thread"].getOrFetch(this, ["hasReadAccess"]);
         return this.hasReadAccess;
     }
 
@@ -670,7 +671,7 @@ export class Thread extends Record {
     }
 
     async openChatWindow({ focus = false, fromMessagingMenu, bypassCompact, swapOpened } = {}) {
-        const thread = await this.store.Thread.getOrFetch(this);
+        const thread = await this.store["mail.thread"].getOrFetch(this);
         if (!thread) {
             return;
         }
@@ -784,10 +785,6 @@ export class Thread extends Record {
                 this.messages.splice(afterIndex - 1, 0, message);
             }
         }
-    }
-
-    _getActualModelName() {
-        return this.model === "discuss.channel" ? "discuss.channel" : "mail.thread";
     }
 }
 

--- a/addons/mail/static/src/core/public_web/@types/models.d.ts
+++ b/addons/mail/static/src/core/public_web/@types/models.d.ts
@@ -3,6 +3,10 @@ declare module "models" {
 
     export interface DiscussApp extends DiscussAppClass {}
 
+    export interface DiscussChannel {
+        autoOpenChatWindowOnNewMessage: Readonly<boolean>;
+        inChathubOnNewMessage: Readonly<boolean>;
+    }
     export interface Store {
         action_discuss_id: number|undefined;
         discuss: DiscussApp;

--- a/addons/mail/static/src/core/public_web/discuss_app_model.js
+++ b/addons/mail/static/src/core/public_web/discuss_app_model.js
@@ -55,10 +55,10 @@ export class DiscussApp extends Record {
             }
         },
     });
-    thread = fields.One("Thread", {
+    thread = fields.One("mail.thread", {
         /** @this {import("models").DiscussApp} */
         onUpdate() {
-            this.lastActiveId = this.store.Thread.localIdToActiveId(this.thread?.localId);
+            this.lastActiveId = this.store["mail.thread"].localIdToActiveId(this.thread?.localId);
         },
     });
     hasRestoredThread = false;

--- a/addons/mail/static/src/core/public_web/discuss_client_action.js
+++ b/addons/mail/static/src/core/public_web/discuss_client_action.js
@@ -39,7 +39,7 @@ export class DiscussClientAction extends Component {
         return (
             props.action.context.active_id ??
             props.action.params?.active_id ??
-            this.store.Thread.localIdToActiveId(this.store.discuss.thread?.localId) ??
+            this.store["mail.thread"].localIdToActiveId(this.store.discuss.thread?.localId) ??
             (this.env.services.ui.isSmall ? undefined : this.store.discuss.lastActiveId)
         );
     }
@@ -76,7 +76,7 @@ export class DiscussClientAction extends Component {
             return;
         }
         const [model, id] = parsedActiveId;
-        const activeThread = await this.store.Thread.getOrFetch({ model, id });
+        const activeThread = await this.store["mail.thread"].getOrFetch({ model, id });
         if (activeThread && activeThread.notEq(this.store.discuss.thread)) {
             const highlight_message_id =
                 props.action?.params?.highlight_message_id || router.current.highlight_message_id;

--- a/addons/mail/static/src/core/web/@types/models.d.ts
+++ b/addons/mail/static/src/core/web/@types/models.d.ts
@@ -8,6 +8,13 @@ declare module "models" {
         markAsDoneAndScheduleNext: () => Promise<ActionDescription>;
         remove: (param0: { broadcast: boolean }) => void;
     }
+    export interface DiscussChannel {
+        activities: Activity[];
+        isDisplayedInDiscussAppDesktop: boolean;
+        recipients: Follower[];
+        recipientsCount: number|undefined;
+        recipientsFullyLoaded: Readonly<boolean>;
+    }
     export interface Message {
         canForward: (thread: Thread) => boolean;
         canReplyAll: (thread: Thread) => boolean;

--- a/addons/mail/static/src/core/web/activity.js
+++ b/addons/mail/static/src/core/web/activity.js
@@ -26,7 +26,7 @@ export class Activity extends Component {
 
     setup() {
         super.setup();
-        this.storeService = useService("mail.store");
+        this.store = useService("mail.store");
         this.state = useState({ showDetails: false });
         this.markDonePopover = usePopover(ActivityMarkAsDone, { position: "right" });
         this.avatarCard = usePopover(AvatarCardPopover);
@@ -108,7 +108,7 @@ export class Activity extends Component {
     }
 
     get thread() {
-        return this.env.services["mail.store"].Thread.insert({
+        return this.env.services["mail.store"]["mail.thread"].insert({
             model: this.props.activity.res_model,
             id: this.props.activity.res_id,
         });
@@ -118,6 +118,6 @@ export class Activity extends Component {
      * @param {MouseEvent} ev
      */
     async onClick(ev) {
-        this.storeService.handleClickOnLink(ev, this.thread);
+        this.store.handleClickOnLink(ev, this.thread);
     }
 }

--- a/addons/mail/static/src/core/web/activity_list_popover_item.js
+++ b/addons/mail/static/src/core/web/activity_list_popover_item.js
@@ -31,7 +31,7 @@ export class ActivityListPopoverItem extends Component {
         this.state = useState({ hasMarkDoneView: false });
         if (this.props.activity.activity_category === "upload_file") {
             this.attachmentUploader = useAttachmentUploader(
-                this.env.services["mail.store"].Thread.insert({
+                this.env.services["mail.store"]["mail.thread"].insert({
                     model: this.props.activity.res_model,
                     id: this.props.activity.res_id,
                 })

--- a/addons/mail/static/src/core/web/activity_mail_template.js
+++ b/addons/mail/static/src/core/web/activity_mail_template.js
@@ -44,7 +44,7 @@ export class ActivityMailTemplate extends Component {
                 force_email: true,
             },
         };
-        const thread = this.store.Thread.insert({
+        const thread = this.store["mail.thread"].insert({
             model: this.props.activity.res_model,
             id: this.props.activity.res_id,
         });
@@ -61,7 +61,7 @@ export class ActivityMailTemplate extends Component {
         ev.stopPropagation();
         ev.preventDefault();
         this.props.onClickButtons();
-        const thread = this.store.Thread.insert({
+        const thread = this.store["mail.thread"].insert({
             model: this.props.activity.res_model,
             id: this.props.activity.res_id,
         });

--- a/addons/mail/static/src/core/web/activity_markasdone_popover.js
+++ b/addons/mail/static/src/core/web/activity_markasdone_popover.js
@@ -34,7 +34,7 @@ export class ActivityMarkAsDone extends Component {
 
     async onClickDone() {
         const { res_id, res_model } = this.props.activity;
-        const thread = this.env.services["mail.store"].Thread.insert({
+        const thread = this.env.services["mail.store"]["mail.thread"].insert({
             model: res_model,
             id: res_id,
         });
@@ -45,7 +45,7 @@ export class ActivityMarkAsDone extends Component {
 
     async onClickDoneAndScheduleNext() {
         const { res_id, res_model } = this.props.activity;
-        const thread = this.env.services["mail.store"].Thread.insert({
+        const thread = this.env.services["mail.store"]["mail.thread"].insert({
             model: res_model,
             id: res_id,
         });

--- a/addons/mail/static/src/core/web/mail_composer_attachment_selector.js
+++ b/addons/mail/static/src/core/web/mail_composer_attachment_selector.js
@@ -7,7 +7,6 @@ import { useX2ManyCrud } from "@web/views/fields/relational_utils";
 import { Component } from "@odoo/owl";
 import { FileUploader } from "@web/views/fields/file_handler";
 
-
 export class MailComposerAttachmentSelector extends Component {
     static template = "mail.MailComposerAttachmentSelector";
     static components = { FileUploader };
@@ -16,9 +15,7 @@ export class MailComposerAttachmentSelector extends Component {
     setup() {
         this.mailStore = useService("mail.store");
         this.attachmentUploadService = useService("mail.attachment_upload");
-        this.operations = useX2ManyCrud(() => {
-            return this.props.record.data["attachment_ids"];
-        }, true);
+        this.operations = useX2ManyCrud(() => this.props.record.data["attachment_ids"], true);
     }
 
     /** @param {Object} data */
@@ -29,7 +26,7 @@ export class MailComposerAttachmentSelector extends Component {
         } else {
             resIds = JSON.parse(this.props.record.data.res_ids);
         }
-        const thread = await this.mailStore.Thread.insert({
+        const thread = await this.mailStore["mail.thread"].insert({
             model: this.props.record.data.model,
             id: resIds[0],
         });
@@ -43,4 +40,6 @@ export const mailComposerAttachmentSelector = {
     component: MailComposerAttachmentSelector,
 };
 
-registry.category("fields").add("mail_composer_attachment_selector", mailComposerAttachmentSelector);
+registry
+    .category("fields")
+    .add("mail_composer_attachment_selector", mailComposerAttachmentSelector);

--- a/addons/mail/static/src/core/web/store_service_patch.js
+++ b/addons/mail/static/src/core/web/store_service_patch.js
@@ -26,9 +26,9 @@ const StorePatch = {
                 return getSortId(g1) - getSortId(g2);
             },
         });
-        this.inbox = fields.One("Thread");
-        this.starred = fields.One("Thread");
-        this.history = fields.One("Thread");
+        this.inbox = fields.One("mail.thread");
+        this.starred = fields.One("mail.thread");
+        this.history = fields.One("mail.thread");
     },
     async initialize() {
         await Promise.all([
@@ -117,7 +117,7 @@ const StorePatch = {
                 break;
             }
             case "RELOAD_CHATTER": {
-                const thread = this.Thread.insert({
+                const thread = this["mail.thread"].insert({
                     model: data.payload.model,
                     id: data.payload.id,
                 });

--- a/addons/mail/static/src/discuss/call/common/@types/models.d.ts
+++ b/addons/mail/static/src/discuss/call/common/@types/models.d.ts
@@ -9,6 +9,20 @@ declare module "models" {
         rtc_inviting_session_id: RtcSession;
         rtcSession: RtcSession;
     }
+    export interface DiscussChannel {
+        activeRtcSession: RtcSession;
+        cancelRtcInvitationTimeout: number|undefined;
+        focusStack: RtcSession[];
+        hadSelfSession: boolean;
+        lastSessionIds: Set<number>;
+        promoteFullscreen: typeof CALL_PROMOTE_FULLSCREEN[keyof CALL_PROMOTE_FULLSCREEN];
+        rtc_session_ids: RtcSession[];
+        showCallView: Readonly<boolean>;
+        useCameraByDefault: null;
+        videoCount: number;
+        videoCountNotSelf: number;
+        visibleCards: CardData[];
+    }
     export interface MailGuest {
         currentRtcSession: RtcSession;
     }

--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -271,13 +271,13 @@ export class Rtc extends Record {
             );
         },
     });
-    channel = fields.One("Thread", {
+    channel = fields.One("mail.thread", {
         compute() {
             if (this.state.channel) {
                 return this.state.channel;
             }
             if (this._remotelyHostedChannelId) {
-                return this.store.Thread.insert({
+                return this.store["mail.thread"].insert({
                     model: "discuss.channel",
                     id: this._remotelyHostedChannelId,
                 });
@@ -287,7 +287,7 @@ export class Rtc extends Record {
             if (!this.channel) {
                 return;
             }
-            this.store.Thread.getOrFetch({
+            this.store["mail.thread"].getOrFetch({
                 model: "discuss.channel",
                 id: this.channel.id,
             });

--- a/addons/mail/static/src/discuss/call/common/store_service_patch.js
+++ b/addons/mail/static/src/discuss/call/common/store_service_patch.js
@@ -13,7 +13,7 @@ const StorePatch = {
                 return {};
             },
         });
-        this.ringingThreads = fields.Many("Thread", {
+        this.ringingThreads = fields.Many("mail.thread", {
             /** @this {import("models").Store} */
             onUpdate() {
                 if (this.ringingThreads.length > 0) {
@@ -27,7 +27,7 @@ const StorePatch = {
         });
         this.allActiveRtcSessions = fields.Many("discuss.channel.rtc.session");
         this.nextTalkingTime = 1;
-        this.fullscreenChannel = fields.One("Thread");
+        this.fullscreenChannel = fields.One("mail.thread");
         this._hasFullscreenUrl = fields.Attr(false, {
             compute() {
                 return this.discuss?.thread?.eq(this.fullscreenChannel);

--- a/addons/mail/static/src/discuss/core/common/@types/models.d.ts
+++ b/addons/mail/static/src/discuss/core/common/@types/models.d.ts
@@ -1,8 +1,59 @@
 declare module "models" {
     import { ChannelMember as ChannelMemberClass } from "@mail/discuss/core/common/channel_member_model";
+    import { DiscussChannel as DiscussChannelClass } from "@mail/discuss/core/common/discuss_channel_model";
 
     export interface ChannelMember extends ChannelMemberClass {}
+    export interface DiscussChannel extends DiscussChannelClass {}
 
+    export interface DiscussChannel {
+        allowCalls: Readonly<boolean>;
+        allowDescription: Readonly<boolean>;
+        allowedToLeaveChannelTypes: Readonly<string[]>;
+        allowedToUnpinChannelTypes: Readonly<string[]>;
+        areAllMembersLoaded: Readonly<boolean>;
+        avatar_cache_key: string;
+        canLeave: Readonly<boolean>;
+        canUnpin: Readonly<boolean>;
+        channel: DiscussChannel;
+        channel_member_ids: ChannelMember[];
+        channel_name_member_ids: ChannelMember[];
+        channel_type: string;
+        correspondent: ChannelMember;
+        correspondentCountry: Country;
+        correspondents: Readonly<ChannelMember[]>;
+        default_display_mode: "video_full_screen"|undefined;
+        fetchChannelInfoDeferred: Deferred<Thread|undefined>;
+        fetchChannelInfoState: "not_fetched"|"fetching"|"fetched";
+        firstUnreadMessage: Message;
+        group_ids: ResGroups[];
+        hasMemberList: Readonly<boolean>;
+        hasOtherMembersTyping: boolean;
+        hasSeenFeature: boolean;
+        hasSelfAsMember: Readonly<boolean>;
+        invitationLink: Readonly<unknown|string>;
+        invited_member_ids: ChannelMember[];
+        isChatChannel: Readonly<boolean>;
+        last_interest_dt: import("luxon").DateTime;
+        lastInterestDt: import("luxon").DateTime;
+        lastMessageSeenByAllId: undefined|number;
+        lastSelfMessageSeenByEveryone: Message;
+        markedAsUnread: boolean;
+        markingAsRead: boolean;
+        member_count: number|undefined;
+        membersThatCanSeen: Readonly<ChannelMember[]>;
+        name: string;
+        offlineMembers: ChannelMember[];
+        onlineMembers: ChannelMember[];
+        otherTypingMembers: ChannelMember[];
+        scrollUnread: boolean;
+        self_member_id: ChannelMember;
+        showCorrespondentCountry: Readonly<boolean>;
+        showUnreadBanner: Readonly<boolean>;
+        toggleBusSubscription: boolean;
+        typesAllowingCalls: Readonly<string[]>;
+        typingMembers: ChannelMember[];
+        unknownMembersCount: Readonly<number>;
+    }
     export interface MailGuest {
         channelMembers: ChannelMember[];
     }
@@ -23,6 +74,7 @@ declare module "models" {
         channel_types_with_seen_infos: string[];
         channelIdsFetchingDeferred: Map<number, Deferred>;
         createGroupChat: (param0: { default_display_mode: string, partners_to: number[], name: string }) => Promise<Thread>;
+        "discuss.channel": StaticMailRecord<DiscussChannel, typeof DiscussChannelClass>;
         "discuss.channel.member": StaticMailRecord<ChannelMember, typeof ChannelMemberClass>;
         fetchChannel: (channelId: number) => Promise<void>;
         getRecentChatPartnerIds: () => number[];
@@ -33,14 +85,24 @@ declare module "models" {
     }
     export interface Thread {
         _computeOfflineMembers: () => ChannelMember[];
+        allowCalls: Readonly<boolean>;
+        allowDescription: Readonly<boolean>;
+        allowedToLeaveChannelTypes: Readonly<string[]>;
+        allowedToUnpinChannelTypes: Readonly<string[]>;
         areAllMembersLoaded: Readonly<boolean>;
+        avatar_cache_key: string;
+        canLeave: Readonly<boolean>;
+        canUnpin: Readonly<boolean>;
+        channel: DiscussChannel;
         channel_member_ids: ChannelMember[];
         channel_name_member_ids: ChannelMember[];
+        channel_type: string;
         computeCorrespondent: () => ChannelMember;
         correspondent: ChannelMember;
         correspondentCountry: Country;
         correspondents: Readonly<ChannelMember[]>;
         default_display_mode: "video_full_screen"|undefined;
+        executeCommand: (command: unknown, body: string) => unknown;
         fetchChannelInfoDeferred: Deferred<Thread|undefined>;
         fetchChannelInfoState: "not_fetched"|"fetching"|"fetched";
         fetchChannelMembers: () => Promise<void>;
@@ -51,31 +113,40 @@ declare module "models" {
         hasOtherMembersTyping: boolean;
         hasSeenFeature: boolean;
         hasSelfAsMember: Readonly<boolean>;
+        invitationLink: Readonly<unknown|string>;
         invited_member_ids: ChannelMember[];
-        last_interest_dt: luxon.DateTime;
-        lastInterestDt: luxon.DateTime;
+        isChatChannel: Readonly<boolean>;
+        last_interest_dt: import("luxon").DateTime;
+        lastInterestDt: import("luxon").DateTime;
         lastMessageSeenByAllId: undefined|number;
         lastSelfMessageSeenByEveryone: Message;
+        leaveChannel: (param0: { force: boolean }) => Promise<void>;
+        markAsFetched: () => Promise<void>;
         markedAsUnread: boolean;
         markingAsRead: boolean;
         markReadSequential: () => Promise<any>;
         member_count: number|undefined;
         membersThatCanSeen: Readonly<ChannelMember[]>;
         name: string;
+        notifyAvatarToServer: (data: string) => Promise<void>;
+        notifyDescriptionToServer: (description: unknown) => Promise<unknown>;
         offlineMembers: ChannelMember[];
         onlineMembers: ChannelMember[];
         openChannel: () => boolean;
         otherTypingMembers: ChannelMember[];
+        rename: (name: string) => Promise<void>;
         scrollUnread: boolean;
         self_member_id: ChannelMember;
         showCorrespondentCountry: Readonly<boolean>;
         showUnreadBanner: Readonly<boolean>;
         toggleBusSubscription: boolean;
+        typesAllowingCalls: Readonly<string[]>;
         typingMembers: ChannelMember[];
         unknownMembersCount: Readonly<number>;
     }
 
     export interface Models {
+        "discuss.channel": DiscussChannel;
         "discuss.channel.member": ChannelMember;
     }
 }

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.js
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.js
@@ -235,8 +235,8 @@ export class ChannelInvitation extends Component {
                     return _t("Invite");
                 }
                 if (this.selectedPartners.length === 1) {
-                    const alreadyChat = Object.values(this.store.Thread.records).some((thread) =>
-                        thread.correspondent?.partner_id.eq(this.selectedPartners[0])
+                    const alreadyChat = Object.values(this.store["mail.thread"].records).some(
+                        (thread) => thread.correspondent?.partner_id.eq(this.selectedPartners[0])
                     );
                     if (alreadyChat) {
                         return _t("Go to conversation");

--- a/addons/mail/static/src/discuss/core/common/channel_member_model.js
+++ b/addons/mail/static/src/discuss/core/common/channel_member_model.js
@@ -44,8 +44,8 @@ export class ChannelMember extends Record {
     get persona() {
         return this.partner_id || this.guest_id;
     }
-    channel_id = fields.One("Thread", { inverse: "channel_member_ids" });
-    threadAsSelf = fields.One("Thread", {
+    channel_id = fields.One("mail.thread", { inverse: "channel_member_ids" });
+    threadAsSelf = fields.One("mail.thread", {
         compute() {
             if (this.store.self?.eq(this.persona)) {
                 return this.channel_id;
@@ -99,7 +99,7 @@ export class ChannelMember extends Record {
             }
         },
     });
-    threadAsTyping = fields.One("Thread", {
+    threadAsTyping = fields.One("mail.thread", {
         compute() {
             return this.isTyping ? this.channel_id : undefined;
         },

--- a/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
@@ -2,16 +2,18 @@ import { fields, Record } from "@mail/core/common/record";
 
 export class DiscussChannel extends Record {
     static _name = "discuss.channel";
+    static _inherits = { Thread: "thread" };
     static id = "id";
+
+    static new() {
+        const channel = super.new(...arguments);
+        // ensure thread is set before reading/writing any other field
+        channel.thread = { id: channel.id, model: "discuss.channel" };
+        return channel;
+    }
 
     /** @type {number} */
     id;
-    get channel_member_ids() {
-        return this.thread.channel_member_ids;
-    }
-    get channel_type() {
-        return this.thread.channel_type;
-    }
     thread = fields.One("Thread", {
         inverse: "channel",
         onDelete: (r) => r.delete(),

--- a/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
@@ -2,7 +2,7 @@ import { fields, Record } from "@mail/core/common/record";
 
 export class DiscussChannel extends Record {
     static _name = "discuss.channel";
-    static _inherits = { Thread: "thread" };
+    static _inherits = { "mail.thread": "thread" };
     static id = "id";
 
     static new() {
@@ -14,7 +14,7 @@ export class DiscussChannel extends Record {
 
     /** @type {number} */
     id;
-    thread = fields.One("Thread", {
+    thread = fields.One("mail.thread", {
         inverse: "channel",
         onDelete: (r) => r.delete(),
     });

--- a/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
@@ -18,7 +18,7 @@ export class DiscussCoreCommon {
 
     setup() {
         this.busService.subscribe("discuss.channel/delete", (payload, metadata) => {
-            const thread = this.store.Thread.insert({
+            const thread = this.store["mail.thread"].insert({
                 id: payload.id,
                 model: "discuss.channel",
             });
@@ -79,7 +79,7 @@ export class DiscussCoreCommon {
 
     async _handleNotificationNewMessage(payload, { id: notifId }) {
         const { data, id: channelId, silent, temporary_id } = payload;
-        const thread = await this.store.Thread.getOrFetch({
+        const thread = await this.store["mail.thread"].getOrFetch({
             model: "discuss.channel",
             id: channelId,
         });

--- a/addons/mail/static/src/discuss/core/common/message_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/message_model_patch.js
@@ -47,7 +47,7 @@ const messagePatch = {
         });
         /** @type {Promise<Thread>[]} @deprecated */
         this.mentionedChannelPromises = [];
-        this.threadAsFirstUnread = fields.One("Thread", { inverse: "firstUnreadMessage" });
+        this.threadAsFirstUnread = fields.One("mail.thread", { inverse: "firstUnreadMessage" });
     },
     /** @returns {import("models").ChannelMember[]} */
     get channelMemberHaveSeen() {

--- a/addons/mail/static/src/discuss/core/common/store_service_patch.js
+++ b/addons/mail/static/src/discuss/core/common/store_service_patch.js
@@ -60,7 +60,7 @@ const storeServicePatch = {
      * @returns {number[]}
      */
     getRecentChatPartnerIds() {
-        return Object.values(this.Thread.records)
+        return Object.values(this["mail.thread"].records)
             .filter((thread) => thread.channel?.channel_type === "chat" && thread.correspondent)
             .sort((a, b) => compareDatetime(b.lastInterestDt, a.lastInterestDt) || b.id - a.id)
             .map((thread) => thread.correspondent.partner_id.id);

--- a/addons/mail/static/src/discuss/core/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_model_patch.js
@@ -20,7 +20,7 @@ const threadStaticPatch = {
         if (data.model !== "discuss.channel" || data.id < 1) {
             return super.getOrFetch(...arguments);
         }
-        const thread = this.store.Thread.get({ id: data.id, model: data.model });
+        const thread = this.store["mail.thread"].get({ id: data.id, model: data.model });
         if (thread?.fetchChannelInfoState === "fetched") {
             return Promise.resolve(thread);
         }
@@ -33,7 +33,7 @@ const threadStaticPatch = {
         this.store.fetchChannel(data.id).then(
             () => {
                 this.store.channelIdsFetchingDeferred.delete(data.id);
-                const thread = this.store.Thread.get({ id: data.id, model: data.model });
+                const thread = this.store["mail.thread"].get({ id: data.id, model: data.model });
                 if (thread?.exists()) {
                     thread.fetchChannelInfoState = "fetched";
                     def.resolve(thread);
@@ -43,7 +43,7 @@ const threadStaticPatch = {
             },
             () => {
                 this.store.channelIdsFetchingDeferred.delete(data.id);
-                const thread = this.store.Thread.get({ id: data.id, model: data.model });
+                const thread = this.store["mail.thread"].get({ id: data.id, model: data.model });
                 if (thread?.exists()) {
                     def.reject(thread);
                 } else {

--- a/addons/mail/static/src/discuss/core/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_model_patch.js
@@ -60,6 +60,8 @@ patch(Thread, threadStaticPatch);
 const threadPatch = {
     setup() {
         super.setup();
+        /** @type {string} */
+        this.avatar_cache_key = undefined;
         this.channel = fields.One("discuss.channel", {
             inverse: "thread",
             /** @this {import("models").Thread} */
@@ -73,6 +75,8 @@ const threadPatch = {
             onDelete: (r) => r.delete(),
             sort: (m1, m2) => m1.id - m2.id,
         });
+        /** @type {string} */
+        this.channel_type = undefined;
         this.correspondent = fields.One("discuss.channel.member", {
             /** @this {import("models").Thread} */
             compute() {

--- a/addons/mail/static/src/discuss/core/public_web/@types/models.d.ts
+++ b/addons/mail/static/src/discuss/core/public_web/@types/models.d.ts
@@ -10,6 +10,19 @@ declare module "models" {
         computeChats: () => object;
         unreadChannels: Thread[];
     }
+    export interface DiscussChannel {
+        appAsUnreadChannels: DiscussApp;
+        categoryAsThreadWithCounter: DiscussAppCategory;
+        discussAppCategory: DiscussAppCategory;
+        displayInSidebar: boolean;
+        from_message_id: Message;
+        hasSubChannelFeature: Readonly<boolean>;
+        isBusSubscribed: boolean;
+        lastSubChannelLoaded: Thread|null;
+        loadSubChannelsDone: boolean;
+        parent_channel_id: Thread;
+        sub_channel_ids: Thread[];
+    }
     export interface Message {
         linkedSubChannel: Thread;
     }

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app_category_model.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app_category_model.js
@@ -90,13 +90,13 @@ export class DiscussAppCategory extends Record {
 
     /** @type {string} */
     serverStateKey;
-    threads = fields.Many("Thread", {
+    threads = fields.Many("mail.thread", {
         sort(t1, t2) {
             return this.sortThreads(t1, t2);
         },
         inverse: "discussAppCategory",
     });
-    threadsWithCounter = fields.Many("Thread", { inverse: "categoryAsThreadWithCounter" });
+    threadsWithCounter = fields.Many("mail.thread", { inverse: "categoryAsThreadWithCounter" });
 }
 
 DiscussAppCategory.register();

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app_model_patch.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app_model_patch.js
@@ -35,7 +35,7 @@ const discussAppPatch = {
             },
             eager: true,
         });
-        this.unreadChannels = fields.Many("Thread", { inverse: "appAsUnreadChannels" });
+        this.unreadChannels = fields.Many("mail.thread", { inverse: "appAsUnreadChannels" });
     },
     computeChats() {
         return {

--- a/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.js
@@ -175,7 +175,7 @@ export class DiscussCommandPalette {
             // selfPersona filtered here to put at the bottom as lowest priority
             partners = partners.filter((p) => p.notEq(selfPartner));
         }
-        const channels = Object.values(this.store.Thread.records)
+        const channels = Object.values(this.store["mail.thread"].records)
             .filter(
                 (thread) =>
                     thread.channel?.channel_type &&
@@ -230,7 +230,7 @@ export class DiscussCommandPalette {
             return {
                 Component: DiscussCommand,
                 action: async () => {
-                    const channel = await this.store.Thread.getOrFetch(thread);
+                    const channel = await this.store["mail.thread"].getOrFetch(thread);
                     channel.open({ focus: true, bypassCompact: true });
                 },
                 name: thread.displayName,

--- a/addons/mail/static/src/discuss/core/public_web/discuss_core_public_web_service.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_core_public_web_service.js
@@ -35,7 +35,10 @@ export class DiscussCorePublicWeb {
             const { data, channel_id, invited_by_user_id: invitedByUserId } = payload;
             this.store.insert(data);
             await this.store.fetchChannel(channel_id);
-            const thread = this.store.Thread.get({ id: channel_id, model: "discuss.channel" });
+            const thread = this.store["mail.thread"].get({
+                id: channel_id,
+                model: "discuss.channel",
+            });
             if (thread && invitedByUserId && invitedByUserId !== this.store.self.main_user_id?.id) {
                 this.notificationService.add(
                     _t("You have been invited to #%s", thread.displayName),
@@ -47,7 +50,7 @@ export class DiscussCorePublicWeb {
             "message",
             async ({ data: { action, data } }) => {
                 if (action === "OPEN_CHANNEL") {
-                    const channel = await this.store.Thread.getOrFetch({
+                    const channel = await this.store["mail.thread"].getOrFetch({
                         model: "discuss.channel",
                         id: data.id,
                     });

--- a/addons/mail/static/src/discuss/core/public_web/message_model_patch.js
+++ b/addons/mail/static/src/discuss/core/public_web/message_model_patch.js
@@ -5,6 +5,6 @@ import { patch } from "@web/core/utils/patch";
 patch(Message.prototype, {
     setup() {
         super.setup(...arguments);
-        this.linkedSubChannel = fields.One("Thread", { inverse: "from_message_id" });
+        this.linkedSubChannel = fields.One("mail.thread", { inverse: "from_message_id" });
     },
 });

--- a/addons/mail/static/src/discuss/core/public_web/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/public_web/thread_model_patch.js
@@ -29,12 +29,12 @@ const threadPatch = {
         });
         this.isBusSubscribed = false;
         this.from_message_id = fields.One("mail.message");
-        this.parent_channel_id = fields.One("Thread", {
+        this.parent_channel_id = fields.One("mail.thread", {
             onDelete() {
                 this.delete();
             },
         });
-        this.sub_channel_ids = fields.Many("Thread", {
+        this.sub_channel_ids = fields.Many("mail.thread", {
             inverse: "parent_channel_id",
             sort: (a, b) => b.id - a.id,
         });
@@ -92,7 +92,9 @@ const threadPatch = {
             name,
         });
         this.store.insert(store_data);
-        this.store.Thread.get({ model: "discuss.channel", id: sub_channel }).open({ focus: true });
+        this.store["mail.thread"]
+            .get({ model: "discuss.channel", id: sub_channel })
+            .open({ focus: true });
     },
     /**
      * @param {*} param0
@@ -112,7 +114,7 @@ const threadPatch = {
         });
         this.store.insert(store_data);
         const threads = sub_channel_ids.map((subChannelId) =>
-            this.store.Thread.get({ model: "discuss.channel", id: subChannelId })
+            this.store["mail.thread"].get({ model: "discuss.channel", id: subChannelId })
         );
 
         if (searchTerm) {

--- a/addons/mail/static/src/discuss/core/web/messaging_menu_patch.js
+++ b/addons/mail/static/src/discuss/core/web/messaging_menu_patch.js
@@ -26,7 +26,7 @@ patch(MessagingMenu.prototype, {
         const channelsContribution =
             this.store.channels.status !== "fetched"
                 ? this.store.initChannelsUnreadCounter
-                : Object.values(this.store.Thread.records).filter(
+                : Object.values(this.store["mail.thread"].records).filter(
                       (thread) =>
                           thread.displayToSelf &&
                           !thread.self_member_id?.mute_until_dt &&
@@ -34,7 +34,7 @@ patch(MessagingMenu.prototype, {
                               thread.message_needaction_counter)
                   ).length;
         // Needactions are already counted in the super call, but we want to discard them for channel so that there is only +1 per channel.
-        const channelsNeedactionCounter = Object.values(this.store.Thread.records).reduce(
+        const channelsNeedactionCounter = Object.values(this.store["mail.thread"].records).reduce(
             (acc, thread) =>
                 acc + (thread.model === "discuss.channel" ? thread.message_needaction_counter : 0),
             0

--- a/addons/mail/static/src/discuss/core/web/store_service_patch.js
+++ b/addons/mail/static/src/discuss/core/web/store_service_patch.js
@@ -16,7 +16,7 @@ const StorePatch = {
     },
     /** @returns {import("models").Thread[]} */
     getSelfRecentChannels() {
-        return Object.values(this.Thread.records)
+        return Object.values(this["mail.thread"].records)
             .filter((thread) => thread.model === "discuss.channel" && thread.self_member_id)
             .sort((a, b) => compareDatetime(b.lastInterestDt, a.lastInterestDt) || b.id - a.id);
     },

--- a/addons/mail/static/src/discuss/message_pin/common/@types/models.d.ts
+++ b/addons/mail/static/src/discuss/message_pin/common/@types/models.d.ts
@@ -1,7 +1,11 @@
 declare module "models" {
+    export interface DiscussChannel {
+        pinnedMessages: Message[];
+        pinnedMessagesState: 'loaded'|'loading'|'error'|undefined;
+    }
     export interface Message {
         pin: () => Deferred<boolean>;
-        pinned_at: luxon.DateTime;
+        pinned_at: import("luxon").DateTime;
         unpin: () => Deferred<boolean>;
     }
     export interface Thread {

--- a/addons/mail/static/src/model/misc.js
+++ b/addons/mail/static/src/model/misc.js
@@ -204,3 +204,5 @@ export const fields = {
         };
     },
 };
+
+export const technicalKeysOnRecords = ["_", "_proxy", "_proxyInternal", "_raw", "env", "Model"];

--- a/addons/mail/static/src/model/model_internal.js
+++ b/addons/mail/static/src/model/model_internal.js
@@ -29,6 +29,12 @@ export class ModelInternal {
     fieldsSort = new Map();
     /** @type {Map<string, string>} */
     fieldsType = new Map();
+    /**
+     * Map of field name to the name of the relation field through which this field should be read.
+     *
+     * @type {Map<string, string>}
+     * */
+    parentFields = new Map();
 
     prepareField(fieldName, data) {
         this.fields.set(fieldName, true);

--- a/addons/mail/static/src/model/record.js
+++ b/addons/mail/static/src/model/record.js
@@ -353,7 +353,7 @@ export class Record {
      * @returns {Object} A data object grouped by model names.
      */
     toData(options = { depth: false }) {
-        const prefix = this._getActualModelName();
+        const prefix = this.Model.getName();
         const ongoing = {
             seenRecords: new Set(),
             storeData: {},
@@ -369,10 +369,6 @@ export class Record {
 
     _cleanupData(data) {
         technicalKeysOnRecords.forEach((field) => delete data[field]);
-    }
-
-    _getActualModelName() {
-        return this.Model.getName();
     }
 
     /**
@@ -423,9 +419,9 @@ export class Record {
         }
 
         this._cleanupData(data);
-        const pyModelName = record._getActualModelName();
-        ongoing.storeData[pyModelName] ||= [];
-        ongoing.storeData[pyModelName].push(data);
+        const modelName = record.Model.getName();
+        ongoing.storeData[modelName] ||= [];
+        ongoing.storeData[modelName].push(data);
     }
 
     /**

--- a/addons/mail/static/src/model/record.js
+++ b/addons/mail/static/src/model/record.js
@@ -8,6 +8,7 @@ import {
     isRecord,
     isRelation,
     modelRegistry,
+    technicalKeysOnRecords,
 } from "./misc";
 import { serializeDate, serializeDateTime } from "@web/core/l10n/dates";
 
@@ -367,16 +368,7 @@ export class Record {
     }
 
     _cleanupData(data) {
-        const fieldsToDelete = [
-            "_",
-            "_fieldsValue",
-            "_proxy",
-            "_proxyInternal",
-            "_raw",
-            "env",
-            "Model",
-        ];
-        fieldsToDelete.forEach((field) => delete data[field]);
+        technicalKeysOnRecords.forEach((field) => delete data[field]);
     }
 
     _getActualModelName() {

--- a/addons/mail/static/src/model/record_internal.js
+++ b/addons/mail/static/src/model/record_internal.js
@@ -2,7 +2,7 @@
 /** @typedef {import("./record_list").RecordList} RecordList */
 
 import { onChange } from "@mail/utils/common/misc";
-import { IS_DELETED_SYM, IS_RECORD_SYM, isRelation } from "./misc";
+import { IS_DELETED_SYM, IS_RECORD_SYM, isFieldDefinition, isRelation } from "./misc";
 import { RecordList } from "./record_list";
 import { reactive, toRaw } from "@odoo/owl";
 import { RecordUses } from "./record_uses";
@@ -89,7 +89,9 @@ export class RecordInternal {
             });
             record[fieldName] = recordList;
         } else {
-            record[fieldName] = record[fieldName].default;
+            record[fieldName] = isFieldDefinition(record[fieldName])
+                ? record[fieldName].default
+                : record[fieldName];
         }
         if (Model._.fieldsCompute.get(fieldName)) {
             if (!Model._.fieldsEager.get(fieldName)) {

--- a/addons/mail/static/src/model/store.js
+++ b/addons/mail/static/src/model/store.js
@@ -9,7 +9,6 @@ export const storeInsertFns = {
     getActualModelName(store, ctx, pyOrJsModelName) {
         return pyOrJsModelName;
     },
-    getExtraFieldsFromModel(store) {},
 };
 
 export class Store extends Record {
@@ -212,13 +211,6 @@ export class Store extends Record {
                 }
                 const insertData = [];
                 for (const vals of Array.isArray(data) ? data : [data]) {
-                    const extraFields = storeInsertFns.getExtraFieldsFromModel(
-                        store,
-                        pyOrJsModelName
-                    );
-                    if (extraFields) {
-                        Object.assign(vals, extraFields);
-                    }
                     if (vals._DELETE) {
                         delete vals._DELETE;
                         recordsDataToDelete.push([modelName, vals]);

--- a/addons/mail/static/src/model/store.js
+++ b/addons/mail/static/src/model/store.js
@@ -4,13 +4,6 @@ import { reactive, toRaw } from "@odoo/owl";
 
 /** @typedef {import("./record_list").RecordList} RecordList */
 
-export const storeInsertFns = {
-    makeContext(store) {},
-    getActualModelName(store, ctx, pyOrJsModelName) {
-        return pyOrJsModelName;
-    },
-};
-
 export class Store extends Record {
     /** @type {import("./store_internal").StoreInternal} */
     _;
@@ -200,11 +193,9 @@ export class Store extends Record {
      */
     insert(dataByModelName = {}, options = {}) {
         const store = this;
-        const ctx = storeInsertFns.makeContext(store);
         Record.MAKE_UPDATE(function storeInsert() {
             const recordsDataToDelete = [];
-            for (const [pyOrJsModelName, data] of Object.entries(dataByModelName)) {
-                const modelName = storeInsertFns.getActualModelName(store, ctx, pyOrJsModelName);
+            for (const [modelName, data] of Object.entries(dataByModelName)) {
                 if (!store[modelName]) {
                     console.warn(`store.insert() received data for unknown model “${modelName}”.`);
                     continue;
@@ -288,7 +279,7 @@ export class Store extends Record {
     }
     _cleanupData(data) {
         super._cleanupData(data);
-        if (this._getActualModelName() === "Store") {
+        if (this.Model.getName() === "Store") {
             delete data.Models;
             for (const [name] of modelRegistry.getEntries()) {
                 delete data[name];

--- a/addons/mail/static/tests/composer/composer.test.js
+++ b/addons/mail/static/tests/composer/composer.test.js
@@ -1496,7 +1496,7 @@ test("composer reply-to message is restored on thread change", async () => {
     const store = getService("mail.store");
     expect(
         browser.localStorage.getItem(
-            store.Thread.get({ model: "discuss.channel", id: channelId }).composer.localId
+            store["mail.thread"].get({ model: "discuss.channel", id: channelId }).composer.localId
         )
     ).toBe(
         '{"emailAddSignature":true,"replyToMessageId":1,"composerHtml":["markup","<div class=\'o-paragraph\'><br></div>"]}'
@@ -1535,7 +1535,7 @@ test("composer reply-to message is restored page reload", async () => {
     // simulate composer was replying to 1st message before page reload
     // not taking last message as to not fetch last message data prematurely
     browser.localStorage.setItem(
-        `Composer,(Thread,discuss.channel AND ${channelId}) OR (undefined)`,
+        `Composer,(mail.thread,discuss.channel AND ${channelId}) OR (undefined)`,
         `{"replyToMessageId":${messageId_1},"text":""}`
     );
     await start();

--- a/addons/mail/static/tests/core/common/store_service.test.js
+++ b/addons/mail/static/tests/core/common/store_service.test.js
@@ -74,8 +74,8 @@ test("store.insert different PY model having same JS model", async () => {
     };
 
     store.insert(data);
-    expect(store.Thread.records).toHaveLength(6); // 3 mailboxes + 3 channels
-    expect(Boolean(store.Thread.get({ id: 1, model: "discuss.channel" }))).toBe(true);
-    expect(Boolean(store.Thread.get({ id: 2, model: "discuss.channel" }))).toBe(true);
-    expect(Boolean(store.Thread.get({ id: 3, model: "discuss.channel" }))).toBe(true);
+    expect(store["mail.thread"].records).toHaveLength(6); // 3 mailboxes + 3 channels
+    expect(Boolean(store["mail.thread"].get({ id: 1, model: "discuss.channel" }))).toBe(true);
+    expect(Boolean(store["mail.thread"].get({ id: 2, model: "discuss.channel" }))).toBe(true);
+    expect(Boolean(store["mail.thread"].get({ id: 3, model: "discuss.channel" }))).toBe(true);
 });

--- a/addons/mail/static/tests/core/message_model.test.js
+++ b/addons/mail/static/tests/core/message_model.test.js
@@ -15,7 +15,7 @@ test("Message model properties", async () => {
     store.Store.insert({
         self_partner: { id: serverState.partnerId },
     });
-    store.Thread.insert({
+    store["mail.thread"].insert({
         id: serverState.partnerId,
         model: "res.partner",
         name: "general",

--- a/addons/mail/static/tests/discuss/core/web/messaging_menu.test.js
+++ b/addons/mail/static/tests/discuss/core/web/messaging_menu.test.js
@@ -236,7 +236,9 @@ test("counter is taking into account non-fetched channels", async () => {
     await start();
     await contains(".o-mail-MessagingMenu-counter", { text: "1" });
     expect(
-        Boolean(getService("mail.store").Thread.get({ model: "discuss.channel", id: channelId }))
+        Boolean(
+            getService("mail.store")["mail.thread"].get({ model: "discuss.channel", id: channelId })
+        )
     ).toBe(false);
 });
 
@@ -263,7 +265,9 @@ test("counter is updated on receiving message on non-fetched channels", async ()
     await contains(".o_menu_systray .dropdown-toggle i[aria-label='Messages']");
     await contains(".o-mail-MessagingMenu-counter", { count: 0 });
     expect(
-        Boolean(getService("mail.store").Thread.get({ model: "discuss.channel", id: channelId }))
+        Boolean(
+            getService("mail.store")["mail.thread"].get({ model: "discuss.channel", id: channelId })
+        )
     ).toBe(false);
     withUser(userId, () =>
         rpc("/mail/message/post", {

--- a/addons/portal/static/src/chatter/frontend/@types/models.d.ts
+++ b/addons/portal/static/src/chatter/frontend/@types/models.d.ts
@@ -2,6 +2,9 @@ declare module "models" {
     export interface Composer {
         portalComment: boolean;
     }
+    export interface DiscussChannel {
+        hasReadAccess: boolean|undefined;
+    }
     export interface Thread {
         hasReadAccess: boolean|undefined;
     }

--- a/addons/portal/static/src/chatter/frontend/portal_chatter.js
+++ b/addons/portal/static/src/chatter/frontend/portal_chatter.js
@@ -25,7 +25,7 @@ export class PortalChatter extends Component {
     }
 
     async _reloadChatterContent(data) {
-        const thread = this.store.Thread.get({
+        const thread = this.store["mail.thread"].get({
             id: this.props.resId,
             model: this.props.resModel,
         });

--- a/addons/portal/static/src/chatter/frontend/portal_chatter_service.js
+++ b/addons/portal/static/src/chatter/frontend/portal_chatter_service.js
@@ -74,7 +74,7 @@ export class PortalChatterService {
                 dev: env.debug,
             }).mount(shadow);
         });
-        const thread = this.store.Thread.insert({ model: props.resModel, id: props.resId });
+        const thread = this.store["mail.thread"].insert({ model: props.resModel, id: props.resId });
         Object.assign(thread, {
             access_token: chatterEl.getAttribute("data-token"),
             hash: chatterEl.getAttribute("data-hash"),

--- a/addons/project/static/src/core/web/@types/models.d.ts
+++ b/addons/project/static/src/core/web/@types/models.d.ts
@@ -1,4 +1,7 @@
 declare module "models" {
+    export interface DiscussChannel {
+        collaborator_ids: ResPartner[];
+    }
     export interface Thread {
         collaborator_ids: ResPartner[];
     }

--- a/addons/website/static/src/common/@types/models.d.ts
+++ b/addons/website/static/src/common/@types/models.d.ts
@@ -1,12 +1,12 @@
 declare module "models" {
     import { Website as WebsiteClass } from "@website/common/website_model";
     import { WebsiteVisitor as WebsiteVisitorClass } from "@website/common/website_visitor_model";
-    
+
     export interface Website extends WebsiteClass {}
     export interface WebsiteVisitor extends WebsiteVisitorClass {}
 
     export interface Store {
-        "website": StaticMailRecord<Website, typeof WebsiteClass>;
+        website: StaticMailRecord<Website, typeof WebsiteClass>;
         "website.visitor": StaticMailRecord<WebsiteVisitor, typeof WebsiteVisitorClass>;
     }
 

--- a/addons/website_livechat/static/src/common/@types/models.d.ts
+++ b/addons/website_livechat/static/src/common/@types/models.d.ts
@@ -1,5 +1,8 @@
 declare module "models" {
+    export interface DiscussChannel {
+        livechat_visitor_id: WebsiteVisitor;
+    }
     export interface Thread {
-        livechat_visitor_id: website.visitor;
+        livechat_visitor_id: WebsiteVisitor;
     }
 }

--- a/addons/website_livechat/static/src/web/@types/models.d.ts
+++ b/addons/website_livechat/static/src/web/@types/models.d.ts
@@ -1,0 +1,7 @@
+declare module "models" {
+    export interface WebsiteVisitor {
+        discuss_channel_ids: Thread[];
+        page_visit_history: Array<[string, string]>;
+        pageVisitHistoryText: Readonly<string>;
+    }
+}

--- a/addons/website_livechat/static/src/web/website_visitor_model_patch.js
+++ b/addons/website_livechat/static/src/web/website_visitor_model_patch.js
@@ -7,12 +7,15 @@ import { WebsiteVisitor } from "@website/common/website_visitor_model";
 
 const { DateTime } = luxon;
 
-patch(WebsiteVisitor.prototype, {
+/** @type {import("models").WebsiteVisitor} */
+const websiteVisitorPatch = {
     setup() {
         super.setup();
+        /** @type {Array<[string, string]>} */
         this.page_visit_history = [];
-        this.discuss_channel_ids = fields.Many("Thread");
+        this.discuss_channel_ids = fields.Many("mail.thread");
     },
+    /** @returns {string} */
     get pageVisitHistoryText() {
         const history = [];
         for (const h of this.page_visit_history) {
@@ -22,4 +25,5 @@ patch(WebsiteVisitor.prototype, {
         }
         return history.join(" → ");
     },
-});
+};
+patch(WebsiteVisitor.prototype, websiteVisitorPatch);


### PR DESCRIPTION
As we are creating the channel model in JS to reflect python, we also need to reflect the inheritance of mail.thread in discuss.channel.
    
This allows accessing thread fields directly on channel records.
    
As we already have the thread model, this commit introduces composition inheritance, which does not follow the mixin in python, but which is easier to implement and provides the necessary features allowing to split the 2 models for now.

This implies:

- methods are currently not inherited (and therefore cannot be extended
  either)
- channel records cannot be added into relation targetting thread

These limitations can be improved in the future by fully supporting mixin when it is needed.

Part of task-4675831

https://github.com/odoo/enterprise/pull/96394
