### PR TITLE
[FIX] pos_sale: confirm SO paid with POS online payment

### DIFF
--- a/addons/point_of_sale/models/pos_payment_method.py
+++ b/addons/point_of_sale/models/pos_payment_method.py
@@ -17,6 +17,9 @@ class PosPaymentMethod(models.Model):
             selection.append(('qr_code', self.env._("Bank App (QR Code)")))
         return selection
 
+    def _is_online_payment(self):
+        return False
+
     name = fields.Char(string="Method", required=True, translate=True, help='Defines the name of the payment method that will be displayed in the Point of Sale when the payments are selected.')
     sequence = fields.Integer(copy=False)
     outstanding_account_id = fields.Many2one('account.account',

--- a/addons/pos_online_payment/models/pos_payment_method.py
+++ b/addons/pos_online_payment/models/pos_payment_method.py
@@ -129,3 +129,6 @@ class PosPaymentMethod(models.Model):
                         pos_config_id=pos_config_id,
                     ))
         return payment_method_id
+
+    def _is_online_payment(self):
+        return self.is_online_payment


### PR DESCRIPTION
When a Sale Order was imported in PoS and paid using online payment method, the SO's state stayed in Quotation.

Steps to reproduce:
-------------------
* Create a new Sale Order with a product available in POS
* Add Online Payment in the Payment Methods
* Import and settle the Order in POS
* Pay the order with the Online Payment

> Observation:
In Sale app, the Sale Order is still in Quotation state.

Why the fix:
------------
Online payments call `action_pos_order_paid()` directly, which only sets the POS order state to paid and never confirms the linked sale.order. Other payment methods do it in `sync_from_ui()`.
Extended `action_pos_order_paid()` in pos_sale will now confirm linked quotations after POS marks the order as paid.

opw-5022526
