### PR TITLE
[IMP] product: allow defining specific UoMs/packagings per variant

### DIFF
--- a/addons/account/models/account_analytic_line.py
+++ b/addons/account/models/account_analytic_line.py
@@ -77,7 +77,7 @@ class AccountAnalyticLine(models.Model):
     @api.depends('product_id')
     def _compute_allowed_uom_ids(self):
         for line in self:
-            line.allowed_uom_ids = line.product_id.product_tmpl_id._get_available_uoms()
+            line.allowed_uom_ids = line.product_id._get_available_uoms()
 
     @api.onchange('product_id', 'product_uom_id', 'unit_amount', 'currency_id')
     def on_change_unit_amount(self):

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1063,10 +1063,10 @@ class AccountMoveLine(models.Model):
                 and foreign_curr.is_zero(line.amount_residual_currency)
             )
 
-    @api.depends('product_id', 'product_id.uom_id', 'product_id.uom_ids')
+    @api.depends('product_id', 'product_id.uom_id', 'product_id.uom_ids', 'product_id.extra_uom_ids')
     def _compute_allowed_uom_ids(self):
         for line in self:
-            line.allowed_uom_ids = line.product_id.uom_id | line.product_id.uom_ids
+            line.allowed_uom_ids = line.product_id._get_available_uoms()
 
     @api.depends('product_id')
     def _compute_product_uom_id(self):

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -420,10 +420,10 @@ class MrpProduction(models.Model):
             ):
                 production.product_id = bom.product_id or bom.product_tmpl_id.product_variant_id
 
-    @api.depends('product_id', 'product_id.uom_id', 'product_id.uom_ids', 'product_id.bom_ids', 'product_id.bom_ids.uom_id')
+    @api.depends('product_id', 'product_id.uom_id', 'product_id.uom_ids', 'product_id.extra_uom_ids', 'product_id.bom_ids', 'product_id.bom_ids.uom_id')
     def _compute_allowed_uom_ids(self):
         for production in self:
-            production.allowed_uom_ids = production.product_id.uom_id | production.product_id.uom_ids | production.product_id.bom_ids.uom_id
+            production.allowed_uom_ids = production.product_id._get_available_uoms() | production.product_id.bom_ids.uom_id
 
     @api.depends('product_id', 'never_product_template_attribute_value_ids')
     def _compute_bom_id(self):

--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -64,6 +64,9 @@ class ProductProduct(models.Model):
 
     combination_indices = fields.Char(compute='_compute_combination_indices', store=True, index=True)
     is_product_variant = fields.Boolean(compute='_compute_is_product_variant')
+    extra_uom_ids = fields.Many2many(
+        'uom.uom', string='Extra Packagings', domain="[('id', '!=', uom_id)]",
+        help="Variant-specific additional packagings for this product which can be used for sales")
 
     standard_price = fields.Float(
         'Cost', company_dependent=True,
@@ -1242,3 +1245,13 @@ class ProductProduct(models.Model):
         """ Hook to handle an UoM modification. Avoid recomputation and just replace the
         many2one field on the impacted models."""
         return True
+
+    def _has_multiple_uoms(self):
+        if self.type == 'combo':
+            return False
+        return self.env['res.groups']._is_feature_enabled('uom.group_uom') and len(
+            self._get_available_uoms()
+        ) > 1
+
+    def _get_available_uoms(self):
+        return self.product_tmpl_id._get_available_uoms() | self.extra_uom_ids

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -969,6 +969,8 @@ class ProductTemplate(models.Model):
         variants_to_create = []
         variants_to_activate = Product
         variants_to_unlink = Product
+        # {tmpl_id: [(ptav_ids_frozenset, extra_uom_ids), ...]} to propagate to new variants
+        templates_extra_uom_ids = {}
 
         for tmpl_id in self:
             lines_without_no_variants = tmpl_id.valid_product_template_attribute_line_ids._without_no_variant_attributes()
@@ -1035,13 +1037,31 @@ class ProductTemplate(models.Model):
                 )
                 variants_to_activate += current_variants_to_activate
 
