### PR TITLE
[FIX] web, website: industry autocomplete option clicking not working

### DIFF
--- a/addons/web/static/src/core/autocomplete/autocomplete.js
+++ b/addons/web/static/src/core/autocomplete/autocomplete.js
@@ -42,7 +42,6 @@ export class AutoComplete extends Component {
         menuPositionOptions: { type: Object, optional: true },
         menuCssClass: { type: [String, Array, Object], optional: true },
         selectOnBlur: { type: Boolean, optional: true },
-        selectOnTab: { type: Boolean, optional: true },
     };
     static defaultProps = {
         value: "",
@@ -71,6 +70,7 @@ export class AutoComplete extends Component {
         this.sources = [];
         this.inEdition = false;
         this.mouseSelectionActive = false;
+        this.isOptionSelected = false;
 
         this.state = useState({
             navigationRev: 0,
@@ -107,7 +107,7 @@ export class AutoComplete extends Component {
 
         useExternalListener(window, "scroll", this.externalClose, true);
         useExternalListener(window, "pointerdown", this.externalClose, true);
-        useExternalListener(window, "mousemove", () => this.mouseSelectionActive = true, true);
+        useExternalListener(window, "mousemove", () => (this.mouseSelectionActive = true), true);
 
         this.hotkey = useService("hotkey");
         this.hotkeysToRemove = [];
@@ -270,7 +270,7 @@ export class AutoComplete extends Component {
         if (this.props.resetOnSelect) {
             this.inputRef.el.value = "";
         }
-
+        this.isOptionSelected = true;
         this.forceValFromProp = true;
         option.onSelect();
         this.close();
@@ -332,18 +332,18 @@ export class AutoComplete extends Component {
         }
         // If selectOnBlur is true, we select the first element
         // of the autocomplete suggestions list, if this element exists
-        if (this.props.selectOnBlur && this.sources[0]) {
+        if (this.props.selectOnBlur && !this.isOptionSelected && this.sources[0]) {
             const firstOption = this.sources[0].options[0];
             if (firstOption) {
                 this.state.activeSourceOption = firstOption.unselectable ? null : [0, 0];
                 this.selectOption(this.activeOption);
-                return;
             }
         }
         this.props.onBlur({
             inputValue: this.inputRef.el.value,
         });
         this.inEdition = false;
+        this.isOptionSelected = false;
     }
     onInputClick() {
         if (!this.isOpened && this.props.searchOnInputClick) {
@@ -409,10 +409,6 @@ export class AutoComplete extends Component {
                     return;
                 }
                 this.selectOption(this.activeOption);
-                if (this.props.selectOnBlur) {
-                    this.ignoreBlur = true;
-                    this.inputRef.el.blur();
-                }
                 break;
             case "escape":
                 if (!this.isOpened) {
@@ -421,15 +417,6 @@ export class AutoComplete extends Component {
                 this.cancel();
                 break;
             case "tab":
-                if (this.props.selectOnTab) {
-                    if (!this.isOpened || !this.state.activeSourceOption) {
-                        return;
-                    }
-                    this.selectOption(this.activeOption);
-                    this.ignoreBlur = true;
-                    this.inputRef.el.blur();
-                    break;
-                }
             case "shift+tab":
                 if (!this.isOpened) {
                     return;

--- a/addons/web/static/tests/core/autocomplete.test.js
+++ b/addons/web/static/tests/core/autocomplete.test.js
@@ -647,6 +647,60 @@ test("tab and shift+tab close the dropdown", async () => {
     expect(dropdown).not.toHaveCount();
 });
 
+test("Clicking away selects the first option when selectOnBlur is true", async () => {
+    class Parent extends Component {
+        static template = xml`<AutoComplete value="state.value" sources="sources" selectOnBlur="true"/>`;
+        static components = { AutoComplete };
+        static props = [];
+
+        state = useState({ value: "" });
+        sources = buildSources(() => [
+            item("World", this.onSelect.bind(this)),
+            item("Hello", this.onSelect.bind(this)),
+        ]);
+
+        onSelect(option) {
+            this.state.value = option.label;
+            expect.step(option.label);
+        }
+    }
+
+    await mountWithCleanup(Parent);
+    const input = ".o-autocomplete input";
+    await contains(input).click();
+    expect(".o-autocomplete--dropdown-menu").toBeVisible();
+    queryFirst(input).blur();
+    await animationFrame();
+    expect(input).toHaveValue("World");
+    expect.verifySteps(["World"]);
+});
+
+test("selectOnBlur doesn't interfere with selecting by mouse clicking", async () => {
+    class Parent extends Component {
+        static template = xml`<AutoComplete value="state.value" sources="sources" selectOnBlur="true"/>`;
+        static components = { AutoComplete };
+        static props = [];
+
+        state = useState({ value: "" });
+        sources = buildSources(() => [
+            item("World", this.onSelect.bind(this)),
+            item("Hello", this.onSelect.bind(this)),
+        ]);
+
+        onSelect(option) {
+            this.state.value = option.label;
+            expect.step(option.label);
+        }
+    }
+
+    await mountWithCleanup(Parent);
+    const input = ".o-autocomplete input";
+    await contains(input).click();
+    await contains(".o-autocomplete--dropdown-item:last").click();
+    expect(input).toHaveValue("Hello");
+    expect.verifySteps(["Hello"]);
+});
+
 test("autocomplete scrolls when moving with arrows", async () => {
     class Parent extends Component {
         static template = xml`

--- a/addons/website/static/src/client_actions/configurator/configurator.xml
+++ b/addons/website/static/src/client_actions/configurator/configurator.xml
@@ -74,7 +74,7 @@
                             menuPositionOptions="{ position: 'bottom-fit' }"
                             menuCssClass="'custom-ui-autocomplete shadow-lg border-0 o_configurator_show_fast o_configurator_industry_dropdown'"
                             selectOnBlur="true"
-                            selectOnTab="true"
+                            autoSelect="true"
                         />
                     </label>
                     <span> business</span>


### PR DESCRIPTION
Problem
In the website configuration wizard, when selecting an industry
by mouse clicking, the first industry in the list would get selected
instead of the clicked one.

Steps
- In Odoo with the Website addon installed
- Create a new website in the website settings
- Select any type of website
- Write an industry name
- Click on any industry in the dropdown list
- The first industry of the list get selected

Cause
This bug only happens if the param `selectOnBlur` is activated.
`selectOnBlur` makes clicking away from the input as a select
of the first option.
But, clicking on an option in the list is also considered as an onBlur,
so when the user clicks on an industry, it will always select
the first one of the list.

Fix
Added a flag `isOptionSelected`, set to true every time an option is
selected. This is to prevent the `selectOnBlur` of overwriting what has
been already selected.

Deleted `selectOnTab` brought in this commit 8e6410b because the
function already existed under `autoSelect`.

Also added tests, and fixed linter errors in `autocomplete.js`.

task-5139708