### PR TITLE
[REF] account,*: test helpers on record creations

### DIFF
--- a/addons/account/tests/test_account_inalterable_hash.py
+++ b/addons/account/tests/test_account_inalterable_hash.py
@@ -64,7 +64,7 @@ class TestAccountMoveInalterableHash(AccountTestInvoicingCommon):
         self.company_data['default_journal_sale'].restrict_mode_hash_table = True
         self.company_data['default_journal_purchase'].restrict_mode_hash_table = True
         move = self._init_and_post([{'partner': self.partner_a, 'date': '2023-01-01', 'amounts': [1000]}])
-        in_invoice = self.init_invoice("in_invoice", self.partner_a, "2023-01-01", amounts=[1000], post=True)
+        in_invoice = self._create_invoice_one_line(price_unit=1000, move_type='in_invoice', partner_id=self.partner_a.id, post=True)
         # in_invoice and out_invoice should both be hashed on post
         self.assertNotEqual(move.inalterable_hash, False)
         self.assertNotEqual(in_invoice.inalterable_hash, False)

--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -18,7 +18,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
 
         cls.other_currency = cls.setup_other_currency('EUR')
 
-        cls.invoice = cls.init_invoice('in_invoice', products=cls.product_a+cls.product_b)
+        cls.invoice = cls.init_invoice('in_invoice', products=cls.product_a + cls.product_b)
 
         cls.product_line_vals_1 = {
             'name': 'product_a',
@@ -31,7 +31,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
             'price_unit': 800.0,
             'price_subtotal': 800.0,
             'price_total': 920.0,
-            'tax_ids': cls.product_a.supplier_taxes_id.ids,
+            'tax_ids': cls.product_a.supplier_taxes_id.filtered(lambda t: t.company_id == cls.invoice.company_id).ids,
             'tax_line_id': False,
             'currency_id': cls.company_data['currency'].id,
             'amount_currency': 800.0,
@@ -50,7 +50,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
             'price_unit': 160.0,
             'price_subtotal': 160.0,
             'price_total': 208.0,
-            'tax_ids': cls.product_b.supplier_taxes_id.ids,
+            'tax_ids': cls.product_b.supplier_taxes_id.filtered(lambda t: t.company_id == cls.invoice.company_id).ids,
             'tax_line_id': False,
             'currency_id': cls.company_data['currency'].id,
             'amount_currency': 160.0,

--- a/addons/account/tests/test_account_move_in_refund.py
+++ b/addons/account/tests/test_account_move_in_refund.py
@@ -18,7 +18,7 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
 
         cls.other_currency = cls.setup_other_currency('EUR')
 
-        cls.invoice = cls.init_invoice('in_refund', products=cls.product_a+cls.product_b)
+        cls.invoice = cls.init_invoice('in_refund', products=cls.product_a + cls.product_b)
 
         cls.product_line_vals_1 = {
             'product_id': cls.product_a.id,
@@ -30,7 +30,7 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
             'price_unit': 800.0,
             'price_subtotal': 800.0,
             'price_total': 920.0,
-            'tax_ids': cls.product_a.supplier_taxes_id.ids,
+            'tax_ids': cls.product_a.supplier_taxes_id.filtered(lambda tax: tax.company_id == cls.env.company).ids,
             'tax_line_id': False,
             'currency_id': cls.company_data['currency'].id,
             'amount_currency': -800.0,
@@ -49,7 +49,7 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
             'price_unit': 160.0,
             'price_subtotal': 160.0,
             'price_total': 208.0,
-            'tax_ids': cls.product_b.supplier_taxes_id.ids,
+            'tax_ids': cls.product_b.supplier_taxes_id.filtered(lambda tax: tax.company_id == cls.env.company).ids,
             'tax_line_id': False,
             'currency_id': cls.company_data['currency'].id,
             'amount_currency': -160.0,

--- a/addons/account/tests/test_account_move_out_refund.py
+++ b/addons/account/tests/test_account_move_out_refund.py
@@ -15,7 +15,7 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
 
         cls.other_currency = cls.setup_other_currency('HRK')
 
-        cls.invoice = cls.init_invoice('out_refund', products=cls.product_a+cls.product_b)
+        cls.invoice = cls.init_invoice('out_refund', products=cls.product_a + cls.product_b)
 
         cls.product_line_vals_1 = {
             'name': 'product_a',
@@ -28,7 +28,7 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
             'price_unit': 1000.0,
             'price_subtotal': 1000.0,
             'price_total': 1150.0,
-            'tax_ids': cls.product_a.taxes_id.ids,
+            'tax_ids': cls.product_a.taxes_id.filtered(lambda t: t.company_id == cls.invoice.company_id).ids,
             'tax_line_id': False,
             'currency_id': cls.company_data['currency'].id,
             'amount_currency': 1000.0,
@@ -47,7 +47,7 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
             'price_unit': 200.0,
             'price_subtotal': 200.0,
             'price_total': 260.0,
-            'tax_ids': cls.product_b.taxes_id.ids,
+            'tax_ids': cls.product_b.taxes_id.filtered(lambda t: t.company_id == cls.invoice.company_id).ids,
             'tax_line_id': False,
             'currency_id': cls.company_data['currency'].id,
             'amount_currency': 200.0,

--- a/addons/account/tests/test_early_payment_discount.py
+++ b/addons/account/tests/test_early_payment_discount.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.exceptions import ValidationError
-from odoo.tests import tagged, Form
+from odoo.tests import tagged, Form, freeze_time
 from odoo import fields, Command
 
 
@@ -54,17 +54,13 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
         })
 
     # ========================== Tests Payment Terms ==========================
+    @freeze_time('2019-01-01')
     def test_early_payment_end_date(self):
-        inv_1200_10_percents_discount_no_tax = self.env['account.move'].create({
-            'move_type': 'in_invoice',
-            'partner_id': self.partner_a.id,
-            'invoice_date': '2019-01-01',
-            'date': '2019-01-01',
-            'invoice_line_ids': [Command.create({
-                'name': 'line', 'price_unit': 1200.0, 'tax_ids': []
-            })],
-            'invoice_payment_term_id': self.early_pay_10_percents_10_days.id,
-        })
+        inv_1200_10_percents_discount_no_tax = self._create_invoice_one_line(
+            move_type='in_invoice',
+            price_unit=1200.0,
+            invoice_payment_term_id=self.early_pay_10_percents_10_days,
+        )
         for line in inv_1200_10_percents_discount_no_tax.line_ids:
             if line.display_type == 'payment_term':
                 self.assertEqual(
@@ -72,22 +68,18 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
                     fields.Date.from_string('2019-01-11') or False
                 )
 
+    @freeze_time('2019-01-01')
     def test_early_payment_date_eligibility(self):
         """
         Test to check early payment eligibility is based on the date stored
         on the payment term line
         """
-        inv = self.env['account.move'].create({
-            'move_type': 'in_invoice',
-            'partner_id': self.partner_a.id,
-            'invoice_date': '2019-01-01',
-            'date': '2019-01-01',
-            'invoice_line_ids': [Command.create({
-                'name': 'line', 'price_unit': 1200.0, 'tax_ids': []
-            })],
-            'invoice_payment_term_id': self.early_pay_10_percents_10_days.id,
-        })
-        inv.action_post()
+        inv = self._create_invoice_one_line(
+            price_unit=1200.0,
+            post=True,
+            move_type='in_invoice',
+            invoice_payment_term_id=self.early_pay_10_percents_10_days.id,
+        )
         self.assertTrue(inv._is_eligible_for_early_payment_discount(inv.currency_id, fields.Date.from_string('2019-01-10')))
         self.assertFalse(inv._is_eligible_for_early_payment_discount(inv.currency_id, fields.Date.from_string('2019-01-12')))
         # Changing number of days on payment term should not change the discount eligibility
@@ -95,19 +87,15 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
         self.assertTrue(inv._is_eligible_for_early_payment_discount(inv.currency_id, fields.Date.from_string('2019-01-10')))
         self.assertFalse(inv._is_eligible_for_early_payment_discount(inv.currency_id, fields.Date.from_string('2019-01-12')))
 
+    @freeze_time('2019-01-01')
     def test_early_payment_date_eligibility2(self):
         self.early_pay_10_percents_10_days.early_discount = False
-        inv = self.env['account.move'].create({
-            'move_type': 'in_invoice',
-            'partner_id': self.partner_a.id,
-            'invoice_date': '2019-01-01',
-            'date': '2019-01-01',
-            'invoice_line_ids': [Command.create({
-                'name': 'line', 'price_unit': 1200.0, 'tax_ids': []
-            })],
-            'invoice_payment_term_id': self.early_pay_10_percents_10_days.id,
-        })
-        inv.action_post()
+        inv = self._create_invoice_one_line(
+            price_unit=1200.0,
+            post=True,
+            move_type='in_invoice',
+            invoice_payment_term_id=self.early_pay_10_percents_10_days.id,
+        )
         self.assertFalse(inv._is_eligible_for_early_payment_discount(inv.currency_id, fields.Date.from_string('2019-01-10')))
         self.assertFalse(inv._is_eligible_for_early_payment_discount(inv.currency_id, fields.Date.from_string('2019-01-12')))
 
@@ -144,31 +132,22 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
         self.assertTrue(new_report)
 
     # ========================== Tests Taxes Amounts =============================
+    @freeze_time('2019-01-01')
     def test_fixed_tax_amount_discounted_payment_mixed(self):
-        fixed_tax = self.env['account.tax'].create({
-            'name': 'Test 0.05',
-            'amount_type': 'fixed',
-            'amount': 0.05,
-        })
+        fixed_tax = self.fixed_tax(0.05)
         self.early_pay_10_percents_10_days.early_pay_discount_computation = 'mixed'
-        invoice = self.env['account.move'].create({
-            'move_type': 'out_invoice',
-            'partner_id': self.partner_a.id,
-            'invoice_date': '2019-01-01',
-            'date': '2019-01-01',
-            'invoice_line_ids': [Command.create({
-                'name': 'line',
-                'price_unit': 1000.0,
-                'tax_ids': [Command.set(self.product_a.taxes_id.ids + fixed_tax.ids)], #15% tax + fixed 0.05
-            })],
-            'invoice_payment_term_id': self.early_pay_10_percents_10_days.id,
-        })
+
+        invoice = self._create_invoice_one_line(
+            price_unit=1000.0,
+            tax_ids=self.product_a.taxes_id + fixed_tax,
+            invoice_payment_term_id=self.early_pay_10_percents_10_days.id,
+        )
 
         self.assertInvoiceValues(invoice, [
             # pylint: disable=bad-whitespace
+            {'display_type': 'product',         'balance': -1000.0},
             {'display_type': 'epd',             'balance': -100.0},
             {'display_type': 'epd',             'balance': 100.0},
-            {'display_type': 'product',         'balance': -1000.0},
             {'display_type': 'tax',             'balance': -135},
             {'display_type': 'tax',             'balance': -0.05},
             {'display_type': 'payment_term',    'balance': 1135.05},
@@ -179,22 +158,16 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
          })
 
     # ========================== Tests Payment Register ==========================
+    @freeze_time('2019-01-01')
     def test_register_discounted_payment_on_single_invoice(self):
         self.early_pay_10_percents_10_days.early_pay_discount_computation = 'included'
-        out_invoice_1 = self.env['account.move'].create({
-            'move_type': 'out_invoice',
-            'date': '2019-01-01',
-            'invoice_date': '2019-01-01',
-            'partner_id': self.partner_a.id,
-            'currency_id': self.other_currency.id,
-            'invoice_line_ids': [Command.create({'product_id': self.product_a.id, 'price_unit': 1000.0, 'tax_ids': []})],
-            'invoice_payment_term_id': self.early_pay_10_percents_10_days.id,
-        })
-        out_invoice_1.action_post()
-        active_ids = out_invoice_1.ids
-        payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=active_ids).create({
-            'payment_date': '2019-01-02',
-        })._create_payments()
+        out_invoice_1 = self._create_invoice_one_line(
+            currency_id=self.other_currency.id,
+            price_unit=1000.0,
+            invoice_payment_term_id=self.early_pay_10_percents_10_days.id,
+            post=True,
+        )
+        payments = self._register_payment(out_invoice_1, payment_date='2019-01-02')
 
         self.assertTrue(payments.is_reconciled)
         self.assertEqual(
@@ -202,32 +175,19 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
             [-1000.0, 100.0, 900.0],
         )
 
+    @freeze_time('2019-01-01')
     def test_register_discounted_payment_on_single_invoice_with_fixed_tax_1(self):
         self.early_pay_10_percents_10_days.early_pay_discount_computation = 'included'
-        fixed_tax = self.env['account.tax'].create({
-            'name': 'Test 0.05',
-            'amount_type': 'fixed',
-            'amount': 0.05,
-            'type_tax_use': 'purchase',
-        })
+        fixed_tax = self.fixed_tax(0.05, type_tax_use='purchase')
 
