### PR TITLE
[IMP] html_builder*: use event listener to limit selection in container

### DIFF
--- a/addons/html_builder/static/src/@types/plugins.d.ts
+++ b/addons/html_builder/static/src/@types/plugins.d.ts
@@ -33,6 +33,7 @@ declare module "plugins" {
     import { apply_custom_css_style_overrides } from "@html_builder/core/core_builder_action_plugin";
     import { on_bg_color_updated_handlers } from "@html_builder/core/color_style_plugin";
     import { reload_context_processors } from "@html_builder/core/utils";
+    import { uncrossable_element_selector, ignore_ctrl_a_predicates } from "@html_builder/core/builder_selection_restriction_plugin";
 
     interface SharedMethods {
         // Main
@@ -113,6 +114,7 @@ declare module "plugins" {
         is_element_in_invisible_panel_predicates: is_element_in_invisible_panel_predicates;
         is_node_empty_predicates: is_node_empty_predicates;
         is_valid_for_sibling_dropzone_predicates: is_valid_for_sibling_dropzone_predicates;
+        ignore_ctrl_a_predicates: ignore_ctrl_a_predicates;
 
         // Processors
         reload_context_processors: reload_context_processors;
@@ -153,5 +155,6 @@ declare module "plugins" {
         so_snippet_addition_selectors: so_snippet_addition_selectors;
         snippet_preview_dialog_bundles: snippet_preview_dialog_bundles;
         builder_options_render_context: builder_options_render_context;
+        uncrossable_element_selector: uncrossable_element_selector;
     }
 }

--- a/addons/html_builder/static/src/core/builder_options_plugin.js
+++ b/addons/html_builder/static/src/core/builder_options_plugin.js
@@ -198,12 +198,6 @@ export class BuilderOptionsPlugin extends Plugin {
             this.getResource("builder_header_middle_buttons")
         );
         this.builderContainerTitle = withIds(this.getResource("container_title"));
-        // doing this manually instead of using addDomListener. This is because
-        // addDomListener will ignore all events from protected targets. But in
-        // our case, we still want to update the containers.
-        this.onClick = this.onClick.bind(this);
-        this.editable.addEventListener("click", this.onClick, { capture: true });
-
         this.lastContainers = [];
 
         // Selector of elements that should not update/have containers when they
@@ -219,16 +213,6 @@ export class BuilderOptionsPlugin extends Plugin {
             ".transfo-container",
             ".o_datetime_picker",
         ].join(", ");
-    }
-
-    destroy() {
-        this.editable.removeEventListener("click", this.onClick, { capture: true });
-    }
-
-    onClick(ev) {
-        this.dependencies.operation.next(() => {
-            this.updateContainers(ev.target);
-        });
     }
     /**
      * Checks if the given element is a valid builder option target.

--- a/addons/html_builder/static/src/core/builder_selection_restriction_plugin.js
+++ b/addons/html_builder/static/src/core/builder_selection_restriction_plugin.js
@@ -1,0 +1,352 @@
+import { Plugin } from "@html_editor/plugin";
+import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
+import { getDeepestPosition, isElement, isIconElement } from "@html_editor/utils/dom_info";
+import { DIRECTIONS, nodeSize } from "@html_editor/utils/position";
+import { closestElement } from "@html_editor/utils/dom_traversal";
+
+/** @typedef {import("plugins").CSSSelector} CSSSelector */
+/**
+ * @typedef {CSSSelector[]} uncrossable_element_selector
+ * CSS selectors of elements that should not be crossed by the selection.
+ *
+ * @typedef {((selection: EditorSelection) => boolean)[]} ignore_ctrl_a_predicates
+ * Cases where nothing should be done when pressing ctrl + a.
+ */
+
+export class BuilderSelectionRestrictionPlugin extends Plugin {
+    static id = "builderSelectionRestriction";
+    static dependencies = ["selection", "operation", "builderOptions"];
+
+    /** @type {import("plugins").BuilderResources} */
+    resources = {
+        uncrossable_element_selector: ["blockquote", "form", "div", "section", ".row"],
+    };
+
+    setup() {
+        this.uncrossableSelectors = this.getResource("uncrossable_element_selector").join(", ");
+        this.isCtrlAIgnored = (selection) =>
+            this.checkPredicates("ignore_ctrl_a_predicates", selection) ?? false;
+
+        // Tell if the containers should be/were updated with the corrected
+        // selection
+        this.shouldUpdateContainersWithSelection = false;
+
+        this.addDomListener(this.editable.ownerDocument, "keydown", (ev) => {
+            if (getActiveHotkey(ev) !== "control+a") {
+                return;
+            }
+            ev.preventDefault();
+            ev.stopPropagation();
+            this.onCtrlAKeydown();
+        });
+        this.addDomListener(this.document, "mouseup", this.restrictMouseSelection);
+        this.addDomListener(this.document, "touchend", this.restrictMouseSelection);
+
+        // Doing this manually instead of using addDomListener. This is because
+        // addDomListener will ignore all events from protected targets. But in
+        // our case, we still want to update the containers.
+        this.onClick = this.onClick.bind(this);
+        this.editable.addEventListener("click", this.onClick, { capture: true });
+    }
+
+    destroy() {
+        super.destroy();
+        this.editable.removeEventListener("click", this.onClick, { capture: true });
+    }
+
+    /**
+     * Activates the options of the clicked element.
+     * Note: if the selection was corrected, the click is ignored, as the
+     * selection already managed it.
+     *
+     * @param {Event} ev
+     */
+    onClick(ev) {
+        this.dependencies.operation.next(() => {
+            if (this.shouldUpdateContainersWithSelection) {
+                this.shouldUpdateContainersWithSelection = false;
+                return;
+            }
+            this.dependencies.builderOptions.updateContainers(ev.target);
+        });
+    }
+
+    /**
+     * Manages the selection made with the "Control + A" key.
+     */
+    onCtrlAKeydown() {
+        const { editableSelection, documentSelectionIsInEditable } =
+            this.dependencies.selection.getSelectionData();
+        const currentSelectionIsInEditable =
+            documentSelectionIsInEditable && this.dependencies.selection.editableDocumentHasFocus();
+        const { anchorNode } = editableSelection;
+        if (!currentSelectionIsInEditable || this.isCtrlAIgnored(editableSelection)) {
+            return;
+        }
+
+        // Restrict the selection to not select the whole document.
+        const restrictingEl = this.getRestrictingElement(anchorNode);
+        this.selectAllInElement(restrictingEl);
+        if (this.shouldUpdateContainersWithSelection) {
+            const selection = this.dependencies.selection.getEditableSelection();
+            this.dependencies.builderOptions.updateContainers(
+                closestElement(selection.commonAncestorContainer)
+            );
+            this.shouldUpdateContainersWithSelection = false;
+        }
+    }
+
+    /**
+     * Restricts the mouse selection inside the closest div.
+     *
+     * @param {Event} ev
+     */
+    restrictMouseSelection(ev) {
+        const { editableSelection, documentSelectionIsInEditable } =
+            this.dependencies.selection.getSelectionData();
+        const currentSelectionIsInEditable =
+            documentSelectionIsInEditable && this.dependencies.selection.editableDocumentHasFocus();
+        const { anchorNode } = editableSelection;
+        if (!currentSelectionIsInEditable || editableSelection.isCollapsed) {
+            return;
+        }
+
+        const restrictingEl = this.getRestrictingElement(anchorNode);
+        this.restrictSelectionInElement(editableSelection, restrictingEl);
+        if (this.shouldUpdateContainersWithSelection) {
+            const selection = this.dependencies.selection.getEditableSelection();
+            this.dependencies.builderOptions.updateContainers(
+                closestElement(selection.commonAncestorContainer)
+            );
+        }
+    }
+
+    /**
+     * Extends the selection to the whole element, while properly handling
+     * the uncrossable elements.
+     *
+     * @param {Element} element
+     */
+    selectAllInElement(element) {
+        let selection = this.dependencies.selection.getEditableSelection();
+
+        const [newAnchorNode, newAnchorOffset] = getDeepestPosition(element, 0);
+        const [newFocusNode, newFocusOffset] = getDeepestPosition(element, nodeSize(element));
+
+        // First extend the selection to the start of the element from the
+        // focusNode.
+        this.dependencies.selection.setSelection({
+            anchorNode: selection.focusNode,
+            anchorOffset: selection.focusOffset,
+            focusNode: newAnchorNode,
+            focusOffset: newAnchorOffset,
+        });
+        // Then correct the selection if some uncrossable elements are crossed
+        // on the extended part.
+        this.correctSelectionOnUncrossable();
+
+        // Get the fixed extended selection after the first step, and then
+        // extend it to the end of the element.
+        selection = this.dependencies.selection.getEditableSelection();
+        this.dependencies.selection.setSelection({
+            anchorNode: selection.focusNode,
+            anchorOffset: selection.focusOffset,
+            focusNode: newFocusNode,
+            focusOffset: newFocusOffset,
+        });
+        // Finally correct the selection if some uncrossable elements are
+        // crossed on the extended part.
+        this.correctSelectionOnUncrossable();
+
+        // Make sure the selection does not contain uncrossable elements. We
+        // limit this to 5 attempts to not block the editor (it is very unlikely
+        // to have more than 5 nested uncrossable elements, so 5 is acceptable).
+        selection = this.dependencies.selection.getEditableSelection();
+        let attemptsLeft = 5;
+        while (
+            closestElement(selection.anchorNode, this.uncrossableSelectors) !==
+                closestElement(selection.focusNode, this.uncrossableSelectors) &&
+            attemptsLeft
+        ) {
+            this.correctSelectionOnUncrossable();
+            selection = this.dependencies.selection.getEditableSelection();
+            attemptsLeft -= 1;
+        }
+    }
+
+    /**
+     * Returns the element in which the selection should be restricted (by
+     * default, the closest `div` element).
+     *
+     * @param {Node} anchorNode the current selection anchorNode
+     * @returns {HTMLElement}
+     */
+    getRestrictingElement(anchorNode) {
+        const closestDivEl = closestElement(anchorNode, "div");
+
+        if (!closestDivEl) {
+            console.warn(
+                "The anchordeNode of the selection is not inside a <div> element, the selection restriction plugin might not work properly",
+                anchorNode
+            );
+            return closestElement(anchorNode);
+        }
+        return closestDivEl;
+    }
+
+    /**
+     * Restricts the selection inside a given element.
+     *
+     * @param {Selection} selection
+     * @param {Element} elementEl element in which selection will be restricted
+     */
+    restrictSelectionInElement(selection, elementEl) {
+        const { anchorNode, anchorOffset, focusNode, direction } = selection;
+        const isFocusInBlock = elementEl.contains(focusNode);
+
+        // If the focus node is not in the block, we need to put it inside the
+        // elementEl. If the selection is left to right, we put it at the end of
+        // the block, otherwise at the start of the block.
+        if (!isFocusInBlock) {
+            let focusNode, focusOffset;
+            if (direction === DIRECTIONS.RIGHT) {
+                [focusNode, focusOffset] = getDeepestPosition(elementEl, nodeSize(elementEl));
+            } else {
+                [focusNode, focusOffset] = getDeepestPosition(elementEl, 0);
+            }
+            this.dependencies.selection.setSelection({
+                anchorNode,
+                anchorOffset,
+                focusNode,
+                focusOffset,
+            });
+        }
+        // Finally, we correct the selection if some uncrossable elements are
+        // crossed.
+        this.correctSelectionOnUncrossable();
+    }
+
+    /**
+     * Checks if the the given node is uncrossable or inside an uncrossable. If
+     * so, checks if the selected nodes contains the uncrossable.
+     *
+     * @param {Node} node
+     * @param {Array<Node>} selectedNodes
+     * @returns {Boolean}
+     */
+    isNodeSelectionUncrossable(node, selectedNodes) {
+        const closestUncrossableEl = closestElement(node, this.uncrossableSelectors);
+        if (closestUncrossableEl) {
+            return node === closestUncrossableEl || selectedNodes.includes(closestUncrossableEl);
+        }
+
+        return false;
+    }
+
+    /**
+     * Corrects the current editable selection if any uncrossable element is
+     * crossed, see uncrossable_element_selector.
+     */
+    correctSelectionOnUncrossable() {
+        let selection = this.dependencies.selection.getEditableSelection();
+        const { anchorNode, anchorOffset, focusNode, direction } = selection;
+        const selectedNodes = this.dependencies.selection
+            .getTargetedNodes(selection)
+            .filter(isElement);
+        if (direction !== DIRECTIONS.RIGHT) {
+            selectedNodes.reverse();
+        }
+
+        // Do not correct the selection if the only selected node is an image or
+        // an icon, otherwise it would break their option containers (because we
+        // force the selection to be around them when we click on them).
+        if (
+            selectedNodes.length === 1 &&
+            (selectedNodes[0].tagName === "IMG" || isIconElement(selectedNodes[0]))
+        ) {
+            return;
+        }
+        // If no uncrossable element is selected, no need to correct the
+        // selection.
+        if (selectedNodes.every((node) => !node.matches(this.uncrossableSelectors))) {
+            this.shouldUpdateContainersWithSelection = true;
+            return;
+        }
+
+        // This for loop checks for the first uncrossable element in the
+        // selection based on the selection direction. If an uncrossable is
+        // found that is crossed by the selection, the selection is
+        // corrected to be just before or after the uncrossable element based on
+        // the selection direction.
+        let tempFocusNode;
+        for (const node of selectedNodes) {
+            if (this.isNodeSelectionUncrossable(node, selectedNodes)) {
+                let newFocusNode, newFocusOffset;
+                const closestUncrossableEl = closestElement(node, this.uncrossableSelectors);
+                if (!node.contains(anchorNode)) {
+                    // If the anchor is inside the same uncrossable ancestor as
+                    // this node, no boundary is being crossed, both anchor and
+                    // node are on the same side, so we skip it.
+                    if (
+                        closestUncrossableEl !== node &&
+                        closestUncrossableEl.contains(anchorNode)
+                    ) {
+                        tempFocusNode = node;
+                        continue;
+                    }
+                    // The node is not the first selected node and it's
+                    // uncrossable, we need to move the focusNode before
+                    // this uncrossable node (or after if we are selecting to
+                    // the left).
+                    if (direction === DIRECTIONS.RIGHT) {
+                        tempFocusNode = node.previousElementSibling || tempFocusNode;
+                        [newFocusNode, newFocusOffset] = getDeepestPosition(
+                            tempFocusNode,
+                            nodeSize(tempFocusNode)
+                        );
+                    } else {
+                        tempFocusNode = node.nextElementSibling || tempFocusNode;
+                        [newFocusNode, newFocusOffset] = getDeepestPosition(tempFocusNode, 0);
+                    }
+
+                    selection = this.dependencies.selection.setSelection({
+                        anchorNode,
+                        anchorOffset,
+                        focusNode: newFocusNode,
+                        focusOffset: newFocusOffset,
+                    });
+                } else if (!node.contains(focusNode)) {
+                    // We skip it if the focusNode is outside of the uncrossable
+                    // ancestor.
+                    if (
+                        closestUncrossableEl !== node &&
+                        !closestUncrossableEl.contains(focusNode)
+                    ) {
+                        tempFocusNode = node;
+                        continue;
+                    }
+                    // The node is the first selected node and it's uncrossable,
+                    // we need to move the focusNode to the end of the uncrossable
+                    // node (or to the start if we are selecting to the left).
+                    if (direction === DIRECTIONS.RIGHT) {
+                        [newFocusNode, newFocusOffset] = getDeepestPosition(node, nodeSize(node));
+                    } else {
+                        [newFocusNode, newFocusOffset] = getDeepestPosition(node, 0);
+                    }
+
+                    selection = this.dependencies.selection.setSelection({
+                        anchorNode,
+                        anchorOffset,
+                        focusNode: newFocusNode,
+                        focusOffset: newFocusOffset,
+                    });
+                }
+                break;
+            } else {
+                tempFocusNode = node;
+            }
+        }
+
+        this.shouldUpdateContainersWithSelection = true;
+    }
+}

--- a/addons/html_builder/static/src/core/core_plugins.js
+++ b/addons/html_builder/static/src/core/core_plugins.js
@@ -8,6 +8,7 @@ import { BuilderActionsPlugin } from "./builder_actions_plugin";
 import { BuilderComponentPlugin } from "./builder_component_plugin";
 import { BuilderOptionsPlugin } from "./builder_options_plugin";
 import { BuilderOverlayPlugin } from "./builder_overlay/builder_overlay_plugin";
+import { BuilderSelectionRestrictionPlugin } from "./builder_selection_restriction_plugin";
 import { CachedModelPlugin } from "./cached_model_plugin";
 import { ClonePlugin } from "./clone_plugin";
 import { ColorUIPlugin } from "./color_ui_plugin";
@@ -62,6 +63,7 @@ export const MAIN_PLUGINS = [
     BuilderContentEditablePlugin,
     BuilderOptionsPlugin,
     BuilderOverlayPlugin,
+    BuilderSelectionRestrictionPlugin,
     CachedModelPlugin,
     ColorUIPlugin,
     ImagePlugin,

--- a/addons/html_builder/static/tests/block_tab/snippet_content.test.js
+++ b/addons/html_builder/static/tests/block_tab/snippet_content.test.js
@@ -4,6 +4,7 @@ import {
     waitForEndOfOperation,
 } from "@html_builder/../tests/helpers";
 import { BuilderOptionsPlugin } from "@html_builder/core/builder_options_plugin";
+import { BuilderSelectionRestrictionPlugin } from "@html_builder/core/builder_selection_restriction_plugin";
 import { Operation } from "@html_builder/core/operation";
 import { describe, expect, test } from "@odoo/hoot";
 import { animationFrame, click, queryAll, queryAllTexts, queryOne, waitFor } from "@odoo/hoot-dom";
@@ -146,13 +147,15 @@ test("click just after drop is redispatched in next operation", async () => {
         },
     });
     patchWithCleanup(BuilderOptionsPlugin.prototype, {
-        async onClick(ev) {
-            expect.step("onClick");
-            super.onClick(ev);
-        },
         updateContainers(...args) {
             expect.step("updateContainers");
             super.updateContainers(...args);
+        },
+    });
+    patchWithCleanup(BuilderSelectionRestrictionPlugin.prototype, {
+        async onClick(ev) {
+            expect.step("onClick");
+            super.onClick(ev);
         },
     });
     await setupHTMLBuilder("", {

--- a/addons/website/static/src/builder/plugins/website_selection_restriction_plugin.js
+++ b/addons/website/static/src/builder/plugins/website_selection_restriction_plugin.js
@@ -1,0 +1,28 @@
+import { Plugin } from "@html_editor/plugin";
+import { registry } from "@web/core/registry";
+
+class WebsiteSelectionRestrictionPlugin extends Plugin {
+    static id = "websiteSelectionRestriction";
+    /** @type {import("plugins").WebsiteResources} */
+    resources = {
+        ignore_ctrl_a_predicates: (selection) => {
+            const { anchorNode } = selection;
+            // When main body is empty, if we click on the footer (not in its
+            // content) then ctrl+a, the selection is collapsed in editable but
+            // to the main body div, which causes options updating.
+            if (anchorNode.isContentEditable === false && selection.isCollapsed) {
+                return true;
+            }
+        },
+        uncrossable_element_selector: [
+            ".s_cta_badge",
+            ".s_blockquote_line_elt",
+            ".s_blockquote_wrap_icon",
+            ".s_blockquote_infos",
+        ],
+    };
+}
+
+registry
+    .category("website-plugins")
+    .add(WebsiteSelectionRestrictionPlugin.id, WebsiteSelectionRestrictionPlugin);

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -707,7 +707,6 @@ export function selectFullText(elementName, selector) {
         content: `Select all the text of the ${elementName}`,
         trigger: `:iframe ${selector}`,
         async run(actions) {
-            await actions.click();
             const range = document.createRange();
             const selection = this.anchor.ownerDocument.getSelection();
             range.selectNodeContents(this.anchor);
@@ -719,6 +718,7 @@ export function selectFullText(elementName, selector) {
                     cancelable: true,
                 })
             );
+            await actions.click();
         },
     };
 }

