### PR TITLE
[FIX] pos_loyalty: update loylaty points with Global Discount

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/models/loyalty.js
+++ b/addons/pos_loyalty/static/src/overrides/models/loyalty.js
@@ -1709,4 +1709,9 @@ patch(Order.prototype, {
             return super.removeOrderline(lineToRemove);
         }
     },
+    async add_product(product, options) {
+        const res = await super.add_product(...arguments);
+        this._updateRewards();
+        return res;
+    },
 });

--- a/addons/pos_loyalty/static/tests/tours/PosLoyaltyTour.js
+++ b/addons/pos_loyalty/static/tests/tours/PosLoyaltyTour.js
@@ -569,3 +569,17 @@ registry.category("web_tour.tours").add("test_min_qty_points_awarded", {
         ].flat(),
 });
 
+registry.category("web_tour.tours").add("test_points_update_after_global_discount", {
+    test: true,
+    steps: () =>
+        [
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("AAA Partner"),
+            ProductScreen.clickDisplayedProduct("AAA Product"),
+            PosLoyalty.clickDiscountButton(),
+            PosLoyalty.clickConfirmButton(),
+            PosLoyalty.pointsTotalIs(192),
+            PosLoyalty.orderTotalIs("92"),
+            PosLoyalty.finalizeOrder("Bank", "92"),
+        ].flat(),
+});


### PR DESCRIPTION
In V17, when a global discount was applied to an order after adding the customer, loyalty points were not updated.

Steps to reproduce:
-------------------
* Open POS.
* Select a customer.
* Add products to the order.
* Apply a global discount.
* Check loyalty points → not updated.
> Observation:
Points are updated if you remove and re-select the customer.

Why the fix:
------------
The `add_product` method, called when adding the global discount did not trigger a rewards recalculation.
By overriding `add_product` to call `_updateRewards()` after the super call, the loyalty points are now correctly updated in such cases.

opw-5072604