### PR TITLE
[IMP] stock: add action for merging transfers

### DIFF
--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -209,10 +209,10 @@ class SaleOrder(models.Model):
         self.order_line._action_launch_stock_rule()
         return super(SaleOrder, self)._action_confirm()
 
-    @api.depends('picking_ids')
+    @api.depends('order_line.move_ids.picking_id')
     def _compute_picking_ids(self):
         for order in self:
-            order.delivery_count = len(order.picking_ids)
+            order.delivery_count = len(order.order_line.move_ids.picking_id)
 
     @api.depends('user_id', 'company_id')
     def _compute_warehouse_id(self):
@@ -242,7 +242,7 @@ class SaleOrder(models.Model):
         return res
 
     def action_view_delivery(self):
-        return self._get_action_view_picking(self.picking_ids)
+        return self._get_action_view_picking(self.order_line.move_ids.picking_id)
 
     def _action_cancel(self):
         documents = None

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1464,6 +1464,87 @@ class StockPicking(models.Model):
             'res_id': backorder.id,
         }
 
+    def action_merge_pickings(self):
+        if len(self) < 2:
+            raise UserError(self.env._("Please select at least two transfers to merge."))
+        if len(self.picking_type_id) > 1:
+            raise UserError(self.env._("Transfers with different operation types cannot be merged."))
+        if len(set(self.mapped('state'))) > 1:
+            raise UserError(self.env._("Transfers with different states cannot be merged."))
+        if self[0].state in ['done', 'cancel']:
+            raise UserError(self.env._("Transfers with done or cancel states cannot be merged."))
+
+        merge_group_keys = {
+            picking._prepare_merge_group_key(picking)
+            for picking in self
+        }
+        if len(merge_group_keys) > 1:
+            raise UserError(self.env._(
+                "Selected transfers cannot be merged. They must share the same partner, carrier, source, and destination locations."
+            ))
+
+        # Take the picking into which all other pickings are merged.
+        # It is determined based on priority first, then scheduled_date.
+        target_picking = self.sorted(key=lambda p: (p.priority, p.scheduled_date))[-1]
+        other_transfers = self - target_picking
+        target_moves = self.env['stock.move']
+
+        message = self.env._(
+            "This transfer has been merged into %(target_picking)s.",
+            target_picking=target_picking._get_html_link(),
+        )
+
+        for picking in other_transfers:
+            for move in picking.move_ids:
+                # Find a compatible move in the target picking to merge with the current move,
+                # ensuring the move date is within 24 hours.
+                existing_move = target_picking.move_ids.filtered(
+                    lambda m: (
+                        m.product_id == move.product_id
+                        and m.reference_ids == move.reference_ids
+                        and m.location_final_id == move.location_final_id
+                        and m.uom_id == move.uom_id
+                        and m.package_ids == move.package_ids
+                        and m.move_line_ids.mapped('lot_name') == move.move_line_ids.mapped('lot_name')
+                        and m.move_line_ids.lot_id == move.move_line_ids.lot_id
+                        and abs(m.date - move.date).total_seconds() <= 86400
+                    )
+                )
+
+                if existing_move:
+                    target_moves |= existing_move
+                    existing_move.product_uom_qty += move.product_uom_qty
+                else:
+                    move.move_line_ids.picking_id = target_picking
+                    moves_vals = move.copy_data({
+                        'state': 'confirmed',
+                        'picking_id': target_picking.id,
+                        'reference_ids': target_picking.move_ids.reference_ids,
+                        'move_line_ids': [Command.set(move.move_line_ids.ids)],
+                    })
+                    target_moves |= self.env['stock.move'].create(moves_vals)
+
+            # Post a log note with a link of the target picking, allowing users to easily identify and navigate to it.
+            picking.message_post(body=message)
+
+        target_moves._filtered_for_assign()._action_assign()
+        pickings_names = ', '.join(other_transfers.mapped('name'))
+        merged_message = self.env._(
+            "The following transfers have been merged into this one: %s.",
+            pickings_names,
+        )
+        target_picking.message_post(body=merged_message)
+        merged_picking_vals = target_picking._get_merged_picking_vals()
+        target_picking.write(merged_picking_vals)
+        other_transfers.action_cancel()
+
+        return {
+            'type': 'ir.actions.act_window',
+            'res_model': 'stock.picking',
+            'view_mode': 'form',
+            'res_id': target_picking.id,
+        }
+
     def _pre_action_done_hook(self):
         for picking in self:
             has_quantity = False
