### PR TITLE
[FIX] stock: fix PDF layout in report_picking

### DIFF
--- a/addons/stock/report/report_stockpicking_operations.xml
+++ b/addons/stock/report/report_stockpicking_operations.xml
@@ -3,8 +3,8 @@
     <data>
 
         <template id="report_picking">
-            <t t-call="web.report_layout">
-                <div class="article o_report_layout_standard">
+            <t t-call="web.html_container">
+                <t t-call="web.external_layout">
                     <t t-foreach="docs" t-as="o">
                         <t t-set="address" t-value="None"/>
                         <div class="page o_report_stockpicking_operations">
@@ -272,7 +272,7 @@
                             <div class="oe_structure"></div>
                         </div>
                     </t>
-                </div>
+                </t>
             </t>
         </template>
         <template id="report_picking_type_label">

--- a/addons/stock/report/stock_report_views.xml
+++ b/addons/stock/report/stock_report_views.xml
@@ -6,7 +6,7 @@
             <field name="model">stock.picking</field>
             <field name="report_type">qweb-pdf</field>
             <field name="report_name">stock.report_picking</field>
-            <field name="report_file">stock.report_picking_operations</field>
+            <field name="report_file">stock.report_stockpicking_operations</field>
             <field name="print_report_name">'Picking Operations - %s - %s' % (object.partner_id.name or '', object.name)</field>
             <field name="binding_model_id" ref="model_stock_picking"/>
             <field name="binding_type">report</field>

--- a/doc/cla/individual/stp5940.md
+++ b/doc/cla/individual/stp5940.md
@@ -1,0 +1,11 @@
+Thailand, 2025-10-06
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+PA Sitthipong sitthipong114@gmail.com https://github.com/STP5940


### PR DESCRIPTION
[FIX] stock: fix PDF layout in report_picking

Versions
--------
- 19.0+

Steps to reproduce
------------------
1. Go to Inventory > Receipts
2. Click on any receipt
3. Click Print button

Issue
-----
The receipt PDF report uses incorrect layout template
causing formatting issues in the generated document.

Solution
--------
Replace:
```
    <t t-call='web.report_layout'>
        <div class='article o_report_layout_standard'>
           ...
        </div>
    </t>
```
With:
```
    <t t-call='web.html_container'>
        <t t-call='web.external_layout'>
           ...
        </t>
    </t>
```

This ensures the receipt PDF uses the proper external layout
template for consistent formatting.

Signed-off-by: PA Sitthipong <sitthipong114@gmail.com>

<img width="806" height="326" alt="image" src="https://github.com/user-attachments/assets/49ca6cfd-9fd8-4a43-9a89-9d8c5f982e3e" />


<img width="1157" height="862" alt="image" src="https://github.com/user-attachments/assets/e008e987-083b-474d-8e1a-42385f73ff8f" />
