### PR TITLE
[IMP] website_event: add online events option and default country

### DIFF
--- a/addons/website_event/models/event_event.py
+++ b/addons/website_event/models/event_event.py
@@ -589,11 +589,16 @@ class EventEvent(models.Model):
                 domain.append([('tag_ids', 'in', tags.ids)])
 
         no_country_domain = domain.copy()
+        include_online_events = (
+            website.is_view_active('website_event.event_location') and
+            website.is_view_active('website_event.event_location_include_online')
+        )
+
         if country:
             if country == 'online':
                 domain.append([("country_id", "=", False)])
             elif country != 'all':
-                domain.append([("country_id", "=", int(country))])
+                domain.append([("country_id", "in", [int(country), False] if include_online_events else [int(country)])])
 
         no_date_domain = domain.copy()
         dates = self._search_build_dates()

--- a/addons/website_event/static/src/website_builder/events_list_page_option.xml
+++ b/addons/website_event/static/src/website_builder/events_list_page_option.xml
@@ -23,9 +23,18 @@
                 label.translate="Date"
                 actionParam="{views: ['website_event.event_time']}"/>
             <BuilderButton
+                id="'opt_event_location'"
                 label.translate="Countries"
                 actionParam="{views: ['website_event.event_location']}"/>
         </BuilderRow>
+        <t t-if="this.isActiveItem('opt_event_location')">
+            <BuilderRow
+                level="1"
+                label.translate="Include online"
+                tooltip.translate="If enabled, online events will be included when user filters by country.">
+                <BuilderCheckbox actionParam="{views: ['website_event.event_location_include_online']}"/>
+             </BuilderRow>
+        </t>
 
         <BuilderRow label.translate="Sidebar">
             <BuilderCheckbox id="'events_sidebar_opt'" actionParam="{views: ['website_event.opt_index_sidebar']}"/>

--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -219,18 +219,24 @@
                     <t t-out="online_event_text"/>
                 </t>
                 <t t-elif="current_country" t-out="current_country.name"/>
-                <t t-else="">All countries</t>
+                <t t-else="">All Countries</t>
             </button>
             <div class="dropdown-menu">
+                <a t-att-href="keep_event_url(country='all')" t-attf-class="dropdown-item d-flex align-items-center justify-content-between #{searches.get('country') == 'all' and 'active'}" title="All Countries">
+                    All Countries
+                    <span t-out="sum(country['country_id_count'] for country in countries)" class="badge pagination ms-3 text-bg-primary"/>
+                </a>
+                <t t-set="online_count" t-value="sum(country['country_id_count'] for country in countries if not country['country_id'])"/>
                 <t t-foreach="countries" t-as="country">
                     <t t-if="country['country_id']">
                         <t t-set="is_active" t-value="searches.get('country') == str(country['country_id'] and country['country_id'][0])"/>
                         <a t-att-href="keep_event_url(country=country['country_id'][0])" t-attf-class="dropdown-item d-flex align-items-center justify-content-between #{is_active and 'active'}" t-att-title="country['country_id'][1]">
                             <t t-out="country['country_id'][1]"/>
-                            <span t-out="country['country_id_count']" t-attf-class="badge pagination ms-3 text-bg-primary"/>
+                            <span t-if="include_online_events" t-out="country['country_id_count'] + online_count" t-attf-class="badge pagination ms-3 text-bg-primary"/>
+                            <span t-else="" t-out="country['country_id_count']" t-attf-class="badge pagination ms-3 text-bg-primary"/>
                         </a>
                     </t>
-                    <t t-else="">
+                    <t t-elif="not include_online_events">
                         <t t-set="is_active" t-value="searches.get('country') == 'online'"/>
                         <a t-att-href="keep_event_url(country='online')" t-attf-class="dropdown-item d-flex align-items-center justify-content-between #{is_active and 'active'}" title="Online Events">
                             <span>Online Events</span>
@@ -284,6 +290,8 @@
         </div>
     </xpath>
 </template>
+
+<template id="event_location_include_online" active="True"/>
 
 <!-- Index - Events list -->
 <template id="events_list" name="Events list">


### PR DESCRIPTION
**Purpose:**
- On landing at `/events`, visitors may find it hard to locate nearby events.
- By default events should be filtered by logged user's or visitor's country, if any exist in the future.
- Including online events when a country is selected should be optional.

**Specifications:**
- Add 'Include online' toggle in the event editor options, visible only when 'Countries' is active.
- By default, the “Include online” option is enabled.
- When a user arrives on /events and if country filter is active then:
    - If no search parameter for the country is defined and there is at least one future event for the visitor's detected country (`geoip_id`), redirect to `/events?country=geoip_id`
    - If there are no future events for `country=geoip_id`, Stay on `/events?country=all`
- If “Include online” is disabled and there are no future events for the selected country, redirect to `/events?country=all`

Task-5008947