### PR TITLE
[FIX] sms, test_mail_sms: allow resend/cancel for administrators

### DIFF
--- a/addons/sms/models/sms_sms.py
+++ b/addons/sms/models/sms_sms.py
@@ -237,7 +237,8 @@ class SmsSms(models.Model):
     def _update_sms_state_and_trackers(self, new_state, failure_type=None):
         """Update sms state update and related tracking records (notifications, traces)."""
         self.write({'state': new_state, 'failure_type': failure_type})
-        self.sms_tracker_id._action_update_from_sms_state(new_state, failure_type=failure_type)
+        # Use sudo on mail.notification to allow writing other users' notifications; rights are already checked by sms write
+        self.sms_tracker_id.sudo()._action_update_from_sms_state(new_state, failure_type=failure_type)
 
     def _handle_call_result_hook(self, results):
         """Further process SMS sending API results."""

--- a/addons/test_mail_sms/tests/test_sms_management.py
+++ b/addons/test_mail_sms/tests/test_sms_management.py
@@ -4,7 +4,7 @@
 from odoo import Command
 from odoo.addons.sms.tests.common import SMSCommon
 from odoo.addons.test_mail_sms.tests.common import TestSMSRecipients
-from odoo.tests import tagged
+from odoo.tests import tagged, users
 from odoo.tools import mute_logger
 
 
@@ -111,9 +111,10 @@ class TestSMSActions(TestSMSActionsCommon):
             {'partner': self.partner_2, 'number': self.notif_p2.sms_number, 'state': 'exception', 'failure_type': 'sms_server'}
         ], 'TEST BODY', self.msg, check_sms=False)    # do not check new sms as they already exist
 
+    @users('admin')
     def test_sms_set_outgoing(self):
         self._reset_bus()
-        (self.sms_p1 + self.sms_p2).action_set_outgoing()
+        (self.sms_p1 + self.sms_p2).with_user(self.env.user).action_set_outgoing()
         self.assertEqual(self.sms_p1.state, 'outgoing')
         self.assertEqual(self.sms_p2.state, 'outgoing')
 


### PR DESCRIPTION
## Issue:
In debug mode, the administrator could not resend or cancel an SMS that was sent by the system (e.g. delivery confirmation) using the `Retry` / `Cancel` button in the Technical Settings An Access Error was raised

## Cause:
When using the `Retry` or `Cancel` button, the method `_update_sms_notifications()` is called and finds `mail.notifications` records to update However, `notifications.write()` triggers an Access Error because only the recipient of a `mail.notification` is allowed to modify it: https://github.com/odoo/odoo/blob/98610ea2a1369b84b10adb8913c5d7725a0fad67/addons/mail/security/mail_security.xml#L184-L192 This happens even when the user has the rights to resend or cancel the SMS

## Steps to reproduce:
- Install an app like stock_sms to create blocking entries
- Create and confirm a Delivery
- Choose Send SMS
- Enable developer mode
- Search for the technical settings SMS
- Retry sending the automatically sent SMS

opw-4904157