### PR TITLE
[IMP] pos_hr: prevent not logged in employee to go to backend

### DIFF
--- a/addons/point_of_sale/static/tests/tours/utils/chrome_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/chrome_util.js
@@ -24,6 +24,25 @@ export function clickMenuDropdownOption(name, { expectUnloadPage = false } = {})
         expectUnloadPage,
     };
 }
+export function existMenuOption(name) {
+    return [
+        clickMenuButton(),
+        {
+            content: `check that ${name} exists in the burger menu`,
+            trigger: `span.dropdown-item:contains(${name})`,
+        },
+        clickMenuButton(),
+    ];
+}
+export function notExistMenuOption(name) {
+    return [
+        clickMenuButton(),
+        {
+            content: `check that ${name} doesn't exist in the burger menu`,
+            trigger: negate(`span.dropdown-item:contains(${name})`),
+        },
+    ];
+}
 export function isCashMoveButtonHidden() {
     return [
         clickMenuButton(),

--- a/addons/pos_hr/static/src/overrides/components/navbar/navbar.js
+++ b/addons/pos_hr/static/src/overrides/components/navbar/navbar.js
@@ -9,4 +9,11 @@ patch(Navbar.prototype, {
             return false;
         }
     },
+    get showBackend() {
+        const cashier = this.pos.get_cashier_user_id();
+        return (
+            !this.pos.config.module_pos_hr ||
+            (cashier && cashier.id === this.pos.session.user_id?.id)
+        );
+    },
 });

--- a/addons/pos_hr/static/src/overrides/components/navbar/navbar.xml
+++ b/addons/pos_hr/static/src/overrides/components/navbar/navbar.xml
@@ -3,9 +3,7 @@
 
     <t t-name="pos_hr.Navbar" t-inherit="point_of_sale.Navbar" t-inherit-mode="extension">
         <xpath expr="//DropdownItem[contains(text(), 'Backend')]" position="attributes">
-            <attribute name="t-if">
-                !pos.config.module_pos_hr or pos.employeeIsAdmin or pos.get_cashier_user_id() === pos.session.user_id?.id
-            </attribute>
+            <attribute name="t-if">showBackend</attribute>
         </xpath>
         <xpath expr="//DropdownItem[contains(text(), 'Close Register')]" position="attributes">
             <attribute name="t-if">

