### PR TITLE
[FIX] html_editor, *: await mountComponent in PublicComponentInteraction

### DIFF
--- a/addons/html_editor/static/src/core/history_plugin.js
+++ b/addons/html_editor/static/src/core/history_plugin.js
@@ -142,6 +142,7 @@ export class HistoryPlugin extends Plugin {
         "canRedo",
         "canUndo",
         "ignoreDOMMutations",
+        "ignoreDOMMutationsAsync",
         "getHistorySteps",
         "getNodeById",
         "makePreviewableOperation",
@@ -360,6 +361,23 @@ export class HistoryPlugin extends Plugin {
         const enableObserver = this.disableObserver();
         try {
             return callback();
+        } finally {
+            enableObserver();
+        }
+    }
+
+    /**
+     * Execute an async {@link callback} while the MutationObserver is disabled.
+     *
+     * /!\ This method should be used with extreme caution. Not observing some
+     * mutations could lead to mutations that are impossible to undo/redo.
+     *
+     * @param {Function} callback
+     */
+    async ignoreDOMMutationsAsync(callback) {
+        const enableObserver = this.disableObserver();
+        try {
+            return await callback(); // Asynchronous callback
         } finally {
             enableObserver();
         }

--- a/addons/web/static/src/public/colibri.js
+++ b/addons/web/static/src/public/colibri.js
@@ -160,11 +160,13 @@ export class Colibri {
     }
 
     mountComponent(nodes, C, props) {
+        const promises = [];
         for (const node of nodes) {
             const root = this.core.prepareRoot(node, C, props);
-            root.mount();
+            promises.push(root.mount());
             this.cleanups.push(() => root.destroy());
         }
+        return promises;
     }
 
     applyTOut(el, value, initialValue) {
@@ -201,7 +203,7 @@ export class Colibri {
             }
             for (const cl in value) {
                 let toApply = value[cl];
-                for (let c of cl.trim().split(" ")) {
+                for (const c of cl.trim().split(" ")) {
                     if (toApply === INITIAL_VALUE) {
                         toApply = initialValue[cl];
                     }
@@ -368,7 +370,9 @@ export class Colibri {
                     if (!owl) {
                         owl = odoo.loader.modules.get("@odoo/owl");
                     }
-                    const value = node.children.length ? owl.markup(node.innerHTML) : node.textContent;
+                    const value = node.children.length
+                        ? owl.markup(node.innerHTML)
+                        : node.textContent;
                     valuePerNode.set(node, value);
                 }
                 this.applyTOut(node, definition.call(interaction, node), tOut[2].get(node));

--- a/addons/web/static/src/public/interaction.js
+++ b/addons/web/static/src/public/interaction.js
@@ -470,6 +470,6 @@ export class Interaction {
      * @param {Object|null} [props]
      */
     mountComponent(el, C, props = null) {
-        this.__colibri__.mountComponent([el], C, props);
+        return this.__colibri__.mountComponent([el], C, props);
     }
 }

--- a/addons/web/static/src/public/public_component_interaction.js
+++ b/addons/web/static/src/public/public_component_interaction.js
@@ -4,13 +4,14 @@ import { Interaction } from "./interaction";
 export class PublicComponentInteraction extends Interaction {
     static selector = "owl-component[name]";
 
-    setup() {
+    async willStart() {
         const props = JSON.parse(this.el.getAttribute("props") || "{}");
         // clear owl-component content to make sure we don't have any leftover
         // html from a previous page edit, where owl-components were not properly
         // cleaned up while saving
         this.el.replaceChildren();
-        this.mountComponent(this.el, this.Component, props);
+        const promises = this.mountComponent(this.el, this.Component, props);
+        await Promise.all(promises);
     }
 
     get Component() {

--- a/addons/website/static/src/core/website_edit_service.js
+++ b/addons/website/static/src/core/website_edit_service.js
@@ -166,8 +166,10 @@ registry.category("services").add("website_edit", {
                     applyTOut(...args) {
                         historyCallbacks.ignoreDOMMutations(() => super.applyTOut(...args));
                     },
-                    startInteraction(...args) {
-                        historyCallbacks.ignoreDOMMutations(() => super.startInteraction(...args));
+                    async start(...args) {
+                        await historyCallbacks.ignoreDOMMutationsAsync(
+                            async () => await super.start(...args)
+                        );
                     },
                 }),
                 patch(Interaction.prototype, {
@@ -238,7 +240,9 @@ registry.category("services").add("website_edit", {
                 patch(publicInteractions.constructor.prototype, {
                     shouldStop(el, interaction) {
                         if (this.isRefreshing) {
-                            const mustBeRefreshed = super.shouldStop(el, interaction) || interaction.interaction.isImpactedBy(el);
+                            const mustBeRefreshed =
+                                super.shouldStop(el, interaction) ||
+                                interaction.interaction.isImpactedBy(el);
                             return mustBeRefreshed && interaction.interaction.shouldStop();
                         }
                         return super.shouldStop(el, interaction);


### PR DESCRIPTION
*web, website

Before this commit, `PublicComponentInteraction` was not awaiting the mounting of Owl components. Consequently, the DOM mutations generated by the components were not always ignored.

After this commit, the mounting is awaited before restarting the mutation listener.

** HOW TO REPRODUCE THE PROBLEM **
One case were the problem is evident is the `/web/login` page.
1. Navigate to `/web/login`
2. Enter edit mode
3. Inspect the page searching for `o_dirty`
4. The page is already dirty. This happened because of `UserSwitch` not being awaited.

