### PR TITLE
[FIX] point_of_sale: remove missing widget warning when running tour

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -202,6 +202,11 @@
             "barcodes/static/tests/legacy/helpers.js",
             "web/static/tests/legacy/helpers/utils.js",
             "web/static/tests/legacy/helpers/cleanup.js",
+            'mail/static/src/views/web/fields/many2one_avatar_user_field/*',
+            'mail/static/src/views/web/fields/assign_user_command_hook.js',
+            'mail/static/src/views/web/fields/avatar/avatar.js',
+            'mail/static/src/discuss/web/avatar_card/avatar_card_popover.js',
+            'mail/static/src/core/web/open_chat_hook.js',
         ],
         # Bundle that starts the pos, loaded on /pos/ui
         'point_of_sale.assets_prod': [


### PR DESCRIPTION
This will remove missing wigdet warning encountered when using the booking form from the point of sale.

opw-5109501

Enterprise: https://github.com/odoo/enterprise/pull/96811