### PR TITLE
[IMP] [Attendance] Load the Overview Page Faster

### DIFF
--- a/addons/hr_attendance/tests/test_hr_attendance_domain_translation.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_domain_translation.py
@@ -20,8 +20,6 @@ class TestHrAttendanceDomainTranslation(TransactionCase):
         })
 
     def test_searchbar_with_user_domain(self):
-        companies_ids = self.env['res.company'].search([]).ids
-
         # Checks that this domain returns no attendance
         self.assertEqual(
             self.hr_attendance.search([
@@ -32,23 +30,4 @@ class TestHrAttendanceDomainTranslation(TransactionCase):
                         ('employee_id', 'ilike', 'Flora')
             ]),
             self.hr_attendance
-        )
-
-        # Ensure that if an employee is searched with the search bar even if he doesn't have any attendance,
-        # he will be returned.
-        self.assertEqual(
-            self.hr_attendance.with_context(
-                allowed_company_ids=companies_ids,
-                user_domain=[
-                    '|',
-                        ('employee_id', 'ilike', 'Musa'),
-                        ('employee_id', 'ilike', 'Flora')
-                ])._read_group_employee_id(self.hr_employee, [
-                    '&',
-                        ('check_out', "!=", False),
-                        '|',
-                            ('employee_id', 'ilike', 'Musa'),
-                            ('employee_id', 'ilike', 'Flora')
-                    ]),
-            self.employee_musa
         )

--- a/addons/hr_attendance/tests/test_hr_attendance_process.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_process.py
@@ -76,8 +76,9 @@ class TestHrAttendance(TransactionCase):
 
         grouped_employee_ids = [g['employee_id'][0] for g in groups]
 
-        # Check that both employees appears
-        self.assertIn(self.test_employee.id, grouped_employee_ids)
+        # Result should still be the same - test_employee is only added in
+        # overridden get_gantt_data()
+        self.assertNotIn(self.test_employee.id, grouped_employee_ids)
         self.assertIn(self.employee_kiosk.id, grouped_employee_ids)
 
     def test_hours_today(self):


### PR DESCRIPTION
The Gantt page was taking a long time to load when having a 1000+ employees
I enabled pagination for the gantt view to make it load less fields (and
not everything at once).
Previously, active employees were loaded separately, with a second
get_gantt_data() call.
Merging the two calls into one was already an
improvement. Also, the previous way of calling get_gantt_data() twice
did not respect the limit and offset logic.

In community, _read_group_employee_id would return all employees when
"gantt_start_date" was in the context. This was the line slowing the
request the most. Moreover, the result of _read_group_employee_id would
just be discarded if the length of the result was greater than the
limit. So it would be just slowing the request for nothing.
Removing entirely that logic and moving it up in the call chain
(in get_gantt_data) allowed me to add those employees without any
record, while also respecting the limit and offset parameters.

task-4762235