### PR TITLE
[IMP] l10n_br: extract_single_line_per_tax default to False

### DIFF
--- a/addons/l10n_br/models/template_br.py
+++ b/addons/l10n_br/models/template_br.py
@@ -31,6 +31,7 @@ class AccountChartTemplate(models.AbstractModel):
                 'account_purchase_tax_id': 'tax_template_in_icms_interno17',
                 'expense_account_id': 'account_template_30101030101',
                 'income_account_id': 'account_template_30101010105',
+                'extract_single_line_per_tax': False,
             },
         }
 


### PR DESCRIPTION
This PR sets the default value of `extract_single_line_per_tax` to False for Brazilian companies.
This change ensures that NF(S)-e PDFs, which are mostly displayed as a single-line description via OCR, are handled correctly.

task-4753990

Enterprise PR: https://github.com/odoo/enterprise/pull/95581