### PR TITLE
[FIX] hr_recruitment: ensure talent is correctly created in pool

### DIFF
--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -643,6 +643,10 @@ class HrApplicant(models.Model):
         applicants = super().create(vals_list)
         applicants.sudo().interviewer_ids._create_recruitment_interviewers()
 
+        for applicant in applicants:
+            if applicant.talent_pool_ids and not applicant.pool_applicant_id:
+                applicant.pool_applicant_id = applicant
+
         if (applicants.interviewer_ids.partner_id - self.env.user.partner_id):
             for applicant in applicants:
                 interviewers_to_notify = applicant.interviewer_ids.partner_id - self.env.user.partner_id

--- a/addons/hr_recruitment/tests/test_recruitment_talent_pools.py
+++ b/addons/hr_recruitment/tests/test_recruitment_talent_pools.py
@@ -56,6 +56,20 @@ class TestRecruitmentTalentPool(TransactionCase):
             "The talent should be linked to the talent pool",
         )
 
+    def test_create_talent_in_pool(self):
+        talent = self.env["hr.applicant"].with_context(default_talent_pool_ids=self.t_talent_pool_1.ids).create({
+            'partner_name': 'Talent in a pool',
+        })
+
+        self.assertEqual(talent.talent_pool_ids, self.t_talent_pool_1)
+        self.assertEqual(talent.pool_applicant_id, talent)
+
+        job_wizard = Form(self.env["job.add.applicants"].with_context({"default_applicant_ids": talent.ids}))
+        job_wizard.job_ids = self.t_job_1
+        job_1_applicant = job_wizard.save()._add_applicants_to_job()
+
+        self.assertEqual(job_1_applicant.pool_applicant_id, talent)
+
     def test_add_applicant_to_multiple_talent_pools(self):
         """
         Test that a applicant is only duplicated once and linked to multiple pools when creating a talent.


### PR DESCRIPTION
**Steps to reproduce**
- Recruitment > Applications > By Talent Pools
- Click on a talent pool
- Click on "New" and create a new talent
- Click on "Create applications" and create one

Issue: "Add to Pool" button appears, when we would except the "Talent Pools" smart button to appear, linking the new application to the previously created talent. This leads to the creation of duplicates talents.

**Cause**
`pool_applicant_id` is not set on either the talent, or the created applicant.
In the original flow, when adding an applicant to a pool, `_add_applicants_to_pool` ensures `pool_applicant_id` is set to the talent for both the talent and the new applicant.

**Fix**
Since it's now possible to directly create talents in a pool, we set `pool_applicant_id` at creation.

opw-5117977
