### PR TITLE
[FIX] l10n_tr, l10n_jo: restore Cash journal

### DIFF
--- a/addons/l10n_jo/i18n_extra/ar_001.po
+++ b/addons/l10n_jo/i18n_extra/ar_001.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 16.0+e\n"
+"Project-Id-Version: Odoo Server saas~18.2+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-28 07:33+0000\n"
-"PO-Revision-Date: 2023-03-28 07:33+0000\n"
+"POT-Creation-Date: 2025-10-17 07:24+0000\n"
+"PO-Revision-Date: 2025-10-17 07:24+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -209,6 +209,12 @@ msgstr "9. المبيعات غير الخاضعة للضريبة (الضريبة
 #: model:ir.model,name:l10n_jo.model_account_chart_template
 msgid "Account Chart Template"
 msgstr "قالب شجرة الحسابات"
+
+#. module: l10n_jo
+#. odoo-python
+#: code:addons/l10n_jo/models/template_jo_standard.py:0
+msgid "Cash"
+msgstr "نقدي"
 
 #. module: l10n_jo
 #: model:account.report.column,name:l10n_jo.tax_report_vat_return_balance

--- a/addons/l10n_jo/i18n_extra/l10n_jo.pot
+++ b/addons/l10n_jo/i18n_extra/l10n_jo.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 16.0+e\n"
+"Project-Id-Version: Odoo Server saas~18.2+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-28 07:33+0000\n"
-"PO-Revision-Date: 2023-03-28 07:33+0000\n"
+"POT-Creation-Date: 2025-10-17 07:23+0000\n"
+"PO-Revision-Date: 2025-10-17 07:23+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -208,6 +208,12 @@ msgstr ""
 #. module: l10n_jo
 #: model:ir.model,name:l10n_jo.model_account_chart_template
 msgid "Account Chart Template"
+msgstr ""
+
+#. module: l10n_jo
+#. odoo-python
+#: code:addons/l10n_jo/models/template_jo_standard.py:0
+msgid "Cash"
 msgstr ""
 
 #. module: l10n_jo

--- a/addons/l10n_jo/models/template_jo_standard.py
+++ b/addons/l10n_jo/models/template_jo_standard.py
@@ -1,5 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from odoo import models
+from odoo import _, models
 from odoo.addons.account.models.chart_template import template
 
 
@@ -41,5 +41,15 @@ class AccountChartTemplate(models.AbstractModel):
                 'deferred_revenue_account_id': 'jo_account_200401',
                 'expense_account_id': 'jo_account_500101',
                 'income_account_id': 'jo_account_400101',
+            },
+        }
+
+    @template('jo_standard', 'account.journal')
+    def _get_jo_standard_account_journal(self):
+        return {
+            'cash': {
+                'name': _("Cash"),
+                'type': 'cash',
+                'show_on_dashboard': True,
             },
         }

--- a/addons/l10n_tr/i18n/l10n_tr.pot
+++ b/addons/l10n_tr/i18n/l10n_tr.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 15.3alpha1+e\n"
+"Project-Id-Version: Odoo Server saas~18.2+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-21 18:37+0000\n"
-"PO-Revision-Date: 2024-05-29 17:48+0000\n"
+"POT-Creation-Date: 2025-10-17 07:22+0000\n"
+"PO-Revision-Date: 2025-10-17 07:22+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -18,4 +18,10 @@ msgstr ""
 #. module: l10n_tr
 #: model:ir.model,name:l10n_tr.model_account_chart_template
 msgid "Account Chart Template"
+msgstr ""
+
+#. module: l10n_tr
+#. odoo-python
+#: code:addons/l10n_tr/models/template_tr.py:0
+msgid "Cash"
 msgstr ""

--- a/addons/l10n_tr/i18n/tr.po
+++ b/addons/l10n_tr/i18n/tr.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 15.3alpha1+e\n"
+"Project-Id-Version: Odoo Server saas~18.2+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-21 18:37+0000\n"
-"PO-Revision-Date: 2022-03-21 18:37+0000\n"
+"POT-Creation-Date: 2025-10-17 07:19+0000\n"
+"PO-Revision-Date: 2025-10-17 07:19+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -19,3 +19,9 @@ msgstr ""
 #: model:ir.model,name:l10n_tr.model_account_chart_template
 msgid "Account Chart Template"
 msgstr "Hesap Tablosu Şablonu"
+
+#. module: l10n_tr
+#. odoo-python
+#: code:addons/l10n_tr/models/template_tr.py:0
+msgid "Cash"
+msgstr "Kasa"

--- a/addons/l10n_tr/models/template_tr.py
+++ b/addons/l10n_tr/models/template_tr.py
@@ -1,5 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from odoo import models
+from odoo import _, models
 from odoo.addons.account.models.chart_template import template
 
 
@@ -30,5 +30,15 @@ class AccountChartTemplate(models.AbstractModel):
                 'account_purchase_tax_id': 'tr_p_20',
                 'expense_account_id': 'tr150',
                 'income_account_id': 'tr600',
+            },
+        }
+
+    @template('tr', 'account.journal')
+    def _get_tr_account_journal(self):
+        return {
+            'cash': {
+                'name': _("Cash"),
+                'type': 'cash',
+                'show_on_dashboard': True,
             },
         }


### PR DESCRIPTION
This commits adds back default cash journal for companies intializing with l10n_tr and l10n_jr.

In our efforts to cleaning the UX/UI of accounting (PR #192031 task-4430969) We removed the default cash journal, however, some locatizations, such as l10n_tr and l10n_jo, require them for compliance reasons

task-4991218

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
