### PR TITLE
[FIX] html_editor: getAdjacentCharacter for non-collapsed selection

### DIFF
--- a/addons/html_editor/static/src/utils/selection.js
+++ b/addons/html_editor/static/src/utils/selection.js
@@ -239,35 +239,34 @@ export const callbacksForCursorUpdate = {
 };
 
 /**
- * @param {Selection} selection
+ * @param {Node} node
+ * @param {number} offset
  * @param {"previous"|"next"} side
- * @param {HTMLElement} editable
  * @returns {string | undefined}
  */
-export function getAdjacentCharacter(selection, side, editable) {
-    let { focusNode, focusOffset } = selection;
-    [focusNode, focusOffset] = getDeepestPosition(focusNode, focusOffset);
-    const originalBlock = closestBlock(focusNode);
+export function getAdjacentCharacter(node, offset, side) {
+    [node, offset] = getDeepestPosition(node, offset);
+    const originalBlock = closestBlock(node);
     let adjacentCharacter;
-    while (!adjacentCharacter && focusNode) {
+    while (!adjacentCharacter && node) {
         if (side === "previous") {
-            adjacentCharacter = focusOffset > 0 && focusNode.textContent[focusOffset - 1];
+            adjacentCharacter = offset > 0 && node.textContent[offset - 1];
         } else {
-            adjacentCharacter = focusNode.textContent[focusOffset];
+            adjacentCharacter = node.textContent[offset];
         }
         if (!adjacentCharacter) {
             if (side === "previous") {
-                focusNode = previousLeaf(focusNode, editable);
-                focusOffset = focusNode && nodeSize(focusNode);
+                node = previousLeaf(node, originalBlock);
+                offset = node && nodeSize(node);
             } else {
-                focusNode = nextLeaf(focusNode, editable);
-                focusOffset = 0;
+                node = nextLeaf(node, originalBlock);
+                offset = 0;
             }
-            const characterIndex = side === "previous" ? focusOffset - 1 : focusOffset;
-            adjacentCharacter = focusNode && focusNode.textContent[characterIndex];
+            const characterIndex = side === "previous" ? offset - 1 : offset;
+            adjacentCharacter = node && node.textContent[characterIndex];
         }
     }
-    if (!focusNode || !isContentEditable(focusNode) || closestBlock(focusNode) !== originalBlock) {
+    if (!node || !isContentEditable(node)) {
         return undefined;
     }
     return adjacentCharacter;

--- a/addons/html_editor/static/tests/utils/selection.test.js
+++ b/addons/html_editor/static/tests/utils/selection.test.js
@@ -8,7 +8,6 @@ import { describe, expect, test } from "@odoo/hoot";
 import { dispatch } from "@odoo/hoot-dom";
 import { insertText, setupEditor, testEditor } from "../_helpers/editor";
 import { unformat } from "../_helpers/format";
-import { setSelection } from "../_helpers/selection";
 
 describe("ensureFocus", () => {
     // TODO @phoenix: unskipped when ensureFocus is add in the code base
@@ -155,11 +154,25 @@ describe("getCursorDirection", () => {
 
 describe("getAdjacentCharacter", () => {
     test("should return the ZWS character before the cursor", async () => {
-        const { editor, el } = await setupEditor("<p><span>abc</span>\u200b</p>");
+        const { el } = await setupEditor("<p><span>abc</span>\u200b</p>");
         const p = el.firstChild;
-        // Place the cursor at the end of the P (not in a leaf node)
-        setSelection({ anchorNode: p, anchorOffset: nodeSize(p) });
-        const selection = editor.document.getSelection();
-        expect(getAdjacentCharacter(selection, "previous", el)).toBe("\u200b");
+        // From the end of the P (not from the leaf node)
+        expect(getAdjacentCharacter(p, nodeSize(p), "previous", el)).toBe("\u200b");
+    });
+
+    test("should return the correct previous character for multiple nodes", async () => {
+        const { el } = await setupEditor("<p>abc</p>");
+        const p = el.firstChild;
+        const def = document.createTextNode("def");
+        p.appendChild(def);
+        expect(getAdjacentCharacter(def, 0, "previous", el)).toBe("c");
+    });
+
+    test("should return the correct next character for multiple nodes", async () => {
+        const { el } = await setupEditor("<p>abc</p>");
+        const p = el.firstChild;
+        const def = document.createTextNode("def");
+        p.appendChild(def);
+        expect(getAdjacentCharacter(p.firstChild, 3, "next", el)).toBe("d");
     });
 });


### PR DESCRIPTION
Description of the issue this PR addresses:

Current behavior before PR:

`getAdjacentCharacter` always used `focusNode` for both previous and next-side calculations. For non-collapsed selections this could return the wrong character.

Desired behavior after PR is merged:

Use `anchorNode` when calculating the previous-side adjacent character. This ensures the utility returns the correct character for non-collapsed selections.

task-4207610

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
