### PR TITLE
[IMP] iot_drivers: send token in websocket subscribe message

### DIFF
--- a/addons/iot_drivers/main.py
+++ b/addons/iot_drivers/main.py
@@ -24,7 +24,6 @@ unsupported_devices = {}
 
 class Manager(Thread):
     daemon = True
-    ws_channel = ""
 
     def __init__(self):
         super().__init__()
@@ -108,8 +107,6 @@ class Manager(Thread):
                     timeout=5,
                 )
                 response.raise_for_status()
-                data = response.json()
-                self.ws_channel = data.get('result', '')
                 break  # Success, exit the retry loop
             except requests.exceptions.RequestException:
                 if attempt < max_retries:
@@ -120,9 +117,6 @@ class Manager(Thread):
                     time.sleep(delay)
                 else:
                     _logger.exception('Could not reach configured server to send all IoT devices after %d attempts.', max_retries)
-            except ValueError:
-                _logger.exception('Could not load JSON data: Received data is not valid JSON.\nContent:\n%s', response.content)
-                break
 
     def run(self):
         """Thread that will load interfaces and drivers and contact the odoo server
@@ -158,7 +152,7 @@ class Manager(Thread):
         schedule.every().day.at("00:00").do(helpers.reset_log_level)
 
         # Set up the websocket connection
-        ws_client = WebsocketClient(self.ws_channel)
+        ws_client = WebsocketClient()
         if ws_client:
             ws_client.start()
 

--- a/addons/iot_drivers/tools/helpers.py
+++ b/addons/iot_drivers/tools/helpers.py
@@ -502,7 +502,6 @@ def disconnect_from_server():
         'screen_orientation': '',
         'browser_url': '',
         'iot_handlers_etag': '',
-        'last_websocket_message_id': '',
     })
     odoo_restart()
 


### PR DESCRIPTION
Enterprise PR: https://github.com/odoo/enterprise/pull/96592

Before this commit, the IoT box would use the websocket channel name from the `/iot/setup` result to make its subscribe message, and use a last message ID of either 0 or a previously saved value. The main issue with this approach is that on first connection, the websocket could receive stale messages, including `server_clear` which could immediately unpair the IoT box after it connects.

After this commit, we no longer send the channel to the IoT box. Instead, the IoT box sends its token in the subscribe message, and we override the subscribe method in the backend to set the correct channel and the latest message ID. This both simplifies the process and fixes the stale message problem.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
