### PR TITLE
[IMP] product, website_sale(_comparison): Quick clean on attribute view

### DIFF
--- a/addons/product/views/product_attribute_views.xml
+++ b/addons/product/views/product_attribute_views.xml
@@ -38,11 +38,14 @@
                         </div>
                     </button>
                 </div>
+                <div class="oe_title">
+                    <h1>
+                        <field name="name" placeholder="Attribute Name"/>
+                    </h1>
+                </div>
                 <group name="main_fields">
                     <group name="sale_main_fields">
-                        <label for="name" string="Attribute Name"/>
-                        <field name="name" nolabel="1"/>
-                        <field name="display_type" widget="radio" options="{'horizontal': True}"/>
+                        <field name="display_type"/>
                         <field name="create_variant"
                                widget="radio"
                                options="{'horizontal': True}"

--- a/addons/website_sale/views/product_attribute_views.xml
+++ b/addons/website_sale/views/product_attribute_views.xml
@@ -6,30 +6,34 @@
         <field name="model">product.attribute</field>
         <field name="inherit_id" ref="product.product_attribute_view_form"/>
         <field name="arch" type="xml">
-            <group name="main_fields" position="inside">
-                <group name="ecommerce_main_fields">
-                    <field
-                        name="visibility"
-                        string="eCommerce Filter"
-                        widget="radio"
-                        options="{'horizontal': True}"
-                    />
-                    <field
-                        name="preview_variants"
-                        widget="radio"
-                        options="{'horizontal': True}"
-                        readonly="create_variant != 'always' or display_type == 'multi'"
-                        force_save="1"
-                    />
-                    <field
-                        name="is_thumbnail_visible"
-                        widget="boolean_toggle"
-                        readonly="create_variant != 'always' or display_type == 'multi'"
-                        invisible="preview_variants == 'hidden'"
-                        force_save="1"
-                    />
-                </group>
-            </group>
+            <page name="attribute_values" position="after">
+                <page name="ecommerce_attributes" string="eCommerce">
+                    <group>
+                        <group name="ecommerce_main_fields">
+                            <field
+                                name="visibility"
+                                string="Filter"
+                                widget="radio"
+                                options="{'horizontal': True}"
+                            />
+                            <field
+                                name="preview_variants"
+                                widget="radio"
+                                options="{'horizontal': True}"
+                                readonly="create_variant != 'always' or display_type == 'multi'"
+                                force_save="1"
+                            />
+                            <field
+                                name="is_thumbnail_visible"
+                                widget="boolean_toggle"
+                                readonly="create_variant != 'always' or display_type == 'multi'"
+                                invisible="preview_variants == 'hidden'"
+                                force_save="1"
+                            />
+                        </group>
+                    </group>
+                </page>
+            </page>
         </field>
     </record>
 

--- a/addons/website_sale_comparison/models/product_attribute.py
+++ b/addons/website_sale_comparison/models/product_attribute.py
@@ -8,7 +8,7 @@ class ProductAttribute(models.Model):
 
     category_id = fields.Many2one(
         comodel_name='product.attribute.category',
-        string="eCommerce Category",
+        string="Category",
         index=True,
         help="Set a category to regroup similar attributes under the same section in the Comparison"
              " page of eCommerce.",

--- a/addons/website_sale_comparison/views/product_attribute_views.xml
+++ b/addons/website_sale_comparison/views/product_attribute_views.xml
@@ -18,9 +18,9 @@
         <field name="inherit_id" ref="website_sale.product_attribute_view_form"/>
         <field name="priority" eval="8"/>
         <field name="arch" type="xml">
-            <group name="ecommerce_main_fields" position="inside">
+            <field name="visibility" position="before">
                 <field name="category_id"/>
-            </group>
+            </field>
         </field>
     </record>
 


### PR DESCRIPTION
**Purpose:**
    The attribute form view was not as clean as it could have been now that we have several eCommerce fields.
    The goal was to move the eCommerce fields in a tab, change a bit their labels and clean the view to align it with other form views.

**Specification:**
- Create a new tab 'eCommerce'
- Move the eCommerce fields into this new tab
- Rename some fields:
  - eCommerce filter   -> Filter
  - eCommerce category -> Category
- Change the order of those fields to be:
  - Category
  - Filter
  - On Products Cards
  - Show Thumbnails
- Change the attribute name field to have a big model title look
- Change the type of the field 'Display Type' from radio to select

Task-5154273

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
