### PR TITLE
[FIX] analytic: minor fix to analytic_distribution component

### DIFF
--- a/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.js
+++ b/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.js
@@ -465,7 +465,7 @@ export class AnalyticDistribution extends Component {
             'default_analytic_distribution': this.dataToJson(),
             'default_partner_id': record.data['partner_id'] ? record.data['partner_id'][0] : undefined,
             'default_product_id': product_field ? record.data[product_field][0] : undefined,
-            'default_account_prefix': account_field ? record.data[account_field][1].substr(0, 3) : undefined,
+            'default_account_prefix': account_field ? record.data[account_field][1]?.substr(0, 3) : undefined,
         }});
     }
 

--- a/doc/cla/corporate/tecnativa.md
+++ b/doc/cla/corporate/tecnativa.md
@@ -28,3 +28,4 @@ Pilar Vargas pilar.vargas@tecnativa.com https://github.com/pilarvargas-tecnativa
 Carolina Fernández carolina.fernandez@tecnativa.com https://github.com/carolinafernandez-tecnativa
 Josep Guardiola josep.guardiola@tecnativa.com https://github.com/josep-tecnativa
 Carlos Lopez carlos.lopez@tecnativa.com https://github.com/carlos-lopez-tecnativa
+Eduardo Ezerouali eduardo.ezerouali@tecnativa.com https://github.com/eduezerouali-tecnativa


### PR DESCRIPTION
Current behavior before PR:

When trying to create a new analytic distribution model might fail because string might not be defined and substr() could fail.
<img width="1139" height="435" alt="odoo" src="https://github.com/user-attachments/assets/2be5a35c-600e-4484-af72-91f778681bcf" />

Desired behavior after PR is merged:

We could check if there is string before de substr method. That would solve the problem and will not affect anywhere else.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
