### PR TITLE
[FIX] point_of_sale: allow keyboard input on cashier password

### DIFF
--- a/addons/point_of_sale/static/src/app/utils/number_buffer_service.js
+++ b/addons/point_of_sale/static/src/app/utils/number_buffer_service.js
@@ -161,7 +161,11 @@ class NumberBuffer extends EventBus {
             : 0;
     }
     _onKeyboardInput(event) {
-        if (Object.keys(this.overlay.overlays).length) {
+        const overlays = Object.values(this.overlay.overlays);
+        if (
+            overlays.length &&
+            !overlays.some((overlay) => overlay.props.subComponent?.name === "NumberPopup")
+        ) {
             return;
         }
         return (

--- a/addons/pos_hr/static/tests/tours/pos_hr_tour.js
+++ b/addons/pos_hr/static/tests/tours/pos_hr_tour.js
@@ -22,7 +22,14 @@ registry.category("web_tour.tours").add("PosHrTour", {
             SelectionPopup.has("Pos Employee1", { run: "click" }),
             NumberPopup.enterValue("25"),
             NumberPopup.isShown("••"),
-            NumberPopup.enterValue("81"),
+            {
+                trigger: "body",
+                run: () => {
+                    window.dispatchEvent(new KeyboardEvent("keyup", { key: "8" }));
+                },
+            },
+            NumberPopup.isShown("•••"),
+            NumberPopup.enterValue("1"),
             NumberPopup.isShown("••••"),
             Dialog.confirm(),
             // after trying to close the number popup, the error popup should be shown


### PR DESCRIPTION
Before this commit, when the NumberPopup was open (for example, when entering the cashier password), the keyboard input was ignored because the overlay manager blocked all keyboard events while any popup was active. As a result, it was only possible to use the on-screen number buttons.

After this commit, the keyboard input is allowed when a NumberPopup is open, enabling users to type the password directly using the keyboard.

opw-5152235

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
