### PR TITLE
[IMP] hr_holidays: Separate time off unit taken/given

### DIFF
--- a/addons/hr_holidays/data/hr_holidays_demo.xml
+++ b/addons/hr_holidays/data/hr_holidays_demo.xml
@@ -20,6 +20,8 @@
         <field name="employee_requests">False</field>
         <field name="leave_validation_type">both</field>
         <field name="allocation_validation_type">hr</field>
+        <field name="request_unit">day</field>
+        <field name="unit_of_measure">day</field>
         <field name="responsible_ids" eval="[(4, ref('base.user_admin'))]"/>
         <field name="icon_id" ref="hr_holidays.icon_17"/>
     </record>
@@ -30,6 +32,8 @@
         <field name="employee_requests">False</field>
         <field name="leave_validation_type">both</field>
         <field name="allocation_validation_type">hr</field>
+        <field name="request_unit">day</field>
+        <field name="unit_of_measure">day</field>
         <field name="responsible_ids" eval="[(4, ref('base.user_admin'))]"/>
         <field name="icon_id" ref="hr_holidays.icon_26"/>
         <field name="allows_negative" eval="True"/>

--- a/addons/hr_holidays/data/hr_leave_type_data.xml
+++ b/addons/hr_holidays/data/hr_leave_type_data.xml
@@ -7,6 +7,8 @@
         <field name="employee_requests">False</field>
         <field name="leave_validation_type">both</field>
         <field name="allocation_validation_type">hr</field>
+        <field name="request_unit">day</field>
+        <field name="unit_of_measure">day</field>
         <field name="leave_notif_subtype_id" ref="mt_leave"/>
         <field name="allocation_notif_subtype_id" ref="mt_leave_allocation"/>
         <field name="responsible_ids" eval="[(4, ref('base.user_admin'))]"/>
@@ -20,6 +22,8 @@
     <record id="leave_type_sick_time_off" model="hr.leave.type">
         <field name="name">Sick Time Off</field>
         <field name="requires_allocation">False</field>
+        <field name="request_unit">day</field>
+        <field name="unit_of_measure">day</field>
         <field name="leave_notif_subtype_id" ref="mt_leave_sick"/>
         <field name="responsible_ids" eval="[(4, ref('base.user_admin'))]"/>
         <field name="support_document">True</field>
@@ -38,6 +42,7 @@
         <field name="leave_validation_type">manager</field>
         <field name="allocation_validation_type">hr</field>
         <field name="request_unit">day</field>
+        <field name="unit_of_measure">day</field>
         <field name="leave_notif_subtype_id" ref="mt_leave"/>
         <field name="responsible_ids" eval="[(4, ref('base.user_admin'))]"/>
         <field name="icon_id" ref="hr_holidays.icon_4"/>
@@ -53,6 +58,7 @@
         <field name="leave_validation_type">both</field>
         <field name="allocation_validation_type">hr</field>
         <field name="request_unit">hour</field>
+        <field name="unit_of_measure">hour</field>
         <field name="hide_on_dashboard">True</field>
         <field name="unpaid" eval="True"/>
         <field name="leave_notif_subtype_id" ref="mt_leave_unpaid"/>
@@ -72,6 +78,7 @@
         <field name="allocation_validation_type">hr</field>
         <field name="hide_on_dashboard">True</field>
         <field name="request_unit">half_day</field>
+        <field name="unit_of_measure">day</field>
         <field name="leave_notif_subtype_id" ref="hr_holidays.mt_leave"/>
         <field name="responsible_ids" eval="[(4, ref('base.user_admin'))]"/>
         <field name="sequence">4</field>
@@ -81,6 +88,7 @@
     <record id="holiday_status_extra_hours" model="hr.leave.type">
         <field name="name">Extra Hours</field>
         <field name="request_unit">hour</field>
+        <field name="unit_of_measure">hour</field>
         <field name="requires_allocation">False</field>
         <field name="leave_validation_type">manager</field>
         <field name="active" eval="True"/>
@@ -97,6 +105,7 @@
         <field name="requires_allocation">True</field>
         <field name="employee_requests">True</field>
         <field name="request_unit">half_day</field>
+        <field name="unit_of_measure">day</field>
         <field name="leave_notif_subtype_id" ref="hr_holidays.mt_leave"/>
         <field name="company_id" eval="False"/>
         <field name="country_id" ref="base.be"/>
@@ -107,6 +116,7 @@
         <field name="requires_allocation">False</field>
         <field name="leave_validation_type">no_validation</field>
         <field name="request_unit">half_day</field>
+        <field name="unit_of_measure">day</field>
         <field name="leave_notif_subtype_id" ref="hr_holidays.mt_leave"/>
         <field name="icon_id" ref="hr_holidays.icon_17"/>
         <field name="company_id" eval="False"/>
@@ -118,6 +128,7 @@
         <field name="requires_allocation">False</field>
         <field name="leave_validation_type">no_validation</field>
         <field name="request_unit">half_day</field>
+        <field name="unit_of_measure">day</field>
         <field name="leave_notif_subtype_id" ref="hr_holidays.mt_leave"/>
         <field name="icon_id" ref="hr_holidays.icon_17"/>
         <field name="company_id" eval="False"/>
@@ -129,6 +140,7 @@
         <field name="requires_allocation">False</field>
         <field name="leave_validation_type">no_validation</field>
         <field name="request_unit">half_day</field>
+        <field name="unit_of_measure">day</field>
         <field name="leave_notif_subtype_id" ref="hr_holidays.mt_leave"/>
         <field name="icon_id" ref="hr_holidays.icon_17"/>
         <field name="company_id" eval="False"/>
@@ -139,6 +151,7 @@
         <field name="name">Unpredictable Reason</field>
         <field name="requires_allocation">False</field>
         <field name="request_unit">half_day</field>
+        <field name="unit_of_measure">day</field>
         <field name="leave_notif_subtype_id" ref="hr_holidays.mt_leave"/>
         <field name="company_id" eval="False"/>
         <field name="country_id" ref="base.be"/>
@@ -149,6 +162,7 @@
         <field name="requires_allocation">True</field>
         <field name="employee_requests">True</field>
         <field name="request_unit">half_day</field>
+        <field name="unit_of_measure">day</field>
         <field name="leave_notif_subtype_id" ref="hr_holidays.mt_leave"/>
         <field name="icon_id" ref="hr_holidays.icon_26"/>
         <field name="company_id" eval="False"/>
@@ -160,6 +174,7 @@
         <field name="requires_allocation">True</field>
         <field name="employee_requests">True</field>
         <field name="request_unit">half_day</field>
+        <field name="unit_of_measure">day</field>
         <field name="leave_notif_subtype_id" ref="hr_holidays.mt_leave"/>
         <field name="icon_id" ref="hr_holidays.icon_4"/>
         <field name="company_id" eval="False"/>
@@ -172,6 +187,7 @@
         <field name="requires_allocation">True</field>
         <field name="employee_requests">True</field>
         <field name="request_unit">day</field>
+        <field name="unit_of_measure">day</field>
         <field name="leave_notif_subtype_id" ref="hr_holidays.mt_leave"/>
         <field name="company_id" eval="False"/>
         <field name="country_id" ref="base.be"/>
@@ -182,6 +198,7 @@
         <field name="requires_allocation">True</field>
         <field name="employee_requests">True</field>
         <field name="request_unit">half_day</field>
+        <field name="unit_of_measure">day</field>
         <field name="leave_notif_subtype_id" ref="hr_holidays.mt_leave"/>
         <field name="icon_id" ref="hr_holidays.icon_14"/>
         <field name="company_id" eval="False"/>
@@ -192,6 +209,7 @@
         <field name="name">Credit Time</field>
         <field name="requires_allocation">False</field>
         <field name="request_unit">half_day</field>
+        <field name="unit_of_measure">day</field>
         <field name="leave_notif_subtype_id" eval="ref('hr_holidays.mt_leave')"/>
         <field name="company_id" eval="False"/>
         <field name="country_id" ref="base.be"/>
@@ -200,6 +218,8 @@
     <record id="l10n_be_leave_type_work_accident" model="hr.leave.type">
         <field name="name">Work Accident Time Off</field>
         <field name="requires_allocation">False</field>
+        <field name="request_unit">day</field>
+        <field name="unit_of_measure">day</field>
         <field name="leave_notif_subtype_id" ref="hr_holidays.mt_leave"/>
         <field name="company_id" eval="False"/>
         <field name="country_id" ref="base.be"/>
@@ -209,6 +229,7 @@
         <field name="name">Strike</field>
         <field name="requires_allocation">False</field>
         <field name="request_unit">half_day</field>
+        <field name="unit_of_measure">day</field>
         <field name="leave_notif_subtype_id" ref="hr_holidays.mt_leave"/>
         <field name="company_id" eval="False"/>
         <field name="country_id" ref="base.be"/>
@@ -218,6 +239,7 @@
         <field name="name">Sick Leave Without Certificate</field>
         <field name="requires_allocation">False</field>
         <field name="request_unit">half_day</field>
+        <field name="unit_of_measure">day</field>
         <field name="leave_notif_subtype_id" ref="hr_holidays.mt_leave"/>
         <field name="company_id" eval="False"/>
         <field name="country_id" ref="base.be"/>
@@ -228,6 +250,7 @@
         <field name="requires_allocation">yes</field>
         <field name="employee_requests">yes</field>
         <field name="request_unit">half_day</field>
+        <field name="unit_of_measure">day</field>
         <field name="leave_notif_subtype_id" ref="hr_holidays.mt_leave"/>
         <field name="company_id" eval="False"/>
         <field name="country_id" ref="base.be"/>
@@ -241,6 +264,7 @@
         <field name="requires_allocation">False</field>
         <field name="leave_validation_type">no_validation</field>
         <field name="request_unit">half_day</field>
+        <field name="unit_of_measure">day</field>
         <field name="company_id" eval="False"/>
         <field name="sequence">1</field>
         <field name="color">1</field>
@@ -253,6 +277,7 @@
         <field name="requires_allocation">False</field>
         <field name="leave_validation_type">no_validation</field>
         <field name="request_unit">half_day</field>
+        <field name="unit_of_measure">day</field>
         <field name="sequence">2</field>
         <field name="company_id" eval="False"/>
         <field name="color">2</field>
@@ -265,6 +290,7 @@
         <field name="requires_allocation">False</field>
         <field name="leave_validation_type">no_validation</field>
         <field name="request_unit">half_day</field>
+        <field name="unit_of_measure">day</field>
         <field name="sequence">3</field>
         <field name="company_id" eval="False"/>
         <field name="color">3</field>
@@ -277,6 +303,7 @@
         <field name="requires_allocation">False</field>
         <field name="leave_validation_type">no_validation</field>
         <field name="request_unit">half_day</field>
+        <field name="unit_of_measure">day</field>
         <field name="sequence">4</field>
         <field name="company_id" eval="False"/>
         <field name="color">4</field>
@@ -289,6 +316,7 @@
         <field name="requires_allocation">False</field>
         <field name="leave_validation_type">no_validation</field>
         <field name="request_unit">half_day</field>
+        <field name="unit_of_measure">day</field>
         <field name="sequence">4</field>
         <field name="company_id" eval="False"/>
         <field name="color">5</field>
@@ -301,6 +329,7 @@
         <field name="requires_allocation">False</field>
         <field name="leave_validation_type">no_validation</field>
         <field name="request_unit">day</field>
+        <field name="unit_of_measure">day</field>
         <field name="sequence">5</field>
         <field name="company_id" eval="False"/>
         <field name="color">6</field>
@@ -311,6 +340,8 @@
     <record id="l10n_eg_leave_type_marriage" model="hr.leave.type">
         <field name="name">Marriage Leave</field>
         <field name="requires_allocation">False</field>
+        <field name="request_unit">day</field>
+        <field name="unit_of_measure">day</field>
         <field name="company_id" eval="False"/>
         <field name="country_id" ref="base.eg"/>
     </record>
@@ -318,6 +349,8 @@
     <record id="l10n_eg_leave_type_maternity" model="hr.leave.type">
         <field name="name">Maternity Leave</field>
         <field name="requires_allocation">False</field>
+        <field name="request_unit">day</field>
+        <field name="unit_of_measure">day</field>
         <field name="country_id" ref="base.eg"/>
         <field name="company_id" eval="False"/>
     </record>
@@ -325,6 +358,8 @@
     <record id="l10n_eg_leave_type_hajj" model="hr.leave.type">
         <field name="name">Hajj Leave</field>
         <field name="requires_allocation">False</field>
+        <field name="request_unit">day</field>
+        <field name="unit_of_measure">day</field>
         <field name="company_id" eval="False"/>
         <field name="country_id" ref="base.eg"/>
     </record>
@@ -332,6 +367,8 @@
     <record id="l10n_eg_leave_type_death" model="hr.leave.type">
         <field name="name">Death Leave</field>
         <field name="requires_allocation">False</field>
