### PR TITLE
[FIX] account, web: allow saving section and note sale order lines with tab key

### DIFF
--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
@@ -1,6 +1,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { AutoComplete } from "@web/core/autocomplete/autocomplete";
 import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
+import { useInputField } from "@web/views/fields/input_field_hook";
 import { Many2XAutocomplete } from "@web/views/fields/relational_utils";
 import { Many2OneField, many2OneField } from "@web/views/fields/many2one/many2one_field";
 import { onMounted, onPatched, onWillUnmount, useEffect, useRef, useState } from "@odoo/owl";
@@ -139,6 +140,14 @@ export class ProductLabelSectionAndNoteField extends Many2OneField {
         useProductAndLabelAutoresize(this.labelNode, { targetParentName: this.props.name });
         this.productNode = useRef("productNodeRef");
         useProductAndLabelAutoresize(this.productNode, { targetParentName: this.props.name });
+
+        if (this.isSectionOrNote) {
+            useInputField({
+                ref: this.labelNode,
+                fieldName: "name",
+                getValue: () => this.label,
+            });
+        }
 
         useEffect(
             () => {

--- a/addons/account/static/tests/tours/invoice_line_keydown.js
+++ b/addons/account/static/tests/tours/invoice_line_keydown.js
@@ -1,0 +1,40 @@
+import { registry } from '@web/core/registry';
+import { stepUtils } from "@web_tour/tour_service/tour_utils";
+
+registry.category('web_tour.tours').add('section_saved_on_tab_keydown_tour', {
+    steps: () => [
+        {
+            content: "Create new invoice",
+            trigger: '.o_control_panel_main_buttons .o_list_button_add',
+            run: 'click',
+        },
+        // Set customer
+        {
+            content: "Add customer",
+            trigger: 'div.o_field_widget.o_field_res_partner_many2one[name="partner_id"] div input',
+            run: 'edit Deco Addict',
+        },
+        {
+            content: "Valid customer",
+            trigger: '.ui-menu-item a:contains("Deco Addict")',
+            run: 'click',
+        },
+        ...stepUtils.saveForm(),
+        {
+            content: 'Add a section line',
+            trigger: '.o_field_x2many_list_row_add a:contains("Add a section")',
+            run: 'click',
+        },
+        {
+            content: 'Edit the section label textarea',
+            trigger: '.o_field_product_label_section_and_note_cell textarea',
+            run() {
+                const textarea = this.anchor;
+                textarea.focus();
+                textarea.value = "Section content";
+                textarea.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
+            },
+        },
+        ...stepUtils.saveForm(),
+    ],
+});

--- a/addons/account/tests/test_tour.py
+++ b/addons/account/tests/test_tour.py
@@ -87,3 +87,8 @@ class TestUi(AccountTestInvoicingHttpCommon):
         product.supplier_taxes_id = new_tax
 
         self.start_tour("/odoo", 'account_tax_group', login="admin")
+
+    def test_section_saved_on_tab_keydown_tour(self):
+        self.start_tour('/odoo/customer-invoices', 'section_saved_on_tab_keydown_tour', login='accountman')
+        invoice = self.env['account.move'].search([('move_type', '=', 'out_invoice')])
+        self.assertEqual(invoice.invoice_line_ids[0].name, 'Section content')

--- a/addons/web/static/src/views/fields/input_field_hook.js
+++ b/addons/web/static/src/views/fields/input_field_hook.js
@@ -93,7 +93,11 @@ export function useInputField(params) {
     }
     function onKeydown(ev) {
         const hotkey = getActiveHotkey(ev);
-        if (["enter", "tab", "shift+tab"].includes(hotkey)) {
+        const keys = ["tab", "shift+tab"];
+        if (ev.target.tagName.toLowerCase() !== "textarea") {
+            keys.push("enter");
+        }
+        if (keys.includes(hotkey)) {
             commitChanges(false);
         }
         if (params.preventLineBreaks && ["enter", "shift+enter"].includes(hotkey)) {


### PR DESCRIPTION
## Versions
18.0 > saas-18.4
Fixed in 19.0 thanks to bc6592a8514d6557037868a0f42265070fa02263 introducing the `parseLabel` method:
https://github.com/odoo-dev/odoo/blob/19e03df5d9546d3948c2a184a6f26db7ba3aec71/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js#L47-L51

## Issue
When adding a section or a note line in the sale order lines list view, pressing TAB key caused the line to be cleared and
removed instead of being saved.

## Steps to reproduce
- Open an invoice or create one for any customer:
  - Click either on "Add a section" or "Add a note";
  - Write something down;
  - Press the TAB key.

## Fix
Handle the field with the appropriate `useInputField` hook.

opw-4967733