### PR TITLE
[FIX] spreadsheet_dashboard: fix dashboard UI alignment

### DIFF
--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.scss
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.scss
@@ -73,22 +73,8 @@
         min-width: 0;
     }
 
-    /* Not in mobile */
-    @media (min-width: 768px){
-        .o_control_panel_actions {
-            max-height: 200px;
-            /* Place the search bar before the navigation buttons */
-            order: 1 !important;
-        }
-    }
-
     /* In mobile */
     @media (max-width: 768px){
-        .o_control_panel_navigation {
-            /* DashboardMobileSearchPanel is added in navigation buttons in mobile, and should be aligned left*/
-            justify-content: start !important;
-        }
-
         .o_control_panel_main {
             /* We don't want a gap before the DashboardMobileSearchPanel */
             column-gap: 0px !important;

--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_search_bar/dashboard_search_bar.scss
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_search_bar/dashboard_search_bar.scss
@@ -5,14 +5,9 @@
         height: fit-content;
     }
 
-    .o_searchview {
-        overflow-y: auto;
-        border-top-right-radius: 0;
-        border-bottom-right-radius: 0;
-    }
-
     @media (min-width: 768px){
-        .o_searchview {
+        .o_searchview .o_searchview_input_container {
+            overflow-y: auto;
             max-height: 200px;
         }
     }

--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_search_bar/dashboard_search_bar.xml
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_search_bar/dashboard_search_bar.xml
@@ -2,7 +2,7 @@
 <templates>
     <t t-name="spreadsheet_dashboard.DashboardSearchBar">
         <div class="o_sp_dashboard_search d-flex flex-wrap flex-lg-nowrap gap-1 gap-lg-2 w-100 w-lg-auto">
-            <div class="d-flex flex-grow-1 w-100 w-lg-auto" t-if="visibilityState.showSearchBar" >
+            <div class="d-flex flex-grow-1 input-group w-auto" t-if="visibilityState.showSearchBar" >
                 <Dropdown
                     state="inputDropdownState"
                     manual="true"

--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/mobile_search_panel/mobile_search_panel.xml
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/mobile_search_panel/mobile_search_panel.xml
@@ -5,7 +5,7 @@
             <t t-portal="'body'">
                 <div class="o_spreadsheet_dashboard_search_panel o_search_panel o_searchview o_mobile_search">
                     <div class="o_mobile_search_header">
-                        <button type="button" class="o_mobile_search_button btn" t-on-click="() => this.state.isOpen = false">
+                        <button type="button" class="o_mobile_search_button btn w-100 d-flex justify-content-start align-items-center" t-on-click="() => this.state.isOpen = false">
                             <i class="oi oi-arrow-left" />
                             <strong class="ml8">BACK</strong>
                         </button>


### PR DESCRIPTION
Current behavior before PR:
- On medium screens, the navigation panel (share, favorite) was misaligned 
With the control panel breadcrumbs, taking up extra space and looking off.
- When many filters were applied, the search view had a max height with overflow-y-auto, 
but users couldn’t scroll back to the top.
- On mobile, the back button in the search panel didn’t use the full width, 
making the clickable area too small to close the panel easily.

Desired behavior after PR is merged:
- Navigation panel aligns properly with breadcrumbs on medium screens.
- Search view allows smooth scrolling to the top with many filters.
- Mobile back button now takes full width, improving click usability.

Task: [4882429](https://www.odoo.com/odoo/2328/tasks/4882429)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
