### PR TITLE
[FIX] sale_gelato: fix crash when receiving order cancelation webhook

### DIFF
--- a/addons/sale_gelato/controlers/main.py
+++ b/addons/sale_gelato/controlers/main.py
@@ -61,10 +61,12 @@ class GelatoController(Controller):
                 # caching.
                 order_sudo.order_line.currency_id
 
-                # Send the generic order cancellation email.
-                order_sudo.message_post_with_source(
-                    source_ref=request.env.ref('sale.mail_template_sale_cancellation'),
-                    author_id=request.env.ref('base.partner_root').id,
+                # Log a message on the order.
+                log_message = _(
+                    "Gelato has canceled order %(reference)s.", reference=order_sudo.display_name
+                )
+                order_sudo.message_post(
+                    body=log_message, author_id=request.env.ref('base.partner_root').id
                 )
             elif fulfillment_status == 'in_transit':
                 # Send the Gelato order status update email.


### PR DESCRIPTION
After an order is canceled on Gelato, we receveive a webhook with an `fulfillmentStatus` of `cancel` and while processing it, it crash with:

```
ValueError: External ID not found in the system: sale.mail_template_sale_cancellation
```

The mail template used to notify the status change has been removed in odoo/odoo@2c858ed15e50, so instead we simplify log the information on the sale order chatter.

opw-5110226

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
