### PR TITLE
[FIX] mail: prevent non-deterministic failure in channel tour

### DIFF
--- a/addons/mail/static/tests/tours/create_channel_tour.js
+++ b/addons/mail/static/tests/tours/create_channel_tour.js
@@ -2,6 +2,13 @@ import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("can_create_channel_from_form_view", {
     steps: () => [
+        {
+            trigger: ".o-mail-DiscussSidebarChannel-itemName:contains(OdooBot)",
+            run: "click",
+        },
+        {
+            trigger: ".o-mail-DiscussContent-threadName[title='OdooBot']",
+        },
         { trigger: "button[title='View or join channels']:not(:visible)", run: "click" },
         {
             trigger: ".o_control_panel_main_buttons button:contains('New')",
@@ -12,7 +19,7 @@ registry.category("web_tour.tours").add("can_create_channel_from_form_view", {
             run: "edit Test channel",
         },
         {
-            trigger: ".breadcrumb-item:contains('Discuss')",
+            trigger: ".breadcrumb-item:contains('OdooBot')",
             run: "click",
         },
         {


### PR DESCRIPTION
Before this commit, the `test_05_can_create_channel_tour` could sometimes fail. The test checks that creating a channel from the form view adds it to the sidebar.

The failure happened because the tour relied on a breadcrumb showing "Discuss". When first opening the discuss app, the "OdooBot" channel appears, so the breadcrumb shows "OdooBot" instead.

This commit fixes the issue by giving the "OdooBot" channel time to open and updating the breadcrumb selector.

fixes runbot-233232

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
