### PR TITLE
[FIX] web: restore scroll position in views

### DIFF
--- a/addons/web/static/src/search/action_hook.js
+++ b/addons/web/static/src/search/action_hook.js
@@ -88,6 +88,27 @@ export function useSetupAction(params = {}) {
             return state;
         });
     }
+
+    function setScrollFromState() {
+        const { state } = component.props;
+        const scrolling = state && state[scrollSymbol];
+        if (scrolling) {
+            if (component.env.isSmall) {
+                rootRef.el.scrollTop = (scrolling.root && scrolling.root.top) || 0;
+                rootRef.el.scrollLeft = (scrolling.root && scrolling.root.left) || 0;
+            } else if (scrolling.content) {
+                const contentEl =
+                    rootRef.el.querySelector(
+                        ".o_component_with_search_panel > .o_renderer_with_searchpanel," +
+                            ".o_component_with_search_panel > .o_renderer"
+                    ) || rootRef.el.querySelector(".o_content");
+                if (contentEl) {
+                    contentEl.scrollTop = scrolling.content.top || 0;
+                    contentEl.scrollLeft = scrolling.content.left || 0;
+                }
+            }
+        }
+    }
     if (__getLocalState__ && (getLocalState || rootRef)) {
         useCallbackRecorder(__getLocalState__, () => {
             const state = {};
@@ -116,26 +137,7 @@ export function useSetupAction(params = {}) {
         });
 
         if (rootRef) {
-            onMounted(() => {
-                const { state } = component.props;
-                const scrolling = state && state[scrollSymbol];
-                if (scrolling) {
-                    if (component.env.isSmall) {
-                        rootRef.el.scrollTop = (scrolling.root && scrolling.root.top) || 0;
-                        rootRef.el.scrollLeft = (scrolling.root && scrolling.root.left) || 0;
-                    } else if (scrolling.content) {
-                        const contentEl =
-                            rootRef.el.querySelector(
-                                ".o_component_with_search_panel > .o_renderer_with_searchpanel," +
-                                    ".o_component_with_search_panel > .o_renderer"
-                            ) || rootRef.el.querySelector(".o_content");
-                        if (contentEl) {
-                            contentEl.scrollTop = scrolling.content.top || 0;
-                            contentEl.scrollLeft = scrolling.content.left || 0;
-                        }
-                    }
-                }
-            });
+            onMounted(() => setScrollFromState());
         }
     }
     if (__getContext__ && params.getContext) {
@@ -144,4 +146,8 @@ export function useSetupAction(params = {}) {
     if (__getOrderBy__ && params.getOrderBy) {
         useCallbackRecorder(__getOrderBy__, params.getOrderBy);
     }
+
+    return {
+        setScrollFromState,
+    };
 }

--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -104,18 +104,6 @@ export class ListController extends Component {
             this.isExportEnable = await user.hasGroup("base.group_allow_export");
         });
 
-        let { rendererScrollPositions } = this.props.state || {};
-        useEffect(() => {
-            if (rendererScrollPositions) {
-                const renderer = this.rootRef.el.querySelector(".o_list_renderer");
-                if (renderer) {
-                    renderer.scrollLeft = rendererScrollPositions.left;
-                    renderer.scrollTop = rendererScrollPositions.top;
-                    rendererScrollPositions = null;
-                }
-            }
-        });
-
         this.archiveEnabled =
             "active" in this.props.fields
                 ? !this.props.fields.active.readonly
@@ -128,7 +116,7 @@ export class ListController extends Component {
             afterExecuteAction: this.afterExecuteActionButton.bind(this),
             reload: () => this.model.load(),
         });
