### PR TITLE
[FIX] hr_holidays : Use request_date_to and request_date_from to check dates

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -434,7 +434,7 @@ class HolidaysRequest(models.Model):
                 continue
             if leave.employee_id:
                 # For flexible employees, if it's a single day leave, we force it to the real duration since the virtual intervals might not match reality on that day, especially for custom hours
-                if leave.employee_id.is_flexible and leave.date_to.date() == leave.date_from.date():
+                if leave.employee_id.is_flexible and leave.request_date_to == leave.request_date_from:
                     public_holidays = self.env['resource.calendar.leaves'].search([
                         ('resource_id', '=', False),
                         ('date_from', '<', leave.date_to),

--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -1674,3 +1674,27 @@ class TestLeaveRequests(TestHrHolidaysCommon):
 
         # Assert the manager can approve the leave request assign to portal employee
         leave.with_user(self.user_hrmanager_id).action_approve()
+
+    @freeze_time("2025-10-07")
+    def test_duration_flexible_employee_different_timezone(self):
+        calendar = self.env['resource.calendar'].create({
+            'name': 'Test calendar',
+            'hours_per_day': 8,
+            'full_time_required_hours': 56,
+            'flexible_hours': True
+        })
+
+        self.employee_emp.tz = 'Australia/Darwin'
+        self.employee_emp.resource_calendar_id = calendar
+        self.env.user.tz = 'Europe/Brussels'
+
+        leave = self.env['hr.leave'].with_user(self.env.user).create({
+            'name': 'Test',
+            'employee_id': self.employee_emp.id,
+            'holiday_status_id': self.holidays_type_1.id,
+            'request_unit_hours': True,
+            'request_hour_from': 8,
+            'request_hour_to': 21,
+        })
+
+        self.assertEqual(leave.number_of_hours, 13.0)


### PR DESCRIPTION
### Steps to reproduce:
	- Create an employee with Flexible working schedule
	- Set the timezone for this employee very far from yours
	- Create an Unpaid leave with Custom Hours for this employee
	- Set the hours of the leave from 8 to 21
	- Notice the duration is just 8 hours

### Cause:
When calculating the duration of the flexible employee leave we check if the date_from and the date_to has the same date and if so we get the difference between the hour_to - hour_from but sometime when the tz is different when we convert it to UTC the dates overlap in two days so the condition sets to false so we get the working hours of the employee.

### Fix:
Using the request_date_from and request_date_to in this condition where it will always be accurate in terms of days

opw-5118689