### PR TITLE
[FIX] hr_recruitment_skill: prevent ZeroDivisionError in job_total

### DIFF
--- a/addons/hr_recruitment_skills/models/hr_applicant.py
+++ b/addons/hr_recruitment_skills/models/hr_applicant.py
@@ -69,7 +69,7 @@ class HrApplicant(models.Model):
 
             matching_skill_ids = matching_applicant_skills.mapped("skill_id")
             missing_skill_ids = job_skills.mapped("skill_id") - matching_applicant_skills.mapped("skill_id")
-            matching_score = round(applicant_total / job_total * 100)
+            matching_score = round(applicant_total / job_total * 100) if job_total else 100
 
             applicant.matching_skill_ids = matching_skill_ids
             applicant.missing_skill_ids = missing_skill_ids


### PR DESCRIPTION
**Traceback :**
```
File "/home/odoo/src/odoo/19.0/addons/hr_recruitment_skills/models/
hr_applicant.py", line 72, in _compute_matching_skill_ids
  matching_score = round(applicant_total / job_total * 100)
ZeroDivisionError: float division by zero
```

**Steps to Reproduce:**
- Install recruitment app.
- For any job position, select all expected skill level such that level_progress
  is 0 and no expected degree .

**Description:**
- While calculating matching score for applicants here 
https://github.com/odoo/odoo/blob/19.0/addons/hr_recruitment_skills/models/hr_applicant.py#L72
a ZeroDivisionError occurs if 'job_total' is zero.

- This situation occured because in 19 version new feature to calculate applicants 
matching score was introduced in https://github.com/odoo/odoo/commit/164b55c324e63c45339088823e3d55dfe2147b61
and job_degree,applicant_degree, level_progress in skills for job and applicants 
were not present in older versions making job_total as 0 causing above traceback

- This commit adds a safety check to ensure the division only occurs
if 'job_total' is non-zero . and if job_total is 0 , there is no expectation 
required for this position which makes matching score 100 .
