### PR TITLE
[FIX] hr_attendance: barcode scanner disabled in barcode_manual kiosk mode

### DIFF
--- a/addons/hr_attendance/static/src/public_kiosk/public_kiosk_app.xml
+++ b/addons/hr_attendance/static/src/public_kiosk/public_kiosk_app.xml
@@ -8,7 +8,7 @@
 <t t-name="hr_attendance.BarcodeScanner" t-inherit="barcodes.BarcodeScanner" t-inherit-mode="primary">
     <xpath expr="//div[hasclass('o_barcode_mobile_container')]" position="replace">
         <div class="o_hr_attendance_kiosk d-flex justify-content-around" t-att-class="{'position-relative' : !isDisplayStandalone}">
-            <button t-if="isBarcodeScannerSupported" t-att-disabled="props.kioskMode === 'barcode_manual'"  t-on-click="openMobileScanner" class="o_mobile_barcode btn btn-light btn-lg p-5 rounded-3" t-att-class="{'position-absolute' : !isDisplayStandalone}">
+            <button t-if="isBarcodeScannerSupported" t-on-click="openMobileScanner" class="o_mobile_barcode btn btn-light btn-lg p-5 rounded-3" t-att-class="{'position-absolute' : !isDisplayStandalone}">
                 <i class="fa fa-3x fa-barcode mb-3"/>
                 <span class="d-block">Scan your badge</span>
             </button>


### PR DESCRIPTION
Issue:

In this bug, barcode scanner is disabled in barcode_manual kiosk mode.

To reproduce:
1- Create a db with `hr_attendance` installed
2- Set `Kiosk Mode` to `Barcode / RFID AND Manual Selection`
3- Open `Kiosk Mode`. As you see the scanner is disabled.

`t-att-disabled` shouldn't be set to `barcode_manual` as it should not be disabled in `barcode_manual` mode.

Also there is no need of `t-att-disabled` attribute at all as:
https://github.com/odoo/odoo/blob/f6b430245b98fb55cac7c8303b7f5bd8a3e1c84e/addons/hr_attendance/static/src/public_kiosk/public_kiosk_app.xml#L113-L114
the `KioskBarcodeScanner` will not be mounted if the mode is manual.

opw-5153954
