### PR TITLE
[IMP] mail: show unread badge on meeting chat action

### DIFF
--- a/addons/mail/static/src/core/common/action.js
+++ b/addons/mail/static/src/core/common/action.js
@@ -7,6 +7,7 @@ import { Reactive } from "@web/core/utils/reactive";
 export const ACTION_TAGS = Object.freeze({
     DANGER: "DANGER",
     SUCCESS: "SUCCESS",
+    IMPORTANT_BADGE: "IMPORTANT_BADGE",
     WARNING_BADGE: "WARNING_BADGE",
     CALL_LAYOUT: "CALL_LAYOUT",
     JOIN_LEAVE_CALL: "JOIN_LEAVE_CALL",
@@ -18,6 +19,9 @@ export const ACTION_TAGS = Object.freeze({
 
 /**
  * @typedef {Object} ActionDefinition
+ * @property {boolean|(action: Action) => boolean} [badge]
+ * @property {string|(action: Action) => string} [badgeIcon]
+ * @property {string|(action: Action) => string} [badgeText]
  * @property {Object|(action: Action) => Object} [btnAttrs]
  * @property {string|(action: Action) => string} [btnClass]
  * @property {Component} [component]
@@ -72,6 +76,42 @@ export class Action {
 
     get params() {
         return { action: this, store: this.store, owner: this.owner };
+    }
+
+    /** @param {Action} action @returns {boolean|undefined} */
+    _badge(action) {}
+    /** Condition for showing badge on this action */
+    get badge() {
+        return (
+            this._badge(this.params) ??
+            (typeof this.definition.badge === "function"
+                ? this.definition.badge.call(this, this.params)
+                : this.definition.badge)
+        );
+    }
+
+    /** @param {Action} action @returns {string|undefined} */
+    _badgeIcon(action) {}
+    /** When action shows badge @see badge this property tells the icon inside badge */
+    get badgeIcon() {
+        return (
+            this._badgeIcon(this.params) ??
+            (typeof this.definition.badgeIcon === "function"
+                ? this.definition.badgeIcon.call(this, this.params)
+                : this.definition.badgeIcon)
+        );
+    }
+
+    /** @param {Action} action @returns {string|undefined} */
+    _badgeText(action) {}
+    /** When action shows badge @see badge this property tells the text inside badge. */
+    get badgeText() {
+        return (
+            this._badgeText(this.params) ??
+            (typeof this.definition.badgeText === "function"
+                ? this.definition.badgeText.call(this, this.params)
+                : this.definition.badgeText)
+        );
     }
 
     /** @param {Action} action @returns {Object|undefined} */
@@ -149,7 +189,7 @@ export class Action {
 
     /** @param {Action} action @returns {boolean|undefined} */
     _dropdown(action) {}
-    /** Determines whether this action opens a dropdown on selection. Value is shaped { template, menuClass } */
+    /** Determines whether this action opens a dropdown on selection. */
     get dropdown() {
         return this._dropdown(this.params) ?? this.definition.dropdown;
     }

--- a/addons/mail/static/src/core/common/action_list.xml
+++ b/addons/mail/static/src/core/common/action_list.xml
@@ -81,12 +81,9 @@
     </DropdownItem>
     <button t-else="" t-att-class="btnClass" t-att="Object.assign(attrs, { 'title': action.name })" t-on-click="(ev) => this.onSelected(action, ev)" t-att-data-hotkey="action.hotkey" t-att-style="props.style">
         <t t-call="mail.Action.content"/>
-        <span
-            t-if="action.tags.includes('WARNING_BADGE')"
-            class="position-absolute me-n1 mt-n1 end-0 fw-bolder badge p-0 rounded-circle bg-warning d-flex justify-content-center align-items-center" style="aspect-ratio: 1; font-size: 0.6rem;"
-        >
-            <i class="fa fa-exclamation"/>
-        </span>
+        <t t-if="action.badge" t-call="mail.Action.badge">
+            <t t-set="extraBadgeClass" t-value="'position-absolute me-n1 mt-n1 end-0'"/>
+        </t>
     </button>
 </t>
 
@@ -97,6 +94,13 @@
     <i t-elif="action.icon" t-attf-class="{{ action.icon }}" t-att-class="{ 'o-fs-small': props.dropdown, 'fa-fw': props.fw }"/>
     <i t-elif="props.dropdown" class="fa-question fa-fw opacity-0" t-att-class="props.fw ? 'fa-fw' : ''"/>
     <span t-if="action.name and (props.dropdown or (props.inline and (!action.icon or action.inlineName)))" class="o-mail-ActionList-actionLabel" t-attf-class="{{ action.nameClass }}" t-att-class="{ 'mx-1': props.dropdown }" t-out="(props.inline and action.inlineName) or action.name"/>
+    <t t-if="props.dropdown and action.badge" t-call="mail.Action.badge"/>
+</t>
+
+<t t-name="mail.Action.badge">
+    <span class="fw-bolder badge p-0 rounded-circle d-flex justify-content-center align-items-center" t-attf-class="{{ extraBadgeClass }}" t-att-class="{ 'bg-warning': action.tags.includes('WARNING_BADGE'), 'o-discuss-badge': action.tags.includes('IMPORTANT_BADGE') }" style="aspect-ratio: 1; font-size: 0.6rem;">
+        <i t-if="action.badgeIcon" t-att-class="action.badgeIcon"/><span t-elif="action.badgeText" t-esc="action.badgeText"/>
+    </span>
 </t>
 
 </templates>

--- a/addons/mail/static/src/core/common/thread_actions.js
+++ b/addons/mail/static/src/core/common/thread_actions.js
@@ -4,7 +4,7 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { SearchMessagesPanel } from "@mail/core/common/search_messages_panel";
 import { markEventHandled } from "@web/core/utils/misc";
-import { Action, UseActions } from "@mail/core/common/action";
+import { Action, ACTION_TAGS, UseActions } from "@mail/core/common/action";
 import { MeetingChat } from "@mail/discuss/call/common/meeting_chat";
 import { useService } from "@web/core/utils/hooks";
 
@@ -93,12 +93,22 @@ registerThreadAction("search-messages", {
 });
 registerThreadAction("meeting-chat", {
     actionPanelComponent: MeetingChat,
+    badge: ({ thread }) => thread.isUnread,
+    badgeIcon: ({ thread }) => !thread.importantCounter && "fa fa-circle text-700",
+    badgeText: ({ thread }) => thread.importantCounter || undefined,
     condition: ({ owner }) => owner.env.inMeetingView,
     icon: "fa fa-fw fa-comments",
     name: _t("Chat"),
     panelOuterClass: "bg-100 border border-secondary",
     sequence: 30,
     toggle: true,
+    tags: ({ thread }) => {
+        const tags = [];
+        if (thread.importantCounter) {
+            tags.push(ACTION_TAGS.IMPORTANT_BADGE);
+        }
+        return tags;
+    },
 });
 
 export class ThreadAction extends Action {

--- a/addons/mail/static/src/discuss/call/common/call_actions.js
+++ b/addons/mail/static/src/discuss/call/common/call_actions.js
@@ -30,6 +30,8 @@ export function registerCallAction(id, definition) {
 }
 
 export const muteAction = {
+    badge: ({ store }) => store.rtc.microphonePermission !== "granted",
+    badgeIcon: "fa fa-exclamation",
     condition: ({ store, thread }) => thread?.eq(store.rtc?.channel),
     name: ({ store }) => (store.rtc.selfSession.isMute ? _t("Unmute") : _t("Mute")),
     isActive: ({ store }) =>
@@ -83,6 +85,8 @@ registerCallAction("deafen", {
     tags: ({ action }) => (action.isActive ? ACTION_TAGS.DANGER : undefined),
 });
 export const cameraOnAction = {
+    badge: ({ store }) => store.rtc.cameraPermission !== "granted",
+    badgeIcon: "fa fa-exclamation",
     condition: ({ store, thread }) => thread?.eq(store.rtc?.channel),
     disabledCondition: ({ store }) => store.rtc?.isRemote,
     name: ({ store }) =>

--- a/addons/mail/static/src/discuss/call/common/meeting_side_actions.js
+++ b/addons/mail/static/src/discuss/call/common/meeting_side_actions.js
@@ -1,6 +1,6 @@
 import { ActionList } from "@mail/core/common/action_list";
 
-import { Component, onWillRender, toRaw, useSubEnv } from "@odoo/owl";
+import { Component, useSubEnv } from "@odoo/owl";
 
 import { useService } from "@web/core/utils/hooks";
 
@@ -19,32 +19,31 @@ export class MeetingSideActions extends Component {
     setup() {
         this.store = useService("mail.store");
         useSubEnv({ inMeetingSideActions: true });
-        onWillRender(() => {
-            const quickThreadActionIds = ["invite-people", "meeting-chat"];
-            const threadActions = toRaw(this.props.threadActions);
-            const { quick, other, group } = threadActions.partition;
-            const partitionedActions = {
-                quick: quick.filter((action) => !quickThreadActionIds.includes(action.id)),
-                other: other.filter((action) => !quickThreadActionIds.includes(action.id)),
-                group: group
-                    .map((group) =>
-                        group.filter((action) => !quickThreadActionIds.includes(action.id))
-                    )
-                    .filter((g) => g.length > 0),
-            };
-            const actions = threadActions.actions.filter((action) =>
-                quickThreadActionIds.includes(action.id)
-            );
-            actions.push(
-                threadActions.more({
-                    actions: [
-                        partitionedActions.quick,
-                        partitionedActions.other,
-                        ...partitionedActions.group,
-                    ],
-                })
-            );
-            this.actions = actions;
-        });
+    }
+
+    computeActions() {
+        const quickThreadActionIds = ["invite-people", "meeting-chat"];
+        const threadActions = this.props.threadActions;
+        const { quick, other, group } = threadActions.partition;
+        const partitionedActions = {
+            quick: quick.filter((action) => !quickThreadActionIds.includes(action.id)),
+            other: other.filter((action) => !quickThreadActionIds.includes(action.id)),
+            group: group
+                .map((group) => group.filter((action) => !quickThreadActionIds.includes(action.id)))
+                .filter((g) => g.length > 0),
+        };
+        const actions = threadActions.actions.filter((action) =>
+            quickThreadActionIds.includes(action.id)
+        );
+        actions.push(
+            threadActions.more({
+                actions: [
+                    partitionedActions.quick,
+                    partitionedActions.other,
+                    ...partitionedActions.group,
+                ],
+            })
+        );
+        this.actions = actions;
     }
 }

--- a/addons/mail/static/src/discuss/call/common/meeting_side_actions.xml
+++ b/addons/mail/static/src/discuss/call/common/meeting_side_actions.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.MeetingSideActions">
+        <t t-set="dummy" t-value="computeActions()"/>
         <div class="o-mail-MeetingSideActions d-flex">
             <ActionList actions="actions" inline="true" hasBtnBg="true" thread="store.rtc.channel" odooControlPanelSwitchStyle="true"/>
         </div>

--- a/addons/mail/static/tests/tours/discuss_channel_meeting_view_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_meeting_view_tour.js
@@ -2,6 +2,8 @@ import { browser } from "@web/core/browser/browser";
 import { registry } from "@web/core/registry";
 import { dragenterFiles } from "@web/../tests/utils";
 
+const CLICK_ON_CHAT_STEP = "click-on-chat-action";
+
 function getMeetingViewTourSteps({ inWelcomePage = false } = {}) {
     const steps = [
         { trigger: ".o-mail-Meeting" },
@@ -23,10 +25,27 @@ function getMeetingViewTourSteps({ inWelcomePage = false } = {}) {
         {
             trigger: ".o-mail-Meeting [title='Chat']",
             run: "click",
+            content: CLICK_ON_CHAT_STEP,
         },
         {
             trigger:
                 ".o-mail-Meeting .o-mail-ActionPanel .o-mail-Thread:contains('john (base.group_user) and bob (base.group_user)')",
+        },
+        {
+            trigger: ".o-mail-Message[data-persistent]:contains('Hello everyone!')",
+            run: "hover && click .o-mail-Message-actions button[title='Expand']",
+        },
+        {
+            trigger: ".o-dropdown-item:contains('Mark as Unread')",
+            run: "click",
+        },
+        { trigger: ".o-mail-Meeting [title='Chat']:has(.badge:contains(1))" },
+        {
+            trigger: ".o-mail-Thread-banner span:contains('Mark as Read')",
+            run: "click",
+        },
+        {
+            trigger: ".o-mail-Meeting [title='Chat']:not(:has(.badge))",
             async run({ waitFor }) {
                 const files = [new File(["hi there"], "file2.txt", { type: "text/plain" })];
                 await dragenterFiles(".o-mail-Meeting .o-mail-ActionPanel", files);
@@ -58,7 +77,18 @@ registry
             // Avoid starting with mic/camera to prevent an unhandleable browser permission popup.
             browser.localStorage.setItem("discuss_call_preview_join_mute", "true");
             browser.localStorage.setItem("discuss_call_preview_join_video", "false");
-            return getMeetingViewTourSteps();
+            const steps = getMeetingViewTourSteps();
+            const clickOnChatIndex = steps.find((step) => step.content === CLICK_ON_CHAT_STEP);
+            steps.splice(
+                clickOnChatIndex,
+                0,
+                {
+                    trigger: ".o-mail-Composer.o-focused .o-mail-Composer-input",
+                    run: "edit Hello everyone!",
+                },
+                { trigger: ".o-mail-Composer button[title='Send']:enabled", run: "click" }
+            );
+            return steps;
         },
     })
     .add("discuss.meeting_view_public_tour", {


### PR DESCRIPTION
With this commit, meeting chat action in the discuss call meeting view now shows a badge when it has unread messages:

- shows grey dot when chat has unread but no important messages.
- shows red badge when it has important messages, and counter is the number of important messages in the chat.

This makes it easier to know when there's new content in chat and incite user to open the chat in the meeting view.

<img width="1022" height="912" alt="Screenshot 2025-10-06 at 18 32 38" src="https://github.com/user-attachments/assets/020c9dbb-99b4-43e3-95c5-1679be8c7649" />
