### PR TITLE
[IMP] base: Warning on unused attributes in ir.qweb

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -435,7 +435,7 @@
                                                         <span t-out="term_index + 1">1</span> - Installment of
                                                         <t t-options='{"widget": "monetary", "display_currency": o.currency_id}' t-out="term.get('amount')" class="text-end">31.05</t>
                                                         <span> due on </span>
-                                                        <t t-out="term.get('date')" class="text-start">2024-01-01</t>
+                                                        <t t-out="term.get('date')">2024-01-01</t>
                                                     </div>
                                                 </t>
                                             </div>

--- a/addons/account_peppol/data/mail_templates_email_layouts.xml
+++ b/addons/account_peppol/data/mail_templates_email_layouts.xml
@@ -5,7 +5,7 @@
                   name="Mail: mail notification layout with responsible signature (user_id of the record) and Peppol status"
                   inherit_id="mail.mail_notification_layout_with_responsible_signature"
                   primary="True">
-            <xpath expr="//t[hasclass('o_signature')]" position="after">
+            <xpath expr="//t[@name='o_signature']" position="after">
                 <div id="peppol_status" t-if="peppol_info" style="font-size: 13px;">
                     <br/><br/>
                     <t t-if="peppol_info['is_peppol_sent']">

--- a/addons/l10n_gcc_invoice/views/report_invoice.xml
+++ b/addons/l10n_gcc_invoice/views/report_invoice.xml
@@ -177,7 +177,7 @@
                         <span t-out="term_index + 1">1</span> - دفعة من
                         <t t-options='{"widget": "monetary", "display_currency": o_sec.currency_id}' t-out="term.get('amount')" class="text-end">31.05</t>
                         <span> مستحق في </span>
-                        <t t-out="term.get('date')" class="text-start">2024-01-01</t>
+                        <t t-out="term.get('date')">2024-01-01</t>
                     </div>
                 </t>
                 <t name="div_payment_term_en" t-if="len(payment_term_details_sec) > 1 and display_in_en" t-foreach="payment_term_details_sec" t-as="term" t-translation="off">
@@ -185,7 +185,7 @@
                         <span t-out="term_index + 1">1</span> - Installment of
                         <t t-options='{"widget": "monetary", "display_currency": o_sec.currency_id}' t-out="term.get('amount')" class="text-end">31.05</t>
                         <span> due on </span>
-                        <t t-out="term.get('date')" class="text-start">2024-01-01</t>
+                        <t t-out="term.get('date')">2024-01-01</t>
                     </div>
                 </t>
             </xpath>

--- a/addons/l10n_in_ewaybill/views/edi_pdf_report.xml
+++ b/addons/l10n_in_ewaybill/views/edi_pdf_report.xml
@@ -10,7 +10,6 @@
                 <p t-if="o.l10n_in_ewaybill_name" class="m-0" t-out="o.l10n_in_ewaybill_name"/>
                 Until: 
                 <t t-if="o.l10n_in_ewaybill_expiry_date"
-                   class="m-0"
                    t-out="o.l10n_in_ewaybill_expiry_date"/>
             </div>
         </xpath>

--- a/addons/l10n_sa/views/report_invoice.xml
+++ b/addons/l10n_sa/views/report_invoice.xml
@@ -218,12 +218,12 @@
             <span name="untaxed_amount_en" t-if="display_in_en" t-translation="off" class="text-nowrap">Invoice Taxable Amount</span>
         </span>
         <span t-out="tax_group['group_name']" position="after">
-            <t t-if="display_in_lang_sec and tax_group_sec['group_name'] != tax_group['group_name']" class="text-nowrap">
+            <t t-if="display_in_lang_sec and tax_group_sec['group_name'] != tax_group['group_name']">
                 / <span t-out="tax_group_sec['group_name']"/>
             </t>
         </span>
         <xpath expr="//tr[hasclass('o_taxes')]/t[@t-else='']//span" position="after">
-            <t t-if="display_in_lang_sec and tax_group_sec['group_name'] != tax_group['group_name']" class="text-nowrap">
+            <t t-if="display_in_lang_sec and tax_group_sec['group_name'] != tax_group['group_name']">
                 / <span t-out="tax_group_sec['group_name']"/>
             </t>
         </xpath>
@@ -255,12 +255,12 @@
             <span name="untaxed_amount_en" t-if="display_in_en" t-translation="off" class="text-nowrap">Invoice Taxable Amount</span>
         </span>
         <span t-out="tax_group['group_name']" position="after">
-            <t t-if="display_in_lang_sec and tax_group_sec['group_name'] != tax_group['group_name']" class="text-nowrap">
+            <t t-if="display_in_lang_sec and tax_group_sec['group_name'] != tax_group['group_name']">
                 / <span t-out="tax_group_sec['group_name']"/>
             </t>
         </span>
         <xpath expr="//tr[hasclass('o_taxes')]/t[@t-else='']//span" position="after">
-            <t t-if="display_in_lang_sec and tax_group_sec['group_name'] != tax_group['group_name']" class="text-nowrap">
+            <t t-if="display_in_lang_sec and tax_group_sec['group_name'] != tax_group['group_name']">
                 / <span t-out="tax_group_sec['group_name']"/>
             </t>
         </xpath>

