### PR TITLE
[REF] im_livechat: move fields to channel model

### DIFF
--- a/addons/im_livechat/static/src/core/common/@types/models.d.ts
+++ b/addons/im_livechat/static/src/core/common/@types/models.d.ts
@@ -25,6 +25,12 @@ declare module "models" {
     export interface DataResponse {
         chatbot_step: ChatbotStep;
     }
+    export interface DiscussChannel {
+        livechat_channel_id: LivechatChannel;
+    }
+    export interface LivechatChannel {
+        channel_ids: DiscussChannel[];
+    }
     export interface Message {
         chatbotStep: ChatbotStep;
     }

--- a/addons/im_livechat/static/src/core/common/discuss_channel_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/discuss_channel_model_patch.js
@@ -1,0 +1,14 @@
+import { DiscussChannel } from "@mail/discuss/core/common/discuss_channel_model";
+
+import { fields } from "@mail/model/misc";
+
+import { patch } from "@web/core/utils/patch";
+
+/** @type {import("@models").DiscussChannel} */
+const discussChannelPatch = {
+    setup() {
+        super.setup(...arguments);
+        this.livechat_channel_id = fields.One("im_livechat.channel", { inverse: "channel_ids" });
+    },
+};
+patch(DiscussChannel.prototype, discussChannelPatch);

--- a/addons/im_livechat/static/src/core/common/livechat_channel_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/livechat_channel_model_patch.js
@@ -1,0 +1,13 @@
+import { LivechatChannel } from "@im_livechat/core/common/livechat_channel_model";
+
+import { fields } from "@mail/core/common/record";
+
+import { patch } from "@web/core/utils/patch";
+
+const livechatChannelPatch = {
+    setup() {
+        super.setup(...arguments);
+        this.channel_ids = fields.Many("discuss.channel", { inverse: "livechat_channel_id" });
+    },
+};
+patch(LivechatChannel.prototype, livechatChannelPatch);

--- a/addons/im_livechat/static/src/core/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/thread_model_patch.js
@@ -14,7 +14,7 @@ patch(Thread.prototype, {
                 if (this.channel?.channel_type !== "livechat") {
                     return;
                 }
-                // For livechat threads, the correspondent is the first
+                // For live chat conversation, the correspondent is the first
                 // channel member that is not the operator.
                 const orderedChannelMembers = [...this.channel.channel_member_ids].sort(
                     (a, b) => a.id - b.id

--- a/addons/im_livechat/static/src/core/public_web/@types/models.d.ts
+++ b/addons/im_livechat/static/src/core/public_web/@types/models.d.ts
@@ -1,18 +1,18 @@
 declare module "models" {
     export interface DiscussApp {
         defaultLivechatCategory: DiscussAppCategory;
-        livechats: Thread[];
+        livechats: DiscussChannel[];
     }
     export interface DiscussAppCategory {
         livechat_channel_id: LivechatChannel;
     }
+    export interface DiscussChannel {
+        appAsLivechats: DiscussApp;
+    }
     export interface LivechatChannel {
         appCategory: DiscussAppCategory;
-        threads: Thread[];
     }
     export interface Thread {
-        appAsLivechats: DiscussApp;
         country_id: Country;
-        livechat_channel_id: LivechatChannel;
     }
 }

--- a/addons/im_livechat/static/src/core/public_web/discuss_app_model_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/discuss_app_model_patch.js
@@ -20,6 +20,6 @@ patch(DiscussApp.prototype, {
             },
             eager: true,
         });
-        this.livechats = fields.Many("mail.thread", { inverse: "appAsLivechats" });
+        this.livechats = fields.Many("discuss.channel", { inverse: "appAsLivechats" });
     },
 });

--- a/addons/im_livechat/static/src/core/public_web/discuss_channel_model_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/discuss_channel_model_patch.js
@@ -1,0 +1,17 @@
+import { DiscussChannel } from "@mail/discuss/core/common/discuss_channel_model";
+
+import { fields } from "@mail/model/misc";
+
+import { patch } from "@web/core/utils/patch";
+
+const discussChannelPatch = {
+    setup() {
+        super.setup(...arguments);
+        this.appAsLivechats = fields.One("DiscussApp", {
+            compute() {
+                return this.channel_type === "livechat" ? this.store.discuss : null;
+            },
+        });
+    },
+};
+patch(DiscussChannel.prototype, discussChannelPatch);

--- a/addons/im_livechat/static/src/core/public_web/livechat_channel_model_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/livechat_channel_model_patch.js
@@ -20,7 +20,6 @@ const livechatChannelPatch = {
             eager: true,
             inverse: "livechat_channel_id",
         });
-        this.threads = fields.Many("mail.thread", { inverse: "livechat_channel_id" });
     },
 };
 patch(LivechatChannel.prototype, livechatChannelPatch);

