### PR TITLE
[FIX] account: fiscal pos tax mapping inactive tax

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -95,7 +95,7 @@ class AccountFiscalPosition(models.Model):
         for position in self:
             tax_map = defaultdict(list)
             for tl in position.tax_ids:
-                if tl.tax_dest_id:
+                if tl.tax_dest_active:
                     tax_map[tl.tax_src_id.id].append(tl.tax_dest_id.id)
                 else:
                     tax_map[tl.tax_src_id.id]  # map to an empty list


### PR DESCRIPTION
With this commit we exclude inactive taxes from the tax mapping of
fiscal positions.

Steps:

- Create a fiscal position FP that maps an active tax to an inactive one
- Create an invoice, set FP and create add an invoice line with a
  product having the active tax
-> The tax mapping is applied and the inactive tax is set, it shoudln't

opw-5117775
