### PR TITLE
[FIX] account_peppol: Fix Peppol sending of invoices with mixed sendi…

### DIFF
--- a/addons/account_peppol/tests/test_peppol_messages.py
+++ b/addons/account_peppol/tests/test_peppol_messages.py
@@ -418,8 +418,44 @@ class TestPeppolMessage(TestAccountMoveSendCommon, MailCommon):
         # the cron is ran asynchronously and should be agnostic from the current self.env.company
         with self.enter_registry_test_mode():
             self.env.ref('account.ir_cron_account_move_send').with_company(company_2).method_direct_trigger()
-        # only move 1 & 2 should be processed, move_3 is related to an invalid partner (with regard to company_2) thus should fail to send
-        self.assertEqual((move_1 + move_2 + move_3).mapped('peppol_move_state'), ['processing', 'processing', 'error'])
+        # only move 1 & 2 should be processed, move_3 is related to an invalid partner (with regard to company_2) thus should not be sent
+        self.assertRecordValues((move_1 + move_2 + move_3), [
+            {'peppol_move_state': 'processing', 'is_move_sent': True},
+            {'peppol_move_state': 'processing', 'is_move_sent': True},
+            {'peppol_move_state': False, 'is_move_sent': True},  # only sent by email
+        ])
+
+    def test_peppol_send_multi_async_mixed(self):
+        """Try to send invoices to partners with multiple sending methods each. """
+        peppol_partner = self.env['res.partner'].create({
+            'name': 'Peppol partner',
+            'country_id': self.env.ref('base.be').id,
+            'vat': 'BE0477472701',
+        })
+        self.assertRecordValues(peppol_partner, [{
+            'peppol_verification_state': 'not_verified',
+            'peppol_eas': '0208',
+            'peppol_endpoint': '0477472701',
+        }])
+        not_peppol_partner = self.env['res.partner'].create({
+            'name': 'Not Peppol partner',
+            'country_id': self.env.ref('base.us').id,
+        })
+        self.assertEqual(not_peppol_partner.peppol_verification_state, 'not_verified')
+        move_1 = self.create_move(peppol_partner)
+        move_2 = self.create_move(not_peppol_partner)
+        (move_1 + move_2).action_post()
+        wizard = self.create_send_and_print(move_1 + move_2)
+        self.assertEqual(peppol_partner.peppol_verification_state, 'valid')
+        self.assertEqual(not_peppol_partner.peppol_verification_state, 'not_verified')
+        wizard.action_send_and_print()
+        self.assertEqual((move_1 + move_2).mapped('is_being_sent'), [True, True])
+        with self.enter_registry_test_mode():
+            self.env.ref('account.ir_cron_account_move_send').method_direct_trigger()
+        self.assertRecordValues((move_1 + move_2), [
+            {'peppol_move_state': 'processing', 'is_move_sent': True},
+            {'peppol_move_state': False, 'is_move_sent': True},  # only sent by email
+        ])
 
     def test_available_peppol_sending_methods(self):
         company_us = self.setup_other_company()['company']  # not a valid Peppol country

--- a/addons/account_peppol/wizard/account_move_send_batch_wizard.py
+++ b/addons/account_peppol/wizard/account_move_send_batch_wizard.py
@@ -6,8 +6,9 @@ class AccountMoveSendBatchWizard(models.TransientModel):
 
     def action_send_and_print(self, force_synchronous=False, allow_fallback_pdf=False):
         # EXTENDS 'account'
-        self.ensure_one()
-        if peppol_moves := self.move_ids.filtered(lambda m: 'peppol' in self._get_default_sending_methods(m)):
+        if peppol_moves := self.move_ids.filtered(
+                lambda m: 'peppol' in self._get_default_sending_methods(m) and self._is_applicable_to_move('peppol', m)
+        ):
             if registration_action := self._do_peppol_pre_send(peppol_moves):
                 return registration_action
         return super().action_send_and_print(force_synchronous=force_synchronous, allow_fallback_pdf=allow_fallback_pdf)


### PR DESCRIPTION
…ng methods

When sending invoices in batch with multiple sending methods (for example 1 by Peppol, 2 by Email), Peppol was wrongly set on invoices where it didn't make sense.

Steps to reproduce:
1. Go into a Peppol compatiable company (Eg: Belgium)
2. Go into settings, enable Peppol.
3. Create & post two invoices: one to an US partner, the other one to a Peppol partner (For example a belgian partner with a vat set.). Make sure to set the email on both.
4. Send them in batch: the wizard says 1 by Peppol, 2 by Email, which is correct.
5. If you send them, the one to the US partner that is not supposed to go through Peppol will end up in error, with the email not sent either.

Root cause:
We are doing some Peppol checks before checking if it actually make sense to apply this sending method on the move.

task-none (reported from our production)