-            variants_to_unlink += all_variants - current_variants_to_activate
+            variants_being_replaced = all_variants - current_variants_to_activate
+            if current_variants_to_create and variants_being_replaced:
+                extra_uom_mapping = []
+                for variant in variants_being_replaced:
+                    if variant.extra_uom_ids:
+                        ptav_ids = frozenset(variant.product_template_attribute_value_ids.ids)
+                        extra_uom_mapping.append((ptav_ids, variant.extra_uom_ids))
+                if extra_uom_mapping:
+                    templates_extra_uom_ids[tmpl_id.id] = extra_uom_mapping
+            variants_to_unlink += variants_being_replaced
 
         if variants_to_activate:
             # Only activate variants whose template is active
             variants_to_activate.filtered(lambda v: v.product_tmpl_id.active).write({'active': True})
         if variants_to_create:
-            Product.create(variants_to_create)
+            new_variants = Product.create(variants_to_create)
+            extra_uom_mapping = templates_extra_uom_ids.get(new_variants[0].product_tmpl_id.id, [])
+            for new_variant in new_variants:
+                new_ptav_ids = frozenset(new_variant.product_template_attribute_value_ids.ids)
+                inherited_uom_ids = self.env['uom.uom']
+                for old_ptav_ids, old_extra_uom_ids in extra_uom_mapping:
+                    if old_ptav_ids <= new_ptav_ids:  # old is a subset of new
+                        inherited_uom_ids |= old_extra_uom_ids
+                if inherited_uom_ids:
+                    new_variant.extra_uom_ids = inherited_uom_ids
         if variants_to_unlink:
             variants_to_unlink._unlink_or_archive()
             # prevent change if exclusion deleted template by deleting last variant

--- a/addons/product/tests/test_variants.py
+++ b/addons/product/tests/test_variants.py
@@ -443,6 +443,96 @@ class TestVariants(ProductVariantsCommon):
             'THIS IS A BARCODE',
         )
 
+    def test_extra_uom_ids_propagation_on_variant_recreation(self):
+        """When adding a new attribute to a template, existing extra_uom_ids
+        should propagate to new variants based on PTAV subset matching."""
+        template = self.env['product.template'].create({
+            'name': 'Test Extra UoM Propagation',
+            'attribute_line_ids': [
+                Command.create({
+                    'attribute_id': self.size_attribute.id,
+                    'value_ids': [Command.set([
+                        self.size_attribute_s.id,
+                        self.size_attribute_m.id,
+                        self.size_attribute_l.id,
+                    ])],
+                }),
+            ],
+        })
+        self.assertEqual(len(template.product_variant_ids), 3)
+
+        # Assign extra_uom_ids per variant
+        variants = template.product_variant_ids.sorted('id')
+        variant_s, variant_m, variant_l = variants
+        variant_s.extra_uom_ids = self.uom_gram
+        variant_m.extra_uom_ids = self.uom_kgm
+        variant_l.extra_uom_ids = self.uom_ton
+
+        # Add Color attribute → triggers variant recreation → 6 variants
+        template.write({
+            'attribute_line_ids': [
+                Command.create({
+                    'attribute_id': self.color_attribute.id,
+                    'value_ids': [Command.set([
+                        self.color_attribute_red.id,
+                        self.color_attribute_blue.id,
+                    ])],
+                }),
+            ],
+        })
+        self.assertEqual(len(template.product_variant_ids), 6)
+
+        # Check propagation by PTAV subset matching
+        for variant in template.product_variant_ids:
+            ptav_names = variant.product_template_attribute_value_ids.mapped(
+                'product_attribute_value_id.name'
+            )
+            if 'S' in ptav_names:
+                self.assertEqual(variant.extra_uom_ids, self.uom_gram,
+                    f"Variant {ptav_names} should inherit gram from S")
+            elif 'M' in ptav_names:
+                self.assertEqual(variant.extra_uom_ids, self.uom_kgm,
+                    f"Variant {ptav_names} should inherit kgm from M")
+            elif 'L' in ptav_names:
+                self.assertEqual(variant.extra_uom_ids, self.uom_ton,
+                    f"Variant {ptav_names} should inherit ton from L")
+
+    def test_extra_uom_ids_not_propagated_without_match(self):
+        """When old variants have no PTAV overlap with new ones,
+        extra_uom_ids should not propagate."""
+        template = self.env['product.template'].create({
+            'name': 'Test No Propagation',
+            'attribute_line_ids': [
+                Command.create({
+                    'attribute_id': self.size_attribute.id,
+                    'value_ids': [Command.set([
+                        self.size_attribute_s.id,
+                        self.size_attribute_m.id,
+                    ])],
+                }),
+            ],
+        })
+        variants = template.product_variant_ids.sorted('id')
+        variants[0].extra_uom_ids = self.uom_gram  # S only
+
+        # Remove Size, add Color → completely new variants with no PTAV overlap
+        template.write({
+            'attribute_line_ids': [
+                Command.create({
+                    'attribute_id': self.color_attribute.id,
+                    'value_ids': [Command.set([
+                        self.color_attribute_red.id,
+                        self.color_attribute_blue.id,
+                    ])],
+                }),
+                Command.unlink(template.attribute_line_ids[0].id),
+            ],
+        })
+
+        self.assertFalse(template.product_variant_ids.extra_uom_ids,
+            "New variants with no PTAV overlap should have empty extra_uom_ids")
+
+
 @tagged('post_install', '-at_install')
 class TestVariantsNoCreate(ProductVariantsCommon):
 

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -163,7 +163,7 @@
                         </page>
                         <page string="Sales" name="sales" invisible="1 or not sale_ok">
                             <group name="sale" class="o_label_nowrap">
