### PR TITLE
[FIX] payment_paypal: show paypal button on mobile checkout

### DIFF
--- a/addons/payment_paypal/static/src/interactions/payment_form.js
+++ b/addons/payment_paypal/static/src/interactions/payment_form.js
@@ -20,14 +20,14 @@ patch(PaymentForm.prototype, {
     /**
      * @override
      */
-    async start() {
+    async willStart() {
         // Suffix the button IDs to prevent collisions when multiple button containers are present.
         const paypalEnabledButtons = [...document.querySelectorAll('#o_paypal_enabled_button')];
         const paypalDisabledButtons = [...document.querySelectorAll('#o_paypal_disabled_button')];
         paypalEnabledButtons.forEach((button, index) => button.id += `_${index}`);
         paypalDisabledButtons.forEach((button, index) => button.id += `_${index}`);
 
-        await super.start(...arguments);
+        await super.willStart(...arguments);
     },
 
     /**


### PR DESCRIPTION
## Versions
19.0+

## Issue
PayPal payment button appears twice on desktop and doesn't show up on mobile if PayPal is the only payment provider.

## Steps to reproduce
- Go to Payment Providers and set up PayPal in test mode (use sandbox credentials)
- Ensure PayPal is the only provider enabled by disabling all the other ones (even Demo)
- Go to the Website shop and buy a product:
  - Move to the checkout step and see 2 PayPal buttons rendered on desktop view, none on mobile view.

## Cause
Commit 2ca31a8b5566e4994c1e12e518e5e6da8f05e7ed didn't check for the `start` override name change and replaced by `willStart`.

opw-5151848