### PR TITLE
[FIX] l10n_nl: Correct default deferred accounts

### DIFF
--- a/addons/l10n_nl/data/template/account.account-nl.csv
+++ b/addons/l10n_nl/data/template/account.account-nl.csv
@@ -74,7 +74,7 @@
 "recv_pos","Debtors (PoS)","1101","asset_receivable","l10n_nl.account_tag_27","True","Debiteuren (PoS)","Debitoren (PoS)"
 "1150","Doubtful debtors","1150","asset_current","l10n_nl.account_tag_27","False","Dubieuze debiteuren","Zweifelhafte Schuldner"
 "1160","Provision for doubtful debts","1160","asset_current","l10n_nl.account_tag_27","False","Voorziening dubieuze debiteuren","Rückstellung für zweifelhafte Forderungen"
-"1205","Prepaid expenses","1205","asset_prepayments","l10n_nl.account_tag_27","False","Vooruitbetaalde kosten","Aktive Rechnungsabgrenzungsposten"
+"1205","Prepaid expenses","1205",asset_current,"l10n_nl.account_tag_27","False","Vooruitbetaalde kosten","Aktive Rechnungsabgrenzungsposten"
 "1210","Deposit","1210","asset_prepayments","l10n_nl.account_tag_27","False","Borg","Einzahlung"
 "1220","Interest to be received","1220","asset_current","l10n_nl.account_tag_27","False","Te ontvangen rente","Zu erhaltende Zinsen"
 "1230","Sick pay to be received","1230","asset_current","l10n_nl.account_tag_27","False","Te ontvangen ziekengeld","Zu erhaltendes Krankengeld"

--- a/addons/l10n_nl/models/template_nl.py
+++ b/addons/l10n_nl/models/template_nl.py
@@ -35,5 +35,7 @@ class AccountChartTemplate(models.AbstractModel):
                 'account_journal_early_pay_discount_gain_account_id': '8065',
                 'account_sale_tax_id': 'btw_21',
                 'account_purchase_tax_id': 'btw_21_buy',
+                'deferred_expense_account_id': '1205',
+                'deferred_revenue_account_id': '1405',
             },
         }


### PR DESCRIPTION
The default deferred accounts in the Dutch localization were incorrect.

This commit sets the proper accounts and adjusts
the `account_type` of the default deferred expense account from "Prepayments" to "Current Assets".

task-5152529

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
