### PR TITLE
[FIX] project_todo: hide converted todo breadcrumb

### DIFF
--- a/addons/project_todo/static/src/views/todo_form/todo_form_controller.js
+++ b/addons/project_todo/static/src/views/todo_form/todo_form_controller.js
@@ -28,7 +28,7 @@ export class TodoFormController extends FormController {
         const filteredActions =
             menuItems.action?.filter((action) => actionToKeep.includes(action.key)) || [];
 
-        if (this.projectAccess) {
+        if (this.projectAccess && !this.model.root.data.project_id) {
             filteredActions.push({
                 description: _t("Convert to Task"),
                 callback: () => {

--- a/addons/project_todo/views/project_task_views.xml
+++ b/addons/project_todo/views/project_task_views.xml
@@ -101,6 +101,8 @@
                   class="o_todo_form_view"
                   js_class="todo_form">
                 <field name="name" invisible="1"/>
+                <field name="company_id" invisible="1"/>
+                <field name="project_id" invisible="1"/>
                 <header>
                     <div class="py-1 px-2 border rounded bg-view">
                         <field name="tag_ids"


### PR DESCRIPTION
Steps to reproduce:

- Create a Todo and convert into task using cog Menu option.
- Todo is converted to task and is displayed.
- Through breadcrumb go back to Todo
- Try to convert it again

Issue:

- The converted todo is again converted (change of project etc)

Fix:

- Hiding the convert cog menu when a project is set.

task-5075327