+        <field name="request_unit">day</field>
+        <field name="unit_of_measure">day</field>
         <field name="company_id" eval="False"/>
         <field name="country_id" ref="base.eg"/>
     </record>
@@ -339,6 +376,8 @@
     <record id="l10n_eg_leave_type_paid_sick_time_off" model="hr.leave.type">
         <field name="name">Paid Sick time off</field>
         <field name="requires_allocation">True</field>
+        <field name="request_unit">day</field>
+        <field name="unit_of_measure">day</field>
         <field name="employee_requests">no</field>
         <field name="country_id" ref="base.eg"/>
     </record>
@@ -346,12 +385,16 @@
     <record id="l10n_eg_leave_type_sick_leave_75" model="hr.leave.type">
         <field name="name">Sick Leave (75% Paid)</field>
         <field name="requires_allocation">True</field>
+        <field name="request_unit">day</field>
+        <field name="unit_of_measure">day</field>
         <field name="country_id" ref="base.eg"/>
     </record>
 
     <record id="l10n_eg_leave_type_sick_leave_unpaid" model="hr.leave.type">
         <field name="name">Sick Leave (UnPaid)</field>
         <field name="requires_allocation">False</field>
+        <field name="request_unit">day</field>
+        <field name="unit_of_measure">day</field>
         <field name="country_id" ref="base.eg"/>
     </record>
 
@@ -360,6 +403,7 @@
         <field name="name">HK Annual Leaves</field>
         <field name="requires_allocation">True</field>
         <field name="request_unit">half_day</field>
+        <field name="unit_of_measure">day</field>
         <field name="leave_validation_type">no_validation</field>
         <field name="company_id" eval="False" />
         <field name="country_id" ref="base.hk"/>
@@ -369,6 +413,7 @@
         <field name="name">HK Compensation Leaves</field>
         <field name="requires_allocation">True</field>
         <field name="request_unit">half_day</field>
+        <field name="unit_of_measure">day</field>
         <field name="leave_validation_type">no_validation</field>
         <field name="company_id" eval="False" />
         <field name="country_id" ref="base.hk"/>
@@ -378,6 +423,7 @@
         <field name="name">HK Sick Leaves</field>
         <field name="requires_allocation">False</field>
         <field name="request_unit">half_day</field>
+        <field name="unit_of_measure">day</field>
         <field name="support_document">True</field>
         <field name="icon_id" ref="hr_holidays.icon_21"/>
         <field name="company_id" eval="False" />
@@ -388,6 +434,7 @@
         <field name="name">HK Sick Leaves 80%</field>
         <field name="requires_allocation">False</field>
         <field name="request_unit">half_day</field>
+        <field name="unit_of_measure">day</field>
         <field name="support_document">True</field>
         <field name="icon_id" ref="hr_holidays.icon_21"/>
         <field name="company_id" eval="False" />
@@ -398,6 +445,7 @@
         <field name="name">HK Unpaid Leaves</field>
         <field name="requires_allocation">False</field>
         <field name="request_unit">half_day</field>
+        <field name="unit_of_measure">day</field>
         <field name="company_id" eval="False" />
         <field name="country_id" ref="base.hk"/>
     </record>
@@ -405,6 +453,8 @@
     <record id="l10n_hk_leave_type_marriage_leave" model="hr.leave.type">
         <field name="name">HK Marriage Leaves</field>
         <field name="requires_allocation">False</field>
+        <field name="request_unit">day</field>
+        <field name="unit_of_measure">day</field>
         <field name="support_document">True</field>
         <field name="company_id" eval="False" />
         <field name="country_id" ref="base.hk"/>
@@ -413,6 +463,8 @@
     <record id="l10n_hk_leave_type_maternity_leave" model="hr.leave.type">
         <field name="name">HK Maternity Leaves</field>
         <field name="requires_allocation">False</field>
+        <field name="request_unit">day</field>
+        <field name="unit_of_measure">day</field>
         <field name="company_id" eval="False" />
         <field name="country_id" ref="base.hk"/>
     </record>
@@ -420,6 +472,8 @@
     <record id="l10n_hk_leave_type_maternity_leave_80" model="hr.leave.type">
         <field name="name">HK Maternity Leaves 80%</field>
         <field name="requires_allocation">False</field>
+        <field name="request_unit">day</field>
+        <field name="unit_of_measure">day</field>
         <field name="company_id" eval="False" />
         <field name="country_id" ref="base.hk"/>
     </record>
@@ -427,6 +481,8 @@
     <record id="l10n_hk_leave_type_paternity_leave" model="hr.leave.type">
         <field name="name">HK Paternity Leaves</field>
         <field name="requires_allocation">False</field>
+        <field name="request_unit">day</field>
+        <field name="unit_of_measure">day</field>
         <field name="company_id" eval="False" />
         <field name="country_id" ref="base.hk"/>
     </record>
@@ -434,6 +490,8 @@
     <record id="l10n_hk_leave_type_paternity_leave_80" model="hr.leave.type">
         <field name="name">HK Paternity Leaves 80%</field>
         <field name="requires_allocation">False</field>
+        <field name="request_unit">day</field>
+        <field name="unit_of_measure">day</field>
         <field name="company_id" eval="False" />
         <field name="country_id" ref="base.hk"/>
     </record>
@@ -441,6 +499,8 @@
     <record id="l10n_hk_leave_type_compassionate_leave" model="hr.leave.type">
         <field name="name">HK Compassionate Leaves</field>
         <field name="requires_allocation">False</field>
+        <field name="request_unit">day</field>
+        <field name="unit_of_measure">day</field>
         <field name="company_id" eval="False" />
         <field name="country_id" ref="base.hk"/>
     </record>
@@ -449,6 +509,7 @@
         <field name="name">HK Examination Leaves</field>
         <field name="requires_allocation">False</field>
         <field name="request_unit">half_day</field>
+        <field name="unit_of_measure">day</field>
         <field name="company_id" eval="False" />
         <field name="country_id" ref="base.hk"/>
     </record>
@@ -458,6 +519,7 @@
         <field name="name">ID Annual Leaves</field>
         <field name="requires_allocation">True</field>
         <field name="request_unit">half_day</field>
+        <field name="unit_of_measure">day</field>
         <field name="leave_validation_type">no_validation</field>
         <field name="company_id" eval="False" />
         <field name="country_id" ref="base.id"/>
@@ -467,6 +529,7 @@
         <field name="name">ID Sick Leaves</field>
         <field name="requires_allocation">False</field>
         <field name="request_unit">half_day</field>
+        <field name="unit_of_measure">day</field>
         <field name="support_document">True</field>
         <field name="company_id" eval="False" />
         <field name="country_id" ref="base.id"/>
@@ -476,6 +539,7 @@
         <field name="name">ID Unpaid Leaves</field>
         <field name="requires_allocation">False</field>
         <field name="request_unit">half_day</field>
+        <field name="unit_of_measure">day</field>
         <field name="company_id" eval="False" />
         <field name="country_id" ref="base.id"/>
     </record>
@@ -483,6 +547,8 @@
     <record id="l10n_id_leave_type_marriage_leave" model="hr.leave.type">
         <field name="name">ID Marriage Leaves</field>
         <field name="requires_allocation">False</field>
+        <field name="request_unit">day</field>
+        <field name="unit_of_measure">day</field>
         <field name="support_document">True</field>
         <field name="company_id" eval="False" />
         <field name="country_id" ref="base.id"/>
@@ -491,6 +557,8 @@
     <record id="l10n_id_leave_type_maternity_leave" model="hr.leave.type">
         <field name="name">ID Maternity Leaves</field>
         <field name="requires_allocation">False</field>
+        <field name="request_unit">day</field>
+        <field name="unit_of_measure">day</field>
         <field name="company_id" eval="False" />
         <field name="country_id" ref="base.id"/>
     </record>
@@ -498,6 +566,8 @@
     <record id="l10n_id_leave_type_paternity_leave" model="hr.leave.type">
         <field name="name">ID Paternity Leaves</field>
         <field name="requires_allocation">False</field>
+        <field name="request_unit">day</field>
+        <field name="unit_of_measure">day</field>
         <field name="company_id" eval="False" />
         <field name="country_id" ref="base.id"/>
     </record>
@@ -505,6 +575,8 @@
     <record id="l10n_id_leave_type_bereavement_leave" model="hr.leave.type">
         <field name="name">ID Bereavement Leaves</field>
         <field name="requires_allocation">False</field>
+        <field name="request_unit">day</field>
+        <field name="unit_of_measure">day</field>
         <field name="company_id" eval="False" />
         <field name="country_id" ref="base.id"/>
     </record>
@@ -513,6 +585,8 @@
     <record id="l10n_jo_leave_type_unpaid_sick" model="hr.leave.type">
         <field name="name">Sick Leave (Unpaid)</field>
         <field name="requires_allocation">False</field>
+        <field name="request_unit">day</field>
+        <field name="unit_of_measure">day</field>
         <field name="leave_validation_type">hr</field>
         <field name="company_id" eval="False"/>
         <field name="country_id" ref="base.jo"/>
@@ -521,6 +595,8 @@
     <record id="l10n_jo_leave_type_maternity" model="hr.leave.type">
         <field name="name">Maternity Leave</field>
         <field name="requires_allocation">no</field>
+        <field name="request_unit">day</field>
+        <field name="unit_of_measure">day</field>
         <field name="leave_validation_type">hr</field>
         <field name="company_id" eval="False"/>
         <field name="country_id" ref="base.jo"/>
@@ -529,6 +605,8 @@
     <record id="l10n_jo_leave_type_pilgrimage" model="hr.leave.type">
         <field name="name">Pilgrimage Leave</field>
         <field name="requires_allocation">no</field>
+        <field name="request_unit">day</field>
+        <field name="unit_of_measure">day</field>
         <field name="leave_validation_type">hr</field>
         <field name="company_id" eval="False"/>
         <field name="country_id" ref="base.jo"/>
@@ -537,6 +615,8 @@
     <record id="l10n_jo_leave_type_paternity" model="hr.leave.type">
         <field name="name">Paternity Leave</field>
         <field name="requires_allocation">no</field>
+        <field name="request_unit">day</field>
+        <field name="unit_of_measure">day</field>
         <field name="leave_validation_type">hr</field>
         <field name="company_id" eval="False"/>
         <field name="country_id" ref="base.jo"/>
@@ -545,6 +625,8 @@
     <record id="l10n_jo_leave_type_study" model="hr.leave.type">
         <field name="name">Study Leave</field>
         <field name="requires_allocation">no</field>
+        <field name="request_unit">day</field>
+        <field name="unit_of_measure">day</field>
         <field name="leave_validation_type">hr</field>
         <field name="company_id" eval="False"/>
         <field name="country_id" ref="base.jo"/>
@@ -557,6 +639,7 @@
         <field name="leave_validation_type">no_validation</field>
         <field name="allocation_validation_type">hr</field>
         <field name="request_unit">hour</field>
+        <field name="unit_of_measure">hour</field>
         <field name="unpaid" eval="True"/>
         <field name="leave_notif_subtype_id" ref="hr_holidays.mt_leave_unpaid"/>
         <field name="responsible_ids" eval="[(4, ref('base.user_admin'))]"/>
@@ -573,6 +656,7 @@
         <field name="leave_validation_type">no_validation</field>
         <field name="allocation_validation_type">hr</field>
         <field name="request_unit">day</field>
+        <field name="unit_of_measure">day</field>
         <field name="unpaid" eval="True"/>
         <field name="leave_notif_subtype_id" ref="hr_holidays.mt_leave_unpaid"/>
         <field name="responsible_ids" eval="[(4, ref('base.user_admin'))]"/>
@@ -588,6 +672,7 @@
         <field name="leave_validation_type">no_validation</field>
         <field name="allocation_validation_type">hr</field>
         <field name="request_unit">day</field>
+        <field name="unit_of_measure">day</field>
         <field name="unpaid" eval="True"/>
         <field name="leave_notif_subtype_id" ref="hr_holidays.mt_leave_unpaid"/>
         <field name="responsible_ids" eval="[(4, ref('base.user_admin'))]"/>
@@ -603,6 +688,7 @@
         <field name="leave_validation_type">no_validation</field>
         <field name="allocation_validation_type">hr</field>
         <field name="request_unit">day</field>
+        <field name="unit_of_measure">day</field>
         <field name="unpaid" eval="True"/>
         <field name="leave_notif_subtype_id" ref="hr_holidays.mt_leave_unpaid"/>
         <field name="responsible_ids" eval="[(4, ref('base.user_admin'))]"/>
@@ -616,6 +702,8 @@
     <record id="l10n_sa_leave_type_marriage" model="hr.leave.type">
         <field name="name">Marriage Leave</field>
         <field name="requires_allocation">no</field>
+        <field name="request_unit">day</field>
+        <field name="unit_of_measure">day</field>
         <field name="leave_validation_type">hr</field>
         <field name="country_id" ref="base.sa"/>
     </record>
