### PR TITLE
[FIX] html_builder: handle errors on outdated snippets gracefully

### DIFF
--- a/addons/html_builder/static/src/core/core_plugins.js
+++ b/addons/html_builder/static/src/core/core_plugins.js
@@ -36,6 +36,7 @@ import { BuilderContentEditablePlugin } from "./builder_content_editable_plugin"
 import { ImageFieldPlugin } from "@html_builder/plugins/image_field_plugin";
 import { MonetaryFieldPlugin } from "@html_builder/plugins/monetary_field_plugin";
 import { Many2OneOptionPlugin } from "@html_builder/plugins/many2one_option_plugin";
+import { VersionErrorPlugin } from "./version_error_plugin";
 
 const mainEditorPluginsToRemove = [
     "PowerButtonsPlugin",
@@ -94,4 +95,5 @@ export const CORE_PLUGINS = [
     ImageFieldPlugin,
     MonetaryFieldPlugin,
     Many2OneOptionPlugin,
+    VersionErrorPlugin,
 ];

--- a/addons/html_builder/static/src/core/utils.js
+++ b/addons/html_builder/static/src/core/utils.js
@@ -677,6 +677,28 @@ function getValueWithDefault(userInputValue, defaultValue, formatRawValue) {
     return userInputValue;
 }
 
+/**
+ * Handles errors during builder actions.
+ * Currently it only checks if the error was triggered on an outdated snippet,
+ * and in that case it suppresses the error and shows a notification instead.
+ * This function can potentially be extended in the future to handle additional
+ * errors and recovery strategies.
+ *
+ * @param {Error} error - The caught error
+ * @param {Element} editingElement - The element being edited
+ * @param {Component} comp -  The component
+ * @throws {Error} If editingElement is not an outdated snippet
+ */
+function handleBuilderActionError(error, editingElement, comp) {
+    // Check if editingElement belongs to an outdated snippet, and displays a
+    // warning notification if yes.
+    const isOutdated =
+        comp.env.editor.shared.versionError.checkNotifyOutdatedSnippet(editingElement);
+    if (!isOutdated) {
+        throw error;
+    }
+}
+
 export function useInputBuilderComponent({
     id,
     defaultValue,
@@ -728,11 +750,16 @@ export function useInputBuilderComponent({
             ({ actionId }) => getAction(actionId).getValue
         );
         const { actionId, actionParam } = actionWithGetValue;
-        const actionValue =
-            getAction(actionId).getValue({ editingElement, params: actionParam }) || defaultValue;
-        return {
-            value: actionValue,
-        };
+        try {
+            const actionValue =
+                getAction(actionId).getValue({ editingElement, params: actionParam }) ||
+                defaultValue;
+            return {
+                value: actionValue,
+            };
+        } catch (error) {
+            handleBuilderActionError(error, editingElement, comp);
+        }
     }
 
     function commit(userInputValue) {
@@ -975,28 +1002,45 @@ export function getAllActionsAndOperations(comp) {
         const isPreviewing = !!params.preview;
         const actionsSpecs = getActionsSpecs(getAllActions(), params.userInputValue);
 
-        comp.env.editor.shared.operation.next(() => fn(actionsSpecs, isPreviewing), {
-            load: async () =>
-                Promise.all(
-                    actionsSpecs.map(async (applySpec) => {
-                        if (!applySpec.action.has("load")) {
-                            return;
-                        }
-                        const hasClean = !!applySpec.action.has("clean");
-                        if (!applySpec.loadOnClean && _shouldClean(comp, hasClean, isApplied())) {
-                            // The element will be cleaned, do not load
-                            return;
-                        }
-                        const result = await applySpec.action.load({
-                            editingElement: applySpec.editingElement,
-                            params: applySpec.actionParam,
-                            value: applySpec.actionValue,
-                        });
-                        applySpec.loadResult = result;
-                    })
-                ),
-            ...params.operationParams,
-        });
+        comp.env.editor.shared.operation.next(
+            async () => {
+                try {
+                    await fn(actionsSpecs, isPreviewing);
+                } catch (error) {
+                    handleBuilderActionError(error, comp.env.getEditingElement(), comp);
+                }
+            },
+            {
+                load: async () => {
+                    try {
+                        return await Promise.all(
+                            actionsSpecs.map(async (applySpec) => {
+                                if (!applySpec.action.has("load")) {
+                                    return;
+                                }
+                                const hasClean = !!applySpec.action.has("clean");
+                                if (
+                                    !applySpec.loadOnClean &&
+                                    _shouldClean(comp, hasClean, isApplied())
+                                ) {
+                                    // The element will be cleaned, do not load
+                                    return;
+                                }
+                                const result = await applySpec.action.load({
+                                    editingElement: applySpec.editingElement,
+                                    params: applySpec.actionParam,
+                                    value: applySpec.actionValue,
+                                });
+                                applySpec.loadResult = result;
+                            })
+                        );
+                    } catch (error) {
+                        handleBuilderActionError(error, comp.env.getEditingElement(), comp);
+                    }
+                },
+                ...params.operationParams,
+            }
+        );
     }
     function isApplied() {
         const getAction = comp.env.editor.shared.builderActions.getAction;
@@ -1011,12 +1055,16 @@ export function getAllActionsAndOperations(comp) {
             if (!isConnectedElement(editingElement)) {
                 return false;
             }
-            const isApplied = getAction(actionId).isApplied?.({
-                editingElement,
-                params: actionParam,
-                value: actionValue,
-            });
-            return comp.props.inverseAction ? !isApplied : isApplied;
+            try {
+                const isApplied = getAction(actionId).isApplied?.({
+                    editingElement,
+                    params: actionParam,
+                    value: actionValue,
+                });
+                return comp.props.inverseAction ? !isApplied : isApplied;
+            } catch (error) {
+                handleBuilderActionError(error, editingElement, comp);
+            }
         });
         // If there is no `isApplied` method for the widget return false
         if (areActionsActiveTabs.every((el) => el === undefined)) {

--- a/addons/html_builder/static/src/core/version_error_plugin.js
+++ b/addons/html_builder/static/src/core/version_error_plugin.js
@@ -1,0 +1,62 @@
+import { Plugin } from "@html_editor/plugin";
+import { _t } from "@web/core/l10n/translation";
+
+export class VersionErrorPlugin extends Plugin {
+    static id = "versionError";
+    static shared = ["checkNotifyOutdatedSnippet"];
+    static dependencies = [];
+
+    resources = {};
+
+    /**
+     * Checks if a snippet is up to date by comparing its versions (vcss, vxml, vjs)
+     * with those of the original snippet in the model.
+     *
+     * @param {HTMLElement} el - The element to check (will look for parent with data-snippet if needed)
+     * @returns {boolean} - true if the snippet is up to date, or if the element is not a snippet
+     */
+    isSnippetUpToDate(el) {
+        const snippetEl = el?.closest?.("[data-snippet]");
+        if (!snippetEl) {
+            return true;
+        }
+        const snippetKey = snippetEl.dataset.snippet;
+        const snippet = this.config.snippetModel.getOriginalSnippet(snippetKey);
+        if (!snippet) {
+            return true;
+        }
+        const {
+            vcss: originalVcss,
+            vxml: originalVxml,
+            vjs: originalVjs,
+        } = snippet.content.dataset;
+        const { vcss: elVcss, vxml: elVxml, vjs: elVjs } = snippetEl.dataset;
+        return originalVcss === elVcss && originalVxml === elVxml && originalVjs === elVjs;
+    }
+
+    /**
+     * Checks if snippet is outdated. If yes, displays an appropriate
+     * notification and returns true, otherwise return false. Only one
+     * notification is open per time.
+     *
+     * @param {HTMLElement} editingElement - The element being checked
+     * @return {Boolean} - True if the snippet is outdated
+     */
+    checkNotifyOutdatedSnippet(editingElement) {
+        if (!this.isSnippetUpToDate(editingElement)) {
+            this.closeExistingNotification?.();
+            this.closeExistingNotification = this.services.notification.add(
+                _t(
+                    "It might have caused problem during the editing. Please drag the new version from the snippet panel to update it."
+                ),
+                {
+                    type: "warning",
+                    title: _t("This snippet is outdated"),
+                    sticky: true,
+                }
+            );
+            return true;
+        }
+        return false;
+    }
+}

--- a/addons/html_builder/static/tests/operation.test.js
+++ b/addons/html_builder/static/tests/operation.test.js
@@ -2,13 +2,15 @@ import {
     addBuilderOption,
     addBuilderAction,
     setupHTMLBuilder,
+    getSnippetStructure,
 } from "@html_builder/../tests/helpers";
 import { BuilderAction } from "@html_builder/core/builder_action";
+import { ClassAction } from "@html_builder/core/core_builder_action_plugin";
 import { Operation } from "@html_builder/core/operation";
 import { BaseOptionComponent } from "@html_builder/core/utils";
 import { HistoryPlugin } from "@html_editor/core/history_plugin";
 import { beforeEach, describe, expect, test } from "@odoo/hoot";
-import { advanceTime, Deferred, delay, hover, press, tick } from "@odoo/hoot-dom";
+import { advanceTime, animationFrame, Deferred, delay, hover, press, tick } from "@odoo/hoot-dom";
 import { xml } from "@odoo/owl";
 import { contains, patchWithCleanup } from "@web/../tests/web_test_helpers";
 
@@ -325,5 +327,344 @@ describe("Operation that will fail", () => {
         );
         // preview + commit
         expect.verifyErrors(["This action should crash", "This action should crash"]);
+    });
+});
+
+const UPDATED_SNIPPET = {
+    snippet_structure: [
+        getSnippetStructure({
+            name: "Title",
+            groupName: "a",
+            content: `
+                <section class="s_title" data-snippet="s_title" data-vcss="001" data-name="Title">
+                    <h1>Title</h1>
+                </section>`,
+        }),
+    ],
+};
+
+describe("Operations failing on outdated snippets", () => {
+    test("Error in apply() on outdated snippet shows warning notification", async () => {
+        expect.errors(1);
+        class TestAction extends BuilderAction {
+            static id = "testAction";
+            apply({ editingElement }) {
+                editingElement.classList.add("fail");
+                throw new Error("Error on apply");
+            }
+        }
+        addBuilderAction({
+            TestAction,
+        });
+        addBuilderOption(
+            class extends BaseOptionComponent {
+                static selector = ".s_title";
+                static template = xml`<BuilderButton action="'testAction'"/>`;
+            }
+        );
+        await setupHTMLBuilder(
+            `<section class="s_title" data-snippet="s_title" data-name="Title">
+                <h1>Old</h1>
+            </section>
+            <section class="s_title" data-snippet="s_title" data-vcss="001" data-name="Title">
+                <h1>New</h1>
+            </section>`,
+            {
+                snippets: UPDATED_SNIPPET,
+            }
+        );
+
+        // Interacting with an outdated snippet. We test that only one
+        // notification is displayed (the one triggered by the hover), while the
+        // error triggered by the click does not result in a second notification
+        // because one is already open.
+        await contains(":iframe .s_title h1:contains('Old')").click();
+        await contains("[data-action-id='testAction']").hover();
+        await animationFrame();
+        await contains("[data-action-id='testAction']").click();
+        expect(".o_notification .o_notification_bar.bg-warning").toHaveCount(1);
+        expect(".o_notification_content").toHaveText(
+            "This snippet is outdated. It might have caused problem during the editing. Please drag the new version from the snippet panel to update it."
+        );
+        expect.verifyErrors([]);
+
+        // Close the notification and try to interact with an up-to-date snippet
+        await contains(`.o_notification_close`).click();
+        await contains(":iframe .s_title h1:contains('New')").click();
+        await contains("[data-action-id='testAction']").hover();
+        await animationFrame();
+        expect(".o_notification").toHaveCount(0);
+        expect.verifyErrors(["Error on apply"]);
+    });
+
+    test("Error in load() on outdated snippet shows warning notification", async () => {
+        expect.errors(1);
+        class TestAction extends BuilderAction {
+            static id = "testAction";
+            load() {
+                throw new Error("Error on load");
+            }
+            apply({ editingElement }) {
+                editingElement.classList.add("success");
+            }
+        }
+        addBuilderAction({
+            TestAction,
+        });
+        addBuilderOption(
+            class extends BaseOptionComponent {
+                static selector = ".s_title";
+                static template = xml`<BuilderButton action="'testAction'"/>`;
+            }
+        );
+        await setupHTMLBuilder(
+            `<section class="s_title" data-snippet="s_title" data-name="Title">
+                <h1>Old</h1>
+            </section>
+            <section class="s_title" data-snippet="s_title" data-vcss="001" data-name="Title">
+                <h1>New</h1>
+            </section>`,
+            {
+                snippets: UPDATED_SNIPPET,
+            }
+        );
+
+        // Interacting with an outdated snippet. We test that only one
+        // notification is displayed (the one triggered by the hover), while the
+        // error triggered by the click does not result in a second notification
+        // because one is already open.
+        await contains(":iframe .s_title h1:contains('Old')").click();
+        await contains("[data-action-id='testAction']").hover();
+        await animationFrame();
+        await contains("[data-action-id='testAction']").click();
+        expect(".o_notification .o_notification_bar.bg-warning").toHaveCount(1);
+        expect(".o_notification_content").toHaveText(
+            "This snippet is outdated. It might have caused problem during the editing. Please drag the new version from the snippet panel to update it."
+        );
+        expect.verifyErrors([]);
+
+        // Close the notification and try to interact with an up-to-date snippet
+        await contains(`.o_notification_close`).click();
+        await contains(":iframe .s_title h1:contains('New')").click();
+        await contains("[data-action-id='testAction']").hover();
+        await animationFrame();
+        expect(".o_notification").toHaveCount(0);
+        expect.verifyErrors(["Error on load"]);
+    });
+
+    test("Error in clean() on outdated snippet shows warning notification", async () => {
+        expect.errors(1);
+        class TestAction extends BuilderAction {
+            static id = "testAction";
+            isApplied({ editingElement }) {
+                return editingElement.classList.contains("applied");
+            }
+            clean() {
+                throw new Error("Error on clean");
+            }
+            apply({ editingElement }) {
+                editingElement.classList.add("applied");
+            }
+        }
+        addBuilderAction({
+            TestAction,
+        });
+        addBuilderOption(
+            class extends BaseOptionComponent {
+                static selector = ".s_title";
+                static template = xml`<BuilderButton action="'testAction'"/>`;
+            }
+        );
+        await setupHTMLBuilder(
+            `<section class="s_title applied" data-snippet="s_title" data-name="Title">
+                <h1>Old</h1>
+            </section>
+            <section class="s_title applied" data-snippet="s_title" data-vcss="001" data-name="Title">
+                <h1>New</h1>
+            </section>`,
+            {
+                snippets: UPDATED_SNIPPET,
+            }
+        );
+
+        // Interacting with an outdated snippet. We test that only one
+        // notification is displayed (the one triggered by the hover), while the
+        // error triggered by the click does not result in a second notification
+        // because one is already open.
+        await contains(":iframe .s_title h1:contains('Old')").click();
+        await contains("[data-action-id='testAction']").hover();
+        await animationFrame();
+        await contains("[data-action-id='testAction']").click();
+        expect(".o_notification .o_notification_bar.bg-warning").toHaveCount(1);
+        expect(".o_notification_content").toHaveText(
+            "This snippet is outdated. It might have caused problem during the editing. Please drag the new version from the snippet panel to update it."
+        );
+        expect.verifyErrors([]);
+
+        // Close the notification and try to interact with an up-to-date snippet
+        await contains(`.o_notification_close`).click();
+        await contains(":iframe .s_title h1:contains('New')").click();
+        await contains("[data-action-id='testAction']").hover();
+        await animationFrame();
+        expect(".o_notification").toHaveCount(0);
+        expect.verifyErrors(["Error on clean"]);
+    });
+
+    test("Error in getValue() on outdated snippet shows warning notification", async () => {
+        class TestAction extends BuilderAction {
+            static id = "testAction";
+            getValue() {
+                throw new Error("getValue should crash");
+            }
+        }
+        addBuilderAction({
+            TestAction,
+        });
+        addBuilderOption(
+            class extends BaseOptionComponent {
+                static selector = ".s_title";
+                static template = xml`<BuilderNumberInput action="'testAction'"/>`;
+            }
+        );
+
+        await setupHTMLBuilder(
+            `<section class="s_title applied" data-snippet="s_title" data-name="Title">
+                <h1>Old</h1>
+            </section>`,
+            {
+                snippets: UPDATED_SNIPPET,
+            }
+        );
+
+        // Interacting with an outdated snippet. Notification is shown
+        await contains(":iframe .s_title h1:contains('Old')").click();
+        expect(".o_notification .o_notification_bar.bg-warning").toHaveCount(1);
+        expect(".o_notification_content").toHaveText(
+            "This snippet is outdated. It might have caused problem during the editing. Please drag the new version from the snippet panel to update it."
+        );
+        expect.verifyErrors([]);
+    });
+
+    test("Error in isApplied() on outdated snippet shows warning notification", async () => {
+        class TestAction extends BuilderAction {
+            static id = "testAction";
+            isApplied() {
+                throw new Error("isApplied should crash");
+            }
+        }
+        addBuilderAction({
+            TestAction,
+        });
+        addBuilderOption(
+            class extends BaseOptionComponent {
+                static selector = ".s_title";
+                static template = xml`<BuilderButton action="'testAction'"/>`;
+            }
+        );
+
+        await setupHTMLBuilder(
+            `<section class="s_title applied" data-snippet="s_title" data-name="Title">
+                <h1>Old</h1>
+            </section>`,
+            {
+                snippets: UPDATED_SNIPPET,
+            }
+        );
+
+        // Interacting with an outdated snippet. Notification is shown
+        await contains(":iframe .s_title h1:contains('Old')").click();
+        expect(".o_notification .o_notification_bar.bg-warning").toHaveCount(1);
+        expect(".o_notification_content").toHaveText(
+            "This snippet is outdated. It might have caused problem during the editing. Please drag the new version from the snippet panel to update it."
+        );
+        expect.verifyErrors([]);
+    });
+
+    test("Error in clean() via cleanSelectedItem on outdated snippet shows warning notification", async () => {
+        expect.errors(1);
+        class TestAction extends ClassAction {
+            static id = "testAction";
+            clean({ editingElement }) {
+                throw new Error("Clean via cleanSelectedItem should crash");
+            }
+        }
+        addBuilderAction({
+            TestAction,
+        });
+        addBuilderOption(
+            class extends BaseOptionComponent {
+                static selector = ".s_title";
+                static template = xml`
+                    <BuilderButtonGroup action="'testAction'">
+                        <BuilderButton actionParam="'class1'">1</BuilderButton>
+                        <BuilderButton actionParam="'class2'">2</BuilderButton>
+                    </BuilderButtonGroup>`;
+            }
+        );
+
+        await setupHTMLBuilder(
+            `<section class="s_title class1" data-snippet="s_title" data-name="Title">
+                <h1>Old</h1>
+            </section>
+            <section class="s_title class1" data-snippet="s_title" data-vcss="001" data-name="Title">
+                <h1>New</h1>
+            </section>`,
+            {
+                snippets: UPDATED_SNIPPET,
+            }
+        );
+
+        // Interacting with an outdated snippet. Notification is shown
+        await contains(":iframe .s_title h1:contains('Old')").click();
+        await contains("[data-action-param='class2']").hover();
+        await animationFrame();
+        expect(".o_notification .o_notification_bar.bg-warning").toHaveCount(1);
+        expect(".o_notification_content").toHaveText(
+            "This snippet is outdated. It might have caused problem during the editing. Please drag the new version from the snippet panel to update it."
+        );
+
+        // Close the notification and try to interact with an up-to-date snippet
+        await contains(`.o_notification_close`).click();
+        await contains(":iframe .s_title h1:contains('New')").click();
+        await contains("[data-action-param='class2']").hover();
+        expect.verifyErrors(["Clean via cleanSelectedItem should crash"]);
+    });
+
+    test("A single outdated snippet warning notification should be displayed per time", async () => {
+        class TestAction extends BuilderAction {
+            static id = "testAction";
+            isApplied() {
+                throw new Error("isApplied should crash");
+            }
+            apply() {
+                throw new Error("apply should crash");
+            }
+        }
+        addBuilderAction({
+            TestAction,
+        });
+        addBuilderOption(
+            class extends BaseOptionComponent {
+                static selector = ".s_title";
+                static template = xml`
+                    <BuilderButton action="'testAction'">A</BuilderButton>`;
+            }
+        );
+
+        await setupHTMLBuilder(
+            `<section class="s_title" data-snippet="s_title" data-name="Title">
+                <h1>Title</h1>
+            </section>`,
+            {
+                snippets: UPDATED_SNIPPET,
+            }
+        );
+
+        await contains(":iframe .s_title").click();
+        await contains("[data-action-id='testAction']").click();
+        expect(".o_notification .o_notification_bar.bg-warning").toHaveCount(1);
+        expect(".o_notification_content").toHaveText(
+            "This snippet is outdated. It might have caused problem during the editing. Please drag the new version from the snippet panel to update it."
+        );
     });
 });


### PR DESCRIPTION
Since [1], the warning to inform the user that a snippet is outdated has been removed.

After this commit, if a builder action fail on outdated snippets (mismatched vcss/vxml/vjs versions), we show a warning notification instead of propagating the error. The notification informs the user that an error occurred on an outdated snippet, and prompts them to drag a new version of the snippet.

This is achieved by wrapping try-catch blocks around all builder action lifecycle methods (apply, clean, load, getValue, isApplied) and implementing an error handling method that detects if the snippet is outdated.

task-4297808

[1]: https://github.com/odoo/odoo/pull/224382