### PR TITLE
[IMP] account:  Allow batch journal update for all draft entries

### DIFF
--- a/addons/account/__manifest__.py
+++ b/addons/account/__manifest__.py
@@ -48,6 +48,7 @@ You could use this simplified accounting in case you work with an (external) acc
         'views/res_partner_bank_views.xml',
         'views/report_statement.xml',
         'views/terms_template.xml',
+        'wizard/account_move_set_journal_wizard_views.xml',
         'wizard/account_validate_move_view.xml',
         'views/res_company_views.xml',
         'views/product_view.xml',

--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -11,6 +11,16 @@ import re
 _logger = logging.getLogger(__name__)
 
 
+JOURNAL_TYPE = [
+    ('sale', 'Sales'),
+    ('purchase', 'Purchase'),
+    ('cash', 'Cash'),
+    ('bank', 'Bank'),
+    ('credit', 'Credit Card'),
+    ('general', 'Miscellaneous'),
+]
+
+
 class AccountJournalGroup(models.Model):
     _name = 'account.journal.group'
     _description = "Account Journal Group"
@@ -93,14 +103,9 @@ class AccountJournal(models.Model):
              "The journal entries of this journal will also be named using this prefix by default."
     )
     active = fields.Boolean(default=True, help="Set active to false to hide the Journal without removing it.")
-    type = fields.Selection([
-            ('sale', 'Sales'),
-            ('purchase', 'Purchase'),
-            ('cash', 'Cash'),
-            ('bank', 'Bank'),
-            ('credit', 'Credit Card'),
-            ('general', 'Miscellaneous'),
-        ], required=True,
+    type = fields.Selection(
+        selection=JOURNAL_TYPE,
+        required=True,
         help="""
         Select 'Sale' for customer invoices journals.
         Select 'Purchase' for vendor bills journals.

--- a/addons/account/security/ir.model.access.csv
+++ b/addons/account/security/ir.model.access.csv
@@ -117,6 +117,7 @@ access_account_payment_register,access.account.payment.register,model_account_pa
 access_account_automatic_entry_wizard,access.account.automatic.entry.wizard,model_account_automatic_entry_wizard,account.group_account_user,1,1,1,0
 access_account_autopost_bills_wizard,access.account.autopost.bills.wizard,model_account_autopost_bills_wizard,account.group_account_invoice,1,1,1,0
 access_account_resequence,access.account.resequence.wizard,model_account_resequence_wizard,account.group_account_manager,1,1,1,0
+access_account_move_set_journal_wizard,access.account.move.set.journal.wizard,model_account_move_set_journal_wizard,account.group_account_invoice,1,1,1,0
 access_validate_account_move,access.validate.account.move,model_validate_account_move,account.group_account_invoice,1,1,1,0
 access_account_move_reversal,access.account.move.reversal,model_account_move_reversal,account.group_account_invoice,1,1,1,0
 access_account_financial_year_op,access.account.financial.year.op,model_account_financial_year_op,account.group_account_manager,1,1,1,0

--- a/addons/account/wizard/__init__.py
+++ b/addons/account/wizard/__init__.py
@@ -10,6 +10,7 @@ from . import account_secure_entries_wizard
 from . import setup_wizards
 from . import account_move_send_wizard
 from . import account_move_send_batch_wizard
+from . import account_move_set_journal_wizard
 from . import base_document_layout
 from . import account_payment_register
 from . import accrued_orders

--- a/addons/account/wizard/account_move_set_journal_wizard.py
+++ b/addons/account/wizard/account_move_set_journal_wizard.py
@@ -1,0 +1,57 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import Command, api, fields, models
+from odoo.exceptions import UserError
+
+from odoo.addons.account.models.account_journal import JOURNAL_TYPE
+
+
+class AccountMoveSetJournalWizard(models.TransientModel):
+    _name = 'account.move.set.journal.wizard'
+    _description = "Set Journal for Account Moves"
+
+    move_ids = fields.Many2many('account.move')
+    company_id = fields.Many2one('res.company', readonly=True)
+    journal_type = fields.Selection(selection=JOURNAL_TYPE)
+    journal_id = fields.Many2one(
+        'account.journal',
+        string="Journal",
+        required=True,
+        check_company=True,
+        domain="[('type', '=', journal_type)]",
+    )
+
+    @api.model
+    def default_get(self, fields):
+        res = super().default_get(fields)
+        active_ids = self.env.context.get('active_ids')
+        if self.env.context.get('active_model') != 'account.move' or not active_ids:
+            raise UserError(self.env._("This action can only be performed on selected account moves."))
+
+        moves = self.env['account.move'].browse(active_ids)
+        if moves.filtered(lambda m: m.state != 'draft'):
+            raise UserError(self.env._("The selected entries must be in a draft state to set a journal."))
+        if len(company := moves.mapped('company_id')) > 1:
+            raise UserError(self.env._("The selected entries must belong to the same company to set a journal."))
+        if len(journal_types := moves.mapped('journal_id.type')) > 1:
+            raise UserError(self.env._("The selected entries must have the same journal type to set a journal."))
+        company_id = company.id if company else self.env.company.id
+        journal_type = journal_types[0] if journal_types else False
+        journals_exist = self.env['account.journal'].search_count([
+            ('company_id', '=', company_id),
+            ('type', '=', journal_type),
+        ])
+        if journals_exist < 2:
+            raise UserError(self.env._("Only one %s journal exists and it is already set.", journal_type))
+
+        res.update({
+            'move_ids': [Command.set(moves.ids)],
+            'company_id': company_id,
+            'journal_type': journal_type,
+        })
+        return res
+
+    def action_set_journal(self):
+        self.ensure_one()
+        self.move_ids.write({'journal_id': self.journal_id.id})
+        return {'type': 'ir.actions.act_window_close'}

--- a/addons/account/wizard/account_move_set_journal_wizard_views.xml
+++ b/addons/account/wizard/account_move_set_journal_wizard_views.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="account_move_set_journal_wizard_form" model="ir.ui.view">
+            <field name="name">account.move.set.journal.wizard.form</field>
+            <field name="model">account.move.set.journal.wizard</field>
+            <field name="arch" type="xml">
+                <form string="Set Journal">
+                    <group>
+                        <field name="journal_id" options="{'no_create': True, 'no_edit': True}"/>
+                    </group>
+                    <footer>
+                        <button string="Confirm"
+                            name="action_set_journal"
+                            type="object"
+                            default_focus="1"
+                            class="btn-primary"
+                            data-hotkey="q"/>
+                        <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                    </footer>
+                </form>
+            </field>
+        </record>
+
+        <record id="account_move_set_journal_action" model="ir.actions.act_window">
+            <field name="name">Set Journal</field>
+            <field name="res_model">account.move.set.journal.wizard</field>
+            <field name="view_mode">form</field>
+            <field name="view_id" ref="account_move_set_journal_wizard_form"/>
+            <field name="target">new</field>
+            <field name="binding_model_id" ref="account.model_account_move"/>
+            <field name="binding_view_types">list,kanban</field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
Before PR:
- Setting journals on multiple entries was manual process.
- No option existed to batch edit journals from the list view.

After PR:
- Added 'Set Journal' action for batch updating journals on draft entries.
- Ensures all selected entries belong to the same company before editing.

Impact:
- Simplifies and speeds up journal assignment for multiple draft entries.

task-4815773