### PR TITLE
[FIX] hr: no force create for default structure on employee

### DIFF
--- a/addons/hr/data/hr_data.xml
+++ b/addons/hr/data/hr_data.xml
@@ -218,7 +218,7 @@
         </record>
 
         <!-- Add default Structure to employee admin -->
-        <record id="employee_admin" model="hr.employee">
+        <record id="employee_admin" model="hr.employee" forcecreate="0">
             <field name="structure_type_id" ref="hr.structure_type_employee"/>
         </record>
     </data>


### PR DESCRIPTION
After this commit:
https://github.com/odoo/odoo/commit/6247dc36f703ee2ec45913802ad175cb79873845 and this one:
https://github.com/odoo-dev/odoo/commit/5686072b8e7b827269573e8ab1f5b84b61b9315c

when we set default Structure to employee admin
but Later when clients set up their work flow
they set up their own admin employee.
This record is not present, so when employee admin record is not there , no need to set default structure too so need to set no forcecreate  on that employee admin too.

When we try to set default structure and if admin record does not exit,
we got error when we try to create employee as no name found and we try to pop name from val here :

https://github.com/odoo/odoo/blob/7e0cc5ec686a52b8c1f8270213acac54575ed469/addons/hr/models/hr_employee.py#L1275

Generated during upgrade

```
 File "/home/odoo/src/odoo/19.0/addons/resource/models/resource_mixin.py", line 37, in create
    self._prepare_resource_values(
  File "/home/odoo/src/odoo/19.0/addons/hr/models/hr_employee.py", line 1275, in _prepare_resource_values
    vals.pop('name')  # Already considered by super call but no popped
KeyError: 'name'
```

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
