### PR TITLE
[IMP] website: add fullscreen loader when loading more themes

### DIFF
--- a/addons/website/static/src/client_actions/configurator/configurator.js
+++ b/addons/website/static/src/client_actions/configurator/configurator.js
@@ -26,7 +26,6 @@ import {
     useExternalListener,
 } from "@odoo/owl";
 import { standardActionServiceProps } from "@web/webclient/actions/action_service";
-import { addLoadingEffect as addButtonLoadingEffect } from "@web/core/utils/ui";
 
 export const ROUTES = {
     descriptionScreen: 2,
@@ -563,7 +562,7 @@ export class ThemeSelectionScreen extends ApplyConfiguratorScreen {
     }
 
     async getMoreThemes() {
-        const removeLoadingEffect = addButtonLoadingEffect(this.extraThemesButtonRef.el);
+        this.uiService.block();
         const themes = await getRecommendedThemes(
             this.orm,
             this.state,
@@ -574,7 +573,7 @@ export class ThemeSelectionScreen extends ApplyConfiguratorScreen {
         const mainThemeNames = this.state.themes.map((theme) => theme.name);
         this.state.extraThemes = themes.filter((extraTheme) => !mainThemeNames.includes(extraTheme.name));
         this.state.extraThemesLoaded = true;
-        removeLoadingEffect();
+        this.uiService.unblock();
     }
 
     getExtraThemeName(idx) {


### PR DESCRIPTION
Steps to reproduce:

1. Create a new website and proceed to the theme configuration step.
2. Click on View More Themes. -> You’ll notice a loading effect on the button, but the existing themes remain selectable.

Before this commit:
Users could still select existing themes while additional themes were being loaded.

After this commit:
A fullscreen loader is displayed while loading more themes via the View More Themes button, preventing any unintended interactions.

task-4661292

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
