### PR TITLE
[FIX] mail: prevent traceback on adding reaction from pinned message panel

### DIFF
--- a/addons/mail/static/src/core/common/quick_reaction_menu.js
+++ b/addons/mail/static/src/core/common/quick_reaction_menu.js
@@ -37,7 +37,7 @@ export class QuickReactionMenu extends Component {
         this.dropdown = useState(
             useDropdownState({
                 onClose: () => {
-                    const currentThread = this.env.getCurrentThread();
+                    const currentThread = this.env.getCurrentThread?.();
                     if (!currentThread || currentThread.notEq(this.props.message.thread)) {
                         return;
                     }

--- a/addons/mail/static/tests/discuss/message_pin/pinned_messages.test.js
+++ b/addons/mail/static/tests/discuss/message_pin/pinned_messages.test.js
@@ -123,3 +123,23 @@ test("Jump to message from notification", async () => {
     await click(".o_mail_notification a", { text: "message" });
     await contains(".o-mail-Thread", { count: 0, scroll: "bottom" });
 });
+
+test("can add reactions from pinned panel", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    pyEnv["mail.message"].create({
+        body: "Hello world!",
+        model: "discuss.channel",
+        res_id: channelId,
+        pinned_at: "2025-10-09 11:15:04",
+    });
+    await start();
+    await openDiscuss(channelId);
+    await click(".o-mail-Message-actions [title='Add a Reaction']");
+    await click(".o-mail-QuickReactionMenu button", { text: "👍" });
+    await contains(".o-mail-MessageReaction", { text: "👍1" });
+    await click(".o-mail-DiscussContent-header button[title='Pinned Messages']");
+    await click(".o-discuss-PinnedMessagesPanel .o-mail-Message [title='Add a Reaction']");
+    await click(".o-mail-QuickReactionMenu button", { text: "👍" });
+    await contains(".o-mail-MessageReaction", { count: 0 });
+});


### PR DESCRIPTION
**Description of the issue this PR addresses:**
Prevent traceback occurs on pinned panel

**Steps to reproduce:**
- Send any message to the channel
- Add a reaction
- Pin that message
- Go to the pinned message panel
- Try adding a reaction again

**Current behavior before PR:**

Before this PR, when a user tries to add a reaction from the pinned panel, 
it throws an error because `env.getCurrentThread` is not defined in that 
environment and is called unconditionally.

**Desired behavior after PR is merged:**

This PR ensures `env.getCurrentThread` is only accessed if it is defined, 
preventing the error in contexts where the thread environment is not available.

task-[5153215](https://www.odoo.com/odoo/project/1519/tasks/5153215)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