@@ -623,6 +711,8 @@
     <record id="l10n_sa_leave_type_maternity" model="hr.leave.type">
         <field name="name">Maternity Leave</field>
         <field name="requires_allocation">no</field>
+        <field name="request_unit">day</field>
+        <field name="unit_of_measure">day</field>
         <field name="leave_validation_type">hr</field>
         <field name="country_id" ref="base.sa"/>
     </record>
@@ -630,6 +720,8 @@
     <record id="l10n_sa_leave_type_iddah" model="hr.leave.type">
         <field name="name">Iddah Leave</field>
         <field name="requires_allocation">no</field>
+        <field name="request_unit">day</field>
+        <field name="unit_of_measure">day</field>
         <field name="leave_validation_type">hr</field>
         <field name="country_id" ref="base.sa"/>
     </record>
@@ -637,6 +729,8 @@
     <record id="l10n_sa_leave_type_hajj" model="hr.leave.type">
         <field name="name">Hajj Leave</field>
         <field name="requires_allocation">no</field>
+        <field name="request_unit">day</field>
+        <field name="unit_of_measure">day</field>
         <field name="leave_validation_type">hr</field>
         <field name="country_id" ref="base.sa"/>
     </record>
@@ -644,6 +738,8 @@
     <record id="l10n_sa_leave_type_paternity" model="hr.leave.type">
         <field name="name">Paternity Leave</field>
         <field name="requires_allocation">no</field>
+        <field name="request_unit">day</field>
+        <field name="unit_of_measure">day</field>
         <field name="leave_validation_type">hr</field>
         <field name="country_id" ref="base.sa"/>
     </record>
@@ -651,6 +747,8 @@
     <record id="l10n_sa_leave_type_study" model="hr.leave.type">
         <field name="name">Study Leave</field>
         <field name="requires_allocation">no</field>
+        <field name="request_unit">day</field>
+        <field name="unit_of_measure">day</field>
         <field name="leave_validation_type">hr</field>
         <field name="country_id" ref="base.sa"/>
     </record>
@@ -658,6 +756,8 @@
     <record id="l10n_sa_leave_type_emergency" model="hr.leave.type">
         <field name="name">Emergency Leave</field>
         <field name="requires_allocation">no</field>
+        <field name="request_unit">day</field>
+        <field name="unit_of_measure">day</field>
         <field name="leave_validation_type">hr</field>
         <field name="country_id" ref="base.sa"/>
     </record>
@@ -668,6 +768,7 @@
         <field name="requires_allocation">False</field>
         <field name="leave_validation_type">no_validation</field>
         <field name="request_unit">half_day</field>
+        <field name="unit_of_measure">day</field>
         <field name="leave_notif_subtype_id" ref="hr_holidays.mt_leave"/>
         <field name="company_id" eval="False"/>
         <field name="country_id" ref="base.sk"/>
@@ -678,6 +779,7 @@
         <field name="name">PL Sick Leaves 80% </field>
         <field name="requires_allocation">no</field>
         <field name="request_unit">half_day</field>
+        <field name="unit_of_measure">day</field>
         <field name="support_document">True</field>
         <field name="icon_id" ref="hr_holidays.icon_21"/>
         <field name="color">6</field>

--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -98,7 +98,7 @@ class HrEmployee(models.Model):
                             and (not allocation.date_to or allocation.date_to >= current_date):
                         virtual_remaining_leaves = leaves_taken[employee][leave_type][allocation]['virtual_remaining_leaves']
                         employee_remaining_leaves += virtual_remaining_leaves\
-                            if leave_type.request_unit in ['day', 'half_day']\
+                            if leave_type.unit_of_measure == 'day'\
                             else virtual_remaining_leaves / (employee.resource_calendar_id.hours_per_day or HOURS_PER_DAY)
                         employee_max_leaves += allocation.number_of_days
             employee.allocation_remaining_display = "%g" % float_round(employee_remaining_leaves, precision_digits=2)
@@ -492,7 +492,7 @@ class HrEmployee(models.Model):
             if allocation.allocation_type == 'accrual':
                 future_leaves = allocation._get_future_leaves_on(target_date)
             max_leaves = allocation.number_of_hours_display\
-                if allocation.holiday_status_id.request_unit in ['hour']\
+                if allocation.holiday_status_id.unit_of_measure == 'hour'\
                 else allocation.number_of_days_display
             max_leaves += future_leaves
             allocation_data.update({
@@ -532,7 +532,7 @@ class HrEmployee(models.Model):
                         allocations_without_date_to |= leave_allocation
                 sorted_leave_allocations = allocations_with_date_to.sorted(key='date_to') + allocations_without_date_to
 
-                if leave_type.request_unit in ['day', 'half_day']:
+                if leave_type.unit_of_measure == 'day':
                     leave_duration_field = 'number_of_days'
                     leave_unit = 'days'
                 else:
@@ -622,7 +622,7 @@ class HrEmployee(models.Model):
                         date_accrual_bonus += consumed_content[allocation]['accrual_bonus']
                         virtual_remaining += consumed_content[allocation]['virtual_remaining_leaves']
                     for leave in content['to_recheck_leaves']:
-                        additional_leaves_duration += leave.number_of_hours if leave_type.request_unit == 'hour' else leave.number_of_days
+                        additional_leaves_duration += leave.number_of_hours if leave_type.unit_of_measure == 'hour' else leave.number_of_days
                     latest_remaining = virtual_remaining - date_accrual_bonus + latest_accrual_bonus
                     content['exceeding_duration'] = round(min(0, latest_remaining - additional_leaves_duration), 2)
 

--- a/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
+++ b/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
@@ -194,22 +194,20 @@ class HrLeaveAccrualLevel(models.Model):
         for level in self:
             level.sequence = level.start_count * start_type_multipliers[level.start_type]
 
-    @api.depends('accrual_plan_id', 'accrual_plan_id.level_ids', 'accrual_plan_id.time_off_type_id')
+    @api.depends('accrual_plan_id', 'accrual_plan_id.level_ids')
     def _compute_can_modify_value_type(self):
         for level in self:
-            level.can_modify_value_type = not level.accrual_plan_id.time_off_type_id and level.accrual_plan_id.level_ids and level.accrual_plan_id.level_ids[0] == level
+            level.can_modify_value_type = level.accrual_plan_id.level_ids and level.accrual_plan_id.level_ids[0] == level
 
     def _inverse_added_value_type(self):
         for level in self:
             if level.accrual_plan_id.level_ids[0] == level:
                 level.accrual_plan_id.added_value_type = level.added_value_type
 
-    @api.depends('accrual_plan_id', 'accrual_plan_id.level_ids', 'accrual_plan_id.added_value_type', 'accrual_plan_id.time_off_type_id')
+    @api.depends('accrual_plan_id', 'accrual_plan_id.level_ids', 'accrual_plan_id.added_value_type')
     def _compute_added_value_type(self):
         for level in self:
-            if level.accrual_plan_id.time_off_type_id:
-                level.added_value_type = "day" if level.accrual_plan_id.time_off_type_id.request_unit in ["day", "half_day"] else "hour"
-            elif level.accrual_plan_id.level_ids and level.accrual_plan_id.level_ids[0] != level:
+            if level.accrual_plan_id.level_ids and level.accrual_plan_id.level_ids[0] != level:
                 level.added_value_type = level.accrual_plan_id.level_ids[0].added_value_type
             elif not level.added_value_type:
                 level.added_value_type = "day"  # default value

--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -291,7 +291,7 @@ class HrLeaveAllocation(models.Model):
         if self.allocation_type == "accrual" and self.accrual_plan_id:
             return self.accrual_plan_id.sudo().added_value_type
         elif self.allocation_type == "regular":
-            return self.holiday_status_id.request_unit
+            return self.holiday_status_id.unit_of_measure
         else:
             return "day"
 

--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -121,9 +121,8 @@ class HrLeaveAllocation(models.Model):
         ('accrual', 'Accrual Allocation')
     ], string="Allocation Type", default="regular", required=True, readonly=True)
     is_officer = fields.Boolean(compute='_compute_is_officer')
-    accrual_plan_id = fields.Many2one('hr.leave.accrual.plan',
-        compute="_compute_accrual_plan_id", inverse="_inverse_accrual_plan_id", store=True, index='btree_not_null', readonly=False, tracking=True,
-        domain="['|', ('time_off_type_id', '=', False), ('time_off_type_id', '=', holiday_status_id)]")
+    accrual_plan_id = fields.Many2one('hr.leave.accrual.plan', compute="_compute_accrual_plan_id",
+    inverse="_inverse_accrual_plan_id", store=True, index='btree_not_null', readonly=False, tracking=True)
     max_leaves = fields.Float(compute='_compute_leaves')
     leaves_taken = fields.Float(compute='_compute_leaves', string='Time off Taken')
     virtual_remaining_leaves = fields.Float(compute='_compute_leaves', string='Available Time Off')
@@ -264,12 +263,9 @@ class HrLeaveAllocation(models.Model):
         default_holiday_status_id = None
         for allocation in self:
             if not allocation.holiday_status_id:
-                if allocation.accrual_plan_id:
-                    allocation.holiday_status_id = allocation.accrual_plan_id.time_off_type_id
-                else:
-                    if not default_holiday_status_id:  # fetch when we need it
-                        default_holiday_status_id = self._default_holiday_status_id()
-                    allocation.holiday_status_id = default_holiday_status_id
+                if not default_holiday_status_id:  # fetch when we need it
+                    default_holiday_status_id = self._default_holiday_status_id()
+                allocation.holiday_status_id = default_holiday_status_id
 
     @api.depends('holiday_status_id', 'number_of_hours_display', 'number_of_days_display', 'type_request_unit', 'employee_id')
     def _compute_number_of_days(self):
@@ -280,21 +276,11 @@ class HrLeaveAllocation(models.Model):
             elif allocation_unit == 'hour' and allocation.employee_id:
                 allocation.number_of_days = allocation.number_of_hours_display / allocation.employee_id._get_hours_per_day(allocation.date_from)
 
-    @api.depends('holiday_status_id', 'allocation_type')
+    @api.depends('allocation_type')
     def _compute_accrual_plan_id(self):
-        accrual_allocations = self.filtered(lambda alloc: alloc.allocation_type == 'accrual' and not alloc.accrual_plan_id and alloc.holiday_status_id)
-        accruals_read_group = self.env['hr.leave.accrual.plan']._read_group(
-            [('time_off_type_id', 'in', accrual_allocations.holiday_status_id.ids)],
-            ['time_off_type_id'],
-            ['id:array_agg'],
-        )
-        accruals_dict = {time_off_type.id: ids for time_off_type, ids in accruals_read_group}
         for allocation in self:
-            if (allocation.allocation_type == 'regular' and allocation.accrual_plan_id) or allocation.accrual_plan_id.time_off_type_id.id not in (False, allocation.holiday_status_id.id):
+            if (allocation.allocation_type == 'regular' and allocation.accrual_plan_id):
                 allocation.accrual_plan_id = False
-            if allocation.allocation_type == 'accrual' and not allocation.accrual_plan_id:
-                if allocation.holiday_status_id:
-                    allocation.accrual_plan_id = accruals_dict.get(allocation.holiday_status_id.id, [False])[0]
 
     def _inverse_accrual_plan_id(self):
         for allocation in self:

--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -105,9 +105,12 @@ class HrLeaveType(models.Model):
     time_type = fields.Selection([('other', 'Worked Time'), ('leave', 'Absence')], default='leave', string="Kind of Time Off",
                                  help="The distinction between working time (ex. Attendance) and absence (ex. Training) will be used in the computation of Accrual's plan rate.")
     request_unit = fields.Selection([
-        ('day', 'Day'),
+        ('day', 'Full Day'),
         ('half_day', 'Half-Day'),
-        ('hour', 'Hours')], default='day', string='Duration Type', required=True)
+        ('hour', 'Custom Hours')], default='day', string='Duration Type', required=True,
+        help="Define the minimum time off duration in which an employee can take when requesting a leave")
+    unit_of_measure = fields.Selection([('hour', 'Hours'), ('day', 'Days')], default="hour", string="Unit of measure", required=True,
+                                       help="Define if the time off type will be allocated/accrued in hours or days")
     unpaid = fields.Boolean('Is Unpaid', default=False)
     include_public_holidays_in_duration = fields.Boolean('Ignore Public Holidays', default=False, help="Public holidays should be counted in the leave duration when applying for leaves")
     leave_notif_subtype_id = fields.Many2one('mail.message.subtype', string='Time Off Notification Subtype', default=lambda self: self.env.ref('hr_holidays.mt_leave', raise_if_not_found=False))
@@ -364,7 +367,7 @@ class HrLeaveType(models.Model):
     def requested_display_name(self):
         return self.env.context.get('holiday_status_display_name', True) and self.env.context.get('employee_id')
 