--- a/addons/pos_hr/static/src/overrides/screens/login_screen/login_screen.js
+++ b/addons/pos_hr/static/src/overrides/screens/login_screen/login_screen.js
@@ -56,10 +56,7 @@ patch(LoginScreen.prototype, {
             this.pos.login = false;
         } else {
             const employee = await this.selectCashier();
-            if (
-                employee &&
-                (employee._role === "manager" || employee.user_id?.id === this.pos.user.id)
-            ) {
+            if (employee && employee.user_id?.id === this.pos.user.id) {
                 super.clickBack();
                 return;
             }

--- a/addons/pos_hr/static/tests/tours/pos_hr_tour.js
+++ b/addons/pos_hr/static/tests/tours/pos_hr_tour.js
@@ -176,3 +176,77 @@ registry.category("web_tour.tours").add("test_cashier_changed_in_receipt", {
             ReceiptScreen.clickNextOrder(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("pos_hr_go_backend_closed_registered", {
+    steps: () =>
+        [
+            // Admin --> 403: not the one that opened the session
+            Chrome.clickBtn("Backend"),
+            SelectionPopup.has("Mitchell Admin", { run: "click" }),
+            PosHr.loginScreenIsShown(),
+
+            // Employee with user --> 403
+            Chrome.clickBtn("Backend"),
+            SelectionPopup.has("Pos Employee1", { run: "click" }),
+            PosHr.enterPin("2580"),
+            PosHr.loginScreenIsShown(),
+
+            // Employee without user --> 403
+            Chrome.clickBtn("Backend"),
+            SelectionPopup.has("Test Employee 3", { run: "click" }),
+            PosHr.loginScreenIsShown(),
+
+            // Manager without user --> 403
+            Chrome.clickBtn("Backend"),
+            SelectionPopup.has("Test Manager 2", { run: "click" }),
+            PosHr.enterPin("5652"),
+            PosHr.loginScreenIsShown(),
+
+            // Manager that opened the session --> access granted
+            Chrome.clickBtn("Backend"),
+            SelectionPopup.has("Test Manager 1", { run: "click" }),
+            PosHr.enterPin("5651"),
+            PosHr.loginScreenIsNotShown(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("pos_hr_go_backend_opened_registered", {
+    steps: () =>
+        [
+            Chrome.clickBtn("Open Register"),
+            PosHr.clickLoginButton(),
+
+            // Admin --> 403: not the one that opened the session
+            SelectionPopup.has("Mitchell Admin", { run: "click" }),
+            Chrome.clickBtn("Open Register"),
+            Chrome.existMenuOption("Close Register"),
+            Chrome.notExistMenuOption("Backend"),
+
+            // Employee with user --> 403
+            PosHr.clickCashierName(),
+            SelectionPopup.has("Pos Employee1", { run: "click" }),
+            PosHr.enterPin("2580"),
+            Chrome.notExistMenuOption("Close Register"),
+            Chrome.notExistMenuOption("Backend"),
+
+            // Employee without user --> 403
+            PosHr.clickCashierName(),
+            SelectionPopup.has("Test Employee 3", { run: "click" }),
+            Chrome.notExistMenuOption("Close Register"),
+            Chrome.notExistMenuOption("Backend"),
+
+            // Manager without user --> 403
+            PosHr.clickCashierName(),
+            SelectionPopup.has("Test Manager 2", { run: "click" }),
+            PosHr.enterPin("5652"),
+            Chrome.existMenuOption("Close Register"),
+            Chrome.notExistMenuOption("Backend"),
+
+            // Manager that opened the session --> access granted
+            PosHr.clickCashierName(),
+            SelectionPopup.has("Test Manager 1", { run: "click" }),
+            PosHr.enterPin("5651"),
+            Chrome.existMenuOption("Close Register"),
+            Chrome.clickMenuOption("Backend", { expectUnloadPage: true }),
+        ].flat(),
+});

--- a/addons/pos_hr/static/tests/tours/utils/pos_hr_helpers.js
+++ b/addons/pos_hr/static/tests/tours/utils/pos_hr_helpers.js
@@ -1,6 +1,7 @@
 import * as SelectionPopup from "@point_of_sale/../tests/tours/utils/selection_popup_util";
 import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
 import * as NumberPopup from "@point_of_sale/../tests/tours/utils/number_popup_util";
+import { negate } from "@point_of_sale/../tests/tours/utils/common";
 
 export function clickLoginButton() {
     return [
@@ -28,6 +29,14 @@ export function loginScreenIsShown() {
         },
     ];
 }
+export function loginScreenIsNotShown() {
+    return [
+        {
+            content: "login screen is not shown",
+            trigger: negate(".login-overlay .screen-login"),
+        },
+    ];
+}
 export function cashierNameIs(name) {
     return [
         {
@@ -47,11 +56,10 @@ export function login(name, pin) {
     if (!pin) {
         return res;
     }
-    return res.concat([
-        ...NumberPopup.enterValue(pin),
-        ...NumberPopup.isShown("••••"),
-        Dialog.confirm(),
-    ]);
+    return res.concat(enterPin(pin));
+}
+export function enterPin(pin) {
+    return [...NumberPopup.enterValue(pin), ...NumberPopup.isShown("••••"), Dialog.confirm()];
 }
 export function clickLockButton() {
     return {

--- a/addons/pos_hr/tests/test_frontend.py
+++ b/addons/pos_hr/tests/test_frontend.py
@@ -23,6 +23,26 @@ class TestPosHrHttpCommon(TestPointOfSaleHttpCommon):
             "pin": False,
         })
 
+        # Managers
+        cls.manager_user = new_test_user(
+            cls.env,
+            login="manager_user",
+            groups="point_of_sale.group_pos_manager",
+            name="Pos Manager",
+            email="manager_user@pos.com",
+        )
+        cls.manager1 = cls.env['hr.employee'].create({
+            'name': 'Test Manager 1',
+            "company_id": cls.env.company.id,
+            "user_id": cls.manager_user.id,
+            "pin": "5651"
+        })
+        cls.manager2 = cls.env['hr.employee'].create({
+            'name': 'Test Manager 2',
+            "company_id": cls.env.company.id,
+            "pin": "5652"
+        })
+
         # User employee
         cls.emp1 = cls.env['hr.employee'].create({
             'name': 'Test Employee 1',
@@ -52,7 +72,8 @@ class TestPosHrHttpCommon(TestPointOfSaleHttpCommon):
         })
 
         cls.main_pos_config.write({
-            'basic_employee_ids': [Command.link(cls.emp1.id), Command.link(cls.emp2.id), Command.link(cls.emp3.id)]
+            'basic_employee_ids': [Command.link(cls.emp1.id), Command.link(cls.emp2.id), Command.link(cls.emp3.id)],
+            'advanced_employee_ids': [Command.link(cls.manager1.id), Command.link(cls.manager2.id)]
         })
 
 
@@ -141,3 +162,9 @@ class TestUi(TestPosHrHttpCommon):
         order = self.main_pos_config.current_session_id.order_ids[0]
         self.assertEqual(order.cashier, "Test Employee 3")
         self.assertEqual(order.employee_id.display_name, "Test Employee 3")
+
+    def test_go_backend(self):
+        self.main_pos_config.with_user(self.manager_user).open_ui()
+
+        self.start_pos_tour("pos_hr_go_backend_closed_registered", login="manager_user")
+        self.start_pos_tour("pos_hr_go_backend_opened_registered", login="manager_user")


### PR DESCRIPTION
Task: [5154178](https://www.odoo.com/odoo/project/1737/tasks/5154178)

---
Previously, any employee with the role `manager` could go to the backend. Now, the only employees that can go back to the backend are those binded to the user connected.

Managers can still close the session.