### PR TITLE
[FIX] l10n_se: wrong IBAN in demo data

### DIFF
--- a/addons/l10n_se/demo/demo_company.xml
+++ b/addons/l10n_se/demo/demo_company.xml
@@ -21,7 +21,7 @@
     </record>
 
     <record id="base.demo_bank_se" model="res.partner.bank" forcecreate="1">
-        <field name="acc_number">SE0826566594158439377422</field>
+        <field name="acc_number">SE5850000000014938684140</field>
         <field name="partner_id" ref="base.partner_demo_company_se"/>
         <field name="company_id" ref="base.demo_company_se"/>
     </record>


### PR DESCRIPTION
This commit replace the wrong `SE0826566594158439377422` IBAN by
`SE5850000000014938684140`

The actual IBAN of the sweden bank journal demo data
is not following the official format, which is:

- Country code: 'SE' -> **OK**
- Valid checksum digit: '58' -> **OK**
- Valid bank code: '5000' -> **KO**, '2656' is not a valid SE bank code
- n zeros to fill the IBAN: '0000' -> **KO**, it's missing the zeros
- Account number: '14938684140' -> **OK**

Linked:https://github.com/odoo/enterprise/pull/95463

task-5107240
