### PR TITLE
[ADD] ir.qweb: Adapt portal templates to new t-call behavior

### DIFF
--- a/addons/account/views/account_portal_templates.xml
+++ b/addons/account/views/account_portal_templates.xml
@@ -137,12 +137,9 @@
 
     <template id="portal_invoice_page" name="Invoice/Bill" inherit_id="portal.portal_sidebar" primary="True">
         <xpath expr="//div[hasclass('o_portal_sidebar')]" position="inside">
-            <t t-set="o_portal_fullwidth_alert" groups="sales_team.group_sale_salesman,account.group_account_invoice,account.group_account_readonly">
-                <t t-call="portal.portal_back_in_edit_mode">
-                    <t t-set="backend_url" t-value="'/odoo/action-account.action_move_out_invoice_type/%s' % invoice.id"/>
-                </t>
-            </t>
-
+             <div class="alert alert-info alert-dismissible fade show d-print-none css_editable_mode_hidden" groups="sales_team.group_sale_salesman,account.group_account_invoice,account.group_account_readonly">
+                <t t-call="portal.portal_back_in_edit_mode" backend_url="'/odoo/action-account.action_move_out_invoice_type/%s' % invoice.id"/>
+            </div>
             <div class="row o_portal_invoice_sidebar">
                 <!-- Sidebar -->
                 <t t-call="portal.portal_record_sidebar">

--- a/addons/account/views/terms_template.xml
+++ b/addons/account/views/terms_template.xml
@@ -10,11 +10,9 @@
 
     <template id="account_terms_conditions_page" name="Terms &amp; Conditions">
         <t t-call="web.frontend_layout">
-            <t t-set="o_portal_fullwidth_alert" groups="account.group_account_manager">
-                <t t-call="account.account_terms_conditions_setting_banner">
-                    <t t-set="backend_url" t-value="'/odoo/action-account.action_open_settings'"/>
-                </t>
-            </t>
+             <div class="alert alert-info alert-dismissible fade show d-print-none css_editable_mode_hidden" groups="account.group_account_manager">
+                <t t-call="account.account_terms_conditions_setting_banner" backend_url ="'/odoo/action-account.action_open_settings'"/>
+            </div>
             <div class="oe_structure" id="oe_structure_terms_conditions"/>
                 <div class="container oe_website_terms_conditions">
                     <div id="o_terms_conditions">

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -123,10 +123,10 @@
     <!-- Complete page of the sale_order -->
     <template id="sale_order_portal_template" name="Sales Order" inherit_id="portal.portal_sidebar" primary="True">
         <xpath expr="//div[hasclass('o_portal_sidebar')]" position="inside">
-            <t t-set="o_portal_fullwidth_alert" groups="sales_team.group_sale_salesman">
+            <div class="alert alert-info alert-dismissible fade show d-print-none css_editable_mode_hidden" groups="sales_team.group_sale_salesman">
                 <!-- Uses backend_url provided in rendering values -->
                 <t t-call="portal.portal_back_in_edit_mode"/>
-            </t>
+            </div>
 
             <div
                 class="row o_portal_sale_sidebar"


### PR DESCRIPTION
In this commit(#197296), the behavior of `<t t-call>` has been updated to support parametric template calls. Variables defined inside a nested <t t-set> within a  `<t t-call>` block are no longer visible to the called template due to lazy XML evaluation.

This commit updates QWeb templates to: Pass parameters directly as attributes on <t t-call> instead of using inner <t t-set> tags.
Before fix:
<img width="1875" height="985" alt="image" src="https://github.com/user-attachments/assets/c55d42bc-69a5-42d7-9878-e8334b3cebd9" />
After fix:
<img width="1869" height="974" alt="image" src="https://github.com/user-attachments/assets/62286ffe-879a-4741-a83f-7fbb8d94bb2c" />

opw-5152781

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
