### PR TITLE
[FIX] pos_self_order: show missing attribute details conditionally

### DIFF
--- a/addons/pos_self_order/static/src/app/components/missing_required_details/missing_required_details.xml
+++ b/addons/pos_self_order/static/src/app/components/missing_required_details/missing_required_details.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="pos_self_order.MissingRequiredDetails">
-        <div class="missing_required_details d-flex flex-column align-items-center p-3 text-center">
-            <button class="btn btn-primary mb-2 rounded-circle" t-on-click="scrollUpToRequired" style="width:60px; height: 60px;">
+        <div class="missing_required_details d-flex flex-column align-items-center p-3">
+            <button class="btn btn-primary mb-2 rounded-circle d-flex align-items-center justify-content-center" t-on-click="scrollUpToRequired" style="width:60px; height: 60px;">
                 <i class="fa fa-fw fa-arrow-up" aria-hidden="true"/>
             </button>
             <h2 class="mb-3">See what you missed</h2>

--- a/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.js
+++ b/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.js
@@ -91,6 +91,17 @@ export class ComboPage extends Component {
         return (this.state.choices[this.state.selectedChoiceIndex] ??= {});
     }
 
+    shouldShowMissingDetails() {
+        const el = this.scrollContainerRef?.el;
+        if (!el) {
+            return false;
+        }
+        return (
+            el.scrollHeight > el.clientHeight &&
+            this.currentChoiceState.displayAttributesOfItem.product_id.attribute_line_ids.length > 1
+        );
+    }
+
     selectItem(item) {
         const product = item.product_id;
         if (!product.self_order_available) {

--- a/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.xml
@@ -111,7 +111,7 @@
                         <div class="">
                             <AttributeSelection t-if="product.attribute_line_ids.length" productTemplate="product" onSelection="onAttributeSelection" />
                         </div>
-                        <t t-if="hasMissingAttributeValues(currentChoiceState.displayAttributesOfItem)" t-call="pos_self_order.MissingRequiredDetails" />
+                        <t t-if="hasMissingAttributeValues(currentChoiceState.displayAttributesOfItem) and shouldShowMissingDetails()" t-call="pos_self_order.MissingRequiredDetails" />
                     </div>
 
                     <!-- Confirmation -->

--- a/addons/pos_self_order/static/src/app/pages/product_page/product_page.js
+++ b/addons/pos_self_order/static/src/app/pages/product_page/product_page.js
@@ -63,6 +63,16 @@ export class ProductPage extends Component {
         return this.props.productTemplate;
     }
 
+    shouldShowMissingDetails() {
+        const el = this.scrollContainerRef?.el;
+        if (!el) {
+            return false;
+        }
+        return (
+            el.scrollHeight > el.clientHeight && this.productTemplate.attribute_line_ids.length > 1
+        );
+    }
+
     changeQuantity(increase) {
         const currentQty = this.state.qty;
 

--- a/addons/pos_self_order/static/src/app/pages/product_page/product_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/product_page/product_page.xml
@@ -41,7 +41,7 @@
                  <div  t-if="showQtyButtons and selfOrder.ordering" class="d-flex container o_self_container justify-content-end pt-0 py-3">
                      <t t-call="pos_self_order.QuantityWidget" />
                  </div>
-                 <t t-if="hasMissingAttributeValues()" t-call="pos_self_order.MissingRequiredDetails" />
+                 <t t-if="hasMissingAttributeValues() and shouldShowMissingDetails()" t-call="pos_self_order.MissingRequiredDetails" />
             </div>
 
             <!-- Footer -->


### PR DESCRIPTION
Before this commit:
================
- `MissingRequiredDetails` template was always displayed and had no condition based on the product attributes and screen layout.
- The arrow-up icon inside the template was not displayed properly.

After this commit:
================
- Added `shouldDisplayMissingAttributes()` method to handle conditional display.
- The component now shows only when content overflows and there are multiple attributes.
- Fixed the button styling so the arrow-up icon displays correctly.

Task - 5153070
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
