### PR TITLE
[FIX] web: Navigation system focuses items on hover when it should not

### DIFF
--- a/addons/web/static/src/core/record_selectors/tag_navigation_hook.js
+++ b/addons/web/static/src/core/record_selectors/tag_navigation_hook.js
@@ -48,7 +48,8 @@ export function useTagNavigation(refName, options = {}) {
         getItems: () =>
             tagsContainerRef.el?.querySelectorAll(":scope .o_tag, :scope .o-autocomplete--input") ??
             [],
-        isNavigationAvailable: ({ navigator, target }) => isEnabled() && navigator.contains(target),
+        isNavigationAvailable: ({ navigator, target }) =>
+            isEnabled() && navigator.isFocused && navigator.contains(target),
         hotkeys: {
             tab: null,
             "shift+tab": null,

--- a/addons/web/static/src/search/search_bar/search_bar.js
+++ b/addons/web/static/src/search/search_bar/search_bar.js
@@ -12,7 +12,7 @@ import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
 import { hasTouch } from "@web/core/browser/feature_detection";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
-import { ACTIVE_ELEMENT_CLASS, useNavigation } from "@web/core/navigation/navigation";
+import { useNavigation } from "@web/core/navigation/navigation";
 
 const parsers = registry.category("parsers");
 
@@ -470,7 +470,6 @@ export class SearchBar extends Component {
                 }
                 return [];
             },
-            isNavigationAvailable: ({ navigator, target }) => navigator.contains(target),
             hotkeys: {
                 enter: {
                     isAvailable: () => !this.inputDropdownState.isOpen,
@@ -544,6 +543,7 @@ export class SearchBar extends Component {
                 this.inputDropdownState.isOpen &&
                 (this.facetContainerRef.el?.contains(target) || navigator.contains(target)),
             onUpdated: (navigator) => (this.navigator = navigator),
+            onItemActivated: (itemEl) => (this.lastActiveItemId = parseInt(itemEl.id, 10)),
             hotkeys: {
                 escape: {
                     callback: () => {
@@ -657,7 +657,7 @@ export class SearchBar extends Component {
             this.resetState();
         }
     }
-    
+
     /**
      * @param {CompositionEvent} ev
      */
@@ -673,14 +673,9 @@ export class SearchBar extends Component {
         if (!this.state.query.length) {
             this.env.searchModel.search();
         } else {
-            const els = [
-                ...this.root.el.ownerDocument.querySelectorAll(
-                    ".o_searchview_autocomplete .o-dropdown-item"
-                ),
-            ];
-            const index = els.findIndex((el) => el.classList.contains(ACTIVE_ELEMENT_CLASS));
-            if (this.items[index]) {
-                this.selectItem(this.items[index]);
+            const item = this.items.find((item) => item.id === this.lastActiveItemId);
+            if (item) {
+                this.selectItem(item);
             }
         }
     }


### PR DESCRIPTION
This commit fixes an issue where some navigation items would be focused after a patch if it was hovered before. Now navigation items are not set as active when hovered, only if the container already was navigable.

This commit also remove the "focus" class from any navigable items when the focus moves to a target that's outside of navigatable container.

Task: [5145033](https://www.odoo.com/odoo/project.task/5145033)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
