### PR TITLE
[FIX] website: prevent `.o_tag` from overriding `.badge` font size

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -720,6 +720,7 @@ font[class*='bg-'] {
     background: var(--badge-bg, var(--background-color)) !important;
     color: var(--badge-color, var(--color)) !important;
     border: $border-width solid var(--badge-border-color) !important;
+    font-size: var(--badge-font-size);
 
     // Similarly to list-group-item-x and alert-* classes, override text-bg-*
     // classes behavior when used on badges.


### PR DESCRIPTION
| saas-18.4 and above | This PR |
|--------|--------|
| <img width="439" height="400" alt="image" src="https://github.com/user-attachments/assets/00db2fab-69db-410b-8ed2-f8063e033ce5" /> | <img width="437" height="392" alt="image" src="https://github.com/user-attachments/assets/b6896545-34b5-4816-a35f-5c2605d4153b" /> | 

Prior to Commit[^1], the front-end badges using `.badge.o_tag` were receiving a `12px` font size, which came from a rule defined in portal. This looked fine, although odd, since a style from portal was affecting the entire front end.

After Commit[^1], this rule no longer exists, meaning that `.o_tag` now falls back to `0.875rem` (14px by default), while standard badges use a default font size of `0.75em` (12px by default)

Since using `.badge.o_tag` never allowed overriding the `font-size` value, we fixed the issue by assigning the `--badge-font-size` CSS variable directly to the badge definition, ensuring the correct visual result.

task-4900376

[^1]: https://github.com/odoo/odoo/commit/8f8a370a84d136f3d2316eb1a55c7168b7ae6ccf#diff-23677f06a9aaf2e3395e957cfb9580ce6fcc9aba2635b560fe8f15fa27707313L29
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
