### PR TITLE
[FIX] hr_timesheet: fix no notification showed when timesheets are not created

### DIFF
--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -223,6 +223,8 @@ class AccountAnalyticLine(models.Model):
         if self.env.context.get('timesheet_calendar'):
             self.env['hr.employee'].browse([vals.get('employee_id') for vals in vals_list])
         # 1/ Collect the user_ids and employee_ids from each timesheet vals
+        skipped_vals = 0
+        valid_vals = 0
         for vals in vals_list[:]:
             if self.env.context.get('timesheet_calendar'):
                 if not 'employee_id' in vals:
@@ -234,6 +236,7 @@ class AccountAnalyticLine(models.Model):
                     datetime.combine(date, time.max, tzinfo=user_timezone),
                 )[0][employee.resource_id.id]):
                     vals_list.remove(vals)
+                    skipped_vals += 1
                     continue
             task = self.env['project.task'].sudo().browse(vals.get('task_id'))
             project = self.env['project.project'].sudo().browse(vals.get('project_id'))
@@ -266,6 +269,7 @@ class AccountAnalyticLine(models.Model):
                 user_id = vals.get('user_id', default_user_id)
                 if user_id not in user_ids:
                     user_ids.append(user_id)
+            valid_vals += 1
 
         # 2/ Search all employees related to user_ids and employee_ids, in the selected companies
         HrEmployee_sudo = self.env['hr.employee'].sudo()
@@ -334,6 +338,19 @@ class AccountAnalyticLine(models.Model):
         for line, values in zip(lines, vals_list):
             if line.project_id:  # applied only for timesheet
                 line._timesheet_postprocess(values)
+
+        if skipped_vals:
+            if valid_vals:
+                message = self.env._("Some timesheets were not created: employees aren’t working on the selected days")
+            else:
+                message = self.env._("No timesheets created: employees aren’t working on the selected days")
+
+            self.env.user._bus_send('simple_notification', {
+                    'type': 'danger',
+                    'message': message,
+                }
+            )
+
         return lines
 
     def write(self, values):

--- a/addons/hr_timesheet/tests/test_timesheet.py
+++ b/addons/hr_timesheet/tests/test_timesheet.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from lxml import etree
+from unittest.mock import patch
 
 from odoo import fields
 from odoo.fields import Command
@@ -924,16 +925,34 @@ class TestTimesheet(TestCommonTimesheet):
 
         self.empl_employee.resource_calendar_id = calendar
         self.empl_employee2.resource_calendar_id = calendar
+        with patch.object(self.env.registry['bus.bus'], '_sendone') as mock_send:
+            timesheets = HrTimesheet.create([{
+                'project_id': self.project_customer.id,
+                'unit_amount': 1,
+                'date': f'2025-05-{day}',
+                'employee_id': employee.id,
+            } for day in ('25', '26', '27') for employee in (self.empl_employee, self.empl_employee2)])
+            self.assertEqual(len(timesheets), 2)
+            self.assertEqual(fields.Date.to_string(timesheets[0].date), '2025-05-26', "The timesheet creation should skip non-working days")
+            self.assertEqual(fields.Date.to_string(timesheets[1].date), '2025-05-26', "The timesheet creation should skip non-working days")
+            mock_send.assert_called_with(self.env.user.partner_id, 'simple_notification', {
+                'type': 'danger',
+                'message': 'Some timesheets were not created: employees aren’t working on the selected days'
+            })
+            mock_send.reset_mock()
 
-        timesheets = HrTimesheet.create([{
-            'project_id': self.project_customer.id,
-            'unit_amount': 1,
-            'date': f'2025-05-{day}',
-            'employee_id': employee.id,
-        } for day in ('25', '26', '27') for employee in (self.empl_employee, self.empl_employee2)])
-        self.assertEqual(len(timesheets), 2)
-        self.assertEqual(fields.Date.to_string(timesheets[0].date), '2025-05-26', "The timesheet creation should skip non-working days")
-        self.assertEqual(fields.Date.to_string(timesheets[1].date), '2025-05-26', "The timesheet creation should skip non-working days")
+            timesheets = HrTimesheet.create([{
+                'project_id': self.project_customer.id,
+                'unit_amount': 1,
+                'date': f'2025-05-{day}',  # Sundays
+                'employee_id': employee.id,
+            } for day in ('18', '25') for employee in (self.empl_employee, self.empl_employee2)])
+            self.assertEqual(len(timesheets), 0)
+            mock_send.assert_called_with(self.env.user.partner_id, 'simple_notification', {
+                'type': 'danger',
+                'message': 'No timesheets created: employees aren’t working on the selected days'
+            })
+            mock_send.reset_mock()
 
     def test_keep_create_account_values_at_timesheet_creation(self):
         field_name = self.analytic_plan._column_name()


### PR DESCRIPTION
Steps to reproduce:

- Open Timesheets and navigate to calendar mode (My Timesheets).
- Click on weekend cell and no shift is created and no notification or explanation is given

Issue:

- No issue explanation why timesheets were not created.

Fix:

- Check if we have skipped creating record because we have no timesheets and raise the notification accordingly

task-5076642