-        inv = self.env['account.move'].create({
-            'move_type': 'in_invoice',
-            'partner_id': self.partner_a.id,
-            'invoice_date': '2019-01-01',
-            'date': '2019-01-01',
-            'invoice_line_ids': [Command.create({
-                'name': 'line',
-                'price_unit': 1500.0,
-                'tax_ids': [Command.set(self.product_a.supplier_taxes_id.ids + fixed_tax.ids)]
-            })],
-            'invoice_payment_term_id': self.early_pay_10_percents_10_days.id,
-        })
-        inv.action_post()
-        active_ids = inv.ids
-        payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=active_ids).create({
-            'payment_date': '2017-01-01',
-        })._create_payments()
+        inv = self._create_invoice_one_line(
+            move_type='in_invoice',
+            price_unit=1500.0,
+            tax_ids=self.product_a.supplier_taxes_id + fixed_tax,
+            invoice_payment_term_id=self.early_pay_10_percents_10_days.id,
+            post=True,
+        )
+        payments = self._register_payment(inv, payment_date='2017-01-01')
 
         self.assertTrue(payments.is_reconciled)
         self.assertRecordValues(payments.move_id.line_ids.sorted('balance'), [
@@ -237,33 +197,19 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
             {'amount_currency': 1725.05},
         ])
 
+    @freeze_time('2019-01-01')
     def test_register_discounted_payment_on_single_invoice_with_fixed_tax_2(self):
         self.early_pay_10_percents_10_days.early_pay_discount_computation = 'included'
-        fixed_tax = self.env['account.tax'].create({
-            'name': 'Test 0.05',
-            'amount_type': 'fixed',
-            'amount': 0.05,
-            'type_tax_use': 'purchase',
-        })
+        fixed_tax = self.fixed_tax(0.05, type_tax_use='purchase')
 
-        invoice = self.env['account.move'].create({
-            'move_type': 'in_invoice',
-            'partner_id': self.partner_a.id,
-            'invoice_date': '2019-01-01',
-            'date': '2019-01-01',
-            'invoice_line_ids': [Command.create({
-                'name': 'line',
-                'price_unit': 50.0,
-                'tax_ids': [Command.set(self.product_a.supplier_taxes_id.ids + fixed_tax.ids)]
-            })],
-            'invoice_payment_term_id': self.early_pay_10_percents_10_days.id,
-        })
-
-        invoice.action_post()
-        payments = self.env['account.payment.register']\
-            .with_context(active_model='account.move', active_ids=invoice.ids)\
-            .create({'payment_date': '2017-01-01'})\
-            ._create_payments()
+        inv = self._create_invoice_one_line(
+            move_type='in_invoice',
+            price_unit=50.0,
+            tax_ids=self.product_a.supplier_taxes_id + fixed_tax,
+            invoice_payment_term_id=self.early_pay_10_percents_10_days.id,
+            post=True,
+        )
+        payments = self._register_payment(inv, payment_date='2017-01-01')
 
         self.assertTrue(payments.is_reconciled)
         self.assertRecordValues(payments.move_id.line_ids.sorted('balance'), [
@@ -273,21 +219,17 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
             {'amount_currency': 57.55},
         ])
 
+    @freeze_time('2019-01-01')
     def test_register_discounted_payment_on_single_invoice_with_tax(self):
         self.early_pay_10_percents_10_days.early_pay_discount_computation = 'included'
-        inv_1500_10_percents_discount_tax_incl_15_percents_tax = self.env['account.move'].create({
-            'move_type': 'in_invoice',
-            'partner_id': self.partner_a.id,
-            'invoice_date': '2019-01-01',
-            'date': '2019-01-01',
-            'invoice_line_ids': [Command.create({'name': 'line', 'price_unit': 1500.0, 'tax_ids': [Command.set(self.product_a.supplier_taxes_id.ids)]})],
-            'invoice_payment_term_id': self.early_pay_10_percents_10_days.id,
-        })
-        inv_1500_10_percents_discount_tax_incl_15_percents_tax.action_post()
-        active_ids = inv_1500_10_percents_discount_tax_incl_15_percents_tax.ids
-        payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=active_ids).create({
-            'payment_date': '2017-01-01',
-        })._create_payments()
+        inv_1500_10_percents_discount_tax_incl_15_percents_tax = self._create_invoice_one_line(
+            move_type='in_invoice',
+            price_unit=1500.0,
+            tax_ids=self.product_a.supplier_taxes_id,
+            invoice_payment_term_id=self.early_pay_10_percents_10_days.id,
+            post=True,
+        )
+        payments = self._register_payment(inv_1500_10_percents_discount_tax_incl_15_percents_tax, payment_date='2017-01-01')
 
         self.assertTrue(payments.is_reconciled)
         self.assertRecordValues(payments.move_id.line_ids.sorted('balance'), [
@@ -297,21 +239,16 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
             {'amount_currency': 1725.0},
         ])
 
+    @freeze_time('2019-01-01')
     def test_register_discounted_payment_on_single_out_invoice_with_tax(self):
         self.early_pay_10_percents_10_days.early_pay_discount_computation = 'included'
-        inv_1500_10_percents_discount_tax_incl_15_percents_tax = self.env['account.move'].create({
-            'move_type': 'out_invoice',
-            'partner_id': self.partner_a.id,
-            'invoice_date': '2019-01-01',
-            'date': '2019-01-01',
-            'invoice_line_ids': [Command.create({'name': 'line', 'price_unit': 1500.0, 'tax_ids': [Command.set(self.product_a.taxes_id.ids)]})],
-            'invoice_payment_term_id': self.early_pay_10_percents_10_days.id,
-        })
-        inv_1500_10_percents_discount_tax_incl_15_percents_tax.action_post()
-        active_ids = inv_1500_10_percents_discount_tax_incl_15_percents_tax.ids
-        payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=active_ids).create({
-            'payment_date': '2017-01-01',
-        })._create_payments()
+        inv_1500_10_percents_discount_tax_incl_15_percents_tax = self._create_invoice_one_line(
+            price_unit=1500.0,
+            tax_ids=self.product_a.taxes_id,
+            invoice_payment_term_id=self.early_pay_10_percents_10_days.id,
+            post=True,
+        )
+        payments = self._register_payment(inv_1500_10_percents_discount_tax_incl_15_percents_tax, payment_date='2017-01-01')
 
         self.assertTrue(payments.is_reconciled)
         self.assertRecordValues(payments.move_id.line_ids.sorted('balance'), [
@@ -321,25 +258,19 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
             {'amount_currency': 1552.5},
         ])
 
+    @freeze_time('2019-01-01')
     def test_register_discounted_payment_multi_line_discount(self):
         self.early_pay_10_percents_10_days.early_pay_discount_computation = 'included'
-        inv_mixed_lines_discount_and_no_discount = self.env['account.move'].create({
-            'move_type': 'in_invoice',
-            'partner_id': self.partner_a.id,
-            'invoice_date': '2019-01-01',
-            'date': '2019-01-01',
-            'invoice_line_ids': [
-                Command.create({'name': 'line', 'price_unit': 1000.0, 'tax_ids': [Command.set(self.product_a.supplier_taxes_id.ids)]}),
-                Command.create({'name': 'line', 'price_unit': 2000.0, 'tax_ids': None})
+        inv_mixed_lines_discount_and_no_discount = self._create_invoice(
+            move_type='in_invoice',
+            invoice_line_ids=[
+                self._prepare_invoice_line(price_unit=1000.0, tax_ids=self.product_a.supplier_taxes_id),
+                self._prepare_invoice_line(price_unit=2000.0),
             ],
-            'invoice_payment_term_id': self.early_pay_10_percents_10_days.id,
-        })
-        inv_mixed_lines_discount_and_no_discount.action_post()
-        active_ids = inv_mixed_lines_discount_and_no_discount.ids
-        payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=active_ids).create({
-            'payment_date': '2017-01-01',
-            'group_payment': True
-        })._create_payments()
+            invoice_payment_term_id=self.early_pay_10_percents_10_days.id,
+            post=True,
+        )
+        payments = self._register_payment(inv_mixed_lines_discount_and_no_discount, payment_date='2017-01-01')
 
         self.assertTrue(payments.is_reconciled)
         self.assertRecordValues(payments.move_id.line_ids.sorted('balance'), [
@@ -350,32 +281,23 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
             {'amount_currency': 3150.0},
         ])
 
+    @freeze_time('2019-01-01')
     def test_register_payment_batch_included(self):
         self.early_pay_10_percents_10_days.early_pay_discount_computation = 'included'
-        out_invoice_1 = self.env['account.move'].create({
-            'move_type': 'out_invoice',
-            'date': '2019-01-01',
-            'invoice_date': '2019-01-01',
-            'partner_id': self.partner_a.id,
-            'currency_id': self.other_currency.id,
-            'invoice_line_ids': [Command.create({'product_id': self.product_a.id, 'price_unit': 1000.0, 'tax_ids': []})],
-            'invoice_payment_term_id': self.early_pay_10_percents_10_days.id,
-        })
-        out_invoice_2 = self.env['account.move'].create({
-            'move_type': 'out_invoice',
-            'date': '2019-01-01',
-            'invoice_date': '2019-01-01',
-            'partner_id': self.partner_a.id,
-            'currency_id': self.other_currency.id,
-            'invoice_line_ids': [Command.create({'product_id': self.product_a.id, 'price_unit': 2000.0, 'tax_ids': []})],
-            'invoice_payment_term_id': self.early_pay_10_percents_10_days.id,
-        })
+        out_invoice_1 = self._create_invoice_one_line(
+            price_unit=1000.0,
+            currency_id=self.other_currency,
+            invoice_payment_term_id=self.early_pay_10_percents_10_days,
+            post=True,
+        )
+        out_invoice_2 = self._create_invoice_one_line(
+            price_unit=2000.0,
+            currency_id=self.other_currency,
+            invoice_payment_term_id=self.early_pay_10_percents_10_days,
+            post=True,
+        )
+        payments = self._register_payment(out_invoice_1 + out_invoice_2, payment_date='2019-01-01')
 
-        (out_invoice_1 + out_invoice_2).action_post()
-        active_ids = (out_invoice_1 + out_invoice_2).ids
-        payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=active_ids).create({
-            'payment_date': '2019-01-01', 'group_payment': True
-        })._create_payments()
         self.assertTrue(payments.is_reconciled)
         self.assertRecordValues(payments.move_id.line_ids.sorted('balance'), [
             {'amount_currency': -3000.0},
@@ -383,32 +305,24 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
             {'amount_currency': 2700},
         ])
 
+    @freeze_time('2019-01-01')
     def test_register_payment_batch_excluded(self):
         self.early_pay_10_percents_10_days.early_pay_discount_computation = 'excluded'
-        out_invoice_1 = self.env['account.move'].create({
-            'move_type': 'out_invoice',
-            'date': '2019-01-01',
-            'invoice_date': '2019-01-01',
-            'partner_id': self.partner_a.id,
-            'currency_id': self.other_currency.id,
-            'invoice_line_ids': [Command.create({'product_id': self.product_a.id, 'price_unit': 1000.0, 'tax_ids': [Command.set(self.product_a.taxes_id.ids)]})],
-            'invoice_payment_term_id': self.early_pay_10_percents_10_days.id,
-        })
-        out_invoice_2 = self.env['account.move'].create({
-            'move_type': 'out_invoice',
-            'date': '2019-01-01',
-            'invoice_date': '2019-01-01',
-            'partner_id': self.partner_a.id,
-            'currency_id': self.other_currency.id,
-            'invoice_line_ids': [Command.create({'product_id': self.product_a.id, 'price_unit': 2000.0, 'tax_ids': []})],
-            'invoice_payment_term_id': self.early_pay_10_percents_10_days.id,
-        })
+        out_invoice_1 = self._create_invoice_one_line(
+            price_unit=1000.0,
+            tax_ids=self.product_a.taxes_id,
+            currency_id=self.other_currency,
+            invoice_payment_term_id=self.early_pay_10_percents_10_days,
+            post=True,
+        )
+        out_invoice_2 = self._create_invoice_one_line(
+            price_unit=2000.0,
+            currency_id=self.other_currency,
+            invoice_payment_term_id=self.early_pay_10_percents_10_days,
+            post=True,
+        )
+        payments = self._register_payment(out_invoice_1 + out_invoice_2, payment_date='2019-01-01')
 
-        (out_invoice_1 + out_invoice_2).action_post()
-        active_ids = (out_invoice_1 + out_invoice_2).ids
-        payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=active_ids).create({
-            'payment_date': '2019-01-01', 'group_payment': True
-        })._create_payments()
         self.assertTrue(payments.is_reconciled)
         self.assertRecordValues(payments.move_id.line_ids.sorted('balance'), [
             {'amount_currency': -3150.0},
@@ -416,32 +330,24 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
             {'amount_currency': 2850},
         ])
 
+    @freeze_time('2019-01-01')
     def test_register_payment_batch_mixed(self):
         self.early_pay_10_percents_10_days.early_pay_discount_computation = 'mixed'
