### PR TITLE
[IMP] html_builder: use event listener to limit selection in container

### DIFF
--- a/addons/html_builder/static/src/core/builder_options_plugin.js
+++ b/addons/html_builder/static/src/core/builder_options_plugin.js
@@ -75,12 +75,6 @@ export class BuilderOptionsPlugin extends Plugin {
             this.getResource("builder_header_middle_buttons")
         );
         this.builderContainerTitle = withIds(this.getResource("container_title"));
-        // doing this manually instead of using addDomListener. This is because
-        // addDomListener will ignore all events from protected targets. But in
-        // our case, we still want to update the containers.
-        this.onClick = this.onClick.bind(this);
-        this.editable.addEventListener("click", this.onClick, { capture: true });
-
         this.lastContainers = [];
 
         // Selector of elements that should not update/have containers when they
@@ -96,16 +90,6 @@ export class BuilderOptionsPlugin extends Plugin {
             ".transfo-container",
             ".o_datetime_picker",
         ].join(", ");
-    }
-
-    destroy() {
-        this.editable.removeEventListener("click", this.onClick, { capture: true });
-    }
-
-    onClick(ev) {
-        this.dependencies.operation.next(() => {
-            this.updateContainers(ev.target);
-        });
     }
 
     getReloadSelector(editingElement) {

--- a/addons/html_builder/static/src/core/builder_selection_restriction_plugin.js
+++ b/addons/html_builder/static/src/core/builder_selection_restriction_plugin.js
@@ -1,0 +1,250 @@
+import { Plugin } from "@html_editor/plugin";
+import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
+import { getDeepestPosition } from "@html_editor/utils/dom_info";
+import { DIRECTIONS, nodeSize } from "@html_editor/utils/position";
+import { closestElement } from "@html_editor/utils/dom_traversal";
+
+// we probably need to move these special blocks to a resource in different plugins
+const SPECIAL_BLOCK_WITH_TEXT_IN_NON_DIV = ["BLOCKQUOTE"];
+const UNCROSSABLE_ELEMENTS = ["BLOCKQUOTE", "FORM", "SECTION", "DIV"];
+const UNCROSSABLE_ELEMENT_CLASSES = ["alert", "row"];
+
+export class BuilderSelectionRestrictionPlugin extends Plugin {
+    static id = "builderSelectionRestriction";
+    static dependencies = ["history", "selection", "operation", "builderOptions"];
+
+    resources = {
+        uncrossable_elements: UNCROSSABLE_ELEMENTS,
+        uncrossable_element_classes: UNCROSSABLE_ELEMENT_CLASSES,
+        special_block_with_text_in_non_div: SPECIAL_BLOCK_WITH_TEXT_IN_NON_DIV,
+    };
+
+    setup() {
+        Window.selection = this.dependencies.selection;
+        this.uncrossable_elements = [...new Set(this.getResource("uncrossable_elements"))];
+        this.uncrossable_element_classes = [
+            ...new Set(this.getResource("uncrossable_element_classes")),
+        ];
+        this.special_block_with_text_in_non_div = [
+            ...new Set(this.getResource("special_block_with_text_in_non_div")),
+        ];
+        this.selectionCorrected = false;
+
+        this.addDomListener(this.editable, "keydown", this.onKeydown);
+        this.addDomListener(this.editable, "mouseup", this.restrictSelectionInClosestDiv);
+        this.addDomListener(this.editable, "touchend", this.restrictSelectionInClosestDiv);
+
+        // doing this manually instead of using addDomListener. This is because
+        // addDomListener will ignore all events from protected targets. But in
+        // our case, we still want to update the containers.
+        this.onClick = this.onClick.bind(this);
+        this.editable.addEventListener("click", this.onClick, { capture: true });
+    }
+
+    destroy() {
+        this.editable.removeEventListener("click", this.onClick, { capture: true });
+    }
+
+    onClick(ev) {
+        this.dependencies.operation.next(() => {
+            if (this.selectionCorrected) {
+                this.selectionCorrected = false;
+                return;
+            }
+            this.dependencies.builderOptions.updateContainers(ev.target);
+        });
+    }
+
+    onKeydown(ev) {
+        if (getActiveHotkey(ev) === "control+a") {
+            const { editableSelection, currentSelectionIsInEditable } =
+                this.dependencies.selection.getSelectionData();
+            if (
+                !currentSelectionIsInEditable ||
+                // make it a resource for adding other cases?
+                editableSelection.commonAncestorContainer.nodeName === "FIGURE"
+            ) {
+                ev.preventDefault();
+                ev.stopPropagation();
+                return;
+            }
+            ev.preventDefault();
+            // make it a resource for adding other cases?
+            const closestSpecialBlock = closestElement(
+                editableSelection.anchorNode,
+                this.special_block_with_text_in_non_div.join(",")
+            );
+            const closestDiv = closestElement(editableSelection.anchorNode, "div");
+
+            // if the closest special block doesn't contains the closest div block,
+            // we select the paragraph, otherwise we select the whole closest div block
+            if (closestSpecialBlock && !closestSpecialBlock.contains(closestDiv)) {
+                this.selectAllInElement(closestElement(editableSelection.anchorNode, "p"));
+            } else {
+                this.selectAllInElement(closestDiv);
+            }
+            ev.stopPropagation();
+        }
+    }
+
+    // we extend the selection to the whole element step by step to properly
+    // handle uncrossable elements (like row, blockquote...)
+    selectAllInElement(element) {
+        let selection = this.dependencies.selection.getEditableSelection();
+        let { anchorNode, anchorOffset, focusNode, focusOffset, direction } = selection;
+
+        const [newAnchorNode, newAnchorOffset] = getDeepestPosition(element, 0);
+        const [newFocusNode, newFocusOffset] = getDeepestPosition(element, nodeSize(element));
+        if (direction === DIRECTIONS.RIGHT) {
+            this.dependencies.selection.setSelection({
+                anchorNode: focusNode,
+                anchorOffset: focusOffset,
+                focusNode: newAnchorNode,
+                focusOffset: newAnchorOffset,
+            });
+        } else {
+            this.dependencies.selection.setSelection({
+                anchorNode: anchorNode,
+                anchorOffset: anchorOffset,
+                focusNode: newAnchorNode,
+                focusOffset: newAnchorOffset,
+            });
+        }
+        this.correctSelectionOnUncrossable();
+        selection = this.dependencies.selection.getEditableSelection();
+        ({ focusNode, focusOffset } = selection);
+        this.dependencies.selection.setSelection({
+            anchorNode: focusNode,
+            anchorOffset: focusOffset,
+            focusNode: newFocusNode,
+            focusOffset: newFocusOffset,
+        });
+        this.correctSelectionOnUncrossable();
+    }
+
+    restrictSelectionInElement(selection, block) {
+        const { anchorNode, anchorOffset, focusNode, direction } = selection;
+        const isFocusInBlock = block.contains(focusNode);
+
+        if (!isFocusInBlock) {
+            let focusNode, focusOffset;
+            if (direction === DIRECTIONS.RIGHT) {
+                [focusNode, focusOffset] = getDeepestPosition(block, nodeSize(block));
+            } else {
+                [focusNode, focusOffset] = getDeepestPosition(block, 0);
+            }
+            this.dependencies.selection.setSelection({
+                anchorNode,
+                anchorOffset,
+                focusNode,
+                focusOffset,
+            });
+        }
+        this.correctSelectionOnUncrossable();
+    }
+
+    restrictSelectionInClosestDiv(ev) {
+        const { editableSelection, currentSelectionIsInEditable } =
+            this.dependencies.selection.getSelectionData();
+        if (!currentSelectionIsInEditable) {
+            return;
+        }
+        if (editableSelection.isCollapsed) {
+            return;
+        }
+
+        // make it a resource for adding other cases?
+        const closestSpecialBlock = closestElement(
+            editableSelection.anchorNode,
+            this.special_block_with_text_in_non_div.join(",")
+        );
+        const closestDiv = closestElement(editableSelection.anchorNode, "div");
+
+        if (closestSpecialBlock && !closestSpecialBlock.contains(closestDiv)) {
+            const closestParagraph = closestElement(editableSelection.anchorNode, "p");
+            this.restrictSelectionInElement(editableSelection, closestParagraph);
+        } else {
+            this.restrictSelectionInElement(editableSelection, closestDiv);
+        }
+    }
+
+    isNodeSelectionUncrossable(node, selectedNodes) {
+        return (
+            this.uncrossable_elements.includes(node.nodeName) ||
+            this.uncrossable_elements.some((tagName) =>
+                selectedNodes.includes(closestElement(node, tagName))
+            ) ||
+            this.uncrossable_element_classes.some(
+                (className) =>
+                    node.classList?.contains(className) ||
+                    selectedNodes.includes(closestElement(node, `.${className}`))
+            )
+        );
+    }
+
+    correctSelectionOnUncrossable() {
+        const selection = this.dependencies.selection.getEditableSelection();
+        const { anchorNode, anchorOffset, focusNode, direction } = selection;
+        const selectedNodes = this.dependencies.selection
+            .getTargetedNodes(selection)
+            .filter((node) => node.nodeType === Node.ELEMENT_NODE);
+        const selectedNodesLooping =
+            direction === DIRECTIONS.RIGHT ? selectedNodes : selectedNodes.reverse();
+
+        // do not do selection correction if 1. the only selected node is an image cause we force
+        // the selection to be around the image when clicking on it, correction would break the
+        // option container for images 2. icon elements (i.fa, span.fa...)
+        if (
+            selectedNodesLooping.length === 1 &&
+            (selectedNodesLooping[0].tagName === "IMG" ||
+                selectedNodesLooping[0].classList?.contains("fa"))
+        ) {
+            return;
+        }
+
+        let temperaryFocusNode;
+        for (const node of selectedNodesLooping) {
+            if (this.isNodeSelectionUncrossable(node, selectedNodesLooping)) {
+                if (node.contains(anchorNode) && node.contains(focusNode)) {
+                    break;
+                } else if (!node.contains(anchorNode)) {
+                    let focusNode, focusOffset;
+                    if (direction === DIRECTIONS.RIGHT) {
+                        temperaryFocusNode = node.previousElementSibling
+                            ? node.previousElementSibling
+                            : temperaryFocusNode;
+                        [focusNode, focusOffset] = getDeepestPosition(
+                            temperaryFocusNode,
+                            nodeSize(temperaryFocusNode)
+                        );
+                    } else {
+                        temperaryFocusNode = node.nextElementSibling
+                            ? node.nextElementSibling
+                            : temperaryFocusNode;
+                        [focusNode, focusOffset] = getDeepestPosition(temperaryFocusNode, 0);
+                    }
+
+                    const currentSelection = this.dependencies.selection.setSelection({
+                        anchorNode,
+                        anchorOffset,
+                        focusNode,
+                        focusOffset,
+                    });
+                    this.dependencies.builderOptions.updateContainers(
+                        closestElement(currentSelection.commonAncestorContainer)
+                    );
+                    this.selectionCorrected = true;
+                    break;
+                } else {
+                    break;
+                }
+            } else {
+                temperaryFocusNode = node;
+            }
+        }
+        this.dependencies.builderOptions.updateContainers(
+            closestElement(selection.commonAncestorContainer)
+        );
+        this.selectionCorrected = true;
+    }
+}

--- a/addons/html_builder/static/src/core/core_plugins.js
+++ b/addons/html_builder/static/src/core/core_plugins.js
@@ -4,6 +4,7 @@ import { AnchorPlugin } from "./anchor/anchor_plugin";
 import { BuilderActionsPlugin } from "./builder_actions_plugin";
 import { BuilderComponentPlugin } from "./builder_component_plugin";
 import { BuilderOptionsPlugin } from "./builder_options_plugin";
+import { BuilderSelectionRestrictionPlugin } from "./builder_selection_restriction_plugin";
 import { BuilderOverlayPlugin } from "./builder_overlay/builder_overlay_plugin";
 import { CachedModelPlugin } from "./cached_model_plugin";
 import { ClonePlugin } from "./clone_plugin";
@@ -54,6 +55,7 @@ export const CORE_PLUGINS = [
     BuilderOptionsPlugin,
     BuilderActionsPlugin,
     BuilderComponentPlugin,
+    BuilderSelectionRestrictionPlugin,
     OperationPlugin,
     BuilderOverlayPlugin,
     OverlayButtonsPlugin,

--- a/addons/html_builder/static/tests/block_tab/snippet_content.test.js
+++ b/addons/html_builder/static/tests/block_tab/snippet_content.test.js
@@ -4,6 +4,7 @@ import {
     waitForEndOfOperation,
 } from "@html_builder/../tests/helpers";
 import { BuilderOptionsPlugin } from "@html_builder/core/builder_options_plugin";
+import { BuilderSelectionRestrictionPlugin } from "@html_builder/core/builder_selection_restriction_plugin";
 import { Operation } from "@html_builder/core/operation";
 import { describe, expect, test } from "@odoo/hoot";
 import {
@@ -154,13 +155,15 @@ test("click just after drop is redispatched in next operation", async () => {
         },
     });
     patchWithCleanup(BuilderOptionsPlugin.prototype, {
-        async onClick(ev) {
-            expect.step("onClick");
-            super.onClick(ev);
-        },
         updateContainers(...args) {
             expect.step("updateContainers");
             super.updateContainers(...args);
+        },
+    });
+    patchWithCleanup(BuilderSelectionRestrictionPlugin.prototype, {
+        async onClick(ev) {
+            expect.step("onClick");
+            super.onClick(ev);
         },
     });
     await setupHTMLBuilder("", {

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -680,12 +680,12 @@ export function selectFullText(elementName, selector) {
         content: `Select all the text of the ${elementName}`,
         trigger: `:iframe ${selector}`,
         async run(actions) {
-            await actions.click();
             const range = document.createRange();
             const selection = this.anchor.ownerDocument.getSelection();
             range.selectNodeContents(this.anchor);
             selection.removeAllRanges();
             selection.addRange(range);
+            await actions.click();
         },
     };
 }

--- a/addons/website/static/tests/builder/builder_selection_restrict.test.js
+++ b/addons/website/static/tests/builder/builder_selection_restrict.test.js
@@ -1,0 +1,353 @@
+import { expect, test } from "@odoo/hoot";
+import { defineWebsiteModels, setupWebsiteBuilder } from "./website_helpers";
+import { dummyBase64Img } from "@html_builder/../tests/helpers";
+import { getContent, setSelection } from "@html_editor/../tests/_helpers/selection";
+import { manuallyDispatchProgrammaticEvent, animationFrame } from "@odoo/hoot-dom";
+
+defineWebsiteModels();
+
+test("the selection should be restricted in the closest div when press ctrl+a", async () => {
+    const { getEditableContent, getEditor } = await setupWebsiteBuilder(
+        `<section class="parent-target o_colored_level">
+            <div class="child-target first-child">
+                <p class="grandchild-target first-grandchild">first grand child</p>
+            </div>
+            <div class="child-target second-child">
+                <p class="grandchild-target second-grandchild">second grand child</p>
+            </div>
+        </section>`
+    );
+    const editableContent = getEditableContent();
+    const editor = getEditor();
+    const first_grandchild = editor.editable.querySelector("p.first-grandchild");
+
+    // set the selection to be inside the first grandchild
+    setSelection({
+        anchorNode: first_grandchild.firstChild,
+        anchorOffset: 0,
+    });
+
+    // press ctrl+a to select all the content in the first grandchild
+    await manuallyDispatchProgrammaticEvent(editor.editable, "keydown", {
+        key: "a",
+        ctrlKey: true,
+    });
+
+    expect(getContent(editableContent)).toBe(
+        `<section class="parent-target o_colored_level">
+            <div class="child-target first-child">
+                <p class="grandchild-target first-grandchild">[first grand child]</p>
+            </div>
+            <div class="child-target second-child">
+                <p class="grandchild-target second-grandchild">second grand child</p>
+            </div>
+        </section>`
+    );
+});
+
+test("the selection should be restricted when it acrosses different div from left to right", async () => {
+    const { getEditableContent, getEditor } = await setupWebsiteBuilder(
+        `<section class="parent-target o_colored_level">
+            <div class="child-target first-child">
+                <p class="grandchild-target first-grandchild">first grand child</p>
+            </div>
+            <div class="child-target second-child">
+                <p class="grandchild-target second-grandchild">second grand child</p>
+            </div>
+        </section>`
+    );
+    const editableContent = getEditableContent();
+    const editor = getEditor();
+    const first_grandchild = editor.editable.querySelector("p.first-grandchild");
+    const second_grandchild = editor.editable.querySelector("p.second-grandchild");
+
+    // set the selection to be inside the first grandchild
+    setSelection({
+        anchorNode: first_grandchild.firstChild,
+        anchorOffset: 0,
+        focusOffset: 4,
+    });
+
+    manuallyDispatchProgrammaticEvent(first_grandchild, "mouseup", {
+        detail: 1,
+    });
+    manuallyDispatchProgrammaticEvent(first_grandchild, "click");
+    await animationFrame();
+
+    // the selection should be not be modified when it is inside the most inner container
+    expect(getContent(editableContent)).toBe(
+        `<section class="parent-target o_colored_level">
+            <div class="child-target first-child">
+                <p class="grandchild-target first-grandchild">[firs]t grand child</p>
+            </div>
+            <div class="child-target second-child">
+                <p class="grandchild-target second-grandchild">second grand child</p>
+            </div>
+        </section>`
+    );
+
+    // set the selection across the two grandchildren
+    setSelection({
+        anchorNode: first_grandchild.firstChild,
+        anchorOffset: 0,
+        focusNode: second_grandchild.firstChild,
+        focusOffset: 4,
+    });
+
+    manuallyDispatchProgrammaticEvent(second_grandchild, "mouseup", {
+        detail: 1,
+    });
+    manuallyDispatchProgrammaticEvent(second_grandchild, "click");
+    await animationFrame();
+
+    // the selection should be modified when it is outside the most inner container
+    expect(getContent(editableContent)).toBe(
+        `<section class="parent-target o_colored_level">
+            <div class="child-target first-child">
+                <p class="grandchild-target first-grandchild">[first grand child]</p>
+            </div>
+            <div class="child-target second-child">
+                <p class="grandchild-target second-grandchild">second grand child</p>
+            </div>
+        </section>`
+    );
+});
+
+test("the selection should be restricted when it acrosses different div from right to left", async () => {
+    const { getEditableContent, getEditor } = await setupWebsiteBuilder(
+        `<section class="parent-target o_colored_level">
+            <div class="child-target first-child">
+                <p class="grandchild-target first-grandchild">first grand child</p>
+            </div>
+            <div class="child-target second-child">
+                <p class="grandchild-target second-grandchild">second grand child</p>
+            </div>
+        </section>`
+    );
+    const editableContent = getEditableContent();
+    const editor = getEditor();
+    const first_grandchild = editor.editable.querySelector("p.first-grandchild");
+    const second_grandchild = editor.editable.querySelector("p.second-grandchild");
+
+    // set the selection to be inside the first grandchild
+    setSelection({
+        anchorNode: first_grandchild.firstChild,
+        anchorOffset: 4,
+        focusOffset: 0,
+    });
+
+    manuallyDispatchProgrammaticEvent(first_grandchild, "mouseup", {
+        detail: 1,
+    });
+    manuallyDispatchProgrammaticEvent(first_grandchild, "click");
+    await animationFrame();
+
+    // the selection should be not be modified when it is inside the most inner container
+    expect(getContent(editableContent)).toBe(
+        `<section class="parent-target o_colored_level">
+            <div class="child-target first-child">
+                <p class="grandchild-target first-grandchild">]firs[t grand child</p>
+            </div>
+            <div class="child-target second-child">
+                <p class="grandchild-target second-grandchild">second grand child</p>
+            </div>
+        </section>`
+    );
+
+    // set the selection across the two grandchildren
+    setSelection({
+        anchorNode: second_grandchild.firstChild,
+        anchorOffset: 4,
+        focusNode: first_grandchild.firstChild,
+        focusOffset: 0,
+    });
+
+    manuallyDispatchProgrammaticEvent(second_grandchild, "mouseup", {
+        detail: 1,
+    });
+    manuallyDispatchProgrammaticEvent(second_grandchild, "click");
+    await animationFrame();
+
+    // the selection should be modified when it is outside the most inner container
+    expect(getContent(editableContent)).toBe(
+        `<section class="parent-target o_colored_level">
+            <div class="child-target first-child">
+                <p class="grandchild-target first-grandchild">first grand child</p>
+            </div>
+            <div class="child-target second-child">
+                <p class="grandchild-target second-grandchild">]seco[nd grand child</p>
+            </div>
+        </section>`
+    );
+});
+
+test("selection restriction should be inside a <p> for special snippets - blockquote when pressing ctrl+a", async () => {
+    const { getEditableContent, getEditor } = await setupWebsiteBuilder(
+        `<section class="parent-target o_colored_level">
+            <div class="container first-child">
+                <blockquote>
+                    <p class="p-target">p element in blockquote</p>
+                    <div class="s_blockquote_infos">
+                        <img src="${dummyBase64Img}">
+                        <div class="s_blockquote_author o-paragraph">
+                            <span class="o_small">
+                                <strong>Paul Dawson</strong><br>
+                                <span class="text-muted">CEO of MyCompany</span>
+                            </span>
+                        </div>
+                    </div>
+                </blockquote>
+            </div>
+        </section>`
+    );
+    const editableContent = getEditableContent();
+    const editor = getEditor();
+    const p_element = editor.editable.querySelector("p.p-target");
+
+    // set the selection to be inside the p element
+    setSelection({
+        anchorNode: p_element.firstChild,
+        anchorOffset: 0,
+    });
+
+    // press ctrl+a to select all the content in the p element
+    await manuallyDispatchProgrammaticEvent(editor.editable, "keydown", {
+        key: "a",
+        ctrlKey: true,
+    });
+
+    expect(getContent(editableContent)).toBe(
+        `<section class="parent-target o_colored_level" contenteditable="false">
+            <div class="container first-child" contenteditable="true">
+                <blockquote>
+                    <p class="p-target">[p element in blockquote]</p>
+                    <div class="s_blockquote_infos">
+                        <img src="${dummyBase64Img}">
+                        <div class="s_blockquote_author o-paragraph">
+                            <span class="o_small">
+                                <strong>Paul Dawson</strong><br>
+                                <span class="text-muted">CEO of MyCompany</span>
+                            </span>
+                        </div>
+                    </div>
+                </blockquote>
+            </div>
+        </section>`
+    );
+});
+
+test("selection restriction should be inside a <p> for special snippets - blockquote when selecting cross elements (left to right)", async () => {
+    const { getEditableContent, getEditor } = await setupWebsiteBuilder(
+        `<section class="parent-target o_colored_level">
+            <div class="container first-child">
+                <blockquote class="o_draggable">
+                    <p class="p-target">p element in blockquote</p>
+                    <div class="s_blockquote_infos">
+                        <img src="${dummyBase64Img}">
+                        <div class="s_blockquote_author o-paragraph">
+                            <span class="o_small">
+                                <strong>Paul Dawson</strong><br>
+                                <span class="text-muted">CEO of MyCompany</span>
+                            </span>
+                        </div>
+                    </div>
+                </blockquote>
+            </div>
+        </section>`
+    );
+    const editableContent = getEditableContent();
+    const editor = getEditor();
+    const p_element = editor.editable.querySelector("p.p-target");
+    const muted_element = editor.editable.querySelector("span.text-muted");
+
+    // set the selection to be inside the p element
+    setSelection({
+        anchorNode: p_element.firstChild,
+        anchorOffset: 0,
+        focusNode: muted_element.firstChild,
+        focusOffset: 2,
+    });
+
+    manuallyDispatchProgrammaticEvent(muted_element, "mouseup", {
+        detail: 1,
+    });
+    manuallyDispatchProgrammaticEvent(muted_element, "click");
+    await animationFrame();
+
+    expect(getContent(editableContent)).toBe(
+        `<section class="parent-target o_colored_level" contenteditable="false">
+            <div class="container first-child" contenteditable="true">
+                <blockquote class="o_draggable">
+                    <p class="p-target">[p element in blockquote]</p>
+                    <div class="s_blockquote_infos">
+                        <img src="${dummyBase64Img}">
+                        <div class="s_blockquote_author o-paragraph">
+                            <span class="o_small">
+                                <strong>Paul Dawson</strong><br>
+                                <span class="text-muted">CEO of MyCompany</span>
+                            </span>
+                        </div>
+                    </div>
+                </blockquote>
+            </div>
+        </section>`
+    );
+});
+
+test("selection restriction should be inside a <p> for special snippets - blockquote when selecting cross elements (right to left)", async () => {
+    const { getEditableContent, getEditor } = await setupWebsiteBuilder(
+        `<section class="parent-target o_colored_level">
+            <div class="container first-child">
+                <blockquote class="o_draggable">
+                    <p class="p-target">p element in blockquote</p>
+                    <div class="s_blockquote_infos">
+                        <img src="${dummyBase64Img}">
+                        <div class="s_blockquote_author o-paragraph">
+                            <span class="o_small">
+                                <strong>Paul Dawson</strong><br>
+                                <span class="text-muted">CEO of MyCompany</span>
+                            </span>
+                        </div>
+                    </div>
+                </blockquote>
+            </div>
+        </section>`
+    );
+    const editableContent = getEditableContent();
+    const editor = getEditor();
+    const p_element = editor.editable.querySelector("p.p-target");
+    const muted_element = editor.editable.querySelector("span.text-muted");
+
+    // set the selection to be inside the p element
+    setSelection({
+        anchorNode: muted_element.firstChild,
+        anchorOffset: 3,
+        focusNode: p_element.firstChild,
+        focusOffset: 2,
+    });
+
+    manuallyDispatchProgrammaticEvent(muted_element, "mouseup", {
+        detail: 1,
+    });
+    manuallyDispatchProgrammaticEvent(muted_element, "click");
+    await animationFrame();
+
+    expect(getContent(editableContent)).toBe(
+        `<section class="parent-target o_colored_level" contenteditable="false">
+            <div class="container first-child" contenteditable="true">
+                <blockquote class="o_draggable">
+                    <p class="p-target">p element in blockquote</p>
+                    <div class="s_blockquote_infos">
+                        <img src="${dummyBase64Img}">
+                        <div class="s_blockquote_author o-paragraph">
+                            <span class="o_small">
+                                <strong>]Paul Dawson</strong><br>
+                                <span class="text-muted">CEO[ of MyCompany</span>
+                            </span>
+                        </div>
+                    </div>
+                </blockquote>
+            </div>
+        </section>`
+    );
+});


### PR DESCRIPTION
Before this commit: we can select the whole editing area in website builder by mouse selection or ctrl+a

After this commit: when we do selection, the selection is checked that if it's inside the current element bond to the blue container. if the selection is out of the container, we reset the selection to keep it inside.

In this commit, we introduced a new plugin in the html_builder to restrict the selections to the closest div element or p element. We also moved the click listener in builder_options_plugin.js to properly update the blue container to properly align with the restricted selection.

We have the restriction function called on event keydown, mouseup and touchend. The listeners are set this way to avoid unnecessary selection restriction during the selection making. The keydown event is to handle ctrl+a to select the whole block and then restrict it. The mouseup and touchend handle the cases where we make the seleciton by mouse or touch.

We introduced two concepts SPECIAL_BLOCK_WITH_TEXT_IN_NON_DIV and UNCROSSABLR_ELEMENTS. In general cases, we restrict the selection to the closes div element. However, for special blocks in SPECIAL_BLOCK_WITH_TEXT_IN_NON_DIV, we restrict selection in closest p element. UNCROSSABLR_ELEMENTS can be defined by tag name or classes. They are the elements that the selection should not cross, these elements can appear in a div element and the restricted selection should stop before crossing them.

When we do select all, we first check if we should select the whole div element or the p element, then we extend the selection to one direction + correct the selection on UNCROSSABLR_ELEMENTS, then we do the same for the other direction.

When we make selection by mouse, we first check if the current selection is beyond the div or p element it should be and we set the selection inside if it is. Then we check inside the div or p element, if there are UNCROSSABLR_ELEMENTS, we correct the selection by stopping the selection ahead of them.

task-4901968

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
