### PR TITLE
[FIX] discuss: remove incorrect test assertion

### DIFF
--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -17,15 +17,13 @@ import { mailDataHelpers } from "@mail/../tests/mock_server/mail_mock_server";
 
 import { describe, expect, test } from "@odoo/hoot";
 import { advanceTime, hover, manuallyDispatchProgrammaticEvent, queryFirst } from "@odoo/hoot-dom";
-import { mockSendBeacon, mockUserAgent } from "@odoo/hoot-mock";
+import { mockSendBeacon } from "@odoo/hoot-mock";
 import {
     Command,
     mockService,
     patchWithCleanup,
     serverState,
 } from "@web/../tests/web_test_helpers";
-
-import { isMobileOS } from "@web/core/browser/feature_detection";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -51,10 +49,6 @@ test("basic rendering", async () => {
     await click("[title='More']");
     await contains("[title='Raise Hand']");
     await contains("[title='Enter Full Screen']");
-    // screen sharing not available in mobile OS
-    mockUserAgent("Chrome/0.0.0 Android (OdooMobile; Linux; Android 13; Odoo TestSuite)");
-    expect(isMobileOS()).toBe(true);
-    await contains("[title='Share Screen']", { count: 0 });
 });
 
 test("keep the `more` popover active when hovering it", async () => {


### PR DESCRIPTION
Before this commit ([1]), we were testing the absence of a button for mobile, but the test can lead to undeterministic behavior as `isMobileOS` is not reactive as we do not expect a live transition of userAgent, like from desktop to mobile, so testing for this behavior is not useful.

A dedicated test for call mobile was introduced in v19 ([2])

https://runbot.odoo.com/odoo/runbot.build.error/233350

[1]: https://github.com/odoo/odoo/pull/177374
[2]: https://github.com/odoo/odoo/pull/218119

