### PR TITLE
[FIX] mail: show reply context for attachment-only messages

### DIFF
--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -66,9 +66,10 @@
                         >
                             <div class="o-mail-Message-content o-min-width-0" t-att-class="{ 'w-100': state.isEditing, 'opacity-50': message.isPending, 'pt-1': message.is_note }">
                                 <div class="o-mail-Message-textContent position-relative d-flex" t-att-class="{ 'w-100': state.isEditing }">
+                                    <t t-set="showTextVisually" t-value="!message.linkPreviewSquash and (message.hasTextContent or showSubtypeDescription)"/>
                                     <t t-if="message.message_type === 'notification' and message.body" t-call="mail.Message.bodyAsNotification" name="bodyAsNotification"/>
-                                    <t t-if="message.message_type !== 'notification' and !message.is_transient and (message.hasTextContent or message.subtype_description or state.isEditing or message.edited)">
-                                        <LinkPreviewList t-if="!state.isEditing and message.linkPreviewSquash" linkPreviews="message.linkPreviews" deletable="false"/>
+                                    <t t-if="message.message_type !== 'notification' and !message.is_transient and (message.hasTextContent or message.subtype_description or state.isEditing or message.edited or message.parentMessage)">
+                                        <LinkPreviewList t-if="!state.isEditing and message.linkPreviewSquash and !message.parentMessage" linkPreviews="message.linkPreviews" deletable="false"/>
                                         <t t-else="">
                                             <div class="position-relative overflow-x-auto overflow-y-hidden d-inline-block text-body" t-att-class="{ 'w-100': state.isEditing }">
                                                 <div t-if="message.bubbleColor" class="o-mail-Message-bubble rounded-bottom-3 position-absolute top-0 start-0 w-100 h-100 border" t-att-class="{
@@ -76,12 +77,12 @@
                                                     'o-green': message.bubbleColor === 'green',
                                                     'o-orange': message.bubbleColor === 'orange',
                                                     }" t-attf-class="{{ isAlignedRight ? 'rounded-start-3' : 'rounded-end-3' }}"/>
-                                                <MessageInReply t-if="message.parentMessage" message="message" onClick="props.onParentMessageClick"/>
+                                                <MessageInReply t-if="message.parentMessage" class="'mx-2 p-1 pb-0 ' + (showTextVisually ? 'mt-1' : 'my-1')" message="message" onClick="props.onParentMessageClick"/>
                                                 <div class="position-relative text-break o-mail-Message-body" t-att-class="{
                                                             'p-1': message.is_note,
                                                             'fs-1': !state.isEditing and !env.inChatter and message.onlyEmojis,
                                                             'mb-0': !message.is_note,
-                                                            'py-2': !message.is_note and !state.isEditing,
+                                                            'py-2': !message.is_note and !state.isEditing and showTextVisually,
                                                             'pt-2 pb-1': !message.is_note and state.isEditing,
                                                             'o-note': message.is_note,
                                                             'align-self-start rounded-end-3 rounded-bottom-3': !state.isEditing and !message.is_note,
@@ -92,7 +93,7 @@
                                                         <em t-if="message.subject and !message.isSubjectSimilarToThreadName and !message.isSubjectDefault" class="d-block text-muted smaller">Subject: <t t-out="props.messageSearch?.highlight(message.subject) ?? message.subject"/></em>
                                                         <div class="overflow-x-auto" t-if="message.message_type and message.message_type.includes('email')" t-ref="shadowBody"/>
                                                         <t t-elif="message.showTranslation" t-out="message.translationValue"/>
-                                                        <t t-elif="message.body" t-out="props.messageSearch?.highlight(message.body) ?? message.body"/>
+                                                        <t t-elif="message.body and !message.linkPreviewSquash" t-out="props.messageSearch?.highlight(message.body) ?? message.body"/>
                                                         <p class="fst-italic text-muted small" t-if="message.showTranslation">
                                                             <t t-if="message.translationSource" t-esc="translatedFromText"/>
                                                         </p>