-                                <group string="Upsell &amp; Cross-Sell" name="upsell" invisible="1">
+                                <group string="Upsell &amp; Cross-Sell" name="upsell" invisible="product_variant_count != 1">
                                     <field
                                         name="uom_ids"
                                         widget="many2many_uom_tags"
@@ -441,6 +441,12 @@
                                     force_save="1"
                                     readonly="1"
                                     context="{'product_id': id}"/>
+                                <field
+                                    name="extra_uom_ids"
+                                    widget="many2many_uom_tags"
+                                    options="{'no_quick_create': True, 'on_tag_click': 'open_form'}"
+                                    groups="uom.group_uom"
+                                    context="{'product_id': id}"/>
                                 <field name="product_tag_ids" widget="many2many_tags" readonly="1"/>
                                 <field name="additional_product_tag_ids" widget="many2many_tags" context="{'product_variant_id': id}"/>
                             </group>
@@ -596,7 +602,17 @@
                     />
                 </field>
                 <field name="uom_ids" position="attributes">
+                    <attribute name="readonly">product_variant_count != 1</attribute>
                     <attribute name="context">{'product_id': id}</attribute>
+                </field>
+                <field name="uom_ids" position="after">
+                    <field
+                        name="extra_uom_ids"
+                        widget="many2many_uom_tags"
+                        options="{'no_quick_create': True, 'on_tag_click': 'open_form'}"
+                        groups="uom.group_uom"
+                        invisible="product_variant_count == 1"
+                        context="{'product_id': id}"/>
                 </field>
             </field>
         </record>

--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -406,10 +406,10 @@ class PurchaseOrderLine(models.Model):
 
         self._compute_tax_id()
 
-    @api.depends('product_id', 'product_id.uom_id', 'product_id.uom_ids', 'product_id.seller_ids', 'product_id.seller_ids.uom_id')
+    @api.depends('product_id', 'product_id.uom_id', 'product_id.uom_ids', 'product_id.extra_uom_ids', 'product_id.seller_ids', 'product_id.seller_ids.uom_id')
     def _compute_allowed_uom_ids(self):
         for line in self:
-            line.allowed_uom_ids = line.product_id.uom_id | line.product_id.uom_ids | line.product_id.seller_ids.uom_id
+            line.allowed_uom_ids = line.product_id._get_available_uoms() | line.product_id.seller_ids.uom_id
 
     @api.depends('product_qty', 'uom_id', 'company_id', 'order_id.partner_id')
     def _compute_price_unit_and_date_planned_and_name(self):

--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -222,10 +222,10 @@ class RepairOrder(models.Model):
             else:
                 repair.product_qty = 1.0
 
