### PR TITLE
[IMP] various: improve confirmation modals with meaningful action verbs

### DIFF
--- a/addons/fleet/static/src/js/fleet_form.js
+++ b/addons/fleet/static/src/js/fleet_form.js
@@ -12,9 +12,11 @@ export class FleetFormController extends FormController {
         const menuItems = super.getStaticActionMenuItems();
         menuItems.archive.callback = () => {
             const dialogProps = {
+                title: _t("Archive Vehicle"),
                 body: _t(
-                    "Every service and contract of this vehicle will be considered as archived. Are you sure that you want to archive this record?"
+                    "All services and contracts linked to this vehicle will also be archived.\nAre you sure you want to proceed?"
                 ),
+                confirmLabel: _t("Archive Vehicle & Contracts"),
                 confirm: () => this.model.root.archive(),
                 cancel: () => {},
             };

--- a/addons/hr_expense/static/src/views/expense_form_view.js
+++ b/addons/hr_expense/static/src/views/expense_form_view.js
@@ -25,11 +25,14 @@ export class ExpenseFormController extends FormController {
             await record.save();
             return new Promise((resolve) => {
                 this.dialogService.add(ConfirmationDialog, {
-                    body: _t("An expense of same category, amount and date already exists."),
+                    title: _t("Duplicate Expense found"),
+                    body: _t("An expense with the same category, amount, and date already exists.\nAre you sure you want to submit this one as well?"),
+                    confirmLabel: _t("Submit Expense"),
                     confirm: async () => {
                         await this.orm.call("hr.expense", "action_approve_duplicates", [record.resId]);
                         resolve(true);
                     },
+                    cancel: () => {},
                 }, {
                     onClose: resolve.bind(null, false),
                 });

--- a/addons/hr_recruitment/static/src/views/recruitment_form_controller.js
+++ b/addons/hr_recruitment/static/src/views/recruitment_form_controller.js
@@ -7,11 +7,12 @@ export class RecruitmentFormController extends FormController {
      */
     get archiveDialogProps() {
         const result = super.archiveDialogProps;
+        result.title = _t("Archive job position")
+        result.confirmLabel = _t("Archive")
         result.body =
             this.model.root.data.all_application_count > 0
-                ? _t("This job position and all related applicants will be archived. Are you sure?")
+                ? _t("If you archive this job position, all its applicants will be archived too. Are you sure?")
                 : _t("Are you sure that you want to archive this job position?");
-        console.log(this.model.root.data.all_application_count);
         return result;
     }
 }

--- a/addons/hr_recruitment/static/src/views/recruitment_kanban_view.js
+++ b/addons/hr_recruitment/static/src/views/recruitment_kanban_view.js
@@ -16,8 +16,9 @@ export class RecruitmentKanbanRenderer extends KanbanRenderer {
     async archiveRecord(record, active) {
         if (active && record.data.application_count > 0) {
             this.dialog.add(ConfirmationDialog, {
+                title: _t("Archive job position"),
                 body: _t(
-                    "This job position and all related applicants will be archived. Are you sure?"
+                    "If you archive this job position, all its applicants will be archived too. Are you sure?"
                 ),
                 confirmLabel: _t("Archive"),
                 confirm: () => {

--- a/addons/hr_recruitment/static/src/views/recruitment_list_controller.js
+++ b/addons/hr_recruitment/static/src/views/recruitment_list_controller.js
@@ -7,13 +7,15 @@ export class RecruitmentListController extends ListController {
      */
     get archiveDialogProps() {
         const result = super.archiveDialogProps;
+        result.title = _t("Archive job position")
+        result.confirmLabel = _t("Archive")
         result.body =
             this.model.root.isDomainSelected || this.model.root.selection.length > 1
                 ? _t(
-                      "These job positions and all related applicants will be archived. Are you sure?"
+                      "If you archive these job positions, all their applicants will be archived too. Are you sure?"
                   )
                 : _t(
-                      "This job position and all related applicants will be archived. Are you sure?"
+                      "If you archive this job position, all its applicants will be archived too. Are you sure?"
                   );
         return result;
     }

--- a/addons/html_builder/static/src/core/building_blocks/builder_fontfamilypicker.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_fontfamilypicker.js
@@ -45,9 +45,11 @@ export class BuilderFontFamilyPicker extends Component {
     async onDeleteFontClick(font) {
         const save = await new Promise((resolve) => {
             this.env.services.dialog.add(ConfirmationDialog, {
+                title: _t("Delete Font"),
                 body: _t(
-                    "Deleting a font requires a reload of the page. This will save all your changes and reload the page, are you sure you want to proceed?"
+                    "This change will be applied after saving and reloading the page. Are you sure you want to continue?"
                 ),
+                confirmLabel: _t("Delete & Reload"),
                 confirm: () => resolve(true),
                 cancel: () => resolve(false),
             });

--- a/addons/mail/static/src/core/common/attachment_list.js
+++ b/addons/mail/static/src/core/common/attachment_list.js
@@ -82,7 +82,9 @@ export class AttachmentList extends Component {
             return this.props.unlinkAttachment(attachment);
         }
         this.dialog.add(ConfirmationDialog, {
-            body: _t('Do you really want to delete "%s"?', attachment.name),
+            title: _t('Delete Attachment'),
+            body: _t('Are you sure you want to delete "%s"?\nThis action cannot be undone.', attachment.name),
+            confirmLabel: _t('Delete Attachment'),
             cancel: () => {},
             confirm: () => this.onConfirmUnlink(attachment),
         });

--- a/addons/mail/static/tests/chatter/web/attachment_box.test.js
+++ b/addons/mail/static/tests/chatter/web/attachment_box.test.js
@@ -65,7 +65,7 @@ test("remove attachment should ask for confirmation", async () => {
     await contains(".o-mail-AttachmentCard");
     await contains("button[title='Remove']");
     await click("button[title='Remove']");
-    await contains(".modal-body", { text: 'Do you really want to delete "Blah.txt"?' });
+    await contains(".modal-body", { text: 'Are you sure you want to delete "Blah.txt"?\nThis action cannot be undone.' });
     // Confirm the deletion
     await click(".modal-footer .btn-primary");
     await contains(".o-mail-AttachmentImage", { count: 0 });

--- a/addons/mail/static/tests/crosstab/crosstab.test.js
+++ b/addons/mail/static/tests/crosstab/crosstab.test.js
@@ -155,7 +155,7 @@ test("Remove attachment from message", async () => {
     await openDiscuss(channelId, { target: env2 });
     await contains(`${env1.selector} .o-mail-AttachmentCard`, { text: "test.txt" });
     await click(`${env2.selector} .o-mail-Attachment-unlink`);
-    await click(`${env2.selector} .modal-footer .btn`, { text: "Ok" });
+    await click(`${env2.selector} .modal-footer .btn`, { text: "Delete Attachment" });
     await contains(`${env1.selector} .o-mail-AttachmentCard`, { count: 0, text: "test.txt" });
 });
 

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -1368,7 +1368,7 @@ test("allow attachment delete on authored message", async () => {
     await openDiscuss(channelId);
     await contains(".o-mail-AttachmentImage");
     await click("button[title='Remove']");
-    await contains(".modal-dialog .modal-body", { text: 'Do you really want to delete "BLAH"?' });
+    await contains(".modal-dialog .modal-body", { text: 'Are you sure you want to delete "BLAH"?\nThis action cannot be undone.' });
     await click(".modal-footer .btn-primary");
     await contains(".o-mail-AttachmentImage", { count: 0 });
 });
@@ -1699,7 +1699,7 @@ test("delete all attachments of a message with some text content should still ke
     await openDiscuss(channelId);
     await contains(".o-mail-Message");
     await click(".o-mail-AttachmentContainer button[title='Remove']");
-    await click(".modal button", { text: "Ok" });
+    await click(".modal button", { text: "Delete Attachment" });
     await contains(".o-mail-Message");
 });
 

--- a/addons/mail/static/tests/tours/discuss_channel_public_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_public_tour.js
@@ -180,7 +180,7 @@ registry.category("web_tour.tours").add("discuss_channel_public_tour.js", {
             run: "click",
         },
         {
-            trigger: ".modal:contains(Confirmation) .btn:contains(Ok)",
+            trigger: ".modal:contains(Delete Attachment) .btn:contains(Delete Attachment)",
             run: "click",
         },
         {

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -45,7 +45,9 @@
                     <header>
                         <button name="button_plan" type="object" string="Plan"/>
                         <button name="action_assign"  type="object" string="Check availability"/>
-                        <button name="action_cancel" type="object" string="Cancel" confirm="Are you sure you want to cancel these manufacturing orders?"/>
+                        <button name="action_cancel" type="object" string="Cancel"
+                            confirm="Are you sure you want to cancel these manufacturing orders?&#10;This action cannot be undone."
+                            confirm-title="Cancel Manufacturing Orders" confirm-label="Cancel these Orders"/>
                     </header>
                     <field name="company_id" column_invisible="True"/>
                     <field name="priority" optional="show" widget="priority" nolabel="1" width="20px"/>
@@ -201,9 +203,9 @@
                     <field name="state" widget="statusbar" statusbar_visible="draft,confirmed,done"/>
                     <button name="action_cancel" type="object" string="Cancel" data-hotkey="x"
                             invisible="not id or state in ('done', 'cancel')"
-                            confirm="Are you sure you want to cancel this manufacturing order?"
-                            confirm-label="Confirm"
-                            cancel-label="Discard"/>
+                            confirm="Are you sure you want to cancel this manufacturing order?&#10;This action cannot be undone."
+                            confirm-title="Cancel Manufacturing Order"
+                            confirm-label="Cancel this Order"/>
                     <button name="button_unbuild" type="object" string="Unbuild" invisible="state != 'done'" data-hotkey="shift+v"/>
                 </header>
                 <sheet>

--- a/addons/pos_sale/static/src/app/services/pos_store.js
+++ b/addons/pos_sale/static/src/app/services/pos_store.js
@@ -146,6 +146,7 @@ patch(PosStore.prototype, {
                     useLoadedLots = await ask(this.dialog, {
                         title: _t("SN/Lots Loading"),
                         body: _t("Do you want to load the SN/Lots linked to the Sales Order?"),
+                        cancelLabel: _t("Cancel"),
                     });
                     userWasAskedAboutLoadedLots = true;
                 }

--- a/addons/project/static/src/components/subtask_one2many_field/subtask_list_renderer.js
+++ b/addons/project/static/src/components/subtask_one2many_field/subtask_list_renderer.js
@@ -6,7 +6,9 @@ export class SubtaskListRenderer extends NotebookTaskListRenderer {
     async onDeleteRecord(record) {
         return new Promise((resolve) => {
             this.dialog.add(ConfirmationDialog, {
-                body: _t("Are you sure you want to delete this record?"),
+                title: _t("Delete Subtask"),
+                body: _t("Are you sure you want to delete this subtask? All its content will be lost."),
+                confirmLabel: _t("Delete"),
                 confirm: () => super.onDeleteRecord(record).then(resolve),
                 cancel: resolve,
             });

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -358,7 +358,10 @@
                     string="Cancel"
                     name="action_cancel"
                     type="object"
-                    confirm="Are you sure you want to cancel this order? This may affect related documents or processes."
+                    confirm-title="Cancel Order"
+                    confirm="Cancelling this order will set its status to 'Cancelled' and will update related documents and processes. Are you sure?"
+                    confirm-label="Yes, cancel order"
+                    cancel-label="No, go back"
                     data-hotkey="x"
                     invisible="state not in ['draft', 'sent', 'sale'] or not id or locked"/>
                 <button

--- a/addons/survey/static/src/interactions/survey_form.js
+++ b/addons/survey/static/src/interactions/survey_form.js
@@ -416,9 +416,10 @@ export class SurveyForm extends Interaction {
         } else if (targetEl.value === "finish" && !this.options.sessionInProgress) {
             // Adding pop-up before the survey is submitted when not in live session
             this.dialog.add(ConfirmationDialog, {
-                title: _t("Submit confirmation"),
-                body: _t("Are you sure you want to submit the survey?"),
-                confirmLabel: _t("Submit"),
+                title: _t("Submit survey"),
+                body: _t("Submit your survey? Once it's out, it is like a letter in the mail: it cannot be recalled."),
+                confirmLabel: _t("Yes, submit"),
+                cancelLabel: _t("No, wait a minute"),
                 confirm: () => {
                     this.waitForTimeout(() => this.submitForm({ isFinish: true }), 0);
                 },

--- a/addons/test_website/static/tests/tours/custom_snippets.js
+++ b/addons/test_website/static/tests/tours/custom_snippets.js
@@ -104,7 +104,7 @@ registerWebsitePreviewTour(
         },
         {
             content: "Confirm delete",
-            trigger: ".modal-dialog button:contains('Yes')",
+            trigger: ".modal-dialog button:contains('Delete Block')",
             run: "click",
         },
         {

--- a/addons/web/static/src/core/confirmation_dialog/confirmation_dialog.js
+++ b/addons/web/static/src/core/confirmation_dialog/confirmation_dialog.js
@@ -35,7 +35,7 @@ export class ConfirmationDialog extends Component {
     };
     static defaultProps = {
         confirmLabel: _t("Ok"),
-        cancelLabel: _t("Cancel"),
+        cancelLabel: _t("Discard"),
         confirmClass: "btn-primary",
         title: _t("Confirmation"),
     };

--- a/addons/web/static/src/core/confirmation_dialog/confirmation_dialog.xml
+++ b/addons/web/static/src/core/confirmation_dialog/confirmation_dialog.xml
@@ -3,7 +3,7 @@
 
   <t t-name="web.ConfirmationDialog">
     <Dialog size="'md'" title="props.title" modalRef="modalRef">
-      <p t-out="props.body" class="text-prewrap"/>
+      <p t-out="props.body" class="text-prewrap mb-0"/>
       <t t-set-slot="footer">
         <button class="btn" t-att-class="props.confirmClass" t-on-click="_confirm" t-esc="props.confirmLabel" data-hotkey="q"/>
         <button t-if="props.cancel" class="btn btn-secondary" t-on-click="_cancel" t-esc="props.cancelLabel" data-hotkey="x"/>

--- a/addons/website/static/src/builder/snippet_model.js
+++ b/addons/website/static/src/builder/snippet_model.js
@@ -40,10 +40,14 @@ patch(SnippetModel.prototype, {
      */
     async deleteCustomSnippet(snippet) {
         return new Promise((resolve) => {
-            const message = _t("Are you sure you want to delete the block %s?", snippet.title);
+            const message = _t(
+                "Are you sure you want to remove %(snippetName)s from your list of Custom Blocks?\nThis action is permanent and will affect all users across the website.", {
+                snippetName: snippet.title
+            });
             this.dialog.add(
                 ConfirmationDialog,
                 {
+                    title: _t("Delete Custom Block"),
                     body: message,
                     confirm: async () => {
                         const isInnerContent =
@@ -61,8 +65,8 @@ patch(SnippetModel.prototype, {
                         });
                     },
                     cancel: () => {},
-                    confirmLabel: _t("Yes"),
-                    cancelLabel: _t("No"),
+                    confirmLabel: _t("Delete Block"),
+                    cancelLabel: _t("Keep it"),
                 },
                 {
                     onClose: resolve,

--- a/addons/website/static/src/components/resource_editor/resource_editor.js
+++ b/addons/website/static/src/components/resource_editor/resource_editor.js
@@ -486,10 +486,11 @@ export class ResourceEditor extends Component {
 
     onReset() {
         this.dialog.add(ConfirmationDialog, {
-            title: _t("Careful"),
+            title: _t("Reset to default?"),
             body: _t(
-                "If you reset this file, all your customizations will be lost as it will be reverted to the default file."
+                "All your custom changes will be lost. Are you sure?"
             ),
+            confirmLabel: _t("Reset"),
             confirm: () => this.resetResource(),
             cancel: () => {},
         });

--- a/addons/website/static/tests/tours/html_editor.js
+++ b/addons/website/static/tests/tours/html_editor.js
@@ -315,7 +315,7 @@ registerWebsitePreviewTour(
         },
         {
             content: "confirm reset warning",
-            trigger: ".modal:contains(careful) .modal-footer .btn-primary",
+            trigger: ".modal:contains(Reset to default?) .modal-footer .btn-primary",
             run: "click",
         },
         {

--- a/addons/website_sale/static/src/website_builder/product_ribbon_options_plugin.js
+++ b/addons/website_sale/static/src/website_builder/product_ribbon_options_plugin.js
@@ -396,7 +396,9 @@ class DeleteRibbonAction extends BuilderAction {
     async apply({ editingElement }) {
         const save = await new Promise((resolve) => {
             this.services.dialog.add(ConfirmationDialog, {
-                body: _t("Are you sure you want to delete this ribbon?"),
+                title: _t("Delete Ribbon"),
+                body: _t("It will be removed from all products. Are you sure?"),
+                confirmLabel: _t("Delete Ribbon"),
                 confirm: () => resolve(true),
                 cancel: () => resolve(false),
             });

--- a/odoo/addons/base/rng/common.rng
+++ b/odoo/addons/base/rng/common.rng
@@ -328,6 +328,7 @@
             <rng:optional><rng:attribute name="readonly"/></rng:optional>
             <rng:optional><rng:attribute name="context"/></rng:optional>
             <rng:optional><rng:attribute name="confirm"/></rng:optional>
+            <rng:optional><rng:attribute name="confirm-title"/></rng:optional>
             <rng:optional><rng:attribute name="confirm-label"/></rng:optional>
             <rng:optional><rng:attribute name="cancel-label"/></rng:optional>
             <rng:optional><rng:attribute name="help"/></rng:optional>

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -74,7 +74,7 @@ TRANSLATED_ELEMENTS = {
 TRANSLATED_ATTRS = {
     'string', 'add-label', 'help', 'sum', 'avg', 'confirm', 'placeholder', 'alt', 'title', 'aria-label',
     'aria-keyshortcuts', 'aria-placeholder', 'aria-roledescription', 'aria-valuetext',
-    'value_label', 'data-tooltip', 'label', 'confirm-label', 'cancel-label',
+    'value_label', 'data-tooltip', 'label', 'confirm-label', 'cancel-label', 'confirm-title',
 }
 
 TRANSLATED_ATTRS.update({f't-attf-{attr}' for attr in TRANSLATED_ATTRS})


### PR DESCRIPTION
Improve the clarity of confirmation dialogs by replacing generic "Ok/Cancel" labels with descriptive, action-oriented verbs.
This helps users understand the impact of their decisions and reduces ambiguity in critical actions.

Task-5106240
