### PR TITLE
[FIX] event_sale: allow rewards for the same events in so

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1974,6 +1974,16 @@ class SaleOrder(models.Model):
             'partner_id': self.partner_id.id,
         }
 
+    def _get_reward_values_product(self, reward, coupon, product=None, **kwargs):
+        """
+        Hook method for reward values customization.
+        This method is meant to be overridden by other modules (like event_sale)
+        to add specific fields when creating reward lines.
+
+        :return: list of values dict for order line creation
+        """
+        return []
+
     def _prepare_down_payment_section_line(self, **optional_values):
         """ Prepare the values to create a new down payment section.
 


### PR DESCRIPTION
Steps to reproduce:

1. Create a discount program as buy 2 tickets get 1 free.
2. Create a sales order and add 2 or more tickets of an event.
3. Now try to apply the (2 + 1 free) reward.

Issue:
Normally, the event tickets within the sales order are managed through the EventConfiguratorController, which is in charge of opening the event action to specify the event_id and the event_ticket_id. However, the way the reward lines are added to the sales order is purely throught the python side where the code is not aware of the event_id and event_ticket_id need.

Solution:
Override the _get_reward_values_product method to add the event_id and event_ticket_id when the product is an event ticket. This way, the reward lines will be correctly created with the necessary information.

opw-5048934