-        out_invoice_1 = self.env['account.move'].create({
-            'move_type': 'out_invoice',
-            'date': '2019-01-01',
-            'invoice_date': '2019-01-01',
-            'partner_id': self.partner_a.id,
-            'currency_id': self.other_currency.id,
-            'invoice_line_ids': [Command.create({'product_id': self.product_a.id, 'price_unit': 1000.0, 'tax_ids': [Command.set(self.product_a.taxes_id.ids)]})],
-            'invoice_payment_term_id': self.early_pay_10_percents_10_days.id,
-        })
-        out_invoice_2 = self.env['account.move'].create({
-            'move_type': 'out_invoice',
-            'date': '2019-01-01',
-            'invoice_date': '2019-01-01',
-            'partner_id': self.partner_a.id,
-            'currency_id': self.other_currency.id,
-            'invoice_line_ids': [Command.create({'product_id': self.product_a.id, 'price_unit': 2000.0, 'tax_ids': []})],
-            'invoice_payment_term_id': self.early_pay_10_percents_10_days.id,
-        })
+        out_invoice_1 = self._create_invoice_one_line(
+            price_unit=1000.0,
+            tax_ids=self.product_a.taxes_id,
+            currency_id=self.other_currency,
+            invoice_payment_term_id=self.early_pay_10_percents_10_days,
+            post=True,
+        )
+        out_invoice_2 = self._create_invoice_one_line(
+            price_unit=2000.0,
+            currency_id=self.other_currency,
+            invoice_payment_term_id=self.early_pay_10_percents_10_days,
+            post=True,
+        )
+        payments = self._register_payment(out_invoice_1 + out_invoice_2, payment_date='2019-01-01')
 
-        (out_invoice_1 + out_invoice_2).action_post()
-        active_ids = (out_invoice_1 + out_invoice_2).ids
-        payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=active_ids).create({
-            'payment_date': '2019-01-01', 'group_payment': True
-        })._create_payments()
         self.assertTrue(payments.is_reconciled)
         self.assertRecordValues(payments.move_id.line_ids.sorted('balance'), [
             {'amount_currency': -3135.0},
@@ -451,30 +357,23 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
 
     def test_register_payment_batch_mixed_one_too_late(self):
         self.early_pay_10_percents_10_days.early_pay_discount_computation = 'mixed'
-        out_invoice_1 = self.env['account.move'].create({
-            'move_type': 'out_invoice',
-            'date': '2017-01-01',
-            'invoice_date': '2017-01-01',
-            'partner_id': self.partner_a.id,
-            'currency_id': self.other_currency.id,
-            'invoice_line_ids': [Command.create({'product_id': self.product_a.id, 'price_unit': 1000.0, 'tax_ids': [Command.set(self.product_a.taxes_id.ids)]})],
-            'invoice_payment_term_id': self.early_pay_10_percents_10_days.id,
-        })
-        out_invoice_2 = self.env['account.move'].create({
-            'move_type': 'out_invoice',
-            'date': '2019-01-01',
-            'invoice_date': '2019-01-01',
-            'partner_id': self.partner_a.id,
-            'currency_id': self.other_currency.id,
-            'invoice_line_ids': [Command.create({'product_id': self.product_a.id, 'price_unit': 2000.0, 'tax_ids': []})],
-            'invoice_payment_term_id': self.early_pay_10_percents_10_days.id,
-        })
+        with freeze_time('2017-01-01'):
+            out_invoice_1 = self._create_invoice_one_line(
+                price_unit=1000.0,
+                tax_ids=self.product_a.taxes_id,
+                currency_id=self.other_currency,
+                invoice_payment_term_id=self.early_pay_10_percents_10_days,
+                post=True,
+            )
+        with freeze_time('2019-01-01'):
+            out_invoice_2 = self._create_invoice_one_line(
+                price_unit=2000.0,
+                currency_id=self.other_currency,
+                invoice_payment_term_id=self.early_pay_10_percents_10_days,
+                post=True,
+            )
+        payments = self._register_payment(out_invoice_1 + out_invoice_2, payment_date='2019-01-01')
 
-        (out_invoice_1 + out_invoice_2).action_post()
-        active_ids = (out_invoice_1 + out_invoice_2).ids
-        payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=active_ids).create({
-            'payment_date': '2019-01-01', 'group_payment': True
-        })._create_payments()
         self.assertTrue(payments.is_reconciled)
         self.assertRecordValues(payments.move_id.line_ids.sorted('balance'), [
             {'amount_currency': -3135.0},
@@ -521,6 +420,7 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
                 ],
             })
 
+    @freeze_time('2019-01-01')
     def test_intracomm_bill_with_early_payment_included(self):
         tax_tags = self.env['account.account.tag'].create([{
             'name': f'tax_tag_{i}',
@@ -563,26 +463,14 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
             ],
         })
 
-        bill = self.env['account.move'].create({
-            'move_type': 'in_invoice',
-            'partner_id': self.partner_a.id,
-            'invoice_payment_term_id': early_payment_term.id,
-            'invoice_date': '2019-01-01',
-            'date': '2019-01-01',
-            'invoice_line_ids': [
-                Command.create({
-                    'name': 'line',
-                    'price_unit': 1000.0,
-                    'tax_ids': [Command.set(intracomm_tax.ids)],
-                }),
-            ],
-        })
-        bill.action_post()
-
-        payment = self.env['account.payment.register']\
-            .with_context(active_model='account.move', active_ids=bill.ids)\
-            .create({'payment_date': '2019-01-01'})\
-            ._create_payments()
+        bill = self._create_invoice_one_line(
+            price_unit=1000.0,
+            tax_ids=intracomm_tax,
+            move_type='in_invoice',
+            invoice_payment_term_id=early_payment_term,
+            post=True,
+        )
+        payment = self._register_payment(bill, payment_date='2019-01-01')
 
         self.assertRecordValues(payment.move_id.line_ids.sorted('balance'), [
             # pylint: disable=bad-whitespace
@@ -628,35 +516,21 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
         })
 
         self.early_pay_10_percents_10_days.early_pay_discount_computation = 'mixed'
-        bill = self.env['account.move'].create({
-            'move_type': 'in_invoice',
-            'partner_id': self.partner_a.id,
-            'invoice_date': '2019-01-01',
-            'date': '2019-01-01',
-            'invoice_payment_term_id': self.early_pay_10_percents_10_days.id,
-        })
-        bill.write({
-            'invoice_line_ids': [
-                Command.create({
-                    'name': 'line1',
-                    'price_unit': 1000.0,
-                    'tax_ids': [Command.set(tax_21.ids)],
-                }),
+        bill = self._create_invoice(
+            move_type='in_invoice',
+            invoice_payment_term_id=self.early_pay_10_percents_10_days,
+            invoice_line_ids=[
+                self._prepare_invoice_line(price_unit=1000.0, tax_ids=tax_21),
+                self._prepare_invoice_line(price_unit=1000.0, tax_ids=tax_21),
             ],
-        })
-        bill.write({
-            'invoice_line_ids': [Command.create({
-                'name': 'line2',
-                'price_unit': 1000.0,
-                'tax_ids': [Command.set(tax_21.ids)],
-            })],
-        })
+        )
         epd_lines = bill.line_ids.filtered(lambda line: line.display_type == 'epd')
         self.assertRecordValues(epd_lines.sorted('balance'), [
             {'balance': -200.0},
             {'balance': 200.0},
         ])
 
+    @freeze_time('2022-02-01')
     def test_mixed_epd_with_tax_included(self):
         early_pay_2_percents_10_days = self.env['account.payment.term'].create({
             'name': '2% discount if paid within 10 days',
@@ -671,57 +545,44 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
                 'value_amount': 100,
             })]
         })
-        tax = self.env['account.tax'].create({
-            'name': 'Tax 21% included',
-            'amount': 21,
-            'price_include_override': 'tax_included',
+        tax_21_included = self.percent_tax(21, price_include_override='tax_included')
+        invoice = self._create_invoice_one_line(
+            price_unit=121.0,
+            tax_ids=tax_21_included,
+            invoice_payment_term_id=early_pay_2_percents_10_days,
+        )
+
+        self._assert_tax_totals_summary(invoice.tax_totals, {
+            'same_tax_base': False,
+            'currency_id': self.env.company.currency_id.id,
+            'base_amount_currency': 100.0,
+            'tax_amount_currency': 20.58,
+            'total_amount_currency': 120.58,
+            'subtotals': [
+                {
+                    'name': "Untaxed Amount",
+                    'base_amount_currency': 100.0,
+                    'tax_amount_currency': 20.58,
+                    'tax_groups': [
+                        {
+                            'id': tax_21_included.tax_group_id.id,
+                            'base_amount_currency': 98.0,
+                            'tax_amount_currency': 20.58,
+                            'display_base_amount_currency': 98.0,
+                        },
+                    ],
+                },
+            ],
         })
 
-        with Form(self.env['account.move'].with_context(default_move_type='out_invoice')) as invoice:
-            invoice.partner_id = self.partner_a
-            invoice.invoice_date = fields.Date.from_string('2022-02-21')
-            invoice.invoice_payment_term_id = early_pay_2_percents_10_days
-            with invoice.invoice_line_ids.new() as line_form:
-                line_form.product_id = self.product_a
-                line_form.price_unit = 121
-                line_form.quantity = 1
-                line_form.tax_ids.clear()
-                line_form.tax_ids.add(tax)
-            self._assert_tax_totals_summary(invoice.tax_totals, {
-                'same_tax_base': False,
-                'currency_id': self.env.company.currency_id.id,
-                'base_amount_currency': 100.0,
-                'tax_amount_currency': 20.58,
-                'total_amount_currency': 120.58,
-                'subtotals': [
-                    {
-                        'name': "Untaxed Amount",
-                        'base_amount_currency': 100.0,
-                        'tax_amount_currency': 20.58,
-                        'tax_groups': [
-                            {
-                                'id': tax.tax_group_id.id,
-                                'base_amount_currency': 98.0,
-                                'tax_amount_currency': 20.58,
-                                'display_base_amount_currency': 98.0,
-                            },
-                        ],
-                    },
-                ],
-            })
-
+    @freeze_time('2019-01-01')
     def test_mixed_epd_with_tax_no_duplication(self):
         (self.pay_terms_a | self.early_pay_10_percents_10_days).write({'early_pay_discount_computation': 'mixed'})
-        inv = self.env['account.move'].create({
-            'move_type': 'out_invoice',
-            'partner_id': self.partner_a.id,
-            'invoice_date': '2019-01-01',
-            'date': '2019-01-01',
-            'invoice_line_ids': [
-                Command.create({'name': 'line', 'price_unit': 100.0, 'tax_ids': [Command.set(self.product_a.taxes_id.ids)]}),
-            ],
-            'invoice_payment_term_id': self.early_pay_10_percents_10_days.id,
-        })
+        inv = self._create_invoice_one_line(
+            price_unit=100.0,
+            tax_ids=self.product_a.taxes_id,
+            invoice_payment_term_id=self.early_pay_10_percents_10_days,
+        )
         self.assertEqual(len(inv.line_ids), 5)  # 1 prod, 1 tax, 1 epd, 1 epd tax discount, 1 payment terms
         inv.write({'invoice_payment_term_id': self.pay_terms_a.id})
         self.assertEqual(len(inv.line_ids), 3)  # 1 prod, 1 tax, 1 payment terms
@@ -730,55 +591,29 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
 
     def test_mixed_epd_with_tax_deleted_line(self):
         self.early_pay_10_percents_10_days.write({'early_pay_discount_computation': 'mixed'})
-        tax_a = self.env['account.tax'].create({
-             'name': 'Test A',
-             'amount': 10,
-        })
-        tax_b = self.env['account.tax'].create({
-             'name': 'Test B',
-             'amount': 15,
-        })
-
-        inv = self.env['account.move'].create({
-            'move_type': 'out_invoice',
-            'partner_id': self.partner_a.id,
-            'invoice_date': '2019-01-01',
-            'date': '2019-01-01',
-            'invoice_line_ids': [
-                Command.create({'name': 'line', 'price_unit': 100.0, 'tax_ids': [Command.set(tax_a.ids)]}),
-                Command.create({'name': 'line2', 'price_unit': 100.0, 'tax_ids': [Command.set(tax_b.ids)]}),
+        tax_a = self.percent_tax(10)
+        tax_b = self.percent_tax(15)
+        inv = self._create_invoice(
+            invoice_payment_term_id=self.early_pay_10_percents_10_days,
+            invoice_line_ids=[
+                self._prepare_invoice_line(price_unit=100.0, tax_ids=tax_a),
+                self._prepare_invoice_line(price_unit=100.0, tax_ids=tax_b),
             ],
-            'invoice_payment_term_id': self.early_pay_10_percents_10_days.id,
-        })
+        )
         self.assertEqual(len(inv.line_ids), 8)  # 2 prod, 2 tax, 1 epd, 2 epd tax discount, 1 payment terms
         inv.invoice_line_ids[1].unlink()
         self.assertEqual(len(inv.line_ids), 5)  # 1 prod, 1 tax, 1 epd, 1 epd tax discount, 1 payment terms
         self.assertEqual(inv.amount_tax, 9.00)  # $100.0 @ 10% tax (-10% epd)
 
+    @freeze_time('2022-02-21')
     def test_mixed_epd_with_rounding_issue(self):
         """
         Ensure epd line will not unbalance the invoice
         """
-        tax_6 = self.env['account.tax'].create({
-             'name': '6%',
-             'amount': 6,
-        })
-        tax_12 = self.env['account.tax'].create({
-             'name': '12%',
-             'amount': 12,
-        })
-        tax_136 = self.env['account.tax'].create({
-             'name': '136',
-             'amount': 0.136,
-             'amount_type': 'fixed',
-             'include_base_amount': True,
-        })
-        tax_176 = self.env['account.tax'].create({
-             'name': '176',
-             'amount': 0.176,
-             'amount_type': 'fixed',
-             'include_base_amount': True,
-        })
+        tax_6 = self.percent_tax(6)
+        tax_12 = self.percent_tax(12)
+        tax_136 = self.fixed_tax(0.136, include_base_amount=True)
+        tax_176 = self.fixed_tax(0.176, include_base_amount=True)
 
         early_pay_1_percents_7_days = self.env['account.payment.term'].create({
             'name': '1% discount if paid within 7 days',
@@ -794,29 +629,19 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
             })]
         })
 
