### PR TITLE
[FIX] {mrp,stock}_account: display correct value overview MO comp other uom

### DIFF
--- a/addons/mrp_account/tests/test_mrp_account.py
+++ b/addons/mrp_account/tests/test_mrp_account.py
@@ -827,3 +827,45 @@ class TestMrpAccountMove(TestAccountMoveStockCommon):
         mo._post_inventory()
         mo.button_mark_done()
         self.assertEqual(mo.state, 'done')
+
+    def test_mo_overview_comp_different_uom(self):
+        """ Test that the overview takes into account the uom of the component in the price computation
+        """
+        product_chocolate = self.env['product.product'].create({
+            'name': 'Chocolate',
+            'is_storable': True,
+            'uom_id': self.uom_kgm.id,
+            'standard_price': 40,
+        })
+        self.env['stock.quant'].with_context(inventory_mode=True).create({
+            'product_id': product_chocolate.id,
+            'inventory_quantity': 20,
+            'location_id': self.env.ref('stock.stock_location_stock').id,
+        })
+        product_chococake = self.env['product.product'].create({
+            'name': 'Choco Cake',
+            'is_storable': True,
+        })
+
+        self.env['mrp.bom'].create({
+            'product_id': product_chococake.id,
+            'product_tmpl_id': product_chococake.product_tmpl_id.id,
+            'product_uom_id': product_chococake.uom_id.id,
+            'product_qty': 1.0,
+            'type': 'normal',
+            'bom_line_ids': [
+                Command.create({'product_id': product_chocolate.id, 'product_qty': 100, 'product_uom_id': self.uom_gram.id}),
+            ],
+        })
+        mo = self.env['mrp.production'].create({
+            'name': 'MO',
+            'product_qty': 1.0,
+            'product_id': product_chococake.id,
+        })
+
+        mo.action_confirm()
+        overview_values = self.env['report.mrp.report_mo_overview'].get_report_values(mo.id)
+        self.assertEqual(round(overview_values['data']['summary']['mo_cost'], 2), 4)
+        mo.button_mark_done()
+        overview_values = self.env['report.mrp.report_mo_overview'].get_report_values(mo.id)
+        self.assertEqual(round(overview_values['data']['summary']['mo_cost'], 2), 4)

--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -191,11 +191,12 @@ class StockMove(models.Model):
 
     def _get_price_unit(self):
         """ Returns the unit price to value this stock move """
-        if len(self.product_id) > 1:
+        if len(self.product_id) != 1:
             return 0
         total_value = sum(self.mapped('value'))
         total_qty = sum(m._get_valued_qty() for m in self)
-        return total_value / total_qty if total_qty else self.product_id.standard_price
+        price_unit = total_value / total_qty if total_qty else self.product_id.standard_price
+        return self.product_id.uom_id._compute_price(price_unit, self.product_uom)
 
     @api.model
     def _get_valued_types(self):


### PR DESCRIPTION
**Problem:**
The overview of a produced MO does not take into account the uom 
of the component for the valuation

**Steps to reproduce:**
- Create a storable product (the comp) 
- set the uom as L and the cost as 40$ per L
- set an on hand quantity
- Create a storable product (the final product)
- Create a bom for this final product using 100 ml of the comp
- Create, confirm and produce a MO for the final product
- click on the overview smart button

**Current behavior:**
the real cost is 4000$ (100*40)

**Expected behavior:**
it should be 4 (0.1 * 40)

**Cause of the issue:**
https://github.com/odoo/odoo/blob/11cbbb85b1ee2a620d752b79e86fc51a8e3b33e4/addons/stock_account/models/stock_move.py#L191-L198
_get_price_unit() does not take into account the case where 
the uom of the move is not the uom of the product

opw-5102760