### PR TITLE
[IMP] stock: improve UX of return wizard by refining buttons and labels

### DIFF
--- a/addons/stock/wizard/stock_picking_return.py
+++ b/addons/stock/wizard/stock_picking_return.py
@@ -79,7 +79,8 @@ class StockReturnPickingLine(models.TransientModel):
                 new_return_move.write(vals)
             else:
                 self.env['stock.move'].create(vals)
-        return True
+            return True
+        return False
 
 
 class StockReturnPicking(models.TransientModel):

--- a/addons/stock/wizard/stock_picking_return_views.xml
+++ b/addons/stock/wizard/stock_picking_return_views.xml
@@ -25,9 +25,9 @@
                 </field>
                 <footer>
                     <button name="action_create_returns" string="Return" type="object" class="btn-primary" data-hotkey="q"/>
-                    <button name="action_create_returns_all" string="Return All" type="object" class="btn-primary"/>
-                    <button name="action_create_exchanges" string="Return for Exchange" invisible="picking_type_code not in ('incoming', 'outgoing')" type="object" class="btn-primary"/>
-                    <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x" />
+                    <button name="action_create_returns_all" string="Return All" type="object" class="btn-secondary"/>
+                    <button name="action_create_exchanges" string="Return for Exchange" invisible="picking_type_code not in ('incoming', 'outgoing')" type="object" class="btn-secondary"/>
+                    <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>


### PR DESCRIPTION
Previously, the return wizard displayed multiple primary buttons, which could
confuse users and affect the clarity of actions. This commit updates the wizard
to have a single primary button, with all other action buttons changed to
secondary for better user experience.

Additionally, some button labels have been updated for clarity:
- `Cancel` → `Discard`

These changes make the return wizard more consistent, intuitive, and easier
to use for all types of stock operations.

This commit also enables improved user error when attempting to return products
with zero quantities.

Task - 5144914