### PR TITLE
[FIX] html_editor: remove unfortunate variable redefinition

### DIFF
--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -371,9 +371,9 @@ export class DomPlugin extends Plugin {
             }
             // Ensure that all adjacent paragraph elements are converted to
             // <li> when inserting in a list.
-            const container = closestBlock(currentNode);
+            const block = closestBlock(currentNode);
             for (const processor of this.getResource("node_to_insert_processors")) {
-                nodeToInsert = processor({ nodeToInsert, container });
+                nodeToInsert = processor({ nodeToInsert, container: block });
             }
             if (insertBefore) {
                 currentNode.before(nodeToInsert);


### PR DESCRIPTION
In `dom.insert`, the variable `container` was being redefined to a constant within a `while` loop, making it impossible to use the original variable within the loop. This caused an `Uncaught Javascript Error` ("Cannot access 'container' before initialization") whenever trying to access it within the loop but above the redefinition. This commit renames the constant to a previously unused name.

opw-5053872

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