--- a/addons/mail/data/mail_templates_email_layouts.xml
+++ b/addons/mail/data/mail_templates_email_layouts.xml
@@ -67,7 +67,7 @@
         <li><t t-out="tracking[0]"/>: <t t-if="tracking[1]" t-out="tracking[1]"/><em t-else="">None</em> &#8594; <t t-if="tracking[2]" t-out="tracking[2]"/><em t-else="">None</em></li>
     </t>
 </ul>
-<t class="o_signature">
+<t name="o_signature">
     <div t-if="email_add_signature and not is_html_empty(signature)" t-out="signature" class="o_signature" style="font-size: 13px;"/>
 </t>
 <!-- FOOTER -->
@@ -184,8 +184,8 @@
         <template id="mail_notification_layout_with_responsible_signature"
                   name="Mail: mail notification layout with responsible signature (user_id of the record)"
                   inherit_id="mail.mail_notification_layout" primary="True">
-            <xpath expr="//t[hasclass('o_signature')]" position="replace">
-                <t class="o_signature">
+            <xpath expr="//t[@name='o_signature']" position="replace">
+                <t name="o_signature">
                     <div t-if="email_add_signature and record and 'user_id' in record and record.user_id and not record.env.user._is_superuser() and not is_html_empty(record.user_id.sudo().signature)"
                          t-out="record.user_id.sudo().signature" class="o_signature" style="font-size: 13px;"/>
                 </t>

--- a/addons/payment/views/portal_templates.xml
+++ b/addons/payment/views/portal_templates.xml
@@ -351,8 +351,8 @@
             </div>
             <div id="o_payment_status_message" class="w-100">
                 <h5 t-if="status_heading" t-out="status_heading" class="alert-heading mb-0"/>
-                <t t-if="status_message" t-out="status_message" class="mb-0"/>
-                <t t-if="tx.state_message" t-out="tx.state_message" class="mb-0"/>
+                <t t-if="status_message" t-out="status_message"/>
+                <t t-if="tx.state_message" t-out="tx.state_message"/>
             </div>
             <a t-if="is_processing"
                t-att-href="tx.landing_route"

--- a/addons/point_of_sale/views/pos_session_sales_details.xml
+++ b/addons/point_of_sale/views/pos_session_sales_details.xml
@@ -328,7 +328,7 @@
                     <h6 class="bg-secondary p-1 fw-bold">Invoices</h6>
                     <table  class="table table-sm table-borderless" >
                         <tbody>
-                        <t t-foreach="invoiceList" t-as="invoiceSession" class="border-bottom border-secondary">
+                        <t t-foreach="invoiceList" t-as="invoiceSession">
                             <t t-if="invoiceSession['invoices']">
                                 <tr t-foreach='invoiceSession["invoices"]' t-as='invoice'>
                                     <td class="ps-2 fw-bold"><span t-out="invoice['name']">Invoice Name</span></td>

--- a/addons/stock_account/views/report_invoice.xml
+++ b/addons/stock_account/views/report_invoice.xml
@@ -20,7 +20,7 @@
                             <t t-out="snln_line['quantity']">6.00</t>
                             <t t-out="snln_line['uom_name']" groups="uom.group_uom">units</t>
                         </td>
-                        <td><t class="text-end" t-out="snln_line['lot_name']">BC46282798</t></td>
+                        <td><t t-out="snln_line['lot_name']">BC46282798</t></td>
                     </tr>
                 </tbody>
             </table>

--- a/addons/survey/views/survey_templates_print.xml
+++ b/addons/survey/views/survey_templates_print.xml
@@ -75,9 +75,7 @@
                                                 </t>
                                                 <t t-else="">
                                                     <t t-if="question.question_type == 'text_box'" t-call="survey.question_text_box"/>
-                                                    <t t-if="question.question_type == 'char_box'" class="o_survey_print o_survey_comment_container p-0">
-                                                        <span t-out="answer_lines[0].value_char_box or None"/>
-                                                    </t>
+                                                    <span t-if="question.question_type == 'char_box'" t-out="answer_lines[0].value_char_box or None" class="o_survey_print o_survey_comment_container p-0"/>
                                                     <t t-if="question.question_type == 'numerical_box'" t-call="survey.question_numerical_box"/>
                                                     <t t-if="question.question_type == 'date'" t-call="survey.question_date"/>
                                                     <t t-if="question.question_type == 'datetime'" t-call="survey.question_datetime"/>

--- a/addons/test_website/data/test_website_data.xml
+++ b/addons/test_website/data/test_website_data.xml
@@ -42,8 +42,9 @@
             <field name="name">Test View</field>
             <field name="type">qweb</field>
             <field name="key">test_website.test_view</field>
+            <field name="priority">29</field>
             <field name="arch" type="xml">
-                <t name="Test View" priority="29" t-name="test_website.test_view">
+                <t name="Test View" t-name="test_website.test_view">
                     <t t-call="website.layout">
                         <p>Test View</p>
                         <p>placeholder</p>
