### PR TITLE
[FIX] website: fix carousel id duplication

### DIFF
--- a/addons/website/static/src/builder/plugins/carousel_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/carousel_option_plugin.js
@@ -13,7 +13,7 @@ import { BaseOptionComponent } from "@html_builder/core/utils";
 export const CAROUSEL_CARDS_SEQUENCE = between(WEBSITE_BACKGROUND_OPTIONS, BOX_BORDER_SHADOW);
 
 const carouselWrapperSelector =
-    ".s_carousel_wrapper, .s_carousel_intro_wrapper, .s_carousel_cards_wrapper";
+    ".s_carousel_wrapper, .s_carousel_intro_wrapper, .s_carousel_cards_wrapper, .s_quotes_carousel_wrapper";
 const carouselControlsSelector =
     ".carousel-control-prev, .carousel-control-next, .carousel-indicators";
 


### PR DESCRIPTION
The selector used to target the carousel, to generate unique ID, did not include some carousels (s_quotes[...]). This led to issues with the controllers that would not be linked to the correct carousel.

Steps to reproduce the issue:
- Go to Edit
- Drop two "s_quotes_carousel"
- Save
- Click on the "next" arrow of the second carousel 
=> The second carousel does not slide, but the first one does.