### PR TITLE
[FIX] mail: fix access right error in mentioning users in chatter

### DIFF
--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -264,7 +264,7 @@ class ResPartner(models.Model):
             "avatar_128",
             "im_status",
             "is_company",
-            Store.One("main_user_id", ["share"]),
+            Store.One("main_user_id", ["share"], sudo=True),  # sudo: to access portal user of another company in chatter
             "name",
         ]
         if target.is_internal(self.env):

--- a/addons/mail/tests/test_res_partner.py
+++ b/addons/mail/tests/test_res_partner.py
@@ -121,6 +121,15 @@ class TestPartner(MailCommon):
         for i in range(0, 2):
             mail_new_test_user(self.env, login=f'{name}-{i}-portal-user', groups='base.group_portal')
             mail_new_test_user(self.env, login=f'{name}-{i}-internal-user', groups='base.group_user')
+
+        # suggest portal user of this company in another company
+        suggested_partners = self.env["res.partner"].with_user(self.user_employee_c2).get_mention_suggestions("portal-user")
+
+        porter_user_suggested = [
+            p for p in suggested_partners['res.partner']
+            if p["name"] == f'{name}-1-portal-user (base.group_portal)'
+        ]
+        self.assertEqual(len(porter_user_suggested), 1, "porter_user_suggested should contain one user")
         store_data = self.env["res.partner"].get_mention_suggestions(name, limit=5)
         partners_format = store_data["res.partner"]
         self.assertEqual(len(partners_format), 5, "should have found limit (5) partners")


### PR DESCRIPTION
Steps to reproduce:
1. Create a portal user in the current company
2. Create a new company and switch to it.
3. In the Chatter of any record, mention the portal user from the previous company.

Issue:
- An AccessError is raised when mentioning a user belonging to another company.

Cause:
- The missing forward port of this commit
https://github.com/odoo/odoo/commit/b1133f6a1efaef1d62f32f7f0197f2d8eb0cb191 was not merged, which caused the user to access res.users records without sudo()  from version saas-18.4. Since the mentioned user belongs to a different company, the current user lacks the necessary read permissions, triggering the error.
https://github.com/odoo/odoo/blob/6c35edb9dabaf8ce0b276ca26459401ac43d10e4/addons/mail/models/res_partner.py#L267


Solution:
- Add sudo() to access the user.

opw-5105598