### PR TITLE
[FIX] mail: discuss demo data of message of Alex shows Alex as author

### DIFF
--- a/addons/mail/demo/discuss/public_channel_demo.xml
+++ b/addons/mail/demo/discuss/public_channel_demo.xml
@@ -28,6 +28,7 @@
             <field name="res_id" ref="mail.channel_public_community_demo"/>
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id"/>
             <field name="author_guest_id" ref="mail.guest_alex_demo"/>
             <field name="parent_id" ref="mail.channel_public_community_message_0_demo"/>
             <field name="date" eval="(DateTime.today() - timedelta(minutes=20)).strftime('%Y-%m-%d %H:%M')"/>


### PR DESCRIPTION
Before this commit, Alex's messages in discuss demo data were displayed as "Odoobot" rather than Alex.

This happens because message had proper author_guest_id but no author_id defined, thus it had default value Odoobot and since [1] the author_id has precedence over `author_guest_id`.

Before [1] there was no bug because the server returned formatted data of a single author as a persona, and guest_author_id had precedence over author_id.

[1]: https://github.com/odoo/odoo/pull/211868

Before
<img width="811" height="279" alt="Screenshot 2025-10-10 at 16 18 53" src="https://github.com/user-attachments/assets/862cfd18-24a0-485f-89b6-77277b9098ad" />


After
<img width="815" height="280" alt="Screenshot 2025-10-10 at 16 17 45" src="https://github.com/user-attachments/assets/f83b98dd-ffb1-4419-851c-f34f3261792d" />

