### PR TITLE
[IMP] account_peppol: peppol status verification partner on eCommerce orders

### DIFF
--- a/addons/sale/models/payment_transaction.py
+++ b/addons/sale/models/payment_transaction.py
@@ -163,10 +163,7 @@ class PaymentTransaction(models.Model):
                 if mail_template.exists():
                     send_context['mail_template'] = mail_template
 
-            tx.env['account.move.send']._generate_and_send_invoices(
-                invoice_to_send,
-                **send_context,
-            )
+            invoice_to_send._generate_and_send(**send_context)
 
     def _cron_send_invoice(self):
         """


### PR DESCRIPTION
### PURPOSE
 - While an order is created from the e-commerce website and The automatic invoice is on.
 - The people status of the newly created partner is not verified in invoices.
 - This may lead to inconsistent user behavior if users want to send invoices in a batch to peppol.

### SPECIFICATION
 - Added the functionality that if
    - Invoice is generated from the eCommerce
    - Automatic invoice is enabled.
 - than auto-verify the peppol status of the partner.

task-5025176