### PR TITLE
[FIX] test_website_modules: one less query when there is no enterprise

### DIFF
--- a/addons/test_website_modules/tests/test_performance.py
+++ b/addons/test_website_modules/tests/test_performance.py
@@ -132,7 +132,8 @@ class TestWebsiteAllPerformance(TestWebsitePerformanceCommon, TestWebsitePriceLi
         self.assertIn(f'<img src="/web/image/product.template/{self.productA.product_tmpl_id.id}/', html)
         self.assertIn(f'<img src="/web/image/product.image/{self.product_images.ids[1]}/', html)
 
-        self.assertEqual(self._get_url_hot_query('/shop'), 37)  # To increase this number you must ask the permission to al
+        # Test in community: 36
+        self.assertLessEqual(self._get_url_hot_query('/shop'), 37)  # To increase this number you must ask the permission to al
 
     def _get_cart_quantity(self):
         return int(re.search(
@@ -254,4 +255,5 @@ class TestWebsiteAllPerformancePostInstall(TestWebsiteAllPerformance):
         self.assertIn(f'<img src="/web/image/product.template/{self.productA.product_tmpl_id.id}/', html)
         self.assertIn(f'<img src="/web/image/product.image/{self.product_images.ids[1]}/', html)
 
-        self.assertEqual(self._get_url_hot_query('/shop'), 47)  # To increase this number you must ask the permission to al
+        # Test in community: 45
+        self.assertLessEqual(self._get_url_hot_query('/shop'), 47)  # To increase this number you must ask the permission to al


### PR DESCRIPTION
The difference query is not relevant to the overall performance of the page. This difference depends on how you run the tests with the other addons installed.

issue: AssertionError: 36 != 37