### PR TITLE
[FIX] base:  handle missing PDF outlines by fallback to individual PDF generation

### DIFF
--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -916,11 +916,11 @@ class IrActionsReport(models.Model):
                 root = reader.trailer['/Root']
                 has_valid_outlines = '/Outlines' in root and '/First' in root['/Outlines']
                 if not has_valid_outlines:
-                    return {False: {
-                        'report_action': self,
-                        'stream': pdf_content_stream,
-                        'attachment': None,
-                    }}
+                    for res_id in res_ids_wo_stream:
+                        individual_collected_stream = self._render_qweb_pdf_prepare_streams(report_ref=report_ref, data=data, res_ids=[res_id])
+                        collected_streams[res_id]['stream'] = individual_collected_stream[res_id]['stream']
+
+                    return collected_streams
 
                 outlines_pages = []
                 node = root['/Outlines']['/First']


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
When wkhtmltopdf does not generate valid outlines, Odoo returns the full PDF as a single stream instead of splitting it per record. This caused scheduled actions (crons) to fail multiple times and eventually deactivate after repeated errors.

This change modifies `_render_qweb_pdf_prepare_streams` to render each record individually when outlines are missing, ensuring that all reports are generated and sent correctly without blocking the cron.


**Current behavior before PR:**
The _render_qweb_pdf_prepare_streams method does not correctly generate individual PDF streams when the PDF outlines are missing or invalid.
In these cases, the method returns a single combined PDF stream (keyed as False) instead of splitting it per record.
As a result, the system fails to send individual reports through scheduled actions (crons). 
After several failed attempts, the cron automatically deactivates.

The issue occurs when all the following conditions are true:

- reader.numPages != len(res_ids_wo_stream)
- len(res_ids_wo_stream) > 1 and set(res_ids_wo_stream) == set(html_ids_wo_none)
- has_valid_outlines is False

**Desired behavior after PR is merged:**
The method should correctly generate a valid PDF stream for each res_id, even when outlines are missing, 
allowing the reports to be sent individually and preventing cron execution failures.

**Steps to Reproduce:**
1. Generate a multi-record PDF report where the number of pages does not match the number of res_ids.
2. Ensure that wkhtmltopdf does not produce valid /Outlines and /Dests structures.
3. Observe that the method returns a combined PDF stream instead of individual ones.
4. Run a scheduled action (cron) that sends these PDFs — it will fail multiple times and eventually deactivate.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
