### PR TITLE
[FIX] project: fix row visibility when searching or filtering by user

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -1380,10 +1380,15 @@ class Task(models.Model):
             for dom in domain:
                 if len(dom) == 3:
                     _, op, value = dom
+                    if op in ("any", "not any"):
+                        new_op = "in" if op == "any" else "not in"
+                        ids = [val[2] for val in value if isinstance(val, (tuple, list)) and isinstance(val[2], int)]
+                        new_domain.append(("id", new_op, ids))
+                        continue
                     op = "ilike" if op == "child_of" else op
                     if isinstance(value, list) and all(isinstance(val, int) for val in value):
                         new_domain.append(("id", op, value))
-                    if isinstance(value, str) or (isinstance(value, list) and not all(isinstance(val, str) for val in value)):
+                    elif isinstance(value, str) or (isinstance(value, list) and not all(isinstance(val, str) for val in value)):
                         new_domain.append(("name", op, value))
                     if isinstance(value, int):
                         if op == "=":


### PR DESCRIPTION
**Steps to reproduce:**
Go to Project
Go to  All Tasks.
Switch to the Gantt view.
Search for an assignee who has no tasks assigned.

**Cause:**
The method was adding multiple conditions for the same field because both if statements were being applied.
This made the domain incorrect when searching for users or custom filter on user

**Issue:**
The searched user’s row did not appear in the gantt view if they had no tasks.

**Fix:**
Changed the second if to elif so only one condition is applied at a time, ensuring the correct domain is used and the user row is visible.

Task-5076701





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
