### PR TITLE
[FIX] hr: don't track unsupported Html field

### DIFF
--- a/addons/hr/models/hr_version.py
+++ b/addons/hr/models/hr_version.py
@@ -127,7 +127,7 @@ class HrVersion(models.Model):
 
     departure_reason_id = fields.Many2one("hr.departure.reason", string="Departure Reason",
                                           groups="hr.group_hr_user", copy=False, ondelete='restrict', tracking=True)
-    departure_description = fields.Html(string="Additional Information", groups="hr.group_hr_user", copy=False, tracking=True)
+    departure_description = fields.Html(string="Additional Information", groups="hr.group_hr_user", copy=False)
     departure_date = fields.Date(string="Departure Date", groups="hr.group_hr_user", copy=False, tracking=True)
 
     resource_calendar_id = fields.Many2one('resource.calendar', inverse='_inverse_resource_calendar_id', check_company=True, string="Working Hours", tracking=True)

--- a/addons/hr/tests/test_hr_version.py
+++ b/addons/hr/tests/test_hr_version.py
@@ -650,7 +650,7 @@ class TestHrVersion(TransactionCase):
                 continue
             if hasattr(field, 'store') and field.store is False:
                 continue
-            if not (hasattr(field, 'tracking') and field.tracking):
+            if hasattr(field, 'tracking') and not field.tracking:
                 fields_without_tracking.append(field_name)
 
         self.assertFalse(


### PR DESCRIPTION
Html fields are not part of the supported fields for tracking, see https://github.com/odoo/odoo/blob/11289fd128827587f6ed3fc5beed28f461c0e039/addons/mail/models/mail_tracking_value.py#L49 This causes a traceback when saving the `departure_description` on an archived employee.
Added in https://github.com/odoo/odoo/commit/aa4d13b89b4497d2e5b33faa49ad86e0788782a2

Previous related fix: 9b723e2591224f2b563924d3b3dfe27ab909b7d0

opw-5140525
