### PR TITLE
[FIX] html_editor: correctly focus image caption input

### DIFF
--- a/addons/html_editor/static/src/main/media/image_description.js
+++ b/addons/html_editor/static/src/main/media/image_description.js
@@ -1,4 +1,4 @@
-import { Component } from "@odoo/owl";
+import { Component, useEffect, useRef } from "@odoo/owl";
 import { Dialog } from "@web/core/dialog/dialog";
 import { toolbarButtonProps } from "@html_editor/main/toolbar/toolbar";
 import { useHotkey } from "@web/core/hotkeys/hotkey_hook";
@@ -32,6 +32,11 @@ export class ImageDescriptionPopover extends Component {
             description: this.props.description,
             tooltip: this.props.tooltip,
         };
+        this.inputRef = useRef("description");
+        useEffect(
+            (el) => el?.focus(),
+            () => [this.inputRef.el]
+        );
         useHotkey("escape", () => this.props.close());
     }
 

--- a/addons/html_editor/static/src/main/media/image_description.xml
+++ b/addons/html_editor/static/src/main/media/image_description.xml
@@ -8,6 +8,7 @@
     <t t-name="html_editor.ImageDescriptionPopover">
         <div class="o-we-image-description-popover p-3">
             <input
+                t-ref="description"
                 type="text"
                 t-model="this.state.description"
                 placeholder="Description"

--- a/addons/html_editor/static/src/others/embedded_components/plugins/caption_plugin/caption_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/caption_plugin/caption_plugin.js
@@ -127,6 +127,10 @@ export class CaptionPlugin extends Plugin {
             // => <figure><img/></figure></p>
             // but still <p><a><figure><img/></figure></p>
             unwrapContents(figure.parentElement);
+            // Figure is contenteditable="false", so selection would jump
+            // to the nearest editable sibling <div>. Setting cursor at
+            // the end ensures caption input receives focus correctly.
+            this.dependencies.selection.setCursorEnd(figure);
         }
         // Set the caption and its ID.
         const captionId = this.getCaptionId();

--- a/addons/html_editor/static/tests/caption.test.js
+++ b/addons/html_editor/static/tests/caption.test.js
@@ -278,6 +278,7 @@ test("leaving the caption persists its value", async () => {
             const heading = queryOne("h1");
             await click(heading);
             expect(editor.document.activeElement).not.toBe(input);
+            editor.shared.selection.setCursorStart(heading);
             await animationFrame(); // Wait for the selection to change.
         },
         contentAfterEdit: unformat(
@@ -318,6 +319,7 @@ test("can't use the powerbox in a caption", async () => {
             await expectElementCount(".o-we-powerbox", 0);
             const heading = queryOne("h1");
             await click(heading);
+            editor.shared.selection.setCursorStart(heading);
             await animationFrame(); // Wait for the selection to change.
         },
         contentAfter: unformat(

--- a/addons/html_editor/static/tests/image.test.js
+++ b/addons/html_editor/static/tests/image.test.js
@@ -104,6 +104,20 @@ test("can undo a shape", async () => {
     expect("img").not.toHaveClass("rounded");
 });
 
+test("focus description input by default when image description popover opens", async () => {
+    await setupEditor(`
+        <img src="${base64Img}">
+    `);
+    await click("img");
+    await waitFor(".o-we-toolbar");
+
+    await click(".o-we-toolbar .btn-group[name='image_description'] button");
+    await animationFrame();
+
+    expect(".o-we-image-description-popover").toHaveCount(1);
+    expect("input[name='description']").toBeFocused();
+});
+
 test("can add an image description & tooltip", async () => {
     await setupEditor(`
         <img src="${base64Img}">


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

- Commit [1](https://github.com/odoo/odoo/commit/9a3abd5f9e5658b72b8a5d2fa0384bdbb580873f) changed `selectionchange` listener to `addGlobalDomListener`. As result, calling this.captionInput.el.focus() in caption.js triggered `selectionchange` event. Since `<figure>` is contenteditable="false", the `fixSelectionOnEditableRootGeneric` method moved the selection to sibling `<div>`, causing the cursor to jump unexpectedly.

### Desired behavior after PR is merged:

- The selection is explicitly set at the end of the `<figure>` when adding caption, preventing the cursor from moving to a sibling editable `<div>`.
- When the image description popover opens, the cursor automatically focuses on the description input field by default.

task-5122745

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
