### PR TITLE
[FIX] html_editor: make caption input background transparent

### DIFF
--- a/addons/html_editor/static/src/others/embedded_components/backend/caption/caption.scss
+++ b/addons/html_editor/static/src/others/embedded_components/backend/caption/caption.scss
@@ -1,3 +1,7 @@
 figcaption {
     color: #9e9d9a;
+
+    input {
+        background-color: transparent;
+    }
 }


### PR DESCRIPTION
### Purpose of this PR:

- Set the default background of inputs inside `<figcaption>` to transparent. This prevents them from appearing dark gray (rgb(59,59,59)) in caption.

task-5122745

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
