### PR TITLE
[FIX] mail: no crash on record.delete() on already deleted record

### DIFF
--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -59,7 +59,7 @@ export class Message extends Record {
             return decorateEmojis(this.translationValue) ?? "";
         },
     });
-    composer = fields.One("Composer", { inverse: "message", onDelete: (r) => r.delete() });
+    composer = fields.One("Composer", { inverse: "message", onDelete: (r) => r?.delete() });
     date = fields.Datetime();
     /** @type {string} */
     default_subject;

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -93,7 +93,7 @@ export class Thread extends Record {
     composer = fields.One("Composer", {
         compute: () => ({}),
         inverse: "thread",
-        onDelete: (r) => r.delete(),
+        onDelete: (r) => r?.delete(),
     });
     counter = 0;
     counter_bus_id = 0;
@@ -119,14 +119,14 @@ export class Thread extends Record {
         onAdd(r) {
             r.thread = this;
         },
-        onDelete: (r) => r.delete(),
+        onDelete: (r) => r?.delete(),
     });
     selfFollower = fields.One("mail.followers", {
         /** @this {import("models").Thread} */
         onAdd(r) {
             r.thread = this;
         },
-        onDelete: (r) => r.delete(),
+        onDelete: (r) => r?.delete(),
     });
     /** @type {integer|undefined} */
     followersCount;

--- a/addons/mail/static/src/core/web/thread_model_patch.js
+++ b/addons/mail/static/src/core/web/thread_model_patch.js
@@ -14,9 +14,7 @@ const threadPatch = {
         this.recipients = fields.Many("mail.followers");
         this.activities = fields.Many("mail.activity", {
             sort: (a, b) => compareDatetime(a.date_deadline, b.date_deadline) || a.id - b.id,
-            onDelete(r) {
-                r.remove();
-            },
+            onDelete: (r) => r?.remove(),
         });
         /** @type {boolean} */
         this.isDisplayedInDiscussAppDesktop = fields.Attr(undefined, {

--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -2159,22 +2159,6 @@ export class Rtc extends Record {
         await this.refreshMicAudioStatus();
     }
 
-    /**
-     * @param {import("models").RtcSession} session
-     */
-    deleteSession(session) {
-        if (session) {
-            if (this.localSession && session.eq(this.localSession)) {
-                this.log(this.localSession, "self session deleted, ending call", {
-                    important: true,
-                });
-                this.endCall();
-            }
-            this.disconnect(session);
-            session.delete();
-        }
-    }
-
     formatInfo() {
         this.localSession.is_camera_on = Boolean(this.state.cameraTrack);
         this.localSession.is_screen_sharing_on = Boolean(this.state.screenTrack);

--- a/addons/mail/static/src/discuss/call/common/rtc_session_model.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_session_model.js
@@ -54,6 +54,15 @@ export class RtcSession extends Record {
         return record;
     }
 
+    delete() {
+        if (this.eq(this.store.rtc.localSession)) {
+            this.store.rtc.log(this, "self session deleted, ending call", { important: true });
+            this.store.rtc.endCall();
+        }
+        this.store.rtc.disconnect(this);
+        super.delete(...arguments);
+    }
+
     // Server data
     channel_member_id = fields.One("discuss.channel.member", { inverse: "rtcSession" });
     partner_id = fields.One("res.partner", {

--- a/addons/mail/static/src/discuss/call/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/call/common/thread_model_patch.js
@@ -31,10 +31,7 @@ const ThreadPatch = {
         /** @type {number|undefined} */
         this.cancelRtcInvitationTimeout;
         this.rtc_session_ids = fields.Many("discuss.channel.rtc.session", {
-            /** @this {import("models").Thread} */
-            onDelete(r) {
-                this.store.env.services["discuss.rtc"].deleteSession(r);
-            },
+            onDelete: (r) => r?.delete(),
             /** @this {import("models").Thread} */
             async onUpdate() {
                 const hadSelfSession = this.hadSelfSession;

--- a/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
@@ -16,7 +16,7 @@ export class DiscussChannel extends Record {
     id;
     thread = fields.One("mail.thread", {
         inverse: "channel",
-        onDelete: (r) => r.delete(),
+        onDelete: (r) => r?.delete(),
     });
 }
 

--- a/addons/mail/static/src/discuss/core/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_model_patch.js
@@ -68,11 +68,11 @@ const threadPatch = {
             compute() {
                 return this.model === "discuss.channel" ? this.id : undefined;
             },
-            onDelete: (r) => r.delete(),
+            onDelete: (r) => r?.delete(),
         });
         this.channel_member_ids = fields.Many("discuss.channel.member", {
             inverse: "channel_id",
-            onDelete: (r) => r.delete(),
+            onDelete: (r) => r?.delete(),
             sort: (m1, m2) => m1.id - m2.id,
         });
         /** @type {string} */

--- a/addons/mail/static/src/model/record.js
+++ b/addons/mail/static/src/model/record.js
@@ -314,6 +314,9 @@ export class Record {
 
     delete() {
         const record = toRaw(this)._raw;
+        if (!record.exists()) {
+            return;
+        }
         const store = record._rawStore;
         return store.MAKE_UPDATE(function recordDelete() {
             store._.ADD_QUEUE("delete", record);

--- a/addons/mail/static/src/model/store.js
+++ b/addons/mail/static/src/model/store.js
@@ -110,7 +110,10 @@ export class Store extends Record {
                         const onDelete = record.Model._.fieldsOnDelete.get(fieldName);
                         for (const removedRec of fieldMap.keys()) {
                             try {
-                                onDelete?.call(record._proxy, removedRec._proxy);
+                                onDelete?.call(
+                                    record._proxy,
+                                    removedRec.exists() ? removedRec._proxy : undefined
+                                );
                             } catch (err) {
                                 this.handleError(err);
                             }


### PR DESCRIPTION
Before this commit, when opening AI chat from systray in home menu and immediatley closing the chat window, it crashed with following error:

```
TypeError: Cannot read properties of undefined (reading '_proxy')
```

This happens because closing chat window triggers deletion of the thread, and there are the following side-effects in code:
- delete of thread implies delete of channel
- delete of thread implies deletion of the members
- thread correspondent field is computed based on members field
(Note: deletions are in JS, not necessarily made server-side)

When thread is being deleted, it triggers deletion of members and channels, but both fields have side-effect `onDelete` to delete the thread. This leads to invoking thread deletion twice, which is not a problem usually but here this crashes.

This crashes in this case because field `correspondent` is computed. Compute of fields are not triggered for soft-deleted records, but internal code relies on `onChange` that necessarily triggers proxy accessor, including on soft-deleted records like thread.

This commit fixes the issue by not passing a deleted record to the `onDelete` hook of a field. (Note: record deletion deletion of record in a field).

https://github.com/odoo/enterprise/pull/96724