--- a/addons/website/static/tests/builder/builder_selection_restrict.test.js
+++ b/addons/website/static/tests/builder/builder_selection_restrict.test.js
@@ -1,0 +1,180 @@
+import { expect, test } from "@odoo/hoot";
+import { defineWebsiteModels, setupWebsiteBuilder } from "./website_helpers";
+import { getContent, setSelection } from "@html_editor/../tests/_helpers/selection";
+import { manuallyDispatchProgrammaticEvent, animationFrame } from "@odoo/hoot-dom";
+import { unformat } from "@html_editor/../tests/_helpers/format";
+
+defineWebsiteModels();
+
+const sectionSnippet = unformat(`
+    <section class="parent-target o_colored_level">
+        <div class="child-target first-child">
+            <p class="grandchild-target first-grandchild">first grand child</p>
+        </div>
+        <div class="child-target second-child">
+            <p class="grandchild-target second-grandchild">second grand child</p>
+        </div>
+    </section>
+`);
+
+test("the selection should be restricted in the closest div when pressing ctrl+a", async () => {
+    const { getEditableContent, getEditor } = await setupWebsiteBuilder(sectionSnippet);
+    const editableContent = getEditableContent();
+    const editor = getEditor();
+    const firstGrandchildEl = editor.editable.querySelector("p.first-grandchild");
+
+    // Set the selection to be inside the first grandchild.
+    setSelection({
+        anchorNode: firstGrandchildEl.firstChild,
+        anchorOffset: 0,
+    });
+
+    // Press ctrl+a to select all the content in the first grandchild.
+    await manuallyDispatchProgrammaticEvent(editor.editable, "keydown", {
+        key: "a",
+        ctrlKey: true,
+    });
+
+    expect(getContent(editableContent)).toBe(
+        unformat(
+            `<section class="parent-target o_colored_level">
+                <div class="child-target first-child">
+                    <p class="grandchild-target first-grandchild">[first grand child]</p>
+                </div>
+                <div class="child-target second-child">
+                    <p class="grandchild-target second-grandchild">second grand child</p>
+                </div>
+            </section>`
+        )
+    );
+});
+
+test("the selection should be restricted when it crosses different div from left to right", async () => {
+    const { getEditableContent, getEditor } = await setupWebsiteBuilder(sectionSnippet);
+    const editableContent = getEditableContent();
+    const editor = getEditor();
+    const firstGrandchildEl = editor.editable.querySelector("p.first-grandchild");
+    const secondGrandchildEl = editor.editable.querySelector("p.second-grandchild");
+
+    // Set the selection to be inside the first grandchild.
+    setSelection({
+        anchorNode: firstGrandchildEl.firstChild,
+        anchorOffset: 0,
+        focusOffset: 4,
+    });
+
+    manuallyDispatchProgrammaticEvent(firstGrandchildEl, "mouseup", {
+        detail: 1,
+    });
+    manuallyDispatchProgrammaticEvent(firstGrandchildEl, "click");
+    await animationFrame();
+
+    // The selection should not be modified when it is inside the innermost
+    // container.
+    expect(getContent(editableContent)).toBe(
+        unformat(
+            `<section class="parent-target o_colored_level">
+                <div class="child-target first-child">
+                    <p class="grandchild-target first-grandchild">[firs]t grand child</p>
+                </div>
+                <div class="child-target second-child">
+                    <p class="grandchild-target second-grandchild">second grand child</p>
+                </div>
+            </section>`
+        )
+    );
+
+    // Set the selection across the two grandchildren
+    setSelection({
+        anchorNode: firstGrandchildEl.firstChild,
+        anchorOffset: 0,
+        focusNode: secondGrandchildEl.firstChild,
+        focusOffset: 4,
+    });
+
+    manuallyDispatchProgrammaticEvent(secondGrandchildEl, "mouseup", {
+        detail: 1,
+    });
+    manuallyDispatchProgrammaticEvent(secondGrandchildEl, "click");
+    await animationFrame();
+
+    // The selection should be modified when it is outside the innermost
+    // container. It should be restricted to the first div.
+    expect(getContent(editableContent)).toBe(
+        unformat(
+            `<section class="parent-target o_colored_level">
+                <div class="child-target first-child">
+                    <p class="grandchild-target first-grandchild">[first grand child]</p>
+                </div>
+                <div class="child-target second-child">
+                    <p class="grandchild-target second-grandchild">second grand child</p>
+                </div>
+            </section>`
+        )
+    );
+});
+
+test("the selection should be restricted when it crosses different div from right to left", async () => {
+    const { getEditableContent, getEditor } = await setupWebsiteBuilder(sectionSnippet);
+    const editableContent = getEditableContent();
+    const editor = getEditor();
+    const firstGrandchildEl = editor.editable.querySelector("p.first-grandchild");
+    const secondGrandchildEl = editor.editable.querySelector("p.second-grandchild");
+
+    // Set the selection to be inside the second grandchild.
+    setSelection({
+        anchorNode: secondGrandchildEl.firstChild,
+        anchorOffset: 4,
+        focusOffset: 0,
+    });
+
+    manuallyDispatchProgrammaticEvent(firstGrandchildEl, "mouseup", {
+        detail: 1,
+    });
+    manuallyDispatchProgrammaticEvent(firstGrandchildEl, "click");
+    await animationFrame();
+
+    // The selection should not be modified when it is inside the innermost
+    // container.
+    expect(getContent(editableContent)).toBe(
+        unformat(
+            `<section class="parent-target o_colored_level">
+                <div class="child-target first-child">
+                    <p class="grandchild-target first-grandchild">first grand child</p>
+                </div>
+                <div class="child-target second-child">
+                    <p class="grandchild-target second-grandchild">]seco[nd grand child</p>
+                </div>
+            </section>`
+        )
+    );
+
+    // Set the selection across the two grandchildren.
+    setSelection({
+        anchorNode: secondGrandchildEl.firstChild,
+        anchorOffset: 4,
+        focusNode: firstGrandchildEl.firstChild,
+        focusOffset: 0,
+    });
+
+    manuallyDispatchProgrammaticEvent(secondGrandchildEl, "mouseup", {
+        detail: 1,
+    });
+    manuallyDispatchProgrammaticEvent(secondGrandchildEl, "click");
+    await animationFrame();
+
+    // The selection should be modified when it is outside the innermost
+    // container. It should be restricted to the first div.
+    expect(getContent(editableContent)).toBe(
+        unformat(
+            `<section class="parent-target o_colored_level">
+                <div class="child-target first-child">
+                    <p class="grandchild-target first-grandchild">first grand child</p>
+                </div>
+                <div class="child-target second-child">
+                    <p class="grandchild-target second-grandchild">]seco[nd grand child</p>
+                </div>
+            </section>`
+        )
+    );
+});


