### PR TITLE
[FIX] website_sale: close cart notification after 4 seconds

### DIFF
--- a/addons/website_sale/static/src/js/notification/cart_notification/cart_notification.js
+++ b/addons/website_sale/static/src/js/notification/cart_notification/cart_notification.js
@@ -1,6 +1,8 @@
-import { Component } from "@odoo/owl";
+import { Component, onMounted } from "@odoo/owl";
 import { AddToCartNotification } from "../add_to_cart_notification/add_to_cart_notification";
 import { WarningNotification } from "../warning_notification/warning_notification";
+
+const AUTOCLOSE_DELAY = 4000;
 
 export class CartNotification extends Component {
     static components = { AddToCartNotification, WarningNotification };
@@ -31,6 +33,10 @@ export class CartNotification extends Component {
         close: Function,
         refresh: Function,
         freeze: Function,
+    }
+
+    setup() {
+        onMounted(() => setTimeout(this.props.close, AUTOCLOSE_DELAY));
     }
 
     /**


### PR DESCRIPTION
Due to the notifications revamp in https://github.com/odoo/odoo/commit/bbe90382f6c65a6b8737b3e8ec8295b2ee733475, eCommerce notifications were
showing indefinitely, with no way to hide them.

This commit adapts the cart notification component to close itself after
4 seconds.