### PR TITLE
[IMP] orm: simplify Query

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -8,7 +8,8 @@ import json
 from odoo import api, fields, models, _, Command
 from odoo.fields import Domain
 from odoo.exceptions import UserError, ValidationError, RedirectWarning
-from odoo.tools import SQL, Query
+from odoo.models import Query
+from odoo.tools import SQL
 
 
 ACCOUNT_REGEX = re.compile(r'(?:(\S*\d+\S*))?(.*)')

--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -409,7 +409,7 @@ class AccountAccount(models.Model):
     def _search_placeholder_code(self, operator, value):
         if operator not in ('=ilike', 'in'):
             return NotImplemented
-        query = Query(self.env, 'account_account')
+        query = Query(self)
         placeholder_code_sql = self.env['account.account']._field_to_sql('account_account', 'placeholder_code', query)
         if operator == 'in':
             query.add_where(SQL("%s IN %s", placeholder_code_sql, tuple(value)))
@@ -1269,7 +1269,7 @@ class AccountAccount(models.Model):
                 return
             # We would get a ValueError if the _field_to_sql is not implemented. In that case, we return None.
             with contextlib.suppress(ValueError):
-                query = Query(self.env, self.env[model]._table, self.env[model]._table_sql)
+                query = Query(self.env[model])
                 return query.select(
                     SQL('%s AS id', self.env[model]._field_to_sql(query.table, 'id')),
                     SQL('%s AS company_id', self.env[model]._field_to_sql(query.table, company_id_field, query)),

--- a/addons/account/models/account_account_tag.py
+++ b/addons/account/models/account_account_tag.py
@@ -50,7 +50,7 @@ class AccountAccountTag(models.Model):
     def _field_to_sql(self, alias: str, field_expr: str, query: (Query | None) = None) -> SQL:
         if field_expr in ('report_expression_id', 'balance_negate'):
             rhs_alias = query.make_alias(alias, 'expression')
-            if rhs_alias not in query._tables:
+            if rhs_alias not in query._joins:
                 query.add_join(
                     kind='LEFT JOIN',
                     alias=rhs_alias,

--- a/addons/account/models/account_account_tag.py
+++ b/addons/account/models/account_account_tag.py
@@ -1,6 +1,6 @@
 from odoo import api, fields, models, _
 from odoo.fields import Domain
-from odoo.tools import SQL, Query
+from odoo.tools import SQL
 from odoo.exceptions import UserError
 
 
@@ -47,7 +47,7 @@ class AccountAccountTag(models.Model):
         for tag in self:
             tag.report_expression_id, tag.balance_negate = id2expression.get(tag._origin.id, (False, False))
 
-    def _field_to_sql(self, alias: str, field_expr: str, query: (Query | None) = None) -> SQL:
+    def _field_to_sql(self, alias: str, field_expr: str, query=None) -> SQL:
         if field_expr in ('report_expression_id', 'balance_negate'):
             rhs_alias = query.make_alias(alias, 'expression')
             if rhs_alias not in query._joins:

--- a/addons/account/models/account_code_mapping.py
+++ b/addons/account/models/account_code_mapping.py
@@ -1,6 +1,6 @@
 from odoo import fields, models, api
 from odoo.fields import Domain
-from odoo.tools import Query
+from odoo.models import Query
 
 COMPANY_OFFSET = 10000
 

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -7,7 +7,8 @@ import re
 from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError, UserError, RedirectWarning
 from odoo.fields import Command, Domain
-from odoo.tools import frozendict, float_compare, groupby, Query, SQL, OrderedSet
+from odoo.models import Query
+from odoo.tools import frozendict, float_compare, groupby, SQL, OrderedSet
 from odoo.addons.web.controllers.utils import clean_action
 
 from odoo.addons.account.models.account_move import MAX_HASH_VERSION

--- a/addons/account/models/account_root.py
+++ b/addons/account/models/account_root.py
@@ -3,7 +3,7 @@ from itertools import accumulate
 
 from odoo import api, fields, models
 from odoo.exceptions import UserError
-from odoo.tools import Query
+from odoo.models import Query
 
 
 class AccountRoot(models.Model):

--- a/addons/account/report/account_invoice_report.py
+++ b/addons/account/report/account_invoice_report.py
@@ -1,11 +1,7 @@
-# -*- coding: utf-8 -*-
-
 from odoo import models, fields, api
+from odoo.models import Query
 from odoo.tools import SQL
-from odoo.tools.query import Query
 from odoo.addons.account.models.account_move import PAYMENT_STATE_SELECTION
-
-from functools import lru_cache
 
 
 class AccountInvoiceReport(models.Model):

--- a/addons/analytic/models/analytic_mixin.py
+++ b/addons/analytic/models/analytic_mixin.py
@@ -111,18 +111,17 @@ class AnalyticMixin(models.AbstractModel):
         """To group by `analytic_distribution`, we first need to separate the analytic_ids and associate them with the ids to be counted
         Do note that only '__count' can be passed in the `aggregates`"""
         if groupby_spec == 'analytic_distribution':
-            query._tables = {
-                'distribution': SQL(
+            query._joins = {
+                'distribution': (SQL(), SQL(
                     r"""(SELECT DISTINCT %s, (regexp_matches(jsonb_object_keys(%s), '\d+', 'g'))[1]::int AS account_id FROM %s WHERE %s)""",
                     self._get_count_id(query),
                     self._field_to_sql(self._table, 'analytic_distribution', query),
                     query.from_clause,
                     query.where_clause,
-                )
+                ), SQL())
             }
 
             # After using the from and where clauses in the nested query, they are no longer needed in the main one
-            query._joins = {}
             query._where_clauses = []
             return SQL("account_id")
 

--- a/addons/analytic/models/analytic_mixin.py
+++ b/addons/analytic/models/analytic_mixin.py
@@ -4,7 +4,8 @@ from collections import defaultdict
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
 from odoo.fields import Domain
-from odoo.tools import SQL, Query, unique
+from odoo.models import Query
+from odoo.tools import SQL, unique
 from odoo.tools.float_utils import float_compare, float_round
 
 

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -14,7 +14,8 @@ from markupsafe import Markup
 from odoo import api, fields, models, _, tools
 from odoo.fields import Domain
 from odoo.exceptions import ValidationError, AccessError, RedirectWarning, UserError
-from odoo.tools import convert, format_time, email_normalize, SQL, Query
+from odoo.models import Query
+from odoo.tools import convert, format_time, email_normalize, SQL
 from odoo.tools.intervals import Intervals
 from odoo.addons.hr.models.hr_version import format_date_abbr
 from odoo.addons.mail.tools.discuss import Store

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -35,7 +35,7 @@ from odoo.exceptions import MissingError, AccessError
 from odoo.fields import Domain
 from odoo.tools import (
     is_html_empty, html_escape, html2plaintext,
-    clean_context, split_every, Query, SQL,
+    clean_context, split_every, SQL,
     ormcache, is_list_of,
 )
 from odoo.tools.mail import (

--- a/addons/project/report/project_task_burndown_chart_report.py
+++ b/addons/project/report/project_task_burndown_chart_report.py
@@ -199,7 +199,7 @@ class ProjectTaskBurndownChartReport(models.AbstractModel):
 
         # hardcode 'project_task_burndown_chart_report' as the query above
         # (with its own parameters)
-        main_query._tables['project_task_burndown_chart_report'] = burndown_chart_sql
+        main_query._joins['project_task_burndown_chart_report'] = (SQL(), burndown_chart_sql, SQL())
 
         return main_query
 

--- a/addons/purchase/report/purchase_report.py
+++ b/addons/purchase/report/purchase_report.py
@@ -1,12 +1,11 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 #
 # Please note that these reports are not multi-currency !!!
 #
 
-from odoo import fields, models, api
-from odoo.tools.query import Query
+from odoo import fields, models
+from odoo.models import Query
 from odoo.tools.sql import SQL
 
 

--- a/addons/sale_project/models/project_project.py
+++ b/addons/sale_project/models/project_project.py
@@ -442,7 +442,7 @@ class ProjectProject(models.Model):
             f'{SaleOrderLine._table}.id AS sale_line_id',
         )
 
-        return Query(self.env, 'project_sale_order_item', SQL('(%s)', SQL(' UNION ').join([
+        return Query(None, 'project_sale_order_item', SQL('(%s)', SQL(' UNION ').join([
             project_sql, task_sql, milestone_sql, sale_order_line_sql,
         ])))
 

--- a/addons/sale_project/models/project_project.py
+++ b/addons/sale_project/models/project_project.py
@@ -6,7 +6,8 @@ from collections import defaultdict
 
 from odoo import api, fields, models
 from odoo.fields import Domain
-from odoo.tools import Query, SQL
+from odoo.models import Query
+from odoo.tools import SQL
 from odoo.tools.misc import unquote
 from odoo.tools.translate import _
 

--- a/addons/sale_timesheet/models/project_project.py
+++ b/addons/sale_timesheet/models/project_project.py
@@ -326,11 +326,13 @@ class ProjectProject(models.Model):
             f'{EmployeeMapping._table}.sale_line_id',
         )
 
-        query._tables['project_sale_order_item'] = SQL('(%s)', SQL(' UNION ').join([
-            query._tables['project_sale_order_item'],
+        join, sql, condition = query._joins['project_sale_order_item']
+        sql = SQL('(%s)', SQL(' UNION ').join([
+            sql,
             timesheet_sql,
             employee_mapping_sql,
         ]))
+        query._joins['project_sale_order_item'] = (join, sql, condition)
         return query
 
     def _get_domain_from_section_id(self, section_id):

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -25,8 +25,9 @@ from odoo.addons.iap.tools import iap_tools
 from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.fields import Domain
 from odoo.http import request
+from odoo.models import Query
 from odoo.modules.module import get_manifest
-from odoo.tools import SQL, Query
+from odoo.tools import SQL
 from odoo.tools.image import image_process
 from odoo.tools.sql import escape_psql
 from odoo.tools.translate import _

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -2143,7 +2143,7 @@ class Website(models.Model):
             :rel_table: name of the rel table when search_fields in search_details contains a Many2many.
             :rel_joinkey: name of the column used to join model._table with rel_table.
             """
-            subquery = Query(self.env.cr, model._table, model._table_query)
+            subquery = Query(model)
             unaccent = self.env.registry.unaccent
             similarity = SQL(
                 "GREATEST(%(similarities)s) as similarity",

--- a/odoo/addons/base/tests/test_query.py
+++ b/odoo/addons/base/tests/test_query.py
@@ -1,7 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo.models import Query
 from odoo.tests.common import BaseCase, TransactionCase
-from odoo.tools import Query, SQL
+from odoo.tools import SQL
 
 
 class QueryTestCase(BaseCase):

--- a/odoo/addons/base/tests/test_query.py
+++ b/odoo/addons/base/tests/test_query.py
@@ -7,7 +7,7 @@ from odoo.tools import Query, SQL
 class QueryTestCase(BaseCase):
 
     def test_basic_query(self):
-        query = Query(None, 'product_product')
+        query = Query(None, 'product_product', SQL.identifier('product_product'))
         query.add_table('product_template')
         query.add_where("product_product.template_id = product_template.id")
         # add inner join
@@ -23,7 +23,7 @@ class QueryTestCase(BaseCase):
             "product_product.template_id = product_template.id")
 
     def test_query_chained_explicit_joins(self):
-        query = Query(None, 'product_product')
+        query = Query(None, 'product_product', SQL.identifier('product_product'))
         query.add_table('product_template')
         query.add_where("product_product.template_id = product_template.id")
         # add inner join
@@ -39,7 +39,7 @@ class QueryTestCase(BaseCase):
             "product_product.template_id = product_template.id")
 
     def test_mixed_query_chained_explicit_implicit_joins(self):
-        query = Query(None, 'product_product')
+        query = Query(None, 'product_product', SQL.identifier('product_product'))
         query.add_table('product_template')
         query.add_where("product_product.template_id = product_template.id")
         # add inner join
@@ -58,12 +58,12 @@ class QueryTestCase(BaseCase):
             "product_product.template_id = product_template.id AND product_category.expense_account_id = account_account.id")
 
     def test_raise_missing_lhs(self):
-        query = Query(None, 'product_product')
+        query = Query(None, 'product_product', SQL.identifier('product_product'))
         with self.assertRaises(AssertionError):
             query.join("product_template", "categ_id", "product_category", "id", "categ_id")
 
     def test_long_aliases(self):
-        query = Query(None, 'product_product')
+        query = Query(None, 'product_product', SQL.identifier('product_product'))
         tmp = query.join('product_product', 'product_tmpl_id', 'product_template', 'id', 'product_tmpl_id')
         self.assertEqual(tmp, 'product_product__product_tmpl_id')
         # no hashing
@@ -81,7 +81,7 @@ class QueryTestCase(BaseCase):
         self.assertEqual(tmp_cat_stm_par, 'product_product__product_tmpl_id__product_category_id__00363fdd')
 
     def test_table_expression(self):
-        query = Query(None, 'foo')
+        query = Query(None, 'foo', SQL.identifier('foo'))
         from_clause = query.from_clause.code
         self.assertEqual(from_clause, '"foo"')
 
@@ -89,18 +89,18 @@ class QueryTestCase(BaseCase):
         from_clause = query.from_clause.code
         self.assertEqual(from_clause, '(SELECT id FROM foo) AS "bar"')
 
-        query = Query(None, 'foo')
+        query = Query(None, 'foo', SQL.identifier('foo'))
         query.add_table('bar', SQL('(SELECT id FROM foo)'))
         from_clause = query.from_clause.code
         self.assertEqual(from_clause, '"foo", (SELECT id FROM foo) AS "bar"')
 
-        query = Query(None, 'foo')
+        query = Query(None, 'foo', SQL.identifier('foo'))
         query.join('foo', 'bar_id', SQL('(SELECT id FROM foo)'), 'id', 'bar')
         from_clause = query.from_clause.code
         self.assertEqual(from_clause, '"foo" JOIN (SELECT id FROM foo) AS "foo__bar" ON ("foo"."bar_id" = "foo__bar"."id")')
 
     def test_empty_set_result_ids(self):
-        query = Query(None, 'foo')
+        query = Query(None, 'foo', SQL.identifier('foo'))
         query.set_result_ids([])
         self.assertEqual(query.get_result_ids(), ())
         self.assertTrue(query.is_empty())
@@ -110,7 +110,7 @@ class QueryTestCase(BaseCase):
         self.assertTrue(query.is_empty(), "adding where clauses keeps the result empty")
 
     def test_set_result_ids(self):
-        query = Query(None, 'foo')
+        query = Query(None, 'foo', SQL.identifier('foo'))
         query.set_result_ids([1, 2, 3])
         self.assertEqual(query.get_result_ids(), (1, 2, 3))
         self.assertFalse(query.is_empty())

--- a/odoo/models/__init__.py
+++ b/odoo/models/__init__.py
@@ -22,6 +22,7 @@ from odoo.orm.models import (
 )
 from odoo.orm.model_classes import is_model_class, is_model_definition
 from odoo.orm.models_transient import TransientModel
+from odoo.orm.query import Query
 from odoo.orm.table_objects import Constraint, Index, UniqueIndex
 from odoo.orm.utils import (
     READ_GROUP_TIME_GRANULARITY,

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -63,9 +63,10 @@ import warnings
 from datetime import date, datetime, time, timedelta, timezone
 
 from odoo.exceptions import UserError
-from odoo.tools import SQL, OrderedSet, Query, classproperty, partition, str2bool
+from odoo.tools import SQL, OrderedSet, classproperty, partition, str2bool
 from odoo.tools.date_utils import parse_date, parse_iso_date
 from .identifiers import NewId
+from .query import Query
 from .utils import COLLECTION_TYPES, parse_field_expr
 
 if typing.TYPE_CHECKING:

--- a/odoo/orm/environments.py
+++ b/odoo/orm/environments.py
@@ -914,7 +914,7 @@ class Cache:
                 return
 
             # select the column for the given ids
-            query = Query(env, model._table, model._table_sql)
+            query = Query(model)
             sql_id = SQL.identifier(model._table, 'id')
             sql_field = model._field_to_sql(model._table, field.name, query)
             if field.type == 'binary' and (

--- a/odoo/orm/environments.py
+++ b/odoo/orm/environments.py
@@ -17,11 +17,12 @@ from weakref import WeakSet
 
 from odoo.exceptions import AccessError, UserError, CacheMiss
 from odoo.sql_db import BaseCursor
-from odoo.tools import clean_context, frozendict, reset_cached_properties, OrderedSet, Query, SQL
+from odoo.tools import clean_context, frozendict, reset_cached_properties, OrderedSet, SQL
 from odoo.tools.translate import get_translation, get_translated_module, LazyGettext
 from odoo.tools.misc import StackMap, SENTINEL
 
 from .registry import Registry
+from .query import Query
 from .utils import SUPERUSER_ID
 
 if typing.TYPE_CHECKING:

--- a/odoo/orm/fields.py
+++ b/odoo/orm/fields.py
@@ -17,11 +17,12 @@ from operator import attrgetter
 from psycopg2.extras import Json as PsycopgJson
 
 from odoo.exceptions import AccessError, MissingError
-from odoo.tools import Query, SQL, sql
+from odoo.tools import SQL, sql
 from odoo.tools.constants import PREFETCH_MAX
 from odoo.tools.misc import SENTINEL, ReadonlyDict, Sentinel, unique
 
 from .domains import Domain
+from .query import Query
 from .utils import COLLECTION_TYPES, SQL_OPERATORS, SUPERUSER_ID, expand_ids
 
 if typing.TYPE_CHECKING:

--- a/odoo/orm/fields_binary.py
+++ b/odoo/orm/fields_binary.py
@@ -18,9 +18,8 @@ from .fields import Field
 from .utils import SQL_OPERATORS
 
 if typing.TYPE_CHECKING:
-    from odoo.tools import Query
-
     from .models import BaseModel
+    from .query import Query
 
 # http://initd.org/psycopg/docs/usage.html#binary-adaptation
 # Received data is returned as buffer (in Python 2) or memoryview (in Python 3).

--- a/odoo/orm/fields_misc.py
+++ b/odoo/orm/fields_misc.py
@@ -13,7 +13,7 @@ from .identifiers import IdType
 
 if typing.TYPE_CHECKING:
     from .models import BaseModel
-    from odoo.tools import Query
+    from .query import Query
 
 # integer needs to be imported before Id because of `type` attribute clash
 from . import fields_numeric  # noqa: F401

--- a/odoo/orm/fields_properties.py
+++ b/odoo/orm/fields_properties.py
@@ -19,7 +19,7 @@ from .fields import Field, _logger
 from .models import BaseModel
 from .utils import COLLECTION_TYPES, SQL_OPERATORS, parse_field_expr, regex_alphanumeric
 if typing.TYPE_CHECKING:
-    from odoo.tools import Query
+    from .query import Query
 
 NoneType = type(None)
 

--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -8,7 +8,7 @@ from collections.abc import Reversible
 from operator import attrgetter
 
 from odoo.exceptions import AccessError, MissingError, UserError
-from odoo.tools import SQL, OrderedSet, Query, sql, unique
+from odoo.tools import SQL, OrderedSet, sql, unique
 from odoo.tools.constants import PREFETCH_MAX
 from odoo.tools.misc import SENTINEL, Sentinel, unquote
 
@@ -18,6 +18,7 @@ from .fields import IR_MODELS, Field, _logger
 from .fields_reference import Many2oneReference
 from .identifiers import NewId
 from .models import BaseModel
+from .query import Query
 from .utils import COLLECTION_TYPES, SQL_OPERATORS, check_pg_name
 
 if typing.TYPE_CHECKING:

--- a/odoo/orm/fields_temporal.py
+++ b/odoo/orm/fields_temporal.py
@@ -14,9 +14,9 @@ from .utils import parse_field_expr, READ_GROUP_NUMBER_GRANULARITY
 
 if typing.TYPE_CHECKING:
     from collections.abc import Callable
-    from odoo.tools import Query
 
     from .models import BaseModel
+    from .query import Query
 
 T = typing.TypeVar("T")
 

--- a/odoo/orm/fields_textual.py
+++ b/odoo/orm/fields_textual.py
@@ -23,11 +23,9 @@ from .fields import Field, _logger
 from .utils import COLLECTION_TYPES, SQL_OPERATORS
 
 if typing.TYPE_CHECKING:
-    from .models import BaseModel
-    from odoo.tools import Query
-
-if typing.TYPE_CHECKING:
     from collections.abc import Callable
+    from .models import BaseModel
+    from .query import Query
 
 
 class BaseString(Field[str | typing.Literal[False]]):

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -4694,7 +4694,7 @@ class BaseModel(metaclass=MetaModel):
         domain = domain.optimize_full(self)
         if domain.is_false():
             return self.browse()._as_query()
-        query = Query(self.env, self._table, self._table_sql)
+        query = Query(self)
         if not domain.is_true():
             query.add_where(domain._to_sql(self, self._table, query))
 
@@ -4724,7 +4724,7 @@ class BaseModel(metaclass=MetaModel):
 
         :param ordered: whether the recordset order must be enforced by the query
         """
-        query = Query(self.env, self._table, self._table_sql)
+        query = Query(self)
         query.set_result_ids(self._ids, ordered)
         return query
 
@@ -4877,7 +4877,7 @@ class BaseModel(metaclass=MetaModel):
         new_ids, ids = partition(lambda i: isinstance(i, NewId), self._ids)
         if not ids:
             return self
-        query = Query(self.env, self._table, self._table_sql)
+        query = Query(self)
         query.add_where(SQL("%s IN %s", SQL.identifier(self._table, 'id'), tuple(ids)))
         real_ids = (id_ for [id_] in self.env.execute_query(query.select()))
         valid_ids = {*real_ids, *new_ids}
@@ -4899,7 +4899,7 @@ class BaseModel(metaclass=MetaModel):
         ids = {id_ for id_ in self._ids if id_}
         if not ids:
             return
-        query = Query(self.env, self._table, self._table_sql)
+        query = Query(self)
         query.add_where(SQL("%s IN %s", SQL.identifier(self._table, 'id'), tuple(ids)))
         # Use SKIP LOCKED instead of NOWAIT because the later aborts the
         # transaction and we do not want to use SAVEPOINTS.
@@ -4931,7 +4931,7 @@ class BaseModel(metaclass=MetaModel):
             query = self.browse(ids)._as_query(ordered=True)
             query.limit = limit - len(new_ids)
         else:
-            query = Query(self.env, self._table, self._table_sql)
+            query = Query(self)
             query.add_where(SQL("%s IN %s", SQL.identifier(self._table, 'id'), tuple(ids)))
         if not ids:
             return self

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -23,14 +23,12 @@ from __future__ import annotations
 
 import collections
 import contextlib
-import datetime
 import functools
 import inspect
 import itertools
 import io
 import json
 import logging
-import pytz
 import re
 import typing
 import uuid
@@ -40,18 +38,15 @@ from collections.abc import Callable, Mapping
 from inspect import getmembers
 from operator import attrgetter, itemgetter
 
-import babel
-import babel.dates
 import psycopg2.errors
 import psycopg2.extensions
 from psycopg2.extras import Json
 
 from odoo.exceptions import AccessError, LockError, MissingError, ValidationError, UserError
 from odoo.tools import (
-    clean_context, date_utils,
-    DEFAULT_SERVER_DATE_FORMAT, DEFAULT_SERVER_DATETIME_FORMAT, format_list,
+    clean_context, format_list,
     frozendict, get_lang, OrderedSet,
-    ormcache, partition, Query, split_every, unique,
+    ormcache, partition, split_every, unique,
     SQL, sql, groupby,
 )
 from odoo.tools.constants import PREFETCH_MAX
@@ -68,6 +63,7 @@ from .fields_temporal import Date, Datetime
 from .fields_textual import Char
 
 from .identifiers import NewId
+from .query import Query
 from .utils import (
     OriginIds, check_object_name, parse_field_expr,
     COLLECTION_TYPES, SQL_OPERATORS,

--- a/odoo/orm/query.py
+++ b/odoo/orm/query.py
@@ -5,9 +5,9 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
-    from odoo.orm.models import BaseModel
+    from .models import BaseModel
 
-from .sql import SQL, make_identifier
+from odoo.tools.sql import SQL, make_identifier
 
 
 def _sql_from_table(alias: str, table: SQL) -> SQL:
@@ -103,7 +103,7 @@ class Query:
 
     def add_where(self, where_clause: str | SQL, where_params=()):
         """ Add a condition to the where clause. """
-        self._where_clauses.append(SQL(where_clause, *where_params)) # pylint: disable = sql-injection
+        self._where_clauses.append(SQL(where_clause, *where_params))  # pylint: disable = sql-injection
         self._ids = self._ids and None
 
     def join(self, lhs_alias: str, lhs_column: str, rhs_table: str | SQL, rhs_column: str, link: str) -> str:
@@ -144,7 +144,7 @@ class Query:
 
     @order.setter
     def order(self, value: SQL | str | None):
-        self._order = SQL(value) if value is not None else None # pylint: disable = sql-injection
+        self._order = SQL(value) if value is not None else None  # pylint: disable = sql-injection
 
     @property
     def table(self) -> str:

--- a/odoo/tools/__init__.py
+++ b/odoo/tools/__init__.py
@@ -12,7 +12,6 @@ from .i18n import format_list, py_to_js_locale
 from .json import json_default
 from .mail import *
 from .misc import *
-from .query import Query
 from .sql import *
 from .translate import _, html_translate, xml_translate, LazyTranslate
 from .xml_utils import cleanup_xml_node, load_xsd_files_from_url, validate_xml_from_attachment

--- a/odoo/tools/query.py
+++ b/odoo/tools/query.py
@@ -198,16 +198,18 @@ class Query:
                 return SQL("(SELECT 1 WHERE FALSE)")
             return SQL("%s", self._ids)
 
-        if self.limit or self.offset:
+        if self.limit is not None or self.offset:
             # in this case, the ORDER BY clause is necessary
             return SQL("(%s)", self.select(*args))
 
         sql_args = map(SQL, args) if args else [SQL.identifier(self.table, 'id')]
         return SQL(
-            "(%s%s%s)",
+            "(%s%s%s%s%s)",
             SQL("SELECT %s", SQL(", ").join(sql_args)),
             SQL(" FROM %s", self.from_clause),
             SQL(" WHERE %s", self.where_clause) if self._where_clauses else SQL(),
+            SQL(" GROUP BY %s", self.groupby) if self.groupby else SQL(),
+            SQL(" HAVING %s", self.having) if self.having else SQL(),
         )
 
     def get_result_ids(self) -> tuple[int, ...]:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- `Query(model)` constructor.
- Removing `Query.add_table` as we can always use joins
- Fixing generation of GROUP BY statement in subqueries
- Moving the file to odoo.orm because it really depends on it and should not be in tools.

https://github.com/odoo/enterprise/pull/96699

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
