### PR TITLE
[FIX] resource_mail:  prevent error when opening avatar popover of archived employee

### DIFF
--- a/addons/resource_mail/models/resource_resource.py
+++ b/addons/resource_mail/models/resource_resource.py
@@ -10,6 +10,4 @@ class ResourceResource(models.Model):
     im_status = fields.Char(related='user_id.im_status')
 
     def get_avatar_card_data(self, fields):
-        return self.env['resource.resource'].search_read(
-            domain=[('id', 'in', self.ids)],
-        )
+        return self.read(fields)


### PR DESCRIPTION
**Steps to reproduce:**
- Open the Planning app.
- Archive an employee.
- Open the archived employee's avatar popover.

**Current behavior before PR:**
Opening the popover raised an error because `get_avatar_card_data` returned an empty list for archived records. This occurred since `search_read` ignored inactive records by default.

**Desired behavior after PR is merged:**
The method now uses `read` instead, ensuring archived records are properly handled without error.

enterprise PR: https://github.com/odoo/enterprise/pull/98230

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
