### PR TITLE
[FIX] l10n_in: prevent error on creating contact via crm lead

### DIFF
--- a/addons/l10n_in/models/res_partner.py
+++ b/addons/l10n_in/models/res_partner.py
@@ -4,6 +4,7 @@ import re
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError, AccessError, ValidationError
 from odoo.addons.l10n_in.models.iap_account import IAP_SERVICE_NAME
+from odoo.tools.misc import clean_context
 
 _logger = logging.getLogger(__name__)
 
@@ -110,7 +111,8 @@ class ResPartner(models.Model):
         pan_number = vat[2:12].upper()
         pan_entity = self.env['l10n_in.pan.entity'].search([('name', '=', pan_number)], limit=1)
         if not pan_entity:
-            pan_entity = self.env['l10n_in.pan.entity'].create({'name': pan_number})
+            context = clean_context(self.env.context)
+            pan_entity = self.env['l10n_in.pan.entity'].with_context(context).create({'name': pan_number})
         return pan_entity
 
     def action_l10n_in_verify_gstin_status(self):


### PR DESCRIPTION
Currently, with Indian localization, creating a contact from a CRM lead raises an error.

**Steps to Reproduce:**
1) Install CRM,l10n_in (with Demo)
2) Switch to IN Company
3) Navigate to CRM> Click on 'New'
4) For **Contact** value click on 'Search more'>'New'. 'Create contact'
   wizard will open and set the following values
 >- Set contact as 'Company'
 >- Set 'GSTIN' (e.g 22AAFCH6738N1Z8)
5) Click Save

Error:
`ValueError: Wrong value for l10n_in.pan.entity.type: 'contact'`

Root Cause:
since [this commit](https://github.com/odoo/odoo/pull/214189/commits/c943637ef4aef740b97abaf1852ceb6fdfcd55bb), the field `l10n_in_pan_entity_id` at [1] was changed from `char` to `Many2one` which depends on the field `type` in the `l10n_in_pan_entity` as shown at [2]. Now following the above steps, the type of the partner is set as 'contact' from [3], which is not available at [2], raising an error.

Fix:
Updated the context value before creating a record for Pan Entity.

[1]- https://github.com/odoo/odoo/blob/b81d119fae5f5194334cee94bacffefeb1cd8c6e/addons/l10n_in/models/res_partner.py#L27-L35

[2]- https://github.com/odoo/odoo/blob/b81d119fae5f5194334cee94bacffefeb1cd8c6e/addons/l10n_in/models/l10n_in_pan_entity.py#L15-L27

[3]- https://github.com/odoo/odoo/blob/b81d119fae5f5194334cee94bacffefeb1cd8c6e/addons/crm/views/crm_lead_views.xml#L454

sentry-6916949666