@@ -2124,6 +2205,12 @@ class StockPicking(models.Model):
                 package_ids.update(picking.move_line_ids.result_package_id._get_all_package_dest_ids())
         return self.env['stock.package'].browse(package_ids)
 
+    def _get_merged_picking_vals(self):
+        self.ensure_one()
+        return {
+            'scheduled_date': self.scheduled_date,
+        }
+
     def _add_reference(self, references):
         """ link the given references to the list of references. """
         self.ensure_one()
@@ -2155,3 +2242,6 @@ class StockPicking(models.Model):
                 'is_entire_pack': True,
             })
         return move_line_vals
+
+    def _prepare_merge_group_key(self, picking):
+        return (picking.partner_id.id, picking.location_id.id, picking.location_dest_id.id)

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -511,6 +511,18 @@
             <field name="binding_view_types">list,kanban</field>
         </record>
 
+        <record id="action_merge_pickings" model="ir.actions.server">
+            <field name="name">Merge Transfers</field>
+            <field name="model_id" ref="stock.model_stock_picking"/>
+            <field name="binding_model_id" ref="stock.model_stock_picking"/>
+            <field name="state">code</field>
+            <field name="binding_view_types">list,kanban</field>
+            <field name="code">
+                if records:
+                    action = records.action_merge_pickings()
+            </field>
+        </record>
+
         <record id="click_dashboard_graph" model="ir.actions.server">
             <field name="name">stock.click_dashboard_graph</field>
             <field name="model_id" ref="stock.model_stock_picking"/>

--- a/addons/stock_delivery/models/stock_picking.py
+++ b/addons/stock_delivery/models/stock_picking.py
@@ -180,6 +180,10 @@ class StockPicking(models.Model):
             'name': self.carrier_id.with_context(lang=self.partner_id.lang).name,
         }
 
+    def _prepare_merge_group_key(self, picking):
+        grouped_fields = super()._prepare_merge_group_key(picking)
+        return grouped_fields + (picking.carrier_id.id,)
+
     def _add_delivery_cost_to_so(self):
         self.ensure_one()
         sale_order = self.sale_id

--- a/addons/stock_dropshipping/models/sale.py
+++ b/addons/stock_dropshipping/models/sale.py
@@ -18,7 +18,7 @@ class SaleOrder(models.Model):
             order.dropship_picking_count = dropship_count
 
     def action_view_delivery(self):
-        return self._get_action_view_picking(self.picking_ids.filtered(lambda p: not p.is_dropship))
+        return self._get_action_view_picking(self.order_line.move_ids.picking_id.filtered(lambda p: not p.is_dropship))
 
     def action_view_dropship(self):
         return self._get_action_view_picking(self.picking_ids.filtered(lambda p: p.is_dropship))


### PR DESCRIPTION
Managing multiple transfers with identical characteristics often leads to
unnecessary fragmentation of shipments, increased manual work, higher logistics
overhead, and duplicate shipping operations. This is especially common when
pickings are created separately or mistakenly split.

This commit introduces an action to merge multiple transfers (pickings).
Users can now select multiple transfers in the list view and
click 'Merge Transfers' from the Actions menu. When multiple transfers are selected,
all their operations are merged into a single target transfer,
chosen based on the highest priority and then the latest scheduled date.
All other selected transfers are automatically cancelled.

Merging of pickings is only applicable if all the selected pickings share
the following characteristics:
- Same partner
- Same source location
- Same destination location
- Same operation type
- Same state
- Same carrier

Use Cases:
- When a customer places multiple orders that can be delivered together using
  shipping, but initially it wasn’t possible to group them under a single shipment.
- When a picking was mistakenly split and needs to be recombined into one.

By using this feature, users can merge such pickings and apply a single shipping
method at once, improving logistics efficiency. Also, this feature allows users to
efficiently merge pickings with identical attributes directly from the list view
using action menu.

Task-4903746