### PR TITLE
[FIX] l10n_hu_edi: fix error when printing invoice with section lines

### DIFF
--- a/addons/l10n_hu_edi/views/report_invoice.xml
+++ b/addons/l10n_hu_edi/views/report_invoice.xml
@@ -82,7 +82,7 @@
             <attribute name="t-options">{"widget": "monetary", "display_currency": o.currency_id}</attribute>
         </xpath>
         <xpath expr="//table[@name='invoice_line_table']//span[@t-out='section_subtotal']" position="attributes">
-            <attribute name="t-out">current_subtotal * sign</attribute>
+            <attribute name="t-out">section_subtotal * sign</attribute>
         </xpath>
         <xpath expr="//div[hasclass('clearfix')]//span[@t-field='o.amount_residual']" position="attributes">
             <attribute name="t-field"/>


### PR DESCRIPTION
When a user tries to print an invoice with section lines for Hungarian company, a traceback occurs.

Steps to reproduce the error:
- Install ``l10n_hu_edi`` module with demo data and switch to ``HU Company``
- Create an invoice > Add a seaction >Add a line under that section > Save
- Confirm > Print

Traceback:
```py
QWebError: Error while rendering the template:
TypeError: unsupported operand type(s) for *: 'NoneType' and 'int'
```

https://github.com/odoo/odoo/blob/dc6dd927faea1f4501d6c50c586d5ea46bd1fc95/addons/l10n_hu_edi/views/report_invoice.xml#L84-L86
Here, ``current_subtotal`` is used instead of ``section_subtotal``.
So, It will lead to the above traceback.

``current_subtotal`` was changed to ``section_subtotal`` in the commit [1],
but the t-out attribute in the same block was not changed accordingly.

[1]: https://github.com/odoo/odoo/commit/af9bf2ac1939aa8d64c4ba5caa202b229debba3f

sentry-6933103730

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
