### PR TITLE
[IMP] mail: forward notifications when out of office

### DIFF
--- a/addons/mail/models/res_users.py
+++ b/addons/mail/models/res_users.py
@@ -39,6 +39,12 @@ class ResUsers(models.Model):
     out_of_office_from = fields.Datetime()
     out_of_office_to = fields.Datetime()
     out_of_office_message = fields.Html('Vacation Responder')
+    out_of_office_forward_to = fields.Many2one(
+        "res.users",
+        string="Forward to",
+        help="Forward your messages to another user while you’re out of office. "
+             "Notifications about documents they can’t access won’t be forwarded.",
+    )
     is_out_of_office = fields.Boolean('Out of Office', compute='_compute_is_out_of_office')
     # sudo: res.users - can access presence of accessible user
     im_status = fields.Char("IM Status", compute="_compute_im_status", compute_sudo=True)
@@ -161,6 +167,7 @@ class ResUsers(models.Model):
             "out_of_office_from",
             "out_of_office_message",
             "out_of_office_to",
+            "out_of_office_forward_to",
             "role_ids",
             "has_external_mail_server",
             "outgoing_mail_server_id",
@@ -174,6 +181,7 @@ class ResUsers(models.Model):
             "out_of_office_from",
             "out_of_office_message",
             "out_of_office_to",
+            "out_of_office_forward_to",
         ]
 
     @api.model_create_multi

--- a/addons/mail/views/res_users_views.xml
+++ b/addons/mail/views/res_users_views.xml
@@ -42,6 +42,7 @@
                             <field name="out_of_office_to" invisible="1"/> <!-- otherwise it is visible, smort -->
                         </div>
                         <field name="out_of_office_message" string="" options="{'height': 112}" class="border border-secondary w-100" placeholder="Your out-of-office message..."/>
+                        <field name="out_of_office_forward_to" widget="many2one_avatar_user" invisible="not out_of_office_from" />
                     </group>
                 </data>
             </field>

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -1737,7 +1737,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
 
         self.env.invalidate_all()
         with self.assertBus(get_params=get_bus_params):
-            with self.assertQueryCount(18):
+            with self.assertQueryCount(19):
                 record.message_post(
                     body=Markup("<p>Test Post Performances with multiple inbox ping!</p>"),
                     message_type="comment",
@@ -1875,7 +1875,7 @@ class TestPerformance(BaseMailPostPerformance):
         self.push_to_end_point_mocked.reset_mock()  # reset as executed twice
         self.flush_tracking()
 
-        with self.assertQueryCount(employee=839):  # tm: 830
+        with self.assertQueryCount(employee=848):  # tm: 830
             for ticket, attachments in zip(tickets, attachments_all, strict=True):
                 ticket.message_post(
                     attachments=attachments_vals,

--- a/addons/test_mail_full/tests/test_mail_performance.py
+++ b/addons/test_mail_full/tests/test_mail_performance.py
@@ -75,7 +75,7 @@ class TestMailPerformance(FullBaseMailPerformance):
         self.push_to_end_point_mocked.reset_mock()  # reset as executed twice
         self.flush_tracking()
 
-        with self.assertQueryCount(employee=108):  # test_mail_full: 106
+        with self.assertQueryCount(employee=109):  # test_mail_full: 106
             new_message = record_ticket.message_post(
                 attachment_ids=attachments.ids,
                 body=Markup('<p>Test Content</p>'),


### PR DESCRIPTION
Before this commit, when user went out of office, multiple important messages could be missed due to the fact that other users were not aware of them. Actions could be taken to work around the problem (adding the user as follower, assigning the record to another user), but those were losing their purpose (losing history of the owner) or error-prone.

Now, with this commit, a user can forward notification of notes (only when mentioned in them) and all his messages to another user. This is simply set in the preferences of the current user.

task-5135665

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
