### PR TITLE
[FIX] base,sales_team: never show address of parent_id

### DIFF
--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -157,7 +157,7 @@
                                 placeholder="Company Name..."
                                 string="Company"
                                 domain="[('is_company', '=', True)]"
-                                context="{'default_is_company': True, 'default_user_id': user_id}"
+                                context="{'default_is_company': True, 'default_user_id': user_id, 'show_address': False}"
                                 invisible="((is_company and not parent_id) or company_name) and company_name != ''"/>
                             <div colspan="2" class="d-flex gap-2" invisible="not company_name or company_name == '' or is_company">
                                 <label for="company_name" class="fw-bold text-nowrap"/>


### PR DESCRIPTION
Be on a sale order, set as customer a contact that isn't company, but which has a parent_id with an address. From the sale order, open the customer (with the right arrow icon). In the partner form view, the address of the contact's company (the parent_id field) is displayed, it shouldn't. This commit fixes the issue by forcing `show_address: False` on that field, as we never want to see the address there. This overrides the context that is propagated from the many2one field of the sale order form view.

opw~5026032

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
