### PR TITLE
[FIX] html_editor, *: set contenteditable attribute on correct elements

### DIFF
--- a/addons/html_builder/static/src/core/builder_content_editable_plugin.js
+++ b/addons/html_builder/static/src/core/builder_content_editable_plugin.js
@@ -1,21 +1,24 @@
 import { Plugin } from "@html_editor/plugin";
+import { selectElements } from "@html_editor/utils/dom_traversal";
 import { registry } from "@web/core/registry";
 
 export class BuilderContentEditablePlugin extends Plugin {
     static id = "builderContentEditablePlugin";
     resources = {
-        force_not_editable_selector: [
+        content_not_editable_selectors: [
             "section:has(> .o_container_small, > .container, > .container-fluid)",
             ".o_not_editable",
             "[data-oe-field='arch']:empty",
         ],
-        force_editable_selector: [
+        content_editable_selectors: [
             "section > .o_container_small",
             "section > .container",
             "section > .container-fluid",
             ".o_editable",
         ],
-        filter_contenteditable_handlers: this.filterContentEditable.bind(this),
+        valid_contenteditable_predicates: this.isValidContentEditable.bind(this),
+        content_editable_providers: this.getContentEditableEls.bind(this),
+        content_not_editable_providers: this.getContentNotEditableEls.bind(this),
         contenteditable_to_remove_selector: "[contenteditable]",
     };
 
@@ -23,12 +26,33 @@ export class BuilderContentEditablePlugin extends Plugin {
         this.editable.setAttribute("contenteditable", false);
     }
 
-    filterContentEditable(contentEditableEls) {
-        return contentEditableEls.filter(
-            (el) =>
-                !el.matches("input, [data-oe-readonly]") &&
-                el.closest(".o_editable") &&
-                !el.closest(".o_not_editable")
+    getContentEditableEls(rootEl) {
+        const editableSelector = this.getResource("content_editable_selectors").join(",");
+        return [...selectElements(rootEl, editableSelector)];
+    }
+
+    getContentNotEditableEls(rootEl) {
+        const notEditableSelector = this.getResource("content_not_editable_selectors").join(",");
+        return [...selectElements(rootEl, notEditableSelector)];
+    }
+
+    isValidContentEditable(contentEditableEl) {
+        // Check if an element is inside a ".o_not_editable" element that is not
+        // inside a snippet.
+        const isDescendantOfNotEditableNotSnippet = (el) => {
+            let notEditableEl = el.closest(".o_not_editable");
+            if (!notEditableEl) {
+                return false;
+            }
+            while (notEditableEl.parentElement.closest(".o_not_editable")) {
+                notEditableEl = notEditableEl.parentElement.closest(".o_not_editable");
+            }
+            return !notEditableEl.closest("[data-snippet]");
+        };
+        return (
+            !contentEditableEl.matches("input, [data-oe-readonly]") &&
+            contentEditableEl.closest(".o_editable") &&
+            !isDescendantOfNotEditableNotSnippet(contentEditableEl)
         );
     }
 }

--- a/addons/html_builder/static/src/plugins/background_option/background_image_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/background_option/background_image_option_plugin.js
@@ -25,7 +25,7 @@ export class BackgroundImageOptionPlugin extends Plugin {
             ReplaceBgImageAction,
             DynamicColorAction,
         },
-        force_not_editable_selector: ".o_we_bg_filter",
+        content_not_editable_selectors: ".o_we_bg_filter",
         get_target_element_providers: withSequence(5, (el) => el),
     };
     /**

--- a/addons/html_builder/static/src/plugins/background_option/background_shape_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/background_option/background_shape_option_plugin.js
@@ -27,7 +27,7 @@ export class BackgroundShapeOptionPlugin extends Plugin {
         background_shape_target_providers: withSequence(5, (editingElement) =>
             editingElement.querySelector(":scope > .o_we_bg_filter")
         ),
-        force_not_editable_selector: ".o_we_shape",
+        content_not_editable_selectors: ".o_we_shape",
     };
     static shared = [
         "getShapeStyleUrl",

--- a/addons/html_builder/static/src/plugins/date_time_field_plugin.js
+++ b/addons/html_builder/static/src/plugins/date_time_field_plugin.js
@@ -4,7 +4,7 @@ import { registry } from "@web/core/registry";
 class DateTimeFieldPlugin extends Plugin {
     static id = "dateTimeField";
     resources = {
-        force_not_editable_selector: [
+        content_not_editable_selectors: [
             "[data-oe-field][data-oe-type=date]",
             "[data-oe-field][data-oe-type=datetime]",
         ],

--- a/addons/html_builder/static/src/plugins/image_field_plugin.js
+++ b/addons/html_builder/static/src/plugins/image_field_plugin.js
@@ -4,8 +4,8 @@ import { registry } from "@web/core/registry";
 export class ImageFieldPlugin extends Plugin {
     static id = "imageField";
     resources = {
-        force_editable_selector: "[data-oe-field][data-oe-type=image] img",
-        force_not_editable_selector: "[data-oe-field][data-oe-type=image]",
+        content_editable_selectors: "[data-oe-field][data-oe-type=image] img",
+        content_not_editable_selectors: "[data-oe-field][data-oe-type=image]",
     };
 }
 

--- a/addons/html_builder/static/src/plugins/many2one_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/many2one_option_plugin.js
@@ -10,7 +10,7 @@ export class Many2OneOptionPlugin extends Plugin {
         builder_actions: {
             Many2OneAction,
         },
-        force_not_editable_selector: "[data-oe-field][data-oe-many2one-id]",
+        content_not_editable_selectors: "[data-oe-field][data-oe-many2one-id]",
     };
 }
 

--- a/addons/html_builder/static/src/plugins/monetary_field_plugin.js
+++ b/addons/html_builder/static/src/plugins/monetary_field_plugin.js
@@ -7,8 +7,8 @@ export class MonetaryFieldPlugin extends Plugin {
     static id = "monetaryField";
     static dependencies = ["selection"];
     resources = {
-        force_editable_selector: `${monetarySel} .oe_currency_value`,
-        force_not_editable_selector: monetarySel,
+        content_editable_selectors: `${monetarySel} .oe_currency_value`,
+        content_not_editable_selectors: monetarySel,
     };
 
     setup() {

--- a/addons/html_builder/static/tests/contenteditable.test.js
+++ b/addons/html_builder/static/tests/contenteditable.test.js
@@ -3,6 +3,7 @@ import {
     addBuilderPlugin,
     setupHTMLBuilder,
     dummyBase64Img,
+    addBuilderAction,
 } from "@html_builder/../tests/helpers";
 import { Plugin } from "@html_editor/plugin";
 import { expect, test, describe } from "@odoo/hoot";
@@ -11,12 +12,13 @@ import { contains, onRpc } from "@web/../tests/web_test_helpers";
 
 describe.current.tags("desktop");
 import { BaseOptionComponent } from "@html_builder/core/utils";
+import { BuilderAction } from "@html_builder/core/builder_action";
 
 test("Do not set contenteditable to true on elements inside o_not_editable", async () => {
     class TestPlugin extends Plugin {
         static id = "testPlugin";
         resources = {
-            force_editable_selector: ".target",
+            content_editable_selectors: ".target",
         };
     }
     addBuilderPlugin(TestPlugin);
@@ -82,4 +84,69 @@ test("clone of editable media inside not editable area should be editable", asyn
     await contains(".oe_snippet_clone").click();
     await contains(":iframe section:last-of-type img").click();
     expect(".options-container[data-container-title='Image']").toBeDisplayed();
+});
+
+const setupEditable = async (contentEl) => {
+    class TestPlugin extends Plugin {
+        static id = "test";
+        resources = {
+            content_editable_selectors: ".target-extra",
+        };
+    }
+    addBuilderPlugin(TestPlugin);
+    addBuilderOption(
+        class extends BaseOptionComponent {
+            static selector = ".parent";
+            static template = xml`<BuilderButton action="'customAction'">Custom Action</BuilderButton>`;
+        }
+    );
+    addBuilderOption(
+        class extends BaseOptionComponent {
+            static selector = ".parent";
+            static template = xml`<BuilderButton classAction="'dummy'">Dummy action</BuilderButton>`;
+        }
+    );
+    addBuilderAction({
+        customAction: class extends BuilderAction {
+            static id = "customAction";
+            apply({ editingElement }) {
+                editingElement.querySelector(".target").classList.add("target-extra");
+            }
+        },
+    });
+    await setupHTMLBuilder(contentEl);
+    await contains(":iframe .parent").click();
+    // Dummy action to mark the editable as "dirty"
+    await contains("[data-class-action='dummy']").click();
+    await contains("[data-action-id='customAction']").click();
+};
+
+test("Set contenteditable attribute to true on element that is descendant of '.o_not_editable' that is itself descendant of a snippet", async () => {
+    await setupEditable(`
+        <div class="parent" data-snippet="test">
+            <div class="o_not_editable">
+                Not editable
+                <div class="target">
+                    Target
+                </div>
+            </div>
+        </div>
+    `);
+    expect(":iframe .target-extra").toHaveAttribute("contenteditable", "true");
+});
+
+test("Don't set contenteditable attribute to true on element that is inside '.o_not_editable' that is not a descendant of a snippet", async () => {
+    await setupEditable(`
+        <div class="parent">
+            <div class="o_not_editable">
+                <div class="o_not_editable" data-snippet="test">
+                    Not editable
+                    <div class="target">
+                        Target
+                    </div>
+                </div>
+            </div>
+        </div>
+    `);
+    expect(":iframe .target-extra").not.toHaveAttribute("contenteditable", "true");
 });

--- a/addons/html_editor/static/src/main/separator_plugin.js
+++ b/addons/html_editor/static/src/main/separator_plugin.js
@@ -1,7 +1,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { Plugin } from "../plugin";
 import { closestBlock } from "../utils/blocks";
-import { closestElement } from "../utils/dom_traversal";
+import { closestElement, selectElements } from "../utils/dom_traversal";
 import {
     isEmptyBlock,
     isListItemElement,
@@ -30,7 +30,7 @@ export class SeparatorPlugin extends Plugin {
             categoryId: "structure",
             commandId: "insertSeparator",
         }),
-        force_not_editable_selector: "hr",
+        content_not_editable_providers: (rootEl) => [...selectElements(rootEl, "hr")],
         contenteditable_to_remove_selector: "hr[contenteditable]",
         /** Handlers */
         selectionchange_handlers: this.handleSelectionInHr.bind(this),

--- a/addons/html_editor/static/src/main/tabulation_plugin.js
+++ b/addons/html_editor/static/src/main/tabulation_plugin.js
@@ -7,6 +7,7 @@ import {
     getAdjacentPreviousSiblings,
     closestElement,
     firstLeaf,
+    selectElements,
 } from "@html_editor/utils/dom_traversal";
 import { parseHTML } from "@html_editor/utils/html";
 import { DIRECTIONS, childNodeIndex } from "@html_editor/utils/position";
@@ -55,7 +56,7 @@ export class TabulationPlugin extends Plugin {
             { hotkey: "tab", commandId: "tab" },
             { hotkey: "shift+tab", commandId: "shiftTab" },
         ],
-        force_not_editable_selector: ".oe-tabs",
+        content_not_editable_providers: (rootEl) => [...selectElements(rootEl, ".oe-tabs")],
         contenteditable_to_remove_selector: "span.oe-tabs",
 
         /** Handlers */

--- a/addons/html_editor/static/tests/content_editable.test.js
+++ b/addons/html_editor/static/tests/content_editable.test.js
@@ -2,13 +2,14 @@ import { expect, test } from "@odoo/hoot";
 import { setupEditor } from "./_helpers/editor";
 import { Plugin } from "@html_editor/plugin";
 import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
+import { selectElements } from "@html_editor/utils/dom_traversal";
 
 test("set o_editable_media class on contenteditable false media elements", async () => {
     class TestPlugin extends Plugin {
         static id = "test";
         resources = {
-            force_not_editable_selector: "i",
-            force_editable_selector: "i",
+            content_not_editable_providers: (rootEl) => [...selectElements(rootEl, "i")],
+            content_editable_providers: (rootEl) => [...selectElements(rootEl, "i")],
         };
     }
     const Plugins = [...MAIN_PLUGINS, TestPlugin];

--- a/addons/website/static/src/builder/plugins/company_team_plugin.js
+++ b/addons/website/static/src/builder/plugins/company_team_plugin.js
@@ -1,21 +1,18 @@
 import { Plugin } from "@html_editor/plugin";
 import { registry } from "@web/core/registry";
 import { isMediaElement } from "@html_editor/utils/dom_info";
+import { selectElements } from "@html_editor/utils/dom_traversal";
 
 class CompanyTeamPlugin extends Plugin {
     static id = "companyTeam";
     resources = {
-        extra_contenteditable_handlers: this.extraContentEditableHandlers.bind(this),
+        content_editable_providers: this.getEditableEls.bind(this),
     };
 
-    extraContentEditableHandlers(filteredContentEditableEls) {
+    getEditableEls(rootEl) {
         // To fix db in stable
-        const extraContentEditableEls = filteredContentEditableEls.flatMap(
-            (filteredContentEditableEl) => [
-                ...filteredContentEditableEl.querySelectorAll(".s_company_team .o_not_editable *"),
-            ]
-        );
-        return extraContentEditableEls.filter((el) => isMediaElement(el) || el.tagName === "IMG");
+        const contentEditableEls = [...selectElements(rootEl, ".s_company_team .o_not_editable *")];
+        return contentEditableEls.filter((el) => isMediaElement(el) || el.tagName === "IMG");
     }
 }
 

--- a/addons/website/static/src/builder/plugins/form/form_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/form/form_option_plugin.js
@@ -142,8 +142,8 @@ export class FormOptionPlugin extends Plugin {
             PropertyAction,
             SetMultipleFilesAction,
         },
-        force_not_editable_selector: ".s_website_form form",
-        force_editable_selector: [
+        content_not_editable_selectors: ".s_website_form form",
+        content_editable_selectors: [
             ".s_website_form_send",
             ".s_website_form_field_description",
             ".s_website_form_recaptcha",

--- a/addons/website/static/src/builder/plugins/options/parallax_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/parallax_option_plugin.js
@@ -14,7 +14,7 @@ class WebsiteParallaxPlugin extends Plugin {
             SetParallaxTypeAction,
         },
         on_bg_image_hide_handlers: this.onBgImageHide.bind(this),
-        force_not_editable_selector: ".s_parallax_bg, section.s_parallax > .oe_structure",
+        content_not_editable_selectors: ".s_parallax_bg, section.s_parallax > .oe_structure",
         get_target_element_providers: withSequence(1, this.getTargetElement),
     };
     setup() {

--- a/addons/website/static/src/builder/plugins/options/social_media_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/social_media_option_plugin.js
@@ -141,20 +141,14 @@ class SocialMediaOptionPlugin extends Plugin {
         },
         normalize_handlers: this.normalize.bind(this),
         save_handlers: this.saveRecordedSocialMedia.bind(this),
-        extra_contenteditable_handlers: this.extraContentEditableHandlers.bind(this),
-        force_not_editable_selector: [".s_share"],
-        force_editable_selector: [".s_share a > i", ".s_share .s_share_title"],
+        content_not_editable_selectors: [".s_share"],
+        content_editable_selectors: [
+            ".s_share a > i",
+            ".s_share .s_share_title",
+            ".s_social_media a > i",
+            ".s_social_media .s_social_media_title",
+        ],
     };
-
-    extraContentEditableHandlers(filteredContentEditableEls) {
-        // To fix db in stable
-        // grep: SOCIAL_MEDIA_TITLE_CONTENTEDITABLE
-        return filteredContentEditableEls.flatMap((filteredContentEditableEl) => [
-            ...filteredContentEditableEl.querySelectorAll(
-                ".s_social_media a > i, .s_social_media .s_social_media_title"
-            ),
-        ]);
-    }
 
     /** The social media's name for which there is an entry in the orm */
     async getRecordedSocialMediaNames() {

--- a/addons/website/static/src/builder/plugins/options/table_of_content_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/table_of_content_option_plugin.js
@@ -56,7 +56,7 @@ class TableOfContentOptionPlugin extends Plugin {
             return true;
         },
         is_unremovable_selector: ".s_table_of_content_navbar_wrap, .s_table_of_content_main",
-        force_not_editable_selector: ".s_table_of_content_navbar",
+        content_not_editable_selectors: ".s_table_of_content_navbar",
     };
 
     normalize(root) {

--- a/addons/website/static/src/builder/plugins/options/table_of_content_option_plugin_translate.js
+++ b/addons/website/static/src/builder/plugins/options/table_of_content_option_plugin_translate.js
@@ -6,7 +6,7 @@ export class TranslateTableOfContentOptionPlugin extends Plugin {
 
     resources = {
         normalize_handlers: this.normalize.bind(this),
-        force_not_editable_selector: [".s_table_of_content_navbar"],
+        content_not_editable_selectors: [".s_table_of_content_navbar"],
     };
 
     normalize(root) {

--- a/addons/website/static/tests/builder/content_editable.test.js
+++ b/addons/website/static/tests/builder/content_editable.test.js
@@ -65,8 +65,8 @@ test("Do not set contenteditable attribute on data-oe-readonly", async () => {
     class TestPlugin extends Plugin {
         static id = "testPlugin";
         resources = {
-            force_editable_selector: ".target",
-            force_not_editable_selector: ".non-editable",
+            content_editable_selectors: ".target",
+            content_not_editable_selectors: ".non-editable",
         };
     }
     addPlugin(TestPlugin);
@@ -123,4 +123,13 @@ test("feff on links are cleaned up", async () => {
     expect(link.innerText).toMatch(/\u{FEFF}/u);
     await contains(".o-snippets-top-actions button:contains(Save)").click();
     expect.verifySteps(["save"]);
+});
+
+test("Set contenteditable to true on social media title", async () => {
+    await setupWebsiteBuilder(`
+        <div class="s_social_media text-start o_not_editable" data-snippet="s_social_media">
+            <h4 class="s_social_media_title">Social Media</h4>
+        </div>
+    `);
+    expect(":iframe .s_social_media_title").toHaveAttribute("contenteditable", "true");
 });


### PR DESCRIPTION
[FIX] html_builder, *: set contenteditable attribute on correct elements
*: html_editor, website

The goal of this commit is to fix the behavior of the
`extra_contenteditable_handlers` resource; its goal is to mark as
editable an element that is inside an `.o_not_editable`. The problem is
that this was not working as intended as the elements given as argument
to the handler were a list that was filtered of the elements that have
an `.o_not_editable` ancestor.

Note: even if it is in stable, the `force_editable_selector` resource
has been renamed as `content_editable_providers` as a provider is needed
in some cases. Because it has become a provider, the
`force_not_editable_selector` resource has also been renamed and becomes
a provider. This choice has been made to maintain consistency throughout
the plugin.
