### PR TITLE
[FIX] point_of_sale: sendForceDone set paymentTerminalInProgress to false

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -608,6 +608,7 @@ export class PaymentScreen extends Component {
     }
     async sendForceDone(line) {
         line.set_payment_status("done");
+        this.pos.paymentTerminalInProgress = false;
         const config = this.pos.config;
         const currency = this.pos.currency;
         const currentOrder = line.pos_order_id;


### PR DESCRIPTION
Before this commit, the function sendForceDone was not setting paymentTerminalInProgress to false, which blocked the user from doing another terminal payment as the payment methods linked to a terminal are not clickable.

After this commit, sendForceDone can be used without blocking future terminal payments.

opw-4978772

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
