### PR TITLE
[IMP] website_sale: add eCommerce dashboard

### DIFF
--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -1,6 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
+    <!-- Kept first because this server action is referenced by the SO list header button -->
+    <record id="model_sale_order_action_quotation_confirm" model="ir.actions.server">
+        <field name="name">Confirm Orders</field>
+        <field name="model_id" ref="sale.model_sale_order"/>
+        <field name="binding_model_id" ref="sale.model_sale_order"/>
+        <field name="binding_view_types">list</field>
+        <field name="state">code</field>
+        <field name="code">records.action_confirm()</field>
+    </record>
+
     <!-- VIEWS -->
 
     <record id="sale_order_view_activity" model="ir.ui.view">
@@ -123,6 +133,12 @@
                         name="%(sale.action_view_sale_advance_payment_inv)d"
                         type="action"
                         class="btn-secondary"/>
+                    <button
+                        string="Confirm Orders"
+                        name="%(sale.model_sale_order_action_quotation_confirm)d"
+                        type="action"
+                        class="btn-secondary"
+                    />
                 </header>
                 <field name="message_needaction" column_invisible="True"/>
                 <field name="currency_id" column_invisible="True"/>

--- a/addons/website_sale/__manifest__.py
+++ b/addons/website_sale/__manifest__.py
@@ -156,6 +156,14 @@
             'website_sale/static/src/js/tours/website_sale_shop.js',
             'website_sale/static/src/xml/website_sale.xml',
             'website_sale/static/src/scss/kanban_record.scss',
