### PR TITLE
[FIX] stock: Display Lot/SN column on Detailed Operations to allow navigation

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -250,10 +250,6 @@ class StockQuant(models.Model):
     def copy(self, default=None):
         raise UserError(_('You cannot duplicate stock quants.'))
 
-    @api.model
-    def name_create(self, name):
-        return False
-
     @api.model_create_multi
     def create(self, vals_list):
         """ Override to handle the "inventory mode" and create a quant as

--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -243,9 +243,9 @@
                         context="{'default_location_id': location_id, 'default_product_id': product_id, 'search_view_ref': 'stock.quant_search_view', 'list_view_ref': 'stock.view_stock_quant_tree_simple', 'form_view_ref': 'stock.view_stock_quant_form', 'readonly_form': False}"
                         readonly="state in ('done', 'cancel') and is_locked"
                         widget="pick_from"
-                        options="{'no_open': True}"/>
-                    <field name="lot_id" column_invisible="context.get('picking_code') != 'incoming' or context.get('show_lots_text')" groups="stock.group_production_lot" invisible="not lots_visible" readonly="state in ('done', 'cancel') and is_locked" context="{'default_product_id': product_id, 'active_picking_id': picking_id}" optional="show"/>
-                    <field name="lot_name" column_invisible="context.get('picking_code') != 'incoming' or not context.get('show_lots_text')"  groups="stock.group_production_lot" invisible="not lots_visible" readonly="state in ('done', 'cancel') and is_locked" context="{'default_product_id': product_id}"/>
+                        options="{'no_open': True, 'no_create': True}"/>
+                    <field name="lot_id" column_invisible="context.get('show_lots_text')" groups="stock.group_production_lot" invisible="not lots_visible" readonly="state in ('done', 'cancel') and is_locked" context="{'default_product_id': product_id, 'active_picking_id': picking_id}" optional="show"/>
+                    <field name="lot_name" column_invisible="not context.get('show_lots_text')"  groups="stock.group_production_lot" invisible="not lots_visible" readonly="state in ('done', 'cancel') and is_locked" context="{'default_product_id': product_id}"/>
                     <field name="location_dest_id" options="{'no_create': True}" column_invisible="context.get('picking_code') == 'outgoing'" readonly="state in ('done', 'cancel') and is_locked" groups="stock.group_stock_multi_locations" domain="[('id', 'child_of', picking_location_dest_id), '|', ('company_id', '=', False), ('company_id', '=', company_id), ('usage', '!=', 'view')]"/>
                     <field name="package_id" readonly="state in ('done', 'cancel') and is_locked" column_invisible="True"/>
                     <field name="result_package_id" column_invisible="True"/>


### PR DESCRIPTION
The Lot/SN column was removed from the Detailed Operations tree view because it was considered redundant with the "Pick From" column in #199630. 

However, the lot or SN number displayed in the "Pick From" column is plain text and cannot be clicked to navigate to the corresponding `stock.lot` form view, which can be inconvenient. This PR brings back the Lot/SN column to restore direct navigation to the lot or serial number records.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
