### PR TITLE
[FIX] mass_mailing: add mail contact to mail list through wizard

### DIFF
--- a/addons/mass_mailing/tests/test_mailing_list.py
+++ b/addons/mass_mailing/tests/test_mailing_list.py
@@ -34,8 +34,12 @@ class TestMailingContactToList(MassMailCommon):
         # set mailing list and add contacts
         wizard_form.mailing_list_id = mailing
         wizard = wizard_form.save()
-        action = wizard.action_add_contacts()
-        self.assertEqual(contacts.list_ids, mailing)
+        frozen_time = datetime(2025, 1, 1, 0, 0)
+        with self.mock_datetime_and_now(frozen_time):
+            action = wizard.action_add_contacts()
+            self.assertEqual(contacts.list_ids, mailing)
+            create_dates = contacts.subscription_ids.mapped('create_date')
+            self.assertTrue(all(date == frozen_time for date in create_dates), "All create dates should be equal to frozen datetime")
         self.assertEqual(action["type"], "ir.actions.client")
         self.assertTrue(action.get("params", {}).get("next"), "Should return a notification with a next action")
         subaction = action["params"]["next"]

--- a/addons/mass_mailing/wizard/mailing_contact_to_list.py
+++ b/addons/mass_mailing/wizard/mailing_contact_to_list.py
@@ -30,13 +30,15 @@ class MailingContactToList(models.TransientModel):
     def _add_contacts_to_mailing_list(self, action):
         self.ensure_one()
 
-        previous_count = len(self.mailing_list_id.contact_ids)
+        contacts_to_add = self.contact_ids.filtered(lambda c: c not in self.mailing_list_id.contact_ids)
         self.mailing_list_id.write({
-            'contact_ids': [
-                (4, contact.id)
-                for contact in self.contact_ids
-                if contact not in self.mailing_list_id.contact_ids]
-            })
+            'subscription_ids': [
+                (0, 0, {
+                    'contact_id': contact.id,
+                    'list_id': self.mailing_list_id.id,
+                }) for contact in contacts_to_add
+            ]
+        })
 
         return {
             'type': 'ir.actions.client',
@@ -44,7 +46,7 @@ class MailingContactToList(models.TransientModel):
             'params': {
                 'type': 'info',
                 'message': _("%s Mailing Contacts have been added. ",
-                             len(self.mailing_list_id.contact_ids) - previous_count
+                             len(contacts_to_add)
                             ),
                 'sticky': False,
                 'next': action,


### PR DESCRIPTION
Steps to reproduce:
-------------------------
1. Install Email Marketing Module
2. Create a new Mail List
3. Go to Mailing List Contacts
4. Select multiple contacts from list and click on Add to List button
5. From wizard select the newly created list and click on Add button
6. Open one of the contact added in step 4

Observation:
-------------------------
In the Mailing Lists tab of the contact, the newly added list does not show a Subscription Date. However, if we add the same through Add a line, the subscription date is shown correctly.

Issue:
-------------------------
When adding contacts to a mailing list through the wizard, the code https://github.com/odoo/odoo/blob/1e6ba783fcd898875dadb47924147688685707cf/addons/mass_mailing/wizard/mailing_contact_to_list.py#L34-L39 adds the contact using a direct database operation. This bypasses the ORM record creation for `mailing.subscription`, so the `create_date` (subscription date) is never set.

Solution:
-------------------------
Use `Command.create` on the `subscription_ids` field to properly create the `mailing.subscription` records and ensure the Subscription Date is set.

opw-5055372
