### PR TITLE
[IMP] project: unify icons in tasks stat buttons

### DIFF
--- a/addons/project/views/project_milestone_views.xml
+++ b/addons/project/views/project_milestone_views.xml
@@ -10,7 +10,7 @@
                         <button name="%(project.action_view_task_from_milestone)d"
                                 type="action"
                                 class="oe_stat_button"
-                                icon="fa-tasks"
+                                icon="fa-check"
                                 context="{'default_project_id': project_id}"
                                 groups="project.group_project_milestone"
                                 close="1"

--- a/addons/project/views/project_sharing_project_task_views.xml
+++ b/addons/project/views/project_sharing_project_task_views.xml
@@ -121,7 +121,7 @@
                     <div class="oe_button_box" name="button_box">
                         <field name="display_parent_task_button" invisible="1"/>
                         <field name="recurrence_id" invisible="1" />
-                        <button name="action_project_sharing_view_parent_task" type="object" class="oe_stat_button" icon="fa-tasks" invisible="not display_parent_task_button">
+                        <button name="action_project_sharing_view_parent_task" type="object" class="oe_stat_button" icon="fa-check" invisible="not display_parent_task_button">
                             <div class="o_stat_info">
                                 <span class="o_stat_text">Parent Task</span>
                             </div>
@@ -139,7 +139,7 @@
                             <field name="subtask_count" widget="statinfo" string="Sub-tasks"/>
                             <field name="display_in_project" invisible="True"/>
                         </button>
-                        <button name="action_project_sharing_open_blocking" type="object" invisible="not dependent_tasks_count or not allow_task_dependencies" class="oe_stat_button" icon="fa-tasks">
+                        <button name="action_project_sharing_open_blocking" type="object" invisible="not dependent_tasks_count or not allow_task_dependencies" class="oe_stat_button" icon="fa-check">
                             <div class="o_field_widget o_stat_info">
                                 <span class="o_stat_text">Blocked Tasks</span>
                                 <span class="o_stat_value ">

--- a/addons/project/views/res_partner_views.xml
+++ b/addons/project/views/res_partner_views.xml
@@ -7,7 +7,7 @@
             <field name="priority" eval="8"/>
             <field name="arch" type="xml">
                 <div name="button_box" position="inside">
-                    <button class="oe_stat_button" type="object" name="action_view_tasks" groups="project.group_project_user" icon="fa-tasks">
+                    <button class="oe_stat_button" type="object" name="action_view_tasks" groups="project.group_project_user" icon="fa-check">
                         <field  string="Tasks" name="task_count" widget="statinfo"/>
                     </button>
                 </div>


### PR DESCRIPTION
Before this commit:
---
The 'Tasks' stat button in the Partner form view used a different icon, which
was inconsistent with other related views. Similarly, the icons used in the
Milestone form view, the Parent Task stat button in the Project Sharing form
view, and the Task Dependencies stat button in the same view were not consistent
with the standard task icon.

After this commit:
---
The 'Tasks' stat button now uses the fa-check icon across all related views for
consistency and visual clarity. The icon has been unified in the Partner form
view, Milestone form view, Parent Task stat button, and Task Dependencies stat
button in the Project Sharing form view.

task-5138828