### PR TITLE
[FIX] project: remove redundant behavior for archived subtasks visibility

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -2025,7 +2025,6 @@ class ProjectTask(models.Model):
         child_tasks = self.child_ids.filtered(lambda child_task: not child_task.display_in_project)
         if child_tasks:
             child_tasks.action_archive()
-        self.filtered(lambda t: not t.display_in_project and t.parent_id).display_in_project = True
         return super().action_archive()
 
     # ---------------------------------------------------

--- a/addons/project/tests/test_project_subtasks.py
+++ b/addons/project/tests/test_project_subtasks.py
@@ -409,19 +409,6 @@ class TestProjectSubtasks(TestProjectCommon):
         task = task_form.save()
         self.assertEqual(task.message_follower_ids.mapped('email'), task.child_ids[0].message_follower_ids.mapped('email'), "The parent and child message_follower_ids should have the same emails")
 
-    def test_subtask_is_visible_after_archiving(self):
-        """
-            Check if `display_in_project` of subtask is set to `True` once the subtask is archived
-        """
-        subtask = self.env['project.task'].create({
-            'name': 'Subtask',
-            'parent_id': self.task_1.id,
-            'project_id': self.project_pigs.id,
-        })
-        self.assertFalse(subtask.display_in_project)
-        subtask.action_archive()
-        self.assertTrue(subtask.display_in_project)
-
     def test_toggle_active_task_with_subtasks(self):
         """ This test will check archiving task should archive it's subtasks and vice versa """
         parent_task = self.env['project.task'].with_context({'mail_create_nolog': True}).create({


### PR DESCRIPTION
Steps to reproduce:
- Install the Project app.
- Create a task and a subtask under it.
- Archive the subtask, then unarchive it.
- Untoggle the Show Sub-Tasks

Issue:
Subtask remains visible in Kanban even when Show Sub-Tasks is untoggled.

Cause:
When a subtask is archived, the PR https://github.com/odoo/odoo/pull/148342 forces `display_in_project' to True

Fix:
Remove the logic that sets display_in_project to True on archived subtasks,
since their visibility is now managed by the Show/Hide Subtasks toggle.

task-5075134
