### PR TITLE
[IMP] {l10n_in_,}hr_holidays: modify previous holidays legend color

### DIFF
--- a/addons/hr_holidays/static/src/views/calendar/calendar_side_panel/calendar_side_panel.js
+++ b/addons/hr_holidays/static/src/views/calendar/calendar_side_panel/calendar_side_panel.js
@@ -34,6 +34,8 @@ export class TimeOffCalendarSidePanel extends CalendarSidePanel {
             (start, end) => `${serializeDateTime(start)},${serializeDateTime(end)}`
         );
 
+        this.currentDateTime = luxon.DateTime.now();
+
         onWillStart(async () => {
             await this.updateSpecialDays();
             await this.loadHolidayData();

--- a/addons/hr_holidays/static/src/views/calendar/calendar_side_panel/calendar_side_panel.xml
+++ b/addons/hr_holidays/static/src/views/calendar/calendar_side_panel/calendar_side_panel.xml
@@ -24,10 +24,12 @@
                 <div class="d-flex flex-column mt-4" t-if="leaveState.mandatoryDays.length">
                     <h5>Mandatory Days</h5>
                     <ul class="ps-0">
-                        <li t-foreach="leaveState.mandatoryDays" t-as="mandatoryDay" t-key="mandatoryDay.id" class="mt-2 list-unstyled">
-                            <strong
+                        <li t-foreach="leaveState.mandatoryDays" t-as="mandatoryDay" t-key="mandatoryDay.id" class="mt-2 list-unstyled"
+                            t-att-class="mandatoryDay.end &lt; currentDateTime ? 'text-muted' : 'fw-bold'">
+                            <span
                                     t-esc="getFormattedDateSpan(mandatoryDay.start, mandatoryDay.end)"
-                                    t-att-class="'hr_mandatory_day_'+mandatoryDay.colorIndex"/>
+                                    t-attf-class="hr_mandatory_day_{{ mandatoryDay.colorIndex }}"
+                                    t-att-class="{ 'opacity-50': mandatoryDay.end &lt; currentDateTime }"/>
                             : <t t-esc="mandatoryDay.title"/>
                         </li>
                     </ul>
@@ -36,8 +38,9 @@
                 <div class="d-flex flex-column mt-4" t-if="leaveState.bankHolidays.length">
                     <h5>Public Holidays</h5>
                     <ul class="ps-0">
-                        <li t-foreach="leaveState.bankHolidays" t-as="bankHoliday" t-key="bankHoliday.id" class="mt-2 list-unstyled">
-                            <strong
+                        <li t-foreach="leaveState.bankHolidays" t-as="bankHoliday" t-key="bankHoliday.id" class="mt-2 list-unstyled"
+                            t-att-class="bankHoliday.end &lt; currentDateTime ? 'text-muted' : 'fw-bold'">
+                            <span
                                     t-esc="getFormattedDateSpan(bankHoliday.start, bankHoliday.end)"/>
                             : <t t-esc="bankHoliday.title"/>
                         </li>

--- a/addons/l10n_in_hr_holidays/static/src/views/calendar/side_panel/calendar_side_panel.xml
+++ b/addons/l10n_in_hr_holidays/static/src/views/calendar/side_panel/calendar_side_panel.xml
@@ -6,8 +6,9 @@
                 <h5>Optional Holidays</h5>
                 <ul class="ps-0">
                     <li t-foreach="leaveState.optionalHolidays" t-as="optionalHoliday" t-key="optionalHoliday.id"
-                        class="mt-2 list-unstyled">
-                        <strong t-out="getFormattedDateSpan(optionalHoliday.start, optionalHoliday.end)"/>
+                        class="mt-2 list-unstyled"
+                        t-att-class="optionalHoliday.end.startOf('day') &lt; currentDateTime.startOf('day') ? 'text-muted' : 'fw-bold'">
+                        <span t-out="getFormattedDateSpan(optionalHoliday.start, optionalHoliday.end)"/>
                         : <t t-out="optionalHoliday.title"/>
                     </li>
                 </ul>


### PR DESCRIPTION
This commit improves the user experience by modifying the color of past holidays in the legend in the dashboard side panel to a lighter shade, making it easier to distinguish between past and upcoming holidays.

task-5129928

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
