### PR TITLE
[FIX] html_editor: prevent tour timeout when editor is missing from bundle

### DIFF
--- a/addons/html_editor/static/tests/tours/helpers/editor.js
+++ b/addons/html_editor/static/tests/tours/helpers/editor.js
@@ -1,12 +1,15 @@
 import { patch } from "@web/core/utils/patch";
-import { Editor } from "@html_editor/editor";
 
 // To expose the editor instance globally for tour.
 export const editorsWeakMap = new WeakMap();
 
-patch(Editor.prototype, {
-    attachTo(editable) {
-        editorsWeakMap.set(editable.ownerDocument, this);
-        return super.attachTo(...arguments);
-    },
-});
+const editorModule = odoo.loader.modules.get("@html_editor/editor");
+if (editorModule) {
+    const { Editor } = editorModule;
+    patch(Editor.prototype, {
+        attachTo(editable) {
+            editorsWeakMap.set(editable.ownerDocument, this);
+            return super.attachTo(...arguments);
+        },
+    });
+}


### PR DESCRIPTION
Steps to reproduce
==================

Run the test test_contactus_form_email_stay_dynamic
The ready "odoo.isTourReady('...')" code was always falsy

Cause of the issue
==================

website_form_editor.js import @html_editor/../tests/tours/helpers/editor
it itself import @html_editor/editor
Since the editor is not part of the bundle when loading the tour, nothing is loaded

Solution
========

As it not that easy to include the editor in the web.assets_tests bundle,
we check if the editor module is present before patching it.
When actually running the tour, it will be present.

runbot-231561