### PR TITLE
[PERF] point_of_sale: implement background queue for order sync

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -300,14 +300,16 @@ export class PaymentScreen extends Component {
             }
         }
 
-        this.pos.addPendingOrder([this.currentOrder.id]);
         this.currentOrder.state = "paid";
 
         this.env.services.ui.block();
         let syncOrderResult;
         try {
             // 1. Save order to server.
-            syncOrderResult = await this.pos.syncAllOrders({ throw: true });
+            syncOrderResult = await this.pos.syncAllOrders({
+                orders: [this.currentOrder],
+                throw: true,
+            });
             if (!syncOrderResult) {
                 return;
             }

--- a/addons/pos_loyalty/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_loyalty/static/src/overrides/components/payment_screen/payment_screen.js
@@ -2,7 +2,6 @@ import { _t } from "@web/core/l10n/translation";
 import { PaymentScreen } from "@point_of_sale/app/screens/payment_screen/payment_screen";
 import { patch } from "@web/core/utils/patch";
 import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
-import { omit } from "@web/core/utils/objects";
 import { useService } from "@web/core/utils/hooks";
 
 patch(PaymentScreen.prototype, {
@@ -80,127 +79,13 @@ patch(PaymentScreen.prototype, {
             .readMany(server_ids)
             .filter((o) => !["draft", "cancel"].includes(o.state));
         for (const order of orders) {
-            await this._postProcessLoyalty(order);
-        }
-        return super._postPushOrderResolve(order, server_ids);
-    },
-    async _postProcessLoyalty(order) {
-        // Compile data for our function
-        const ProgramModel = this.pos.models["loyalty.program"];
-        const rewardLines = order._get_reward_lines();
-        const partner = order.get_partner();
-        let couponData = Object.values(order.uiState.couponPointChanges).reduce((agg, pe) => {
-            agg[pe.coupon_id] = Object.assign({}, pe, {
-                points: pe.points - order._getPointsCorrection(ProgramModel.get(pe.program_id)),
-            });
-            const program = ProgramModel.get(pe.program_id);
-            if (
-                (program.is_nominative || program.program_type == "next_order_coupons") &&
-                partner
-            ) {
-                agg[pe.coupon_id].partner_id = partner.id;
-            }
-            if (program.program_type != "loyalty") {
-                agg[pe.coupon_id].expiration_date = program.date_to || pe.expiration_date;
-            }
-            return agg;
-        }, {});
-        for (const line of rewardLines) {
-            const reward = line.reward_id;
-            const couponId = line.coupon_id.id;
-            if (!couponData[couponId]) {
-                couponData[couponId] = {
-                    points: 0,
-                    program_id: reward.program_id.id,
-                    coupon_id: couponId,
-                    barcode: false,
-                };
-                if (reward.program_type != "loyalty") {
-                    couponData[couponId].expiration_date = reward.program_id.date_to;
-                }
-            }
-            if (!couponData[couponId].line_codes) {
-                couponData[couponId].line_codes = [];
-            }
-            if (!couponData[couponId].line_codes.includes(line.reward_identifier_code)) {
-                !couponData[couponId].line_codes.push(line.reward_identifier_code);
-            }
-            couponData[couponId].points -= line.points_cost;
-        }
-        // We actually do not care about coupons for 'current' programs that did not claim any reward, they will be lost if not validated
-        couponData = Object.fromEntries(
-            Object.entries(couponData)
-                .filter(([key, value]) => {
-                    const program = ProgramModel.get(value.program_id);
-                    if (program.applies_on === "current") {
-                        return value.line_codes && value.line_codes.length;
-                    }
-                    return true;
-                })
-                .map(([key, value]) => [key, omit(value, "appliedRules")])
-        );
-        if (Object.keys(couponData || {}).length > 0) {
-            const payload = await this.pos.data.call("pos.order", "confirm_coupon_programs", [
-                order.id,
-                couponData,
-            ]);
-            if (payload.coupon_updates) {
-                for (const couponUpdate of payload.coupon_updates) {
-                    // The following code is a workaround to update the id of an existing record.
-                    // It's so ugly.
-                    // FIXME: Find a better way of updating the id of an existing record.
-                    // It would be better if we can do this:
-                    // const coupon = this.pos.models["loyalty.card"].get(couponUpdate.old_id);
-                    // coupon.update({ id: couponUpdate.id, points: couponUpdate.points })
-
-                    if (couponUpdate.old_id == couponUpdate.id) {
-                        // just update the points
-                        const coupon = this.pos.models["loyalty.card"].get(couponUpdate.id);
-
-                        if (!coupon) {
-                            await this.pos.data.read("loyalty.card", [couponUpdate.id]);
-                        } else {
-                            coupon.update({ points: couponUpdate.points });
-                        }
-                    } else {
-                        // create a new coupon and delete the old one
-                        const coupon = this.pos.models["loyalty.card"].create({
-                            id: couponUpdate.id,
-                            code: couponUpdate.code,
-                            program_id: this.pos.models["loyalty.program"].get(
-                                couponUpdate.program_id
-                            ),
-                            partner_id: this.pos.models["res.partner"].get(couponUpdate.partner_id),
-                            points: couponUpdate.points,
-                        });
-
-                        // Before deleting the old coupon, update the order lines that use it.
-                        for (const line of order.lines) {
-                            if (line.coupon_id?.id == couponUpdate.old_id) {
-                                line.update({ coupon_id: coupon });
-                            }
-                        }
-
-                        this.pos.models["loyalty.card"].get(couponUpdate.old_id)?.delete();
-                    }
-                }
-            }
-            // Update the usage count since it is checked based on local data
-            if (payload.program_updates) {
-                for (const programUpdate of payload.program_updates) {
-                    const program = ProgramModel.get(programUpdate.program_id);
-                    if (program) {
-                        program.total_order_count = programUpdate.usages;
-                    }
-                }
-            }
-            if (payload.coupon_report) {
+            const payload = await this.pos._postProcessLoyalty(order);
+            if (payload?.coupon_report) {
                 for (const [actionId, active_ids] of Object.entries(payload.coupon_report)) {
                     await this.report.doAction(actionId, active_ids);
                 }
-                order.has_pdf_gift_card = Object.keys(payload.coupon_report).length > 0;
             }
-            order.new_coupon_info = payload.new_coupon_info;
         }
+        return super._postPushOrderResolve(order, server_ids);
     },
 });

--- a/addons/pos_loyalty/static/src/overrides/models/pos_order.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_order.js
@@ -947,7 +947,7 @@ patch(PosOrder.prototype, {
         });
 
         if (newGiftCardCode) {
-            couponId = applicableCouponIds.shift() || loyaltyIdsGenerator();
+            couponId = parseInt(applicableCouponIds.shift() || loyaltyIdsGenerator());
             couponData.coupon_id = couponId;
             couponData.code = newGiftCardCode;
             couponData.partner_id = partner_id;

--- a/addons/pos_loyalty/static/src/overrides/models/pos_store.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_store.js
@@ -9,6 +9,7 @@ import { Mutex } from "@web/core/utils/concurrency";
 import { effect } from "@web/core/utils/reactive";
 import { batched } from "@web/core/utils/timing";
 import { serializeDate } from "@web/core/l10n/dates";
+import { omit } from "@web/core/utils/objects";
 
 let nextId = -1;
 const mutex = new Mutex();
@@ -784,6 +785,129 @@ patch(PosStore.prototype, {
                     });
                 }
             }
+        }
+    },
+    async afterProcessQueue(orders) {
+        await super.afterProcessQueue(...arguments);
+        for (const order of orders) {
+            if (!["draft", "cancel"].includes(order.state)) {
+                await this._postProcessLoyalty(order);
+            }
+        }
+    },
+    async _postProcessLoyalty(order) {
+        // Compile data for our function
+        const ProgramModel = this.models["loyalty.program"];
+        const rewardLines = order._get_reward_lines();
+        const partner = order.get_partner();
+        let couponData = Object.values(order.uiState.couponPointChanges).reduce((agg, pe) => {
+            agg[pe.coupon_id] = Object.assign({}, pe, {
+                points: pe.points - order._getPointsCorrection(ProgramModel.get(pe.program_id)),
+            });
+            const program = ProgramModel.get(pe.program_id);
+            if (
+                (program.is_nominative || program.program_type == "next_order_coupons") &&
+                partner
+            ) {
+                agg[pe.coupon_id].partner_id = partner.id;
+            }
+            if (program.program_type != "loyalty") {
+                agg[pe.coupon_id].expiration_date = program.date_to || pe.expiration_date;
+            }
+            return agg;
+        }, {});
+        for (const line of rewardLines) {
+            const reward = line.reward_id;
+            const couponId = line.coupon_id.id;
+            if (!couponData[couponId]) {
+                couponData[couponId] = {
+                    points: 0,
+                    program_id: reward.program_id.id,
+                    coupon_id: couponId,
+                    barcode: false,
+                };
+                if (reward.program_type != "loyalty") {
+                    couponData[couponId].expiration_date = reward.program_id.date_to;
+                }
+            }
+            if (!couponData[couponId].line_codes) {
+                couponData[couponId].line_codes = [];
+            }
+            if (!couponData[couponId].line_codes.includes(line.reward_identifier_code)) {
+                !couponData[couponId].line_codes.push(line.reward_identifier_code);
+            }
+            couponData[couponId].points -= line.points_cost;
+        }
+        // We actually do not care about coupons for 'current' programs that did not claim any reward, they will be lost if not validated
+        couponData = Object.fromEntries(
+            Object.entries(couponData)
+                .filter(([key, value]) => {
+                    const program = ProgramModel.get(value.program_id);
+                    if (program.applies_on === "current") {
+                        return value.line_codes && value.line_codes.length;
+                    }
+                    return true;
+                })
+                .map(([key, value]) => [key, omit(value, "appliedRules")])
+        );
+        if (Object.keys(couponData || {}).length > 0) {
+            const payload = await this.data.call("pos.order", "confirm_coupon_programs", [
+                order.id,
+                couponData,
+            ]);
+            if (payload.coupon_updates) {
+                for (const couponUpdate of payload.coupon_updates) {
+                    // The following code is a workaround to update the id of an existing record.
+                    // It's so ugly.
+                    // FIXME: Find a better way of updating the id of an existing record.
+                    // It would be better if we can do this:
+                    // const coupon = this.pos.models["loyalty.card"].get(couponUpdate.old_id);
+                    // coupon.update({ id: couponUpdate.id, points: couponUpdate.points })
+
+                    if (couponUpdate.old_id == couponUpdate.id) {
+                        // just update the points
+                        const coupon = this.models["loyalty.card"].get(couponUpdate.id);
+
+                        if (!coupon) {
+                            await this.data.read("loyalty.card", [couponUpdate.id]);
+                        } else {
+                            coupon.update({ points: couponUpdate.points });
+                        }
+                    } else {
+                        // create a new coupon and delete the old one
+                        const coupon = this.models["loyalty.card"].create({
+                            id: couponUpdate.id,
+                            code: couponUpdate.code,
+                            program_id: this.models["loyalty.program"].get(couponUpdate.program_id),
+                            partner_id: this.models["res.partner"].get(couponUpdate.partner_id),
+                            points: couponUpdate.points,
+                        });
+
+                        // Before deleting the old coupon, update the order lines that use it.
+                        for (const line of order.lines) {
+                            if (line.coupon_id?.id == couponUpdate.old_id) {
+                                line.update({ coupon_id: coupon });
+                            }
+                        }
+
+                        this.models["loyalty.card"].get(couponUpdate.old_id)?.delete();
+                    }
+                }
+            }
+            // Update the usage count since it is checked based on local data
+            if (payload.program_updates) {
+                for (const programUpdate of payload.program_updates) {
+                    const program = ProgramModel.get(programUpdate.program_id);
+                    if (program) {
+                        program.total_order_count = programUpdate.usages;
+                    }
+                }
+            }
+            if (payload.coupon_report) {
+                order.has_pdf_gift_card = Object.keys(payload.coupon_report).length > 0;
+            }
+            order.new_coupon_info = payload.new_coupon_info;
+            return payload;
         }
     },
 });

