### PR TITLE
[FIX] hr_recruitment_skills: changed fallback value for matching score

### DIFF
--- a/addons/hr_recruitment_skills/models/hr_applicant.py
+++ b/addons/hr_recruitment_skills/models/hr_applicant.py
@@ -69,7 +69,7 @@ class HrApplicant(models.Model):
 
             matching_skill_ids = matching_applicant_skills.mapped("skill_id")
             missing_skill_ids = job_skills.mapped("skill_id") - matching_applicant_skills.mapped("skill_id")
-            matching_score = round(applicant_total / job_total * 100) if job_total else 100
+            matching_score = round(applicant_total / job_total * 100) if job_total else 0
 
             applicant.matching_skill_ids = matching_skill_ids
             applicant.missing_skill_ids = missing_skill_ids

--- a/addons/hr_recruitment_skills/tests/test_applicant_skills.py
+++ b/addons/hr_recruitment_skills/tests/test_applicant_skills.py
@@ -493,3 +493,11 @@ class TestApplicantSkills(TransactionCase):
         )
         self.assertEqual(len(self.t_applicant.applicant_skill_ids), 6)
         self.assertEqual(len(self.t_applicant.current_applicant_skill_ids), 4)
+
+    def test_job_with_no_skills_and_degree_with_score_zero(self):
+        self.t_job.expected_degree = self.env["hr.recruitment.degree"].create({
+            "name": "Degree",
+            "score": 0,
+        })
+
+        self.assertEqual(self.t_applicant.matching_score, 0)


### PR DESCRIPTION
- The [PR] added a fallback value for matching score as `100`, whereas in the
  versions `saas-18.4` and before... we had the fallback value as `0` [source].

- Therefore, to maintain consistency this commit changes the fallback value for
  `matching_score` to 0.

- Also added a testcase for the same.

[PR]: https://github.com/odoo/odoo/pull/230323

[source]: https://github.com/odoo/odoo/blob/d13ea53ef64d0281387ad0daf66c90163dded63b/addons/hr_recruitment_skills/models/hr_applicant.py#L47-L51
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
