### PR TITLE
[IMP] base: unify portal accounts

### DIFF
--- a/addons/auth_signup/tests/test_auth_signup.py
+++ b/addons/auth_signup/tests/test_auth_signup.py
@@ -10,6 +10,7 @@ from odoo.addons.base.tests.common import HttpCaseWithUserPortal, HttpCaseWithUs
 from odoo.exceptions import AccessError, UserError
 
 from datetime import datetime, timedelta
+from odoo.tools import mute_logger
 
 class TestAuthSignupFlow(HttpCaseWithUserPortal, HttpCaseWithUserDemo):
 
@@ -97,3 +98,36 @@ class TestAuthSignupFlow(HttpCaseWithUserPortal, HttpCaseWithUserDemo):
             u.create_date = datetime.now() - timedelta(days=5, minutes=10)
         with self.registry.cursor() as cr:
             users.with_env(users.env(cr=cr)).send_unregistered_user_reminder(after_days=5, batch_size=100)
+
+    @mute_logger('odoo.sql_db', 'odoo.addons.auth_signup.controllers.main')
+    def test_signup_with_similar_user(self):
+        self._activate_free_signup()
+
+        def web_signup(url, data, login):
+            self.authenticate(None, None)
+            data.update({'login': login, 'csrf_token': http.Request.csrf_token(self)})
+            res = self.url_open(url, data=data)
+            self.logout()
+            return res.content
+
+        # Values from login form
+        payload = {
+            'name': 'user',
+            'password': 'mypassword',
+            'confirm_password': 'mypassword',
+        }
+
+        url_free_signup = self._get_free_signup_url()
+
+        # Signup a first time with a unique login
+        res = web_signup(url_free_signup, payload, 'Unique@Example.com')
+        self.assertIn(b'You are logged in.', res)
+        # Make sure the created user has login in lowercase
+        self.assertEqual(len(self.env['res.users'].search([('login', '=', 'unique@example.com')])), 1)
+
+        # Try to signup with similar logins (case insensitive)
+        similar_logins = ['Unique@example.com', 'UNIQUE@example.com', '  unique@Example.com  ']
+        for login in similar_logins:
+            with self.subTest(login=login):
+                res = web_signup(url_free_signup, payload, login)
+                self.assertIn(b'Another user is already registered using this email address.', res)

--- a/addons/base_import_module/tests/test_import_module.py
+++ b/addons/base_import_module/tests/test_import_module.py
@@ -336,7 +336,7 @@ class TestImportModule(odoo.tests.TransactionCase):
 
     def test_import_and_update_module(self):
         self.test_user = new_test_user(
-            self.env, login='Admin',
+            self.env, login='Admin_',
             groups='base.group_user,base.group_system',
             name='Admin',
         )

