### PR TITLE
[FIX] sale_gelato: remove 'upgrade_boolean' from Gelato setting

### DIFF
--- a/addons/sale/wizard/res_config_settings_views.xml
+++ b/addons/sale/wizard/res_config_settings_views.xml
@@ -186,7 +186,7 @@
                             documentation="/applications/sales/sales/gelato.html"
                             help="Place orders through Gelato's print-on-demand service"
                         >
-                            <field name="module_sale_gelato" widget="upgrade_boolean"/>
+                            <field name="module_sale_gelato"/>
                             <div
                                 class="content-group"
                                 name="gelato_credentials"


### PR DESCRIPTION
Remove the 'Enterprise' widget from Gelato setting, which prevented community users from installing Gelato module from settings without upgrading to enterprise.
