### PR TITLE
[FIX] im_livechat: correct chatbot answers display in info side panel

### DIFF
--- a/addons/im_livechat/models/mail_message.py
+++ b/addons/im_livechat/models/mail_message.py
@@ -73,6 +73,7 @@ class MailMessage(models.Model):
                                 [
                                     ("script_step_id", "=", step.id),
                                     ("id", "!=", chatbot_message.id),
+                                    ("discuss_channel_id", "=", channel.id),
                                 ],
                                 limit=1,
                             )

--- a/addons/im_livechat/static/src/core/web/livechat_channel_info_list.js
+++ b/addons/im_livechat/static/src/core/web/livechat_channel_info_list.js
@@ -33,7 +33,7 @@ export class LivechatChannelInfoList extends Component {
 
     get expectAnswerSteps() {
         return this.props.thread.messages
-            .filter((m) => m.chatbotStep?.expectAnswer)
+            .filter((m) => m.chatbotStep?.expectAnswer && m.chatbotStep.answer)
             .map((m) => m.chatbotStep);
     }
 


### PR DESCRIPTION
**Description of the issue this PR addresses:**
The info side panel in livechat displayed incorrect or empty chatbot answers for previous sessions.
1. When a visitor used the same chatbot multiple times, the panel showed answers from the latest session instead of the selected one.
2. when a user skipped a question, the panel still displayed an empty line with a comment icon.

**Current behavior before PR:**
1. Chatbot answers were fetched using an incorrect query that didn’t consider the specific livechat session or channel.
2. Empty chatbot responses appeared in the side panel.

**Desired behavior after PR is merged:**
1. The correct chatbot answers for the selected session are now shown in the info side panel.
2. Empty chatbot answers are hidden.

task-[4981175](https://www.odoo.com/odoo/project/1519/tasks/4981175)