### PR TITLE
[IMP] base_import: allow import records in grid view

### DIFF
--- a/addons/base_import/static/src/import_records/import_records.js
+++ b/addons/base_import/static/src/import_records/import_records.js
@@ -42,7 +42,7 @@ export const importRecordsItem = {
     isDisplayed: ({ config, isSmall }) =>
         !isSmall &&
         config.actionType === "ir.actions.act_window" &&
-        ["kanban", "list"].includes(config.viewType) &&
+        ["kanban", "list", "grid"].includes(config.viewType) &&
         exprToBoolean(config.viewArch.getAttribute("import"), true) &&
         exprToBoolean(config.viewArch.getAttribute("create"), true),
 };


### PR DESCRIPTION
Previously import record option was available only in list and kanban views. 
This commit adds support for importing records directly from the grid view as well.

task-4918681


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
