### PR TITLE
[FIX] account: prevent new empty prefix in report expressions

### DIFF
--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -22,6 +22,24 @@ FIGURE_TYPE_SELECTION_VALUES = [
 DOMAIN_REGEX = re.compile(r'(-?sum)\((.*)\)')
 CROSS_REPORT_REGEX = re.compile(r'^cross_report\((.+)\)$')
 
+ACCOUNT_CODES_ENGINE_SPLIT_REGEX = re.compile(r"(?=[+-])")
+ACCOUNT_CODES_ENGINE_TERM_REGEX = re.compile(
+    r"^(?P<sign>[+-]?)"
+    r"(?P<prefix>([A-Za-z\d.]*|tag\([\w.]+\))((?=\\)|(?<=[^CD])))"
+    r"(\\\((?P<excluded_prefixes>([A-Za-z\d.]+,)*[A-Za-z\d.]*)\))?"
+    r"(?P<balance_character>[DC]?)$"
+)
+
+number_regex = r"[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?"
+report_line_code_regex = r"[+-]?[\s(]*[^().\s*/+\-]+\.[^().\s*/+\-]+"
+operator_regex = r"[\s*/+\-]"
+hard_formulas = ['sum_children']
+AGGREGATION_ENGINE_FORMULA_REGEX = re.compile(
+    f'{"|".join(hard_formulas)}|'
+    rf"[\s(]*(?:{number_regex}|{report_line_code_regex})[\s)]*"
+    rf"(?:{operator_regex}[\s(]*(?:{number_regex}|{report_line_code_regex})[\s)]*)*"
+)
+
 
 class AccountReport(models.Model):
     _name = 'account.report'
@@ -623,14 +641,32 @@ class AccountReportExpression(models.Model):
                 raise UserError(_("When targeting an expression for carryover, the label of that expression must start with _applied_carryover_"))
 
     @api.constrains('formula')
-    def _check_domain_formula(self):
-        for expression in self.filtered(lambda expr: expr.engine == 'domain'):
+    def _check_formula(self):
+        def raise_formula_error(expression):
+            raise ValidationError(_("Invalid formula for expression '%(label)s' of line '%(line)s': %(formula)s",
+                                    label=expression.label, line=expression.report_line_name,
+                                    formula=expression.formula))
+
+        expressions_by_engine = self.grouped('engine')
+        for expression in expressions_by_engine.get('domain', []):
             try:
                 domain = ast.literal_eval(expression.formula)
                 self.env['account.move.line']._search(domain)
             except:
-                raise UserError(_("Invalid domain for expression '%(label)s' of line '%(line)s': %(formula)s",
-                                label=expression.label, line=expression.report_line_name, formula=expression.formula))
+                raise_formula_error(expression)
+
+        for expression in expressions_by_engine.get('account_codes', []):
+            for token in ACCOUNT_CODES_ENGINE_SPLIT_REGEX.split(expression.formula.replace(' ', '')):
+                if token:  # e.g. if the first character of the formula is "-", the first token is ''
+                    token_match = ACCOUNT_CODES_ENGINE_TERM_REGEX.match(token)
+                    prefix = token_match['prefix']
+                    if not prefix:
+                        raise_formula_error(expression)
+
+        for expression in expressions_by_engine.get('aggregation', []):
+            if not AGGREGATION_ENGINE_FORMULA_REGEX.fullmatch(expression.formula):
+                raise_formula_error(expression)
+
 
     @api.depends('engine')
     def _compute_auditable(self):

--- a/addons/account/tests/test_account_report.py
+++ b/addons/account/tests/test_account_report.py
@@ -34,7 +34,7 @@ class TestAccountReport(AccountTestInvoicingCommon):
                         Command.create({
                             'date_scope': 'strict_range',
                             'engine': 'aggregation',
-                            'formula': 'test_line_1',
+                            'formula': 'test_line_1.balance',
                             'subformula': 'if_other_expr_above(test_line_1.balance, USD(0))',
                             'label': 'balance',
                         })
@@ -48,5 +48,5 @@ class TestAccountReport(AccountTestInvoicingCommon):
         self.assertEqual(copy.line_ids[1].code, 'test_line_2_COPY')
         # Ensure that the line 2 expression formula and subformula point to the correct code.
         expression = copy.line_ids[1].expression_ids
-        self.assertEqual(expression.formula, 'test_line_1_COPY')
+        self.assertEqual(expression.formula, 'test_line_1_COPY.balance')
         self.assertEqual(expression.subformula, 'if_other_expr_above(test_line_1_COPY.balance, USD(0))')

--- a/addons/account/tests/test_tax_report.py
+++ b/addons/account/tests/test_tax_report.py
@@ -271,7 +271,7 @@ class TaxReportTest(AccountTestInvoicingCommon):
                 Command.create({
                     'label': 'balance',
                     'engine': 'aggregation',
-                    'formula': 'Dudu',
+                    'formula': 'Dudu.balance',
                 }),
             ],
         })
@@ -281,9 +281,9 @@ class TaxReportTest(AccountTestInvoicingCommon):
 
         aggregation_line.expression_ids.engine = 'tax_tags'
 
-        tags_after = self._get_tax_tags(self.test_country_1, tag_name='Dudu')
+        tags_after = self._get_tax_tags(self.test_country_1, tag_name='Dudu.balance')
         self.assertEqual(len(tags_after), 1, "Changing the engine should have created a tag")
-        self.assertEqual(tags_after.mapped('name'), ['Dudu'])
+        self.assertEqual(tags_after.mapped('name'), ['Dudu.balance'])
 
     def test_change_engine_shared_tags(self):
         aggregation_line = self.env['account.report.line'].create({
@@ -293,7 +293,7 @@ class TaxReportTest(AccountTestInvoicingCommon):
                 Command.create({
                     'label': 'balance',
                     'engine': 'aggregation',
-                    'formula': 'Dudu',
+                    'formula': 'Dudu.balance',
                 }),
             ],
         })


### PR DESCRIPTION
Empty account code prefixes in report expressions (e.g., "12 + 13 +") unintentionally include all accounts, which can lead to duplicated amounts.

This PR raises a UserError when a newly created or modified expression includes an empty prefix.

task-id: 4975559
