### PR TITLE
[FIX] mail: show all participants on other user stops screen share

### DIFF
--- a/addons/mail/static/src/discuss/call/common/rtc_session_model.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_session_model.js
@@ -54,7 +54,17 @@ export class RtcSession extends Record {
     /** @type {boolean} */
     is_camera_on;
     /** @type {boolean} */
-    is_screen_sharing_on;
+    is_screen_sharing_on = fields.Attr(undefined, {
+        onUpdate() {
+            if (
+                this.eq(this.channel?.activeRtcSession) &&
+                this.mainVideoStreamType === "screen" &&
+                !this.is_screen_sharing_on
+            ) {
+                this.channel.activeRtcSession = undefined;
+            }
+        },
+    });
     /** @type {number} */
     id;
     /** @type {boolean} */


### PR DESCRIPTION
Before this commit, when another user stops the screen sharing, said user would be now focused (the expected behavior is showing all call participants).

Steps to reproduce:
1. Have a call between user A and B
2. As user A start and then stop Screen Share
3. Observe on user B that user A is focused

This happened because the activeRtcSession would not be correctly cleared (regression introduced in [1]).

This commit fixes the issue by reintroducing the clearing of the activeRtcSession in a more declarative way.

[1]: https://github.com/odoo/odoo/pull/221019

task-5090261