### PR TITLE
[FIX] web: correctly highlight repeated characters in command palette

### DIFF
--- a/addons/web/static/src/core/utils/html.js
+++ b/addons/web/static/src/core/utils/html.js
@@ -55,7 +55,7 @@ export function highlightText(query, text, classes) {
     let result = text;
     for (const match of matches) {
         const regex = new RegExp(
-            `(${escapeRegExp(htmlEscape(match))})+(?=(?:[^>]*<[^<]*>)*[^<>]*$)`,
+            `(${escapeRegExp(htmlEscape(match))})(?=(?:[^>]*<[^<]*>)*[^<>]*$)`,
             "ig"
         );
         result = htmlReplace(result, regex, (_, match) => {

--- a/addons/web/static/tests/core/utils/html.test.js
+++ b/addons/web/static/tests/core/utils/html.test.js
@@ -47,6 +47,9 @@ test("highlightText", () => {
     expect(highlightText("b", "abcb", "hl").toString()).toBe(
         'a<span class="hl">b</span>c<span class="hl">b</span>'
     );
+    expect(highlightText("b", "abbc", "hl").toString()).toBe(
+        'a<span class="hl">b</span><span class="hl">b</span>c'
+    );
     expect(highlightText("b", "<p>ab</p>", "hl").toString()).toBe(
         '&lt;p&gt;a<span class="hl">b</span>&lt;/p&gt;'
     );


### PR DESCRIPTION
**Before this commit :**
When searching for apps whose names contain repeated characters, the command palette incorrectly omitted the second occurrence of that repeated character while searching for it.

Example:
App name: Meeting Rooms
input: o
Result: Meeting Roms(missing the second `o`), which was incorrect.

**After this commit:**
The command palette now correctly displays all characters without skipping any repeated ones.

task-5129947

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
