### PR TITLE
[IMP] web: calendar view wrong end time at create

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
@@ -253,7 +253,14 @@ export class CalendarCommonRenderer extends Component {
             }, 250);
         }
     }
-    onEventContent({ event }) {
+    onEventContent(arg) {
+        const { event } = arg;
+        if (event.start && event.end) {
+            const timeFormat = is24HourFormat() ? "HH:mm" : "hh:mm a";
+            const dateFmt = (date) =>
+                luxon.DateTime.fromISO(date.toISOString()).toLocal().toFormat(timeFormat);
+            arg.timeText = `${dateFmt(event.start)} - ${dateFmt(event.end)}`;
+        }
         const record = this.props.model.records[event.id];
         if (record) {
             // This is needed in order to give the possibility to change the event template.


### PR DESCRIPTION
When creating an event in week view over multiple days, all parts of the event display 12pm as end date (except the last one) and 00am as the start date (except the first one).

This comes from the default behavior of fullcalendar.

task-4700158
