### PR TITLE
[FIX] hr_payroll: fix error not raise on compute sheet

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -388,6 +388,7 @@ class HrLeave(models.Model):
         self.ensure_one()
         domain = Domain.AND([
             Domain('employee_id', '=', self.employee_id.id),
+            Domain('date_version', '<=', self.date_to),
             Domain('contract_date_start', '<=', self.date_to),
             Domain.OR([
                 Domain('contract_date_end', '>=', self.date_from),
@@ -395,7 +396,10 @@ class HrLeave(models.Model):
             ])
         ])
         versions = self.env['hr.version'].sudo().search(domain)
-        return versions.filtered(lambda v: v._is_overlapping_period(self.date_from.date(), self.date_to.date()))
+        versions_before_leave = versions.filtered(lambda v: v.date_version <= self.date_from.date())
+        if versions_before_leave:
+            versions_before_leave = versions_before_leave[:-1]
+        return versions - versions_before_leave
 
     @api.constrains('date_from', 'date_to')
     def _check_contracts(self):


### PR DESCRIPTION
Bug:
When there is an issue on a payslip with an error level, and we try to compute the sheet, the sheet is computed. Instead of computing, it should raise and the message should specify what errors need to be resolved first.

Cause:
When computing the sheet, we were calling the self._get_error_message() without using the result which is a string.

Fix:
Actually raise a ValidationError and use the result of self._get_error_message() for the error message. Introducing the raise brought other problems because some code supposed to fail was running seamlessly fine. But now, the raise is called and those needed to be solved as well. The issue raised multiple times is the "No contract in the payslip period".

Task: 5153497
