### PR TITLE
[FIX] mail: remove stale followers from chatter on auto-unfollow

### DIFF
--- a/addons/mail/static/src/core/web/thread_service_patch.js
+++ b/addons/mail/static/src/core/web/thread_service_patch.js
@@ -76,9 +76,12 @@ patch(ThreadService.prototype, {
         if ("followers" in result) {
             if (result.selfFollower) {
                 thread.selfFollower = { followedThread: thread, ...result.selfFollower };
+            } else {
+                thread.selfFollower = false;
             }
             thread.followersCount = result.followersCount;
             Record.MAKE_UPDATE(() => {
+                thread.followers.clear()
                 for (const followerData of result.followers) {
                     const follower = this.store.Follower.insert({
                         followedThread: thread,


### PR DESCRIPTION
In a customized flow: when reassigning a Ticket from employee A to B, the code unsubscribes A and subscribes B automatically. However, A still appears in the Chatter Followers list even after the unsubscribe call.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
