### PR TITLE
[FIX] website_sale: fix images in dynamic catalog block

### DIFF
--- a/addons/website_sale/models/website_snippet_filter.py
+++ b/addons/website_sale/models/website_snippet_filter.py
@@ -157,7 +157,7 @@ class WebsiteSnippetFilter(models.Model):
         else:  # Only top-level categories
             categories = CategorySudo.search(domain & Domain('parent_id', '=', False))
 
-        base_url = request.website.get_base_url()
+        base_url = CategorySudo.get_base_url()
         default_img_path = request.env['product.template']._get_product_placeholder_filename()
         default_img_url = f'{base_url}/{default_img_path}'
         return [{

--- a/addons/website_sale/tests/test_website_sale_snippets.py
+++ b/addons/website_sale/tests/test_website_sale_snippets.py
@@ -60,3 +60,24 @@ class TestSnippets(HttpCase):
 
         self.start_tour('/', 'website_sale.products_snippet_recently_viewed', login='admin')
         self.assertEqual(before_tour_product_ids, website_visitor.product_ids.ids, "There shouldn't be any new product in recently viewed after this tour")
+
+    def test_website_category_url(self):
+        # Create a public category with a cover image
+        category = self.env['product.public.category'].create({
+            'name': "Test Category",
+        })
+
+        self.env['website'].get_current_website().domain = "http://www.example.com"
+
+        # Monkey patch get_base_url to test its usage
+        original_get_base_url = self.env['product.public.category'].sudo().get_base_url()
+
+        # Simulate a request with correct context
+        with MockRequest(self.env, website=self.env['website'].get_current_website()):
+            data = self.env['website.snippet.filter'].sudo()._prepare_category_list_data(
+                parent_id=category.id,
+            )
+
+        # Assert that the returned cover_image uses the mocked base URL
+        self.assertTrue(data[0]['cover_image'].startswith(original_get_base_url))
+        self.assertFalse(self.env['website'].get_current_website().domain in data[0]['cover_image'])


### PR DESCRIPTION
Steps to reproduce:
====================
- Add a Catalog dynamic block.
- Set a custom domain for the website.
→ Product category images do not display.

Why?
====
Image URLs were generated using the website base domain, not the category's base url. As a result,
links pointed to non-existent resources.

Fix:
====
Generate image URLs using the category URL instead of the website's base URL.

opw-5143162
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
