### PR TITLE
[FIX] im_livechat: prevent user creation from the agent list

### DIFF
--- a/addons/im_livechat/views/im_livechat_channel_views.xml
+++ b/addons/im_livechat/views/im_livechat_channel_views.xml
@@ -101,14 +101,14 @@
                                            domain="[['all_group_ids', 'in', %(im_livechat.im_livechat_group_user)d]]"
                                            mode="list,kanban"
                                            context="{'add_livechat_channel_ctx': True}">
-                                        <list no_open="1">
+                                        <list no_open="1" create="0">
                                             <field name="partner_id" string="Agent" widget="many2one_avatar_user" width="175px" context="{'im_livechat_hide_partner_company': True}"/>
                                             <field name="livechat_is_in_call" widget="boolean_phone" nolabel="1"/>
                                             <field string="Languages" name="livechat_lang_ids" widget="many2many_tags" optional="show"/>
                                             <field string="Expertise" name="livechat_expertise_ids" widget="many2many_tags" optional="show"/>
                                             <field string="Ongoing Sessions" name="livechat_ongoing_session_count" width="150px" optional="show"/>
                                         </list>
-                                        <kanban class="o_kanban_mobile" can_open="False">
+                                        <kanban class="o_kanban_mobile" can_open="False" create="0">
                                             <templates>
                                                 <t t-name="card" class="flex-row">
                                                     <aside>


### PR DESCRIPTION
**Steps to reproduce:**

Go to 'Live Chat'
Open the live chat channel form view by clicking on the hamburger icon 
Click 'Add a line' to add another agent
A popup with live chat users will appear
Click 'New' at the bottom to create the new user
A simplified form view will open to create a user
Fill in all the details and click 'Save & Close'

**Current behavior before PR:**

A banner appears with the message 'Missing required fields'. This occurs because the 'partner_id' field, which is required, is included in the agent list view but not in the user creation form. As a result, the user creation process cannot be completed.

**Desired behavior after PR is merged:**

It will no longer be possible to create a new user from the agent list view.

task-5172541

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