-    @api.depends('product_id', 'product_id.uom_id', 'product_id.uom_ids', 'product_id.seller_ids', 'product_id.seller_ids.uom_id')
+    @api.depends('product_id', 'product_id.uom_id', 'product_id.uom_ids', 'product_id.extra_uom_ids', 'product_id.seller_ids', 'product_id.seller_ids.uom_id')
     def _compute_allowed_uom_ids(self):
         for repair in self:
-            repair.allowed_uom_ids = repair.product_id.uom_id | repair.product_id.uom_ids | repair.product_id.seller_ids.uom_id
+            repair.allowed_uom_ids = repair.product_id._get_available_uoms() | repair.product_id.seller_ids.uom_id
 
     @api.depends('picking_id')
     def _compute_partner_id(self):

--- a/addons/sale/controllers/product_configurator.py
+++ b/addons/sale/controllers/product_configurator.py
@@ -179,6 +179,9 @@ class SaleProductConfiguratorController(Controller):
         )
         # Shouldn't be sent client-side
         values.pop("pricelist_rule_id", None)
+        if product and not product._has_multiple_uoms():
+            # Enforce the default UoM if there is no other choice for this variant.
+            values["uom"] = product.uom_id.read(["id", "display_name"])[0]
         return values
 
     @route(
@@ -288,7 +291,6 @@ class SaleProductConfiguratorController(Controller):
                 }],
                 'exclusions': dict,
                 'archived_combination': dict,
-                'available_uoms': dict (optional),
             }
         """
         uom = (
@@ -319,6 +321,7 @@ class SaleProductConfiguratorController(Controller):
                 uom=uom,
                 currency=currency,
                 date=so_date,
+                show_packaging=show_packaging,
                 **kwargs,
             ),
             quantity=quantity,
@@ -347,11 +350,6 @@ class SaleProductConfiguratorController(Controller):
             exclusions=attribute_exclusions["exclusions"],
             archived_combinations=attribute_exclusions["archived_combinations"],
         )
-        if show_packaging and product_template._has_multiple_uoms():
-            values["available_uoms"] = product_template._get_available_uoms().read([
-                "id",
-                "display_name",
-            ])
         # Shouldn't be sent client-side
         values.pop("pricelist_rule_id", None)
         return values
@@ -371,6 +369,7 @@ class SaleProductConfiguratorController(Controller):
                 'description_sale': str|False,
                 'display_name': str,
                 'price': float,
+                'available_uoms': dict (optional),
             }
         """
         basic_information = dict(
@@ -393,6 +392,11 @@ class SaleProductConfiguratorController(Controller):
             pricelist=pricelist,
             **kwargs,
         )
+        if kwargs.get('show_packaging', True) and product_or_template._has_multiple_uoms():
+            basic_information["available_uoms"] = product_or_template._get_available_uoms().read([
+                "id",
+                "display_name",
+            ])
         return dict(
             **basic_information,
             price=price,

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -601,10 +601,10 @@ class SaleOrderLine(models.Model):
                 line.product_id.sale_line_warn_msg if has_warning_group else ""
             )
 
-    @api.depends("product_id", "product_id.uom_id", "product_id.uom_ids")
+    @api.depends("product_id", "product_id.uom_id", "product_id.uom_ids", "product_id.extra_uom_ids")
     def _compute_allowed_uom_ids(self):
         for line in self:
-            line.allowed_uom_ids = line.product_id.uom_id | line.product_id.uom_ids
+            line.allowed_uom_ids = line.product_id._get_available_uoms()
 
     @api.depends("product_id", "company_id")
     def _compute_tax_ids(self):

