### PR TITLE
[FIX] website_event_track_quiz: show community menu button

### DIFF
--- a/addons/website_event_track_quiz/views/event_event_views.xml
+++ b/addons/website_event_track_quiz/views/event_event_views.xml
@@ -9,6 +9,9 @@
             <xpath expr="//label[@for='community_menu']" position="attributes">
                 <attribute name="invisible">0</attribute>
             </xpath>
+            <field name="community_menu" position="attributes">
+                <attribute name="invisible">0</attribute>
+            </field>
         </field>
     </record>
 


### PR DESCRIPTION
In the event form the "community" button is supposed to be shown when "track quiz" is installed.

However when this was done in [1] there a mistake was made and only the label was removed, as well as the wrong field added after it. That field was removed in [2] but it was again not noticed that only the label was made visible.

It may not appear easily because installing website_event_meet also unhides both the label and the field. Hence you only ge this issue when installing track quiz without it.

However in 18.3 [3] removed website_event_meet which means the issue is not corrected anymore.

task-5159806

[1]: https://github.com/odoo/odoo/commit/147cf5f328f5a55882a62a4279d1d92511628320
[2]: https://github.com/odoo/odoo/commit/c0f0f9f47573b74ca6b1fcdc3383e43f28f7a2e1
[3]: https://github.com/odoo/odoo/commit/9cab4f8f77f71e405971c184544765e8f252a012