### PR TITLE
[FIX] bus: fix postcommit test

### DIFF
--- a/addons/bus/tests/test_notify.py
+++ b/addons/bus/tests/test_notify.py
@@ -63,24 +63,28 @@ class NotifyTests(TransactionCase):
 
         def single_listen():
             nonlocal channels
-            with odoo.sql_db.db_connect(
-                "postgres"
-            ).cursor() as cr, selectors.DefaultSelector() as sel:
+            with (
+                odoo.sql_db.db_connect("postgres").cursor() as cr,
+                selectors.DefaultSelector() as sel,
+            ):
                 cr.execute("listen imbus")
                 cr.commit()
                 conn = cr._cnx
                 sel.register(conn, selectors.EVENT_READ)
                 selector_ready_event.set()
-                while not stop_event.is_set():
+                found = False
+                while not stop_event.is_set() and not found:
                     if sel.select(timeout=5):
                         conn.poll()
-                        if notify_channels := [
-                            c
-                            for c in json.loads(conn.notifies.pop().payload)
-                            if c[0] == self.env.cr.dbname
-                        ]:
-                            channels = notify_channels
-                            break
+                        while conn.notifies:
+                            if notify_channels := [
+                                c
+                                for c in json.loads(conn.notifies.pop().payload)
+                                if c[0] == self.env.cr.dbname
+                            ]:
+                                channels = notify_channels
+                                found = True
+                                break
 
         thread = threading.Thread(target=single_listen)
         thread.start()


### PR DESCRIPTION
This commit fixes the `test_postcommit` that fails in a non deterministic fashion. This test ensures bus notifications created in the post commit hook result in only one batch.

However, the listener only consider the first notification of the batch (`conn.notifies.pop()`) and ignore the rest. When the expected notifications come as part of a bigger batch, they can be ignored thus making the test fail.

This commit ensures we read every notification received.

fixes runbot-233185

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
