### PR TITLE
[FIX] stock: reserve on quants at quantity increase

### DIFF
--- a/addons/mrp/static/tests/tours/mrp_sm_sml_synchronization.js
+++ b/addons/mrp/static/tests/tours/mrp_sm_sml_synchronization.js
@@ -48,7 +48,7 @@ registry.category("web_tour.tours").add('test_manufacturing_and_byproduct_sm_to_
         },
         {
             trigger: ".modal .modal-body .o_field_widget[name=quantity] input",
-            run: 'edit 27',
+            run: 'edit 25',
         },
         {
             content: "Click Save",
@@ -56,7 +56,7 @@ registry.category("web_tour.tours").add('test_manufacturing_and_byproduct_sm_to_
             run: "click",
         },
         {
-            trigger: ".o_data_row > td:contains('43')",
+            trigger: ".o_data_row:has([name=product_uom_qty]:contains(5.00)) > td:contains(25)",
             run: "click",
         },
         {

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -980,28 +980,6 @@ class TestMrpOrder(TestMrpCommon):
         mo.button_mark_done()
         self.assertEqual(mo.state, 'done')
 
-    def test_product_produce_9(self):
-        """ Checks the production wizard contains lines even for untracked products. """
-        serial = self.env['product.product'].create({
-            'name': 'S1',
-            'tracking': 'serial',
-        })
-        mo, bom, p_final, p1, p2 = self.generate_mo()
-        self.assertEqual(len(mo), 1, 'MO should have been created')
-
-        self.env['stock.quant']._update_available_quantity(p1, self.stock_location, 100)
-        self.env['stock.quant']._update_available_quantity(p2, self.stock_location, 5)
-
-        mo.action_assign()
-        mo_form = Form(mo)
-
-        # change the quantity done in one line
-        with self.assertRaises(AssertionError):
-            with mo_form.move_raw_ids.new() as move:
-                move.product_id = serial
-                move.quantity = 2
-            mo_form.save()
-
     def test_product_produce_10(self):
         """ Produce byproduct with serial, lot and not tracked.
         byproduct1 serial 1.0

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -452,7 +452,6 @@
                                         decoration-info="manual_consumption"
                                         decoration-muted="not manual_consumption"
                                         decoration-bf="manual_consumption"
-                                        readonly="has_tracking != 'none'"
                                         force_save="1"/>
                                     <field name="product_uom" readonly="state != 'draft' and id" options="{'no_open': True, 'no_create': True}" groups="uom.group_uom" widget="many2one_uom"/>
                                     <field name="picked" column_invisible="True"/>

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -2275,44 +2275,82 @@ Please change the quantity done or the rounding precision in your settings.""",
             return []
 
     def _set_quantity_done_prepare_vals(self, qty):
+        def _move_qty(qty):
+            return self.product_id.uom_id._compute_quantity(qty, self.product_uom, round=False)
+
+        self.ensure_one()
         res = []
+        qty = self.product_uom._compute_quantity(qty, self.product_id.uom_id, round=False)
+        total_qty = qty
+        consumed_quant = set()
         for ml in self.move_line_ids:
             ml_qty = ml.quantity
-            if self.product_uom.is_zero(qty):
-                res.append((2, ml.id))
+            if ml.product_uom_id.compare(ml_qty, 0) < 0:
                 continue
-            if (qty_comparison := ml.product_uom_id.compare(ml_qty, 0)) < 0:
-                continue
-            elif qty_comparison == 0:
-                # Convert qty into move line uom
-                if ml.product_uom_id != self.product_uom:
-                    qty = self.product_uom._compute_quantity(qty, ml.product_uom_id, round=False)
-                return [Command.update(ml.id, {'quantity': qty})]
-            # Convert move line qty into move uom
-            if ml.product_uom_id != self.product_uom:
-                ml_qty = ml.product_uom_id._compute_quantity(ml_qty, self.product_uom, round=False)
 
+            if ml.product_uom_id != self.product_id.uom_id:
+                ml_qty = ml.product_uom_id._compute_quantity(ml_qty, self.product_id.uom_id, round=False)
+
+            if self.product_uom.is_zero(_move_qty(qty)):
+                res.append(Command.delete(ml.id))
+                continue
+
+            if ml.product_id.uom_id.compare(ml_qty, qty) > 0:
+                if ml.product_uom_id != self.product_id.uom_id:
+                    qty = ml.product_id.uom_id._compute_quantity(qty, ml.product_uom_id, round=False)
+                res.append(Command.update(ml.id, {'quantity': qty}))
+                qty = 0
+                continue
+
+            if ml.result_package_id:
+                qty -= ml_qty
+                continue
+            # remove what already on the line
             taken_qty = min(qty, ml_qty)
-            # Convert taken qty into move line uom
-            if ml.product_uom_id != self.product_uom:
-                taken_qty = self.product_uom._compute_quantity(taken_qty, ml.product_uom_id, round=False)
-
-            # Assign qty_done and explicitly round to make sure there is no inconsistency between
-            # ml.qty_done and qty.
-            taken_qty = ml.product_uom_id.round(taken_qty)
-            res.append((1, ml.id, {'quantity': taken_qty}))
-            if ml.product_uom_id != self.product_uom:
-                taken_qty = ml.product_uom_id._compute_quantity(taken_qty, self.product_uom, round=False)
             qty -= taken_qty
+            if self.product_uom.compare(_move_qty(qty), 0) <= 0:
+                continue
 
-        if self.product_uom.compare(qty, 0.0) > 0:
+            # find a quant similar to the move line on which we can reserve
+            ml_quants = self.env['stock.quant']._get_reserve_quantity(self.product_id,
+                                                                      ml.location_id,
+                                                                      qty,
+                                                                      lot_id=ml.lot_id,
+                                                                      package_id=ml.package_id,
+                                                                      owner_id=ml.owner_id,
+                                                                      strict=True)
+            avail_qty = sum(q[1] for q in ml_quants)
+            # the quant did not add the quantity reserved on this specific move line
+            consumed_quant |= {q[0].id for q in ml_quants}
+            if self.product_uom.compare(avail_qty, qty) <= 0:
+                qty -= avail_qty  # decrease the target quantity for the next move lines
+                avail_qty += ml_qty  # add the actual move line quantity as we will update it and not `+=` it
+                if ml.product_uom_id != self.product_id.uom_id:
+                    avail_qty = ml.product_id.uom_id._compute_quantity(avail_qty, ml.product_uom_id, round=False)
+                res.append(Command.update(ml.id, {'quantity': avail_qty}))
+
+        # First reserve on quants
+        if self.product_uom.compare(_move_qty(qty), 0.0) > 0:
+            quants = self.env['stock.quant']._get_reserve_quantity(self.product_id, self.location_id, total_qty)
+            for quant, avail_qty in quants:
+                if quant.id in consumed_quant:
+                    continue
+                # compare the stock move quantity with the product free quantity
+                taken_qty = min(qty, avail_qty)
+                qty -= taken_qty
+                res.append(Command.create(self._prepare_move_line_vals(quantity=taken_qty, reserved_quant=quant)))
+                if self.product_id.uom_id.compare(_move_qty(qty), 0.0) <= 0:
+                    break
+
+        # If quant is not enough, create a(some) move lines from the move itself
+        if self.product_uom.compare(_move_qty(qty), 0.0) > 0:
             if self.product_id.tracking != 'serial':
+                qty = _move_qty(qty)
                 vals = self._prepare_move_line_vals(quantity=0)
                 vals['quantity'] = qty
                 res.append((0, 0, vals))
             else:
-                uom_qty = self.product_uom._compute_quantity(qty, self.product_id.uom_id)
-                for _i in range(0, int(uom_qty)):
+                for _i in range(0, int(qty)):
                     vals = self._prepare_move_line_vals(quantity=0)
                     vals['quantity'] = 1
                     vals['product_uom_id'] = self.product_id.uom_id.id

--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -2008,6 +2008,46 @@ class TestStockMove(TestStockCommon):
         move_partial._action_assign()
         self.assertEqual(move_partial.state, 'assigned')
 
+    def test_availability_10(self):
+        """ test the reservation is taken into account when updating the quantity on a move."""
+        # make some stock
+        lot1, lot2, lot3 = self.env['stock.lot'].create([{
+            'name': 'lot%s' % str(i),
+            'product_id': self.product_lot.id,
+        } for i in range(1, 4)])
+        pack = self.env['stock.package'].create({'name': 'pack'})
+        self.env['stock.quant']._update_available_quantity(self.product_lot, self.shelf_1, 3, lot_id=lot1)
+        self.env['stock.quant']._update_available_quantity(self.product_lot, self.shelf_2, 3, lot_id=lot2)
+        self.env['stock.quant']._update_available_quantity(self.product_lot, self.shelf_1, 1, lot_id=lot3)
+        self.env['stock.quant']._update_available_quantity(self.product_lot, self.shelf_2, 3, lot_id=lot2, package_id=pack)
+
+        move = self.env['stock.move'].create({
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+            'product_id': self.product_lot.id,
+            'product_uom': self.product_lot.uom_id.id,
+            'product_uom_qty': 1.0,
+        })
+
+        move._action_confirm()
+        move._action_assign()
+        self.assertRecordValues(move.move_line_ids, [
+            {'quantity': 1.0, 'location_id': self.shelf_1.id, 'lot_id': lot1.id, 'package_id': False},
+        ])
+
+        move.quantity = 8.0
+        self.assertRecordValues(move.move_line_ids, [
+            {'quantity': 3.0, 'location_id': self.shelf_1.id, 'lot_id': lot1.id, 'package_id': False},
+            {'quantity': 3.0, 'location_id': self.shelf_2.id, 'lot_id': lot2.id, 'package_id': False},
+            {'quantity': 1.0, 'location_id': self.shelf_1.id, 'lot_id': lot3.id, 'package_id': False},
+            {'quantity': 1.0, 'location_id': self.shelf_2.id, 'lot_id': lot2.id, 'package_id': pack.id},
+        ])
+
+        move.quantity = 3.0
+        self.assertRecordValues(move.move_line_ids, [
+            {'quantity': 3.0, 'location_id': self.shelf_1.id, 'lot_id': lot1.id, 'package_id': False},
+        ])
+
     def test_past_quantity(self):
         """Test the quantity is correct when looking in the past."""
         # make some stock

--- a/addons/stock/tests/test_move2.py
+++ b/addons/stock/tests/test_move2.py
@@ -2547,6 +2547,60 @@ class TestSinglePicking(TestStockCommon):
             ('Shell 2', 'LOT004', 2.0),
         ])
 
