### PR TITLE
[IMP] core: adapt gc settings for python 3.13-14

### DIFF
--- a/odoo/init.py
+++ b/odoo/init.py
@@ -10,8 +10,10 @@ assert sys.version_info > MIN_PY_VERSION, f"Outdated python version detected, Od
 
 # ----------------------------------------------------------
 # Set gc thresolds if they are default, see `odoo.tools.gc`.
+# Defaults changed from (700, 10, 10) to (2000, 10, 10) in 3.13
+# and the last generation was removed in 3.14.
 # ----------------------------------------------------------
-if gc.get_threshold()[0] == 700:
+if gc.get_threshold()[0] in (700, 2000):
     # Handling requests can sometimes allocate over 5k new objects, let leave
     # some space before starting any collection.
     gc.set_threshold(12_000, 20, 25)

--- a/odoo/tools/gc.py
+++ b/odoo/tools/gc.py
@@ -13,10 +13,11 @@ There is also one permanent generation that is never collected (see
 The GC is triggered by the number of created objects. For the first collection,
 at every allocation and deallocation, a counter is respectively increased and
 decreased. Once it reaches a threshold, that collection is automatically
-collected. Other thresolds indicate that every X collections, the next
-collection is collected.
-
-Default thresolds are 700, 10, 10.
+collected.
+Before 3.14, other thresolds indicate that every X collections, the next
+collection is collected. Since the, there is only one additional collection
+which is collected inrementally; `1 / threshold1` percent of the heap is
+collected.
 """
 import contextlib
 import gc
@@ -39,6 +40,7 @@ def _timing_gc_callback(event, info):
     gen = info['generation']
     if event == 'start':
         _gc_start = _gc_time()
+        # python 3.14; gen2 is only collected when calling gc.collect() manually
         if gen == 2 and _logger.isEnabledFor(logging.DEBUG):
             _logger.debug("info %s, starting collection of gen2", gc_info())
     else:


### PR DESCRIPTION
The thresholds were changed in 3.13: threshold0 = 2000 instead of 700

There are only 2 collections instead of 3 since 3.14 and the second collection is processed incrementally.
https://github.com/python/cpython/blob/3.14/InternalDocs/garbage_collector.md

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
