### PR TITLE
[FIX] point_of_sale: avoid infinite loop when false

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -635,7 +635,7 @@ class PosConfig(models.Model):
         result = super(PosConfig, self).write(vals)
 
         for config in self:
-            if config.use_presets and config.default_preset_id.id not in config.available_preset_ids.ids:
+            if config.use_presets and config.default_preset_id and config.default_preset_id.id not in config.available_preset_ids.ids:
                 config.available_preset_ids |= config.default_preset_id
 
         self.sudo()._set_fiscal_position()


### PR DESCRIPTION
The condition `config.default_preset_id.id not in config.available_preset_ids.ids` is
equivalent to True when both default_preset_id and available_preset_ids are empty. This
triggers an infinite loop as assigning with `|=` triggers a nested write.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
