### PR TITLE
[FIX] website: wait iframe before open SEO dialog

### DIFF
--- a/addons/website/static/src/components/dialog/seo.js
+++ b/addons/website/static/src/components/dialog/seo.js
@@ -400,6 +400,9 @@ export class OptimizeSEODialog extends Component {
         this.contentClass = "oe_seo_configuration";
 
         onWillStart(async () => {
+            // Wait for the preview iframe because this dialog reads directly
+            // from the iframe DOM.
+            await this.waitForIframe();
             const { metadata: { mainObject, seoObject, path } } = this.website.currentWebsite;
 
             this.object = seoObject || mainObject;
@@ -435,6 +438,16 @@ export class OptimizeSEODialog extends Component {
 
             this.canEditKeywords = 'website_meta_keywords' in this.data;
             seoContext.keywords = this.getMeta({ name: 'keywords' });
+        });
+    }
+
+    async waitForIframe() {
+        await new Promise((resolve) => {
+            const iframeEl = document.querySelector(".o_iframe");
+            if (!iframeEl || iframeEl.contentDocument?.readyState === "complete") {
+                return resolve();
+            }
+            iframeEl.addEventListener("load", resolve, { once: true });
         });
     }
 


### PR DESCRIPTION
Steps to reproduce:

- Open Website app and enter edit mode on any page.
- Reload the page with a slow connection.
- Immediately open "Optimize SEO" from the navbar menu.

Before this commit, the dialog accessed the preview document while the iframe was reloading, so reading location.origin raised a TypeError.

After this commit, the dialog waits for the iframe to finish loading or returns immediately when it is already complete, preventing crashes.

task-5104033