### PR TITLE
[FIX] l10n_uk: remove account 123456

### DIFF
--- a/addons/l10n_uk/data/template/account.account-uk.csv
+++ b/addons/l10n_uk/data/template/account.account-uk.csv
@@ -27,7 +27,6 @@
 "110200","110200","Other Debtors","asset_current","False","","True","","",""
 "110300","110300","Prepayments","asset_current","False","","True","","",""
 "110400","110400","Debtors Control Account (PoS)","asset_receivable","True","","True","","",""
-"123456","123456","Account Payslip Houserental","liability_payable","True","","True","","",""
 "124000","124000","Company Credit Card","asset_current","True","","True","","",""
 "210000","210000","Creditors Control Account","liability_payable","True","","True","","",""
 "210100","210100","Sundry Creditors","liability_current","False","","True","","",""

--- a/addons/l10n_uk/models/template_uk.py
+++ b/addons/l10n_uk/models/template_uk.py
@@ -20,9 +20,9 @@ class AccountChartTemplate(models.AbstractModel):
             self.env.company.id: {
                 'anglo_saxon_accounting': True,
                 'account_fiscal_country_id': 'base.uk',
-                'bank_account_code_prefix': '120001',
-                'cash_account_code_prefix': '999001',
-                'transfer_account_code_prefix': '122001',
+                'bank_account_code_prefix': '1200',
+                'cash_account_code_prefix': '1210',
+                'transfer_account_code_prefix': '1220',
                 'account_default_pos_receivable_account_id': '110400',
                 'income_currency_exchange_account_id': '770000',
                 'expense_currency_exchange_account_id': '770000',


### PR DESCRIPTION
That account is meant to be a demo data, created in `hr_payroll_account It was probably exported without much consideration during this refactor 1017d6278b665e0f00ec63d7ed94a5aaee500682

Same goes for the bank and cash prefixes: having a full number up to the last digit doesn't make sense for a prefix.

