### PR TITLE
[IMP] l10n_gcc_invoice: remove l10n_gcc_country_is_gcc

### DIFF
--- a/addons/l10n_gcc_invoice/i18n/ar.po
+++ b/addons/l10n_gcc_invoice/i18n/ar.po
@@ -76,11 +76,6 @@ msgid "Journal Item"
 msgstr "بند اليومية"
 
 #. module: l10n_gcc_invoice
-#: model:ir.model.fields,field_description:l10n_gcc_invoice.field_res_company__l10n_gcc_country_is_gcc
-msgid "L10N Gcc Country Is Gcc"
-msgstr "البلد من دول مجلس التعاون الخليجي"
-
-#. module: l10n_gcc_invoice
 #: model:ir.model.fields,field_description:l10n_gcc_invoice.field_account_move_line__l10n_gcc_line_name
 msgid "L10N Gcc Line Name"
 msgstr "اسم السطر لتنسيق دول مجلس التعاون الخليجي"

--- a/addons/l10n_gcc_invoice/i18n/l10n_gcc_invoice.pot
+++ b/addons/l10n_gcc_invoice/i18n/l10n_gcc_invoice.pot
@@ -77,11 +77,6 @@ msgid "Journal Item"
 msgstr ""
 
 #. module: l10n_gcc_invoice
-#: model:ir.model.fields,field_description:l10n_gcc_invoice.field_res_company__l10n_gcc_country_is_gcc
-msgid "L10N Gcc Country Is Gcc"
-msgstr ""
-
-#. module: l10n_gcc_invoice
 #: model:ir.model.fields,field_description:l10n_gcc_invoice.field_account_move_line__l10n_gcc_line_name
 msgid "L10N Gcc Line Name"
 msgstr ""

--- a/addons/l10n_gcc_invoice/models/res_company.py
+++ b/addons/l10n_gcc_invoice/models/res_company.py
@@ -1,13 +1,7 @@
-from odoo import api, fields, models
+from odoo import fields, models
 
 
 class ResCompany(models.Model):
     _inherit = 'res.company'
 
     l10n_gcc_dual_language_invoice = fields.Boolean(string="GCC Formatted Invoices")
-    l10n_gcc_country_is_gcc = fields.Boolean(compute='_compute_l10n_gcc_country_is_gcc')
-
-    @api.depends('partner_id.country_id.country_group_ids.code')
-    def _compute_l10n_gcc_country_is_gcc(self):
-        for record in self:
-            record.l10n_gcc_country_is_gcc = record.country_id and 'GCC' in record.country_id.country_group_codes

--- a/addons/l10n_gcc_invoice/models/res_config_settings.py
+++ b/addons/l10n_gcc_invoice/models/res_config_settings.py
@@ -5,4 +5,3 @@ class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
     l10n_gcc_dual_language_invoice = fields.Boolean(related='company_id.l10n_gcc_dual_language_invoice', readonly=False)
-    l10n_gcc_country_is_gcc = fields.Boolean(related='company_id.l10n_gcc_country_is_gcc')

--- a/addons/l10n_gcc_invoice/views/report_invoice.xml
+++ b/addons/l10n_gcc_invoice/views/report_invoice.xml
@@ -7,7 +7,10 @@
                     <t t-if="lang != 'ar_001'" t-set="lang_sec" t-value="o.env['res.lang']._get_code('ar_001')"/>
                     <t t-else="" t-set="lang_sec" t-value="o.env['res.lang']._get_code('en_US')"/>
                     <t t-set="o_sec" t-value="o.with_context(lang=lang_sec)"/>
-                    <t t-set="display_in_lang_sec" t-value="o.company_id.l10n_gcc_country_is_gcc and o.company_id.l10n_gcc_dual_language_invoice"/>
+                    <t t-set="display_in_lang_sec"
+                       t-value="o.company_id.country_id
+                                and 'GCC' in o.company_id.country_id.country_group_codes
+                                and o.company_id.l10n_gcc_dual_language_invoice"/>
                     <t t-set="display_in_ar" t-value="display_in_lang_sec and lang_sec == 'ar_001'"/>
                     <t t-set="display_in_en" t-value="display_in_lang_sec and lang_sec == 'en_US'"/>
                     <t t-set="invoice_gcc_title" t-value="o._l10n_gcc_get_invoice_title()"/>

--- a/addons/l10n_gcc_invoice/views/res_config_settings_views.xml
+++ b/addons/l10n_gcc_invoice/views/res_config_settings_views.xml
@@ -8,7 +8,7 @@
             <field name="arch" type="xml">
                 <block name="fiscal_localization_setting_container" position="inside">
                     <setting string="Gulf Cooperation Council Format" company_dependent="1"
-                             invisible="not l10n_gcc_country_is_gcc"
+                             invisible="'GCC' not in company_country_group_codes"
                              help="Add Arabic as a secondary language to your invoices, credit notes, debit notes, vendor bills, and refund bills">
                         <field name="l10n_gcc_dual_language_invoice"/>
                     </setting>

--- a/addons/l10n_gcc_pos/views/res_config_settings_views.xml
+++ b/addons/l10n_gcc_pos/views/res_config_settings_views.xml
@@ -8,7 +8,7 @@
             <field name="arch" type="xml">
                 <block id="pos_bills_and_receipts_section" position="inside">
                     <setting string="Gulf Cooperation Council Format"
-                             invisible="not company_id.l10n_gcc_country_is_gcc"
+                             invisible="'GCC' not in company_country_group_codes"
                              help="Add Arabic as a secondary language to your receipt">
                         <field name="l10n_gcc_dual_language_receipt"/>
                     </setting>


### PR DESCRIPTION
l10n_gcc_country_is_gcc is used to control visibility in views. However, it is not required, as the same functionality can be achieved using the generic fields based on country_group_codes.

ref - https://github.com/odoo/odoo/pull/220167/commits/39ba5962923f04eef85174aaf2667481510cfaf4

Upgrade PR - https://github.com/odoo/upgrade/pull/8612