### PR TITLE
[FIX] mrp_account: generate correct cogs when kit dropship avco comp

### DIFF
--- a/addons/mrp_account/models/product.py
+++ b/addons/mrp_account/models/product.py
@@ -66,11 +66,13 @@ class ProductProduct(models.Model):
         for bom_line, moves_list in groupby(stock_moves.filtered(lambda sm: sm.state != 'cancel'), lambda sm: sm.bom_line_id):
             if bom_line not in bom_lines:
                 for move in moves_list:
-                    component_quantity = next(
-                        (bml.product_qty for bml in move.product_id.bom_line_ids if bml in bom_lines),
-                        1
+                    component_bml = next(
+                        (bml for bml in move.product_id.bom_line_ids if bml in bom_lines),
+                        False
                     )
-                    value += component_quantity * move.product_id._compute_average_price(qty_invoiced * move.product_qty, qty_to_invoice * move.product_qty, move, is_returned=is_returned)
+                    component_quantity = component_bml.product_uom_id._compute_quantity(component_bml.product_qty, move.product_uom) \
+                        if component_bml else 1
+                    value += component_quantity * move.product_id._compute_average_price(qty_invoiced * component_quantity, qty_to_invoice * component_quantity, move, is_returned=is_returned)
                 continue
             line_qty = bom_line.product_uom_id._compute_quantity(bom_lines[bom_line]['qty'], bom_line.product_id.uom_id)
             moves = self.env['stock.move'].concat(*moves_list)

--- a/addons/mrp_subcontracting_dropshipping/tests/test_anglo_saxon_valuation.py
+++ b/addons/mrp_subcontracting_dropshipping/tests/test_anglo_saxon_valuation.py
@@ -228,13 +228,19 @@ class TestSubcontractingDropshippingValuation(ValuationReconciliationTestCommon)
             'product_qty': 1.0,
             'type': 'phantom',
         })
-        kit_bom.bom_line_ids = [(0, 0, {
-            'product_id': self.product_b.id,
-            'product_qty': 4,
-        }), (0, 0, {
-            'product_id': product_c.id,
-            'product_qty': 2,
-        })]
+        # bom line of product_c is expressed in unit to check the uom conversion (24 unit should give the same result as 2 dozens)
+        kit_bom.bom_line_ids = [
+            Command.create({
+                'product_id': self.product_b.id,
+                'product_qty': 4,
+
+            }),
+            Command.create({
+                'product_id': product_c.id,
+                'product_qty': 24,
+                'product_uom_id': self.env.ref('uom.product_uom_unit').id
+            })
+        ]
 
         self.env['product.supplierinfo'].create({
             'product_id': self.product_b.id,
@@ -246,7 +252,7 @@ class TestSubcontractingDropshippingValuation(ValuationReconciliationTestCommon)
             'partner_id': self.partner_a.id,
             'price': 100,
         })
-
+        self.product_b.standard_price = 10
         (kit_final_prod + self.product_b).categ_id.write({
             'property_cost_method': 'fifo',
             'property_valuation': 'real_time',
@@ -254,7 +260,7 @@ class TestSubcontractingDropshippingValuation(ValuationReconciliationTestCommon)
 
         sale_order = self.env['sale.order'].create({
             'partner_id': self.partner_b.id,
-            'order_line': [(0, 0, {
+            'order_line': [Command.create({
                 'price_unit': 900,
                 'product_id': kit_final_prod.id,
                 'route_id': self.dropship_route.id,
@@ -265,7 +271,6 @@ class TestSubcontractingDropshippingValuation(ValuationReconciliationTestCommon)
         purchase_order = sale_order._get_purchase_orders()[0]
         purchase_order.button_confirm()
         dropship_transfer = purchase_order.picking_ids[0]
-        dropship_transfer.move_ids[0].quantity = 2.0
         dropship_transfer.button_validate()
 
         account_move = sale_order._create_invoices()


### PR DESCRIPTION
**Problem:**
When confirming the invoice of an order delivered via dropship for some kit bom 
product with fifo/avco comp, if the price was manually set on the purchase order, 
the invoice lines generated for the cogs are inaccurate

**Steps to reproduce:**
- In settings enable dropshipping, automatic account and anglosaxon accounting
- Create a kit product with one component.
- Set the route as Dropship for the component.
- add a vendor in the purchase tab of the component.
- set the cost of the component at 2
- Set the product category to AVCO (Automated) for the component and the product.
- Create and confirm a sales order with a quantity of 2 for the product.
- On the purchase order set the unit price at 20 for the component.
- Confirm the purchase order, then validate the delivery and create the customer invoice.
- Confirm the invoice

**Current behavior:**
In the journal items tab of the invoice the lines for the cogs (expenses and stock interim) have a value of 22

**Expected behavior:**
The value should be 40, in accordance with the purchase order

**Cause of the issue:**
In the mrp_account override of _compute_average_price,
the stock move has no bom because it was generated from the purchase order, 
so this condition will be true
https://github.com/odoo/odoo/blob/936ab5f3f120413c7af901dd6ecc414d3e3a6d78/addons/mrp_account/models/product.py#L67
This is not a problem, however the problem comes from the fact that
move.product_id is already equal to qty_to_invoice \*component_quantity.
https://github.com/odoo/odoo/blob/936ab5f3f120413c7af901dd6ecc414d3e3a6d78/addons/mrp_account/models/product.py#L73
Multiplying it a second time by qty_to_invoice is an error.
For instance in our steps, qty_to_invoice is 2, compenent_quantity is 1 
and move.product_qty is 2.
So when calling _compute_average_price for the comp, we call it with a 
qty_to_invoice parameter of 4 instead of 2.
As a result, because the candidates svls only have a quantity of 2, there will 
be we a missing quantity.
https://github.com/odoo/odoo/blob/936ab5f3f120413c7af901dd6ecc414d3e3a6d78/addons/stock_account/models/product.py#L927-L934
So the result will be the average between the quantity on the purchase order (20)
and the standard price (2).
Which is why the account line has a value of 22 (2*11)

opw-4985440