@@ -121,6 +122,7 @@
                                     unlinkAttachment.bind="onClickAttachmentUnlink"
                                     imagesHeight="message.attachment_ids.length === 1 ? 300 : 75"
                                     messageSearch="props.messageSearch"/>
+                                <LinkPreviewList t-if="!state.isEditing and message.linkPreviewSquash and message.parentMessage" linkPreviews="message.linkPreviews" deletable="false"/>
                                 <LinkPreviewList t-if="message.linkPreviews.length > 0 and store.hasLinkPreviewFeature and !message.linkPreviewSquash" linkPreviews="message.linkPreviews" deletable="message.isSelfAuthored or store.self.isAdmin"/>
                             </div>
                             <t t-if="!message.is_note and (!message.hasTextContent or env.inChatWindow)" t-call="mail.Message.actions"/>

--- a/addons/mail/static/src/core/common/message_in_reply.js
+++ b/addons/mail/static/src/core/common/message_in_reply.js
@@ -4,7 +4,8 @@ import { useService } from "@web/core/utils/hooks";
 import { url } from "@web/core/utils/urls";
 
 export class MessageInReply extends Component {
-    static props = ["message", "onClick?"];
+    static props = ["class?", "message", "onClick?"];
+    static defaultProps = { class: "" };
     static template = "mail.MessageInReply";
 
     setup() {

--- a/addons/mail/static/src/core/common/message_in_reply.xml
+++ b/addons/mail/static/src/core/common/message_in_reply.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.MessageInReply">
-        <div class="o-mail-MessageInReply mx-2 mt-1 p-1 pb-0">
+        <div class="o-mail-MessageInReply" t-attf-class="{{ props.class }}">
             <small class="o-mail-MessageInReply-core o-mail-Message-bubble o-muted border position-relative d-flex px-2 py-1 rounded-3 rounded-start-0 d-inline-flex" t-att-class="{
                 'o-blue': props.message.parentMessage.bubbleColor === 'blue',
                 'o-green': props.message.parentMessage.bubbleColor === 'green',

--- a/addons/mail/static/tests/message/message_reply.test.js
+++ b/addons/mail/static/tests/message/message_reply.test.js
@@ -96,3 +96,31 @@ test("reply shows correct author avatar", async () => {
         }/avatar_128?unique=${deserializeDateTime(partner.write_date).ts}`}`
     );
 });
+
+test("reply with only attachment shows parent message context", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "general" });
+    const originalMessageId = pyEnv["mail.message"].create({
+        body: "Original message content",
+        message_type: "comment",
+        model: "discuss.channel",
+        res_id: channelId,
+    });
+    const attachmentId = pyEnv["ir.attachment"].create({
+        name: "test_image.png",
+        mimetype: "image/png",
+    });
+    pyEnv["mail.message"].create({
+        attachment_ids: [attachmentId],
+        body: "",
+        message_type: "comment",
+        model: "discuss.channel",
+        parent_id: originalMessageId,
+        res_id: channelId,
+    });
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-mail-MessageInReply-message", {
+        text: "Original message content",
+    });
+});


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
----------------------------------------------
Currently, when replying to a message with only attachments (no text content),
the parent message context is not displayed. This makes it unclear which message
the user is replying to when they only attach files without typing any text.

**Current behavior before PR:**
----------------------------------------------
- Reply messages with only attachments do not show the parent message context
- Users cannot see what message they are replying to when only attaching files
- The MessageInReply component is not rendered for attachment-only replies

**Desired behavior after PR is merged:**
----------------------------------------------
- Reply messages with only attachments now display the parent message context
- Users can clearly see what message they are replying to, even with only attachments
- The MessageInReply component renders consistently for all reply types
- Visual structure maintains proper Odoo message styling
- Better user experience with clear reply context

Task-5109159

----------------------------------------------
I confirm I have signed the CLA and read the PR guidelines at https://www.odoo.com/submit-pr
