### PR TITLE
[FIX] product: forbid pricelist-based pricelist rules without base pricelist

### DIFF
--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1525,7 +1525,6 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
         self.env['product.pricelist.item'].create({
             'pricelist_id': sale_10_pl.id,
-            'base': 'pricelist',
             'compute_price': 'percentage',
             'applied_on': '3_global',
             'percent_price': 10,

--- a/addons/product/models/product_pricelist_item.py
+++ b/addons/product/models/product_pricelist_item.py
@@ -283,6 +283,11 @@ class PricelistItem(models.Model):
 
     #=== CONSTRAINT METHODS ===#
 
+    @api.constrains('base_pricelist_id', 'base')
+    def _check_base_pricelist_id(self):
+        if any(item.base == 'pricelist' and not item.base_pricelist_id for item in self):
+            raise ValidationError(_('A pricelist item with "Other Pricelist" as base must have a base_pricelist_id.'))
+
     @api.constrains('base_pricelist_id', 'pricelist_id', 'base')
     def _check_pricelist_recursion(self):
         if any(item.base == 'pricelist' and item.pricelist_id and item.pricelist_id == item.base_pricelist_id for item in self):

--- a/addons/product/tests/test_product_pricelist.py
+++ b/addons/product/tests/test_product_pricelist.py
@@ -291,7 +291,6 @@ class TestProductPricelist(ProductCommon):
             'item_ids': [
                 Command.create({
                     'compute_price': 'formula',
-                    'base': 'pricelist',
                 }),
             ] * 101,
         })


### PR DESCRIPTION
Before this commit, only a view-level required attribute ensured that pricelist items with `base=='pricelist'` have a `base_pricelist_id` set.

Creating pricelist items from a custom view or the API or the shell could result in missing values for this field, causing `_compute_base_price` to incorrectly assume that `base=='list_price'``

This commit introduces a new constraint ensuring any pricelist whose price is `base`d on an "Other Pricelist"  has a value for `base_pricelist_id`.

Note: in the views, `base_pricelist_id` is required if `compute_price == 'formula' and base == 'pricelist'` but the first condition is not neeeded because `_onchange_compute_price` sets `base` to `'list_price'` when `compute_price!='formula'`

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
