### PR TITLE
[FIX] web: backport part of smarter position hook

### DIFF
--- a/addons/web/static/src/core/position/utils.js
+++ b/addons/web/static/src/core/position/utils.js
@@ -129,10 +129,12 @@ function computePosition(popper, target, { container, margin, position }) {
     };
 
     function getPositioningData(d = directions[0], v = variants[0], containerRestricted = false) {
+        const result = { direction: DIRECTIONS[d], variant: VARIANTS[v] };
         const vertical = ["t", "b"].includes(d);
         const variantPrefix = vertical ? "v" : "h";
         const directionValue = directionsData[d];
-        const variantValue = variantsData[variantPrefix + v];
+        let variantValue = variantsData[variantPrefix + v];
+        let malus = null;
 
         if (containerRestricted) {
             const [directionSize, variantSize] = vertical
@@ -155,46 +157,57 @@ function computePosition(popper, target, { container, margin, position }) {
                 }
             }
 
-            // Abort if outside container boundaries
-            const directionOverflow =
-                Math.ceil(directionValue) < Math.floor(directionMin) ||
-                Math.floor(directionValue + directionSize) > Math.ceil(directionMax);
-            const variantOverflow =
-                Math.ceil(variantValue) < Math.floor(variantMin) ||
-                Math.floor(variantValue + variantSize) > Math.ceil(variantMax);
-            if (directionOverflow || variantOverflow) {
-                return null;
+            // Compute overflows
+            let directionOverflow = 0;
+            if (Math.floor(directionValue) < Math.ceil(directionMin)) {
+                directionOverflow = Math.floor(directionValue) - Math.ceil(directionMin);
+            } else if (Math.ceil(directionValue + directionSize) > Math.floor(directionMax)) {
+                directionOverflow =
+                    Math.ceil(directionValue + directionSize) - Math.floor(directionMax);
             }
+            let variantOverflow = 0;
+            if (Math.floor(variantValue) < Math.ceil(variantMin)) {
+                variantOverflow = Math.floor(variantValue) - Math.ceil(variantMin);
+            } else if (Math.ceil(variantValue + variantSize) > Math.floor(variantMax)) {
+                variantOverflow = Math.ceil(variantValue + variantSize) - Math.floor(variantMax);
+            }
+
+            // All non zero values of variantOverflow lead to the
+            // same malus value since it can be corrected by shifting
+            malus = Math.abs(directionOverflow) + (variantOverflow && 1);
+
+            // Apply variant offset
+            variantValue -= variantOverflow;
+            result.variantOffset = -variantOverflow;
         }
 
         const positioning = vertical
             ? { top: directionValue, left: variantValue }
             : { top: variantValue, left: directionValue };
-        return {
-            // Subtract the offsets of the containing block (relative to the
-            // viewport). It can be done like that because the style top and
-            // left were reset to 0px in `reposition`
-            // https://developer.mozilla.org/en-US/docs/Web/CSS/Containing_block#identifying_the_containing_block
-            top: positioning.top - popBox.top,
-            left: positioning.left - popBox.left,
-            direction: DIRECTIONS[d],
-            variant: VARIANTS[v],
-        };
+        // Subtract the offsets of the containing block (relative to the
+        // viewport). It can be done like that because the style top and
+        // left were reset to 0px in `reposition`
+        // https://developer.mozilla.org/en-US/docs/Web/CSS/Containing_block#identifying_the_containing_block
+        result.top = positioning.top - popBox.top;
+        result.left = positioning.left - popBox.left;
+        return { result, malus };
     }
 
     // Find best solution
