### PR TITLE
[FIX] hr_attendance: prevent error when removing check-in value

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -83,7 +83,7 @@ class HrAttendance(models.Model):
     @api.depends("check_in", "employee_id")
     def _compute_date(self):
         for attendance in self:
-            if not attendance.employee_id:  # weird precompute edge cases. Never after creation
+            if not attendance.employee_id or not attendance.check_in:  # weird precompute edge cases. Never after creation
                 attendance.date = datetime.today()
                 continue
             tz = timezone(attendance.employee_id._get_tz())

--- a/addons/hr_attendance/tests/test_hr_attendance_process.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_process.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from unittest.mock import patch
 
 from odoo import fields
-from odoo.tests import new_test_user
+from odoo.tests import Form, new_test_user
 from odoo.tests.common import tagged, TransactionCase, freeze_time
 
 
@@ -99,6 +99,13 @@ class TestHrAttendance(TransactionCase):
         # now = 2019/3/2 14:00 in the employee's timezone
         with patch.object(fields.Datetime, 'now', lambda: tz_datetime(2019, 3, 2, 14, 0).astimezone(pytz.utc).replace(tzinfo=None)):
             self.assertEqual(employee.hours_today, 5, "It should have counted 5 hours")
+
+    def test_remove_check_in_value_from_attendance(self):
+        attendance_form = Form(self.env['hr.attendance'])
+        attendance_form.employee_id = self.test_employee
+        attendance_form.check_in = False
+        with self.assertRaises(AssertionError):
+            attendance_form.save()
 
     # @freeze_time("2024-02-1")
     # def test_change_in_out_mode_when_manual_modification(self):


### PR DESCRIPTION
The system crashes with an error when the user removes the Check In value while creating a new attendance record and then tries to modify other fields.

**Steps to produce:**
- Install the `Attendances` module.
- Go to the `Attendance app` and click on `New`.
- In the wizard, remove the `Check In` value and click anywhere.

**Error:**
```py
AttributeError: 'bool' object has no attribute 'tzinfo'
```

**Cause:**
- At [1], when the `check_in` value is changed, the `_compute_date` method is triggered. If `attendance.check_in` is `False`, the computation attempts to access `tzinfo` on a boolean value.

**Solution:**
- If the `check_in` value is not present, set the `attendance.date` to today’s date.

[1]
https://github.com/odoo/odoo/blob/b5a08dcd33cf72c129c4c512045edfe1d8c852a7/addons/hr_attendance/models/hr_attendance.py#L83-L90

**sentry-6924425687**

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
