### PR TITLE
[FIX] maintenance: prevent error when opening equipment

### DIFF
--- a/addons/maintenance/models/maintenance.py
+++ b/addons/maintenance/models/maintenance.py
@@ -105,7 +105,7 @@ class MaintenanceMixin(models.AbstractModel):
     @api.depends('effective_date', 'maintenance_ids.stage_id', 'maintenance_ids.close_date', 'maintenance_ids.request_date')
     def _compute_maintenance_request(self):
         for record in self:
-            maintenance_requests = record.maintenance_ids.filtered(lambda mr: mr.maintenance_type == 'corrective' and mr.stage_id.done)
+            maintenance_requests = record.maintenance_ids.filtered(lambda mr: mr.maintenance_type == 'corrective' and mr.stage_id.done and mr.close_date)
             record.mttr = len(maintenance_requests) and (sum(int((request.close_date - request.request_date).days) for request in maintenance_requests) / len(maintenance_requests)) or 0
             record.latest_failure_date = max((request.request_date for request in maintenance_requests), default=False)
             record.mtbf = record.latest_failure_date and (record.latest_failure_date - record.effective_date).days / len(maintenance_requests) or 0

--- a/addons/maintenance/tests/test_maintenance.py
+++ b/addons/maintenance/tests/test_maintenance.py
@@ -119,3 +119,36 @@ class TestEquipment(TransactionCase):
             {'kanban_state': 'blocked', 'stage_id': self.ref('maintenance.stage_0')},
             {'kanban_state': 'blocked', 'stage_id': self.ref('maintenance.stage_0')},
         ])
+
+    def test_maintenance_request_with_equipment(self):
+        """
+        Ensure Equipment can be accessed through maintenance request
+
+        Steps:
+            1. Create a new maintenance stage.
+            2. Create an equipment.
+            3. Create a maintenance request linked to that equipment.
+            4. Mark the maintenance stage as done.
+            5. Open the equipment.
+        """
+
+        new_maintenance_stage = self.env['maintenance.stage'].create({
+            'name': 'New Done',
+        })
+
+        equipment_01 = self.equipment.with_user(self.manager).create({
+            'name': 'Samsung Monitor "15',
+            'category_id': self.equipment_monitor.id,
+            'serial_no': 'MT/127/18291015',
+        })
+
+        self.maintenance_request.create({
+            'name': 'Resolution is bad',
+            'user_id': self.user.id,
+            'equipment_id': equipment_01.id,
+            'stage_id': new_maintenance_stage.id,
+        })
+
+        new_maintenance_stage.done = True
+
+        self.assertEqual(equipment_01.mttr, 0)


### PR DESCRIPTION
**Steps:**
   1. Create a new maintenance stage.
   2. Create an equipment.
   3. Create a maintenance request linked to that equipment.
   4. Mark the maintenance stage as done.
   5. Open the equipment.

**Issue:**
   Opening equipment caused an error if close_date was empty:
   `unsupported operand type(s) for -: 'bool' and 'datetime.date'`.

Cause:
   The maintenance request’s close_date remained empty when the stage was marked DONE.

**Fix:**
   Check that close_date is not empty prior to computing MTBF.

**Technical:**
   In _compute_maintenance_request, we calculate the difference between close_date and request_date.If close_date is empty, this calculation fails.
