### PR TITLE
[FIX] mail: properly translate public page components

### DIFF
--- a/addons/mail/static/src/discuss/core/public/boot.js
+++ b/addons/mail/static/src/discuss/core/public/boot.js
@@ -5,6 +5,7 @@ import { DiscussPublic } from "@mail/discuss/core/public/discuss_public";
 import { mount, whenReady } from "@odoo/owl";
 
 import { templates } from "@web/core/assets";
+import { _t } from "@web/core/l10n/translation";
 import { MainComponentsContainer } from "@web/core/main_components_container";
 import { registry } from "@web/core/registry";
 import { makeEnv, startServices } from "@web/env";
@@ -22,5 +23,10 @@ import { makeEnv, startServices } from "@web/env";
     await startServices(env);
     env.services["mail.store"].inPublicPage = true;
     odoo.isReady = true;
-    await mount(MainComponentsContainer, document.body, { env, templates, dev: env.debug });
+    await mount(MainComponentsContainer, document.body, {
+        dev: env.debug,
+        env,
+        templates,
+        translateFn: _t,
+    });
 })();


### PR DESCRIPTION
Human-readable content defined in public page components isn't translated. This is because we forgot to give Owl a translation function, so it falls back to returning the source terms as they are (identity function).

This commit resolves the issue by providing the missing translation function.

Task-4493082
Task-5140665