### PR TITLE
[FIX] l10n_es_edi_verifactu: remove `RedirectWarnings` causing the cron to fail

### DIFF
--- a/addons/l10n_es_edi_verifactu/models/account_move.py
+++ b/addons/l10n_es_edi_verifactu/models/account_move.py
@@ -1,5 +1,4 @@
 from odoo import _, api, fields, models
-from odoo.exceptions import RedirectWarning
 
 
 class AccountMove(models.Model):
@@ -332,25 +331,6 @@ class AccountMove(models.Model):
             move._l10n_es_edi_verifactu_get_record_values(cancellation=cancellation)
             for move in self
         ]
-
-        for move, vals in zip(self, record_values_list):
-            # Add redirect warnings to journal entries with missing Veri*Factu documents for easier user flow.
-            if vals['verifactu_move_type'] == 'correction_substitution' and not vals['substituted_document']:
-                substituted_move = move.l10n_es_edi_verifactu_substituted_entry_id
-                msg = _("There is no Veri*Factu document for the substituted record.")
-                action = self._l10n_es_edi_verifactu_action_go_to_journal_entry(substituted_move)
-                raise RedirectWarning(msg, action, _("Go to the journal entry"))
-            if vals['verifactu_move_type'] == 'correction_substitution' and not vals['substituted_document_reversal_document']:
-                substituted_move = move.l10n_es_edi_verifactu_substituted_entry_id
-                msg = _("There is no Veri*Factu document for the reversal of the substituted record.")
-                action = self._l10n_es_edi_verifactu_action_go_to_journal_entry(substituted_move.reversal_move_id)
-                raise RedirectWarning(msg, action, _("Go to the journal entry"))
-            if vals['verifactu_move_type'] in ('correction_incremental', 'reversal_for_substitution') and not vals['refunded_document']:
-                reversed_move = move.reversed_entry_id
-                msg = _("There is no Veri*Factu document for the refunded record.")
-                action = self._l10n_es_edi_verifactu_action_go_to_journal_entry(reversed_move)
-                raise RedirectWarning(msg, action, _("Go to the journal entry"))
-
         return {
             record_values['record']: self.env['l10n_es_edi_verifactu.document']._create_for_record(record_values)
             for record_values in record_values_list

--- a/addons/l10n_es_edi_verifactu/tests/test_document.py
+++ b/addons/l10n_es_edi_verifactu/tests/test_document.py
@@ -2,8 +2,8 @@ import datetime
 from freezegun import freeze_time
 from unittest import mock
 
-from odoo import _
-from odoo.exceptions import UserError
+from odoo import _, Command
+from odoo.exceptions import UserError, RedirectWarning
 from odoo.tests import tagged
 from odoo.tools import zeep
 from .common import TestL10nEsEdiVerifactuCommon
@@ -59,6 +59,90 @@ class TestL10nEsEdiVerifactuDocument(TestL10nEsEdiVerifactuCommon):
             'l10n_es_edi_verifactu_warning_level': 'danger',
         }
         self.assertRecordValues(invoice, [expected_record_values])