--- a/addons/sale/static/src/js/product_configurator_dialog/product_configurator_dialog.js
+++ b/addons/sale/static/src/js/product_configurator_dialog/product_configurator_dialog.js
@@ -315,6 +315,11 @@ export class ProductConfiguratorDialog extends Component {
         if (this._isPossibleCombination(product)) {
             const updatedValues = await this._updateCombination(product, product.quantity, product.uom.id);
             Object.assign(product, updatedValues);
+            if (product.available_uoms?.length) {
+                if (!product.available_uoms.find(uom => uom.id === product.uom.id)) {
+                    product.uom = product.available_uoms[0];
+                }
+            }
             // When a combination should exist but was deleted from the database, it should not be
             // selectable and considered as an exclusion.
             if (!product.id && product.attribute_lines.every(ptal => ptal.create_variant === "always")) {

--- a/addons/sale_management/models/sale_order_template_line.py
+++ b/addons/sale_management/models/sale_order_template_line.py
@@ -74,10 +74,10 @@ class SaleOrderTemplateLine(models.Model):
 
     # === COMPUTE METHODS ===#
 
-    @api.depends("product_id", "product_id.uom_id", "product_id.uom_ids")
+    @api.depends("product_id", "product_id.uom_id", "product_id.uom_ids", "product_id.extra_uom_ids")
     def _compute_allowed_uom_ids(self):
         for option in self:
-            option.allowed_uom_ids = option.product_id.uom_id | option.product_id.uom_ids
+            option.allowed_uom_ids = option.product_id._get_available_uoms()
 
     @api.depends("product_id")
     def _compute_product_uom_id(self):

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -200,10 +200,10 @@ class StockMove(models.Model):
 
     _product_location_index = models.Index("(product_id, location_id, location_dest_id, company_id, state)")
 
-    @api.depends('product_id', 'product_id.uom_id', 'product_id.uom_ids', 'product_id.seller_ids', 'product_id.seller_ids.uom_id')
+    @api.depends('product_id', 'product_id.uom_id', 'product_id.uom_ids', 'product_id.extra_uom_ids', 'product_id.seller_ids', 'product_id.seller_ids.uom_id')
     def _compute_allowed_uom_ids(self):
         for move in self:
-            move.allowed_uom_ids = move.product_id.uom_id | move.product_id.uom_ids | move.sudo().product_id.seller_ids.uom_id
+            move.allowed_uom_ids = move.product_id._get_available_uoms() | move.sudo().product_id.seller_ids.uom_id
 
     @api.depends('product_id')
     def _compute_uom_id(self):

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -97,10 +97,10 @@ class StockMoveLine(models.Model):
     _free_reservation_index = models.Index("""(id, company_id, product_id, lot_id, location_id, owner_id, package_id)
         WHERE (state IS NULL OR state NOT IN ('cancel', 'done')) AND quantity_product_uom > 0 AND picked IS NOT TRUE""")
 
-    @api.depends('product_id', 'product_id.uom_id', 'product_id.uom_ids', 'product_id.seller_ids', 'product_id.seller_ids.uom_id')
+    @api.depends('product_id', 'product_id.uom_id', 'product_id.uom_ids', 'product_id.extra_uom_ids', 'product_id.seller_ids', 'product_id.seller_ids.uom_id')
     def _compute_allowed_uom_ids(self):
         for line in self:
-            line.allowed_uom_ids = line.product_id.uom_id | line.product_id.uom_ids | line.sudo().product_id.seller_ids.uom_id
+            line.allowed_uom_ids = line.product_id._get_available_uoms() | line.sudo().product_id.seller_ids.uom_id
 
     @api.depends('move_id.uom_id', 'product_id.uom_id')
     def _compute_uom_id(self):

--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -212,10 +212,10 @@ class StockWarehouseOrderpoint(models.Model):
             if orderpoint.product_max_qty < orderpoint.product_min_qty or not orderpoint.product_max_qty:
                 orderpoint.product_max_qty = orderpoint.product_min_qty
 
-    @api.depends('route_id', 'product_id', 'product_id.seller_ids', 'product_id.seller_ids.uom_id')
+    @api.depends('route_id', 'product_id', 'product_id.uom_ids', 'product_id.extra_uom_ids', 'product_id.seller_ids', 'product_id.seller_ids.uom_id')
     def _compute_allowed_replenishment_uom_ids(self):
         for orderpoint in self:
-            orderpoint.allowed_replenishment_uom_ids = orderpoint.product_id.uom_ids
+            orderpoint.allowed_replenishment_uom_ids = orderpoint.product_id.uom_ids | orderpoint.product_id.extra_uom_ids
             if 'buy' in orderpoint.rule_ids.mapped('action'):
                 orderpoint.allowed_replenishment_uom_ids += orderpoint.product_id.seller_ids.uom_id
 

--- a/addons/stock/wizard/product_replenish.py
+++ b/addons/stock/wizard/product_replenish.py
@@ -33,10 +33,10 @@ class ProductReplenish(models.TransientModel):
         if not self.env.context.get('default_quantity'):
             self.quantity = abs(self.forecasted_quantity) if self.forecasted_quantity < 0 else 1
 
-    @api.depends('product_id', 'product_id.uom_id', 'product_id.uom_ids', 'product_id.seller_ids', 'product_id.seller_ids.uom_id')
+    @api.depends('product_id', 'product_id.uom_id', 'product_id.uom_ids', 'product_id.extra_uom_ids', 'product_id.seller_ids', 'product_id.seller_ids.uom_id')
     def _compute_allowed_uom_ids(self):
         for rec in self:
-            rec.allowed_uom_ids = rec.product_id.uom_id | rec.product_id.uom_ids | rec.product_id.seller_ids.uom_id
+            rec.allowed_uom_ids = rec.product_id._get_available_uoms() | rec.product_id.seller_ids.uom_id
 
     @api.depends('warehouse_id', 'product_id')
     def _compute_forecasted_quantity(self):

--- a/addons/website_sale/controllers/cart.py
+++ b/addons/website_sale/controllers/cart.py
@@ -546,7 +546,7 @@ class Cart(PaymentPortal):
             ):
                 infos["image_url"] = image_data_uri(combo_item.product_id.image_128)
 
-        if line.product_template_id._has_multiple_uoms():
+        if line.product_id._has_multiple_uoms():
             infos["uom_name"] = line.product_uom_id.name
 
         return infos

--- a/addons/website_sale/controllers/variant.py
+++ b/addons/website_sale/controllers/variant.py
@@ -68,6 +68,12 @@ class WebsiteSaleVariantController(Controller):
                 "website_sale.product_tags",
                 values={"all_product_tags": all_tags.filtered("visible_to_customers")},
             )
+
+        combination_info["packaging_selector"] = request.env["ir.ui.view"]._render_template(
+            "website_sale.product_packaging_selector",
+            values={"product": product_template, "product_variant": product},
+        )
+
         return combination_info
 
     @route(

--- a/addons/website_sale/static/src/interactions/product_page.js
+++ b/addons/website_sale/static/src/interactions/product_page.js
@@ -9,7 +9,7 @@ import { memoize, uniqueId } from '@web/core/utils/functions';
 import { KeepLast } from '@web/core/utils/concurrency';
 import { insertThousandsSep } from '@web/core/utils/numbers';
 import { throttleForAnimation } from '@web/core/utils/timing';
-import { markup } from '@odoo/owl';
+import { htmlEscape, markup } from '@odoo/owl';
 import wSaleUtils from '@website_sale/js/website_sale_utils';
 import { ProductImageViewer } from '@website_sale/js/components/website_sale_image_viewer';
 
@@ -336,6 +336,10 @@ export class ProductPage extends Interaction {
             'product_template_id': productTemplateId,
             'combination': combination,
         }));
