### PR TITLE
[FIX] account: adapt dashboard for dark mode

### DIFF
--- a/addons/account/static/src/components/bill_guide/bill_guide.scss
+++ b/addons/account/static/src/components/bill_guide/bill_guide.scss
@@ -21,5 +21,5 @@
 .account_drag_drop_btn {
     border-style: dashed !important;
     border-color: $o-brand-primary;
-    background-color: #F2EDF0;
+    background-color: mix($o-brand-primary, $o-view-background-color, 15%);
 }

--- a/addons/account/static/src/components/upload_drop_zone/upload_drop_zone.scss
+++ b/addons/account/static/src/components/upload_drop_zone/upload_drop_zone.scss
@@ -2,7 +2,7 @@
     width: calc(100% + 2px);
     height: calc(100% + 2px);
     position: absolute;
-    background: #F2EDF0;
+    background-color: mix($o-brand-primary, $o-view-background-color, 15%);
     border: 3px dashed $o-brand-primary;
     z-index: 3;
     left: -1px;

--- a/addons/account/static/src/views/account_dashboard_kanban/account_dashboard_kanban.scss
+++ b/addons/account/static/src/views/account_dashboard_kanban/account_dashboard_kanban.scss
@@ -4,7 +4,7 @@
         border: 1px dashed $border-color;
         &.drag_to_card {
             border-color: $o-brand-primary;
-            background-color: #F2EDF0;
+            background-color: mix($o-brand-primary, $o-view-background-color, 15%);
         }
     }
 }


### PR DESCRIPTION
This commit adjusts dashboard element colors to enhance readability in dark mode.

task-5122380

| Before | After |
|--------|--------|
| <img width="665" height="336" alt="image" src="https://github.com/user-attachments/assets/c3270f8d-bd3b-47a9-807f-ca4ca5c7e6c2" /> | <img width="632" height="317" alt="Capture d’écran 2025-09-30 à 14 48 22" src="https://github.com/user-attachments/assets/d0eb8ab1-6ff7-484f-aedb-b668ba337a43" /> |
| <img width="1914" height="967" alt="image" src="https://github.com/user-attachments/assets/4d7b9c00-41b7-46a3-addb-4ec09cbbca85" /> | <img width="1916" height="922" alt="Capture d’écran 2025-09-30 à 14 48 59" src="https://github.com/user-attachments/assets/711375aa-5b01-4c81-b7ab-ba462fdbb0b6" /> |
| <img width="1716" height="953" alt="image" src="https://github.com/user-attachments/assets/a023d555-3f92-433d-a07f-dc8bb1c2513c" /> | <img width="1640" height="803" alt="Capture d’écran 2025-09-30 à 14 50 07" src="https://github.com/user-attachments/assets/26ae7b94-222d-4527-87ad-68ed55b495d0" /> |




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
