### PR TITLE
[FIX] auth_timeout: race in tour

### DIFF
--- a/addons/auth_timeout/static/tests/tours/auth_timeout_tour.js
+++ b/addons/auth_timeout/static/tests/tours/auth_timeout_tour.js
@@ -1,3 +1,4 @@
+import { rpc } from "@web/core/network/rpc";
 import { registry } from "@web/core/registry";
 import { patch } from "@web/core/utils/patch";
 
@@ -75,6 +76,21 @@ const assertNoRPC = {
 registry.category("web_tour.tours").add("auth_timeout_tour_lock_timeout_inactivity", {
     url: "/odoo",
     steps: () => [
+        {
+            trigger: "body",
+            run() {
+                const oldRpc = rpc._rpc;
+                rpc._rpc = function (...args) {
+                    return oldRpc(...args).catch((err) => {
+                        if (err.data?.name === "odoo.addons.auth_timeout.models.ir_http.CheckIdentityException") {
+                            return new Promise(() => {});
+                        } else {
+                            throw err;
+                        }
+                    });
+                }
+            },
+        },
         // Check identity using a password
         assertCheckIdentityForm,
         assertNoRPC,


### PR DESCRIPTION
Error seems very rare on the runbot (only one occurrence recorded) but happens pretty often when I run the tours locally, and is "sticky".

The problem is that it's possible for an RPC to run between the instant where the identity check is invalidated / times out and the next check of `retryUntil` (especially since that only checks every second, but even with a smaller interval it would likely still have a window of opportunity for the race).

If that happens and the RPC doesn't otherwise handle RPC errors internally (which whatever calls `discuss.channel.channel_fetched` apparently does not as that's what causes the issue both locally and on runbot), then the session timeout will trigger an `RPC_ERROR` which will get logged as an `ERROR` to the driver, which causes the tour to fail.

The workaround isn't exactly sexy: if we see an RPC hit with a check identity timeout then instead of returning the error we convert it to an infinite wait (a promise which never resolves), which avoids failing the tour. This seems preferrable to trying to return a success as we can't know what future RPCs falling into that same interval would need to return.

https://runbot.odoo.com/odoo/error/232711
