### PR TITLE
[FIX] *: have Owl translate data-tooltip attributes

### DIFF
--- a/addons/im_livechat/static/src/embed/external/boot.js
+++ b/addons/im_livechat/static/src/embed/external/boot.js
@@ -28,6 +28,7 @@ odoo.livechatReady = new Deferred();
     await mount(MainComponentsContainer, target, {
         env,
         templates,
+        translatableAttributes: ["data-tooltip"],
         translateFn: _t,
         dev: env.debug,
     });

--- a/addons/mail/static/src/discuss/core/public/boot.js
+++ b/addons/mail/static/src/discuss/core/public/boot.js
@@ -27,6 +27,7 @@ import { makeEnv, startServices } from "@web/env";
         dev: env.debug,
         env,
         templates,
+        translatableAttributes: ["data-tooltip"],
         translateFn: _t,
     });
 })();

--- a/addons/point_of_sale/static/src/app/main.js
+++ b/addons/point_of_sale/static/src/app/main.js
@@ -15,7 +15,12 @@ const loader = reactive({ isShown: true });
 whenReady(() => {
     // Show loader as soon as the page is ready, do not wait for services to be started
     // as some services load data over RPC and this is why we want to show a loader.
-    mount(Loader, document.body, { templates, translateFn: _t, props: { loader } });
+    mount(Loader, document.body, {
+        templates,
+        translatableAttributes: ["data-tooltip"],
+        translateFn: _t,
+        props: { loader },
+    });
 });
 // The following is mostly a copy of startWebclient but without any of the legacy stuff
 (async function startPosApp() {


### PR DESCRIPTION
Unless you tell Owl to do so, custom attributes like data-tooltip aren't translated.

This commit adds the data-tooltip attribute to the list of translated attributes when missing.

*: im_livechat, mail, point_of_sale