### PR TITLE
[FIX] purchase_stock: incorrect value with UoM or currency

### DIFF
--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -160,11 +160,11 @@ class StockMove(models.Model):
                 continue
             aml_ids.add(aml.id)
             if aml.move_type == 'in_invoice':
-                aml_quantity += aml.quantity
-                value += aml.price_subtotal
+                aml_quantity += aml.product_uom_id._compute_quantity(aml.quantity, self.product_id.uom_id)
+                value += aml.currency_id._convert(aml.price_subtotal, self.company_id.currency_id, date=aml.date)
             elif aml.move_type == 'in_refund':
-                aml_quantity -= aml.quantity
-                value -= aml.price_subtotal
+                aml_quantity -= aml.product_uom_id._compute_quantity(aml.quantity, self.product_id.uom_id)
+                value -= aml.currency_id._convert(aml.price_subtotal, self.company_id.currency_id, date=aml.date)
 
         if aml_quantity <= 0:
             return valuation_data


### PR DESCRIPTION
Currently the move valuation base on BILL use the value define on the BILL without checking the currency nor the UoM.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
