### PR TITLE
[FIX] sale: make product configurator more responsive

### DIFF
--- a/addons/sale/static/src/js/product/product.xml
+++ b/addons/sale/static/src/js/product/product.xml
@@ -8,8 +8,8 @@
                 alt="Product Image"
             />
         </td>
-        <td class="p-3" t-att-colspan="this.props.optional ? 2:false">
-            <div class="mb-4 text-break" name="o_sale_product_configurator_name">
+        <td class="p-0 p-lg-3" t-att-colspan="this.props.optional ? 2:false">
+            <div class="mb-2 mb-lg-4 text-break" name="o_sale_product_configurator_name">
                 <span class="h5" t-out="this.props.display_name"/>
                 <div
                     t-if="this.props.description_sale"

--- a/addons/sale/static/src/js/product_template_attribute_line/product_template_attribute_line.xml
+++ b/addons/sale/static/src/js/product_template_attribute_line/product_template_attribute_line.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <!-- Attributes line template -->
     <t t-name="sale.ProductTemplateAttributeLine">
-        <div name="ptal" t-attf-class="#{this.props.attribute_values.length === 1 &amp;&amp; hasPTAVCustom() ? 'd-flex' : ''}">
+        <div name="ptal" t-attf-class="#{this.props.attribute_values.length === 1 &amp;&amp; hasPTAVCustom() ? 'd-lg-flex' : ''}">
         <!-- If the attribute line contains only one attribute value, we don't show the attribute
              value template or the attribute line title unless the single attribute value is custom,
              whereas in this case, only the title of the attribute line and the custom value
@@ -16,7 +16,7 @@
                 <t t-if="showValuesChoice" t-call="{{getPTAVTemplate()}}"/>
             </div>
             <input
-                class="o_input w-lg-75 mb-4 ms-lg-auto"
+                class="o_input w-100 w-lg-75 mb-4 ms-lg-auto"
                 type="text"
                 t-att-placeholder="customValuePlaceholder"
                 t-if="hasPTAVCustom &amp;&amp; isSelectedPTAVCustom()"


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Create a product attribute with a single custom value;
2. add the attribute to a product A;
3. set product A as an optional product of product B;
4. go to product B's product page in mobile view;
5. click on the cart button.

Issue
-----
The custom text field takes up way too much real estate.

Cause
-----
The template isn't fully adapted for mobile view.

Solution
--------
Change `d-flex` to `d-lg-flex` on the `ptal` element, making the attribute name & input online display in-line on large screens.

Additionally, change some bootstrap classes to also have the cart button button displayed within the screen.

opw-5114495