### PR TITLE
[FIX] base: Remove unique constraint on `res.groups`

### DIFF
--- a/odoo/addons/base/models/res_groups.py
+++ b/odoo/addons/base/models/res_groups.py
@@ -36,8 +36,6 @@ class ResGroups(models.Model):
     privilege_id = fields.Many2one('res.groups.privilege', string='Privilege', index=True)
     view_group_hierarchy = fields.Json(string='Technical field for default group setting', compute='_compute_view_group_hierarchy')
 
-    _name_uniq = models.Constraint("UNIQUE (privilege_id, name)",
-        'The name of the group must be unique within a group privilege!')
     _check_api_key_duration = models.Constraint(
         'CHECK(api_key_duration >= 0)',
         'The api key duration cannot be a negative value.',


### PR DESCRIPTION
The unique constraint on the `name` and `privilege_id` of the security groups (`res.groups`) is being removed due to practical issues:

- Index Size Limitation: Since the `name` field is translatable, its content is stored as JSON, which can exceed the maximum size limit for a PostgreSQL `btree` index used for unique constraints.
- Localization Conflict: Changing the translation (e.g., from French to English) can result in different translated names mapping to the same untranslated value, but the unique constraint only applies to the stored JSON, leading to unexpected uniqueness violations across languages or making it unnecessarily difficult to manage.
