### PR TITLE
[REF] iot_drivers: simplify webrtc/websocket message handling

### DIFF
--- a/addons/iot_drivers/tools/communication.py
+++ b/addons/iot_drivers/tools/communication.py
@@ -1,0 +1,75 @@
+import logging
+import pprint
+import time
+
+from odoo.addons.iot_drivers import main
+from odoo.addons.iot_drivers.tools import helpers, system
+from odoo.addons.iot_drivers.tools.system import IS_WINDOWS, IOT_IDENTIFIER
+from odoo.addons.iot_drivers.server_logger import close_server_log_sender_handler
+
+_logger = logging.getLogger(__name__)
+
+
+def handle_message(message_type: str, **kwargs: dict) -> dict:
+    """General handler for messages received from the Odoo server either
+    via WebSocket or WebRTC.
+
+    :param message_type: The type of message received.
+    :param kwargs: Additional parameters passed with the message.
+    :return: A dictionary response based on the message type and processing.
+    """
+    device_identifier = kwargs.get('device_identifier')
+    base_response = {
+        'owner': kwargs.get('session_id', '0'),  # TODO: remove 'owner' in future versions
+        'session_id': kwargs.get('session_id', '0'),
+        'iot_box_identifier': IOT_IDENTIFIER,
+        'device_identifier': device_identifier,
+        'time': time.time(),
+    }
+
+    match message_type:
+        case 'iot_action':
+            if device_identifier not in main.iot_devices:
+                # Notify the controller that the device is not connected
+                return {**base_response, 'status': 'disconnected'}
+            _logger.info("Received message of type %s:\n%s", message_type, pprint.pformat(kwargs))
+            main.iot_devices[device_identifier].action(kwargs)
+        case 'server_clear':
+            helpers.disconnect_from_server()
+            close_server_log_sender_handler()
+        case 'server_update':
+            system.update_conf({
+                'remote_server': kwargs['server_url']
+            })
+            helpers.get_odoo_server_url.cache_clear()
+        case 'restart_odoo':
+            helpers.odoo_restart()
+        case 'remote_debug':
+            if IS_WINDOWS:
+                return {}
+            if not kwargs.get("status"):
+                system.toggle_remote_connection(kwargs.get("token", ""))
+                time.sleep(1)
+            return {
+                **base_response,
+                'device_identifier': None,
+                'status': 'success',
+                'result': {'enabled': system.is_ngrok_enabled()}
+            }
+        case "test_protocol":
+            return {
+                **base_response,
+                'status': 'success',
+            }
+        case "test_connection":
+            return {
+                **base_response,
+                'status': 'success',
+                'result': {
+                    'lan_quality': helpers.check_network(),
+                    'wan_quality': helpers.check_network("www.odoo.com"),
+                }
+            }
+        case _:
+            pass
+    return {}

--- a/addons/iot_drivers/tools/helpers.py
+++ b/addons/iot_drivers/tools/helpers.py
@@ -66,7 +66,7 @@ def toggleable(function):
                 _logger.warning("Refusing call to %s: longpolling is disabled by devtools", fname)
                 raise Locked("Longpolling disabled by devtools")  # raise to make the http request fail
         elif function.__name__ == 'action':
-            action = args[1].get('action', 'default')  # first argument is self (containing Driver instance), second is 'data'
+            action = kwargs.get('action', 'default')  # first argument is self (containing Driver instance), second is 'data'
             disabled_actions = (system.get_conf('actions', section='devtools') or '').split(',')
             if action in disabled_actions or '*' in disabled_actions:
                 _logger.warning("Ignoring call to %s: '%s' action is disabled by devtools", fname, action)

--- a/addons/iot_drivers/webrtc_client.py
+++ b/addons/iot_drivers/webrtc_client.py
@@ -1,13 +1,10 @@
 import asyncio
 import json
 import logging
-import pprint
 from threading import Thread
-import time
 from aiortc import RTCDataChannel, RTCPeerConnection, RTCSessionDescription
 
-from odoo.addons.iot_drivers import main
-from odoo.addons.iot_drivers.tools.system import IOT_IDENTIFIER
+from odoo.addons.iot_drivers.tools import communication
 
 _logger = logging.getLogger(__name__)
 
@@ -55,30 +52,15 @@ class WebRtcClient(Thread):
 
                 # Handle regular message
                 message = json.loads(message_str)
-                message_type = message["message_type"]
-                _logger.info("Received message of type %s:\n%s", message_type, pprint.pformat(message))
-                if message_type == "iot_action":
-                    device_identifier = message["device_identifier"]
-                    data = message["data"]
-                    data["session_id"] = message["session_id"]
-                    if device_identifier in main.iot_devices:
-                        _logger.info("device '%s' action started with: %s", device_identifier, pprint.pformat(data))
-                        await self.event_loop.run_in_executor(None, lambda: main.iot_devices[device_identifier].action(data))
-                    else:
-                        # Notify that the device is not connected
-                        self.send({
-                            'owner': message['session_id'],
-                            'device_identifier': device_identifier,
-                            'time': time.time(),
-                            'status': 'disconnected',
-                        })
-                elif message_type == "test_protocol":
-                    self.send({
-                        'owner': message['session_id'],
-                        'device_identifier': IOT_IDENTIFIER,
-                        'time': time.time(),
-                        'status': 'success',
-                    })
+                message["data"]["session_id"] = message["session_id"]
+                result = await self.event_loop.run_in_executor(
+                    None,
+                    lambda: communication.handle_message(
+                        message["message_type"], device_identifier=message["device_identifier"], **message["data"]
+                    )
+                )
+                if result:
+                    self.send(result)
 
             @channel.on("close")
             def on_close():


### PR DESCRIPTION
In order to be able to use webrtc and websocket the same way, we extracted the message handling in a method on a parent class.

This allows getting the same behaviour after sending the same message to websocket or webrtc.

Enterprise PR: odoo/enterprise#96497