### PR TITLE
[FIX] web_tour: include bundle in assets_unit_test

### DIFF
--- a/addons/web_tour/__manifest__.py
+++ b/addons/web_tour/__manifest__.py
@@ -40,6 +40,8 @@ Odoo Web tours.
         ],
         'web.assets_unit_tests': [
             ('include', 'web_tour.recorder'),
+            ('include', 'web_tour.automatic'),
+            ('include', 'web_tour.interactive'),
             'web_tour/static/tests/*.test.js',
         ],
         "web.assets_tests": [

--- a/addons/web_tour/static/tests/check_undeterminisms.test.js
+++ b/addons/web_tour/static/tests/check_undeterminisms.test.js
@@ -3,14 +3,12 @@
 import { afterEach, beforeEach, describe, expect, test } from "@odoo/hoot";
 import { advanceTime, animationFrame, queryFirst } from "@odoo/hoot-dom";
 import { Component, xml } from "@odoo/owl";
-import { mountWithCleanup, patchWithCleanup, preloadBundle } from "@web/../tests/web_test_helpers";
+import { mountWithCleanup, patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { browser } from "@web/core/browser/browser";
 import { Macro } from "@web/core/macro";
 import { registry } from "@web/core/registry";
 
 describe.current.tags("desktop");
-
-preloadBundle("web_tour.automatic");
 
 const mainErrorMessage = (trigger) =>
     `Error: Potential non deterministic behavior found in 300ms for trigger ${trigger}.`;
@@ -73,7 +71,7 @@ beforeEach(async () => {
         log: (s) => expect.step(`log: ${s}`),
         error: (s) => {
             s = s.replace(/\n +at.*/g, ""); // strip stack trace
-            expect.step(`error: ${s}`)
+            expect.step(`error: ${s}`);
         },
         warn: () => {},
         dir: () => {},

--- a/addons/web_tour/static/tests/tour_automatic.test.js
+++ b/addons/web_tour/static/tests/tour_automatic.test.js
@@ -8,7 +8,6 @@ import {
     makeMockEnv,
     mountWithCleanup,
     patchWithCleanup,
-    preloadBundle,
 } from "@web/../tests/web_test_helpers";
 import { browser } from "@web/core/browser/browser";
 import { Dialog } from "@web/core/dialog/dialog";
@@ -17,8 +16,6 @@ import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 
 describe.current.tags("desktop");
-
-preloadBundle("web_tour.automatic");
 
 const tourRegistry = registry.category("web_tour.tours");
 let macro;
@@ -140,7 +137,7 @@ test("a failing tour logs the step that failed in run", async () => {
         warn: (s) => {},
         error: (s) => {
             s = s.replace(/\n +at.*/g, ""); // strip stack trace
-            expect.step(`error: ${s}`)
+            expect.step(`error: ${s}`);
         },
     });
     class Root extends Component {

--- a/addons/web_tour/static/tests/tour_interactive.test.js
+++ b/addons/web_tour/static/tests/tour_interactive.test.js
@@ -13,7 +13,6 @@ import {
     models,
     fields,
     defineModels,
-    preloadBundle,
 } from "@web/../tests/web_test_helpers";
 import { browser } from "@web/core/browser/browser";
 import { Dialog } from "@web/core/dialog/dialog";
@@ -22,8 +21,6 @@ import { session } from "@web/session";
 import { WebClient } from "@web/webclient/webclient";
 
 describe.current.tags("desktop");
-
-preloadBundle("web_tour.interactive");
 
 class Partner extends models.Model {
     _name = "partner";

--- a/addons/web_tour/static/tests/tour_recorder.test.js
+++ b/addons/web_tour/static/tests/tour_recorder.test.js
@@ -7,7 +7,6 @@ import {
     mountWithCleanup,
     onRpc,
     patchWithCleanup,
-    preloadBundle,
     serverState,
 } from "@web/../tests/web_test_helpers";
 import { AutoComplete } from "@web/core/autocomplete/autocomplete";
@@ -22,8 +21,6 @@ import { useAutofocus } from "@web/core/utils/hooks";
 import { WebClient } from "@web/webclient/webclient";
 
 describe.current.tags("desktop");
-
-preloadBundle("web_tour.recorder");
 
 let tourRecorder;
 


### PR DESCRIPTION
In this commit, we add the appropriate bundles in assets_unit_test. These bundles will only be loaded if we run unit tests (i.e. in debug mode).
As a result, we no longer need to run preloadbundle in unit tests.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
