### PR TITLE
[FIX] analytic : fix company_id dependencies (analytic_distribution)

### DIFF
--- a/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.js
+++ b/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.js
@@ -683,7 +683,6 @@ export const analyticDistribution = {
     supportedTypes: ["json"],
     fieldDependencies: [
         { name: "analytic_precision", type: "integer" },
-        { name: "company_id", type: "many2one" },
     ],
     supportedOptions: [
         {


### PR DESCRIPTION
Before this commit, the widget analytic_distribution has a field dependency on company_id.
But this widget is used for the field analytic_distribution in the model "hr.salary.rule" and this model doesn't have a field "company_id". So to solve this issue, this widget is duplicated (with/without company).

task-5155490

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
