### PR TITLE
[FIX] web: fix properties field test

### DIFF
--- a/addons/web/static/tests/views/fields/properties_field.test.js
+++ b/addons/web/static/tests/views/fields/properties_field.test.js
@@ -820,11 +820,9 @@ test("properties: tags", async () => {
     });
 
     const createNewTag = async (selector, text) => {
-        await click(selector);
-        await edit(text);
+        await contains(selector).edit(text, { confirm: false });
         await runAllTimers();
-        await click(".o_field_property_dropdown_add .dropdown-item");
-        await animationFrame();
+        await contains(".o_field_property_dropdown_add .dropdown-item").click();
     };
 
     await toggleActionMenu();


### PR DESCRIPTION
This commit tries to fix a test that crashes randomly. The error was: found 0 elements instead of 1: 0 matching ".o_field_property_dropdown_add .dropdown-item". It could just mean that the dropdown is not displayed yet. The change just waits for the dropdown to display before clicking on the item.

runbot-230131