### PR TITLE
[FIX] stock_account: fix error when journal is not set in inventory valuation

### DIFF
--- a/addons/stock_account/models/res_company.py
+++ b/addons/stock_account/models/res_company.py
@@ -53,6 +53,10 @@ class ResCompany(models.Model):
         if not aml_vals_list:
             # No account moves to create, so nothing to display.
             raise UserError(_("Everything is correctly closed"))
+        if not self.account_stock_journal_id:
+            raise UserError(self.env._("Please set the Journal for Inventory Valuation in the settings."))
+        if not self.account_stock_valuation_id:
+            raise UserError(self.env._("Please set the Valuation Account for Inventory Valuation in the settings."))
 
         moves_vals = {
             'journal_id': self.account_stock_journal_id.id,

--- a/addons/stock_account/tests/test_stockvaluationlayer.py
+++ b/addons/stock_account/tests/test_stockvaluationlayer.py
@@ -969,6 +969,7 @@ class TestStockValuationChangeValuation(TestStockValuationCommon):
             'property_stock_valuation_account_id': cls.stock_valuation_account.id,
             'property_stock_journal': cls.stock_journal.id,
         })
+        cls.env.company.account_stock_valuation_id = cls.stock_valuation_account
 
     def test_standard_manual_to_auto_1(self):
         self.product1.product_tmpl_id.categ_id.property_cost_method = 'standard'


### PR DESCRIPTION
When the journal is not set in the inventory valuation settings,
running the cron ``Stock Account: Inventory Valuation Closing`` results in a traceback.

Steps to reproduce the error:
- Install ``accountant`` and ``stock`` modules
- Go to Settings > Inventory Valuation > Periodicity: Daily >
  Unset the Journal > Save
- Run the cron ``Stock Account: Inventory Valuation Closing``

Traceback:
```py
NotNullViolation: null value in column "journal_id" of relation "account_move" violates not-null constraint
```

https://github.com/odoo/odoo/blob/4cd1ad3aa46ad4645fc7b5e530b79d53382de6d5/addons/stock_account/models/res_company.py#L57-L63
This occurs because when the journal is unset, ``journal_id`` becomes null,
leading to the above error when the cron runs.

Error also occurs when the Valuation Account is unset.

Traceback:
```py
CheckViolation: new row for relation "account_move_line" violates check constraint "account_move_line_check_accountable_required_fields"
```

sentry-6925934391

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