--- a/addons/im_livechat/static/src/core/public_web/messaging_menu_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/messaging_menu_patch.js
@@ -3,14 +3,15 @@ import { MessagingMenu } from "@mail/core/public_web/messaging_menu";
 import { _t } from "@web/core/l10n/translation";
 import { patch } from "@web/core/utils/patch";
 
-patch(MessagingMenu.prototype, {
+/** @type {MessagingMenu} */
+const messagingMenuPatch = {
     /**
      * @override
      */
     get _tabs() {
         const items = super._tabs;
-        const hasLivechats = Object.values(this.store["mail.thread"].records).some(
-            (thread) => thread.channel?.channel_type === "livechat"
+        const hasLivechats = Object.values(this.store["discuss.channel"].records).some(
+            (channel) => channel.channel_type === "livechat"
         );
         if (hasLivechats) {
             items.push({
@@ -28,4 +29,5 @@ patch(MessagingMenu.prototype, {
         }
         return items;
     },
-});
+};
+patch(MessagingMenu.prototype, messagingMenuPatch);

--- a/addons/im_livechat/static/src/core/public_web/thread_model_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/thread_model_patch.js
@@ -7,20 +7,15 @@ import { patch } from "@web/core/utils/patch";
 patch(Thread.prototype, {
     setup() {
         super.setup(...arguments);
-        this.appAsLivechats = fields.One("DiscussApp", {
-            compute() {
-                return this.channel?.channel_type === "livechat" ? this.store.discuss : null;
-            },
-        });
         this.country_id = fields.One("res.country");
-        this.livechat_channel_id = fields.One("im_livechat.channel", { inverse: "threads" });
     },
     _computeDiscussAppCategory() {
         if (this.channel?.channel_type !== "livechat") {
             return super._computeDiscussAppCategory();
         }
         return (
-            this.livechat_channel_id?.appCategory ?? this.appAsLivechats?.defaultLivechatCategory
+            this.channel.livechat_channel_id?.appCategory ??
+            this.channel.appAsLivechats?.defaultLivechatCategory
         );
     },
     get hasMemberList() {

--- a/addons/im_livechat/static/src/core/web/composer_patch.js
+++ b/addons/im_livechat/static/src/core/web/composer_patch.js
@@ -3,7 +3,8 @@ import { _t } from "@web/core/l10n/translation";
 
 import { patch } from "@web/core/utils/patch";
 
-patch(Composer.prototype, {
+/** @type {Composer} */
+const composerPatch = {
     onKeydown(ev) {
         super.onKeydown(ev);
         if (
@@ -34,8 +35,9 @@ patch(Composer.prototype, {
         return (
             this.thread?.channel?.channel_type === "livechat" &&
             this.store.discuss.livechats.some(
-                (thread) => thread.notEq(this.thread) && thread.isUnread
+                (channel) => channel.thread.notEq(this.thread) && channel.isUnread
             )
         );
     },
-});
+};
+patch(Composer.prototype, composerPatch);

--- a/addons/im_livechat/static/src/core/web/livechat_channel_command_provider.js
+++ b/addons/im_livechat/static/src/core/web/livechat_channel_command_provider.js
@@ -24,7 +24,7 @@ registry.category("command_provider").add("im_livechat.channel_join_leave", {
         await store.livechatChannels.fetch();
         const activeChannels = new Set(
             Object.values(store["im_livechat.channel"].records)
-                .filter((c) => c.threads.length > 0)
+                .filter((c) => c.channel_ids.length > 0)
                 .map((c) => c.id)
         );
         // Show live chat channels with ongoing conversations first

--- a/addons/im_livechat/static/src/core/web/store_service_patch.js
+++ b/addons/im_livechat/static/src/core/web/store_service_patch.js
@@ -20,25 +20,24 @@ const storePatch = {
             this.livechatChannels.fetch();
         }
     },
-    /** @returns {boolean} Whether the livechat thread changed. */
     goToOldestUnreadLivechatThread() {
-        const [oldestUnreadThread] = this.discuss.livechats
-            .filter((thread) => thread.isUnread)
+        const [oldestUnreadConversation] = this.discuss.livechats
+            .filter((conversation) => conversation.isUnread)
             .sort(
-                (t1, t2) =>
-                    !t2.livechat_end_dt - !t1.livechat_end_dt ||
-                    compareDatetime(t1.lastInterestDt, t2.lastInterestDt) ||
-                    t1.id - t2.id
+                (c1, c2) =>
+                    !c2.livechat_end_dt - !c1.livechat_end_dt ||
+                    compareDatetime(c1.lastInterestDt, c2.lastInterestDt) ||
+                    c1.id - c2.id
             );
-        if (!oldestUnreadThread) {
+        if (!oldestUnreadConversation) {
             return false;
         }
         if (this.discuss.isActive) {
-            oldestUnreadThread.setAsDiscussThread();
+            oldestUnreadConversation.setAsDiscussThread();
             return true;
         }
         this.store.chatHub.initPromise.then(() => {
-            const chatWindow = this.ChatWindow.insert({ thread: oldestUnreadThread });
+            const chatWindow = this.ChatWindow.insert({ thread: oldestUnreadConversation.thread });
             chatWindow.open({ focus: true, jumpToNewMessage: true });
         });
         return true;

--- a/addons/im_livechat/static/src/embed/common/@types/models.d.ts
+++ b/addons/im_livechat/static/src/embed/common/@types/models.d.ts
@@ -1,9 +1,12 @@
 declare module "models" {
+    export interface DiscussChannel {
+        storeAsActiveLivechats: Store;
+    }
     export interface Message {
         disableChatbotAnswers: boolean;
     }
     export interface Store {
-        activeLivechats: Thread[];
+        activeLivechats: DiscussChannel[];
         guest_token: null;
         livechat_available: boolean;
         livechat_rule: LivechatChannelRule;
@@ -19,6 +22,5 @@ declare module "models" {
         livechatWelcomeMessage: Message;
         readyToSwapDeferred: Deferred;
         requested_by_operator: boolean;
-        storeAsActiveLivechats: Store;
     }
 }

--- a/addons/im_livechat/static/src/embed/common/discuss_channel_model_patch.js
+++ b/addons/im_livechat/static/src/embed/common/discuss_channel_model_patch.js
@@ -1,0 +1,21 @@
+import { DiscussChannel } from "@mail/discuss/core/common/discuss_channel_model";
+
+import { fields } from "@mail/model/misc";
+
+import { patch } from "@web/core/utils/patch";
+
+/** @type {import("models").DiscussChannel} */
+const discussChannelPatch = {
+    setup() {
+        super.setup(...arguments);
+        this.storeAsActiveLivechats = fields.One("Store", {
+            compute() {
+                return this.channel_type === "livechat" && !this.livechat_end_dt
+                    ? this.store
+                    : null;
+            },
+            inverse: "activeLivechats",
+        });
+    },
+};
+patch(DiscussChannel.prototype, discussChannelPatch);

--- a/addons/im_livechat/static/src/embed/common/livechat_service.js
+++ b/addons/im_livechat/static/src/embed/common/livechat_service.js
@@ -129,14 +129,14 @@ export class LivechatService {
             return;
         }
         this.store.insert(store_data);
-        const thread = this.store["mail.thread"].get({ id: channel_id, model: "discuss.channel" });
+        const channel = this.store["discuss.channel"].get(channel_id);
         const ONE_DAY_TTL = 60 * 60 * 24;
         expirableStorage.setItem(
             "im_livechat_previous_operator",
-            thread.livechat_operator_id.id,
+            channel.livechat_operator_id.id,
             ONE_DAY_TTL * 7
         );
-        return thread;
+        return channel.thread;
     }
 
     getSessionExtraParams(thread, options) {

--- a/addons/im_livechat/static/src/embed/common/store_service_patch.js
+++ b/addons/im_livechat/static/src/embed/common/store_service_patch.js
@@ -9,7 +9,9 @@ export const GUEST_TOKEN_STORAGE_KEY = "im_livechat_guest_token";
 const StorePatch = {
     setup() {
         super.setup(...arguments);
-        this.activeLivechats = fields.Many("mail.thread", { inverse: "storeAsActiveLivechats" });
+        this.activeLivechats = fields.Many("discuss.channel", {
+            inverse: "storeAsActiveLivechats",
+        });
         expirableStorage.onChange(GUEST_TOKEN_STORAGE_KEY, (value) => (this.guest_token = value));
         this.guest_token = fields.Attr(null, {
             compute() {

--- a/addons/im_livechat/static/src/embed/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/embed/common/thread_model_patch.js
@@ -72,13 +72,6 @@ patch(Thread.prototype, {
             },
             eager: true,
         });
-        this.storeAsActiveLivechats = fields.One("Store", {
-            compute() {
-                return this.channel?.channel_type === "livechat" && !this.livechat_end_dt
-                    ? this.store
-                    : null;
-            },
-        });
         this.requested_by_operator = false;
         this._prevComposerDisabled = false;
     },

--- a/addons/im_livechat/static/tests/sidebar_patch.test.js
+++ b/addons/im_livechat/static/tests/sidebar_patch.test.js
@@ -175,7 +175,7 @@ test("No counter if category is folded and without unread messages", async () =>
     await contains(".o-mail-DiscussSidebarCategory-livechat .o-discuss-badge", { count: 0 });
 });
 
-test("Counter should have correct value of unread threads if category is folded and with unread messages", async () => {
+test("Counter should have count of unread conversations if category is folded and with unread messages", async () => {
     const pyEnv = await startServer();
     const guestId = pyEnv["mail.guest"].create({ name: "Visitor 11" });
     const channelId = pyEnv["discuss.channel"].create({


### PR DESCRIPTION
To match python structure.

Note: this PR focused on relations towards `mail.thread`
To be done separately `getOrFetch` in general, `thread` on `Chatbot`, and all other channel fields.