--- a/addons/calendar/tests/test_res_users.py
+++ b/addons/calendar/tests/test_res_users.py
@@ -58,8 +58,8 @@ class TestResUsers(TransactionCase):
         not useful tracking these fields for non-internal users.
         """
         username_and_group = {
-            'PORTAL': 'base.group_portal',
-            'PUBLIC': 'base.group_public',
+            'PORTAL0': 'base.group_portal',
+            'PUBLIC0': 'base.group_public',
         }
 
         for username, group in username_and_group.items():

--- a/addons/portal/wizard/portal_wizard.py
+++ b/addons/portal/wizard/portal_wizard.py
@@ -3,7 +3,7 @@
 import logging
 
 from odoo.tools.translate import _
-from odoo.tools import email_normalize
+from odoo.tools import email_normalize, single_email_re
 from odoo.exceptions import UserError
 
 from odoo import api, fields, models, Command
@@ -105,7 +105,7 @@ class PortalWizardUser(models.TransientModel):
             if next((user for user in existing_users if self._is_portal_similar_than_user(user, portal_user)), None):
                 portal_user.email_state = 'exist'
             else:
-                portal_user.email_state = 'ok'
+                portal_user.email_state = 'ok' if single_email_re.match(portal_user.email) else 'ko'
 
     @api.depends('partner_id')
     def _compute_user_id(self):

--- a/addons/web/tests/test_login.py
+++ b/addons/web/tests/test_login.py
@@ -1,5 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import datetime
+
 from odoo import http
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 from odoo.tests.common import get_db_name, HOST, HttpCase, new_test_user, Opener, tagged
@@ -59,6 +61,57 @@ class TestWebLogin(TestWebLoginCommon):
 
         # log in using the above form, it should still be valid
         self.login('internal_user', 'internal_user', csrf_token)
+
+    def test_web_login_case_insensitive(self):
+        # Test that login is case insensitive
+        login = '  InterNal_User  '
+        res_post = self.login(login, 'internal_user')
+
+        # ensure we are logged-in
+        self.url_open(
+            '/web/session/check',
+            headers={'Content-Type': 'application/json'},
+            data='{}'
+        ).raise_for_status()
+        # ensure we end up on the right page for internal users.
+        self.assertEqual(res_post.request.path_url, '/odoo')
+
+    def test_web_login_with_similar_logins(self):
+        " Test that similar logins (case insensitive) are properly ordered by _get_login_order. "
+        User = self.env['res.users']
+
+        similar_logins = ['User', 'user', 'user2', 'USER2']
+        users = User.with_context(force_lowercase_login=False).create([
+            {'login': login, 'name': login, 'password': login}
+            for login in similar_logins
+        ])
+
+        for idx, user in enumerate(users[:-1]):
+            self.patch(self.env.cr, 'now', lambda: datetime.datetime.now() + datetime.timedelta(minutes=idx))
+            User.with_user(user)._update_last_login()
+
+        # Search those users and check that the order is correct
+        similar_users = User.search(User._get_login_domain('user'), order=User._get_login_order())
+        self.assertEqual(len(similar_users), 2)
+        self.assertEqual(similar_users[0].login, 'user')
+        self.assertGreater(similar_users[0].login_date, similar_users[1].login_date)
+
+        # Check order for the similar logins involving null login dates.
+        similar_users = User.search(User._get_login_domain('user2'), order=User._get_login_order())
+        self.assertEqual(len(similar_users), 2)
+        self.assertEqual(similar_users[0].login, 'user2')
+        self.assertTrue(similar_users[0].login_date)
+        self.assertFalse(similar_users[1].login_date)
+
+        res_post = self.login('user', 'user')
+        # ensure we are logged-in
+        self.url_open(
+            '/web/session/check',
+            headers={'Content-Type': 'application/json'},
+            data='{}'
+        ).raise_for_status()
+        # ensure we end up on the right page for internal users.
+        self.assertEqual(res_post.request.path_url, '/odoo')
 
 
 @tagged('post_install', '-at_install')

--- a/odoo/addons/base/tests/test_res_users.py
+++ b/odoo/addons/base/tests/test_res_users.py
@@ -117,6 +117,20 @@ class TestUsers(UsersCommonCase):
             "If the partner_id of a user has already a company, it is replaced by the user company"
         )
 
+    def test_user_login_in_lowercase(self):
+        """ Check that the user login is stored in lowercase """
+
+        test_user = self.env['res.users'].create({'name': 'John Smith', 'login': 'JSmith'})
+        self.assertEqual(
+            test_user.login, 'jsmith',
+            "The login of a user shall be stored in lowercase",
+        )
+
+        test_user.write({'login': 'JSmiTh'})
+        self.assertEqual(
+            test_user.login, 'jsmith',
+            "The login of a user shall be stored in lowercase",
+        )
 
     def test_change_user_company(self):
         """ Check the partner company update when the user company is changed """

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -485,7 +485,8 @@ class BaseCase(case.TestCase):
         old_uid = self.uid
         old_env = self.env
         try:
-            user = self.env['res.users'].sudo().search([('login', '=', login)])
+            # lowercase login to match case insensitively
+            user = self.env['res.users'].sudo().search([('login', '=', login.strip().lower())])
             assert user, "Login %s not found" % login
             # switch user
             self.uid = user.id

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -2541,12 +2541,14 @@ def users(*logins):
             old_uid = self.uid
             try:
                 # retrieve users
-                Users = self.env['res.users'].with_context(active_test=False)
+                Users = self.env['res.users'].with_context(active_test=False)\
+                # Lower case the logins because logins is in lower case only.
+                lower_logins = [login.lower() for login in logins]
                 user_id = {
                     user.login: user.id
-                    for user in Users.search([('login', 'in', list(logins))])
+                    for user in Users.search([('login', 'in', list(lower_logins))])
                 }
-                for login in logins:
+                for login in lower_logins:
                     with self.subTest(login=login):
                         # switch user and execute func
                         self.uid = user_id[login]


### PR DESCRIPTION
This commit adds a validation on the portal user signup. From this commit, new login emails are matched to exisiting logins case-insensitively and by removing the trailing whitespaces.

Task-4247745

