### PR TITLE
[FIX] tools: ignore byte strings for format_list

### DIFF
--- a/odoo/addons/test_translation_import/tests/test_term_count.py
+++ b/odoo/addons/test_translation_import/tests/test_term_count.py
@@ -218,6 +218,13 @@ class TestImport(common.TransactionCase):
             "Translation placeholders were not applied"
         )
 
+        # don't translate byte strings as lists
+        self.assertEqual(
+            model_fr_BE.get_code_placeholder_translation(b'Test byte string'),
+            "Code, b'Test byte string', Français, Belgium",
+            "Translation placeholders were not applied, byte string argument mishandled"
+        )
+
         # correctly format lists
         self.assertEqual(
             model_fr_BE.get_code_placeholder_translation(["1", "2", "3"]),

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -411,10 +411,10 @@ def get_translation(module: str, lang: str, source: str, args: tuple | dict) -> 
             args = {k: v._translate(lang) if isinstance(v, LazyGettext) else v for k, v in args.items()}
         else:
             args = tuple(v._translate(lang) if isinstance(v, LazyGettext) else v for v in args)
-    if any(isinstance(a, Iterable) and not isinstance(a, str) for a in (args.values() if args_is_dict else args)):
+    if any(isinstance(a, Iterable) and not isinstance(a, (str, bytes)) for a in (args.values() if args_is_dict else args)):
         # automatically format list-like arguments in a localized way
         def process_translation_arg(v):
-            return format_list(env=None, lst=v, lang_code=lang) if isinstance(v, Iterable) and not isinstance(v, str) else v
+            return format_list(env=None, lst=v, lang_code=lang) if isinstance(v, Iterable) and not isinstance(v, (str, bytes)) else v
         if args_is_dict:
             args = {k: process_translation_arg(v) for k, v in args.items()}
         else:


### PR DESCRIPTION
Improvements introduced by https://github.com/odoo/odoo/pull/197702 streamlined the auto formating of iterables to lists when passed as an argument to translatable strings in Odoo.

While doing so, strings were ignored (to prevent formating them as a list of the individual characters), but they failed to account for the fact that **byte strings** might also be passed as arguments in certain parts of the code.

An example can be found here:
https://github.com/odoo/odoo/blob/f037c39ad4d33384f81a418cb63fcdd6a5085d56/odoo/addons/base/models/ir_mail_server.py#L265-L278

`repl` in this context will be a byte string object returned by the SMTP connection.

## BUG:

Before the fix, if you would pass a byte string as an argument to a translatable string using keyword templating, the output would be the raw representation of the bytes as a list instead of the human readable content.

For example if we use in a french localisation:
`raise UserError(_('The server refused the test connection with error %(repl)s', repl=b'TEST byte string'))`

Before the fix we could get:
`Le serveur a refusé la connexion de test avec l'erreur 84, 69, 83, 84, 32, 98, 121, 116, 101, 32, 115, 116, 114, 105, 110 et 103`

And after the fix:
`Le serveur a refusé la connexion de test avec l'erreur b'TEST byte string'`

## Proposed fix:
In the same way that we ignore `str` arguments before auto applying the `format_list` method, we will also ignore them if the type is `bytes`

OPW-5107313

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
