### PR TITLE
[FIX] website_sale: skip ecommerce non-existent products tags display

### DIFF
--- a/addons/website_sale/controllers/variant.py
+++ b/addons/website_sale/controllers/variant.py
@@ -55,10 +55,11 @@ class WebsiteSaleVariantController(Controller):
                 },
             )
 
-        if product and request.website.is_view_active('website_sale.product_tags'):
+        if request.website.is_view_active('website_sale.product_tags'):
+            all_tags = product.all_product_tag_ids if product else product_template.product_tag_ids
             combination_info['product_tags'] = request.env['ir.ui.view']._render_template(
                 'website_sale.product_tags', values={
-                    'all_product_tags': product.all_product_tag_ids.filtered('visible_to_customers')
+                    'all_product_tags': all_tags.filtered('visible_to_customers'),
                 }
             )
         return combination_info


### PR DESCRIPTION
## Versions
19.0+

## Issue
"Undefined" is displayed under a product' name when selecting an unavailable variant configuration.

## Steps to reproduce
- Activate variants in the Settings' App;
- Create a product with 2 attributes ("A" and "B") and 2 values ("c" and "d") for each attribute;
- Click on the "Configure" button for attribute "A":
  - Select the first value:
    - Add an exclusion line applied on the same product and value "c" of attribute "B" ("B:c").
- Go to the product's eCommerce page:
  - Select the unavailable configuration (A:c and B:c).

## Cause
A condition introduced on line https://github.com/odoo/odoo/blob/609ce29d5232707f7c6d05a7b82909cd3b09c75a/addons/website_sale/views/templates.xml#L2476 relies on `visible_tags` which is not defined because based on `product_variant.all_product_tag_ids` where `product_variant` is empty as the selected variant is archived.

opw-5145405