### PR TITLE
[FIX] mail: fix runbot-233201 mention a channel thread [18.4]

### DIFF
--- a/addons/mail/static/tests/suggestion/suggestion.test.js
+++ b/addons/mail/static/tests/suggestion/suggestion.test.js
@@ -240,6 +240,7 @@ test("mention a channel thread", async () => {
         channel_type: "channel",
     });
     pyEnv["discuss.channel"].create({
+        channel_member_ids: [],
         name: "ThreadOne",
         parent_channel_id: channelId,
     });


### PR DESCRIPTION
Back-port of https://github.com/odoo/odoo/pull/230157

https://runbot.odoo.com/odoo/runbot.build.error/233201

Problematic line introduced: https://github.com/odoo/odoo/pull/209240
Test introduced: https://github.com/odoo/odoo/pull/226563

Test adapted to be more deterministic: remove current user from channel to ensure the channel is always found through the suggestion route.

Fixed returned format of mock server.