### PR TITLE
[FIX] website: use tour helper to switch website

### DIFF
--- a/addons/website/static/tests/tours/snippet_translation.js
+++ b/addons/website/static/tests/tours/snippet_translation.js
@@ -6,6 +6,7 @@ import {
     clickOnSave,
     insertSnippet,
     registerWebsitePreviewTour,
+    testSwitchWebsite,
 } from '@website/js/tours/tour_utils';
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
@@ -103,20 +104,7 @@ registerWebsitePreviewTour(
                 ":iframe .s_cover .btn-outline-secondary:contains('Contact us in Parseltongue')",
         },
         ...clickOnSave(),
-        {
-            content: "Open website switcher dropdown",
-            trigger: ".o_website_switcher_container button",
-            run: "click",
-        },
-        {
-            content: "Switch to website fu_GB",
-            trigger: ".o-dropdown--menu .o-dropdown-item:contains('website fu_GB')",
-            run: "click",
-        },
-        {
-            content: "Wait for website fu_GB",
-            trigger: ":iframe .o_homepage_editor_welcome_message",
-        },
+        ...testSwitchWebsite("website fu_GB"),
         ...clickOnEditAndWaitEditMode(),
         ...insertSnippet({ id: "s_cover", name: "Cover", groupName: "Intro" }),
         {

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -283,7 +283,7 @@ class TestUiTranslate(odoo.tests.HttpCase):
             'language_ids': [(6, 0, [self.env.ref('base.lang_en').id, parseltongue.id])],
             'default_lang_id': parseltongue.id,
         })
-        self.env['website'].create({
+        website_3 = self.env['website'].create({
             'name': 'website fu_GB',
             'language_ids': [Command.set([fake_user_lang.id])],
             'default_lang_id': fake_user_lang.id,
@@ -291,7 +291,9 @@ class TestUiTranslate(odoo.tests.HttpCase):
 
         self.start_tour(f"/website/force/{website.id}", 'snippet_translation', login='admin')
         self.start_tour(f"/website/force/{website_2.id}", 'snippet_translation_changing_lang', login='admin')
-        self.start_tour(f"/website/force/{website_2.id}", 'snippet_translation_switching_website', login='admin')
+        self.start_tour(f"/website/force/{website_2.id}", 'snippet_translation_switching_website', login='admin', cookies={
+            'websiteIdMapping': json.dumps({website_3.name: website_3.id})
+        })
         self.start_tour(f"/website/force/{website.id}", 'snippet_dialog_rtl', login='admin')
 
 


### PR DESCRIPTION
`snippet_translation_switching_website` was previously using custom
steps to switch the website. Though it worked, it was not very
deterministic and broke the tour in a few runbot builds.

This commit updates the `snippet_translation_switching_website` tour to
use the `testSwitchWebsite` helper function instead of custom steps,
providing a more reliable and deterministic way to switch websites.

runbot-[229696](https://runbot.odoo.com/odoo/error/229696)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr