### PR TITLE
[FIX] l10n_in: remove l10n_us_account dependency from testcases

### DIFF
--- a/addons/l10n_in/tests/common.py
+++ b/addons/l10n_in/tests/common.py
@@ -30,10 +30,10 @@ class L10nInTestInvoicingCommon(AccountTestInvoicingCommon):
             'zip': "365220",
         })
 
-        cls.outside_in_company = cls._create_company(
-            name='Outside India Company',
-            country_id=cls.country_us.id,
-        )
+        cls.outside_in_company = cls.env['res.company'].create({
+            'name': 'Outside India Company',
+            'country_id': cls.country_us.id,
+        })
 
         cls.user.write({
             'company_ids': [cls.default_company.id, cls.outside_in_company.id],


### PR DESCRIPTION
Standalone `l10n_in` tests were failing when running without demo data because  
outside-India companies (e.g., US) were defaulting to their country-based chart of accounts.  
This required the `l10n_us_account` module, causing errors when the module was not installed.

<img width="518" height="28" alt="image" src="https://github.com/user-attachments/assets/748663a0-f329-459c-b0e8-0c3de7019258" />

This commit adapts the test cases to run without l10n_us_account dependency.

task- 5116352