### PR TITLE
[FIX] html_builder: fix condition for default image mimetype

### DIFF
--- a/addons/html_builder/static/src/plugins/image/image_format_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/image_format_option_plugin.js
@@ -56,7 +56,7 @@ class ImageFormatOptionPlugin extends Plugin {
         ];
         const mimetypeBeforeConversion = data.mimetypeBeforeConversion;
         widths[maxWidth] = [_t("%spx (Original)", maxWidth), mimetypeBeforeConversion, true];
-        if (mimetypeBeforeConversion !== this.config.defaultImageMimetype ?? "image/webp") {
+        if (mimetypeBeforeConversion !== (this.config.defaultImageMimetype ?? "image/webp")) {
             // Avoid a key collision by subtracting 0.1 - putting the default image mimetype
             // above the original format one of the same size.
             widths[maxWidth - 0.1] = [


### PR DESCRIPTION
This commit fixes an issue introduced by
9685f54b53525429d5fbcfd5bdc45e0ff75d4581 with a condition that isn't properly interpreted by the browser's engine following the operators' precedence.

The `!==` is interepreted before the `??` which leads to unwanted behaviors.

[Source](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_precedence#table)

task-5152847

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
