### PR TITLE
[FIX] web: correctly reset datetimepicker service state when switching record

### DIFF
--- a/addons/web/static/src/core/datetime/datetimepicker_service.js
+++ b/addons/web/static/src/core/datetime/datetimepicker_service.js
@@ -109,17 +109,19 @@ export const datetimePickerService = {
 
                 const computeBasePickerProps = () => {
                     const nextProps = markValuesRaw(hookParams.pickerProps);
-                    const nextStringProps = stringifyProps(nextProps);
+                    const oldStringProps = stringProps;
 
-                    if (shallowEqual(stringProps, nextStringProps)) {
+                    stringProps = stringifyProps(nextProps);
+                    lastAppliedStringValue = stringProps.value;
+
+                    if (shallowEqual(oldStringProps, stringProps)) {
                         return;
                     }
 
-                    stringProps = nextStringProps;
                     inputsChanged = ensureArray(nextProps.value).map(() => false);
 
                     for (const [key, value] of Object.entries(nextProps)) {
-                        if (pickerProps[key] !== value && !areDatesEqual(pickerProps[key], value)) {
+                        if (!areDatesEqual(pickerProps[key], value)) {
                             pickerProps[key] = value;
                         }
                     }


### PR DESCRIPTION
Steps to reproduce
==================

- Install accounting
- Go to Accounting > Accounting > Journal Entries
- Create a new record
- Select an Accounting Date in the previous month
- An onchange is called and the title is changed to draft
- Save the record
- Click on New
- Select the same date
- The onchange isn't triggered
- Save the record
- The record stays dirty and the title is missing

Cause of the issue
==================

https://github.com/odoo/odoo/commit/44f69ae726b1ff8876c38e858c64fed0f5b1a766

lastAppliedStringValue should be reset inside computeBasePickerProps

Solution
========

We backport the code from 19.0 where this was fixed

opw-5145113