### PR TITLE
[FIX] html_builder, website: enable `background-size` to reset to `auto`

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_number_input.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_number_input.js
@@ -93,7 +93,7 @@ export class BuilderNumberInput extends Component {
     }
 
     clampValue(value) {
-        if (!value) {
+        if (!value && value !== 0) {
             return value;
         }
         value = parseFloat(value);

--- a/addons/html_builder/static/src/plugins/background_option/background_position_option.xml
+++ b/addons/html_builder/static/src/plugins/background_option/background_position_option.xml
@@ -12,10 +12,10 @@
         </BuilderRow>
         <BuilderContext t-if="isActiveItem('background_repeat_opt')" action="'setBackgroundSize'">
             <BuilderRow label.translate="Width" level="3">
-                <BuilderNumberInput actionParam="'width'" placeholder.translate="auto" unit="'px'" min="0"/>
+                <BuilderNumberInput actionParam="'width'" placeholder.translate="auto" unit="'px'" min="1" default="null"/>
             </BuilderRow>
             <BuilderRow label.translate="Height" level="3">
-                <BuilderNumberInput actionParam="'height'" placeholder.translate="auto" unit="'px'" min="0"/>
+                <BuilderNumberInput actionParam="'height'" placeholder.translate="auto" unit="'px'" min="1" default="null"/>
             </BuilderRow>
         </BuilderContext>
     </t>

--- a/addons/html_builder/static/src/plugins/background_option/background_position_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/background_option/background_position_option_plugin.js
@@ -53,8 +53,8 @@ export class SetBackgroundSizeAction extends BuilderAction {
             params: { mainParam: otherParam },
         });
         let bgSize;
+        value ||= "auto";
         if (styleName === "width") {
-            value = !value && otherBgSize ? "auto" : value;
             otherBgSize = otherBgSize === "" ? "" : ` ${otherBgSize}`;
             bgSize = `${value}${otherBgSize}`;
         } else {

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_number_input.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_number_input.test.js
@@ -839,6 +839,40 @@ describe("sanitized values", () => {
         expect.verifySteps(["customAction 0", "customAction 0"]); // input, change
         expect(".options-container input").toHaveValue("0");
     });
+    test("clamp to min value when pressing down arrow with min > 0", async () => {
+        addBuilderAction({
+            customAction: class extends BuilderAction {
+                static id = "customAction";
+                getValue({ editingElement }) {
+                    return editingElement.textContent;
+                }
+                apply({ editingElement, value }) {
+                    expect.step(`customAction ${value}`);
+                    editingElement.textContent = value;
+                }
+            },
+        });
+        addBuilderOption(
+            class extends BaseOptionComponent {
+                static selector = ".test-options-target";
+                static template = xml`<BuilderNumberInput action="'customAction'" min="1"/>`;
+            }
+        );
+        await setupHTMLBuilder(`
+            <div class="test-options-target">2</div>
+        `);
+        await contains(":iframe .test-options-target").click();
+        // Simulate pressing arrow down
+        await contains(".options-container input").keyDown("ArrowDown");
+        expect.verifySteps(["customAction 1"]);
+        expect(".options-container input").toHaveValue("1");
+        expect(":iframe .test-options-target").toHaveText("1");
+        // Pressing down again should stay at min value
+        await contains(".options-container input").keyDown("ArrowDown");
+        expect.verifySteps(["customAction 1"]);
+        expect(".options-container input").toHaveValue("1");
+        expect(":iframe .test-options-target").toHaveText("1");
+    });
     test("use max when the given value is bigger", async () => {
         addBuilderAction({
             customAction: class extends BuilderAction {

--- a/addons/website/static/tests/builder/website_builder/background_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/background_option.test.js
@@ -418,3 +418,40 @@ test("remove background image removes color filter", async () => {
     await contains("[data-action-id='toggleBgImage']").click();
     expect(":iframe section .o_we_bg_filter").not.toHaveCount();
 });
+
+test("change background size", async () => {
+    const { waitSidebarUpdated } = await setupWebsiteBuilder(`
+        <section class="o_bg_img_opt_repeat" style="background-image: url('/web/image/123/transparent.png'); width: 500px; height:500px; background-size: 100px;">
+        </section>`);
+
+    const section = await waitFor(":iframe section");
+    await contains(section).click();
+
+    await waitSidebarUpdated();
+
+    const widthInput = await waitFor(
+        '[data-action-id="setBackgroundSize"][data-action-param="width"] > input'
+    );
+    const heightInput = await waitFor(
+        '[data-action-id="setBackgroundSize"][data-action-param="height"] > input'
+    );
+
+    expect(heightInput).toHaveValue("");
+
+    await contains(heightInput).edit("0");
+    expect(heightInput).toHaveValue("1", { message: "minimum value is 1" });
+    expect(section).toHaveStyle("background-size: 100px 1px");
+
+    await contains(heightInput).edit("");
+    expect(heightInput).toHaveValue("");
+    expect(section).toHaveStyle("background-size: 100px");
+
+    await contains(widthInput).edit("");
+    expect(widthInput).toHaveValue("");
+    expect(heightInput).toHaveValue("", { message: "height input should stay empty" });
+    expect(section).toHaveStyle("background-size: auto");
+
+    await contains(widthInput).edit("0");
+    expect(widthInput).toHaveValue("1", { message: "minimum value is 1" });
+    expect(section).toHaveStyle("background-size: 1px");
+});


### PR DESCRIPTION
__Current behavior before commit:__
In "Repeat pattern" mode, users can set the background image's width and height to 0px, which doesn't make sense. Additionally, clearing these input fields resets their values to 0px instead of reverting them to `auto`.

__Description of the fix:__
Make it possible to clear those fields by setting their default value to `null` and set the minimum value to 1 to prevent the image from disappearing.

__Steps to reproduce:__
1. On the website, drop a `s_cover` snippet
2. Set Background > Image > Position to "Repeat pattern"
3. Delete the content of the "Width" input

=> The background disappears.

task-5094899
