### PR TITLE
[IMP] mail: add attachment icon on reply

### DIFF
--- a/addons/mail/static/src/core/common/message_in_reply.xml
+++ b/addons/mail/static/src/core/common/message_in_reply.xml
@@ -13,14 +13,12 @@
                         <span class="o-mail-MessageInReply-content overflow-hidden smaller">
                             <b class="o-mail-MessageInReply-author"><t t-out="props.message.parent_id.authorName"/></b>:
                             <span class="o-mail-MessageInReply-message ms-1 text-break">
+                                <i t-if="props.message.parent_id.hasAttachments" class="fa fa-fw me-1" t-att-class="props.message.parent_id.previewIcon" /> 
                                 <t t-if="!props.message.parent_id.isBodyEmpty">
                                     <t t-out="props.message.parent_id.inlineBody"/>
                                     <em t-if="props.message.parent_id.edited" class="smaller fw-bold text-500"> (edited)</em>
                                 </t>
-                                <t t-elif="props.message.parent_id.attachment_ids.length > 0">
-                                    <span class="me-2 fst-italic">Click to see the attachments</span>
-                                    <i class="fa fa-image"/>
-                                </t>
+                                <span t-else="" class="fst-italic">Click to see the attachments</span>
                             </span>
                         </span>
                     </t>

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -436,8 +436,12 @@ export class Message extends Record {
         );
     }
 
+    get hasAttachments() {
+        return this.attachment_ids?.length > 0;
+    }
+
     get hasOnlyAttachments() {
-        return this.isBodyEmpty && this.attachment_ids.length > 0;
+        return this.isBodyEmpty && this.hasAttachments;
     }
 
     previewText = fields.Html("", {
@@ -470,7 +474,7 @@ export class Message extends Record {
 
     get previewIcon() {
         const { attachment_ids: attachments } = this;
-        if (!attachments || attachments.length === 0) {
+        if (!this.hasAttachments) {
             return "";
         }
         const firstAttachment = attachments[0];

--- a/addons/mail/static/tests/message/message_reply.test.js
+++ b/addons/mail/static/tests/message/message_reply.test.js
@@ -185,3 +185,29 @@ test("Replying to a message containing line breaks should be correctly inlined",
         text: "Message first line. Message second line. Message third line.",
     });
 });
+
+test("Replying to a message containing attachments should display an attachment icon", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "general" });
+    const messageId = pyEnv["mail.message"].create({
+        body: "<p>Message first line.</p>",
+        message_type: "comment",
+        model: "discuss.channel",
+        res_id: channelId,
+        attachment_ids: [
+            pyEnv["ir.attachment"].create({ name: "test.txt", mimetype: "text/plain" }),
+        ],
+    });
+    const partnerId = pyEnv["res.partner"].create({ name: "John Doe" });
+    pyEnv["mail.message"].create({
+        body: "Howdy",
+        message_type: "comment",
+        model: "discuss.channel",
+        author_id: partnerId,
+        parent_id: messageId,
+        res_id: channelId,
+    });
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-mail-MessageInReply .fa-file");
+});


### PR DESCRIPTION
This PR refactors the attachment icon in message replies. The goal is to
always display it when attachments are included in the message.

task-4933289

<img width="472" height="356" alt="image" src="https://github.com/user-attachments/assets/22a6e980-fc27-4310-b02a-a2834313c369" />
<img width="393" height="91" alt="image" src="https://github.com/user-attachments/assets/84cd9218-abf6-4c39-b7fa-5933b8f4b80d" />
<img width="1421" height="212" alt="image" src="https://github.com/user-attachments/assets/2297bb9f-3945-4db0-a797-d62d4461d96b" />
