### PR TITLE
[IMP] html_editor: alternating row colors

### DIFF
--- a/addons/html_editor/static/src/main/table/table.dark.scss
+++ b/addons/html_editor/static/src/main/table/table.dark.scss
@@ -2,3 +2,7 @@ th.o_table_header {
     background-color: #1B1D26;
     font-weight: 900;
 }
+
+table.o_alternating_rows tr:nth-child(even) td {
+    background-color: #1B1D26;
+}

--- a/addons/html_editor/static/src/main/table/table.scss
+++ b/addons/html_editor/static/src/main/table/table.scss
@@ -10,3 +10,7 @@ th.o_table_header {
         }
     }
 }
+
+table.o_alternating_rows tr:nth-child(even) td {
+    background-color: #EFEFEF;
+}

--- a/addons/html_editor/static/src/main/table/table_menu.js
+++ b/addons/html_editor/static/src/main/table/table_menu.js
@@ -21,6 +21,7 @@ export class TableMenu extends Component {
         resetTableSize: Function,
         clearColumnContent: Function,
         clearRowContent: Function,
+        toggleAlternatingRows: Function,
         overlay: Object,
         dropdownState: Object,
         target: { validate: (el) => el.nodeType === Node.ELEMENT_NODE },
@@ -125,6 +126,8 @@ export class TableMenu extends Component {
     }
 
     rowItems() {
+        const table = closestElement(this.props.target, "table");
+        const hasAlternatingRowClass = table.classList.contains("o_alternating_rows");
         return [
             this.isFirst &&
                 !this.isTableHeader && {
@@ -163,6 +166,14 @@ export class TableMenu extends Component {
                 icon: "fa-plus",
                 text: _t("Insert below"),
                 action: (target) => this.props.addRow("after", target.parentElement),
+            },
+            {
+                name: "toggle_alternating_rows",
+                icon: "fa-paint-brush",
+                text: hasAlternatingRowClass
+                    ? _t("Clear alternate colors")
+                    : _t("Alternate row colors"),
+                action: () => this.props.toggleAlternatingRows(table),
             },
             {
                 name: "delete",

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -63,6 +63,7 @@ function isUnremovableTableComponent(node, root) {
  * @property { TablePlugin['resetTableSize'] } resetTableSize
  * @property { TablePlugin['clearColumnContent'] } clearColumnContent
  * @property { TablePlugin['clearRowContent'] } clearRowContent
+ * @property { TablePlugin['toggleAlternatingRows'] } toggleAlternatingRows
  */
 
 /**
@@ -95,6 +96,7 @@ export class TablePlugin extends Plugin {
         "resetTableSize",
         "clearColumnContent",
         "clearRowContent",
+        "toggleAlternatingRows",
     ];
     resources = {
         user_commands: [
@@ -624,6 +626,16 @@ export class TablePlugin extends Plugin {
             td.replaceChildren(baseContainer);
         });
     }
+
+    /**
+     * Toggles the CSS class that enables alternating row styles on a table.
+     *
+     * @param {HTMLTableElement} table
+     */
+    toggleAlternatingRows(table) {
+        table.classList.toggle("o_alternating_rows");
+    }
+
     deleteTable(table) {
         table =
             table || findInSelection(this.dependencies.selection.getEditableSelection(), "table");

--- a/addons/html_editor/static/src/main/table/table_ui_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_ui_plugin.js
@@ -163,6 +163,7 @@ export class TableUIPlugin extends Plugin {
             resetTableSize: withAddStep(this.dependencies.table.resetTableSize),
             clearColumnContent: withAddStep(this.dependencies.table.clearColumnContent),
             clearRowContent: withAddStep(this.dependencies.table.clearRowContent),
+            toggleAlternatingRows: withAddStep(this.dependencies.table.toggleAlternatingRows),
         };
         if (td.cellIndex === 0) {
             this.rowMenu.open({


### PR DESCRIPTION
**Specification:**

- Added a new "Alternate row colors" option (available for rows) that applies background color to every second row, making tables easier to read.
- Added a "Clear alternate colors" option to remove the applied row striping and restore the default table style.
- Only one of the two options—"Alternate row colors" or "Clear alternate colors" is displayed at a time, based on the current table state.

**Purpose:**

- Enhance table readability and visual clarity by allowing users to toggle alternating row colors.

**task**-5117403
