### PR TITLE
[IMP] html_builder, *: added tooltip to color picker

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
@@ -116,6 +116,7 @@ export class BuilderColorPicker extends Component {
         grayscales: { type: Object, optional: true },
         unit: { type: String, optional: true },
         title: { type: String, optional: true },
+        tooltip: { type: String, optional: true },
         getUsedCustomColors: { type: Function, optional: true },
         selectedTab: { type: String, optional: true },
         defaultColor: { type: String, optional: true },

--- a/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.xml
@@ -3,7 +3,7 @@
 
 <t t-name="html_builder.BuilderColorPicker">
     <BuilderComponent>
-        <button t-att-title="props.title" class="o_we_color_preview" t-ref="colorButton" t-att-style="this.getSelectedColorStyle()" />
+        <button t-att-title="props.title" class="o_we_color_preview" t-ref="colorButton" t-att-style="this.getSelectedColorStyle()" t-att-data-tooltip="this.props.tooltip or this.props.title"/>
     </BuilderComponent>
 </t>
 

--- a/addons/website/static/src/builder/plugins/theme/theme_colors_option.xml
+++ b/addons/website/static/src/builder/plugins/theme/theme_colors_option.xml
@@ -130,21 +130,25 @@
                                     <BuilderColorPicker
                                         action="'customizeWebsiteColor'"
                                         actionParam="`o-cc${preset.id}-btn-primary`"
-                                        enabledTabs="['solid', 'custom']"/>
+                                        enabledTabs="['solid', 'custom']"
+                                        tooltip.translate="Fill Color"/>
                                     <BuilderColorPicker
                                         action="'customizeWebsiteColor'"
                                         actionParam="`o-cc${preset.id}-btn-primary-border`"
-                                        enabledTabs="['solid', 'custom']"/>
+                                        enabledTabs="['solid', 'custom']"
+                                        tooltip.translate="Border Color"/>
                                 </BuilderRow>
                                 <BuilderRow label.translate="Secondary Buttons">
                                     <BuilderColorPicker
                                         action="'customizeWebsiteColor'"
                                         actionParam="`o-cc${preset.id}-btn-secondary`"
-                                        enabledTabs="['solid', 'custom']"/>
+                                        enabledTabs="['solid', 'custom']"
+                                        tooltip.translate="Fill Color"/>
                                     <BuilderColorPicker
                                         action="'customizeWebsiteColor'"
                                         actionParam="`o-cc${preset.id}-btn-secondary-border`"
-                                        enabledTabs="['solid', 'custom']"/>
+                                        enabledTabs="['solid', 'custom']"
+                                        tooltip.translate="Border Color"/>
                                 </BuilderRow>
                             </t>
                         </BuilderRow>


### PR DESCRIPTION
[*]=website

This PR introduces the _tooltip_ property on the `BuilderColorPicker` component, allowing a tooltip to be displayed when hovering over the color picker button. Additionally, the tooltip property of "Fill Color" and "Border Color" has been added to the respective color picker buttons of both the _primary_ and _secondary_ button options in the _theme_ editor's _color presets_.

task-5066118