### PR TITLE
[FIX] mail: disable Log Note button for users without access rights

### DIFF
--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -75,6 +75,8 @@ export class Thread extends Record {
                 "avatarCacheKey",
                 "description",
                 "hasWriteAccess",
+                "hasReadAccess",
+                "canPostOnreadonly",
                 "is_pinned",
                 "isLoaded",
                 "isLoadingAttachments",

--- a/addons/mail/static/src/core/web/chatter.xml
+++ b/addons/mail/static/src/core/web/chatter.xml
@@ -17,7 +17,7 @@
                     'btn-primary active': state.composerType === 'note',
                     'btn-secondary': state.composerType !== 'note',
                     'my-2': !props.compactHeight
-                }" data-hotkey="shift+m" t-on-click="() => this.toggleComposer('note')">
+                }" t-att-disabled="!state.thread.hasWriteAccess and !(state.thread.hasReadAccess and state.thread.canPostOnReadonly) and props.threadId" data-hotkey="shift+m" t-on-click="() => this.toggleComposer('note')">
                     Log note
                 </button>
                 <div class="flex-grow-1 d-flex">

--- a/addons/project/static/tests/tours/project_chatter_access_tour_tests.js
+++ b/addons/project/static/tests/tours/project_chatter_access_tour_tests.js
@@ -1,0 +1,64 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import { stepUtils } from "@web_tour/tour_service/tour_utils";
+
+registry.category("web_tour.tours").add("project_chatter_log_disabled", {
+    test: true,
+    url: "/web",
+    steps: () => [
+        stepUtils.showAppsMenuItem(),
+        {
+            content: "Open Project app",
+            trigger: '.o_app[data-menu-xmlid="project.menu_main_pm"]',
+        },
+        {
+            content: "Toggle a Project's dropdown",
+            trigger: ".o_kanban_record .dropdown-toggle.o-no-caret",
+        },
+        {
+            content: "Select View action",
+            trigger: ".oe_kanban_action:contains('View')",
+        },
+        {
+            content: "Check that Log Note button is disabled",
+            trigger: ".o-mail-Chatter-logNote:disabled",
+            isCheck: true,
+        },
+        {
+            content: "Check that Log Note button is disabled",
+            trigger: ".o-mail-Chatter-sendMessage:disabled",
+            isCheck: true,
+        },
+    ],
+});
+
+registry.category("web_tour.tours").add("project_chatter_log_enabled", {
+    test: true,
+    url: "/web",
+    steps: () => [
+        stepUtils.showAppsMenuItem(),
+        {
+            content: "Open Project app",
+            trigger: '.o_app[data-menu-xmlid="project.menu_main_pm"]',
+        },
+        {
+            content: "Toggle a Project's dropdown",
+            trigger: ".o_kanban_record .dropdown-toggle.o-no-caret",
+        },
+        {
+            content: "Select Settings action",
+            trigger: ".oe_kanban_action:contains('Settings')",
+        },    
+        {
+            content: "Check that Log Note button is enabled",
+            trigger: ".o-mail-Chatter-logNote:enabled",
+            isCheck: true,
+        },
+        {
+            content: "Check that Log Note button is disabled",
+            trigger: ".o-mail-Chatter-sendMessage:enabled",
+            isCheck: true,
+        },
+    ],
+});

--- a/addons/project/tests/test_project_ui.py
+++ b/addons/project/tests/test_project_ui.py
@@ -13,3 +13,7 @@ class TestUi(odoo.tests.HttpCase):
 
     def test_01_project_tour(self):
         self.start_tour("/web", 'project_tour', login="admin")
+
+    def test_limited_user_log_note_permission(self):
+        self.start_tour('/', 'project_chatter_log_disabled', login='demo')
+        self.start_tour('/', 'project_chatter_log_enabled', login='admin')


### PR DESCRIPTION
Before this fix, users without sufficient read/write access could still click the "Log Note" button, unlike the "Send Message" button. Attempting to log a note would raise an access error, leading to a poor user experience.

This issue has already been fixed in later versions (see odoo/odoo@fc1bb984ff373f54375072a5a3cbc8585c7dfc58). This commit applies the same fix here and adds a test.

**Steps to reproduce:**

- Log as a user with User access to projects
- Open Projects
- Open the dropdown on a Project and click view
- The Send Message button should be disabled, but not the Log Note button.

opw-5090572

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
