### PR TITLE
[IMP] web: decouple record duplication from create permission

### DIFF
--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -516,7 +516,7 @@ export class FormController extends Component {
                 callback: () => this.model.bus.trigger("PROPERTY_FIELD:EDIT"),
             },
             duplicate: {
-                isAvailable: () => activeActions.create && activeActions.duplicate,
+                isAvailable: () => activeActions.duplicate,
                 sequence: 30,
                 icon: "fa fa-clone",
                 description: _t("Duplicate"),

--- a/addons/web/static/src/views/utils.js
+++ b/addons/web/static/src/views/utils.js
@@ -155,15 +155,13 @@ export function getFormattedValue(record, fieldName, fieldInfo = null) {
  * @returns {ViewActiveActions}
  */
 export function getActiveActions(rootNode) {
-    const activeActions = {
+    return {
         type: "view",
         edit: exprToBoolean(rootNode.getAttribute("edit"), true),
         create: exprToBoolean(rootNode.getAttribute("create"), true),
         delete: exprToBoolean(rootNode.getAttribute("delete"), true),
+        duplicate: exprToBoolean(rootNode.getAttribute("duplicate"), true),
     };
-    activeActions.duplicate =
-        activeActions.create && exprToBoolean(rootNode.getAttribute("duplicate"), true);
-    return activeActions;
 }
 
 export function getClassNameFromDecoration(decoration) {

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -4256,6 +4256,29 @@ test(`can duplicate a record`, async () => {
     expect(`.o_form_editable`).toHaveCount(1);
 });
 
+test(`can duplicate a record even with create="0"`, async () => {
+    onRpc("copy", ({ args, model }) => {
+        if (model === "partner") {
+            expect(args).toEqual([[1]]);
+            expect.step("copy");
+        }
+    });
+    await mountView({
+        resModel: "partner",
+        type: "form",
+        arch: `<form create="0"><field name="foo"/></form>`,
+        resId: 1,
+        actionMenus: {},
+    });
+    expect(`.o_breadcrumb`).toHaveText("first record");
+
+    await toggleActionMenu();
+    await toggleMenuItem("Duplicate");
+    expect.verifySteps(["copy"]);
+    expect(`.o_breadcrumb`).toHaveText("first record (copy)");
+    expect(`.o_form_editable`).toHaveCount(1);
+});
+
 test(`duplicating a record preserves the context`, async () => {
     onRpc("web_read", ({ kwargs }) => expect.step(kwargs.context.hey));
     await mountView({

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -5622,6 +5622,26 @@ test(`duplicate one record`, async () => {
     expect(`tbody tr`).toHaveCount(5, { message: "should have 5 rows" });
 });
 
+test(`duplicate is possible even with create="0"`, async () => {
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `<list editable="top" create="0"><field name="foo"/></list>`,
+        actionMenus: {},
+    });
+
+    // Initial state: there should be 4 records
+    expect(`tbody tr`).toHaveCount(4, { message: "should have 4 rows" });
+
+    // Duplicate one record
+    await clickRecordSelector();
+    await contains(`.o_cp_action_menus .dropdown-toggle`).click();
+    await toggleMenuItem("Duplicate");
+
+    // Final state: there should be 5 records
+    expect(`tbody tr`).toHaveCount(5, { message: "should have 5 rows" });
+});
+
 test(`duplicate all records`, async () => {
     await mountView({
         resModel: "foo",


### PR DESCRIPTION
This commit allows record duplication even when creation is disabled (create="0").

Duplication permissions should depend only on specific duplication rules (e.g., duplicate attribute) and server-side access rights — not on the create attribute. This makes sense in cases where users are allowed to duplicate existing records but not create new ones from scratch.

task-5131124
