### PR TITLE
[IMP] website, html_builder: add age verification popup snippet

### DIFF
--- a/addons/html_builder/static/src/core/save_snippet_plugin.js
+++ b/addons/html_builder/static/src/core/save_snippet_plugin.js
@@ -8,7 +8,7 @@ import { BLOCKQUOTE_PARENT_HANDLERS } from "@html_builder/core/utils";
 const savableSelector = `[data-snippet], a.btn, ${BLOCKQUOTE_PARENT_HANDLERS}`;
 // TODO `so_submit_button_selector` ?
 const savableExclude =
-    ".o_no_save, .s_donation_donate_btn, .s_website_form_send, .js_subscribe_btn";
+    ".o_no_save, .s_donation_donate_btn, .s_website_form_send, .js_subscribe_btn, .o_age_verification_btn";
 
 // Checks if the element can be saved as a custom snippet.
 function isSavable(el) {

--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -198,6 +198,7 @@
         'views/snippets/s_banner_connected.xml',
         'views/snippets/s_ecomm_categories_showcase.xml',
         'views/snippets/s_banner_categories.xml',
+        'views/snippets/s_age_verification_popup.xml',
         'views/new_page_template_templates.xml',
         'views/website_views.xml',
         'views/website_pages_views.xml',
@@ -280,6 +281,7 @@
             'website/static/src/js/content/redirect.js',
             'website/static/src/js/content/adapt_content.js',
             'website/static/src/js/content/generate_video_iframe.js',
+            'website/static/src/js/content/age_verification_content_blur.js',
         ],
         'web.assets_frontend_lazy': [
             # Remove assets_frontend_minimal

--- a/addons/website/static/src/builder/plugins/options/age_verification_popup_option.xml
+++ b/addons/website/static/src/builder/plugins/options/age_verification_popup_option.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+<t t-name="website.AgeVerificationOption" t-inherit="website.PopupOption" t-inherit-mode="primary">
+    <xpath expr="//BuilderRow[@label.translate=&quot;Display&quot;]" position="replace"/>
+    <xpath expr="//BuilderRow[@label.translate=&quot;Delay&quot;]" position="replace"/>
+    <xpath expr="." position="inside">
+        <BuilderRow label.translate="Confirmation">
+            <BuilderSelect action="'setAgeConfirmationTemplate'">
+                <BuilderSelectItem actionParam="'yes_or_no'" title.translate="Quick age check with simple yes/no buttons">Yes or No</BuilderSelectItem>
+                <BuilderSelectItem id="'birth_year_verification'" actionParam="'birth_year'" title.translate="User selects their birth year to confirm age">Birth Year</BuilderSelectItem>
+                <BuilderSelectItem id="'birth_date_verification'" actionParam="'birth_date'" title.translate="User selects full birth date for precise verification">Birth Date</BuilderSelectItem>
+            </BuilderSelect>
+            <BuilderButton id="'error_message_opt'"
+                title.translate="Show Rejection Message"
+                className="'fa ' + (isActiveItem('error_message_opt') ? 'fa-eye' : 'fa-eye-slash')"
+                classAction="'d-none'" inverseAction="true" applyTo="'#verification_error'"
+                preview="false"/>
+        </BuilderRow>
+        <BuilderRow label.translate="Minimum Age" t-if="isActiveItem('birth_year_verification') || isActiveItem('birth_date_verification')" level="1">
+            <BuilderNumberInput dataAttributeAction="'minAge'" default="18" unit.translate="years" saveUnit="''" min="1"/>
+        </BuilderRow>
+        <BuilderRow label.translate="Placeholder" t-if="isActiveItem('birth_year_verification') || isActiveItem('birth_date_verification')" level="1">
+            <BuilderTextInput attributeAction="'placeholder'" applyTo="'input[name^=&quot;age_verification_birth_&quot;]'"/>
+        </BuilderRow>
+        <BuilderRow label.translate="Background blur">
+            <BuilderCheckbox dataAttributeAction="'blurBackground'" dataAttributeActionValue="'true'"/>
+        </BuilderRow>
+    </xpath>
+</t>
+
+<t t-name="website.age_confirmation.yes_or_no">
+    <!-- When updating this template, make sure to also update the backend
+        `website.s_age_verification_popup` template -->
+    <div class="d-flex align-items-center gap-2 col-lg-12 pt16 pb16 oe_unremovable oe_unmovable">
+        <a href="#" class="o_age_verification_btn o_age_verification_yes_btn btn btn-primary flex-fill oe_unremovable">Yes</a>
+        <a href="#" class="o_age_verification_btn o_age_verification_no_btn btn btn-secondary flex-fill oe_unremovable">No</a>
+    </div>
+</t>
+
+<t t-name="website.age_confirmation.birth_year">
+    <div class="d-flex align-items-center gap-2 col-lg-12 pt16 pb16 oe_unremovable oe_unmovable">
+        <input
+            type="number"
+            class="form-control oe_unremovable"
+            name="age_verification_birth_year"
+            step="1"
+            min="1900"
+            placeholder="Enter your birth year"
+            aria-label="Enter your birth year"/>
+        <a href="#" class="o_age_verification_btn o_age_verification_year_btn btn btn-primary oe_unremovable">Verify</a>
+    </div>
+</t>
+
+<t t-name="website.age_confirmation.birth_date">
+    <div class="col-lg-12 pt16 pb16 text-center oe_unremovable oe_unmovable">
+        <div class="input-group oe_unremovable">
+            <input
+                type="text"
+                class="form-control"
+                name="age_verification_birth_date"
+                placeholder="Enter your birth date"
+                aria-label="Select your birth date"/>
+            <div class="input-group-text o_input_group_date_icon"><i class="fa fa-calendar"></i></div>
+        </div>
+        <p><a href="#" class="o_age_verification_btn o_age_verification_date_btn btn btn-primary mt-2 oe_unremovable">Verify</a></p>
+    </div>
+</t>
+
+<t t-inherit="website.BuilderOptions" t-inherit-mode="extension">
+    <xpath expr="//t[@id='snippet_specific_options']" position="after">
+        <age_verification_option
+            template="website.AgeVerificationOption"
+            selector=".s_popup.s_age_verification_popup"
+            applyTo=".modal"/>
+    </xpath>
+</t>
+
+</templates>

--- a/addons/website/static/src/builder/plugins/options/age_verification_popup_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/age_verification_popup_option_plugin.js
@@ -1,0 +1,36 @@
+import { BuilderAction } from "@html_builder/core/builder_action";
+import { Plugin } from "@html_editor/plugin";
+import { registry } from "@web/core/registry";
+import { renderToElement } from "@web/core/utils/render";
+
+class AgeVerificationOptionPlugin extends Plugin {
+    static id = "AgeVerificationOption";
+    resources = {
+        builder_actions: {
+            SetAgeConfirmationTemplateAction,
+        },
+        immutable_link_selectors: [".o_age_verification_btn"],
+    };
+}
+
+export class SetAgeConfirmationTemplateAction extends BuilderAction {
+    static id = "setAgeConfirmationTemplate";
+    apply({ editingElement, params: { mainParam: confirmationType } }) {
+        const confirmationBlockEl = editingElement.querySelector("#age_confirmation_block");
+        const renderedEl = renderToElement(`website.age_confirmation.${confirmationType}`);
+        confirmationBlockEl.replaceChildren(renderedEl);
+    }
+    isApplied({ editingElement, params: { mainParam: confirmationType } }) {
+        const confirmationTypeSelectors = {
+            yes_or_no: ".o_age_verification_yes_btn",
+            birth_year: ".o_age_verification_year_btn",
+            birth_date: ".o_age_verification_date_btn",
+        };
+        const selector = confirmationTypeSelectors[confirmationType];
+        return selector ? !!editingElement.querySelector(selector) : false;
+    }
+}
+
+registry
+    .category("website-plugins")
+    .add(AgeVerificationOptionPlugin.id, AgeVerificationOptionPlugin);

--- a/addons/website/static/src/builder/plugins/options/popup_option.xml
+++ b/addons/website/static/src/builder/plugins/options/popup_option.xml
@@ -68,7 +68,7 @@
         <popup_option
             template="website.PopupOption"
             selector=".s_popup"
-            exclude="#website_cookies_bar"
+            exclude="#website_cookies_bar, .s_age_verification_popup"
             applyTo=".modal"/>
         <popup_cookies_option
             template="website.PopupCookiesOption"

--- a/addons/website/static/src/builder/translate.edit.scss
+++ b/addons/website/static/src/builder/translate.edit.scss
@@ -18,7 +18,7 @@ html[lang] > body.editor_enable [data-oe-translation-state] {
     }
 }
 
