### PR TITLE
[FIX] hr: prevent error when period date is missing

### DIFF
--- a/addons/hr/models/hr_version.py
+++ b/addons/hr/models/hr_version.py
@@ -383,7 +383,7 @@ class HrVersion(models.Model):
         :param date date_from: the start of the period
         :param date date_to: the stop of the period
         """
-        if not self.contract_date_start:
+        if not (self.contract_date_start and date_from and date_to):
             return False
         return self.date_start <= date_to and (not self.date_end or self.date_end >= date_from)
 


### PR DESCRIPTION
This error occurs when the user removes the period date from the payslip.

Steps to reproduce:
---
- Install `hr_payroll` module
- Create a New Payslip
- Add `Employee` and remove `Period` date

Traceback:
---
`TypeError: '<=' not supported between instances of 'datetime.date' and 'bool'`

This error occurs because at [1], the `date_to` field is received as `False` after the date is removed from the payslip.

[1]: https://github.com/odoo/odoo/blob/4cd1ad3aa46ad4645fc7b5e530b79d53382de6d5/addons/hr/models/hr_version.py#L388

sentry-6925445279

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
