### PR TITLE
[Fix] master hr_referral fix optional cookies issue yoahm

### DIFF
--- a/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
+++ b/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
@@ -326,6 +326,27 @@
                                         <a href="#" role="button" class="btn btn-primary btn-lg s_website_form_send" id="apply-btn">I'm feeling lucky</a>
                                         <span id="s_website_form_result"></span>
                                     </div>
+                                    <div class="col-sm" >
+                                        <input id="recruitment9" type="hidden"
+                                            class="form-control s_website_form_input pl64"
+                                            style="padding-inline-start: calc(40px + 0.375rem)"
+                                            name="ref_user_id"
+                                            t-att-value="ref_user_id"/>
+                                    </div>
+                                    <div class="col-sm" >
+                                        <input id="recruitment10" type="hidden"
+                                            class="form-control s_website_form_input pl64"
+                                            style="padding-inline-start: calc(40px + 0.375rem)"
+                                            name="utm_campaign_id"
+                                            t-att-value="utm_campaign_id"/>
+                                    </div>
+                                    <div class="col-sm" >
+                                        <input id="recruitment11" type="hidden"
+                                            class="form-control s_website_form_input pl64"
+                                            style="padding-inline-start: calc(40px + 0.375rem)"
+                                            name="utm_medium_id"
+                                            t-att-value="utm_medium_id"/>
+                                    </div>
                                 </div>
                             </form>
                         </div>


### PR DESCRIPTION
Description of the issue/feature this PR addresses: [Fix] fix optional UTM cookies issue on hr_referral module on the enterprise repository

Current behavior before PR: In a recent change from the website, UTM cookies are now considered as optional, it means that if you refuse non-essential cookies, you will not record the information about the fact it's a referral and who's the referee. 

Desired behavior after PR is merged: track the information about the fact it's a referral and who's the referee.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
