### PR TITLE
[FIX] fleet: correctly set plan to change

### DIFF
--- a/addons/fleet/models/fleet_vehicle.py
+++ b/addons/fleet/models/fleet_vehicle.py
@@ -368,31 +368,34 @@ class FleetVehicle(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
-        vehicles = super().create(vals_list)
         to_update_drivers_cars = set()
         to_update_drivers_bikes = set()
         state_waiting_list = self.env.ref('fleet.fleet_vehicle_state_waiting_list', raise_if_not_found=False)
-        for vehicle, vals in zip(vehicles, vals_list):
-            if vals.get('driver_id'):
-                vehicle.create_driver_history(vals)
+        for vals in vals_list:
             if vals.get('future_driver_id'):
-                state_id = vehicle.state_id.id
+                state_id = vals.get('state_id')
                 if not state_waiting_list or state_waiting_list.id != state_id:
                     future_driver = vals['future_driver_id']
-                    if vehicle.vehicle_type == 'bike':
+                    if vals.get('vehicle_type') == 'bike':
                         to_update_drivers_bikes.add(future_driver)
-                    elif vehicle.vehicle_type == 'car':
+                    elif vals.get('vehicle_type') == 'car':
                         to_update_drivers_cars.add(future_driver)
         if to_update_drivers_cars:
             self.search([
                 ('driver_id', 'in', to_update_drivers_cars),
                 ('vehicle_type', '=', 'car'),
-            ]).plan_to_change_car = False
+            ]).plan_to_change_car = True
         if to_update_drivers_bikes:
             self.search([
                 ('driver_id', 'in', to_update_drivers_bikes),
                 ('vehicle_type', '=', 'bike'),
-            ]).plan_to_change_bike = False
+            ]).plan_to_change_bike = True
+
+        vehicles = super().create(vals_list)
+
+        for vehicle, vals in zip(vehicles, vals_list):
+            if vals.get('driver_id'):
+                vehicle.create_driver_history(vals)
         return vehicles
 
     def write(self, vals):
@@ -417,7 +420,7 @@ class FleetVehicle(models.Model):
                                 vals.get('state_id', vehicle.state_id.id) not in [state_waiting_list.id, state_new_request.id]).mapped('vehicle_type'))
             if vehicle_types:
                 vehicle_read_group = dict(self.env['fleet.vehicle']._read_group(
-                    domain=[('driver_id', '=', future_driver), ('vehicle_type', 'in', vehicle_types)],
+                    domain=[('driver_id', '=', future_driver), ('vehicle_type', 'in', vehicle_types), ('id', 'not in', self.ids)],
                     groupby=['vehicle_type'],
                     aggregates=['id:recordset'])
                 )


### PR DESCRIPTION
WHen a new vehicle is created for someone in a non waiting column, we are settign his other cars in plan_to_change.

When we set a future driver on a car, we set the others as plan to change, but not the one on which we are setting the future_driver

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
