### PR TITLE
[REF] iot_drivers: move system helpers to system.py

### DIFF
--- a/addons/iot_drivers/__init__.py
+++ b/addons/iot_drivers/__init__.py
@@ -31,7 +31,7 @@ def set_default_options(func):
         verify = kwargs.pop('verify', False)
         headers['User-Agent'] = 'OdooIoTBox/1.0'
         server_url = tools.helpers.get_odoo_server_url()
-        db_name = tools.helpers.get_conf('db_name')
+        db_name = tools.system.get_conf('db_name')
         if server_url and db_name and args[0].startswith(server_url) and '/web/login?db=' not in args[0]:
             headers['X-Odoo-Database'] = db_name
         return func(*args, headers=headers, verify=verify, **kwargs)

--- a/addons/iot_drivers/connection_manager.py
+++ b/addons/iot_drivers/connection_manager.py
@@ -6,8 +6,8 @@ from threading import Thread
 import time
 
 from odoo.addons.iot_drivers.main import iot_devices, manager
-from odoo.addons.iot_drivers.tools import helpers, upgrade, wifi
-from odoo.addons.iot_drivers.tools.system import IS_RPI, IS_TEST
+from odoo.addons.iot_drivers.tools import helpers, system, upgrade, wifi
+from odoo.addons.iot_drivers.tools.system import IS_RPI, IS_TEST, IOT_IDENTIFIER
 
 _logger = logging.getLogger(__name__)
 
@@ -58,7 +58,7 @@ class ConnectionManager(Thread):
     def _should_poll_to_connect_database(self):
         return (
             not helpers.get_odoo_server_url() and
-            helpers.get_ip() and
+            system.get_ip() and
             not (IS_RPI and wifi.is_access_point()) and
             not self.pairing_code_expired
         )
@@ -68,7 +68,7 @@ class ConnectionManager(Thread):
             'params': {
                 'pairing_code': self.pairing_code,
                 'pairing_uuid': self.pairing_uuid,
-                'serial_number': helpers.get_identifier(),
+                'serial_number': IOT_IDENTIFIER,
             }
         }
 

--- a/addons/iot_drivers/event_manager.py
+++ b/addons/iot_drivers/event_manager.py
@@ -4,7 +4,7 @@ from threading import Event
 import time
 
 from odoo.http import request
-from odoo.addons.iot_drivers.tools import helpers
+from odoo.addons.iot_drivers.tools.system import IOT_IDENTIFIER
 from odoo.addons.iot_drivers.webrtc_client import webrtc_client
 from odoo.addons.iot_drivers.websocket_client import send_to_controller
 
@@ -64,7 +64,7 @@ class EventManager:
         send_to_controller({
             **event,
             'session_id': data.get('action_args', {}).get('session_id', ''),
-            'iot_box_identifier': helpers.get_identifier(),
+            'iot_box_identifier': IOT_IDENTIFIER,
             **data,
         })
         webrtc_client.send(event)

--- a/addons/iot_drivers/iot_handlers/drivers/display_driver_L.py
+++ b/addons/iot_drivers/iot_handlers/drivers/display_driver_L.py
@@ -12,8 +12,9 @@ from odoo import http
 from odoo.addons.iot_drivers.browser import Browser, BrowserState
 from odoo.addons.iot_drivers.driver import Driver
 from odoo.addons.iot_drivers.main import iot_devices
-from odoo.addons.iot_drivers.tools import helpers, route
+from odoo.addons.iot_drivers.tools import helpers, route, system
 from odoo.addons.iot_drivers.tools.helpers import Orientation
+from odoo.addons.iot_drivers.tools.system import IOT_IDENTIFIER
 
 _logger = logging.getLogger(__name__)
 
