### PR TITLE
[FIX] website: config dropdown option clicking not working on Safari

### DIFF
--- a/addons/website/static/src/client_actions/configurator/configurator.xml
+++ b/addons/website/static/src/client_actions/configurator/configurator.xml
@@ -30,7 +30,9 @@
                 <div class="o_configurator_typing_text d-inline d-md-block mb-md-2 mb-lg-4 o_configurator_show">
                     <span>I want </span>
                     <div t-attf-class="dropdown o_configurator_type_dd d-inline-block {{state.selectedType ? 'o_step_completed' : 'o_step_todo show'}}"
-                         t-on-focusout="onDropdownFocusout">
+                         t-on-focusout="onDropdownFocusout"
+                         t-on-pointerdown="onDropdownPointerDown"
+                         t-on-pointerup="onDropdownPointerUp">
                         <button id="selectTypeToggle"
                                 class="o_btn_reset w-100 px-2"
                                 data-bs-toggle="dropdown"
@@ -83,7 +85,9 @@
                 <div t-if="state.selectedType and state.selectedIndustry" class="o_configurator_typing_text d-inline d-md-block mb-md-2 mb-lg-4 o_configurator_show">
                     <span>with the main objective to </span>
                     <div t-attf-class="dropdown d-inline-block o_configurator_purpose_dd {{state.selectedPurpose ? 'o_step_completed' : 'o_step_todo'}}"
-                         t-on-focusout="onDropdownFocusout">
+                         t-on-focusout="onDropdownFocusout"
+                         t-on-pointerdown="onDropdownPointerDown"
+                         t-on-pointerup="onDropdownPointerUp">
                         <button id="selectPurposeToggle"
                                 class="o_btn_reset w-100 px-2"
                                 data-bs-toggle="dropdown"


### PR DESCRIPTION
Problem
Using Safari, in the website configuration wizard, 
when selecting a website type or an objective
by mouse clicking, nothing would get selected, 
and the dropdown would close prematurely.


Steps
- Using Safari
- In Odoo with the Website addon installed
- Create a new website in the website settings
- Try to select any type of website by mouse clicking
- Nothing would get selected, and the dropdown closes before pointerUp

Cause
On Safari, buttons are not focusable by default.
So if we want good accessibility on these dropdowns,
a workaround is needed.

Fix
Delay focusout actions until a pointerUp 
event is triggered on the dropdown, if the Safari user uses 
its mouse to choose an option.

task-5139708

Closes https://github.com/odoo/odoo/pull/226637