### PR TITLE
[18.0][FIX] account_payment: Move the field payment_method_code from account_payment to account

### DIFF
--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -126,6 +126,7 @@ class AccountPaymentRegister(models.TransientModel):
         "SEPA Credit Transfer: Pay in the SEPA zone by submitting a SEPA Credit Transfer file to your bank. Module account_sepa is necessary.\n"
         "SEPA Direct Debit: Get paid in the SEPA zone thanks to a mandate your partner will have granted to you. Module account_sepa is necessary.\n")
     available_payment_method_line_ids = fields.Many2many('account.payment.method.line', compute='_compute_payment_method_line_fields')
+    payment_method_code = fields.Char(related='payment_method_line_id.code')
 
     # == Payment difference fields ==
     payment_difference = fields.Monetary(

--- a/addons/account_payment/wizards/account_payment_register.py
+++ b/addons/account_payment/wizards/account_payment_register.py
@@ -25,8 +25,6 @@ class AccountPaymentRegister(models.TransientModel):
     use_electronic_payment_method = fields.Boolean(
         compute='_compute_use_electronic_payment_method',
     )
-    payment_method_code = fields.Char(
-        related='payment_method_line_id.code')
 
     # -------------------------------------------------------------------------
     # COMPUTE METHODS


### PR DESCRIPTION
Odoo 18 have an error, the view `account_sepa_direct_debit.account_payment_register_form_inherit_account_sepa_direct_debit` (Enterprise)
references the field `payment_method_code` from `account.payment.register`.
This field is added to the model in the `account_payment` module, which is not among the dependencies of `account_sepa_direct_debit`.
This means that if the `account_payment` module is not installed, the installation/update of `account_sepa_direct_debit` will also fail.

To avoid this error, the field `payment_method_code` in the `account_payment` module needs to be defined instead in the `account` module.
I open this PR on the recommendation of @hupo-odoo ([comment](https://github.com/odoo/enterprise/pull/96254#pullrequestreview-3310607477)).

Here’s a screenshot of the error (runbot)
<img width="1498" height="857" alt="runbot_account_sepa_direct_debit" src="https://github.com/user-attachments/assets/e8d66a96-59a3-4cf3-857b-e07a3337338c" />

Here’s the screenshot after changing to this commit
<img width="1594" height="725" alt="image" src="https://github.com/user-attachments/assets/ea2fbe2c-31b8-4d61-8cf2-00e003ec3587" />

[OPW](https://www.odoo.com/es_ES/my/tasks/5139827)
[PR enterprise](https://github.com/odoo/enterprise/pull/96254#pullrequestreview-3310607477)

@moduon MT-12067

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
