### PR TITLE
[IMP] mail: show message seen indicator in message preview

### DIFF
--- a/addons/mail/static/src/core/common/chat_bubble.js
+++ b/addons/mail/static/src/core/common/chat_bubble.js
@@ -1,4 +1,5 @@
 import { ImStatus } from "@mail/core/common/im_status";
+import { MessageSeenIndicator } from "@mail/discuss/core/common/message_seen_indicator";
 
 import { Component, useEffect, useRef, useState, useSubEnv } from "@odoo/owl";
 
@@ -9,6 +10,7 @@ import { CountryFlag } from "@mail/core/common/country_flag";
 import { isMobileOS } from "@web/core/browser/feature_detection";
 
 class ChatBubblePreview extends Component {
+    static components = { MessageSeenIndicator };
     static props = ["chatWindow", "close"];
     static template = "mail.ChatBubblePreview";
 

--- a/addons/mail/static/src/core/common/chat_bubble.xml
+++ b/addons/mail/static/src/core/common/chat_bubble.xml
@@ -28,6 +28,7 @@
                 <t t-call="mail.message_preview_prefix">
                     <t t-set="message" t-value="message"/>
                 </t>
+                <MessageSeenIndicator t-if="message.showSeenIndicator(thread)" message="message" thread="thread" />
                 <t t-if="message.hasOnlyAttachments">
                     <i class="fa me-1" t-att-class="message.previewIcon"/>
                     <t t-out="message.previewText" />

--- a/addons/mail/static/src/core/public_web/notification_item.js
+++ b/addons/mail/static/src/core/public_web/notification_item.js
@@ -1,5 +1,6 @@
 import { isToday } from "@mail/utils/common/dates";
 import { useHover } from "@mail/utils/common/hooks";
+import { MessageSeenIndicator } from "@mail/discuss/core/common/message_seen_indicator";
 
 import { Component, useRef, useSubEnv } from "@odoo/owl";
 
@@ -9,7 +10,7 @@ import { useService } from "@web/core/utils/hooks";
 const { DateTime } = luxon;
 
 export class NotificationItem extends Component {
-    static components = { ActionSwiper };
+    static components = { ActionSwiper, MessageSeenIndicator };
     static props = [
         "counter?",
         "datetime?",
@@ -56,6 +57,10 @@ export class NotificationItem extends Component {
 
     onClick(ev) {
         this.props.onClick(this.markAsReadRef.el?.contains(ev.target));
+    }
+
+    get message() {
+        return this.props.thread?.newestPersistentOfAllMessage;
     }
 
     webkitLineClamp(maxLine) {

--- a/addons/mail/static/src/core/public_web/notification_item.xml
+++ b/addons/mail/static/src/core/public_web/notification_item.xml
@@ -33,6 +33,7 @@
                 <div class="d-flex o-mail-NotificationItem-line">
                     <div class="o-mail-NotificationItem-text" t-att-class="{ 'text-truncate': props.textTruncate, 'text-start': !props.textTruncate, 'small': !ui.isSmall }" t-att-style="props.textMaxLine !== undefined ? webkitLineClamp(props.textMaxLine) : ''">
                         <t t-slot="body-icon"/>
+                        <MessageSeenIndicator t-if="message?.showSeenIndicator(props.thread)" message="message" thread="props.thread" />
                         <t t-if="props.slots?.body" name="notificationBody" t-slot="body"/>
                     </div>
                     <div class="flex-grow-1"/>

--- a/addons/mail/static/src/discuss/core/common/message_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/message_model_patch.js
@@ -67,5 +67,12 @@ const messagePatch = {
             mentionedRoles,
         });
     },
+    /**
+     * @param {Thread} thread the thread being viewed
+     * @returns {boolean}
+     */
+    showSeenIndicator(thread) {
+        return this.isSelfAuthored && thread?.hasSeenFeature;
+    },
 };
 patch(Message.prototype, messagePatch);

--- a/addons/mail/static/src/discuss/core/common/message_patch.js
+++ b/addons/mail/static/src/discuss/core/common/message_patch.js
@@ -1,14 +1,4 @@
 import { Message } from "@mail/core/common/message";
 import { MessageSeenIndicator } from "@mail/discuss/core/common/message_seen_indicator";
 
-import { patch } from "@web/core/utils/patch";
-
 Message.components = { ...Message.components, MessageSeenIndicator };
-
-/** @type {Message} */
-const messagePatch = {
-    get showSeenIndicator() {
-        return this.props.message.isSelfAuthored && this.props.thread?.hasSeenFeature;
-    },
-};
-patch(Message.prototype, messagePatch);

--- a/addons/mail/static/src/discuss/core/common/message_patch.xml
+++ b/addons/mail/static/src/discuss/core/common/message_patch.xml
@@ -4,7 +4,7 @@
         <xpath expr="//div[hasclass('o-mail-Message-body')]" position="after">
             <div class="o-mail-Message-seenContainer position-absolute">
                 <MessageSeenIndicator
-                    t-if="showSeenIndicator"
+                    t-if="props.message.showSeenIndicator(props.thread)"
                     message="props.message"
                     thread="props.thread"
                 />
@@ -13,7 +13,7 @@
         <xpath expr="//AttachmentList" position="after">
             <div t-if="props.message.isBodyEmpty and message.attachment_ids.length > 0" class="o-mail-Message-seenContainer position-absolute ratio-1x1 rounded-circle p-1">
                 <MessageSeenIndicator
-                    t-if="showSeenIndicator"
+                    t-if="props.message.showSeenIndicator(props.thread)"
                     message="props.message"
                     thread="props.thread"
                 />


### PR DESCRIPTION
Previously, for chat and group channels, the message seen indicator was only visible inside the thread view — either in Discuss or the chat window. To check the delivery status of a sent message, users had to open the thread manually.

With this improvement, the message seen indicator is now also displayed in the message preview — both in the chat bubble and in the messaging menu. This makes it easier for users to track message delivery status at a glance without needing to open the thread.

For Messaging Menu:
Before:
<img width="477" height="57" alt="image" src="https://github.com/user-attachments/assets/3d736c06-643a-4eca-8153-9fb9ed3cc98f" />
After:
<img width="456" height="60" alt="image" src="https://github.com/user-attachments/assets/9f316728-32cf-4683-932b-3802821feab0" />

For Chat bubble:
Before:
<img width="242" height="91" alt="image" src="https://github.com/user-attachments/assets/5d186133-f5f7-44ae-8057-2b9de382ec3c" />
After:
<img width="259" height="82" alt="image" src="https://github.com/user-attachments/assets/53e2be6b-4752-4cd3-ab27-8989d36a0de0" />


Enterprise: https://github.com/odoo/enterprise/pull/96478

task-4825814

