### PR TITLE
[FIX] mail: restore mentioned channels when editing via ArrowUp

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -496,7 +496,7 @@ export class Composer extends Component {
                 if (this.props.messageEdition && composer.text === "") {
                     const messageToEdit = composer.thread.lastEditableMessageOfSelf;
                     if (messageToEdit) {
-                        this.props.messageEdition.enterEditMode(messageToEdit);
+                        this.props.messageEdition.enterEditModeAsync(messageToEdit);
                     }
                 }
                 break;

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -91,7 +91,7 @@ messageActionsRegistry
         icon: "fa fa-pencil",
         title: _t("Edit"),
         onClick: (component) => {
-            component.props.messageEdition.enterEditMode(component.props.message);
+            component.props.messageEdition.enterEditModeAsync(component.props.message);
             component.optionsDropdown?.close();
         },
         sequence: 80,

--- a/addons/mail/static/src/discuss/core/common/message_actions.js
+++ b/addons/mail/static/src/discuss/core/common/message_actions.js
@@ -1,11 +1,9 @@
 import { messageActionsRegistry } from "@mail/core/common/message_actions";
-import { createDocumentFragmentFromContent } from "@mail/utils/common/html";
 
 import { toRaw } from "@odoo/owl";
 
 import { _t } from "@web/core/l10n/translation";
 import { rpc } from "@web/core/network/rpc";
-import { patch } from "@web/core/utils/patch";
 
 messageActionsRegistry.add("set-new-message-separator", {
     /** @param {import("@mail/core/common/message").Message} component */
@@ -36,23 +34,4 @@ messageActionsRegistry.add("set-new-message-separator", {
         });
     },
     sequence: 70,
-});
-
-const editAction = messageActionsRegistry.get("edit");
-
-patch(editAction, {
-    /** @param {import("@mail/core/common/message").Message} component */
-    onClick(component) {
-        const doc = createDocumentFragmentFromContent(component.message.body);
-        const mentionedChannelElements = doc.querySelectorAll(".o_channel_redirect");
-        component.message.mentionedChannelPromises = Array.from(mentionedChannelElements)
-            .filter((el) => el.dataset.oeModel === "discuss.channel")
-            .map(async (el) =>
-                component.store.Thread.getOrFetch({
-                    id: el.dataset.oeId,
-                    model: el.dataset.oeModel,
-                })
-            );
-        return super.onClick(component);
-    },
 });

--- a/addons/mail/static/src/discuss/core/common/message_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/message_model_patch.js
@@ -57,12 +57,8 @@ const messagePatch = {
      * @override
      */
     async edit(body, attachments = [], { mentionedChannels = [], mentionedPartners = [] } = {}) {
-        const validChannels = (await Promise.all(this.mentionedChannelPromises)).filter(
-            (channel) => channel !== undefined
-        );
-        const allChannels = this.store.Thread.insert([...validChannels, ...mentionedChannels]);
         return await super.edit(body, attachments, {
-            mentionedChannels: allChannels,
+            mentionedChannels,
             mentionedPartners,
         });
     },

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -172,6 +172,16 @@ test("Editing message keeps the mentioned channels", async () => {
     await contains(".o-mail-Message-content", { text: "other bye (edited)" });
     await click(".o_channel_redirect", { text: "other" });
     await contains(".o-mail-Discuss-threadName", { value: "other" });
+    // Test editing via arrow up shortcut
+    await click(".o-mail-DiscussSidebarChannel", { text: "general" });
+    await contains(".o-mail-Message");
+    await press("ArrowUp");
+    await contains(".o-mail-Message .o-mail-Composer-input", { value: "#other bye" });
+    await insertText(".o-mail-Message .o-mail-Composer-input", "#other hello", { replace: true });
+    await click(".o-mail-Message a", { text: "save" });
+    await contains(".o-mail-Message-content", { text: "other hello (edited)" });
+    await click(".o_channel_redirect", { text: "other" });
+    await contains(".o-mail-Discuss-threadName", { value: "other" });
 });
 
 test("Can edit message comment in chatter", async () => {


### PR DESCRIPTION
**Description of the issue this PR addresses:**
------------------------------------------------

When editing a message via the ArrowUp shortcut, any previously mentioned channels (e.g., `#general`) were not restored in the composer. This happened because the logic to restore mentions was only applied in the `onClick()` handler of the Edit message action.

**Current behavior before PR:**
---------------------------------

- Editing a message using ArrowUp does not restore mentioned channels  
- Editing via the Edit message action still works correctly  

**Desired behavior after PR is merged:**
-----------------------------------------

- Mentioned channels are restored when entering edit mode via ArrowUp  
- Behavior is consistent with editing through the Edit message action
- No mentions are lost in any edit scenario  

**Important: This PR should only be merged for versions saas-18.2, saas-18.3, and saas-18.4.**

**Backport of https://github.com/odoo/odoo/pull/229546/commits/5878e398615596adcf09eef8acbbe5aa739918f3**

**Task:** 5133698

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

