### PR TITLE
[FIX] base,hr: stable-friendlier login field in user form

### DIFF
--- a/addons/hr/static/src/scss/res_users.scss
+++ b/addons/hr/static/src/scss/res_users.scss
@@ -1,0 +1,6 @@
+.o_form_view.o_res_users_form_view_full {
+    .o_contact_image_large img {
+        width: 155px;
+        height: 155px;
+    }
+}

--- a/addons/hr/views/res_users.xml
+++ b/addons/hr/views/res_users.xml
@@ -188,23 +188,23 @@
                 </xpath>
                 <!-- Must be replaced by work_email when the user has an employee_id. -->
                 <xpath expr="//h5[@name='h5_email']" position="attributes">
-                    <attribute name="invisible">employee_id or login == email</attribute>
+                    <attribute name="invisible">employee_id</attribute>
                 </xpath>
                 <!-- Must be replaced by work_phone when the user has an employee_id. -->
                 <xpath expr="//h5[@name='h5_phone']" position="attributes">
                     <attribute name="invisible">employee_id</attribute>
                 </xpath>
-                <xpath expr="//h5[@name='h5_login']/i[hasclass('fa-envelope')]" position="attributes">
-                    <attribute name="invisible">(not employee_id and login != email) or (employee_id and login != work_email)</attribute>
-                </xpath>
-                <xpath expr="//h5[@name='h5_login']/i[hasclass('fa-key')]" position="attributes">
-                    <attribute name="invisible">(not employee_id and login == email) or (employee_id and login == work_email)</attribute>
-                </xpath>
                 <xpath expr="//div[hasclass('oe_title')]" position="inside">
-                    <h5 class="d-flex align-items-baseline mb-0" invisible="not employee_id or login == work_email">
-                        <i class="fa fa-envelope fa-fw me-1 text-primary" title="Work Email"/>
+                    <h5 class="d-flex flex-wrap align-items-baseline mb-0" invisible="not employee_id">
+                        <div class="w-100">
+                            <i class="fa fa-fw fa-envelope me-1 text-primary" title="Login / Email" invisible="login != work_email"/>
+                            <i class="fa fa-fw fa-key me-1 text-primary" title="Login" invisible="login == work_email"/>
+                            <field name="login" placeholder="Login" class="w-75"/><br/>
+                        </div>
+                    
+                        <i class="fa fa-envelope fa-fw me-1 text-primary" title="Work Email" invisible="login == work_email"/>
                         <field name="email_domain_placeholder" invisible="1" />
-                        <field name="work_email" widget="email" string="Work Email" class="w-75" options="{'placeholder_field': 'email_domain_placeholder'}"/>
+                        <field name="work_email" widget="email" string="Work Email" class="w-75" options="{'placeholder_field': 'email_domain_placeholder'}" invisible="login == work_email"/>
                     </h5>
                     <h5 class="d-flex align-items-baseline mb-0" invisible="not employee_id">
                         <i class="fa fa-phone fa-fw me-1 text-primary" title="Work Phone"/>

--- a/addons/hr/views/res_users.xml
+++ b/addons/hr/views/res_users.xml
@@ -186,6 +186,14 @@
                         </div>
                     </button>
                 </xpath>
+                <!--increase image size to accommodate the additional login field-->
+                <field name="image_1920" widget="contact_image" position="attributes">
+                    <attribute name="invisible">employee_id and work_email != login</attribute>
+                </field>
+                <field name="image_1920" widget="contact_image" position="after">
+                    <field name="image_1920" class="o_contact_image_large" invisible="not employee_id or work_email == login"
+                        widget="contact_image" options="{'preview_image': 'avatar_128', 'img_class': 'rounded-4'}"/>
+                </field>
                 <!-- Must be replaced by work_email when the user has an employee_id. -->
                 <xpath expr="//h5[@name='h5_email']" position="attributes">
                     <attribute name="invisible">employee_id</attribute>

