### PR TITLE
[FIX] survey: prevent error when open session manager after deleting question

### DIFF
--- a/addons/survey/models/survey_survey.py
+++ b/addons/survey/models/survey_survey.py
@@ -804,7 +804,7 @@ class Survey(models.Model):
           - All the following questions are conditional AND were not triggered by previous answers,
             AND cannot be triggered by any answer given on the current page/question.
         """
-        if self.questions_layout == "one_page":
+        if self.questions_layout == "one_page" or not page_or_question:
             return True
         pages_or_questions = self._get_pages_or_questions(user_input)
         current_page_index = pages_or_questions.ids.index(page_or_question.id)


### PR DESCRIPTION
Currently, an error occurs when opening the session manager after deleting a question.

**Steps to reproduce:**

- Install the `survey` module.
- Create a `new survey`, add two questions, and click `Create Live Session`.
- Complete the survey and leave it on the `Thank You` page.
- Switch back to the first tab, delete the second question, and click `Open Session Manager`.

(Refer [this](https://drive.google.com/file/d/1_f7OwV6h2gWd-CluCYc7HpOXyDMIqGga/view?usp=sharing) for step to produce.)

**Error:**
`ValueError: False is not in list`

**Root Cause:**
At [1], the code assumes the `page_or_question` exists and tries to access 
`.index(page_or_question.id)`, but when the question has been deleted, 
`page_or_question.id` is `False`, causing an `error`.

**Fix:**
This commit prevents a crash when opening the session manager if the question 
was deleted.

[1]:
https://github.com/odoo/odoo/blob/ad03751ef0a9e617c2b24a30b1c06aa4e25d48a1/addons/survey/models/survey_survey.py#L810

sentry-5285798473