### PR TITLE
[FIX] sale_timesheet: use string boolean in wizard template

### DIFF
--- a/addons/sale_timesheet/wizard/sale_make_invoice_advance_views.xml
+++ b/addons/sale_timesheet/wizard/sale_make_invoice_advance_views.xml
@@ -20,7 +20,7 @@
                         string="Timesheets Period"
                         widget="daterange"
                         required="date_start_invoice_timesheet or date_end_invoice_timesheet"
-                        options="{'end_date_field': 'date_end_invoice_timesheet', 'always_range': true}"
+                        options="{'end_date_field': 'date_end_invoice_timesheet', 'always_range': 'true'}"
                         title="Only timesheets not yet invoiced (and validated, if applicable) from this period will be invoiced. If the period is not indicated, all timesheets not yet invoiced (and validated, if applicable) will be invoiced without distinction."
                     />
                     <field name="date_end_invoice_timesheet" invisible="1" />


### PR DESCRIPTION
Versions
--------
- 17.0+

Issue
-----
Some customizations may parse XML views using Python, in which case the `date_start_invoice_timesheet` field could return an error, as the `options` attribute uses a Javascript boolean `true`.

Solution
--------
Use `'true'`, which will get parsed as `true` in JS via `archParseBoolean`.