### PR TITLE
[FIX] html_builder, website: prevent removing last list item in form

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_list.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_list.js
@@ -35,6 +35,7 @@ export class BuilderList extends Component {
         hiddenProperties: { type: Array, optional: true },
         records: { type: String, optional: true },
         defaultNewValue: { type: Object, optional: true },
+		forbidLastItemRemoval: { type: Boolean, optional: true },
     };
     static defaultProps = {
         addItemTitle: _t("Add"),
@@ -44,6 +45,7 @@ export class BuilderList extends Component {
         hiddenProperties: [],
         mode: "button",
         defaultNewValue: {},
+		forbidLastItemRemoval: false,
     };
     static components = { BuilderComponent, Dropdown };
 

--- a/addons/html_builder/static/src/core/building_blocks/builder_list.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_list.xml
@@ -7,7 +7,8 @@
             <t t-if="state.value?.length > 2">
                 <div class="o_we_table_wrapper">
                     <table t-ref="table">
-                        <t t-foreach="formatRawValue(state.value)" t-as="item" t-key="item._id">
+                        <t t-set="items" t-value="formatRawValue(state.value)"/>
+                        <t t-foreach="items" t-as="item" t-key="item._id">
                             <tr class="o_row_draggable" t-att-data-id="item._id">
                                 <td t-if="props.sortable" class="o_handle_cell">
                                     <button type="button" class="btn">
@@ -41,6 +42,7 @@
                                 </t>
                                 <td>
                                     <button type="button" class="btn text-danger builder_list_remove_item"
+                                            t-if="!(this.props.forbidLastItemRemoval and (items.length === 1))"
                                             t-on-click="() => this.deleteItem(item._id)">
                                         <i class="fa fa-fw fa-minus" aria-hidden="true"/>
                                         <span class="visually-hidden">Delete item</span>

--- a/addons/website/static/src/builder/plugins/form/form_option.xml
+++ b/addons/website/static/src/builder/plugins/form/form_option.xml
@@ -225,6 +225,7 @@
                 itemShape="{ display_name: 'text', selected: state.valueList.checkType }"
                 default="{ display_name: state.valueList.defaultItemName, selected: false }"
                 defaultNewValue="{ id: state.valueList.defaultItemName }"
+                forbidLastItemRemoval="true"
                 records="state.valueList.availableRecords" />
         </div>
     </BuilderRow>

--- a/addons/website/static/tests/builder/website_builder/form_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/form_option.test.js
@@ -359,14 +359,67 @@ test("Changing max files number option updates file input 'multiple' attribute",
         </form>
     </section>
         `);
-    expect(":iframe input[type=file]").toHaveAttribute("data-max-files-number", "1")
+    expect(":iframe input[type=file]").toHaveAttribute("data-max-files-number", "1");
     expect(":iframe input[type=file]").not.toHaveAttribute("multiple");
     await contains(":iframe .s_website_form_input").click();
     await contains(".options-container div[data-action-id='setMultipleFiles'] input").edit("2");
-    expect(":iframe input[type=file]").toHaveAttribute("data-max-files-number", "2")
+    expect(":iframe input[type=file]").toHaveAttribute("data-max-files-number", "2");
     expect(":iframe input[type=file]").toHaveAttribute("multiple");
     await contains(":iframe .s_website_form_input").click();
     await contains(".options-container div[data-action-id='setMultipleFiles'] input").edit("1");
-    expect(":iframe input[type=file]").toHaveAttribute("data-max-files-number", "1")
+    expect(":iframe input[type=file]").toHaveAttribute("data-max-files-number", "1");
     expect(":iframe input[type=file]").not.toHaveAttribute("multiple");
+});
+
+test("Last list entry cannot be removed", async () => {
+    onRpc("get_authorized_fields", () => ({}));
+    await setupWebsiteBuilder(`
+<section class="s_website_form" data-vcss="001" data-snippet="s_website_form" data-name="Form">
+    <form data-model_name="mail.mail">
+        <div class="s_website_form_rows">
+			<div data-name="Field" class="s_website_form_field mb-3 col-12 s_website_form_custom" data-type="one2many">
+			    <div class="row s_col_no_resize s_col_no_bgcolor">
+			        <label class="col-sm-auto s_website_form_label" style="width: 200px" for="ofwe8fyqws37">
+			            <span class="s_website_form_label_content">Custom Text</span>
+			        </label>
+			        <div class="col-sm">
+			            <div class="row s_col_no_resize s_col_no_bgcolor s_website_form_multiple" data-name="Custom Text" data-display="horizontal">
+			                <div class="checkbox col-12 col-lg-4 col-md-6">
+			                    <div class="form-check">
+			                        <input type="checkbox" class="s_website_form_input form-check-input" id="ofwe8fyqws370" name="Custom Text" value="Option 1" data-fill-with="undefined">
+			                        <label class="form-check-label s_website_form_check_label" for="ofwe8fyqws370">Option 1</label>
+			                    </div>
+			                </div>
+			                <div class="checkbox col-12 col-lg-4 col-md-6">
+			                    <div class="form-check">
+			                        <input type="checkbox" class="s_website_form_input form-check-input" id="ofwe8fyqws371" name="Custom Text" value="Option 2">
+			                        <label class="form-check-label s_website_form_check_label" for="ofwe8fyqws371">Option 2</label>
+			                    </div>
+			                </div>
+			                <div class="checkbox col-12 col-lg-4 col-md-6">
+			                    <div class="form-check">
+			                        <input type="checkbox" class="s_website_form_input form-check-input" id="ofwe8fyqws372" name="Custom Text" value="Option 3">
+			                        <label class="form-check-label s_website_form_check_label" for="ofwe8fyqws372">Option 3</label>
+			                    </div>
+			                </div>
+			            </div>
+			        </div>
+			    </div>
+            </div>
+	    </div>
+    </form>
+</section>
+        `);
+    await contains(":iframe .s_website_form_field").click();
+    expect(".options-container .builder_list_remove_item").toHaveCount(3);
+    await contains(
+        ".options-container .o_row_draggable:has(input[data-id='0']) .builder_list_remove_item"
+    ).click();
+    expect(".options-container .builder_list_remove_item").toHaveCount(2);
+    await contains(
+        ".options-container .o_row_draggable:has(input[data-id='1']) .builder_list_remove_item"
+    ).click();
+    expect(".options-container .builder_list_remove_item").toHaveCount(0);
+    await contains(".options-container .builder_list_add_item").click();
+    expect(".options-container .builder_list_remove_item").toHaveCount(2);
 });


### PR DESCRIPTION
Since `html_builder`, the last element of a multiple checkboxes form field can be removed, but it leads to a situation where no element can be added anymore to the field.

To avoid this, this commit restores the former behavior which did forbid the removal of the last element.

Steps to reproduce:
- Drop a form snippet
- Add a field
- Set the field type to "Multiple checkboxes"
- Remove all options

=> It was possible to remove the last option.

task-4367641
