### PR TITLE
[FIX] attachment_indexation: Fix PDF/Tabular attachment indexation

### DIFF
--- a/addons/attachment_indexation/models/ir_attachment.py
+++ b/addons/attachment_indexation/models/ir_attachment.py
@@ -2,16 +2,19 @@
 import io
 import importlib.util
 import logging
+import re
+import warnings
 import xml.dom.minidom
 import zipfile
+from lxml import etree
 
 from odoo import api, models
 from odoo.tools.lru import LRU
 
 _logger = logging.getLogger(__name__)
 
-if not importlib.util.find_spec('pdfminer'):
-    _logger.warning("Attachment indexation of PDF documents is unavailable because the 'pdfminer' Python library cannot be found on the system. "
+if not importlib.util.find_spec('pdfminer.high_level'):
+    _logger.warning("Attachment indexation of PDF documents is unavailable because the 'pdfminer.six' Python library cannot be found on the system. "
                     "You may install it from https://pypi.org/project/pdfminer.six/ (e.g. `pip3 install pdfminer.six`)")
 
 FTYPES = ['docx', 'pptx', 'xlsx', 'opendoc', 'pdf']
@@ -27,6 +30,38 @@ def textToString(element):
         elif node.nodeType == xml.dom.Node.ELEMENT_NODE:
             buff += textToString(node)
     return buff
+
+
+def _clean_text_content(buf):
+    """Clean PDF content: remove NULs, normalize whitespace and line breaks."""
+    if not buf:
+        return buf
+    # Remove NULs, normalize CRLF/CR to LF, replace tabs with spaces
+    buf = buf.translate({
+        ord('\x00'): None,
+        ord('\r'): None,
+        ord('\t'): ord(' '),
+    })
+
+    # Collapse runs of whitespace while preserving at most a single blank line
+    def _compact_whitespace(match):
+        chunk = match.group(0)
+        newline_count = chunk.count('\n')
+        if newline_count == 0:
+            return ' '
+        return '\n\n' if newline_count > 1 else '\n'
+
+    buf = re.sub(r'\s{2,}', _compact_whitespace, buf)
+    return buf.strip()
+
+
+def _csv_escape(value):
+    if value is None:
+        return ''
+    value = str(value)
+    if ',' in value or '"' in value or '\n' in value or '\r' in value:
+        return '"' + value.replace('"', '""') + '"'
+    return value
 
 
 class IrAttachment(models.Model):
@@ -68,42 +103,125 @@ class IrAttachment(models.Model):
     def _index_xlsx(self, bin_data):
         '''Index Microsoft .xlsx documents'''
 
-        buf = u""
+        try:
+            from openpyxl import load_workbook  # noqa: PLC0415
+            logging.getLogger("openpyxl").setLevel(logging.CRITICAL)
+        except ImportError:
+            _logger.info('openpyxl is not installed.')
+            return ""
+
         f = io.BytesIO(bin_data)
-        if zipfile.is_zipfile(f):
-            try:
-                zf = zipfile.ZipFile(f)
-                content = xml.dom.minidom.parseString(zf.read("xl/sharedStrings.xml"))
-                for val in ["t"]:
-                    for element in content.getElementsByTagName(val):
-                        buf += textToString(element) + "\n"
-            except Exception:
-                pass
-        return buf
+        all_sheets = []
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                workbook = load_workbook(f, data_only=True, read_only=True)
+                for sheet in workbook.worksheets:
+                    sheet_name = sheet.title
+                    sheet_name_escaped = _csv_escape(sheet_name)
+                    sheet_rows = []
+                    for row in sheet.iter_rows(values_only=True):
+                        if not any(row):
+                            continue
+                        row_cells = [sheet_name_escaped] + [
+                            _csv_escape(str(cell) if cell is not None else '') for cell in row
+                        ]
+                        sheet_rows.append(','.join(row_cells))
+                    sheet_data = '\n'.join(sheet_rows)
+                    if sheet_data:
+                        all_sheets.append(sheet_data)
+        except Exception:  # noqa: BLE001
+            pass
+
+        all_sheets_str = '\n\n'.join(all_sheets)
+        return _clean_text_content(all_sheets_str)
 
     def _index_opendoc(self, bin_data):
         '''Index OpenDocument documents (.odt, .ods...)'''
 
-        buf = u""
         f = io.BytesIO(bin_data)
+        buf = []
+        MAX_COLUMN_REPEAT = 100
+        MAX_ROW_REPEAT = 50
+        main_namespaces = {
+            'office': 'urn:oasis:names:tc:opendocument:xmlns:office:1.0',
+            'text': 'urn:oasis:names:tc:opendocument:xmlns:text:1.0',
+            'table': 'urn:oasis:names:tc:opendocument:xmlns:table:1.0',
+            'manifest': 'urn:oasis:names:tc:opendocument:xmlns:manifest:1.0'
+        }
+
+        def extract_row(row):
+            cells = []
+            for cell in row.xpath('.//table:table-cell | .//table:covered-table-cell', namespaces=main_namespaces):
+                repeat = cell.get(f'{{{main_namespaces["table"]}}}number-columns-repeated')
+                repeat_count = min(int(repeat), MAX_COLUMN_REPEAT) if repeat and repeat.isdigit() else 1
+                text_parts = cell.xpath('.//text:p//text()', namespaces=main_namespaces)
+                cell_text = ' '.join(t.strip() for t in text_parts if t.strip())
+                cells.extend([cell_text] * repeat_count)
+            return cells
+
+        def extract_spreadsheet(content):
+            sheets_csv = []
+            tables = content.xpath('.//table:table', namespaces=main_namespaces)
+            for table in tables:
+                table_rows = []
+                table_name = table.get(f'{{{main_namespaces["table"]}}}name')
+                if not table_name:
+                    table_name = f"Sheet{len(sheets_csv) + 1}"
+                table_name_escaped = _csv_escape(table_name)
+                for row in table.xpath('.//table:table-row', namespaces=main_namespaces):
+                    row_repeat = row.get(f'{{{main_namespaces["table"]}}}number-rows-repeated')
+                    row_repeat_count = min(int(row_repeat), MAX_ROW_REPEAT) if row_repeat and row_repeat.isdigit() else 1
+
+                    cells = extract_row(row)
+                    if not any(cells):
+                        continue
+
+                    while cells and not cells[-1]:
+                        cells.pop()
+
+                    row_str = ','.join([table_name_escaped] + list(map(_csv_escape, cells)))
+                    if row_str.replace(',', '').strip():
+                        table_rows.extend([row_str] * row_repeat_count)
+
+                if table_rows:
+                    sheets_csv.append('\n'.join(table_rows))
+
+            return sheets_csv
+
+        def extract_text(content):
+            lines = []
+            for element in content.xpath('.//text:p | .//text:h | .//text:list-item', namespaces=main_namespaces):
+                text = ''.join(element.xpath('.//text()', namespaces=main_namespaces)).strip()
+                if text:
+                    lines.append(text)
+            return lines
+
         if zipfile.is_zipfile(f):
             try:
                 zf = zipfile.ZipFile(f)
-                content = xml.dom.minidom.parseString(zf.read("content.xml"))
-                for val in ["text:p", "text:h", "text:list"]:
-                    for element in content.getElementsByTagName(val):
-                        buf += textToString(element) + "\n"
+                content = etree.fromstring(zf.read('content.xml'))
+                mime_type = zf.read('mimetype').decode('utf-8').strip()
+                if mime_type and 'spreadsheet' in mime_type:
+                    buf.extend(extract_spreadsheet(content))
+                else:
+                    buf.extend(extract_text(content))
             except Exception:
                 pass
-        return buf
+
+        buf_str = '\n\n'.join(buf)
+        return _clean_text_content(buf_str)
 
     def _index_pdf(self, bin_data):
         '''Index PDF documents'''
         if not bin_data.startswith(b'%PDF-'):
             return ""
         try:
+            if not importlib.util.find_spec('pdfminer.high_level'):
+                return ""
             from pdfminer.pdfinterp import PDFResourceManager, PDFPageInterpreter  # noqa: PLC0415
             from pdfminer.converter import TextConverter  # noqa: PLC0415
+            from pdfminer.layout import LAParams  # noqa: PLC0415
             from pdfminer.pdfpage import PDFPage  # noqa: PLC0415
             logging.getLogger("pdfminer").setLevel(logging.CRITICAL)
         except ImportError:
@@ -112,13 +230,19 @@ class IrAttachment(models.Model):
         f = io.BytesIO(bin_data)
         try:
             resource_manager = PDFResourceManager()
-            with io.StringIO() as content, TextConverter(resource_manager, content) as device:
-                interpreter = PDFPageInterpreter(resource_manager, device)
+            laparams = LAParams(detect_vertical=True)
 
+            with io.StringIO() as content, TextConverter(
+                resource_manager,
+                content,
+                laparams=laparams
+            ) as device:
+                interpreter = PDFPageInterpreter(resource_manager, device)
                 for page in PDFPage.get_pages(f):
                     interpreter.process_page(page)
 
-                return content.getvalue()
+                buf = content.getvalue()
+            return _clean_text_content(buf)
         except Exception:  # noqa: BLE001
             return ""
 

--- a/addons/attachment_indexation/tests/test_indexation.py
+++ b/addons/attachment_indexation/tests/test_indexation.py
@@ -21,4 +21,4 @@ class TestCaseIndexation(TransactionCase):
         with file_open(os.path.join(directory, 'files', 'test_content.pdf'), 'rb') as file:
             pdf = file.read()
             text = self.env['ir.attachment']._index(pdf, 'application/pdf')
-            self.assertEqual(text, 'TestContent!!\x0c', 'the index content should be correct')
+            self.assertEqual(text, 'TestContent!!', 'the index content should be correct')


### PR DESCRIPTION
### Problem
1. **PDF documents** often produced fragmented or misaligned text, especially in multi-column or tightly formatted layouts.  
2. **Tabular files** (`.xlsx`, `.ods`) lost their row–column relationships during extraction, making the indexed text less meaningful for semantic processing.  

### Changes

#### PDF Attachments
- Introduced configurable **`LAParams`** parameters in `pdfminer` to fine-tune text extraction for complex or multi-column layouts.  

#### Tabular Attachments
- Updated **XLSX** and **ODS** indexers to output data in **CSV-like format**, preserving **row–column context** for better AI readability.  
- Uses **`openpyxl`** (now part of Odoo requirements) to efficiently extract and format spreadsheet data in xlsx files.

---

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

task-id-5045336
