### PR TITLE
[FIX] l10n_eu_oss: prevent error on OSS Tax mapping when tax group is missing

### DIFF
--- a/addons/l10n_eu_oss/models/res_company.py
+++ b/addons/l10n_eu_oss/models/res_company.py
@@ -46,7 +46,9 @@ class ResCompany(models.Model):
             oss_countries = eu_countries - company.account_fiscal_country_id - multi_tax_reports_countries_fpos.country_id
             tg = self.env['account.tax.group'].search([
                 *self.env['account.tax.group']._check_company_domain(company),
-                ('tax_payable_account_id', '!=', False)], limit=1)
+                ('tax_payable_account_id', '!=', False), ('tax_receivable_account_id', '!=', False)], limit=1)
+            if not tg:
+                continue
             default_oss_payable_account = self.env['account.account']
 
             eu_vat_country_group_id = self.env.ref('account.europe_vat').id


### PR DESCRIPTION
**Steps to Reproduce:**
1. Install the "**Belgium - Accounting**" (`l10n_be`) module with demo data.
2. Switch to the company - **BE Company CoA**.
3. Remove the "**Tax Payable Account**" from all the tax groups.
4. In setting, under _EU Intra-community Distance Selling_ section, click on "**OSS Tax mapping**".

**Error:**
`ValueError - External ID not found in the system: account.1_oss_tax_group_20_0_SK`

**Note:** If only the "**Tax Receivable Account**" is removed from all tax groups. The following error occurs;
`TypeError: expected string or bytes-like object`

**Cause:**
At [1], the system searches for a tax group with a defined `tax_payable_account_id`.
Also, at [2], the `oss_tax_group_local_xml_id` is created only when the tax group (tg) exists. However, when no tax group is found, the code tries to fetch the missing xml id at [3], resulting in a ValueError.
Similarly, when the receivable account is missing, the execution also fails, leading to a TypeError.

**Fix:**
This commit updated the tax group search condition to include both `tax_payable_account_id` and `tax_receivable_account_id`. Also, added skipping further processing if the related tax group is not found.

[1] - https://github.com/odoo/odoo/blob/fb30a9b12667f6b1195e6bd6f8db69f44ad5ca2a/addons/l10n_eu_oss/models/res_company.py#L47-L49
[2] - https://github.com/odoo/odoo/blob/fb30a9b12667f6b1195e6bd6f8db69f44ad5ca2a/addons/l10n_eu_oss/models/res_company.py#L115-L146
[3] - https://github.com/odoo/odoo/blob/fb30a9b12667f6b1195e6bd6f8db69f44ad5ca2a/addons/l10n_eu_oss/models/res_company.py#L164

sentry-6932155430