### PR TITLE
[IMP] mail: html composer shows command suggestion

### DIFF
--- a/addons/mail/static/src/core/common/suggestion_hook.js
+++ b/addons/mail/static/src/core/common/suggestion_hook.js
@@ -184,7 +184,10 @@ export class UseSuggestion {
     }
     insert(option) {
         let position = this.search.position + 1;
-        if ([":", "::"].includes(this.search.delimiter) || this.comp.composerService.htmlEnabled) {
+        if (
+            [":", "::"].includes(this.search.delimiter) ||
+            (this.comp.composerService.htmlEnabled && this.search.delimiter !== "/")
+        ) {
             position = this.search.position;
         }
         if (this.comp.composerService.htmlEnabled) {

--- a/addons/mail/static/src/discuss/core/common/suggestion_service_patch.js
+++ b/addons/mail/static/src/discuss/core/common/suggestion_service_patch.js
@@ -10,9 +10,6 @@ const commandRegistry = registry.category("discuss.channel_commands");
 const suggestionServicePatch = {
     getSupportedDelimiters(thread, env) {
         const res = super.getSupportedDelimiters(...arguments);
-        if (this.composer.htmlEnabled) {
-            return res;
-        }
         return thread?.model === "discuss.channel" ? [...res, ["/", 0]] : res;
     },
     /**


### PR DESCRIPTION
This commit adds the ability to show channel command suggestions when typing '/' in the html composer.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
