### PR TITLE
[FIX] website_slides: fix fullscreen title

### DIFF
--- a/addons/website_slides/static/src/js/slides_course_fullscreen_player.js
+++ b/addons/website_slides/static/src/js/slides_course_fullscreen_player.js
@@ -721,7 +721,7 @@
             var slide = this.get('slide');
             self._pushUrlState();
             return this._fetchSlideContent().then(function() { // render content
-                var websiteName = document.title.split(" | ")[1]; // get the website name from title
+                var websiteName = document.title.split(" | ").at(-1); // get the website name from title
                 document.title =  (websiteName) ? slide.name + ' | ' + websiteName : slide.name;
                 if  (config.device.size_class < config.device.SIZES.MD) {
                     self._toggleSidebar(); // hide sidebar when small device screen


### PR DESCRIPTION
How to reproduce:

  - Go to a course with a slide containing "|" in its name. (e.g. Basics of Gardening)
  - Change slide to this special named slide.
  - Change back to another slide.
  - The browser title contains the string part after the "|" instead of the website name.

This commit now handles slides with name containing the "|" character.

Task-5152858



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
