### PR TITLE
[FIX] html_editor: fix hint and power button visibility in empty blocks

### DIFF
--- a/addons/html_editor/static/src/main/hint_plugin.js
+++ b/addons/html_editor/static/src/main/hint_plugin.js
@@ -1,7 +1,7 @@
 import { Plugin } from "@html_editor/plugin";
-import { isEmptyBlock, isProtected } from "@html_editor/utils/dom_info";
+import { isEditorTab, isEmptyBlock, isProtected } from "@html_editor/utils/dom_info";
 import { removeClass } from "@html_editor/utils/dom";
-import { childNodes, selectElements } from "@html_editor/utils/dom_traversal";
+import { childNodes, descendants, selectElements } from "@html_editor/utils/dom_traversal";
 import { closestBlock } from "../utils/blocks";
 import { baseContainerGlobalSelector } from "@html_editor/utils/base_container";
 
@@ -71,14 +71,24 @@ export class HintPlugin extends Plugin {
             for (const hint of this.getResource("hints")) {
                 if (hint.selector) {
                     const el = closestBlock(editableSelection.anchorNode);
-                    if (el && el.matches(hint.selector) && !isProtected(el) && isEmptyBlock(el)) {
+                    if (
+                        el &&
+                        el.matches(hint.selector) &&
+                        !isProtected(el) &&
+                        isEmptyBlock(el) &&
+                        !descendants(el).some(isEditorTab)
+                    ) {
                         this.makeHint(el, hint.text);
                         this.hint = el;
                     }
                 } else {
                     const target = hint.target(selectionData, this.editable);
                     // Do not replace an existing empty block hint by a temp hint.
-                    if (target && !target.classList.contains("o-we-hint")) {
+                    if (
+                        target &&
+                        !target.classList.contains("o-we-hint") &&
+                        !descendants(target).some(isEditorTab)
+                    ) {
                         this.makeHint(target, hint.text);
                         this.hint = target;
                         return;

--- a/addons/html_editor/static/src/main/power_buttons_plugin.js
+++ b/addons/html_editor/static/src/main/power_buttons_plugin.js
@@ -1,8 +1,8 @@
 import { Plugin } from "@html_editor/plugin";
 import { baseContainerGlobalSelector } from "@html_editor/utils/base_container";
 import { closestBlock } from "@html_editor/utils/blocks";
-import { isEmptyBlock } from "@html_editor/utils/dom_info";
-import { closestElement } from "@html_editor/utils/dom_traversal";
+import { isEditorTab, isEmptyBlock } from "@html_editor/utils/dom_info";
+import { closestElement, descendants } from "@html_editor/utils/dom_traversal";
 import { omit, pick } from "@web/core/utils/objects";
 
 /** @typedef {import("./powerbox/powerbox_plugin").PowerboxCommand} PowerboxCommand */
@@ -110,6 +110,7 @@ export class PowerButtonsPlugin extends Plugin {
             element?.matches(baseContainerGlobalSelector) &&
             editableRect.bottom > blockRect.top &&
             isEmptyBlock(block) &&
+            !descendants(block).some(isEditorTab) &&
             !this.services.ui.isSmall &&
             !closestElement(editableSelection.anchorNode, "td") &&
             !block.style.textAlign &&

--- a/addons/html_editor/static/src/main/power_buttons_plugin.js
+++ b/addons/html_editor/static/src/main/power_buttons_plugin.js
@@ -107,7 +107,7 @@ export class PowerButtonsPlugin extends Plugin {
         const editableRect = this.editable.getBoundingClientRect();
         if (
             editableSelection.isCollapsed &&
-            element?.matches(baseContainerGlobalSelector) &&
+            block?.matches(baseContainerGlobalSelector) &&
             editableRect.bottom > blockRect.top &&
             isEmptyBlock(block) &&
             !descendants(block).some(isEditorTab) &&

--- a/addons/html_editor/static/src/main/powerbox/powerbox_plugin.js
+++ b/addons/html_editor/static/src/main/powerbox/powerbox_plugin.js
@@ -7,6 +7,7 @@ import { Powerbox } from "./powerbox";
 import { withSequence } from "@html_editor/utils/resource";
 import { omit, pick } from "@web/core/utils/objects";
 import { baseContainerGlobalSelector } from "@html_editor/utils/base_container";
+import { closestBlock } from "@html_editor/utils/blocks";
 
 /** @typedef { import("@html_editor/core/selection_plugin").EditorSelection } EditorSelection */
 /** @typedef { import("@html_editor/core/user_command_plugin").UserCommand } UserCommand */
@@ -82,7 +83,7 @@ import { baseContainerGlobalSelector } from "@html_editor/utils/base_container";
  */
 function target(selectionData) {
     const node = selectionData.editableSelection.anchorNode;
-    const el = node.nodeType === Node.ELEMENT_NODE ? node : node.parentElement;
+    const el = closestBlock(node);
     if (
         selectionData.documentSelectionIsInEditable &&
         el.matches(baseContainerGlobalSelector) &&

--- a/addons/html_editor/static/tests/format/bold.test.js
+++ b/addons/html_editor/static/tests/format/bold.test.js
@@ -252,7 +252,10 @@ test("should insert a span zws when toggling a formatting command twice", () =>
         // todo: It would be better to remove the zws entirely so that
         // the P could have the "/" hint but that behavior might be
         // complex with the current implementation.
-        contentAfterEdit: `<p>${span(`[]\u200B`, "first")}</p>`,
+        contentAfterEdit: `<p placeholder='Type "/" for commands' class="o-we-hint">${span(
+            `[]\u200B`,
+            "first"
+        )}</p>`,
     }));
 
 // This test uses execCommand to reproduce as closely as possible the browser's
@@ -387,7 +390,12 @@ test("should not remove empty bold tag in an empty block when changing selection
 
     bold(editor);
     await tick();
-    expect(getContent(el)).toBe(`<p>abcd</p><p>${strong("[]\u200B", "first")}</p>`);
+    expect(getContent(el)).toBe(
+        `<p>abcd</p><p placeholder='Type "/" for commands' class="o-we-hint">${strong(
+            "[]\u200B",
+            "first"
+        )}</p>`
+    );
 
     await simulateArrowKeyPress(editor, "ArrowUp");
     await tick(); // await selectionchange

--- a/addons/html_editor/static/tests/hint.test.js
+++ b/addons/html_editor/static/tests/hint.test.js
@@ -64,6 +64,14 @@ test("should not display hint in paragraph with media content", async () => {
     expect(getContent(el)).toBe(content);
 });
 
+test("should not display hint in paragraph with tab", async () => {
+    const content =
+        '<p><span class="oe-tabs" contenteditable="false" style="width: 40px;">\t</span>\u200b[]</p>';
+    const { el } = await setupEditor(content);
+    // Unchanged, no empty paragraph hint.
+    expect(getContent(el)).toBe(content);
+});
+
 test("should not lose track of temporary hints on split block", async () => {
     const { el, editor, plugins } = await setupEditor("<p>[]</p>", {});
     expect(getContent(el)).toBe(`<p placeholder='Type "/" for commands' class="o-we-hint">[]</p>`);

--- a/addons/html_editor/static/tests/hint.test.js
+++ b/addons/html_editor/static/tests/hint.test.js
@@ -9,6 +9,7 @@ import {
     setSelection,
 } from "./_helpers/selection";
 import { insertText } from "./_helpers/user_actions";
+import { em, s, strong, u } from "./_helpers/tags";
 
 test("hints are removed when editor is destroyed", async () => {
     const { el, editor } = await setupEditor("<p>[]</p>", {});
@@ -70,6 +71,41 @@ test("should not display hint in paragraph with tab", async () => {
     const { el } = await setupEditor(content);
     // Unchanged, no empty paragraph hint.
     expect(getContent(el)).toBe(content);
+});
+
+test("should display hint in paragraph with strong (bold)", async () => {
+    const { el } = await setupEditor(`<p>${strong("[]\u200B", "first")}</p>`);
+    // hint should be visible
+    expect(getContent(el)).toBe(
+        `<p placeholder='Type "/" for commands' class="o-we-hint">${strong(
+            "[]\u200B",
+            "first"
+        )}</p>`
+    );
+});
+
+test("should display hint in paragraph with em (italic)", async () => {
+    const { el } = await setupEditor(`<p>${em("[]\u200B", "first")}</p>`);
+    // hint should be visible
+    expect(getContent(el)).toBe(
+        `<p placeholder='Type "/" for commands' class="o-we-hint">${em("[]\u200B", "first")}</p>`
+    );
+});
+
+test("should display hint in paragraph with u (underline)", async () => {
+    const { el } = await setupEditor(`<p>${u("[]\u200B", "first")}</p>`);
+    // hint should be visible
+    expect(getContent(el)).toBe(
+        `<p placeholder='Type "/" for commands' class="o-we-hint">${u("[]\u200B", "first")}</p>`
+    );
+});
+
+test("should display hint in paragraph with s (strikethrough)", async () => {
+    const { el } = await setupEditor(`<p>${s("[]\u200B", "first")}</p>`);
+    // hint should be visible
+    expect(getContent(el)).toBe(
+        `<p placeholder='Type "/" for commands' class="o-we-hint">${s("[]\u200B", "first")}</p>`
+    );
 });
 
 test("should not lose track of temporary hints on split block", async () => {

--- a/addons/html_editor/static/tests/power_buttons.test.js
+++ b/addons/html_editor/static/tests/power_buttons.test.js
@@ -55,6 +55,13 @@ describe("visibility", () => {
         expect(".o_we_power_buttons").not.toBeVisible();
     });
 
+    test("should not show power buttons on block p tag with tab", async () => {
+        await setupEditor(
+            `<p><span class="oe-tabs" contenteditable="false" style="width: 40px;">\t</span>\u200b[]</p>`
+        );
+        expect(".o_we_power_buttons").not.toBeVisible();
+    });
+
     test("should not show power buttons on non empty block P tag", async () => {
         await setupEditor("<p>[]<br><br></p>");
         expect(".o_we_power_buttons").not.toBeVisible();

--- a/addons/html_editor/static/tests/power_buttons.test.js
+++ b/addons/html_editor/static/tests/power_buttons.test.js
@@ -9,6 +9,7 @@ import { Plugin } from "@html_editor/plugin";
 import { closestElement } from "@html_editor/utils/dom_traversal";
 import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
 import { expectElementCount } from "./_helpers/ui_expectations";
+import { em, s, strong, u } from "./_helpers/tags";
 
 describe.tags("desktop");
 describe("visibility", () => {
@@ -18,6 +19,26 @@ describe("visibility", () => {
         insertText(editor, "a");
         await animationFrame();
         expect(".o_we_power_buttons").not.toBeVisible();
+    });
+
+    test("should show power buttons on P tag containing strong (bold)", async () => {
+        await setupEditor(`<p>${strong("[]\u200B", "first")}</p>`);
+        expect(".o_we_power_buttons").toBeVisible();
+    });
+
+    test("should show power buttons on P tag containing em (italic)", async () => {
+        await setupEditor(`<p>${em("[]\u200B", "first")}</p>`);
+        expect(".o_we_power_buttons").toBeVisible();
+    });
+
+    test("should show power buttons on P tag containing u (underline)", async () => {
+        await setupEditor(`<p>${u("[]\u200B", "first")}</p>`);
+        expect(".o_we_power_buttons").toBeVisible();
+    });
+
+    test("should show power buttons on P tag containing s (strikethrough)", async () => {
+        await setupEditor(`<p>${s("[]\u200B", "first")}</p>`);
+        expect(".o_we_power_buttons").toBeVisible();
     });
 
     test("should not show power buttons on heading tags", async () => {


### PR DESCRIPTION
Description of the issue this PR addresses:

- Hint and power buttons are incorrectly shown or hidden in empty blocks when the block contains a Tab or only empty formatting tags (`<strong>, <em>, <u>, <s>`).

Current behavior before PR:

- Pressing Tab in an empty block leaves the hint and buttons visible.
- Empty paragraphs containing only formatting tags do not show the hint and buttons.

Desired behavior after PR is merged:

- Hint and power buttons are not shown when a block contains a Tab.
- Hint and power buttons are correctly visible when a block contains only empty formatting tags.

task-5062294

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
