### PR TITLE
[FIX] account: prevent error on changing default dashboard grouping using studio

### DIFF
--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -203,6 +203,10 @@ class AccountJournal(models.Model):
                 journal.has_unhashed_entries = False
 
     def _compute_has_entries(self):
+        if not self.ids:
+            self.has_posted_entries = False
+            self.has_entries = False
+            return
         sql_query = SQL(
             """
                        SELECT j.id,


### PR DESCRIPTION
Currently an error occurs when a user tries to group account dashboard with a
group not having any records.

**Steps to replicate:**
* Install `account` and `web_studio`
* Invoicing > studio > Default Group by > Account Online Link

**Error:**
`SyntaxError: syntax error at or near ')' LINE 19: WHERE j.id in () ^`

**Root cause:**
* The compute function [1] contains an SQL query that assumes journal IDs are always present. When the account dashboard is grouped by a category with no records (e.g., 'Online Account' when none are connected), no journals are returned, resulting in no journal IDs for the SQL query at  [2].

* This issue appeared after PR [3], where the compute method is called even when the record isn’t saved, leading to NewId being passed to self and triggering this error. Similar fixes were applied in commit [4].

**Solution:**
* Only run the SQL query if journal IDs exist. If none do,assign false to the computed entry fields. This works because [5] creates a fake group, allowing the dashboard to work normally.

[1]:
https://github.com/odoo/odoo/blob/a9a058aa063a05755ac3c6a78f99af5373d19fbd/addons/account/models/account_journal_dashboard.py#L205
[2]:
https://github.com/odoo/odoo/blob/a9a058aa063a05755ac3c6a78f99af5373d19fbd/addons/account/models/account_journal_dashboard.py#L227
[3]:
https://github.com/odoo/odoo/pull/195203
[4]:
https://github.com/odoo/odoo/commit/7ba64a8c51f2888b301ee6feae140b02ca4b1b95
[5]:
https://github.com/odoo/enterprise/blob/110c23ae23a1c37c15e7913bdcb74f2a26a67858/web_studio/static/src/client_action/view_editor/editors/kanban/kanban_editor.js#L51-L64

sentry-6674695712