### PR TITLE
[FIX] l10n_tr_nilvera_einvoice_extended: remove empty Delivery ID node

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice_extended/data/ubl_tr_templates.xml
+++ b/addons/l10n_tr_nilvera_einvoice_extended/data/ubl_tr_templates.xml
@@ -18,7 +18,7 @@
                     <cbc:ID schemeID="INCOTERMS" t-out="vals.get('incoterm_code')"/>
                 </cac:DeliveryTerms>
                 <cac:Shipment>
-                    <cbc:ID>NO_ID</cbc:ID>
+                    <cbc:ID t-out="vals.get('id')"/>
                     <cac:GoodsItem>
                         <cbc:RequiredCustomsID t-out="vals.get('product_customs_code')"/>
                     </cac:GoodsItem>
@@ -31,7 +31,7 @@
     </template>
 
     <template id="ubl_tr_InvoiceLineType" inherit_id="account_edi_ubl_cii.ubl_21_InvoiceLineType" primary="True">
-        <xpath expr="//*[local-name()='TaxTotal']" position="before">
+        <xpath expr="//*[local-name()='AllowanceCharge']" position="before">
             <t xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2">
                 <t t-call="{{InvoiceLineDelivery_template}}">
                     <t t-set="vals" t-value="vals.get('line_delivery_vals', {})"/>

