### PR TITLE
[FIX] iot_drivers: ignore old server_clear WS messages

### DIFF
--- a/addons/iot_drivers/websocket_client.py
+++ b/addons/iot_drivers/websocket_client.py
@@ -42,6 +42,7 @@ class WebsocketClient(Thread):
         """
             When the client is setup, this function send a message to subscribe to the iot websocket channel
         """
+        self.connect_timestamp = time.monotonic()
         ws.send(json.dumps({
             'event_name': 'subscribe',
             'data': {
@@ -76,6 +77,11 @@ class WebsocketClient(Thread):
                                 'status': 'disconnected',
                             })
                 case 'server_clear':
+                    if time.monotonic() < self.connect_timestamp + 5.0:
+                        # This is a hacky way avoid processing an old server_clear message
+                        # In master we can fix this properly by providing the last message ID to the IoT box on connection
+                        _logger.warning("Ignoring server_clear message")
+                        continue
                     helpers.disconnect_from_server()
                     close_server_log_sender_handler()
                 case 'restart_odoo':


### PR DESCRIPTION
Steps to reproduce:
1. Pair your IoT
2. From the IoT homepage, clear the server configuration
3. From the DB, delete the IoT box record
4. Pair your IoT again

EXPECTED BEHAVIOUR:
- IoT pairs succesfully

ACTUAL BEHAVIOUR:
- IoT pairs but then immediately clears the server configuration

This commit introduces a simply sanity check to workaround the issue, by simply ignoring a `server_clear` message if it was received less than 5 seconds after connecting to the websocket.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
