### PR TITLE
[FIX] spreadsheet: reload pivot on locale update

### DIFF
--- a/addons/spreadsheet/static/src/pivot/plugins/pivot_odoo_ui_plugin.js
+++ b/addons/spreadsheet/static/src/pivot/plugins/pivot_odoo_ui_plugin.js
@@ -15,6 +15,7 @@ export class PivotOdooUIPlugin extends OdooUIPlugin {
      */
     handle(cmd) {
         switch (cmd.type) {
+            case "UPDATE_LOCALE":
             case "REFRESH_ALL_DATA_SOURCES":
                 this.refreshAllPivots();
                 break;

--- a/addons/spreadsheet/static/tests/pivots/model/pivot_plugin.test.js
+++ b/addons/spreadsheet/static/tests/pivots/model/pivot_plugin.test.js
@@ -27,6 +27,7 @@ import {
     getCellValue,
     getEvaluatedCell,
     getFormattedValueGrid,
+    getEvaluatedGrid,
 } from "@spreadsheet/../tests/helpers/getters";
 import { createModelWithDataSource } from "@spreadsheet/../tests/helpers/model";
 import { createSpreadsheetWithPivot } from "@spreadsheet/../tests/helpers/pivot";
@@ -2254,4 +2255,28 @@ test("date are between two years are correctly grouped by weeks and days", async
             B4: "Foo",          C4: "Foo",          D4: "Foo",         E4: "Foo",
             B5: "11",           C5: "12",           D5: "13",          E5: "14",
         })
+});
+
+test("Pivot headers day of week are still correct after updating the locale's week start day", async function () {
+    const { model } = await createSpreadsheetWithPivot({
+        arch: /* xml */ `
+            <pivot>
+                <field name="date" interval="day_of_week" type="row"/>
+                <field name="probability" type="measure"/>
+            </pivot>`,
+    });
+    patchWithCleanup(localization, { weekStart: 1 /* Monday */ });
+    model.dispatch("UPDATE_LOCALE", {
+        locale: { ...model.getters.getLocale(), weekStart: 1 /* Monday */ },
+    });
+    await waitForDataLoaded(model);
+
+    setCellContent(model, "A20", "=PIVOT(1)");
+    expect(getEvaluatedGrid(model, "A22:A24")).toEqual([["Monday"], ["Thursday"], ["Friday"]]);
+
+    model.dispatch("UPDATE_LOCALE", {
+        locale: { ...model.getters.getLocale(), weekStart: 7 /* Sunday */ },
+    });
+    await waitForDataLoaded(model);
+    expect(getEvaluatedGrid(model, "A22:A24")).toEqual([["Monday"], ["Thursday"], ["Friday"]]);
 });


### PR DESCRIPTION
Chaning the locale can change the first day of the week. But the normalization of the server value depends on this `locale.weekStart`, se we need to reload the pivot when the locale changes, otherwise we might display wrong values for a "day_of_week" grouping.

Task: [5149508](https://www.odoo.com/web#id=5149508&cids=1&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
