### PR TITLE
[FIX] website: make menu appear active only if path matches exactly

### DIFF
--- a/addons/website/models/website_menu.py
+++ b/addons/website/models/website_menu.py
@@ -231,6 +231,11 @@ class Menu(models.Model):
 
             menu_url = url_parse(menu_url)
             if unslug_url(menu_url.path) == unslug_url(request_url.path):
+                # By default we compare the unslug version of the current URL
+                # with the menu URL but if the menu is linked to a page we don't
+                # consider it active if the paths don't match exactly.
+                if self.page_id and menu_url.path != request_url.path:
+                    return False
                 if not (
                     set(menu_url.decode_query().items(multi=True))
                     <= set(request_url.decode_query().items(multi=True))

--- a/addons/website/tests/test_menu.py
+++ b/addons/website/tests/test_menu.py
@@ -239,6 +239,21 @@ class TestMenu(common.TransactionCase):
         submenu.url = '/sub/slug-3'
         test_full_case(submenu)
 
+        # Test with a menu that is linked to a page
+        result = website_1.new_page(
+            name='/sub/page-3',
+            add_menu=True,
+        )
+        menu = Menu.browse(result['menu_id'])
+        page = self.env['website.page'].browse(result['page_id'])
+        self.assertEqual(menu.url, page.url, "Menu url should be the same than the page url")
+
+        with MockRequest(self.env, website=website_1), \
+             patch('odoo.addons.website.models.website_menu.url_parse', new=url_parse_mock):
+
+            self.request_url_mock = 'http://localhost:8069/sub/slug-3'
+            self.assertFalse(menu._is_active(), "Page linked, same unslug, should not match")
+
     def test_07_menu_hierarchy_validation(self):
         Menu = self.env['website.menu']
 


### PR DESCRIPTION
__Current behavior before commit:__
A menu is shown as active if the unslug version of its URL matches the current accessed URL.
The issue is that the unslug version of a menu linked to a page has no real meaning. Such menu should only be shown as active if the request URL path matches exactly.

__Description of the fix:__
Added a check to ensure that when a menu is linked to a page, it isn't shown as active if its path doesn't exactly match the request path.

__Steps to reproduce:__
1. On the website, go to Site > Pages
2. Create a new page with title "iOS 26" and another page with title "iPadOS 26"
3. Go to /ios-26
4. Both menus "iOS 26" and "iPadOS 26" are highlighted

task-5094899