### PR TITLE
[FIX] repair: quote warehouse must match the warehouse of the picking type

### DIFF
--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -387,6 +387,7 @@ class RepairOrder(models.Model):
         moves_to_reassign = self.env['stock.move']
         if vals.get('picking_type_id'):
             picking_type = self.env['stock.picking.type'].browse(vals.get('picking_type_id'))
+            self.update_sale_order_warehouse(vals.get('picking_type_id'))
             for repair in self:
                 if repair.state in ('cancel', 'done'):
                     continue
@@ -759,6 +760,15 @@ class RepairOrder(models.Model):
             })
 
         return self.env['product.product'].browse(product_id).list_price
+
+    def update_sale_order_warehouse(self, picking_type_id):
+        for rec in self:
+            if rec.sale_order_id and rec.sale_order_id.state == 'draft':
+                current_warehouse = rec.sale_order_id.warehouse_id
+                picking_type = self.env['stock.picking.type'].browse(picking_type_id)
+                new_warehouse = picking_type.warehouse_id
+                if current_warehouse != new_warehouse:
+                    rec.sale_order_id.warehouse_id = new_warehouse
 
     # ------------------------------------------------------------
     # MAIL.THREAD


### PR DESCRIPTION
When the quotation is created before the picking type is updated, the warehouse linked to the picking type of the repair should be the same than the warehouse of the quotation.

Reproduce:

1.- Create repair with Operation Type "Your company repairs":
<img width="1297" height="602" alt="image" src="https://github.com/user-attachments/assets/90edc7e0-26a4-49f4-97b1-99c9a2d77666" />

2.- Create Quotation
3.- Change the Operation Type in the repair to be another from another WH:
<img width="1141" height="481" alt="image" src="https://github.com/user-attachments/assets/8db91b4d-62e7-4b0e-9126-7c0e02a67acb" />
4.- The warehouse in the quotation is the old one:
<img width="453" height="441" alt="image" src="https://github.com/user-attachments/assets/9318aa0c-28f7-4b22-9f03-5a8b98616a85" />

