### PR TITLE
[FIX] stock_account: fifo move val incorrect on neg

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -333,8 +333,8 @@ class ProductProduct(models.Model):
             quantity -= in_qty
         # When we required more quantity than available we extrapolate with the last known price
         if quantity > 0:
-            if last_move:
-                fifo_cost += quantity * last_move.value
+            if last_move and last_move.quantity:
+                fifo_cost += quantity * (last_move.value / last_move.quantity)
             else:
                 fifo_cost += quantity * self.standard_price
         return fifo_cost


### PR DESCRIPTION
Before this commit:

If there are not enough FIFO in valuations, (i.e. going -ve) the extra value comes from the last known move.

But we should not use the whole move value - just the unit value from it.

After this commit:

The move value is made a unit before multiplying.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