@@ -55,8 +56,9 @@
             <field name="name">Test Page View</field>
             <field name="type">qweb</field>
             <field name="key">test_website.test_page_view</field>
+            <field name="priority">29</field>
             <field name="arch" type="xml">
-                <t name="Test Page View" priority="29" t-name="test_website.test_page_view">
+                <t name="Test Page View" t-name="test_website.test_page_view">
                     <t t-call="website.layout">
                         <div id="oe_structure_test_website_page" class="oe_structure oe_empty"/>
                         <p>Test Page View</p>
@@ -111,8 +113,9 @@
             <field name="name">Test View To Be t-called</field>
             <field name="type">qweb</field>
             <field name="key">test_website.test_view_to_be_t_called</field>
+            <field name="priority">29</field>
             <field name="arch" type="xml">
-                <t name="Test View To Be t-called" priority="29" t-name="test_website.test_view_to_be_t_called">
+                <t name="Test View To Be t-called" t-name="test_website.test_view_to_be_t_called">
                     <p>Test View To Be t-called</p>
                     <p>placeholder</p>
                 </t>

--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -300,9 +300,9 @@
                 <t t-else="">
                     <t t-call-assets="web.assets_web" media="screen" t-js="false"/>
                 </t>
-                <t t-call="web.conditional_assets_tests" media="screen"/>
+                <t t-call="web.conditional_assets_tests"/>
             </t>
-            <t t-set="head" t-value="head_web + (head or '')" media="screen"/>
+            <t t-set="head" t-value="head_web + (head or '')"/>
             <t t-set="body_classname" t-value="'o_web_client'"/>
         </t>
     </template>

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -450,11 +450,10 @@ class Website(Home):
         templates = request.env['ir.ui.view'].sudo().search_read(domain, ['key', 'name', 'arch_db'])
 
         for t in templates:
-            children = etree.fromstring(t.pop('arch_db')).getchildren()
-            attribs = children and children[0].attrib or {}
-            t['numOfEl'] = attribs.get('data-number-of-elements')
-            t['numOfElSm'] = attribs.get('data-number-of-elements-sm')
-            t['numOfElFetch'] = attribs.get('data-number-of-elements-fetch')
+            attribs = etree.fromstring(t.pop('arch_db')).attrib or {}
+            t['numberOfElements'] = attribs.get('data-number-of-elements')
+            t['numberOfElementsSmallDevices'] = attribs.get('data-number-of-elements-sm')
+            t['numberOfRecords'] = attribs.get('data-number-of-elements-fetch')
             t['rowPerSlide'] = attribs.get('data-row-per-slide')
             t['arrowPosition'] = attribs.get('data-arrow-position')
             t['extraClasses'] = attribs.get('data-extra-classes')

--- a/addons/website/models/ir_qweb.py
+++ b/addons/website/models/ir_qweb.py
@@ -28,6 +28,19 @@ class IrQweb(models.AbstractModel):
         'img': 'src',
     }
 
+    def _compile_root(self, element, compile_context):
+        # Removes the attributes used by the "/website/snippet/filter_templates"
+        # controller and used only to be filtered without using irQweb rendering
+        for data_filter in [
+                'data-number-of-elements', 'data-number-of-elements-sm',
+                'data-number-of-elements-fetch', 'data-row-per-slide',
+                'data-arrow-position', 'data-extra-classes',
+                'data-extra-snippet-classes', 'data-container-classes',
+                'data-content-classes', 'data-column-classes', 'data-thumb',
+            ]:
+            element.attrib.pop(data_filter, None)
+        return super()._compile_root(element, compile_context)
+
     def _get_template(self, template):
         element, document, ref = super()._get_template(template)
         if self.env.context.get('website_id'):

--- a/addons/website/static/src/builder/plugins/options/dynamic_snippet_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/dynamic_snippet_option_plugin.js
@@ -140,18 +140,18 @@ class DynamicSnippetOptionPlugin extends Plugin {
         }
         el.classList.add(this.getTemplateClass(newTemplateKey));
 
