### PR TITLE
[FIX] sale_pdf_quote_builder: prevent error when uploading invalid pdf file

### DIFF
--- a/addons/sale_pdf_quote_builder/tests/__init__.py
+++ b/addons/sale_pdf_quote_builder/tests/__init__.py
@@ -1,3 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import test_controllers
 from . import test_pdf_quote_builder

--- a/addons/sale_pdf_quote_builder/tests/test_controllers.py
+++ b/addons/sale_pdf_quote_builder/tests/test_controllers.py
@@ -1,0 +1,17 @@
+from odoo import http
+from odoo.tests import HttpCase, tagged
+from odoo.tools import mute_logger
+
+
+@tagged("-at_install", "post_install")
+class TestUpload(HttpCase):
+
+    @mute_logger("odoo.addons.sale_pdf_quote_builder.controllers.quotation_document", "odoo.http")
+    def test_wrong_pdf(self):
+        self.authenticate("admin", "admin")
+        data = {'csrf_token': http.Request.csrf_token(self)}
+        files = [('ufile', ('test.pdf', b'test', 'application/pdf'))]
+        resp = self.url_open("/sale_pdf_quote_builder/quotation_document/upload", data=data, files=files)
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.headers['Content-Type'], 'application/json; charset=utf-8')
+        self.assertEqual(resp.text, R'''{"error": "It seems that we're not able to process this pdf inside a quotation. It is either encrypted, or encoded in a format we do not support."}''')

--- a/addons/sale_pdf_quote_builder/tests/test_pdf_quote_builder.py
+++ b/addons/sale_pdf_quote_builder/tests/test_pdf_quote_builder.py
@@ -9,6 +9,7 @@ from werkzeug.datastructures import FileStorage
 
 from odoo import Command
 from odoo.exceptions import ValidationError
+from odoo.http import Response
 from odoo.tests import Form, tagged
 from odoo.tools.misc import file_open
 
@@ -293,6 +294,14 @@ class TestPDFQuoteBuilder(BaseUsersCommon, SaleManagementCommon):
             MockRequest(self.env) as request,
             file_open(plain_pdf, 'rb') as file,
             patch.object(request.httprequest.files, 'getlist', lambda _key: [FileStorage(file)]),
+            patch.object(request, 'make_json_response',
+                lambda data, status=200, headers=None: Response(
+                    json.dumps(data),
+                    status=status,
+                    headers=headers,
+                    mimetype='application/json',
+                ),
+            ),
         ):
             request.params['allowed_company_ids'] = json.dumps(allowed_company_ids)
             res = self.QuotationDocumentController.upload_document(ufile=FileStorage(file))
@@ -323,6 +332,14 @@ class TestPDFQuoteBuilder(BaseUsersCommon, SaleManagementCommon):
             MockRequest(self.env) as request,
             file_open(forms_pdf, 'rb') as file,
             patch.object(request.httprequest.files, 'getlist', lambda _key: [FileStorage(file)]),
+            patch.object(request, 'make_json_response',
+                lambda data, status=200, headers=None: Response(
+                    json.dumps(data),
+                    status=status,
+                    headers=headers,
+                    mimetype='application/json',
+                ),
+            ),
         ):
             request.params['allowed_company_ids'] = json.dumps(allowed_company_ids)
             res = self.QuotationDocumentController.upload_document(


### PR DESCRIPTION
Currently, an error occurs when uploading `encrypted or incomplete` 
PDF files (missing EOF marker) while creating a quotation document 
header or footer.

**Steps to reproduce:**
- Install the `sale_pdf_quote_builder` module.
- Navigate to: Sales > Configuration > Headers/Footers.
- Upload encrypted file [1], or incomplete file [2].

**Error:**
`PyPDF2.errors.DependencyError: PyCryptodome is required for AES algorithm`
`PyPDF2.errors.PdfReadError: EOF marker not found`

**Root cause:**
At [3], `_get_form_fields_from_pdf` and `_ensure_document_not_encrypted` directly 
call `pdf.PdfFileReader`, when it fails to read or decrypt the file, Python raises 
an error.

**Fix:**
This commit prevents errors when users upload unreadable or encrypted PDF files.

[1]:
https://drive.google.com/file/d/1moSlwXHkqcV6_7zHBNhLMLi-9Ye_xDGJ/view?usp=sharing

[2]:
https://drive.google.com/file/d/16O4LLH8dL0RWmbOx4HrcooFUyesWaVi-/view?usp=sharing

[3]:
https://github.com/odoo/odoo/blob/694f1d0fb03b56dd41a59eb676e56622634cc91b/addons/sale_pdf_quote_builder/utils.py#L11

sentry-6928220164
opw-5227601