### PR TITLE
[IMP] tools: reimplement frozendict

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3,6 +3,7 @@
 import ast
 import calendar
 from collections import Counter, defaultdict
+from collections.abc import Mapping
 from contextlib import ExitStack, contextmanager
 from datetime import date, timedelta
 from dateutil.relativedelta import relativedelta
@@ -4848,7 +4849,7 @@ class AccountMove(models.Model):
             for grouping_key, values in aggregated_values.items():
                 if not grouping_key:
                     continue
-                if isinstance(grouping_key, dict):
+                if isinstance(grouping_key, Mapping):
                     values.update(grouping_key)
                 tax_details[grouping_key] = values
 
@@ -4857,7 +4858,7 @@ class AccountMove(models.Model):
         for grouping_key, values in values_per_grouping_key.items():
             if not grouping_key:
                 continue
-            if isinstance(grouping_key, dict):
+            if isinstance(grouping_key, Mapping):
                 values.update(grouping_key)
             tax_details[grouping_key] = values
 

--- a/addons/account/wizard/account_automatic_entry_wizard.py
+++ b/addons/account/wizard/account_automatic_entry_wizard.py
@@ -241,7 +241,7 @@ class AccountAutomaticEntryWizard(models.TransientModel):
                     'partner_id': partner.id or None,
                     'currency_id': currency.id,
                     'amount_currency': (account_balance > 0 and -1 or 1) * abs(account_amount_currency),
-                    'analytic_distribution': analytic_distribution,
+                    'analytic_distribution': analytic_distribution and dict(analytic_distribution),
                 })
 
         # Get the lowest child company based on accounts used to avoid access error

--- a/addons/google_calendar/utils/google_event.py
+++ b/addons/google_calendar/utils/google_event.py
@@ -6,7 +6,7 @@ from collections import abc
 from typing import Iterator, Mapping
 
 from odoo.tools import email_normalize
-from odoo.tools.misc import ReadonlyDict
+from odoo.tools.misc import frozendict
 
 _logger = logging.getLogger(__name__)
 
@@ -33,7 +33,7 @@ class GoogleEvent(abc.Set):
                 _events[item.get('id')] = item
             else:
                 raise ValueError("Only %s or iterable of dict are supported" % self.__class__.__name__)
-        self._events = ReadonlyDict(_events)
+        self._events = frozendict(_events)
 
     def __iter__(self) ->  Iterator['GoogleEvent']:
         return iter(GoogleEvent([vals]) for vals in self._events.values())

--- a/addons/microsoft_calendar/utils/microsoft_event.py
+++ b/addons/microsoft_calendar/utils/microsoft_event.py
@@ -5,7 +5,7 @@ from collections import abc
 from typing import Iterator, Mapping
 
 from odoo.tools import email_normalize
-from odoo.tools.misc import ReadonlyDict
+from odoo.tools.misc import frozendict
 
 
 class MicrosoftEvent(abc.Set):
@@ -27,7 +27,7 @@ class MicrosoftEvent(abc.Set):
                 _events[item.get('id')] = item
             else:
                 raise ValueError("Only %s or iterable of dict are supported" % self.__class__.__name__)
-        self._events = ReadonlyDict(_events)
+        self._events = frozendict(_events)
 
     def __iter__(self) -> Iterator['MicrosoftEvent']:
         return iter(MicrosoftEvent([vals]) for vals in self._events.values())

--- a/addons/rpc/controllers/xmlrpc.py
+++ b/addons/rpc/controllers/xmlrpc.py
@@ -4,6 +4,7 @@ import traceback
 import xmlrpc.client
 from collections import defaultdict
 from datetime import date, datetime
+from types import MappingProxyType
 
 from markupsafe import Markup
 
@@ -11,7 +12,6 @@ import odoo.exceptions
 from odoo.fields import Command, Date, Datetime
 from odoo.http import Controller, Response, dispatch_rpc, request, route
 from odoo.tools import lazy
-from odoo.tools.misc import frozendict
 
 from . import RPC_DEPRECATION_NOTICE, _check_request
 
