### PR TITLE
[FIX] website: use the correct cache key

### DIFF
--- a/addons/website/models/website_page.py
+++ b/addons/website/models/website_page.py
@@ -457,7 +457,7 @@ class WebsitePage(models.Model):
 
     @tools.conditional(
         'xml' not in tools.config['dev_mode'],
-        tools.ormcache('request.httprequest.path', cache='templates.cached_values'),
+        tools.ormcache('(request.httprequest.path, self.env.context.get("website_id"))', cache='templates.cached_values'),
     )
     @api.model
     def _get_page_info(self, request) -> dict | None:

--- a/addons/website/tests/__init__.py
+++ b/addons/website/tests/__init__.py
@@ -20,6 +20,7 @@ from . import test_import_files
 from . import test_ir_asset
 from . import test_lang_url
 from . import test_menu
+from . import test_multi_website
 from . import test_page
 from . import test_page_manager
 from . import test_performance

--- a/addons/website/tests/test_multi_website.py
+++ b/addons/website/tests/test_multi_website.py
@@ -1,0 +1,29 @@
+import lxml.html
+
+from odoo.tests import HttpCase, tagged
+
+
+@tagged('-at_install', 'post_install')
+class TestMultiWebsite(HttpCase):
+    def test_multi_website_switch(self):
+        Website = self.env['website']
+
+        website_1 = Website.create({'name': 'Website 1'})
+        website_2 = Website.create({'name': 'Website 2'})
+
+        self.authenticate("admin", "admin")
+        base_url = website_1.get_base_url()
+
+        res1 = self.url_open(base_url + '/website/force/%s' % website_2.id)
+        res2 = self.url_open(base_url + '/website/force/%s' % website_1.id)
+        website_2_tree = lxml.html.fromstring(res1.content)
+        website_1_tree = lxml.html.fromstring(res2.content)
+
+        data_obj_1 = website_1_tree.xpath('//html/@data-main-object')[0]
+        data_obj_2 = website_2_tree.xpath('//html/@data-main-object')[0]
+
+        website_id_1 = website_1_tree.xpath('//html/@data-website-id')[0]
+        website_id_2 = website_2_tree.xpath('//html/@data-website-id')[0]
+
+        self.assertNotEqual(data_obj_1, data_obj_2)
+        self.assertNotEqual(website_id_1, website_id_2)


### PR DESCRIPTION
After this [commit], we had an issue when we had multiple websites and
tried to switch from one of them to another, the cached page of the
previous one would still be present.

task-5152918

[commit]: https://github.com/odoo/odoo/commit/6c8a90ecba45fb99addf1b86fe237fd626fba650