### PR TITLE
[IMP] point_of_sale: use local targetAddressSpace for LNA

### DIFF
--- a/addons/point_of_sale/static/src/app/hardware_proxy/hardware_proxy_service.js
+++ b/addons/point_of_sale/static/src/app/hardware_proxy/hardware_proxy_service.js
@@ -151,6 +151,7 @@ export class HardwareProxy extends EventBus {
             const response = await browser
                 .fetch(`${url}/hw_proxy/hello`, {
                     signal: timeoutController.signal,
+                    targetAddressSpace: "local",
                 })
                 .catch(() => ({}));
             if (response.ok) {


### PR DESCRIPTION
Enterprise PR: https://github.com/odoo/enterprise/pull/96850

Local Network Access restrictions will start shipping by default in Chrome 142.

As part of this change, local requests will be allowed to use HTTP in an HTTPS context (gated by a browser permission prompt). This will work automatically when the IP is provided directly, however in the case of IoT we often use the odoo-iot DNS domain to resolve the IP. In this case, you must specify the option `targetAddressSpace: "local"` in the `fetch` request.

This commit simply adds this change where appropriate.

task-5157145

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
