### PR TITLE
[FIX] project{_todo}: made the display name field required in to-do

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -794,6 +794,8 @@ class ProjectTask(models.Model):
 
     def _inverse_display_name(self):
         for task in self:
+            if not task.display_name:
+                continue
             pattern = re.compile(r'^%s.+?%s$' % (
                 ('').join(task._get_cannot_start_with_patterns()),
                 ('').join(task._get_groups_patterns()))

--- a/addons/project_todo/tests/test_todo_quick_create.py
+++ b/addons/project_todo/tests/test_todo_quick_create.py
@@ -42,3 +42,9 @@ class TestTodoQuickCreate(TestProjectCommon):
             todo = todo_form.save()
             results = (todo.name, len(todo.tag_ids), len(todo.user_ids), todo.priority)
             self.assertEqual(results, values)
+
+    def test_create_task_with_no_name_in_quick_create_view(self):
+        todo_form = Form(self.env['project.task'], view="project_todo.project_task_view_todo_quick_create_form")
+        todo_form.display_name = False
+        with self.assertRaises(AssertionError):
+            todo_form.save()

--- a/addons/project_todo/views/project_task_views.xml
+++ b/addons/project_todo/views/project_task_views.xml
@@ -142,6 +142,7 @@
                         name="display_name"
                         string="To-do Title"
                         placeholder="e.g. Send Invitations"
+                        required="1"
                         help='Use these keywords in the title to streamline your to-dos:&#10;&#10;
                             #tags: Add tags to categorize the to-do&#10;
                             @user: Assign the to-do to a specific user&#10;


### PR DESCRIPTION
Currently, an error occurs when user tries to create a to-do with no name.

Steps to replicate:
- Install Project.
- Go to `To-Do > Click New > Click Add`.
- Error will occur on the terminal.

Error:
`TypeError: expected string or bytes-like object, got 'bool'`

Cause:
- The error occurs after a recent [PR], that changed `name` field in the to-do app's kanban view to `display_name`.
- As `display_name` is not a required field this will allow the creation of task and trigger the method `_inverse_display_name`.
- This will cause the error to occur at line [1] (because `task.display_name` is False).

Solution:
- Made the field required through xml similar to the `project.task` kanban view
  in the project app [2].

- Also handled the case when `display_name` is received falsy at [1] by skipping
  the execution and continuing the loop (this is mostly for the existing DBs).


[PR]: https://github.com/odoo/odoo/pull/205354

[1]: https://github.com/odoo/odoo/blob/b81d119fae5f5194334cee94bacffefeb1cd8c6e/addons/project/models/project_task.py#L801

[2]: https://github.com/odoo/odoo/blob/b81d119fae5f5194334cee94bacffefeb1cd8c6e/addons/project/views/project_task_views.xml#L609

sentry-6913627252

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
