### PR TITLE
[FIX] html_editor: image toolbar not opening after editable loses focus

### DIFF
--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -1047,12 +1047,11 @@ export class SelectionPlugin extends Plugin {
     }
 
     focusEditable() {
-        if (this.editable.contains(this.document.activeElement)) {
+        const { editableSelection, documentSelectionIsInEditable } = this.getSelectionData();
+        if (this.editable.contains(this.document.activeElement) && documentSelectionIsInEditable) {
             // Editor has focus — nothing to do.
             return;
         }
-
-        const { editableSelection, documentSelectionIsInEditable } = this.getSelectionData();
 
         // Manualy focusing the editable is necessary to avoid some non-deterministic error in the HOOT unit tests.
         this.editable.focus({ preventScroll: true });

--- a/addons/html_editor/static/tests/image.test.js
+++ b/addons/html_editor/static/tests/image.test.js
@@ -1,9 +1,9 @@
 import { expect, test } from "@odoo/hoot";
-import { click, dblclick, press, queryOne, waitFor, waitForNone } from "@odoo/hoot-dom";
+import { click, dblclick, pointerUp, press, queryOne, waitFor, waitForNone } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import { contains } from "@web/../tests/web_test_helpers";
 import { setupEditor } from "./_helpers/editor";
-import { getContent, setContent } from "./_helpers/selection";
+import { getContent, moveSelectionOutsideEditor, setContent } from "./_helpers/selection";
 import { insertText, undo } from "./_helpers/user_actions";
 import { expectElementCount } from "./_helpers/ui_expectations";
 
@@ -552,6 +552,20 @@ test("can undo link removing of an image", async () => {
     undo(editor);
     await animationFrame();
     expect(img.parentElement.tagName).toBe("A");
+});
+
+test("image toolbar should open on click even if selection is not in editable", async () => {
+    const { el, editor } = await setupEditor(`
+        <img src="${base64Img}">
+    `);
+
+    el.focus();
+    moveSelectionOutsideEditor();
+    const selectionData = editor.shared.selection.getSelectionData();
+    expect(document.activeElement).toBe(el);
+    expect(selectionData.documentSelectionIsInEditable).toBe(false);
+    await pointerUp("img");
+    await expectElementCount(".o-we-toolbar", 1);
 });
 
 test.tags("desktop");


### PR DESCRIPTION
Description of the issue:
- The image toolbar failed to open when the editable had lost focus.
- Previously, `focusEditable()` exited early if the active element was inside the editable, even when the actual document selection wasn’t.

Solution:
- Updated the condition in `focusEditable()` to also check whether the document selection is inside the editable.
- Now it only returns early when both the active element and the selection are within the editable.

task-5117272

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
