### PR TITLE
[IMP] stock: auto-fill product serial/lot number

### DIFF
--- a/addons/product_expiry/static/tests/tours/stock_picking_tour.js
+++ b/addons/product_expiry/static/tests/tours/stock_picking_tour.js
@@ -11,11 +11,7 @@ registry.category("web_tour.tours").add('test_generate_serial_with_expiration', 
             run: "click",
         },
         {
-            trigger: ".modal .btn-primary:contains('New')",
-            run: "click",
-        },
-        {
-            trigger: ".modal .btn-primary:contains('Generate')",
+            trigger: ".modal .btn-primary:contains('Validate')",
             run: "click",
         },
         // Check that the expiration date is now set after generating Serials/Lots.

--- a/addons/stock/static/src/widgets/lots_dialog.xml
+++ b/addons/stock/static/src/widgets/lots_dialog.xml
@@ -10,7 +10,7 @@
         <Dialog size="size" title="title" withBodyPadding="false">
             <t t-set-slot="footer">
                 <button class="btn btn-primary" t-on-click="_onGenerate">
-                    <t t-if="props.mode === 'generate'">Generate</t>
+                    <t t-if="props.mode === 'generate'">Validate</t>
                     <t t-if="props.mode === 'import'">Import</t>
                 </button>
                 <button class="btn btn-secondary" t-on-click="() => this.props.close()">
@@ -23,7 +23,7 @@
                         <div class="row mb-2">
                             <div class="col-3">
                                 <label class="o_form_label" for="next_serial_0">
-                                    <t t-if="props.move.data.has_tracking === 'lot'">First Lot Number</t>
+                                    <t t-if="isLotTracking">First Lot Number</t>
                                     <t t-else="">First Serial Number</t>
                                 </label>
                             </div>
@@ -32,14 +32,11 @@
                                     <input placeholder="e.g. LOT-PR-00012" class="o_input" t-ref="nextSerial" id="next_serial_0" type="text"/>
                                 </div>
                             </div>
-                            <div class="col">
-                                <button class="btn btn-primary py-1" t-on-click="_onGenerateCustomSerial">New</button>
-                            </div>
                         </div>
                         <div class="row mb-2">
                             <div class="col">
                                 <label class="o_form_label" for="next_serial_count_0">
-                                    <t t-if="props.move.data.has_tracking === 'lot'">Quantity per Lot</t>
+                                    <t t-if="isLotTracking">Quantity per Lot</t>
                                     <t t-else="">Number of SN</t>
                                 </label>
                             </div>
@@ -47,10 +44,10 @@
                                 <div name="next_serial_count" class="o_field_widget o_field_integer">
                                     <input inputmode="numeric" t-ref="nextSerialCount" class="o_input" id="next_serial_count_0" type="text"/>
                                 </div>
-                                <span t-if="props.move.data.has_tracking === 'lot' &amp;&amp; displayUOM" t-esc="props.move.data.product_uom.display_name"/>
+                                <span t-if="isLotTracking &amp;&amp; displayUOM" t-esc="props.move.data.product_uom.display_name"/>
                             </div>
                         </div>
-                        <div t-if="props.move.data.has_tracking === 'lot'" class="row mb-2">
+                        <div t-if="isLotTracking" class="row mb-2">
                             <div class="col">
                                 <label class="o_form_label" for="total_received_0">Quantity Received</label>
                             </div>
@@ -78,7 +75,7 @@
                         <div class="d-flex">
                             <div class="o_cell flex-grow-0 flex-sm-grow-0 text-900 pe-3">
                                 <label class="o_form_label" for="next_serial_0">
-                                    <t t-if="props.move.data.has_tracking==='lot'">Lot numbers</t>
+                                    <t t-if="isLotTracking">Lot numbers</t>
                                     <t t-else="">Serial numbers</t>
                                 </label>
                             </div>

--- a/addons/stock/static/tests/tours/stock_picking_tour.js
+++ b/addons/stock/static/tests/tours/stock_picking_tour.js
@@ -42,7 +42,7 @@ registry.category("web_tour.tours").add('test_generate_serial_1', {  steps: () =
         run: "edit 5 && click body",
     },
     {
-        trigger: ".modal .btn-primary:contains('Generate')",
+        trigger: ".modal .btn-primary:contains('Validate')",
         run: "click",
     },
     {
@@ -146,7 +146,7 @@ registry.category("web_tour.tours").add('test_generate_serial_2', {  steps: () =
         run: "edit 50",
     },
     {
-        trigger: ".modal .modal-footer button.btn-primary:contains(Generate)",
+        trigger: ".modal .modal-footer button.btn-primary:contains(Validate)",
         run: "click",
     },
     {
@@ -183,7 +183,7 @@ registry.category("web_tour.tours").add('test_generate_serial_2', {  steps: () =
         run: "check",
     },
     {
-        trigger: ".modal .modal-footer button.btn-primary:contains(Generate)",
+        trigger: ".modal .modal-footer button.btn-primary:contains(Validate)",
         run: "click",
     },
     {


### PR DESCRIPTION
Currently, for trackable products, Users must manually click the
`New` button to create a custom serial/lot number.

This commit improves the behaviour by automatically pre-filling the
serial/lot number for all products. Users no longer need to click the button
manually, enhancing the overall smooth user experience and reducing unnecessary
actions.

Some minor improvements and adjustments were also made.
- Primary button text changed: `Generate` → `Validate`
- Removed the `New` button since serial/lot numbers are now generated
automatically. Users can still modify it by manually entering their
own custom number if needed.
- Sequence numbers are now only consumed when users validate, not when
the dialog opens, preventing gaps in serial/lot numbering.
- Added autofocus to the relevant input based on tracking type.

Task - 4791403