--- a/addons/pos_online_payment/static/src/overrides/pos_overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_online_payment/static/src/overrides/pos_overrides/components/payment_screen/payment_screen.js
@@ -11,8 +11,7 @@ patch(PaymentScreen.prototype, {
     async addNewPaymentLine(paymentMethod) {
         if (paymentMethod.is_online_payment && typeof this.currentOrder.id === "string") {
             this.currentOrder.date_order = serializeDateTime(luxon.DateTime.now());
-            this.pos.addPendingOrder([this.currentOrder.id]);
-            await this.pos.syncAllOrders();
+            await this.pos.syncAllOrders({ orders: [this.currentOrder] });
         }
         return await super.addNewPaymentLine(...arguments);
     },

--- a/addons/pos_restaurant/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_store.js
@@ -174,18 +174,6 @@ patch(PosStore.prototype, {
         }
         return super.addLineToCurrentOrder(vals, opts, configure);
     },
-    async getServerOrders() {
-        if (this.config.module_pos_restaurant) {
-            const tableIds = [].concat(
-                ...this.models["restaurant.floor"].map((floor) =>
-                    floor.table_ids.map((table) => table.id)
-                )
-            );
-            await this.syncAllOrders({ table_ids: tableIds });
-        }
-        //Need product details from backand to UI for urbanpiper
-        return await super.getServerOrders();
-    },
     getDefaultSearchDetails() {
         if (this.selectedTable && this.selectedTable.id) {
             return {


### PR DESCRIPTION
Implement a background queue system to handle isUnsyncedPaid orders separately from regular order synchronization. This prevents issues when multiple pending orders are being synced simultaneously.

Orders are now categorized into three types:
- Orders from options.orders: sync normally with await
- Non-isUnsyncedPaid pending orders: sync normally
- isUnsyncedPaid orders: process sequentially through background queue

The queue processing pauses during explicit sync operations and resumes automatically afterward. This prevents race conditions and ensures orders are synced reliably one-by-one.

Error handling differentiates between error types:
- RPCError: removes order from queue and shows user notification
- ConnectionLostError: pauses queue and keeps order at front for retry
- Timeout/other errors: moves order to end of queue for retry

opw-5111772

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
