### PR TITLE
[FIX] l10n_ar: display tax totals in comp currency

### DIFF
--- a/addons/l10n_ar/models/template_ar_base.py
+++ b/addons/l10n_ar/models/template_ar_base.py
@@ -29,6 +29,7 @@ class AccountChartTemplate(models.AbstractModel):
                 'expense_currency_exchange_account_id': 'base_diferencias_de_cambio',
                 'expense_account_id': 'base_compra_mercaderia',
                 'income_account_id': 'base_venta_de_mercaderia',
+                'display_invoice_tax_company_currency': False,
             },
         }
 

--- a/addons/l10n_ar/models/template_ar_ex.py
+++ b/addons/l10n_ar/models/template_ar_ex.py
@@ -26,5 +26,6 @@ class AccountChartTemplate(models.AbstractModel):
                 'account_default_pos_receivable_account_id': 'base_deudores_por_ventas_pos',
                 'income_currency_exchange_account_id': 'base_diferencias_de_cambio',
                 'expense_currency_exchange_account_id': 'base_diferencias_de_cambio',
+                'display_invoice_tax_company_currency': False,
             },
         }

--- a/addons/l10n_ar/models/template_ar_ri.py
+++ b/addons/l10n_ar/models/template_ar_ri.py
@@ -28,5 +28,6 @@ class AccountChartTemplate(models.AbstractModel):
                 'expense_currency_exchange_account_id': 'base_diferencias_de_cambio',
                 'account_sale_tax_id': 'ri_tax_vat_21_ventas',
                 'account_purchase_tax_id': 'ri_tax_vat_21_compras',
+                'display_invoice_tax_company_currency': False,
             },
         }

--- a/addons/l10n_ar/views/report_invoice.xml
+++ b/addons/l10n_ar/views/report_invoice.xml
@@ -115,9 +115,6 @@
         <!-- remove default document title -->
         <xpath expr="//t[@t-set='layout_document_title']" position="replace"/>
 
-        <!-- remove detail of taxes when currency != from company's currency -->
-        <t t-call="account.document_tax_totals_company_currency_template" position="replace"/>
-
         <!-- NCM column for fiscal bond -->
         <th name="th_description" position="after">
             <th t-if="fiscal_bond" name="th_ncm_code" class="text-start"><span>NCM</span></th>


### PR DESCRIPTION
Since d392333ba449f3d0b87b32946340c906a8e8f501 the tax totals in company
currency is not display on invoice report even if the option is
activated.

With this commit, we display back the tax totals, but we set the option
to False for users using AR localisation.

opw-5063608
