### PR TITLE
[FIX] website_sale: prevent errors when adding a combo product to the cart

### DIFF
--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -617,7 +617,8 @@ class SaleOrder(models.Model):
         :returns: whether the combo quantities had to be updated
         """
         # Ensure all combo lines have the same quantity
-        combo_lines = line.linked_line_ids
+        if not (combo_lines := line.linked_line_ids):
+            return False
         available_combo_quantity = min(line.product_uom_qty for line in combo_lines)
         if available_combo_quantity < line.product_uom_qty:
             line._set_shop_warning_stock(


### PR DESCRIPTION
Currently, an error occurs when a user adds a combo product to the cart.

Steps to Reproduce [video](https://drive.google.com/file/d/1m-zxaIsrIzogeLun_Dj92Hb37-S9g9dO/view?usp=sharing):

 - Install the `website_sale` module.
 - Create a product of type `combo` and add a `combo choice`.
 - Go to the `combo choices` and delete `that combo choice`.
 - Go to the `website` > `Shop` and add that product to the `cart`.

`ValueError: min() arg is an empty sequence`

This error occurs after this [commit](https://github.com/odoo/odoo/pull/198070/files), When user creates a combo product, adds its related combo choice, and then deletes that combo choice, adding the product to the cart causes the system to check the quantities of the order line [1]. Since there is no sale combo choice for that product, the combo line becomes empty and raises an error[2].

This commit ensures combo choice quantities are checked only if they exist.

[1]-  https://github.com/odoo/odoo/blob/df05ae6d9af6abdfd67c49ac7a4d01762472bfc3/addons/website_sale/controllers/cart.py#L189

[2]- https://github.com/odoo/odoo/blob/df05ae6d9af6abdfd67c49ac7a4d01762472bfc3/addons/website_sale/models/sale_order.py#L621

sentry-6924112987


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
