### PR TITLE
[FIX] web: reload action and breadcrumbs when changing lang

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -1028,6 +1028,7 @@ export function makeActionManager(env, router = _router) {
                         "current_action",
                         action._originalAction || "{}"
                     );
+                    browser.sessionStorage.setItem("current_lang", user.lang);
                 }
                 resolve();
                 env.bus.trigger("ACTION_MANAGER:UI-UPDATED", _getActionMode(action));
@@ -1749,6 +1750,12 @@ export function makeActionManager(env, router = _router) {
      */
 
     async function loadState(state = router.current) {
+        const lang = browser.sessionStorage.getItem("current_lang");
+        if (lang && lang !== user.lang) {
+            browser.sessionStorage.removeItem("current_action");
+            browser.sessionStorage.removeItem("current_lang");
+            browser.sessionStorage.removeItem("current_state");
+        }
         const newStack = await _controllersFromState(state);
         const actionParams = _getActionParams(state);
         if (actionParams) {

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -13489,10 +13489,12 @@ test("kanban records are middle clickable by default", async () => {
     await contains(".o_kanban_record").click({ ctrlKey: true });
     expect.verifySteps([
         "get menu_id-null",
+        "get current_lang-null",
         "get current_state-null",
         "get current_action-null",
         'set current_state-{"actionStack":[{"displayName":"","action":1,"view_type":"kanban"}],"action":1}',
         'set current_action-{"id":1,"res_model":"partner","type":"ir.actions.act_window","views":[[false,"kanban"],[false,"form"]]}',
+        "set current_lang-en",
         'get current_action-{"id":1,"res_model":"partner","type":"ir.actions.act_window","views":[[false,"kanban"],[false,"form"]]}',
         'get current_state-{"actionStack":[{"displayName":"","action":1,"view_type":"kanban"}],"action":1}',
         'set current_action-{"id":1,"res_model":"partner","type":"ir.actions.act_window","views":[[false,"kanban"],[false,"form"]]}',

--- a/addons/web/static/tests/webclient/actions/load_state.test.js
+++ b/addons/web/static/tests/webclient/actions/load_state.test.js
@@ -17,6 +17,7 @@ import {
     stepAllNetworkCalls,
     toggleMenuItem,
     toggleSearchBarMenu,
+    serverState,
 } from "@web/../tests/web_test_helpers";
 
 import { browser } from "@web/core/browser/browser";
@@ -27,7 +28,7 @@ import { redirect } from "@web/core/utils/urls";
 import { ControlPanel } from "@web/search/control_panel/control_panel";
 import { _t as basic_t } from "@web/core/l10n/translation";
 import { user } from "@web/core/user";
-import { queryAllAttributes, queryAllTexts, queryFirst } from "@odoo/hoot-dom";
+import { queryAllAttributes, queryAllTexts, queryFirst, runAllTimers } from "@odoo/hoot-dom";
 
 function _t() {
     odoo.translationContext = "web";
@@ -1416,12 +1417,15 @@ describe(`new urls`, () => {
         expect(`.o_kanban_view`).toHaveCount(1);
         expect.verifySteps([
             "get menu_id-null",
+            "get current_lang-null",
             "get current_state-null",
             "get current_action-null",
             'set current_state-{"actionStack":[{"displayName":"First record","model":"partner","view_type":"form","resId":1}],"resId":1,"model":"partner"}',
             'set current_action-{"type":"ir.actions.act_window","res_model":"partner","res_id":1,"views":[[false,"form"]]}',
+            "set current_lang-en",
             'set current_state-{"actionStack":[{"displayName":"First record","model":"partner","view_type":"form","resId":1},{"displayName":"","model":"partner","view_type":"kanban","active_id":1}],"active_id":1,"model":"partner"}',
             'set current_action-{"type":"ir.actions.act_window","res_model":"partner","views":[[1,"kanban"]],"context":{"lang":"en","tz":"taht","uid":7,"allowed_company_ids":[1],"active_model":"partner","active_id":1,"active_ids":[1]}}',
+            "set current_lang-en",
         ]);
 
         expect(browser.location.href).toBe("http://example.com/odoo/m-partner/1/m-partner");
@@ -1433,10 +1437,12 @@ describe(`new urls`, () => {
         expect(`.o_kanban_view`).toHaveCount(1);
         expect.verifySteps([
             "get menu_id-null",
+            "get current_lang-en",
             'get current_state-{"actionStack":[{"displayName":"First record","model":"partner","view_type":"form","resId":1},{"displayName":"","model":"partner","view_type":"kanban","active_id":1}],"active_id":1,"model":"partner"}',
             'get current_action-{"type":"ir.actions.act_window","res_model":"partner","views":[[1,"kanban"]],"context":{"lang":"en","tz":"taht","uid":7,"allowed_company_ids":[1],"active_model":"partner","active_id":1,"active_ids":[1]}}',
             'set current_state-{"actionStack":[{"displayName":"First record","model":"partner","view_type":"form","resId":1},{"displayName":"","model":"partner","view_type":"kanban","active_id":1}],"active_id":1,"model":"partner"}',
             'set current_action-{"type":"ir.actions.act_window","res_model":"partner","views":[[1,"kanban"]],"context":{"lang":"en","tz":"taht","uid":7,"active_model":"partner","active_id":1,"active_ids":[1]}}',
+            "set current_lang-en",
         ]);
     });
 
@@ -1488,12 +1494,15 @@ describe(`new urls`, () => {
         expect(`.o_kanban_record:not(.o_kanban_ghost)`).toHaveCount(1);
         expect.verifySteps([
             "get menu_id-null",
+            "get current_lang-null",
             "get current_state-null",
             "get current_action-null",
             'set current_state-{"actionStack":[{"displayName":"First record","action":100,"view_type":"form","resId":1}],"resId":1,"action":100}',
             'set current_action-{"binding_type":"action","binding_view_types":"list,form","id":100,"type":"ir.actions.act_window","xml_id":100,"res_model":"partner","res_id":1,"views":[[false,"form"]],"context":{},"embedded_action_ids":[],"group_ids":[],"limit":80,"mobile_view_mode":"kanban","target":"current","view_ids":[],"view_mode":"list,form","cache":true}',
+            "set current_lang-en",
             'set current_state-{"actionStack":[{"displayName":"First record","action":100,"view_type":"form","resId":1},{"displayName":"","action":200,"view_type":"kanban"}],"action":200}',
             'set current_action-{"id":200,"type":"ir.actions.act_window","res_model":"partner","views":[[1,"kanban"]],"domain":[["id","=",1]]}',
+            "set current_lang-en",
         ]);
 
         expect(browser.location.href).toBe("http://example.com/odoo/action-100/1/action-200");
@@ -1510,10 +1519,12 @@ describe(`new urls`, () => {
         expect(`.o_kanban_record:not(.o_kanban_ghost)`).toHaveCount(1);
         expect.verifySteps([
             "get menu_id-null",
+            "get current_lang-en",
             'get current_state-{"actionStack":[{"displayName":"First record","action":100,"view_type":"form","resId":1},{"displayName":"","action":200,"view_type":"kanban"}],"action":200}',
             'get current_action-{"id":200,"type":"ir.actions.act_window","res_model":"partner","views":[[1,"kanban"]],"domain":[["id","=",1]]}',
             'set current_state-{"actionStack":[{"displayName":"First record","action":100,"view_type":"form","resId":1},{"displayName":"","action":200,"view_type":"kanban","active_id":1}],"action":200,"active_id":1}',
             'set current_action-{"id":200,"type":"ir.actions.act_window","res_model":"partner","views":[[1,"kanban"]],"domain":[["id","=",1]]}',
+            "set current_lang-en",
         ]);
     });
 
@@ -1572,16 +1583,20 @@ describe(`new urls`, () => {
         expect.verifySteps([
             "get menu_id-null",
             "set menu_id-100",
+            "get current_lang-null",
             "get current_state-null",
             "get current_action-null",
             'set current_state-{"actionStack":[{"displayName":"Partners","action":9001,"view_type":"list"}],"action":9001}',
             'set current_action-{"binding_type":"action","binding_view_types":"list,form","id":9001,"type":"ir.actions.act_window","xml_id":9001,"name":"Partners","res_model":"partner","views":[[false,"list"],[false,"form"]],"context":{},"embedded_action_ids":[],"group_ids":[],"limit":80,"mobile_view_mode":"kanban","target":"current","view_ids":[],"view_mode":"list,form","cache":true}',
+            "set current_lang-en",
             "pushState http://example.com/odoo/action-9001",
             "get menu_id-100", // F5 reload checks stored menu
+            "get current_lang-en",
             'get current_state-{"actionStack":[{"displayName":"Partners","action":9001,"view_type":"list"}],"action":9001}',
             'get current_action-{"binding_type":"action","binding_view_types":"list,form","id":9001,"type":"ir.actions.act_window","xml_id":9001,"name":"Partners","res_model":"partner","views":[[false,"list"],[false,"form"]],"context":{},"embedded_action_ids":[],"group_ids":[],"limit":80,"mobile_view_mode":"kanban","target":"current","view_ids":[],"view_mode":"list,form","cache":true}',
             'set current_state-{"actionStack":[{"displayName":"Partners","action":9001,"view_type":"list"}],"action":9001}',
             'set current_action-{"binding_type":"action","binding_view_types":"list,form","id":9001,"type":"ir.actions.act_window","xml_id":9001,"name":"Partners","res_model":"partner","views":[[false,"list"],[false,"form"]],"context":{},"embedded_action_ids":[],"group_ids":[],"limit":80,"mobile_view_mode":"kanban","target":"current","view_ids":[],"view_mode":"list,form","cache":true}',
+            "set current_lang-en",
             "Update the state without updating URL, nextState: actionStack,action",
         ]);
     });
@@ -1670,14 +1685,18 @@ describe(`new urls`, () => {
         ]);
         expect.verifySteps([
             "get menu_id-null",
+            "get current_lang-null",
             "get current_state-null",
             "get current_action-null",
             'set current_state-{"actionStack":[{"displayName":"Kanban Partners","action":200,"view_type":"kanban"}],"action":200}',
             'set current_action-{"binding_type":"action","binding_view_types":"list,form","id":200,"type":"ir.actions.act_window","xml_id":200,"res_model":"partner","name":"Kanban Partners","views":[[1,"kanban"],[false,"form"]],"context":{},"embedded_action_ids":[],"group_ids":[],"limit":80,"mobile_view_mode":"kanban","target":"current","view_ids":[],"view_mode":"list,form","cache":true}',
+            "set current_lang-en",
             'set current_state-{"actionStack":[{"displayName":"Kanban Partners","action":200,"view_type":"kanban"},{"displayName":"List Partners with active id","action":300,"view_type":"list","active_id":5}],"action":300,"active_id":5}',
             'set current_action-{"binding_type":"action","binding_view_types":"list,form","id":300,"type":"ir.actions.act_window","xml_id":300,"res_model":"partner","context":{"active_id":5},"name":"List Partners with active id","views":[[false,"list"]],"embedded_action_ids":[],"group_ids":[],"limit":80,"mobile_view_mode":"kanban","target":"current","view_ids":[],"view_mode":"list,form","cache":true}',
+            "set current_lang-en",
             'set current_state-{"actionStack":[{"displayName":"Kanban Partners","action":200,"view_type":"kanban"},{"displayName":"List Partners with active id","action":300,"view_type":"list","active_id":5},{"displayName":"First record","action":100,"view_type":"form","resId":1}],"resId":1,"action":100}',
             'set current_action-{"binding_type":"action","binding_view_types":"list,form","id":100,"type":"ir.actions.act_window","xml_id":100,"res_model":"partner","res_id":1,"name":"Partners","views":[[false,"form"],[false,"list"]],"context":{},"embedded_action_ids":[],"group_ids":[],"limit":80,"mobile_view_mode":"kanban","target":"current","view_ids":[],"view_mode":"list,form","cache":true}',
+            "set current_lang-en",
         ]);
 
         // Emulate a Reload
@@ -1735,11 +1754,104 @@ describe(`new urls`, () => {
         ]);
         expect.verifySteps([
             "get menu_id-null",
+            "get current_lang-en",
             'get current_state-{"actionStack":[{"displayName":"Kanban Partners","action":200,"view_type":"kanban"},{"displayName":"List Partners with active id","action":300,"view_type":"list","active_id":5},{"displayName":"First record","action":100,"view_type":"form","resId":1}],"resId":1,"action":100}',
             'get current_action-{"binding_type":"action","binding_view_types":"list,form","id":100,"type":"ir.actions.act_window","xml_id":100,"res_model":"partner","res_id":1,"name":"Partners","views":[[false,"form"],[false,"list"]],"context":{},"embedded_action_ids":[],"group_ids":[],"limit":80,"mobile_view_mode":"kanban","target":"current","view_ids":[],"view_mode":"list,form","cache":true}',
             'set current_state-{"actionStack":[{"displayName":"Kanban Partners","action":200},{"displayName":"List Partners with active id","action":300,"active_id":5},{"displayName":"First record","action":100,"view_type":"form","resId":1}],"resId":1,"action":100}',
             'set current_action-{"binding_type":"action","binding_view_types":"list,form","id":100,"type":"ir.actions.act_window","xml_id":100,"res_model":"partner","res_id":1,"name":"Partners","views":[[false,"form"],[false,"list"]],"context":{},"embedded_action_ids":[],"group_ids":[],"limit":80,"mobile_view_mode":"kanban","target":"current","view_ids":[],"view_mode":"list,form","cache":true}',
+            "set current_lang-en",
         ]);
+    });
+
+    test(`reload without lang change`, async () => {
+        onRpc("/web/action/load_breadcrumbs", () => {
+            expect.step(`/web/action/load_breadcrumbs`);
+        });
+        onRpc("/web/action/load", () => {
+            expect.step(`/web/action/load`);
+        });
+
+        defineActions([
+            {
+                id: 100,
+                type: "ir.actions.act_window",
+                res_model: "partner",
+                name: "Partners",
+                views: [
+                    [false, "list"],
+                    [false, "form"],
+                ],
+            },
+            {
+                id: 200,
+                type: "ir.actions.act_window",
+                res_model: "partner",
+                name: "Kanban Partners",
+                views: [[1, "kanban"]],
+            },
+        ]);
+
+        await mountWebClient();
+        await getService("action").doAction(100);
+        await contains(".o_data_cell").click();
+        await getService("action").doAction(200);
+        expect.verifySteps(["/web/action/load", "/web/action/load"]);
+
+        await runAllTimers(); // wait for the router to be updated
+        expect(router.stateToUrl(router.current)).toBe("/odoo/action-100/1/action-200");
+
+        // simulate a reload
+        await startRouter();
+        routerBus.trigger("ROUTE_CHANGE");
+        await runAllTimers();
+        // assert that we didn't reload the action or breadcrumbs as they are stored in session storage
+        expect.verifySteps([]);
+    });
+
+    test(`reload with lang change`, async () => {
+        onRpc("/web/action/load_breadcrumbs", () => {
+            expect.step(`/web/action/load_breadcrumbs`);
+        });
+        onRpc("/web/action/load", () => {
+            expect.step(`/web/action/load`);
+        });
+
+        defineActions([
+            {
+                id: 100,
+                type: "ir.actions.act_window",
+                res_model: "partner",
+                name: "Partners",
+                views: [
+                    [false, "list"],
+                    [false, "form"],
+                ],
+            },
+            {
+                id: 200,
+                type: "ir.actions.act_window",
+                res_model: "partner",
+                name: "Kanban Partners",
+                views: [[1, "kanban"]],
+            },
+        ]);
+
+        await mountWebClient();
+        await getService("action").doAction(100);
+        await contains(".o_data_cell").click();
+        await getService("action").doAction(200);
+        expect.verifySteps(["/web/action/load", "/web/action/load"]);
+
+        await runAllTimers(); // wait for the router to be updated
+        expect(router.stateToUrl(router.current)).toBe("/odoo/action-100/1/action-200");
+
+        // simulate a reload with a new lang
+        serverState.lang = "fr_FR";
+        await startRouter();
+        routerBus.trigger("ROUTE_CHANGE");
+        await runAllTimers();
+        // assert that we properly reload action and breacrumbs as lang changed
+        expect.verifySteps(["/web/action/load_breadcrumbs", "/web/action/load"]);
     });
 });
 

--- a/addons/web_hierarchy/static/tests/hierarchy_view.test.js
+++ b/addons/web_hierarchy/static/tests/hierarchy_view.test.js
@@ -1558,10 +1558,12 @@ test("Open record on new window", async () => {
     expect(".o_form_view").toHaveCount(0);
     expect.verifySteps([
         "get menu_id-null",
+        "get current_lang-null",
         "get current_state-null",
         "get current_action-null",
         'set current_state-{"actionStack":[{"displayName":"","model":"hr.employee","view_type":"hierarchy"}],"model":"hr.employee"}',
         'set current_action-{"res_model":"hr.employee","type":"ir.actions.act_window","views":[[false,"hierarchy"],[false,"form"]]}',
+        "set current_lang-en",
         'get current_action-{"res_model":"hr.employee","type":"ir.actions.act_window","views":[[false,"hierarchy"],[false,"form"]]}',
         'get current_state-{"actionStack":[{"displayName":"","model":"hr.employee","view_type":"hierarchy"}],"model":"hr.employee"}',
         'set current_action-{"res_model":"hr.employee","type":"ir.actions.act_window","views":[[false,"hierarchy"],[false,"form"]]}',


### PR DESCRIPTION
Before this commit, when changing lang, the breacrumbs was still displayed in the former language after the reload (and it persisted even if the user reloaded again). This was due to the fact that we store in the session storage the current action and state, so we can restore it and avoid some rpcs at reload.

This commit fixes the issue by detecting the lang change and clearing the session storage in that case.

closes #230032

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
