### PR TITLE
[FIX] account: disallow modifying readonly fields

### DIFF
--- a/addons/account/models/account_bank_statement_line.py
+++ b/addons/account/models/account_bank_statement_line.py
@@ -383,7 +383,7 @@ class AccountBankStatementLine(models.Model):
     def write(self, vals):
         # OVERRIDE
 
-        res = super().write(vals)
+        res = super(AccountBankStatementLine, self.with_context(skip_readonly_check=True)).write(vals)
         self._synchronize_to_moves(set(vals.keys()))
         return res
 
@@ -423,7 +423,7 @@ class AccountBankStatementLine(models.Model):
         self.payment_ids.unlink()
 
         for st_line in self:
-            st_line.with_context(force_delete=True).write({
+            st_line.with_context(force_delete=True, skip_readonly_check=True).write({
                 'to_check': False,
                 'line_ids': [Command.clear()] + [
                     Command.create(line_vals) for line_vals in st_line._prepare_move_line_default_vals()],
@@ -840,7 +840,7 @@ class AccountBankStatementLine(models.Model):
                 st_line_vals['journal_id'] = journal.id
             if st_line.move_id.partner_id != st_line.partner_id:
                 st_line_vals['partner_id'] = st_line.partner_id.id
-            st_line.move_id.write(st_line_vals)
+            st_line.move_id.with_context(skip_readonly_check=True).write(st_line_vals)
 
 
 # For optimization purpose, creating the reverse relation of m2o in _inherits saves

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2349,6 +2349,15 @@ class AccountMove(models.Model):
                 move._check_fiscalyear_lock_date()
                 move.line_ids._check_tax_lock_date()
 
+            # Disallow modifying readonly fields on a posted move
+            move_state = vals.get('state', move.state)
+            unmodifiable_fields = (
+                'invoice_line_ids', 'line_ids', 'invoice_date', 'date', 'partner_id', 'partner_bank_id',
+                'invoice_payment_term_id', 'currency_id', 'fiscal_position_id', 'invoice_cash_rounding_id')
+            readonly_fields = [val for val in vals if val in unmodifiable_fields]
+            if not self._context.get('skip_readonly_check') and move_state == "posted" and readonly_fields:
+                raise UserError(_("You cannot modify the following readonly fields on a posted move: %s", ', '.join(readonly_fields)))
+
             if move.journal_id.sequence_override_regex and vals.get('name') and vals['name'] != '/' and not re.match(move.journal_id.sequence_override_regex, vals['name']):
                 if not self.env.user.has_group('account.group_account_manager'):
                     raise UserError(_('The Journal Entry sequence is not conform to the current format. Only the Accountant can change it.'))

--- a/addons/account/tests/test_account_bank_statement.py
+++ b/addons/account/tests/test_account_bank_statement.py
@@ -191,7 +191,7 @@ class TestAccountBankStatementLine(AccountTestInvoicingCommon):
         }])
 
         # Check the account.bank.statement.line is still correct after editing the account.move.
-        statement_line.move_id.write({'line_ids': [
+        statement_line.move_id.with_context(skip_readonly_check=True).write({'line_ids': [
             (1, liquidity_lines.id, {
                 'debit': expected_liquidity_values.get('debit', 0.0),
                 'credit': expected_liquidity_values.get('credit', 0.0),

--- a/addons/account/tests/test_account_move_entry.py
+++ b/addons/account/tests/test_account_move_entry.py
@@ -171,49 +171,9 @@ class TestAccountMove(AccountTestInvoicingCommon):
         # Editing the reference should be allowed.
         self.test_move.ref = 'whatever'
 
-        # Try to edit a line into a locked fiscal year.
-        with self.assertRaises(UserError), self.cr.savepoint():
-            self.test_move.write({
-                'line_ids': [
-                    (1, lines[0].id, {'credit': lines[0].credit + 100.0}),
-                    (1, lines[2].id, {'debit': lines[2].debit + 100.0}),
-                ],
-            })
-
         # Try to edit the account of a line.
         with self.assertRaises(UserError), self.cr.savepoint():
             self.test_move.line_ids[0].write({'account_id': self.test_move.line_ids[0].account_id.copy().id})
-
-        # Try to edit a line.
-        with self.assertRaises(UserError), self.cr.savepoint():
-            self.test_move.write({
-                'line_ids': [
-                    (1, lines[0].id, {'credit': lines[0].credit + 100.0}),
-                    (1, lines[3].id, {'debit': lines[3].debit + 100.0}),
-                ],
-            })
-
-        # Try to add a new tax on a line.
-        with self.assertRaises(UserError), self.cr.savepoint():
-            self.test_move.write({
-                'line_ids': [
-                    (1, lines[2].id, {'tax_ids': [(6, 0, self.company_data['default_tax_purchase'].ids)]}),
-                ],
-            })
-
-        # Try to create a new line.
-        with self.assertRaises(UserError), self.cr.savepoint():
-            self.test_move.write({
-                'line_ids': [
-                    (1, lines[0].id, {'credit': lines[0].credit + 100.0}),
-                    (0, None, {
-                        'name': 'revenue line 1',
-                        'account_id': self.company_data['default_account_revenue'].id,
-                        'debit': 100.0,
-                        'credit': 0.0,
-                    }),
-                ],
-            })
 
         # You can't remove the journal entry from a locked period.
         with self.assertRaises(UserError), self.cr.savepoint():
@@ -260,70 +220,8 @@ class TestAccountMove(AccountTestInvoicingCommon):
         # lines[3] = 'revenue line 2'
         lines = self.test_move.line_ids.sorted('debit')
 
-        # Try to edit a line not affecting the taxes.
-        self.test_move.write({
-            'line_ids': [
-                (1, lines[0].id, {'credit': lines[0].credit + 100.0}),
-                (1, lines[2].id, {'debit': lines[2].debit + 100.0}),
-            ],
-        })
-
         # Try to edit the account of a line.
         self.test_move.line_ids[0].write({'account_id': self.test_move.line_ids[0].account_id.copy().id})
-
-        # Try to edit a line having some taxes.
-        with self.assertRaises(UserError), self.cr.savepoint():
-            self.test_move.write({
-                'line_ids': [
-                    (1, lines[0].id, {'credit': lines[0].credit + 100.0}),
-                    (1, lines[3].id, {'debit': lines[3].debit + 100.0}),
-                ],
-            })
-
-        # Try to add a new tax on a line.
-        with self.assertRaises(UserError), self.cr.savepoint():
-            self.test_move.write({
-                'line_ids': [
-                    (1, lines[2].id, {'tax_ids': [(6, 0, self.company_data['default_tax_purchase'].ids)]}),
-                ],
-            })
-
-        # Try to edit a tax line.
-        with self.assertRaises(UserError), self.cr.savepoint():
-            self.test_move.write({
-                'line_ids': [
-                    (1, lines[0].id, {'credit': lines[0].credit + 100.0}),
-                    (1, lines[1].id, {'debit': lines[1].debit + 100.0}),
-                ],
-            })
-
-        # Try to create a line not affecting the taxes.
-        self.test_move.write({
-            'line_ids': [
-                (1, lines[0].id, {'credit': lines[0].credit + 100.0}),
-                (0, None, {
-                    'name': 'revenue line 1',
-                    'account_id': self.company_data['default_account_revenue'].id,
-                    'debit': 100.0,
-                    'credit': 0.0,
-                }),
-            ],
-        })
-
-        # Try to create a line affecting the taxes.
-        with self.assertRaises(UserError), self.cr.savepoint():
-            self.test_move.write({
-                'line_ids': [
-                    (1, lines[0].id, {'credit': lines[0].credit + 100.0}),
-                    (0, None, {
-                        'name': 'revenue line 2',
-                        'account_id': self.company_data['default_account_revenue'].id,
-                        'debit': 100.0,
-                        'credit': 0.0,
-                        'tax_ids': [(6, 0, self.company_data['default_tax_sale'].ids)],
-                    }),
-                ],
-            })
 
         # You can't remove the journal entry from a locked period.
         with self.assertRaises(UserError), self.cr.savepoint():
@@ -394,26 +292,19 @@ class TestAccountMove(AccountTestInvoicingCommon):
 
         (lines[0] + lines[2]).reconcile()
 
-        # You can't write something impacting the reconciliation on an already reconciled line.
-        with self.assertRaises(UserError), self.cr.savepoint():
-            draft_moves[0].write({
-                'line_ids': [
-                    (1, lines[1].id, {'credit': lines[1].credit + 100.0}),
-                    (1, lines[2].id, {'debit': lines[2].debit + 100.0}),
-                ]
-            })
-
-        # The write must not raise anything because the rounding of the monetary field should ignore such tiny amount.
-        draft_moves[0].write({
-            'line_ids': [
-                (1, lines[1].id, {'credit': lines[1].credit + 0.0000001}),
-                (1, lines[2].id, {'debit': lines[2].debit + 0.0000001}),
-            ]
-        })
-
         # You can't unlink an already reconciled line.
         with self.assertRaises(UserError), self.cr.savepoint():
             draft_moves.unlink()
+
+    def test_modify_posted_move_readonly_fields(self):
+        self.test_move.action_post()
+
+        readonly_fields = ('invoice_line_ids', 'line_ids', 'invoice_date', 'date', 'partner_id', 'partner_bank_id',
+                            'invoice_payment_term_id', 'currency_id', 'fiscal_position_id', 'invoice_cash_rounding_id')
+        for field in readonly_fields:
+            with self.assertRaisesRegex(UserError, "You cannot modify the following readonly fields on a posted move"), \
+                    self.cr.savepoint():
+                self.test_move.write({field: False})
 
     def test_add_followers_on_post(self):
         # Add some existing partners, some from another company

--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -2288,7 +2288,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
             reversal = move_reversal.reverse_moves()
             reverse_move = self.env['account.move'].browse(reversal['res_id'])
             if reverse_move.move_type in ('out_refund', 'in_refund'):
-                reverse_move.write({
+                reverse_move.with_context(skip_readonly_check=True).write({
                     'invoice_line_ids': [
                         Command.update(reverse_move.invoice_line_ids.id, {'price_unit': amount}),
                     ],

--- a/addons/account/tests/test_account_move_reconcile.py
+++ b/addons/account/tests/test_account_move_reconcile.py
@@ -1831,11 +1831,11 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
         })
         pay1_liquidity_line = pay1.line_ids.filtered(lambda x: x.account_id.account_type != 'asset_receivable')
         pay1_rec_line = pay1.line_ids.filtered(lambda x: x.account_id.account_type == 'asset_receivable')
-        pay1.action_post()
         pay1.write({'line_ids': [
             Command.update(pay1_liquidity_line.id, {'debit': 36511.34}),
             Command.update(pay1_rec_line.id, {'credit': 36511.34}),
         ]})
+        pay1.action_post()
 
         pay2 = self.env['account.payment'].create({
             'partner_type': 'customer',
@@ -2106,11 +2106,11 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
         })
         pay1_liquidity_line = pay1.line_ids.filtered(lambda x: x.account_id.account_type != 'asset_receivable')
         pay1_rec_line = pay1.line_ids.filtered(lambda x: x.account_id.account_type == 'asset_receivable')
-        pay1.action_post()
         pay1.write({'line_ids': [
             Command.update(pay1_liquidity_line.id, {'debit': 36511.34}),
             Command.update(pay1_rec_line.id, {'credit': 36511.34}),
         ]})
+        pay1.action_post()
 
         pay2 = self.env['account.payment'].create({
             'partner_type': 'customer',

--- a/addons/account/tests/test_account_payment_register.py
+++ b/addons/account/tests/test_account_payment_register.py
@@ -518,8 +518,8 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
             'partner_id': self.partner_a.id,
         })
 
-        self.in_invoice_1.partner_bank_id = bank1
-        self.in_invoice_2.partner_bank_id = bank2
+        self.in_invoice_1.with_context(skip_readonly_check=True).partner_bank_id = bank1
+        self.in_invoice_2.with_context(skip_readonly_check=True).partner_bank_id = bank2
 
         active_ids = (self.in_invoice_1 + self.in_invoice_2 + self.in_refund_1).ids
         payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=active_ids).create({
@@ -660,8 +660,8 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
         ''' Choose to pay multiple batches, one with two customer invoices (1000 + 2000)
          and one with a vendor bill of 600, by splitting payments.
          '''
-        self.in_invoice_1.partner_bank_id = self.partner_bank_account1
-        self.in_invoice_2.partner_bank_id = self.partner_bank_account2
+        self.in_invoice_1.with_context(skip_readonly_check=True).partner_bank_id = self.partner_bank_account1
+        self.in_invoice_2.with_context(skip_readonly_check=True).partner_bank_id = self.partner_bank_account2
 
         active_ids = (self.in_invoice_1 + self.in_invoice_2 + self.in_invoice_3).ids
         payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=active_ids).create({
@@ -1009,7 +1009,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
 
     def test_suggested_default_partner_bank_inbound_payment(self):
         """ Test the suggested bank account on the wizard for inbound payment. """
-        self.out_invoice_1.partner_bank_id = False
+        self.out_invoice_1.with_context(skip_readonly_check=True).partner_bank_id = False
 
         ctx = {'active_model': 'account.move', 'active_ids': self.out_invoice_1.ids}
         wizard = self.env['account.payment.register'].with_context(**ctx).create({})
@@ -1019,7 +1019,8 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
             'partner_bank_id': False,
         }])
 
-        self.bank_journal_2.bank_account_id = self.out_invoice_1.partner_bank_id = self.comp_bank_account2
+        self.out_invoice_1.with_context(skip_readonly_check=True).partner_bank_id = self.comp_bank_account2
+        self.bank_journal_2.bank_account_id = self.comp_bank_account2
         wizard = self.env['account.payment.register'].with_context(**ctx).create({})
         self.assertRecordValues(wizard, [{
             'journal_id': self.bank_journal_2.id,
@@ -1036,7 +1037,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
 
     def test_suggested_default_partner_bank_outbound_payment(self):
         """ Test the suggested bank account on the wizard for outbound payment. """
-        self.in_invoice_1.partner_bank_id = False
+        self.in_invoice_1.with_context(skip_readonly_check=True).partner_bank_id = False
 
         ctx = {'active_model': 'account.move', 'active_ids': self.in_invoice_1.ids}
         wizard = self.env['account.payment.register'].with_context(**ctx).create({})
@@ -1046,7 +1047,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
             'partner_bank_id': self.partner_bank_account1.id,
         }])
 
-        self.in_invoice_1.partner_bank_id = self.partner_bank_account2
+        self.in_invoice_1.with_context(skip_readonly_check=True).partner_bank_id = self.partner_bank_account2
         wizard = self.env['account.payment.register'].with_context(**ctx).create({})
         self.assertRecordValues(wizard, [{
             'journal_id': self.bank_journal_1.id,
@@ -1063,8 +1064,8 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
 
     def test_register_payment_inbound_multiple_bank_account(self):
         """ Pay customer invoices with different bank accounts. """
-        self.out_invoice_1.partner_bank_id = self.comp_bank_account1
-        self.out_invoice_2.partner_bank_id = self.comp_bank_account2
+        self.out_invoice_1.with_context(skip_readonly_check=True).partner_bank_id = self.comp_bank_account1
+        self.out_invoice_2.with_context(skip_readonly_check=True).partner_bank_id = self.comp_bank_account2
         self.bank_journal_2.bank_account_id = self.comp_bank_account2
 
         ctx = {'active_model': 'account.move', 'active_ids': (self.out_invoice_1 + self.out_invoice_2).ids}

--- a/addons/l10n_sa_edi/tests/test_edi_zatca.py
+++ b/addons/l10n_sa_edi/tests/test_edi_zatca.py
@@ -39,7 +39,7 @@ class TestEdiZatca(TestSaEdiCommon):
             self.skipTest("Sale module is not installed")
 
         def test_generated_file(move, test_file, xpath_to_apply):
-            move.write({
+            move.with_context(skip_readonly_check=True).write({
                 'invoice_date': '2022-09-05',
                 'invoice_date_due': '2022-09-22',
                 'state': 'posted',


### PR DESCRIPTION
In V16 and V17, when an invoice is in draft and opened in two tabs, it is possible to confirm the invoice in one tab, then later save changes in the other tab even though the invoice has been posted.

[A previous PR](https://github.com/odoo/odoo/pull/160096) introduced a check to prevent this behavior, but it's been limited to versions 18+.
Thus, this PR aims at replicating the fix for anterior versions.

Quotes from previous PR:

> This commit adds a check on move write function to prevent this behavior, by raising error when modifying a readonly field if the field the user is going to write in a readonly mode depending on its state.

> If by any reason it is needed to modify the readonly field through the code, instead of resetting the move to draft, writing the change, and posting it back (which can be tedious and resource heavy), we'll allow it by adding the context `skip_readonly_check=True` to skip this check.

Related enterprise PR: [96530](https://github.com/odoo/enterprise/pull/96530)

opw-5097635