### PR TITLE
[FIX] base: wrap the user name in their signature in a `div`

### DIFF
--- a/odoo/addons/base/data/res_users_data.xml
+++ b/odoo/addons/base/data/res_users_data.xml
@@ -7,7 +7,7 @@
             <field name="company_id" ref="main_company"/>
             <field name="company_ids" eval="[Command.link(ref('main_company'))]"/>
             <field name="email">odoobot@example.com</field>
-            <field name="signature">System</field>
+            <field name="signature" type="html"><div>System</div></field>
         </record>
 
         <!-- user 2 is the human admin user -->
@@ -18,7 +18,7 @@
             <field name="company_id" ref="main_company"/>
             <field name="company_ids" eval="[Command.link(ref('main_company'))]"/>
             <field name="group_ids" eval="[Command.set([])]"/>
-            <field name="signature">Administrator</field>
+            <field name="signature" type="html"><div>Administrator</div></field>
         </record>
 
         <record id="user_admin_settings" model="res.users.settings" forcecreate="0">

--- a/odoo/addons/base/data/res_users_demo.xml
+++ b/odoo/addons/base/data/res_users_demo.xml
@@ -36,7 +36,7 @@
             <field name="partner_id" ref="base.partner_demo"/>
             <field name="login">demo</field>
             <field name="password">demo</field>
-            <field name="signature">Mr Demo</field>
+            <field name="signature" type="html"><div>Mr Demo</div></field>
             <field name="company_id" ref="main_company"/>
             <field name="group_ids" eval="[Command.set([ref('base.group_user'), ref('base.group_partner_manager'), ref('base.group_allow_export')])]"/>
             <field name="image_1920" type="base64" file="base/static/img/user_demo-image.png"/>
@@ -66,7 +66,7 @@
         </record>
 
         <record id="base.user_admin" model="res.users">
-            <field name="signature">Mitchell Admin</field>
+            <field name="signature" type="html"><div>Mitchell Admin</div></field>
         </record>
 
         <!-- Portal : partner and user -->
@@ -86,7 +86,7 @@
             <field name="partner_id" ref="partner_demo_portal"/>
             <field name="login">portal</field>
             <field name="password">portal</field>
-            <field name="signature">Mr Demo Portal</field>
+            <field name="signature" type="html"><div>Mr Demo Portal</div></field>
             <field name="group_ids" eval="[Command.clear()]"/><!-- Avoid auto-including this user in any default group -->
         </record>
 

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -454,7 +454,7 @@ class ResUsers(models.Model):
     @api.depends('name')
     def _compute_signature(self):
         for user in self.filtered(lambda user: user.name and is_html_empty(user.signature)):
-            user.signature = Markup('<p>%s</p>') % user['name']
+            user.signature = Markup('<div>%s</div>') % user['name']
 
     @api.depends('all_group_ids')
     def _compute_share(self):


### PR DESCRIPTION
Prior to this commit, the default signature for users was their name wrapped in
a `p`. This is not what we want, because a `HTMLParagraphElement` natively has a
margin-bottom, and when a user creates a newline from a paragraph in the HTML
Editor, the paragraph is cloned.

After this commit: the user name is wrapped in a `div` instead.

This does not update existing users signatures. To switch to a `div`, they
will have to select the desired lines, and change their type from "Paragraph"
to "Normal".

Demo and admin users are updated too, because lxml `document_fromstring` would
wrap text content in a `p` during record creation.

task-5149570