### PR TITLE
[IMP] web: open SelectMenu when pressing space bar + UP/DOWN Arrow keys

### DIFF
--- a/addons/web/static/src/core/dropdown/dropdown.js
+++ b/addons/web/static/src/core/dropdown/dropdown.js
@@ -294,13 +294,16 @@ export class Dropdown extends Component {
         this.defaultDirection = this.position.split("-")[0];
         this.setTargetDirectionClass(this.defaultDirection);
 
+        const clickHandler = (ev) => this.handleClick(ev);
+        const mouseEnterHandler = (ev) => this.handleMouseEnter(ev);
+
         if (!this.props.manual) {
-            target.addEventListener("click", this.handleClick.bind(this));
-            target.addEventListener("mouseenter", this.handleMouseEnter.bind(this));
+            target.addEventListener("click", clickHandler);
+            target.addEventListener("mouseenter", mouseEnterHandler);
 
             return () => {
-                target.removeEventListener("click", this.handleClick.bind(this));
-                target.removeEventListener("mouseenter", this.handleMouseEnter.bind(this));
+                target.removeEventListener("click", clickHandler);
+                target.removeEventListener("mouseenter", mouseEnterHandler);
             };
         }
     }

--- a/addons/web/static/src/core/dropdown/dropdown.js
+++ b/addons/web/static/src/core/dropdown/dropdown.js
@@ -232,6 +232,17 @@ export class Dropdown extends Component {
         }
     }
 
+    handleKeydown(event) {
+        if (["ArrowDown", "ArrowUp"].includes(event.key) && !this.state.isOpen && !this.hasParent) {
+            if (this.props.disabled) {
+                return;
+            }
+
+            event.stopPropagation();
+            this.state.open();
+        }
+    }
+
     handleMouseEnter() {
         if (this.props.disabled) {
             return;
@@ -296,14 +307,17 @@ export class Dropdown extends Component {
 
         const clickHandler = (ev) => this.handleClick(ev);
         const mouseEnterHandler = (ev) => this.handleMouseEnter(ev);
+        const keydownHandler = (ev) => this.handleKeydown(ev);
 
         if (!this.props.manual) {
             target.addEventListener("click", clickHandler);
             target.addEventListener("mouseenter", mouseEnterHandler);
+            target.addEventListener("keydown", keydownHandler);
 
             return () => {
                 target.removeEventListener("click", clickHandler);
                 target.removeEventListener("mouseenter", mouseEnterHandler);
+                target.removeEventListener("keydown", keydownHandler);
             };
         }
     }

--- a/addons/web/static/src/core/select_menu/select_menu.js
+++ b/addons/web/static/src/core/select_menu/select_menu.js
@@ -248,6 +248,13 @@ export class SelectMenu extends Component {
         this.onInput("");
     }
 
+    onKeyDown(ev) {
+        if (ev.key === " " && !this.dropdownState.isOpen) {
+            this.dropdownState.open();
+            ev.preventDefault();
+        }
+    }
+
     onInputFocus(ev) {
         if (!this.props.searchable) {
             return ev.target.blur();

--- a/addons/web/static/src/core/select_menu/select_menu.xml
+++ b/addons/web/static/src/core/select_menu/select_menu.xml
@@ -20,6 +20,7 @@
             t-att-name="props.name"
             t-att-disabled="props.disabled"
             t-on-click="onInputClick"
+            t-on-keydown="onKeyDown"
             autocomplete="selectMenuAutocompleteOff"
             autocorrect="off"
             spellcheck="false"

--- a/addons/web/static/tests/core/dropdown/dropdown.test.js
+++ b/addons/web/static/tests/core/dropdown/dropdown.test.js
@@ -1546,3 +1546,21 @@ test("dropdown: no BottomSheet", async () => {
     expect(DROPDOWN_MENU).toHaveCount(1);
     expect(".o_bottom_sheet").toHaveCount(0);
 });
+
+test("can be toggled with the UP/DOWN arrow keys", async () => {
+    class Parent extends SimpleDropdown {}
+
+    await mountWithCleanup(Parent);
+
+    await contains(DROPDOWN_TOGGLE).focus();
+    expect(DROPDOWN_MENU).toHaveCount(0);
+    await press("ArrowDown");
+    await animationFrame();
+    expect(DROPDOWN_MENU).toHaveCount(1);
+    await press("Escape");
+    await animationFrame();
+    expect(DROPDOWN_MENU).toHaveCount(0);
+    await press("ArrowUp");
+    await animationFrame();
+    expect(DROPDOWN_MENU).toHaveCount(1);
+});

--- a/addons/web/static/tests/core/select_menu.test.js
+++ b/addons/web/static/tests/core/select_menu.test.js
@@ -916,7 +916,6 @@ test("Props onInput is executed when the search changes", async () => {
 
     await mountSingleApp(MyParent);
     expect(".o_select_menu_toggler").toHaveValue("Hello");
-
     await open();
     expect.verifySteps(["call with empty search"]);
     expect(queryAllTexts(".o_select_menu_item")).toEqual(["Hello"]);
@@ -1341,4 +1340,16 @@ test("Ensure items are properly sorted", async () => {
     expect(elements[4]).toHaveText("item-group-z");
     expect(elements[5]).toHaveText("item-world");
     expect(elements[6]).toHaveText("item-z");
+});
+
+test.tags("desktop");
+test("Space bar key opens the dropdown", async () => {
+    await mountSingleApp(Parent);
+
+    expect(".o_select_menu_menu").toHaveCount(0);
+    await contains(".o_select_menu_input").focus();
+    await press("Space");
+    await animationFrame();
+    expect(".o_select_menu_menu").toHaveCount(1);
+    expect(".o_select_menu_input").toHaveValue("World");
 });


### PR DESCRIPTION
This commit improves the usability of the selection menu when being used
with navigation and keyboard. Now, instead of searching for a string with
the ' ' value, the menu opens when being focused and the space bar is pressed.

Also, Up/Down arrow keys also open any dropdown, to have a more consistent
experience accross menus (many2one already had such feature)

task-5149033