### PR TITLE
[FIX] mail: error when inviting members from self chat

### DIFF
--- a/addons/mail/static/src/discuss/core/common/channel_invitation.js
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.js
@@ -193,7 +193,7 @@ export class ChannelInvitation extends Component {
     async onClickInvite() {
         if (this.props.thread.channel_type === "chat") {
             const partnerIds = this.selectedPartners.map((partner) => partner.id);
-            if (this.props.thread.correspondent) {
+            if (this.props.thread.correspondent?.partner_id) {
                 partnerIds.unshift(this.props.thread.correspondent.partner_id.id);
             }
             await this.store.startChat(partnerIds);
@@ -235,8 +235,10 @@ export class ChannelInvitation extends Component {
                     return _t("Invite");
                 }
                 if (this.selectedPartners.length === 1) {
-                    const alreadyChat = Object.values(this.store.Thread.records).some((thread) =>
-                        thread.correspondent?.partner_id.eq(this.selectedPartners[0])
+                    const alreadyChat = Object.values(this.store.Thread.records).some(
+                        (thread) =>
+                            thread.channel_type === "chat" &&
+                            thread.correspondent?.partner_id?.eq(this.selectedPartners[0])
                     );
                     if (alreadyChat) {
                         return _t("Go to conversation");

--- a/addons/mail/static/src/discuss/core/common/store_service_patch.js
+++ b/addons/mail/static/src/discuss/core/common/store_service_patch.js
@@ -61,7 +61,7 @@ const storeServicePatch = {
      */
     getRecentChatPartnerIds() {
         return Object.values(this.Thread.records)
-            .filter((thread) => thread.channel_type === "chat" && thread.correspondent)
+            .filter((thread) => thread.channel_type === "chat" && thread.correspondent?.partner_id)
             .sort((a, b) => compareDatetime(b.lastInterestDt, a.lastInterestDt) || b.id - a.id)
             .map((thread) => thread.correspondent.partner_id.id);
     },


### PR DESCRIPTION
Steps to reproduce:
1. Open Discuss
2. Create a channel/chat with at least one guest member
3. Open self chat
4. Open the `Invite People`
5. Select any user from the invitation list => An error is thrown

Cause:
To display the `Invite` button text, the code filters thread correspondents by
`partner_id`, but guest members have no `partner_id`, resulting in a crash.

This PR fixes this issue.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
