### PR TITLE
[FIX] html_editor, mass_mailing, website: fix background repeat pattern

### DIFF
--- a/addons/html_editor/static/src/scss/html_editor.common.scss
+++ b/addons/html_editor/static/src/scss/html_editor.common.scss
@@ -724,7 +724,7 @@ pre {
 
     &.o_bg_img_opt_repeat {
         background-size: auto;
-        background-repeat: repeat;
+        background-repeat: repeat !important;
     }
     &.o_bg_img_center {
         background-position: center;

--- a/addons/mass_mailing/static/src/scss/themes/theme_default.scss
+++ b/addons/mass_mailing/static/src/scss/themes/theme_default.scss
@@ -76,17 +76,6 @@ div.col:not([align]) {
     }
     // Background Images
     .oe_img_bg {
-        background-size: cover;
-        background-repeat: no-repeat;
-
-        &.o_bg_img_opt_repeat {
-            background-size: auto;
-            background-repeat: repeat;
-        }
-        &.o_bg_img_center {
-            background-position: center;
-        }
-
         // Compatibility <= 13.0, TODO remove?
         // -----------------------------------
         &.o_bg_img_opt_contain {

--- a/addons/website/static/tests/builder/website_builder/parallax_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/parallax_option.test.js
@@ -1,6 +1,9 @@
 import { expect, test } from "@odoo/hoot";
 import { contains } from "@web/../tests/web_test_helpers";
-import { defineWebsiteModels, setupWebsiteBuilder } from "@website/../tests/builder/website_helpers";
+import {
+    defineWebsiteModels,
+    setupWebsiteBuilder,
+} from "@website/../tests/builder/website_helpers";
 import { waitFor } from "@odoo/hoot-dom";
 
 defineWebsiteModels();
@@ -13,12 +16,13 @@ test("test parallax zoom", async () => {
     expect("[data-label='Intensity'] input").toBeVisible();
 });
 test("add parallax changes editing element", async () => {
-    await setupWebsiteAndOpenParallaxOptions();
+    await setupWebsiteAndOpenParallaxOptions({}, { loadIframeBundles: true });
     await contains("[data-action-value='fixed']").click();
     await contains("[data-label='Position'] .dropdown-toggle").click();
     await contains("[data-action-value='repeat-pattern']").click();
     expect(":iframe section").not.toHaveClass("o_bg_img_opt_repeat");
     expect(":iframe section .s_parallax_bg").toHaveClass("o_bg_img_opt_repeat");
+    expect(":iframe section .s_parallax_bg").toHaveStyle("background-repeat: repeat");
 });
 test("add parallax removes classes on the original editing element", async () => {
     await setupWebsiteAndOpenParallaxOptions({ editingElClasses: "o_modified_image_to_save" });
@@ -100,12 +104,18 @@ test("parallax scroll effect 'none' doesn't remove the color filter", async () =
     expect(":iframe section .o_we_bg_filter").toHaveCount(1);
 });
 
-async function setupWebsiteAndOpenParallaxOptions({ editingElClasses = "" } = {}) {
+async function setupWebsiteAndOpenParallaxOptions(
+    { editingElClasses = "" } = {},
+    builderOptions = {}
+) {
     const backgroundImageUrl = "url('/web/image/123/transparent.png')";
     const editingElClass = editingElClasses ? `class=${editingElClasses}` : "";
-    const websiteBuilder = await setupWebsiteBuilder(`
+    const websiteBuilder = await setupWebsiteBuilder(
+        `
         <section ${editingElClass} style="background-image: ${backgroundImageUrl}; width: 500px; height:500px">
-        </section>`);
+        </section>`,
+        builderOptions
+    );
     await contains(":iframe section").click();
     // Timeout: Images are fetched from the network for some values in the
     // options, the normal timeout is sometimes too short


### PR DESCRIPTION
__Current behavior before commit:__
When setting the background image position to "Repeat pattern" in the website builder, the background image does not repeat as expected. This is due to conflicting CSS rules where `background-repeat: no-repeat` from [`html_builder/static/src/scss/background.scss`][1] overrides the intended `background-repeat: repeat` from `html_editor.common.scss`.

__Description of the fix:__
1. Added `!important` to `background-repeat: repeat` to ensure the repeat pattern takes precedence over other styles
2. Removed duplicate and conflicting background styles from `mass_mailing/theme_default.scss` since these are already properly defined in `html_editor.common.scss`
3. Updated the test in `parallax_option.test.js` to verify `background-repeat: repeat` style is actually applied

__Steps to reproduce:__
1. Open website builder
2. Add a section with a background image
3. Change image position to "Repeat pattern"
4. Bug: background doesn't repeat

[1]: https://github.com/odoo/odoo/blob/f0a34badefd432e9c2ab36acaf018d20d0e342fe/addons/html_builder/static/src/scss/background.scss#L25

task-5145343
