### PR TITLE
[FIX] web_editor: unwrap nested formatting tags

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/color.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/color.test.js
@@ -358,3 +358,109 @@ describe('rgbToHex', () => {
         parent.remove();
     });
 });
+
+describe("color normalization", () => {
+    it("should unwrap nested identical <font> tags with gradient (class and style same)", async () => {
+        await testEditor(BasicEditor, {
+            contentBefore: unformat(`
+                <p><font class="text-gradient" style="background-image: linear-gradient(135deg, rgb(214, 255, 127) 0%, rgb(0, 179, 204) 100%);">
+                    parent
+                    <font class="text-gradient" style="background-image: linear-gradient(135deg, rgb(214, 255, 127) 0%, rgb(0, 179, 204) 100%);">child</font>
+                </font></p>
+            `),
+            contentAfter: unformat(`
+                <p><font class="text-gradient" style="background-image: linear-gradient(135deg, rgb(214, 255, 127) 0%, rgb(0, 179, 204) 100%);">parentchild</font></p>
+            `),
+        });
+    });
+
+    it("should unwrap nested identical <font> tag when parent already has the same class", async () => {
+        await testEditor(BasicEditor, {
+            contentBefore: unformat(`
+                <p><font class="bg-color-1 text-gradient" style="background-image: linear-gradient(135deg, rgb(214, 255, 127) 0%, rgb(0, 179, 204) 100%);">
+                    parent
+                    <font class="bg-color-1">child</font>
+                </font></p>
+            `),
+            contentAfter: unformat(`
+                <p><font class="bg-color-1 text-gradient" style="background-image: linear-gradient(135deg, rgb(214, 255, 127) 0%, rgb(0, 179, 204) 100%);">parentchild</font></p>
+            `),
+        });
+    });
+
+    it("should unwrap nested identical <font> tags with color (class and style same)", async () => {
+        await testEditor(BasicEditor, {
+            contentBefore: unformat(`
+                <p><font class="bg-color-1" style="color:red">
+                    parent
+                    <font class="bg-color-1" style="color:red">child</font>
+                </font></p>
+            `),
+            contentAfter: unformat(`
+                <p><font class="bg-color-1" style="color:red">parentchild</font></p>
+            `),
+        });
+    });
+
+    it("should unwrap nested <font> with same style but no class", async () => {
+        await testEditor(BasicEditor, {
+            contentBefore: unformat(`
+                <p><font class="bg-color-1" style="color:red">
+                    parent
+                    <font style="color:red">child</font>
+                </font></p>
+            `),
+            contentAfter: unformat(`
+                <p><font class="bg-color-1" style="color:red">parentchild</font></p>
+            `),
+        });
+    });
+
+    it("should unwrap nested <font> with same class only", async () => {
+        await testEditor(BasicEditor, {
+            contentBefore: unformat(`
+                <p><font class="bg-color-1" style="color:red">
+                    parent
+                    <font class="bg-color-1">child</font>
+                </font></p>
+            `),
+            contentAfter: unformat(`
+                <p><font class="bg-color-1" style="color:red">parentchild</font></p>
+            `),
+        });
+    });
+
+    it("should unwrap nested <font> with no class or style", async () => {
+        await testEditor(BasicEditor, {
+            contentBefore: unformat(`
+                <p><font class="bg-color-1" style="color:red">
+                    parent
+                    <font>child</font>
+                </font></p>
+            `),
+            contentAfter: unformat(`
+                <p><font class="bg-color-1" style="color:red">parentchild</font></p>
+            `),
+        });
+    });
+
+    it("should unwrap nested <font> with same style and class as closest <font>", async () => {
+        await testEditor(BasicEditor, {
+            contentBefore: unformat(`
+                <p><font class="bg-color-1" style="color:red">
+                        parent
+                        <strong>
+                            text1
+                            <font class="bg-color-1" style="color:red">child</font>
+                            text2
+                        </strong>
+                </font></p>
+            `),
+            contentAfter: unformat(`
+                <p><font class="bg-color-1" style="color:red">
+                        parent<strong>text1childtext2</strong>
+                </font></p>
+            `),
+        });
+    });
+});

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/format.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/format.test.js
@@ -1286,6 +1286,57 @@ describe('Format', () => {
             });
         });
     });
+
+    describe("formatting normalization", () => {
+        it("should unwrap nested identical bold tags", async () => {
+            await repeatWithBoldTags(async (tag) => {
+                await testEditor(BasicEditor, {
+                    contentBefore: `<p>a${tag(`b${tag(`c${tag(`d`)}`)}e`)}f</p>`,
+                    contentAfter: `<p>a${tag("bcde")}f</p>`,
+                });
+            });
+        });
+
+        it("should merge nested strong inside formatting tags", async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: unformat(`
+                    <p>
+                        <strong>
+                            <em>
+                                <u>
+                                    <s>
+                                        text1
+                                        <strong>text2</strong>
+                                        text3
+                                    </s>
+                                </u>
+                            </em>
+                        </strong>
+                    </p>
+                `),
+                contentAfter: unformat(`
+                    <p>
+                        <strong>
+                            <em>
+                                <u>
+                                    <s>
+                                        text1text2text3
+                                    </s>
+                                </u>
+                            </em>
+                        </strong>
+                    </p>
+                `),
+            });
+        });
+
+        it("should merge nested small inside formatting tags", async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: `<p><small><small>text</small></small></p>`,
+                contentAfter: `<p><small>text</small></p>`,
+            });
+        });
+    });
 });
 
 describe('setTagName', () => {


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

- When pasting formatted content (like `<strong>` or `<font>`) into a region that already had same formatting, it caused nested identical tags, leading to exaggerated styling (e.g., "double bold").

```html
<!-- User pastes <strong>text</strong> inside <strong> -->
<p><strong>text []</strong></p>

<!-- Resulting HTML -->
<p><strong>text <strong>text</strong>[]</strong></p>
```

### Desired behavior after PR is merged:

- Prevents unwanted style amplification by unwrapping nested identical formatting tags.

```html
<!-- Resulting HTML -->
<p><strong>text text[]</strong></p>
```

task-5138472

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr