### PR TITLE
[IMP] website_sale: allow hiding categories from /shop structure

### DIFF
--- a/addons/test_website_modules/tests/test_performance.py
+++ b/addons/test_website_modules/tests/test_performance.py
@@ -295,7 +295,7 @@ class TestWebsiteAllPerformance(TestWebsitePerformanceCommon, TestWebsitePriceLi
         self.assertIn(f'<img src="/web/image/product.template/{self.productA.product_tmpl_id.id}/', html)
         self.assertIn(f'<img src="/web/image/product.image/{self.product_images.ids[1]}/', html)
 
-        query_count = 49  # To increase this number you must ask the permission to al
+        query_count = 50  # To increase this number you must ask the permission to al
         queries = {
             'orm_signaling_registry': 1,
             'website': 1,
@@ -303,7 +303,7 @@ class TestWebsiteAllPerformance(TestWebsitePerformanceCommon, TestWebsitePriceLi
             'product_pricelist': 4,
             'product_template': 6,
             'product_tag': 1,
-            'product_public_category': 4,
+            'product_public_category': 5,
             'product_product': 1,
             'product_template_attribute_line': 3,
             'res_users': 1,

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -859,6 +859,8 @@ class ProductTemplate(models.Model):
         min_price = options.get('min_price')
         max_price = options.get('max_price')
         attribute_value_dict = options.get('attribute_value_dict')
+        if extra_domain := options.get('extra_domain'):
+            domains.append(extra_domain)
         if category:
             domains.append([('public_categ_ids', 'child_of', self.env['ir.http']._unslug(category)[1])])
         if tags:

--- a/addons/website_sale/static/src/js/systray_items/website_systray_item.js
+++ b/addons/website_sale/static/src/js/systray_items/website_systray_item.js
@@ -1,0 +1,12 @@
+import { patch } from '@web/core/utils/patch';
+import { WebsiteSystrayItem } from '@website/client_actions/website_preview/website_systray_item';
+
+patch(WebsiteSystrayItem.prototype, {
+    get canPublish() {
+        const mainObject = this.website.currentWebsite.metadata.mainObject;
+
+        return mainObject?.model === 'product.public.category'
+            ? false
+            : super.canPublish;
+    },
+});

--- a/addons/website_sale/views/product_public_category_views.xml
+++ b/addons/website_sale/views/product_public_category_views.xml
@@ -7,22 +7,63 @@
         <field name="arch" type="xml">
             <form string="Website Public Categories">
                 <sheet>
+                    <div class="oe_button_box" name="button_box">
+                        <field name="is_published" widget="website_redirect_button"/>
+                    </div>
                     <field
                         name="image_1920"
                         widget="image"
                         class="oe_avatar"
                         options="{'convert_to_webp': True, 'preview_image': 'image_128'}"
                     />
-                    <div>
-                        <group class="col-md-4 col-lg-6 pe-3">
-                            <field name="name"/>
-                            <field name="parent_id"/>
-                            <field name="website_id" options="{'no_create': True}" groups="website.group_multi_website"/>
-                            <field name="sequence" groups="base.group_no_one"/>
-                            <field name="website_description"/>
-                            <field name="cover_image" widget="image" alt="Cover Image"/>
-                        </group>
+                    <div class="oe_title">
+                        <label for="name" string="Category"/>
+                        <h1>
+                            <field
+                                name="name"
+                                class="text-break"
+                                widget="text"
+                                options="{'line_breaks': False}"
+                            />
+                        </h1>
                     </div>
+                    <group class="col-md-4 col-lg-6">
+                        <field name="parent_id"/>
+                        <field
+                            name="website_id"
+                            options="{'no_create': True}"
+                            groups="website.group_multi_website"
+                        />
+                        <field name="not_in_shop" invisible="parent_id"/>
+                    </group>
+                    <notebook>
+                        <page name="products_page" string="Products">
+                            <field name="product_tmpl_ids">
+                                <list editable="bottom" open_form_view="True">
+                                    <field name="name" readonly="1"/>
+                                    <field name="default_code" readonly="1"/>
+                                    <field name="is_published"/>
+                                    <control>
+                                        <create string="Add a product"/>
+                                    </control>
+                                </list>
+                            </field>
+                        </page>
+                        <page name="description_page" string="Description">
+                            <group>
+                                <group>
+                                    <field name="website_description"/>
+                                </group>
+                                <group>
+                                    <field
+                                        name="cover_image"
+                                        widget="image"
+                                        alt="Cover Image"
+                                    />
+                                </group>
+                            </group>
+                        </page>
+                    </notebook>
                 </sheet>
             </form>
         </field>


### PR DESCRIPTION
Before this commit:
- All website product categories were always displayed under the main /shop page.
- There was no way to exclude a category from the shop hierarchy.
- This prevented creating standalone product category pages or curated product selections that should not appear in the main shop view.

After this commit:
- Added a boolean field to hide specific categories from the /shop structure.
- Hidden categories remain fully functional and can be accessed directly through their URLs and 'Go to website' stat button in their form view.
- Redesigned the eCommerce Category form view.

task-5129498