-    @api.depends('requires_allocation', 'virtual_remaining_leaves', 'max_leaves', 'request_unit')
+    @api.depends('requires_allocation', 'virtual_remaining_leaves', 'max_leaves', 'unit_of_measure')
     @api.depends_context('holiday_status_display_name', 'employee_id')
     def _compute_display_name(self):
         if not self.requested_display_name():
@@ -377,10 +380,10 @@ class HrLeaveType(models.Model):
                 remaining_time = float_round(record.virtual_remaining_leaves, precision_digits=2) or 0.0
                 maximum = float_round(record.max_leaves, precision_digits=2) or 0.0
 
-                if record.request_unit == "hour":
-                    name = _("%(name)s (%(time)g remaining out of %(maximum)g hours)", name=record.name, time=remaining_time, maximum=maximum)
+                if record.unit_of_measure == "hour":
+                    name = self.env._("%(name)s (%(time)g remaining out of %(maximum)g hours)", name=record.name, time=remaining_time, maximum=maximum)
                 else:
-                    name = _("%(name)s (%(time)g remaining out of %(maximum)g days)", name=record.name, time=remaining_time, maximum=maximum)
+                    name = self.env._("%(name)s (%(time)g remaining out of %(maximum)g days)", name=record.name, time=remaining_time, maximum=maximum)
             record.display_name = name
         return None
 
@@ -519,6 +522,7 @@ class HrLeaveType(models.Model):
                         'virtual_excess_data': {},
                         'exceeding_duration': extra_data[employee][leave_type]['exceeding_duration'],
                         'request_unit': leave_type.request_unit,
+                        'unit_of_measure': leave_type.unit_of_measure,
                         'icon': leave_type.sudo().icon_id.url,
                         'allows_negative': leave_type.allows_negative,
                         'max_allowed_negative': leave_type.max_allowed_negative,
@@ -589,7 +593,7 @@ class HrLeaveType(models.Model):
                         # closest_allocation_duration corresponds to the time remaining before the allocation expires
                         calendar_attendance = calendar._work_intervals_batch(start_datetime, end_datetime, resources=employee.resource_id)
                         closest_allocation_dict = calendar._get_attendance_intervals_days_data(calendar_attendance[employee.resource_id.id])
-                    if leave_type.request_unit in ['hour']:
+                    if leave_type.unit_of_measure in ['hour']:
                         closest_allocation_duration = closest_allocation_dict['hours']
                     else:
                         closest_allocation_duration = closest_allocation_dict['days']

