### PR TITLE
[FIX] iot_box_image: aiortc not installing on build

### DIFF
--- a/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
+++ b/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
@@ -167,7 +167,12 @@ rm -rfv /usr/share/doc
 # Remove the default nginx website, we have our own config in /etc/nginx/conf.d/
 rm /etc/nginx/sites-enabled/default
 
-pip3 install -r /home/pi/odoo/addons/iot_box_image/configuration/requirements.txt --break-system-package
+# || true and manual install of aiortc are a quick fix to allow install aiortc while building the image:
+# requirements.txt contains two path to aiortc (one for "rpi" and one for "other linux")
+# While building the image the platform is the builder's computer and not a rpi
+# as we "chroot" into the image, pip3 tries to install the "other linux" version of aiortc and fails
+pip3 install -r /home/pi/odoo/addons/iot_box_image/configuration/requirements.txt --break-system-package || true
+pip3 install /home/pi/odoo/addons/iot_box_image/configuration/aiortc-1.4.0-py3-none-any.whl --break-system-package
 
 # Create Odoo user for odoo service and disable password login
 adduser --disabled-password --gecos "" --shell /usr/sbin/nologin odoo


### PR DESCRIPTION
When building an image in v19.0, we try to install `aiortc` from path. The requirements.txt contain two path: one for rpis and one for other linux machines.
While building, we `chroot` from the builder's machine to the rpi filesystem, so the plateform is still the host machine's one, but the filesystem is the rpi's.

To fix this, we hardcoded the right path in the `init_image` script.
