### PR TITLE
[FIX] html_editor: preserve style on text inserted inside empty format

### DIFF
--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -159,9 +159,9 @@ export class FormatPlugin extends Plugin {
         intangible_char_for_keyboard_navigation_predicates: (_, char) => char === "\u200b",
     };
 
-    unwrapEmptyFormat(insertedNode, block) {
+    unwrapEmptyFormat(insertedNode) {
         const anchorNode = this.dependencies.selection.getEditableSelection().anchorNode;
-        if (!block.contains(anchorNode)) {
+        if (!allWhitespaceRegex.test(insertedNode.textContent)) {
             return insertedNode;
         }
         const emptyZWS = closestElement(anchorNode, "[data-oe-zws-empty-inline]");

--- a/addons/html_editor/static/tests/insert/text.test.js
+++ b/addons/html_editor/static/tests/insert/text.test.js
@@ -4,6 +4,7 @@ import { deleteBackward, insertText } from "../_helpers/user_actions";
 import { getContent } from "../_helpers/selection";
 import { execCommand } from "../_helpers/userCommands";
 import { press } from "@odoo/hoot-dom";
+import { unformat } from "../_helpers/format";
 
 describe("collapsed selection", () => {
     test("should insert a char into an empty span without removing the zws", async () => {
@@ -54,6 +55,24 @@ describe("collapsed selection", () => {
                 await insertText(editor, "x");
             },
             contentAfter: "<h1>x[]<br></h1>",
+        });
+    });
+
+    test("should insert text formatted empty node", async () => {
+        await testEditor({
+            contentBefore: unformat(`
+                <div class="o-paragraph">
+                    <strong data-oe-zws-empty-inline="">[]\ufeff</strong>
+                </div>
+            `),
+            stepFunction: async (editor) => {
+                await insertText(editor, "abc");
+            },
+            contentAfterEdit: unformat(`
+                <div class="o-paragraph">
+                    <strong>abc[]</strong>
+                </div>
+            `),
         });
     });
 });


### PR DESCRIPTION
Problem:
When text is inserted inside an empty format, the format is lost.

Cause:
After https://github.com/odoo/odoo/commit/ae33ca3d38d4a5adaad3015f036321d473713638, any empty format gets removed if content is inserted inside.

Solution:
Only remove the empty format if a media element is added. This preserves styling when inserting plain text inside an empty format.

Steps to reproduce:
1. Copy some text from somewhere.
2. In an empty task description, press CTRL+B.
3. Press CTRL+SHIFT+V.
4. Notice that the text is not bold, even though the format was active.

task-5136314

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
