### PR TITLE
[FIX] mrp_subcontracting: prevent extra quant at subcontracting location

### DIFF
--- a/addons/mrp_subcontracting/models/stock_quant.py
+++ b/addons/mrp_subcontracting/models/stock_quant.py
@@ -15,3 +15,6 @@ class StockQuant(models.Model):
             raise UserError(_('Operation not supported'))
 
         return [('location_id.is_subcontracting_location', operator, value)]
+
+    def _should_bypass_product(self, product=False, location=False, reserved_quantity=0, lot_id=False, package_id=False, owner_id=False):
+        return super()._should_bypass_product(product, location, reserved_quantity, lot_id, package_id, owner_id) or (location and location.is_subcontracting_location)


### PR DESCRIPTION
Issue:
--------
When working with a subcontracted product, confirming the purchase order and
opening the physical inventory or location report creates an unwanted quant
for the final product.
Later, when validating the receipt picking, an extra quant appears
in the subcontracting location with on-hand quantity.

Steps to Reproduce:
--------------------------
1. Install `mrp_subcontracting`.
2. Create a lot-tracked subcontracted product and its BoM.
3. Create and confirm a purchase order for the main product.
4. Check the location report → a line with reserved qty is created.
5. Validate the receipt picking.
6. Check the location report again → an extra on-hand qty appears in
   the subcontracting location.

Cause:
-----------
When opening the location report, the scheduler (`_quant_tasks`) triggers
`_clean_reservations`.
In this process, the bypass logic for reservations is not applied in
the subcontracting case, leading to the creation of a reserved quant.
During picking validation, this quant is included in the `quants_cache` inside
`_action_done`. Later, `_synchronize_quant` and `_update_available_quantity`
use it, resulting in an extra quant being created in the subcontracting location.

Fix:
------
Bypass the creation of reserved quants when opening the location report
for subcontracting cases. This prevents unwanted quants and ensures
correct on-hand quantities in subcontracting locations.

After this Commit:
-------------------------
No extra quants will be created in subcontracting locations when viewing
location reports. Users will see accurate on-hand and lot quantities, ensuring
a smooth and reliable workflow.

Task ID: 5115466
