### PR TITLE
[FIX] Removed ID on migration from version 18 to 19

### DIFF
--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -136,8 +136,8 @@
                             <div class="d-flex flex-column flex-grow-1">
                                 <field name="company_type" widget="radio" options="{'horizontal': true}"/>
                                 <h1 class="mb-0 w-md-75">
-                                    <field options="{'line_breaks': False}" widget="text" class="text-break d-block" name="name" default_focus="1" placeholder="e.g. Lumber Inc" invisible="not is_company" required="type == 'contact'"/>
-                                    <field options="{'line_breaks': False}" widget="text" class="text-break d-block" name="name" default_focus="1" placeholder="e.g. Brandon Freeman" invisible="is_company" required="type == 'contact'"/>
+                                    <field id="company" options="{'line_breaks': False}" widget="text" class="text-break d-block" name="name" default_focus="1" placeholder="e.g. Lumber Inc" invisible="not is_company" required="type == 'contact'"/>
+                                    <field id="individual" options="{'line_breaks': False}" widget="text" class="text-break d-block" name="name" default_focus="1" placeholder="e.g. Brandon Freeman" invisible="is_company" required="type == 'contact'"/>
                                 </h1>
                                 <div class="d-flex align-items-baseline w-md-50">
                                     <i class="fa fa-fw me-1 fa-envelope text-primary" title="Email"/>


### PR DESCRIPTION


Description of the issue/feature this PR addresses:

Hello some oca module use this id to catch the correct field. i don't know why but it's remove on the migration process in version 19.0. 

please add reuse the id like others versions

Current behavior before PR:

no id on field and the div and style had change

Desired behavior after PR is merged:

get something to trigger correctly theses fields.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
