### PR TITLE
[FIX] account_edi_ubl_cii: float comparison safeguard

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -724,8 +724,8 @@ class AccountEdiCommon(models.AbstractModel):
 
         # discount
         discount = 0
-        if delivered_qty * price_unit != 0 and price_subtotal is not None:
-            currency = self.env.company.currency_id
+        currency = self.env.company.currency_id
+        if not float_is_zero(delivered_qty * price_unit, currency.decimal_places) and price_subtotal is not None:
             inferred_discount = 100 * (1 - (price_subtotal - charge_amount) / currency.round(delivered_qty * price_unit))
             discount = inferred_discount if not float_is_zero(inferred_discount, currency.decimal_places) else 0.0
 


### PR DESCRIPTION
[FIX] account_edi_ubl_cii: float comparison safeguard.

This fix solves a potential issue where the `delivered_qty * price_unit` is too close to zero making it pass the float comparison check, later we divide against the same product, but this time wrapped in `curency.round` which may round it to zero, resulting in a division by zero error.

Whilst I found no functional way to reproduce the issue as the value of price_unit should already be zero when we get here but, the fix is to simply safeguard from potential future changes.

Ticket [link](https://www.odoo.com/odoo/project.task/5013588)
opw-5013588