### PR TITLE
[FIX] html_editor: single cell selection incorrect behavior

### DIFF
--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -643,12 +643,13 @@ export class TablePlugin extends Plugin {
         const startTd = closestElement(selection.startContainer, "td");
         const endTd = closestElement(selection.endContainer, "td");
         if (startTd && startTd === endTd && !isProtected(startTd) && !isProtecting(startTd)) {
-            const targetedNodes = this.dependencies.selection.getTargetedNodes();
+            const selectedNodes = this.dependencies.selection
+                .getTargetedNodes()
+                .filter(this.dependencies.selection.areNodeContentsFullySelected);
             const cellContents = descendants(startTd);
-            /** @todo Test. Should probably use areNodeContentsFullySelected. */
             const areCellContentsFullySelected = cellContents
                 .filter((d) => !isBlock(d))
-                .every((child) => targetedNodes.includes(child));
+                .every((child) => selectedNodes.includes(child));
             if (areCellContentsFullySelected) {
                 const SENSITIVITY = 5;
                 if (!this._mouseMovePositionWhenAllContentsSelected) {

--- a/addons/html_editor/static/tests/table/selection.test.js
+++ b/addons/html_editor/static/tests/table/selection.test.js
@@ -1,10 +1,11 @@
 import { describe, expect, test } from "@odoo/hoot";
-import { tick } from "@odoo/hoot-mock";
+import { animationFrame, tick } from "@odoo/hoot-mock";
 import { setupEditor, testEditor } from "../_helpers/editor";
 import { unformat } from "../_helpers/format";
 import { bold, resetSize, setColor } from "../_helpers/user_actions";
-import { getContent } from "../_helpers/selection";
-import { queryAll } from "@odoo/hoot-dom";
+import { getContent, setSelection } from "../_helpers/selection";
+import { manuallyDispatchProgrammaticEvent, queryAll } from "@odoo/hoot-dom";
+import { nodeSize } from "@html_editor/utils/position";
 
 describe("custom selection", () => {
     test("should indicate selected cells with blue background", async () => {
@@ -457,6 +458,73 @@ describe("select a full table on cross over", () => {
                     <p><font style="color: aquamarine;">a]</font>bc</p>`),
             });
         });
+    });
+});
+
+describe("single cell selection", () => {
+    test("should not select single cell via mouse movement if content is not fully selected", async () => {
+        const content = unformat(`
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr>
+                        <td>
+                            <p>abcd</p>
+                        </td>
+                        <td><p><br></p></td>
+                    </tr>
+                    <tr>
+                        <td><p><br></p></td>
+                        <td><p><br></p></td>
+                    </tr>
+                </tbody>
+            </table>
+        `);
+
+        const { el } = await setupEditor(content);
+
+        const firstTd = el.querySelector("td");
+        const firstP = firstTd.firstElementChild;
+        const textNode = firstP.firstChild;
+
+        // Get bounding rect of selection range at the end of text.
+        const range = document.createRange();
+        range.setStart(textNode, nodeSize(textNode));
+        range.setEnd(textNode, nodeSize(textNode));
+        const rangeRect = range.getBoundingClientRect();
+
+        // Simulate mousedown at the end of text.
+        await manuallyDispatchProgrammaticEvent(firstP, "mousedown", {
+            detail: 1,
+            clientX: rangeRect.right,
+            clientY: rangeRect.top,
+        });
+
+        // Put cursor at the end of text.
+        setSelection({
+            anchorNode: textNode,
+            anchorOffset: nodeSize(textNode),
+        });
+        await animationFrame();
+
+        // Simulate attempt to select single cell.
+        manuallyDispatchProgrammaticEvent(firstP, "mousemove", {
+            detail: 1,
+            clientX: rangeRect.right,
+            clientY: rangeRect.top,
+        });
+        manuallyDispatchProgrammaticEvent(firstP, "mousemove", {
+            detail: 1,
+            clientX: rangeRect.right + 15,
+            clientY: rangeRect.top,
+        });
+        manuallyDispatchProgrammaticEvent(firstP, "mouseup", {
+            detail: 1,
+            clientX: rangeRect.right + 15,
+            clientY: rangeRect.top,
+        });
+
+        await animationFrame();
+        expect(firstTd).not.toHaveClass("o_selected_td");
     });
 });
 


### PR DESCRIPTION
Current behavior before PR:

- Create an m x n table.
- Write some text in a cell.
- Put cursor at the end of text.
- Try to select cell by moving mouse rightwards.

Notice that the cell is selected although the cell content is not fully selected.

Desired behavior after PR:

This PR backports commit [1] to ensure that single cell is selected only if the cell content is fully selected.

[1]: https://github.com/odoo/odoo/commit/09d369e118f622f30149f46702f58c656a3cee04




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
