### PR TITLE
[FIX] web: increase the initial size of some dialogs

### DIFF
--- a/addons/web/static/src/core/confirmation_dialog/confirmation_dialog.xml
+++ b/addons/web/static/src/core/confirmation_dialog/confirmation_dialog.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
   <t t-name="web.ConfirmationDialog">
-    <Dialog size="'sm'" title="props.title" modalRef="modalRef">
+    <Dialog size="'md'" title="props.title" modalRef="modalRef">
       <p t-out="props.body" class="text-prewrap"/>
       <t t-set-slot="footer">
         <button class="btn" t-att-class="props.confirmClass" t-on-click="_confirm" t-esc="props.confirmLabel" data-hotkey="q"/>

--- a/addons/web/static/src/core/errors/error_dialogs.xml
+++ b/addons/web/static/src/core/errors/error_dialogs.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.WarningDialog">
-        <Dialog title="title" size="'sm'" contentClass="'o_error_dialog'">
+        <Dialog title="title" size="'md'" contentClass="'o_error_dialog'">
             <div role="alert">
                 <p t-esc="message" class="text-prewrap"/>
             </div>
@@ -51,7 +51,7 @@
     </t>
 
     <t t-name="web.ErrorDialog">
-        <Dialog title.translate="Oops!" size="state.showTraceback ? 'xl' : 'sm'" contentClass="'o_error_dialog'">
+        <Dialog title.translate="Oops!" size="state.showTraceback ? 'xl' : 'md'" contentClass="'o_error_dialog'">
             <div role="alert">
                 <p>
                     Something went wrong... If you really are stuck, share the report with your friendly support service

--- a/addons/web/static/src/webclient/settings_form_view/settings_confirmation_dialog.xml
+++ b/addons/web/static/src/webclient/settings_form_view/settings_confirmation_dialog.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="web.SettingsConfirmationDialog">
-        <Dialog size="'sm'" title="props.title" modalRef="modalRef">
+        <Dialog size="'md'" title="props.title" modalRef="modalRef">
             <t t-esc="props.body" />
             <t t-set-slot="footer">
                 <button class="btn btn-primary" t-on-click="_confirm">

--- a/addons/web/static/tests/webclient/clickbot.test.js
+++ b/addons/web/static/tests/webclient/clickbot.test.js
@@ -459,7 +459,7 @@ test("clickbot show rpc error when an error dialog is detected", async () => {
     });
     const expectedModalHtml = /* xml */ `
         <header class="modal-header">
-            <h4 class="modal-title text-break flex-grow-1 fs-5">Oops!</h4>
+            <h4 class="modal-title text-break flex-grow-1">Oops!</h4>
             <button type="button" class="btn-close position-absolute top-0 end-0 mt-1 me-1" aria-label="Close" tabindex="-1"></button>
         </header>
         <main class="modal-body">


### PR DESCRIPTION
Following feedback received since the redesign of the dialog [1], the initial size of some dialogs will be increased to avoid unsightly excessive line breaks.

Steps to reproduce:

- Go to event and create a new event.
- Create a range in the date
- Enable multi-slots
- Click on the slot
- Select a first day inside the slot
- Click on the "Add" button
- Select an hour before the event start and click on "Add" button => Validation Error is displayed with an unsightly line breaks

task-5049469

[1]: https://github.com/odoo/odoo/pull/226581

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