-        useSetupAction({
+        const { setScrollFromState } = useSetupAction({
             rootRef: this.rootRef,
             beforeLeave: async () => this.model.root.leaveEditMode(),
             beforeUnload: async (ev) => {
@@ -152,6 +140,24 @@ export class ListController extends Component {
             },
             getOrderBy: () => this.model.root.orderBy,
         });
+
+        useEffect(
+            (isReady) => {
+                if (isReady) {
+                    if (this.env.isSmall) {
+                        setScrollFromState();
+                    } else {
+                        const { rendererScrollPositions } = this.props.state || {};
+                        if (rendererScrollPositions) {
+                            const renderer = this.rootRef.el.querySelector(".o_list_renderer");
+                            renderer.scrollLeft = rendererScrollPositions.left;
+                            renderer.scrollTop = rendererScrollPositions.top;
+                        }
+                    }
+                }
+            },
+            () => [this.model.isReady]
+        );
 
         usePager(() => {
             if (this.model.useSampleModel) {

--- a/addons/web/static/src/views/pivot/pivot_controller.js
+++ b/addons/web/static/src/views/pivot/pivot_controller.js
@@ -6,7 +6,7 @@ import { SearchBar } from "@web/search/search_bar/search_bar";
 import { useSearchBarToggler } from "@web/search/search_bar/search_bar_toggler";
 import { CogMenu } from "@web/search/cog_menu/cog_menu";
 
-import { Component, useRef } from "@odoo/owl";
+import { Component, useEffect, useRef } from "@odoo/owl";
 
 export class PivotController extends Component {
     static template = "web.PivotView";
@@ -26,7 +26,7 @@ export class PivotController extends Component {
             this.modelOptions
         );
 
-        useSetupAction({
+        const { setScrollFromState } = useSetupAction({
             rootRef: useRef("root"),
             getLocalState: () => {
                 const { data, metaData } = this.model;
@@ -34,6 +34,14 @@ export class PivotController extends Component {
             },
             getContext: () => this.getContext(),
         });
+        useEffect(
+            (isReady) => {
+                if (isReady) {
+                    setScrollFromState();
+                }
+            },
+            () => [this.model.isReady]
+        );
         this.searchBarToggler = useSearchBarToggler();
     }
 

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -18176,3 +18176,56 @@ test(`basic open record with allowOpenAction`, async () => {
     await contains(".o_field_cell").click();
     expect.verifySteps([]);
 });
+
+test.tags("mobile");
+test("scroll position is restored when coming back to list view", async () => {
+    Foo._views = {
+        kanban: `
+            <kanban>
+                <templates>
+                    <t t-name="card">
+                        <field name="foo"/>
+                    </t>
+                </templates>
+            </kanban>`,
+        list: `<list><field name="foo"/></list>`,
+        search: `<search />`,
+    };
+
+    for (let i = 1; i < 30; i++) {
+        Foo._records.push({ id: 100 + i, foo: `Record ${i}` });
+    }
+
+    let def;
+    onRpc("web_search_read", () => def);
+    await mountWithCleanup(WebClient);
+    await getService("action").doAction({
+        res_model: "foo",
+        type: "ir.actions.act_window",
+        views: [
+            [false, "kanban"],
+            [false, "list"],
+        ],
+    });
+
+    expect(".o_kanban_view").toHaveCount(1);
+    await getService("action").switchView("list");
+    expect(".o_list_view").toHaveCount(1);
+
+    // simulate a scroll in the list view
+    queryOne(".o_list_view").scrollTop = 200;
+
+    await getService("action").switchView("kanban");
+    expect(".o_kanban_view").toHaveCount(1);
+
+    // the list is "lazy", so it displays the control panel directly, and the renderer later with
+    // the data => simulate this and check that the scroll position is correctly restored
+    def = new Deferred();
+    await getService("action").switchView("list");
+    expect(".o_list_view").toHaveCount(1);
+    expect(".o_list_renderer").toHaveCount(0);
+    def.resolve();
+    await animationFrame();
+    expect(".o_list_renderer").toHaveCount(1);
+    expect(".o_list_view").toHaveProperty("scrollTop", 200);
+});

--- a/addons/web/static/tests/views/pivot_view.test.js
+++ b/addons/web/static/tests/views/pivot_view.test.js
@@ -1,5 +1,5 @@
 import { expect, test } from "@odoo/hoot";
-import { queryAll, queryAllTexts, queryFirst, queryOne, queryText } from "@odoo/hoot-dom";
+import { queryAll, queryAllTexts, queryFirst, queryOne, queryText, resize } from "@odoo/hoot-dom";
 import { animationFrame, Deferred, mockDate } from "@odoo/hoot-mock";
 import { markup } from "@odoo/owl";
 import {
@@ -3909,4 +3909,103 @@ test("pivot views make their control panel available directly", async () => {
     def.resolve();
     await animationFrame();
     expect(".o_pivot_view .o_pivot").toHaveCount(1);
+});
+
+test.tags("desktop");
+test("scroll position is restored when coming back to pivot view", async () => {
+    Partner._views = {
+        kanban: `
+            <pivot>
+                <field name="foo" type="row"/>
+            </pivot>`,
+        list: `<list><field name="foo"/></list>`,
+        search: `<search />`,
+    };
+
+    for (let i = 1; i < 20; i++) {
+        Partner._records.push({ id: 100 + i, foo: 100 + i });
+    }
+
+    let def;
+    onRpc("formatted_read_group", () => def);
+    await resize({ width: 800, height: 300 });
+    await mountWithCleanup(WebClient);
+    await getService("action").doAction({
+        res_model: "partner",
+        type: "ir.actions.act_window",
+        views: [
+            [false, "pivot"],
+            [false, "list"],
+        ],
+        context: {
+            group_by: ["foo"],
+        },
+    });
+
+    expect(".o_pivot_view").toHaveCount(1);
+    // simulate a scroll in the pivot view
+    queryOne(".o_content").scrollTop = 200;
+
+    await getService("action").switchView("list");
+    expect(".o_list_view").toHaveCount(1);
+
+    // the pivot is "lazy", so it displays the control panel directly, and the renderer later with
+    // the data => simulate this and check that the scroll position is correctly restored
+    def = new Deferred();
+    await getService("action").switchView("pivot");
+    expect(".o_pivot_view").toHaveCount(1);
+    expect(".o_content .o_pivot").toHaveCount(0);
+    def.resolve();
+    await animationFrame();
+    expect(".o_content .o_pivot").toHaveCount(1);
+    expect(".o_content").toHaveProperty("scrollTop", 200);
+});
+
+test.tags("mobile");
+test("scroll position is restored when coming back to pivot view (mobile)", async () => {
+    Partner._views = {
+        kanban: `
+            <pivot>
+                <field name="foo" type="row"/>
+            </pivot>`,
+        list: `<list><field name="foo"/></list>`,
+        search: `<search />`,
+    };
+
+    for (let i = 1; i < 20; i++) {
+        Partner._records.push({ id: 100 + i, foo: 100 + i });
+    }
+
+    let def;
+    onRpc("formatted_read_group", () => def);
+    await mountWithCleanup(WebClient);
+    await getService("action").doAction({
+        res_model: "partner",
+        type: "ir.actions.act_window",
+        views: [
+            [false, "pivot"],
+            [false, "list"],
+        ],
+        context: {
+            group_by: ["foo"],
+        },
+    });
+
+    expect(".o_pivot_view").toHaveCount(1);
+    // simulate a scroll in the pivot view
+    queryOne(".o_pivot_view").scrollTop = 200;
+
+    await getService("action").switchView("list");
+    expect(".o_list_view").toHaveCount(1);
+
+    // the pivot is "lazy", so it displays the control panel directly, and the renderer later with
+    // the data => simulate this and check that the scroll position is correctly restored
+    def = new Deferred();
+    await getService("action").switchView("pivot");
+    expect(".o_pivot_view").toHaveCount(1);
+    expect(".o_content .o_pivot").toHaveCount(0);
+    def.resolve();
+    await animationFrame();
+    expect(".o_content .o_pivot").toHaveCount(1);
+    expect(".o_pivot_view").toHaveProperty("scrollTop", 200);
 });


### PR DESCRIPTION
When coming back to a view using the breadcrumb or with the view switcher, we want to restore the local state of the view as it was when we left it, in particular the scroll position. This is handled by the `useSetupAction` hook, for all views (except for the list as the scrolling container is custom, because of the fixed table header).

However, since [1], it was no longer working in kanban, pivot and list (mobile only). This was due to the fact that those views are now "lazy", i.e. they are rendered directly, without the data, such that the control panel is available asap. As a consequence, when `onMounted` is called (i.e. when the hook attempts to restore the scroll position), there's no scrollable content yet.

This commit fixes the issue by allowing the controllers to restore the scroll position themselves, when their content is ready. In addition, a custom treatment was necessary for the kanban view, in mobile *and* if grouped, as each column has its own vertical scrollbar.

[1] https://github.com/odoo/odoo/pull/205129

task~5086324

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
