### PR TITLE
[FIX] website: limit SVG width in highlighted text to prevent overflow

### DIFF
--- a/addons/website/static/src/scss/website_common.scss
+++ b/addons/website/static/src/scss/website_common.scss
@@ -13,5 +13,6 @@
     svg {
         z-index: -1;
         height: 1px;
+        width: 1px;
     }
 }


### PR DESCRIPTION
Steps to reproduce:
====================
1. Open Website Builder and switch to mobile screen
2. Select any word of a text
3. Apply highlight and animation

Bug:
- Page becomes scrollable to the right

Cause:
=======
SVG elements default to a `300px` `width`, which can overflow on smaller screens (e.g. mobile). This commit sets a `width` to prevent horizontal overflow. This is the link for the same issue but for vertical overflow.
https://github.com/odoo/odoo/pull/215826

Reference:
https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/width

opw-5120678
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
