### PR TITLE
[FIX] l10n_es_pos: display state name on spanish receipt

### DIFF
--- a/addons/l10n_es_pos/static/src/overrides/components/receipt_header/receipt_header.xml
+++ b/addons/l10n_es_pos/static/src/overrides/components/receipt_header/receipt_header.xml
@@ -11,7 +11,7 @@
                 <div t-if="props.data.company.street" t-esc="props.data.company.street" />
                 <div t-if="props.data.company.zip" t-esc="props.data.company.zip" />
                 <div t-if="props.data.company.city" t-esc="props.data.company.city" />
-                <div t-if="props.data.company.state_id">(<t t-esc="props.data.company.state_id[1]"/>)</div>
+                <div t-if="props.data.company.state_id">(<t t-esc="props.data.company.state_id.name"/>)</div>
             </t>
         </xpath>
         <xpath expr="//div[hasclass('pos-receipt-contact')]" position="inside">

--- a/addons/l10n_es_pos/static/tests/tours/spanish_pos_tour.js
+++ b/addons/l10n_es_pos/static/tests/tours/spanish_pos_tour.js
@@ -6,7 +6,7 @@ import * as Chrome from "@point_of_sale/../tests/tours/utils/chrome_util";
 import * as PartnerList from "@point_of_sale/../tests/tours/utils/partner_list_util";
 import * as Utils from "@point_of_sale/../tests/tours/utils/common";
 import { registry } from "@web/core/registry";
-import { checkSimplifiedInvoiceNumber, pay } from "./utils/receipt_util";
+import { checkSimplifiedInvoiceNumber, checkCompanyState, pay } from "./utils/receipt_util";
 
 const SIMPLIFIED_INVOICE_LIMIT = 1000;
 
@@ -43,11 +43,13 @@ registry.category("web_tour.tours").add("spanish_pos_tour", {
                     "verify that the simplified invoice number does not appear on the receipt, because this order is invoiced, so it does not have a simplified invoice number",
                 trigger: ".receipt-screen:not(:has(.simplified-invoice-number))",
             },
+            checkCompanyState("Badajoz"),
             ReceiptScreen.clickNextOrder(),
 
             ProductScreen.addOrderline("Desk Pad", "1"),
             pay(),
             checkSimplifiedInvoiceNumber("0003"),
+            checkCompanyState("Badajoz"),
             ReceiptScreen.clickNextOrder(),
             ProductScreen.addOrderline("Desk Pad", "1"),
             ProductScreen.clickPayButton(),

--- a/addons/l10n_es_pos/static/tests/tours/utils/receipt_util.js
+++ b/addons/l10n_es_pos/static/tests/tours/utils/receipt_util.js
@@ -17,3 +17,12 @@ export function pay() {
         ...PaymentScreen.clickValidate(),
     ];
 }
+
+export function checkCompanyState(state) {
+    return [
+        {
+            content: "verify that the company state is on the receipt",
+            trigger: `.pos-receipt-container div:contains('(${state})')`,
+        },
+    ];
+}

--- a/addons/l10n_es_pos/tests/test_frontend.py
+++ b/addons/l10n_es_pos/tests/test_frontend.py
@@ -13,6 +13,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         cls.company_data["company"].country_id = cls.env.ref("base.es").id
         cls.company_data["company"].currency_id = cls.env.ref("base.EUR").id
         cls.company_data["company"].vat = "ESA12345674"
+        cls.company_data["company"].state_id = cls.env.ref("base.state_es_ba").id
         return cls.company_data["company"]
 
     def test_spanish_pos(self):


### PR DESCRIPTION
**Steps to reproduce:**
- Set a spanish company, set the state
- Set the "Simplified Invoice" journal in the settings
- Go to PoS and make a purchase
- On the receipt, empty brackets are shown where the state should be

**Why the fix:**
Before this commit, we checked that the company had a state set, and if it had, we displayed *state_id[1]* between brackets. Even if the state_id existed, this is not the correct structure for the state_id, so *state_id[1]* did not exist, and we displayed only the brackets.

We now display the correct state name, still between brackets.

opw-5098212