### PR TITLE
[FIX] orm: reading m2m filter after read

### DIFF
--- a/odoo/addons/test_orm/models/test_orm.py
+++ b/odoo/addons/test_orm/models/test_orm.py
@@ -1212,6 +1212,13 @@ class TestOrmAttachment(models.Model):
         for rec in self:
             rec.name = self.env[rec.res_model].browse(rec.res_id).display_name
 
+    # override those methods for many2many search
+    def _search(self, domain, offset=0, limit=None, order=None, *, active_test=True, bypass_access=False):
+        return super()._search(domain, offset, limit, order, active_test=active_test, bypass_access=bypass_access)
+
+    def _check_access(self, operation):
+        return super()._check_access(operation)
+
     # DLE P55: `test_cache_invalidation`
     def modified(self, fnames, *args, **kwargs):
         if not self:
@@ -1231,6 +1238,9 @@ class TestOrmAttachmentHost(models.Model):
     attachment_ids = fields.One2many(
         'test_orm.attachment', 'res_id', bypass_search_access=True,
         domain=lambda self: [('res_model', '=', self._name)],
+    )
+    m2m_attachment_ids = fields.Many2many(
+        'test_orm.attachment', bypass_search_access=True,
     )
 
 

--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -1358,10 +1358,14 @@ class Many2many(_RelationalMulti):
         context.update(self.context)
         comodel = records.env[self.comodel_name].with_context(**context)
 
+        # bypass the access during search if method is overwriten to avoid
+        # possibly filtering all records of the comodel before joining
+        filter_access = self.bypass_search_access and type(comodel)._search is not BaseModel._search
+
         # make the query for the lines
         domain = self.get_comodel_domain(records)
         try:
-            query = comodel._search(domain, order=comodel._order)
+            query = comodel._search(domain, order=comodel._order, bypass_access=filter_access)
         except AccessError as e:
             raise AccessError(records.env._("Failed to read field %s", self) + '\n' + str(e)) from e
 
@@ -1377,6 +1381,16 @@ class Many2many(_RelationalMulti):
         group = defaultdict(list)
         for id1, id2 in records.env.execute_query(query.select(sql_id1, sql_id2)):
             group[id1].append(id2)
+
+        # filter using record rules
+        if filter_access and group:
+            corecord_ids = OrderedSet(id_ for ids in group.values() for id_ in ids)
+            accessible_corecords = comodel.browse(corecord_ids)._filtered_access('read')
+            if len(accessible_corecords) < len(corecord_ids):
+                # some records are inaccessible, remove them from groups
+                corecord_ids = set(accessible_corecords._ids)
+                for id1, ids in group.items():
+                    group[id1] = [id_ for id_ in ids if id_ in corecord_ids]
 
         # store result in cache
         values = [tuple(group[id_]) for id_ in records._ids]


### PR DESCRIPTION
Reading `attachment_ids` on a Many2many field uses `_search` on the comodel, but does not necessarily use the `bypass_search_access` flag because we are reading (not searching).
On some models, such as attachments, the `_search` method may start filtering all data in memory. To avoid such cases, if the method is overwritten, generate the query on the comodel with bypassing accesses, then join with the model ids, retrieve the records and filter them.

closes #226845
closes #226908

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
