### PR TITLE
[FIX] hr_attendance: auto check out attendances older than 24h

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -735,7 +735,7 @@ class HrAttendance(models.Model):
             to_verify_company = to_verify.filtered(lambda a: a.employee_id.company_id.id == company.id)
 
             # Attendances where Last open attendance time + previously worked time on that day + tolerance greater than the attendances hours (including lunch) in his calendar
-            to_check_out = to_verify_company.filtered(lambda a: (fields.Datetime.now() - a.check_in).seconds / 3600 + mapped_previous_duration[a.employee_id][check_in_tz(a).date()] - max_tol >
+            to_check_out = to_verify_company.filtered(lambda a: (fields.Datetime.now() - a.check_in).total_seconds() / 3600 + mapped_previous_duration[a.employee_id][check_in_tz(a).date()] - max_tol >
                                                                 (sum(a.employee_id.resource_calendar_id.attendance_ids.filtered(lambda att: att.dayofweek == str(check_in_tz(a).weekday()) and (not att.two_weeks_calendar or att.week_type == str(att.get_week_type(check_in_tz(a).date())))).mapped(lambda at: at.hour_to - at.hour_from))))
             body = _('This attendance was automatically checked out because the employee exceeded the allowed time for their scheduled work hours.')
 

--- a/addons/hr_attendance/tests/test_hr_attendance_overtime.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_overtime.py
@@ -405,6 +405,12 @@ class TestHrAttendanceOvertime(TransactionCase):
             'employee_id': self.employee.id,
             'check_in': datetime(2024, 2, 1, 14, 0)
         })
+
+        # Attendance slightly older than 24 hours
+        attendance_old_pending = self.env['hr.attendance'].create({
+            'employee_id': self.honolulu_employee.id,
+            'check_in': datetime(2024, 1, 31, 18, 0),
+        })
         
         # Based on the employee's working calendar, they should be within the allotted hours.
         attendance_utc_pending_within_allotted_hours = self.env['hr.attendance'].create({
@@ -437,6 +443,7 @@ class TestHrAttendanceOvertime(TransactionCase):
         self.env['hr.attendance']._cron_auto_check_out()
 
         self.assertEqual(attendance_utc_pending.check_out, datetime(2024, 2, 1, 19, 0))
+        self.assertEqual(attendance_old_pending.check_out, datetime(2024, 2, 1, 5, 0))
         self.assertEqual(attendance_utc_pending_within_allotted_hours.check_out, False)
         self.assertEqual(attendance_utc_done.check_out, datetime(2024, 2, 1, 17, 0))
         self.assertEqual(attendance_jpn_pending.check_out, datetime(2024, 2, 1, 21, 0))


### PR DESCRIPTION
`.seconds` returns the seconds component of the timedelta, after extracting the days. For attendances checked in more than 24 hours ago (processed by the cron, see `previous_attendances` search domain), `total_seconds()` will correctly return the number of elapsed seconds.

no-task