### PR TITLE
[FIX] account: correctly batch price-included taxes with same base-affecting flags

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -846,6 +846,15 @@ class AccountTax(models.Model):
                         # Tax affecting the following taxes but in batch using 'is_base_affected'.
                         is_base_affected = tax.is_base_affected
                         same_batch = True
+                    elif (
+                        include_base_amount
+                        and tax.include_base_amount
+                        and tax.price_include
+                        and batch[0].price_include
+                        and not is_base_affected
+                        and not tax.is_base_affected
+                    ):
+                        same_batch = True
 
                 if not same_batch:
                     for batch_tax in batch:

--- a/addons/account/static/src/helpers/account_tax.js
+++ b/addons/account/static/src/helpers/account_tax.js
@@ -91,6 +91,11 @@ export const accountTaxHelpers = {
                         // Tax affecting the following taxes but in batch using 'is_base_affected'.
                         is_base_affected = tax.is_base_affected;
                         same_batch = true;
+                    } else if (
+                        include_base_amount && tax.include_base_amount && !is_base_affected &&
+                        !tax.is_base_affected && tax.price_include && batch[0].price_include
+                    ) {
+                        same_batch = true;
                     }
                 }
 


### PR DESCRIPTION
…fecting flags

Issue:
When creating an invoice with two price-included taxes of the same amount, both having Affect Base of Subsequent Taxes (`include_base_amount=True`) and not being Base Affected by Previous Taxes (`is_base_affected=False`), the tax computation produces different values for each tax, whereas they should be identical.

Steps to Reproduce:
1. Create two taxes with `price_include=True` and the same amount.
2. Set Affect Base of Subsequent Taxes = True and Base Affected by Previous Taxes = False for both taxes.
3. Add both taxes to the same invoice line and confirm the invoice. → The computed tax amounts differ, but they should be the same.

Fix:
Adjusted the batching conditions to group taxes together when both have `include_base_amount=True` and `is_base_affected=False`. This ensures that price-included taxes with the same configuration and amount are consistently batched and produce identical values.

Opw-5142180
