### PR TITLE
[FIX] sale{,_management} : Update price of optional products upon pricelist change

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1141,7 +1141,7 @@ class SaleOrder(models.Model):
     def action_update_prices(self):
         self.ensure_one()
 
-        self._recompute_prices()
+        self.with_context(pricelist_update=True)._recompute_prices()
 
         if self.pricelist_id:
             message = _("Product prices have been recomputed according to pricelist %s.",

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -1123,3 +1123,52 @@ class TestSalesTeam(SaleCommon):
 
         sale_order = self.env['sale.order'].with_user(user).create({'partner_id': self.partner.id})
         self.assertEqual(sale_order.team_id, self.sale_team)
+
+    def test_updating_price_upon_changing_pricelist(self):
+        optional_product = self.env['product.product'].create({'name': 'Optional Product'})
+        pricelist_1 = self.env['product.pricelist'].create({
+            'name': 'pricelist 1',
+            'currency_id': self.env.ref('base.USD').id,
+            'item_ids': [Command.create({
+                'name': 'Item 1',
+                'compute_price': 'fixed',
+                'base': 'list_price',
+                'fixed_price': 10,
+                'applied_on': '1_product',
+                'product_tmpl_id': optional_product.product_tmpl_id.id,
+            })],
+        })
+
+        pricelist_2 = self.env['product.pricelist'].create({
+            'name': 'pricelist 2',
+            'currency_id': self.env.ref('base.USD').id,
+            'item_ids': [Command.create({
+                'name': 'Item 1',
+                'compute_price': 'fixed',
+                'base': 'list_price',
+                'fixed_price': 20,
+                'applied_on': '1_product',
+                'product_tmpl_id': optional_product.product_tmpl_id.id,
+            })],
+        })
+
+        product = self.env['product.product'].create({'name': 'Product'})
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+            'pricelist_id': pricelist_1.id,
+            'order_line': [Command.create({
+                'product_id': product.id,
+                'product_uom_qty': 1,
+            })],
+            'sale_order_option_ids': [Command.create({
+                'product_id': optional_product.id,
+            })],
+        })
+
+        sale_order.sale_order_option_ids.add_option_to_order()
+        sale_order.write({
+            'pricelist_id': pricelist_2.id,
+        })
+        sale_order.action_update_prices()
+
+        self.assertEqual(sale_order.order_line[1].price_unit, pricelist_2.item_ids.fixed_price)

--- a/addons/sale_management/models/sale_order_line.py
+++ b/addons/sale_management/models/sale_order_line.py
@@ -38,6 +38,9 @@ class SaleOrderLine(models.Model):
 
     def _lines_without_price_recomputation(self):
         """ Hook to allow filtering the lines to avoid the recomputation of the price. """
+        if self.env.context.get('pricelist_update'):
+            # Recompute the optional products only if the pricelist got updated
+            return self.env['sale.order.line']
         return self.filtered('sale_order_option_ids')
 
     #=== TOOLING ===#


### PR DESCRIPTION
### Steps to reproduce:
	- Create a sale order with a SOL and an optional product
	- Preview the sale order and add the optional product to the order
	- Go back to edit mode and change the pricelist
	- Click on 'Update Prices'
	- Notice the optional product price won't change

### Cause:
When updating the prices of the SOLs we filter some lines that we won't recompute. Upon this commit https://github.com/odoo-dev/odoo/commit/2d919694d5c9588e0644d5ba82b15b9d3f762373 we remove the optional products from the recordset that will get price recomputation.

If sale_subscription is installed we will set the product's prices to 0 

https://github.com/odoo/enterprise/blob/85e0689ba12442e22e83f3337749c7ad2eb9d7d8/sale_subscription/models/sale_order.py#L674 

so the price of the 'Optional product' SOL will change but will be equal to 0

### Fix:
An exception for the filtering has been introduced as we will recompute the price of the optional products only if the pricelist is getting changed

opw-5058609