### PR TITLE
[FIX] website: prevent editing searchbar input on firefox

### DIFF
--- a/addons/website/static/src/builder/plugins/options/searchbar_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/searchbar_option_plugin.js
@@ -52,6 +52,10 @@ class SearchbarOptionPlugin extends Plugin {
                 dependency: "search_all_opt",
             },
         ],
+        // input group should not be contenteditable, while all other children
+        // beside the input are contenteditable
+        content_not_editable_selectors: [".input-group:has( > input)"],
+        content_editable_selectors: [".input-group:has( > input) > *:not(input)"],
     };
 }
 

--- a/addons/website/static/tests/builder/website_builder/searchbar_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/searchbar_option.test.js
@@ -89,3 +89,14 @@ test("Switching search type keeps 'order by' option if it exists on both types",
     expect("[data-label='Search within'] button.o-dropdown").toHaveText("Everything");
     expect("[data-label='Order by'] button.o-dropdown").toHaveText("something");
 });
+
+test("Input parent is not contenteditable, while all other children beside the input are", async () => {
+    await setupWebsiteBuilder(searchbarHTML("name asc"));
+
+    expect(":iframe .input-group:has(:scope > input)").toHaveAttribute("contenteditable", "false");
+
+    expect(":iframe .input-group:has(:scope > input) > *:not(input)").toHaveAttribute(
+        "contenteditable",
+        "true"
+    );
+});


### PR DESCRIPTION
Since the [html_builder refactoring], it's possible to type something
inside of an input while in the edit mode on Firefox, which is not
the expected behavior and which is not the case in other browsers, for
example, Chrome.
Steps to see the issue:
- Open Website and start editing
- Drop a searchbar
- Click on the input
- Type something

=> It will remove the searchbar and add text to the searchbar button.
This happens because of the different behavior on Chrome and Firefox of
`pointer-events`. When the input has `pointer-events` set to
`none` Chrome blocks any activity on it, including `beforeinput` events,
but Firefox doesn't.
This commit fixes this problem making the input not `contenteditable`.

task-5144517

[html_builder refactoring]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
