### PR TITLE
[FIX] hr_holidays: fix virtual accrual leaves computation

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -628,9 +628,9 @@ class HolidaysAllocation(models.Model):
         fake_allocation = self.env['hr.leave.allocation'].with_context(default_date_from=accrual_date).new(origin=self)
         fake_allocation.sudo().with_context(default_date_from=accrual_date)._process_accrual_plans(accrual_date, log=False)
         if self.holiday_status_id.request_unit in ['hour']:
-            res = float_round(fake_allocation.number_of_hours_display - self.number_of_hours_display, precision_digits=2)
+            res = float_round(fake_allocation.number_of_hours_display, precision_digits=2)
         else:
-            res = round((fake_allocation.number_of_days - self.number_of_days), 2)
+            res = round((fake_allocation.number_of_days), 2)
         fake_allocation.invalidate_recordset()
         return res
 


### PR DESCRIPTION
To reproduce:
=============
- create accrual plan to get 1 day of WFH every week on monday, no carry over
- create allocation with this plan for an employee
- in the actual week you can see on dashboard that you have 1 day of WFH
- let's say we are a Monday, take 1 day of WFH on Wednesday (don't approve it)
- before Wednesday dashboard shows 1 day of WFH
- after Wednesday in same week dashboard shows 0 day of WFH
- in next week dashboard shows 0 day of WFH which is wrong

Problem:
========
The computation of virtual accrual leaves was wrong because it took into account the leaves already taken in the current week, while they should be ignored.

Solution:
=========
as we already check if the allocation we are computing virtual accrual for is in same time range as the current one here : https://github.com/odoo/odoo/blob/4c9eadc3c1b2d5ef6a495b89ab33481d5d545ec4/addons/hr_holidays/models/hr_leave_allocation.py#L625 we don't need to subtract the number of days/hours of the current allocation

opw-4712586

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