-        # The following vals will create a rounding issue
-        line_create_vals = [
-           (116, 6, tax_6),
-           (0.91, 350, tax_6),
-           (194.21, 1, tax_136 | tax_12),
-           (31.46, 5, tax_176 | tax_12)
-        ]
-
+        # These `invoice_line_ids` values will create a rounding issue
         # If invoice is not balanced the following create will fail
-        self.env['account.move'].create({
-            'move_type': 'out_invoice',
-            'partner_id': self.partner_a.id,
-            'invoice_date': '2022-02-21',
-            'invoice_payment_term_id': early_pay_1_percents_7_days.id,
-            'invoice_line_ids': [
-                Command.create({
-                    'price_unit': price_unit,
-                    'quantity': quantity,
-                    'tax_ids': [Command.set(taxes.ids)]
-                }) for price_unit, quantity, taxes in line_create_vals
+        self._create_invoice(
+            invoice_payment_term_id=early_pay_1_percents_7_days,
+            invoice_line_ids=[
+                self._prepare_invoice_line(price_unit=116, quantity=6, tax_ids=tax_6),
+                self._prepare_invoice_line(price_unit=0.91, quantity=350, tax_ids=tax_6),
+                self._prepare_invoice_line(price_unit=194.21, quantity=1, tax_ids=tax_136 | tax_12),
+                self._prepare_invoice_line(price_unit=31.46, quantity=5, tax_ids=tax_176 | tax_12),
             ]
-        })
+        )
 
+    @freeze_time('2019-01-01')
     def test_register_payment_batch_with_discount_and_without_discount(self):
         """
         Test that a batch payment, that is
@@ -824,30 +649,20 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
             - with invoices having different payment terms (1 with discount, 1 without)
         -> will not crash
         """
-        out_invoice_1 = self.env['account.move'].create({
-            'move_type': 'out_invoice',
-            'date': '2019-01-01',
-            'invoice_date': '2019-01-01',
-            'partner_id': self.partner_a.id,
-            'currency_id': self.other_currency.id,
-            'invoice_line_ids': [Command.create({'product_id': self.product_a.id, 'price_unit': 1000.0, 'tax_ids': []})],
-            'invoice_payment_term_id': self.pay_term_net_30_days.id,
-        })
-        out_invoice_2 = self.env['account.move'].create({
-            'move_type': 'out_invoice',
-            'date': '2019-01-01',
-            'invoice_date': '2019-01-01',
-            'partner_id': self.partner_a.id,
-            'currency_id': self.other_currency.id,
-            'invoice_line_ids': [Command.create({'product_id': self.product_a.id, 'price_unit': 2000.0, 'tax_ids': []})],
-            'invoice_payment_term_id': self.early_pay_10_percents_10_days.id,
-        })
-        (out_invoice_1 + out_invoice_2).action_post()
-        active_ids = (out_invoice_1 + out_invoice_2).ids
+        out_invoice_1 = self._create_invoice_one_line(
+            price_unit=1000.0,
+            currency_id=self.other_currency,
+            invoice_payment_term_id=self.pay_term_net_30_days,
+            post=True,
+        )
+        out_invoice_2 = self._create_invoice_one_line(
+            price_unit=2000.0,
+            currency_id=self.other_currency,
+            invoice_payment_term_id=self.early_pay_10_percents_10_days,
+            post=True,
+        )
+        payments = self._register_payment(out_invoice_1 + out_invoice_2, payment_date='2019-01-01', group_payment=False)
 
-        payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=active_ids).create({
-            'payment_date': '2019-01-01', 'group_payment': False
-        })._create_payments()
         self.assertTrue(all(payments.mapped('is_reconciled')))
         self.assertRecordValues(payments.move_id.line_ids.sorted('balance'), [
             {'amount_currency': -2000.0},
@@ -857,6 +672,7 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
             {'amount_currency': 1800},
         ])
 
+    @freeze_time('2019-01-01')
     def test_register_payment_batch_without_discount(self):
         """
         Test that a batch payment, that is
@@ -864,30 +680,20 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
             - with invoices having the same payment terms (without discount)
         -> will not crash
         """
-        out_invoice_1 = self.env['account.move'].create({
-            'move_type': 'out_invoice',
-            'date': '2019-01-01',
-            'invoice_date': '2019-01-01',
-            'partner_id': self.partner_a.id,
-            'currency_id': self.other_currency.id,
-            'invoice_line_ids': [Command.create({'product_id': self.product_a.id, 'price_unit': 1000.0, 'tax_ids': []})],
-            'invoice_payment_term_id': self.pay_term_net_30_days.id,
-        })
-        out_invoice_2 = self.env['account.move'].create({
-            'move_type': 'out_invoice',
-            'date': '2019-01-01',
-            'invoice_date': '2019-01-01',
-            'partner_id': self.partner_a.id,
-            'currency_id': self.other_currency.id,
-            'invoice_line_ids': [Command.create({'product_id': self.product_a.id, 'price_unit': 2000.0, 'tax_ids': []})],
-            'invoice_payment_term_id': self.pay_term_net_30_days.id,
-        })
-        (out_invoice_1 + out_invoice_2).action_post()
-        active_ids = (out_invoice_1 + out_invoice_2).ids
+        out_invoice_1 = self._create_invoice_one_line(
+            currency_id=self.other_currency,
+            price_unit=1000.0,
+            invoice_payment_term_id=self.pay_term_net_30_days,
+            post=True,
+        )
+        out_invoice_2 = self._create_invoice_one_line(
+            currency_id=self.other_currency,
+            price_unit=2000.0,
+            invoice_payment_term_id=self.pay_term_net_30_days,
+            post=True,
+        )
+        payments = self._register_payment(out_invoice_1 + out_invoice_2, payment_date='2019-01-01', group_payment=False)
 
-        payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=active_ids).create({
-            'payment_date': '2019-01-01', 'group_payment': False
-        })._create_payments()
         self.assertTrue(all(payments.mapped('is_reconciled')))
         self.assertRecordValues(payments.move_id.line_ids.sorted('balance'), [
             {'amount_currency': -2000.0},
@@ -896,26 +702,18 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
             {'amount_currency': 2000},
         ])
 
+    @freeze_time('2022-02-21')
     def test_mixed_epd_with_tax_refund(self):
         """
         Ensure epd line are addeed to refunds
         """
         self.early_pay_10_percents_10_days.write({'early_pay_discount_computation': 'mixed'})
