### PR TITLE
[FIX] account : Recompute narration language on partner language change

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1757,7 +1757,7 @@ class AccountMove(models.Model):
         for move in self.filtered(lambda move: move.is_invoice()):
             move.access_url = '/my/invoices/%s' % (move.id)
 
-    @api.depends('move_type', 'partner_id', 'company_id')
+    @api.depends('move_type', 'partner_id', 'partner_id.lang', 'company_id')
     def _compute_narration(self):
         use_invoice_terms = self.env['ir.config_parameter'].sudo().get_param('account.use_invoice_terms')
         invoice_to_update_terms = self.filtered(lambda m: use_invoice_terms and m.is_sale_document(include_receipts=True))

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -4778,6 +4778,32 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             "Narration should be preserved after partner change when invoice terms are disabled"
         )
 
+    def test_narration_translation_on_partner_language_change(self):
+        """Ensure narration translates when partner.lang changes (HTML terms link)."""
+        self.env['ir.config_parameter'].sudo().set_param('account.use_invoice_terms', True)
+        self.env['res.lang']._activate_lang('fr_FR')
+
+        self.env.company.terms_type = 'html'
+
+        # Baseline: en_US user/partner
+        self.partner_a.lang = 'en_US'
+
+        # Create invoice
+        invoice = self.init_invoice(move_type='out_invoice', partner=self.partner_a)
+
+        baseurl = self.env.company.get_base_url() + '/terms'
+
+        # Check the initial narration is in English
+        expected_en = f"<p>Terms &amp; Conditions: {baseurl}</p>"
+        self.assertEqual(invoice.narration, expected_en)
+
+        # Switch to fr_FR
+        self.partner_a.lang = 'fr_FR'
+
+        # Check the narration is in French
+        expected_fr = f"<p>Conditions générales : {baseurl} </p>"
+        self.assertEqual(invoice.narration, expected_fr)
+
     def test_multiple_currency_change(self):
         """
         Test amount currency and balance are correctly recomputed when switching currency multiple times


### PR DESCRIPTION
Issue:
When changing the customer’s language during invoice creation, the terms & services were not retranslated, unlike when creating a new partner in a different language.

Repro Steps:

1. Create an invoice with terms link or plain enabled.
2. Change the partner's language from the invoice creation view.
3. Terms is not translated.

Cause:
The translation compute was only triggered on partner change, not language change.

Fix:
Added dependency for partner_id.lang to the narration compute to ensure it updates when the language changes.

opw-5031933
