### PR TITLE
[FIX] website_sale: center carousel image on auto aspect ratio

### DIFF
--- a/addons/website_sale/static/src/js/components/website_sale_image_viewer.js
+++ b/addons/website_sale/static/src/js/components/website_sale_image_viewer.js
@@ -27,6 +27,7 @@ export class ProductImageViewer extends Dialog {
         this.state = useState({
             selectedImageIdx: this.props.selectedImageIdx || 0,
             imageScale: 1,
+            carouselOffset: 0,
         });
         this.isDragging = false;
         this.dragStartPos = { x: 0, y: 0 };
@@ -55,12 +56,12 @@ export class ProductImageViewer extends Dialog {
             const carousel = document.querySelector('.o_wsale_image_viewer_carousel');
             carousel.addEventListener('touchstart', this._onTouchstartCarousel.bind(this));
             carousel.addEventListener('touchmove', this._onTouchmoveCarousel.bind(this));
-            this._updateCarousel();
+            const lastImg = carousel.querySelector('li:last-of-type img');
+            lastImg?.addEventListener('load', this._updateCarousel.bind(this), { once: true });
         });
         // For some reason the styling does not always update properly.
         onRendered(() => {
             this.updateImage();
-            this._updateCarousel();
         })
     }
 
@@ -72,6 +73,7 @@ export class ProductImageViewer extends Dialog {
         this.state.imageScale = 1;
         this.imageTranslate = { x: 0, y: 0 };
         this.state.selectedImageIdx = this.images.indexOf(image);
+        this._updateCarousel();
     }
 
     get imageStyle() {
@@ -112,11 +114,10 @@ export class ProductImageViewer extends Dialog {
         }
         const { selectedImageIdx } = this.state;
         const thumbnail = thumbnailList.childNodes[selectedImageIdx];
+        const { left: thumbOffset, width: thumbWidth } = thumbnail.getBoundingClientRect();
 
-        const thumbWidth = thumbnail.clientWidth;
-        const parentOffset = thumbnailList.parentElement.offsetLeft;
-        const offset = (viewWidth - thumbWidth) / 2 - thumbWidth * selectedImageIdx - parentOffset;
-        thumbnailList.style.transform = `translate(${offset}px)`;
+        this.state.carouselOffset += (viewWidth - thumbWidth) / 2 - thumbOffset;
+        thumbnailList.style.transform = `translate(${this.state.carouselOffset}px)`;
     }
 
     onGlobalClick(ev) {


### PR DESCRIPTION
Versions
--------
- 19.0+

Steps
-----
1. Open eCommerce editor on product page;
2. set image ratio to 'auto';
3. enable zoom-on-click;
4. add extra media with different sizes;
5. close editor & click on product image;

Issue
-----
The thumbnail row on the bottom isn't centering the active image properly.

Cause
-----
The `_updateCarousel` hook added in cfc9814feba08 centers the images with the assumption that they all have identical widths. As of commit 7c0020e054dc5, this is no longer guaranteed, if the `auto` image ratio is chosen.

Solution
--------
Modify the centering logic to calculate the appropriate position based on the thumbnail currrent offset. As this requires the images to be loaded, we add `_updateCarousel` as an event listener on the last image, listening for the `load` event.

opw-4937009