### PR TITLE
17.0 adyen redirect params fix anko

### DIFF
--- a/addons/payment_adyen/controllers/main.py
+++ b/addons/payment_adyen/controllers/main.py
@@ -89,12 +89,16 @@ class AdyenController(http.Controller):
         # Prepare the payment request to Adyen
         provider_sudo = request.env['payment.provider'].sudo().browse(provider_id).exists()
         tx_sudo = request.env['payment.transaction'].sudo().search([('reference', '=', reference)])
+        partner_country_code = (
+            tx_sudo.partner_country_id.code or provider_sudo.company_id.country_id.code or 'NL'
+        )
         data = {
             'merchantAccount': provider_sudo.adyen_merchant_account,
             'amount': {
                 'value': converted_amount,
                 'currency': request.env['res.currency'].browse(currency_id).name,  # ISO 4217
             },
+            'countryCode': partner_country_code,  # ISO 3166-1 alpha-2 (e.g.: 'BE')
             'reference': reference,
             'paymentMethod': payment_method,
             'shopperReference': provider_sudo._adyen_compute_shopper_reference(partner_id),
@@ -121,6 +125,11 @@ class AdyenController(http.Controller):
                 f'/payment/adyen/return?merchantReference={reference}'
             ),
             **adyen_utils.include_partner_addresses(tx_sudo),
+            'lineItems': [{
+                'amountIncludingTax': converted_amount,
+                'quantity': '1',
+                'description': reference,
+            }],
         }
 
         # Force the capture delay on Adyen side if the provider is not configured for capturing

--- a/addons/payment_adyen/models/payment_transaction.py
+++ b/addons/payment_adyen/models/payment_transaction.py
@@ -64,12 +64,16 @@ class PaymentTransaction(models.Model):
         converted_amount = payment_utils.to_minor_currency_units(
             self.amount, self.currency_id, const.CURRENCY_DECIMALS.get(self.currency_id.name)
         )
+        partner_country_code = (
+            self.partner_country_id.code or self.provider_id.company_id.country_id.code or 'NL'
+        )
         data = {
             'merchantAccount': self.provider_id.adyen_merchant_account,
             'amount': {
                 'value': converted_amount,
                 'currency': self.currency_id.name,
             },
+            'countryCode': partner_country_code,
             'reference': self.reference,
             'paymentMethod': {
                 'storedPaymentMethodId': self.token_id.provider_ref,
@@ -82,6 +86,11 @@ class PaymentTransaction(models.Model):
             'shopperName': adyen_utils.format_partner_name(self.partner_name),
             'telephoneNumber': self.partner_phone,
             **adyen_utils.include_partner_addresses(self),
+            'lineItems': [{
+                'amountIncludingTax': converted_amount,
+                'quantity': '1',
+                'description': self.reference,
+            }],
         }
 
         # Force the capture delay on Adyen side if the provider is not configured for capturing


### PR DESCRIPTION
Some payment methods eg. Klarna require 'country code' and 'line items'
in order to process the transaction.

opw-5077617