+            'website_sale/static/src/js/dashboard/dashboard.js',
+            'website_sale/static/src/js/dashboard/dashboard.xml',
+            'website_sale/static/src/js/dashboard/dashboard.scss',
+            'website_sale/static/src/js/date_filter_button/**/*',
+            'website_sale/static/src/views/**/*',
+        ],
+        'web.assets_web_dark': [
+            'website_sale/static/src/js/dashboard/**/*.dark.scss',
         ],
         'website.website_builder_assets': [
             'website_sale/static/src/js/website_sale_form_editor.js',

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -9,7 +9,7 @@ from odoo import SUPERUSER_ID, _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
 from odoo.fields import Command, Domain
 from odoo.http import request
-from odoo.tools import float_is_zero
+from odoo.tools import SQL, float_is_zero, float_round
 
 from odoo.addons.website_sale.models.website import (
     FISCAL_POSITION_SESSION_CACHE_KEY,
@@ -45,6 +45,10 @@ class SaleOrder(models.Model):
     only_services = fields.Boolean(string="Only Services", compute='_compute_cart_info')
     is_abandoned_cart = fields.Boolean(
         string="Abandoned Cart", compute='_compute_abandoned_cart', search='_search_abandoned_cart',
+    )
+    # filter related fields
+    is_unfulfilled = fields.Boolean(
+        string="Unfulfilled Orders", search='_search_is_unfulfilled', store=False
     )
 
     #=== COMPUTE METHODS ===#
@@ -163,6 +167,20 @@ class SaleOrder(models.Model):
 
     def _default_team_id(self):
         return super()._default_team_id() or self.website_id.salesteam_id.id
+
+    def _search_is_unfulfilled(self, operator, value):
+        if operator not in ('=', '!='):
+            return NotImplemented
+
+        if (operator == '=' and value) or (operator == '!=' and not value):
+            effective_operator = 'any'
+        else:
+            effective_operator = 'not any'
+
+        line_domain = Domain.custom(
+            to_sql=lambda table: SQL('%s < %s', table.qty_delivered, table.product_uom_qty),
+        )
+        return Domain('state', '=', 'sale') & Domain('order_line', effective_operator, line_domain)
 
     #=== CRUD METHODS ===#
 
@@ -920,3 +938,111 @@ class SaleOrder(models.Model):
                 partners_to_archive |= commercial_partner + commercial_partner.child_ids
 
         partners_to_archive.active = False
+
+    @api.model
+    def retrieve_ecommerce_dashboard(self, period_days):
+        """Retrieve statistics for the eCommerce dashboard for a given period(number of days).
+
+        This includes:
+        - Current period metrics: total visitors, total sales, and total orders.
+        - Period-over-period gains: comparison with the previous equivalent period.
+        - Overall global counts: orders to fulfill, to confirm, and to invoice.
+
+        :param int period_days: The selected days used to filter orders and visitors.
+        :return: A dictionary containing all computed dashboard statistics.
+        :rtype: dict
+        """
+        # Shape of the return value
+        dashboard_data = {
+            'visitors': {'total': 0, 'gain': None},
+            'sales': {'total': 0, 'gain': None},
+            'orders': {'total': 0, 'gain': None},
+            'to_fulfill': 0,
+            'to_confirm': 0,
+            'to_invoice': 0,
+            'currency_id': self.env.company.currency_id.id,
+        }
+
+        # Build domain for the given period
+        ecommerce_orders_domain = Domain('website_id', '!=', False) & Domain('state', '=', 'sale')
+
+        sale_report_period_domain = (
+            self._get_period_domain('date', period_days) & ecommerce_orders_domain
+        )
+        sale_report_previous_period_domain = (
+            self._get_period_domain('date', period_days, previous=True)
+            & ecommerce_orders_domain
+        )
+
+        visitor_period_domain = self._get_period_domain('last_connection_datetime', period_days)
+        visitor_previous_period_domain = self._get_period_domain(
+            'last_connection_datetime', period_days, previous=True,
+        )
+
+        current_period_totals = self._get_period_totals(sale_report_period_domain, visitor_period_domain)
+        previous_period_totals = self._get_period_totals(
+            sale_report_previous_period_domain,
+            visitor_previous_period_domain,
+        )
+
+        # update totals + compute gain
+        for key in current_period_totals:
+            current_total = current_period_totals[key]
+            previous_total = previous_period_totals[key]
+
+            dashboard_data[key]['total'] = current_total
+            dashboard_data[key]['gain'] = (
+                round(((current_total - previous_total) / previous_total) * 100)
+                if previous_total
+                else None
+            )
+
+        dashboard_data.update({
+            'to_fulfill': self.search_count(
+                Domain('is_unfulfilled', '=', True) & ecommerce_orders_domain,
+            ),
+            'to_confirm': self.search_count(
+                Domain('state', '=', 'sent') & Domain('website_id', '!=', False),
+            ),
+            'to_invoice': self.search_count(
+                Domain('invoice_status', '=', 'to invoice') & ecommerce_orders_domain,
+            ),
+        })
+
+        return dashboard_data
+
+    def _get_period_domain(self, field, period_days, previous=False):
+        """Build a domain to filter records for a given time period.
+
+        :param str field: The datetime field used for date filtering.
+        :param int period_days: Number of days representing the target period.
+        :param bool previous: When True, returns a domain for the previous equivalent period.
+        :return: Domain used to filter records by date range.
+        """
+        if not previous:
+            return Domain(field, '>', f'today -{period_days}d +1d')
+        return (
+            Domain(field, '>', f'today -{period_days * 2}d +1d')
+            & Domain(field, '<', f'today -{period_days}d +1d')
+        )
+
+    def _get_period_totals(self, report_period_domain, visitor_period_domain):
+        """Calculate aggregated statistics for orders and visitors for a given period.
+
+        :param Domain report_period_domain: Domain used to filter sale orders.
+        :param Domain visitor_period_domain: Domain used to filter website visitors.
+        :return: A dictionary containing total orders, total sales, and total visitors for
+                the given period.
+        :rtype: dict
+        """
+        aggregated_order_data = self.env['sale.report']._read_group(
+            domain=report_period_domain,
+            aggregates=['price_total:sum', '__count'],
+        )
+        visitor_count = self.env['website.visitor'].sudo().search_count(visitor_period_domain)
+        total_sales, total_orders = aggregated_order_data[0]
+        return {
+            'orders': total_orders,
+            'sales': float_round(total_sales, precision_rounding=0.01),
+            'visitors': visitor_count,
+        }

--- a/addons/website_sale/static/src/js/dashboard/dashboard.dark.scss
+++ b/addons/website_sale/static/src/js/dashboard/dashboard.dark.scss
@@ -1,0 +1,8 @@
+.o_dashboard_card {
+    --DashboardCard__purple-bg-color: #{$purple-200};
+    --DashboardCard__purple-bg-color--active: #{$purple-300};
+    --DashboardCard__orange-bg-color: #{$orange-200};
+    --DashboardCard__orange-bg-color--active: #{$orange-300};
+    --DashboardCard__cyan-bg-color: #{$cyan-200};
+    --DashboardCard__cyan-bg-color--active: #{$cyan-300};
+}

--- a/addons/website_sale/static/src/js/dashboard/dashboard.js
+++ b/addons/website_sale/static/src/js/dashboard/dashboard.js
@@ -1,0 +1,136 @@
+import { _t } from '@web/core/l10n/translation';
+import { Component, onWillStart, useState } from '@odoo/owl';
+import { formatCurrency } from '@web/core/currency';
+import { useService, useBus } from '@web/core/utils/hooks';
+import { DateFilterButton, DATE_OPTIONS } from '../date_filter_button/date_filter_button';
+
+export const CARD_COLORS_MAPPING = {
+    'to_fulfill': 'purple',
+    'to_confirm': 'orange',
+    'to_invoice': 'cyan',
+};
+
+export const CARD_FILTERS_MAPPING = {
+    'to_fulfill': ['to_fulfill', 'from_website', 'order_confirmed'],
+    'to_confirm': ['to_confirm', 'from_website'],
+    'to_invoice': ['to_invoice', 'from_website', 'order_confirmed'],
+};
+
+export const DEFAULT_FILTERS = ['from_website', 'order_confirmed'];
+
+export class Dashboard extends Component {
+	static template = 'website_sale.Dashboard';
+    static props = {};
+	static components = { DateFilterButton };
+
+	setup() {
+		this.state = useState({
+			dashboardData: {},
+			selectedDateFilter: DATE_OPTIONS[0],
+			selectedCard: '',
+		});
+		this.orm = useService('orm');
+		this.dashboardCards = [
+			{ key: 'to_fulfill', label: _t("To Fulfill"), title: _t("Orders to Fulfill"), alwaysVisible: true },
+			{ key: 'to_confirm', label: _t("To Confirm"), title: _t("Orders to Confirm"), alwaysVisible: false },
+			{ key: 'to_invoice', label: _t("To Invoice"), title: _t("Orders to Invoice"), alwaysVisible: true },
+		]
+
+        this.dashboardPeriodCards = [
+            { key: 'visitors', title: _t("Visitors"), monetary: false },
+            { key: 'orders', title: _t("Orders"), monetary: false },
+            { key: 'sales', title: _t("Sales"), monetary: true },
+        ]
+
+		useBus(this.env.searchModel, 'update', () => {
+            for (const [cardName, filters] of Object.entries(CARD_FILTERS_MAPPING)) {
+                if (this.isSameFilter(filters)) {
+					this.state.selectedCard = cardName;
+					return;
+                }
+            }
+            this.state.selectedCard = '';
+		});
+
+		onWillStart(async () => {
+			await this.loadDashboardData();
+		});
+	}
+
+	async loadDashboardData(filter = false) {
+		if (filter) {
+			this.state.selectedDateFilter = filter;
+		}
+		this.state.dashboardData = await this.orm.call(
+            'sale.order',
+            'retrieve_ecommerce_dashboard',
+            [this.state.selectedDateFilter.periodDays],
+        );
+	}
+
+	handleCardClick(ev) {
+        const cardName = ev.currentTarget.getAttribute('card_name');
+
+		if (this.state.selectedCard === cardName) {
+			this.setFilters(DEFAULT_FILTERS);
+		} else {
+			const filters = CARD_FILTERS_MAPPING[cardName];
+            this.setFilters(filters);
+		}
+	}
+
+	/**
+	 * This method clears the current search query and activates
+	 * the filters found in `filters`.
+	 */
+    setFilters(filters) {
+        const searchItems = this.env.searchModel.getSearchItems((item) =>
+			filters.includes(item.name)
+		);
+		this.env.searchModel.query = [];
+		for (const item of searchItems) {
+			this.env.searchModel.toggleSearchItem(item.id);
+		}
+    }
+
+	isSameFilter(filters) {
+		const activeFilters = this.env.searchModel.getSearchItems(
+			(el) => el.isActive && el.type === 'filter'
+		);
+		const activeFilterNames = activeFilters && activeFilters.map((el) => el.name);
+        if (filters.length !== activeFilterNames.length) {
+			return false;
+		}
+
+		const activeFilterSet = new Set(activeFilterNames);
+        return filters.every(val => activeFilterSet.has(val));
+	}
+
+	getPeriodCardClass(cardName) {
+        const periodGain = this.state.dashboardData[cardName]['gain'];
+		if (periodGain > 0) {
+			return 'text-success';
+		} else if (periodGain < 0) {
+			return 'text-danger';
+		}
+		return 'text-muted';
+	}
+
+	getDashboardCardAdditionalClass(cardName) {
+		let dashboardCardClasses = [];
+		const cardDataCount = this.state.dashboardData[cardName];
+		if (cardDataCount == 0) {
+			dashboardCardClasses.push('bg-secondary text-secondary-emphasis disabled')
+		} else {
+			dashboardCardClasses.push('o_dashboard_card_' + CARD_COLORS_MAPPING[cardName])
+		}
+		if (this.state.selectedCard === cardName) {
+			dashboardCardClasses.push('active');
+		}
+		return dashboardCardClasses.join(' ');
+	}
+
+    formatCurrency(value) {
+        return formatCurrency(value, this.state.dashboardData.currency_id);
+    }
+}

--- a/addons/website_sale/static/src/js/dashboard/dashboard.scss
+++ b/addons/website_sale/static/src/js/dashboard/dashboard.scss
@@ -1,0 +1,59 @@
+.o_dashboard_card {
+    $dashboard-colors: (
+        purple: (
+            bg: var(--DashboardCard__purple-bg-color, #{$purple-100}),
+            bg-active: var(--DashboardCard__purple-bg-color--active, #{$purple-200}),
+            color: var(--DashboardCard__purple-color, #{$purple-700}),
+            color-active: var(--DashboardCard__purple-color--active, #{$purple-800}),
+        ),
+        cyan: (
+            bg: var(--DashboardCard__cyan-bg-color, #{$cyan-100}),
+            bg-active: var(--DashboardCard__cyan-bg-color--active, #{$cyan-200}),
+            color: var(--DashboardCard__cyan-color, #{$cyan-700}),
+            color-active: var(--DashboardCard__cyan-color--active, #{$cyan-800}),
+        ),
+        orange: (
+            bg: var(--DashboardCard__orange-bg-color, #{$orange-100}),
+            bg-active: var(--DashboardCard__orange-bg-color--active, #{$orange-200}),
+            color: var(--DashboardCard__orange-color, #{$orange-700}),
+            color-active: var(--DashboardCard__orange-color--active, #{$orange-800}),
+        ),
+    );
+
+    @each $name, $states in $dashboard-colors {
+        &.o_dashboard_card_#{$name} {
+            --btn-bg: #{map-get($states, bg)};
+            --btn-hover-bg: #{map-get($states, bg-active)};
+            --btn-active-bg: #{map-get($states, bg-active)};
+            --btn-active-border-color: transparent;
+
+            .o_dashboard_card_data {
+                color: #{map-get($states, color)};
+            }
+
+            &.active {
+                outline: $border-width $border-style #{map-get($states, color-active)};
+                outline-offset: $border-width;
+
+                .o_dashboard_card_data {
+                    color: #{map-get($states, color-active)};
+                }
+            }
+        }
+    }
+}
+
+.o_date_filter_wrapper {
+    @include media-breakpoint-up(md) {
+        border-right: $border-width $border-style $border-color;
+        background: transparent !important;
+    }
+}
+
+.o_website_sale_dashboard {
+    background-color: $o-control-panel-background-color;
+
+    @include media-breakpoint-up(md) {
+        border-bottom: $border-width $border-style $border-color;
+    }
+}

--- a/addons/website_sale/static/src/js/dashboard/dashboard.xml
+++ b/addons/website_sale/static/src/js/dashboard/dashboard.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates>
+    <t t-name="website_sale.Dashboard">
+        <div class="o_website_sale_dashboard container-fluid d-flex flex-column-reverse flex-lg-row justify-content-between align-items-center gap-3 p-3 pt-0 pt-md-3">
+
+            <!-- Left Section -->
+            <div class="d-flex justify-content-lg-start justify-content-md-center gap-1 gap-md-3 gap-lg-2 px-md-5 px-lg-0 w-100 w-lg-auto">
+                <t t-foreach="dashboardCards" t-as="card" t-key="card.key">
+                    <button
+                        t-if="card.alwaysVisible || state.dashboardData[card.key] > 0"
+                        t-att-title="card.title"
+                        class="o_dashboard_card btn flex-grow-1 d-md-flex d-lg-block align-items-md-baseline justify-content-md-center gap-md-1 py-2 px-4 lh-sm"
+                        t-att-class="this.getDashboardCardAdditionalClass(card.key)"
+                        t-on-click="state.dashboardData[card.key] > 0 ? handleCardClick : () => {}"
+                        t-att-card_name="card.key"
+                    >
+                        <span
+                            class="o_dashboard_card_data fs-4 fw-bolder"
+                            t-out="state.dashboardData[card.key]"
+                        />
+                        <span class="d-block" t-out="card.label"/>
+                    </button>
+                </t>
+            </div>
+
+            <!-- Right Section -->
+            <div class="d-flex flex-column flex-md-row border rounded-3 pb-2 py-md-2 w-100 w-md-auto gap-2 gap-md-0">
+                <div class="o_date_filter_wrapper d-flex align-items-center py-2 px-3 bg-200 bg-opacity-75">
+                    <DateFilterButton update.bind="loadDashboardData" selectedDateFilter="state.selectedDateFilter"/>
+                </div>
+
+                <div class="o_cards_container d-flex align-items-center gap-4 border-md-start px-3 px-md-4">
+                    <t t-foreach="dashboardPeriodCards" t-as="dashboardPeriodCard" t-key="dashboardPeriodCard.key">
+                        <div class="d-flex flex-column px-1 lh-sm">
+                            <span class="text-body fw-bold"><t t-out="dashboardPeriodCard.title"/></span>
+                            <div class="d-flex align-items-baseline gap-1">
+                                <span class="fs-4 fw-bold">
+                                    <t t-out="dashboardPeriodCard.monetary ? formatCurrency(state.dashboardData[dashboardPeriodCard.key]['total']) : state.dashboardData[dashboardPeriodCard.key]['total']"/>
+                                </span>
+                                <span
+                                    t-if="state.dashboardData[dashboardPeriodCard.key]['gain'] !== null"
+                                    class="o_dashboard_card_evolution"
+                                    t-att-class="this.getPeriodCardClass(dashboardPeriodCard.key)"
+                                >
+                                    <t
+                                        t-out="state.dashboardData[dashboardPeriodCard.key]['gain']"
+                                    />%
+                                </span>
+                                <span
+                                    t-else=""
+                                    class="o_dashboard_card_evolution"
+                                    t-att-class="this.getPeriodCardClass(dashboardPeriodCard.key)"
+                                >
+                                    N/A
+                                </span>
+                            </div>
+                        </div>
+                    </t>
+                </div>
+            </div>
+        </div>
+    </t>
+</templates>

--- a/addons/website_sale/static/src/js/date_filter_button/date_filter_button.js
+++ b/addons/website_sale/static/src/js/date_filter_button/date_filter_button.js
@@ -1,0 +1,31 @@
+import { Component } from '@odoo/owl';
+import { Dropdown } from '@web/core/dropdown/dropdown';
+import { DropdownItem } from '@web/core/dropdown/dropdown_item';
+import { _t } from '@web/core/l10n/translation';
+
+export const DATE_OPTIONS = [
+	{ id: 'last_7_days', label: _t("Last 7 days"), periodDays: 7 },
+	{ id: 'last_30_days', label: _t("Last 30 days"), periodDays: 30 },
+	{ id: 'last_90_days', label: _t("Last 90 days"), periodDays: 90 },
+	{ id: 'last_365_days', label: _t("Last 365 days"), periodDays: 365 },
+];
+
+export class DateFilterButton extends Component {
+	static template = 'website_sale.DateFilterButton';
+	static components = { Dropdown, DropdownItem };
+	static props = {
+		selectedDateFilter: {
+			type: Object,
+			optional: true,
+			shape: {
+				id: String,
+				label: String,
+			},
+		},
+		update: Function,
+	};
+
+	get dateFilters() {
+		return DATE_OPTIONS;
+	}
+}

--- a/addons/website_sale/static/src/js/date_filter_button/date_filter_button.xml
+++ b/addons/website_sale/static/src/js/date_filter_button/date_filter_button.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates>
+    <t t-name="website_sale.DateFilterButton">
+        <Dropdown position="'bottom-end'">
+            <button class="border-0 bg-transparent fw-normal">
+                <i class="fa fa-calendar-o me-2"/>
+                <span t-out="props.selectedDateFilter.label"/>
+                <i class="fa fa-caret-down ms-2"/>
+            </button>
+            <t t-set-slot="content">
+                <t t-foreach="dateFilters" t-as="filter" t-key="filter.id">
+                    <DropdownItem
+                        tag="'div'"
+                        class="{ 'selected': props.selectedDateFilter.id === filter.id, 'd-flex justify-content-between': true }"
+                        closingMode="'none'"
+                        onSelected="() => this.props.update(filter)"
+                    >
+                        <div t-out="filter.label"/>
+                    </DropdownItem>
+                </t>
+            </t>
+        </Dropdown>
+    </t>
+</templates>

--- a/addons/website_sale/static/src/views/dashboard_kanban_view/dashboard_kanban_view.js
+++ b/addons/website_sale/static/src/views/dashboard_kanban_view/dashboard_kanban_view.js
@@ -1,0 +1,19 @@
+import { registry } from '@web/core/registry';
+import { KanbanRenderer } from '@web/views/kanban/kanban_renderer';
+import { kanbanView } from '@web/views/kanban/kanban_view';
+import { Dashboard } from '../../js/dashboard/dashboard';
+
+export class DashboardKanbanRenderer extends KanbanRenderer {
+	static template = 'website_sale.KanbanRenderer';
+	static components = {
+		...KanbanRenderer.components,
+		Dashboard,
+	};
+}
+
+export const dashboardKanbanView = {
+	...kanbanView,
+	Renderer: DashboardKanbanRenderer,
+};
+
+registry.category('views').add('website_sale_dashboard_kanban', dashboardKanbanView);

--- a/addons/website_sale/static/src/views/dashboard_kanban_view/dashboard_kanban_view.scss
+++ b/addons/website_sale/static/src/views/dashboard_kanban_view/dashboard_kanban_view.scss
@@ -1,0 +1,5 @@
+.o_website_sale_dashboard_kanban_view {
+    .o_kanban_renderer.o_kanban_ungrouped {
+        min-height: auto;
+    }
+}

--- a/addons/website_sale/static/src/views/dashboard_kanban_view/dashboard_kanban_view.xml
+++ b/addons/website_sale/static/src/views/dashboard_kanban_view/dashboard_kanban_view.xml
@@ -1,0 +1,11 @@
+<templates>
+    <t
+        t-name="website_sale.KanbanRenderer"
+        t-inherit="web.KanbanRenderer"
+        t-inherit-mode="primary"
+    >
+        <xpath expr="//div[hasclass('o_kanban_renderer')]" position="before">
+            <Dashboard/>
+        </xpath>
+    </t>
+</templates>

--- a/addons/website_sale/static/src/views/dashboard_list_view/dashboard_list_view.js
+++ b/addons/website_sale/static/src/views/dashboard_list_view/dashboard_list_view.js
@@ -1,0 +1,19 @@
+import { registry } from '@web/core/registry';
+import { ListRenderer } from '@web/views/list/list_renderer';
+import { listView } from '@web/views/list/list_view';
+import { Dashboard } from '../../js/dashboard/dashboard';
+
+export class DashboardListRenderer extends ListRenderer {
+	static template = 'website_sale.ListRenderer';
+	static components = {
+		...ListRenderer.components,
+		Dashboard,
+	};
+}
+
+export const dashboardListView = {
+	...listView,
+	Renderer: DashboardListRenderer,
+};
+
+registry.category('views').add('website_sale_dashboard_list', dashboardListView);

--- a/addons/website_sale/static/src/views/dashboard_list_view/dashboard_list_view.scss
+++ b/addons/website_sale/static/src/views/dashboard_list_view/dashboard_list_view.scss
@@ -1,0 +1,19 @@
+.o_website_sale_dashboard_list_view {
+    @include media-breakpoint-down(md) {
+        .o_control_panel {
+            border-bottom: none;
+        }
+
+        .o_content {
+            display: flex;
+            flex-direction: column;
+            height: auto !important;
+        }
+    }
+
+    @include media-breakpoint-up(md) {
+        .o_list_renderer {
+            height: auto;
+        }
+    }
+}

--- a/addons/website_sale/static/src/views/dashboard_list_view/dashboard_list_view.xml
+++ b/addons/website_sale/static/src/views/dashboard_list_view/dashboard_list_view.xml
@@ -1,0 +1,7 @@
+<templates>
+    <t t-name="website_sale.ListRenderer" t-inherit="web.ListRenderer" t-inherit-mode="primary">
+        <xpath expr="//div[hasclass('o_list_renderer')]" position="before">
+            <Dashboard/>
+        </xpath>
+    </t>
+</templates>

--- a/addons/website_sale/views/sale_order_views.xml
+++ b/addons/website_sale/views/sale_order_views.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
+
+    <!-- Views -->
     <record id="view_sales_order_filter_ecommerce" model="ir.ui.view">
         <field name="name">sale.order.ecommerce.search.view</field>
         <field name="model">sale.order</field>
@@ -14,6 +16,10 @@
                 <filter string="Order Date" name="order_date" date="date_order"/>
                 <separator/>
                 <filter string="From Website" name="from_website" domain="[('website_id', '!=', False)]"/>
+                <separator/>
+                <filter string="To Fulfill" name="to_fulfill" domain="[('is_unfulfilled', '=', True)]"/>
+                <filter string="To Confirm" name="to_confirm" domain="[('state', '=', 'sent')]"/>
+                <filter string="To Invoice" name="to_invoice" domain="[('invoice_status', '=', 'to invoice')]"/>
                 <separator/>
                 <!-- Dashboard filter - used by context -->
                 <filter string="Last Week" invisible="1" name="week" domain="[('date_order', '&gt;', 'today -7d')]"/>
@@ -40,6 +46,117 @@
         </field>
     </record>
 
+    <record id="sale_order_list_view_ecommerce" model="ir.ui.view">
+        <field name="name">website.sale.order.list.dashboard</field>
+        <field name="model">sale.order</field>
+        <field name="arch" type="xml">
+            <list
+                class="o_sale_order"
+                string="Orders"
+                sample="1"
+                decoration-muted="state == 'cancel'"
+                js_class="website_sale_dashboard_list"
+            >
+                <header>
+                    <button
+                        string="Create Invoices"
+                        name="%(sale.action_view_sale_advance_payment_inv)d"
+                        type="action"
+                        class="btn-secondary"
+                    />
+                    <button
+                        string="Confirm Orders"
+                        name="%(sale.model_sale_order_action_quotation_confirm)d"
+                        type="action"
+                        class="btn-secondary"
+                    />
+                </header>
+                <field name="message_needaction" column_invisible="True"/>  <!--for JS side widgets-->
+                <field name="currency_id" column_invisible="True"/> <!--for JS side widgets-->
+
+                <field name="name" string="Number" readonly="1" decoration-bf="1"/>
+                <field name="date_order" readonly="state in ['cancel', 'sale']"/>
+                <field name="commitment_date"/>
+                <field name="partner_id" readonly="1"/>
+                <field name="user_id" widget="many2one_avatar_user" optional="hide"/>
+                <field name="team_id" optional="hide"/>
+                <field name="company_id" groups="!base.group_multi_company" column_invisible="True"/>  <!--for JS widgets-->
+                <field
+                    name="company_id"
+                    groups="base.group_multi_company"
+                    optional="hide"
+                    readonly="1"
+                />
+                <field
+                    name="amount_untaxed"
+                    sum="Total Tax Excluded"
+                    widget="monetary"
+                    optional="hide"
+                />
+                <field
+                    name="amount_tax"
+                    sum="Tax Total"
+                    widget="monetary"
+                    optional="hide"
+                />
+                <field
+                    name="amount_total"
+                    sum="Total Tax Included"
+                    widget="monetary"
+                    decoration-bf="1"
+                    decoration-info="invoice_status == 'to invoice'"
+                />
+                <field
+                    name="state"
+                    decoration-success="state == 'sale'"
+                    decoration-info="state == 'draft'"
+                    decoration-primary="state == 'sent'"
+                    widget="badge"
+                />
+                <field
+                    name="tag_ids"
+                    widget="many2many_tags"
+                    options="{'color_field': 'color'}"
+                    optional="hide"
+                />
+                <field
+                    name="invoice_status"
+                    decoration-success="invoice_status == 'invoiced'"
+                    decoration-info="invoice_status == 'to invoice'"
+                    decoration-warning="invoice_status == 'upselling'"
+                    widget="badge"
+                />
+                <field name="activity_ids" widget="list_activity" optional="show"/>
+                <field name="client_order_ref" optional="hide"/>
+                <field name="validity_date" optional="hide"/>
+            </list>
+        </field>
+    </record>
+
+    <!-- override to add website_id in sale.order related views -->
+    <record id="sale_order_tree" model="ir.ui.view">
+        <field name="name">sale.order.list.inherit.website.sale</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.sale_order_tree"/>
+        <field name="arch" type="xml">
+            <field name="user_id" position="before">
+                <field name="website_id" groups="website.group_multi_website" optional="show"/>
+            </field>
+        </field>
+    </record>
+
+    <record id="sale_order_kanban_view_ecommerce" model="ir.ui.view">
+        <field name="name">sale.order.kanban.inherit.website.sale.dashboard</field>
+        <field name="model">sale.order</field>
+        <field name="mode">primary</field>
+        <field name="inherit_id" ref="sale.view_sale_order_kanban"/>
+        <field name="arch" type="xml">
+            <kanban class="o_kanban_mobile" position="attributes">
+                <attribute name="js_class">website_sale_dashboard_kanban</attribute>
+            </kanban>
+        </field>
+    </record>
+
     <record id="action_orders_ecommerce" model="ir.actions.act_window">
         <field name="name">Orders</field>
         <field name="res_model">sale.order</field>
@@ -53,6 +170,17 @@
                 There is no confirmed order from the website
             </p>
         </field>
+    </record>
+
+    <record id="website_sale_order_list" model="ir.actions.act_window.view">
+        <field name="view_mode">list</field>
+        <field name="view_id" ref="sale_order_list_view_ecommerce"/>
+        <field name="act_window_id" ref="action_orders_ecommerce"/>
+    </record>
+    <record id="website_sale_order_kanban" model="ir.actions.act_window.view">
+        <field name="view_mode">kanban</field>
+        <field name="view_id" ref="sale_order_kanban_view_ecommerce"/>
+        <field name="act_window_id" ref="action_orders_ecommerce"/>
     </record>
 
     <!-- Dashboard Action -->
@@ -167,17 +295,6 @@
             </field>
             <field name="team_id" position="after">
                 <field name="website_id" invisible="not website_id" groups="website.group_multi_website"/>
-            </field>
-        </field>
-    </record>
-
-    <record id="sale_order_tree" model="ir.ui.view">
-        <field name="name">sale.order.list.inherit.website.sale</field>
-        <field name="model">sale.order</field>
-        <field name="inherit_id" ref="sale.sale_order_tree"/>
-        <field name="arch" type="xml">
-            <field name="user_id" position="before">
-                <field name="website_id" groups="website.group_multi_website" optional="show"/>
             </field>
         </field>
     </record>

--- a/addons/website_sale_stock/__manifest__.py
+++ b/addons/website_sale_stock/__manifest__.py
@@ -18,6 +18,7 @@ Then it can be made specific at the product level.
     'data': [
         'views/product_template_views.xml',
         'views/res_config_settings_views.xml',
+        'views/sale_order_views.xml',
         'views/website_sale_stock_templates.xml',
         'data/template_email.xml',
         'data/ir_cron_data.xml',

--- a/addons/website_sale_stock/views/sale_order_views.xml
+++ b/addons/website_sale_stock/views/sale_order_views.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<odoo>
+
+    <record id="sale_order_list_view_ecommerce" model="ir.ui.view">
+        <field name="name">website.sale.order.list.inherit.website.sale.stock</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="website_sale.sale_order_list_view_ecommerce"/>
+        <field name="arch" type="xml">
+            <field name="tag_ids" position="after">
+                <field
+                    name="warehouse_id"
+                    options="{'no_create': True}"
+                    readonly="state == 'sale'"
+                    groups="stock.group_stock_multi_warehouses"
+                    optional="hide"
+                />
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
This commit brings back the eCommerce dashboard for admins, providing
a quick overview of eCommerce sales performance.

- Adds the dashboard in list view.
- Implements custom search filters for relevant card data.
- Adds a dropdown with predefined time periods to view sales, average
  cart value, and conversion rate.
- Adds a new view for eCommerce orders as some extesions of main `sale`
  has no relevence in eCommerce context.

design task-5177259
task-5153059

See Also:
- https://github.com/odoo/enterprise/pull/98246

Co-authored and Designed by: Laetitia Daubechies (ldau) <ldau@odoo.com>

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
