### PR TITLE
[FIX] repair, website_sale: display repair service products on website

### DIFF
--- a/addons/repair/models/product.py
+++ b/addons/repair/models/product.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models, _
+from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
 
@@ -56,3 +56,7 @@ class ProductTemplate(models.Model):
 
     service_tracking = fields.Selection(selection_add=[('repair', 'Repair Order')],
                                         ondelete={'repair': 'set default'})
+
+    @api.model
+    def _get_saleable_tracking_types(self):
+        return super()._get_saleable_tracking_types() + ['repair']

--- a/addons/website_sale/static/tests/tours/website_sale_buy.js
+++ b/addons/website_sale/static/tests/tours/website_sale_buy.js
@@ -16,3 +16,16 @@ registry.category("web_tour.tours").add('shop_buy_product', {
         ...tourUtils.payWithTransfer({ redirect: true }),
     ]
 });
+
+registry.category("web_tour.tours").add('shop_repair_product', {
+    url: '/shop',
+    steps: () => [
+        ...tourUtils.searchProduct("Test Repair Service", { select: true }),
+        {
+            content: "click on add to cart",
+            trigger: '#product_detail form #add_to_cart',
+            run: "click",
+        },
+        tourUtils.goToCart(),
+    ]
+});

--- a/addons/website_sale/tests/test_sale_process.py
+++ b/addons/website_sale/tests/test_sale_process.py
@@ -170,6 +170,20 @@ class TestSaleProcess(HttpCaseWithUserDemo, WebsiteSaleCommon, HttpCaseWithWebsi
         })
         self.start_tour("/shop", 'google_analytics_add_to_cart')
 
+    def test_06_public_user_shop_repair(self):
+        """ Public user purchasing repair service products in website shop. """
+        if self.env['ir.module.module']._get('repair').state != 'installed':
+            self.skipTest("Repair is not installed")
+
+        self.env['product.template'].create({
+            'name': 'Test Repair Service',
+            'type': 'service',
+            'service_tracking': 'repair',
+            'sale_ok': True,
+            'is_published': True,
+        })
+        self.start_tour("/", 'shop_repair_product', login=None)
+
     def test_update_same_address_billing_shipping_edit(self):
         ''' Phone field should be required when updating an adress for billing and shipping '''
         self.env['product.product'].create({


### PR DESCRIPTION
Steps to reproduce:
-------------------------
1. Install repair and website_sale modules
2. Create a product that is the service type
3. Configure a product to create a repair order when the product is ordered
4. Publish the product from the Sales tab
5. Open the website without being signed in
6. Search for that product

Observation:
-------------------------
The product is not visible on the website shop.

Issue:
-------------------------
The method `_get_saleable_tracking_types(self)` is used to determine which product service tracking types are considered saleable on the website. However, this method was not defined for repair products, causing them to be excluded from the domain used to fetch saleable products. https://github.com/odoo/odoo/blob/b0203ae02d472bd7522bc21971f0e659766eaffe/addons/website_sale/models/website.py#L301-L308

Solution:
-------------------------
Define the `_get_saleable_tracking_types(self)` method for repair products so they are properly included in website listings.

opw-5102204