### PR TITLE
[FIX] website: prevent editing searchbar input on firefox

### DIFF
--- a/addons/website/static/src/builder/plugins/options/searchbar_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/searchbar_option_plugin.js
@@ -3,6 +3,7 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { SearchbarOption } from "./searchbar_option";
 import { BuilderAction } from "@html_builder/core/builder_action";
+import { isNull } from "@web/views/utils";
 
 class SearchbarOptionPlugin extends Plugin {
     static id = "searchbarOption";
@@ -63,6 +64,25 @@ class SearchbarOptionPlugin extends Plugin {
             },
         ],
     };
+
+    setup() {
+        for (const searchBarInput of this.document.querySelectorAll(
+            ".s_searchbar_input .search-query"
+        )) {
+            this.setContentEditable(searchBarInput);
+        }
+    }
+
+    setContentEditable(searchBar) {
+        searchBar.setAttribute("contenteditable", false);
+        const parentEl = searchBar.parentElement;
+        parentEl.setAttribute("contenteditable", false);
+        for (const child of parentEl.children) {
+            if (child != searchBar && isNull(child.getAttribute("contenteditable"))) {
+                child.setAttribute("contenteditable", true);
+            }
+        }
+    }
 }
 
 export class BaseSearchBarAction extends BuilderAction {

--- a/addons/website/static/tests/builder/website_builder/searchbar_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/searchbar_option.test.js
@@ -3,7 +3,10 @@ import { click } from "@odoo/hoot-dom";
 import { Plugin } from "@html_editor/plugin";
 import { registry } from "@web/core/registry";
 import { contains } from "@web/../tests/web_test_helpers";
-import { defineWebsiteModels, setupWebsiteBuilder } from "@website/../tests/builder/website_helpers";
+import {
+    defineWebsiteModels,
+    setupWebsiteBuilder,
+} from "@website/../tests/builder/website_helpers";
 
 defineWebsiteModels();
 
@@ -88,4 +91,33 @@ test("Switching search type keeps 'order by' option if it exists on both types",
     await contains(".o_popover[role=menu] [data-action-value='/website/search']").click();
     expect("[data-label='Search within'] button.o-dropdown").toHaveText("Everything");
     expect("[data-label='Order by'] button.o-dropdown").toHaveText("something");
+});
+
+test("Search query's parent is not contenteditable", async () => {
+    await setupWebsiteBuilder(searchbarHTML("name asc"));
+
+    expect(":iframe .s_searchbar_input .search-query").toHaveAttribute("contenteditable", "false");
+    expect(":iframe .s_searchbar_input :has(:scope > .search-query)").toHaveAttribute(
+        "contenteditable",
+        "false"
+    );
+
+    expect(
+        ":iframe .s_searchbar_input :has(:scope > .search-query) > *:not(.search-query)"
+    ).toHaveAttribute("contenteditable", "true");
+});
+
+test("Multiple searchbars parents are disabled", async () => {
+    await setupWebsiteBuilder(`
+        ${searchbarHTML("name asc")}
+        ${searchbarHTML("date desc")}
+    `);
+
+    expect(":iframe .s_searchbar_input .search-query").toHaveCount(2);
+    expect(":iframe .s_searchbar_input .search-query").toHaveAttribute("contenteditable", "false");
+
+    expect(":iframe .s_searchbar_input :has(:scope > .search-query)").toHaveAttribute(
+        "contenteditable",
+        "false"
+    );
 });


### PR DESCRIPTION
It's possible to type something inside of a searchbar while in the edit
mode on Firefox, which is not the expected behavior and which is not the
case in other browsers, for example, Chrome.
Steps to see the issue:
- Open Website and start editing
- Drop a searchbar
- Click on the input
- Type something

=> It will remove the searchbar and add text to the searchbar button.
This happens because of the different behavior on Chrome and Firefox of
`pointer-events`. The searchbar input has `pointer-events` set to `none`
and in Chrome it blocks any activity on the input, including `beforeinput`
events, but Firefox doesn't.
This commit fixes this problem making the searchbar input not
`contenteditable`.

task-5144517