### PR TITLE
[FIX] crm: race condition in tour 01

### DIFF
--- a/addons/crm/static/src/js/tours/crm.js
+++ b/addons/crm/static/src/js/tours/crm.js
@@ -36,8 +36,10 @@ registry.category("web_tour.tours").add('crm_tour', {
     run: "edit Brandon Freeman",
 }, {
     isActive: ["auto"],
-    trigger: ".ui-menu-item > a",
+    trigger: ".ui-menu-item > a:contains('Brandon Freeman')",
     run: "click",
+}, {
+    trigger: ".o_kanban_quick_create .o_field_widget[name='name'] input:value('Brandon Freeman')",
 }, {
     trigger: ".o_kanban_quick_create .o_kanban_add",
     content: markup(_t("Now, <b>add your Opportunity</b> to your Pipeline.")),

--- a/addons/crm/tests/test_crm_ui.py
+++ b/addons/crm/tests/test_crm_ui.py
@@ -17,28 +17,12 @@ class TestUi(HttpCase, TestCrmCommon):
         cls.env.ref('base.user_admin').tour_enabled = False
 
     def test_01_crm_tour(self):
-        # TODO: The tour is raising a JS error when selecting Brandon Freeman
-        # but with the demo data it succeeds to continue if there is already another lead
-        # in the pipe. Then the tour is using a record in the Qualified stage to create
-        # an activity, which is not existing without demo data as well
-        brandon = self.env["res.partner"].create({
+        self.env["res.partner"].create({
             'name': 'Brandon Freeman',
             'email': 'brandon.freeman55@example.com',
             'phone': '(355)-687-3262',
+            'is_company': True,
         })
-        self.env['crm.lead'].create([{
-            'name': "Zizizbroken",
-            'type': 'opportunity',
-            'partner_id': brandon.id,
-            'stage_id': self.stage_team1_1.id,
-            'user_id': self.env.ref('base.user_admin').id,
-        }, {
-            'name': "Zizizbroken 2",
-            'type': 'opportunity',
-            'partner_id': brandon.id,
-            'stage_id': self.stage_gen_1.id,
-            'user_id': self.env.ref('base.user_admin').id,
-        }])
         self.start_tour("/odoo", 'crm_tour', login="admin")
 
     @skipIf(os.getenv("ODOO_FAKETIME_TEST_MODE"), 'This tour uses CURRENT_DATE which cannot work in faketime mode')


### PR DESCRIPTION
The problem here is twofolds:

- After odoo/odoo#206314 the field being searched is filtered on `is_company` which means it's literally impossible to find the partner we create as that field defaults to `False`.
- Before that PR, since we just `click` the first link we find in the dropdown, we might get a random company which exists in the database (if any) or we might hit the "create" option.

  In the latter case we have a non-zero chance of clicking `o_kanban_add` before the client has had the time to `name_create` the record, set the partner, call the onchange, and return with the opportunity's name, leading to an attempt to create a nameless opportunity and a "missing required field" error

Selecting the very specific partner we created (correctly this time) and then actually waiting for the opportunity's name to be set should resolve the issue, and make problems in that step show up in the right location in the future rather than hit some sub-sub-sub-symptom 20 steps later.

https://runbot.odoo.com/odoo/error/229719
