### PR TITLE
[FIX] point_of_sale: serial refund

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.js
@@ -35,11 +35,15 @@ export class OrderSummary extends Component {
 
     async editPackLotLines(line) {
         const isAllowOnlyOneLot = line.product_id.isAllowOnlyOneLot();
-        const editedPackLotLines = await this.pos.editLots(
-            line.product_id,
-            line.getPackLotLinesToEdit(isAllowOnlyOneLot)
-        );
-
+        let editedPackLotLines = [];
+        if (line.refunded_orderline_id) {
+            editedPackLotLines = await this.pos.editLotsRefund(line);
+        } else {
+            editedPackLotLines = await this.pos.editLots(
+                line.product_id,
+                line.getPackLotLinesToEdit(isAllowOnlyOneLot)
+            );
+        }
         line.editPackLotLines(editedPackLotLines);
     }
 

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -311,6 +311,13 @@ export class TicketScreen extends Component {
         const lines = [];
         for (const refundDetail of this._getRefundableDetails(partner, order)) {
             const refundLine = refundDetail.line;
+            const alreadyRefundedLots = refundLine.refund_orderline_ids
+                .filter((item) => !["cancel", "draft"].includes(item.order_id.state))
+                .flatMap((item) => item.pack_lot_ids)
+                .map((pack_lot) => pack_lot.lot_name);
+            const options = refundLine.pack_lot_ids
+                .map((p) => p.lot_name)
+                .filter((lotName) => !alreadyRefundedLots.includes(lotName));
             const line = this.pos.models["pos.order.line"].create({
                 qty: -refundDetail.qty,
                 price_unit: refundLine.price_unit,
@@ -319,10 +326,10 @@ export class TicketScreen extends Component {
                 discount: refundLine.discount,
                 tax_ids: refundLine.tax_ids.map((tax) => ["link", tax]),
                 refunded_orderline_id: refundLine,
-                pack_lot_ids: refundLine.pack_lot_ids.map((packLot) => [
-                    "create",
-                    { lot_name: packLot.lot_name },
-                ]),
+                // Only include as many pack_lot_ids as the refunded quantity requires.
+                pack_lot_ids: options
+                    .slice(0, refundDetail.qty)
+                    .map((lotName) => ["create", { lot_name: lotName }]),
                 price_type: "automatic",
             });
             lines.push(line);

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -2245,6 +2245,43 @@ export class PosStore extends WithLazyGetterTrap {
 
         return payload;
     }
+    async editLotsRefund(line) {
+        const product = line.getProduct();
+        const packLotLinesToEdit = line.pack_lot_ids.map((p) => p.lot_name);
+        const alreadyRefundedLots = line.refunded_orderline_id.refund_orderline_ids
+            .filter((item) => !["cancel", "draft"].includes(item.order_id.state))
+            .flatMap((item) => item.pack_lot_ids)
+            .map((pack_lot) => pack_lot.lot_name);
+        const options = line.refunded_orderline_id.pack_lot_ids
+            .map((p) => p.lot_name)
+            .filter((lotName) => !alreadyRefundedLots.includes(lotName));
+
+        const payload = await makeAwaitable(this.dialog, EditListPopup, {
+            title: _t("Lot/Serial number(s) required for"),
+            name: product.display_name,
+            isSingleItem: product.isAllowOnlyOneLot(),
+            array: packLotLinesToEdit,
+            options: options,
+            customInput: false,
+            uniqueValues: product.tracking === "serial",
+            isLotNameUsed: () => false,
+        });
+        if (payload) {
+            const modifiedPackLotLines = {};
+            const newPackLotLines = [];
+            for (const item of payload) {
+                if (item.id) {
+                    modifiedPackLotLines[item.id] = item.text;
+                } else {
+                    newPackLotLines.push({ lot_name: item.text });
+                }
+            }
+            return { modifiedPackLotLines, newPackLotLines };
+        } else {
+            return null;
+        }
+    }
+
     async editLots(product, packLotLinesToEdit) {
         const isAllowOnlyOneLot = product.isAllowOnlyOneLot();
         let canCreateLots = this.pickingType.use_create_lots || !this.pickingType.use_existing_lots;

--- a/addons/point_of_sale/static/tests/pos/tours/ticket_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/ticket_screen_tour.js
@@ -379,3 +379,52 @@ registry.category("web_tour.tours").add("test_order_with_existing_serial", {
             }),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_lot_refund_lower_qty", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Serial Product"),
+            ProductScreen.enterLotNumbers(["SN1", "SN2"]),
+            ProductScreen.selectedOrderlineHas("Serial Product", "2.00"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+            ReceiptScreen.clickNextOrder(),
+            ProductScreen.clickRefund(),
+            TicketScreen.selectOrder("001"),
+            ProductScreen.clickNumpad("1"),
+            TicketScreen.toRefundTextContains("To Refund: 1"),
+            TicketScreen.confirmRefund(),
+            ProductScreen.isShown(),
+            {
+                trigger: ".info-list:contains('SN SN1')",
+            },
+            ProductScreen.clickLotIcon(),
+            {
+                trigger: ".options-dropdown .option:contains('SN2')",
+            },
+            Dialog.confirm(),
+            {
+                content: "go back to the products",
+                trigger: ".actionpad .back-button",
+                run: "click",
+                isActive: ["mobile"],
+            },
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+            ReceiptScreen.clickNextOrder(),
+            ProductScreen.clickRefund(),
+            TicketScreen.selectOrder("001"),
+            ProductScreen.clickNumpad("1"),
+            TicketScreen.confirmRefund(),
+            ProductScreen.isShown(),
+            {
+                trigger: ".info-list:contains('SN SN2')",
+            },
+        ].flat(),
+});

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -2969,6 +2969,25 @@ class TestUi(TestPointOfSaleHttpCommon):
             self.start_pos_tour("test_sync_from_ui_one_by_one", login="pos_user")
             self.assertEqual(sync_counter['count'], 6)
 
+    def test_lot_refund_lower_qty(self):
+        product = self.env['product.product'].create({
+            'name': 'Serial Product',
+            'is_storable': True,
+            'tracking': 'serial',
+            'available_in_pos': True,
+        })
+        for sn in ["SN1", "SN2"]:
+            self.env['stock.quant'].create({
+                'product_id': product.id,
+                'inventory_quantity': 1,
+                'location_id': self.env.user._get_default_warehouse_id().lot_stock_id.id,
+                'lot_id': self.env['stock.lot'].create({'name': sn, 'product_id': product.id}).id,
+            }).sudo().action_apply_inventory()
+        self.env['stock.picking.type'].search([('name', '=', 'PoS Orders')]).use_create_lots = False
+
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour("test_lot_refund_lower_qty")
+
 
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):


### PR DESCRIPTION
When refunding an order that contains a product tracked by serial number if you refund less than the total quantity of the product in the order all the serial numbers of the original order would be set anyway. Also you were not able to select the serial numbers to refund. 

Steps to reproduce:
-------------------
* Create product P1, storable, tracked by serial number
* Create 2 Serial Numbers SN1, SN2 for P1
* Create a POS order with 2x P1 (SN1, SN2)
* Pay and validate the order
* Refund the order, set quantity of P1 to 1
* Validate the refund
> Observation: The refund order contains P1 with SN1 and SN2, and you
cannot edit the serial numbers.

Why the fix:
------------
We now allow to select the serial numbers when doing a refund and only show the serial numbers that were in the original order. We also select by default the same number of serial numbers as the quantity to refund.

opw-4965171