### PR TITLE
[FIX] discuss: prevent the display of connection warning out of host tab

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_participant_card.js
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.js
@@ -123,6 +123,7 @@ export class CallParticipantCard extends Component {
     get showConnectionState() {
         if (
             !this.rtcSession ||
+            !this.rtc.isHost ||
             !this.isOfActiveCall ||
             HIDDEN_CONNECTION_STATES.has(this.rtcSession.connectionState)
         ) {


### PR DESCRIPTION
Before this commit, the forward port[1] of a call indicator fix[2] did not account for the cross-tab call feature[3], introduced in saas 18.2 which makes it possible to be considered inside a call without having connection state information (as the remote tab does not manage connections), thus incorrectly showing the connection state indicator.

[1]: https://github.com/odoo/odoo/pull/229166
[2]: https://github.com/odoo/odoo/pull/228601
[3]: https://github.com/odoo/odoo/pull/198109