+    def test_unreservation_on_qty_decrease_2(self):
+        """
+        Check that the move_lines are unreserved correctly when decreasing quantity via
+        internal method `_set_quantity_done_prepare_vals`
+        """
+        packages = self.env['stock.package'].create([
+            {'name': 'pack1'}, {'name': 'pack2'},
+        ])
+        self.env['stock.quant']._update_available_quantity(self.productA, self.stock_location, 3, package_id=packages[0])
+        self.env['stock.quant']._update_available_quantity(self.productA, self.stock_location, 2, package_id=packages[1])
+
+        move = self.env['stock.move'].create({
+            'product_id': self.productA.id,
+            'product_uom_qty': 10,
+            'product_uom': self.productA.uom_id.id,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+            'picking_type_id': self.picking_type_out.id,
+            })
+        move._action_confirm()
+        move._action_assign()
+        self.assertEqual(move.quantity, 5)
+        move.move_line_ids = move._set_quantity_done_prepare_vals(1)
+        self.assertRecordValues(move.move_line_ids, [{
+            'quantity': 1, 'result_package_id': packages[0].id,
+        }])
+
+    def test_unreservation_on_qty_decrease_3(self):
+        """
+        Check that the move_lines are unreserved correctly when decreasing quantity via
+        internal method `_set_quantity_done_prepare_vals`
+        """
+        packages = self.env['stock.package'].create([
+            {'name': 'pack1'},
+        ])
+        self.env['stock.quant']._update_available_quantity(self.productA, self.stock_location, 3, package_id=packages[0])
+        self.env['stock.quant']._update_available_quantity(self.productA, self.stock_location, 2)
+
+        move = self.env['stock.move'].create({
+            'product_id': self.productA.id,
+            'product_uom_qty': 10,
+            'product_uom': self.productA.uom_id.id,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+            'picking_type_id': self.picking_type_out.id,
+            })
+        move._action_confirm()
+        move._action_assign()
+        self.assertEqual(move.quantity, 5)
+        move.move_line_ids = move._set_quantity_done_prepare_vals(1)
+        self.assertRecordValues(move.move_line_ids, [{
+            'quantity': 1, 'result_package_id': packages[0].id,
+        }])
+
     def test_onchange_picking_locations(self):
         """
         Check that changing the location/destination of a picking propagets the info

--- a/addons/stock_picking_batch/static/tests/tours/stock_picking_batch_tour.js
+++ b/addons/stock_picking_batch/static/tests/tours/stock_picking_batch_tour.js
@@ -41,7 +41,7 @@ registry.category("web_tour.tours").add("test_stock_picking_batch_sm_to_sml_sync
         },
         {
             trigger:
-                ".modal:contains(detailed operations) .o_list_footer .o_list_number > span:contains('8')",
+                ".modal:contains(detailed operations) .o_list_footer .o_list_number > span:contains('7')",
         },
         {
             content: "Click Save",
@@ -81,7 +81,7 @@ registry.category("web_tour.tours").add("test_stock_picking_batch_sm_to_sml_sync
         },
         {
             content: "Click in cell to start edition",
-            trigger: ".modal:contains(open: transfers) .o_data_row > td:contains(46)",
+            trigger: ".modal:contains(open: transfers) .o_data_row > td:contains(27)",
             run: "click",
         },
         {


### PR DESCRIPTION
Increasing the quantity of a stock move will create a move line with the same data as the stock move (location and product), no lot, nor package.

This commit make the increase of quantity mimic the reservation process by getting first the available quants. The move line are then created accordingly.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
