### PR TITLE
[FIX] website_sale: restore alert for archived product variants

### DIFF
--- a/addons/website_sale/static/src/js/sale_variant_mixin.js
+++ b/addons/website_sale/static/src/js/sale_variant_mixin.js
@@ -364,6 +364,10 @@ var VariantMixin = {
      * @param {Array} combination
      */
     _onChangeCombination: function (ev, $parent, combination) {
+        // Update archived combination alert
+        const $alert = $parent.find('.o_archived_combination_alert');
+        $alert.toggleClass('d-none', combination.is_combination_possible);
+
         const isCombinationPossible = !!combination.is_combination_possible;
         const $pricePerUom = $parent.find(".o_base_unit_price:first .oe_currency_value");
         if ($pricePerUom.length) {

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2040,6 +2040,9 @@
                                                     t-value="combination_info['combination']"
                                                 />
                                             </t>
+                                            <p t-attf-class="o_archived_combination_alert alert alert-warning">
+                                                This combination does not exist
+                                            </p>
                                         </t>
                                         <t
                                             t-if="not is_fullwidth_content"


### PR DESCRIPTION
**Steps to reproduce:**
1. Install the `website_sale` module.
2. Create a product with multiple variants.
3. Archive one of the variants.
4. Publish the product on the website.
5. Try selecting the archived variant.

**Observed behavior:**
* The variant appeared greyed out without any alert, leaving users without feedback.

**Root cause:**
* The alert element was removed in this [commit](https://github.com/odoo/odoo/commit/eac892a4ad7373d18f954afbbcd2f1213ac5f281).

**Solution:**
* Restore the alert in the template and toggle its visibility in the JS handler.
* Selecting an archived variant now displays the message: “This combination does not exist”.

opw-5069059