### PR TITLE
[FIX] mail: call settings select's options text visibility and styling

### DIFF
--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -66,6 +66,20 @@ $o-discuss-talkingColor: lighten($success, 10%);
         select, .form-check-input {
             border-color: $gray-600;
         }
+
+        .form-select {
+            --#{$prefix}form-select-bg-img: #{escape-svg($form-select-indicator-dark)};
+        }
+
+        .form-switch .form-check-input {
+            &:not(:checked):not(:focus) {
+                --#{$prefix}form-switch-bg: #{escape-svg($form-switch-bg-image-dark)};
+            }
+        }
+
+        select option {
+            background-color: $gray-700;
+        }
     }
 
     .o_bottom_sheet_sheet:has(&) {

--- a/addons/mail/static/src/discuss/call/common/quick_video_settings.xml
+++ b/addons/mail/static/src/discuss/call/common/quick_video_settings.xml
@@ -3,14 +3,14 @@
 
     <t t-name="discuss.QuickVideoSettings">
         <div class="o-discuss-QuickVideoSettings d-flex flex-column gap-1">
-            <label class="btn d-flex flex-column align-items-baseline">
+            <label class="btn border-transparent d-flex flex-column align-items-baseline">
                 <span class="flex-shrink-0 pe-2">
                     Camera
                 </span>
                 <div class="flex-grow-1"/>
                 <DeviceSelect kind="'videoinput'"/>
             </label>
-            <div t-if="!isBrowserSafari()" class="btn d-flex" t-on-click="() => store.settings.useBlur = !store.settings.useBlur">
+            <div t-if="!isBrowserSafari()" class="btn d-flex gap-2" t-on-click="() => store.settings.useBlur = !store.settings.useBlur">
                 <label class="d-flex align-items-center flex-wrap mw-100 cursor-pointer gap-2">
                     <i class="fa fa-fw fa-photo"/><span class="text-truncate text-wrap">Blur background</span>
                 </label>
@@ -19,7 +19,7 @@
                     <input class="form-check-input" type="checkbox" role="switch" t-att-checked="store.settings?.useBlur ? 'checked' : ''"/>
                 </div>
             </div>
-            <button class="btn d-flex align-items-center gap-2" t-on-click="onClickVideoSettings">
+            <button class="btn border-transparent d-flex align-items-center gap-2" t-on-click="onClickVideoSettings">
                 <i class="fa fa-fw fa-gear"/><span>Video Settings</span>
             </button>
         </div>

--- a/addons/mail/static/src/discuss/call/common/quick_voice_settings.xml
+++ b/addons/mail/static/src/discuss/call/common/quick_voice_settings.xml
@@ -3,21 +3,21 @@
 
     <t t-name="discuss.QuickVoiceSettings">
         <div class="o-discuss-QuickVoiceSettings d-flex flex-column gap-1">
-            <label class="btn d-flex flex-column align-items-baseline">
+            <label class="btn border-transparent d-flex flex-column align-items-baseline">
                 <span class="flex-shrink-0 pe-2">
                     Microphone
                 </span>
                 <div class="flex-grow-1"/>
                 <DeviceSelect kind="'audioinput'"/>
             </label>
-            <label class="btn d-flex flex-column align-items-baseline">
+            <label class="btn border-transparent d-flex flex-column align-items-baseline">
                 <span class="flex-shrink-0 pe-2">
                     Audio Output
                 </span>
                 <div class="flex-grow-1"/>
                 <DeviceSelect kind="'audiooutput'"/>
             </label>
-            <button t-if="store.rtc.selfSession" class="btn d-flex" t-on-click="() => this.store.rtc.toggleDeafen()">
+            <button t-if="store.rtc.selfSession" class="btn border-transparent d-flex" t-on-click="() => this.store.rtc.toggleDeafen()">
                 <label class="d-flex align-items-center flex-wrap mw-100 cursor-pointer">
                     <span class="text-truncate text-wrap">Deafen</span>
                 </label>
@@ -26,7 +26,7 @@
                     <input class="form-check-input" type="checkbox" role="switch" t-att-checked="store.rtc.selfSession?.is_deaf ? 'checked' : ''"/>
                 </div>
             </button>
-            <button class="btn d-flex" t-on-click="() => this.store.settings.use_push_to_talk = !this.store.settings.use_push_to_talk">
+            <button class="btn border-transparent d-flex" t-on-click="() => this.store.settings.use_push_to_talk = !this.store.settings.use_push_to_talk">
                 <label class="d-flex align-items-center flex-wrap mw-100 cursor-pointer">
                     <span class="text-truncate text-wrap">Push-to-Talk</span>
                 </label>
@@ -35,7 +35,7 @@
                     <input class="form-check-input" type="checkbox" role="switch" t-att-checked="store.settings.use_push_to_talk ? 'checked' : ''"/>
                 </div>
             </button>
-            <button class="btn d-flex align-items-center gap-2" t-on-click="onClickVoiceSettings">
+            <button class="btn border-transparent d-flex align-items-center gap-2" t-on-click="onClickVoiceSettings">
                 <i class="fa fa-fw fa-gear"/><span>Voice Settings</span>
             </button>
         </div>


### PR DESCRIPTION
**Current behavior before PR:**
When opening the dropdown to select input/output devices during calls in light mode, the following issues were observed:
- select options had white text on white background, making them unreadable.
- The select's down arrow icon was invisible.
- The toggle thumb was barely visible when unchecked.
- A border appeared unnecessarily when the dropdown was clicked (in both light and dark mode).
- The blur background toggle spacing was incorrect.

**Desired behavior after PR is merged:**
- select options now have a dark gray background ($gray-700), ensuring proper contrast and readability in light mode.
- The select's down arrow icon and toggle elements have consistent visibility.
- The extra border on dropdown click is removed.
- The toggle spacing is visually corrected.

task-5163527

> **Note:** Spotted in Chrome Browser

**Before:**
<img width="945" height="438" alt="image" src="https://github.com/user-attachments/assets/fdfa24a4-c089-428c-b20d-0cdd4a7fb945" />
<img width="189" height="40" alt="image" src="https://github.com/user-attachments/assets/88a3372e-7ee6-4be5-b224-51c1c998a5e0" />


**After:**
<img width="743" height="319" alt="image" src="https://github.com/user-attachments/assets/a06eb60c-88e2-4c75-852b-6e04a06a6336" />
<img width="212" height="51" alt="image" src="https://github.com/user-attachments/assets/602ea08f-edaa-472f-884f-81c36afe1429" />



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
