### PR TITLE
[FIX] mail: fix thread action button and messaging menu UI

### DIFF
--- a/addons/mail/static/src/core/common/action_list.scss
+++ b/addons/mail/static/src/core/common/action_list.scss
@@ -34,7 +34,7 @@
             i.o-xsmaller {
                 transform: translateY(-2px);
             }
-            &:not(:has(i.o-xsmaller)) {
+            &:has(i:not(.o-xsmaller)) {
                 aspect-ratio: 1;
             }
         }

--- a/addons/mail/static/src/core/public_web/messaging_menu.xml
+++ b/addons/mail/static/src/core/public_web/messaging_menu.xml
@@ -60,7 +60,7 @@
         </div>
     </div>
     <nav t-if="ui.isSmall" t-attf-class="o-mail-MessagingMenu-navbar d-flex flex-shrink-0 bg-view border-top w-100 p-2 gap-2 o-mail-MessagingMenu-navbar-with-{{tabs.length}}-elements {{ tabs.length > 4 ? 'overflow-x-scroll' : '' }}">
-        <button t-foreach="tabs" t-key="tab.id" t-as="tab" class="o-mail-MessagingMenu-tab btn d-flex flex-column flex-grow-1 flex-shrink-1 p-1 bg-transparent position-relative border-0" t-att-class="{
+        <button t-foreach="tabs" t-key="tab.id" t-as="tab" class="o-mail-MessagingMenu-tab btn d-flex flex-column align-items-center flex-grow-1 flex-shrink-1 p-1 bg-transparent position-relative border-0" t-att-class="{
             'active': store.discuss.activeTab === tab.id,
             'pb-4': isIosPwa,
             'pb-2': !isIosPwa,


### PR DESCRIPTION
Current behavior before PR:

1. Since [1], in thread actions like `Mark all read` and `Unstar all`, buttons had extra height because aspect-ratio was applied even when there was no icon, making the UI look uneven.
2. Since [2], text in the messaging menu tab in mobile was not centered, leading to misaligned UI.


Desired behavior after PR is merged:

- Aspect-ratio is applied only if an icon exists in the action button, fixing the height issue.
- Added a class to center text in the messaging menu tab, improving visual alignment.

[1]: https://github.com/odoo/odoo/pull/225216
[2]: https://github.com/odoo/odoo/pull/228657

Task-5145022

1. Before/ After
<div style="display: flex;">
<img  style="margin-right: 10%;" height="145" alt="image" src="https://github.com/user-attachments/assets/a9fcffdc-5e56-454f-882a-dc5296decd47" />
<img height="136"style="margin-right: 10%;"  alt="image" src="https://github.com/user-attachments/assets/105ce999-4e15-4c67-9b62-01c666c6fc2d" />
</div>

2. Before/ After
<img width="691" height="114" alt="image" src="https://github.com/user-attachments/assets/6aa4965c-a34f-4058-bdb9-4d91f4ac9146" />
<img width="688" height="94" alt="image" src="https://github.com/user-attachments/assets/ce110144-9314-4b2f-aa30-bf12b7ecf1ec" />





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
