### PR TITLE
[IMP] web: fine-tune pivot tree pruning algorithm

### DIFF
--- a/addons/web/static/src/views/pivot/pivot_model.js
+++ b/addons/web/static/src/views/pivot/pivot_model.js
@@ -1310,12 +1310,14 @@ export class PivotModel extends Model {
         // keep folded groups folded after the reload if the structure of the table is the same
         if (prune && this._hasData(data) && this._hasData(this.data)) {
             if (
-                symmetricalDifference(metaData.rowGroupBys, this.metaData.rowGroupBys).length === 0
+                symmetricalDifference(metaData.fullRowGroupBys, this.metaData.fullRowGroupBys)
+                    .length === 0
             ) {
                 this._pruneTree(data.rowGroupTree, this.data.rowGroupTree);
             }
             if (
-                symmetricalDifference(metaData.colGroupBys, this.metaData.colGroupBys).length === 0
+                symmetricalDifference(metaData.fullColGroupBys, this.metaData.fullColGroupBys)
+                    .length === 0
             ) {
                 this._pruneTree(data.colGroupTree, this.data.colGroupTree);
             }
@@ -1429,11 +1431,8 @@ export class PivotModel extends Model {
         }
         [...tree.directSubTrees.keys()].forEach((subTreeKey) => {
             const subTree = tree.directSubTrees.get(subTreeKey);
-            if (!oldTree.directSubTrees.has(subTreeKey)) {
-                subTree.directSubTrees.clear();
-                delete subTree.sortedKeys;
-            } else {
-                const oldSubTree = oldTree.directSubTrees.get(subTreeKey);
+            const oldSubTree = oldTree.directSubTrees.get(subTreeKey);
+            if (oldSubTree) {
                 this._pruneTree(subTree, oldSubTree);
             }
         });

--- a/addons/web/static/tests/views/pivot_view.test.js
+++ b/addons/web/static/tests/views/pivot_view.test.js
@@ -3570,8 +3570,8 @@ test("filter -> sort -> unfilter should not crash", async () => {
     await toggleSearchBarMenu();
     await toggleMenuItem("xphone");
     expect(getFacetTexts()).toEqual([]);
-    expect(queryAllTexts("tbody th")).toEqual(["Total", "xphone", "Yes", "xpad"]);
-    expect(getCurrentValues()).toBe(["4", "1", "1", "3"].join());
+    expect(queryAllTexts("tbody th")).toEqual(["Total", "xphone", "Yes", "xpad", "No", "Yes"]);
+    expect(getCurrentValues()).toBe(["4", "1", "1", "3", "1", "2"].join());
 });
 
 test("no class 'o_view_sample_data' when real data are presented", async () => {


### PR DESCRIPTION
This commit adjusts the pruning algorithm to better preserve leaf folding information when applying query changes in the pivot view.

The algorithm is now less aggressive with unknown leaves — instead of removing them, it expands leaves that were not previously part of the tree. Additionally, pruning now triggers based on the similarity of the total tree dimensions, rather than only on the inferred dimensions from the grouping.

task-5106744
