### PR TITLE
[IMP] maintenance: remove calendar menu & Request Date field

### DIFF
--- a/addons/maintenance/models/maintenance.py
+++ b/addons/maintenance/models/maintenance.py
@@ -316,9 +316,9 @@ class MaintenanceRequest(models.Model):
 
     def _read_group_equipment_id(self, records, domain):
         """ Read group customization in order to display all the equipment in
-            the kanban view, even if they are empty.
+            the gantt/kanban view, even if they are empty.
         """
-        return records + self.env['maintenance.equipment'].search([])
+        return self.env['maintenance.equipment'].search([])
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/maintenance/models/maintenance.py
+++ b/addons/maintenance/models/maintenance.py
@@ -91,12 +91,15 @@ class MaintenanceMixin(models.AbstractModel):
             if record.maintenance_team_id.company_id and record.maintenance_team_id.company_id.id != record.company_id.id:
                 record.maintenance_team_id = False
 
-    @api.depends('effective_date', 'maintenance_ids.stage_id', 'maintenance_ids.close_date', 'maintenance_ids.request_date')
+    @api.depends('effective_date', 'maintenance_ids.stage_id', 'maintenance_ids.close_date', 'maintenance_ids.schedule_date')
     def _compute_maintenance_request(self):
         for record in self:
             maintenance_requests = record.maintenance_ids.filtered(lambda mr: mr.maintenance_type == 'corrective' and mr.stage_id.done)
-            record.mttr = len(maintenance_requests) and (sum(int((request.close_date - request.request_date).days) if request.close_date and request.request_date else 0 for request in maintenance_requests) / len(maintenance_requests)) or 0
-            record.latest_failure_date = max((request.request_date for request in maintenance_requests), default=False)
+            failure_dates = [(request.schedule_date or request.create_date).date() for request in maintenance_requests]
+            record.mttr = len(maintenance_requests) and sum((request.close_date - failure_date).days
+                if request.close_date else 0
+                for request, failure_date in zip(maintenance_requests, failure_dates)) / len(maintenance_requests)
+            record.latest_failure_date = max(failure_dates, default=False)
             record.mtbf = record.latest_failure_date and (record.latest_failure_date - record.effective_date).days / len(maintenance_requests) or 0
             record.estimated_next_failure = record.mtbf and record.latest_failure_date + relativedelta(days=record.mtbf) or False
 
@@ -208,8 +211,6 @@ class MaintenanceRequest(models.Model):
     company_id = fields.Many2one('res.company', string='Company', required=True,
         default=lambda self: self.env.company)
     description = fields.Html('Description')
-    request_date = fields.Date('Request Date', tracking=True, default=fields.Date.context_today,
-                               help="Date requested for the maintenance to happen")
     owner_user_id = fields.Many2one('res.users', string='Created by User', default=lambda s: s.env.uid)
     category_id = fields.Many2one('maintenance.equipment.category', related='equipment_id.category_id', string='Category', store=True, readonly=True, index='btree_not_null')
     equipment_id = fields.Many2one('maintenance.equipment', string='Equipment',

--- a/addons/maintenance/models/maintenance.py
+++ b/addons/maintenance/models/maintenance.py
@@ -214,7 +214,8 @@ class MaintenanceRequest(models.Model):
     owner_user_id = fields.Many2one('res.users', string='Created by User', default=lambda s: s.env.uid)
     category_id = fields.Many2one('maintenance.equipment.category', related='equipment_id.category_id', string='Category', store=True, readonly=True, index='btree_not_null')
     equipment_id = fields.Many2one('maintenance.equipment', string='Equipment',
-                                   ondelete='restrict', index=True, check_company=True)
+                                   ondelete='restrict', index=True, check_company=True,
+                                   group_expand='_read_group_equipment_id')
     user_id = fields.Many2one('res.users', string='Technician', compute='_compute_user_id', store=True, readonly=False, tracking=True)
     stage_id = fields.Many2one('maintenance.stage', string='Stage', ondelete='restrict', tracking=True,
                                group_expand='_read_group_stage_ids', default=_default_stage, copy=False)
@@ -312,6 +313,12 @@ class MaintenanceRequest(models.Model):
         for request in self:
             if request.maintenance_type != 'preventive':
                 request.recurring_maintenance = False
+
+    def _read_group_equipment_id(self, records, domain):
+        """ Read group customization in order to display all the equipment in
+            the kanban view, even if they are empty.
+        """
+        return records + self.env['maintenance.equipment'].search([])
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/maintenance/tests/test_maintenance.py
+++ b/addons/maintenance/tests/test_maintenance.py
@@ -152,10 +152,10 @@ class TestEquipmentPostInstall(TestEquipmentCommon):
             form = Form(self.env['maintenance.equipment'].browse(equipment.id))
             self.assertEqual(form.name, equipment_name)
 
