### PR TITLE
[FIX] hr_recruitment_skills: ensure interviewer can see applicant skills

### DIFF
--- a/addons/hr_recruitment_skills/models/hr_applicant.py
+++ b/addons/hr_recruitment_skills/models/hr_applicant.py
@@ -54,7 +54,7 @@ class HrApplicant(models.Model):
                 applicant.matching_score = False
                 continue
             job_skills = job.job_skill_ids
-            job_degree = job.expected_degree.score * 100
+            job_degree = job.expected_degree.sudo().score * 100
             job_total = sum(job_skills.mapped("level_progress")) + job_degree
             job_skill_map = {js.skill_id: js.level_progress for js in job_skills}
 

--- a/addons/hr_recruitment_skills/tests/test_recruitment_skills.py
+++ b/addons/hr_recruitment_skills/tests/test_recruitment_skills.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.tests import Form, TransactionCase, tagged
+from odoo.tests.common import new_test_user
 
 
 @tagged("recruitment")
@@ -549,3 +550,21 @@ class TestRecruitmentSkills(TransactionCase):
         applicant_skills_name_list = applicant.applicant_skill_ids.mapped(lambda s: (s.skill_id, s.skill_type_id, s.skill_level_id))
         employee_skills_name_list = applicant.employee_id.employee_skill_ids.mapped(lambda s: (s.skill_id, s.skill_type_id, s.skill_level_id))
         self.assertCountEqual(applicant_skills_name_list, employee_skills_name_list)
+
+    def test_interviewer_skills_access(self):
+        """
+        Test that an interviewer can see the skills of an applicant
+        """
+        interviewer_user = new_test_user(self.env, 'itw',
+            groups='base.group_user,hr_recruitment.group_hr_recruitment_interviewer',
+            name='Recruitment Interviewer', email='itw@example.com')
+
+        self.t_job.expected_degree = self.env['hr.recruitment.degree'].create({
+            'name': 'Master',
+            'score': 0.5,
+        })
+        self.t_applicant.interviewer_ids = interviewer_user.ids
+        # flush to force compute methods when reading fields
+        self.env.flush_all()
+        matching_skill_ids = self.t_applicant.with_user(interviewer_user).matching_skill_ids
+        self.assertEqual(matching_skill_ids, self.t_applicant.matching_skill_ids, "The interviewer should see the skills of the applicant")


### PR DESCRIPTION
To reproduce:
=============
1. give Marc Demo access to Recruitement app as interviewer
2. assign him to a job position as interviewer
3. as Marc Demo try to open an applicant linked to that job position -> Error

Problem:
========
when opening an applicant, the field matching_skill_ids is computed where we try to access the expected_degree field of the job position, which is not accessible to an interviewer.

Solution:
=========
Use sudo() to access the expected_degree field of the job position.

opw-5138588

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
