### PR TITLE
[FIX] html_builder: prevent image shape selection traceback

### DIFF
--- a/addons/html_builder/static/src/plugins/image/image_shape_option.js
+++ b/addons/html_builder/static/src/plugins/image/image_shape_option.js
@@ -19,10 +19,7 @@ export class ImageShapeOption extends BaseOptionComponent {
         this.imageShapeOption = this.dependencies.imageShapeOption;
         this.toRatio = toRatio;
         this.state = useDomState((editingElement) => {
-            let shape = editingElement.dataset.shape;
-            if (shape) {
-                shape = shape.replace("web_editor", "html_builder");
-            }
+            const shape = editingElement.dataset.shape;
             return {
                 hasShape: !!shape && !this.imageShapeOption.isTechnicalShape(shape),
                 shapeLabel: this.imageShapeOption.getShapeLabel(shape),


### PR DESCRIPTION
Steps to reproduce:
===================
1. Drop a snippet having an image with a shape (e.g. "Intro Pill",
"Images Mosaic", ...).
2. Try to change the image shape.
→ Traceback occurs.

This issue also happens when clicking on images with shapes that
were added in previous versions.

Cause:
======
Before the refactoring, shape URLs started with `web_editor`, but now
`html_builder` is expected.
This mismatch causes the shape to be considered invalid when parsed,
leading to a traceback.

The issue was introduced by this PR:
https://github.com/odoo/odoo/pull/222471

Solution:
=========
Ensure backward compatibility by allowing shapes using the old
`web_editor` path to remain functional after the migration to
`html_builder`.