### PR TITLE
[FIX] base: new version of the build-breaking i18n test

### DIFF
--- a/odoo/addons/base/tests/test_cli.py
+++ b/odoo/addons/base/tests/test_cli.py
@@ -1,12 +1,17 @@
+import argparse
 import os
 import re
 import subprocess as sp
 import sys
 import unittest
+from contextlib import redirect_stdout
+from io import BytesIO, TextIOWrapper
 from pathlib import Path
 
 from odoo.cli.command import commands, load_addons_commands, load_internal_commands
-from odoo.tests import tagged, BaseCase
+from odoo.cli.i18n import I18n
+from odoo.tests import BaseCase, TransactionCase, tagged
+from odoo.tests.common import Like
 from odoo.tools import config, file_path
 
 
@@ -130,3 +135,71 @@ class TestCommand(BaseCase):
         # we skip local variables as they differ based on configuration (e.g.: if a database is specified or not)
         lines = [line for line in shell.stdout.read().splitlines() if line.startswith('>>>')]
         self.assertEqual(lines, [">>> Hello from Python!", '>>> '])
+
+
+@tagged('at_install', '-post_install')  # LEGACY at_install
+class TestCommandUsingDb(TestCommand, TransactionCase):
+
+    def test_i18n_export(self):
+        reader_mock_result = [
+            ('base', 'code', 'addons/template_inheritance.py', 331,
+             "Invalid position attribute: '%s'", '', ('odoo-python',)),
+            ('base', 'code', 'addons/template_inheritance.py', 341,
+             "Element '%s' cannot be located in parent view", '', ('odoo-python',)),
+        ]
+        expected_text = [
+            "# Translation of Odoo Server.",
+            "# This file contains the translation of the following modules:",
+            '# \t* base',
+            "#",
+            'msgid ""',
+            'msgstr ""',
+            Like('"Project-Id-Version: ..."'),
+            '"Report-Msgid-Bugs-To: \\n"',
+            Like('"POT-Creation-Date: ...'),
+            Like('"PO-Revision-Date: ...'),
+            '"Last-Translator: \\n"',
+            '"Language-Team: \\n"',
+            '"MIME-Version: 1.0\\n"',
+            '"Content-Type: text/plain; charset=UTF-8\\n"',
+            '"Content-Transfer-Encoding: \\n"',
+            '"Plural-Forms: \\n"',
+            '#. module: base',
+            '#. odoo-python',
+            '#: code:addons/template_inheritance.py:0',
+            'msgid "Element \'%s\' cannot be located in parent view"',
+            'msgstr ""',
+            '#. module: base',
+            '#. odoo-python',
+            '#: code:addons/template_inheritance.py:0',
+            'msgid "Invalid position attribute: \'%s\'"',
+            'msgstr ""',
+        ]
+
+        def mock_result():
+            def inner(env, modules, lang):
+                return reader_mock_result
+            return inner
+
+        with unittest.mock.patch('odoo.tools.translate.TranslationModuleReader', new_callable=mock_result):
+            output_buffer = BytesIO()
+            output_wrapper = TextIOWrapper(output_buffer, encoding="utf-8")
+            with redirect_stdout(output_wrapper):
+                # Do not call ``config.parse_args(...)`` in tests.
+                # It would modify the global ``config`` object and disable
+                # the ``--test-enable`` flag, breaking the ``at-install``
+                # CI test build.
+                I18n()._export(argparse.Namespace(
+                    db_name=self.env.cr.dbname,
+                    output='-',
+                    modules=['base'],
+                    languages=['pot'],
+                ))
+                output_wrapper.flush()
+
+            actual_text = [
+                stripped
+                for line in output_buffer.getvalue().decode().splitlines()
+                if (stripped := line.strip()) and stripped
+            ]
+            self.assertEqual(actual_text, expected_text)


### PR DESCRIPTION
We reinstate the test, this time avoiding modifying the global ``config`` object, that used to disable the ``--test-enable`` flag and broke the ``at-install`` CI build.

See: odoo/odoo#230504
Also see: odoo/odoo#229755