### PR TITLE
[ADD] account_edi_ubl_cii: Proper handling of LeitwegID for XRechnung

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_xrechnung.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_xrechnung.py
@@ -24,6 +24,10 @@ class AccountEdiXmlUBLDE(models.AbstractModel):
         # EXTENDS account.edi.xml.ubl_bis3
         vals = super()._export_invoice_vals(invoice)
         vals['vals']['customization_id'] = self._get_customization_ids()['xrechnung']
+        customer = invoice.partner_id
+        # X-Rechnung expects the LeitwegID in BT-10, thus if our Peppol Endpoint is a LeitwegID, we copy it over
+        if customer.peppol_eas == "0204" and customer.peppol_endpoint:
+            vals['vals']['buyer_reference'] = customer.peppol_endpoint
         if not vals['vals'].get('buyer_reference'):
             vals['vals']['buyer_reference'] = 'N/A'
         return vals


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
German regulations specify that the LeitwegID appears in the field BT-10. However, this field is usually filled with the value of the "ref" field of the customer, potentially creating a situation where the Odoo user thinks they have entered the data into Odoo correctly (Having set the Peppol Endpoint Type to "Leitweg ID" and entered the Leitweg-ID into the Peppol Endpoint field), but their invoice is still rejected because the Leiweg ID does not appear in the correct spot.

Current behavior before PR:
To generate a valid X-Rechnung to a German government office, the Leitweg-ID has to be put into the "Reference" field of the contact, conflicting with other potential uses for that field.

Desired behavior after PR is merged:
If the Peppol Endpoint is set to be a LeitwegID, the X-Rechnung also fills it into the BT-10 Field to ensure conformity to the German regulations.


References:
[German FAQ regarding Leitweg-ID](https://e-rechnung-bund.de/faq/#leitweg-id)
[Specification of the LeitwegID](https://xeinkauf.de/app/uploads/2022/11/Leitweg-ID-Formatspezifikation-v2-0-2-1.pdf)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
