### PR TITLE
[IMP] web: calendar view wrong end time at create

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
@@ -61,6 +61,7 @@ export class CalendarCommonRenderer extends Component {
         this.fc = useFullCalendar("fullCalendar", this.options);
         this.click = useClickHandler(this.onClick, this.onDblClick);
         this.popover = useCalendarPopover(this.constructor.components.Popover);
+        this.timeFormat = is24HourFormat() ? "HH:mm" : "hh:mm a";
         useBus(this.props.model.bus, "SCROLL_TO_CURRENT_HOUR", () =>
             this.fc.api.scrollToTime(`${luxon.DateTime.local().hour - 2}:00:00`)
         );
@@ -139,13 +140,11 @@ export class CalendarCommonRenderer extends Component {
     }
 
     getStartTime(record) {
-        const timeFormat = is24HourFormat() ? "HH:mm" : "hh:mm a";
-        return record.start.toFormat(timeFormat);
+        return record.start.toFormat(this.timeFormat);
     }
 
     getEndTime(record) {
-        const timeFormat = is24HourFormat() ? "HH:mm" : "hh:mm a";
-        return record.end.toFormat(timeFormat);
+        return record.end.toFormat(this.timeFormat);
     }
 
     computeEventSelector(event) {
@@ -221,7 +220,13 @@ export class CalendarCommonRenderer extends Component {
     onEventClick(info) {
         this.click(info);
     }
-    onEventContent({ event }) {
+    onEventContent(arg) {
+        const { event } = arg;
+        if (event.start && event.end) {
+            const dateFmt = (date) =>
+                luxon.DateTime.fromJSDate(date).toFormat(this.timeFormat);
+            arg.timeText = `${dateFmt(event.start)} - ${dateFmt(event.end)}`;
+        }
         const record = this.props.model.records[event.id];
         if (record) {
             // This is needed in order to give the possibility to change the event template.

--- a/addons/web/static/tests/views/calendar/calendar_view.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_view.test.js
@@ -1421,9 +1421,8 @@ test(`create event with timezone in week mode European locale`, async () => {
             </calendar>
         `,
     });
-
     await selectTimeRange("2016-12-13 08:00:00", "2016-12-13 10:00:00");
-    expect(`.fc-event-main .fc-event-time`).toHaveText("8:00 - 10:00");
+    expect(`.fc-event-main .fc-event-time`).toHaveText("08:00 - 10:00");
 
     await contains(`.o-calendar-quick-create--input`).edit("new event", { confirm: false });
     await contains(`.o-calendar-quick-create--create-btn`).click();
@@ -1434,6 +1433,23 @@ test(`create event with timezone in week mode European locale`, async () => {
     await contains(`.o_cw_popover_delete`).click();
     await contains(`.modal button.btn-primary`).click();
     expect(`.fc-event-main`).toHaveCount(0);
+});
+
+test(`create multi day event in week mode`, async () => {
+    mockTimeZone(2);
+
+    patchWithCleanup(CalendarCommonRenderer.prototype, {
+        get options() {
+            return { ...super.options, selectAllow: () => true };
+        },
+    });
+    await mountView({
+        resModel: "event",
+        type: "calendar",
+        arch: `<calendar date_start="start" date_stop="stop" mode="week"/>`,
+    });
+    await selectTimeRange("2016-12-13 11:00:00", "2016-12-14 16:00:00");
+    expect(`.fc-event-main .fc-event-time`).toHaveText("11:00 - 16:00");
 });
 
 test(`default week start (US)`, async () => {


### PR DESCRIPTION
When creating an event in week view spanning over multiple days, all parts of the event display 12pm as end date (except the last one) and 00am as the start date (except the first one).

This fix allow calendar views to display the correct hour in week view when the event spans multiple days.

task-4700158