### PR TITLE
[FIX] web: overlapping footer in wave layout

### DIFF
--- a/addons/l10n_hu_edi/views/report_templates.xml
+++ b/addons/l10n_hu_edi/views/report_templates.xml
@@ -131,15 +131,15 @@
         </xpath>
 
         <!-- support for custom footer -->
-        <div t-attf-class="o_footer_content {{report_type != 'pdf' and 'position-absolute end-0 start-0 bottom-0 mx-5'}} pt-5 text-center" position="attributes">
+        <xpath expr="//div[contains(@t-attf-class,'o_footer_content')]" position="attributes">
             <attribute name="t-if">not custom_footer</attribute>
-        </div>
-        <div t-attf-class="o_footer_content {{report_type != 'pdf' and 'position-absolute end-0 start-0 bottom-0 mx-5'}} pt-5 text-center" position="after">
-            <div t-attf-class="o_footer_content {{report_type != 'pdf' and 'position-absolute end-0 start-0 bottom-0 mx-5'}} pt-5 text-center"
+        </xpath>
+        <xpath expr="//div[contains(@t-attf-class,'o_footer_content')]" position="after">
+            <div t-attf-class="o_footer_content {{report_type != 'pdf' and 'mx-5'}} pt-5 text-center"
                  t-if="custom_footer and company.account_fiscal_country_id.code == 'HU'">
                 <t t-out="custom_footer"/>
             </div>
-        </div>
+        </xpath>
     </template>
 
     <template id="external_layout_folder" inherit_id="web.external_layout_folder">

--- a/addons/l10n_latam_invoice_document/views/report_templates.xml
+++ b/addons/l10n_latam_invoice_document/views/report_templates.xml
@@ -130,15 +130,15 @@
         </xpath>
 
         <!-- support for custom footer -->
-        <div t-attf-class="o_footer_content {{report_type != 'pdf' and 'position-absolute end-0 start-0 bottom-0 mx-5'}} pt-5 text-center" position="attributes">
+        <xpath expr="//div[contains(@t-attf-class,'o_footer_content')]" position="attributes">
             <attribute name="t-if">not custom_footer</attribute>
-        </div>
-        <div t-attf-class="o_footer_content {{report_type != 'pdf' and 'position-absolute end-0 start-0 bottom-0 mx-5'}} pt-5 text-center" position="after">
-            <div t-attf-class="o_footer_content {{report_type != 'pdf' and 'position-absolute end-0 start-0 bottom-0 mx-5'}} pt-5 text-center"
+        </xpath>
+        <xpath expr="//div[contains(@t-attf-class,'o_footer_content')]" position="after">
+            <div t-attf-class="o_footer_content {{report_type != 'pdf' and 'mx-5'}} pt-5 text-center"
                  t-if="custom_footer and company._localization_use_documents()">
                 <t t-out="custom_footer"/>
             </div>
-        </div>
+        </xpath>
     </template>
 
     <template id="external_layout_folder" inherit_id="web.external_layout_folder">

--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -672,10 +672,10 @@
 
         <!-- Footer -->
         <div t-attf-class="footer o_company_#{company.id}_layout {{report_type != 'pdf' and 'position-relative mt-auto mx-n5'}}">
-            <svg t-attf-class="{{report_type == 'pdf' and 'position-fixed start-0'}} w-100" preserveAspectRatio="none" t-att-height="report_type == 'pdf' and '180'" viewBox="0 0 1000 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <svg t-attf-class="{{report_type == 'pdf' and 'position-fixed start-0' or 'position-absolute'}} w-100" preserveAspectRatio="none" t-attf-height="{{report_type == 'pdf' and '180' or '100%'}}" viewBox="0 0 1000 180" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path d="M427.731 19.757C686.904 51.3469 898.971 38.039 1000 27.6922V180H0V8.20934C66.363 -0.991089 198.347 -8.20218 427.731 19.757Z" t-att-fill="company.secondary_color" fill-opacity=".1"/>
             </svg>
-            <div t-attf-class="o_footer_content {{report_type != 'pdf' and 'position-absolute end-0 start-0 bottom-0 mx-5'}} pt-5 text-center">
+            <div t-attf-class="o_footer_content {{report_type != 'pdf' and 'mx-5'}} pt-5 text-center">
                 <div t-field="company.report_footer"/>
                 <span t-if="report_type == 'pdf' and display_name_in_footer" class="text-muted" t-out="str(o.name) + ', '">(document name)</span>
                 <span t-if="report_type == 'pdf'" class="text-muted">Page <span class="page"/> / <span class="topage"/></span>


### PR DESCRIPTION
In the Wave layout, a multi-line footer overlaps document information when the
portal view is opened from a mobile interface.

Steps to reproduce:
- Open Settings > General settings > Configure Document Layout
- Select Wave layout and add a multi-line footer
- Open an invoice, go to portal preview, switch to mobile view

Issue: The footer overlaps invoice information.

This occurs because the boundaries of the SVG drawing are not well
defined and it will unexpectedly shrink.

opw-5023032