### PR TITLE
[FIX] website: unskip test_03_snippets_all_drag_and_drop

### DIFF
--- a/addons/website/tests/test_snippets.py
+++ b/addons/website/tests/test_snippets.py
@@ -37,6 +37,7 @@ class TestSnippets(HttpCase):
             's_map',  # avoid call to maps.google.com
             's_instagram_page',  # avoid call to instagram.com
             's_image',  # Avoid specific case where the media dialog opens on drop
+            's_video',  # Avoid specific case where the media dialog opens on drop
             's_snippet_group',  # Snippet groups are not snippets
             's_inline_text',
         ]


### PR DESCRIPTION
Since PR odoo/odoo#214984, the “test_03_snippets_all_drag_and_drop” test fails because the video snippet opens the media dialog and the test does not handle it.
Solution: as with image snippets, we will ignore them in this test.

Error: https://runbot.odoo.com/odoo/runbot.build.error/231594

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
