### PR TITLE
[FIX] account: keep fields in `tocompute` after `_set_next_sequence`

### DIFF
--- a/addons/account/models/sequence_mixin.py
+++ b/addons/account/models/sequence_mixin.py
@@ -431,6 +431,9 @@ class SequenceMixin(models.AbstractModel):
         self.ensure_one()
         format_string, format_values = self._get_next_sequence_format()
 
+        sequence = self._locked_increment(format_string, format_values)
+        self.with_context(clear_sequence_mixin_cache=False)[self._sequence_field] = sequence
+
         registry = self.env.registry
         triggers = registry._field_triggers[self._fields[self._sequence_field]]
         for inverse_field, triggered_fields in triggers.items():
@@ -439,9 +442,6 @@ class SequenceMixin(models.AbstractModel):
                     continue
                 for field in registry.field_inverses[inverse_field[0]] if inverse_field else [None]:
                     self.env.add_to_compute(triggered_field, self[field.name] if field else self)
-
-        sequence = self._locked_increment(format_string, format_values)
-        self.with_context(clear_sequence_mixin_cache=False)[self._sequence_field] = sequence
 
         self._compute_split_sequence()
 


### PR DESCRIPTION
This is the backport of https://github.com/odoo/odoo/pull/225558/commits/2373808e9768afa5a1a56dbd1491ebd13da3f88a

Issue:
In the list view of Journal Items, cash basis lines show a `move_name` of '/' event if the move is posted and has a name.

Steps to reproduce:
- Activate Cash Basis in the accounting settings
- Create a tax with "Tax Exigibility" set "Based on Payment"
- Set the "Cash Basis Transition Account" to "Current Assets"
- Activate reconciliation on "Current Assets"
- Create an invoice with this tax, confirm
- In the dashboard, click on Bank and new
- Set the name of the invoice as the label, and the amount of the invoice as amount
- Save & Close
- Go in Accounting > Transactions > Journal Items
- The lines created for the cah basis entry display '/' in the column "Journal Entry"

Cause:
This issue is linked to the order in which things are done in `_set_next_sequence`: the fields triggered by the sequence field are added in `self.env.transaction.tocompute` then the sequence is computed and assigned.

When `_set_next_sequence()` is called from [`_create_tax_cash_basis_moves()`](https://github.com/odoo/odoo/blob/849e4a87178d8c8588b75e3f7d9073d6a78326f9/addons/account/models/account_partial_reconcile.py#L649-L654) this order is problematic as `account.move.line.move_name` will be computed and removed from `self.env.transaction.tocompute`. So it will not be updated when the sequence is assigned in `account.move.name`. The callstack is something like this:
- `_set_next_sequence()` calls `_locked_increment()` to compute the sequence
- `_locked_increment()` calls `flush_recordset()` which will call `_recompute_recordset()` to recompute all fields
- `_compute_invoice_date_due()` needs the field `needed_terms` triggering `_compute_needed_terms()`
- `_compute_needed_terms()` needs `invoice_line_ids`
- the fetch on `account.move.line` is ordered by `move_name`
- So `_compute_related()` is triggered for `move_name` and `account.move.line.move_name` is removed from `self.env.transaction.tocompute` Then `_locked_increment()` returns the sequence, it gets assigned as the move name and `move_name` is never updated because it's not in `self.env.transaction.tocompute`.

This doesn't occur in other flows (like calling `action_post()`) because the value of `needed_terms` is read from the cache.

Solution:
Swap the order in which things are done in `_set_next_sequence()`: first compute and assign the sequence and then add the triggered fields in `self.env.transaction.tocompute` so that they are computed afterwards.

It seems more logic that way: we change the `_sequence_field` then mark all fields that will be impacted in `tocompute`.

Enterprise PR - https://github.com/odoo/enterprise/pull/96721

opw-4747878