### PR TITLE
[FIX] l10n_sa_edi: correct placeholder of street2 field

### DIFF
--- a/addons/l10n_sa_edi/data/res_country_data.xml
+++ b/addons/l10n_sa_edi/data/res_country_data.xml
@@ -11,7 +11,7 @@
                     <field name="type" invisible="1"/>
                     <field name="street" placeholder="Street" class="o_address_street"
                            readonly="type == 'contact' and parent_id"/>
-                    <field name="street2" placeholder="Neighborhood" class="o_address_street"
+                    <field name="street2" placeholder="District" class="o_address_street"
                             readonly="type == 'contact' and parent_id"/>
                     <field name="city" placeholder="City" class="o_address_city"
                            readonly="type == 'contact' and parent_id"/>

--- a/addons/l10n_sa_edi/i18n/ar.po
+++ b/addons/l10n_sa_edi/i18n/ar.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-22 06:34+0000\n"
-"PO-Revision-Date: 2025-08-22 10:51+0400\n"
+"POT-Creation-Date: 2025-10-13 12:36+0000\n"
+"PO-Revision-Date: 2025-10-13 12:36+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: ar\n"
@@ -393,6 +393,12 @@ msgid "Display Name"
 msgstr "اسم العرض"
 
 #. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.sa_partner_address_form
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_company_form
+msgid "District"
+msgstr "اﺳﻢ اﻟﺤﻲ"
+
+#. module: l10n_sa_edi
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_account_bank_statement_line__l10n_sa_uuid
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_account_move__l10n_sa_uuid
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_account_payment__l10n_sa_uuid
@@ -635,11 +641,6 @@ msgstr "غير منطبق"
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__res_partner__l10n_sa_additional_identification_scheme__nat
 msgid "National ID"
 msgstr "الهوية الوطنية"
-
-#. module: l10n_sa_edi
-#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.sa_partner_address_form
-msgid "Neighborhood"
-msgstr "الحي"
 
 #. module: l10n_sa_edi
 #. odoo-python
@@ -914,6 +915,11 @@ msgid "Street"
 msgstr "الشارع"
 
 #. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_company_form
+msgid "Street 2..."
+msgstr "الشارع ..."
+
+#. module: l10n_sa_edi
 #. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
@@ -1063,7 +1069,6 @@ msgstr "VATEX-SA-34-1 الشحن الدولي للبضائع."
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax__l10n_sa_exemption_reason_code__vatex-sa-34-2
-#: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax_template__l10n_sa_exemption_reason_code__vatex-sa-34-2
 msgid "VATEX-SA-34-2 The international transport of Passengers."
 msgstr "VATEX-SA-34-2 المواصلات الدولية للركاب."
 

--- a/addons/l10n_sa_edi/i18n/l10n_sa_edi.pot
+++ b/addons/l10n_sa_edi/i18n/l10n_sa_edi.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-22 06:34+0000\n"
-"PO-Revision-Date: 2025-08-22 06:34+0000\n"
+"POT-Creation-Date: 2025-10-13 12:35+0000\n"
+"PO-Revision-Date: 2025-10-13 12:35+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -410,6 +410,12 @@ msgid "Display Name"
 msgstr ""
 
 #. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.sa_partner_address_form
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_company_form
+msgid "District"
+msgstr ""
+
+#. module: l10n_sa_edi
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_account_bank_statement_line__l10n_sa_uuid
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_account_move__l10n_sa_uuid
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_account_payment__l10n_sa_uuid
@@ -658,11 +664,6 @@ msgstr ""
 #. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__res_partner__l10n_sa_additional_identification_scheme__nat
 msgid "National ID"
-msgstr ""
-
-#. module: l10n_sa_edi
-#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.sa_partner_address_form
-msgid "Neighborhood"
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -951,6 +952,11 @@ msgid "Street"
 msgstr ""
 
 #. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_company_form
+msgid "Street 2..."
+msgstr ""
+
+#. module: l10n_sa_edi
 #. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
@@ -1118,7 +1124,6 @@ msgstr ""
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax__l10n_sa_exemption_reason_code__vatex-sa-34-2
-#: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax_template__l10n_sa_exemption_reason_code__vatex-sa-34-2
 msgid "VATEX-SA-34-2 The international transport of Passengers."
 msgstr ""
 

--- a/addons/l10n_sa_edi/views/res_company_views.xml
+++ b/addons/l10n_sa_edi/views/res_company_views.xml
@@ -18,6 +18,10 @@
                     <field name="l10n_sa_additional_identification_scheme" invisible="country_code != 'SA'"/>
                     <field name="l10n_sa_additional_identification_number" invisible="country_code != 'SA' or l10n_sa_additional_identification_scheme == 'TIN'"/>
                 </xpath>
+                <xpath expr="//field[@name='street2']" position="replace">
+                    <field name="street2" placeholder="District" class="o_address_street" invisible="country_code != 'SA'"/>
+                    <field name="street2" placeholder="Street 2..." class="o_address_street" invisible="country_code == 'SA'"/>
+                </xpath>
             </field>
         </record>
     </data>


### PR DESCRIPTION
## Before this commit
The `street2` field on `res.company` and `res.partner` was mapped to `cac:AccountingSupplierParty/cac:Party/cac:PostalAddress/cbc:CitySubdivisionName`, but its placeholder displayed `Street 2…`.

This caused confusion among users, as they assumed it referred to `cbc:AdditionalStreetName`, leading to incorrect data entry and potential non-compliance.

## After this commit
The placeholder of the `street2` field has been changed from `Street 2…` to `District…`, clarifying that this field represents the city subdivision (district or borough) of the Seller/Customer, in line with the Saudi Arabia e-invoicing specification.

> Task-4951545




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
