### PR TITLE
[FIX] website: avoid using `t-portal` when editing login page

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -257,7 +257,7 @@
             'website/static/src/js/text_processing.js',
             'website/static/src/js/highlight_utils.js',
             'website/static/src/client_actions/website_preview/website_builder_action.editor.scss',
-            'website/static/src/components/user_switch.js',
+            'website/static/src/components/user_switch.*',
         ],
         'web.assets_frontend_minimal': [
             'website/static/src/utils/misc.js',

--- a/addons/website/static/src/components/user_switch.js
+++ b/addons/website/static/src/components/user_switch.js
@@ -1,12 +1,7 @@
 import { UserSwitch } from "@web/core/user_switch/user_switch";
-import { patch } from "@web/core/utils/patch";
+import { registry } from "@web/core/registry";
+export class UserSwitchEdit extends UserSwitch {
+    static template = "website.login_user_switch.edit";
+}
 
-patch(UserSwitch.prototype, {
-    toggleFormDisplay() {
-        if (document.body.classList.contains("editor_enable")) {
-            return;
-        }
-        super.toggleFormDisplay();
-    },
-});
-
+registry.category("public_components.edit").add("web.user_switch", UserSwitchEdit);

--- a/addons/website/static/src/components/user_switch.xml
+++ b/addons/website/static/src/components/user_switch.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+<t t-name="website.login_user_switch.edit" t-inherit="web.login_user_switch" t-inherit-mode="primary">
+    <xpath expr="//t[@t-portal]" position="replace"/>
+</t>
+
+</templates>


### PR DESCRIPTION
Before this commit, part of the `/web/login` page was immediately marked as dirty when the editor opened. This happened because `UserSwitch` component used a `t-portal` directive that rendered an element outside the `owl-component` tag, causing it to be tracked by the mutation observer.

After this commit, the `t-portal` directive is ignored when in edit mode. A side effect of this solution is that the "Choose a user" button is hidden during editing, but this button was already non-editable and non-clickable during edit.

**How to reproduce the problem**

1. Navigate to "/web/login"
2. Activate edit mode
3. The "o_dirty" class is present in the login form
