### PR TITLE
[IMP] mail: convert `mail.thread` in channel/delete

### DIFF
--- a/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
@@ -18,11 +18,10 @@ export class DiscussCoreCommon {
 
     setup() {
         this.busService.subscribe("discuss.channel/delete", (payload, metadata) => {
-            const thread = this.store["mail.thread"].insert({
+            const channel = this.store["discuss.channel"].insert({
                 id: payload.id,
-                model: "discuss.channel",
             });
-            this._handleNotificationChannelDelete(thread, metadata);
+            this._handleNotificationChannelDelete(channel, metadata);
         });
         this.busService.subscribe("discuss.channel/new_message", (payload, metadata) => {
             // Insert should always be done before any async operation. Indeed,
@@ -71,10 +70,10 @@ export class DiscussCoreCommon {
      * @param {import("models").Thread} thread
      * @param {{ notifId: number}} metadata
      */
-    async _handleNotificationChannelDelete(thread, metadata) {
-        await thread.closeChatWindow({ force: true });
-        thread.messages.splice(0, thread.messages.length);
-        thread.delete();
+    async _handleNotificationChannelDelete(channel, metadata) {
+        await channel.closeChatWindow({ force: true });
+        channel.messages.splice(0, channel.messages.length);
+        channel.delete();
     }
 
     async _handleNotificationNewMessage(payload, { id: notifId }) {

--- a/addons/mail/static/src/discuss/core/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_model_patch.js
@@ -232,8 +232,10 @@ const threadPatch = {
     },
     /** @returns {import("models").ChannelMember[]} */
     _computeOfflineMembers() {
-        return this.channel?.channel_member_ids.filter(
-            (member) => !this.store.onlineMemberStatuses.includes(member.im_status)
+        return (
+            this.channel?.channel_member_ids.filter(
+                (member) => !this.store.onlineMemberStatuses.includes(member.im_status)
+            ) ?? []
         );
     },
     get areAllMembersLoaded() {


### PR DESCRIPTION
Convert `mail.thread` into `discuss.channel` in channel deletion notification.
