### PR TITLE
[FIX] l10n_tr_nilvera_einvoice: remove test mode message and adjust send label

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice/i18n/l10n_tr_nilvera_einvoice.pot
+++ b/addons/l10n_tr_nilvera_einvoice/i18n/l10n_tr_nilvera_einvoice.pot
@@ -294,12 +294,6 @@ msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
-#: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
-msgid "Testing mode is enabled."
-msgstr ""
-
-#. module: l10n_tr_nilvera_einvoice
-#. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/res_partner_category.py:0
 msgid ""
 "The Contact Tag(s) cannot be deleted because it is used in Türkiye "
@@ -438,4 +432,10 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
 msgid "by Nilvera"
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
+msgid "by Nilvera (Demo)"
 msgstr ""

--- a/addons/l10n_tr_nilvera_einvoice/i18n/tr.po
+++ b/addons/l10n_tr_nilvera_einvoice/i18n/tr.po
@@ -315,12 +315,6 @@ msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
-#: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
-msgid "Testing mode is enabled."
-msgstr "Test modu etkinleştirildi."
-
-#. module: l10n_tr_nilvera_einvoice
-#. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/res_partner_category.py:0
 msgid ""
 "The Contact Tag(s) cannot be deleted because it is used in Türkiye "
@@ -474,4 +468,10 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
 msgid "by Nilvera"
-msgstr "Nilvera tarafından"
+msgstr "Nilvera'ya Gönder"
+
+#. module: l10n_tr_nilvera_einvoice
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
+msgid "by Nilvera (Demo)"
+msgstr "Nilvera'ya Gönder (Demo)"

--- a/addons/l10n_tr_nilvera_einvoice/models/account_move_send.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_move_send.py
@@ -16,7 +16,8 @@ class AccountMoveSend(models.AbstractModel):
     def _get_all_extra_edis(self) -> dict:
         # EXTENDS 'account'
         res = super()._get_all_extra_edis()
-        res.update({'tr_nilvera': {'label': _("by Nilvera"), 'is_applicable': self._is_tr_nilvera_applicable}})
+        label = _("by Nilvera (Demo)") if self.env.company.l10n_tr_nilvera_use_test_env else _("by Nilvera")
+        res.update({'tr_nilvera': {'label': label, 'is_applicable': self._is_tr_nilvera_applicable}})
         return res
 
     # -------------------------------------------------------------------------
@@ -28,13 +29,6 @@ class AccountMoveSend(models.AbstractModel):
 
         # Filter for moves that have 'tr_nilvera' in their EDI data
         tr_nilvera_moves = moves.filtered(lambda m: 'tr_nilvera' in moves_data[m]['extra_edis'])
-
-        # Show alert if the current company is in Türkiye and test mode is enabled for Nilvera
-        if self.env.company.account_fiscal_country_id.code == 'TR' and self.env.company.l10n_tr_nilvera_use_test_env:
-            alerts['l10n_tr_nilvera_einvoice_test_mode'] = {
-                'level': 'info',
-                'message': _("Testing mode is enabled."),
-            }
 
         if tr_companies_missing_required_codes := tr_nilvera_moves.company_id.filtered(lambda c: c.country_code == 'TR' and not (c.partner_id.category_id.parent_id and self.env["res.partner.category"]._get_l10n_tr_official_mandatory_categories())):
             alerts["tr_companies_missing_required_codes"] = {


### PR DESCRIPTION
In this commit:
---
- Removed the "Testing mode is enabled." message.
- Updated the Nilvera sending option label to display
  `by Nilvera (Demo)` when testing mode is enabled and

  <img width="977" height="37" alt="image" src="https://github.com/user-attachments/assets/76593af6-c0f5-4598-82d7-368b491320ac" />

  `by Nilvera` when disabled.

  <img width="966" height="37" alt="image" src="https://github.com/user-attachments/assets/bc0a49a2-50ad-4da1-a07f-f44042d25086" />


---

task-5136038
