### PR TITLE
[IMP] Add new shadow controls

### DIFF
--- a/addons/html_builder/static/src/builder.js
+++ b/addons/html_builder/static/src/builder.js
@@ -85,6 +85,7 @@ export class Builder extends Component {
         this.lastTrigerUpdateId = 0;
         this.editorBus = new EventBus();
         this.colorPresetToShow = null;
+        this.shadowSizeToShow = null;
         this.activeTargetEl = null;
         const mobileBreakpoint = this.props.config.mobileBreakpoint ?? "lg";
 
@@ -232,6 +233,7 @@ export class Builder extends Component {
             editorBus: this.editorBus,
             triggerDomUpdated: this.triggerDomUpdated.bind(this),
             editColorCombination: this.editColorCombination.bind(this),
+            editShadow: this.editShadow.bind(this),
         });
         onWillDestroy(() => {
             this.editor.destroy();
@@ -286,7 +288,7 @@ export class Builder extends Component {
      * @param {Number | null} presetId the color preset expanding on "theme" tab
      * open.
      */
-    onTabClick(tab, presetId = null) {
+    onTabClick(tab, { presetId = null, shadowSize = null } = {}) {
         if (this.state.activeTab === tab) {
             // If the tab is already active, do nothing.
             return;
@@ -295,6 +297,7 @@ export class Builder extends Component {
         // Deactivate the options when clicking on the "BLOCKS" or "THEME" tabs.
         if (tab === "theme" || tab === "blocks") {
             this.colorPresetToShow = presetId;
+            this.shadowSizeToShow = shadowSize;
             this.activeTargetEl = this.activeTargetEl || this.getActiveTarget();
             this.editor.shared.builderOptions.deactivateContainers();
         } else if (this.activeTargetEl) {
@@ -336,7 +339,11 @@ export class Builder extends Component {
     }
 
     editColorCombination(presetId) {
-        this.onTabClick("theme", presetId);
+        this.onTabClick("theme", { presetId });
+    }
+
+    editShadow(shadowSize) {
+        this.onTabClick("theme", { shadowSize });
     }
 
     getActiveTarget() {

--- a/addons/html_builder/static/src/builder.xml
+++ b/addons/html_builder/static/src/builder.xml
@@ -47,7 +47,7 @@
                 <CustomizeTab currentOptionsContainers="state.currentOptionsContainers" snippetModel="snippetModel"/>
             </t>
             <t t-if="state.activeTab === 'theme'">
-                <t t-component="ThemeTab" colorPresetToShow="colorPresetToShow"/>
+                <t t-component="ThemeTab" colorPresetToShow="colorPresetToShow" shadowSizeToShow="shadowSizeToShow"/>
             </t>
         </div>
         <div class="o_we_lower_panel mt-auto flex-grow-0 flex-shrink-0">

--- a/addons/html_builder/static/src/plugins/shadow_option.js
+++ b/addons/html_builder/static/src/plugins/shadow_option.js
@@ -12,4 +12,8 @@ export class ShadowOption extends BaseOptionComponent {
         setShadowModeAction: "setShadowMode",
         setShadowStyleAction: "setShadowStyle",
     };
+
+    getOnClick(shadowClass) {
+        return () => this.env.editShadow(shadowClass);
+    }
 }

--- a/addons/html_builder/static/src/plugins/shadow_option.js
+++ b/addons/html_builder/static/src/plugins/shadow_option.js
@@ -3,11 +3,13 @@ import { BaseOptionComponent } from "@html_builder/core/utils";
 export class ShadowOption extends BaseOptionComponent {
     static template = "html_builder.ShadowOption";
     static props = {
+        setShadowClassAction: { type: String, optional: true },
         setShadowModeAction: { type: String, optional: true },
-        setShadowAction: { type: String, optional: true },
+        setShadowStyleAction: { type: String, optional: true },
     };
     static defaultProps = {
+        setShadowClassAction: "setShadowClass",
         setShadowModeAction: "setShadowMode",
-        setShadowAction: "setShadow",
+        setShadowStyleAction: "setShadowStyle",
     };
 }

--- a/addons/html_builder/static/src/plugins/shadow_option.scss
+++ b/addons/html_builder/static/src/plugins/shadow_option.scss
@@ -1,0 +1,28 @@
+.o-hb-shadow-text {
+    flex: 1;
+}
+
+.o-hb-shadow-button {
+    border-width: 0;
+    padding: 10px;
+
+    &::before {
+        color: #{$o-we-color-global};
+    }
+    
+    &:hover::before {
+        color: lighten($o-we-color-global, 50%);
+    }
+}
+
+.hb-row-content {
+    .o-hb-shadow-button {
+        display: none;;
+    }
+}
+
+.o-hb-select-dropdown-item {
+    &:has(.o-hb-shadow-button) {
+        padding-right: 0;
+    }
+}

--- a/addons/html_builder/static/src/plugins/shadow_option.xml
+++ b/addons/html_builder/static/src/plugins/shadow_option.xml
@@ -5,9 +5,18 @@
     <BuilderRow label.translate="Shadow">
         <BuilderSelect action="props.setShadowClassAction">
             <BuilderSelectItem actionParam="''">None</BuilderSelectItem>
-            <BuilderSelectItem actionParam="'shadow'">Normal</BuilderSelectItem>
-            <BuilderSelectItem actionParam="'shadow-sm'">Small</BuilderSelectItem>
-            <BuilderSelectItem actionParam="'shadow-lg'">Large</BuilderSelectItem>
+            <BuilderSelectItem actionParam="'shadow'">
+                <t t-set="onClick" t-value="getOnClick('shadow')"/>
+                <t t-call="html_builder.ShadowOptionItem">Normal</t>
+            </BuilderSelectItem>
+            <BuilderSelectItem actionParam="'shadow-sm'">
+                <t t-set="onClick" t-value="getOnClick('shadow-sm')"/>
+                <t t-call="html_builder.ShadowOptionItem">Small</t>
+            </BuilderSelectItem>
+            <BuilderSelectItem actionParam="'shadow-lg'">
+                <t t-set="onClick" t-value="getOnClick('shadow-lg')"/>
+                <t t-call="html_builder.ShadowOptionItem">Large</t>
+            </BuilderSelectItem>
             <BuilderSelectItem id="'custom_shadow'" actionParam="'o-shadow-custom'">Custom</BuilderSelectItem>
         </BuilderSelect>
     </BuilderRow>
@@ -37,6 +46,17 @@
             </BuilderRow>
         </BuilderContext>
     </t>
+</t>
+
+<t t-name="html_builder.ShadowOptionItem">
+    <div class="d-flex">
+        <div class="o-hb-shadow-text">
+            <t t-out="0"/>
+        </div>
+        <a class="fa fa-pencil btn o-hb-shadow-button"
+                title="Edit"
+                t-on-click="onClick"/>
+    </div>
 </t>
 
 </templates>

--- a/addons/html_builder/static/src/plugins/shadow_option.xml
+++ b/addons/html_builder/static/src/plugins/shadow_option.xml
@@ -3,30 +3,40 @@
 
 <t t-name="html_builder.ShadowOption">
     <BuilderRow label.translate="Shadow">
-       <BuilderButtonGroup action="props.setShadowModeAction">
-         <BuilderButton actionValue="'none'" id="'no_shadow'" className="'lh-1'">None</BuilderButton>
-         <BuilderButton actionValue="'outset'" title.translate="Outset" iconImg="'/html_builder/static/img/options/shadow_out.svg'"/>
-         <BuilderButton actionValue="'inset'" title.translate="Inset" iconImg="'/html_builder/static/img/options/shadow_in.svg'"/>
-       </BuilderButtonGroup>
+        <BuilderSelect action="props.setShadowClassAction">
+            <BuilderSelectItem actionParam="''">None</BuilderSelectItem>
+            <BuilderSelectItem actionParam="'shadow'">Normal</BuilderSelectItem>
+            <BuilderSelectItem actionParam="'shadow-sm'">Small</BuilderSelectItem>
+            <BuilderSelectItem actionParam="'shadow-lg'">Large</BuilderSelectItem>
+            <BuilderSelectItem id="'custom_shadow'" actionParam="'o-shadow-custom'">Custom</BuilderSelectItem>
+        </BuilderSelect>
     </BuilderRow>
-    <BuilderContext t-if="!this.isActiveItem('no_shadow')" action="props.setShadowAction">
-        <BuilderRow label.translate="Color" level="1">
-            <BuilderColorPicker actionParam="'color'"  enabledTabs="['solid', 'custom']"/>
+    <t t-if="this.isActiveItem('custom_shadow')">
+        <BuilderRow label.translate="Outset/Inset" level="1">
+            <BuilderButtonGroup action="props.setShadowModeAction">
+                <BuilderButton actionValue="'outset'" title.translate="Outset" iconImg="'/html_builder/static/img/options/shadow_out.svg'"/>
+                <BuilderButton actionValue="'inset'" title.translate="Inset" iconImg="'/html_builder/static/img/options/shadow_in.svg'"/>
+            </BuilderButtonGroup>
         </BuilderRow>
+        <BuilderContext action="props.setShadowStyleAction">
+            <BuilderRow label.translate="Color" level="1">
+                <BuilderColorPicker actionParam="'color'" enabledTabs="['solid', 'custom']"/>
+            </BuilderRow>
 
-        <BuilderRow label.translate="Offset" tooltip.translate="Horizontal and Vertical offset" level="1">
-            <BuilderNumberInput actionParam="'offsetX'" unit="'px'" prefixIcon="'oi oi-arrows-h'"/>
-            <BuilderNumberInput actionParam="'offsetY'" unit="'px'" prefixIcon="'oi oi-arrows-v'"/>
-        </BuilderRow>
+            <BuilderRow label.translate="Offset" tooltip.translate="Horizontal and Vertical offset" level="1">
+                <BuilderNumberInput actionParam="'offsetX'" unit="'px'" prefixIcon="'oi oi-arrows-h'"/>
+                <BuilderNumberInput actionParam="'offsetY'" unit="'px'" prefixIcon="'oi oi-arrows-v'"/>
+            </BuilderRow>
 
-        <BuilderRow label.translate="Blur" level="1">
-            <BuilderNumberInput actionParam="'blur'" unit="'px'"/>
-        </BuilderRow>
+            <BuilderRow label.translate="Blur" level="1">
+                <BuilderNumberInput actionParam="'blur'" unit="'px'"/>
+            </BuilderRow>
 
-        <BuilderRow label.translate="Spread" level="1">
-            <BuilderNumberInput actionParam="'spread'" unit="'px'"/>
-        </BuilderRow>
-    </BuilderContext>
+            <BuilderRow label.translate="Spread" level="1">
+                <BuilderNumberInput actionParam="'spread'" unit="'px'"/>
+            </BuilderRow>
+        </BuilderContext>
+    </t>
 </t>
 
 </templates>

--- a/addons/html_builder/static/tests/shadow_option.test.js
+++ b/addons/html_builder/static/tests/shadow_option.test.js
@@ -25,50 +25,61 @@ test("edit box-shadow with ShadowOption", async () => {
         '<div class="test-options-target">b</div>'
     );
 
+    await contains(".o-hb-select-toggle").click();
+    await contains("div.o-hb-select-dropdown-item:contains(Normal)").click();
+    expect(":iframe .test-options-target").toHaveOuterHTML(
+        '<div class="test-options-target shadow">b</div>'
+    );
+
+    await contains(".o-hb-select-toggle").click();
+    await contains("div.o-hb-select-dropdown-item:contains(Custom)").click();
     await contains('.options-container button[title="Outset"]').click();
     expect(queryAllTexts(".hb-row .hb-row-label")).toEqual([
         "Shadow",
+        "Outset/Inset",
         "Color",
         "Offset",
         "Blur",
         "Spread",
     ]);
-    expect(queryAllValues('[data-action-id="setShadow"] input')).toEqual([0, 8, 16, 0]);
+    expect(queryAllValues('[data-action-id="setShadowStyle"] input')).toEqual([0, 8, 16, 0]);
     expect(":iframe .test-options-target").toHaveOuterHTML(
-        '<div class="test-options-target shadow" style="box-shadow: rgba(0, 0, 0, 0.15) 0px 8px 16px 0px !important;">b</div>'
+        '<div class="test-options-target o-shadow-custom" style="box-shadow: rgba(0, 0, 0, 0.15) 0px 8px 16px 0px !important;">b</div>'
     );
 
     await contains('[data-action-param="offsetX"] input').fill(10);
     await contains('[data-action-param="offsetY"] input').fill(2);
     expect(":iframe .test-options-target").toHaveOuterHTML(
-        '<div class="test-options-target shadow" style="box-shadow: rgba(0, 0, 0, 0.15) 10px 82px 16px 0px !important;">b</div>'
+        '<div class="test-options-target o-shadow-custom" style="box-shadow: rgba(0, 0, 0, 0.15) 10px 82px 16px 0px !important;">b</div>'
     );
 
     await contains('[data-action-param="blur"] input').clear();
     await contains('[data-action-param="blur"] input').fill(10.5, { instantly: true });
     expect(":iframe .test-options-target").toHaveOuterHTML(
-        '<div class="test-options-target shadow" style="box-shadow: rgba(0, 0, 0, 0.15) 10px 82px 10.5px 0px !important;">b</div>'
+        '<div class="test-options-target o-shadow-custom" style="box-shadow: rgba(0, 0, 0, 0.15) 10px 82px 10.5px 0px !important;">b</div>'
     );
 
     await contains('[data-action-param="spread"] input').fill(".4", { instantly: true });
     expect(":iframe .test-options-target").toHaveOuterHTML(
-        '<div class="test-options-target shadow" style="box-shadow: rgba(0, 0, 0, 0.15) 10px 82px 10.5px 0.4px !important;">b</div>'
+        '<div class="test-options-target o-shadow-custom" style="box-shadow: rgba(0, 0, 0, 0.15) 10px 82px 10.5px 0.4px !important;">b</div>'
     );
 
     await contains('.options-container button[title="Inset"]').click();
     expect(queryAllTexts(".hb-row .hb-row-label")).toEqual([
         "Shadow",
+        "Outset/Inset",
         "Color",
         "Offset",
         "Blur",
         "Spread",
     ]);
-    expect(queryAllValues('[data-action-id="setShadow"] input')).toEqual([10, 82, 10.5, 0.4]);
+    expect(queryAllValues('[data-action-id="setShadowStyle"] input')).toEqual([10, 82, 10.5, 0.4]);
     expect(":iframe .test-options-target").toHaveOuterHTML(
-        '<div class="test-options-target shadow" style="box-shadow: rgba(0, 0, 0, 0.15) 10px 82px 10.5px 0.4px inset !important;">b</div>'
+        '<div class="test-options-target o-shadow-custom" style="box-shadow: rgba(0, 0, 0, 0.15) 10px 82px 10.5px 0.4px inset !important;">b</div>'
     );
 
-    await contains(".options-container button:contains(None)").click();
+    await contains(".o-hb-select-toggle").click();
+    await contains("div.o-hb-select-dropdown-item:contains(None)").click();
     expect(queryAllTexts(".hb-row .hb-row-label")).toEqual(["Shadow"]);
     expect(":iframe .test-options-target").toHaveOuterHTML(
         '<div class="test-options-target" style="">b</div>'

--- a/addons/mass_mailing/static/src/builder/tabs/design_tab.js
+++ b/addons/mass_mailing/static/src/builder/tabs/design_tab.js
@@ -7,6 +7,7 @@ export class DesignTab extends Component {
     static components = { OptionsContainer };
     static props = {
         colorPresetToShow: { optional: true },
+        shadowSizeToShow: { optional: true },
     };
 
     setup() {

--- a/addons/website/static/src/builder/plugins/options/header/header_box_option.xml
+++ b/addons/website/static/src/builder/plugins/options/header/header_box_option.xml
@@ -9,8 +9,9 @@
         withRoundCorner="this.domState.withRoundCorner"
     />
     <ShadowOption
+        setShadowClassAction="'setShadowClassHeader'"
         setShadowModeAction="'setShadowModeHeader'"
-        setShadowAction="'setShadowHeader'"
+        setShadowStyleAction="'setShadowStyleHeader'"
     />
 </t>
 

--- a/addons/website/static/src/builder/plugins/options/header/header_template_option.xml
+++ b/addons/website/static/src/builder/plugins/options/header/header_template_option.xml
@@ -11,7 +11,7 @@
                             action: 'websiteConfig',
                             actionParam: {
                                 views: ['website.template_header_default'],
-                                vars: { 'header-template': 'default' },
+                                vars: { 'header-template': 'default', 'menu-shadow-class': 'shadow-sm', 'menu-box-shadow-style': null },
                                 checkVars: false,
                             }
                         }
@@ -26,7 +26,7 @@
                             action: 'websiteConfig',
                             actionParam: {
                                 views: ['website.template_header_hamburger', 'website.no_autohide_menu'],
-                                vars: { 'header-template': 'hamburger' },
+                                vars: { 'header-template': 'hamburger', 'menu-shadow-class': 'shadow-sm', 'menu-box-shadow-style': null },
                                 checkVars: false,
                             }
                         }
@@ -41,7 +41,7 @@
                             action: 'websiteConfig',
                             actionParam: {
                                 views: ['website.template_header_boxed'],
-                                vars: { 'header-template': 'boxed' },
+                                vars: { 'header-template': 'boxed', 'menu-shadow-class': 'shadow-sm', 'menu-box-shadow-style': null },
                                 checkVars: false,
                             }
                         }
@@ -56,7 +56,7 @@
                             action: 'websiteConfig',
                             actionParam: {
                                 views: ['website.template_header_stretch'],
-                                vars: { 'header-template': 'stretch' },
+                                vars: { 'header-template': 'stretch', 'menu-shadow-class': 'shadow-sm', 'menu-box-shadow-style': null },
                                 checkVars: false,
                             }
                         }
@@ -71,7 +71,7 @@
                             action: 'websiteConfig',
                             actionParam: {
                                 views: ['website.template_header_vertical'],
-                                vars: { 'header-template': 'vertical' },
+                                vars: { 'header-template': 'vertical', 'menu-shadow-class': 'shadow-sm', 'menu-box-shadow-style': null },
                                 checkVars: false,
                             }
                         }
@@ -86,7 +86,7 @@
                             action: 'websiteConfig',
                             actionParam: {
                                 views: ['website.template_header_search'],
-                                vars: { 'header-template': 'search' },
+                                vars: { 'header-template': 'search', 'menu-shadow-class': 'shadow-sm', 'menu-box-shadow-style': null },
                                 checkVars: false,
                             }
                         }
@@ -101,7 +101,7 @@
                             action: 'websiteConfig',
                             actionParam: {
                                 views: ['website.template_header_sales_one'],
-                                vars: { 'header-template': 'sales_one' },
+                                vars: { 'header-template': 'sales_one', 'menu-shadow-class': 'shadow-sm', 'menu-box-shadow-style': null },
                                 checkVars: false,
                             }
                         }
@@ -116,7 +116,7 @@
                             action: 'websiteConfig',
                             actionParam: {
                                 views: ['website.template_header_sales_two'],
-                                vars: { 'header-template': 'sales_two' },
+                                vars: { 'header-template': 'sales_two', 'menu-shadow-class': 'shadow-sm', 'menu-box-shadow-style': null },
                                 checkVars: false,
                             }
                         }
@@ -131,7 +131,7 @@
                             action: 'websiteConfig',
                             actionParam: {
                                 views: ['website.template_header_sales_three'],
-                                vars: { 'header-template': 'sales_three' },
+                                vars: { 'header-template': 'sales_three', 'menu-shadow-class': 'shadow-sm', 'menu-box-shadow-style': null },
                                 checkVars: false,
                             }
                         }
@@ -146,7 +146,7 @@
                             action: 'websiteConfig',
                             actionParam: {
                                 views: ['website.template_header_sales_four'],
-                                vars: { 'header-template': 'sales_four' },
+                                vars: { 'header-template': 'sales_four', 'menu-shadow-class': 'shadow-sm', 'menu-box-shadow-style': null },
                                 checkVars: false,
                             }
                         }
@@ -161,7 +161,7 @@
                             action: 'websiteConfig',
                             actionParam: {
                                 views: ['website.template_header_sidebar', 'website.no_autohide_menu'],
-                                vars: { 'header-template': 'sidebar' },
+                                vars: { 'header-template': 'sidebar', 'menu-shadow-class': 'shadow-lg', 'menu-box-shadow-style': null },
                                 checkVars: false,
                             }
                         }

--- a/addons/website/static/src/builder/plugins/theme/theme_shadow_option.js
+++ b/addons/website/static/src/builder/plugins/theme/theme_shadow_option.js
@@ -1,0 +1,5 @@
+import { BaseOptionComponent } from "@html_builder/core/utils";
+
+export class ThemeShadowOption extends BaseOptionComponent {
+    static template = "website.ThemeShadowOption";
+}

--- a/addons/website/static/src/builder/plugins/theme/theme_shadow_option.js
+++ b/addons/website/static/src/builder/plugins/theme/theme_shadow_option.js
@@ -1,5 +1,18 @@
 import { BaseOptionComponent } from "@html_builder/core/utils";
+import { onMounted, useRef } from "@odoo/owl";
 
 export class ThemeShadowOption extends BaseOptionComponent {
     static template = "website.ThemeShadowOption";
+
+    setup() {
+        super.setup();
+        this.shadowSizeToShow = this.env.shadowSizeToShow;
+        const root = useRef("root");
+
+        onMounted(() => {
+            if (this.shadowSizeToShow) {
+                root.el.scrollIntoView({ behavior: "instant", block: "center" });
+            }
+        });
+    }
 }

--- a/addons/website/static/src/builder/plugins/theme/theme_shadow_option.xml
+++ b/addons/website/static/src/builder/plugins/theme/theme_shadow_option.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+<t t-name="website.ThemeShadowOption">
+    <BuilderContext action="'customizeWebsiteVariable'">
+        <BuilderRow label.translate="Normal" tooltip.translate="Horizontal and Vertical Offset">
+            <BuilderNumberInput actionParam="'box-shadow-offset-x'" unit="'px'" saveUnit="'rem'" prefixIcon="'oi oi-arrows-h'"/>
+            <BuilderNumberInput actionParam="'box-shadow-offset-y'" unit="'px'" saveUnit="'rem'" prefixIcon="'oi oi-arrows-v'"/>
+            <t t-set-slot="collapse">
+                <BuilderRow label.translate="Color" level="1">
+                    <BuilderColorPicker actionParam="'box-shadow-color'" enabledTabs="['solid', 'custom']"/>
+                </BuilderRow>
+                <BuilderRow label.translate="Blur" level="1">
+                    <BuilderNumberInput actionParam="'box-shadow-blur-radius'" unit="'px'" saveUnit="'rem'"/>
+                </BuilderRow>
+                <BuilderRow label.translate="Spread" level="1">
+                    <BuilderNumberInput actionParam="'box-shadow-spread-radius'" unit="'px'" saveUnit="'rem'"/>
+                </BuilderRow>
+            </t>
+        </BuilderRow>
+        <BuilderRow label.translate="Small" tooltip.translate="Horizontal and Vertical Offset">
+            <BuilderNumberInput actionParam="'box-shadow-sm-offset-x'" unit="'px'" saveUnit="'rem'" prefixIcon="'oi oi-arrows-h'"/>
+            <BuilderNumberInput actionParam="'box-shadow-sm-offset-y'" unit="'px'" saveUnit="'rem'" prefixIcon="'oi oi-arrows-v'"/>
+            <t t-set-slot="collapse">
+                <BuilderRow label.translate="Color" level="1">
+                    <BuilderColorPicker actionParam="'box-shadow-sm-color'" enabledTabs="['solid', 'custom']"/>
+                </BuilderRow>
+                <BuilderRow label.translate="Blur" level="1">
+                    <BuilderNumberInput actionParam="'box-shadow-sm-blur-radius'" unit="'px'" saveUnit="'rem'"/>
+                </BuilderRow>
+                <BuilderRow label.translate="Spread" level="1">
+                    <BuilderNumberInput actionParam="'box-shadow-sm-spread-radius'" unit="'px'" saveUnit="'rem'"/>
+                </BuilderRow>
+            </t>
+        </BuilderRow>
+        <BuilderRow label.translate="Large" tooltip.translate="Horizontal and Vertical Offset">
+            <BuilderNumberInput actionParam="'box-shadow-lg-offset-x'" unit="'px'" saveUnit="'rem'" prefixIcon="'oi oi-arrows-h'"/>
+            <BuilderNumberInput actionParam="'box-shadow-lg-offset-y'" unit="'px'" saveUnit="'rem'" prefixIcon="'oi oi-arrows-v'"/>
+            <t t-set-slot="collapse">
+                <BuilderRow label.translate="Color" level="1">
+                    <BuilderColorPicker actionParam="'box-shadow-lg-color'" enabledTabs="['solid', 'custom']"/>
+                </BuilderRow>
+                <BuilderRow label.translate="Blur" level="1">
+                    <BuilderNumberInput actionParam="'box-shadow-lg-blur-radius'" unit="'px'" saveUnit="'rem'"/>
+                </BuilderRow>
+                <BuilderRow label.translate="Spread" level="1">
+                    <BuilderNumberInput actionParam="'box-shadow-lg-spread-radius'" unit="'px'" saveUnit="'rem'"/>
+                </BuilderRow>
+            </t>
+        </BuilderRow>
+    </BuilderContext>
+</t>
+
+</templates>

--- a/addons/website/static/src/builder/plugins/theme/theme_shadow_option.xml
+++ b/addons/website/static/src/builder/plugins/theme/theme_shadow_option.xml
@@ -2,8 +2,9 @@
 <templates xml:space="preserve">
 
 <t t-name="website.ThemeShadowOption">
+    <div t-ref="root" />
     <BuilderContext action="'customizeWebsiteVariable'">
-        <BuilderRow label.translate="Normal" tooltip.translate="Horizontal and Vertical Offset">
+        <BuilderRow label.translate="Normal" initialExpandAnim="shadowSizeToShow === 'shadow'" tooltip.translate="Horizontal and Vertical Offset">
             <BuilderNumberInput actionParam="'box-shadow-offset-x'" unit="'px'" saveUnit="'rem'" prefixIcon="'oi oi-arrows-h'"/>
             <BuilderNumberInput actionParam="'box-shadow-offset-y'" unit="'px'" saveUnit="'rem'" prefixIcon="'oi oi-arrows-v'"/>
             <t t-set-slot="collapse">
@@ -18,7 +19,7 @@
                 </BuilderRow>
             </t>
         </BuilderRow>
-        <BuilderRow label.translate="Small" tooltip.translate="Horizontal and Vertical Offset">
+        <BuilderRow label.translate="Small" initialExpandAnim="shadowSizeToShow === 'shadow-sm'" tooltip.translate="Horizontal and Vertical Offset">
             <BuilderNumberInput actionParam="'box-shadow-sm-offset-x'" unit="'px'" saveUnit="'rem'" prefixIcon="'oi oi-arrows-h'"/>
             <BuilderNumberInput actionParam="'box-shadow-sm-offset-y'" unit="'px'" saveUnit="'rem'" prefixIcon="'oi oi-arrows-v'"/>
             <t t-set-slot="collapse">
@@ -33,7 +34,7 @@
                 </BuilderRow>
             </t>
         </BuilderRow>
-        <BuilderRow label.translate="Large" tooltip.translate="Horizontal and Vertical Offset">
+        <BuilderRow label.translate="Large" initialExpandAnim="shadowSizeToShow === 'shadow-lg'" tooltip.translate="Horizontal and Vertical Offset">
             <BuilderNumberInput actionParam="'box-shadow-lg-offset-x'" unit="'px'" saveUnit="'rem'" prefixIcon="'oi oi-arrows-h'"/>
             <BuilderNumberInput actionParam="'box-shadow-lg-offset-y'" unit="'px'" saveUnit="'rem'" prefixIcon="'oi oi-arrows-v'"/>
             <t t-set-slot="collapse">

--- a/addons/website/static/src/builder/plugins/theme/theme_tab.js
+++ b/addons/website/static/src/builder/plugins/theme/theme_tab.js
@@ -8,6 +8,7 @@ export class ThemeTab extends Component {
     static props = {
         // optionsContainers: { type: Array, optional: true },
         colorPresetToShow: { type: Number | null, optional: true },
+        shadowSizeToShow: { type: String | null, optional: true },
     };
     static defaultProps = {
         // optionsContainers: [],
@@ -17,6 +18,7 @@ export class ThemeTab extends Component {
         useOptionsSubEnv(() => [this.env.editor.document.body]);
         useSubEnv({
             colorPresetToShow: this.props.colorPresetToShow,
+            shadowSizeToShow: this.props.shadowSizeToShow,
         });
         this.state = useState({
             fontsData: {},

--- a/addons/website/static/src/builder/plugins/theme/theme_tab_plugin.js
+++ b/addons/website/static/src/builder/plugins/theme/theme_tab_plugin.js
@@ -2,6 +2,7 @@ import { Plugin } from "@html_editor/plugin";
 import { getCSSVariableValue, getHtmlStyle } from "@html_editor/utils/formatting";
 import { withSequence } from "@html_editor/utils/resource";
 import { ThemeAdvancedOption } from "./theme_advanced_option";
+import { ThemeShadowOption } from "./theme_shadow_option";
 import { ThemeButtonOption } from "./theme_button_option";
 import { ThemeColorsOption } from "./theme_colors_option";
 import { ThemeHeadingsOption } from "./theme_headings_option";
@@ -47,7 +48,8 @@ export const OPTION_POSITIONS = {
     BUTTON: 50,
     LINK: 60,
     INPUT: 70,
-    ADVANCED: 80,
+    SHADOW: 80,
+    ADVANCED: 90,
 };
 
 export class ThemeTabPlugin extends Plugin {
@@ -116,6 +118,10 @@ export class ThemeTabPlugin extends Plugin {
                         static template = "website.ThemeInputOption";
                     }
                 )
+            ),
+            withSequence(
+                OPTION_POSITIONS.SHADOW,
+                this.getThemeOptionBlock("theme-shadow", _t("Shadow"), ThemeShadowOption)
             ),
             withSequence(
                 OPTION_POSITIONS.ADVANCED,

--- a/addons/website/static/src/scss/bootstrap_overridden.scss
+++ b/addons/website/static/src/scss/bootstrap_overridden.scss
@@ -348,9 +348,27 @@ $popover-arrow-outer-color: $border-color !default;
 $badge-border-radius: $border-radius-pill !default;
 
 // Shadows
-$box-shadow: 0px 4px 16px rgba($black, 0.12) !default;
-$box-shadow-sm: 0px 1px 3px rgba($black, .1) !default;
-$box-shadow-lg: 0px 12px 32px rgba($black, .175) !default;
+$box-shadow-color: o-website-value('box-shadow-color') !default;
+$box-shadow-offset-x: o-website-value('box-shadow-offset-x') !default;
+$box-shadow-offset-y: o-website-value('box-shadow-offset-y') !default;
+$box-shadow-blur-radius: o-website-value('box-shadow-blur-radius') !default;
+$box-shadow-spread-radius: o-website-value('box-shadow-spread-radius') !default;
+
+$box-shadow-sm-color: o-website-value('box-shadow-sm-color') !default;
+$box-shadow-sm-offset-x: o-website-value('box-shadow-sm-offset-x') !default;
+$box-shadow-sm-offset-y: o-website-value('box-shadow-sm-offset-y') !default;
+$box-shadow-sm-blur-radius: o-website-value('box-shadow-sm-blur-radius') !default;
+$box-shadow-sm-spread-radius: o-website-value('box-shadow-sm-spread-radius') !default;
+
+$box-shadow-lg-color: o-website-value('box-shadow-lg-color') !default;
+$box-shadow-lg-offset-x: o-website-value('box-shadow-lg-offset-x') !default;
+$box-shadow-lg-offset-y: o-website-value('box-shadow-lg-offset-y') !default;
+$box-shadow-lg-blur-radius: o-website-value('box-shadow-lg-blur-radius') !default;
+$box-shadow-lg-spread-radius: o-website-value('box-shadow-lg-spread-radius') !default;
+
+$box-shadow: var(--box-shadow-offset-x) var(--box-shadow-offset-y) var(--box-shadow-blur-radius) var(--box-shadow-spread-radius) var(--box-shadow-color) !default;
+$box-shadow-sm: var(--box-shadow-sm-offset-x) var(--box-shadow-sm-offset-y) var(--box-shadow-sm-blur-radius) var(--box-shadow-sm-spread-radius) var(--box-shadow-sm-color) !default;
+$box-shadow-lg: var(--box-shadow-lg-offset-x) var(--box-shadow-lg-offset-y) var(--box-shadow-lg-blur-radius) var(--box-shadow-lg-spread-radius) var(--box-shadow-lg-color) !default;
 
 // Cards
 $card-border-color: $border-color !default;

--- a/addons/website/static/src/scss/primary_variables.scss
+++ b/addons/website/static/src/scss/primary_variables.scss
@@ -2174,7 +2174,8 @@ $o-base-website-values-palette: (
     'menu-border-width': null, // Default to classes used on the template
     'menu-border-style': solid, // Default to classes used on the template
     'menu-border-radius': null, // Default to classes used on the template
-    'menu-box-shadow': null, // Default to classes used on the template
+    'menu-box-shadow-style': null,
+    'menu-shadow-class': 'shadow-sm', // '' / 'shadow' / 'shadow-sm' / 'shadow-lg'
     'sidebar-width': 18.75rem, // 300px
 
     'portal-card-border-width': null,  // Portal width

--- a/addons/website/static/src/scss/primary_variables.scss
+++ b/addons/website/static/src/scss/primary_variables.scss
@@ -2184,6 +2184,25 @@ $o-base-website-values-palette: (
     'footer-template': 'default',
     'footer-effect': null, // null / 'slideout_slide_hover' / 'slideout_shadow'
     'footer-scrolltop': false,
+
+    // Box shadows
+    'box-shadow-color': rgba(0, 0, 0, 0.12),
+    'box-shadow-offset-x': 0px,
+    'box-shadow-offset-y': 4px,
+    'box-shadow-blur-radius': 16px,
+    'box-shadow-spread-radius': 0px,
+
+    'box-shadow-sm-color': rgba(0, 0, 0, .1),
+    'box-shadow-sm-offset-x': 0px,
+    'box-shadow-sm-offset-y': 1px,
+    'box-shadow-sm-blur-radius': 3px,
+    'box-shadow-sm-spread-radius': 0px,
+
+    'box-shadow-lg-color': rgba(0, 0, 0, .175),
+    'box-shadow-lg-offset-x': 0px,
+    'box-shadow-lg-offset-y': 12px,
+    'box-shadow-lg-blur-radius': 32px,
+    'box-shadow-lg-spread-radius': 0px,
 );
 $o-font-aliases-to-keys: (
     'base': 'font',

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -142,6 +142,22 @@ $-seen-urls: ();
     @include print-variable('btn-border-radius-sm', $btn-border-radius-sm);
     @include print-variable('btn-border-radius-lg', $btn-border-radius-lg);
 
+    @include print-variable('box-shadow-color', $box-shadow-color);
+    @include print-variable('box-shadow-offset-x', $box-shadow-offset-x);
+    @include print-variable('box-shadow-offset-y', $box-shadow-offset-y);
+    @include print-variable('box-shadow-blur-radius', $box-shadow-blur-radius);
+    @include print-variable('box-shadow-spread-radius', $box-shadow-spread-radius);
+    @include print-variable('box-shadow-sm-color', $box-shadow-sm-color);
+    @include print-variable('box-shadow-sm-offset-x', $box-shadow-sm-offset-x);
+    @include print-variable('box-shadow-sm-offset-y', $box-shadow-sm-offset-y);
+    @include print-variable('box-shadow-sm-blur-radius', $box-shadow-sm-blur-radius);
+    @include print-variable('box-shadow-sm-spread-radius', $box-shadow-sm-spread-radius);
+    @include print-variable('box-shadow-lg-color', $box-shadow-lg-color);
+    @include print-variable('box-shadow-lg-offset-x', $box-shadow-lg-offset-x);
+    @include print-variable('box-shadow-lg-offset-y', $box-shadow-lg-offset-y);
+    @include print-variable('box-shadow-lg-blur-radius', $box-shadow-lg-blur-radius);
+    @include print-variable('box-shadow-lg-spread-radius', $box-shadow-lg-spread-radius);
+
     @include print-variable('input-padding-y', $input-padding-y);
     @include print-variable('input-padding-x', $input-padding-x);
     @include print-variable('input-font-size', $input-font-size);

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1764,7 +1764,17 @@ header {
             }
         }
         border-radius: o-website-value('menu-border-radius') !important;
-        box-shadow: o-website-value('menu-box-shadow') !important;
+        
+        @if o-website-value('menu-shadow-class') == 'shadow' {
+            box-shadow: var(--box-shadow) !important;
+        } @else if o-website-value('menu-shadow-class') == 'shadow-sm' {
+            box-shadow: var(--box-shadow-sm) !important;
+        } @else if o-website-value('menu-shadow-class') == 'shadow-lg' {
+            box-shadow: var(--box-shadow-lg) !important;
+        } @else if o-website-value('menu-shadow-class') == 'o-shadow-custom' {
+            box-shadow: o-website-value('menu-box-shadow-style') !important;
+        }
+        
 
         &.o_header_force_no_radius {
             border-radius: 0 !important;

--- a/addons/website/static/tests/builder/website_builder/shadow_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/shadow_option.test.js
@@ -1,0 +1,37 @@
+import { expect, test } from "@odoo/hoot";
+import { contains, defineModels, models, onRpc } from "@web/../tests/web_test_helpers";
+import {
+    defineWebsiteModels,
+    setupWebsiteBuilder,
+} from "@website/../tests/builder/website_helpers";
+
+defineWebsiteModels();
+test("bootstrap shadow controls in the theme tab of website builder", async () => {
+    class WebsiteAssets extends models.Model {
+        _name = "website.assets";
+        make_scss_customization(location, changes) {
+            expect.step(`${location} ${JSON.stringify(changes)}`);
+        }
+    }
+    defineModels([WebsiteAssets]);
+    onRpc("/website/theme_customize_bundle_reload", async (request) => {
+        expect.step("asset reload");
+        return "";
+    });
+    await setupWebsiteBuilder("");
+
+    await contains("#theme-tab").click();
+    await contains("[data-action-param='box-shadow-offset-x'] input").fill("100");
+    expect.waitForSteps([
+        '/website/static/src/scss/options/user_values.scss {"box-shadow-offset-x":"6.25rem"}',
+        "asset reload",
+    ]);
+
+    await contains("div.hb-row-label:contains('Normal')").click();
+    await contains("div[data-label='Color'] button.o_we_color_preview").click();
+    await contains("div.o_popover button.o_color_button[data-color='#FF0000']").click();
+    expect.waitForSteps([
+        '/website/static/src/scss/options/user_values.scss {"box-shadow-color":"#FF0000"}',
+        "asset reload",
+    ]);
+});

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -458,7 +458,7 @@
     <t t-set="is_mobile" t-value="True"/>
 
     <t t-call="website.navbar"
-        _navbar_classes.f="o_header_mobile d-block d-lg-none shadow-sm"
+        _navbar_classes.f="o_header_mobile d-block d-lg-none"
         _navbar_expand_class.f=""
         _navbar_name.f="Mobile">
 
@@ -596,7 +596,7 @@
 <!-- "Default" template -->
 <template id="template_header_default" inherit_id="website.layout" name="Template Header Default" active="True">
     <xpath expr="//header//nav" position="replace">
-        <t t-set="_navbar_classes" t-valuef="d-none d-lg-block shadow-sm"/>
+        <t t-set="_navbar_classes" t-valuef="d-none d-lg-block"/>
         <t t-call="website.navbar" _navbar_classes="_navbar_classes">
 
             <div id="o_main_nav" t-attf-class="o_main_nav #{header_content_width}">
@@ -663,7 +663,7 @@
 <template id="template_header_hamburger" inherit_id="website.layout" name="Template Header Hamburger" active="False">
     <xpath expr="//header//nav" position="replace">
         <t t-call="website.navbar"
-            _navbar_classes.f="d-none d-lg-block shadow-sm"
+            _navbar_classes.f="d-none d-lg-block"
             _navbar_expand_class.f="">
 
             <div id="o_main_nav" t-attf-class="o_main_nav d-grid py-0 o_grid_header_3_cols #{header_content_width}">
@@ -787,7 +787,7 @@
 <template id="template_header_stretch" inherit_id="website.layout" name="Template Header Stretch" active="False">
     <xpath expr="//header//nav" position="replace">
         <t t-call="website.navbar"
-            _navbar_classes.f="d-none d-lg-block py-0 shadow-sm">
+            _navbar_classes.f="d-none d-lg-block py-0">
 
             <div id="o_main_nav" t-attf-class="o_main_nav align-items-stretch #{header_content_width}">
                 <!-- Brand -->
@@ -869,7 +869,7 @@
 <template id="template_header_vertical" inherit_id="website.layout" name="Template Header Vertical" active="False">
     <xpath expr="//header//nav" position="replace">
         <t t-call="website.navbar"
-            _navbar_classes.f="d-none d-lg-block pt-3 shadow-sm">
+            _navbar_classes.f="d-none d-lg-block pt-3">
 
             <div id="o_main_nav" t-attf-class="o_main_nav flex-wrap #{header_content_width}">
                 <div class="o_header_hide_on_scroll d-grid align-items-center w-100 o_grid_header_3_cols pb-3">
@@ -941,7 +941,7 @@
 <template id="template_header_search" inherit_id="website.layout" name="Template Header Search" active="False">
     <xpath expr="//header//nav" position="replace">
         <t t-call="website.navbar"
-            _navbar_classes.f="d-none d-lg-block p-0 shadow-sm">
+            _navbar_classes.f="d-none d-lg-block p-0">
 
             <div id="o_main_nav" class="o_main_nav flex-wrap">
                 <div aria-label="Top" class="o_header_hide_on_scroll border-bottom o_border_contrast">
@@ -1030,7 +1030,7 @@
 <template id="template_header_sales_one" inherit_id="website.layout" name="Template Header Sale 1" active="False">
     <xpath expr="//header//nav" position="replace">
         <t t-call="website.navbar"
-            _navbar_classes.f="o_header_force_no_radius d-none d-lg-block p-0 shadow-sm">
+            _navbar_classes.f="o_header_force_no_radius d-none d-lg-block p-0">
             <div id="o_main_nav" class="o_main_nav">
                 <div aria-label="Top" t-attf-class="#{header_content_width} d-flex align-items-center justify-content-between py-3">
                     <!-- Brand -->
@@ -1111,7 +1111,7 @@
 <template id="template_header_sales_two" inherit_id="website.layout" name="Template Header Sale 2" active="False">
     <xpath expr="//header//nav" position="replace">
         <t t-call="website.navbar"
-            _navbar_classes.f="o_header_force_no_radius d-none d-lg-block p-0 shadow-sm">
+            _navbar_classes.f="o_header_force_no_radius d-none d-lg-block p-0">
             <div id="o_main_nav" class="o_main_nav">
                 <div class="o_header_hide_on_scroll">
                     <div aria-label="Top" t-if="is_view_active('website.header_text_element') or is_view_active('website.header_social_links') or is_view_active('website.header_language_selector')" class="o_header_sales_two_top py-1">
@@ -1203,7 +1203,7 @@
 <template id="template_header_sales_three" inherit_id="website.layout" name="Template Header Sale 3" active="False">
     <xpath expr="//header//nav" position="replace">
         <t t-call="website.navbar"
-            _navbar_classes.f="o_header_force_no_radius d-none d-lg-block p-0 shadow-sm rounded-0">
+            _navbar_classes.f="o_header_force_no_radius d-none d-lg-block p-0 rounded-0">
             <div id="o_main_nav" class="o_main_nav">
                 <div aria-label="Top" t-if="is_view_active('website.header_text_element') or is_view_active('website.header_social_links') or is_view_active('website.header_search_box') or is_view_active('website.header_call_to_action')"
                      class="o_header_sales_three_top o_header_hide_on_scroll position-relative border-bottom z-1 o_border_contrast">
@@ -1294,7 +1294,7 @@
     </xpath>
     <xpath expr="//header//nav" position="replace">
         <t t-call="website.navbar"
-            _navbar_classes.f="o_header_sales_four_top o_header_force_no_radius d-none d-lg-block p-0 shadow-sm z-1">
+            _navbar_classes.f="o_header_sales_four_top o_header_force_no_radius d-none d-lg-block p-0 z-1">
             <div id="o_main_nav" class="o_main_nav">
                 <div aria-label="Top" t-attf-class="#{header_content_width} d-flex">
                     <!-- Navbar -->
@@ -1387,7 +1387,7 @@
     </xpath>
     <xpath expr="//header//nav" position="replace">
         <t t-call="website.navbar"
-            _navbar_classes.f="o_border_right_only d-none d-lg-block shadow">
+            _navbar_classes.f="o_border_right_only d-none d-lg-block">
             <div id="o_main_nav" class="o_main_nav navbar-nav d-flex flex-column justify-content-between h-100 w-100">
                <div class="d-flex flex-column w-100 h-100">
                     <div class="d-flex pb-3">
@@ -1499,7 +1499,7 @@
     <xpath expr="//header//nav" position="replace">
         <div t-attf-class="#{header_content_width} py-3 px-0">
             <t t-call="website.navbar"
-                    _navbar_classes.f="o_full_border d-none d-lg-block rounded-pill px-4 shadow-sm">
+                    _navbar_classes.f="o_full_border d-none d-lg-block rounded-pill px-4">
                 <div id="o_main_nav" t-attf-class="#{header_content_width} o_main_nav">
                     <!-- Brand -->
                     <t t-call="website.placeholder_header_brand"


### PR DESCRIPTION
This PR improves how shadows are added in the Website Builder by introducing support for Bootstrap shadow classes and enhancing the editing experience.

**List of commits**

[IMP] website: add controls to edit Bootstrap shadow classes

This commit introduces new controls in the Theme tab of the Website Builder, allowing users to edit Bootstrap shadow classes directly from the interface.

In a subsequent commit, the mechanism for applying shadows to website elements will be enhanced to support both Bootstrap shadow classes and custom shadow values.

---

[IMP] html_builder: use Bootstrap shadow classes in shadow option

This commit enhances the shadow option controls to support Bootstrap’s built-in shadow utility classes in addition to existing custom CSS styles. Users can now apply shadows more easily using standard Bootstrap classes or continue defining custom shadows for finer control. If needed, the default Bootstrap shadow values can be adjusted from the
Theme tab.

For consistency, the header box shadow option has also been updated to emulate the behaviour of the Bootstrap shadow utilities.

---

[IMP] html_builder, website: add editable icons to shadow options

This commit adds edit icons to the shadow option controls as visual cues indicating that these options can be customized in the Theme tab. Clicking an icon takes the user directly to the corresponding setting in the Theme tab, improving user experience.

---

Task: [4951262](https://www.odoo.com/odoo/project/974/tasks/4951262)
