### PR TITLE
[FIX] point_of_sale: prevent del/arch spec. prod.

### DIFF
--- a/addons/point_of_sale/models/product_product.py
+++ b/addons/point_of_sale/models/product_product.py
@@ -31,6 +31,10 @@ class ProductProduct(models.Model):
                     "Deleting a product available in a session would be like attempting to snatch a hamburger from a customer’s hand mid-bite; chaos will ensue as ketchup and mayo go flying everywhere!",
                 ))
 
+    @api.ondelete(at_uninstall=False)
+    def _unlink_except_special_product(self):
+        self.product_tmpl_id._check_is_special_product()
+
     def _post_read_pos_data(self, data):
         config = self.env['pos.config'].browse(self.env.context.get('config_id'))
         different_currency = config.currency_id != self.env.company.currency_id
@@ -46,4 +50,5 @@ class ProductProduct(models.Model):
 
     def action_archive(self):
         self.product_tmpl_id._ensure_unused_in_pos()
+        self.product_tmpl_id._check_is_special_product()
         return super().action_archive()

--- a/addons/point_of_sale/models/product_template.py
+++ b/addons/point_of_sale/models/product_template.py
@@ -274,6 +274,10 @@ class ProductTemplate(models.Model):
                     "Deleting a product available in a session would be like attempting to snatch a hamburger from a customer’s hand mid-bite; chaos will ensue as ketchup and mayo go flying everywhere!",
                 ))
 
+    @api.ondelete(at_uninstall=False)
+    def _unlink_except_special_product(self):
+        self._check_is_special_product()
+
     def _ensure_unused_in_pos(self):
         open_pos_sessions = self.env['pos.session'].search([('state', '!=', 'closed')])
         used_products = open_pos_sessions.order_ids.filtered(lambda o: o.state == "draft").lines.product_id.product_tmpl_id
@@ -283,8 +287,15 @@ class ProductTemplate(models.Model):
                 "Make sure to close all sessions first to avoid any issues.",
             ))
 
+    def _check_is_special_product(self):
+        special_products = self.env['pos.config']._get_special_products().product_tmpl_id
+        for product in self:
+            if product in special_products:
+                raise UserError(_("You cannot archive a product that is set as a special product in a Point of Sale configuration. Please change the configuration first."))
+
     def action_archive(self):
         self._ensure_unused_in_pos()
+        self._check_is_special_product()
         return super().action_archive()
 
     @api.onchange('sale_ok')

--- a/addons/point_of_sale/tests/test_pos_basic_config.py
+++ b/addons/point_of_sale/tests/test_pos_basic_config.py
@@ -8,8 +8,9 @@ from odoo.addons.point_of_sale.tests.common import TestPoSCommon
 from freezegun import freeze_time
 from dateutil.relativedelta import relativedelta
 from datetime import datetime, timedelta
-from pprint import pformat
 import unittest.mock
+from odoo.http import UserError
+
 
 @odoo.tests.tagged('post_install', '-at_install')
 class TestPoSBasicConfig(TestPoSCommon):
@@ -1406,3 +1407,14 @@ class TestPoSBasicConfig(TestPoSCommon):
         self.assertEqual(len(product_data['_archived_combinations']), 1, "There should be one archived combination for the product")
         self.assertEqual(len(product_data['_archived_combinations'][0]), 2, "Archived combination should have two values")
         self.assertTrue(all(value in product_data['_archived_combinations'][0] for value in first_variant.product_template_attribute_value_ids.ids), "Archived combination should match the first variant's attribute values")
+
+    def test_archive_delete_special_product(self):
+        special_product = self.env.ref('point_of_sale.product_product_tip')
+        with self.assertRaisesRegex(UserError, "You cannot archive a product that is set as a special product in a Point of Sale configuration. Please change the configuration first."):
+            special_product.action_archive()
+        with self.assertRaisesRegex(UserError, "You cannot archive a product that is set as a special product in a Point of Sale configuration. Please change the configuration first."):
+            special_product.product_variant_ids[0].action_archive()
+        with self.assertRaisesRegex(UserError, "You cannot archive a product that is set as a special product in a Point of Sale configuration. Please change the configuration first."):
+            special_product.unlink()
+        with self.assertRaisesRegex(UserError, "You cannot archive a product that is set as a special product in a Point of Sale configuration. Please change the configuration first."):
+            special_product.product_variant_ids[0].unlink()


### PR DESCRIPTION
Backport of https://github.com/odoo/odoo/pull/229074

Before this commit, it was possible to delete or archive some products even if they were special for the pos (discount, tips, settle, etc.). This commit adds a mechanism to prevent this and reduce the risk of errors linked to missing products in the pos.

Enterprise PR: https://github.com/odoo/enterprise/pull/96820
Task id: 5080126

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