+        if (combinationInfo.product_tags) {
+            combinationInfo.product_tags = markup(combinationInfo.product_tags);
+        }
+        combinationInfo.packaging_selector = markup(combinationInfo.packaging_selector);
 
         this._onChangeCombination(ev, parent, combinationInfo, attributeValueImages);
         this._checkExclusions(parent, combination);
@@ -626,12 +630,34 @@ export class ProductPage extends Interaction {
 
         this._toggleDisable(parent, isCombinationPossible);
 
-        // Only update the images and tags if the product has changed.
+        // Only update the images, tags and packaging selector if the product has changed.
         if (!combination.no_product_change) {
             this._updateProductImages(parent.closest('#product_detail_main'), combination.carousel);
             const productTags = parent.querySelector('.o_product_tags');
-            productTags?.insertAdjacentHTML('beforebegin', markup(combination.product_tags));
+            productTags?.insertAdjacentHTML('beforebegin', htmlEscape(combination.product_tags));
             productTags?.remove();
+
+            const packagingSelector = parent.querySelector('[name="packaging_selector"]');
+            if (packagingSelector) {
+                packagingSelector.insertAdjacentHTML(
+                    'beforebegin', htmlEscape(combination.packaging_selector)
+                );
+                packagingSelector.remove();
+            }
+            // Toggle variant section visibility when UOM availability changes (edge case:
+            // template has no attributes, only some variants have UOMs).
+            const variantSection = parent.querySelector(
+                '.o_wsale_product_details_content_section_attributes'
+            );
+            if (variantSection) {
+                const hasAttributes = parent.querySelector(
+                    '.o_wsale_product_page_variants li.variant_attribute'
+                );
+                const hasPackaging = parent.querySelector(
+                    '[name="packaging_selector"] .o_wsale_product_page_variants'
+                );
+                variantSection.classList.toggle('d-none', !hasAttributes && !hasPackaging);
+            }
         }
 
         const productIdElements = parent.querySelectorAll('[data-product-id]');

--- a/addons/website_sale/templates/checkout/cart_templates.xml
+++ b/addons/website_sale/templates/checkout/cart_templates.xml
@@ -103,7 +103,7 @@
                                         <t t-set="combination_name" t-value="line._get_combination_name()"/>
                                         <span t-if="combination_name" class="d-none d-md-inline h6 text-muted mb-1">-</span>
                                         <div
-                                            t-if="combination_name or line.product_template_id._has_multiple_uoms()"
+                                            t-if="combination_name or line.product_id._has_multiple_uoms()"
                                             class="d-inline-flex flex-wrap column-gap-2 row-gap-1 align-items-center my-1 my-md-0 w-100 w-md-auto"
                                         >
                                             <span
@@ -112,7 +112,7 @@
                                                 t-out="combination_name"
                                             />
                                             <span
-                                                t-if="line.product_template_id._has_multiple_uoms()"
+                                                t-if="line.product_id._has_multiple_uoms()"
                                                 class="badge bg-light mb-1"
                                                 t-out="line.product_uom_id.name"
                                             />
@@ -430,7 +430,7 @@
                                     </ul>
                                 </div>
                                 <small
-                                    t-if="order_line.product_template_id._has_multiple_uoms()"
+                                    t-if="order_line.product_id._has_multiple_uoms()"
                                     t-out="order_line.product_uom_id.name"
                                     class="badge mt-1 bg-light"
                                 />

--- a/addons/website_sale/templates/checkout/checkout_templates.xml
+++ b/addons/website_sale/templates/checkout/checkout_templates.xml
@@ -380,7 +380,7 @@
                                 <span class="text-wrap" t-out="line._get_line_header()"/>
                                 <p class="text-muted small mb-0" t-out="line._get_combination_name()"/>
                                 <span
-                                    t-if="line.product_template_id._has_multiple_uoms()"
+                                    t-if="line.product_id._has_multiple_uoms()"
                                     class="badge mt-1 bg-light"
                                     t-out="line.product_uom_id.name"
                                 />

--- a/addons/website_sale/templates/product_page_templates.xml
+++ b/addons/website_sale/templates/product_page_templates.xml
@@ -136,7 +136,7 @@
 
                                     <t name="variant_info">
                                         <div
-                                            t-attf-class="o_wsale_product_details_content_section o_wsale_product_details_content_section_attributes mb-4 {{not (product.valid_product_template_attribute_line_ids or product._has_multiple_uoms()) and 'd-none' or ''}}"
+                                            t-attf-class="o_wsale_product_details_content_section o_wsale_product_details_content_section_attributes mb-4 {{not (product.valid_product_template_attribute_line_ids or (product_variant and product_variant._has_multiple_uoms())) and 'd-none' or ''}}"
                                         >
                                             <t t-call="website_sale.variants"
                                                 ul_class.f="flex-column"
@@ -439,34 +439,7 @@
                 </li>
             </t>
         </ul>
-        <ul
-            t-if="product._has_multiple_uoms()"
-            t-attf-class="o_wsale_product_page_variants d-flex flex-column gap-4 list-unstyled js_add_cart_variants mt-4 #{ul_class}"
-        >
-            <li>
-                <!-- Separate template to reduce views duplication -->
-                <t t-call="website_sale.packaging_title"/>
-                <ul class="btn-group-toggle list-inline list-unstyled" data-bs-toggle="buttons">
-                    <t t-set="product_uoms" t-value="product._get_available_uoms()"/>
-                    <t t-foreach="product_uoms" t-as="uom">
-                        <t t-set="is_main_uom" t-value="uom.id == product.uom_id.id"/>
-                        <li t-attf-class="o_variant_pills border btn m-0 cursor-pointer #{'active border-primary text-primary-emphasis bg-primary-subtle' if is_main_uom else ''}">
-                            <input
-                                class="position-absolute opacity-0 cursor-pointer"
-                                type="radio"
-                                t-att-checked="is_main_uom"
-                                name="uom_id"
-                                t-att-value="uom.id"
-                                t-attf-id="uom-{{uom.id}}"
-                                t-att-autocomplete="off"/>
-                            <label class="radio_input_value cursor-pointer" t-attf-for="uom-{{uom.id}}">
-                                <span t-field="uom.name"/>
-                            </label>
-                        </li>
-                    </t>
-                </ul>
-            </li>
-        </ul>
+        <t t-call="website_sale.product_packaging_selector"/>
     </template>
 
     <template id="website_sale.badge_extra_price" name="Badge Extra Price">
@@ -498,6 +471,38 @@
 
     <template id="website_sale.packaging_title" name="Packaging title">
         <h6 class="attribute_name mb-2">Packaging</h6>
+    </template>
+
+    <template id="website_sale.product_packaging_selector" name="Product Packaging Selector">
+        <div name="packaging_selector">
+            <ul
+                t-if="product_variant and product_variant._has_multiple_uoms()"
+                t-attf-class="o_wsale_product_page_variants d-flex flex-column gap-4 list-unstyled js_add_cart_variants mt-4 #{ul_class}"
+            >
+                <li>
+                    <t t-call="website_sale.packaging_title"/>
+                    <ul class="btn-group-toggle list-inline list-unstyled" data-bs-toggle="buttons">
+                        <t t-set="product_uoms" t-value="product_variant._get_available_uoms()"/>
+                        <t t-foreach="product_uoms" t-as="uom">
+                            <t t-set="is_main_uom" t-value="uom.id == product.uom_id.id"/>
+                            <li t-attf-class="o_variant_pills border btn m-0 cursor-pointer #{'active border-primary text-primary-emphasis bg-primary-subtle' if is_main_uom else ''}">
+                                <input
+                                    class="position-absolute opacity-0 cursor-pointer"
+                                    type="radio"
+                                    t-att-checked="is_main_uom"
+                                    name="uom_id"
+                                    t-att-value="uom.id"
+                                    t-attf-id="uom-{{uom.id}}"
+                                    t-att-autocomplete="off"/>
+                                <label class="radio_input_value cursor-pointer" t-attf-for="uom-{{uom.id}}">
+                                    <span t-field="uom.name"/>
+                                </label>
+                            </li>
+                        </t>
+                    </ul>
+                </li>
+            </ul>
+        </div>
     </template>
 
     <template id="website_sale.product_title">

--- a/addons/website_sale_collect/views/delivery_form_templates.xml
+++ b/addons/website_sale_collect/views/delivery_form_templates.xml
@@ -33,7 +33,7 @@
                         <t t-out="order_line.product_id.name"/>
                         <t t-if="attrib_names" t-out="' - ' + attrib_names"/>
                         <t
-                            t-if="order_line.product_id.product_tmpl_id._has_multiple_uoms()"
+                            t-if="order_line.product_id._has_multiple_uoms()"
                             t-out="' (' + order_line.product_uom_id.name + ')'"
                         />
                     </div>


### PR DESCRIPTION
This commit enables defining dedicated units of measure, or packagings
per product variant. Since 18.1, it was only possible to set UoMs on the
template level. However, before 18.1, it was possible to define different
packagings on the variant level. This commit partially restores the old
behavior, and users can select dedicated UoMs on the variant from the new
field `extra_uom_ids`.

Task-5152612
