### PR TITLE
[FIX] mrp_subcontracting: prevent unbuild subcontracted MO

### DIFF
--- a/addons/mrp_subcontracting/models/__init__.py
+++ b/addons/mrp_subcontracting/models/__init__.py
@@ -13,3 +13,4 @@ from . import stock_replenish_mixin
 from . import stock_rule
 from . import stock_warehouse
 from . import mrp_production
+from . import mrp_unbuild

--- a/addons/mrp_subcontracting/models/mrp_unbuild.py
+++ b/addons/mrp_subcontracting/models/mrp_unbuild.py
@@ -1,0 +1,15 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models, _
+from odoo.exceptions import UserError
+
+
+class MrpProduction(models.Model):
+    _inherit = 'mrp.production'
+
+    def button_unbuild(self):
+        if self.subcontractor_id:
+            raise UserError(_(
+                "You can't unbuild a subcontracted Manufacturing Order.",
+            ))
+        return super().button_unbuild()

--- a/addons/mrp_subcontracting/tests/test_subcontracting.py
+++ b/addons/mrp_subcontracting/tests/test_subcontracting.py
@@ -1199,6 +1199,21 @@ class TestSubcontractingFlows(TestMrpSubcontractingCommon):
             {'product_qty': 16, 'qty_producing': 16, 'state': 'cancel'},
         ])
 
+    def test_subcontracting_unbuild_warning(self):
+        with Form(self.env['stock.picking']) as picking_form:
+            picking_form.picking_type_id = self.env.ref('stock.picking_type_in')
+            picking_form.partner_id = self.subcontractor_partner1
+            with picking_form.move_ids_without_package.new() as move:
+                move.product_id = self.finished
+                move.product_uom_qty = 3
+                move.quantity = 3
+            picking_receipt = picking_form.save()
+        picking_receipt.action_confirm()
+        subcontract = picking_receipt._get_subcontract_production()
+        error_message = "You can't unbuild a subcontracted Manufacturing Order."
+        with self.assertRaisesRegex(UserError, error_message):
+            subcontract.button_unbuild()
+
 
 @tagged('post_install', '-at_install')
 class TestSubcontractingTracking(TransactionCase):


### PR DESCRIPTION
**Problem:**
unbuilding a Manufactring order created through a subcontracting
process gives the wrong account move lines

**Steps to reproduce:**
- create a storable product (the comp) and set a cost
- create a storable product (the final product), set a cost
and set a vendor
- for the final product set the category as avco and automated
- for the final product create a bill of materials subcontracted
 and set the same vendor
- for the components add the comp for a quantity of 1
- create a Purchase order for the final product and the same vendor
and confirm
- validate the receipt
- From the receipt click on the valuation smart button and click on 
the book widget of the line of the final product
- notice how there is 3 journal items line including one 
crediting "stock interim (Received)"
- unarchive the operation type "subcontracting"
- open Manufacturing/Manufacturing Orders, delete the "to do" 
filter and search for a Manufacturing order with your final product
- unbuild it
- Open accounting/journal entries and select the journal entry for 
the unbuild

**Current behavior:**
There is only two account lines. 
There is no line balancing the "Stock Interim" line of the
manufacturing order.

**Cause of the issue:**
The override of _generate_valuation_lines_data in
mrp_subcontracted_account adds the stock interim line on the 
manufacturing order.
However when unbuilding, the qty is negative so we exit the function
https://github.com/odoo/odoo/blob/1358f93a4c73de5a28cda72ec78769625c863efd/addons/mrp_subcontracting_account/models/stock_move.py#L20

**fix**
Because subcontracted Manufacturing orders are not meant 
to be unbuilt, we prevent it

opw-4998137