@@ -79,7 +80,7 @@ class DisplayDriver(Driver):
         :return: URL to display or None.
         """
         try:
-            response = requests.get(f"{server_url}/iot/box/{helpers.get_identifier()}/display_url", timeout=5)
+            response = requests.get(f"{server_url}/iot/box/{IOT_IDENTIFIER}/display_url", timeout=5)
             response.raise_for_status()
             data = json.loads(response.content.decode())
             return data.get(self.device_identifier)
@@ -112,7 +113,7 @@ class DisplayDriver(Driver):
         self.update_url(f"{origin}/pos_customer_display/{data['pos_id']}/{data['access_token']}")
 
     def _action_close_customer_display(self, data):
-        helpers.update_conf({"browser_url": "", "screen_orientation": ""})
+        system.update_conf({"browser_url": "", "screen_orientation": ""})
         self.browser.disable_kiosk_mode()
         self.update_url()
 

--- a/addons/iot_drivers/iot_handlers/drivers/keyboard_usb_driver_L.py
+++ b/addons/iot_drivers/iot_handlers/drivers/keyboard_usb_driver_L.py
@@ -19,7 +19,7 @@ from odoo.addons.iot_drivers.controllers.proxy import proxy_drivers
 from odoo.addons.iot_drivers.driver import Driver
 from odoo.addons.iot_drivers.event_manager import event_manager
 from odoo.addons.iot_drivers.main import iot_devices
-from odoo.addons.iot_drivers.tools import helpers, route
+from odoo.addons.iot_drivers.tools import helpers, route, system
 
 _logger = logging.getLogger(__name__)
 xlib = ctypes.cdll.LoadLibrary('libX11.so.6')
@@ -191,21 +191,21 @@ class KeyboardUSBDriver(Driver):
                 - variant (str): An optional key to represent the variant of the
                                  selected layout
         """
-        file_path = helpers.path_file('odoo-keyboard-layouts.conf')
-        if file_path.exists():
-            data = json.loads(file_path.read_text())
+        layout_conf = system.path_file('odoo-keyboard-layouts.conf')
+        if layout_conf.exists():
+            data = json.loads(layout_conf.read_text())
         else:
             data = {}
         data[self.device_identifier] = layout
-        helpers.write_file('odoo-keyboard-layouts.conf', json.dumps(data))
+        layout_conf.write_text(json.dumps(data))
 
     def load_layout(self):
         """Read the layout from the saved filed and set it as current layout.
         If no file or no layout is found we use 'us' by default.
         """
-        file_path = helpers.path_file('odoo-keyboard-layouts.conf')
-        if file_path.exists():
-            data = json.loads(file_path.read_text())
+        layout_conf = system.path_file('odoo-keyboard-layouts.conf')
+        if layout_conf.exists():
+            data = json.loads(layout_conf.read_text())
             layout = data.get(self.device_identifier, {'layout': 'us'})
         else:
             layout = {'layout': 'us'}
@@ -222,7 +222,7 @@ class KeyboardUSBDriver(Driver):
         scanner_name = ['barcode', 'scanner', 'reader']
         is_scanner = any(x in device_name for x in scanner_name) or self.dev.interface_protocol == '0'
 
-        file_path = helpers.path_file('odoo-keyboard-is-scanner.conf')
+        file_path = system.path_file('odoo-keyboard-is-scanner.conf')
         if file_path.exists():
             data = json.loads(file_path.read_text())
             is_scanner = data.get(self.device_identifier, {}).get('is_scanner', is_scanner)
