### PR TITLE
[FIX] hr_recruitment: log refusal email in chatter

### DIFF
--- a/addons/hr_recruitment/wizard/applicant_refuse_reason.py
+++ b/addons/hr_recruitment/wizard/applicant_refuse_reason.py
@@ -153,7 +153,9 @@ class ApplicantGetRefuseReason(models.TransientModel):
     def _prepare_send_refusal_mails(self):
         mail_values = []
         for applicant in self.applicant_ids:
-            mail_values.append(self._prepare_mail_values(applicant))
+            mail_value = self._prepare_mail_values(applicant)
+            applicant.message_post(body=mail_value.get('body_html'))
+            mail_values.append(mail_value)
         self.env['mail.mail'].sudo().create(mail_values)
 
     def _prepare_mail_values(self, applicant):


### PR DESCRIPTION
To reproduce:
=============
refuse an application with `send_email` checked, the email is sent but not logged in the chatter

Solution:
=========
Add a `message_post` in the `_prepare_send_refusal_mails` method

opw-5137342

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