-        if (template.numOfEl) {
-            el.dataset.numberOfElements = template.numOfEl;
+        if (template.numberOfElements) {
+            el.dataset.numberOfElements = template.numberOfElements;
         } else {
             delete el.dataset.numberOfElements;
         }
-        if (template.numOfElSm) {
-            el.dataset.numberOfElementsSmallDevices = template.numOfElSm;
+        if (template.numberOfElementsSmallDevices) {
+            el.dataset.numberOfElementsSmallDevices = template.numberOfElementsSmallDevices;
         } else {
             delete el.dataset.numberOfElementsSmallDevices;
         }
-        if (template.numOfElFetch) {
-            el.dataset.numberOfRecords = template.numOfElFetch;
+        if (template.numberOfRecords) {
+            el.dataset.numberOfRecords = template.numberOfRecords;
         }
         if (template.extraClasses) {
             el.dataset.extraClasses = template.extraClasses;

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -458,8 +458,6 @@
                 t-image-preview="/website/static/src/img/snippets_previews/s_facebook_preview.webp">
                 <keywords>social media, fb, feed</keywords>
             </t>
-            <!-- TODO: remove 'snippet_google_map_hook', it does not seem to be used -->
-            <t id="snippet_google_map_hook"/>
             <t t-set="google_maps_api_key" t-value="request.env['website'].get_current_website().google_maps_api_key"/>
             <t t-if="debug or not google_maps_api_key" t-snippet="website.s_map" string="Map"
                 t-thumbnail="/website/static/src/img/snippets_thumbs/s_map.svg" group="social"

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -1919,7 +1919,7 @@
                                     <a href="#">Terms of Services</a>
                                 </li>
                                 <t t-set="configurator_footer_links" t-value="[]"/>
-                                <t t-foreach="configurator_footer_links" t-as="link" class="list-inline-item">
+                                <t t-foreach="configurator_footer_links" t-as="link">
                                     <li class="list-inline-item">•</li>
                                     <li class="list-inline-item">
                                         <a t-att-href="link['href']" t-out="link['text']"/>

--- a/addons/website_blog/views/snippets/s_blog_posts.xml
+++ b/addons/website_blog/views/snippets/s_blog_posts.xml
@@ -68,8 +68,10 @@
 
 <!-- Multi record "Load-time" templates (rendered in JS on page load) -->
 <!-- List layout -->
-<template id="dynamic_filter_template_blog_post_list" name="List">
-    <div t-foreach="records" t-as="data" class="s_blog_posts_post border-0 rounded-3" data-extra-classes="g-4" data-column-classes="col-12 col-sm-6 col-lg-4">
+<template id="dynamic_filter_template_blog_post_list" name="List"
+        data-extra-classes="g-4"
+        data-column-classes="col-12 col-sm-6 col-lg-4">
+    <div t-foreach="records" t-as="data" class="s_blog_posts_post border-0 rounded-3">
         <t t-set="record" t-value="data['_record']"/>
         <div class="d-flex flex-wrap mb-2 small">
             <span class="w-100 w-sm-auto">
@@ -90,8 +92,11 @@
     </div>
 </template>
 <!-- Big picture layout -->
-<template id="dynamic_filter_template_blog_post_big_picture" name="Big picture">
-    <div t-foreach="records" t-as="data" class="s_blog_posts_post position-relative w-100" data-extra-classes="g-3" data-column-classes="col-12 col-sm-6 col-lg-4" data-extra-snippet-classes="s_blog_posts_effect_marley s_blog_posts_post_picture_size_default">
+<template id="dynamic_filter_template_blog_post_big_picture" name="Big picture"
+        data-extra-classes="g-3"
+        data-column-classes="col-12 col-sm-6 col-lg-4"
+        data-extra-snippet-classes="s_blog_posts_effect_marley s_blog_posts_post_picture_size_default">
+    <div t-foreach="records" t-as="data" class="s_blog_posts_post position-relative w-100">
         <t t-set="record" t-value="data['_record']"/>
         <a class="s_blog_posts_post_cover position-relative d-block h-100 rounded shadow-sm overflow-hidden text-decoration-none text-reset ratio ratio-1x1" t-att-title="'Read ' + data['name']" t-att-href="data['call_to_action_url']">
             <t t-call="website.record_cover">
@@ -114,8 +119,9 @@
     </div>
 </template>
 <!-- Horizontal layout -->
-<template id="dynamic_filter_template_blog_post_horizontal" name="Horizontal">
-    <div t-foreach="records" t-as="data" class="s_blog_posts_post w-100" data-number-of-elements="1">
+<template id="dynamic_filter_template_blog_post_horizontal" name="Horizontal"
+        data-number-of-elements="1">
+    <div t-foreach="records" t-as="data" class="s_blog_posts_post w-100">
         <t t-set="record" t-value="data['_record']"/>
         <div t-attf-class="pb-4 {{not data_last and 'border-bottom'}}">
             <div class="row flex-md-nowrap">
@@ -150,8 +156,10 @@
     </div>
 </template>
 <!-- Card layout -->
-<template id="dynamic_filter_template_blog_post_card" name="Card">
-    <div t-foreach="records" t-as="data" class="s_blog_posts_post w-100" data-extra-classes="g-3" data-column-classes="col-12 col-sm-6 col-lg-4 col-xxl-3">
+<template id="dynamic_filter_template_blog_post_card" name="Card"
+        data-extra-classes="g-3"
+        data-column-classes="col-12 col-sm-6 col-lg-4 col-xxl-3">
+    <div t-foreach="records" t-as="data" class="s_blog_posts_post w-100">
         <t t-set="record" t-value="data['_record']"/>
         <div class="card h-100">
             <a class="text-decoration-none text-reset" t-att-href="data['call_to_action_url']" t-att-title="'Read ' + data['name']">
@@ -182,8 +190,10 @@
 
 <!-- Single record templates -->
 <!-- Full Layout -->
-<template id="dynamic_filter_template_blog_post_single_full" name="Solo Full">
-    <t t-if="len(records)" class="s_blog_posts_post" data-extra-snippet-classes="o_cc o_cc5" data-column-classes="col-lg-12">
+<template id="dynamic_filter_template_blog_post_single_full" name="Solo Full"
+        data-extra-snippet-classes="o_cc o_cc5"
+        data-column-classes="col-lg-12">
+    <t t-if="len(records)">
         <t t-set="data" t-value="records[0]"/>
         <t t-set="record" t-value="data['_record']"/>
         <div t-if="is_sample" class="position-absolute bottom-0 end-0 px-4 py-2 text-bg-info rounded-pill">Sample</div>
@@ -208,8 +218,9 @@
     </t>
 </template>
 <!-- Aside Layout -->
-<template id="dynamic_filter_template_blog_post_single_aside" name="Solo Aside">
-    <t t-if="len(records)" class="s_blog_posts_post" data-column-classes="col-lg-12">
+<template id="dynamic_filter_template_blog_post_single_aside" name="Solo Aside"
+        data-column-classes="col-lg-12">
+    <t t-if="len(records)">
         <t t-set="data" t-value="records[0]"/>
         <t t-set="record" t-value="data['_record']"/>
         <div t-if="is_sample" class="position-absolute bottom-0 end-0 px-4 py-2 text-bg-info rounded-pill">Sample</div>
@@ -240,8 +251,11 @@
     </t>
 </template>
 <!-- Circle Layout -->
-<template id="dynamic_filter_template_blog_post_single_circle" name="Solo Circle">
-    <t t-if="len(records)" class="s_blog_posts_post" data-extra-snippet-classes="o_cc o_cc2" data-column-classes="col-lg-12" data-container-classes="o_container_small">
+<template id="dynamic_filter_template_blog_post_single_circle" name="Solo Circle"
+        data-extra-snippet-classes="o_cc o_cc2"
+        data-column-classes="col-lg-12"
+        data-container-classes="o_container_small">
+    <t t-if="len(records)">
         <t t-set="data" t-value="records[0]"/>
         <t t-set="record" t-value="data['_record']"/>
         <div t-if="is_sample" class="position-absolute bottom-0 end-0 px-4 py-2 text-bg-info rounded-pill">Sample</div>
@@ -270,8 +284,9 @@
     </t>
 </template>
 <!-- CTA Badge Layout -->
-<template id="dynamic_filter_template_blog_post_single_badge" name="Solo Badge">
-    <t t-if="len(records)" class="s_blog_posts_post" data-column-classes="col-lg-12 text-center">
+<template id="dynamic_filter_template_blog_post_single_badge" name="Solo Badge"
+        data-column-classes="col-lg-12 text-center">
+    <t t-if="len(records)">
         <t t-set="data" t-value="records[0]"/>
         <t t-set="record" t-value="data['_record']"/>
         <div t-if="is_sample" class="position-absolute bottom-0 end-0 px-4 py-2 text-bg-info rounded-pill">Sample</div>

--- a/addons/website_event/views/snippets/s_events.xml
+++ b/addons/website_event/views/snippets/s_events.xml
@@ -65,8 +65,10 @@
 
 <!-- Multi record templates-->
 <!-- Picture Layout -->
-<template id="dynamic_filter_template_event_event_picture" name="Picture Layout" priority="5">
-    <div t-foreach="records" t-as="data" class="s_events_event w-100" data-extra-classes="g-3" data-column-classes="col-12 col-sm-6 col-lg-4">
+<template id="dynamic_filter_template_event_event_picture" name="Picture Layout" priority="5"
+        data-extra-classes="g-3"
+        data-column-classes="col-12 col-sm-6 col-lg-4">
+    <div t-foreach="records" t-as="data" class="s_events_event w-100">
         <t t-set="record" t-value="data['_record']._set_tz_context()"/>
         <a class="s_events_event_cover position-relative d-flex align-items-center rounded overflow-hidden text-decoration-none ratio ratio-1x1"
            t-att-href="data['call_to_action_url']">
@@ -95,8 +97,10 @@
     </div>
 </template>
 <!-- Card Layout -->
-<template id="dynamic_filter_template_event_event_card" name="Card Layout" priority="10">
-    <t t-foreach="records" t-as="data" data-extra-classes="g-3" data-column-classes="col-12 col-sm-6 col-lg-4 col-xxl-3">
+<template id="dynamic_filter_template_event_event_card" name="Card Layout" priority="10"
+        data-extra-classes="g-3"
+        data-column-classes="col-12 col-sm-6 col-lg-4 col-xxl-3">
+    <t t-foreach="records" t-as="data">
         <t t-set="record" t-value="data['_record']._set_tz_context()"/>
         <a t-att-href="data['call_to_action_url']" class="s_events_event card h-100 text-decoration-none">
             <div class="s_events_event_cover">
@@ -131,8 +135,10 @@
 
 <!-- Single record templates -->
 <!-- Offset Layout -->
-<template id="dynamic_filter_template_event_event_single_offset" name="Solo Offset">
-    <t t-if="len(records)" class="s_events_event" data-column-classes="col-lg-12" data-content-classes="o_cc o_cc5 bg-transparent">
+<template id="dynamic_filter_template_event_event_single_offset" name="Solo Offset"
+        data-column-classes="col-lg-12"
+        data-content-classes="o_cc o_cc5 bg-transparent">
+    <t t-if="len(records)">
         <t t-set="data" t-value="records[0]"/>
         <t t-set="record" t-value="data['_record']"/>
         <t t-set="bg" t-value="record._get_background()"/>
@@ -172,8 +178,10 @@
     </t>
 </template>
 <!-- Entry Layout -->
-<template id="dynamic_filter_template_event_event_single_entry" name="Solo Entry">
-    <t t-if="len(records)" class="s_events_event" data-column-classes="col-lg-12" data-content-classes="o_cc o_cc5 bg-transparent">
+<template id="dynamic_filter_template_event_event_single_entry" name="Solo Entry"
+        data-column-classes="col-lg-12"
+        data-content-classes="o_cc o_cc5 bg-transparent">
+    <t t-if="len(records)">
         <t t-set="data" t-value="records[0]"/>
         <t t-set="record" t-value="data['_record']"/>
         <t t-set="bg" t-value="record._get_background()"/>
@@ -205,8 +213,10 @@
     </t>
 </template>
 <!-- Card Layout -->
-<template id="dynamic_filter_template_event_event_single_card" name="Solo Card">
-    <t t-if="len(records)" class="s_events_event" data-column-classes="col-lg-12" data-content-classes="o_cc o_cc5 bg-transparent">
+<template id="dynamic_filter_template_event_event_single_card" name="Solo Card"
+        data-column-classes="col-lg-12"
+        data-content-classes="o_cc o_cc5 bg-transparent">
+    <t t-if="len(records)">
         <t t-set="data" t-value="records[0]"/>
         <t t-set="record" t-value="data['_record']"/>
         <t t-set="bg" t-value="record._get_background()"/>
@@ -241,8 +251,9 @@
     </t>
 </template>
 <!-- CTA Badge Layout -->
-<template id="dynamic_filter_template_event_event_single_badge" name="Solo Badge">
-    <t t-if="len(records)" class="s_events_event" data-column-classes="col-lg-12 text-center">
+<template id="dynamic_filter_template_event_event_single_badge" name="Solo Badge"
+        data-column-classes="col-lg-12 text-center">
+    <t t-if="len(records)">
         <t t-set="data" t-value="records[0]"/>
         <t t-set="record" t-value="data['_record']"/>
         <div t-if="is_sample" class="position-absolute bottom-0 end-0 px-4 py-2 text-bg-info rounded-pill">Sample</div>
@@ -267,8 +278,9 @@
     </t>
 </template>
 <!-- Aside Layout -->
-<template id="dynamic_filter_template_event_event_single_aside" name="Solo Aside">
-    <t t-if="len(records)" class="s_events_event" data-column-classes="col-lg-12">
+<template id="dynamic_filter_template_event_event_single_aside" name="Solo Aside"
+        data-column-classes="col-lg-12">
+    <t t-if="len(records)">
         <t t-set="data" t-value="records[0]"/>
         <t t-set="record" t-value="data['_record']"/>
         <div t-if="is_sample" class="position-absolute bottom-0 end-0 px-4 py-2 text-bg-info rounded-pill">Sample</div>

--- a/addons/website_forum/views/forum_forum_templates_post.xml
+++ b/addons/website_forum/views/forum_forum_templates_post.xml
@@ -31,7 +31,7 @@
     </div>
 
     <div t-if="not is_profile" t-attf-class="o_wforum_index_entry_tags mb-lg-1">
-        <t if="tag.posts_count and not hide_tags" t-foreach="question.tag_ids" t-as="question_tag">
+        <t t-foreach="question.tag_ids" t-as="question_tag" t-if="question_tag.posts_count and not hide_tags">
 
             <!-- Toggle Tags on click -->
             <t t-if="tag and tag.name == question_tag.name" t-set="click_action"

--- a/addons/website_sale/templates/shop_page_templates.xml
+++ b/addons/website_sale/templates/shop_page_templates.xml
@@ -1589,7 +1589,7 @@
     </template>
 
     <template id="website_sale.filter_products_tags_list">
-        <t t-foreach="all_tags" t-as="tag" class="list-group-item border-0 ps-0 pb-0">
+        <t t-foreach="all_tags" t-as="tag">
             <div class="form-check mb-1">
                 <input type="checkbox"
                        name="tags"

--- a/addons/website_sale/templates/snippets/product_snippet_template_data.xml
+++ b/addons/website_sale/templates/snippets/product_snippet_template_data.xml
@@ -6,14 +6,10 @@
         <template
             id="website_sale.dynamic_filter_template_product_product_products_item"
             name="Generic Product Template (customizable)"
+            data-number-of-elements="4"
+            data-number-of-elements-sm="2"
         >
-            <t
-                t-foreach="records"
-                t-as="data"
-                data-number-of-elements="4"
-                data-number-of-elements-sm="2"
-            >
-
+            <t t-foreach="records" t-as="data">
                 <t t-set="record" t-value="data['_record']"/>
                 <t t-set="product" t-value="record"/>
                 <t t-set="product_template_id" t-value="record.id if not record.is_product_variant else record.product_tmpl_id.id"/>

--- a/odoo/addons/base/tests/test_qweb.py
+++ b/odoo/addons/base/tests/test_qweb.py
@@ -949,7 +949,7 @@ class TestQWebBasic(TransactionCase):
             'type': 'qweb',
             'arch_db': '''<t t-name="bibi">
                 <div t-foreach="[1, 2]" t-as="v" class="toto"/>
-                <t class="remove_me" t-set="data">a</t>
+                <t id="remove_me" t-set="data">a</t>
                 <div t-out="data"/>
             </t>'''
         })

--- a/odoo/import_xml.rng
+++ b/odoo/import_xml.rng
@@ -208,6 +208,19 @@
                 <rng:optional><rng:attribute name="active"></rng:attribute></rng:optional>
                 <rng:optional><rng:attribute name="customize_show"></rng:attribute></rng:optional>
             </rng:group>
+            <rng:group>
+                <rng:optional><rng:attribute name="data-number-of-elements"/></rng:optional>
+                <rng:optional><rng:attribute name="data-number-of-elements-sm"/></rng:optional>
+                <rng:optional><rng:attribute name="data-number-of-elements-fetch"/></rng:optional>
+                <rng:optional><rng:attribute name="data-row-per-slide"/></rng:optional>
+                <rng:optional><rng:attribute name="data-arrow-position"/></rng:optional>
+                <rng:optional><rng:attribute name="data-extra-classes"/></rng:optional>
+                <rng:optional><rng:attribute name="data-extra-snippet-classes"/></rng:optional>
+                <rng:optional><rng:attribute name="data-container-classes"/></rng:optional>
+                <rng:optional><rng:attribute name="data-content-classes"/></rng:optional>
+                <rng:optional><rng:attribute name="data-column-classes"/></rng:optional>
+                <rng:optional><rng:attribute name="data-thumb"/></rng:optional>
+            </rng:group>
             <rng:zeroOrMore>
                 <rng:choice>
                     <rng:text/>

--- a/odoo/tools/convert.py
+++ b/odoo/tools/convert.py
@@ -475,6 +475,7 @@ form: module.record_id""" % (xml_id,)
         # This helper transforms a <template> element into a <record> and forwards it
         tpl_id = el.get('id', el.get('t-name'))
         full_tpl_id = tpl_id
+        attrib = el.attrib
         if '.' not in full_tpl_id:
             full_tpl_id = '%s.%s' % (self.module, tpl_id)
         # set the full template name for qweb <module>.<id>
@@ -483,7 +484,7 @@ form: module.record_id""" % (xml_id,)
             el.tag = 't'
         else:
             el.tag = 'data'
-        el.attrib.pop('id', None)
+        attrib.pop('id', None)
 
         if self.module.startswith('theme_'):
             model = 'theme.ir.ui.view'
@@ -495,8 +496,8 @@ form: module.record_id""" % (xml_id,)
             'model': model,
         }
         for att in ['forcecreate', 'context']:
-            if att in el.attrib:
-                record_attrs[att] = el.attrib.pop(att)
+            if att in attrib:
+                record_attrs[att] = attrib.pop(att)
 
         Field = builder.E.field
         name = el.get('name', tpl_id)
@@ -505,27 +506,27 @@ form: module.record_id""" % (xml_id,)
         record.append(Field(name, name='name'))
         record.append(Field(full_tpl_id, name='key'))
         record.append(Field("qweb", name='type'))
-        if 'track' in el.attrib:
-            record.append(Field(el.get('track'), name='track'))
-        if 'priority' in el.attrib:
-            record.append(Field(el.get('priority'), name='priority'))
-        if 'inherit_id' in el.attrib:
-            record.append(Field(name='inherit_id', ref=el.get('inherit_id')))
-        if 'website_id' in el.attrib:
-            record.append(Field(name='website_id', ref=el.get('website_id')))
-        if 'key' in el.attrib:
-            record.append(Field(el.get('key'), name='key'))
-        if el.get('active') in ("True", "False"):
+        if 'track' in attrib:
+            record.append(Field(attrib.pop('track'), name='track'))
+        if 'priority' in attrib:
+            record.append(Field(attrib.pop('priority'), name='priority'))
+        if 'inherit_id' in attrib:
+            record.append(Field(name='inherit_id', ref=attrib.pop('inherit_id')))
+        if 'website_id' in attrib:
+            record.append(Field(name='website_id', ref=attrib.pop('website_id')))
+        if 'key' in attrib:
+            record.append(Field(attrib.pop('key'), name='key'))
+        if (active := attrib.pop('active', None)) in ("True", "False"):
             view_id = self.id_get(tpl_id, raise_if_not_found=False)
             if self.mode != "update" or not view_id:
-                record.append(Field(name='active', eval=el.get('active')))
-        if el.get('customize_show') in ("True", "False"):
-            record.append(Field(name='customize_show', eval=el.get('customize_show')))
-        groups = el.attrib.pop('groups', None)
+                record.append(Field(name='active', eval=active))
+        if (customize_show := attrib.pop('customize_show', None)) in ("True", "False"):
+            record.append(Field(name='customize_show', eval=customize_show))
+        groups = attrib.pop('groups', None)
         if groups:
             grp_lst = [("ref('%s')" % x) for x in groups.split(',')]
             record.append(Field(name="group_ids", eval="[Command.set(["+', '.join(grp_lst)+"])]"))
-        if el.get('primary') == 'True':
+        if attrib.pop('primary', None) == 'True':
             # Pseudo clone mode, we'll set the t-name to the full canonical xmlid
             el.append(
                 builder.E.xpath(

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -207,14 +207,16 @@ def tag_quote(el):
     # gmail or yahoo // # outlook, html // # msoffice
     if 'gmail_extra' in el_class or \
             ('SkyDrivePlaceholder' in el_class or 'SkyDrivePlaceholder' in el_class):
-        el.set('data-o-mail-quote', '1')
-        if el.getparent() is not None:
+        if el.tag != 't':
+            el.set('data-o-mail-quote', '1')
+        if el.getparent() is not None and el.getparent().tag != 't':
             el.getparent().set('data-o-mail-quote-container', '1')
 
     if (el.tag == 'hr' and ('stopSpelling' in el_class or 'stopSpelling' in el_id)) or \
        'yahoo_quoted' in el_class:
         # Quote all elements after this one
-        el.set('data-o-mail-quote', '1')
+        if el.tag != 't':
+            el.set('data-o-mail-quote', '1')
         for sibling in el.itersiblings(preceding=False):
             sibling.set('data-o-mail-quote', '1')
 
@@ -225,7 +227,7 @@ def tag_quote(el):
     is_outlook_reply_quote = 'divRplyFwdMsg' in el_id
     is_gmail_quote = 'gmail_quote' in el_class
     is_quote_wrapper = is_signature_wrapper or is_gmail_quote or is_outlook_reply_quote
-    if is_quote_wrapper:
+    if is_quote_wrapper and el.tag != 't':
         el.set('data-o-mail-quote-container', '1')
         el.set('data-o-mail-quote', '1')
 
@@ -235,11 +237,11 @@ def tag_quote(el):
         reply_quote = el.getnext()
         if hr is not None and hr.tag == 'hr':
             hr.set('data-o-mail-quote', '1')
-        if reply_quote is not None:
+        if reply_quote is not None and reply_quote.tag != 't':
             reply_quote.set('data-o-mail-quote-container', '1')
             reply_quote.set('data-o-mail-quote', '1')
 
-    if is_outlook_auto_message:
+    if is_outlook_auto_message and el.tag != 't':
         if not el.text or not el.text.strip():
             el.set('data-o-mail-quote-container', '1')
             el.set('data-o-mail-quote', '1')
@@ -247,8 +249,9 @@ def tag_quote(el):
     # html signature (-- <br />blah)
     signature_begin = re.compile(r"((?:(?:^|\n)[-]{2}[\s]?$))")
     if el.text and el.find('br') is not None and re.search(signature_begin, el.text):
-        el.set('data-o-mail-quote', '1')
-        if el.getparent() is not None:
+        if el.tag != 't':
+            el.set('data-o-mail-quote', '1')
+        if el.getparent() is not None and el.getparent().tag != 't':
             el.getparent().set('data-o-mail-quote-container', '1')
 
     # text-based quotes (>, >>) and signatures (-- Signature)
@@ -261,7 +264,7 @@ def tag_quote(el):
         el.set('data-o-mail-quote-node', '1')
         el.set('data-o-mail-quote', '1')
     if el.getparent() is not None and not el.getparent().get('data-o-mail-quote-node'):
-        if el.getparent().get('data-o-mail-quote'):
+        if el.getparent().get('data-o-mail-quote') and el.tag != 't':
             el.set('data-o-mail-quote', '1')
         # only quoting the elements following the first quote in the container
         # avoids issues with repeated calls to html_normalize
@@ -270,9 +273,9 @@ def tag_quote(el):
                 siblings = el.getparent().getchildren()
                 quote_index = siblings.index(first_sibling_quote)
                 element_index = siblings.index(el)
-                if quote_index < element_index:
+                if quote_index < element_index and el.tag != 't':
                     el.set('data-o-mail-quote', '1')
-    if el.getprevious() is not None and el.getprevious().get('data-o-mail-quote') and not el.text_content().strip():
+    if el.getprevious() is not None and el.getprevious().get('data-o-mail-quote') and not el.text_content().strip() and el.tag != 't':
         el.set('data-o-mail-quote', '1')
 
 


### PR DESCRIPTION
Adds a warning for attributes on `<t>` tags that are not consumed during QWeb template rendering.

This change helps to:
- Clean up existing code by identifying unused attributes (e.g., unnecessary class attributes).
- Fix common errors where developers mistakenly used standard HTML attributes instead of QWeb directives (e.g., `if` instead of `t-if`).

The `name` attribute is explicitly added to the list of allowed attributes that will not trigger the warning, as it is heavily used across Odoo views for inheritance. The inheritance branding attributes (e.g., `data-oe-model`) are also exempted.