### PR TITLE
[FIX] website_sale: prevent traceback on zoom-on-click

### DIFF
--- a/addons/website_sale/static/src/js/components/website_sale_image_viewer.js
+++ b/addons/website_sale/static/src/js/components/website_sale_image_viewer.js
@@ -54,9 +54,11 @@ export class ProductImageViewer extends Dialog {
         );
         onMounted(() => {
             const carousel = document.querySelector('.o_wsale_image_viewer_carousel');
-            carousel.addEventListener('touchstart', this._onTouchstartCarousel.bind(this));
-            carousel.addEventListener('touchmove', this._onTouchmoveCarousel.bind(this));
-            this._updateCarousel();
+            if (carousel) {
+                carousel.addEventListener('touchstart', this._onTouchstartCarousel.bind(this));
+                carousel.addEventListener('touchmove', this._onTouchmoveCarousel.bind(this));
+                this._updateCarousel();
+            }
         });
         // For some reason the styling does not always update properly.
         onRendered(() => {


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Enable zoom-on-click on product page;
2. have a product page with only a single image;
3. click on the image.

Issue
-----
> Odoo Client Error
> Caused by: TypeError: can't access property "addEventListener", carousel is null

Cause
-----
Commit 83b79c198eac added event listeners to make the carousel interactive. Issue is that the carousel element doesn't exist in the DOM if there's no extra media.

Solution
--------
Check if the carousel element exists before adding event listeners.

opw-4937009