### PR TITLE
[FIX] html_editor: fix selection on shift + click inside cell

### DIFF
--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -623,8 +623,8 @@ export class TablePlugin extends Plugin {
             if (closestElement(ev.target, "td.o_selected_td")) {
                 this.dependencies.selection.setCursorStart(currentSelection.anchorNode);
             }
+            this.deselectTable();
         }
-        this.deselectTable();
     }
 
     onMouseup(ev) {

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -616,13 +616,15 @@ export class TablePlugin extends Plugin {
     onMousedown(ev) {
         this._currentMouseState = ev.type;
         this._lastMousedownPosition = [ev.x, ev.y];
-        this.deselectTable();
         if (this.isPointerInsideCell(ev)) {
             this.editable.addEventListener("mousemove", this.onMousemove);
             const currentSelection = this.dependencies.selection.getEditableSelection();
             // disable dragging on table
-            this.dependencies.selection.setCursorStart(currentSelection.anchorNode);
+            if (closestElement(ev.target, "td.o_selected_td")) {
+                this.dependencies.selection.setCursorStart(currentSelection.anchorNode);
+            }
         }
+        this.deselectTable();
     }
 
     onMouseup(ev) {

--- a/addons/html_editor/static/src/main/table/table_resize.scss
+++ b/addons/html_editor/static/src/main/table/table_resize.scss
@@ -1,16 +1,8 @@
 .odoo-editor-editable {
     &.o_col_resize {
         cursor: col-resize;
-
-        ::selection {
-            background-color: transparent;
-        }
     }
     &.o_row_resize {
         cursor: row-resize;
-
-        ::selection {
-            background-color: transparent;
-        }
     }
 }


### PR DESCRIPTION
**Current behaviour before PR:**

Steps to reproduce:

- Create a table
- Write a sentence in one of the cell
- Put your caret somewhere in your sentence (e.g. "He[]llo wold")
- Shift + click in the same sentence (e.g. "Hello wor[]ld")

The expect result should be "He[llo wor]ld", but it's "[Hello wor]ld". This issue happens because in `onMousedown` method of table_plugin, cursor is set to the starting of `anchorNode`, which leads to wrong selection on shift + click.

**Desired behaviour after PR:**

This PR ensures that Shift + Click sets the selection in the same way as the default browser behavior.

task-5152807





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
