### PR TITLE
[FIX] sale, account: remove padding on non section lines

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -190,7 +190,7 @@
                                     <t t-if="is_section">
                                         <t t-set="current_section" t-value="line"/>
                                         <t t-set="current_subsection" t-value="None"/>
-                                        <t t-set="line_padding" t-value="0"/>
+                                        <t t-set="line_padding" t-value="1"/>
                                     </t>
                                     <t t-elif="is_subsection">
                                         <t t-set="current_subsection" t-value="line"/>
@@ -201,7 +201,7 @@
                                            t-value="3 if current_subsection else (2 if current_section else 0)"
                                         />
                                     </t>
-                                    <t t-set="padding_style" t-value="line_padding and ('padding-left:' + str(line_padding * 8) + 'px') or 'padding-left: 4px'"/>
+                                    <t t-set="padding_style" t-value="line_padding and ('padding-left:' + str(line_padding * 8) + 'px') or ''"/>
                                     <t t-set="hide_details" t-value="line.collapse_composition"/>
                                     <t t-set="hide_prices" t-value="line.collapse_prices"/>
 

--- a/addons/sale/report/ir_actions_report_templates.xml
+++ b/addons/sale/report/ir_actions_report_templates.xml
@@ -118,7 +118,7 @@
                         <t t-if="is_section">
                             <t t-set="current_section" t-value="line"/>
                             <t t-set="current_subsection" t-value="None"/>
-                            <t t-set="line_padding" t-value="0"/>
+                            <t t-set="line_padding" t-value="1"/>
                             <t t-set="collapse_prices" t-value="line.collapse_prices"/>
                         </t>
                         <t t-elif="is_subsection">
@@ -137,7 +137,7 @@
                             <t t-set="line_padding" t-value="line_padding + 1"/>
                         </t>
 
-                        <t t-set="padding_style" t-value="line_padding and ('padding-left:' + str(line_padding * 8) + 'px') or 'padding-left: 4px'"/>
+                        <t t-set="padding_style" t-value="line_padding and ('padding-left:' + str(line_padding * 8) + 'px') or ''"/>
 
                         <t t-if="not line.collapse_composition">
                             <tr


### PR DESCRIPTION
In commit 4e81bb2e2f99ef6e038534de05a4dbe48080c49e the section design was reviewed on the reports. However the condition applying the default padding applies on every line instead of the sections, defaulting the line padding-left to 4px instead of its table design offset. We now set the first section to 8px padding to follow the natural external_layout table design offset.

task-5152869
Followup task-5085892

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