@@ -99,7 +99,7 @@ class OdooMarshaller(xmlrpc.client.Marshaller):
         # XML 1.0 disallows control characters, remove them otherwise they break clients
         return super().dump_unicode(value.translate(CONTROL_CHARACTERS), write)
 
-    dispatch[frozendict] = dump_frozen_dict
+    dispatch[MappingProxyType] = dump_frozen_dict
     dispatch[bytes] = dump_bytes
     dispatch[datetime] = dump_datetime
     dispatch[date] = dump_date

--- a/odoo/addons/base/models/ir_qweb.py
+++ b/odoo/addons/base/models/ir_qweb.py
@@ -641,8 +641,14 @@ class QwebContent:
 
 
 class QwebJSON(json.JSON):
+
+    def default(self, obj):
+        if isinstance(obj, Mapping):
+            return dict(obj)
+        return obj
+
     def dumps(self, *args, **kwargs):
-        prev_default = kwargs.pop('default', lambda obj: obj)
+        prev_default = kwargs.pop('default', self.default)
         return super().dumps(*args, **kwargs, default=(
             lambda obj: prev_default(str(obj) if isinstance(obj, QwebContent) else obj)
         ))

--- a/odoo/addons/base/models/res_lang.py
+++ b/odoo/addons/base/models/res_lang.py
@@ -6,21 +6,37 @@ import json
 import locale
 import logging
 import re
+from collections.abc import Mapping
 from typing import Any, Literal
 
 from odoo import api, fields, models, tools, _
 from odoo.exceptions import UserError, ValidationError
 from odoo.tools import OrderedSet
-from odoo.tools.misc import ReadonlyDict
 
 _logger = logging.getLogger(__name__)
 
-class LangData(ReadonlyDict):
+
+class LangData(Mapping):
     """ A ``dict``-like class which can access field value like a ``res.lang`` record.
     Note: This data class cannot store data for fields with the same name as
     ``dict`` methods, like ``dict.keys``.
     """
-    __slots__ = ()
+    __slots__ = ('__data',)
+
+    def __init__(self, data):
+        self.__data = dict(data)
+
+    def __getitem__(self, key):
+        return self.__data[key]
+
+    def __len__(self):
+        return len(self.__data)
+
+    def __iter__(self):
+        return iter(self.__data)
+
+    def __contains__(self, key):
+        return key in self.__data
 
     def __bool__(self) -> bool:
         return bool(self.id)
@@ -32,18 +48,30 @@ class LangData(ReadonlyDict):
             raise AttributeError
 
 
-class LangDataDict(ReadonlyDict):
+class LangDataDict(Mapping):
     """ A ``dict`` of :class:`LangData` objects indexed by some key, which returns
     a special dummy :class:`LangData` for missing keys.
     """
-    __slots__ = ()
+    __slots__ = ('__data',)
+
+    def __init__(self, data):
+        self.__data = dict(data)
 
     def __getitem__(self, key: Any) -> LangData:
         try:
-            return self._data__[key]
+            return self.__data[key]
         except KeyError:
             some_lang = next(iter(self.values()))  # should have at least one active language
             return LangData(dict.fromkeys(some_lang, False))
+
+    def __len__(self):
+        return len(self.__data)
+
+    def __iter__(self):
+        return iter(self.__data)
+
+    def __contains__(self, key):
+        return key in self.__data
 
 
 class ResLang(models.Model):

--- a/odoo/addons/base/tests/test_misc.py
+++ b/odoo/addons/base/tests/test_misc.py
@@ -342,7 +342,7 @@ class TestAddonsFileAccess(BaseCase):
 @tagged('at_install', '-post_install')  # LEGACY at_install
 class TestDictTools(BaseCase):
     def test_readonly_dict(self):
-        d = misc.ReadonlyDict({'foo': 'bar'})
+        d = misc.frozendict({'foo': 'bar'})
         with self.assertRaises(TypeError):
             d['baz'] = 'xyz'
         with self.assertRaises(AttributeError):

--- a/odoo/orm/fields.py
+++ b/odoo/orm/fields.py
@@ -19,7 +19,7 @@ from psycopg2.extras import Json as PsycopgJson
 from odoo.exceptions import AccessError, MissingError
 from odoo.tools import SQL, sql
 from odoo.tools.constants import PREFETCH_MAX
