### PR TITLE
[IMP] project: kanban substasks redesign

### DIFF
--- a/addons/project/static/src/views/widget/subtask_counter.xml
+++ b/addons/project/static/src/views/widget/subtask_counter.xml
@@ -6,7 +6,7 @@
         <a t-att-title="counterTitle"
            class="subtask_list_button btn-link text-dark"
            t-on-click.prevent="() => this.onClick()">
-            <span class="fa fa-check-square-o me-1"/>
+            <i class="fa fa-level-down me-1"></i>
             <t t-esc="counterDisplay"/>
         </a>
     </t>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -699,9 +699,12 @@
                         </t>
                         <t t-name="card">
                             <main t-att-class="['1_done', '1_canceled'].includes(record.state.raw_value) ? 'opacity-50' : ''">
+                                <a t-if="record.parent_id.raw_value" class="o_kanban_parent mw-100 me-auto pe-3 btn-link o_small-fs text-dark text-truncate" title="See Parent Task" name="action_open_parent_task" type="object" role="button">
+                                    <i class="fa fa-level-down me-1"/>
+                                    <field name="parent_id"/>
+                                </a>
                                 <field name="name" class="fw-bold fs-5"/>
                                 <div class="text-muted d-flex flex-column">
-                                    <field t-if="record.parent_id.raw_value" invisible="context.get('default_parent_id', False)" name="parent_id"/>
                                     <field invisible="context.get('default_project_id', False)" name="project_id" options="{'no_open': True}"/>
                                     <field name="partner_id" invisible="context.get('template_project')"/>
                                     <field t-if="record.allow_milestones.raw_value and record.milestone_id.raw_value" t-att-class="record.has_late_and_unreached_milestone.raw_value and !record.state.raw_value.startsWith('1_') ? 'text-danger' : ''" name="milestone_id" options="{'no_open': True}"/>
@@ -724,7 +727,7 @@
                                         <t t-if="record.project_id.raw_value and record.subtask_count.raw_value">
                                             <widget name="subtask_counter" class="me-1"/>
                                         </t>
-                                        <field name="priority" class="pt-1" widget="priority"/>
+                                        <field name="priority" class="lh-1" widget="priority"/>
                                         <field name="is_rotting" invisible="1"/>
                                         <field name="rotting_days" widget="rotting" class="ms-1 d-flex"/>
                                     </div>


### PR DESCRIPTION
This PR aims to improve the display of subtasks in the kanban view, by changing the position of the label above the title, and by reviewing the icon associated to subtasks in both the parent and child card.

| Before | After |
|--------|--------|
| <img width="421" height="153" alt="image" src="https://github.com/user-attachments/assets/eeacdcc8-43df-463e-bbc7-763753e2ae1d" /> | <img width="421" height="146" alt="image" src="https://github.com/user-attachments/assets/cb53d003-f997-4317-8a49-94cdf961b183" /> | 

task-5000360

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
