### PR TITLE
[IMP] point_of_sale: disable autofocus on pos config kanban for mobiles

### DIFF
--- a/addons/point_of_sale/static/src/backend/pos_kanban_view/pos_kanban_view.js
+++ b/addons/point_of_sale/static/src/backend/pos_kanban_view/pos_kanban_view.js
@@ -10,6 +10,7 @@ import { useService } from "@web/core/utils/hooks";
 import { useTrackedAsync } from "@point_of_sale/app/utils/hooks";
 import { _t } from "@web/core/l10n/translation";
 import { KanbanController } from "@web/views/kanban/kanban_controller";
+import { hasTouch } from "@web/core/browser/feature_detection";
 
 async function updatePosKanbanViewState(orm, stateObj) {
     const result = await orm.call("pos.config", "get_pos_kanban_view_state");
@@ -28,6 +29,8 @@ export class PosKanbanController extends KanbanController {
             show_predefined_scenarios: true,
             is_main_company: true,
         };
+        this.autofocus = hasTouch() ? false : true;
+
         onWillStart(() => updatePosKanbanViewState(this.orm, this.initialPosState));
     }
 }

--- a/addons/point_of_sale/static/src/backend/pos_kanban_view/pos_kanban_view.xml
+++ b/addons/point_of_sale/static/src/backend/pos_kanban_view/pos_kanban_view.xml
@@ -4,6 +4,10 @@
         <xpath expr="//t[@t-component='props.Renderer']" position="attributes">
             <attribute name="initialPosState">initialPosState</attribute>
         </xpath>
+
+        <xpath expr="//t[@t-set-slot='layout-actions']/SearchBar" position="attributes">
+            <attribute name="autofocus">this.autofocus</attribute>
+        </xpath>
     </t>
 
     <t t-name="point_of_sale.PosKanbanRenderer">


### PR DESCRIPTION
Task: [#5016943](https://www.odoo.com/odoo/project/1737/tasks/5016943)

---

On tablets and phones, the search bar was autofocus when opening the POS config kanban view. This was causing the keyboard to open automatically, which was not a good user experience.

Now the search bar is not autofocus on touch devices for the POS config kanban view ('view_pos_config_kanban').