### PR TITLE
[FIX] base_import: reset start line after test import

### DIFF
--- a/addons/base_import/static/src/import_model.js
+++ b/addons/base_import/static/src/import_model.js
@@ -286,7 +286,7 @@ export class BaseImportModel {
         }
 
         if (!importRes.hasError) {
-            if (importRes.nextrow) {
+            if (!isTest && importRes.nextrow) {
                 this._addMessage("warning", [
                     _t(
                         "Click 'Resume' to proceed with the import, resuming at line %s.",
@@ -297,6 +297,7 @@ export class BaseImportModel {
             }
             if (isTest) {
                 this._addMessage("info", [_t("Everything seems valid.")]);
+                this.setOption("skip", 0);
             }
         } else {
             importRes.nextrow = startRow;

--- a/addons/base_import/static/tests/import_action_tests.js
+++ b/addons/base_import/static/tests/import_action_tests.js
@@ -1218,6 +1218,43 @@ QUnit.module("Base Import Tests", (hooks) => {
         );
     });
 
+    QUnit.test("Import view: test in batches then reset starting row", async function (assert) {
+        registerFakeHTTPService();
+
+        patchWithCleanup(ImportAction.prototype, {
+            get isBatched() {
+                return true;
+            },
+        });
+
+        await createImportAction({
+            "base_import.import/execute_import": (route, args) => executeImport(args, true),
+        });
+
+        const file = new File(["fake_file"], "fake_file.xls", { type: "text/plain" });
+        await editInput(target, ".o_control_panel_main_buttons input[type='file']", file);
+        await editInput(target, "input#o_import_batch_limit", 1);
+
+        // click on the test button
+        await click(target.querySelector(".o_control_panel_main_buttons button:nth-child(2)"));
+        await nextTick();
+        assert.strictEqual(target.querySelector("input#o_import_row_start").value, "2");
+        await nextTick();
+        assert.strictEqual(target.querySelector("input#o_import_row_start").value, "3");
+
+        // The import is now done
+        await nextTick();
+        assert.strictEqual(
+            target.querySelector(".o_import_data_content .alert-info").textContent,
+            "Everything seems valid."
+        );
+        assert.strictEqual(
+            target.querySelector("input#o_import_row_start").value,
+            "1",
+            "the actual import will start at line 1 after testing"
+        );
+    });
+
     QUnit.test(
         "Import view: relational fields correctly mapped on preview",
         async function (assert) {


### PR DESCRIPTION
Steps to reproduce
==================

- Go to contacts
- Click on the cog menu > Import records
- Upload a csv file
- Limit the batch limit to a value lower than the total number of records in the csv file
- Click on the test button
- Click on the Import button

=> Only the last batch is imported

Cause of the issue
==================

The start line is not reset after the test import, which can be confusing

Solution
========

When the test import fully succeeds, we reset the start line

opw-4916102