-.s_website_form, .s_searchbar_input, .js_subscribe, .s_group, .s_donation_form {
+.s_website_form, .s_searchbar_input, .js_subscribe, .s_group, .s_donation_form, .s_age_verification_popup {
     input:not(.o_translatable_attribute) {
         pointer-events: none;
     }

--- a/addons/website/static/src/builder/website_options.xml
+++ b/addons/website/static/src/builder/website_options.xml
@@ -30,7 +30,7 @@
             selector=".s_share, .s_text_highlight, .s_social_media"/>
         <layout_option
             selector="section, section.s_carousel_wrapper .carousel-item, .s_carousel_intro_item"
-            exclude=".s_dynamic, .s_dynamic_snippet_content, .s_dynamic_snippet_title, .s_masonry_block, .s_framed_intro, .s_features_grid, .s_media_list, .s_table_of_content, .s_process_steps, .s_image_gallery, .s_pricelist_boxed, .s_quadrant, .s_pricelist_cafe, .s_faq_horizontal, .s_image_frame, .s_card_offset, .s_contact_info, .s_tabs, .s_tabs_images, .s_floating_blocks .s_floating_blocks_block, .s_banner_categories, .s_splash_intro"
+            exclude=".s_dynamic, .s_dynamic_snippet_content, .s_dynamic_snippet_title, .s_masonry_block, .s_framed_intro, .s_features_grid, .s_media_list, .s_table_of_content, .s_process_steps, .s_image_gallery, .s_pricelist_boxed, .s_quadrant, .s_pricelist_cafe, .s_faq_horizontal, .s_image_frame, .s_card_offset, .s_contact_info, .s_tabs, .s_tabs_images, .s_floating_blocks .s_floating_blocks_block, .s_banner_categories, .s_splash_intro, .s_age_verification_popup section"
             applyTo=":scope > *:has(> .row), :scope > .s_allow_columns"/>
         <layout_grid_option
             selector="section.s_masonry_block, section.s_quadrant, section.s_image_frame, section.s_card_offset, section.s_contact_info, section.s_framed_intro, section.s_banner_categories"

--- a/addons/website/static/src/interactions/popup/age_verification_popup.js
+++ b/addons/website/static/src/interactions/popup/age_verification_popup.js
@@ -1,0 +1,157 @@
+import { registry } from "@web/core/registry";
+import { Popup } from "@website/interactions/popup/popup";
+
+const { DateTime } = luxon;
+
+export class AgeVerificationPopup extends Popup {
+    static selector = ".s_popup.s_age_verification_popup";
+    dynamicContent = {
+        ...this.dynamicContent,
+        _root: {
+            ...this.dynamicContent._root,
+            "t-att-data-age-verification-pending": () => String(!this.popupAlreadyShown),
+        },
+        ".o_age_verification_yes_btn": {
+            "t-on-click.prevent": this.hidePopup,
+        },
+        ".o_age_verification_no_btn": {
+            "t-on-click.prevent": () => {
+                this.showAlert = true;
+            },
+        },
+        ".o_age_verification_year_btn": {
+            "t-on-click.prevent": this.verifyAgeByYear,
+        },
+        ".o_age_verification_date_btn": {
+            "t-on-click.prevent": this.verifyAgeByDate,
+        },
+        "#verification_error": {
+            "t-att-class": () => ({
+                "d-none": !this.showAlert,
+            }),
+        },
+        "input[name='age_verification_birth_year']": {
+            "t-att-max": () => DateTime.now().year,
+        },
+        "input[name^='age_verification_birth_']": {
+            "t-att-class": () => ({ "is-invalid": this.inputError }),
+        },
+    };
+
+    setup() {
+        super.setup();
+        this.inputError = false;
+        this.showAlert = false;
+    }
+
+    start() {
+        super.start();
+        this.initDatepicker();
+    }
+
+    /**
+     * Prevent closing the popup via any primary button to avoid bypassing
+     * verification.
+     *
+     * @override
+     */
+    canBtnPrimaryClosePopup(primaryBtnEl) {
+        return false;
+    }
+
+    /**
+     * Prevent closing the popup on backdrop click to enforce verification.
+     *
+     * @override
+     */
+    onBackdropModalClick(ev) {
+        return;
+    }
+
+    /**
+     * Initializes and enables the date picker when the birth date input is
+     * present, and registers required cleanups.
+     */
+    initDatepicker() {
+        const dateInputEl = this.el.querySelector("input[name='age_verification_birth_date']");
+        if (!dateInputEl) {
+            return;
+        }
+        this.datePicker = this.services.datetime_picker.create({
+            target: dateInputEl,
+            pickerProps: {
+                type: "date",
+                minDate: DateTime.local(1900, 1, 1),
+                maxDate: DateTime.now(),
+            },
+        });
+        this.registerCleanup(this.datePicker.enable());
+        this.registerCleanup(this.datePicker.close);
+    }
+
+    /**
+     * Validates the birth year input and triggers age verification.
+     */
+    verifyAgeByYear() {
+        const yearInputEl = this.el.querySelector("input[name='age_verification_birth_year']");
+        const yearVal = Number(yearInputEl.value); // Use `Number` to avoid accepting fractional values.
+        const minYear = parseInt(yearInputEl.min);
+        const maxYear = parseInt(yearInputEl.max);
+        if (!Number.isInteger(yearVal) || yearVal < minYear || yearVal > maxYear) {
+            this.inputError = true;
+            return;
+        }
+        const birthDate = DateTime.local(yearVal, 1, 1);
+        this.handleAgeVerification(birthDate);
+    }
+
+    /**
+     * Validates the selected date and triggers age verification.
+     */
+    verifyAgeByDate() {
+        const dateVal = this.datePicker.state.value;
+        if (!dateVal) {
+            this.inputError = true;
+            return;
+        }
+        const birthDate = DateTime.local(dateVal.year, dateVal.month, dateVal.day);
+        this.handleAgeVerification(birthDate);
+    }
+
+    /**
+     * Checks if user meets minimum age requirement. Shows alert if user is
+     * underage, otherwise hides the popup.
+     *
+     * @param {DateTime} birthDate - The user's birth date
+     */
+    handleAgeVerification(birthDate) {
+        this.inputError = false;
+        const age = this.calculateAge(birthDate);
+        const minAge = parseInt(this.modalEl.dataset.minAge);
+        if (age < minAge) {
+            this.showAlert = true;
+        } else {
+            this.showAlert = false;
+            this.hidePopup();
+        }
+    }
+
+    /**
+     * Calculates the user's age based on the given birth date.
+     *
+     * @param {DateTime} birthDate - The user's birth date
+     * @returns {number} The computed age in years
+     */
+    calculateAge(birthDate) {
+        const today = DateTime.now();
+        const age = today.year - birthDate.year;
+        const hasBirthdayPassed =
+            today.month > birthDate.month ||
+            (today.month === birthDate.month && today.day >= birthDate.day);
+        return hasBirthdayPassed ? age : age - 1;
+    }
+}
+
+registry
+    .category("public.interactions")
+    .add("website.age_verification_popup", AgeVerificationPopup);

--- a/addons/website/static/src/interactions/popup/popup.js
+++ b/addons/website/static/src/interactions/popup/popup.js
@@ -7,7 +7,7 @@ import { utils as uiUtils, SIZES } from "@web/core/ui/ui_service";
 import { getTabableElements } from "@web/core/utils/ui";
 
 export class Popup extends Interaction {
-    static selector = ".s_popup:not(#website_cookies_bar)";
+    static selector = ".s_popup:not(#website_cookies_bar):not(.s_age_verification_popup)";
     dynamicContent = {
         ".js_close_popup": {
             "t-on-click": this.onCloseClick,

--- a/addons/website/static/src/js/content/age_verification_content_blur.js
+++ b/addons/website/static/src/js/content/age_verification_content_blur.js
@@ -1,0 +1,13 @@
+import { cookie } from "@web/core/browser/cookie";
+
+// Blur page content immediately if age verification is pending to prevent
+// restricted content from being visible before the popup interaction loads.
+document.addEventListener("DOMContentLoaded", () => {
+    const ageVerificationPopupEl = document.querySelector(
+        ".s_age_verification_popup:has([data-blur-background='true'])"
+    );
+    if (ageVerificationPopupEl) {
+        const isAgeVerified = cookie.get(ageVerificationPopupEl.id);
+        ageVerificationPopupEl.dataset.ageVerificationPending = !isAgeVerified;
+    }
+});

--- a/addons/website/static/src/snippets/s_age_verification_popup/001.scss
+++ b/addons/website/static/src/snippets/s_age_verification_popup/001.scss
@@ -1,0 +1,26 @@
+.s_age_verification_popup[data-vcss='001'] {
+    .modal {
+        z-index: $zindex-modal + 2; // Always appear on top in case of multiple popups.
+    }
+}
+
+@mixin o-apply-age-popup-blur-overlay {
+    content: "";
+    position: fixed;
+    inset: 0;
+    z-index: $zindex-modal + 1;
+    background: rgba(black, 0.15);
+    backdrop-filter: blur(16px);
+}
+
+body:not(.editor_enable) {
+    #wrapwrap:has([data-age-verification-pending="true"]):has([data-blur-background="true"])::before {
+        @include o-apply-age-popup-blur-overlay;
+    }
+}
+
+.editor_enable {
+    #wrapwrap:has(.show[data-blur-background="true"])::before {
+        @include o-apply-age-popup-blur-overlay;
+    }
+}

--- a/addons/website/static/tests/builder/website_builder/age_verification_popup_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/age_verification_popup_option.test.js
@@ -1,0 +1,42 @@
+import { expect, test } from "@odoo/hoot";
+import { contains } from "@web/../tests/web_test_helpers";
+import {
+    defineWebsiteModels,
+    setupWebsiteBuilderWithSnippet,
+} from "@website/../tests/builder/website_helpers";
+
+defineWebsiteModels();
+
+test("Age verification popup options works correctly", async () => {
+    await setupWebsiteBuilderWithSnippet("s_age_verification_popup", {
+        loadIframeBundles: true,
+        loadAssetsFrontendJS: true,
+    });
+    await contains(":iframe .s_age_verification_popup .modal").click();
+    expect("[data-label='Display']").toHaveCount(0);
+    expect("[data-label='Delay']").toHaveCount(0);
+    expect("[data-label='Confirmation'] .dropdown-toggle").toHaveText("Yes or No");
+    expect(
+        ":iframe #age_confirmation_block .o_age_verification_yes_btn.oe_unremovable"
+    ).toHaveCount(1);
+    expect(":iframe #age_confirmation_block .o_age_verification_no_btn.oe_unremovable").toHaveCount(
+        1
+    );
+    expect("[data-label='Minimum Age']").toHaveCount(0);
+
+    await contains("[data-label='Confirmation'] .dropdown-toggle").click();
+    await contains(".o-dropdown-item:contains('Birth Year')").click();
+    expect(":iframe input[name='age_verification_birth_year']").toHaveCount(1);
+    expect(":iframe .o_age_verification_year_btn.oe_unremovable").toHaveCount(1);
+    expect("[data-label='Minimum Age'] input").toHaveValue(18);
+
+    await contains("[data-label='Confirmation'] .dropdown-toggle").click();
+    await contains(".o-dropdown-item:contains('Birth Date')").click();
+    expect(":iframe input[name='age_verification_birth_date']").toHaveCount(1);
+    expect(":iframe .o_age_verification_date_btn.oe_unremovable").toHaveCount(1);
+    expect("[data-label='Minimum Age'] input").toHaveCount(1);
+
+    expect(":iframe #verification_error").not.toBeVisible();
+    await contains(".fa-eye-slash[data-class-action='d-none']").click();
+    expect(":iframe #verification_error").toBeVisible();
+});

--- a/addons/website/static/tests/interactions/popup/age_verification_popup.test.js
+++ b/addons/website/static/tests/interactions/popup/age_verification_popup.test.js
@@ -1,0 +1,170 @@
+import { describe, expect, test } from "@odoo/hoot";
+import { animationFrame, tick } from "@odoo/hoot-dom";
+import { mockDate } from "@odoo/hoot-mock";
+import { setupInteractionWhiteList, startInteractions } from "@web/../tests/public/helpers";
+import { contains } from "@web/../tests/web_test_helpers";
+
+setupInteractionWhiteList("website.age_verification_popup");
+describe.current.tags("interaction_dev");
+
+const modalSelector = "#sAgeVerificationPopup .modal";
+const modalErrorMessageSelector = `${modalSelector} #verification_error span`;
+
+/**
+ * Generate age verification popup template.
+ *
+ * @param {Object} [options]
+ * @param {string} [options.confirmationType="yes_or_no"]
+ * @param {number} [options.minAge=18]
+ * @returns {string} Age verification popup template
+ */
+function getAgeVerificationTemplate({ confirmationType = "yes_or_no", minAge = 18 } = {}) {
+    const TEMPLATES = {
+        yes_or_no: `
+            <div>
+                <a href="#" class="o_age_verification_btn o_age_verification_yes_btn oe_unremovable">Yes</a>
+                <a href="#" class="o_age_verification_btn o_age_verification_no_btn oe_unremovable">No</a>
+            </div>
+        `,
+        birth_year: `
+            <div>
+                <input
+                    type="number"
+                    class="form-control"
+                    name="age_verification_birth_year"
+                    min="1900"
+                    placeholder="Enter your birth year"/>
+                <a href="#" class="o_age_verification_btn o_age_verification_year_btn oe_unremovable">Verify</a>
+            </div>
+        `,
+        birth_date: `
+            <div>
+                <div class="input-group">
+                    <input
+                        type="text"
+                        class="form-control"
+                        name="age_verification_birth_date"
+                        placeholder="Enter your birth date"/>
+                    <div><i class="fa fa-calendar"></i></div>
+                </div>
+                <p><a href="#" class="o_age_verification_btn o_age_verification_date_btn oe_unremovable">Verify</a></p>
+            </div>
+        `,
+    };
+
+    return `
+        <div class="s_popup s_age_verification_popup o_snippet_invisible" data-vcss="001" id="sAgeVerificationPopup" data-invisible="1">
+            <div class="modal fade s_popup_middle" tabindex="-1" role="dialog"
+                data-bs-focus="false" data-bs-backdrop="false" data-bs-keyboard="false"
+                data-min-age="${minAge}" data-blur-background="true" data-show-after="0" data-display="afterDelay" data-consents-duration="30">
+                <div class="modal-dialog">
+                    <div class="modal-content oe_structure">
+                        <section>
+                            <div id="verification_error" class="d-none">
+                                <span>You must be older to continue!</span>
+                            </div>
+                            <div>
+                                <h2>Are you 18 years or older?</h2>
+                                <p>Our services are available only to adults of legal age.</p>
+                            </div>
+                            <div id="age_confirmation_block" class="row">
+                                ${TEMPLATES[confirmationType]}
+                            </div>
+                        </section>
+                    </div>
+                </div>
+            </div>
+        </div>
+    `;
+}
+
+/**
+ * Setup the age verification popup for tests.
+ *
+ * @param {Object} [options]
+ * @param {string} [options.confirmationType="yes_or_no"]
+ * @param {number} [options.minAge=18]
+ * @returns {Promise<{ core: InteractionService }>}
+ */
+async function setupAgeVerificationPopup(options) {
+    const { core } = await startInteractions(getAgeVerificationTemplate(options));
+    await tick();
+    await animationFrame();
+    expect(core.interactions).toHaveLength(1);
+    expect(modalSelector).toBeVisible();
+    expect(modalErrorMessageSelector).not.toBeVisible();
+    return core;
+}
+
+test("Yes button closes popup and No button displays the error message", async () => {
+    await setupAgeVerificationPopup();
+    await contains(`${modalSelector} .o_age_verification_no_btn`).click();
+    expect("#sAgeVerificationPopup").toHaveAttribute("data-age-verification-pending", "true");
+    expect(modalErrorMessageSelector).toBeVisible();
+
+    await contains(`${modalSelector} .o_age_verification_yes_btn`).click();
+    expect("#sAgeVerificationPopup").toHaveAttribute("data-age-verification-pending", "false");
+    expect(modalSelector).not.toBeVisible();
+});
+
+test("Using birth year input, Verify button closes popup when age meets minimum", async () => {
+    mockDate("2025-11-14 12:00:00");
+    await setupAgeVerificationPopup({
+        confirmationType: "birth_year",
+        minAge: 20,
+    });
+    const verifyBtnSelector = `${modalSelector} .o_age_verification_year_btn`;
+    const birthYearInputSelector = `${modalSelector} input[name="age_verification_birth_year"]`;
+    expect(birthYearInputSelector).not.toHaveClass("is-invalid");
+    await contains(verifyBtnSelector).click();
+    expect(birthYearInputSelector).toHaveClass("is-invalid");
+
+    await contains(birthYearInputSelector).edit("2006");
+    await contains(verifyBtnSelector).click();
+    expect("#sAgeVerificationPopup").toHaveAttribute("data-age-verification-pending", "true");
+    expect(modalErrorMessageSelector).toBeVisible();
+    expect(birthYearInputSelector).not.toHaveClass("is-invalid");
+
+    // Value below min (1900) is not allowed.
+    await contains(birthYearInputSelector).edit("1899");
+    await contains(verifyBtnSelector).click();
+    expect(birthYearInputSelector).toHaveClass("is-invalid");
+
+    // Value above max (current year) is not allowed.
+    await contains(birthYearInputSelector).edit("2026");
+    await contains(verifyBtnSelector).click();
+    expect(birthYearInputSelector).toHaveClass("is-invalid");
+
+    // Fractional value is not allowed.
+    await contains(birthYearInputSelector).edit("1950.25");
+    await contains(verifyBtnSelector).click();
+    expect(birthYearInputSelector).toHaveClass("is-invalid");
+
+    await contains(birthYearInputSelector).edit("2000");
+    await contains(verifyBtnSelector).click();
+    expect("#sAgeVerificationPopup").toHaveAttribute("data-age-verification-pending", "false");
+    expect(modalSelector).not.toBeVisible();
+});
+
+test("Using birth date input, Verify button closes popup when age meets minimum", async () => {
+    mockDate("2025-11-14 12:00:00");
+    await setupAgeVerificationPopup({
+        confirmationType: "birth_date",
+        minAge: 20,
+    });
+    const verifyBtnSelector = `${modalSelector} .o_age_verification_date_btn`;
+    const birthDateInputSelector = `${modalSelector} input[name='age_verification_birth_date']`;
+    expect(birthDateInputSelector).not.toHaveClass("is-invalid");
+    await contains(verifyBtnSelector).click();
+    expect(birthDateInputSelector).toHaveClass("is-invalid");
+
+    await contains(birthDateInputSelector).edit("01/01/2006");
+    await contains(verifyBtnSelector).click();
+    expect("#sAgeVerificationPopup").toHaveAttribute("data-age-verification-pending", "true");
+    expect(modalErrorMessageSelector).toBeVisible();
+
+    await contains(birthDateInputSelector).edit("01/01/2004");
+    await contains(verifyBtnSelector).click();
+    expect("#sAgeVerificationPopup").toHaveAttribute("data-age-verification-pending", "false");
+    expect(modalSelector).not.toBeVisible();
+});

--- a/addons/website/static/tests/tours/snippets_all_drag_and_drop.js
+++ b/addons/website/static/tests/tours/snippets_all_drag_and_drop.js
@@ -46,6 +46,7 @@ registry.category("web_tour.tours").add("snippets_all_drag_and_drop", {
                 "s_popup",
                 "s_newsletter_subscribe_popup",
                 "s_newsletter_benefits_popup",
+                "s_age_verification_popup",
             ].includes(snippet.name);
             const isDropInOnlySnippet = Object.keys(DROP_IN_ONLY_SNIPPETS).includes(snippet.name);
             const snippetKey = SUB_SNIPPET_TEMPLATES[snippet.name] || snippet.name;

--- a/addons/website/views/snippets/s_age_verification_popup.xml
+++ b/addons/website/views/snippets/s_age_verification_popup.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_age_verification_popup" name="Age Verification Popup">
+    <div class="s_popup s_age_verification_popup o_snippet_invisible" data-vcss="001">
+        <div class="modal fade s_popup_middle" style="background-color: var(--black-50) !important;"
+            data-bs-focus="false" data-bs-backdrop="false" data-bs-keyboard="false"
+            data-min-age="18" data-blur-background="true" data-show-after="0" data-display="afterDelay" data-consents-duration="30"
+            tabindex="-1" role="dialog" aria-label="Age Verification Popup">
+            <div class="modal-dialog d-flex">
+                <div class="modal-content oe_structure">
+                    <section class="s_text_block pt48 pb48 oe_unremovable oe_unmovable" data-snippet="s_text_block" data-name="Text">
+                        <div class="container">
+                            <div id="verification_error" class="s_alert s_alert_md alert alert-danger d-none clearfix w-100 oe_unremovable oe_unmovable" data-snippet="s_alert" data-name="Alert" role="alert" data-vcss="001">
+                                <i class="fa fa-exclamation-circle fa-stack d-flex align-items-center justify-content-center me-2 rounded-1 s_alert_icon oe_unremovable"/>
+                                <div class="s_alert_content">
+                                    <p>You are not old enough to access this page!</p>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="container">
+                            <span class="fa fa-check-circle-o fa-5x d-block mx-auto mb-2 rounded-circle text-primary"/>
+                            <h2 style="text-align: center;">Are you 18 years or older?</h2>
+                            <p style="text-align: center;">Our services are available only to adults of legal age.</p>
+                            <div id="age_confirmation_block" class="row">
+                                <!-- Keep this section in sync with the rendering of the `website.age_confirmation.yes_or_no` client template -->
+                                <div class="d-flex align-items-center gap-2 col-lg-12 pt16 pb16 oe_unremovable oe_unmovable">
+                                    <a href="#" class="o_age_verification_btn o_age_verification_yes_btn btn btn-primary flex-fill oe_unremovable">Yes</a>
+                                    <a href="#" class="o_age_verification_btn o_age_verification_no_btn btn btn-secondary flex-fill oe_unremovable">No</a>
+                                </div>
+                            </div>
+                        </div>
+                    </section>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<asset id="website.s_age_verification_popup_001_scss" name="Age Verification Popup 001 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_age_verification_popup/001.scss</path>
+</asset>
+
+</odoo>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -400,6 +400,9 @@
             <t t-snippet="website.s_form_aside" string="Form Aside" t-forbid-sanitize="form" group="contact_and_forms" label="Form">
                 <keywords>contact, collect, submission, input, fields, questionnaire, survey, registration, request, image, picture, photo, illustration, media, visual, get-in-touch</keywords>
             </t>
+            <t t-snippet="website.s_age_verification_popup" string="Age Verification Popup" t-forbid-sanitize="form" group="contact_and_forms" label="Popup">
+                <keywords>consent, confirmation, restriction, adult, eligibility, validation</keywords>
+            </t>
 
             <!-- Catalog group -->
             <t t-snippet="website.s_floating_blocks" string="Floating Cards" group="catalog">


### PR DESCRIPTION
**Previously,** website module did not provide any way to verify the
age of visitors before accessing restricted content, such as smoking,
drinking, or adult-oriented material. This left websites without a
built-in mechanism to block underage users.

**After this improvement,** the module now includes an “Age Verification
Popup” snippet. This popup can only be closed after the visitor
successfully verifies their age. It cannot be dismissed using the close
button or the escape key. For this snippet, the existing “Display” and
“Delay” options are hidden.

**Available confirmation modes:**

- Yes or No: Clicking Yes closes the popup; clicking No shows an alert.
- Birth Year: Visitors enter a year and click Verify. Underage users
  see an alert; valid users close the popup.
- Birth Date: Visitors select a date using a date picker and click
  Verify. Underage users see an alert; valid users close the popup.

**Additional options:**

- Show Rejection Message: Allows viewing and editing the rejection
  message shown when the visitor is underage or clicks No.
- Minimum Age: Visible only for Birth Year and Birth Date modes.
  Determines whether the visitor meets the age requirement. Default is
  18.
- Placeholder: Visible for Birth Year and Birth Date modes. Allows
  changing the input placeholder used for age confirmation.
- Background Blur: Toggle to blur the content behind the popup. Default
  is on.
  
  task-[3790120](https://www.odoo.com/odoo/all-tasks/3790120)
  
  ---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
