### PR TITLE
[FIX] website_sale: hide mega menu options when no category

### DIFF
--- a/addons/website_sale/views/snippets/snippets.xml
+++ b/addons/website_sale/views/snippets/snippets.xml
@@ -398,27 +398,29 @@
     </xpath>
     <xpath expr="//div[@data-js='MegaMenuLayout']" position="inside">
         <t t-set="categories" t-value="request.env['product.public.category'].search([])"/>
-        <we-row t-if="categories">
-            <we-title class="o_long_title">eCommerce Categories</we-title>
-            <div class="o_switch ms-4">
-                <we-checkbox
-                    class="o_mega_menu"
-                    data-name="fetch_ecom_categories_opt"
-                    data-select-class="fetchEcomCategories"
-                    data-toggle-fetch-ecom-categories=""
+        <div t-attf-class="#{'d-none' if not categories else ''}">
+            <we-row>
+                <we-title class="o_long_title">eCommerce Categories</we-title>
+                <div class="o_switch ms-4">
+                    <we-checkbox
+                        class="o_mega_menu"
+                        data-name="fetch_ecom_categories_opt"
+                        data-select-class="fetchEcomCategories"
+                        data-toggle-fetch-ecom-categories=""
+                        data-no-preview="true"
+                    />
+                </div>
+                <we-button
+                    type="button"
+                    title="Reset Categories"
+                    data-refresh-mega-menu-template=""
                     data-no-preview="true"
-                />
-            </div>
-            <we-button
-                type="button"
-                title="Reset Categories"
-                data-refresh-mega-menu-template=""
-                data-no-preview="true"
-                class="ms-4"
-            >
-                <i class="fa fa-refresh"/>
-            </we-button>
-        </we-row>
+                    class="ms-4"
+                >
+                    <i class="fa fa-refresh"/>
+                </we-button>
+            </we-row>
+        </div>
     </xpath>
     <xpath
         expr="//div[@data-js='MegaMenuLayout']/we-select[@data-name='mega_menu_template_opt']/we-button[@data-select-template='website.s_mega_menu_multi_menus']"


### PR DESCRIPTION
When `website_sale` is installed but there are no eCommerce categories, all mega menu options will be shown twice in the web editor. When you use the duplicated one it's empty and you'll also get an error.