### PR TITLE
[FIX] web: prevent double closing of the datetime picker in list

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -288,10 +288,11 @@ export class ListRenderer extends Component {
                     const column = this.cellToFocus.column;
                     const forward = this.cellToFocus.forward;
                     this.focusCell(column, forward);
-                } else if (this.lastEditedCell) {
-                    this.focusCell(this.lastEditedCell.column, true);
                 } else {
-                    this.focusCell(this.columns[0]);
+                    const column = this.lastEditedCell?.column || this.columns[0];
+                    if (column.widget !== "daterange" || !this.editedRecord.data[column.name]) {
+                        this.focusCell(column);
+                    }
                 }
             }
             this.cellToFocus = null;

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -10934,6 +10934,48 @@ test(`list daterange with empty start date and end date`, async () => {
     ]);
 });
 
+test(`list daterange in form: open/close picker`, async () => {
+    Foo._fields.foo_o2m = fields.One2many({ relation: "foo" });
+    Foo._fields.date_end = fields.Date();
+
+    await mountView({
+        resModel: "foo",
+        type: "form",
+        arch: `
+            <form>
+                <sheet>
+                    <field name="foo_o2m">
+                        <list editable="bottom">
+                            <field name="date" widget="daterange" options="{'end_date_field': 'date_end', 'always_range': '1'}"/>
+                        </list>
+                    </field>
+                </sheet>
+            </form>
+        `,
+        resId: 1,
+    });
+
+    await contains(`.o_field_x2many_list_row_add a`).click();
+    await contains(".o_field_daterange[name=date]").click();
+    await animationFrame();
+    await animationFrame();
+    expect(".o_datetime_picker").toBeDisplayed();
+    expect("input[data-field=date]").toBeFocused();
+
+    await contains(getPickerCell("15")).click();
+    await contains(getPickerCell("20")).click();
+
+    // Close picker
+    await pointerDown(`.o_view_controller`);
+    await animationFrame();
+    expect(".o_datetime_picker").toHaveCount(0);
+
+    // Wait to check if the picker is still closed
+    await animationFrame();
+    await animationFrame();
+    expect(".o_datetime_picker").toHaveCount(0);
+});
+
 test.tags("desktop");
 test(`editable list view: contexts are correctly sent`, async () => {
     serverState.userContext = { someKey: "some value" };


### PR DESCRIPTION
Before this commit, the datetime picker would reopen after being closed, requiring it to be closed a second time.

The issue was caused by the list view automatically focusing on the first cell or the last edited field after the picker was closed. When the <button> element received focus, the activeInput value was updated, causing the <button> to switch to an <input> due to reactivity.

As a result of this remounting, the useEffect() hook was triggered, which caused the picker to reopen (see openPicker()).

An alternative solution would be to call `leaveEditMode()` before the focus, but that's not feasible since `onGlobalClick` is triggered later, after the update.

To fix this, we prevented the list view from automatically focusing the date range field except if the field is empty. This preserves the intended behavior of opening the picker when adding a new item to the list. With this change, after selecting a value in the picker, no focus occurs, and therefore the picker does not reopen after being closed.

Steps to reproduce:
- Go to "Appointments"
- Configure -> Option
- Set "Schedule" as "Flexible"
- In the "Availabilities" tab,
- Add a new line
- After selecting a range, close the picker -> The picker is still open

task-5080321

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
