### PR TITLE
[FIX] mail: prevent error when creating helpdesk ticket

### DIFF
--- a/addons/mail/models/mail_tracking_duration_mixin.py
+++ b/addons/mail/models/mail_tracking_duration_mixin.py
@@ -180,7 +180,10 @@ class MailTrackingDurationMixin(models.AbstractModel):
         rot_enabled = self.filtered_domain(self._get_rotting_domain())
         others = self - rot_enabled
         for stage, records in rot_enabled.grouped(self._track_duration_field).items():
-            rotting = records.filtered(lambda record: (record.date_last_stage_update or record.create_date) + timedelta(days=stage.rotting_threshold_days) < now)
+            rotting = records.filtered(lambda record:
+                (record.date_last_stage_update or record.create_date or fields.Datetime.now())
+                + timedelta(days=stage.rotting_threshold_days) < now
+            )
             for record in rotting:
                 record.is_rotting = True
                 record.rotting_days = (now - (record.date_last_stage_update or record.create_date)).days


### PR DESCRIPTION
Currently an error occurs when user creates the helpdesk ticket.

Steps to Reproduce:

 - Install the `helpdesk` module.
 - Go to `Stages` and, in the `Kanban view`, open the `New Stage` record.
 - Set a value `greater than 0` in the `Days to rot` field.
 - Go to `Tickets` and click `New`.

`TypeError: unsupported operand type(s) for +: 'bool' and 'datetime.timedelta'`

This error occurs when a user sets the Days to rot value greater than zero in a new stage. When creating a helpdesk ticket, the compute method runs and filters the records[1] to check which records have stayed too long in their current stage based on the last stage update date or create date. For the current record, both of these fields are not set now, which raises the error[1].

This commit ensures that if the record does not have a last stage update or create date, the current date and time will be used instead.

[1]- https://github.com/odoo/odoo/blob/7748345e11b542b00656d3586767e064c2d1e2e8/addons/mail/models/mail_tracking_duration_mixin.py#L183

sentry-6927500374


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
