### PR TITLE
[IMP] mail: direct access to isTransient

### DIFF
--- a/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
@@ -9,7 +9,7 @@ export class DiscussChannel extends Record {
     id = fields.Attr(undefined, {
         onUpdate() {
             const busService = this.store.env.services.bus_service;
-            if (!busService.isActive && !this.thread.isTransient) {
+            if (!busService.isActive && !this.isTransient) {
                 busService.start();
             }
         },


### PR DESCRIPTION
Since 478647c4526f, we can now access inherited getters and methods. The call to thread is no longer useful.
