### PR TITLE
[FIX] mail: fix non-deterministic call invitation tour

### DIFF
--- a/addons/mail/tests/discuss/test_rtc.py
+++ b/addons/mail/tests/discuss/test_rtc.py
@@ -1292,4 +1292,5 @@ class TestChannelRTC(MailCommon, HttpCase):
         john = new_test_user(self.env, "john", groups="base.group_user", email="john@test.com")
         channel = self.env["discuss.channel"].with_user(bob)._create_group(partners_to=(bob | john).partner_id.ids)
         channel.with_user(bob).self_member_id.sudo()._rtc_join_call()
+        self._reset_bus()
         self.start_tour("/odoo", "discuss_call_invitation.js", login="john")


### PR DESCRIPTION
Before this commit, the `test_07_call_invitation_ui` test could fail in a non-deterministic way.

At some point, the test tries to open the channel invitation camera preview which sometimes does not open because the component state is lost due to outdated bus notifications.

In detail:
- Invitation is received after calling the `/mail/data` route.
- Notification resulting from channel creation are received. However, invitation was not yet created at that point, leading to invitation deletion.
- Notification resulting from invitation creation is received, the invitation is shown again but the component state is lost.

In practice, this rarely happens and is not critical. This commit fixes the issue by clearing the notifications before starting the tour.

fixes runbot-233231