### PR TITLE
[FIX] pos_self_order: fix several issues kot labels, order button

### DIFF
--- a/addons/point_of_sale/static/src/app/store/order_change_receipt_template.xml
+++ b/addons/point_of_sale/static/src/app/store/order_change_receipt_template.xml
@@ -13,7 +13,7 @@
                     <span>By: <t t-esc="data.employee_name"/></span>
                 </div>
                 <span class="my-4" style="font-size: 150%;">
-                    <span>Order <strong><t t-esc="data.pos_reference"/></strong></span>
+                    <span class='order-ref-prefix'>Order </span><strong><t t-esc="data.pos_reference"/></strong>
                     <strong t-if="data.tracking_number" class="fw-light my-3">
                         # <t t-esc="data.tracking_number"/>
                     </strong>

--- a/addons/pos_online_payment_self_order/__manifest__.py
+++ b/addons/pos_online_payment_self_order/__manifest__.py
@@ -27,6 +27,9 @@
         'pos_self_order.assets_tests': [
             'pos_online_payment_self_order/static/tests/tours/pos_self_order_mobile_online_payment_tour.js',
         ],
+        'web.assets_unit_tests': [
+            'pos_online_payment_self_order/static/tests/unit/**/*',
+        ],
     },
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',

--- a/addons/pos_online_payment_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_online_payment_self_order/static/src/app/services/self_order_service.js
@@ -62,4 +62,16 @@ patch(SelfOrder.prototype, {
         );
         return [...new Set([...pm, ...online_pms])];
     },
+    shouldUpdateLastOrderChange() {
+        if (
+            this.config.self_ordering_mode === "mobile" &&
+            this.config.self_order_online_payment_method_id &&
+            this.config.self_ordering_pay_after !== "meal"
+        ) {
+            // The last order change should not be updated in this case,
+            // because the POS will print the prep order when the payment succeeds (see pos_store.js).
+            return false;
+        }
+        return super.shouldUpdateLastOrderChange(...arguments);
+    },
 });

--- a/addons/pos_online_payment_self_order/static/tests/unit/data/pos_config.data.js
+++ b/addons/pos_online_payment_self_order/static/tests/unit/data/pos_config.data.js
@@ -1,0 +1,6 @@
+import { PosConfig } from "@point_of_sale/../tests/unit/data/pos_config.data";
+
+PosConfig._records = PosConfig._records.map((record) => ({
+    ...record,
+    self_order_online_payment_method_id: 99,
+}));

--- a/addons/pos_online_payment_self_order/static/tests/unit/data/pos_payment_method.data.js
+++ b/addons/pos_online_payment_self_order/static/tests/unit/data/pos_payment_method.data.js
@@ -1,0 +1,25 @@
+import { patch } from "@web/core/utils/patch";
+import { PosPaymentMethod } from "@point_of_sale/../tests/unit/data/pos_payment_method.data";
+
+patch(PosPaymentMethod.prototype, {
+    _load_pos_data_fields() {
+        return [...super._load_pos_data_fields(), "is_online_payment"];
+    },
+});
+
+PosPaymentMethod._records = [
+    ...PosPaymentMethod._records,
+    {
+        id: 99,
+        name: "Online payment",
+        is_cash_count: false,
+        split_transactions: false,
+        type: "bank",
+        image: false,
+        sequence: 1,
+        payment_method_type: "none",
+        use_payment_terminal: false,
+        default_qr: false,
+        is_online_payment: true,
+    },
+];

--- a/addons/pos_online_payment_self_order/static/tests/unit/services/self_order_service.test.js
+++ b/addons/pos_online_payment_self_order/static/tests/unit/services/self_order_service.test.js
@@ -1,0 +1,22 @@
+import { test, expect } from "@odoo/hoot";
+import { setupSelfPosEnv, getFilledSelfOrder } from "@pos_self_order/../tests/unit/utils";
+import { definePosSelfModels } from "@pos_self_order/../tests/unit/data/generate_model_definitions";
+
+definePosSelfModels();
+
+test("sendDraftOrderToServer updateLastOrderChange", async () => {
+    const store = await setupSelfPosEnv();
+    const order = await getFilledSelfOrder(store);
+
+    store.config.self_ordering_mode = "mobile";
+    const product4 = store.models["product.template"].get(11);
+    await store.addToCart(product4, 1, "");
+    await store.sendDraftOrderToServer();
+    expect(Object.keys(order.last_order_preparation_change.lines)).toHaveLength(0);
+
+    store.config.self_ordering_pay_after = "meal";
+    const product3 = store.models["product.template"].get(10);
+    await store.addToCart(product3, 1, "");
+    await store.sendDraftOrderToServer();
+    expect(Object.keys(order.last_order_preparation_change.lines)).toHaveLength(4);
+});

