### PR TITLE
[FIX] l10n_sa_edi: Check ZATCA misconfiguration if empty country.

### DIFF
--- a/addons/l10n_sa_edi/models/account_edi_format.py
+++ b/addons/l10n_sa_edi/models/account_edi_format.py
@@ -413,7 +413,7 @@ class AccountEdiFormat(models.Model):
         company = invoice.company_id
 
         errors = super()._check_move_configuration(invoice)
-        if self.code != 'sa_zatca' or company.country_id.code != 'SA':
+        if self.code != 'sa_zatca' or company.country_id and company.country_id.code != 'SA':
             return errors
 
         if invoice.commercial_partner_id == invoice.company_id.partner_id.commercial_partner_id:


### PR DESCRIPTION
Odoo allows companies to install a localization, then remove the country from the address line. The method _check_move_configuration does not anticipate this edge case and will not check for ZATCA misconfiguration errors if the country is empty.

This misconfigured EDI document will then cause the scheduled action "EDI : Perform web services operations" to fail. This is a significant problem for several EDI services, as some impose fines if invoices are not submitted within a set time after invoice creation.

This commit allows _check_move_configuration to check this edge case, preventing misconfigured invoices from being created.

Ticket [link](https://www.odoo.com/odoo/project.task/5057792)
opw-5057792