### PR TITLE
[FIX] hr_attendance: provide correct arguments to ValidationError

### DIFF
--- a/addons/hr_attendance/models/hr_attendance_overtime_rule.py
+++ b/addons/hr_attendance/models/hr_attendance_overtime_rule.py
@@ -144,10 +144,10 @@ class HrAttendanceOvertimeRule(models.Model):
                 and not rule.expected_hours_from_contract
                 and not rule.expected_hours
             ):
-                raise ValidationError(self.env._("Rule '%(name)s' is based off quantity, but the usual amount of work hours is not specified"), name=rule.name)
+                raise ValidationError(self.env._("Rule '%(name)s' is based off quantity, but the usual amount of work hours is not specified", name=rule.name))
 
             if rule.base_off == 'quantity' and not rule.quantity_period:
-                raise ValidationError(self.env._("Rule '%(name)s' is based off quantity, but the period is not specified"), name=rule.name)
+                raise ValidationError(self.env._("Rule '%(name)s' is based off quantity, but the period is not specified", name=rule.name))
 
     # Timing rule well defined
     @api.constrains('base_off', 'timing_type', 'resource_calendar_id')


### PR DESCRIPTION
Currently, an error occurs when user saves an overtime ruleset.

Steps to reproduce:
 - Install the `hr_attendance` module.
 - Go to `Overtime Rulesets` and create a rule.
 - Add an `overtime rule` in this `ruleset` with:
    - `Rule is based on: Quantity`
    - and `clear the 'If the worked hours on' field`.
 - Save the `rule` and `ruleset`.

`TypeError: UserError.__init__() got an unexpected keyword argument 'name'`

This error occurs when a user saves the ruleset without setting the rule's quantity period, and due to two arguments being wrongly placed in the ValidationError[1], the error is raised.

This commit ensures that the validation error works correctly by passing a single argument.

[1]: https://github.com/odoo/odoo/blob/34409128de0bb84cdee309b031b307c46d8b07c7/addons/hr_attendance/models/hr_attendance_overtime_rule.py#L147

sentry-6932048427

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
