### PR TITLE
[FIX] base_vat: Allow companies from out of EU to put European VAT number.

### DIFF
--- a/addons/base_vat/tests/test_vat_numbers.py
+++ b/addons/base_vat/tests/test_vat_numbers.py
@@ -228,6 +228,17 @@ class TestStructure(TransactionCase):
         with self.assertRaisesRegex(ValidationError, msg):
             test_partner.write({'vat': '152-0000706-99'})
 
+    def test_vat_notEU_with_EU_vat(self):
+        test_partner = self.env["res.partner"].create({"name": "CN Company", "country_id": self.env.ref("base.cn").id})
+        # Valid Chinese or French (European Vat)
+        test_partner.write({"vat": "123456789012345678"})
+        test_partner.write({"vat": "FR17698800935"})
+        # Test australian VAT (should raise a ValidationError)
+        with self.assertRaises(ValidationError):
+            test_partner.write({"vat": "83914571673"})
+        test_partner.write({"vat": "BE0477.47.27.01"})
+        self.assertEqual(test_partner.vat, 'BE0477472701')
+
 
 @tagged('-standard', 'external')
 class TestStructureVIES(TestStructure):


### PR DESCRIPTION
****Behavior:****

**Current:**

When a company is assigned a VAT number, the integrity of the VAT is checked according to the rules of the company's country except when a EU country is assigned an other EU country's VAT, then the integrity of the VAT is checked according to the other EU country's rules.

**Expected:**
We want to allow Foreign companies to have valid European VAT numbers.

**Steps to reproduce:**
- Create a new contact, select company and add any name
- Select a country that is not in the EU and has implemented the VAT system (Ex: China, Australia | Some countries, like the US or some smaller countries, don't have an implementation in Odoo, or just dont use VATs, in that case they are allowed to put whatever in the VAT field)
- Input a valid EU VAT number in the Tax ID field (ex: FR17698800935)
- when saving, the system should raise a Validation Error.

opw-5080231
