### PR TITLE
[FIX] mrp: workorder duration inverse matching compute logic

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -341,7 +341,7 @@ class MrpWorkorder(models.Model):
     @api.depends('time_ids.duration', 'qty_produced')
     def _compute_duration(self):
         for order in self:
-            order.duration = sum(order.time_ids.mapped('duration'))
+            order.duration = order.get_duration()
             order.duration_unit = round(order.duration / max(order.qty_produced, 1), 2)  # rounding 2 because it is a time
             if order.duration_expected:
                 order.duration_percent = max(-2147483648, min(2147483647, 100 * (order.duration_expected - order.duration) / order.duration_expected))
@@ -356,7 +356,7 @@ class MrpWorkorder(models.Model):
             return minutes * 60 + seconds
 
         for order in self:
-            old_order_duration = sum(order.time_ids.mapped('duration'))
+            old_order_duration = order.get_duration()
             new_order_duration = order.duration
             if new_order_duration == old_order_duration:
                 continue
@@ -928,8 +928,9 @@ class MrpWorkorder(models.Model):
         """Get the additional duration for 'open times' i.e. productivity lines with no date_end."""
         self.ensure_one()
         duration = 0
+        now = self.env.cr.now()
         for time in self.time_ids.filtered(lambda time: not time.date_end):
-            duration += (datetime.now() - time.date_start).total_seconds() / 60
+            duration += (now - time.date_start).total_seconds() / 60
         return duration
 
     def get_duration(self):


### PR DESCRIPTION
Issue:

In this bug, workorder duration inverse is causing some time_ids to be deleted.

To reproduce:
1- Create a db with mrp installed, and enable work orders in Setting
2- Create a MO, and confirm it
3- Add a new work order to the MO
4- Add two time tracking lines:
   - First one 10:00 -> 12:00
   - Second one 10:00 -> 11:00
    
5- As you see, duration reflects duration of first line as it is the interval duration
6- Save and close work center form. Then save MO form.
7- Open work orders again: As you see second line is unlinked

Cause:

The reason to this bug, is because in Enterprise, the `_compute_duration` override changes the logic of how duration is computed but the inverse function doesn't reflect the same logic.

To be specific this is the compute function override:
https://github.com/odoo/enterprise/blob/3cbe2bbbfd989a3daaa32769a843aeaa09c7ed3e/mrp_workorder/models/mrp_workorder.py#L757-L766

In which duration is calculated using get_duration:
https://github.com/odoo/enterprise/blob/3cbe2bbbfd989a3daaa32769a843aeaa09c7ed3e/mrp_workorder/models/mrp_workorder.py#L828-L837

Which doesn't sum the durations, but calculates the intervals duration counting overlaps only once.

However, there is no override of inverse method in Enterprise, meaning that the logic behind inverse will not match with this logic. In the inverse it is assumed duration is sum of all time_ids intervals:
https://github.com/odoo/odoo/blob/9b286285a6c66bc2d629eacf651c3439cffb55cc/addons/mrp/models/mrp_workorder.py#L355-L400

As a result, if time_ids overlap:
new_order_duration < old_order_duration

As a result some time_ids will be unlinked and some will have duration changed.

Fix:

Inside the inverse function in Community we can do:
```diff
+ old_order_duration = order.get_duration()
- sum(order.time_ids.mapped('duration'))
```

As get_duration in Odoo Community is:
https://github.com/odoo/odoo/blob/9b286285a6c66bc2d629eacf651c3439cffb55cc/addons/mrp/models/mrp_workorder.py#L889-L899

The order.get_duration will be sum of duration of all time_ids in community, hence the logic will be unchanged.

In Enterprise, this is going to reflect the logic implemented in override of get_duration, as a result the duration logic will be consistent in compute and inverse function.


opw-5082477
