### PR TITLE
[FIX] im_livechat: prevent error when clearing data in chrome

### DIFF
--- a/addons/im_livechat/static/src/core/common/expirable_storage.js
+++ b/addons/im_livechat/static/src/core/common/expirable_storage.js
@@ -22,7 +22,7 @@ function cleanupExpirableStorage() {
 const storageBus = new EventBus();
 const storageFnToWrapper = new Map();
 browser.addEventListener("storage", ({ key, newValue }) => {
-    if (key.startsWith(BASE_STORAGE_KEY)) {
+    if (key?.startsWith(BASE_STORAGE_KEY)) {
         const actualKey = key.slice(BASE_STORAGE_KEY.length);
         storageBus.trigger(actualKey, newValue ? JSON.parse(newValue).value : null);
     }


### PR DESCRIPTION
**Steps to reproduce:**

Install 'Live Chat'
Open Chrome
Log in as 'Admin'
Clear browser data

**Current behavior before PR:**

Clearing data triggers a storage event where the key parameter is null. 
An event listener attempts to call a method on this null key, leading to a runtime error.

**Desired behavior after PR is merged:**

A check has been added to ensure the key is not null, preventing the error.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
