### PR TITLE
[FIX] api_doc: fix body in JS generated example

### DIFF
--- a/addons/api_doc/static/src/utils/doc_code_gen.js
+++ b/addons/api_doc/static/src/utils/doc_code_gen.js
@@ -44,7 +44,7 @@ export function createRequestCode({ language, url, requestObj }) {
             "Authorization": "Bearer " + apiKey,
             // "X-Odoo-Database": "...",
         },
-        body: ${objStr},
+        body: JSON.stringify(${objStr}),
     };
 
     const response = await fetch("${url}", request);


### PR DESCRIPTION
**Current behavior before PR:**
Before this commit, the example generated for JS was incorrect and returned a 400 Bad Request error.

This was due to the fact that we must use `JSON.stringify` on the body before making the request.

**Desired behavior after PR is merged:**
JS example works




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
