### PR TITLE
[FIX] hr_expense: prevent error when user tries to post journal entries

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -1770,6 +1770,9 @@ class HrExpense(models.Model):
         account_ref = 'account_journal_payment_debit_account_id' if self.payment_method_line_id.payment_type == 'inbound' else 'account_journal_payment_credit_account_id'
         chart_template = self.with_context(allowed_company_ids=self.company_id.root_id.ids).env['account.chart.template']
         outstanding_account = chart_template.ref(account_ref, raise_if_not_found=False)
+        if not self.company_id.chart_template:
+            action = self.env.ref('account.action_account_config')
+            raise RedirectWarning(_('You should install a Fiscal Localization first.'), action.id, _('Accounting Settings'))
         if not outstanding_account:
             bank_prefix = self.company_id.bank_account_code_prefix
             template_data = chart_template._get_chart_template_data(self.company_id.chart_template).get('template_data')


### PR DESCRIPTION
The system will crash with error when user tries to Post Journal Entries of expense.

**Steps to produce:**
- Install `Accouting, Expense, Payment provider demo` module without demo data.
- Create new company (Do not set the country) and switch to that company.
- Set the demo payment provider state to `test`. (You may have to create `new journal` and in that `new `suspense account` also.)
- Go to `expense` and create new record.
- Set the `paid by` as `company` and also set `account` and `employee`.
- Click on `Submit` and then click on `Post Journal Entries`.

**Error:**
`TypeError: 'NoneType' object is not subscriptable`

**Cause:**
- When we create new company then there is no default chart accounting template is set until we set the country of the company.

**Solution:**
- If the Chart template is not set in the company, then we simply raise the `Usererror`.

**sentry-6920693674**

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
