### PR TITLE
[FIX] hr: fix default work address

### DIFF
--- a/addons/hr/models/hr_version.py
+++ b/addons/hr/models/hr_version.py
@@ -29,7 +29,7 @@ class HrVersion(models.Model):
     _rec_name = 'name'
 
     def _get_default_address_id(self):
-        address = self.env.user.company_id.partner_id.address_get(['default'])
+        address = self.env.company.partner_id.address_get(['default'])
         return address['default'] if address else False
 
     def _default_salary_structure(self):


### PR DESCRIPTION
Steps to reproduce:
- Open the Employee app.
- Create a new employee in a company different from the current user's company.

Issue:
- The default address is taken from the current user's company instead of the active company's address.

Fix:
- Default address now uses the active company's address instead of the user's company.

task-5138714

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
