### PR TITLE
[FIX] website: prevent traceback when field changed to attachment

### DIFF
--- a/addons/website/static/src/snippets/s_website_form/form.js
+++ b/addons/website/static/src/snippets/s_website_form/form.js
@@ -232,9 +232,10 @@ export class Form extends Interaction {
         // default values...)
         if (dataForValues || Object.keys(this.preFillValues).length) {
             dataForValues = dataForValues || {};
-            const fieldNames = [...this.el.querySelectorAll("[name]")].map(
-                (el) => el.name
-            );
+            const fieldNames = [...this.el.querySelectorAll("[name]")]
+            .filter(el => !(["submit", "button", "image", "reset", "file"].includes(el.type)))
+            .map(el => el.name);
+
             // All types of inputs do not have a value property (eg:hidden),
             // for these inputs any function that is supposed to put a value
             // property actually puts a HTML value attribute. Because of


### PR DESCRIPTION
Steps to reproduce:
===================
1- Add a Contact Us form.
2- Change the "Phone" field type to "Attachment" and save. → Traceback occurs.

Cause:
======
After changing the field type, the field still keeps its `fillWith` value. When saving or refreshing, the system tries to prefill it with a phone number. Since the type is now "file", it cannot be prefilled, causing a traceback.

Why it didn't happen before:
============================
In older versions, fields were fetched using `serializeArray()`:
https://github.com/odoo/odoo/blob/ad03751ef0a9e617c2b24a30b1c06aa4e25d48a1/addons/website/static/src/snippets/s_website_form/000.js#L167
That method automatically filtered out unsupported input types: 
https://github.com/odoo/odoo/blob/ad03751ef0a9e617c2b24a30b1c06aa4e25d48a1/addons/web/static/lib/jquery/jquery.js#L9001

Fix:
====
Exclude fields of file-like types from the prefill logic, similar to the behavior of `serializeArray()`.

opw-5145855
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
