### PR TITLE
[FIX] l10n_gcc_invoice: use `_get_section_lines` to compute section totals

### DIFF
--- a/addons/l10n_gcc_invoice/models/account_move.py
+++ b/addons/l10n_gcc_invoice/models/account_move.py
@@ -103,9 +103,9 @@ class AccountMoveLine(models.Model):
         return res
 
     def _l10n_gcc_get_section_total(self):
-        section_lines = self.child_ids + self.child_ids.child_ids
+        section_lines = self._get_section_lines()
         return sum(section_lines.mapped('price_total'))
 
     def _l10n_gcc_get_section_tax_amount(self):
-        section_lines = self.child_ids + self.child_ids.child_ids
+        section_lines = self._get_section_lines()
         return sum(section_lines.mapped('l10n_gcc_invoice_tax_amount'))

--- a/addons/l10n_sa_edi/tests/__init__.py
+++ b/addons/l10n_sa_edi/tests/__init__.py
@@ -3,3 +3,4 @@
 
 from . import common
 from . import test_edi_zatca
+from . import test_invoice

--- a/addons/l10n_sa_edi/tests/test_invoice.py
+++ b/addons/l10n_sa_edi/tests/test_invoice.py
@@ -1,0 +1,32 @@
+from odoo import Command
+from odoo.tests import tagged
+from odoo.addons.l10n_sa_edi.tests.common import TestSaEdiCommon
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestL10nSaInvoice(TestSaEdiCommon):
+
+    def test_invoice_section_lines_rendering(self):
+        invoice = self.env['account.move'].create([{
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_sa_simplified.id,
+            'invoice_line_ids': [
+                Command.create({
+                    'product_id': self.product_a.id,
+                    'tax_ids': self.tax_15.ids,
+                    'price_unit': 100.0,
+                }),
+                Command.create({
+                    'display_type': 'line_section',
+                    'name': 'section line',
+                }),
+                 Command.create({
+                    'product_id': self.product_b.id,
+                    'tax_ids': self.tax_15.ids,
+                    'price_unit': 200.0,
+                })
+            ]
+        }])
+        invoice.action_post()
+        html = self.env['ir.actions.report']._render_qweb_html('account.report_invoice_with_payments', invoice.ids)[0]
+        self.assertTrue(html)


### PR DESCRIPTION
### Issue:
Printing a Saudi invoice with section lines results in a traceback.

### Steps to reproduce:
- Install l10n_sa and switch to a Saudi company
- Create an invoice with section lines for a Saudi partner
- Click "Print"

### Cause:
To compute the totals for the section lines, we try to use the field `child_ids` but it was removed in [this commit](https://github.com/odoo/odoo/commit/572680aa30d41900223f1bea36e410e5c0270b37) for performance issues.

### Solution:
Use `_get_section_lines()` added by the same commit.

opw-5140406