### PR TITLE
[FIX] stock: allow barcode assignment on packaging in a single step

### DIFF
--- a/addons/stock/views/uom_uom_views.xml
+++ b/addons/stock/views/uom_uom_views.xml
@@ -23,7 +23,7 @@
                 />
                 <field 
                     name="product_uom_ids"
-                    invisible="not context.get('product_id')"
+                    invisible="not (context.get('product_id') and id)"
                     widget="many2many_barcode_tags"
                     options="{'no_create_edit': True, 'no_open': True}"
                     readonly="not context.get('product_id')"


### PR DESCRIPTION
Before this commit:
-------------------------
- In the product form view, when creating new packaging, a pop-up form opens to
  Create a new Unit of Measure (UoM), and if the user tries to assign a barcode
  Within that form, a second pop-up opens instead of assigning the barcode
  directly.
- In the second pop-up, if the user creates the same UoM again, it causes data
  duplication; the same UoM gets created in 'Units and  Packagings' with a
  default quantity of 1 without reference unit. This incorrect behavior leads to
  confusion when selecting the UoM later.

Steps to reproduce:
-------------------------
1. Install the 'sale_stock' module.
2. Enable Units of Measure & Packagings in stock.
3. Create or open any product.
4. Go to the Sales tab.
5. Create new packaging (e.g., Pack of 5), set the quantity and reference unit,
   and try to create a barcode.
6. A second pop-up form opens to again create a new UoM and assign the barcode.
7. It causes data duplication; the same UoM gets created in 'Units and
   Packagings' with a default quantity of 1 without reference unit.

Cause of the issue
-------------------------
When assigning a new barcode to a UoM, the field could not fetch the
corresponding UoM(In uom.uom) record because it did not yet exist in the
database. As a result, the system opened another pop-up to create the same
UoM(In product.uom) again and assign a barcode to it.

After this commit:
-----------------------
- The barcode field is hidden until the UoM is created.
- Once the packaging is saved, users can edit it to assign a barcode to the
  specific UoM of the product.
- This improves the flow by preventing duplicate UoM creation and ensuring a
  clear, single-step process for assigning barcodes to product packaging.

Task ID:5023229