### PR TITLE
[FIX] test_website: adapt page properties tour to new page dialog

### DIFF
--- a/addons/test_website/static/tests/tours/website_page_properties.js
+++ b/addons/test_website/static/tests/tours/website_page_properties.js
@@ -39,7 +39,7 @@ const openCreatePageDialog = [
     },
     {
         content: "Create a new page",
-        trigger: 'button[title="New Page"]',
+        trigger: 'button[aria-label="New Page"]',
         run: "click",
     },
 ];
@@ -57,11 +57,11 @@ function checkIsTemplate(isTemplate, pageTitle = undefined) {
     return [
         ...openCreatePageDialog,
         {
-            trigger: 'a[data-id="custom"]',
+            trigger: 'button[data-id="custom"]',
         },
         {
             content: "Go to custom section",
-            trigger: 'a[data-id="custom"]',
+            trigger: 'button[data-id="custom"]',
             run: "click",
         },
         ...(isTemplate
@@ -213,9 +213,14 @@ function testWebsitePageProperties() {
             run: "check",
         },
         {
-            content: "Set redirect type to temporary",
+            content: "Open redirect type popup",
             trigger: "#redirect_type_0",
-            run: 'select "302"',
+            run: "click"
+        },
+        {
+            content: "Set redirect type to temporary",
+            trigger: ".o-dropdown-item[data-choice-index='1']",
+            run: "click"
         },
         {
             // TODO: this needs to be tested
@@ -229,10 +234,15 @@ function testWebsitePageProperties() {
             run: "uncheck",
         },
         {
+            content: "Open visibility popup",
+            trigger: "#visibility_0",
+            run: "click",
+        },
+        {
             // TODO: this needs to be tested
             content: "Make visible with password only",
-            trigger: "#visibility_0",
-            run: 'select "password"',
+            trigger: ".o-dropdown-item[data-choice-index='3']",
+            run: "click",
         },
         {
             content: "Set password to 123",
@@ -271,9 +281,14 @@ function testWebsitePageProperties() {
             run: `edit new-page && press Enter`,
         },
         {
-            content: "Reset date published",
+            content: "Open date published popup",
             trigger: "#date_publish_0",
-            run: "edit ",
+            run: "click",
+        },
+        {
+            content: "Reset date published",
+            trigger: "button[title='Clear']",
+            run: "click",
         },
         {
             content: "Do index",
@@ -281,9 +296,14 @@ function testWebsitePageProperties() {
             run: "check",
         },
         {
-            content: "Make visibility Public",
+            content: "Open visibility popup",
             trigger: "#visibility_0",
-            run: 'select ""',
+            run: "click",
+        },
+        {
+            content: "Make visible public",
+            trigger: ".o-dropdown-item[data-choice-index='0']",
+            run: "click",
         },
         {
             content: "Remove from templates",


### PR DESCRIPTION
Recent UI refactors in the page creation dialog broke the page_properties tour.
In particular, [1] replaced the legacy tab markup with a WCAG-compliant tablist and adjusted focus management and tab activation logic. Combined with additional changes from [2] that modified the dialog's structure, this caused the tour to fail at several steps.

This patch updates the tour selectors and interactions to align with the new accessible tablist and the revised DOM structure.

[1]: https://github.com/odoo/odoo/commit/4defd0944656ac9f45ecc26f7d58bfe8184bd197
[2]: https://github.com/odoo/odoo/commit/7ca9b006fb50dfd37415fa184629edfed99575d5

runbot-233168

