### PR TITLE
[FIX] point_of_sale: BottomSheet don't start at the bottom of the view

### DIFF
--- a/addons/point_of_sale/static/src/overrides/core/dialog/dialog.xml
+++ b/addons/point_of_sale/static/src/overrides/core/dialog/dialog.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
+    <t t-name="point_of_sale.Dialog" t-inherit="web.Dialog" t-inherit-mode="extension">
+        <xpath expr="//div[hasclass('modal-dialog-scrollable')]" position="attributes" >
+            <attribute name="class" remove="modal-dialog-scrollable" separator=" "/>
+        </xpath>
+    </t>
     <t t-name="point_of_sale.Dialog.header" t-inherit="web.Dialog.header" t-inherit-mode="extension">
         <xpath expr="//button[hasclass('o_expand_button')]" position="attributes" >
             <attribute name="t-if">false</attribute>


### PR DESCRIPTION
Since the commit [1], we add the class `modal-dialog-scrollable` to the `modal-dialog`. On mobile, this class has a side effect when used into the POS, all small BottomSheet (dialog) are centered vertically.

This commit adds a XPath to remove this class for the POS bundle.

[1]: odoo/odoo@293723cfe78de90fe210a4e786818350a1267ba4

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
