### PR TITLE
[FIX] pos_viva_com: fix webhook not finding model

### DIFF
--- a/addons/pos_viva_com/controllers/main.py
+++ b/addons/pos_viva_com/controllers/main.py
@@ -15,7 +15,7 @@ class PosVivaComController(http.Controller):
 
         viva_payment_methods = request.env['pos.payment.method'].sudo().search([
             ('use_payment_terminal', '=', 'viva_com'),
-            ('company_id.id', '=', company_id)
+            ('company_id.id', '=', int(company_id))
         ])
         payment_method_sudo = next(
             (pm for pm in viva_payment_methods if consteq(pm.viva_com_webhook_verification_key, token)),


### PR DESCRIPTION
Steps to reproduce:
1. Configure a Viva payment method
2. Copy the webhook URL and attempt to configure it on viva.com
3. Click the 'Verify' button to confirm the webhook is functioning

EXPECTED BEHAVIOUR:
- The webhook verifies successfully

ACTUAL BEHAVIOUR:
- An error message is displayed, and the Odoo server also logs an error

In the commit cc60da3, an optimisation was added to domain searches that subtly changed the behaviour. In particular, in the case where a domain is written like such:

```python
env['pos.payment.method'].search([('company_id.id', '=', company_id)])
```

The `company_id` variable is no longer implicitly converted from `str` to `int`. In the `pos_viva_com` controller, we were relying on this conversion as the parameter is passed to the method as a string.

To fix this, we now explictly cast the variable to `int`.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
