### PR TITLE
[FIX] hr_timesheet: filter employee_id to avoid falsy id traceback

### DIFF
--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -218,7 +218,7 @@ class AccountAnalyticLine(models.Model):
         employee_ids = []
         # If batch creating from the calendar view, prefetch all employees to avoid fetching them one by one in the loop
         if self.env.context.get('timesheet_calendar'):
-            self.env['hr.employee'].browse([vals.get('employee_id') for vals in vals_list])
+            self.env['hr.employee'].browse([vals['employee_id'] for vals in vals_list if vals.get('employee_id')])
         # 1/ Collect the user_ids and employee_ids from each timesheet vals
         for vals in vals_list[:]:
             if self.env.context.get('timesheet_calendar'):

--- a/addons/hr_timesheet/tests/test_timesheet.py
+++ b/addons/hr_timesheet/tests/test_timesheet.py
@@ -861,6 +861,14 @@ class TestTimesheet(TestCommonTimesheet):
         """
         HrTimesheet = self.env['account.analytic.line'].with_context(timesheet_calendar=True)
 
+        timesheet = HrTimesheet.with_user(self.user_manager).create({
+            'name': 'Timesheet',
+            'task_id': self.task1.id,
+            'unit_amount': 1,
+        })
+        self.assertEqual(timesheet.employee_id, self.user_manager.employee_id)
+        self.assertTrue(timesheet, "Timesheet should be created even without an employee")
+
         timesheet = HrTimesheet.create({
             'project_id': self.project_customer.id,
             'unit_amount': 1,


### PR DESCRIPTION
Steps to reproduce:

- Try to create a timesheets from calendar multicreate

Issue:

- A falsy id ORM traceback

Reason:

- While trying to prefetch all employees required for mutli creation we don't check if every record has employee.

Fix:

- On try to prefetch(browse) when there is employee_id else Skip.
