### PR TITLE
[FIX] web: browser back on invalid form doesn't lock ui

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -1450,7 +1450,7 @@ export function makeActionManager(env, router = _router) {
                         pick(options, "forceLeave")
                     );
                     if (!canProceed) {
-                        return new Promise(() => {});
+                        return;
                     }
                 }
                 return _executeActWindowAction(action, options);


### PR DESCRIPTION
Be in an invalid form view and do browser back. The form view can't be saved as it is invalid, so it can't be left. Before this commit, the body was `pointer-events: none`, i.e. the user couldn't interact with the webclient anymore.

This is due to a code in webclient.js, which listens to the `ROUTE_CHANGE` event and calls `loadState`. PR [1] prevented the user to interact with the UI during the state loading, as it could lead to weird side-effects. To achieve this, it set the `point-events: none` rule on the body, and reset it once the promise returned by loadState was fullfilled.

Unfortunately, in the above mentionned case, loadState returned a promise that was left pending forever, leading to a fully locked webclient. This commit fixes the issue by returning nothing, like we already do in other similar cases in the action service, when the requested action can't be executed.

[1] https://github.com/odoo/odoo/pull/205290

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
