### PR TITLE
[IMP] portal: allow users to change their profile picture

### DIFF
--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -508,6 +508,19 @@ class CustomerPortal(Controller):
 
         return json.dumps(feedback_dict)
 
+    @http.route('/my/profile/save', type='jsonrpc', auth='user', methods=['POST'], website=True)
+    def save_edited_profile(self, user_id, image_1920):
+        """ Save the edited profile image.
+
+        :param int user_id: The identifier of the user whose profile is being edited.
+        :param str image_1920: The new profile image in base64 format.
+        :return: Boolean indicating whether the write operation was successful.
+        :rtype: bool
+        """
+        if (user_id != request.env.user.id):
+            raise UserError(_("You cannot edit another user's profile."))
+        return request.env.user.write({"image_1920": image_1920})
+
     def _create_or_update_address(
         self,
         partner_sudo,

--- a/addons/portal/static/src/interactions/portal_profile_editor.js
+++ b/addons/portal/static/src/interactions/portal_profile_editor.js
@@ -1,0 +1,83 @@
+import { registry } from "@web/core/registry";
+import { Interaction } from "@web/public/interaction";
+import { getDataURLFromFile } from "@web/core/utils/urls";
+import { checkFileSize } from "@web/core/utils/files";
+import { _t } from "@web/core/l10n/translation";
+import { rpc } from "@web/core/network/rpc";
+
+export class PortalProfileEditor extends Interaction {
+    static selector = ".o_portal_profile_card";
+    dynamicContent = {
+        ".o_file_upload": {
+            "t-on-change": this.onFileChange,
+        },
+        ".o_portal_profile_pic_edit": {
+            "t-on-click.prevent": this.onEditProfile,
+        },
+        ".o_portal_profile_pic_clear": {
+            "t-on-click.prevent": this.onClearProfile,
+        },
+    };
+
+    setup() {
+        this.notification = this.services.notification;
+        this.fileInputEl = this.el.querySelector(".o_file_upload");
+        this.profileEl = this.el.querySelector(".o_profile_picture");
+        this.editBtnEl = this.el.querySelector(".o_portal_profile_pic_edit");
+        this.clearBtnEl = this.el.querySelector(".o_portal_profile_pic_clear");
+    }
+
+    onEditProfile() {
+        this.fileInputEl.click();
+    }
+
+    async onClearProfile() {
+        await this.updateProfileImage({
+            imageData: false,
+        });
+    }
+
+    async onFileChange() {
+        const file = this.fileInputEl.files[0];
+        if (!file || !checkFileSize(file.size, this.notification)) {
+            return;
+        }
+
+        const dataUrl = await getDataURLFromFile(file);
+        const base64Data = dataUrl.split(",")[1];
+        await this.updateProfileImage({
+            imageData: base64Data,
+        });
+    }
+
+    async updateProfileImage({ imageData }) {
+        this.setButtonsDisabled(true);
+        try {
+            await rpc("/my/profile/save", {
+                user_id: parseInt(this.profileEl.dataset.userId),
+                image_1920: imageData,
+            });
+        } catch {
+            this.notification.add(_t("An error occurred while saving your profile."), {
+                type: "danger",
+            });
+        } finally {
+            this.setButtonsDisabled(false);
+            this.fileInputEl.value = '';
+            // Reload the image by adding a timestamp to bypass browser cache.
+            // This is necessary because the image URL remains the same,
+            // and browsers may cache it, preventing the updated image
+            // from being displayed.
+            const imgEl = this.profileEl.querySelector('img');
+            const  imageSrc = imgEl.getAttribute('src').split('?')[0];
+            imgEl.setAttribute('src', `${imageSrc}?t=${Date.now()}`);
+        }
+    }
+
+    setButtonsDisabled(isDisabled) {
+        this.editBtnEl.classList.toggle("disabled", isDisabled);
+        this.clearBtnEl.classList.toggle("disabled", isDisabled);
+    }
+}
+
+registry.category("public.interactions").add("portal.portal_profile_editor", PortalProfileEditor);

--- a/addons/portal/views/address_templates.xml
+++ b/addons/portal/views/address_templates.xml
@@ -405,12 +405,33 @@
         </div>
     </template>
 
+    <template id="portal.profile_picture_card" name="Profile picture card">
+        <div class="o_portal_profile_card">
+            <div class="card mt-3">
+                <div class="card-body">
+                    <div class="d-flex flex-column align-items-center">
+                        <input type="file" class="o_file_upload d-none" accept="image/*"/>
+                        <span class="o_profile_picture d-flex justify-content-center w-75 mb-3" t-att-data-user-id="request.env.user.id" t-field="request.env.user.avatar_512" t-options="{'widget': 'image'}"/>
+                    </div>
+                    <div class="d-flex justify-content-center gap-2">
+                        <button class="btn btn-primary o_portal_profile_pic_edit oe_unremovable" aria-label="Edit">
+                            <i class="fa fa-pencil" title="Edit"/>
+                        </button>
+                        <button class="btn btn-outline-secondary o_portal_profile_pic_clear oe_unremovable" aria-label="Clear">
+                            <i class="fa fa-trash-o" title="Clear"/>
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </template>
+
     <template id="portal.portal_my_details" name="Contact Details">
         <t t-set="no_footer" t-value="1"/>
         <t t-call="portal.portal_layout" additional_title.translate="Contact Details">
             <div class="o_customer_address_fill">
                 <div class="row">
-                    <div name="address_div" class="oe_clear_stucture col-12 col-lg-8">
+                    <div name="address_div" class="oe_clear_stucture col-12">
                         <div>
                             <div id="errors"/> <!-- for js -->
                             <form
@@ -421,10 +442,19 @@
                                 t-att-data-company-country-code="res_company.country_id.code"
                                 t-att-data-submit-url="'/my/address/submit'"
                             >
-                                <div name="address_details" class="row">
-                                    <t t-call="portal.address_form_fields"/>
+                                <div name="form_details" class="row d-flex flex-column-reverse flex-md-row">
+                                    <div class="col-md-9">
+                                        <div name="address_details" class="row">
+                                            <t t-call="portal.address_form_fields"/>
+                                        </div>
+                                    </div>
+                                    <div class="col-md-3">
+                                        <t t-call="portal.profile_picture_card"/>
+                                    </div>
                                 </div>
-                                <t t-call="portal.address_footer"/>
+                                <div class="col-md-9">
+                                    <t t-call="portal.address_footer"/>
+                                </div>
                             </form>
                         </div>
                     </div>


### PR DESCRIPTION
Purpose:
- Previously, modifying a contact or portal user's profile photo was
only possible by a database user.
- This enhancement allows each portal user to update their own profile
picture directly from the portal interface.

After this commit:
- A new interaction is introduced in the portal, enabling users to
change their profile picture.
- The selected image is uploaded and immediately reflected as the
user's new profile picture.

Task: 4049054

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
