### PR TITLE
[FIX] stock: fix 229958 PR test

### DIFF
--- a/addons/stock/tests/test_move2.py
+++ b/addons/stock/tests/test_move2.py
@@ -3764,8 +3764,8 @@ class TestPickShipBackorder(TestStockCommon):
                 "name": "Lot Product",
                 "type": "consu",
                 "is_storable": True,
+                "tracking": "lot",
                 "uom_id": cls.env.ref("uom.product_uom_unit").id,
-                "uom_po_id": cls.env.ref("uom.product_uom_unit").id,
             }
         )
 
@@ -3782,7 +3782,8 @@ class TestPickShipBackorder(TestStockCommon):
             }
         )
 
-        cls.stock_location = cls.env.ref("stock.stock_location_stock")
+        cls.warehouse = cls.env["stock.warehouse"].search([], limit=1)
+        cls.stock_location = cls.warehouse.out_type_id.default_location_src_id or cls.warehouse.lot_stock_id
 
         cls.env["stock.quant"]._update_available_quantity(
             cls.product_lot, cls.stock_location, 5.0, lot_id=cls.lot1
@@ -3794,8 +3795,7 @@ class TestPickShipBackorder(TestStockCommon):
     def test_pick_assign_and_backorder(self):
         cust = self.env.ref("stock.stock_location_customers")
         pg = self.env["procurement.group"].create({"name": "sale order"})
-        warehouse = self.env["stock.warehouse"].search([], limit=1)
-        warehouse.delivery_steps = "pick_ship"
+        self.warehouse.delivery_steps = "pick_ship"
         self.env["procurement.group"].run(
             [
                 pg.Procurement(
@@ -3805,8 +3805,8 @@ class TestPickShipBackorder(TestStockCommon):
                     cust,
                     "sale_order",
                     "sale_order",
-                    warehouse.company_id,
-                    {"warehouse_id": warehouse, "group_id": pg},
+                    self.warehouse.company_id,
+                    {"warehouse_id": self.warehouse, "group_id": pg},
                 )
             ]
         )


### PR DESCRIPTION
Due to an issue in the runbot, the test associated with the PR: odoo#229958 passed despite underlying conflicts and the PR was merged. This PR addresses and resolves those issues to ensure the test functions correctly.

Impacted versions:

- 18.0
- saas-18.2
- saas-18.3
- saas-18.4

19.0 and master are addressed in odoo#230685 to replace `procurement.group` with `stock.rule`


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
