### PR TITLE
[FIX] product: search product by vendor code no purchase_product_matrix

### DIFF
--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -602,7 +602,7 @@ class ProductProduct(models.Model):
         if not products and operator in positive_operators and (m := re.search(r'(\[(.*?)\])', name)):
             match_domain = [('default_code', '=', m.group(2))]
             products = self.search_fetch(expression.AND([domain, match_domain]), ['display_name'], limit=limit)
-        if not products and (partner_id := self.env.context.get('partner_id')):
+        if partner_id := self.env.context.get('partner_id'):
             # still no results, partner in context: search on supplier info as last hope to find something
             supplier_domain = [
                 ('partner_id', '=', partner_id),
@@ -611,7 +611,7 @@ class ProductProduct(models.Model):
                 ('product_name', operator, name),
             ]
             match_domain = [('product_tmpl_id.seller_ids', 'any', supplier_domain)]
-            products = self.search_fetch(expression.AND([domain, match_domain]), ['display_name'], limit=limit)
+            products |= self.search_fetch(expression.AND([domain, match_domain]), ['display_name'], limit=limit)
         return [(product.id, product.display_name) for product in products.sudo()]
 
     @api.model


### PR DESCRIPTION
**Problem:**
With purchase_product_matrix module is not installed.
When we search for a product by vendor code in a purchase 
order where the vendor is set, the product does not show up 
if another product has the same code as internal reference.

**Steps to reproduce:**
- Uninstall purchase_product_matrix.
- Create a first product (the main product).
- Set a vendor and a vendor code.
- Create another product (the decoy product).
- Set the internal reference as the same as the main product
vendor code.
- Create a purchase order for this vendor.
- Click on "add a product" and type the vendor code of the main product.

**Current behavior:**
Only the decoy product is visible.

**Expected behavior:**
Both products should be visible.
If you delete the decoy product, the main product will 
be visible.

**Cause of the issue:**
The purchase_order_form_view inside purchase_product_matrix replaces
The product_id field with product_template_id.
https://github.com/odoo/odoo/blob/7c513de528c9f9fdbfc8c5fa8496c94c2c7e96a0/addons/purchase_product_matrix/views/purchase_views.xml#L10-L14
So, when this module is not installed,  instead of calling name_search 
on product.template we call it on product.product. 
Inside the name_search method of product.product,
if a result is found using the default code, we do not look 
for a result based on the vendor code.
https://github.com/odoo/odoo/blob/7c513de528c9f9fdbfc8c5fa8496c94c2c7e96a0/addons/product/models/product_product.py#L605

opw-4971675