### PR TITLE
[FIX] purchase_stock: remove duplicate code

### DIFF
--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -147,7 +147,7 @@ class StockMove(models.Model):
 
     def _get_value_from_account_move(self, quantity, at_date=None):
         valuation_data = super()._get_value_from_account_move(quantity, at_date=at_date)
-        if not (self.purchase_line_id and self.purchase_line_id):
+        if not self.purchase_line_id:
             return valuation_data
 
         aml_quantity = 0


### PR DESCRIPTION
The same field is used twice in the condition at [1].

This commit removes duplicate code.

[1]- https://github.com/odoo/odoo/blob/b84741d494f12b8d595b2977bc5bc40da39eed89/addons/purchase_stock/models/stock_move.py#L150

No task ID

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
