### PR TITLE
[FIX] web: don't show mismatch for offset timezones

### DIFF
--- a/addons/web/static/src/views/fields/timezone_mismatch/timezone_mismatch_field.js
+++ b/addons/web/static/src/views/fields/timezone_mismatch/timezone_mismatch_field.js
@@ -27,7 +27,7 @@ export class TimezoneMismatchField extends SelectionField {
         if (userOffset && this.props.record.data[this.props.name]) {
             const offset = -new Date().getTimezoneOffset();
             let browserOffset = offset < 0 ? "-" : "+";
-            browserOffset += Math.abs(offset / 60)
+            browserOffset += Math.floor(Math.abs(offset / 60))
                 .toFixed(0)
                 .padStart(2, "0");
             browserOffset += Math.abs(offset % 60)


### PR DESCRIPTION
**Steps to reproduce**
- Set your machine timezone to one ending in :30 or :45
- Open your user preferences and chose the same timezone
Issue: the timezone mismatch icon is displayed.

**Cause**
`.toFixed(0)` rounds to the nearest integer.

**Change**
Always round down the hour part.

opw-5123025