### PR TITLE
[IMP] web: cache identical name_search calls in M2X

### DIFF
--- a/addons/mass_mailing/static/tests/mass_mailing_favourite_filter.test.js
+++ b/addons/mass_mailing/static/tests/mass_mailing_favourite_filter.test.js
@@ -161,7 +161,7 @@ test("create favorite filter", async () => {
     expect(".o_mass_mailing_remove_filter").toBeVisible();
     expect(".o_mass_mailing_save_filter_container").not.toBeVisible();
     await contains(".o_field_mailing_filter input").click();
-    expect(".o_field_mailing_filter .dropdown li.ui-menu-item").toHaveCount(3);
+    expect(".o_field_mailing_filter .dropdown li.ui-menu-item").toHaveCount(2);
     await clickSave();
 });
 

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -9212,7 +9212,9 @@ test(`context is correctly passed after save & new in FormViewDialog`, async () 
 
     // set a value on the m2o
     await contains(`.o_field_many2one[name="partner_type_id"] input`).click();
-    expect.verifySteps(["web_name_search"]);
+    expect.verifySteps([], {
+        message: "No additional name search since the request is identical",
+    });
 
     await contains(`.dropdown .dropdown-item:contains(silver)`).click();
     await contains(`.modal-footer .o_form_button_save`).click();


### PR DESCRIPTION
This commit builds upon https://github.com/odoo/odoo/pull/222028 by adding a cache for the most recent web_name_search call in addition to the one dedicated to empty search results.

If a new search request is strictly identical to the previous one, the cached result is returned directly. This avoids unnecessary server calls, which often occur due to leading or trailing spaces or when reopening the autocomplete after closing it.

task-5150399
