### PR TITLE
[FIX] website_sale: unescape placeholder for search

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -569,7 +569,8 @@
                                             t-attf-class="o_wsale_products_header_search_form_container {{ _has_all_sibligns and 'd-none d-sm-inline-block'}} col-xl-5 me-auto {{not hasLeftColumn and 'col-xl-6'}}"
                                             t-call="website_sale.search"
                                         >
-                                            <t t-if="category" t-set="placeholder">Search in <t t-out="category.name"/></t>
+                                            <t t-set="search_term">Search in</t>
+                                            <t t-if="category" t-set="placeholder" t-valuef="{{ search_term }} {{ category.name }}"/>
                                             <t t-set="search" t-value="original_search or search"/>
                                         </div>
                                         <!-- Mobile Search button -->
@@ -728,7 +729,8 @@
                                 <t t-set="_classes" t-valuef="input-group rounded o_cc o_cc1 mb-1"/>
                                 <t t-set="_input_classes" t-valuef="border-0 p-3"/>
                                 <t t-set="_submit_classes" t-valuef="px-4"/>
-                                <t t-if="category" t-set="placeholder">Search in <t t-out="category.name"/></t>
+                                <t t-set="search_term">Search in</t>
+                                <t t-if="category" t-set="placeholder" t-valuef="{{ search_term }} {{ category.name }}"/>
                             </t>
                         </div>
                     </div>
@@ -1137,7 +1139,8 @@
                 class="offcanvas-body flex-grow-0 overflow-visible"
             >
                 <t t-call="website_sale.search">
-                    <t t-if="category" t-set="placeholder">Search in <t t-out="category.name"/></t>
+                    <t t-set="search_term">Search in</t>
+                    <t t-if="category" t-set="placeholder" t-valuef="{{ search_term }} {{ category.name }}"/>
                     <t t-set="search" t-value="original_search or search"/>
                     <t t-set="_s_searchbar_autocomplete_classes" t-valuef="bg-primary"> </t>
                 </t>


### PR DESCRIPTION
currently, we use `t-out` to set the placeholder, which escapes HTML so `desk's lamp` becomes `desk&#39;s lamp`

Fix:
- replace `t-out` with `t-value` to properly store placeholder.

**Before**
<img width="513" height="270" alt="image" src="https://github.com/user-attachments/assets/92046e41-e471-4eba-9510-a9ea91eeccd8" />


**After**
<img width="472" height="252" alt="image" src="https://github.com/user-attachments/assets/79157a51-adac-4c95-8e39-a0caa7cf1537" />

opw-5136972


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
