### PR TITLE
[FIX] hr_holidays: Sync overlapping time off creation in bulk generation

### DIFF
--- a/addons/hr_holidays/tests/test_company_leave.py
+++ b/addons/hr_holidays/tests/test_company_leave.py
@@ -18,7 +18,6 @@ class TestCompanyLeave(TransactionCase):
         cls.company = cls.env['res.company'].create({'name': 'A company'})
         cls.company.resource_calendar_id.tz = "Europe/Brussels"
 
-
         cls.bank_holiday = cls.env['hr.leave.type'].create({
             'name': 'Bank Holiday',
             'responsible_ids': [Command.link(cls.env.ref('base.user_admin').id)],
@@ -34,6 +33,15 @@ class TestCompanyLeave(TransactionCase):
             'requires_allocation': False,
         })
 
+        cls.overlap_leave_type = cls.env['hr.leave.type'].create({
+            'name': 'Overlap Allowed Leave Type',
+            'request_unit': 'day',
+            'company_id': cls.company.id,
+            'requires_allocation': False,
+            'allow_request_on_top': True,
+            'time_type': 'other',
+        })
+
         cls.employee = cls.env['hr.employee'].create({
             'name': 'My Employee',
             'company_id': cls.company.id,
@@ -43,12 +51,12 @@ class TestCompanyLeave(TransactionCase):
     def test_01_leave_whole_company(self):
         # TEST CASE 1: Leaves taken in days. Take a 3 days leave
         # Add a company leave on the second day.
-        # Check that leave is split into 2.
+        # Check that the existing leave is kept and the company leave is created on top.
 
         leave = self.env['hr.leave'].create({
             'name': 'Hol11',
             'employee_id': self.employee.id,
-            'holiday_status_id': self.paid_time_off.id,
+            'holiday_status_id': self.overlap_leave_type.id,
             'request_date_from': date(2020, 1, 7),
             'request_date_to': date(2020, 1, 9),
         })
@@ -64,33 +72,26 @@ class TestCompanyLeave(TransactionCase):
         company_leave.action_generate_time_off()
 
         all_leaves = self.env['hr.leave'].search([('employee_id', '=', self.employee.id)], order='id')
-        self.assertEqual(len(all_leaves), 3)
-        # Before Time Off
-        self.assertEqual(all_leaves[0].date_from, datetime(2020, 1, 7, 7, 0))
-        self.assertEqual(all_leaves[0].date_to, datetime(2020, 1, 7, 16, 0))
-        self.assertEqual(all_leaves[0].number_of_days, 1)
-        self.assertEqual(all_leaves[0].state, 'confirm')
-        # After Time Off
-        self.assertEqual(all_leaves[1].date_from, datetime(2020, 1, 9, 7, 0))
-        self.assertEqual(all_leaves[1].date_to, datetime(2020, 1, 9, 16, 0))
+        self.assertEqual(len(all_leaves), 2)
+        self.assertEqual(leave.date_from, datetime(2020, 1, 7, 7, 0))
+        self.assertEqual(leave.date_to, datetime(2020, 1, 9, 16, 0))
+        self.assertEqual(leave.number_of_days, 3)
+        self.assertEqual(leave.state, 'confirm')
+        self.assertEqual(all_leaves[1].date_from, datetime(2020, 1, 8, 7, 0))
+        self.assertEqual(all_leaves[1].date_to, datetime(2020, 1, 8, 16, 0))
         self.assertEqual(all_leaves[1].number_of_days, 1)
-        self.assertEqual(all_leaves[1].state, 'confirm')
-        # Company Time Off
-        self.assertEqual(all_leaves[2].date_from, datetime(2020, 1, 8, 7, 0))
-        self.assertEqual(all_leaves[2].date_to, datetime(2020, 1, 8, 16, 0))
-        self.assertEqual(all_leaves[2].number_of_days, 1)
-        self.assertEqual(all_leaves[2].state, 'validate')
+        self.assertEqual(all_leaves[1].state, 'validate')
 
     def test_02_leave_whole_company(self):
         # TEST CASE 2: Leaves taken in half-days. Take a 3 days leave
         # Add a company leave on the second day
-        # Check that leave is split into 2
-        self.paid_time_off.request_unit = 'half_day'
+        # Check that the existing leave is kept and the company leave is created on top.
+        self.overlap_leave_type.request_unit = 'half_day'
 
         leave = self.env['hr.leave'].create({
             'name': 'Hol11',
             'employee_id': self.employee.id,
-            'holiday_status_id': self.paid_time_off.id,
+            'holiday_status_id': self.overlap_leave_type.id,
             'request_date_from': date(2020, 1, 7),
             'request_date_to': date(2020, 1, 9),
         })
@@ -108,37 +109,29 @@ class TestCompanyLeave(TransactionCase):
         company_leave.action_generate_time_off()
 
         all_leaves = self.env['hr.leave'].search([('employee_id', '=', self.employee.id)], order='id')
-        self.assertEqual(len(all_leaves), 3)
-        # Before Time Off
-        self.assertEqual(all_leaves[0].date_from, datetime(2020, 1, 7, 7, 0))
-        self.assertEqual(all_leaves[0].date_to, datetime(2020, 1, 7, 16, 0))
-        self.assertEqual(all_leaves[0].number_of_days, 1)
-        self.assertEqual(all_leaves[0].state, 'confirm')
-        # After Time Off
-        self.assertEqual(all_leaves[1].date_from, datetime(2020, 1, 9, 7, 0))
-        self.assertEqual(all_leaves[1].date_to, datetime(2020, 1, 9, 16, 0))
+        self.assertEqual(len(all_leaves), 2)
+        self.assertEqual(leave.date_from, datetime(2020, 1, 7, 7, 0))
+        self.assertEqual(leave.date_to, datetime(2020, 1, 9, 16, 0))
+        self.assertEqual(leave.number_of_days, 3)
+        self.assertEqual(leave.state, 'confirm')
+        self.assertEqual(all_leaves[1].date_from, datetime(2020, 1, 8, 7, 0))
+        self.assertEqual(all_leaves[1].date_to, datetime(2020, 1, 8, 16, 0))
         self.assertEqual(all_leaves[1].number_of_days, 1)
-        self.assertEqual(all_leaves[1].state, 'confirm')
-        # Company Time Off
-        self.assertEqual(all_leaves[2].date_from, datetime(2020, 1, 8, 7, 0))
-        self.assertEqual(all_leaves[2].date_to, datetime(2020, 1, 8, 16, 0))
-        self.assertEqual(all_leaves[2].number_of_days, 1)
-        self.assertEqual(all_leaves[2].state, 'validate')
+        self.assertEqual(all_leaves[1].state, 'validate')
 
     def test_03_leave_whole_company(self):
         # TEST CASE 3: Time Off taken in half-days. Take a 0.5 days leave
         # Add a company leave on the same day
-        # Check that leave refused
-        self.paid_time_off.request_unit = 'half_day'
+        # Check that the existing leave is kept and the company leave is created on top.
+        self.overlap_leave_type.request_unit = 'half_day'
 
         leave = self.env['hr.leave'].create({
             'name': 'Hol11',
             'employee_id': self.employee.id,
-            'holiday_status_id': self.paid_time_off.id,
+            'holiday_status_id': self.overlap_leave_type.id,
             'request_date_from': date(2020, 1, 7),
             'request_date_to': date(2020, 1, 7),
-            'request_date_from_period': 'am',
-
+            'request_date_from_period': 'pm',
         })
         leave._compute_date_from_to()
 
@@ -154,9 +147,8 @@ class TestCompanyLeave(TransactionCase):
 
         all_leaves = self.env['hr.leave'].search([('employee_id', '=', self.employee.id)], order='id')
         self.assertEqual(len(all_leaves), 2)
-        # Original Time Off
-        self.assertEqual(leave.state, 'refuse')
-        # Company Time Off
+        self.assertEqual(leave.state, 'confirm')
+        self.assertEqual(leave.number_of_days, 0.5)
         self.assertEqual(all_leaves[1].date_from, datetime(2020, 1, 7, 7, 0))
         self.assertEqual(all_leaves[1].date_to, datetime(2020, 1, 7, 16, 0))
         self.assertEqual(all_leaves[1].number_of_days, 1)
@@ -165,13 +157,13 @@ class TestCompanyLeave(TransactionCase):
     def test_04_leave_whole_company(self):
         # TEST CASE 4: Leaves taken in days. Take a 1 days leave
         # Add a company leave on the same day
-        # Check that leave is refused
-        self.paid_time_off.request_unit = 'day'
+        # Check that the existing leave is kept and the company leave is created on top.
+        self.overlap_leave_type.request_unit = 'day'
 
         leave = self.env['hr.leave'].create({
             'name': 'Hol11',
             'employee_id': self.employee.id,
-            'holiday_status_id': self.paid_time_off.id,
+            'holiday_status_id': self.overlap_leave_type.id,
             'request_date_from': date(2020, 1, 9),
             'request_date_to': date(2020, 1, 9),
 
@@ -191,9 +183,8 @@ class TestCompanyLeave(TransactionCase):
 
         all_leaves = self.env['hr.leave'].search([('employee_id', '=', self.employee.id)], order='id')
         self.assertEqual(len(all_leaves), 2)
-        # Original Time Off
-        self.assertEqual(leave.state, 'refuse')
-        # Company Time Off
+        self.assertEqual(leave.state, 'confirm')
+        self.assertEqual(leave.number_of_days, 1)
         self.assertEqual(all_leaves[1].date_from, datetime(2020, 1, 9, 7, 0))
         self.assertEqual(all_leaves[1].date_to, datetime(2020, 1, 9, 16, 0))
         self.assertEqual(all_leaves[1].number_of_days, 1)
@@ -202,7 +193,7 @@ class TestCompanyLeave(TransactionCase):
     def test_06_leave_whole_company(self):
         # Test case 6: Leaves taken in days. But the employee
         # only works on Monday, Wednesday and Friday
-        # Takes a time off for all the week (3 days), should be split
+        # Takes a time off for all the week (3 days); the company leave should be created on top.
 
         self.employee.resource_calendar_id.write({'attendance_ids': [
             (5, 0, 0),
@@ -220,7 +211,7 @@ class TestCompanyLeave(TransactionCase):
         leave = self.env['hr.leave'].create({
             'name': 'Hol11',
             'employee_id': self.employee.id,
-            'holiday_status_id': self.paid_time_off.id,
+            'holiday_status_id': self.overlap_leave_type.id,
             'request_date_from': date(2020, 1, 6),
             'request_date_to': date(2020, 1, 10),
         })
@@ -238,12 +229,10 @@ class TestCompanyLeave(TransactionCase):
 
         all_leaves = self.env['hr.leave'].search([('employee_id', '=', self.employee.id)], order='id')
         self.assertEqual(len(all_leaves), 2)
-        # Before Time Off
-        self.assertEqual(all_leaves[0].date_from, datetime(2020, 1, 6, 7, 0))
-        self.assertEqual(all_leaves[0].date_to, datetime(2020, 1, 9, 16, 0))
-        self.assertEqual(all_leaves[0].number_of_days, 2)
-        self.assertEqual(all_leaves[0].state, 'confirm')
-        # Company Time Off
+        self.assertEqual(leave.date_from, datetime(2020, 1, 6, 7, 0))
+        self.assertEqual(leave.date_to, datetime(2020, 1, 10, 16, 0))
+        self.assertEqual(leave.number_of_days, 3)
+        self.assertEqual(leave.state, 'confirm')
         self.assertEqual(all_leaves[1].date_from, datetime(2020, 1, 10, 7, 0))
         self.assertEqual(all_leaves[1].date_to, datetime(2020, 1, 10, 16, 0))
         self.assertEqual(all_leaves[1].number_of_days, 1)
@@ -263,7 +252,7 @@ class TestCompanyLeave(TransactionCase):
         leaves = self.env['hr.leave'].create([{
             'name': 'Holiday - %s' % employee.name,
             'employee_id': employee.id,
-            'holiday_status_id': self.paid_time_off.id,
+            'holiday_status_id': self.overlap_leave_type.id,
             'request_date_from': date(2020, 3, 29),
             'request_date_to': date(2020, 4, 1),
         } for employee in employees[0:15]])
@@ -285,3 +274,45 @@ class TestCompanyLeave(TransactionCase):
 
         leaves = self.env['hr.leave'].search([('holiday_status_id', '=', self.bank_holiday.id)])
         self.assertEqual(len(leaves), 101)
+
+    def test_08_leave_whole_company(self):
+        leave = self.env['hr.leave'].create({
+            'name': 'Holiday without overlap',
+            'employee_id': self.employee.id,
+            'holiday_status_id': self.paid_time_off.id,
+            'request_date_from': date(2025, 11, 10),
+            'request_date_to': date(2025, 11, 12),
+        })
+
+        company_leave = self.env['hr.leave.generate.multi.wizard'].create({
+            'name': 'Bank Holiday',
+            'allocation_mode': 'company',
+            'company_id': self.company.id,
+            'holiday_status_id': self.bank_holiday.id,
+            'date_from': date(2025, 11, 11),
+            'date_to': date(2025, 11, 11),
+        })
+        company_leave.action_generate_time_off()
+
+        all_leaves = self.env['hr.leave'].search([
+            ('employee_id', '=', self.employee.id),
+            ('holiday_status_id', 'in', [self.bank_holiday.id, self.paid_time_off.id]),
+        ], order='id')
+        split_leave = all_leaves.filtered(lambda l: l.holiday_status_id == self.paid_time_off and l != leave)
+        generated_leave = all_leaves.filtered(lambda l: l.holiday_status_id == self.bank_holiday)
+
+        self.assertEqual(len(all_leaves), 3)
+        self.assertEqual(leave.date_from, datetime(2025, 11, 10, 7, 0))
+        self.assertEqual(leave.date_to, datetime(2025, 11, 10, 16, 0))
+        self.assertEqual(leave.number_of_days, 1)
+        self.assertEqual(leave.state, 'confirm')
+
+        self.assertEqual(split_leave.date_from, datetime(2025, 11, 12, 7, 0))
+        self.assertEqual(split_leave.date_to, datetime(2025, 11, 12, 16, 0))
+        self.assertEqual(split_leave.number_of_days, 1)
+        self.assertEqual(split_leave.state, 'confirm')
+
+        self.assertEqual(generated_leave.date_from, datetime(2025, 11, 11, 7, 0))
+        self.assertEqual(generated_leave.date_to, datetime(2025, 11, 11, 16, 0))
+        self.assertEqual(generated_leave.number_of_days, 1)
+        self.assertEqual(generated_leave.state, 'validate')

--- a/addons/hr_holidays/tests/test_company_leave.py
+++ b/addons/hr_holidays/tests/test_company_leave.py
@@ -18,7 +18,6 @@ class TestCompanyLeave(TransactionCase):
         cls.company = cls.env['res.company'].create({'name': 'A company'})
         cls.company.resource_calendar_id.tz = "Europe/Brussels"
 
-
         cls.bank_holiday = cls.env['hr.leave.type'].create({
             'name': 'Bank Holiday',
             'responsible_ids': [Command.link(cls.env.ref('base.user_admin').id)],
@@ -34,6 +33,15 @@ class TestCompanyLeave(TransactionCase):
             'requires_allocation': False,
         })
 
+        cls.overlap_leave_type = cls.env['hr.leave.type'].create({
+            'name': 'Overlap Allowed Leave Type',
+            'request_unit': 'day',
+            'company_id': cls.company.id,
+            'requires_allocation': False,
+            'allow_request_on_top': True,
+            'time_type': 'other',
+        })
+
         cls.employee = cls.env['hr.employee'].create({
             'name': 'My Employee',
             'company_id': cls.company.id,
@@ -43,12 +51,12 @@ class TestCompanyLeave(TransactionCase):
     def test_01_leave_whole_company(self):
         # TEST CASE 1: Leaves taken in days. Take a 3 days leave
         # Add a company leave on the second day.
-        # Check that leave is split into 2.
+        # Check that the existing leave is kept and the company leave is created on top.
 
         leave = self.env['hr.leave'].create({
             'name': 'Hol11',
             'employee_id': self.employee.id,
-            'holiday_status_id': self.paid_time_off.id,
+            'holiday_status_id': self.overlap_leave_type.id,
             'request_date_from': date(2020, 1, 7),
             'request_date_to': date(2020, 1, 9),
         })
@@ -64,33 +72,26 @@ class TestCompanyLeave(TransactionCase):
         company_leave.action_generate_time_off()
 
         all_leaves = self.env['hr.leave'].search([('employee_id', '=', self.employee.id)], order='id')
-        self.assertEqual(len(all_leaves), 3)
-        # Before Time Off
-        self.assertEqual(all_leaves[0].date_from, datetime(2020, 1, 7, 7, 0))
-        self.assertEqual(all_leaves[0].date_to, datetime(2020, 1, 7, 16, 0))
-        self.assertEqual(all_leaves[0].number_of_days, 1)
-        self.assertEqual(all_leaves[0].state, 'confirm')
-        # After Time Off
-        self.assertEqual(all_leaves[1].date_from, datetime(2020, 1, 9, 7, 0))
-        self.assertEqual(all_leaves[1].date_to, datetime(2020, 1, 9, 16, 0))
+        self.assertEqual(len(all_leaves), 2)
+        self.assertEqual(leave.date_from, datetime(2020, 1, 7, 7, 0))
+        self.assertEqual(leave.date_to, datetime(2020, 1, 9, 16, 0))
+        self.assertEqual(leave.number_of_days, 3)
+        self.assertEqual(leave.state, 'confirm')
+        self.assertEqual(all_leaves[1].date_from, datetime(2020, 1, 8, 7, 0))
+        self.assertEqual(all_leaves[1].date_to, datetime(2020, 1, 8, 16, 0))
         self.assertEqual(all_leaves[1].number_of_days, 1)
-        self.assertEqual(all_leaves[1].state, 'confirm')
-        # Company Time Off
-        self.assertEqual(all_leaves[2].date_from, datetime(2020, 1, 8, 7, 0))
-        self.assertEqual(all_leaves[2].date_to, datetime(2020, 1, 8, 16, 0))
-        self.assertEqual(all_leaves[2].number_of_days, 1)
-        self.assertEqual(all_leaves[2].state, 'validate')
+        self.assertEqual(all_leaves[1].state, 'validate')
 
     def test_02_leave_whole_company(self):
         # TEST CASE 2: Leaves taken in half-days. Take a 3 days leave
         # Add a company leave on the second day
-        # Check that leave is split into 2
-        self.paid_time_off.request_unit = 'half_day'
+        # Check that the existing leave is kept and the company leave is created on top.
+        self.overlap_leave_type.request_unit = 'half_day'
 
         leave = self.env['hr.leave'].create({
             'name': 'Hol11',
             'employee_id': self.employee.id,
-            'holiday_status_id': self.paid_time_off.id,
+            'holiday_status_id': self.overlap_leave_type.id,
             'request_date_from': date(2020, 1, 7),
             'request_date_to': date(2020, 1, 9),
         })
@@ -108,37 +109,29 @@ class TestCompanyLeave(TransactionCase):
         company_leave.action_generate_time_off()
 
         all_leaves = self.env['hr.leave'].search([('employee_id', '=', self.employee.id)], order='id')
-        self.assertEqual(len(all_leaves), 3)
-        # Before Time Off
-        self.assertEqual(all_leaves[0].date_from, datetime(2020, 1, 7, 7, 0))
-        self.assertEqual(all_leaves[0].date_to, datetime(2020, 1, 7, 16, 0))
-        self.assertEqual(all_leaves[0].number_of_days, 1)
-        self.assertEqual(all_leaves[0].state, 'confirm')
-        # After Time Off
-        self.assertEqual(all_leaves[1].date_from, datetime(2020, 1, 9, 7, 0))
-        self.assertEqual(all_leaves[1].date_to, datetime(2020, 1, 9, 16, 0))
+        self.assertEqual(len(all_leaves), 2)
+        self.assertEqual(leave.date_from, datetime(2020, 1, 7, 7, 0))
+        self.assertEqual(leave.date_to, datetime(2020, 1, 9, 16, 0))
+        self.assertEqual(leave.number_of_days, 3)
+        self.assertEqual(leave.state, 'confirm')
+        self.assertEqual(all_leaves[1].date_from, datetime(2020, 1, 8, 7, 0))
+        self.assertEqual(all_leaves[1].date_to, datetime(2020, 1, 8, 16, 0))
         self.assertEqual(all_leaves[1].number_of_days, 1)
-        self.assertEqual(all_leaves[1].state, 'confirm')
-        # Company Time Off
-        self.assertEqual(all_leaves[2].date_from, datetime(2020, 1, 8, 7, 0))
-        self.assertEqual(all_leaves[2].date_to, datetime(2020, 1, 8, 16, 0))
-        self.assertEqual(all_leaves[2].number_of_days, 1)
-        self.assertEqual(all_leaves[2].state, 'validate')
+        self.assertEqual(all_leaves[1].state, 'validate')
 
     def test_03_leave_whole_company(self):
         # TEST CASE 3: Time Off taken in half-days. Take a 0.5 days leave
         # Add a company leave on the same day
-        # Check that leave refused
-        self.paid_time_off.request_unit = 'half_day'
+        # Check that the existing leave is kept and the company leave is created on top.
+        self.overlap_leave_type.request_unit = 'half_day'
 
         leave = self.env['hr.leave'].create({
             'name': 'Hol11',
             'employee_id': self.employee.id,
-            'holiday_status_id': self.paid_time_off.id,
+            'holiday_status_id': self.overlap_leave_type.id,
             'request_date_from': date(2020, 1, 7),
             'request_date_to': date(2020, 1, 7),
-            'request_date_from_period': 'am',
-
+            'request_date_from_period': 'pm',
         })
         leave._compute_date_from_to()
 
@@ -154,9 +147,8 @@ class TestCompanyLeave(TransactionCase):
 
         all_leaves = self.env['hr.leave'].search([('employee_id', '=', self.employee.id)], order='id')
         self.assertEqual(len(all_leaves), 2)
-        # Original Time Off
-        self.assertEqual(leave.state, 'refuse')
-        # Company Time Off
+        self.assertEqual(leave.state, 'confirm')
+        self.assertEqual(leave.number_of_days, 0.5)
         self.assertEqual(all_leaves[1].date_from, datetime(2020, 1, 7, 7, 0))
         self.assertEqual(all_leaves[1].date_to, datetime(2020, 1, 7, 16, 0))
         self.assertEqual(all_leaves[1].number_of_days, 1)
@@ -165,13 +157,13 @@ class TestCompanyLeave(TransactionCase):
     def test_04_leave_whole_company(self):
         # TEST CASE 4: Leaves taken in days. Take a 1 days leave
         # Add a company leave on the same day
-        # Check that leave is refused
-        self.paid_time_off.request_unit = 'day'
+        # Check that the existing leave is kept and the company leave is created on top.
+        self.overlap_leave_type.request_unit = 'day'
 
         leave = self.env['hr.leave'].create({
             'name': 'Hol11',
             'employee_id': self.employee.id,
-            'holiday_status_id': self.paid_time_off.id,
+            'holiday_status_id': self.overlap_leave_type.id,
             'request_date_from': date(2020, 1, 9),
             'request_date_to': date(2020, 1, 9),
 
@@ -191,9 +183,8 @@ class TestCompanyLeave(TransactionCase):
 
         all_leaves = self.env['hr.leave'].search([('employee_id', '=', self.employee.id)], order='id')
         self.assertEqual(len(all_leaves), 2)
-        # Original Time Off
-        self.assertEqual(leave.state, 'refuse')
-        # Company Time Off
+        self.assertEqual(leave.state, 'confirm')
+        self.assertEqual(leave.number_of_days, 1)
         self.assertEqual(all_leaves[1].date_from, datetime(2020, 1, 9, 7, 0))
         self.assertEqual(all_leaves[1].date_to, datetime(2020, 1, 9, 16, 0))
         self.assertEqual(all_leaves[1].number_of_days, 1)
@@ -202,7 +193,7 @@ class TestCompanyLeave(TransactionCase):
     def test_06_leave_whole_company(self):
         # Test case 6: Leaves taken in days. But the employee
         # only works on Monday, Wednesday and Friday
-        # Takes a time off for all the week (3 days), should be split
+        # Takes a time off for all the week (3 days); the company leave should be created on top.
 
         self.employee.resource_calendar_id.write({'attendance_ids': [
             (5, 0, 0),
@@ -220,7 +211,7 @@ class TestCompanyLeave(TransactionCase):
         leave = self.env['hr.leave'].create({
             'name': 'Hol11',
             'employee_id': self.employee.id,
-            'holiday_status_id': self.paid_time_off.id,
+            'holiday_status_id': self.overlap_leave_type.id,
             'request_date_from': date(2020, 1, 6),
             'request_date_to': date(2020, 1, 10),
         })
@@ -238,12 +229,10 @@ class TestCompanyLeave(TransactionCase):
 
         all_leaves = self.env['hr.leave'].search([('employee_id', '=', self.employee.id)], order='id')
         self.assertEqual(len(all_leaves), 2)
-        # Before Time Off
-        self.assertEqual(all_leaves[0].date_from, datetime(2020, 1, 6, 7, 0))
-        self.assertEqual(all_leaves[0].date_to, datetime(2020, 1, 9, 16, 0))
-        self.assertEqual(all_leaves[0].number_of_days, 2)
-        self.assertEqual(all_leaves[0].state, 'confirm')
-        # Company Time Off
+        self.assertEqual(leave.date_from, datetime(2020, 1, 6, 7, 0))
+        self.assertEqual(leave.date_to, datetime(2020, 1, 10, 16, 0))
+        self.assertEqual(leave.number_of_days, 3)
+        self.assertEqual(leave.state, 'confirm')
         self.assertEqual(all_leaves[1].date_from, datetime(2020, 1, 10, 7, 0))
         self.assertEqual(all_leaves[1].date_to, datetime(2020, 1, 10, 16, 0))
         self.assertEqual(all_leaves[1].number_of_days, 1)
@@ -263,7 +252,7 @@ class TestCompanyLeave(TransactionCase):
         leaves = self.env['hr.leave'].create([{
             'name': 'Holiday - %s' % employee.name,
             'employee_id': employee.id,
-            'holiday_status_id': self.paid_time_off.id,
+            'holiday_status_id': self.overlap_leave_type.id,
             'request_date_from': date(2020, 3, 29),
             'request_date_to': date(2020, 4, 1),
         } for employee in employees[0:15]])
@@ -285,3 +274,33 @@ class TestCompanyLeave(TransactionCase):
 
         leaves = self.env['hr.leave'].search([('holiday_status_id', '=', self.bank_holiday.id)])
         self.assertEqual(len(leaves), 101)
+
+    def test_08_leave_whole_company(self):
+        self.env['hr.leave'].create({
+            'name': 'Holiday without overlap',
+            'employee_id': self.employee.id,
+            'holiday_status_id': self.paid_time_off.id,
+            'request_date_from': date(2025, 11, 10),
+            'request_date_to': date(2025, 11, 12),
+        })
+
+        company_leave = self.env['hr.leave.generate.multi.wizard'].create({
+            'name': 'Bank Holiday',
+            'allocation_mode': 'company',
+            'company_id': self.company.id,
+            'holiday_status_id': self.bank_holiday.id,
+            'date_from': date(2025, 11, 11),
+            'date_to': date(2025, 11, 11),
+        })
+        company_leave.action_generate_time_off()
+
+        all_leaves = self.env['hr.leave'].search([
+            ('employee_id', '=', self.employee.id),
+            ('holiday_status_id', 'in', [self.bank_holiday.id, self.paid_time_off.id]),
+        ], order='id')
+        self.assertEqual(len(all_leaves), 1)
+        # As the employee has the overlapping leave, the wizard will not create a new one
+        self.assertEqual(all_leaves[0].date_from, datetime(2025, 11, 10, 7, 0))
+        self.assertEqual(all_leaves[0].date_to, datetime(2025, 11, 12, 16, 0))
+        self.assertEqual(all_leaves[0].number_of_days, 3)
+        self.assertEqual(all_leaves[0].state, 'confirm')

--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -2187,31 +2187,31 @@ class TestLeaveRequests(TestHrHolidaysCommon):
         self.assertEqual(leave.number_of_hours, 13.0)
 
     def test_group_leave_conflicting_days_computation(self):
-        """Test that a group leave that overrides existing approved time off days
-        correctly computes the duration of each leave.
+        """Test that a group leave is created on top of existing approved worked time
+        and correctly computes the duration of each leave.
         """
         LeaveType = self.env['hr.leave.type'].with_user(self.user_hrmanager_id)
-        self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-            'name': 'Annual Time Off',
-            'employee_id': self.employee_emp_id,
-            'holiday_status_id': self.holidays_type_4.id,
-            'number_of_days': 20,
-            'date_from': '2026-01-01',
-        }).action_approve()
+        overlap_allowed_type = LeaveType.create({
+            'name': 'Worked Time on Top',
+            'requires_allocation': False,
+            'leave_validation_type': 'both',
+            'time_type': 'other',
+            'allow_request_on_top': True,
+        })
 
         # Create existing approved time off: Feb 23 - Feb 24 (2 days) and Feb 26 - Feb 27
         leave1, leave2 = self.env['hr.leave'].with_user(self.user_employee_id).create([
             {
                 'name': 'Approved Leave 1',
                 'employee_id': self.employee_emp_id,
-                'holiday_status_id': self.holidays_type_4.id,
+                'holiday_status_id': overlap_allowed_type.id,
                 'request_date_from': '2026-02-23',
                 'request_date_to': '2026-02-24',
             },
             {
                 'name': 'Approved Leave 2',
                 'employee_id': self.employee_emp_id,
-                'holiday_status_id': self.holidays_type_1.id,
+                'holiday_status_id': overlap_allowed_type.id,
                 'request_date_from': '2026-02-26',
                 'request_date_to': '2026-02-27',
             }])
@@ -2230,7 +2230,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
         })
 
         # Use the Wizard to create a Training for the whole company: Feb 24 - Feb 26
-        # This overlaps with two days of approved allocated leaves
+        # This overlaps with two days of approved worked time
         # Last day of leave 1 and first day of leave 2
         leave_wizard_form = Form(self.env['hr.leave.generate.multi.wizard'].with_user(self.user_hrmanager_id))
         leave_wizard_form.allocation_mode = 'company'
@@ -2248,27 +2248,24 @@ class TestLeaveRequests(TestHrHolidaysCommon):
         ])
 
         # ASSERTS
-        # Assert correct duration calculation for the training leave
+        # The new leave is created on top of the existing ones.
         self.assertEqual(generated_training.number_of_days, 3.0,
             "The training (Feb 25-27) should be 3 days, since it overrides other leaves.")
 
-        # Assert the original time off was split correctly
-        # It should now only cover Feb 23 (1 day) and Feb 27 (1 day)
-        leave1.invalidate_recordset(['number_of_days', 'request_date_to'])
-        self.assertEqual(leave1.request_date_to, date(2026, 2, 23),
-            "Leave 1 should have been shortened to end before the training.")
-        self.assertEqual(leave1.number_of_days, 1.0,
-            "Leave 1 duration should have been updated to 1 day.")
+        # The original time off stays untouched.
+        leave1.invalidate_recordset(['number_of_days', 'request_date_from', 'request_date_to'])
+        self.assertEqual(leave1.request_date_from, date(2026, 2, 23))
+        self.assertEqual(leave1.request_date_to, date(2026, 2, 24))
+        self.assertEqual(leave1.number_of_days, 2.0)
 
-        leave2.invalidate_recordset(['number_of_days', 'request_date_to'])
-        self.assertEqual(leave2.request_date_from, date(2026, 2, 27),
-            "Leave 2 should have been shortened to start after the training.")
-        self.assertEqual(leave2.number_of_days, 1.0,
-            "Leave 2 duration should have been updated to 1 day.")
+        leave2.invalidate_recordset(['number_of_days', 'request_date_from', 'request_date_to'])
+        self.assertEqual(leave2.request_date_from, date(2026, 2, 26))
+        self.assertEqual(leave2.request_date_to, date(2026, 2, 27))
+        self.assertEqual(leave2.number_of_days, 2.0)
 
     def test_group_leave_hourly_conflict(self):
-        """Ensure batch generation fails if overlapping hourly time off exists
-        and does not unlink the related calendar leaves."""
+        """Ensure batch generation creates the new leave on top of overlapping hourly worked time
+        and keeps the related calendar leaves intact."""
 
         # Create an hourly leave and validate it
         LeaveType = self.env['hr.leave.type'].with_user(self.user_hrmanager_id)
@@ -2277,6 +2274,8 @@ class TestLeaveRequests(TestHrHolidaysCommon):
             'request_unit': 'hour',
             'requires_allocation': False,
             'leave_validation_type': 'both',
+            'time_type': 'other',
+            'allow_request_on_top': True,
         })
         hourly_leave = self.env['hr.leave'].with_user(self.user_employee_id).create({
             'name': 'Hourly Leave',
@@ -2298,10 +2297,10 @@ class TestLeaveRequests(TestHrHolidaysCommon):
 
         # Create a group leave that overlaps with the hourly leave
         training_type = LeaveType.create({
-                    'name': 'Training',
-                    'requires_allocation': False,
-                    'leave_validation_type': 'no_validation',
-                })
+            'name': 'Training',
+            'requires_allocation': False,
+            'leave_validation_type': 'no_validation',
+        })
         leave_wizard_form = Form(self.env['hr.leave.generate.multi.wizard'].with_user(self.user_hrmanager_id))
         leave_wizard_form.allocation_mode = 'company'
         leave_wizard_form.company_id = self.env.company
@@ -2309,15 +2308,20 @@ class TestLeaveRequests(TestHrHolidaysCommon):
         leave_wizard_form.date_from = date(2026, 2, 24)
         leave_wizard_form.date_to = date(2026, 2, 24)
         leave_wizard = leave_wizard_form.save()
+        leave_wizard.action_generate_time_off()
 
-        # ASSERTIONS
-        # Should raise an error and the approved leave should not be changed or removed
-        with self.assertRaises(UserError):
-            leave_wizard.action_generate_time_off()
+        generated_training = self.env['hr.leave'].search([
+            ('employee_id', '=', self.employee_emp_id),
+            ('holiday_status_id', '=', training_type.id),
+            ('request_date_from', '=', '2026-02-24'),
+            ('request_date_to', '=', '2026-02-24'),
+        ])
 
-        self.assertTrue(calendar_leave.exists(), "Calendar leaves should not be unlinked on error")
+        self.assertTrue(calendar_leave.exists(), "Calendar leaves should stay linked to the original hourly leave")
+        self.assertEqual(len(generated_training), 1)
+        self.assertEqual(generated_training.number_of_days, 1.0)
 
-        hourly_leave.invalidate_recordset()
+        hourly_leave.invalidate_recordset(['state'])
         self.assertEqual(hourly_leave.state, 'validate')
 
     def test_leave_request_both_notified_users(self):

--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -2187,31 +2187,31 @@ class TestLeaveRequests(TestHrHolidaysCommon):
         self.assertEqual(leave.number_of_hours, 13.0)
 
     def test_group_leave_conflicting_days_computation(self):
-        """Test that a group leave that overrides existing approved time off days
-        correctly computes the duration of each leave.
+        """Test that a group leave is created on top of existing approved worked time
+        and correctly computes the duration of each leave.
         """
         LeaveType = self.env['hr.leave.type'].with_user(self.user_hrmanager_id)
-        self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-            'name': 'Annual Time Off',
-            'employee_id': self.employee_emp_id,
-            'holiday_status_id': self.holidays_type_4.id,
-            'number_of_days': 20,
-            'date_from': '2026-01-01',
-        }).action_approve()
+        overlap_allowed_type = LeaveType.create({
+            'name': 'Worked Time on Top',
+            'requires_allocation': False,
+            'leave_validation_type': 'both',
+            'time_type': 'other',
+            'allow_request_on_top': True,
+        })
 
         # Create existing approved time off: Feb 23 - Feb 24 (2 days) and Feb 26 - Feb 27
         leave1, leave2 = self.env['hr.leave'].with_user(self.user_employee_id).create([
             {
                 'name': 'Approved Leave 1',
                 'employee_id': self.employee_emp_id,
-                'holiday_status_id': self.holidays_type_4.id,
+                'holiday_status_id': overlap_allowed_type.id,
                 'request_date_from': '2026-02-23',
                 'request_date_to': '2026-02-24',
             },
             {
                 'name': 'Approved Leave 2',
                 'employee_id': self.employee_emp_id,
-                'holiday_status_id': self.holidays_type_1.id,
+                'holiday_status_id': overlap_allowed_type.id,
                 'request_date_from': '2026-02-26',
                 'request_date_to': '2026-02-27',
             }])
@@ -2230,7 +2230,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
         })
 
         # Use the Wizard to create a Training for the whole company: Feb 24 - Feb 26
-        # This overlaps with two days of approved allocated leaves
+        # This overlaps with two days of approved worked time
         # Last day of leave 1 and first day of leave 2
         leave_wizard_form = Form(self.env['hr.leave.generate.multi.wizard'].with_user(self.user_hrmanager_id))
         leave_wizard_form.allocation_mode = 'company'
@@ -2248,27 +2248,24 @@ class TestLeaveRequests(TestHrHolidaysCommon):
         ])
 
         # ASSERTS
-        # Assert correct duration calculation for the training leave
+        # The new leave is created on top of the existing ones.
         self.assertEqual(generated_training.number_of_days, 3.0,
             "The training (Feb 25-27) should be 3 days, since it overrides other leaves.")
 
-        # Assert the original time off was split correctly
-        # It should now only cover Feb 23 (1 day) and Feb 27 (1 day)
-        leave1.invalidate_recordset(['number_of_days', 'request_date_to'])
-        self.assertEqual(leave1.request_date_to, date(2026, 2, 23),
-            "Leave 1 should have been shortened to end before the training.")
-        self.assertEqual(leave1.number_of_days, 1.0,
-            "Leave 1 duration should have been updated to 1 day.")
+        # The original time off stays untouched.
+        leave1.invalidate_recordset(['number_of_days', 'request_date_from', 'request_date_to'])
+        self.assertEqual(leave1.request_date_from, date(2026, 2, 23))
+        self.assertEqual(leave1.request_date_to, date(2026, 2, 24))
+        self.assertEqual(leave1.number_of_days, 2.0)
 
-        leave2.invalidate_recordset(['number_of_days', 'request_date_to'])
-        self.assertEqual(leave2.request_date_from, date(2026, 2, 27),
-            "Leave 2 should have been shortened to start after the training.")
-        self.assertEqual(leave2.number_of_days, 1.0,
-            "Leave 2 duration should have been updated to 1 day.")
+        leave2.invalidate_recordset(['number_of_days', 'request_date_from', 'request_date_to'])
+        self.assertEqual(leave2.request_date_from, date(2026, 2, 26))
+        self.assertEqual(leave2.request_date_to, date(2026, 2, 27))
+        self.assertEqual(leave2.number_of_days, 2.0)
 
     def test_group_leave_hourly_conflict(self):
-        """Ensure batch generation fails if overlapping hourly time off exists
-        and does not unlink the related calendar leaves."""
+        """Ensure batch generation creates the new leave on top of overlapping hourly worked time
+        and keeps the related calendar leaves intact."""
 
         # Create an hourly leave and validate it
         LeaveType = self.env['hr.leave.type'].with_user(self.user_hrmanager_id)
@@ -2277,6 +2274,8 @@ class TestLeaveRequests(TestHrHolidaysCommon):
             'request_unit': 'hour',
             'requires_allocation': False,
             'leave_validation_type': 'both',
+            'time_type': 'other',
+            'allow_request_on_top': True,
         })
         hourly_leave = self.env['hr.leave'].with_user(self.user_employee_id).create({
             'name': 'Hourly Leave',
@@ -2298,10 +2297,10 @@ class TestLeaveRequests(TestHrHolidaysCommon):
 
         # Create a group leave that overlaps with the hourly leave
         training_type = LeaveType.create({
-                    'name': 'Training',
-                    'requires_allocation': False,
-                    'leave_validation_type': 'no_validation',
-                })
+            'name': 'Training',
+            'requires_allocation': False,
+            'leave_validation_type': 'no_validation',
+        })
         leave_wizard_form = Form(self.env['hr.leave.generate.multi.wizard'].with_user(self.user_hrmanager_id))
         leave_wizard_form.allocation_mode = 'company'
         leave_wizard_form.company_id = self.env.company
@@ -2309,13 +2308,18 @@ class TestLeaveRequests(TestHrHolidaysCommon):
         leave_wizard_form.date_from = date(2026, 2, 24)
         leave_wizard_form.date_to = date(2026, 2, 24)
         leave_wizard = leave_wizard_form.save()
+        leave_wizard.action_generate_time_off()
 
-        # ASSERTIONS
-        # Should raise an error and the approved leave should not be changed or removed
-        with self.assertRaises(UserError):
-            leave_wizard.action_generate_time_off()
+        generated_training = self.env['hr.leave'].search([
+            ('employee_id', '=', self.employee_emp_id),
+            ('holiday_status_id', '=', training_type.id),
+            ('request_date_from', '=', '2026-02-24'),
+            ('request_date_to', '=', '2026-02-24'),
+        ])
 
-        self.assertTrue(calendar_leave.exists(), "Calendar leaves should not be unlinked on error")
+        self.assertTrue(calendar_leave.exists(), "Calendar leaves should stay linked to the original hourly leave")
+        self.assertEqual(len(generated_training), 1)
+        self.assertEqual(generated_training.number_of_days, 1.0)
 
-        hourly_leave.invalidate_recordset()
+        hourly_leave.invalidate_recordset(['state'])
         self.assertEqual(hourly_leave.state, 'validate')

--- a/addons/hr_holidays/wizard/hr_leave_generate_multi_wizard.py
+++ b/addons/hr_holidays/wizard/hr_leave_generate_multi_wizard.py
@@ -69,9 +69,34 @@ class HrLeaveGenerateMultiWizard(models.TransientModel):
             'state': 'validate' if validated else 'confirm',
         } for employee in employees if work_days_data[employee.id]['days']]
 
+    def _get_generated_time_off_action(self, leaves):
+        return {
+            'type': 'ir.actions.act_window',
+            'name': self.env._('Generated Time Off'),
+            'views': [
+                [self.env.ref('hr_holidays.hr_leave_view_tree').id, "list"],
+                [self.env.ref('hr_holidays.hr_leave_view_form_manager').id, "form"],
+            ],
+            'view_mode': 'list',
+            'res_model': 'hr.leave',
+            'domain': [('id', 'in', leaves.ids)],
+            'context': {'active_id': False},
+        }
+
     def action_generate_time_off(self):
         self.ensure_one()
         employees = self._get_employees_from_allocation_mode()
+        if not employees:
+            return {
+                'type': 'ir.actions.client',
+                'tag': 'display_notification',
+                'params': {
+                    'type': 'warning',
+                    'sticky': False,
+                    'title': self.env._('No Employees Found'),
+                    'message': self.env._('No employees found for the selected criteria.'),
+                },
+            }
 
         tz = timezone(self.company_id.resource_calendar_id.tz or self.env.user.tz or 'UTC')
         date_from_tz = tz.localize(datetime.combine(self.date_from, datetime.min.time())).astimezone(UTC).replace(tzinfo=None)
@@ -88,13 +113,13 @@ class HrLeaveGenerateMultiWizard(models.TransientModel):
             ('employee_id', 'in', employees.ids)])
 
         if conflicting_leaves:
-            # YTI: More complex use cases could be managed later
-            invalid_time_off = conflicting_leaves.filtered(lambda leave: leave.leave_type_request_unit == 'hour')
-            if invalid_time_off:
-                raise UserError(self.env._('Some employees already have time off requests in hours that overlap with the selected period, Odoo cannot automatically adjust or split hourly leaves during batch generation. Conflicting time off:\n%s', '\n'.join(f"- {l.display_name}" for l in invalid_time_off)))
-            one_day_leaves = conflicting_leaves.filtered(lambda leave: leave.request_date_from == leave.request_date_to)
-            one_day_leaves.action_refuse()
-            (conflicting_leaves - one_day_leaves)._split_leaves(self.date_from, self.date_to + timedelta(days=1))
+            if blocking_leaves := conflicting_leaves.filtered(lambda leave: not leave.holiday_status_id.allow_request_on_top):
+                # YTI: More complex use cases could be managed later
+                if invalid_time_off := blocking_leaves.filtered(lambda leave: leave.leave_type_request_unit == 'hour'):
+                    raise UserError(self.env._('Some employees already have time off requests in hours that overlap with the selected period, Odoo cannot automatically adjust or split hourly leaves during batch generation. Conflicting time off:\n%s', '\n'.join(f"- {l.display_name}" for l in invalid_time_off)))
+                one_day_leaves = blocking_leaves.filtered(lambda leave: leave.request_date_from == leave.request_date_to)
+                one_day_leaves.action_refuse()
+                (blocking_leaves - one_day_leaves)._split_leaves(self.date_from, self.date_to + timedelta(days=1))
 
         vals_list = self._prepare_employees_holiday_values(employees, date_from_tz, date_to_tz)
         leaves = self.env['hr.leave'].with_context(
@@ -110,15 +135,28 @@ class HrLeaveGenerateMultiWizard(models.TransientModel):
         ).create(vals_list)
         leaves._validate_leave_request()
 
+        notify_type = notify_title = notify_message = None
+        next_action = (
+            self._get_generated_time_off_action(leaves)
+            if leaves else {'type': 'ir.actions.act_window_close'}
+        )
+        if leaves:
+            notify_type = 'success'
+            notify_title = self.env._('Time Off Generated')
+            notify_message = self.env._(
+                '%(success_count)s time off request(s) created successfully.',
+                success_count=len(leaves),
+            )
+
         return {
-            'type': 'ir.actions.act_window',
-            'name': self.env._('Generated Time Off'),
-            "views": [[self.env.ref('hr_holidays.hr_leave_view_tree').id, "list"], [self.env.ref('hr_holidays.hr_leave_view_form_manager').id, "form"]],
-            'view_mode': 'list',
-            'res_model': 'hr.leave',
-            'domain': [('id', 'in', leaves.ids)],
-            'context': {
-                'active_id': False,
+            'type': 'ir.actions.client',
+            'tag': 'display_notification',
+            'params': {
+                'type': notify_type,
+                'sticky': False,
+                'title': notify_title,
+                'message': notify_message,
+                'next': next_action,
             },
         }
 

--- a/addons/hr_holidays/wizard/hr_leave_generate_multi_wizard.py
+++ b/addons/hr_holidays/wizard/hr_leave_generate_multi_wizard.py
@@ -1,11 +1,11 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from pytz import UTC, timezone
 
 from odoo import api, fields, models
-from odoo.exceptions import AccessError, UserError
+from odoo.exceptions import AccessError
 from odoo.fields import Domain
 
 
@@ -72,6 +72,17 @@ class HrLeaveGenerateMultiWizard(models.TransientModel):
     def action_generate_time_off(self):
         self.ensure_one()
         employees = self._get_employees_from_allocation_mode()
+        if not employees:
+            return {
+                'type': 'ir.actions.client',
+                'tag': 'display_notification',
+                'params': {
+                    'type': 'warning',
+                    'sticky': False,
+                    'title': self.env._('No Employees Found'),
+                    'message': self.env._('No employees found for the selected criteria.'),
+                },
+            }
 
         tz = timezone(self.company_id.resource_calendar_id.tz or self.env.user.tz or 'UTC')
         date_from_tz = tz.localize(datetime.combine(self.date_from, datetime.min.time())).astimezone(UTC).replace(tzinfo=None)
@@ -87,16 +98,15 @@ class HrLeaveGenerateMultiWizard(models.TransientModel):
             ('state', 'not in', ['cancel', 'refuse']),
             ('employee_id', 'in', employees.ids)])
 
+        employees_with_blocking_conflicts = self.env['hr.employee']
+        allowed_conflicting_leaves = self.env['hr.leave']
         if conflicting_leaves:
-            # YTI: More complex use cases could be managed later
-            invalid_time_off = conflicting_leaves.filtered(lambda leave: leave.leave_type_request_unit == 'hour')
-            if invalid_time_off:
-                raise UserError(self.env._('Some employees already have time off requests in hours that overlap with the selected period, Odoo cannot automatically adjust or split hourly leaves during batch generation. Conflicting time off:\n%s', '\n'.join(f"- {l.display_name}" for l in invalid_time_off)))
-            one_day_leaves = conflicting_leaves.filtered(lambda leave: leave.request_date_from == leave.request_date_to)
-            one_day_leaves.action_refuse()
-            (conflicting_leaves - one_day_leaves)._split_leaves(self.date_from, self.date_to + timedelta(days=1))
-
-        vals_list = self._prepare_employees_holiday_values(employees, date_from_tz, date_to_tz)
+            allowed_conflicting_leaves = conflicting_leaves.filtered(lambda leave: leave.holiday_status_id.allow_request_on_top)
+            blocking_leaves = conflicting_leaves - allowed_conflicting_leaves
+            if blocking_leaves:
+                employees_with_blocking_conflicts = blocking_leaves.employee_id
+        employees_to_process = employees - employees_with_blocking_conflicts
+        vals_list = self._prepare_employees_holiday_values(employees_to_process, date_from_tz, date_to_tz)
         leaves = self.env['hr.leave'].with_context(
             tracking_disable=True,
             mail_activity_automation_skip=True,
@@ -109,16 +119,70 @@ class HrLeaveGenerateMultiWizard(models.TransientModel):
             leave_compute_date_from_to=True,
         ).create(vals_list)
         leaves._validate_leave_request()
+        created_on_top = bool(leaves.employee_id & allowed_conflicting_leaves.employee_id)
+
+        notify_type = notify_title = notify_message = None
+        next_action = {'type': 'ir.actions.act_window_close'}
+        if employees_with_blocking_conflicts and not leaves:
+            notify_type = 'danger'
+            notify_title = self.env._('Time Off Generation Failed')
+            notify_message = self.env._(
+                'No time off requests were created. %(failure_count)s employee(s) have overlapping time off that does not allow requests on top: %(employees)s',
+                failure_count=len(employees_with_blocking_conflicts),
+                employees=', '.join(employees_with_blocking_conflicts.mapped('name')),
+            )
+        elif employees_with_blocking_conflicts:
+            notify_type = 'warning'
+            notify_title = self.env._('Time Off Partially Generated')
+            if created_on_top:
+                notify_message = self.env._(
+                    '%(success_count)s time off request(s) created successfully, including overlapping requests where existing time off allows requests on top. %(failure_count)s employee(s) skipped due to overlapping time off that does not allow requests on top: %(employees)s',
+                    success_count=len(leaves),
+                    failure_count=len(employees_with_blocking_conflicts),
+                    employees=', '.join(employees_with_blocking_conflicts.mapped('name')),
+                )
+            else:
+                notify_message = self.env._(
+                    '%(success_count)s time off request(s) created successfully. %(failure_count)s employee(s) skipped due to overlapping time off that does not allow requests on top: %(employees)s',
+                    success_count=len(leaves),
+                    failure_count=len(employees_with_blocking_conflicts),
+                    employees=', '.join(employees_with_blocking_conflicts.mapped('name')),
+                )
+        elif leaves:
+            notify_type = 'success'
+            notify_title = self.env._('Time Off Generated')
+            next_action = {
+                'type': 'ir.actions.act_window',
+                'name': self.env._('Generated Time Off'),
+                'views': [
+                    [self.env.ref('hr_holidays.hr_leave_view_tree').id, "list"],
+                    [self.env.ref('hr_holidays.hr_leave_view_form_manager').id, "form"]
+                ],
+                'view_mode': 'list',
+                'res_model': 'hr.leave',
+                'domain': [('id', 'in', leaves.ids)],
+                'context': {'active_id': False},
+            }
+            if created_on_top:
+                notify_message = self.env._(
+                    '%(success_count)s time off request(s) created successfully, including overlapping requests where existing time off allows requests on top.',
+                    success_count=len(leaves),
+                )
+            else:
+                notify_message = self.env._(
+                    '%(success_count)s time off request(s) created successfully.',
+                    success_count=len(leaves),
+                )
 
         return {
-            'type': 'ir.actions.act_window',
-            'name': self.env._('Generated Time Off'),
-            "views": [[self.env.ref('hr_holidays.hr_leave_view_tree').id, "list"], [self.env.ref('hr_holidays.hr_leave_view_form_manager').id, "form"]],
-            'view_mode': 'list',
-            'res_model': 'hr.leave',
-            'domain': [('id', 'in', leaves.ids)],
-            'context': {
-                'active_id': False,
+            'type': 'ir.actions.client',
+            'tag': 'display_notification',
+            'params': {
+                'type': notify_type,
+                'sticky': False,
+                'title': notify_title,
+                'message': notify_message,
+                'next': next_action,
             },
         }
 


### PR DESCRIPTION
**Issue**
When creating multiple time off requests through the bulk generation wizard, the system exhibited problematic behavior with overlapping leaves that led to data inconsistencies. The automatic leave splitting logic created data inconsistencies between leave records and work entries.

**Steps to reproduce**
- Create a leave from October 10th to 25th for an employee
- Create another leave from October 15th to 20th using the bulk wizard
	- The second leave doesn't get created
	- The first leave gets split into 2 leaves (October 10-14 and October 21-25). However, work entries still reference the original leave from October 10-25
- Attempt to create a third leave from October 16th to 17th
	- The system still detects a conflicting leave from October 10-25
	- The new leave creation is blocked

**Solution**
This fix targets version 19.0 and later. Unlike the 18.2-18.4 versions which prevented overlapping time off requests entirely, this implementation properly handles the leave splitting behavior.

For 19.0+, the fix:
- Only allows leave splitting when the time off type has "allow requests on top" enabled
- Properly updates calendar entries when leaves are split (this was causing the bug originally)
- Add notification to inform about the outcome of the generation (which requests succeeded, which failed, and why)

Task ID: 5138876

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