-from odoo.tools.misc import SENTINEL, ReadonlyDict, Sentinel, unique
+from odoo.tools.misc import frozendict, SENTINEL, Sentinel, unique
 
 from .domains import Domain
 from .query import Query
@@ -320,7 +320,7 @@ class Field(typing.Generic[T]):
     def __init__(self, string: str | Sentinel = SENTINEL, **kwargs):
         kwargs['string'] = string
         self._sequence = next(_global_seq)
-        self._args__ = ReadonlyDict({key: val for key, val in kwargs.items() if val is not SENTINEL})
+        self._args__ = frozendict({key: val for key, val in kwargs.items() if val is not SENTINEL})
 
     def __str__(self):
         if not self.name:

--- a/odoo/orm/fields_selection.py
+++ b/odoo/orm/fields_selection.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import typing
 from collections import defaultdict
 
-from odoo.tools.misc import ReadonlyDict, SENTINEL, Sentinel, merge_sequences
+from odoo.tools.misc import SENTINEL, Sentinel, merge_sequences
 from odoo.tools.sql import pg_varchar
 
 from .fields import Field, _logger, determine, resolve_mro

--- a/odoo/tools/json.py
+++ b/odoo/tools/json.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
+from collections.abc import Mapping
 from datetime import date, datetime
 import json as json_
 import re
 
 import markupsafe
 from .func import lazy
-from .misc import ReadonlyDict
 
 JSON_SCRIPTSAFE_MAPPER = {
     '&': r'\u0026',
@@ -66,7 +66,7 @@ def json_default(obj):
         return fields.Date.to_string(obj)
     if isinstance(obj, lazy):
         return obj._value
-    if isinstance(obj, ReadonlyDict):
+    if isinstance(obj, Mapping):
         return dict(obj)
     if isinstance(obj, bytes):
         return obj.decode()

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -37,7 +37,7 @@ import odoo
 from odoo.exceptions import UserError
 from .config import config
 from .i18n import format_list
-from .misc import file_open, file_path, get_iso_codes, split_every, OrderedSet, ReadonlyDict, SKIPPED_ELEMENT_TYPES
+from .misc import file_open, file_path, frozendict, get_iso_codes, split_every, OrderedSet, SKIPPED_ELEMENT_TYPES
 
 if typing.TYPE_CHECKING:
     from odoo.api import Environment
@@ -1839,15 +1839,15 @@ class CodeTranslations:
         def filter_func(row):
             return row.get('value') and PYTHON_TRANSLATION_COMMENT in row['comments']
         translations = CodeTranslations._get_code_translations(module_name, lang, filter_func)
-        self.python_translations[(module_name, lang)] = ReadonlyDict(translations)
+        self.python_translations[module_name, lang] = frozendict(translations)
 
     def _load_web_translations(self, module_name, lang):
         def filter_func(row):
             return row.get('value') and JAVASCRIPT_TRANSLATION_COMMENT in row['comments']
         translations = CodeTranslations._get_code_translations(module_name, lang, filter_func)
-        self.web_translations[(module_name, lang)] = ReadonlyDict({
+        self.web_translations[module_name, lang] = frozendict({
             "messages": tuple(
-                ReadonlyDict({"id": src, "string": value})
+                frozendict({"id": src, "string": value})
                 for src, value in translations.items())
         })
 


### PR DESCRIPTION
Before this commit, Odoo had two implementations for creating an immutable dictionary. These two implementations have different behaviors and coexist for backward compatibility reasons.

The purpose of this commit is to leave only one implementation for the immutable dictionary, called `frozendict`.

This implementation makes it truly impossible to modify the mapping.

In addition, by default, we don't override internal methods of the dictionary which improves performance (despite the cost during creation).

Note 1:
Classes `LangData` and `LangDataDict` are adapted as `Mapping` subclasses instead of `ReadonlyDict`. This simplifies their implementation, which is not performance-critical.

Note 2:
This change is possible because the `MappingProxyType` class implements fallback on the `__hash__` method since version 3.12 (thanks to https://github.com/odoo/odoo/commit/d357125e09b8f3613269bb8627972588c20900aa).

task-4808836