+
+    def test_refund_without_refunded_error(self):
+        "Asserts no error is raised during the generation of the document."
+        invoice = self._create_dummy_invoice(name='INV/2019/00026', invoice_date='2024-12-30')
+        credit_note = invoice._reverse_moves()
+        credit_note.action_post()
+
+        wizard = self.env['account.move.send'].with_context(
+            active_model='account.move',
+            active_ids=credit_note.ids,
+        ).create({
+            'checkbox_send_mail': False,
+            **({'l10n_es_edi_facturae_checkbox_xml': False} if self.env['ir.module.module']._get('l10n_es_edi_facturae').state == 'installed' else {}),
+        })
+        with self._mock_last_document(None), self.assertRaisesRegex(RedirectWarning, r".*There is no Veri\*Factu document for the refunded record\..*"):
+            wizard.action_send_and_print()
+
+        with self._mock_last_document(None):
+            credit_note._l10n_es_edi_verifactu_create_documents()
+
+        errors = ["There is no Veri*Factu document for the refunded record.", "The refund reason is not specified."]
+        expected_record_values = {
+            'l10n_es_edi_verifactu_state': False,
+            'l10n_es_edi_verifactu_warning': self._mock_format_document_generation_errors(errors),
+            'l10n_es_edi_verifactu_warning_level': 'danger',
+        }
+        self.assertRecordValues(credit_note, [expected_record_values])
+
+    def test_substitution_without_documents_errors(self):
+        invoice = self._create_dummy_invoice(name='INV/2019/00026', invoice_date='2019-01-30')
+
+        self.env['account.move.reversal'].with_company(self.company).create(
+            {
+                'move_ids': [Command.set((invoice.id,))],
+                'date': '2019-02-10',
+                'journal_id': invoice.journal_id.id,
+            }
+        ).reverse_moves(is_modify=True)
+        credit_note = invoice.reversal_move_id
+
+        substitution_move = invoice.l10n_es_edi_verifactu_substitution_move_ids
+        substitution_move.invoice_date = '2019-02-11'
+        substitution_move.action_post()
+        wizard = self.env['account.move.send'].with_context(
+            active_model='account.move',
+            active_ids=substitution_move.ids,
+        ).create({
+            'checkbox_send_mail': False,
+            **({'l10n_es_edi_facturae_checkbox_xml': False} if self.env['ir.module.module']._get('l10n_es_edi_facturae').state == 'installed' else {}),
+        })
+
+        with self.assertRaisesRegex(RedirectWarning, r".*There is no Veri\*Factu document for the substituted record\..*"):
+            wizard.action_send_and_print()
+
+        substitution_move._l10n_es_edi_verifactu_create_documents()
+        errors = ["There is no Veri*Factu document for the substituted record.", "There is no Veri*Factu document for the reversal of the substituted record."]
+        expected_record_values = {
+            'l10n_es_edi_verifactu_state': False,
+            'l10n_es_edi_verifactu_warning': self._mock_format_document_generation_errors(errors),
+            'l10n_es_edi_verifactu_warning_level': 'danger',
+        }
+        self.assertRecordValues(substitution_move, [expected_record_values])
+
+        with self._mock_last_document(None):
+            invoice._l10n_es_edi_verifactu_create_documents()
+
+        with self._mock_zeep_registration_operation_certificate_issue(), self.assertRaisesRegex(RedirectWarning, r".*There is no Veri\*Factu document for the reversal of the substituted record\..*"):
+            wizard.action_send_and_print()
+
+        substitution_move._l10n_es_edi_verifactu_create_documents()
+        errors = ["There is no Veri*Factu document for the reversal of the substituted record."]
+        expected_record_values = {
+            'l10n_es_edi_verifactu_state': False,
+            'l10n_es_edi_verifactu_warning': self._mock_format_document_generation_errors(errors),
+            'l10n_es_edi_verifactu_warning_level': 'danger',
+        }
+        self.assertRecordValues(substitution_move, [expected_record_values])
+
+        credit_note._l10n_es_edi_verifactu_create_documents()
+
+        with self._mock_zeep_registration_operation_certificate_issue():
+            wizard.action_send_and_print()
+
+        self.assertTrue(substitution_move.l10n_es_edi_verifactu_document_ids.json_attachment_id)
 
     def test_certificate_issue(self):
         invoice = self._create_dummy_invoice()


### PR DESCRIPTION
### Steps to reproduce:
- Install l10n_es_edi_verifactu and switch too Spanish company
- Create an invoice, add a nonzero product and Confirm
- Select "Reverse" to create a credit note
- Confirm the credit note
- Select Send (or Send and Print), deselect everything except VeriFactu and email, then select Confirm
- An error appears that takes the user to the failed record
- Navigate to Accounting > Customers > Credit Notes
- Select the credit note created and at least one other credit note, then select "Send"
- Navigate to Settings > Technical > Scheduled Actions
- Click into the "Send Invoices Automatically" record, then select "Run Manually"
	- Version 18.3: the scheduled action fails, no error message appears. The traceback can be seen in the logs
	- Version 18.0 and lower: The scheduled action fails, but an error message does appear

### Cause:
When trying to generate the verifactu documents for a credit note whose invoice has no verifactu document, a `RedirectError` is raised. This means the scheduled action "Send invoices automatically" is cancelled if only one credit note as this issue: no invoices are sent.

### Solution:
The usual way to handle user errors with the scheduled action is to append the key 'error' in the dictionnary `send_and_print_values`. This way a message is displayed when running the scheduled action mentioning the moves in error.

So we check do the checks and remove the invalid moves before calling `_l10n_es_edi_verifactu_mark_for_next_batch()`. Like this we can change the key "error" in the dictionnary and stop the document generation there.
We also extend `_hook_if_errors()` to raise a `RedirectWarning` if it's one of the errors related to Verifactu that we removed.


opw-5091347