@@ -264,13 +264,13 @@ class KeyboardUSBDriver(Driver):
         We need that in order to keep the selected type of device after a reboot.
         """
         is_scanner = {'is_scanner': data.get('is_scanner')}
-        file_path = helpers.path_file('odoo-keyboard-is-scanner.conf')
-        if file_path.exists():
-            data = json.loads(file_path.read_text())
+        is_scanner_conf = system.path_file('odoo-keyboard-is-scanner.conf')
+        if is_scanner_conf.exists():
+            data = json.loads(is_scanner_conf.read_text())
         else:
             data = {}
         data[self.device_identifier] = is_scanner
-        helpers.write_file('odoo-keyboard-is-scanner.conf', json.dumps(data))
+        is_scanner_conf.write_text(json.dumps(data))
         self._set_device_type('scanner') if is_scanner.get('is_scanner') else self._set_device_type()
 
     def _update_layout(self, data):

--- a/addons/iot_drivers/iot_handlers/drivers/printer_driver_L.py
+++ b/addons/iot_drivers/iot_handlers/drivers/printer_driver_L.py
@@ -15,7 +15,8 @@ from odoo.addons.iot_drivers.controllers.proxy import proxy_drivers
 from odoo.addons.iot_drivers.iot_handlers.drivers.printer_driver_base import PrinterDriverBase
 from odoo.addons.iot_drivers.iot_handlers.interfaces.printer_interface_L import conn, cups_lock
 from odoo.addons.iot_drivers.main import iot_devices
-from odoo.addons.iot_drivers.tools import helpers, wifi, route
+from odoo.addons.iot_drivers.tools import helpers, route, system, wifi
+from odoo.addons.iot_drivers.tools.system import IOT_IDENTIFIER
 
 _logger = logging.getLogger(__name__)
 
@@ -110,8 +111,8 @@ class PrinterDriver(PrinterDriverBase):
 
     @classmethod
     def _get_iot_status(cls):
-        identifier = helpers.get_identifier()
-        mac_address = helpers.get_mac_address()
+        identifier = IOT_IDENTIFIER
+        mac_address = system.get_mac_address()
         pairing_code = connection_manager.pairing_code
         ssid = wifi.get_access_point_ssid() if wifi.is_access_point() else wifi.get_current()
 
@@ -153,7 +154,7 @@ class PrinterDriver(PrinterDriverBase):
                     dev.printer.textln(title.decode())
                     dev.printer.set_with_default(align='center', double_height=False, double_width=False)
                     dev.writelines(body.decode())
-                    dev.printer.qr(f"http://{helpers.get_ip()}", size=6)
+                    dev.printer.qr(f"http://{system.get_ip()}", size=6)
                 return
             except (escpos.exceptions.Error, OSError, AssertionError):
                 _logger.warning("Failed to print QR status receipt, falling back to simple receipt")

--- a/addons/iot_drivers/iot_handlers/drivers/printer_driver_W.py
+++ b/addons/iot_drivers/iot_handlers/drivers/printer_driver_W.py
@@ -12,7 +12,7 @@ import ghostscript
 
 from odoo.addons.iot_drivers.controllers.proxy import proxy_drivers
 from odoo.addons.iot_drivers.iot_handlers.drivers.printer_driver_base import PrinterDriverBase
-from odoo.addons.iot_drivers.tools import helpers
+from odoo.addons.iot_drivers.tools import system
 from odoo.tools.mimetypes import guess_mimetype
 from odoo.addons.iot_drivers.iot_handlers.interfaces.printer_interface_W import win32print_lock
 
@@ -76,8 +76,8 @@ class PrinterDriver(PrinterDriverBase):
 
     def print_report(self, data):
         with win32print_lock:
-            helpers.write_file('document.pdf', data, 'wb')
-            file_name = helpers.path_file('document.pdf')
+            file_name = system.path_file('document.pdf')
+            file_name.write_bytes(data)
             printer = self.device_name
 
             args = [

--- a/addons/iot_drivers/server_logger.py
+++ b/addons/iot_drivers/server_logger.py
@@ -4,8 +4,8 @@ import requests
 import threading
 import time
 
-from odoo.addons.iot_drivers.tools import helpers
-from odoo.addons.iot_drivers.tools.system import IS_TEST
+from odoo.addons.iot_drivers.tools import helpers, system
+from odoo.addons.iot_drivers.tools.system import IS_TEST, IOT_IDENTIFIER
 from odoo.netsvc import ColoredFormatter
 
 _logger = logging.getLogger(__name__)
@@ -37,7 +37,7 @@ class AsyncHTTPHandler(logging.Handler):
         """
         super().__init__()
         self._odoo_server_url = odoo_server_url
-        self._db_name = helpers.get_conf('db_name') or ''
+        self._db_name = system.get_conf('db_name') or ''
         self._log_queue = queue.Queue(self._MAX_QUEUE_SIZE)
         self._flush_thread = None
         self._active = None
@@ -70,7 +70,7 @@ class AsyncHTTPHandler(logging.Handler):
             return convert_to_byte(f"{log_level},{line_formatted}")
 
         def empty_queue():
-            yield convert_to_byte(f"identifier {helpers.get_identifier()}")
+            yield convert_to_byte(f"identifier {IOT_IDENTIFIER}")
             for _ in range(self._MAX_BATCH_SIZE):
                 # Use a limit to avoid having too heavy requests & infinite loop of the queue receiving new entries
                 try:
@@ -129,7 +129,7 @@ def close_server_log_sender_handler():
 
 def get_odoo_config_log_to_server_option():
     # Enabled by default if not in test mode
