### PR TITLE
[FIX] point_of_sale: prevent test failures due to missing country

### DIFF
--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -2750,6 +2750,7 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
             'name': 'Branch 1',
             'parent_id': self.env.company.id,
             'chart_template': self.env.company.chart_template,
+            'country_id': self.env.company.country_id.id,
         })
         user = self.env['res.users'].create({
             'name': 'Branch user',


### PR DESCRIPTION
Before this commit, some tests would fail when localizations requiring a country were installed, because the created company did not have a country set.

runbot-233158

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
