### PR TITLE
[FIX] l10n_in_edi: rectify edi json payload

### DIFF
--- a/addons/l10n_in_edi/models/account_edi_format.py
+++ b/addons/l10n_in_edi/models/account_edi_format.py
@@ -520,7 +520,7 @@ class AccountEdiFormat(models.Model):
                 for index, line in enumerate(lines, start=1)
             ],
             "ValDtls": {
-                "AssVal": self._l10n_in_round_value(tax_details.get("base_amount") + global_discount_amount),
+                "AssVal": self._l10n_in_round_value(tax_details.get("base_amount")),
                 "CgstVal": self._l10n_in_round_value(tax_details_by_code.get("cgst_amount", 0.00)),
                 "SgstVal": self._l10n_in_round_value(tax_details_by_code.get("sgst_amount", 0.00)),
                 "IgstVal": self._l10n_in_round_value(tax_details_by_code.get("igst_amount", 0.00)),
@@ -536,7 +536,11 @@ class AccountEdiFormat(models.Model):
                 "RndOffAmt": self._l10n_in_round_value(
                     rounding_amount),
                 "TotInvVal": self._l10n_in_round_value(
-                    (tax_details.get("base_amount") + tax_details.get("tax_amount") + rounding_amount)),
+                    tax_details.get("base_amount")
+                    + tax_details.get("tax_amount")
+                    + rounding_amount
+                    - global_discount_amount
+                ),
             },
         }
         if invoice.company_currency_id != invoice.currency_id:

--- a/addons/l10n_in_edi/tests/test_edi_json.py
+++ b/addons/l10n_in_edi/tests/test_edi_json.py
@@ -136,6 +136,14 @@ class TestEdiJson(L10nInTestInvoicingCommon):
             ]
         })
         cls.invoice_with_export.action_post()
+        cls.invoice_global_discount = cls.init_invoice("out_invoice", post=False, products=cls.product_a)
+        cls.invoice_global_discount.write({
+            "invoice_line_ids": [(0, 0, {
+                "name": "Global Discount Line",
+                "price_unit": -100.0,
+            })]
+        })
+        cls.invoice_global_discount.action_post()
         cls._generate_json = cls.env["account.edi.format"]._l10n_in_edi_generate_invoice_json
 
     def test_edi_json(self):
@@ -728,4 +736,81 @@ class TestEdiJson(L10nInTestInvoicingCommon):
                     'CntCode': 'US'
                   }
                 }
+            )
+
+        # ==================================== Global Discount Line Test ==============================================
+        with self.subTest(scenario="Global Discount Invoice"):
+            self.assertDictEqual(
+                self._generate_json(self.invoice_global_discount),
+                {
+                    'Version': '1.1',
+                    'TranDtls': {
+                        'TaxSch': 'GST',
+                        'SupTyp': 'B2B',
+                        'RegRev': 'N',
+                        'IgstOnIntra': 'N'
+                    },
+                    'DocDtls': {
+                        'Typ': 'INV',
+                        'No': 'INV/18-19/0012',
+                        'Dt': '01/01/2019'
+                    },
+                    'SellerDtls': {
+                        'Addr1': 'Khodiyar Chowk',
+                        'Loc': 'Amreli',
+                        'Pin': 365220,
+                        'Stcd': '24',
+                        'Addr2': 'Sala Number 3',
+                        'LglNm': 'Default Company',
+                        'GSTIN': '24AAGCC7144L6ZE'
+                    },
+                    'BuyerDtls': {
+                        'Addr1': 'Karansinhji Rd',
+                        'Loc': 'Rajkot',
+                        'Pin': 360001,
+                        'Stcd': '24',
+                        'Addr2': 'Karanpara',
+                        'POS': '24',
+                        'LglNm': 'Partner Intra State',
+                        'GSTIN': '24ABCPM8965E1ZE'
+                    },
+                    'ItemList': [
+                        {
+                        'SlNo': '1',
+                        'PrdDesc': 'product_a',
+                        'IsServc': 'N',
+                        'HsnCd': '111111',
+                        'Qty': 1.0,
+                        'Unit': 'UNT',
+                        'UnitPrice': 1000.0,
+                        'TotAmt': 1000.0,
+                        'Discount': 0.0,
+                        'AssAmt': 1000.0,
+                        'GstRt': 5.0,
+                        'IgstAmt': 0.0,
+                        'CgstAmt': 25.0,
+                        'SgstAmt': 25.0,
+                        'CesRt': 0.0,
+                        'CesAmt': 0.0,
+                        'CesNonAdvlAmt': 0.0,
+                        'StateCesRt': 0.0,
+                        'StateCesAmt': 0.0,
+                        'StateCesNonAdvlAmt': 0.0,
+                        'OthChrg': 0.0,
+                        'TotItemVal': 1050.0
+                        }
+                    ],
+                    'ValDtls': {
+                        'AssVal': 1000.0,
+                        'CgstVal': 25.0,
+                        'SgstVal': 25.0,
+                        'IgstVal': 0.0,
+                        'CesVal': 0.0,
+                        'StCesVal': 0.0,
+                        'Discount': 100.0,
+                        'RndOffAmt': 0.0,
+                        'TotInvVal': 950.0
+                    }
+                },
+                "Indian EDI with global discount did not match"
             )


### PR DESCRIPTION
Submitting an EDI for an invoice containing a global discount line (negative amount line without tax) raised the following errors:

1. 2182 – Taxable value of all items must be equal to total taxable value
2. 2189 – Invalid total Invoice Value

This occurred due to the `account_tax` refactor in version 18.0, where lines without taxes are no longer included in `_aggregate_base_line_tax_details`. As a result, the `global_discount_line` in `l10n_in_edi` was excluded from the base_amount computation.

This fix adjusts the following JSON fields:
- `AssVal` → Previously added global_discount_amount to restore the base.
  Now remains directly aligned with base_amount.
- `TotInvVal` → Previously skipped discount deduction.
  Now explicitly deducts the discount.

**task**-5158762