--- a/addons/l10n_tr_nilvera_einvoice_extended/models/account_edi_xml_ubl_tr.py
+++ b/addons/l10n_tr_nilvera_einvoice_extended/models/account_edi_xml_ubl_tr.py
@@ -290,12 +290,15 @@ class AccountEdiXmlUblTr(models.AbstractModel):
     def _get_invoice_line_delivery_vals(self, line):
         """Build delivery values for each invoice line.
 
-        Used to fill the cac:InvoiceLine/cac:Item node in UBL TR XML export.
+        cac:InvoiceLine/cac:Item node in UBL TR XML export, the ID
+        node is required to be present inside the shipmemnt delivery
+        block before GoodsItem node.
 
         :param line: An invoice line.
         :return: A dictionary with delivery information.
         """
         return {
+            "id": "NO_ID",
             "incoterm_code": line.move_id.invoice_incoterm_id.code,
             "product_customs_code": line.l10n_tr_ctsp_number or line.product_id.l10n_tr_ctsp_number,
             "shipping_method_code": line.move_id.l10n_tr_shipping_type,

--- a/addons/l10n_tr_nilvera_einvoice_extended/tests/expected_xmls/invoice_basic_export_registered_einvoice.xml
+++ b/addons/l10n_tr_nilvera_einvoice_extended/tests/expected_xmls/invoice_basic_export_registered_einvoice.xml
@@ -137,11 +137,6 @@
       <cbc:MultiplierFactorNumeric>0.12</cbc:MultiplierFactorNumeric>
       <cbc:Amount currencyID="TRY">18.00</cbc:Amount>
     </cac:AllowanceCharge>
-    <cac:Delivery>
-      <cac:Shipment>
-        <cbc:ID></cbc:ID>
-      </cac:Shipment>
-    </cac:Delivery>
     <cac:TaxTotal>
       <cbc:TaxAmount currencyID="TRY">26.40</cbc:TaxAmount>
       <cac:TaxSubtotal>

--- a/addons/l10n_tr_nilvera_einvoice_extended/tests/expected_xmls/invoice_basic_sale_earchive.xml
+++ b/addons/l10n_tr_nilvera_einvoice_extended/tests/expected_xmls/invoice_basic_sale_earchive.xml
@@ -135,11 +135,6 @@
       <cbc:MultiplierFactorNumeric>0.12</cbc:MultiplierFactorNumeric>
       <cbc:Amount currencyID="TRY">18.00</cbc:Amount>
     </cac:AllowanceCharge>
-    <cac:Delivery>
-      <cac:Shipment>
-        <cbc:ID></cbc:ID>
-      </cac:Shipment>
-    </cac:Delivery>
     <cac:TaxTotal>
       <cbc:TaxAmount currencyID="TRY">26.40</cbc:TaxAmount>
       <cac:TaxSubtotal>

--- a/addons/l10n_tr_nilvera_einvoice_extended/tests/expected_xmls/invoice_basic_sale_einvoice.xml
+++ b/addons/l10n_tr_nilvera_einvoice_extended/tests/expected_xmls/invoice_basic_sale_einvoice.xml
@@ -135,11 +135,6 @@
       <cbc:MultiplierFactorNumeric>0.12</cbc:MultiplierFactorNumeric>
       <cbc:Amount currencyID="TRY">18.00</cbc:Amount>
     </cac:AllowanceCharge>
-    <cac:Delivery>
-      <cac:Shipment>
-        <cbc:ID></cbc:ID>
-      </cac:Shipment>
-    </cac:Delivery>
     <cac:TaxTotal>
       <cbc:TaxAmount currencyID="TRY">26.40</cbc:TaxAmount>
       <cac:TaxSubtotal>

--- a/addons/l10n_tr_nilvera_einvoice_extended/tests/expected_xmls/invoice_basic_tax_exempt_einvoice.xml
+++ b/addons/l10n_tr_nilvera_einvoice_extended/tests/expected_xmls/invoice_basic_tax_exempt_einvoice.xml
@@ -137,11 +137,6 @@
       <cbc:MultiplierFactorNumeric>0.12</cbc:MultiplierFactorNumeric>
       <cbc:Amount currencyID="TRY">18.00</cbc:Amount>
     </cac:AllowanceCharge>
-    <cac:Delivery>
-      <cac:Shipment>
-        <cbc:ID></cbc:ID>
-      </cac:Shipment>
-    </cac:Delivery>
     <cac:TaxTotal>
       <cbc:TaxAmount currencyID="TRY">26.40</cbc:TaxAmount>
       <cac:TaxSubtotal>

--- a/addons/l10n_tr_nilvera_einvoice_extended/tests/expected_xmls/invoice_basic_withholding_einvoice.xml
+++ b/addons/l10n_tr_nilvera_einvoice_extended/tests/expected_xmls/invoice_basic_withholding_einvoice.xml
@@ -148,11 +148,6 @@
       <cbc:MultiplierFactorNumeric>0.12</cbc:MultiplierFactorNumeric>
       <cbc:Amount currencyID="TRY">18.00</cbc:Amount>
     </cac:AllowanceCharge>
-    <cac:Delivery>
-      <cac:Shipment>
-        <cbc:ID></cbc:ID>
-      </cac:Shipment>
-    </cac:Delivery>
     <cac:TaxTotal>
       <cbc:TaxAmount currencyID="TRY">2.64</cbc:TaxAmount>
       <cac:TaxSubtotal>

--- a/addons/l10n_tr_nilvera_einvoice_extended/tests/expected_xmls/invoice_earchive_multicurrency.xml
+++ b/addons/l10n_tr_nilvera_einvoice_extended/tests/expected_xmls/invoice_earchive_multicurrency.xml
@@ -144,11 +144,6 @@
       <cbc:MultiplierFactorNumeric>0.12</cbc:MultiplierFactorNumeric>
       <cbc:Amount currencyID="USD">18.00</cbc:Amount>
     </cac:AllowanceCharge>
-    <cac:Delivery>
-      <cac:Shipment>
-        <cbc:ID></cbc:ID>
-      </cac:Shipment>
-    </cac:Delivery>
     <cac:TaxTotal>
       <cbc:TaxAmount currencyID="USD">26.40</cbc:TaxAmount>
       <cac:TaxSubtotal>

--- a/addons/l10n_tr_nilvera_einvoice_extended/tests/expected_xmls/invoice_einvoice_multicurrency.xml
+++ b/addons/l10n_tr_nilvera_einvoice_extended/tests/expected_xmls/invoice_einvoice_multicurrency.xml
@@ -144,11 +144,6 @@
       <cbc:MultiplierFactorNumeric>0.12</cbc:MultiplierFactorNumeric>
       <cbc:Amount currencyID="USD">18.00</cbc:Amount>
     </cac:AllowanceCharge>
-    <cac:Delivery>
-      <cac:Shipment>
-        <cbc:ID></cbc:ID>
-      </cac:Shipment>
-    </cac:Delivery>
     <cac:TaxTotal>
       <cbc:TaxAmount currencyID="USD">26.40</cbc:TaxAmount>
       <cac:TaxSubtotal>

--- a/addons/l10n_tr_nilvera_einvoice_extended/tests/expected_xmls/invoice_export_earchive.xml
+++ b/addons/l10n_tr_nilvera_einvoice_extended/tests/expected_xmls/invoice_export_earchive.xml
@@ -154,11 +154,6 @@
     <cbc:ID>1</cbc:ID>
     <cbc:InvoicedQuantity unitCode="C62">3.0</cbc:InvoicedQuantity>
     <cbc:LineExtensionAmount currencyID="TRY">132.00</cbc:LineExtensionAmount>
-    <cac:AllowanceCharge>
-      <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
-      <cbc:MultiplierFactorNumeric>0.12</cbc:MultiplierFactorNumeric>
-      <cbc:Amount currencyID="TRY">18.00</cbc:Amount>
-    </cac:AllowanceCharge>
     <cac:Delivery>
       <cac:DeliveryAddress>
         <cbc:StreetName>Gökhane Sokak No:1</cbc:StreetName>
@@ -179,6 +174,11 @@
         </cac:ShipmentStage>
       </cac:Shipment>
     </cac:Delivery>
+    <cac:AllowanceCharge>
+      <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+      <cbc:MultiplierFactorNumeric>0.12</cbc:MultiplierFactorNumeric>
+      <cbc:Amount currencyID="TRY">18.00</cbc:Amount>
+    </cac:AllowanceCharge>
     <cac:TaxTotal>
       <cbc:TaxAmount currencyID="TRY">26.40</cbc:TaxAmount>
       <cac:TaxSubtotal>


### PR DESCRIPTION
The Delivery node is only required for Export E-Invoices. Additionally, the position of the Delivery node should not follow the AllowanceCharge node. This inconsistency in node positioning causes a blocking issue on Nilvera’s side, preventing the successful processing of export E-Invoices with discounts.

task-5155802
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
