### PR TITLE
[FIX] mail: mark messages as read when fetching mails

### DIFF
--- a/addons/mail/models/fetchmail.py
+++ b/addons/mail/models/fetchmail.py
@@ -309,8 +309,7 @@ odoo_mailgate: "|/path/to/odoo-mailgate.py --host=localhost -u %(uid)d -p PASSWO
                         failed += 1
                         _logger.info('Failed to process mail from %s server %s.', *server_type_and_name, exc_info=True)
                         remaining_time = MailThread.env['ir.cron']._commit_progress()
-                    else:
-                        server_connection.handled_message(message_num)
+                    server_connection.handled_message(message_num)
                     if count >= batch_limit or not remaining_time:
                         break
                 server.error_date = False


### PR DESCRIPTION
# CONTEXT
The refactor PR https://github.com/odoo/odoo/pull/191911 introduced a nice/needed refactor of the fetchmail methods.

But in doing so a small logic error sneaked in.
More specifically:
This try/except/else block
https://github.com/odoo/odoo/blob/1f672b95a145b32d1ef2da9e83d82cd950045b5d/addons/mail/models/fetchmail.py#L305-L313 fails to account for the fact that in certain conditions a exception is expected while the `message_process` methods try to match the mail content with Odoo records.

One example:
If you fetch an email in the inbox that is addressed to an email address that is **not** an email alias in the database, it will raise a ValueError. Example:
```
ValueError: No possible route found for incoming message from "John Doe"
<john@example.com> to "Josephine" <mon_amour@odoolove.com>
(Message-Id <shrekislove@odoo.com>:). Create an appropriate mail.alias
or force the destination model.
```

It follows that the `else` block is never triggered and `handled_message` will not be called, which would have marked the email in question as "READ".

This means, that the next time the fetchmail CRON job runs, it will retry to refetch the same (failing) emails, which A) means lost time and processing time for a non relevant email B) if the backlog of failing emails is important enough, it will clog the mail fetching and we will never reach new emails.

## Proposed fix:
Remove the else block, meaning that the `handled_message` get's called even after an exception.

A this level of the stack we presume that any exception is either expected or the results of a misconfiguration (mail flows or Odoo configuration). So the mail was handled and should be marked a read in the mailbox being fetched.

OPW-5122869

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
