### PR TITLE
[FIX] hr_attendance: removed extra prop

### DIFF
--- a/addons/hr_attendance/static/src/public_kiosk/public_kiosk_app.js
+++ b/addons/hr_attendance/static/src/public_kiosk/public_kiosk_app.js
@@ -27,7 +27,6 @@ class kioskAttendanceApp extends Component{
         kioskMode: { type: String },
         barcodeSource: { type: String },
         fromTrialMode: { type: Boolean },
-        activeDisplay: { type: String },
         deviceTrackingEnabled: { type: Boolean },
     };
     static components = {


### PR DESCRIPTION
step to reproduce:
- install Attendances app
- turn on debug mode
- go to Attendance -> kiosk mode

Observation:
- We get a blank screen with error in browser console
```
OwlError: Invalid props for component 'kioskAttendanceApp': 'activeDisplay' is missing (should be a string)
```

Cause:
- Commit [1] mistakenly included an unused `activeDisplay` prop.
- The component already uses the `active_display` state, so the prop was removed.
https://github.com/odoo/odoo/blob/da66ff8b2e60db06872eb926c6f22a6f99a7f879/addons/hr_attendance/static/src/public_kiosk/public_kiosk_app.js#L51-L54

[1] https://github.com/odoo/odoo/commit/bd9351a36cf7394bc5436806d4e6548e6477c497

Issue was identified when fixing https://github.com/odoo/odoo/pull/229225

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
