### PR TITLE
[FIX] web, website: ensure that the neutralize banner shows up

### DIFF
--- a/addons/web/views/neutralize_views.xml
+++ b/addons/web/views/neutralize_views.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <template id="web.neutralize_banner"  name="Neutralize Banner" inherit_id="web.layout" active="False">
+    <template id="web.neutralize_banner"  name="Neutralize Banner" inherit_id="web.layout" priority="999" active="False">
         <xpath expr="//body" position="inside">
             <div>
                 <span id="oe_neutralize_banner" t-attf-style="

--- a/addons/website/views/neutralize_views.xml
+++ b/addons/website/views/neutralize_views.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <template id="website.neutralize_ribbon"  name="Neutralize Ribbon" inherit_id="website.layout" active="False">
+    <template id="website.neutralize_ribbon"  name="Neutralize Ribbon" inherit_id="website.layout" priority="999" active="False">
         <xpath expr="//body" position="inside">
             <div>
                 <span id="oe_neutralize_ribbon" t-attf-style="


### PR DESCRIPTION
Affected versions: any

When we neutralize the db, we want to ensure that no other view in the chain of inheritance has any conflict with the neutralize banner. Otherwise:

- The user could think that the DB isn't neutralized.
- The user might think that that's the production DB instead of the staging one!

cc @moduon MT-12014

OPW-5149264

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