+    const matches = [];
     for (const d of directions) {
         for (const v of variants) {
             const match = getPositioningData(d, v, true);
-            if (match) {
-                // Position match have been found.
-                return match;
+            if (!match.malus) {
+                // A perfect position match has been found.
+                return match.result;
             }
+            matches.push(match);
         }
     }
 
-    // Fallback to default position if no best solution found
-    return getPositioningData();
+    // Settle for the first match with the least malus
+    return matches.sort((a, b) => a.malus - b.malus)[0].result;
 }
 
 /**

--- a/addons/web/static/tests/core/popover/popover.test.js
+++ b/addons/web/static/tests/core/popover/popover.test.js
@@ -92,37 +92,43 @@ test("popover is rendered nearby target (top)", async () => {
 
 test("popover is rendered nearby target (left)", async () => {
     expect.assertions(2);
-    class TestPopover extends Popover {
-        onPositioned(el, { direction, variant }) {
-            expect(direction).toBe("left");
-            expect(variant).toBe("middle");
-        }
-    }
+    await mountWithCleanup(
+        `<div id="target" style="background-color: royalblue; width: 50px; height: 50px; position: absolute; top: 50%; left: 50%;"/>`
+    );
 
-    await mountWithCleanup(TestPopover, {
+    await mountWithCleanup(Popover, {
         props: {
-            target: getFixture(),
+            close: () => {},
+            target: queryOne("#target"),
             position: "left",
             component: Content,
+            onPositioned: (_, { direction, variant }) => {
+                expect(direction).toBe("left");
+                expect(variant).toBe("middle");
+            },
         },
+        noMainContainer: true,
     });
 });
 
 test("popover is rendered nearby target (right)", async () => {
     expect.assertions(2);
-    class TestPopover extends Popover {
-        onPositioned(el, { direction, variant }) {
-            expect(direction).toBe("right");
-            expect(variant).toBe("middle");
-        }
-    }
+    await mountWithCleanup(
+        `<div id="target" style="background-color: royalblue; width: 50px; height: 50px; position: absolute; top: 50%; left: 50%;"/>`
+    );
 
-    await mountWithCleanup(TestPopover, {
+    await mountWithCleanup(Popover, {
         props: {
-            target: getFixture(),
+            close: () => {},
+            target: queryOne("#target"),
             position: "right",
             component: Content,
+            onPositioned: (_, { direction, variant }) => {
+                expect(direction).toBe("right");
+                expect(variant).toBe("middle");
+            },
         },
+        noMainContainer: true,
     });
 });
 

--- a/addons/web/static/tests/core/position/position_hook.test.js
+++ b/addons/web/static/tests/core/position/position_hook.test.js
@@ -929,7 +929,7 @@ test(
 );
 test(
     "reposition from top-start to top-start",
-    getRepositionTest("top-start", "top-start", "slimfit")
+    getRepositionTest("top-start", "top-start", "bottom")
 );
 test(
     "reposition from top-start to top-middle",
@@ -1018,7 +1018,9 @@ test(
 );
 test("reposition from top-end to top-start", getRepositionTest("top-end", "top-start", "left"));
 test("reposition from top-end to top-middle", getRepositionTest("top-end", "top-middle", "w125"));
-test("reposition from top-end to top-end", getRepositionTest("top-end", "top-end", "slimfit"));
+test(
+    "reposition from top-end to top-end",
+    getRepositionTest("top-end", "top-end", "bottom"));
 // -----------------------------------------------------------------------------
 test(
     "reposition from left-start to bottom-start",
@@ -1046,7 +1048,7 @@ test(
 );
 test(
     "reposition from left-start to left-start",
-    getRepositionTest("left-start", "left-start", "slimfit")
+    getRepositionTest("left-start", "left-start", "top")
 );
 test(
     "reposition from left-start to left-middle",
@@ -1156,11 +1158,13 @@ test(
     "reposition from left-end to left-middle",
     getRepositionTest("left-end", "left-middle", "h125")
 );
-test("reposition from left-end to left-end", getRepositionTest("left-end", "left-end", "slimfit"));
+test(
+    "reposition from left-end to left-end",
+    getRepositionTest("left-end", "left-end", "bottom"));
 // -----------------------------------------------------------------------------
 test(
     "reposition from bottom-start to bottom-start",
-    getRepositionTest("bottom-start", "bottom-start", "slimfit")
+    getRepositionTest("bottom-start", "bottom-start", "top")
 );
 test(
     "reposition from bottom-start to bottom-middle",
@@ -1266,7 +1270,7 @@ test(
 );
 test(
     "reposition from bottom-end to bottom-end",
-    getRepositionTest("bottom-end", "bottom-end", "slimfit")
+    getRepositionTest("bottom-end", "bottom-end", "top")
 );
 test(
     "reposition from bottom-end to right-start",
@@ -1316,7 +1320,7 @@ test(
 );
 test(
     "reposition from right-start to right-start",
-    getRepositionTest("right-start", "right-start", "slimfit")
+    getRepositionTest("right-start", "right-start", "top")
 );
 test(
     "reposition from right-start to right-middle",
@@ -1422,7 +1426,7 @@ test(
 );
 test(
     "reposition from right-end to right-end",
-    getRepositionTest("right-end", "right-end", "slimfit")
+    getRepositionTest("right-end", "right-end", "bottom")
 );
 test(
     "reposition from right-end to left-start",


### PR DESCRIPTION
**Steps to reproduce:**
- Activate Developer mode
- Go to CRM -> Activity Type
- Click on any model to open its form
- On hover the Model field tooltip does not display properly its popover component
(cut on the left of the screen)

**Issue:**
When the element cannot be positioned correctly on the screen, it fallbacks to the default position which is often worse.

**Fix:**
Backported part of a fix from newer versions (https://github.com/odoo/odoo/commit/ae25a2bb09a92b39fb7643a1bf18eecae8f24fc8) to keep the best position among the evaluated ones.

opw-5089577

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
