### PR TITLE
[FIX] crm: stage disappears after assigning sales team on edit

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1054,13 +1054,13 @@ class CrmLead(models.Model):
         # - OR ('fold', '=', False): add default columns that are not folded
         # - OR ('team_ids', '=', team_id), ('fold', '=', False) if team_id: add team columns that are not folded
         team_id = self.env.context.get('default_team_id')
-        if team_id:
-            search_domain = ['|', ('id', 'in', stages.ids), '|', ('team_ids', '=', False), ('team_ids', 'in', team_id)]
         if self.env.context.get('show_user_team_stages'):
             team_ids = self.env.user.crm_team_ids._ids
             if team_id:
                 team_ids += (team_id,)
             search_domain = ['|', ('id', 'in', stages.ids), '|', ('team_ids', '=', False), ('team_ids', 'in', team_ids)]
+        elif team_id:
+            search_domain = ['|', ('id', 'in', stages.ids), '|', ('team_ids', '=', False), ('team_ids', 'in', [team_id])]
         else:
             search_domain = ['|', ('id', 'in', stages.ids), ('team_ids', '=', False)]
 


### PR DESCRIPTION
**Steps to reproduce:**
1. Install the CRM module.
2. Go to CRM → Sales → Teams(Team should more than one).
3. Open any Sales Team and create a new Stage.
4. Go to Settings of the created Stage → Edit.
5. Set the 'Sales Teams' same as the selected Team and save.
6. The newly created stage disappears from the list.

**Issue:**
- When editing a stage and assigning a 'Sales Teams', the stage no longer appears in 
the kanban or list view.

**Cause:**
Issue Occur from this [commit](https://github.com/odoo/odoo/commit/7345cbbff6ecb1dcbc508c320e807849167a4f1a)

- The `_read_group_stage_ids` method  overwrite the `search_domain` in the final `else` block, 
even when a valid `team_id` was present in the context. As a result, the search domain ignored 
the selected team and only fetched global stages (with no team assigned).

**Solution:**

Refactored `_read_group_stage_ids` to correctly handle conditional domain
 building:
- Respect `team_id` when present in the context.
- Include user team stages when `show_user_team_stages` is enabled.
- Avoid overwriting `search_domain` when a specific team context is active.

**opw - 5147315**