### PR TITLE
[FIX] point_of_sale: make totals consistent with company rounding policy

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -5,7 +5,7 @@ import { formatDate, formatDateTime, serializeDateTime } from "@web/core/l10n/da
 import { omit } from "@web/core/utils/objects";
 import { parseUTCString, qrCodeSrc, random5Chars, uuidv4, gte, lt } from "@point_of_sale/utils";
 import { floatIsZero, roundPrecision } from "@web/core/utils/numbers";
-import { roundCurrency } from "@point_of_sale/app/models/utils/currency";
+import { roundCurrency, roundOwnerCurrency } from "@point_of_sale/app/models/utils/currency";
 import { computeComboItems } from "./utils/compute_combo_items";
 import { accountTaxHelpers } from "@account/helpers/account_tax";
 import { toRaw } from "@odoo/owl";
@@ -716,14 +716,17 @@ export class PosOrder extends Base {
     }
 
     get_total_with_tax() {
-        return this.taxTotals.order_sign * this.taxTotals.order_total;
+        const sumIncl = (this.get_orderlines() || []).reduce(
+            (sum, line) => sum + line.get_all_prices().priceWithTax,
+            0
+        );
+        return roundOwnerCurrency(sumIncl, this);
     }
 
     get_total_without_tax() {
-        const base_amount =
-            this.taxTotals.base_amount_currency +
-            (this.taxTotals.cash_rounding_base_amount_currency || 0.0);
-        return this.taxTotals.order_sign * base_amount;
+        const sign = (this.taxTotals && this.taxTotals.order_sign) || 1;
+        const base = (this.taxTotals && this.taxTotals.base_amount_currency) || 0;
+        return roundOwnerCurrency(sign * base, this);
     }
 
     _get_ignored_product_ids_total_discount() {
@@ -767,7 +770,8 @@ export class PosOrder extends Base {
     }
 
     get_total_tax() {
-        return this.taxTotals.order_sign * this.taxTotals.tax_amount_currency;
+        const taxes = this.get_total_with_tax() - this.get_total_without_tax();
+        return roundOwnerCurrency(taxes, this);
     }
 
     // TODO: This won't work with round globally. Remove the usage of this because it's the wrong way to do that.

--- a/addons/point_of_sale/static/src/app/models/utils/currency.js
+++ b/addons/point_of_sale/static/src/app/models/utils/currency.js
@@ -1,5 +1,5 @@
 import { formatMonetary } from "@web/views/fields/formatters";
-import { roundDecimals } from "@web/core/utils/numbers";
+import { roundDecimals, roundPrecision } from "@web/core/utils/numbers";
 
 export const formatCurrency = (value, currency, hasSymbol = true) => {
     return formatMonetary(value, {
@@ -10,4 +10,19 @@ export const formatCurrency = (value, currency, hasSymbol = true) => {
 
 export const roundCurrency = (value, currency) => {
     return roundDecimals(value, currency.decimal_places);
+};
+
+export const getCurrencyRounding = (owner) => {
+    if (owner?.currency?.rounding) {
+        return owner.currency.rounding;
+    }
+    if (owner?.pos?.currency?.rounding) {
+        return owner.pos.currency.rounding;
+    }
+    return 0.01;
+};
+
+export const roundOwnerCurrency = (amount, owner) => {
+    const v = roundPrecision(amount, getCurrencyRounding(owner));
+    return v === 0 ? 0 : v;
 };


### PR DESCRIPTION
In PoS, the order summary mixed rounding modes when prices were tax-included and tax rates were mixed (e.g., 22% + 10%). With company set to “Round globally” (common in l10n_it/SdI), the subtotal was effectively rounded globally while taxes were summed per line, yielding 1-cent drifts on the displayed Total (e.g., 30.14 instead of 30.15).

Steps to reproduce:
0. Install l10n_it and switch to it.
1. Company → Accounting → Taxes → Tax calculation rounding method = Round globally.
2. In PoS, add two products:
   - 28.90€ @ 22% VAT (price-included)
   - 1.25€  @ 10% VAT (price-included)
3. Open a session and select those products
4. a total price of 30.14 will be shown not 30.15

Current behavior:
Subtotal ≈ 24.82 (global), Taxes = 5.32 (per-line), Total = 30.14. This does not match document-level rounding and cause an error with SdI/Italian EDI.

Expected behavior:
Totals obey one coherent rounding policy:
Subtotal (global) 24.82, Taxes (global) 5.33, Total 30.15.

Root cause:

The order total was composed from different sources: Subtotal was globally rounded via helpers.
Taxes were summed per line (currency-rounded per line). Cash rounding “base” was applied asymmetrically in subtotal vs total. As a result, Total ≠ Σ(line incl.) under global rounding with mixed rates.

Solution:
Use the tax helper as the single source of truth.
Total as the sum of visible line amounts (priceWithTax) and then subtract the cash rounding base component. Subtotal as the pure global base amount from the tax helpers Taxes = Total − Subtotal so the value always correct regardless of tax-included/excluded, mixed rates, or rounding policy.

OPW-5039256

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