--- a/addons/hr_holidays/static/src/dashboard/time_off_card.js
+++ b/addons/hr_holidays/static/src/dashboard/time_off_card.js
@@ -14,7 +14,7 @@ export class TimeOffCardPopover extends Component {
         "left",
         "warning",
         "closest",
-        "request_unit",
+        "unit_of_measure",
         "exceeding_duration",
         "close?",
         "allows_negative",
@@ -119,7 +119,7 @@ export class TimeOffCard extends Component {
     }
 
     formatDuration(duration) {
-        if (this.props.data.request_unit === 'hour') {
+        if (this.props.data.unit_of_measure === 'hour') {
             return this.formatHour(duration);
         }
         return formatNumber(this.lang, duration);
@@ -148,7 +148,7 @@ export class TimeOffCard extends Component {
             left: formatNumber(this.lang, data.virtual_remaining_leaves),
             warning: this.warning,
             closest: data.closest_allocation_duration,
-            request_unit: data.request_unit,
+            unit_of_measure: data.unit_of_measure,
             exceeding_duration: data.exceeding_duration,
             allows_negative: data.allows_negative,
             max_allowed_negative: data.max_allowed_negative,

--- a/addons/hr_holidays/static/src/dashboard/time_off_card.xml
+++ b/addons/hr_holidays/static/src/dashboard/time_off_card.xml
@@ -18,7 +18,7 @@
         <span
             t-att-class="'text-uppercase o_timeoff_details p-1' + (warning ? ' alert alert-warning' : '')"
             t-on-click.stop="(ev) => (show_popover &amp;&amp; this.onClickInfo(ev))">
-            <t t-if="data.request_unit == 'hour'" name="duration_unit">hours</t>
+            <t t-if="data.unit_of_measure == 'hour'" name="duration_unit">hours</t>
             <t t-else="">days</t>
             <t t-if="props.requires_allocation" name="duration_type">
                 available
@@ -32,7 +32,7 @@
         </span>
         <span t-if="props.requires_allocation and data.closest_allocation_expire !== false" class="text-uppercase o_timeoff_validity">
             <t t-if="data.closest_allocation_remaining != data.virtual_remaining_leaves">
-                (<t t-esc="data.closest_allocation_remaining"/> <t t-if="data.request_unit == 'hour'">hours</t><t t-else="">days</t>
+                (<t t-esc="data.closest_allocation_remaining"/> <t t-if="data.unit_of_measure == 'hour'">hours</t><t t-else="">days</t>
                 valid until <span t-esc="data.closest_allocation_expire"/>)
             </t>
             <t t-else="">
@@ -47,10 +47,10 @@
 
         <span class="float-end o_timeoff_card_mobile">
             <t t-if="props.requires_allocation" name="duration_type">
-                <strong t-esc="duration" class="o_timeoff_green text-success"/> / <span t-esc="data.max_leaves"/> <t t-if="data.request_unit == 'hour'">Hours</t><t t-else="">Days</t> <span class="o_timeoff_green text-success">Available</span>
+                <strong t-esc="duration" class="o_timeoff_green text-success"/> / <span t-esc="data.max_leaves"/> <t t-if="data.unit_of_measure == 'hour'">Hours</t><t t-else="">Days</t> <span class="o_timeoff_green text-success">Available</span>
             </t>
             <t t-else="">
-                <strong t-esc="duration"/> <t t-if="data.request_unit == 'hour'">Hours</t><t t-else="">Days</t> <span class="text-primary">Taken</span>
+                <strong t-esc="duration"/> <t t-if="data.unit_of_measure == 'hour'">Hours</t><t t-else="">Days</t> <span class="text-primary">Taken</span>
             </t>
         </span>
     </t>
@@ -77,7 +77,7 @@
             <span class="d-inline-block m-0 mb-3"
                 t-if="props.closest &amp;&amp; props.closest &lt; props.left">
                 <i class="fa fa-warning"/> Only <t t-esc="props.closest"/>
-                <t t-if="props.request_unit == 'hour'"> hours</t>
+                <t t-if="props.unit_of_measure == 'hour'"> hours</t>
                 <t t-else=""> days</t>
                 can be used before the allocation expires.
             </span>

--- a/addons/hr_holidays/static/src/views/calendar/calendar_side_panel/calendar_side_panel.xml
+++ b/addons/hr_holidays/static/src/views/calendar/calendar_side_panel/calendar_side_panel.xml
@@ -16,7 +16,7 @@
                         <li t-foreach="leaveState.holidays" t-as="holiday" t-key="holiday[3]" class="mt-2 list-unstyled">
                             <strong t-esc="holiday[0]"/>
                             : <span class="o_timeoff_green text-success" t-esc="holiday[2] ? holiday[1].virtual_remaining_leaves : holiday[1].virtual_leaves_taken"/>
-                                <t t-if="holiday[2]"> / <span t-esc="holiday[1].max_leaves"/> <t t-if="holiday[1].request_unit == 'hour'">Hours</t><t t-else="">Days</t> <span class="o_timeoff_green text-success">Available</span></t>
+                                <t t-if="holiday[2]"> / <span t-esc="holiday[1].max_leaves"/> <t t-if="holiday[1].unit_of_measure == 'hour'">Hours</t><t t-else="">Days</t> <span class="o_timeoff_green text-success">Available</span></t>
                         </li>
                     </ul>
                 </div>

--- a/addons/hr_holidays/static/tests/dashboard_card_hour_format.test.js
+++ b/addons/hr_holidays/static/tests/dashboard_card_hour_format.test.js
@@ -22,7 +22,7 @@ function getHourProps(floatHour) {
 			leaves_taken: 0,
 			max_allowed_negative: 0,
 			overtime_deductible: true,
-			request_unit: "hour",
+			unit_of_measure: "hour",
 			total_virtual_excess: 0,
 			virtual_excess_data: {},
 			max_leaves: floatHour,

--- a/addons/hr_holidays/tests/common.py
+++ b/addons/hr_holidays/tests/common.py
@@ -35,6 +35,7 @@ class TestHrHolidaysCommon(common.TransactionCase):
             'name': 'Test Leave Type',
             'requires_allocation': False,
             'request_unit': 'day',
+            'unit_of_measure': 'day',
             'company_id': cls.company.id,
         })
 
@@ -141,6 +142,8 @@ class TestHolidayContract(TransactionCase):
             'name': 'Legal Leaves',
             'time_type': 'leave',
             'requires_allocation': False,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
             'responsible_ids': [Command.link(cls.env.ref('base.user_admin').id)],
         })
         cls.env.ref('base.user_admin').notification_type = 'inbox'

--- a/addons/hr_holidays/tests/test_access_rights.py
+++ b/addons/hr_holidays/tests/test_access_rights.py
@@ -24,6 +24,8 @@ class TestHrHolidaysAccessRightsCommon(TestHrHolidaysCommon):
             'name': 'Unlimited',
             'leave_validation_type': 'hr',
             'requires_allocation': False,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
         cls.rd_dept.manager_id = False
         cls.hr_dept.manager_id = False
@@ -44,24 +46,32 @@ class TestHrHolidaysAccessRightsCommon(TestHrHolidaysCommon):
             'name': 'Validation = no_validation',
             'leave_validation_type': 'hr',
             'requires_allocation': False,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
 
         cls.lt_validation_hr = cls.env['hr.leave.type'].create({
             'name': 'Validation = HR',
             'leave_validation_type': 'hr',
             'requires_allocation': False,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
 
         cls.lt_validation_manager = cls.env['hr.leave.type'].create({
             'name': 'Validation = manager',
             'leave_validation_type': 'hr',
             'requires_allocation': False,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
 
         cls.lt_validation_both = cls.env['hr.leave.type'].create({
             'name': 'Validation = both',
             'leave_validation_type': 'hr',
             'requires_allocation': False,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
 
         cls.confirm_status = [
@@ -448,6 +458,8 @@ class TestMultiCompany(TestHrHolidaysCommon):
             'company_id': cls.new_company.id,
             'leave_validation_type': 'hr',
             'requires_allocation': False,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
         cls.employee_emp.company_id = cls.new_company
         cls.rd_dept.manager_id = False

--- a/addons/hr_holidays/tests/test_accrual_allocations.py
+++ b/addons/hr_holidays/tests/test_accrual_allocations.py
@@ -23,6 +23,8 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'time_type': 'leave',
             'requires_allocation': True,
             'allocation_validation_type': 'hr',
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
         cls.leave_type_hour = cls.env['hr.leave.type'].create({
             'name': 'Paid Time Off',
@@ -30,6 +32,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'requires_allocation': True,
             'allocation_validation_type': 'hr',
             'request_unit': 'hour',
+            'unit_of_measure': 'hour',
         })
         accrual_plan1_levels_fields = {
             'added_value_type': 'day',
@@ -75,6 +78,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'requires_allocation': 'yes',
             'allocation_validation_type': 'no_validation',
             'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
 
     def setAllocationCreateDate(self, allocation_id, date):
@@ -224,6 +228,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'responsible_ids': [(4, self.user_hrmanager_id)],
                 'time_type': 'leave',
                 'request_unit': 'half_day',
+                'unit_of_measure': 'day',
             })
             leave = self.env['hr.leave'].create({
                 'name': 'leave',
@@ -600,6 +605,8 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'requires_allocation': False,
                 'responsible_ids': [Command.link(self.user_hrmanager_id)],
                 'time_type': 'leave',
+                'request_unit': 'day',
+                'unit_of_measure': 'day',
             })
             leave = self.env['hr.leave'].create({
                 'name': 'leave',
@@ -669,6 +676,8 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'time_type': 'leave',
             'requires_allocation': False,
             'elligible_for_accrual_rate': False,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
         timeoff = self.env['hr.leave'].create({
             'name': 'Paid Time Off',
@@ -717,6 +726,8 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'time_type': 'leave',
             'requires_allocation': False,
             'elligible_for_accrual_rate': True,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
         timeoff_eligible = self.env['hr.leave'].create({
             'name': 'Paid Time Off',
@@ -764,6 +775,8 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'name': 'Remote Work',
             'time_type': 'other',
             'requires_allocation': False,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
         remote_work = self.env['hr.leave'].create({
             'name': 'Remote Work',
@@ -1645,6 +1658,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'allocation_validation_type': 'no_validation',
             'leave_validation_type': 'no_validation',
             'request_unit': 'hour',
+            'unit_of_measure': 'hour',
         })
         accrual_plan = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({
             'accrued_gain_time': 'end',
@@ -2114,6 +2128,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'requires_allocation': True,
             'allocation_validation_type': 'no_validation',
             'request_unit': 'hour',
+            'unit_of_measure': 'hour',
         })
         with freeze_time("2023-12-31"):
             accrual_plan = self.env['hr.leave.accrual.plan'].create({
@@ -2383,6 +2398,8 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'allocation_validation_type': 'no_validation',
             'leave_validation_type': 'no_validation',
             'allows_negative': False,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
         leave_type_negative = self.env['hr.leave.type'].create({
             'name': 'Test Accrual - Negative',
@@ -2392,6 +2409,8 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'leave_validation_type': 'no_validation',
             'allows_negative': True,
             'max_allowed_negative': 1,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
         accrual_plan = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({
             'name': 'Monthly accrual',
@@ -2507,6 +2526,8 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'time_type': 'leave',
             'requires_allocation': True,
             'allocation_validation_type': 'no_validation',
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
         accrual_plan = self.env['hr.leave.accrual.plan'].create({
             'name': 'Accrual Plan For Test',
@@ -2551,6 +2572,8 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'time_type': 'leave',
             'requires_allocation': True,
             'allocation_validation_type': 'no_validation',
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
         accrual_plan = self.env['hr.leave.accrual.plan'].create({
             'name': 'Accrual Plan For Test',
@@ -4075,6 +4098,8 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'leave_validation_type': 'hr',
             'allocation_validation_type': 'hr',
             'employee_requests': False,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
         accrual_plan = self.env['hr.leave.accrual.plan'].create({
             'name': 'Accrual Plan with no carryover',
@@ -4161,6 +4186,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'requires_allocation': True,
                 'allocation_validation_type': 'no_validation',
                 'request_unit': 'day',
+                'unit_of_measure': 'day',
             })
 
             allocation = self.env['hr.leave.allocation'].create({
@@ -4203,6 +4229,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'requires_allocation': True,
                 'allocation_validation_type': 'no_validation',
                 'request_unit': 'half_day',
+                'unit_of_measure': 'day',
             })
 
             allocation = self.env['hr.leave.allocation'].create({
@@ -4245,6 +4272,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'requires_allocation': True,
                 'allocation_validation_type': 'no_validation',
                 'request_unit': 'day',
+                'unit_of_measure': 'day',
             })
 
             allocation = self.env['hr.leave.allocation'].create({
@@ -4361,6 +4389,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'requires_allocation': 'yes',
             'allocation_validation_type': 'no_validation',
             'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
 
         allocation = self.env['hr.leave.allocation'].create({

--- a/addons/hr_holidays/tests/test_allocation_access_rights.py
+++ b/addons/hr_holidays/tests/test_allocation_access_rights.py
@@ -23,6 +23,8 @@ class TestAllocationRights(TestHrHolidaysCommon):
             'allocation_validation_type': 'hr',
             'requires_allocation': True,
             'employee_requests': True,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
 
         cls.lt_validation_manager = cls.env['hr.leave.type'].create({
@@ -30,6 +32,8 @@ class TestAllocationRights(TestHrHolidaysCommon):
             'allocation_validation_type': 'manager',
             'requires_allocation': True,
             'employee_requests': True,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
 
         cls.lt_allocation_no_validation = cls.env['hr.leave.type'].create({
@@ -37,6 +41,8 @@ class TestAllocationRights(TestHrHolidaysCommon):
             'allocation_validation_type': 'no_validation',
             'requires_allocation': True,
             'employee_requests': True,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
 
     def request_allocation(self, user, values={}):

--- a/addons/hr_holidays/tests/test_allocations.py
+++ b/addons/hr_holidays/tests/test_allocations.py
@@ -21,6 +21,8 @@ class TestAllocations(TestHrHolidaysCommon):
             'time_type': 'leave',
             'requires_allocation': True,
             'allocation_validation_type': 'no_validation',
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
         cls.department = cls.env['hr.department'].create({
             'name': 'Test Department',
@@ -39,6 +41,8 @@ class TestAllocations(TestHrHolidaysCommon):
             'name': 'Paid Time Off',
             'requires_allocation': True,
             'allocation_validation_type': 'no_validation',
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
 
         cls.calendar_35h = cls.env['resource.calendar'].create({
@@ -208,6 +212,7 @@ class TestAllocations(TestHrHolidaysCommon):
 
     def test_allocation_type_hours_with_resource_calendar(self):
         self.leave_type.request_unit = 'hour'
+        self.leave_type.unit_of_measure = 'hour'
         self.employee.resource_calendar_id = self.calendar_35h
 
         hour_type_allocation = self.env['hr.leave.allocation.generate.multi.wizard'].create({
@@ -377,6 +382,7 @@ class TestAllocations(TestHrHolidaysCommon):
             'requires_allocation': True,
             'allocation_validation_type': 'no_validation',
             'request_unit': 'hour',
+            'unit_of_measure': 'hour',
         })
 
         with Form(self.env['hr.leave.allocation'].with_user(self.user_hrmanager)) as allocation_form:
@@ -398,6 +404,7 @@ class TestAllocations(TestHrHolidaysCommon):
             'requires_allocation': True,
             'allocation_validation_type': 'no_validation',
             'request_unit': 'hour',
+            'unit_of_measure': 'hour',
         })
 
         accrual_plan = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({
@@ -549,6 +556,7 @@ class TestAllocations(TestHrHolidaysCommon):
         not raise an error
         """
         self.leave_type.request_unit = "hour"
+        self.leave_type.unit_of_measure = "hour"
         with self.assertRaises(AssertionError):  # AssertionError raised by Form as employee is required
             with Form(self.env['hr.leave.allocation']) as allocation_form:
                 allocation_form.allocation_type = "regular"
@@ -569,6 +577,8 @@ class TestAllocations(TestHrHolidaysCommon):
         holidays_type_1 = leave_type.create({
             'name': 'archived_holidays',
             'allocation_validation_type': 'no_validation',
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
 
         self.env['hr.leave.allocation'].create({

--- a/addons/hr_holidays/tests/test_automatic_leave_dates.py
+++ b/addons/hr_holidays/tests/test_automatic_leave_dates.py
@@ -16,6 +16,7 @@ class TestAutomaticLeaveDates(TestHrHolidaysCommon):
             'time_type': 'leave',
             'requires_allocation': False,
             'request_unit': 'half_day',
+            'unit_of_measure': 'day',
         })
 
     def test_no_attendances(self):

--- a/addons/hr_holidays/tests/test_change_department.py
+++ b/addons/hr_holidays/tests/test_change_department.py
@@ -17,6 +17,8 @@ class TestChangeDepartment(TestHrHolidaysCommon):
         self.holidays_status_1 = HolidayStatusManagerGroup.create({
             'name': 'NotLimitedHR',
             'requires_allocation': False,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
 
         def create_holiday(name, start, end):

--- a/addons/hr_holidays/tests/test_company_leave.py
+++ b/addons/hr_holidays/tests/test_company_leave.py
@@ -25,11 +25,14 @@ class TestCompanyLeave(TransactionCase):
             'responsible_ids': [Command.link(cls.env.ref('base.user_admin').id)],
             'company_id': cls.company.id,
             'requires_allocation': False,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
 
         cls.paid_time_off = cls.env['hr.leave.type'].create({
             'name': 'Paid Time Off',
             'request_unit': 'day',
+            'unit_of_measure': 'day',
             'leave_validation_type': 'both',
             'company_id': cls.company.id,
             'requires_allocation': False,
@@ -87,6 +90,7 @@ class TestCompanyLeave(TransactionCase):
         # Add a company leave on the second day
         # Check that leave is split into 2
         self.paid_time_off.request_unit = 'half_day'
+        self.paid_time_off.unit_of_measure = 'day'
 
         leave = self.env['hr.leave'].create({
             'name': 'Hol11',
@@ -131,6 +135,7 @@ class TestCompanyLeave(TransactionCase):
         # Add a company leave on the same day
         # Check that leave refused
         self.paid_time_off.request_unit = 'half_day'
+        self.paid_time_off.unit_of_measure = 'day'
 
         leave = self.env['hr.leave'].create({
             'name': 'Hol11',
@@ -168,6 +173,7 @@ class TestCompanyLeave(TransactionCase):
         # Add a company leave on the same day
         # Check that leave is refused
         self.paid_time_off.request_unit = 'day'
+        self.paid_time_off.unit_of_measure = 'day'
 
         leave = self.env['hr.leave'].create({
             'name': 'Hol11',

--- a/addons/hr_holidays/tests/test_expiring_leaves.py
+++ b/addons/hr_holidays/tests/test_expiring_leaves.py
@@ -22,6 +22,8 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
             'time_type': 'leave',
             'requires_allocation': True,
             'allocation_validation_type': 'no_validation',
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
         cls.accrual_plan_with_accrual_validity = cls.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).sudo().create({
             'name': 'Test Accrual Plan With Accrual Validity',

--- a/addons/hr_holidays/tests/test_flexible_resource_calendar.py
+++ b/addons/hr_holidays/tests/test_flexible_resource_calendar.py
@@ -57,10 +57,12 @@ class TestFlexibleResourceCalendar(TransactionCase):
             'name': 'Custom Leave',
             'requires_allocation': False,
             'request_unit': 'hour',
+            'unit_of_measure': 'hour',
         }, {
             'name': 'Half day',
             'requires_allocation': False,
             'request_unit': 'half_day',
+            'unit_of_measure': 'day',
         }])
 
         self.env['hr.leave'].with_context(mail_create_nolog=True, mail_notrack=True).create([{

--- a/addons/hr_holidays/tests/test_global_leaves.py
+++ b/addons/hr_holidays/tests/test_global_leaves.py
@@ -148,6 +148,8 @@ class TestGlobalLeaves(TestHrHolidaysCommon):
             'name': 'Paid Time Off',
             'time_type': 'leave',
             'requires_allocation': False,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
         self.employee_emp.resource_calendar_id = self.calendar_1.id
 
@@ -189,6 +191,7 @@ class TestGlobalLeaves(TestHrHolidaysCommon):
         leave_type = self.env['hr.leave.type'].create({
             'name': 'Paid Time Off',
             'request_unit': 'hour',
+            'unit_of_measure': 'hour',
             'leave_validation_type': 'both',
         })
         self.env['hr.leave.allocation'].create({
@@ -256,6 +259,8 @@ class TestGlobalLeaves(TestHrHolidaysCommon):
             'time_type': 'leave',
             'requires_allocation': False,
             'leave_validation_type': 'both',
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
 
         employee_leave = self.env['hr.leave'].create({

--- a/addons/hr_holidays/tests/test_holidays_flow.py
+++ b/addons/hr_holidays/tests/test_holidays_flow.py
@@ -29,16 +29,22 @@ class TestHolidaysFlow(TestHrHolidaysCommon):
         HolidayStatusManagerGroup.create({
             'name': 'WithMeetingType',
             'requires_allocation': False,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
         self.holidays_status_hr = HolidayStatusManagerGroup.create({
             'name': 'NotLimitedHR',
             'requires_allocation': False,
             'leave_validation_type': 'hr',
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
         self.holidays_status_manager = HolidayStatusManagerGroup.create({
             'name': 'NotLimitedManager',
             'requires_allocation': False,
             'leave_validation_type': 'manager',
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
 
         HolidaysEmployeeGroup = Requests.with_user(self.user_employee_id)
@@ -94,6 +100,8 @@ class TestHolidaysFlow(TestHrHolidaysCommon):
                 'allocation_validation_type': 'hr',
                 'leave_validation_type': 'both',
                 'responsible_ids': [Command.link(self.env.ref('base.user_admin').id)],
+                'request_unit': 'day',
+                'unit_of_measure': 'day',
             })
 
             self.env['hr.leave.allocation'].create([
@@ -130,6 +138,8 @@ class TestHolidaysFlow(TestHrHolidaysCommon):
             HolidayStatusManagerGroup.create({
                 'name': 'WithMeetingType',
                 'requires_allocation': False,
+                'request_unit': 'day',
+                'unit_of_measure': 'day',
             })
 
             self.holidays_status_limited = HolidayStatusManagerGroup.create({
@@ -138,7 +148,9 @@ class TestHolidaysFlow(TestHrHolidaysCommon):
                 'employee_requests': False,
                 'allocation_validation_type': 'hr',
                 'leave_validation_type': 'both',
-                'responsible_ids': [Command.link(self.env.ref('base.user_admin').id)]
+                'responsible_ids': [Command.link(self.env.ref('base.user_admin').id)],
+                'request_unit': 'day',
+                'unit_of_measure': 'day',
             })
             HolidaysEmployeeGroup = Requests.with_user(self.user_employee_id)
 
@@ -241,6 +253,8 @@ class TestHolidaysFlow(TestHrHolidaysCommon):
             'allocation_validation_type': 'hr',
             'leave_validation_type': 'both',
             'responsible_ids': [Command.link(self.env.ref('base.user_admin').id)],
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
 
         self.env['hr.leave.allocation'].create({

--- a/addons/hr_holidays/tests/test_holidays_mail.py
+++ b/addons/hr_holidays/tests/test_holidays_mail.py
@@ -31,6 +31,8 @@ class TestHolidaysMail(TestHrHolidaysCommon, MailCase):
                 'allocation_validation_type': 'hr',
                 'leave_validation_type': 'both',
                 'responsible_ids': [Command.link(self.env.ref('base.user_admin').id)],
+                'request_unit': 'day',
+                'unit_of_measure': 'day',
             })
 
             self.env['hr.leave.allocation'].create([

--- a/addons/hr_holidays/tests/test_hr_departure_wizard.py
+++ b/addons/hr_holidays/tests/test_hr_departure_wizard.py
@@ -26,6 +26,8 @@ class TestHolidaysFlow(TestHrHolidaysCommon):
             'name': 'Paid Time Off',
             'time_type': 'leave',
             'requires_allocation': False,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
 
     def test_departure_without_leave_and_allocation_employee(self):

--- a/addons/hr_holidays/tests/test_hr_holidays_cancel_leave.py
+++ b/addons/hr_holidays/tests/test_hr_holidays_cancel_leave.py
@@ -23,6 +23,8 @@ class TestHrHolidaysCancelLeave(TestHrHolidaysCommon):
         cls.hr_leave_type = cls.env['hr.leave.type'].with_user(cls.user_hrmanager).create({
             'name': 'Time Off Type',
             'requires_allocation': False,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
         cls.holiday = cls.env['hr.leave'].with_context(mail_create_nolog=True, mail_notrack=True).with_user(cls.user_employee).create({
             'name': 'Time Off 1',

--- a/addons/hr_holidays/tests/test_hr_holidays_tour.py
+++ b/addons/hr_holidays/tests/test_hr_holidays_tour.py
@@ -34,6 +34,8 @@ class TestHrHolidaysTour(HttpCase):
             'name': 'NotLimitedHR',
             'requires_allocation': False,
             'leave_validation_type': 'hr',
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
         # add allocation
         self.env['hr.leave.allocation'].create({

--- a/addons/hr_holidays/tests/test_hr_leave_type.py
+++ b/addons/hr_holidays/tests/test_hr_leave_type.py
@@ -19,6 +19,8 @@ class TestHrLeaveType(TestHrHolidaysCommon):
             'name': 'Paid Time Off',
             'time_type': 'leave',
             'requires_allocation': False,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
 
         with self.assertRaises(ValidationError):
@@ -28,6 +30,8 @@ class TestHrLeaveType(TestHrHolidaysCommon):
             'name': 'Worked Time',
             'time_type': 'other',
             'requires_allocation': False,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
 
         with self.assertRaises(ValidationError):
@@ -56,7 +60,7 @@ class TestHrLeaveType(TestHrHolidaysCommon):
                 'holiday_status_id': leave_type.id,
                 'request_date_from': '2025-09-03',
                 'request_date_to': '2025-09-03',
-            })
+        })
 
         worked_leave_type.allow_request_on_top = True
         leave_1 = self.env['hr.leave'].create({
@@ -82,6 +86,8 @@ class TestHrLeaveType(TestHrHolidaysCommon):
             self.env['hr.leave.type'].with_user(self.user_hruser_id).create({
                 'name': 'UserCheats',
                 'requires_allocation': False,
+                'request_unit': 'day',
+                'unit_of_measure': 'day',
             })
 
     def test_users_tz_shift_back(self):
@@ -96,7 +102,11 @@ class TestHrLeaveType(TestHrHolidaysCommon):
           Valid allocation period              day
         """
         employee = self.env['hr.employee'].create({'name': 'Test Employee'})
-        leave_type = self.env['hr.leave.type'].create({'name': 'Test Leave'})
+        leave_type = self.env['hr.leave.type'].create({
+            'name': 'Test Leave',
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
+            })
 
         self.env['hr.leave.allocation'].sudo().create({
             'state': 'confirm',

--- a/addons/hr_holidays/tests/test_hr_leave_type_tour.py
+++ b/addons/hr_holidays/tests/test_hr_leave_type_tour.py
@@ -58,17 +58,23 @@ class TestHrLeaveTypeTour(HttpCase):
             'name': 'leave_type_1',
             'requires_allocation': False,
             'leave_validation_type': 'hr',
-            'country_id': company_1.country_id.id
+            'country_id': company_1.country_id.id,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
         leave_type.create({
             'name': 'leave_type_2',
             'requires_allocation': False,
             'leave_validation_type': 'hr',
-            'company_id': company_2.id
+            'company_id': company_2.id,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
         leave_type.create({
             'name': 'leave_type_3',
             'requires_allocation': False,
-            'leave_validation_type': 'hr'
+            'leave_validation_type': 'hr',
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
         self.start_tour('/web', 'hr_leave_type_tour', login="admin")

--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -43,17 +43,23 @@ class TestLeaveRequests(TestHrHolidaysCommon):
             'name': 'NotLimitedHR',
             'requires_allocation': False,
             'leave_validation_type': 'hr',
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
         cls.holidays_type_2 = LeaveType.create({
             'name': 'Limited',
             'requires_allocation': True,
             'employee_requests': True,
             'leave_validation_type': 'hr',
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
         cls.holidays_type_3 = LeaveType.create({
             'name': 'TimeNotLimited',
             'requires_allocation': False,
             'leave_validation_type': 'manager',
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
 
         cls.holidays_type_4 = LeaveType.create({
@@ -61,24 +67,30 @@ class TestLeaveRequests(TestHrHolidaysCommon):
             'requires_allocation': True,
             'employee_requests': True,
             'leave_validation_type': 'both',
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
         cls.holidays_support_document = LeaveType.create({
             'name': 'Time off with support document',
             'support_document': True,
             'requires_allocation': False,
             'leave_validation_type': 'no_validation',
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
         cls.holidays_type_half = LeaveType.create({
             'name': 'Time off in half-days',
             'requires_allocation': False,
             'leave_validation_type': 'no_validation',
             'request_unit': 'half_day',
+            'unit_of_measure': 'day',
         })
         cls.holidays_type_hours = LeaveType.create({
             'name': 'Time off in hours',
             'requires_allocation': False,
             'leave_validation_type': 'no_validation',
             'request_unit': 'hour',
+            'unit_of_measure': 'hour',
         })
         cls.holidays_type_half_with_alloc = LeaveType.create({
             'name': 'Limited time off in half-days',
@@ -490,6 +502,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
         leave_type = self.env['hr.leave.type'].create({
             'name': 'Paid Time Off',
             'request_unit': 'hour',
+            'unit_of_measure': 'hour',
             'leave_validation_type': 'both',
         })
         self.env['hr.leave.allocation'].create({
@@ -554,6 +567,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
         leave_type = self.env['hr.leave.type'].create({
             'name': 'Paid Time Off',
             'request_unit': 'hour',
+            'unit_of_measure': 'hour',
             'leave_validation_type': 'both',
         })
         self.env['hr.leave.allocation'].create({
@@ -603,6 +617,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
         self.assertEqual(leave2.number_of_hours, 8)
 
         leave_type.request_unit = 'half_day'
+        leave_type.unit_of_measure = 'day'
         leave3 = self.env['hr.leave'].create({
             'name': 'Holiday 1/2 Day',
             'employee_id': employee.id,
@@ -616,6 +631,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
         self.assertEqual(leave3.number_of_hours, 4)
 
         leave_type.request_unit = 'hour'
+        leave_type.unit_of_measure = 'hour'
         leave4 = self.env['hr.leave'].create({
             'name': 'Holiday 3 Hours',
             'employee_id': employee.id,
@@ -678,6 +694,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
         leave_type = self.env['hr.leave.type'].create({
             'name': 'Sick',
             'request_unit': 'hour',
+            'unit_of_measure': 'hour',
             'leave_validation_type': 'both',
             'requires_allocation': False,
         })
@@ -879,6 +896,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
 
         for unit in ['hour', 'day']:
             self.holidays_type_2.request_unit = unit
+            self.holidays_type_2.unit_of_measure = unit
 
             allocation_vals.update({'number_of_days': 4})
             allocation_4days = Allocation.create(allocation_vals)
@@ -1203,6 +1221,8 @@ class TestLeaveRequests(TestHrHolidaysCommon):
             'requires_allocation': True,
             'employee_requests': True,
             'leave_validation_type': 'hr',
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
 
         # Create allocations with no end date
@@ -1250,6 +1270,8 @@ class TestLeaveRequests(TestHrHolidaysCommon):
                 'leave_validation_type': leave_validation_type,
                 'requires_allocation': False,
                 'responsible_ids': [Command.link(self.env.ref('base.user_admin').id)],
+                'request_unit': 'day',
+                'unit_of_measure': 'day',
             })
             current_leave = self.env['hr.leave'].with_user(self.user_employee_id).create({
                 'name': 'Holiday Request',
@@ -1292,6 +1314,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
         sick_leave_type = self.env['hr.leave.type'].create({
             'name': 'Sick Leave (days)',
             'request_unit': 'day',
+            'unit_of_measure': 'day',
             'leave_validation_type': 'hr',
             'requires_allocation': False,
         })
@@ -1305,6 +1328,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
         comp_leave_type = self.env['hr.leave.type'].create({
             'name': 'OT Compensation (hours)',
             'request_unit': 'hour',
+            'unit_of_measure': 'hour',
             'leave_validation_type': 'manager',
             'requires_allocation': False,
         })
@@ -1343,6 +1367,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
         sick_leave_type = self.env['hr.leave.type'].create({
             'name': 'Sick Leave (days)',
             'request_unit': 'day',
+            'unit_of_measure': 'day',
             'leave_validation_type': 'hr',
             'requires_allocation': False,
         })
@@ -1693,6 +1718,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
             'name': 'Test half day Leave Type',
             'requires_allocation': False,
             'request_unit': 'half_day',
+            'unit_of_measure': 'day',
             'company_id': self.company.id,
             'sequence': 10,
         })
@@ -1700,6 +1726,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
             'name': 'Test hour Leave Type',
             'requires_allocation': False,
             'request_unit': 'hour',
+            'unit_of_measure': 'hour',
             'company_id': self.company.id,
         })
 
@@ -1807,6 +1834,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
         sick_leave_type = self.env['hr.leave.type'].create({
             'name': 'leave in days',
             'request_unit': 'day',
+            'unit_of_measure': 'day',
             'leave_validation_type': 'both',
             'requires_allocation': False,
         })
@@ -2029,6 +2057,8 @@ class TestLeaveRequests(TestHrHolidaysCommon):
             'name': 'Smart Leave',
             'requires_allocation': True,
             'leave_validation_type': 'hr',
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
         with self.assertRaises(ValidationError):
             self.env['hr.leave'].create({
@@ -2382,6 +2412,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
         sick_leave_type = self.env['hr.leave.type'].create({
             'name': 'Sick Leave (days)',
             'request_unit': 'day',
+            'unit_of_measure': 'day',
             'leave_validation_type': 'hr',
             'requires_allocation': False,
         })
@@ -2389,6 +2420,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
         sick_leave_type_paid = self.env['hr.leave.type'].create({
             'name': 'Paid Leave (days)',
             'request_unit': 'day',
+            'unit_of_measure': 'day',
             'leave_validation_type': 'hr',
             'requires_allocation': False,
         })

--- a/addons/hr_holidays/tests/test_mandatory_days.py
+++ b/addons/hr_holidays/tests/test_mandatory_days.py
@@ -54,6 +54,8 @@ class TestHrLeaveMandatoryDays(TransactionCase):
             'leave_validation_type': 'hr',
             'requires_allocation': False,
             'company_id': cls.company.id,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
 
         cls.mandatory_day = cls.env['hr.leave.mandatory.day'].create({

--- a/addons/hr_holidays/tests/test_multi_contract.py
+++ b/addons/hr_holidays/tests/test_multi_contract.py
@@ -205,6 +205,7 @@ class TestHolidaysMultiContract(TestHolidayContract):
             'requires_allocation': True,
             'leave_validation_type': 'hr',
             'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
         allocation = self.env['hr.leave.allocation'].create({
             'name': 'Allocation',
@@ -299,6 +300,7 @@ class TestHolidaysMultiContract(TestHolidayContract):
             'requires_allocation': False,
             'leave_validation_type': 'hr',
             'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
 
         leave1 = self.env['hr.leave'].create({
@@ -384,6 +386,7 @@ class TestHolidaysMultiContract(TestHolidayContract):
             'time_type': 'leave',
             'requires_allocation': False,
             'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
 
         with Form(self.env['hr.leave'].with_context(default_employee_id=employee.id)) as leave_form:

--- a/addons/hr_holidays/tests/test_multicompany.py
+++ b/addons/hr_holidays/tests/test_multicompany.py
@@ -26,6 +26,7 @@ class TestHrHolidaysAccessRightsCommon(TestHrHolidaysCommon):
             'name': 'Test Leave Type',
             'requires_allocation': False,
             'request_unit': 'day',
+            'unit_of_measure': 'day',
             'company_id': False,
         })
         leave = self.env['hr.leave'].create({

--- a/addons/hr_holidays/tests/test_negative.py
+++ b/addons/hr_holidays/tests/test_negative.py
@@ -23,6 +23,8 @@ class TestNegative(TestHrHolidaysCommon):
             'company_id': cls.company.id,
             'allows_negative': True,
             'max_allowed_negative': 5,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
 
         cls.allocation_2022 = cls.env['hr.leave.allocation'].create({

--- a/addons/hr_holidays/tests/test_out_of_office.py
+++ b/addons/hr_holidays/tests/test_out_of_office.py
@@ -22,6 +22,8 @@ class TestOutOfOffice(TestHrHolidaysCommon):
             'name': 'Legal Leaves',
             'time_type': 'leave',
             'requires_allocation': False,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
 
     @freeze_time('2024-06-06')
@@ -93,6 +95,8 @@ class TestOutOfOfficePerformance(TestHrHolidaysCommon, TransactionCaseWithUserDe
             'name': 'Legal Leaves',
             'time_type': 'leave',
             'requires_allocation': False,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
         cls.leave_date_end = (datetime.today() + relativedelta(days=2))
         cls.leave = cls.env['hr.leave'].create({

--- a/addons/hr_holidays/tests/test_past_accruals.py
+++ b/addons/hr_holidays/tests/test_past_accruals.py
@@ -17,6 +17,8 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'time_type': 'leave',
             'requires_allocation': True,
             'allocation_validation_type': 'no',
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
         cls.accrual_plan = cls.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({
             'name': 'Test Seniority Plan',

--- a/addons/hr_holidays/tests/test_res_partner.py
+++ b/addons/hr_holidays/tests/test_res_partner.py
@@ -38,7 +38,9 @@ class TestPartner(TransactionCase):
             'requires_allocation': False,
             'name': 'Legal Leaves',
             'time_type': 'leave',
-            'responsible_ids': cls.users.ids
+            'responsible_ids': cls.users.ids,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
         cls.leaves = cls.env['hr.leave'].create([{
             'request_date_from': "2024-06-03",

--- a/addons/hr_holidays/tests/test_time_off_card_tour.py
+++ b/addons/hr_holidays/tests/test_time_off_card_tour.py
@@ -11,6 +11,8 @@ class TestTimeOffCardTour(HttpCase):
             'time_type': 'leave',
             'requires_allocation': True,
             'allocation_validation_type': 'no_validation',
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
         admin_employee = get_admin_employee(self.env)
         self.env['hr.leave.allocation'].create({

--- a/addons/hr_holidays/tests/test_timeoff_event.py
+++ b/addons/hr_holidays/tests/test_timeoff_event.py
@@ -17,6 +17,8 @@ class TestTimeoffEvent(TestHrHolidaysCommon):
         self.hr_leave_type = self.env['hr.leave.type'].with_user(self.user_hrmanager).create({
             'name': 'Time Off Type',
             'requires_allocation': False,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
         self.holiday = self.env['hr.leave'].with_context(mail_create_nolog=True, mail_notrack=True).with_user(self.user_employee).create({
             'name': 'Time Off 1 sura',

--- a/addons/hr_holidays/tests/test_working_hours.py
+++ b/addons/hr_holidays/tests/test_working_hours.py
@@ -24,6 +24,8 @@ class TestWorkingHours(TestHrCalendarCommon):
             'name': 'Unpaid Time Off',
             'requires_allocation': False,
             'leave_validation_type': 'no_validation',
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
 
     def test_multi_companies_2_employees_2_selected_companies_holidays(self):

--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -158,7 +158,7 @@
                                     invisible="not id or date_to or state != 'confirm'">No limit</div>
                             </div>
                             <div colspan="2" class="oe_row alert alert-warning my-2" role="alert"
-                                 invisible="id or not date_to or not (date_to &lt; context_today().strftime('%Y-%m-%d')) or (date_from and (date_to &lt; date_from))">
+                                 invisible="id or not date_to or date_to &gt;= context_today().strftime('%Y-%m-%d')">
                                 <span>The allocated days cannot be used, because the allocation is set to finish in the past.</span>
                             </div>
                             <field name="number_of_days" invisible="1"/>

--- a/addons/hr_holidays/views/hr_leave_type_views.xml
+++ b/addons/hr_holidays/views/hr_leave_type_views.xml
@@ -52,6 +52,7 @@
                     </div>
                     <group>
                         <group>
+                                <field name="unit_of_measure" widget="radio" options="{'horizontal': True}"/>
                                 <field name="request_unit" widget="radio" options="{'horizontal': True}"/>
                                 <field name="time_type" required="1" string="Count as"/>
                                 <field name="responsible_ids"
@@ -105,8 +106,8 @@
                                     <div invisible="not allows_negative">
                                         <span class="mx-2">up to</span>
                                         <field name="max_allowed_negative" class="oe_inline"/>
-                                        <span class="mx-2" invisible="request_unit == 'hour'">days</span>
-                                        <span class="mx-2" invisible="request_unit != 'hour'">hours</span>
+                                        <span class="mx-2" invisible="unit_of_measure == 'hour'">days</span>
+                                        <span class="mx-2" invisible="unit_of_measure != 'hour'">hours</span>
                                     </div>
                                 </div>
                             </group>
@@ -146,6 +147,7 @@
             <list string="Time Off Type" multi_edit="1">
                 <field name="sequence" widget="handle"/>
                 <field name="display_name"/>
+                <field name="unit_of_measure" optional="hide"/>
                 <field name="request_unit" optional="hide"/>
                 <field name="leave_validation_type" optional="hide" string="Time Off Approval"/>
                 <field name="responsible_ids" widget="many2many_tags" invisible="leave_validation_type in ['no_validation', 'manager'] and (not requires_allocation or allocation_validation_type != 'hr')" optional="hide"/>

--- a/addons/hr_holidays/views/hr_leave_type_views.xml
+++ b/addons/hr_holidays/views/hr_leave_type_views.xml
@@ -44,17 +44,6 @@
                                 <span class="o_stat_text">Time Off</span>
                             </div>
                         </button>
-                        <button class="oe_stat_button"
-                                type="object"
-                                name="action_see_accrual_plans"
-                                icon="fa-calendar"
-                                invisible="not id or accrual_count == 0"
-                                help="Count of plans linked to this time off type.">
-                            <div class="o_stat_info">
-                                <field name="accrual_count" class="o_stat_value"/>
-                                <span class="o_stat_text">Accruals</span>
-                            </div>
-                        </button>
                     </div>
                     <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
                     <label for="name">Time off type</label>

--- a/addons/hr_holidays/wizard/hr_leave_allocation_generate_multi_wizard.py
+++ b/addons/hr_holidays/wizard/hr_leave_allocation_generate_multi_wizard.py
@@ -33,7 +33,7 @@ class HrLeaveAllocationGenerateMultiWizard(models.TransientModel):
     holiday_status_id = fields.Many2one(
         "hr.leave.type", string="Time Off Type", required=True,
         domain=_domain_holiday_status_id)
-    request_unit = fields.Selection(related="holiday_status_id.request_unit")
+    unit_of_measure = fields.Selection(related="holiday_status_id.unit_of_measure")
     allocation_mode = fields.Selection([
         ('employee', 'By Employee'),
         ('company', 'By Company'),
@@ -67,10 +67,10 @@ class HrLeaveAllocationGenerateMultiWizard(models.TransientModel):
         if not self.holiday_status_id:
             return self.env._("Allocation Request")
         return self.env._(
-            '%(name)s (%(duration)s %(request_unit)s(s))',
+            '%(name)s (%(duration)s %(unit_of_measure)s(s))',
             name=self.holiday_status_id.name,
             duration=float_round(self.duration, precision_digits=2),
-            request_unit=self.request_unit
+            unit_of_measure=self.unit_of_measure
         )
 
     def _get_employees_from_allocation_mode(self):
@@ -94,7 +94,7 @@ class HrLeaveAllocationGenerateMultiWizard(models.TransientModel):
         return [{
             'name': self.name,
             'holiday_status_id': self.holiday_status_id.id,
-            'number_of_days': self.duration if self.request_unit != "hour" else self.duration / hours_per_day[employee.id],
+            'number_of_days': self.duration if self.unit_of_measure != "hour" else self.duration / hours_per_day[employee.id],
             'employee_id': employee.id,
             'state': 'confirm',
             'allocation_type': self.allocation_type,

--- a/addons/hr_holidays/wizard/hr_leave_allocation_generate_multi_wizard.py
+++ b/addons/hr_holidays/wizard/hr_leave_allocation_generate_multi_wizard.py
@@ -52,8 +52,7 @@ class HrLeaveAllocationGenerateMultiWizard(models.TransientModel):
         ('regular', 'Regular Allocation'),
         ('accrual', 'Based on Accrual Plan')
     ], string="Allocation Type", default="regular", required=True)
-    accrual_plan_id = fields.Many2one('hr.leave.accrual.plan',
-        domain="['|', ('time_off_type_id', '=', False), ('time_off_type_id', '=', holiday_status_id)]")
+    accrual_plan_id = fields.Many2one('hr.leave.accrual.plan')
     date_from = fields.Date('Start Date', default=fields.Date.context_today, required=True)
     date_to = fields.Date('End Date')
     notes = fields.Text('Reasons')

--- a/addons/hr_holidays/wizard/hr_leave_allocation_generate_multi_wizard_views.xml
+++ b/addons/hr_holidays/wizard/hr_leave_allocation_generate_multi_wizard_views.xml
@@ -12,7 +12,7 @@
                         <field name="category_id" invisible="allocation_mode != 'category'" required="allocation_mode == 'category'"/>
                         <field name="holiday_status_id"/>
                         <field name="allocation_type" widget="radio"/>
-                        <field name="request_unit" invisible="1"/>
+                        <field name="unit_of_measure" invisible="1"/>
                         <field name="accrual_plan_id"
                             invisible="allocation_type == 'regular'"
                             required="allocation_type == 'accrual'"/>
@@ -33,8 +33,8 @@
                         </div>
                         <div name="duration_display">
                             <field name="duration" nolabel="1" style="width: 5rem;"/>
-                            <span class="ml8" invisible="request_unit == 'hour'">Days</span>
-                            <span class="ml8" invisible="request_unit != 'hour'">Hours</span>
+                            <span class="ml8" invisible="unit_of_measure == 'hour'">Days</span>
+                            <span class="ml8" invisible="unit_of_measure != 'hour'">Hours</span>
                         </div>
                 </group>
                 <field name="notes" placeholder="Add a reason..." nolabel="1"/>

--- a/addons/hr_holidays_attendance/static/src/xml/time_off_calendar.xml
+++ b/addons/hr_holidays_attendance/static/src/xml/time_off_calendar.xml
@@ -9,7 +9,7 @@
             <t t-set="show_popover" t-value="!props.data['overtime_deductible']"/>
         </xpath>
         <xpath expr="//t[@name='duration_unit']" position="attributes">
-            <attribute name="t-if">props.data.request_unit == 'hour' || props.data['overtime_deductible']</attribute>
+            <attribute name="t-if">props.data.unit_of_measure == 'hour' || props.data['overtime_deductible']</attribute>
         </xpath>
         <xpath expr="//t[@name='duration_type']" position="attributes">
             <attribute name="t-if">props.requires_allocation || props.data['overtime_deductible']</attribute>
@@ -22,7 +22,7 @@
         </xpath>
         <xpath expr="//t[@name='duration_type']" position="before">
             <t t-if="props.data['overtime_deductible'] == true &amp;&amp; !props.requires_allocation">
-                <strong t-esc="duration" class="o_timeoff_green"/> <t t-if="props.data['request_unit'] == 'hour'">Hours</t><t t-else="">Days</t> <span class="o_timeoff_green">Available</span>
+                <strong t-esc="duration" class="o_timeoff_green"/> <t t-if="props.data['unit_of_measure'] == 'hour'">Hours</t><t t-else="">Days</t> <span class="o_timeoff_green">Available</span>
             </t>
         </xpath>
         <xpath expr="//t[@name='duration_type']" position="attributes">

--- a/addons/hr_holidays_attendance/tests/test_accrual_allocations.py
+++ b/addons/hr_holidays_attendance/tests/test_accrual_allocations.py
@@ -20,6 +20,8 @@ class TestAccrualAllocationsAttendance(TestHrHolidaysCommon):
             'time_type': 'leave',
             'requires_allocation': True,
             'allocation_validation_type': 'hr',
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
 
     def test_frequency_hourly_attendance(self):

--- a/addons/hr_holidays_attendance/tests/test_holidays_overtime.py
+++ b/addons/hr_holidays_attendance/tests/test_holidays_overtime.py
@@ -40,6 +40,8 @@ class TestHolidaysOvertime(TransactionCase):
             'company_id': cls.company.id,
             'requires_allocation': False,
             'overtime_deductible': True,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
         cls.leave_type_employee_allocation = cls.env['hr.leave.type'].create({
             'name': 'Overtime Compensation Employee Allocation',
@@ -48,6 +50,8 @@ class TestHolidaysOvertime(TransactionCase):
             'employee_requests': True,
             'allocation_validation_type': 'hr',
             'overtime_deductible': True,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
 
         cls.ruleset = cls.env['hr.attendance.overtime.ruleset'].create({
@@ -170,6 +174,8 @@ class TestHolidaysOvertime(TransactionCase):
                 'employee_requests': True,
                 'allocation_validation_type': 'hr',
                 'overtime_deductible': False,
+                'request_unit': 'day',
+                'unit_of_measure': 'day',
             })
 
             # User can request another allocation even without overtime

--- a/addons/hr_work_entry_holidays/tests/test_leave.py
+++ b/addons/hr_work_entry_holidays/tests/test_leave.py
@@ -137,12 +137,14 @@ class TestWorkEntryLeave(TestWorkEntryHolidaysBase):
             'name': 'Paid leave type',
             'requires_allocation': False,
             'request_unit': 'hour',
+            'unit_of_measure': 'hour',
             'work_entry_type_id': entry_type_paid.id,
         },
         {
             'name': 'Unpaid leave type',
             'requires_allocation': False,
             'request_unit': 'hour',
+            'unit_of_measure': 'hour',
             'work_entry_type_id': entry_type_unpaid.id,
         }])
 
@@ -183,6 +185,7 @@ class TestWorkEntryLeave(TestWorkEntryHolidaysBase):
             'name': 'Paid leave type',
             'requires_allocation': False,
             'request_unit': 'hour',
+            'unit_of_measure': 'hour',
             'work_entry_type_id': entry_type_paid.id,
         })
 

--- a/addons/hr_work_entry_holidays/tests/test_performance.py
+++ b/addons/hr_work_entry_holidays/tests/test_performance.py
@@ -66,6 +66,7 @@ class TestWorkEntryHolidaysPerformancesBigData(TestWorkEntryHolidaysBase):
         cls.paid_time_off = cls.env['hr.leave.type'].create({
             'name': 'Paid Time Off',
             'request_unit': 'day',
+            'unit_of_measure': 'day',
             'leave_validation_type': 'both',
             'company_id': cls.company.id,
             'requires_allocation': False,

--- a/addons/hr_work_entry_holidays/tests/test_work_entry.py
+++ b/addons/hr_work_entry_holidays/tests/test_work_entry.py
@@ -44,6 +44,8 @@ class TestWorkeEntryHolidaysWorkEntry(TestWorkEntryHolidaysBase):
             'requires_allocation': False,
             'allow_request_on_top': True,
             'work_entry_type_id': cls.work_entry_type_remote.id,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
 
         cls.half_day_leave_type = cls.env['hr.leave.type'].create({
@@ -76,6 +78,7 @@ class TestWorkeEntryHolidaysWorkEntry(TestWorkEntryHolidaysBase):
     def test_time_week_leave_work_entry(self):
         # /!\ this is a week day => it exists an calendar attendance at this time
         self.leave_type.request_unit = 'hour'
+        self.leave_type.unit_of_measure = 'hour'
         leave = self.env['hr.leave'].create({
             'name': '1leave',
             'employee_id': self.richard_emp.id,
@@ -113,6 +116,7 @@ class TestWorkeEntryHolidaysWorkEntry(TestWorkEntryHolidaysBase):
         leave_type = self.env['hr.leave.type'].create({
             'name': 'Sick',
             'request_unit': 'hour',
+            'unit_of_measure': 'hour',
             'leave_validation_type': 'both',
             'requires_allocation': False,
         })
@@ -182,6 +186,7 @@ class TestWorkeEntryHolidaysWorkEntry(TestWorkEntryHolidaysBase):
         remote.action_approve()
 
         self.leave_type.request_unit = 'hour'
+        self.leave_type.unit_of_measure = 'hour'
         leave = self.env['hr.leave'].create({
             'name': '1leave',
             'employee_id': self.richard_emp.id,

--- a/addons/l10n_fr_hr_holidays/data/l10n_fr_hr_holidays_demo.xml
+++ b/addons/l10n_fr_hr_holidays/data/l10n_fr_hr_holidays_demo.xml
@@ -48,6 +48,8 @@
         <field name="company_id" ref="base.demo_company_fr"/>
         <field name="country_id" ref="base.fr"/>
         <field name="requires_allocation">True</field>
+        <field name="request_unit">day</field>
+        <field name="unit_of_measure">day</field>
         <field name="employee_requests">False</field>
         <field name="leave_validation_type">both</field>
         <field name="allocation_validation_type">hr</field>

--- a/addons/l10n_fr_hr_holidays/tests/test_french_leaves.py
+++ b/addons/l10n_fr_hr_holidays/tests/test_french_leaves.py
@@ -32,6 +32,7 @@ class TestFrenchLeaves(TransactionCase):
             'name': 'Time Off',
             'requires_allocation': False,
             'request_unit': 'half_day',
+            'unit_of_measure': 'day',
         })
         cls.company.write({
             'l10n_fr_reference_leave_type': cls.time_off_type.id,
@@ -361,6 +362,7 @@ class TestFrenchLeaves(TransactionCase):
         self.assertNotEqual(leave.number_of_hours, 8.0, 'Company and employee hours per day should not match in this case')
 
         self.time_off_type.request_unit = "day"
+        self.time_off_type.unit_of_measure = "day"
         leave = self.env['hr.leave'].create({
             'name': 'Test',
             'holiday_status_id': self.time_off_type.id,

--- a/addons/l10n_fr_hr_work_entry_holidays/tests/test_french_work_entries.py
+++ b/addons/l10n_fr_hr_work_entry_holidays/tests/test_french_work_entries.py
@@ -37,6 +37,8 @@ class TestFrenchWorkEntries(TransactionCase):
         cls.time_off_type = cls.env['hr.leave.type'].create({
             'name': 'Time Off',
             'requires_allocation': False,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
         cls.company.write({
             'l10n_fr_reference_leave_type': cls.time_off_type.id,

--- a/addons/l10n_in_hr_holidays/tests/test_optional_holiday.py
+++ b/addons/l10n_in_hr_holidays/tests/test_optional_holiday.py
@@ -20,12 +20,13 @@ class TestOptionalHoliday(TestHrHolidaysCommon):
             'requires_allocation': False,
             'time_type': 'leave',
             'request_unit': 'hour',
-            'l10n_in_is_limited_to_optional_days': True
+            'unit_of_measure': 'hour',
+            'l10n_in_is_limited_to_optional_days': True,
         })
 
         cls.optional_holiday = cls.env['l10n.in.hr.leave.optional.holiday'].create({
             'name': 'optional holiday',
-            'date': '2025-01-02'
+            'date': '2025-01-02',
         })
 
     def test_optional_holiday_valid_leave_request(self):

--- a/addons/l10n_in_hr_holidays/tests/test_sandwich_leave.py
+++ b/addons/l10n_in_hr_holidays/tests/test_sandwich_leave.py
@@ -49,18 +49,21 @@ class TestSandwichLeave(TransactionCase):
         self.leave_type_day, self.leave_type_half_day, self.leave_type_hours = self.env['hr.leave.type'].create([{
             'name': 'Test Leave Type',
             'request_unit': 'day',
+            'unit_of_measure': 'day',
             'requires_allocation': False,
             'l10n_in_is_sandwich_leave': True,
             'company_id': self.indian_company.id,
         }, {
             'name': 'Test Leave Type 2',
             'request_unit': 'half_day',
+            'unit_of_measure': 'day',
             'requires_allocation': False,
             'l10n_in_is_sandwich_leave': True,
             'company_id': self.indian_company.id,
         }, {
             'name': 'Test Leave Type 3',
             'request_unit': 'hour',
+            'unit_of_measure': 'hour',
             'requires_allocation': False,
             'l10n_in_is_sandwich_leave': True,
             'company_id': self.indian_company.id,
@@ -361,6 +364,7 @@ class TestSandwichLeave(TransactionCase):
         other_leave_type = self.env['hr.leave.type'].create({
             'name': 'Test Leave Type',
             'request_unit': 'day',
+            'unit_of_measure': 'day',
             'requires_allocation': False,
         })
         before_holiday_leave = self.env['hr.leave'].create({

--- a/addons/microsoft_calendar/tests/test_create_events.py
+++ b/addons/microsoft_calendar/tests/test_create_events.py
@@ -585,6 +585,8 @@ class TestCreateEvents(TestCommon):
         self.hr_leave_type = self.env['hr.leave.type'].with_user(self.user_hrmanager).create({
             'name': 'Time Off Type',
             'requires_allocation': False,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
         self.holiday = self.env['hr.leave'].with_context(mail_create_nolog=True, mail_notrack=True).with_user(self.user_employee).create({
             'name': 'Time Off Employee',

--- a/addons/project_timesheet_holidays/tests/test_cancel_time_off.py
+++ b/addons/project_timesheet_holidays/tests/test_cancel_time_off.py
@@ -38,6 +38,8 @@ class TestCancelTimeOff(TransactionCase):
             'requires_allocation': False,
             'leave_validation_type': 'both',
             'company_id': cls.company.id,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
 
     @freeze_time('2020-01-01')

--- a/addons/project_timesheet_holidays/tests/test_timesheet_global_time_off.py
+++ b/addons/project_timesheet_holidays/tests/test_timesheet_global_time_off.py
@@ -436,6 +436,8 @@ class TestTimesheetGlobalTimeOff(common.TransactionCase):
         hr_leave_type_with_ts = self.env['hr.leave.type'].create({
             'name': 'Leave Type with timesheet generation',
             'requires_allocation': False,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
 
         # create and validate a leave for full time employee

--- a/addons/project_timesheet_holidays/tests/test_timesheet_holidays.py
+++ b/addons/project_timesheet_holidays/tests/test_timesheet_holidays.py
@@ -49,12 +49,16 @@ class TestTimesheetHolidays(TestCommonTimesheet):
         self.hr_leave_type_with_ts = self.env['hr.leave.type'].sudo().create({
             'name': 'Time Off Type with timesheet generation (absence)',
             'requires_allocation': False,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
 
         self.hr_leave_type_worked = self.env['hr.leave.type'].sudo().create({
             'name': 'Time Off Type (worked time)',
             'requires_allocation': False,
             'time_type': 'other',
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
 
         # HR Officer allocates some leaves to the employee 1
@@ -310,6 +314,8 @@ class TestTimesheetHolidays(TestCommonTimesheet):
             'name': 'Legal Leaves',
             'time_type': 'leave',
             'requires_allocation': False,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
 
         self.env['hr.leave'].sudo().create([

--- a/addons/test_discuss_full/tests/test_avatar_card_tour.py
+++ b/addons/test_discuss_full/tests/test_avatar_card_tour.py
@@ -71,6 +71,8 @@ class TestAvatarCardTour(MailCommon, HttpCase):
                     "company_id": cls.company_2.id,
                     "time_type": "leave",
                     "requires_allocation": False,
+                    'request_unit': 'day',
+                    'unit_of_measure': 'day',
                 }
             )
         )

--- a/addons/test_discuss_full/tests/test_livechat_hr_holidays.py
+++ b/addons/test_discuss_full/tests/test_livechat_hr_holidays.py
@@ -15,7 +15,13 @@ class TestLivechatHrHolidays(HttpCase, MailCommon):
         super().setUpClass()
         cls.env["mail.presence"]._update_presence(cls.user_employee)
         leave_type = cls.env["hr.leave.type"].create(
-            {"name": "Legal Leaves", "requires_allocation": False, "time_type": "leave"}
+            {
+                "name": "Legal Leaves",
+                "requires_allocation": False,
+                "time_type": "leave",
+                'request_unit': 'day',
+                'unit_of_measure': 'day',
+            }
         )
         employee = cls.env["hr.employee"].create({"user_id": cls.user_employee.id})
         cls.env["hr.leave"].with_context(leave_skip_state_check=True).create(

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -193,6 +193,8 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             'requires_allocation': False,
             'name': 'Legal Leaves',
             'time_type': 'leave',
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
         })
         self.leaves = self.env['hr.leave'].create([{
             'request_date_from': fields.Datetime.today() + relativedelta(days=-2),


### PR DESCRIPTION
Previously, the time off given to the employee (Accrued/Allocated) had the same granularity of that which the employee requests, for example the employee accrues hours in his plan and consequently can use this time off type in hours, or can only accrue days to time off types in days and half-days. 
This task separates the dependency between both so that accrual plans in hours can be taken only in days if needed
task: 4596117

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