### PR DESCRIPTION
*: website

Before this commit: we can select the whole editing area in website
builder by mouse selection or ctrl+a

After this commit: we introduced a new plugin in the html_builder to
restrict the selections to the closest div element or p element. We also
moved the click listener in builder_options_plugin.js to properly update
the blue container to properly align with the restricted selection.

We have the restriction function called on event keydown, mouseup and
touchend. The listeners are set this way to avoid unnecessary selection
restriction during the selection making. The keydown event is to handle
ctrl+a to select the whole block and then restrict it. The mouseup and
touchend handle the cases where we make the selection by mouse or touch.

We introduced two concepts special blocks (with text in non div) and
uncrossable. In general cases, we restrict the selection to the closes
div element. However, for special blocks, we restrict selection in
closest p element. uncrossable can be defined by tag name or classes.
They are the elements that the selection should not cross, these
elements can appear in a div element and the restricted selection should
stop before crossing them.

When we do select all, we first check if we should select the whole div
element or the p element, then we extend the selection to one direction
\+ correct the selection on uncrossable, then we do the same for the
other direction.

When we make selection by mouse, we first check if the current selection
is beyond the div or p element it should be and we set the selection
inside if it is. Then we check inside the div or p element, if there are
uncrossable, we correct the selection by stopping the selection ahead of
them.

task-4901968


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
