### PR TITLE
[FIX] base, account: fix rights of parent_of/child_of domain for many2many

### DIFF
--- a/addons/account/tests/test_account_account.py
+++ b/addons/account/tests/test_account_account.py
@@ -1040,3 +1040,36 @@ class TestAccountAccount(TestAccountMergeCommon):
         invoice.line_ids._compute_account_id()
 
         self.assertEqual(invoice.invoice_line_ids.account_id, self.company_data['default_account_revenue'])
+
+    def test_access_to_parent_accounts_from_branch(self):
+        """ Ensure that a user with access to a branch can access to the accounts of the parent company """
+        parent_company = self.env['res.company'].create([{
+            'name': "Parent Company",
+        }])
+        branch = self.env['res.company'].create([{
+            'name': "Branch Company",
+            'parent_id': parent_company.id,
+        }])
+        self.env['account.account'].create([{
+            'name': 'Parent Account',
+            'code': '444719',
+            'company_ids': [Command.link(parent_company.id)]
+        }])
+        # create a user with account rights and access to the branch company only
+        branch_user = self.env['res.users'].create({
+            'login': 'branch',
+            'name': 'XYZ',
+            'email': 'xyz@example.com',
+            'groups_id': [Command.link(self.env.ref('account.group_account_user').id)],
+            'company_ids': [Command.link(branch.id)],
+            'company_id': branch.id,
+        })
+
+        parent_accounts = self.env['account.account'].search([('company_ids', '=', parent_company.id)])
+        self.assertEqual(len(parent_accounts), 1, "There should be 1 account in the parent company")
+
+        branch_accounts = self.env['account.account'].search([('company_ids', '=', branch.id)])
+        self.assertEqual(len(branch_accounts), 0, "There should be no account in the branch company")
+        # get the accounts from the parent company with the branch user
+        accounts = self.env['account.account'].with_user(branch_user.id).search([('company_ids', 'parent_of', [branch.id])])
+        self.assertEqual(len(accounts), 1, "Branch user should have access to the accounts of the parent company")

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -1269,8 +1269,9 @@ class expression(object):
                 if operator in HIERARCHY_FUNCS:
                     # determine ids2 in comodel
                     ids2 = to_ids(right, comodel, leaf)
+                    ids2 = comodel.browse(ids2)._filtered_access('read').ids
                     domain = HIERARCHY_FUNCS[operator]('id', ids2, comodel)
-                    ids2 = comodel._search(domain)
+                    ids2 = comodel.sudo()._search(domain)
                     rel_alias = self.query.make_alias(alias, field.name)
                     push_result(SQL(
                         "EXISTS (SELECT 1 FROM %s AS %s WHERE %s = %s AND %s IN %s)",


### PR DESCRIPTION
**Steps to reproduce:**
- Install accountant

- Create a company branch for a company
- Create a non-admin user with Accounting rights and access to
the branch only

- Connect with the created user
- Go to "Accounting / Accounting / Journal Entries"
- Create a journal entry and try to set an account on a line

**Issue:**
There is no account available.
The accounts from the parent company should be selectable.

**Cause:**
The accounts are searched with a "parent_of" domain on "company_ids" field, which is a many2many field.
However, as the user doesn't have access to the parent company, the parent company is excluded from the search when parsing the domain.

opw-5096437


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