--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -132,14 +132,15 @@
                                 <h1 class="mb-0 w-sm-75">
                                     <field name="name" placeholder="e.g. John Doe" required="1"/>
                                 </h1>
-                                <h5 name="h5_login" class="d-flex align-items-baseline mb-0">
-                                    <i class="fa fa-fw fa-envelope me-1 text-primary" title="Login / Email" invisible="login != email"/>
-                                    <i class="fa fa-fw fa-key me-1 text-primary" title="Login" invisible="login == email"/>
-                                    <field name="login" placeholder="Login" class="w-75"/>
-                                </h5>
-                                <h5 name="h5_email" class="d-flex align-items-baseline mb-0" invisible="login == email">
-                                    <i class="fa fa-fw fa-envelope me-1 text-primary" title="Email"/>
-                                    <field name="email" placeholder="Email" class="w-75"/>
+                                <h5 name="h5_email" class="d-flex flex-wrap align-items-baseline mb-0">
+                                    <div class="w-100">
+                                        <i class="fa fa-fw fa-envelope me-1 text-primary" title="Login / Email" invisible="login != email"/>
+                                        <i class="fa fa-fw fa-key me-1 text-primary" title="Login" invisible="login == email"/>
+                                        <field name="login" placeholder="Login" class="w-75"/>
+                                    </div>
+
+                                    <i class="fa fa-fw fa-envelope me-1 text-primary" title="Email" invisible="login == email"/>
+                                    <field name="email" placeholder="Email" class="w-75"  invisible="login == email"/>
                                 </h5>
                                 <h5 name="h5_phone" class="d-flex align-items-baseline mb-0">
                                     <i class="fa fa-fw fa-phone me-1 text-primary" title="Email"/>

--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -133,16 +133,16 @@
                                     <field name="name" placeholder="e.g. John Doe" required="1"/>
                                 </h1>
                                 <h5 name="h5_login" class="d-flex align-items-baseline mb-0">
-                                    <i class="fa fa-fw fa-envelope text-primary" title="Login / Email" invisible="login != email"/>
-                                    <i class="fa fa-fw fa-key text-primary" title="Login" invisible="login == email"/>
+                                    <i class="fa fa-fw fa-envelope me-1 text-primary" title="Login / Email" invisible="login != email"/>
+                                    <i class="fa fa-fw fa-key me-1 text-primary" title="Login" invisible="login == email"/>
                                     <field name="login" placeholder="Login" class="w-75"/>
                                 </h5>
                                 <h5 name="h5_email" class="d-flex align-items-baseline mb-0" invisible="login == email">
-                                    <i class="fa fa-fw fa-envelope text-primary" title="Email"/>
+                                    <i class="fa fa-fw fa-envelope me-1 text-primary" title="Email"/>
                                     <field name="email" placeholder="Email" class="w-75"/>
                                 </h5>
                                 <h5 name="h5_phone" class="d-flex align-items-baseline mb-0">
-                                    <i class="fa fa-fw fa-phone text-primary" title="Email"/>
+                                    <i class="fa fa-fw fa-phone me-1 text-primary" title="Email"/>
                                     <field name="phone" placeholder="Phone" class="w-75"/>
                                 </h5>
                             </div>

--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -97,7 +97,7 @@
             <field name="name">res.users.form</field>
             <field name="model">res.users</field>
             <field name="arch" type="xml">
-                <form string="Users">
+                <form string="Users" class="o_res_users_form_view_full">
                     <header>
                     </header>
                     <sheet>


### PR DESCRIPTION
[1] adds back the login button on the user form when login and email are
different.

However as the override in hr is based on the new base view, this causes
issues for people installing hr if they created their database before
that commit was live.

The login can be moved inside the email div and simply duplicated so
that the hr module doesn't need to know about the new div. Although it
may cause the field to appear twice on databases created the week this
commit was live, it's a lesser issue than throwing a traceback.

Icon margins are also tweaked to be consistent accross base and the hr override

task-5130854

[1]: https://github.com/odoo/odoo/commit/db3dee12d7c17ad485800d000ec4cdd87fcfd18b

