### PR TITLE
[17.0][IMP] event_sale: Do not confirm registrations for paid events when the sale is confirmed.

### DIFF
--- a/addons/event_sale/models/sale_order_line.py
+++ b/addons/event_sale/models/sale_order_line.py
@@ -36,6 +36,10 @@ class SaleOrderLine(models.Model):
                     'sale_order_line_id': so_line.id,
                     'sale_order_id': so_line.order_id.id,
                 }
+                # When confirming in backend a single order, keep paid registrations in draft
+                # so attendee details can be filled before confirmation; free ones stay open for seat checks.
+                if len(self.order_id) == 1 and not so_line.currency_id.is_zero(so_line.price_total):
+                    values['state'] = 'draft'
                 registrations_vals.append(values)
 
         if registrations_vals:

--- a/addons/event_sale/tests/test_event_sale.py
+++ b/addons/event_sale/tests/test_event_sale.py
@@ -232,6 +232,42 @@ class TestEventSale(TestEventSaleCommon):
         self.assertEqual(editor_action['res_model'], 'registration.editor')
 
     @users('user_sales_salesman')
+    def test_registration_state_on_so_confirmation(self):
+        """Test that registration stays in draft after SO confirmation
+        and only moves to open after registration editor confirmation.
+        """
+        customer_so = self.customer_so.with_user(self.env.user)
+        ticket = self.event_0.event_ticket_ids[0]
+
+        # Create SO in draft with a ticket
+        customer_so.write({
+            'order_line': [(0, 0, {
+                'event_id': self.event_0.id,
+                'event_ticket_id': ticket.id,
+                'product_id': ticket.product_id.id,
+                'product_uom_qty': 1,
+                'price_unit': 10,
+            })]
+        })
+        customer_so.action_confirm()
+
+        registrations = self.env['event.registration'].search([
+            ('sale_order_id', '=', customer_so.id)
+        ])
+        self.assertEqual(registrations.state, 'draft')
+
+        editor = self.env['registration.editor'].with_context({
+            'default_sale_order_id': customer_so.id
+        }).create({})
+        editor.action_make_registration()
+
+        registrations = self.env['event.registration'].search([
+            ('sale_order_id', '=', customer_so.id)
+        ])
+        self.assertEqual(len(registrations), 1)
+        self.assertEqual(registrations.state, 'open')
+
+    @users('user_sales_salesman')
     def test_event_sale_free_confirm(self):
         """Check that free registrations are immediately
         confirmed if the seats are available.

--- a/addons/event_sale/wizard/event_edit_registration.py
+++ b/addons/event_sale/wizard/event_edit_registration.py
@@ -63,7 +63,8 @@ class RegistrationEditor(models.TransientModel):
                 registrations_to_create.append(registration_line._prepare_registration_data(include_event_values=True))
 
         self.env['event.registration'].create(registrations_to_create)
-
+        # Force compute after wizard so seat validation/emails happen now.
+        self.event_registration_ids.registration_id._compute_registration_status()
         return {'type': 'ir.actions.act_window_close'}
 
 

--- a/addons/website_event_sale/tests/test_website_event_sale_cart.py
+++ b/addons/website_event_sale/tests/test_website_event_sale_cart.py
@@ -1,5 +1,5 @@
 from odoo import Command
-from odoo.tests import tagged
+from odoo.tests import tagged, Form
 
 from odoo.addons.website_event_sale.tests.common import TestWebsiteEventSaleCommon
 from odoo.addons.website_sale.tests.test_website_sale_cart_abandoned import (
@@ -34,7 +34,8 @@ class TestWebsiteEventSaleCart(TestWebsiteEventSaleCommon, TestWebsiteSaleCartAb
 
         # Create registrations & confirm first order
         editor = self.env['registration.editor'].new()
-        editor.with_context(default_sale_order_id=cart1.id).action_make_registration()
+        editor = Form(self.env['registration.editor'].with_context(default_sale_order_id=cart1.id))
+        editor.save().action_make_registration()
         cart1.action_confirm()
         self.assertEqual(self.ticket.seats_available, 0)
         self.assertFalse(


### PR DESCRIPTION
Problem:
- In version 17, event records linked to a sales order can be automatically set to ‘open’ immediately after the sale. This makes the wizard editor less useful (the data provided is not used for the record that is already confirmed) and notifications go to the sales partner instead of the actual assistant.

Current behaviour:
- Confirmed orders automatically confirm attendees, reducing the value of the wizard step and sending emails to the wrong recipient.

Expected behaviour:
- Paid attendee registrations created from Sales should remain in “draft” until attendee details are provided.

Solution:
- Do not set ‘state=“open”’ for payment records created from a sale involving
  the data wizard for records. Ensure they remain in “draft”.
- Confirm registrations once attendee details are present.

Advantages:
- Restores the usefulness of the attendee editor: confirmation occurs after data entry, so notifications are directed to the attendee, not just the sales partner.
- Meets functional expectations for administrative control and proper recipient targeting.

Tests to reproduce the error:
- Create quote with payment entry
- Confirm SO
- Enter attendee details and confirm
- Registrations change to ‘open’ and a confirmation email is sent to the order partner and not to the registered attendee.

@Tecnativa TT58160

@pedrobaeza please review
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
