### PR TITLE
[FIX] pos_sale: Manage products paid on ecommerce in the POS

### DIFF
--- a/addons/pos_sale/models/sale_order.py
+++ b/addons/pos_sale/models/sale_order.py
@@ -25,7 +25,7 @@ class SaleOrder(models.Model):
     @api.model
     def _load_pos_data_fields(self, config):
         return ['name', 'state', 'user_id', 'order_line', 'partner_id', 'pricelist_id', 'fiscal_position_id', 'amount_total', 'amount_untaxed', 'amount_unpaid',
-            'picking_ids', 'partner_shipping_id', 'partner_invoice_id', 'date_order', 'write_date']
+            'picking_ids', 'partner_shipping_id', 'partner_invoice_id', 'date_order', 'write_date', 'amount_paid']
 
     def load_sale_order_from_pos(self, config_id):
         product_ids = self.order_line.product_id.ids
@@ -65,14 +65,14 @@ class SaleOrder(models.Model):
             'domain': [('id', 'in', linked_orders.ids)],
         }
 
-    @api.depends('order_line', 'amount_total', 'order_line.invoice_lines.parent_state', 'order_line.invoice_lines.price_total', 'order_line.pos_order_line_ids')
+    @api.depends('transaction_ids.state', 'transaction_ids.amount', 'order_line', 'amount_total', 'order_line.invoice_lines.parent_state', 'order_line.invoice_lines.price_total', 'order_line.pos_order_line_ids')
     def _compute_amount_unpaid(self):
         for sale_order in self:
             invoices = sale_order.order_line.invoice_lines.move_id.filtered(lambda invoice: invoice.state in ('draft', 'posted'))
             total_invoices_paid = sum(invoices.mapped('amount_total'))
             pos_orders = sale_order.order_line.pos_order_line_ids.order_id
             total_pos_orders_paid = sum(pos_orders.mapped('amount_total'))
-            sale_order.amount_unpaid = max(sale_order.amount_total - total_invoices_paid - total_pos_orders_paid, 0.0)
+            sale_order.amount_unpaid = max(sale_order.amount_total - total_invoices_paid - total_pos_orders_paid - sale_order.amount_paid, 0.0)
 
     @api.depends('order_line.pos_order_line_ids')
     def _compute_amount_to_invoice(self):

