### PR TITLE
[FIX] website_sale: prevent error on loading translation

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -723,8 +723,10 @@
                                         <t t-set="_has_all_sibligns" t-value="hasPricelistDropdown and is_view_active('website_sale.sort') and wsale_has_filters_btn"></t>
                                         <!-- Desktop Search button -->
                                         <div t-attf-class="o_wsale_products_header_search_form_container {{ _has_all_sibligns and 'd-none d-sm-inline-block'}} col-xl-5 me-auto {{not hasLeftColumn and 'col-xl-6'}}">
-                                            <t t-if="category" t-set="placeholder">Search in <t t-out="category.name"/></t>
-                                            <t t-call="website_sale.search" placeholder="placeholder" search="original_search or search"/>
+                                            <t t-call="website_sale.search">
+                                                <t t-if="category" t-set="placeholder">Search in <t t-out="category.name"/></t>
+                                                <t t-set="search" t-value="original_search or search"/>
+                                            </t>
                                         </div>
                                         <!-- Mobile Search button -->
                                         <a


### PR DESCRIPTION
Currently an error occurs when user tries to load translations to website.

**Steps to replicate:**
* Install `website_sale`
* website > Edit > Theme > Add a Language > Add any language
* Go to shop > you should get an error in the terminal.

**Error:**
`Qweb Error:
 Error while rendering the template:
    SyntaxError: invalid syntax (<>, line 1)
    Template: website_sale.products
    Reference: website_sale.products`

**Root cause:**
* When the placeholder variable is not set, the string 'placeholder' is passed to the template [1].

* This 'placeholder' value is translated, and a `<span>` tag is added as its value [2]. This result is then passed to [3], which in turn is passed as an expression to [4], causing the error.

**Solution:**
* Define the placeholder inside the `<t>` tag instead of passing it as a parameter to avoid mistranslation.

[1]:
https://github.com/odoo/odoo/blob/97294a2798f5fd20748ad1e0f4a9bd2403fd7d1a/addons/website_sale/views/templates.xml#L727 
[2]:
https://drive.google.com/file/d/1gpDa8Ua9Zq8XMHKmL3FbVAtetech_twP/view?usp=sharing 
[3]:
https://github.com/odoo/odoo/blob/97294a2798f5fd20748ad1e0f4a9bd2403fd7d1a/odoo/addons/base/models/ir_qweb.py#L2558 
[4]:
https://github.com/odoo/odoo/blob/97294a2798f5fd20748ad1e0f4a9bd2403fd7d1a/odoo/addons/base/models/ir_qweb.py#L1550

sentry-6917649923