### PR TITLE
[REF] iot_drivers: use constant for IoT identifier

### DIFF
--- a/addons/iot_drivers/connection_manager.py
+++ b/addons/iot_drivers/connection_manager.py
@@ -7,6 +7,7 @@ import time
 
 from odoo.addons.iot_drivers.main import iot_devices, manager
 from odoo.addons.iot_drivers.tools import helpers, upgrade, wifi
+from odoo.addons.iot_drivers.tools.helpers import IOT_IDENTIFIER
 from odoo.addons.iot_drivers.tools.system import IS_RPI, IS_TEST
 
 _logger = logging.getLogger(__name__)
@@ -68,7 +69,7 @@ class ConnectionManager(Thread):
             'params': {
                 'pairing_code': self.pairing_code,
                 'pairing_uuid': self.pairing_uuid,
-                'serial_number': helpers.get_identifier(),
+                'serial_number': IOT_IDENTIFIER,
             }
         }
 

--- a/addons/iot_drivers/controllers/homepage.py
+++ b/addons/iot_drivers/controllers/homepage.py
@@ -166,7 +166,7 @@ class IotBoxOwlHomePage(http.Controller):
             'db_uuid': helpers.get_conf('db_uuid'),
             'enterprise_code': helpers.get_conf('enterprise_code'),
             'ip': helpers.get_ip(),
-            'identifier': helpers.get_identifier(),
+            'identifier': helpers.IOT_IDENTIFIER,
             'mac_address': helpers.get_mac_address(),
             'devices': grouped_devices,
             'server_status': odoo_server_url,

--- a/addons/iot_drivers/event_manager.py
+++ b/addons/iot_drivers/event_manager.py
@@ -4,7 +4,7 @@ from threading import Event
 import time
 
 from odoo.http import request
-from odoo.addons.iot_drivers.tools import helpers
+from odoo.addons.iot_drivers.tools.helpers import IOT_IDENTIFIER
 from odoo.addons.iot_drivers.webrtc_client import webrtc_client
 from odoo.addons.iot_drivers.websocket_client import send_to_controller
 
@@ -64,7 +64,7 @@ class EventManager:
         send_to_controller({
             **event,
             'session_id': data.get('action_args', {}).get('session_id', ''),
-            'iot_box_identifier': helpers.get_identifier(),
+            'iot_box_identifier': IOT_IDENTIFIER,
             **data,
         })
         webrtc_client.send(event)

--- a/addons/iot_drivers/iot_handlers/drivers/display_driver_L.py
+++ b/addons/iot_drivers/iot_handlers/drivers/display_driver_L.py
@@ -13,7 +13,7 @@ from odoo.addons.iot_drivers.browser import Browser, BrowserState
 from odoo.addons.iot_drivers.driver import Driver
 from odoo.addons.iot_drivers.main import iot_devices
 from odoo.addons.iot_drivers.tools import helpers, route
-from odoo.addons.iot_drivers.tools.helpers import Orientation
+from odoo.addons.iot_drivers.tools.helpers import Orientation, IOT_IDENTIFIER
 
 _logger = logging.getLogger(__name__)
 