--- a/addons/pos_sale/static/src/app/components/screens/product_screen/control_buttons/control_buttons.js
+++ b/addons/pos_sale/static/src/app/components/screens/product_screen/control_buttons/control_buttons.js
@@ -13,6 +13,7 @@ patch(ControlButtons.prototype, {
             ["state", "!=", "cancel"],
             ["invoice_status", "!=", "invoiced"],
             ["currency_id", "=", this.pos.currency.id],
+            ["amount_unpaid", ">", 0],
         ];
         if (this.pos.getOrder()?.getPartner()) {
             domain = [

--- a/addons/pos_sale/static/src/app/services/pos_store.js
+++ b/addons/pos_sale/static/src/app/services/pos_store.js
@@ -12,25 +12,6 @@ import { getTaxesAfterFiscalPosition } from "@point_of_sale/app/models/utils/tax
 
 patch(PosStore.prototype, {
     async onClickSaleOrder(clickedOrderId) {
-        const selectedOption = await makeAwaitable(this.dialog, SelectionPopup, {
-            title: _t("What do you want to do?"),
-            list: [
-                { id: "0", label: _t("Settle the order"), item: "settle" },
-                {
-                    id: "1",
-                    label: _t("Apply a down payment (percentage)"),
-                    item: "dpPercentage",
-                },
-                {
-                    id: "2",
-                    label: _t("Apply a down payment (fixed amount)"),
-                    item: "dpAmount",
-                },
-            ],
-        });
-        if (!selectedOption) {
-            return;
-        }
         const sale_order = await this._getSaleOrder(clickedOrderId);
 
         const currentSaleOrigin = this.getOrder()
@@ -61,6 +42,29 @@ patch(PosStore.prototype, {
             fiscal_position_id: orderFiscalPos,
         });
 
+        //Add a down payment for transactions that were already done online
+        if (sale_order.amount_paid > 0) {
+            this.addDownPaymentProductOrderlineToOrder(sale_order, -sale_order.amount_paid, false);
+        }
+        const selectedOption = await makeAwaitable(this.dialog, SelectionPopup, {
+            title: _t("What do you want to do?"),
+            list: [
+                { id: "0", label: _t("Settle the order"), item: "settle" },
+                {
+                    id: "1",
+                    label: _t("Apply a down payment (percentage)"),
+                    item: "dpPercentage",
+                },
+                {
+                    id: "2",
+                    label: _t("Apply a down payment (fixed amount)"),
+                    item: "dpAmount",
+                },
+            ],
+        });
+        if (!selectedOption) {
+            return;
+        }
         selectedOption == "settle"
             ? await this.settleSO(sale_order, orderFiscalPos)
             : await this.downPaymentSO(sale_order, selectedOption == "dpPercentage");
@@ -209,18 +213,6 @@ patch(PosStore.prototype, {
     },
 
     async downPaymentSO(saleOrder, isPercentage) {
-        if (!this.config.down_payment_product_id && this.config.raw.down_payment_product_id) {
-            await this.data.read("product.product", [this.config.raw.down_payment_product_id]);
-        }
-        if (!this.config.down_payment_product_id) {
-            this.dialog.add(AlertDialog, {
-                title: _t("No down payment product"),
-                body: _t(
-                    "It seems that you didn't configure a down payment product in your point of sale. You can go to your point of sale configuration to choose one."
-                ),
-            });
-            return;
-        }
         const payload = await makeAwaitable(this.dialog, NumberPopup, {
             title: _t("Down Payment"),
             subtitle: _t("Due balance: %s", this.env.utils.formatCurrency(saleOrder.amount_unpaid)),
@@ -237,6 +229,29 @@ patch(PosStore.prototype, {
             return;
         }
 
+        const amount = parseFloat(payload);
+        this.addDownPaymentProductOrderlineToOrder(saleOrder, amount, isPercentage);
+    },
+    async loadDownPaymentProduct() {
+        if (!this.config.down_payment_product_id && this.config.raw.down_payment_product_id) {
+            await this.data.read("product.product", [this.config.raw.down_payment_product_id]);
+        }
+        if (!this.config.down_payment_product_id) {
+            this.dialog.add(AlertDialog, {
+                title: _t("No down payment product"),
+                body: _t(
+                    "It seems that you didn't configure a down payment product in your point of sale. You can go to your point of sale configuration to choose one."
+                ),
+            });
+            return;
+        }
+    },
+    addDownPaymentProductOrderlineToOrder(saleOrder, amount, isPercentage) {
+        this.loadDownPaymentProduct();
+        if (isPercentage) {
+            const percentage = amount / 100.0;
+            amount = saleOrder.baseLines.length ? saleOrder.amount_unpaid * percentage : 0.0;
+        }
         const saleOrderLines = saleOrder.order_line.filter((soLine) => !soLine.display_type);
         const baseLines = [];
         for (const saleOrderLine of saleOrderLines) {
@@ -250,11 +265,6 @@ patch(PosStore.prototype, {
         accountTaxHelpers.add_tax_details_in_base_lines(baseLines, this.company);
         accountTaxHelpers.round_base_lines_tax_details(baseLines, this.company);
 
-        let amount = parseFloat(payload);
-        if (isPercentage) {
-            const percentage = amount / 100.0;
-            amount = baseLines.length ? saleOrder.amount_unpaid * percentage : 0.0;
-        }
         const downPaymentProduct = this.config.down_payment_product_id;
         const groupingFunction = (base_line) => ({
             grouping_key: { product_id: downPaymentProduct },

--- a/addons/pos_sale/static/tests/tours/pos_sale_tour.js
+++ b/addons/pos_sale/static/tests/tours/pos_sale_tour.js
@@ -550,3 +550,23 @@ registry.category("web_tour.tours").add("test_selected_partner_quotation_loading
             ProductScreen.selectedOrderlineHas("Product B", "2.00"),
         ].flat(),
 });
+registry.category("web_tour.tours").add("test_ecommerce_paid_order_is_hidden_in_pos", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("A Test Partner 1"),
+            PosSale.checkOrdersListEmpty(),
+        ].flat(),
+});
+registry.category("web_tour.tours").add("test_ecommerce_unpaid_order_is_shown_in_pos", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("A Test Partner 1"),
+            PosSale.checkOrdersListNotEmpty(),
+        ].flat(),
+});

--- a/addons/pos_sale/static/tests/tours/utils/pos_sale_utils.js
+++ b/addons/pos_sale/static/tests/tours/utils/pos_sale_utils.js
@@ -83,3 +83,13 @@ export function selectedOrderLinesHasLots(productName, lots) {
     const lotSteps = lots.reduce((acc, serial, i) => acc.concat(getSerialStep(i, serial)), []);
     return [...ProductScreen.selectedOrderlineHas(productName), ...lotSteps];
 }
+
+export function checkOrdersListNotEmpty() {
+    return [
+        ...ProductScreen.clickControlButton("Quotation/Order"),
+        {
+            content: "Check that the orders list is not empty",
+            trigger: ".o_data_row",
+        },
+    ];
+}

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -1569,3 +1569,79 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         })
         self.main_pos_config.open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_selected_partner_quotation_loading', login="accountman")
+
+    def test_ecommerce_paid_order_is_hidden_in_pos(self):
+        """
+        Tests that a Sale Order fully paid via a payment.transaction (eCommerce)
+        does not appear in the list of orders fetched by the Point of Sale.
+        """
+        self.env.user.group_ids += self.quick_ref('sales_team.group_sale_salesman')
+        partner_1 = self.env['res.partner'].create({'name': 'A Test Partner 1'})
+        product_a = self.env['product.product'].create({
+            'name': 'Product A',
+            'available_in_pos': True,
+            'lst_price': 10.0,
+        })
+        sale_order = self.env['sale.order'].create({
+            'partner_id': partner_1.id,
+            'order_line': [(0, 0, {
+                'product_id': product_a.id,
+                'product_uom_qty': 2,
+                'price_unit': product_a.lst_price
+            })]
+        })
+        provider = self.env['payment.provider'].create({
+            'name': 'Test',
+            'code': 'custom',
+        })
+        transaction = self.env['payment.transaction'].create({
+            'provider_id': provider.id,
+            'payment_method_id': self.env.ref('payment.payment_method_unknown').id,
+            'amount': sale_order.amount_total,
+            'currency_id': sale_order.currency_id.id,
+            'partner_id': sale_order.partner_id.id,
+            'sale_order_ids': [(6, 0, [sale_order.id])],
+        })
+        transaction._set_done()
+        sale_order.invalidate_recordset(['transaction_ids'])
+
+        self.assertEqual(
+            sale_order.amount_unpaid, 0.0,
+            "The amount_unpaid for the SO should be 0 after a successful transaction."
+        )
+        self.main_pos_config.open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_ecommerce_paid_order_is_hidden_in_pos', login="accountman")
+
+    def test_ecommerce_unpaid_order_is_shown_in_pos(self):
+        """
+        Tests that a Sale Order fully paid via a payment.transaction (eCommerce)
+        does not appear in the list of orders fetched by the Point of Sale.
+        """
+        self.env.user.group_ids += self.quick_ref('sales_team.group_sale_salesman')
+        partner_1 = self.env['res.partner'].create({'name': 'A Test Partner 1'})
+        product_a = self.env['product.product'].create({
+            'name': 'Product A',
+            'available_in_pos': True,
+            'lst_price': 10.0,
+        })
+        sale_order = self.env['sale.order'].create({
+            'partner_id': partner_1.id,
+            'order_line': [(0, 0, {
+                'product_id': product_a.id,
+                'product_uom_qty': 2,
+                'price_unit': product_a.lst_price
+            })]
+        })
+        sale_order = self.env['sale.order'].create({
+            'partner_id': partner_1.id,
+            'order_line': [(0, 0, {
+                'product_id': product_a.id,
+                'product_uom_qty': 2,
+                'price_unit': product_a.lst_price
+            })]
+        })
+        self.assertEqual(
+            sale_order.amount_unpaid, sale_order.amount_total,
+            "The amount_unpaid for the SO should not be 0 if there are no transactions."
+        )
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_ecommerce_unpaid_order_is_shown_in_pos', login="accountman")


### PR DESCRIPTION
Before, if you paid for something on the website with ecommerce, it would create a sale order with a transaction linked to it, but no invoice. So in the POS the order would show up in the Quotation/Order menu, but the POS didn't have any reference on the payment, so you would have to create another duplicate payment.

Now the amount_paid (which is the amount already paid in transactions) is taken into account when calculating what's left to pay in the POS. So anytime you open a sale order in the POS it should create a down payment line for anything already paid on the website (the same as we were already doing for invoices).

Also to avoid double payments, now the sale orders which have been already paid in full, even if they are not invoiced yet, will not show up in the POS. The invoice can still be created normally from the Sale app in Odoo.

Task-5138081

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
