### PR TITLE
[FIX] mail: discuss call promote fullscreen on fullscreen icon

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_action_list.js
+++ b/addons/mail/static/src/discuss/call/common/call_action_list.js
@@ -8,7 +8,6 @@ import { usePopover } from "@web/core/popover/popover_hook";
 import { Tooltip } from "@web/core/tooltip/tooltip";
 import { CALL_PROMOTE_FULLSCREEN } from "@mail/discuss/call/common/thread_model_patch";
 import { ActionList } from "@mail/core/common/action_list";
-import { attClassObjectToString } from "@mail/utils/common/format";
 import { ACTION_TAGS } from "@mail/core/common/action";
 
 export class CallActionList extends Component {
@@ -45,11 +44,6 @@ export class CallActionList extends Component {
                           this.callActions.more(
                               {
                                   actions: moreActions,
-                                  btnClass: () =>
-                                      attClassObjectToString({
-                                          "o-discuss-CallActionList-pulse":
-                                              this.isPromotingFullscreen,
-                                      }),
                                   dropdownMenuClass: "m-0 mb-1",
                                   dropdownPosition: "top-end",
                                   name: this.MORE,
@@ -64,6 +58,7 @@ export class CallActionList extends Component {
         });
     }
 
+    /** @deprecated */
     get isPromotingFullscreen() {
         return Boolean(
             !this.env.pipWindow &&

--- a/addons/mail/static/src/discuss/call/common/call_action_list.scss
+++ b/addons/mail/static/src/discuss/call/common/call_action_list.scss
@@ -1,3 +1,3 @@
 .o-discuss-CallActionList-pulse {
-    animation: pulse 1s infinite;
+    animation: pulse 1s 10;
 }

--- a/addons/mail/static/src/discuss/call/common/call_actions.js
+++ b/addons/mail/static/src/discuss/call/common/call_actions.js
@@ -7,6 +7,7 @@ import { useService } from "@web/core/utils/hooks";
 import { QuickVoiceSettings } from "./quick_voice_settings";
 import { QuickVideoSettings } from "./quick_video_settings";
 import { attClassObjectToString } from "@mail/utils/common/format";
+import { CALL_PROMOTE_FULLSCREEN } from "./thread_model_patch";
 
 export const callActionsRegistry = registry.category("discuss.call/actions");
 
@@ -180,6 +181,12 @@ export const blurBackgroundAction = {
     sequenceGroup: 200,
 };
 registerCallAction("fullscreen", {
+    btnClass: ({ owner, thread }) =>
+        attClassObjectToString({
+            "o-discuss-CallActionList-pulse": Boolean(
+                !owner.env.pipWindow && thread.promoteFullscreen === CALL_PROMOTE_FULLSCREEN.ACTIVE
+            ),
+        }),
     condition: ({ store, thread }) => thread?.eq(store.rtc?.channel),
     name: ({ store }) => (store.rtc.state.isFullscreen ? _t("Exit Fullscreen") : _t("Fullscreen")),
     isActive: ({ store }) => store.rtc.state.isFullscreen,


### PR DESCRIPTION
Before this commit, when someone enabled video for the 1st time in a discuss conversation, the "..." call action had pulse animation.

This is there to incite using the fullscreen mode, which was in the "..." in the past.

Now that this button is in the bottom right of call view and immediately available, the pulse effect can be immediately moved to the fullscreen button.

Before
![before](https://github.com/user-attachments/assets/84435d73-0302-4cc8-b3e4-8bd71f5e3fee)


After
![after](https://github.com/user-attachments/assets/8c908a58-d2f0-4877-895d-0a0f771bfd67)

