### PR TITLE
[FIX] web: prevent KeyError in web_read when record values are missing

### DIFF
--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -180,7 +180,7 @@ class Base(models.AbstractModel):
                     if not record[field_name]:
                         continue
 
-                    record_values = values_by_id[record.id]
+                    record_values = values_by_id.get(record.id, {})
 
                     if field.type == 'reference':
                         co_record = record[field_name]

--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -180,7 +180,7 @@ class Base(models.AbstractModel):
                     if not record[field_name]:
                         continue
 
-                    record_values = values_by_id.get(record.id, {})
+                    record_values = values_by_id[record.id]
 
                     if field.type == 'reference':
                         co_record = record[field_name]

--- a/odoo/addons/test_new_api/models/test_unity_read.py
+++ b/odoo/addons/test_new_api/models/test_unity_read.py
@@ -14,9 +14,17 @@ class Course(models.Model):
     reference = fields.Reference(string='reference to lesson', selection='_selection_reference_model')
     m2o_reference_id = fields.Many2oneReference(string='reference to lesson too', model_field='m2o_reference_model')
     m2o_reference_model = fields.Char(string='reference to the model for m2o_reference')
+    m2o_reference_name = fields.Char('Ref Name', compute='_compute_m2o_reference_name')
 
     def _selection_reference_model(self):
         return [('test_new_api.lesson', None)]
+
+    def _compute_m2o_reference_name(self):
+        for record in self:
+            if record.m2o_reference_id and record.m2o_reference_model:
+                record.m2o_reference_name = self.env[record.m2o_reference_model].browse(record.m2o_reference_id).name
+            else:
+                record.m2o_reference_name = False
 
 
 class Lesson(models.Model):

--- a/odoo/addons/test_new_api/tests/test_unity_read.py
+++ b/odoo/addons/test_new_api/tests/test_unity_read.py
@@ -888,3 +888,15 @@ class TestUnityRead(TransactionCase):
         self.assertEqual(values[0]['name'], 'discussion_color_code')
         self.assertEqual(values[1]['name'], 'moderator_partner_id')
         self.assertEqual(values[1]['value'], (partner.id, 'Test Partner Properties'))
+
+    def test_read_record_with_no_values(self):
+        self.lesson_day1.unlink()
+        records = self.env['test_new_api.course'].search([('name', '!=', False)])
+        read = records.web_read({'m2o_reference_id': {'fields': {'display_name': {}}}, 'm2o_reference_name': {}})
+        self.assertEqual(read, [
+            {
+                'id': self.course_no_author.id,
+                'm2o_reference_id': 0,
+                'm2o_reference_name': False,
+            }
+        ])

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -4087,6 +4087,8 @@ class BaseModel(metaclass=MetaModel):
                 try:
                     vals[name] = convert(record[name], record, use_display_name)
                 except MissingError:
+                    if record.exists():
+                        raise
                     vals.clear()
         result = [vals for record, vals in data if vals]
 


### PR DESCRIPTION
**Steps to reproduce:**
- Install `crm` and `documents`
- Go to CRM → Activity Types
- Set a 'folder' in the `Upload Document` activity
- Create a CRM lead and schedule an upload document activity
- Delete the created lead
- Open the Documents module

**Issue:**
- A `traceback` occurs because web_read tries to access all active records by `values_by_id[record.id]`, but some records are missing from values_list after `read_format` method filters out records with missing values.
- https://github.com/odoo/odoo/blob/3c62ca1eb96d571b2b686b5caee370324c589ab4/odoo/models.py#L3347-L3356

**Solution:**
- Use values_by_id.get(record.id, {}) to safely fetch values and avoid the KeyError.

opw-5080182
