### PR TITLE
[FIX] mail: fix runbot-233201 mention a channel thread

### DIFF
--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
@@ -805,7 +805,12 @@ export class DiscussChannel extends models.ServerModel {
         const store = new mailDataHelpers.Store(
             mentionSuggestions,
             makeKwArgs({
-                fields: ["name", "channel_type", "group_public_id", "parent_channel_id"],
+                fields: [
+                    "name",
+                    "channel_type",
+                    "group_public_id",
+                    mailDataHelpers.Store.one("parent_channel_id"),
+                ],
             })
         );
         return store.get_result();

--- a/addons/mail/static/tests/suggestion/suggestion.test.js
+++ b/addons/mail/static/tests/suggestion/suggestion.test.js
@@ -531,6 +531,7 @@ test("[text composer] mention a channel thread", async () => {
         channel_type: "channel",
     });
     pyEnv["discuss.channel"].create({
+        channel_member_ids: [],
         name: "ThreadOne",
         parent_channel_id: channelId,
     });
@@ -563,6 +564,7 @@ test("mention a channel thread", async () => {
         channel_type: "channel",
     });
     pyEnv["discuss.channel"].create({
+        channel_member_ids: [],
         name: "ThreadOne",
         parent_channel_id: channelId,
     });


### PR DESCRIPTION
https://runbot.odoo.com/odoo/runbot.build.error/233201

Problematic line introduced: https://github.com/odoo/odoo/pull/209240
Test introduced: https://github.com/odoo/odoo/pull/226563

Test adapted to be more deterministic: remove current user from channel to ensure the channel is always found through the suggestion route.

Fixed returned format of mock server.