### PR TITLE
[IMP] hr_holidays: Show all valid public holidays in working schedule smart button - yoahm

### DIFF
--- a/addons/hr_holidays/models/resource.py
+++ b/addons/hr_holidays/models/resource.py
@@ -170,7 +170,7 @@ class ResourceCalendar(models.Model):
 
     def _compute_associated_leaves_count(self):
         leaves_read_group = self.env['resource.calendar.leaves']._read_group(
-            [('resource_id', '=', False), ('calendar_id', 'in', self.ids)],
+            [('resource_id', '=', False), '|', ('calendar_id', 'in', self.ids), ('calendar_id', '=', False)],
             ['calendar_id'],
             ['__count'],
         )

--- a/addons/hr_holidays/tests/__init__.py
+++ b/addons/hr_holidays/tests/__init__.py
@@ -33,3 +33,4 @@ from . import test_time_off_graph_view_tour
 from . import test_leave_type_data
 from . import test_multi_contract
 from . import test_flexible_resource_calendar
+from . import test_calendar_leaves_count

--- a/addons/hr_holidays/tests/test_calendar_leaves_count.py
+++ b/addons/hr_holidays/tests/test_calendar_leaves_count.py
@@ -1,0 +1,83 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from datetime import datetime
+
+from odoo.addons.hr_holidays.tests.common import TestHrHolidaysCommon
+
+
+class TestResourceCalendarLeaves(TestHrHolidaysCommon):
+    def test_compute_associated_leaves_count(self):
+        """Test the computation of associated_leaves_count, ensuring it correctly sums
+        leaves specific to the calendar (calendar_id=self.id) and global leaves (calendar_id=False).
+        """
+        calendar_a = self.env['resource.calendar'].create({'name': 'Calendar A'})
+        calendar_b = self.env['resource.calendar'].create({'name': 'Calendar B'})
+
+        leave_a_1 = self.env['resource.calendar.leaves'].create({
+            'name': 'CalendarA Specific Leave_1',
+            'calendar_id': calendar_a.id,
+            'date_from': datetime(2025, 1, 1),
+            'date_to': datetime(2025, 1, 1),
+        })
+
+        leave_b_1 = self.env['resource.calendar.leaves'].create({
+            'name': 'CalendarB Specific Leave_1',
+            'calendar_id': calendar_b.id,
+            'date_from': datetime(2025, 2, 1),
+            'date_to': datetime(2025, 2, 1),
+        })
+
+        global_leave_1 = self.env['resource.calendar.leaves'].create({
+            'name': 'Global Leave 1',
+            'calendar_id': False,
+            'date_from': datetime(2025, 3, 1),
+            'date_to': datetime(2025, 3, 1),
+        })
+
+        # 1. Initial check: calendar_a (1 specific + 1 global = 2), calendar_b (1 specific + 1 global = 2)
+        (calendar_a | calendar_b)._compute_associated_leaves_count()
+        self.assertEqual(calendar_a.associated_leaves_count, 2, "Calendar A should have 1 specific + 1 global leave.")
+        self.assertEqual(calendar_b.associated_leaves_count, 2, "Calendar B should have 1 specific + 1 global leave.")
+
+        self.env['resource.calendar.leaves'].create({
+            'name': 'Global Leave 2',
+            'calendar_id': False,
+            'date_from': datetime(2025, 4, 1),
+            'date_to': datetime(2025, 4, 1),
+        })
+
+        # 2. Test updated counts: calendar_a (1 specific + 2 global = 3), calendar_b (1 specific + 2 global = 3)
+        (calendar_a | calendar_b)._compute_associated_leaves_count()
+        self.assertEqual(calendar_a.associated_leaves_count, 3, "Calendar A should have 1 specific + 2 global leaves.")
+        self.assertEqual(calendar_b.associated_leaves_count, 3, "Calendar B should have 1 specific + 2 global leaves.")
+
+        self.env['resource.calendar.leaves'].create({
+            'name': 'CalendarA Specific Leave_2',
+            'calendar_id': calendar_a.id,
+            'date_from': datetime(2025, 2, 1),
+            'date_to': datetime(2025, 2, 1),
+        })
+
+        # 3. Test updated counts: calendar_a (2 specific + 2 global = 4), calendar_b (1 specific + 2 global = 3)
+        (calendar_a | calendar_b)._compute_associated_leaves_count()
+        self.assertEqual(calendar_a.associated_leaves_count, 4, "Calendar A should have 2 specific + 2 global leaves.")
+        self.assertEqual(calendar_b.associated_leaves_count, 3, "Calendar B should have 1 specific + 2 global leaves.")
+
+        # 4. Test Remove a global leave: calendar_a (2 specific + 1 global = 3), calendar_b (1 specific + 1 global = 2)
+        global_leave_1.unlink()
+        (calendar_a | calendar_b)._compute_associated_leaves_count()
+        self.assertEqual(calendar_a.associated_leaves_count, 3, "Calendar A should have 2 specific + 1 remaining global leave.")
+        self.assertEqual(calendar_b.associated_leaves_count, 2, "Calendar B should have 1 specific + 1 remaining global leave.")
+
+        # 5. Test Remove a specific leave to have no leaves specific to calendar_b:
+        # calendar_a (2 specific + 1 global = 3), calendar_b (0 specific + 1 global = 1)
+        leave_b_1.unlink()
+        (calendar_a | calendar_b)._compute_associated_leaves_count()
+        self.assertEqual(calendar_a.associated_leaves_count, 3, "Calendar A should still have 2 specific + 1 global leave.")
+        self.assertEqual(calendar_b.associated_leaves_count, 1, "Calendar B should have 0 specific + 1 global leave.")
+
+        # 6. Test Remove a specific leave calendar_a: calendar_a (1 specific + 1 global = 2), calendar_b (0 specific + 1 global = 1)
+        leave_a_1.unlink()
+        (calendar_a | calendar_b)._compute_associated_leaves_count()
+        self.assertEqual(calendar_a.associated_leaves_count, 2, "Calendar A should still have 2 specific + 1 global leave.")
+        self.assertEqual(calendar_b.associated_leaves_count, 1, "Calendar B should have 0 specific + 1 global leave.")

--- a/addons/hr_holidays/views/resource_views.xml
+++ b/addons/hr_holidays/views/resource_views.xml
@@ -55,10 +55,10 @@
         <field name="res_model">resource.calendar.leaves</field>
         <field name="view_mode">list</field>
         <field name="view_id" ref="resource_calendar_leaves_tree_inherit"/>
-        <field name="domain">[('resource_id', '=', False)]</field>
+        <field name="domain">[('resource_id', '=', False), '|', ('calendar_id', '=', False), ('calendar_id', '=', active_id)]</field>
         <field name="context">{
             'default_calendar_id': active_id,
-            'search_default_calendar_id': active_id}</field>
+            'search_default_filter_date': True}</field>
         <field name="search_view_id" ref="hr_holidays.resource_calendar_leaves_view_search_inherit"/>
     </record>
 


### PR DESCRIPTION
yoahm

Description of the issue/feature this PR addresses: [Employees] Show All Valid Public Holidays in Working Schedule Smart Button 

Current behavior before PR: the pubic holidays for the working schedule shows only its public holidays without including the common public holiday & the pubic holidays listview wasn't sorted

Desired behavior after PR is merged:
. On the Public Holiday smart button of the Working Schedule, include all valid public holidays both common and schedule-specific ones.
. On the public holidays listview is primary sorted where  working hours not null and secondary according to the start_date




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
