### PR TITLE
[FIX] website: translate deepest nodes


### DIFF
--- a/addons/website/static/src/builder/plugins/translation_plugin.js
+++ b/addons/website/static/src/builder/plugins/translation_plugin.js
@@ -60,6 +60,20 @@ export class TranslationPlugin extends Plugin {
             for (const translationSavableEl of translationSavableEls) {
                 translationSavableEl.classList.add("o_editable_attribute");
             }
+            // Apply data-oe-readonly on wrapping editor
+            const editableEls = [
+                ...translationSavableEls,
+                ...this.services.website.pageDocument.querySelectorAll(".o_editable"),
+            ];
+            for (const editableEl of editableEls) {
+                if (
+                    editableEls.some(
+                        (otherEl) => editableEl != otherEl && editableEl.contains(otherEl)
+                    )
+                ) {
+                    editableEl.setAttribute("data-oe-readonly", "true");
+                }
+            }
             return true;
         },
         start_edition_handlers: withSequence(5, () => {
@@ -100,18 +114,6 @@ export class TranslationPlugin extends Plugin {
 
         if (!browser.localStorage.getItem(localStorageNoDialogKey)) {
             this.dialogService.add(TranslatorInfoDialog);
-        }
-
-        // Apply data-oe-readonly on nested data
-        const translatableElSelector = ".o_editable, .o_editable_attribute";
-        const translationSavableEls = [
-            ...this.websiteService.pageDocument.querySelectorAll(translatableElSelector),
-        ];
-        for (const translationSavableEl of translationSavableEls) {
-            if (translationSavableEl.querySelectorAll(translatableElSelector).length) {
-                translationSavableEl.setAttribute("data-oe-readonly", "true");
-                translationSavableEl.removeAttribute("contenteditable");
-            }
         }
 
         const showNotification = (ev) => {

--- a/addons/website/static/tests/builder/translation.test.js
+++ b/addons/website/static/tests/builder/translation.test.js
@@ -119,6 +119,16 @@ test("add text in translate mode do not split", async () => {
     expect(":iframe .s_allow_columns p").toHaveCount(1);
 });
 
+test("only have translation editors on deepest nodes", async () => {
+    await setupSidebarBuilderForTranslation({
+        websiteContent: getTranslateEditable({
+            inWrap: getTranslateEditable({ inWrap: "Hello" }).match(/<span.*<\/span>/)[0],
+        }),
+    });
+    expect(":iframe .o_editable:has(.o_editable)").not.toHaveAttribute("contenteditable");
+    expect(":iframe .o_editable .o_editable").toHaveAttribute("contenteditable", "true");
+});
+
 test("404 page in translate mode", async () => {
     patchWithCleanup(EditWebsiteSystrayItem.prototype, {
         setup() {


### PR DESCRIPTION

Scenario:

- enable second language on website
- go to /shop/1 and try to translate description_ecommerce

Result: this is not translatable

Cause:

Since at least b455ea85853dfc19ed01e33986ad270cf80ee5d6 the
contenteditable attribute in ContentEditablePlugin is not set on an
element if it has a contenteditable ancestor.

TranslationPlugin disable all editable nodes containing editable nodes.

So with this combination, if we had a node for example:

```
<div class="oe_editable" data-oe-model="product.template" data-oe-id="1"
  data-oe-field="description_ecommerce" data-oe-type="html">
    <div>
        <span class="oe_editable" data-oe-model="product.template"
            data-oe-id="1" data-oe-field="description_ecommerce">
            test
        </span>
    </div>
</div>
```

the contenteditable was added to the parent div.oe_editable, but was
removed by TranslationPlugin so the "test" text was not translatable.

Fix: move the code that adds data-oe-readonly class in the
after_setup_editor_handlers so it is run before contenteditable
attributes are set.

opw-5128618