-
-        invoice = self.env['account.move'].create({
-            'move_type': 'out_invoice',
-            'partner_id': self.partner_a.id,
-            'invoice_date': '2022-02-21',
-            'invoice_payment_term_id': self.early_pay_10_percents_10_days.id,
-            'invoice_line_ids': [
-                Command.create({
-                    'price_unit': 100.0,
-                    'quantity': 1,
-                    'tax_ids': [Command.set(self.product_a.taxes_id.ids)],
-                })
-            ]
-        })
-        invoice.action_post()
+        invoice = self._create_invoice_one_line(
+            price_unit=100.0,
+            tax_ids=self.product_a.taxes_id,
+            invoice_payment_term_id=self.early_pay_10_percents_10_days,
+            post=True,
+        )
 
         move_reversal = self.env['account.move.reversal'].with_context(active_model="account.move", active_ids=invoice.ids).create({
             'date': fields.Date.from_string('2017-01-01'),
@@ -990,6 +788,7 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
                 "ValidationError raised unexpectedly for single-line payment term with EPD"
             )
 
+    @freeze_time('2017-01-01')
     def test_epd_multiple_repartition_lines(self):
         """
         In the case of multi repartition lines tax definition with an early payment discount
@@ -1031,31 +830,17 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
         })
 
         # Invoice.
-        invoice = self.env['account.move'].create({
-            'move_type': 'out_invoice',
-            'partner_id': self.partner_a.id,
-            'invoice_payment_term_id': payment_term.id,
-            'invoice_date': '2017-01-01',
-            'invoice_line_ids': [
-                Command.create({
-                    'name': "Line One",
-                    'price_unit': 739.95,
-                    'tax_ids': [Command.set(tax1.ids)],
-                }),
-                Command.create({
-                    'name': "Line Two",
-                    'price_unit': 37.80,
-                    'tax_ids': [Command.set(tax2.ids)],
-                }),
+        invoice = self._create_invoice(
+            invoice_payment_term_id=payment_term,
+            invoice_line_ids=[
+                self._prepare_invoice_line(price_unit=739.95, tax_ids=tax1),
+                self._prepare_invoice_line(price_unit=37.80, tax_ids=tax2),
             ],
-        })
-        invoice.action_post()
+            post=True,
+        )
 
         # Payment.
-        payment = self.env['account.payment.register']\
-            .with_context(active_model='account.move', active_ids=invoice.ids)\
-            .create({'payment_date': '2017-01-01'})\
-            ._create_payments()
+        payment = self._register_payment(invoice, payment_date='2017-01-01')
 
         self.assertRecordValues(payment.move_id.line_ids.sorted('amount_currency'), [
             # Invoice's total:

--- a/addons/account/tests/test_payment_term.py
+++ b/addons/account/tests/test_payment_term.py
@@ -62,7 +62,13 @@ class TestAccountPaymentTerms(AccountTestInvoicingCommon):
             ],
         })
 
-        cls.invoice = cls.init_invoice('out_refund', products=cls.product_a+cls.product_b)
+        cls.invoice = cls._create_invoice(
+            move_type='out_refund',
+            invoice_line_ids=[
+                cls._prepare_invoice_line(product_id=cls.product_a),
+                cls._prepare_invoice_line(product_id=cls.product_b),
+            ],
+        )
 
         cls.pay_term_a = cls.env['account.payment.term'].create({
             'name': "turlututu",
@@ -568,7 +574,7 @@ class TestAccountPaymentTerms(AccountTestInvoicingCommon):
             ],
         })
         # create an invoice with immediate payment term
-        invoice = self.init_invoice('out_invoice', products=self.product_a)
+        invoice = self._create_invoice_one_line(product_id=self.product_a)
         invoice.invoice_payment_term_id = immediate_term
         # check the payment term labels
         invoice_terms = invoice.line_ids.filtered(lambda l: l.display_type == 'payment_term')

--- a/addons/account_edi_ubl_cii/tests/test_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_bis3.py
@@ -4,7 +4,7 @@ from unittest import mock
 from odoo import Command, fields
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.tests import tagged
-from odoo.tools import misc
+from odoo.tools.misc import file_open
 
 
 @tagged('post_install_l10n', 'post_install', '-at_install')
@@ -80,7 +80,7 @@ class TestUblBis3(AccountTestInvoicingCommon):
     def _assert_invoice_ubl_file(self, invoice, filename):
         file_path = f'addons/{self.test_module}/tests/test_files/{filename}.xml'
 
-        with misc.file_open(file_path, 'rb') as file:
+        with file_open(file_path, 'rb') as file:
             expected_content = file.read()
         self.assertTrue(invoice.ubl_cii_xml_id)
         self.assertXmlTreeEqual(
@@ -134,7 +134,7 @@ class TestUblBis3(AccountTestInvoicingCommon):
         })
         invoice.action_post()
         actual_content, _dummy = self.env['account.edi.xml.ubl_bis3'].with_context(lang='en_US')._export_invoice(invoice)
-        with misc.file_open(f'addons/{self.test_module}/tests/test_files/bis3/test_invoice.xml', 'rb') as file:
+        with file_open(f'addons/{self.test_module}/tests/test_files/bis3/test_invoice.xml', 'rb') as file:
             expected_content = file.read()
         self.assertXmlTreeEqual(
             self.get_xml_tree_from_string(actual_content),

--- a/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
@@ -387,8 +387,7 @@ class TestAccountEdiUblCii(AccountTestInvoicingCommon, HttpCase):
         self.assertEqual(end_date.text, '20241231')
 
     def test_export_import_billing_dates(self):
-        if self.env.ref('base.module_accountant').state != 'installed':
-            self.skipTest("payment_custom module is not installed")
+        self.ensure_installed('accountant')
 
         invoice = self.env['account.move'].create({
             'partner_id': self.partner_a.id,

--- a/addons/l10n_ar/tests/common.py
+++ b/addons/l10n_ar/tests/common.py
@@ -662,7 +662,7 @@ class TestAr(AccountTestInvoicingCommon):
         _logger.info('Created journal %s for company %s', journal.name, self.env.company.name)
         return journal
 
-    def _create_invoice(self, data=None, invoice_type='out_invoice'):
+    def _create_invoice_ar(self, data=None, invoice_type='out_invoice'):
         data = data or {}
         with Form(self.env['account.move'].with_context(default_move_type=invoice_type)) as invoice_form:
             invoice_form.partner_id = data.get('partner', self.partner)
@@ -692,7 +692,7 @@ class TestAr(AccountTestInvoicingCommon):
 
     def _create_invoice_product(self, data=None):
         data = data or {}
-        return self._create_invoice(data)
+        return self._create_invoice_ar(data)
 
     def _create_invoice_service(self, data=None):
         data = data or {}
@@ -701,7 +701,7 @@ class TestAr(AccountTestInvoicingCommon):
             line.update({'product': self.service_iva_27})
             newlines.append(line)
         data.update({'lines': newlines})
-        return self._create_invoice(data)
+        return self._create_invoice_ar(data)
 
     def _create_invoice_product_service(self, data=None):
         data = data or {}
@@ -710,7 +710,7 @@ class TestAr(AccountTestInvoicingCommon):
             line.update({'product': self.product_iva_21})
             newlines.append(line)
         data.update({'lines': newlines + [{'product': self.service_iva_27}]})
-        return self._create_invoice(data)
+        return self._create_invoice_ar(data)
 
     def _create_credit_note(self, invoice, data=None):
         data = data or {}

--- a/addons/l10n_ar/tests/test_manual.py
+++ b/addons/l10n_ar/tests/test_manual.py
@@ -23,7 +23,7 @@ class TestManual(common.TestAr):
         * Properly set the tax amount of the product / partner
         * Proper fiscal position (this case not fiscal position is selected)
         """
-        invoice = self._create_invoice()
+        invoice = self._create_invoice_ar()
         self.assertEqual(invoice.company_id, self.company_ri, 'created with wrong company')
         self.assertEqual(invoice.amount_tax, 21, 'invoice taxes are not properly set')
         self.assertEqual(invoice.amount_total, 121.0, 'invoice taxes has not been applied to the total')
@@ -36,19 +36,19 @@ class TestManual(common.TestAr):
 
     def test_02_fiscal_position(self):
         # ADHOC SA > IVA Responsable Inscripto > Without Fiscal Positon
-        invoice = self._create_invoice({'partner': self.partner})
+        invoice = self._create_invoice_ar({'partner': self.partner})
         self.assertFalse(invoice.fiscal_position_id, 'Fiscal position should be set to empty')
 
         # Consumidor Final > IVA Responsable Inscripto > Without Fiscal Positon
-        invoice = self._create_invoice({'partner': self.partner_cf})
+        invoice = self._create_invoice_ar({'partner': self.partner_cf})
         self.assertFalse(invoice.fiscal_position_id, 'Fiscal position should be set to empty')
 
         # Montana Sur > IVA Liberado - Ley Nº 19.640 > Compras / Ventas Zona Franca > IVA Exento
-        invoice = self._create_invoice({'partner': self.res_partner_montana_sur})
+        invoice = self._create_invoice_ar({'partner': self.res_partner_montana_sur})
         self.assertEqual(invoice.fiscal_position_id, self._search_fp('Purchases / Sales Free Trade Zone'))
 
         # Barcelona food > Cliente / Proveedor del Exterior >  > IVA Exento
-        invoice = self._create_invoice({'partner': self.res_partner_barcelona_food})
+        invoice = self._create_invoice_ar({'partner': self.res_partner_barcelona_food})
         self.assertEqual(invoice.fiscal_position_id, self._search_fp('Purchases / Sales abroad'))
 
     def test_03_corner_cases(self):
@@ -110,7 +110,7 @@ class TestManual(common.TestAr):
         self.assertTrue(self.journal.l10n_ar_is_pos)
 
         # If we create an invoice it will not use manual numbering
-        invoice = self._create_invoice({'partner': self.partner})
+        invoice = self._create_invoice_ar({'partner': self.partner})
         self.assertFalse(invoice.l10n_latam_manual_document_number)
 
         # Create a new sale journal that is not ARCA POS

--- a/addons/l10n_eg_edi_eta/tests/common.py
+++ b/addons/l10n_eg_edi_eta/tests/common.py
@@ -84,7 +84,7 @@ class TestEGEdiCommon(AccountEdiTestCommon):
         return cls.env.ref(f'account.{cls.env.company.id}_account_tax_template_{trailing_xml_id}')
 
     @classmethod
-    def create_invoice(cls, **kwargs):
+    def _create_invoice_eg(cls, **kwargs):
         invoice = (
             cls.env['account.move']
             .with_context(edi_test_mode=True)

--- a/addons/l10n_eg_edi_eta/tests/test_edi_json.py
+++ b/addons/l10n_eg_edi_eta/tests/test_edi_json.py
@@ -88,7 +88,7 @@ class TestEdiJson(TestEGEdiCommon):
             'odoo.addons.l10n_eg_edi_eta.models.account_edi_format.AccountEdiFormat._l10n_eg_edi_post_invoice_web_service',
             new=mocked_l10n_eg_edi_post_invoice_web_service,
         ):
-            invoice = self.create_invoice(
+            invoice = self._create_invoice_eg(
                 partner_id=self.partner_a.id,
                 invoice_line_ids=[
                     {
@@ -181,7 +181,7 @@ class TestEdiJson(TestEGEdiCommon):
             'odoo.addons.l10n_eg_edi_eta.models.account_edi_format.AccountEdiFormat._l10n_eg_edi_post_invoice_web_service',
             new=mocked_l10n_eg_edi_post_invoice_web_service,
         ):
-            invoice = self.create_invoice(
+            invoice = self._create_invoice_eg(
                 partner_id=self.partner_a.id,
                 invoice_line_ids=[
                     {
@@ -276,7 +276,7 @@ class TestEdiJson(TestEGEdiCommon):
             'odoo.addons.l10n_eg_edi_eta.models.account_edi_format.AccountEdiFormat._l10n_eg_edi_post_invoice_web_service',
             new=mocked_l10n_eg_edi_post_invoice_web_service,
         ):
-            invoice = self.create_invoice(
+            invoice = self._create_invoice_eg(
                 move_type='out_refund',
                 partner_id=self.partner_a.id,
                 invoice_line_ids=[
@@ -378,7 +378,7 @@ class TestEdiJson(TestEGEdiCommon):
             new=mocked_l10n_eg_edi_post_invoice_web_service,
         ):
             ref_eg_standard_sale_14 = self.env.ref(f'account.{self.env.company.id}_eg_standard_sale_14').ids
-            invoice = self.create_invoice(
+            invoice = self._create_invoice_eg(
                 partner_id=self.partner_a.id,
                 invoice_line_ids=[
                     {
@@ -510,7 +510,7 @@ class TestEdiJson(TestEGEdiCommon):
             'odoo.addons.l10n_eg_edi_eta.models.account_edi_format.AccountEdiFormat._l10n_eg_edi_post_invoice_web_service',
             new=mocked_l10n_eg_edi_post_invoice_web_service,
         ):
-            invoice = self.create_invoice(
+            invoice = self._create_invoice_eg(
                 partner_id=self.partner_b.id,
                 invoice_line_ids=[
                     {
@@ -609,7 +609,7 @@ class TestEdiJson(TestEGEdiCommon):
             'odoo.addons.l10n_eg_edi_eta.models.account_edi_format.AccountEdiFormat._l10n_eg_edi_post_invoice_web_service',
             new=mocked_l10n_eg_edi_post_invoice_web_service,
         ):
-            invoice = self.create_invoice(
+            invoice = self._create_invoice_eg(
                 currency_id=self.currency_aed_id.id,
                 partner_id=self.partner_b.id,
                 invoice_line_ids=[
@@ -718,7 +718,7 @@ class TestEdiJson(TestEGEdiCommon):
             'odoo.addons.l10n_eg_edi_eta.models.account_edi_format.AccountEdiFormat._l10n_eg_edi_post_invoice_web_service',
             new=mocked_l10n_eg_edi_post_invoice_web_service,
         ):
-            invoice = self.create_invoice(
+            invoice = self._create_invoice_eg(
                 move_type='out_invoice',
                 currency_id=self.currency_aed_id.id,
                 partner_id=self.partner_b.id,
@@ -828,7 +828,7 @@ class TestEdiJson(TestEGEdiCommon):
             'odoo.addons.l10n_eg_edi_eta.models.account_edi_format.AccountEdiFormat._l10n_eg_edi_post_invoice_web_service',
             new=mocked_l10n_eg_edi_post_invoice_web_service,
         ):
-            invoice = self.create_invoice(
+            invoice = self._create_invoice_eg(
                 move_type='out_invoice',
                 currency_id=self.currency_aed_id.id,
                 partner_id=self.partner_c.id,
@@ -869,7 +869,7 @@ class TestEdiJson(TestEGEdiCommon):
             new=mocked_l10n_eg_edi_post_invoice_web_service,
         ):
             taxes = self.env.ref(f'account.{self.env.company.id}_eg_standard_sale_14').ids + self.env.ref(f'account.{self.env.company.id}_eg_withholding_3_sale').ids
-            invoice = self.create_invoice(
+            invoice = self._create_invoice_eg(
                 move_type='out_invoice',
                 partner_id=self.partner_a.id,
                 invoice_line_ids=[

--- a/addons/l10n_es_edi_facturae/tests/test_edi_xml.py
+++ b/addons/l10n_es_edi_facturae/tests/test_edi_xml.py
@@ -134,7 +134,7 @@ class TestEdiFacturaeXmls(AccountTestInvoicingCommon):
         cls.maxDiff = None
 
     @classmethod
-    def create_invoice(cls, **kwargs):
+    def _create_invoice_es(cls, **kwargs):
         return cls.env['account.move'].with_context(edi_test_mode=True).create({
             'partner_id': cls.partner_a.id,
             'invoice_date': cls.frozen_today.isoformat(),
@@ -162,7 +162,7 @@ class TestEdiFacturaeXmls(AccountTestInvoicingCommon):
         with freeze_time(date), \
                 patch(f"{self.certificate_module}.fields.Datetime.now", lambda x=None: date), \
                 self._mock_sha1():
-            invoice = self.create_invoice(
+            invoice = self._create_invoice_es(
                 partner_id=self.partner_a.id,
                 move_type='out_invoice',
                 invoice_line_ids=[
@@ -193,7 +193,7 @@ class TestEdiFacturaeXmls(AccountTestInvoicingCommon):
                 patch(f"{self.certificate_module}.fields.Datetime.now", lambda x=None: self.frozen_today), \
                 patch(f'{self.certificate_module}.CertificateCertificate._compute_is_valid', _compute_is_valid), \
                 self._mock_sha1():
-            invoice = self.create_invoice(partner_id=self.partner_a.id, move_type='out_invoice', invoice_line_ids=[{'price_unit': 100.0, 'tax_ids': [self.tax.id]}])
+            invoice = self._create_invoice_es(partner_id=self.partner_a.id, move_type='out_invoice', invoice_line_ids=[{'price_unit': 100.0, 'tax_ids': [self.tax.id]}])
             invoice.action_post()
             wizard = self.create_send_and_print(invoice)
             with self.assertRaises(UserError):
@@ -201,7 +201,7 @@ class TestEdiFacturaeXmls(AccountTestInvoicingCommon):
 
     def test_no_certificate_facturae_not_selected(self):
         self.certificate.unlink()
-        invoice = self.create_invoice(partner_id=self.partner_a.id, move_type='out_invoice', invoice_line_ids=[{'price_unit': 100.0, 'tax_ids': [self.tax.id]}])
+        invoice = self._create_invoice_es(partner_id=self.partner_a.id, move_type='out_invoice', invoice_line_ids=[{'price_unit': 100.0, 'tax_ids': [self.tax.id]}])
         invoice.action_post()
         wizard = self.create_send_and_print(invoice)
         # Expect a UserError if no certificate is configured
@@ -214,7 +214,7 @@ class TestEdiFacturaeXmls(AccountTestInvoicingCommon):
         with freeze_time(self.frozen_today), \
                 patch(f"{self.certificate_module}.fields.Datetime.now", lambda x=None: self.frozen_today), \
                 self._mock_sha1():
-            invoice = self.create_invoice(
+            invoice = self._create_invoice_es(
                 partner_id=self.partner_a.id,
                 move_type='in_invoice',
                 invoice_line_ids=[
@@ -238,7 +238,7 @@ class TestEdiFacturaeXmls(AccountTestInvoicingCommon):
         decimal_precision = self.env['decimal.precision'].search([('name', '=', 'Product Price')])
         decimal_precision.digits = 4
         with freeze_time(self.frozen_today):
-            invoice = self.create_invoice(
+            invoice = self._create_invoice_es(
                 partner_id=self.partner_a.id,
                 move_type='out_invoice',
                 invoice_line_ids=[
@@ -262,7 +262,7 @@ class TestEdiFacturaeXmls(AccountTestInvoicingCommon):
         with freeze_time(self.frozen_today), \
                 patch(f"{self.certificate_module}.fields.Datetime.now", lambda x=None: self.frozen_today), \
                 self._mock_sha1():
-            invoice = self.create_invoice(
+            invoice = self._create_invoice_es(
                 partner_id=self.partner_a.id,
                 move_type='out_invoice',
                 invoice_line_ids=[
@@ -294,7 +294,7 @@ class TestEdiFacturaeXmls(AccountTestInvoicingCommon):
         with freeze_time(self.frozen_today), \
                 patch(f"{self.certificate_module}.fields.Datetime.now", lambda x=None: self.frozen_today), \
                 self._mock_sha1():
-            invoice = self.create_invoice(
+            invoice = self._create_invoice_es(
                 partner_id=self.partner_a.id,
                 move_type='out_invoice',
                 invoice_line_ids=[{'product_id': self.product_a.id, 'price_unit': 1000.0, 'discount': 100.0, 'quantity': 2}],
@@ -395,7 +395,7 @@ class TestEdiFacturaeXmls(AccountTestInvoicingCommon):
 
     @freeze_time('2023-01-01')
     def test_generate_with_administrative_centers(self):
-        invoice = self.create_invoice(
+        invoice = self._create_invoice_es(
             partner_id=self.partner_b.id,
             move_type='out_invoice',
             invoice_line_ids=[{'price_unit': 100.0, 'tax_ids': [self.tax.id]},]
@@ -411,7 +411,7 @@ class TestEdiFacturaeXmls(AccountTestInvoicingCommon):
 
     @freeze_time('2023-01-01')
     def test_generate_with_invoice_period(self):
-        invoice = self.create_invoice(
+        invoice = self._create_invoice_es(
             partner_id=self.partner_a.id,
             move_type='out_invoice',
             invoice_line_ids=[{'price_unit': 100.0, 'tax_ids': [self.tax.id]}],
@@ -429,7 +429,7 @@ class TestEdiFacturaeXmls(AccountTestInvoicingCommon):
 
     @freeze_time('2023-01-01')
     def test_generate_with_payment_means(self):
-        invoice = self.create_invoice(
+        invoice = self._create_invoice_es(
             partner_id=self.partner_a.id,
             move_type='out_invoice',
             invoice_line_ids=[{'price_unit': 100.0, 'tax_ids': [self.tax.id]}],
@@ -455,7 +455,7 @@ class TestEdiFacturaeXmls(AccountTestInvoicingCommon):
 
         # We need to patch dates and uuid to ensure the signature's consistency
         with freeze_time(datetime(2023, 1, 1)):
-            invoice = self.create_invoice(
+            invoice = self._create_invoice_es(
                 partner_id=partner.id,
                 move_type='out_invoice',
                 invoice_line_ids=[
@@ -476,8 +476,7 @@ class TestEdiFacturaeXmls(AccountTestInvoicingCommon):
         with freeze_time(self.frozen_today), \
                 patch(f"{self.certificate_module}.fields.Datetime.now", lambda x=None: self.frozen_today), \
                 self._mock_sha1():
-
-            invoice = self.create_invoice(
+            invoice = self._create_invoice_es(
                 partner_id=self.partner_a.id,
                 move_type='out_invoice',
                 invoice_line_ids=[
@@ -523,8 +522,7 @@ class TestEdiFacturaeXmls(AccountTestInvoicingCommon):
         with freeze_time(self.frozen_today), \
                 patch(f"{self.certificate_module}.fields.Datetime.now", lambda x=None: self.frozen_today), \
                 self._mock_sha1():
-
-            invoice = self.create_invoice(
+            invoice = self._create_invoice_es(
                 partner_id=self.partner_a.id,
                 move_type='out_invoice',
                 invoice_line_ids=[{'price_unit': 150.0, 'tax_ids': [self.tax.id]}],
@@ -565,7 +563,7 @@ class TestEdiFacturaeXmls(AccountTestInvoicingCommon):
             invoices = self.env['account.move']
 
             # Invoice 1: With Factura-e XML
-            invoice1 = self.create_invoice(
+            invoice1 = self._create_invoice_es(
                 partner_id=self.partner_a.id,
                 move_type='out_invoice',
                 invoice_line_ids=[{'price_unit': 100.0, 'tax_ids': [self.tax.id]}],
@@ -582,7 +580,7 @@ class TestEdiFacturaeXmls(AccountTestInvoicingCommon):
             invoices |= invoice1
 
             # Invoice 2: With Factura-e XML
-            invoice2 = self.create_invoice(
+            invoice2 = self._create_invoice_es(
                 partner_id=self.partner_b.id,
                 move_type='out_invoice',
                 invoice_line_ids=[{'price_unit': 200.0, 'tax_ids': [self.tax.id]}],
@@ -599,7 +597,7 @@ class TestEdiFacturaeXmls(AccountTestInvoicingCommon):
             invoices |= invoice2
 
             # Invoice 3: Without Factura-e XML (should be excluded)
-            invoice3 = self.create_invoice(
+            invoice3 = self._create_invoice_es(
                 partner_id=self.partner_a.id,
                 move_type='out_invoice',
                 invoice_line_ids=[{'price_unit': 50.0, 'tax_ids': [self.tax.id]}],
@@ -624,7 +622,7 @@ class TestEdiFacturaeXmls(AccountTestInvoicingCommon):
         company = self.company_data['company']
         company.tax_calculation_rounding_method = 'round_globally'
         with freeze_time(self.frozen_today):
-            invoice = self.create_invoice(
+            invoice = self._create_invoice_es(
                 partner_id=self.partner_a.id,
                 move_type='out_invoice',
                 invoice_line_ids=[

--- a/addons/l10n_es_edi_sii/tests/common.py
+++ b/addons/l10n_es_edi_sii/tests/common.py
@@ -72,7 +72,7 @@ class TestEsEdiCommon(AccountEdiTestCommon):
         return cls.env.ref(f'account.{cls.env.company.id}_account_tax_template_{trailing_xml_id}')
 
     @classmethod
-    def create_invoice(cls, **kwargs):
+    def _create_invoice_es(cls, **kwargs):
         return cls.env['account.move'].with_context(edi_test_mode=True).create({
             'move_type': 'out_invoice',
             'partner_id': cls.partner_a.id,

--- a/addons/l10n_es_edi_sii/tests/test_edi_xml.py
+++ b/addons/l10n_es_edi_sii/tests/test_edi_xml.py
@@ -28,7 +28,7 @@ class TestEdiXmls(TestEsEdiCommon):
         with freeze_time(self.frozen_today), \
              patch('odoo.addons.l10n_es_edi_sii.models.account_edi_format.AccountEdiFormat._l10n_es_edi_call_web_service_sign',
                    new=mocked_l10n_es_edi_call_web_service_sign):
-            invoice = self.create_invoice(
+            invoice = self._create_invoice_es(
                 partner_id=self.partner_a.id,
                 invoice_line_ids=[
                     {'price_unit': 100.0, 'tax_ids': [(6, 0, self._get_tax_by_xml_id('s_iva10b').ids)]},
@@ -101,7 +101,7 @@ class TestEdiXmls(TestEsEdiCommon):
         with freeze_time(self.frozen_today), \
              patch('odoo.addons.l10n_es_edi_sii.models.account_edi_format.AccountEdiFormat._l10n_es_edi_call_web_service_sign',
                    new=mocked_l10n_es_edi_call_web_service_sign):
-            invoice = self.create_invoice(
+            invoice = self._create_invoice_es(
                 partner_id=self.partner_b.id,
                 invoice_line_ids=[
                     {'price_unit': 100.0, 'tax_ids': [(6, 0, self._get_tax_by_xml_id('s_iva10b').ids)]},
@@ -153,7 +153,7 @@ class TestEdiXmls(TestEsEdiCommon):
         with freeze_time(self.frozen_today), \
              patch('odoo.addons.l10n_es_edi_sii.models.account_edi_format.AccountEdiFormat._l10n_es_edi_call_web_service_sign',
                    new=mocked_l10n_es_edi_call_web_service_sign):
-            invoice = self.create_invoice(
+            invoice = self._create_invoice_es(
                 partner_id=self.partner_a.id,
                 invoice_line_ids=[
                     {
@@ -240,7 +240,7 @@ class TestEdiXmls(TestEsEdiCommon):
         with freeze_time(self.frozen_today), \
              patch('odoo.addons.l10n_es_edi_sii.models.account_edi_format.AccountEdiFormat._l10n_es_edi_call_web_service_sign',
                    new=mocked_l10n_es_edi_call_web_service_sign):
-            invoice = self.create_invoice(
+            invoice = self._create_invoice_es(
                 move_type='out_refund',
                 partner_id=self.partner_a.id,
                 invoice_line_ids=[
@@ -316,7 +316,7 @@ class TestEdiXmls(TestEsEdiCommon):
         with freeze_time(self.frozen_today), \
              patch('odoo.addons.l10n_es_edi_sii.models.account_edi_format.AccountEdiFormat._l10n_es_edi_call_web_service_sign',
                    new=mocked_l10n_es_edi_call_web_service_sign):
-            invoice = self.create_invoice(
+            invoice = self._create_invoice_es(
                 partner_id=self.partner_a.id,
                 invoice_line_ids=[
                     {'price_unit': 100.0, 'tax_ids': [(6, 0, self._get_tax_by_xml_id('s_iva0_sp_i').ids)]},
@@ -374,7 +374,7 @@ class TestEdiXmls(TestEsEdiCommon):
         with freeze_time(self.frozen_today), \
              patch('odoo.addons.l10n_es_edi_sii.models.account_edi_format.AccountEdiFormat._l10n_es_edi_call_web_service_sign',
                    new=mocked_l10n_es_edi_call_web_service_sign):
-            invoice = self.create_invoice(
+            invoice = self._create_invoice_es(
                 move_type='out_refund',
                 partner_id=self.partner_a.id,
                 invoice_line_ids=[
@@ -434,7 +434,7 @@ class TestEdiXmls(TestEsEdiCommon):
         with freeze_time(self.frozen_today), \
              patch('odoo.addons.l10n_es_edi_sii.models.account_edi_format.AccountEdiFormat._l10n_es_edi_call_web_service_sign',
                    new=mocked_l10n_es_edi_call_web_service_sign):
-            invoice = self.create_invoice(
+            invoice = self._create_invoice_es(
                 partner_id=self.partner_a.id,
                 invoice_line_ids=[
                     {'price_unit': 100.0, 'tax_ids': [(6, 0, self._get_tax_by_xml_id('s_iva_e').ids)]},
@@ -492,7 +492,7 @@ class TestEdiXmls(TestEsEdiCommon):
         with freeze_time(self.frozen_today), \
              patch('odoo.addons.l10n_es_edi_sii.models.account_edi_format.AccountEdiFormat._l10n_es_edi_call_web_service_sign',
                    new=mocked_l10n_es_edi_call_web_service_sign):
-            invoice = self.create_invoice(
+            invoice = self._create_invoice_es(
                 move_type='out_refund',
                 partner_id=self.partner_a.id,
                 invoice_line_ids=[
@@ -552,7 +552,7 @@ class TestEdiXmls(TestEsEdiCommon):
         with freeze_time(self.frozen_today), \
              patch('odoo.addons.l10n_es_edi_sii.models.account_edi_format.AccountEdiFormat._l10n_es_edi_call_web_service_sign',
                    new=mocked_l10n_es_edi_call_web_service_sign):
-            invoice = self.create_invoice(
+            invoice = self._create_invoice_es(
                 move_type='out_refund',
                 partner_id=self.partner_a.id,
                 currency_id=self.other_currency.id,
@@ -615,7 +615,7 @@ class TestEdiXmls(TestEsEdiCommon):
         with freeze_time(self.frozen_today), \
              patch('odoo.addons.l10n_es_edi_sii.models.account_edi_format.AccountEdiFormat._l10n_es_edi_call_web_service_sign',
                    new=mocked_l10n_es_edi_call_web_service_sign):
-            invoice = self.create_invoice(
+            invoice = self._create_invoice_es(
                 move_type='in_invoice',
                 ref='sup0001',
                 partner_id=self.partner_b.id,
@@ -668,7 +668,7 @@ class TestEdiXmls(TestEsEdiCommon):
         with freeze_time(self.frozen_today), \
              patch('odoo.addons.l10n_es_edi_sii.models.account_edi_format.AccountEdiFormat._l10n_es_edi_call_web_service_sign',
                    new=mocked_l10n_es_edi_call_web_service_sign):
-            invoice = self.create_invoice(
+            invoice = self._create_invoice_es(
                 move_type='in_refund',
                 ref='sup0001',
                 partner_id=self.partner_b.id,
@@ -712,7 +712,7 @@ class TestEdiXmls(TestEsEdiCommon):
         with freeze_time(self.frozen_today), \
              patch('odoo.addons.l10n_es_edi_sii.models.account_edi_format.AccountEdiFormat._l10n_es_edi_call_web_service_sign',
                    new=mocked_l10n_es_edi_call_web_service_sign):
-            invoice = self.create_invoice(
+            invoice = self._create_invoice_es(
                 move_type='in_invoice',
                 ref='sup0001',
                 partner_id=self.partner_b.id,
@@ -777,7 +777,7 @@ class TestEdiXmls(TestEsEdiCommon):
         with freeze_time(self.frozen_today), \
              patch('odoo.addons.l10n_es_edi_sii.models.account_edi_format.AccountEdiFormat._l10n_es_edi_call_web_service_sign',
                    new=mocked_l10n_es_edi_call_web_service_sign):
-            invoice = self.create_invoice(
+            invoice = self._create_invoice_es(
                 move_type='in_invoice',
                 ref='sup0001',
                 partner_id=self.partner_b.id,
@@ -822,7 +822,7 @@ class TestEdiXmls(TestEsEdiCommon):
         with freeze_time(self.frozen_today), \
              patch('odoo.addons.l10n_es_edi_sii.models.account_edi_format.AccountEdiFormat._l10n_es_edi_call_web_service_sign',
                    new=mocked_l10n_es_edi_call_web_service_sign):
-            invoice = self.create_invoice(
+            invoice = self._create_invoice_es(
                 move_type='in_invoice',
                 ref='sup0001',
                 partner_id=self.partner_b.id,
@@ -869,7 +869,7 @@ class TestEdiXmls(TestEsEdiCommon):
         with freeze_time(self.frozen_today), \
              patch('odoo.addons.l10n_es_edi_sii.models.account_edi_format.AccountEdiFormat._l10n_es_edi_call_web_service_sign',
                    new=mocked_l10n_es_edi_call_web_service_sign):
-            invoice = self.create_invoice(
+            invoice = self._create_invoice_es(
                 partner_id=self.partner_b.id,
                 invoice_line_ids=[
                     {
@@ -924,7 +924,7 @@ class TestEdiXmls(TestEsEdiCommon):
         with freeze_time(self.frozen_today), \
              patch('odoo.addons.l10n_es_edi_sii.models.account_edi_format.AccountEdiFormat._l10n_es_edi_call_web_service_sign',
                    new=mocked_l10n_es_edi_call_web_service_sign):
-            invoice = self.create_invoice(
+            invoice = self._create_invoice_es(
                 move_type='in_invoice',
                 ref='sup0001',
                 partner_id=self.partner_b.id,
@@ -976,7 +976,7 @@ class TestEdiXmls(TestEsEdiCommon):
         with freeze_time(self.frozen_today), \
              patch('odoo.addons.l10n_es_edi_sii.models.account_edi_format.AccountEdiFormat._l10n_es_edi_call_web_service_sign',
                    new=mocked_l10n_es_edi_call_web_service_sign):
-            invoice = self.create_invoice(
+            invoice = self._create_invoice_es(
                 move_type='in_refund',
                 ref='sup0001',
                 partner_id=self.partner_b.id,
@@ -1029,7 +1029,7 @@ class TestEdiXmls(TestEsEdiCommon):
         with freeze_time(self.frozen_today), \
              patch('odoo.addons.l10n_es_edi_sii.models.account_edi_format.AccountEdiFormat._l10n_es_edi_call_web_service_sign',
                    new=mocked_l10n_es_edi_call_web_service_sign):
-            invoice = self.create_invoice(
+            invoice = self._create_invoice_es(
                 move_type='in_refund',
                 ref='sup0001',
                 partner_id=self.partner_b.id,
@@ -1084,7 +1084,7 @@ class TestEdiXmls(TestEsEdiCommon):
                 'odoo.addons.l10n_es_edi_sii.models.account_edi_format.AccountEdiFormat._l10n_es_edi_call_web_service_sign',
                 new=mocked_l10n_es_edi_call_web_service_sign
         ):
-            invoice = self.create_invoice(
+            invoice = self._create_invoice_es(
                 move_type='in_invoice',
                 ref='fakedua',
                 partner_id=self.partner_b.id,
@@ -1131,7 +1131,7 @@ class TestEdiXmls(TestEsEdiCommon):
         with freeze_time(self.frozen_today), \
              patch('odoo.addons.l10n_es_edi_sii.models.account_edi_format.AccountEdiFormat._l10n_es_edi_call_web_service_sign',
                    new=mocked_l10n_es_edi_call_web_service_sign):
-            invoice = self.create_invoice(
+            invoice = self._create_invoice_es(
                 move_type='in_invoice',
                 ref='sup0001',
                 partner_id=self.partner_a.id,
@@ -1184,7 +1184,7 @@ class TestEdiXmls(TestEsEdiCommon):
         with freeze_time(self.frozen_today), \
              patch('odoo.addons.l10n_es_edi_sii.models.account_edi_format.AccountEdiFormat._l10n_es_edi_call_web_service_sign',
                    new=mocked_l10n_es_edi_call_web_service_sign):
-            invoice = self.create_invoice(
+            invoice = self._create_invoice_es(
                 move_type='in_refund',
                 ref='sup0001',
                 partner_id=self.partner_a.id,
@@ -1238,7 +1238,7 @@ class TestEdiXmls(TestEsEdiCommon):
         with freeze_time(self.frozen_today), \
              patch('odoo.addons.l10n_es_edi_sii.models.account_edi_format.AccountEdiFormat._l10n_es_edi_call_web_service_sign',
                    new=mocked_l10n_es_edi_call_web_service_sign):
-            invoice = self.create_invoice(
+            invoice = self._create_invoice_es(
                 move_type='in_invoice',
                 ref='sup0001',
                 partner_id=self.partner_a.id,

--- a/addons/l10n_es_edi_sii/tests/test_resequence.py
+++ b/addons/l10n_es_edi_sii/tests/test_resequence.py
@@ -20,20 +20,20 @@ class TestResequenceSII(TestEsEdiCommon):
             mocked_l10n_es_edi_call_web_service_sign,
         )
         # Create 2 customer and 2 vendor invoices, in wrong date order
-        cls.customer_invoice_2 = cls.create_invoice(
+        cls.customer_invoice_2 = cls._create_invoice_es(
             invoice_date="2019-05-15", date="2019-05-15", invoice_line_ids=[{}]
         )
-        cls.customer_invoice_1 = cls.create_invoice(
+        cls.customer_invoice_1 = cls._create_invoice_es(
             invoice_date="2019-05-01", date="2019-05-01", invoice_line_ids=[{}]
         )
-        cls.vendor_invoice_2 = cls.create_invoice(
+        cls.vendor_invoice_2 = cls._create_invoice_es(
             invoice_date="2019-04-15",
             date="2019-04-15",
             move_type="in_invoice",
             ref="vendor/1",
             invoice_line_ids=[{}],
         )
-        cls.vendor_invoice_1 = cls.create_invoice(
+        cls.vendor_invoice_1 = cls._create_invoice_es(
             invoice_date="2019-04-01",
             date="2019-04-01",
             move_type="in_invoice",

--- a/addons/l10n_es_edi_tbai/tests/common.py
+++ b/addons/l10n_es_edi_tbai/tests/common.py
@@ -92,7 +92,7 @@ class TestEsEdiTbaiCommon(TestAccountMoveSendCommon):
         return cls.env.ref(f'account.{cls.env.company.id}_account_tax_template_{trailing_xml_id}')
 
     @classmethod
-    def create_invoice(cls, **kwargs):
+    def _create_invoice_es(cls, **kwargs):
         return cls.env['account.move'].with_context(edi_test_mode=True).create({
             'move_type': 'out_invoice',
             'partner_id': cls.partner_a.id,

--- a/addons/l10n_es_edi_tbai/tests/test_edi_tbai_user_errors.py
+++ b/addons/l10n_es_edi_tbai/tests/test_edi_tbai_user_errors.py
@@ -119,7 +119,7 @@ class TestTbaiUserErrors(TestEsEdiTbaiCommonGipuzkoa):
 
     def test_post_tbai_credit_note_before_reversed_invoice(self):
         # We send a first invoice, so the first invoice sent won't be an invoice imported from a previous system
-        invoice_already_sent = self.create_invoice(invoice_line_ids=[{
+        invoice_already_sent = self._create_invoice_es(invoice_line_ids=[{
             'quantity': 5,
             'discount': 20.0,
             'tax_ids': [(6, 0, self._get_tax_by_xml_id('s_iva21b').ids)],

--- a/addons/l10n_eu_oss/tests/test_oss.py
+++ b/addons/l10n_eu_oss/tests/test_oss.py
@@ -115,8 +115,7 @@ class TestOSSSpain(AccountTestInvoicingCommon):
         """
         Test that the foreign oss taxes generate with l10n_es_type as no_sujeto_loc
         """
-        if self.env['ir.module.module']._get('l10n_es').state != 'installed':
-            self.skipTest(reason="L10n_es is required for this test.")
+        self.ensure_installed('l10n_es')
 
         another_eu_country_code = (self.env.ref('base.europe').country_ids - self.company_data['company'].country_id)[0].code
         tax_oss = self.env['account.tax'].search([('name', 'ilike', f'%"{another_eu_country_code}"%')], limit=1)
@@ -142,8 +141,7 @@ class TestOSSUSA(AccountTestInvoicingCommon):
     def test_oss_tax_on_eu_branch(self):
         """Ensure a company outside EU can have an EU branch with an EU VAT and that the OSS feature could be used on those"""
         # This test can only be run if l10n_be is installed
-        if not self.env['ir.module.module'].search_count([('name', '=', 'l10n_be'), ('state', '=', 'installed')], limit=1):
-            self.skipTest(reason="The belgian CoA is required for this test to be performed but the corresponding localization module isn't installed")
+        self.ensure_installed('l10n_be')
 
         self.root_company = self.company_data['company']
         self.root_company.child_ids = [Command.create({'name': 'Branch A'})]

--- a/addons/l10n_it_edi/tests/test_edi_export.py
+++ b/addons/l10n_it_edi/tests/test_edi_export.py
@@ -470,8 +470,7 @@ class TestItEdiExport(TestItEdi):
 
     @freeze_time("2025-02-03")
     def test_export_invoice_with_two_downpayments(self):
-        if self.env['ir.module.module']._get('sale').state != 'installed':
-            self.skipTest("sale module is not installed")
+        self.ensure_installed('sale')
 
         sale_order = self.env['sale.order'].with_company(self.company).sudo().create({
             'partner_id': self.italian_partner_a.id,

--- a/addons/l10n_it_edi_doi/tests/test_amounts_and_warnings.py
+++ b/addons/l10n_it_edi_doi/tests/test_amounts_and_warnings.py
@@ -14,15 +14,14 @@ class TestItEdiDoiRemaining(TestItEdiDoi):
         super().setUpClass()
         cls.env.user.group_ids |= cls.env.ref('sales_team.group_sale_salesman')
 
-    def create_invoice(self, declaration, invoice_line_vals):
-        return self.env['account.move'].create({
-            'move_type': 'out_invoice',
-            'company_id': self.company.id,
-            'partner_id': declaration.partner_id.id,
-            'invoice_date': declaration.start_date,
-            'l10n_it_edi_doi_id': declaration.id,
-            'invoice_line_ids': invoice_line_vals,
-        })
+    def _create_invoice_doi(self, declaration, invoice_line_vals):
+        return super()._create_invoice(
+            company_id=self.company.id,
+            partner_id=declaration.partner_id.id,
+            invoice_date=declaration.start_date,
+            l10n_it_edi_doi_id=declaration.id,
+            invoice_line_ids=invoice_line_vals,
+        )
 
     def get_sale_order_vals(self, declaration, order_line_vals):
         return {
@@ -34,9 +33,9 @@ class TestItEdiDoiRemaining(TestItEdiDoi):
             'order_line': order_line_vals,
         }
 
-    def create_sale_order(self, declaration, order_line_vals):
+    def _create_sale_order_doi(self, declaration, order_line_vals):
         sale_order_vals = self.get_sale_order_vals(declaration, order_line_vals)
-        return self.env['sale.order'].create(sale_order_vals)
+        return super()._create_sale_order(confirm=False, **sale_order_vals)
 
     def test_invoice_line_edit(self):
         """
@@ -51,7 +50,7 @@ class TestItEdiDoiRemaining(TestItEdiDoi):
             'remaining': 1000.0,
         }])
 
-        invoice = self.create_invoice(declaration, [
+        invoice = self._create_invoice_doi(declaration, [
             Command.create({
                 'name': 'declaration line',
                 'quantity': 2,
@@ -91,7 +90,7 @@ class TestItEdiDoiRemaining(TestItEdiDoi):
             'remaining': 1000.0,
         }])
 
-        order = self.create_sale_order(declaration, [
+        order = self._create_sale_order_doi(declaration, [
             Command.create({
                 'name': 'declaration line',
                 'product_id': self.product_1.id,
@@ -160,7 +159,7 @@ class TestItEdiDoiRemaining(TestItEdiDoi):
             'remaining': 1000.0,
         }])
 
-        invoice = self.create_invoice(declaration, [
+        invoice = self._create_invoice_doi(declaration, [
                 Command.create({
                     'name': 'declaration line',
                     'quantity': 1,
@@ -216,7 +215,7 @@ class TestItEdiDoiRemaining(TestItEdiDoi):
         declaration = self.declaration_1000
         declaration_tax = declaration.company_id.l10n_it_edi_doi_tax_id
 
-        order = self.create_sale_order(declaration, [
+        order = self._create_sale_order_doi(declaration, [
             Command.create({
                 'name': 'declaration line',
                 'product_id': self.product_1.id,
@@ -258,7 +257,7 @@ class TestItEdiDoiRemaining(TestItEdiDoi):
             'remaining': -1000.0,
         }])
 
-        invoice = self.create_invoice(declaration, [
+        invoice = self._create_invoice_doi(declaration, [
             Command.create({
                 'name': 'declaration line',
                 'quantity': 1,
@@ -312,7 +311,7 @@ class TestItEdiDoiRemaining(TestItEdiDoi):
 
         # Add an order that is not used in the rest of this test.
         # This way we can always show the warning and that this amount will not be removed from Not Yet Invoiced.
-        independent_order = self.create_sale_order(declaration, [
+        independent_order = self._create_sale_order_doi(declaration, [
             Command.create({
                 'name': 'declaration line',
                 'product_id': self.product_1.id,
@@ -333,7 +332,7 @@ class TestItEdiDoiRemaining(TestItEdiDoi):
             'remaining': -1000.0,
         }])
 
-        order = self.create_sale_order(declaration, [
+        order = self._create_sale_order_doi(declaration, [
             Command.create({
                 'name': 'declaration line',
                 'product_id': self.product_1.id,

--- a/addons/l10n_my_edi/tests/test_file_generation.py
+++ b/addons/l10n_my_edi/tests/test_file_generation.py
@@ -333,8 +333,7 @@ class L10nMyEDITestFileGeneration(AccountTestInvoicingCommon):
         """
         Ensure that an invoice linked to an SO will not contain this information in the xml.
         """
-        if self.env.ref('base.module_sale').state != 'installed':
-            self.skipTest("This test requires the sale module to be installed.")
+        self.ensure_installed('sale')
 
         sale_order = self.env['sale.order'].sudo().create({
             'partner_id': self.partner_a.id,

--- a/addons/l10n_rs_edi/tests/test_xml_ubl_rs.py
+++ b/addons/l10n_rs_edi/tests/test_xml_ubl_rs.py
@@ -41,7 +41,7 @@ class TestUBLRS(TestUBLCommon):
             'l10n_rs_edi_registration_number': '12345678',
         })
 
-    def create_invoice(self, move_type, **invoice_kwargs):
+    def _create_invoice_rs(self, move_type, **invoice_kwargs):
         return self._generate_move(
             self.env.company.partner_id,
             self.partner_a,
@@ -70,7 +70,7 @@ class TestUBLRS(TestUBLCommon):
         return xml_file
 
     def test_export_invoice(self):
-        invoice = self.create_invoice("out_invoice")
+        invoice = self._create_invoice_rs("out_invoice")
         invoice_xml, _ = self.env['account.edi.xml.ubl.rs']._export_invoice(invoice)
         expected_xml = self._read_xml_test_file('export_invoice')
         self.assertXmlTreeEqual(
@@ -79,7 +79,7 @@ class TestUBLRS(TestUBLCommon):
         )
 
     def test_export_credit_note(self):
-        refund = self.create_invoice("out_refund")
+        refund = self._create_invoice_rs("out_refund")
         refund_xml, _ = self.env['account.edi.xml.ubl.rs']._export_invoice(refund)
         expected_xml = self._read_xml_test_file('export_credit_note')
         self.assertXmlTreeEqual(

--- a/addons/sale/tests/test_taxes_global_discount.py
+++ b/addons/sale/tests/test_taxes_global_discount.py
@@ -1,4 +1,3 @@
-from odoo import Command
 from odoo.exceptions import ValidationError
 from odoo.tests import tagged
 
@@ -10,56 +9,6 @@ from odoo.addons.sale.tests.common import TestTaxCommonSale
 class TestTaxesGlobalDiscountSale(TestTaxCommonSale, TestTaxesGlobalDiscount):
 
     # -------------------------------------------------------------------------
-    # HELPERS
-    # -------------------------------------------------------------------------
-
-    def assert_sale_order_global_discount(
-        self,
-        sale_order,
-        amount_type,
-        amount,
-        expected_values,
-        soft_checking=False,
-    ):
-        """ Assert the expected values for the tax totals summary of the sale order
-        passed as parameter after the applicability of a global discount.
-
-        :param sale_order:      The SO as a sale.order record.
-        :param amount_type:     The type of the global discount: 'percent' or 'fixed'.
-        :param amount:          The amount to consider.
-                                For 'percent', it should be a percentage [0-100].
-                                For 'fixed', any amount.
-        :param expected_values: The expected values for the tax_total_summary.
-        :param soft_checking:   Limit the asserted values to the ones in 'expected_results'
-                                and don't go deeper inside the tax_total_summary.
-                                It allows to assert only the totals without asserting all the
-                                tax details.
-        """
-        if amount_type == 'percent':
-            discount_type = 'so_discount'
-            discount_percentage = amount / 100.0
-            discount_amount = None
-        else:  # amount_type == 'fixed'
-            discount_type = 'amount'
-            discount_percentage = None
-            discount_amount = amount
-        discount_wizard = (
-            self.env['sale.order.discount']
-            .with_context({'active_model': sale_order._name, 'active_id': sale_order.id})
-            .create({
-                'discount_type': discount_type,
-                'discount_percentage': discount_percentage,
-                'discount_amount': discount_amount,
-            })
-        )
-        discount_wizard.action_apply_discount()
-        self._assert_tax_totals_summary(
-            sale_order.tax_totals,
-            expected_values,
-            soft_checking=soft_checking,
-        )
-
-    # -------------------------------------------------------------------------
     # GENERIC TAXES TEST SUITE
     # -------------------------------------------------------------------------
 
@@ -68,21 +17,24 @@ class TestTaxesGlobalDiscountSale(TestTaxCommonSale, TestTaxesGlobalDiscount):
             with self.subTest(test_code=test_mode, amount=amount):
                 sale_order = self.convert_document_to_sale_order(document)
                 sale_order.action_confirm()
-                self.assert_sale_order_global_discount(sale_order, amount_type, amount, expected_values, soft_checking=soft_checking)
+                self._apply_sale_order_discount(sale_order, amount_type, amount)
+                self._assert_tax_totals_summary(sale_order.tax_totals, expected_values, soft_checking=soft_checking)
 
     def test_taxes_l10n_br_sale_orders(self):
         for test_mode, document, soft_checking, amount_type, amount, expected_values in self._test_taxes_l10n_br():
             with self.subTest(test_code=test_mode, amount=amount):
                 sale_order = self.convert_document_to_sale_order(document)
                 sale_order.action_confirm()
-                self.assert_sale_order_global_discount(sale_order, amount_type, amount, expected_values, soft_checking=soft_checking)
+                self._apply_sale_order_discount(sale_order, amount_type, amount)
+                self._assert_tax_totals_summary(sale_order.tax_totals, expected_values, soft_checking=soft_checking)
 
     def test_taxes_l10n_be_sale_orders(self):
         for test_mode, document, soft_checking, amount_type, amount, expected_values in self._test_taxes_l10n_be():
             with self.subTest(test_code=test_mode, amount=amount):
                 sale_order = self.convert_document_to_sale_order(document)
                 sale_order.action_confirm()
-                self.assert_sale_order_global_discount(sale_order, amount_type, amount, expected_values, soft_checking=soft_checking)
+                self._apply_sale_order_discount(sale_order, amount_type, amount)
+                self._assert_tax_totals_summary(sale_order.tax_totals, expected_values, soft_checking=soft_checking)
 
     # -------------------------------------------------------------------------
     # SPECIFIC TESTS
@@ -90,25 +42,12 @@ class TestTaxesGlobalDiscountSale(TestTaxCommonSale, TestTaxesGlobalDiscount):
 
     def test_global_discount_with_sol_discount(self):
         product = self.company_data['product_order_cost']
-        so = self.env['sale.order'].create({
-            'partner_id': self.partner_a.id,
-            'order_line': [
-                # Standalone line with a discount already:
-                Command.create({
-                    'name': 'line_1',
-                    'product_id': product.id,
-                    'price_unit': 1000.0,
-                    'discount': 50.0,
-                }),
-                # Standalone line without any discount:
-                Command.create({
-                    'name': 'line_2',
-                    'product_id': product.id,
-                    'price_unit': 2000.0,
-                }),
+        so = self._create_sale_order(
+            order_line=[
+                self._prepare_order_line(name='line_1', product_id=product, price_unit=1000.0, discount=50.0),
+                self._prepare_order_line(name='line_2', product_id=product, price_unit=2000.0),
             ],
-        })
-        so.action_confirm()
+        )
         self.assertRecordValues(so, [{
             'amount_untaxed': 2500.0,
             'amount_tax': 0.0,
@@ -116,12 +55,7 @@ class TestTaxesGlobalDiscountSale(TestTaxCommonSale, TestTaxesGlobalDiscount):
         }])
 
         # Put a discount of 30% on all SO lines.
-        wizard = self.env['sale.order.discount'].create({
-            'sale_order_id': so.id,
-            'discount_type': 'sol_discount',
-            'discount_percentage': 0.3,
-        })
-        wizard.action_apply_discount()
+        wizard = self._apply_sale_order_discount(so, 'all', 30)
 
         self.assertRecordValues(so.order_line, [
             {'name': 'line_1', 'discount': 30.0},
@@ -153,15 +87,7 @@ class TestTaxesGlobalDiscountSale(TestTaxCommonSale, TestTaxesGlobalDiscount):
 
     def test_cumulative_global_discounts(self):
         product = self.company_data['product_order_cost']
-        so = self.env['sale.order'].create({
-            'partner_id': self.partner_a.id,
-            'order_line': [Command.create({
-                'name': 'line_1',
-                'product_id': product.id,
-                'price_unit': 2000.0,
-            })],
-        })
-        so.action_confirm()
+        so = self._create_sale_order_one_line(name='line_1', product_id=product, price_unit=2000.0)
         self.assertRecordValues(so, [{
             'amount_untaxed': 2000.0,
             'amount_tax': 0.0,
@@ -169,12 +95,7 @@ class TestTaxesGlobalDiscountSale(TestTaxCommonSale, TestTaxesGlobalDiscount):
         }])
 
         # Put a discount of 25%.
-        wizard = self.env['sale.order.discount'].create({
-            'sale_order_id': so.id,
-            'discount_type': 'so_discount',
-            'discount_percentage': 0.25,
-        })
-        wizard.action_apply_discount()
+        wizard = self._apply_sale_order_discount(so, 'percent', 25)
 
         self.assertRecordValues(so.order_line, [
             {'price_unit': 2000.0},

--- a/addons/stock_account/tests/test_stockvaluationlayer.py
+++ b/addons/stock_account/tests/test_stockvaluationlayer.py
@@ -971,7 +971,7 @@ class TestAngloSaxonAccounting(AccountTestInvoicingCommon, TestStockValuationBas
         })
         cls.stock_valuation_account.account_stock_variation_id = cls.stock_valuation_account
 
-    def _create_invoice(self, move_type, product, quantity=1.0, price_unit=1.0):
+    def _create_invoice_stock(self, move_type, product, quantity=1.0, price_unit=1.0):
         rslt = self.env['account.move'].create({
             'partner_id': self.partner_a.id,
             'move_type': move_type,
@@ -1051,7 +1051,7 @@ class TestAngloSaxonAccounting(AccountTestInvoicingCommon, TestStockValuationBas
         out_move = self._make_out_move(self.product1, 10, create_picking=True)
         return_move = self._make_return(out_move, 10)
 
-        out_invoice = self._create_invoice('out_invoice', self.product1, 10, 10)
+        out_invoice = self._create_invoice_stock('out_invoice', self.product1, 10, 10)
         return_credit_note = self._create_credit_note(out_invoice, self.product1, 10, 10)
 
         out_move_line_ids = out_invoice.line_ids
@@ -1077,8 +1077,8 @@ class TestAngloSaxonAccounting(AccountTestInvoicingCommon, TestStockValuationBas
         move1 = self._make_dropship_move(self.product1, 2, unit_cost=10)
         move2 = self._make_return(move1, 2)
 
-        in_invoice = self._create_invoice('in_invoice', self.product1, 2, 10)
-        out_invoice = self._create_invoice('out_invoice', self.product1, 2, 10)
+        in_invoice = self._create_invoice_stock('in_invoice', self.product1, 2, 10)
+        out_invoice = self._create_invoice_stock('out_invoice', self.product1, 2, 10)
         return_in_credit_note = self._create_credit_note(in_invoice, self.product1, 2, 10)
         return_out_credit_note = self._create_credit_note(out_invoice, self.product1, 2, 10)
 
@@ -1127,8 +1127,8 @@ class TestAngloSaxonAccounting(AccountTestInvoicingCommon, TestStockValuationBas
         return_pick.move_ids[0].picked = True
         return_pick._action_done()
 
-        in_invoice = self._create_invoice('in_invoice', self.product1, 2, 10)
-        out_invoice = self._create_invoice('out_invoice', self.product1, 2, 10)
+        in_invoice = self._create_invoice_stock('in_invoice', self.product1, 2, 10)
+        out_invoice = self._create_invoice_stock('out_invoice', self.product1, 2, 10)
         return_in_credit_note = self._create_credit_note(in_invoice, self.product1, 2, 10)
         return_out_credit_note = self._create_credit_note(out_invoice, self.product1, 2, 10)
 


### PR DESCRIPTION
This commit adds bunch of helper methods on AccountTestInvoicingCommon to make it easier to do generic accounting test actions, such as:

- creating invoice
- creating sale order
- reversing invoice
- skipping test if module isn't installed
- creating down payment invoice

... and many more.

We're aware that there are thousands of different helpers for creating invoice out there in different localizations. This commit serves as the first necessary step to create one standard that can be extended across all other test helpers.

Some tests have been rewritten to use these new helpers, but due to the sheer amount of tests out there, we're still far from converting every old tests to use this new helpers. However, this should get our feet in the door, allowing us to start writing test the correct way on new tests after this PR, and improve the DX of (accounting) test writing. :)

task-4891206