### PR TITLE
[FIX] website_blog: add missing demo data for blog_tags_with_date tour

### DIFF
--- a/addons/website_blog/static/tests/tours/blog_tags_with_date.js
+++ b/addons/website_blog/static/tests/tours/blog_tags_with_date.js
@@ -9,16 +9,7 @@ import wTourUtils from "@website/js/tours/tour_utils";
 wTourUtils.registerWebsitePreviewTour("blog_tags_with_date", {
     test: true,
     url: "/blog",
-    edition: true,
 }, () => [{
-        content: "Click on first blog",
-        trigger: "iframe article[name=blog_post] a",
-    }, {
-        content: "Click on sidebar option",
-        trigger: "we-customizeblock-options we-button[data-customize-website-views='website_blog.opt_blog_sidebar_show'] we-title",
-    },
-    ...wTourUtils.clickOnSave(),
-    {
         content: "Check that the sidebar is present",
         trigger: "iframe #o_wblog_sidebar",
         isCheck: true,

--- a/addons/website_blog/tests/test_ui.py
+++ b/addons/website_blog/tests/test_ui.py
@@ -75,7 +75,7 @@ class TestWebsiteBlogUi(odoo.tests.HttpCase, TestWebsiteBlogCommon):
         Blog2 = Blog.create({'name': 'Space'})
 
         # Create first blog post (Feb 2025)
-        Post.create({
+        blog_post_1 = Post.create({
             'name': 'First Blog Post',
             'blog_id': Blog1.id,
             'author_id': self.env.user.id,
@@ -84,7 +84,7 @@ class TestWebsiteBlogUi(odoo.tests.HttpCase, TestWebsiteBlogCommon):
         })
 
         # Create second blog post (Jan 2025)
-        Post.create({
+        blog_post_2 = Post.create({
             'name': 'Second Blog Post',
             'blog_id': Blog2.id,
             'author_id': self.env.user.id,
@@ -93,7 +93,13 @@ class TestWebsiteBlogUi(odoo.tests.HttpCase, TestWebsiteBlogCommon):
         })
 
         self.env.ref("website_blog.opt_blog_sidebar_show").active = True
+        self.env.ref("website_blog.opt_blog_post_sidebar").active = True
         self.start_tour("/blog", "blog_sidebar_with_date_and_tag", login="admin")
 
-    def test_blog_tags_with_date(self):
-        self.start_tour(self.env["website"].get_client_action_url("/blog"), "blog_tags_with_date", login="admin")
+        blog_tag = self.env.ref('website_blog.blog_tag_5', raise_if_not_found=False)
+        if not blog_tag:
+            blog_tag = self.env['blog.tag'].create({'name': "discovery"})
+        blog_post_1.write({'tag_ids': [(4, blog_tag.id)]})
+        blog_post_2.write({'tag_ids': [(4, blog_tag.id)]})
+
+        self.start_tour("/blog", "blog_tags_with_date", login="admin")


### PR DESCRIPTION
With PR [1], the blog_tags_with_date tour was introduced, but the required demo data were missing, causing the tour to fail when executed in an environment without demo data.

This commit adds the necessary demo records to ensure the tour runs successfully even when no demo data are present.

[1]: https://github.com/odoo/odoo/pull/225845

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
