### PR TITLE
[FIX] website, tools: make `<select>` options individually translatable

### DIFF
--- a/addons/website/static/src/js/editor/snippets.editor.js
+++ b/addons/website/static/src/js/editor/snippets.editor.js
@@ -967,7 +967,7 @@ wSnippetMenu.include({
                 const selectOptions = selectEl.tagName === 'SELECT' ? [...selectEl.options] : [];
                 if (selectOptions.length === translatedOptions.length) {
                     selectOptions.map((option, i) => {
-                        option.text = translatedOptions[i].textContent;
+                        option.appendChild(translatedOptions[i].firstChild);
                     });
                 }
                 optionsEl.remove();

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1756,19 +1756,11 @@ ul.o_checklist > li.o_checked::after {
 input[value*="data-oe-translation-initial-sha"] {
     @extend .o_text_content_invisible;
 }
-[data-oe-translation-initial-sha] {
-    > .o_translation_select {
-        border: $input-border-width solid $input-border-color;
-        @include border-radius($input-border-radius, 0);
-
-        // Hide translatable `<select/>`s since we use `.o_translation_select`
-        // elements to handle translations.
-        + select {
-            display: none !important;
-        }
-        > div:not(:last-child) {
-            border-bottom: inherit;
-        }
+.o_translation_select {
+    // Hide translatable `<select/>`s since we use `.o_translation_select`
+    // elements to handle translations.
+    + select {
+        display: none !important;
     }
 }
 

--- a/addons/website/static/src/scss/website.wysiwyg.scss
+++ b/addons/website/static/src/scss/website.wysiwyg.scss
@@ -9,12 +9,12 @@
 }
 
 html[lang] > body.editor_enable [data-oe-translation-state] {
-    &, .o_translation_select_option, &[data-oe-field="mega_menu_content"] * {
+    &, &[data-oe-field="mega_menu_content"] * {
         background-color: rgba($o-we-content-to-translate-color, 0.5) !important;
     }
 
     &[data-oe-translation-state="translated"] {
-        &, .o_translation_select_option, &[data-oe-field="mega_menu_content"] * {
+        &, &[data-oe-field="mega_menu_content"] * {
             background-color: rgba($o-we-translated-content-color, 0.5) !important;
         }
     }

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -152,7 +152,7 @@ TRANSLATED_ELEMENTS = {
     'abbr', 'b', 'bdi', 'bdo', 'br', 'cite', 'code', 'data', 'del', 'dfn', 'em',
     'font', 'i', 'ins', 'kbd', 'keygen', 'mark', 'math', 'meter', 'output',
     'progress', 'q', 'ruby', 's', 'samp', 'small', 'span', 'strong', 'sub',
-    'sup', 'time', 'u', 'var', 'wbr', 'text', 'select', 'option',
+    'sup', 'time', 'u', 'var', 'wbr', 'text',
 }
 
 # Which attributes must be translated. This is a dict, where the value indicates


### PR DESCRIPTION
__Current behavior before commit:__
[This PR] made the `<select>` field translatable by adding `select` and
`option` to `TRANSLATED_ELEMENTS` and implementing a temporary element
to handle the frontend translation.

Consequently the method `translate_xml_node` considers the `<select>`
field translatable as a whole. Editing the text of one option therefore
resets the translation of all the other options as well.

__Description of the fix:__
- Remove `select` and `option` from `TRANSLATED_ELEMENTS` so each option
is considered as an independant translatable term.
- Adapt the temporary element hack consequently as well as its CSS.
- Remove the now useless `SelectTranslateDialog`.

__Steps to reproduce:__
1. Add a form snippet to a website page.
2. Add a selection field to the form.
3. Translate the options in another language.
4. Leave Translation mode and go back to Edit mode.
5. Edit one of the option.
6. Change the website back to the second language.
=> All the options of the select field are reset.

[This PR]: https://github.com/odoo/odoo/pull/117519

task-5116823