### PR TITLE
[FIX] hr: safely handle user groups without XML IDs in action_get

### DIFF
--- a/addons/hr/models/res_users.py
+++ b/addons/hr/models/res_users.py
@@ -249,7 +249,11 @@ class ResUsers(models.Model):
     def action_get(self):
         if self.env.user.employee_id:
             action = self.env['ir.actions.act_window']._for_xml_id('hr.res_users_action_my')
-            groups = {group_xml_id[0]: True for group_xml_id in self.env.user.all_group_ids._get_external_ids().values()}
+            groups = {
+                group_xml_id[0]: True
+                for group_xml_id in self.env.user.all_group_ids._get_external_ids().values()
+                if group_xml_id
+            }
             action_context = ast.literal_eval(action['context']) if action['context'] else {}
             action_context.update(groups)
             action['context'] = str(action_context)


### PR DESCRIPTION
After this commit: odoo/odoo@f409d38bcc858642a981d1b2c765dbe37b3fbd36 all the user groups are being added in the context

This caused an IndexError when the user belonged to a group that does
 not have an external XML ID (e.g., a manually created group),
because _get_external_ids() returns an empty list for such groups.

The fix adds a conditional check to skip empty lists, ensuring that only groups with XML IDs are added to the context.

Steps to reproduce before the fix:
- Go to Settings → Users & Companies → Groups → create a new group.
- Add the current user to this new group.
- Go to the odoo Dashboard → click on My Preferences.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
