### PR TITLE
[FIX] pos_restaurant: fix table dragging on tablet and mobile

### DIFF
--- a/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_screen.js
+++ b/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_screen.js
@@ -162,8 +162,15 @@ export class FloorScreen extends Component {
                 const table = this.getPosTable(element);
                 if (!suggestLinkingPositions()) {
                     table.position_h =
-                        x - offsetX + this.map.el.parentElement.parentElement.scrollLeft;
-                    table.position_v = y - offsetY - this.map.el.getBoundingClientRect().top;
+                        x -
+                        offsetX +
+                        this.map.el.parentElement.parentElement.scrollLeft -
+                        this.state.floorMapOffset.x;
+                    table.position_v =
+                        y -
+                        offsetY -
+                        this.map.el.getBoundingClientRect().top -
+                        this.state.floorMapOffset.y;
                     if (this.pos.isEditMode && !this.activeFloor.floor_background_image) {
                         table.position_h -= table.position_h % GRID_SIZE;
                         table.position_v -= table.position_v % GRID_SIZE;


### PR DESCRIPTION
Task: [#4383744](https://www.odoo.com/odoo/project/1737/tasks/5045938)

---

On mobile and tablet devices, the floor plan removes top and left padding to position tables closer to the top-left corner and avoid unnecessary scrolling.

However, dragging a table did not take these offsets into account, resulting in incorrect placement during the action.