-    return not IS_TEST and (helpers.get_conf(IOT_LOG_TO_SERVER_CONFIG_NAME, section='options') or True)
+    return not IS_TEST and (system.get_conf(IOT_LOG_TO_SERVER_CONFIG_NAME, section='options') or True)
 
 
 def check_and_update_odoo_config_log_to_server_option(new_state):
@@ -137,7 +137,7 @@ def check_and_update_odoo_config_log_to_server_option(new_state):
     :return: wherever the config file need to be updated or not
     """
     if get_odoo_config_log_to_server_option() != new_state:
-        helpers.update_conf({IOT_LOG_TO_SERVER_CONFIG_NAME, new_state}, section='options')
+        system.update_conf({IOT_LOG_TO_SERVER_CONFIG_NAME, new_state}, section='options')
         _server_log_sender_handler.toggle_active(new_state)
         return True
     return False

--- a/addons/iot_drivers/tools/system.py
+++ b/addons/iot_drivers/tools/system.py
@@ -1,7 +1,23 @@
 """Operating system-related utilities for the IoT"""
 
+import configparser
+import logging
+import netifaces
+import requests
+import secrets
+import socket
 import subprocess
+import sys
+import time
+
+from functools import cache
+from pathlib import Path
 from platform import system, release
+
+from odoo import release as odoo_release
+
+_logger = logging.getLogger(__name__)
+
 
 IOT_SYSTEM = system()
 
@@ -20,6 +36,8 @@ IOT_CHAR = IOT_RPI_CHAR if IS_RPI else IOT_WINDOWS_CHAR if IS_WINDOWS else IOT_T
 - 'T' for Test (non-Raspberry Pi nor Windows)"""
 
 if IS_RPI:
+    import crypt
+
     def rpi_only(function):
         """Decorator to check if the system is raspberry pi before running the function."""
         return function
@@ -27,6 +45,260 @@ else:
     def rpi_only(_):
         """No-op decorator for non raspberry pi systems."""
         return lambda *args, **kwargs: None
