### PR TITLE
[FIX] base: wrap the user name in their signature in a `div`

### DIFF
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -525,7 +525,7 @@ class Users(models.Model):
     @api.depends('name')
     def _compute_signature(self):
         for user in self.filtered(lambda user: user.name and is_html_empty(user.signature)):
-            user.signature = Markup('<p>--<br />%s</p>') % user['name']
+            user.signature = Markup('<div>--<br />%s</div>') % user['name']
 
     @api.depends('groups_id')
     def _compute_share(self):


### PR DESCRIPTION
Prior to this commit, the default signature for users was their name wrapped in
a `p`. This is not what we want, because a `HTMLParagraphElement` natively has a
margin-bottom, and when a user creates a newline from a paragraph, it duplicates
itself.

After this commit: the user name is wrapped in a `div` instead.

This does not update existing users signatures. To switch to a `div`, they
will have to select the desired lines, and change their type from "Paragraph"
to "Normal".

task-5149570