@@ -79,7 +79,7 @@ class DisplayDriver(Driver):
         :return: URL to display or None.
         """
         try:
-            response = requests.get(f"{server_url}/iot/box/{helpers.get_identifier()}/display_url", timeout=5)
+            response = requests.get(f"{server_url}/iot/box/{IDENTIFIER}/display_url", timeout=5)
             response.raise_for_status()
             data = json.loads(response.content.decode())
             return data.get(self.device_identifier)

--- a/addons/iot_drivers/iot_handlers/drivers/printer_driver_L.py
+++ b/addons/iot_drivers/iot_handlers/drivers/printer_driver_L.py
@@ -109,7 +109,7 @@ class PrinterDriver(PrinterDriverBase):
 
     @classmethod
     def _get_iot_status(cls):
-        identifier = helpers.get_identifier()
+        identifier = helpers.IOT_IDENTIFIER
         mac_address = helpers.get_mac_address()
         pairing_code = connection_manager.pairing_code
         ssid = wifi.get_access_point_ssid() if wifi.is_access_point() else wifi.get_current()

--- a/addons/iot_drivers/main.py
+++ b/addons/iot_drivers/main.py
@@ -10,6 +10,7 @@ from odoo.addons.iot_drivers.tools import certificate, helpers, upgrade, wifi
 from odoo.addons.iot_drivers.tools.system import IS_RPI
 from odoo.addons.iot_drivers.websocket_client import WebsocketClient
 
+
 if IS_RPI:
     from dbus.mainloop.glib import DBusGMainLoop
     DBusGMainLoop(set_as_default=True)  # Must be started from main thread
@@ -28,7 +29,7 @@ class Manager(Thread):
 
     def __init__(self):
         super().__init__()
-        self.identifier = helpers.get_identifier()
+        self.identifier = helpers.IOT_IDENTIFIER
         self.domain = self._get_domain()
         self.version = helpers.get_version(detailed_version=True)
         self.previous_iot_devices = {}

--- a/addons/iot_drivers/server_logger.py
+++ b/addons/iot_drivers/server_logger.py
@@ -70,7 +70,7 @@ class AsyncHTTPHandler(logging.Handler):
             return convert_to_byte(f"{log_level},{line_formatted}")
 
         def empty_queue():
-            yield convert_to_byte(f"identifier {helpers.get_identifier()}")
+            yield convert_to_byte(f"identifier {helpers.IOT_IDENTIFIER}")
             for _ in range(self._MAX_BATCH_SIZE):
                 # Use a limit to avoid having too heavy requests & infinite loop of the queue receiving new entries
                 try:

--- a/addons/iot_drivers/tools/certificate.py
+++ b/addons/iot_drivers/tools/certificate.py
@@ -7,12 +7,12 @@ from pathlib import Path
 
 from odoo.addons.iot_drivers.tools.helpers import (
     get_conf,
-    get_identifier,
     get_path_nginx,
     odoo_restart,
     require_db,
     start_nginx_server,
     update_conf,
+    IOT_IDENTIFIER,
 )
 from odoo.addons.iot_drivers.tools.system import IS_RPI, IS_TEST, IS_WINDOWS
 
@@ -135,7 +135,7 @@ def inform_database(ssl_certificate_end_date, server_url=None):
     try:
         response = requests.post(
             server_url + "/iot/box/update_certificate_status",
-            json={'params': {'identifier': get_identifier(), 'ssl_certificate_end_date': ssl_certificate_end_date}},
+            json={'params': {'identifier': IOT_IDENTIFIER, 'ssl_certificate_end_date': ssl_certificate_end_date}},
             timeout=5,
         )
         response.raise_for_status()

--- a/addons/iot_drivers/tools/wifi.py
+++ b/addons/iot_drivers/tools/wifi.py
@@ -13,7 +13,7 @@ import time
 from pathlib import Path
 from functools import cache
 
-from .helpers import get_ip, get_identifier, get_conf
+from .helpers import get_ip, get_conf, IOT_IDENTIFIER
 
 _logger = logging.getLogger(__name__)
 
@@ -221,7 +221,7 @@ def get_access_point_ssid():
     :return: Generated SSID
     :rtype: str
     """
-    return "IoTBox-" + get_identifier() or secrets.token_hex(8)
+    return "IoTBox-" + IOT_IDENTIFIER or secrets.token_hex(8)
 
 
 def _configure_access_point(on=True):

--- a/addons/iot_drivers/websocket_client.py
+++ b/addons/iot_drivers/websocket_client.py
@@ -11,6 +11,7 @@ from threading import Thread
 
 from odoo.addons.iot_drivers import main
 from odoo.addons.iot_drivers.tools import helpers
+from odoo.addons.iot_drivers.tools.helpers import IOT_IDENTIFIER
 from odoo.addons.iot_drivers.server_logger import close_server_log_sender_handler
 from odoo.addons.iot_drivers.webrtc_client import webrtc_client
 
@@ -51,7 +52,7 @@ class WebsocketClient(Thread):
             'data': {
                 'channels': [self.channel],
                 'last': self.last_message_id,
-                'identifier': helpers.get_identifier(),
+                'identifier': IOT_IDENTIFIER,
             }
         }))
 
@@ -62,7 +63,7 @@ class WebsocketClient(Thread):
             self.last_message_id = message['id']
             payload = message['message']['payload']
 
-            if not helpers.get_identifier() in payload.get('iot_identifiers', []):
+            if not IOT_IDENTIFIER in payload.get('iot_identifiers', []):
                 continue
 
             match message['message']['type']:
@@ -75,7 +76,7 @@ class WebsocketClient(Thread):
                             # Notify the controller that the device is not connected
                             send_to_controller({
                                 'session_id': payload.get('session_id', '0'),
-                                'iot_box_identifier': helpers.get_identifier(),
+                                'iot_box_identifier': IOT_IDENTIFIER,
                                 'device_identifier': device_identifier,
                                 'status': 'disconnected',
                             })
@@ -93,7 +94,7 @@ class WebsocketClient(Thread):
                 case 'webrtc_offer':
                     answer = webrtc_client.offer(payload['offer'])
                     send_to_controller({
-                        'iot_box_identifier': helpers.get_identifier(),
+                        'iot_box_identifier': IOT_IDENTIFIER,
                         'answer': answer,
                     }, method="webrtc_answer")
                 case 'remote_debug':
@@ -104,7 +105,7 @@ class WebsocketClient(Thread):
                         time.sleep(1)
                     send_to_controller({
                         'session_id': 0,
-                        'iot_box_identifier': helpers.get_identifier(),
+                        'iot_box_identifier': IOT_IDENTIFIER,
                         'device_identifier': None,
                         'status': 'success',
                         'result': {'enabled': helpers.is_ngrok_enabled()}


### PR DESCRIPTION
As the IoT identifier is a serial number or a motherboard uuid, it is not meant to change.
It then makes more sense for it to be a constant as `IS_WINDOWS` or `IS_LINUX` are.

Enterprise PR: odoo/enterprise#96549
Task: 5149362