### PR TITLE
[FIX] hr_timesheet: Fixed access error when printing own timesheet.

### DIFF
--- a/addons/hr_timesheet/report/report_timesheet_templates.xml
+++ b/addons/hr_timesheet/report/report_timesheet_templates.xml
@@ -108,7 +108,7 @@
     <template id="report_timesheet">
         <t t-call="web.html_container">
             <t t-call="web.internal_layout">
-                <t t-set="company" t-value="docs.project_id.company_id if len(docs.project_id) == 1 else docs.env.company"/>
+                <t t-set="company" t-value="docs.project_id.sudo().company_id if len(docs.project_id) == 1 else docs.env.company"/>
                 <t t-set="show_task" t-value="bool(docs.task_id)"/>
                 <t t-set="show_project" t-value="len(docs.project_id) > 1"/>
                 <div class="page">
@@ -118,7 +118,7 @@
                             <h2>
                                 <span>Timesheets
                                     <t t-if="len(docs.project_id) == 1">
-                                        for the <t t-out="docs.project_id.name">Research and Development</t> Project
+                                        for the <t t-out="docs.project_id.sudo().name">Research and Development</t> Project
                                     </t>
                                 </span>
                             </h2>


### PR DESCRIPTION
****Behavior:****

**Current:**
When a user with only 'User' access to Projects and Timesheets, is assigned to a task in a Private project by an admin user, they can then log timesheets on the task as it appears under "My Tasks". The user might then want to print or export the timesheets form the list view.
- If the selected timesheets come from only a single private project : an Access Error is raised
- If the selected timesheets come from multiple private projects, or a mix of public and private ones : no Error is raised

The issue comes from the need to access to the project's name (since the project is private to the user the code raises the error) as well as the company's name. And it only happens when single projects are selected, in the other cases, the exported pdf shows the project's name at another location without error.

**Expected:**
Since the information is already accessible through multiple other places in odoo (and even in the exported pdf), we should allow the access here aswell.

So now when printing or exporting a timesheet from a single private project, no Access Error is raised.

**Steps to reproduce:**
- Create 2 different projects
- Create a task in each
- Assign it to another user (Make sure the other user only has user access to timesheets and projects)
- Set each project's visibility setting to private
- Log in with the other user
- Go to Timesheets --> List View

Single projects:
- Select one or multiple timesheet entries from one of the private projects
- Select Print -> Timesheets
- You should see an Access Error 

Multiple projects:
- Select one or multiple timesheet entries from a combination of both private projects
- Select Print -> Timesheets
- You should not have any Errors

opw-5127526
