### PR TITLE
[FIX] website: ensure copied configurator pages have website_id

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -969,6 +969,7 @@ class Website(models.Model):
             # pages in the landing page category when creating a new page.
             page_view_id.copy({
                 'key': f"{index}_{page_view_id.key}_configurator_pages_landing",
+                'website_id': website.id,
             })
 
         # Configure the images


### PR DESCRIPTION
This PR resolves the runbot build error
https://runbot.odoo.com/odoo/runbot.build.error/232963

Standalone script test_02_theme_default_generate_primary_templates

Reason:
The issue was introduced by commit [1], which creates a copy of configurator pages but does not set the website_id field on the new copy. As a result, the copied page is missing its website association, leading to error.

[1]:https://github.com/odoo/odoo/commit/4231c9e545f

