### PR TITLE
[IMP] mail: Rename `channels` and `chats`

### DIFF
--- a/addons/mail/static/src/core/public_web/messaging_menu.js
+++ b/addons/mail/static/src/core/public_web/messaging_menu.js
@@ -135,7 +135,7 @@ export class MessagingMenu extends Component {
     get _tabs() {
         return [
             {
-                counter: this.store.discuss.chats.threadsWithCounter.length,
+                counter: this.store.discuss.chatCategory.threadsWithCounter.length,
                 icon: "oi oi-users",
                 id: "chat",
                 label: _t("Chats"),
@@ -143,7 +143,7 @@ export class MessagingMenu extends Component {
             },
             {
                 channelHasUnread: Boolean(this.store.discuss.unreadChannels.length),
-                counter: this.store.discuss.channels.threadsWithCounter.length,
+                counter: this.store.discuss.channelCategory.threadsWithCounter.length,
                 icon: "fa fa-hashtag",
                 id: "channel",
                 label: _t("Channels"),

--- a/addons/mail/static/src/discuss/core/public/discuss_app_model_patch.js
+++ b/addons/mail/static/src/discuss/core/public/discuss_app_model_patch.js
@@ -4,8 +4,8 @@ import "@mail/discuss/core/public_web/discuss_app_model_patch";
 import { patch } from "@web/core/utils/patch";
 
 patch(DiscussApp.prototype, {
-    computeChats() {
-        const res = super.computeChats(...arguments);
+    computeChatCategory() {
+        const res = super.computeChatCategory(...arguments);
         res.hideWhenEmpty = true;
         return res;
     },

--- a/addons/mail/static/src/discuss/core/public_web/@types/models.d.ts
+++ b/addons/mail/static/src/discuss/core/public_web/@types/models.d.ts
@@ -7,7 +7,7 @@ declare module "models" {
         allCategories: DiscussAppCategory[];
         channels: DiscussAppCategory;
         chats: DiscussAppCategory;
-        computeChats: () => object;
+        computeChatCategory: () => object;
         unreadChannels: Thread[];
     }
     export interface DiscussChannel {

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app_model_patch.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app_model_patch.js
@@ -14,7 +14,7 @@ const discussAppPatch = {
                     ? c1.sequence - c2.sequence
                     : c1.name.localeCompare(c2.name),
         });
-        this.channels = fields.One("DiscussAppCategory", {
+        this.channelCategory = fields.One("DiscussAppCategory", {
             compute() {
                 return {
                     addTitle: _t("Add or join a channel"),
@@ -29,15 +29,15 @@ const discussAppPatch = {
             },
             eager: true,
         });
-        this.chats = fields.One("DiscussAppCategory", {
+        this.chatCategory = fields.One("DiscussAppCategory", {
             compute() {
-                return this.computeChats();
+                return this.computeChatCategory();
             },
             eager: true,
         });
         this.unreadChannels = fields.Many("mail.thread", { inverse: "appAsUnreadChannels" });
     },
-    computeChats() {
+    computeChatCategory() {
         return {
             addTitle: _t("Start a conversation"),
             canView: false,

--- a/addons/mail/static/src/discuss/core/public_web/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/public_web/thread_model_patch.js
@@ -59,10 +59,10 @@ const threadPatch = {
             return;
         }
         if (["group", "chat"].includes(this.channel?.channel_type)) {
-            return this.store.discuss.chats;
+            return this.store.discuss.chatCategory;
         }
         if (this.channel?.channel_type === "channel") {
-            return this.store.discuss.channels;
+            return this.store.discuss.channelCategory;
         }
     },
     get allowCalls() {

--- a/addons/mail/static/src/discuss/core/web/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/web/thread_model_patch.js
@@ -8,7 +8,7 @@ patch(Thread.prototype, {
         if (!this.displayToSelf && !this.isLocallyPinned && this.eq(this.store.discuss.thread)) {
             if (this.store.discuss.isActive) {
                 const newThread =
-                    this.store.discuss.channels.threads.find(
+                    this.store.discuss.channelCategory.threads.find(
                         (thread) => thread.displayToSelf || thread.isLocallyPinned
                     ) || this.store.inbox;
                 newThread.setAsDiscussThread();


### PR DESCRIPTION
...in `discuss_app_model`

These fields were poorly named:
- Used plural for a one-to-one relation
- Used generic names for what are actually "category" models