--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -633,6 +633,10 @@ export class SelfOrder extends Reactive {
         }
     }
 
+    shouldUpdateLastOrderChange() {
+        return true;
+    }
+
     async sendDraftOrderToServer() {
         if (
             Object.keys(this.currentOrder.changes).length === 0 ||
@@ -645,6 +649,9 @@ export class SelfOrder extends Reactive {
             const tableIdentifier = this.router.getTableIdentifier([]);
             let uuid = this.selectedOrderUuid;
             this.currentOrder.recomputeOrderData();
+            if (this.shouldUpdateLastOrderChange()) {
+                this.currentOrder.updateLastOrderChange();
+            }
             const data = await rpc(
                 `/pos-self-order/process-order/${this.config.self_ordering_mode}`,
                 {

--- a/addons/pos_self_order/static/src/overrides/order_change_receipt_template_inherit.xml
+++ b/addons/pos_self_order/static/src/overrides/order_change_receipt_template_inherit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="pos_self_order.OrderChangeReceiptInherit" t-inherit="point_of_sale.OrderChangeReceipt" t-inherit-mode="extension">
+        <xpath expr="//span[hasclass('order-ref-prefix')]" position="attributes">
+            <attribute name="t-if">!data.pos_reference.startsWith('Self-Order')</attribute>
+        </xpath>
+    </t>
+</templates>

--- a/addons/pos_self_order/static/src/overrides/screens/ticket_screen/ticket_screen.js
+++ b/addons/pos_self_order/static/src/overrides/screens/ticket_screen/ticket_screen.js
@@ -20,6 +20,7 @@ patch(TicketScreen.prototype, {
             return _t("Ongoing");
         }
     },
+    //  Todo: remove in master -->
     getFilteredOrderList() {
         const orders = super.getFilteredOrderList();
         orders.forEach((order) => {

--- a/addons/pos_self_order/static/tests/unit/services/self_order_service.test.js
+++ b/addons/pos_self_order/static/tests/unit/services/self_order_service.test.js
@@ -205,6 +205,16 @@ test("sendDraftOrderToServer", async () => {
     expect(store.models["pos.order"].length).toBe(1);
 });
 
+test("sendDraftOrderToServer updateLastOrderChange", async () => {
+    const store = await setupSelfPosEnv();
+    const order = await getFilledSelfOrder(store);
+
+    const product1 = store.models["product.template"].get(8);
+    await store.addToCart(product1, 1, "");
+    await store.sendDraftOrderToServer();
+    expect(Object.keys(order.last_order_preparation_change.lines)).toHaveLength(3);
+});
+
 describe("cancelOrder", () => {
     test("Normal cancel order", async () => {
         const store = await setupSelfPosEnv();


### PR DESCRIPTION

Configuration:
-------------------------
- Restaurant Mode
- Self-Order Mode: “QR + Ordering”
- Service At: Table (Online Payment)

--------------------------------------------------------------------------------
Issue 1: Extra Order word print in KOT
---------------------

Steps to Reproduce:
1. Make an order using Self Order (QR).
2. Configure and enable the Kitchen Printer.
3. Check the KOT print it shows “Order Self-Order T2”.

Cause:
- The QWeb template always prefixed “Order” regardless of order type.

Fix:
- Added a condition to skip the “Order” label for self-order references:

--------------------------------------------------------------------------------

Issue 2: “Send To Kitchen” Button Visible even order in kitchen
---------------
Steps to Reproduce:
1. Open the Restaurant
2. Place a order from mobile menu and select a table.
3. In the Restaurant UI:
   - Open that table. The "Send To Kitchen" button is still visible even
     though the order was already sent to the kitchen and printed.

Cause:
- In self-order mode  the order is not automatically synced after being sent to
  the kitchen and print.
- As a result, the system still treats it as unsent, leaving the Order button
  visible.

Fix:
- Synced the order state after sending it to the kitchen.
----------------------------------------------------

Task-5106704
