### PR TITLE
[FIX] l10n_sa: Prevent traceback when generating invoice report

### DIFF
--- a/addons/l10n_sa/views/report_invoice.xml
+++ b/addons/l10n_sa/views/report_invoice.xml
@@ -199,7 +199,7 @@
             <attribute name="t-options">{'format': 'YYYY-MM-dd'}</attribute>
         </div>
         <t t-out="payment_vals['date']" position="attributes">
-            <attribute name="t-options">{'format': 'YYYY-MM-dd'}</attribute>
+            <attribute name="t-options">{'widget': 'date', 'format': 'YYYY-MM-dd'}</attribute>
         </t>
         <!-- End Dates in Saudi Format -->
     </template>


### PR DESCRIPTION
Steps to Reproduce:
- Open any customer invoice for l10n_sa localisation.
- Click the Send or Print button.
- The system shows a traceback instead of generating the PDF report.

Issue:
- The problem was caused by a wrong date format setting in the report template.

Fix:
- Updated the date field setup in the report so it formats
  correctly when printing or sending invoices

https://drive.google.com/file/d/1eY3F78YVQzutLikTigXAR0I0_2DwWILs