### PR TITLE
[FIX] website: prevent invalid domain paths containing '.' or '..'

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -413,10 +413,16 @@ class Website(models.Model):
     @api.constrains('domain')
     def _check_domain(self):
         for record in self:
+            if not record.domain:
+                continue
+
             try:
-                urlparse(record.domain)
+                parsed = urlparse(record.domain)
             except ValueError:
                 raise ValidationError(_("The provided website domain is not a valid URL."))
+
+            if tools.urls._contains_dot_segments(parsed.path):
+                raise ValidationError(_("The domain path cannot contain relative path segments like '/./' or '/../'."))
 
     @api.constrains('homepage_url')
     def _check_homepage_url(self):


### PR DESCRIPTION
This error occurs when the domain URL contains `'.' or '..'` segments.

Steps to reproduce:
---
- Install `website` module
- Settings > Domain > Add URL with `'/../'` (eg: `https://power.odoo.com/OA_HTML/help/../ieshostedsurvey.jsp`)
- Open `Website` module

Traceback:
---
`ValueError: Dot segments are not allowed`

This issue occurs because at [1], we intentionally raise a `ValueError` to prevent the use of `'.' or '..'` in the URL path. In Chrome, the sequence `'/../'` is interpreted as a **back path** AFAIK.
For example:
`http://localhost:8069/odoo/action-218/../2 → http://localhost:8069/odoo/2`

This commit fixes the issue by validating the domain URL path. If it contains `'.' or '..'`, a **ValidationError** is raised to clearly inform the user that the entered URL is invalid.

[1]: https://github.com/odoo/odoo/blob/dc6dd927faea1f4501d6c50c586d5ea46bd1fc95/odoo/tools/urls.py#L72-L73

sentry-6932797319

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