-    def test_done_maintenance_no_close_or_request_date(self):
+    def test_done_maintenance_no_close_or_schedule_date(self):
         """
         Ensure equipment with done maintenance requests that have
-        `close_date` or `request_date` set to False can still be opened.
+        `close_date` or `schedule_date` set to False can still be opened.
         In theory this should never happen, but we should fail gracefully
         in case these dates are forced set to False.
         """
@@ -168,11 +168,11 @@ class TestEquipmentPostInstall(TestEquipmentCommon):
         form.equipment_id = equipment
         form.maintenance_type = 'corrective'
         maintenance = form.save()
-        self.assertTrue(maintenance.request_date)
+        self.assertFalse(maintenance.schedule_date)
         self.assertFalse(maintenance.close_date)
 
         maintenance.stage_id = self.ref('maintenance.stage_3')
-        self.assertTrue(maintenance.request_date)
+        self.assertFalse(maintenance.schedule_date)
         self.assertTrue(maintenance.close_date)
         form = Form(equipment)
 
@@ -180,7 +180,6 @@ class TestEquipmentPostInstall(TestEquipmentCommon):
         maintenance.close_date = False
         form = Form(equipment)
         maintenance.close_date = fields.Date.today()
-        maintenance.request_date = False
         form = Form(equipment)
         maintenance.close_date = False
         form = Form(equipment)

--- a/addons/maintenance/views/maintenance_views.xml
+++ b/addons/maintenance/views/maintenance_views.xml
@@ -26,7 +26,6 @@
                 <separator/>
                 <filter string="Unscheduled" name="unscheduled" domain="[('stage_id.done', '=', False), ('schedule_date', '=', False)]"/>
                 <separator/>
-                <filter name="filter_request_date" date="request_date"/>
                 <filter name="filter_schedule_date" date="schedule_date"/>
                 <filter name="filter_close_date" date="close_date"/>
                 <separator/>
@@ -104,7 +103,6 @@
                             <field name="owner_user_id" string="Requested By" invisible="1"/>
                             <field name="equipment_id"  context="{'default_company_id':company_id, 'default_category_id':category_id}"/>
                             <field name="category_id" groups="maintenance.group_equipment_manager" context="{'default_company_id':company_id}" invisible="not equipment_id"/>
-                            <field name="request_date" readonly="True"/>
                             <field name="done" invisible="1"/>
                             <field name="close_date" readonly="True" invisible="not done"/>
                             <field name="archive" invisible="1"/>
@@ -194,7 +192,6 @@
             <list string="Maintenance Request" multi_edit="1" sample="1">
                 <field name="message_needaction" column_invisible="True"/>
                 <field name="name"/>
-                <field name="request_date" groups="base.group_no_one"/>
                 <field name="owner_user_id"/>
                 <field name="user_id"/>
                 <field name="category_id" readonly="1" groups="maintenance.group_equipment_manager"/>
@@ -966,14 +963,6 @@
         action="hr_equipment_request_action"
         groups="group_equipment_manager,base.group_user"
         sequence="1"/>
-
-    <menuitem
-        id="menu_m_request_calendar"
-        name="Maintenance Calendar"
-        parent="menu_m_request"
-        action="hr_equipment_request_action_cal"
-        groups="group_equipment_manager,base.group_user"
-        sequence="2"/>
 
     <menuitem
         id="menu_equipment_form"

--- a/addons/maintenance/views/maintenance_views.xml
+++ b/addons/maintenance/views/maintenance_views.xml
@@ -101,7 +101,7 @@
                     <group>
                         <group>
                             <field name="owner_user_id" string="Requested By" invisible="1"/>
-                            <field name="equipment_id"  context="{'default_company_id':company_id, 'default_category_id':category_id}"/>
+                            <field name="equipment_id" context="{'default_company_id':company_id, 'default_category_id':category_id}" required="1"/>
                             <field name="category_id" groups="maintenance.group_equipment_manager" context="{'default_company_id':company_id}" invisible="not equipment_id"/>
                             <field name="done" invisible="1"/>
                             <field name="close_date" readonly="True" invisible="not done"/>


### PR DESCRIPTION
Purpose:
--------
- It should be easier to visualize maintenance requests than what is possible today. The calendar view is useful but does not provide a comprehensive overview of all equipment or work centers, nor the ability to plan interventions easily.
- The `Request Date` field is unnecessary and potentially confusing since `Scheduled Date` already serves as the definitive start date for a maintenance request.

With this commit:
----------------------
- Removes the `Request Date` field from maintenance requests as it is redundant with `Scheduled Date`; `Scheduled Date` more accurately reflects the intended start of the maintenance request, whereas `Request Date` only indicates when the request was created.
- Replaced `Maintenance Calendar` menu with `Planning by Equipment` and `Planning by Workcenter` as they will be more useful to plan the maintenance request by resources rather than `Maintenance Calendar`.

task-4698325