### PR TITLE
[FIX] l10n_es_edi_verifactu: select the right "Clave Regimen" based on taxes

### DIFF
--- a/addons/l10n_es_edi_verifactu/models/account_tax.py
+++ b/addons/l10n_es_edi_verifactu/models/account_tax.py
@@ -45,11 +45,11 @@ class AccountTax(models.Model):
         """
         taxes = self
         if forced_tax_applicability:
-            # Remove main taxes with different a Veri*Factu tax applicability
+            # Remove main taxes with a different Veri*Factu tax applicability
             main_tax_types = self._l10n_es_get_main_tax_types()
             taxes = taxes.filtered(
                 lambda tax: (tax.l10n_es_type not in main_tax_types
-                             or tax._l10n_es_edi_verifactu_get_applicability() != forced_tax_applicability)
+                             or tax._l10n_es_edi_verifactu_get_applicability() == forced_tax_applicability)
             )
 
         tax_applicability = forced_tax_applicability or taxes._l10n_es_edi_verifactu_get_applicability()

--- a/addons/l10n_es_edi_verifactu/tests/common.py
+++ b/addons/l10n_es_edi_verifactu/tests/common.py
@@ -65,6 +65,7 @@ class TestL10nEsEdiVerifactuCommon(AccountTestInvoicingCommon):
         cls.tax0_no_sujeto_loc = ChartTemplate.ref('account_tax_template_s_iva_ns')
         cls.tax0_isp = ChartTemplate.ref('account_tax_template_s_iva0_isp')
         cls.tax0_exento = ChartTemplate.ref('account_tax_template_s_iva0')
+        cls.tax0_exento_export = ChartTemplate.ref('account_tax_template_s_iva0_g_e')
         # We create a 'no_sujeto' tax since there is currently no such tax in the standard chart
         cls.tax0_no_sujeto = cls.tax0_no_sujeto_loc.copy()
         cls.tax0_no_sujeto.l10n_es_type = 'no_sujeto'

--- a/addons/l10n_es_edi_verifactu/tests/files/test_invoice_export.json
+++ b/addons/l10n_es_edi_verifactu/tests/files/test_invoice_export.json
@@ -1,0 +1,68 @@
+{
+    "Cabecera": {
+        "ObligadoEmision": {
+            "NombreRazon": "company_1_data",
+            "NIF": "A39200019"
+        },
+        "RemisionVoluntaria": {
+            "Incidencia": "N"
+        }
+    },
+    "RegistroFactura": [{
+        "RegistroAlta": {
+            "IDVersion": "1.0",
+            "IDFactura": {
+                "IDEmisorFactura": "A39200019",
+                "NumSerieFactura": "INV/2019/00001",
+                "FechaExpedicionFactura": "30-01-2019"
+            },
+            "NombreRazonEmisor": "company_1_data",
+            "Subsanacion": "N",
+            "TipoFactura": "F1",
+            "FechaOperacion": "01-02-2019",
+            "DescripcionOperacion": "manual",
+            "Destinatarios": {
+                "IDDestinatario": [{
+                    "NombreRazon": "partner_a",
+                    "IDOtro": {
+                        "IDType": "02",
+                        "ID": "BE0477472701"
+                    }
+                }]
+            },
+            "Desglose": {
+                "DetalleDesglose": [
+                    {
+                        "Impuesto": "01",
+                        "ClaveRegimen": "02",
+                        "BaseImponibleOimporteNoSujeto": "100.00",
+                        "OperacionExenta": "E2"
+                    }
+                ]
+            },
+            "CuotaTotal": "0.00",
+            "ImporteTotal": "100.00",
+            "Encadenamiento": {
+                "PrimerRegistro": "S"
+            },
+            "SistemaInformatico": {
+                "NombreRazon": "Odoo SA",
+                "IDOtro": {
+                    "CodigoPais": "BE",
+                    "IDType": "02",
+                    "ID": "BE0477472701"
+                },
+                "NombreSistemaInformatico": "Odoo",
+                "IdSistemaInformatico": "00",
+                "Version": "17.0+e",
+                "NumeroInstalacion": "7244834601315494189",
+                "TipoUsoPosibleSoloVerifactu": "S",
+                "TipoUsoPosibleMultiOT": "S",
+                "IndicadorMultiplesOT": "S"
+            },
+            "FechaHoraHusoGenRegistro": "2024-12-05T01:00:00+01:00",
+            "TipoHuella": "01",
+            "Huella": "7D6E12925DA20552DC8CFA71298287718B75FA9B4B9801A63BF86BD29EBFA1CF"
+        }
+    }]
+}

--- a/addons/l10n_es_edi_verifactu/tests/test_json.py
+++ b/addons/l10n_es_edi_verifactu/tests/test_json.py
@@ -285,6 +285,29 @@ class TestL10nEsEdiVerifactuJson(TestL10nEsEdiVerifactuCommon):
             batch_dict, _info = document._send_as_batch()
         self.assertEqual(batch_dict, self._json_file_to_dict('l10n_es_edi_verifactu/tests/files/test_invoice_4.json'))
 
+    def test_invoice_export(self):
+        """
+        Test the Clave Regimen for exports
+        """
+        invoice = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'invoice_date': '2019-01-30',
+            'delivery_date': '2019-02-01',
+            'date': '2019-01-30',
+            'partner_id': self.partner_a.id,  # Belgian customer
+            'invoice_line_ids': [
+                Command.create({'product_id': self.product_1.id, 'price_unit': 100.0, 'tax_ids': [Command.set(self.tax0_exento_export.ids)]}),
+            ],
+        })
+        invoice.action_post()
+
+        with self._mock_last_document(None):
+            document = invoice._l10n_es_edi_verifactu_create_documents()[invoice]
+        self.assertFalse(document.errors)
+        with self._mock_zeep_registration_operation_certificate_issue():
+            batch_dict, _info = document._send_as_batch()
+        self.assertEqual(batch_dict, self._json_file_to_dict('l10n_es_edi_verifactu/tests/files/test_invoice_export.json'))
+
     def test_invoice_multicurrency_1(self):
         invoice = self.env['account.move'].create({
             'move_type': 'out_invoice',


### PR DESCRIPTION
### Steps to reproduce:
- Install l10n_es_edi_verifactu and switch too Spanish company
- Create an invoice for a partner outside Spain (or with the tax "0% EX G")
- Check the "Veri*Factu Regime Key" under the page "Veri*Factu"
- It should be "Export" (02) but it's "General Regime Operation" (01)

### Cause:
`_l10n_es_edi_verifactu_get_suggested_clave_regimen()` is called on the tax "0% EX G". The line
```taxes.filtered(lambda tax: (tax.l10n_es_type not in main_tax_types or tax._l10n_es_edi_verifactu_get_applicability() != forced_tax_applicability))```
doesn't do what the comment says: remove the main taxes with a different applicability.

### Solution:
Change the `!=` to `==` so that the line does the same thing as the comment.

opw-5071665