### PR TITLE
[FIX] html_editor: change tag when modifying phrasing content

### DIFF
--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_button.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_button.test.js
@@ -209,13 +209,13 @@ test("clean another action", async () => {
     await animationFrame();
     expect(":iframe .test-options-target").toHaveAttribute(
         "class",
-        "test-options-target o-paragraph my-custom-class1"
+        "test-options-target my-custom-class1"
     );
     await click("[data-class-action='my-custom-class2']");
     await animationFrame();
     expect(":iframe .test-options-target").toHaveAttribute(
         "class",
-        "test-options-target o-paragraph my-custom-class2"
+        "test-options-target my-custom-class2"
     );
 });
 test("clean should provide the next action value", async () => {
@@ -389,22 +389,22 @@ test("apply classAction on multi elements", async () => {
     });
     const { getEditableContent } = await setupHTMLBuilder(`
             <div class="test-options-target">
-                <div class="target-apply">a</div>
-                <div class="target-apply">b</div>
+                <p class="target-apply">a</p>
+                <p class="target-apply">b</p>
             </div>`);
     const editableContent = getEditableContent();
     await contains(":iframe .test-options-target").click();
     expect(editableContent).toHaveInnerHTML(`
             <div class="test-options-target">
-                <div class="target-apply o-paragraph">a</div>
-                <div class="target-apply o-paragraph">b</div>
+                <p class="target-apply">a</p>
+                <p class="target-apply">b</p>
             </div>`);
 
     await contains("[data-class-action='my-custom-class']").click();
     expect(editableContent).toHaveInnerHTML(`
             <div class="test-options-target">
-                <div class="target-apply o-paragraph my-custom-class">a</div>
-                <div class="target-apply o-paragraph my-custom-class">b</div>
+                <p class="target-apply my-custom-class">a</p>
+                <p class="target-apply my-custom-class">b</p>
             </div>`);
 });
 test("hide/display base on applyTo", async () => {
@@ -422,19 +422,19 @@ test("hide/display base on applyTo", async () => {
     });
 
     const { getEditableContent } = await setupHTMLBuilder(
-        `<div class="parent-target o-paragraph"><div class="child-target">b</div></div>`
+        `<div class="parent-target"><div class="child-target">b</div></div>`
     );
     const editableContent = getEditableContent();
     await contains(":iframe .parent-target").click();
     expect(editableContent).toHaveInnerHTML(
-        `<div class="parent-target o-paragraph"><div class="child-target">b</div></div>`
+        `<div class="parent-target"><div class="child-target">b</div></div>`
     );
     expect("[data-class-action='my-custom-class']").not.toHaveClass("active");
     expect("[data-class-action='test']").toHaveCount(0);
 
     await contains("[data-class-action='my-custom-class']").click();
     expect(editableContent).toHaveInnerHTML(
-        `<div class="parent-target o-paragraph"><div class="child-target my-custom-class">b</div></div>`
+        `<div class="parent-target"><div class="child-target my-custom-class">b</div></div>`
     );
     expect("[data-class-action='my-custom-class']").toHaveClass("active");
     expect("[data-class-action='test']").toHaveCount(1);

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_button_group.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_button_group.test.js
@@ -36,7 +36,7 @@ test("change the editingElement of sub widget through `applyTo` prop", async () 
     await contains(":iframe .test-options-target").click();
     expect(".options-container").toBeDisplayed();
     await hover("[data-action-id='customAction']");
-    expect.verifySteps(["customAction a o-paragraph"]);
+    expect.verifySteps(["customAction a"]);
 });
 test("should propagate actionParam in the context", async () => {
     class CustomAction extends BuilderAction {
@@ -140,9 +140,7 @@ test("hide/display base on applyTo", async () => {
                 </BuilderButtonGroup>`,
     });
 
-    await setupHTMLBuilder(
-        `<div class="parent-target o-paragraph"><div class="child-target">b</div></div>`
-    );
+    await setupHTMLBuilder(`<div class="parent-target"><div class="child-target">b</div></div>`);
     await contains(":iframe .parent-target").click();
     expect(".options-container .btn-group").toHaveCount(0);
 
@@ -164,9 +162,7 @@ test("hide/display base on applyTo - 2", async () => {
                 </BuilderButtonGroup>`,
     });
 
-    await setupHTMLBuilder(
-        `<div class="parent-target o-paragraph"><div class="child-target">b</div></div>`
-    );
+    await setupHTMLBuilder(`<div class="parent-target"><div class="child-target">b</div></div>`);
     await contains(":iframe .parent-target").click();
     expect(".options-container .btn-group").not.toBeVisible();
 
@@ -182,17 +178,15 @@ test("click on BuilderButton with empty value should remove styleAction", async 
             <BuilderButton styleAction="'width'" styleActionValue="'25%'"/>
         </BuilderButtonGroup>`,
     });
-    const { contentEl } = await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
+    const { contentEl } = await setupHTMLBuilder(`<p class="test-options-target">b</p>`);
     await contains(":iframe .test-options-target").click();
     await contains("[data-style-action='width'][data-style-action-value='25%']").click();
     expect(contentEl).toHaveInnerHTML(
-        `<div class="test-options-target o-paragraph" style="width: 25% !important;">b</div>`
+        `<p class="test-options-target" style="width: 25% !important;">b</p>`
     );
 
     await contains("[data-style-action='width'][data-style-action-value='']").click();
-    expect(contentEl).toHaveInnerHTML(
-        `<div class="test-options-target o-paragraph" style="">b</div>`
-    );
+    expect(contentEl).toHaveInnerHTML(`<p class="test-options-target" style="">b</p>`);
 });
 
 test("button that matches with the highest priority should be active", async () => {

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_checkbox.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_checkbox.test.js
@@ -10,25 +10,21 @@ test("Click on checkbox", async () => {
         selector: ".test-options-target",
         template: xml`<BuilderCheckbox classAction="'checkbox-action'"/>`,
     });
-    const { getEditableContent } = await setupHTMLBuilder(
-        `<div class="test-options-target o-paragraph">b</div>`
-    );
+    const { getEditableContent } = await setupHTMLBuilder(`<p class="test-options-target">b</p>`);
     const editableContent = getEditableContent();
 
     await contains(":iframe .test-options-target").click();
     expect(".options-container").toBeDisplayed();
     expect(".o-checkbox .form-check-input:checked").toHaveCount(0);
-    expect(editableContent).toHaveInnerHTML(`<div class="test-options-target o-paragraph">b</div>`);
+    expect(editableContent).toHaveInnerHTML(`<p class="test-options-target">b</p>`);
 
     await contains(".o-checkbox").click();
     expect(".o-checkbox .form-check-input:checked").toHaveCount(1);
-    expect(editableContent).toHaveInnerHTML(
-        `<div class="test-options-target o-paragraph checkbox-action">b</div>`
-    );
+    expect(editableContent).toHaveInnerHTML(`<p class="test-options-target checkbox-action">b</p>`);
 
     await contains(".o-checkbox").click();
     expect(".o-checkbox .form-check-input:checked").toHaveCount(0);
-    expect(editableContent).toHaveInnerHTML(`<div class="test-options-target o-paragraph">b</div>`);
+    expect(editableContent).toHaveInnerHTML(`<p class="test-options-target">b</p>`);
 });
 test("hide/display base on applyTo", async () => {
     addBuilderOption({
@@ -40,20 +36,20 @@ test("hide/display base on applyTo", async () => {
         template: xml`<BuilderCheckbox classAction="'checkbox-action'" applyTo="'.my-custom-class'"/>`,
     });
     const { getEditableContent } = await setupHTMLBuilder(
-        `<div class="parent-target"><div class="child-target b">b</div></div>`
+        `<div class="parent-target"><p class="child-target b">b</p></div>`
     );
     const editableContent = getEditableContent();
 
     await contains(":iframe .parent-target").click();
     expect(editableContent).toHaveInnerHTML(
-        `<div class="parent-target"><div class="child-target b o-paragraph">b</div></div>`
+        `<div class="parent-target"><p class="child-target b">b</p></div>`
     );
     expect("[data-class-action='my-custom-class']").not.toHaveClass("active");
     expect(".options-container .o-checkbox").toHaveCount(0);
 
     await contains("[data-class-action='my-custom-class']").click();
     expect(editableContent).toHaveInnerHTML(
-        `<div class="parent-target"><div class="child-target b o-paragraph my-custom-class">b</div></div>`
+        `<div class="parent-target"><p class="child-target b my-custom-class">b</p></div>`
     );
     expect("[data-class-action='my-custom-class']").toHaveClass("active");
     expect(".options-container .o-checkbox").toHaveCount(1);

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_colorpicker.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_colorpicker.test.js
@@ -50,19 +50,19 @@ test("hide/display base on applyTo", async () => {
         template: xml`<BuilderColorPicker applyTo="'.my-custom-class'" styleAction="'background-color'"/>`,
     });
     const { getEditableContent } = await setupHTMLBuilder(
-        `<div class="parent-target"><div class="child-target b">b</div></div>`
+        `<div class="parent-target"><p class="child-target b">b</p></div>`
     );
     const editableContent = getEditableContent();
     await contains(":iframe .parent-target").click();
     expect(editableContent).toHaveInnerHTML(
-        `<div class="parent-target"><div class="child-target b o-paragraph">b</div></div>`
+        `<div class="parent-target"><p class="child-target b">b</p></div>`
     );
     expect("[data-class-action='my-custom-class']").not.toHaveClass("active");
     expect(".options-container .o_we_color_preview").toHaveCount(0);
 
     await contains("[data-class-action='my-custom-class']").click();
     expect(editableContent).toHaveInnerHTML(
-        `<div class="parent-target"><div class="child-target b o-paragraph my-custom-class">b</div></div>`
+        `<div class="parent-target"><p class="child-target b my-custom-class">b</p></div>`
     );
     expect("[data-class-action='my-custom-class']").toHaveClass("active");
     expect(".options-container .o_we_color_preview").toHaveCount(1);

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_many2many.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_many2many.test.js
@@ -41,7 +41,7 @@ test("many2many: find tag, select tag, unselect tag", async () => {
     await contains(":iframe .test-options-target").click();
     expect(".options-container").toBeDisplayed();
     expect("table tr").toHaveCount(0);
-    expect(editableContent).toHaveInnerHTML(`<div class="test-options-target o-paragraph">b</div>`);
+    expect(editableContent).toHaveInnerHTML(`<div class="test-options-target">b</div>`);
 
     await contains(".btn.o-dropdown").click();
     expect("input").toHaveCount(1);
@@ -51,7 +51,7 @@ test("many2many: find tag, select tag, unselect tag", async () => {
     expect("span.o-dropdown-item").toHaveCount(3);
     await contains("span.o-dropdown-item").click();
     expect(editableContent).toHaveInnerHTML(
-        `<div class="test-options-target o-paragraph" data-test="[{&quot;id&quot;:1,&quot;display_name&quot;:&quot;First&quot;,&quot;name&quot;:&quot;First&quot;}]">b</div>`
+        `<div class="test-options-target" data-test="[{&quot;id&quot;:1,&quot;display_name&quot;:&quot;First&quot;,&quot;name&quot;:&quot;First&quot;}]">b</div>`
     );
     expect("table tr").toHaveCount(1);
 
@@ -61,13 +61,13 @@ test("many2many: find tag, select tag, unselect tag", async () => {
     expect("span.o-dropdown-item").toHaveCount(2);
     await contains("span.o-dropdown-item").click();
     expect(editableContent).toHaveInnerHTML(
-        `<div class="test-options-target o-paragraph" data-test="[{&quot;id&quot;:1,&quot;display_name&quot;:&quot;First&quot;,&quot;name&quot;:&quot;First&quot;},{&quot;id&quot;:2,&quot;display_name&quot;:&quot;Second&quot;,&quot;name&quot;:&quot;Second&quot;}]">b</div>`
+        `<div class="test-options-target" data-test="[{&quot;id&quot;:1,&quot;display_name&quot;:&quot;First&quot;,&quot;name&quot;:&quot;First&quot;},{&quot;id&quot;:2,&quot;display_name&quot;:&quot;Second&quot;,&quot;name&quot;:&quot;Second&quot;}]">b</div>`
     );
     expect("table tr").toHaveCount(2);
 
     await contains("button.fa-minus").click();
     expect(editableContent).toHaveInnerHTML(
-        `<div class="test-options-target o-paragraph" data-test="[{&quot;id&quot;:2,&quot;display_name&quot;:&quot;Second&quot;,&quot;name&quot;:&quot;Second&quot;}]">b</div>`
+        `<div class="test-options-target" data-test="[{&quot;id&quot;:2,&quot;display_name&quot;:&quot;Second&quot;,&quot;name&quot;:&quot;Second&quot;}]">b</div>`
     );
     expect("table tr").toHaveCount(1);
     expect("table input").toHaveValue("Second");
@@ -116,10 +116,10 @@ test("many2many: async load", async () => {
     expect("span.o-dropdown-item").toHaveCount(3);
     await contains("span.o-dropdown-item").click();
     expect.verifySteps(["load"]);
-    expect(editableContent).toHaveInnerHTML(`<div class="test-options-target o-paragraph">b</div>`);
+    expect(editableContent).toHaveInnerHTML(`<div class="test-options-target">b</div>`);
     defWillLoad.resolve();
     await defDidApply;
     expect(editableContent).toHaveInnerHTML(
-        `<div class="test-options-target o-paragraph" data-test="[{&quot;id&quot;:1,&quot;display_name&quot;:&quot;First&quot;,&quot;name&quot;:&quot;First&quot;}]">b</div>`
+        `<div class="test-options-target" data-test="[{&quot;id&quot;:1,&quot;display_name&quot;:&quot;First&quot;,&quot;name&quot;:&quot;First&quot;}]">b</div>`
     );
 });

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_many2one.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_many2one.test.js
@@ -69,11 +69,11 @@ test("many2one: async load", async () => {
     expect("span.o-dropdown-item").toHaveCount(3);
     await contains("span.o-dropdown-item").click();
     expect.verifySteps(["load"]);
-    expect(editableContent).toHaveInnerHTML(`<div class="test-options-target o-paragraph">b</div>`);
+    expect(editableContent).toHaveInnerHTML(`<div class="test-options-target">b</div>`);
     defWillLoad.resolve();
     await defDidApply;
     expect(editableContent).toHaveInnerHTML(
-        `<div class="test-options-target o-paragraph" data-test="{&quot;id&quot;:1,&quot;display_name&quot;:&quot;First&quot;,&quot;name&quot;:&quot;First&quot;}">b</div>`
+        `<div class="test-options-target" data-test="{&quot;id&quot;:1,&quot;display_name&quot;:&quot;First&quot;,&quot;name&quot;:&quot;First&quot;}">b</div>`
     );
 });
 

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_number_input.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_number_input.test.js
@@ -69,14 +69,14 @@ test("hide/display base on applyTo", async () => {
     const editableContent = getEditableContent();
     await contains(":iframe .parent-target").click();
     expect(editableContent).toHaveInnerHTML(
-        `<div class="parent-target"><div class="child-target o-paragraph">b</div></div>`
+        `<div class="parent-target"><div class="child-target">b</div></div>`
     );
     expect("[data-class-action='my-custom-class']").not.toHaveClass("active");
     expect("[data-action-id='customAction']").toHaveCount(0);
 
     await contains("[data-class-action='my-custom-class']").click();
     expect(editableContent).toHaveInnerHTML(
-        `<div class="parent-target"><div class="child-target o-paragraph my-custom-class">b</div></div>`
+        `<div class="parent-target"><div class="child-target my-custom-class">b</div></div>`
     );
     expect("[data-class-action='my-custom-class']").toHaveClass("active");
     expect("[data-action-id='customAction']").toHaveCount(1);

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_select_item.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_select_item.test.js
@@ -118,14 +118,14 @@ test("hide/display BuilderSelect based on applyTo", async () => {
     const editableContent = getEditableContent();
     await contains(":iframe .parent-target").click();
     expect(editableContent).toHaveInnerHTML(
-        `<div class="parent-target"><div class="child-target b o-paragraph">b</div></div>`
+        `<div class="parent-target"><div class="child-target b">b</div></div>`
     );
     expect("[data-class-action='my-custom-class']").not.toHaveClass("active");
     expect(".options-container button.dropdown-toggle").toHaveCount(0);
 
     await contains("[data-class-action='my-custom-class']").click();
     expect(editableContent).toHaveInnerHTML(
-        `<div class="parent-target"><div class="child-target b o-paragraph my-custom-class">b</div></div>`
+        `<div class="parent-target"><div class="child-target b my-custom-class">b</div></div>`
     );
     expect("[data-class-action='my-custom-class']").toHaveClass("active");
     expect(".options-container button.dropdown-toggle").toHaveCount(1);
@@ -148,12 +148,12 @@ test("hide/display BuilderSelectItem base on applyTo", async () => {
                 </BuilderSelect>`,
     });
     const { getEditableContent } = await setupHTMLBuilder(
-        `<div class="parent-target"><div class="child-target o-paragraph">b</div></div>`
+        `<div class="parent-target"><div class="child-target">b</div></div>`
     );
     const editableContent = getEditableContent();
     await contains(":iframe .parent-target").click();
     expect(editableContent).toHaveInnerHTML(
-        `<div class="parent-target"><div class="child-target o-paragraph">b</div></div>`
+        `<div class="parent-target"><div class="child-target">b</div></div>`
     );
     expect("[data-class-action='my-custom-class']").not.toHaveClass("active");
     expect(".options-container button.dropdown-toggle").toHaveCount(1);
@@ -162,7 +162,7 @@ test("hide/display BuilderSelectItem base on applyTo", async () => {
 
     await contains("[data-class-action='my-custom-class']").click();
     expect(editableContent).toHaveInnerHTML(
-        `<div class="parent-target"><div class="child-target o-paragraph my-custom-class">b</div></div>`
+        `<div class="parent-target"><div class="child-target my-custom-class">b</div></div>`
     );
     expect("[data-class-action='my-custom-class']").toHaveClass("active");
     await contains(".options-container button.dropdown-toggle").click();
@@ -213,7 +213,7 @@ test("use BuilderSelect with styleAction", async () => {
 
     await contains(".o-dropdown--menu div.o-dropdown-item:contains(dotted)").click();
     expect(editableContent).toHaveInnerHTML(
-        `<div class="parent-target o-paragraph" style="border-style: dotted;">b</div>`
+        `<div class="parent-target" style="border-style: dotted;">b</div>`
     );
     expect(".we-bg-options-container .dropdown").toHaveText("dotted");
 });

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_text_input.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_text_input.test.js
@@ -34,14 +34,14 @@ test("hide/display base on applyTo", async () => {
     const editableContent = getEditableContent();
     await contains(":iframe .parent-target").click();
     expect(editableContent).toHaveInnerHTML(
-        `<div class="parent-target"><div class="child-target o-paragraph">b</div></div>`
+        `<div class="parent-target"><div class="child-target">b</div></div>`
     );
     expect("[data-class-action='my-custom-class']").not.toHaveClass("active");
     expect("[data-action-id='customAction']").toHaveCount(0);
 
     await contains("[data-class-action='my-custom-class']").click();
     expect(editableContent).toHaveInnerHTML(
-        `<div class="parent-target"><div class="child-target o-paragraph my-custom-class">b</div></div>`
+        `<div class="parent-target"><div class="child-target my-custom-class">b</div></div>`
     );
     expect("[data-class-action='my-custom-class']").toHaveClass("active");
     expect("[data-action-id='customAction']").toHaveCount(1);

--- a/addons/html_builder/static/tests/custom_tab/builder_shorthand_action.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_shorthand_action.test.js
@@ -227,13 +227,13 @@ describe("styleAction", () => {
         expect("[data-style-action-value='']").toHaveClass("active");
         expect("[data-style-action-value='50%']").not.toHaveClass("active");
         expect(":iframe .test-options-target").toHaveOuterHTML(
-            `<div class="test-options-target x o-paragraph"> a </div>`
+            `<div class="test-options-target x"> a </div>`
         );
 
         await contains("[data-style-action-value='50%']").click();
 
         expect(":iframe .test-options-target").toHaveOuterHTML(
-            `<div class="test-options-target x o-paragraph" style="width: 50% !important;"> a </div>`
+            `<div class="test-options-target x" style="width: 50% !important;"> a </div>`
         );
         expect("[data-style-action-value='']").not.toHaveClass("active");
         expect("[data-style-action-value='50%']").toHaveClass("active");

--- a/addons/html_builder/static/tests/drop_zone.test.js
+++ b/addons/html_builder/static/tests/drop_zone.test.js
@@ -32,8 +32,6 @@ test("drop beside dropzone inserts the snippet", async () => {
     await waitForEndOfOperation();
     expect(contentEl)
         .toHaveInnerHTML(`<section class="s_test" data-snippet="s_test" data-name="Test">
-    <div class="test_a o-paragraph">
-        <br>
-    </div>
-</section>`);
+    <div class="test_a"></div>
+    </section>`);
 });

--- a/addons/html_builder/static/tests/helpers.js
+++ b/addons/html_builder/static/tests/helpers.js
@@ -456,7 +456,7 @@ export function getBasicSection(
     return unformat(
         `<section class="${classes}" data-snippet="${snippet}" ${
             name ? `data-name="${name}"` : ""
-        }><div class="test_a o-paragraph">${content}</div></section>`
+        }><div class="test_a">${content}</div></section>`
     );
 }
 

--- a/addons/html_builder/static/tests/operation.test.js
+++ b/addons/html_builder/static/tests/operation.test.js
@@ -250,7 +250,7 @@ describe("Operation that will fail", () => {
         await contains("[data-action-id='testAction']").hover();
         await contains("[data-class-action='test']").click();
         expect(":iframe .test-options-target").toHaveOuterHTML(
-            '<div class="test-options-target o-paragraph test">b</div>'
+            '<div class="test-options-target test">b</div>'
         );
         expect.verifyErrors(["This action should crash"]);
     });
@@ -278,7 +278,7 @@ describe("Operation that will fail", () => {
         await contains("[data-action-id='testAction']").click();
         await contains("[data-class-action='test']").click();
         expect(":iframe .test-options-target").toHaveOuterHTML(
-            '<div class="test-options-target o-paragraph test">b</div>'
+            '<div class="test-options-target test">b</div>'
         );
         // preview + commit
         expect.verifyErrors(["This action should crash", "This action should crash"]);

--- a/addons/html_builder/static/tests/shadow_option.test.js
+++ b/addons/html_builder/static/tests/shadow_option.test.js
@@ -16,7 +16,7 @@ test("edit box-shadow with ShadowOption", async () => {
     await waitFor(".hb-row");
     expect(queryAllTexts(".hb-row .hb-row-label")).toEqual(["Shadow"]);
     expect(":iframe .test-options-target").toHaveOuterHTML(
-        '<div class="test-options-target o-paragraph">b</div>'
+        '<div class="test-options-target">b</div>'
     );
 
     await contains('.options-container button[title="Outset"]').click();
@@ -29,24 +29,24 @@ test("edit box-shadow with ShadowOption", async () => {
     ]);
     expect(queryAllValues('[data-action-id="setShadow"] input')).toEqual(["0", "8", "16", "0"]);
     expect(":iframe .test-options-target").toHaveOuterHTML(
-        '<div class="test-options-target o-paragraph shadow" style="box-shadow: rgba(0, 0, 0, 0.15) 0px 8px 16px 0px !important;">b</div>'
+        '<div class="test-options-target shadow" style="box-shadow: rgba(0, 0, 0, 0.15) 0px 8px 16px 0px !important;">b</div>'
     );
 
     await contains('[data-action-param="offsetX"] input').fill(10);
     await contains('[data-action-param="offsetY"] input').fill(2);
     expect(":iframe .test-options-target").toHaveOuterHTML(
-        '<div class="test-options-target o-paragraph shadow" style="box-shadow: rgba(0, 0, 0, 0.15) 10px 82px 16px 0px !important;">b</div>'
+        '<div class="test-options-target shadow" style="box-shadow: rgba(0, 0, 0, 0.15) 10px 82px 16px 0px !important;">b</div>'
     );
 
     await contains('[data-action-param="blur"] input').clear();
     await contains('[data-action-param="blur"] input').fill(10.5);
     expect(":iframe .test-options-target").toHaveOuterHTML(
-        '<div class="test-options-target o-paragraph shadow" style="box-shadow: rgba(0, 0, 0, 0.15) 10px 82px 10.5px 0px !important;">b</div>'
+        '<div class="test-options-target shadow" style="box-shadow: rgba(0, 0, 0, 0.15) 10px 82px 10.5px 0px !important;">b</div>'
     );
 
     await contains('[data-action-param="spread"] input').fill(".4");
     expect(":iframe .test-options-target").toHaveOuterHTML(
-        '<div class="test-options-target o-paragraph shadow" style="box-shadow: rgba(0, 0, 0, 0.15) 10px 82px 10.5px 0.4px !important;">b</div>'
+        '<div class="test-options-target shadow" style="box-shadow: rgba(0, 0, 0, 0.15) 10px 82px 10.5px 0.4px !important;">b</div>'
     );
 
     await contains('.options-container button[title="Inset"]').click();
@@ -64,12 +64,12 @@ test("edit box-shadow with ShadowOption", async () => {
         "0.4",
     ]);
     expect(":iframe .test-options-target").toHaveOuterHTML(
-        '<div class="test-options-target o-paragraph shadow" style="box-shadow: rgba(0, 0, 0, 0.15) 10px 82px 10.5px 0.4px inset !important;">b</div>'
+        '<div class="test-options-target shadow" style="box-shadow: rgba(0, 0, 0, 0.15) 10px 82px 10.5px 0.4px inset !important;">b</div>'
     );
 
     await contains(".options-container button:contains(None)").click();
     expect(queryAllTexts(".hb-row .hb-row-label")).toEqual(["Shadow"]);
     expect(":iframe .test-options-target").toHaveOuterHTML(
-        '<div class="test-options-target o-paragraph" style="">b</div>'
+        '<div class="test-options-target" style="">b</div>'
     );
 });

--- a/addons/html_editor/static/src/core/base_container_plugin.js
+++ b/addons/html_editor/static/src/core/base_container_plugin.js
@@ -202,6 +202,9 @@ export class BaseContainerPlugin extends Plugin {
     }
 
     normalizeDivBaseContainers(element = this.editable) {
+        if (this.config.baseContainers && !this.config.baseContainers.includes("DIV")) {
+            return;
+        }
         const newBaseContainers = [];
         const divSelector = `div:not(.${BASE_CONTAINER_CLASS})`;
         const targets = [...element.querySelectorAll(divSelector)];

--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -28,6 +28,7 @@ import {
     isUnprotecting,
     listElementSelector,
     isEditorTab,
+    isPhrasingContent,
 } from "../utils/dom_info";
 import {
     childNodes,
@@ -609,6 +610,7 @@ export class DomPlugin extends Plugin {
             if (
                 isParagraphRelatedElement(block) ||
                 isListItemElement(block) ||
+                isPhrasingContent(block) ||
                 block.nodeName === "BLOCKQUOTE"
             ) {
                 if (newCandidate.matches(baseContainerGlobalSelector) && isListItemElement(block)) {

--- a/addons/html_editor/static/tests/tags.test.js
+++ b/addons/html_editor/static/tests/tags.test.js
@@ -4,6 +4,7 @@ import { setupEditor, testEditor } from "./_helpers/editor";
 import { getContent, setSelection } from "./_helpers/selection";
 import { insertText, tripleClick, undo } from "./_helpers/user_actions";
 import { animationFrame } from "@odoo/hoot-mock";
+import { defineStyle } from "@web/../tests/web_test_helpers";
 
 function setTag(tagName) {
     return (editor) => editor.shared.dom.setBlock({ tagName });
@@ -51,6 +52,32 @@ describe("to paragraph", () => {
             contentBefore: `<div>[ab]</div>`,
             stepFunction: setTag("p"),
             contentAfter: "<p>[ab]</p>",
+        });
+    });
+
+    test("should turn a block <small> element into a paragraph", async () => {
+        defineStyle("small { display: block; }");
+        await testEditor({
+            contentBefore: "<small>[abc]</small>",
+            stepFunction: setTag("p"),
+            contentAfter: "<p>[abc]</p>",
+        });
+    });
+
+    test("shouldn't turn a normal <small> element into a paragraph", async () => {
+        await testEditor({
+            contentBefore: "<small>[abc]</small>",
+            stepFunction: setTag("p"),
+            contentAfter: "<p><small>[]abc</small></p>",
+        });
+    });
+
+    test("shouldn't turn a div into a paragraph (if div isn't eligible for a baseContainer)", async () => {
+        await testEditor({
+            contentBefore: "<div><small>[abc]</small></div>",
+            stepFunction: setTag("p"),
+            contentAfter: "<div><p><small>[abc]</small></p></div>",
+            config: { baseContainers: ["P"] },
         });
     });
 
@@ -188,6 +215,32 @@ describe("to heading 1", () => {
                 setTag("h1")(editor);
             },
             contentAfter: "<h1>[ab]</h1><h2>cd</h2>",
+        });
+    });
+
+    test("should turn a block <small> element into a heading", async () => {
+        defineStyle("small { display: block; }");
+        await testEditor({
+            contentBefore: "<small>[abc]</small>",
+            stepFunction: setTag("h1"),
+            contentAfter: "<h1>[abc]</h1>",
+        });
+    });
+
+    test("shouldn't turn a normal <small> element into a heading", async () => {
+        await testEditor({
+            contentBefore: "<small>[abc]</small>",
+            stepFunction: setTag("h1"),
+            contentAfter: "<h1><small>[]abc</small></h1>",
+        });
+    });
+
+    test("shouldn't turn a div into a heading (if div isn't eligible for a baseContainer)", async () => {
+        await testEditor({
+            contentBefore: "<div><small>[abc]</small></div>",
+            stepFunction: setTag("h1"),
+            contentAfter: "<div><h1><small>[abc]</small></h1></div>",
+            config: { baseContainers: ["P"] },
         });
     });
 

--- a/addons/website/static/tests/builder/custom_tab/container_buttons.test.js
+++ b/addons/website/static/tests/builder/custom_tab/container_buttons.test.js
@@ -318,29 +318,27 @@ test("applying option container button should wait for actions in progress", asy
     });
 
     const { getEditableContent, getEditor } = await setupWebsiteBuilder(`
-        <div class="test-options-target o-paragraph">plop</div>
+        <p class="test-options-target">plop</p>
     `);
     const editor = getEditor();
     const editable = getEditableContent();
 
     await contains(":iframe .test-options-target").click();
     await contains("[data-action-id='customAction']").click();
-    expect(editable).toHaveInnerHTML(`<div class="test-options-target o-paragraph">plop</div>`);
+    expect(editable).toHaveInnerHTML(`<p class="test-options-target">plop</p>`);
 
     await contains(".test_button").click();
-    expect(editable).toHaveInnerHTML(`<div class="test-options-target o-paragraph">plop</div>`);
+    expect(editable).toHaveInnerHTML(`<p class="test-options-target">plop</p>`);
 
     customActionDef.resolve();
     await tick();
     expect(editable).toHaveInnerHTML(
-        `<div class="test-options-target o-paragraph customAction overlayButton">plop</div>`
+        `<p class="test-options-target customAction overlayButton">plop</p>`
     );
 
     undo(editor);
-    expect(editable).toHaveInnerHTML(
-        `<div class="test-options-target o-paragraph customAction">plop</div>`
-    );
+    expect(editable).toHaveInnerHTML(`<p class="test-options-target customAction">plop</p>`);
 
     undo(editor);
-    expect(editable).toHaveInnerHTML(`<div class="test-options-target o-paragraph">plop</div>`);
+    expect(editable).toHaveInnerHTML(`<p class="test-options-target">plop</p>`);
 });

--- a/addons/website/static/tests/builder/linkpopover_website.test.js
+++ b/addons/website/static/tests/builder/linkpopover_website.test.js
@@ -170,7 +170,7 @@ test("LinkPopover opens in full composer", async () => {
     await waitFor(".odoo-editor-editable");
     htmlEditor.editable.focus();
     await insertText(htmlEditor, "test");
-    const node = queryOne(".odoo-editor-editable div.o-paragraph");
+    const node = queryOne(".odoo-editor-editable div");
     setSelection({ anchorNode: node, anchorOffset: 0, focusNode: node, focusOffset: 1 });
     await mailClick(".o-we-toolbar .fa-link");
     await waitFor(".o-we-linkpopover");

--- a/addons/website/static/tests/builder/overlay_buttons.test.js
+++ b/addons/website/static/tests/builder/overlay_buttons.test.js
@@ -250,25 +250,23 @@ test("Applying an overlay button action should wait for the actions in progress"
 
     await contains(":iframe .test-options-target").click();
     await contains("[data-action-id='customAction']").click();
-    expect(editable).toHaveInnerHTML(`<div class="test-options-target o-paragraph">plop</div>`);
+    expect(editable).toHaveInnerHTML(`<div class="test-options-target">plop</div>`);
 
     await contains(":iframe .test-options-target").click();
     await contains(".overlay .test_button").click();
-    expect(editable).toHaveInnerHTML(`<div class="test-options-target o-paragraph">plop</div>`);
+    expect(editable).toHaveInnerHTML(`<div class="test-options-target">plop</div>`);
 
     customActionDef.resolve();
     await tick();
     expect(editable).toHaveInnerHTML(
-        `<div class="test-options-target o-paragraph customAction overlayButton">plop</div>`
+        `<div class="test-options-target customAction overlayButton">plop</div>`
     );
 
     undo(editor);
-    expect(editable).toHaveInnerHTML(
-        `<div class="test-options-target o-paragraph customAction">plop</div>`
-    );
+    expect(editable).toHaveInnerHTML(`<div class="test-options-target customAction">plop</div>`);
 
     undo(editor);
-    expect(editable).toHaveInnerHTML(`<div class="test-options-target o-paragraph">plop</div>`);
+    expect(editable).toHaveInnerHTML(`<div class="test-options-target">plop</div>`);
 });
 
 test("The overlay buttons should only appear for elements in editable areas, unless specified otherwise", async () => {

--- a/addons/website/static/tests/builder/website_builder/background_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/background_option.test.js
@@ -404,7 +404,7 @@ test("remove background image removes color filter", async () => {
     await setupWebsiteBuilder(`
         <section>
             <span class='s_parallax_bg oe_img_bg o_bg_img_center' style="background-image: ${backgroundImageUrl} !important;">aaa</span>
-            <div class="o_we_bg_filter bg-black-50 o-paragraph"><br></div>
+            <div class="o_we_bg_filter bg-black-50"><br></div>
         </section>`);
     await contains(":iframe section").click();
     await contains("[data-action-id='toggleBgImage']").click();

--- a/addons/website/static/tests/builder/website_builder/customize_website.test.js
+++ b/addons/website/static/tests/builder/website_builder/customize_website.test.js
@@ -533,8 +533,8 @@ test("BuilderButton with action “templatePreviewableWebsiteConfig”", async (
 
     await setupWebsiteBuilder(
         `<div class="test-options-target excluded-class">
-            <div class="target1"></div>
-            <div class="target2"></div>
+            <div class="target1">a</div>
+            <div class="target2">b</div>
         </div>`
     );
     await contains(":iframe .test-options-target").click();

--- a/addons/website_payment/static/tests/builder/donation_option.test.js
+++ b/addons/website_payment/static/tests/builder/donation_option.test.js
@@ -50,7 +50,7 @@ test("display/hide prefilled options", async () => {
     await contains(":iframe .s_donation").click();
     expect(":iframe .s_donation_prefilled_buttons").not.toBeEmpty();
     await contains("div:has(> span:contains('Pre-filled Options')) + div input").click();
-    expect(":iframe .s_donation_prefilled_buttons").toHaveInnerHTML("<br>");
+    expect(":iframe .s_donation_prefilled_buttons").toHaveInnerHTML("");
     expect(":iframe .s_donation_range_slider_wrap").toBeVisible();
     await contains("div:has(> span:contains('Pre-filled Options')) + div input").click();
     expect(":iframe .s_donation_prefilled_buttons").not.toBeEmpty();


### PR DESCRIPTION
Before this commit we would insert a block inside of a phrasing content if it's displayed as a block.
For example, if we tried to modify text inside of a `<small>` that has `display: block` style, it would insert a new block inside of it. Steps to see the issue:
- Have an open editor with `<small>Text</small>` content, that has `display: block` style
- Select "Text" and change the font style to paragraph

=> It will be `<small><p>Text</p></small>` which is not valid HTML, and it will be parsed by a browser as `<small></small><p>Text</p>`, which is not the expected behavior.

X-original-commit: 4e6df797f152e473d76e6d60ba31da52123cabd3