+
+
+def path_file(*args) -> Path:
+    """Return the path to the file from `/home/pi` on IoT Box
+    or from `odoo` folder on Virtual IoT Box.
+
+    :return: The path to the file
+    """
+    return Path(sys.path[0]).parent.joinpath(*args)
+
+
+def git(*args):
+    """Run a git command with the given arguments, taking system
+    into account.
+
+    :param args: list of arguments to pass to git
+    """
+    git_executable = 'git' if IS_RPI else path_file('git', 'cmd', 'git.exe')
+    command = [git_executable, f'--work-tree={path_file("odoo")}', f'--git-dir={path_file("odoo", ".git")}', *args]
+
+    p = subprocess.run(command, stdout=subprocess.PIPE, text=True, check=False)
+    if p.returncode == 0:
+        return p.stdout.strip()
+    return None
+
+
+def pip(*args):
+    """Run a pip install command with the given arguments, taking
+    system into account.
+
+    :param args: list of arguments to pass to pip install
+    :return: True if the command was successful, False otherwise
+    """
+    python_executable = [] if IS_RPI else [path_file('python', 'python.exe'), '-m']
+    command = [*python_executable, 'pip', 'install', *args]
+
+    if IS_RPI:
+        command.append('--break-system-package')
+
+    p = subprocess.run(command, stdout=subprocess.PIPE, check=False)
+    return p.returncode == 0
+
+
+@cache
+def get_version(detailed_version=False):
+    if IS_RPI:
+        with open('/var/odoo/iotbox_version', encoding='utf-8') as f:
+            image_version = f.readline().strip()
+    elif IS_WINDOWS:
+        # updated manually when big changes are made to the windows virtual IoT
+        image_version = '23.11'
+    else:
+        image_version = 'test'
+
+    version = IOT_CHAR + image_version
+    if detailed_version:
+        # Note: on windows IoT, the `release.version` finish with the build date
+        version += f"-{odoo_release.version}"
+        if IS_RPI:
+            commit_hash = git("rev-parse", "--short", "HEAD")
+            version += f'#{commit_hash or "unknown"}'
+
+    return version
+
+
+def get_img_name():
+    major, minor = get_version()[1:].split('.')
+    return f'iotboxv{major}_{minor}.zip'
+
+
+def check_image():
+    """Check if the current image of IoT Box is up to date
+
+    :return: dict containing major and minor versions of the latest image available
+    :rtype: dict
+    """
+    try:
+        response = requests.get('https://nightly.odoo.com/master/iotbox/SHA1SUMS.txt', timeout=5)
+        response.raise_for_status()
+        data = response.text
+    except requests.exceptions.HTTPError:
+        _logger.exception('Could not reach the server to get the latest image version')
+        return False
+
+    current, latest = '', ''
+    hashes = {}
+    for line in data.splitlines():
+        if not line.strip():
+            continue
+        value, name = line.split('  ')
+        hashes[value] = name
+        if name == 'iotbox-latest.zip':
+            latest = value
+        elif name == get_img_name():
+            current = value
+    if current == latest:
+        return False
+
+    version = (
+        hashes.get(latest, 'Error')
+        .removeprefix('iotboxv')
+        .removesuffix('.zip')
+        .split('_')
+    )
+    return {'major': version[0], 'minor': version[1]}
+
+
+def update_conf(values, section='iot.box'):
+    """Update odoo.conf with the given key and value.
+
+    :param dict values: key-value pairs to update the config with.
+    :param str section: The section to update the key-value pairs in (Default: iot.box).
+    """
+    _logger.debug("Updating odoo.conf with values: %s", values)
+    conf = get_conf()
+
+    if not conf.has_section(section):
+        _logger.debug("Creating new section '%s' in odoo.conf", section)
+        conf.add_section(section)
+
+    for key, value in values.items():
+        conf.set(section, key, value) if value else conf.remove_option(section, key)
+
+    with open(path_file("odoo.conf"), "w", encoding='utf-8') as f:
+        conf.write(f)
+
+
+def get_conf(key=None, section='iot.box'):
+    """Get the value of the given key from odoo.conf, or the full config if no key is provided.
+
+    :param key: The key to get the value of.
+    :param section: The section to get the key from (Default: iot.box).
+    :return: The value of the key provided or None if it doesn't exist, or full conf object if no key is provided.
+    """
+    conf = configparser.RawConfigParser()
+    conf.read(path_file("odoo.conf"))
+
+    return conf.get(section, key, fallback=None) if key else conf  # Return the key's value or the configparser object
+
+
+def _get_identifier():
+    if IS_RPI:
+        with open('/sys/firmware/devicetree/base/serial-number', encoding='utf-8') as f:
+            return f.readline().strip("\x00")
+    elif IS_TEST:
+        return 'test_identifier'
+
+    # On windows, get motherboard's uuid (serial number isn't reliable as it's not always present)
+    command = ['powershell', '-Command', "(Get-CimInstance Win32_ComputerSystemProduct).UUID"]
+    p = subprocess.run(command, stdout=subprocess.PIPE, check=False)
+    identifier = get_conf('generated_identifier')  # Fallback identifier if windows does not return mb UUID
+    if p.returncode == 0 and p.stdout.decode().strip():
+        return p.stdout.decode().strip()
+
+    _logger.error("Failed to get Windows IoT serial number, defaulting to a random identifier")
+    if not identifier:
+        identifier = secrets.token_hex()
+        update_conf({'generated_identifier': identifier})
+
+    return identifier
+
+
+def _get_system_uptime():
+    if not IS_RPI:
+        return 0
+    with open("/proc/uptime", encoding='utf-8') as f:
+        return float(f.readline().split()[0])
+
+
+def is_ngrok_enabled():
+    """Check if a ngrok tunnel is active on the IoT Box"""
+    try:
+        response = requests.get("http://localhost:4040/api/tunnels", timeout=5)
+        response.raise_for_status()
+        response.json()
+        return True
+    except (requests.exceptions.RequestException, ValueError):
+        # if the request fails or the response is not valid JSON,
+        # it means ngrok is not enabled or not running
+        _logger.debug("Ngrok isn't running.", exc_info=True)
+        return False
+
+
+def toggle_remote_connection(token=""):
+    """Enable/disable remote connection to the IoT Box using ngrok.
+    If the token is provided, it will set up ngrok with the
+    given authtoken, else it will disable the ngrok service.
+
+    :param str token: The ngrok authtoken to use for the connection"""
+    _logger.info("Toggling remote connection with token: %s...", token[:5] if token else "<No Token>")
+    p = subprocess.run(
+        ['sudo', 'ngrok', 'config', 'add-authtoken', token, '--config', '/home/pi/ngrok.yml'],
+        check=False,
+    )
+    if p.returncode == 0:
+        subprocess.run(
+            ['sudo', 'systemctl', 'restart' if token else "stop", 'odoo-ngrok.service'],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+        return True
+    return False
+
+
+@rpi_only
+def generate_password():
+    """Generate an unique code to secure raspberry pi """
+    alphabet = 'abcdefghijkmnpqrstuvwxyz23456789'
+    password = ''.join(secrets.choice(alphabet) for _ in range(12))
+    try:
+        shadow_password = crypt.crypt(password, crypt.mksalt())
+        subprocess.run(('sudo', 'usermod', '-p', shadow_password, 'pi'), check=True)
+        subprocess.run(('sudo', 'cp', '/etc/shadow', '/root_bypass_ramdisks/etc/shadow'), check=True)
+        return password
+    except subprocess.CalledProcessError as e:
+        _logger.exception("Failed to generate password: %s", e.output)
+        return 'Error: Check IoT log'
+
+
+def get_ip():
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        s.connect(('8.8.8.8', 1))  # Google DNS
+        return s.getsockname()[0]
+    except OSError as e:
+        _logger.warning("Could not get local IP address: %s", e)
+        return None
+    finally:
+        s.close()
+
+
+def get_mac_address():
+    interfaces = netifaces.interfaces()
+    for interface in map(netifaces.ifaddresses, interfaces):
+        if interface.get(netifaces.AF_INET):
+            addr = interface.get(netifaces.AF_LINK)[0]['addr']
+            if addr != '00:00:00:00:00:00':
+                return addr
+    return None
+
+
+NGINX_PATH = path_file('nginx')
+
+if IS_WINDOWS and NGINX_PATH:
+    def start_nginx_server():
+        _logger.info('Start Nginx server: %s\\nginx.exe', NGINX_PATH)
+        subprocess.Popen([str(NGINX_PATH / 'nginx.exe')], cwd=str(NGINX_PATH))
+elif IS_RPI:
+    def start_nginx_server():
+        subprocess.check_call(["sudo", "service", "nginx", "restart"])
+else:
+    def start_nginx_server():
+        pass
 
 
 def mtr(host):
@@ -54,3 +326,21 @@ def mtr(host):
         return float(last_line[6]), float(last_line[10])
     except (IndexError, ValueError):
         return None, None
+
+
+def get_gateway():
+    """Get the router IP address (default gateway)
+
+    :return: The IP address of the default gateway or None if it can't be determined
+    """
+    gws = netifaces.gateways()
+    default = gws.get("default", {})
+    gw = default.get(netifaces.AF_INET)
+    if gw:
+        return gw[0]
+    return None
+
+
+IOT_IDENTIFIER = _get_identifier()
+ODOO_START_TIME = time.monotonic()
+SYSTEM_START_TIME = ODOO_START_TIME - _get_system_uptime()

--- a/addons/iot_drivers/webrtc_client.py
+++ b/addons/iot_drivers/webrtc_client.py
@@ -7,7 +7,7 @@ import time
 from aiortc import RTCDataChannel, RTCPeerConnection, RTCSessionDescription
 
 from odoo.addons.iot_drivers import main
-from odoo.addons.iot_drivers.tools import helpers
+from odoo.addons.iot_drivers.tools.system import IOT_IDENTIFIER
 
 _logger = logging.getLogger(__name__)
 
@@ -75,7 +75,7 @@ class WebRtcClient(Thread):
                 elif message_type == "test_protocol":
                     self.send({
                         'owner': message['session_id'],
-                        'device_identifier': helpers.get_identifier(),
+                        'device_identifier': IOT_IDENTIFIER,
                         'time': time.time(),
                         'status': 'success',
                     })


### PR DESCRIPTION
To reduce the size of the helpers file, and avoid struggling with circular imports when trying to add new utilities in system.py, we moved all system utilities to system.py file.

Enterprise PR: odoo/enterprise#96710