### PR TITLE
[IMP] hr_skills: add certificates uploading for certifications

### DIFF
--- a/addons/hr_skills/models/hr_individual_skill_mixin.py
+++ b/addons/hr_skills/models/hr_individual_skill_mixin.py
@@ -61,6 +61,8 @@ class HrIndividualSkillMixin(models.AbstractModel):
     is_certification = fields.Boolean(related="skill_type_id.is_certification",
         export_string_translation=False)  # if is_certification change the model will not trigger the constrains
     display_warning_message = fields.Boolean()
+    certificate_filename = fields.Char()
+    certificate_file = fields.Binary(string="Certificate")
 
     @api.constrains(lambda self: [
         'valid_from', 'valid_to', 'skill_id', 'skill_type_id', 'skill_level_id', self._linked_field_name()
@@ -471,9 +473,13 @@ class HrIndividualSkillMixin(models.AbstractModel):
             skill_type = self.env['hr.skill.type'].browse(new_vals['skill_type_id'])
             valid_from = vals.get('valid_from', ind_skill.valid_from if skill_type.is_certification else fields.Date.today())
             valid_to = vals.get('valid_to', ind_skill.valid_to if skill_type.is_certification else False)
+            certificate_filename = vals.get('certificate_filename', ind_skill.certificate_filename)
+            certificate_file = vals.get('certificate_file', ind_skill.certificate_file)
             new_vals.update({
                 'valid_from': valid_from,
                 'valid_to': valid_to,
+                'certificate_filename': certificate_filename,
+                'certificate_file': certificate_file,
             })
             create_vals.append(new_vals)
         return result_command + (self - remove_from_expire)._expire_individual_skills() + self.env[self._name]._create_individual_skills(create_vals)

--- a/addons/hr_skills/views/hr_views.xml
+++ b/addons/hr_skills/views/hr_views.xml
@@ -420,6 +420,12 @@
                             <field name="valid_to" placeholder="indefinite" nolabel="1" class="w-25"/>
                         </div>
                     </group>
+                    <group>
+                        <group>
+                            <field name="certificate_filename" invisible="1"/>
+                            <field name="certificate_file" string="Certificate" filename="certificate_filename" invisible="not is_certification"/>
+                        </group>
+                    </group>
                     <div class="alert alert-warning ps-3" role="alert" invisible="not display_warning_message">
                         The end date must be after the start date.
                     </div>
@@ -556,6 +562,8 @@
                 <field name="skill_type_id" optional="hide"/>
                 <field name="valid_from" string="From" widget="formatted_date" options="{'month_format': 'short'}" width="300"/>
                 <field name="valid_to" string="To" widget="formatted_date" options="{'month_format': 'short'}" width="300"/>
+                <field name="certificate_filename" column_invisible="1"/>
+                <field name="certificate_file" filename="certificate_filename" widget="binary" optional="hidden"/>
             </list>
         </field>
     </record>


### PR DESCRIPTION
Allow the user to add a file as a proof of an `hr_employee_skill` whose `hr_skill_type` is a certification. If the skill is saved without a new file passed to it, it keeps the old file, and it's up to the user to change or remove it.

[task-5150625](https://www.odoo.com/odoo/project/1251/tasks/5150625)
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
