### PR TITLE
[FIX] analytic: add missing company_id for widget analytic_distribution

### DIFF
--- a/addons/analytic/models/analytic_mixin.py
+++ b/addons/analytic/models/analytic_mixin.py
@@ -12,6 +12,7 @@ class AnalyticMixin(models.AbstractModel):
     _name = 'analytic.mixin'
     _description = 'Analytic Mixin'
 
+    company_id = fields.Many2one('res.company')  # used in widget `analytic_distribution`
     analytic_distribution = fields.Json(
         'Analytic Distribution',
         compute="_compute_analytic_distribution", store=True, copy=True, readonly=False,


### PR DESCRIPTION
A previous commit[^1] added a field dependency on `company_id` for the widget `analytic_distribution`, which is supposed to be used with `analytic.mixin` a lot of times.

In order to avoid issues when models inherited from that mixin without specifying a company, we add it directly in the mixin as a placeholder.

[^1]: 3831c4183bc7dbd370e13d3c9de4a55a5d51bbfd

