### PR TITLE
[FIX] account: fix partner for payment registration

### DIFF
--- a/addons/account_payment/tests/test_account_payment.py
+++ b/addons/account_payment/tests/test_account_payment.py
@@ -547,3 +547,39 @@ class TestAccountPayment(AccountPaymentCommon):
         # _reconcile_after_done() shouldn't raise an error even though the invoice is cancelled
         tx._reconcile_after_done()
         self.assertEqual(tx.payment_id.state, 'posted')
+
+    def test_payment_token_for_invoice_partner_is_available(self):
+        """Test that the payment token of the invoice partner is available"""
+        with self.mocked_get_payment_method_information():
+            bank_journal = self.company_data['default_journal_bank']
+            payment_method_line = bank_journal.inbound_payment_method_line_ids\
+                .filtered(lambda line: line.payment_provider_id == self.dummy_provider)
+            self.assertTrue(payment_method_line)
+            child_partner = self.env['res.partner'].create(
+                {
+                    'name': "test_payment_token_for_invoice_partner_is_available",
+                    'is_company': False,
+                    'parent_id': self.partner.id,
+                }
+            )
+            invoice = self.env['account.move'].create({
+                'move_type': 'out_invoice',
+                'partner_id': child_partner.id,
+                'invoice_line_ids': [
+                    Command.create({
+                        'name': 'test line',
+                        'price_unit': 100.0,
+                    }),
+                ],
+            })
+            invoice.action_post()
+            payment_token = self._create_token(partner_id=child_partner.id)
+            wizard = (
+                self.env["account.payment.register"]
+                .with_context(active_model="account.move", active_ids=invoice.ids)
+                .create({"payment_method_line_id": payment_method_line.id})
+            )
+            self.assertRecordValues(wizard, [{
+                'suitable_payment_token_ids': payment_token.ids,
+                'payment_token_id': payment_token.id,
+            }])

--- a/addons/account_payment/wizards/account_payment_register.py
+++ b/addons/account_payment/wizards/account_payment_register.py
@@ -35,15 +35,17 @@ class AccountPaymentRegister(models.TransientModel):
     @api.depends('payment_method_line_id')
     def _compute_suitable_payment_token_ids(self):
         for wizard in self:
+            wizard.suitable_payment_token_ids = [Command.clear()]
             if wizard.can_edit_wizard and wizard.use_electronic_payment_method:
-                wizard.suitable_payment_token_ids = self.env['payment.token'].sudo().search([
-                    *self.env['payment.token']._check_company_domain(wizard.company_id),
-                    ('provider_id.capture_manually', '=', False),
-                    ('partner_id', '=', wizard.partner_id.id),
-                    ('provider_id', '=', wizard.payment_method_line_id.payment_provider_id.id),
-                ])
-            else:
-                wizard.suitable_payment_token_ids = [Command.clear()]
+                batch = wizard._get_batches()[0]
+                partner = batch['lines'].move_id.partner_id
+                if len(partner) == 1:
+                    wizard.suitable_payment_token_ids = self.env['payment.token'].sudo().search([
+                        *self.env['payment.token']._check_company_domain(wizard.company_id),
+                        ('provider_id.capture_manually', '=', False),
+                        ('partner_id', '=', partner.id),
+                        ('provider_id', '=', wizard.payment_method_line_id.payment_provider_id.id),
+                    ])
 
     @api.depends('payment_method_line_id')
     def _compute_use_electronic_payment_method(self):
@@ -53,23 +55,17 @@ class AccountPaymentRegister(models.TransientModel):
             codes = [key for key in dict(self.env['payment.provider']._fields['code']._description_selection(self.env))]
             wizard.use_electronic_payment_method = wizard.payment_method_code in codes
 
-    @api.onchange('can_edit_wizard', 'payment_method_line_id', 'journal_id')
+    @api.depends('can_edit_wizard', 'suitable_payment_token_ids', 'journal_id')
     def _compute_payment_token_id(self):
         codes = [key for key in dict(self.env['payment.provider']._fields['code']._description_selection(self.env))]
         for wizard in self:
-            if wizard.can_edit_wizard \
-                    and wizard.payment_method_line_id.code in codes \
-                    and wizard.journal_id \
-                    and wizard.partner_id:
-
-                wizard.payment_token_id = self.env['payment.token'].sudo().search([
-                    *self.env['payment.token']._check_company_domain(wizard.company_id),
-                    ('partner_id', '=', wizard.partner_id.id),
-                    ('provider_id.capture_manually', '=', False),
-                    ('provider_id', '=', wizard.payment_method_line_id.payment_provider_id.id),
-                 ], limit=1)
-            else:
+            if wizard.payment_method_line_id and wizard.payment_method_line_id.code not in codes:
                 wizard.payment_token_id = False
+            elif wizard.payment_token_id in wizard.suitable_payment_token_ids:
+                # The selected payment token is still valid.
+                continue
+            else:
+                wizard.payment_token_id = wizard.suitable_payment_token_ids[:1]
 
     # -------------------------------------------------------------------------
     # BUSINESS METHODS


### PR DESCRIPTION
Currently, when user A from company AA records a payment method, a payment token is stored for that user. However, when an invoice is issued for that user, the payment token cannot be used because the payment registration form uses the partner AA instead of the user linked to the move, partner A.

Step to reproduce:
1. Create a user A in company AA
2. Create an invoice for user A
3. Register a payment on the invoice and save the payment method (token)
4. Create another invoice for user A
5. Try to register a payment on the invoice: the payment token is not proposed

This fix updates the logic to use the user linked to the move instead of the partner on the line, allowing proper selection of a payment token.

opw-5036106