### PR TITLE
[FIX] l10n_tr_nilvera_einvoice_extended: Payable Amount in Export Invoices

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice_extended/models/account_edi_xml_ubl_tr.py
+++ b/addons/l10n_tr_nilvera_einvoice_extended/models/account_edi_xml_ubl_tr.py
@@ -286,6 +286,15 @@ class AccountEdiXmlUblTr(models.AbstractModel):
             vals['withholding_tax_total_vals_list'] = self._get_tr_tax_totals(line.move_id, taxes_vals, withholding=True)
         return vals
 
+    def _get_invoice_monetary_total_vals(self, invoice, taxes_vals, line_extension_amount, allowance_total_amount, charge_total_amount):
+        # EXTENDS account.edi.xml.ubl_20
+        vals = super()._get_invoice_monetary_total_vals(invoice, taxes_vals, line_extension_amount, allowance_total_amount, charge_total_amount)
+        # UBL TR: If the Invoice Type is IHRACKAYITLI (Registered for Export), then the cbc:PayableAmount node
+        # should have tax exclusive amount instead of tax inclusive amount.
+        if invoice.l10n_tr_gib_invoice_type == 'IHRACKAYITLI':
+            vals["payable_amount"] = vals["tax_exclusive_amount"]
+        return vals
+
     @api.model
     def _get_invoice_line_delivery_vals(self, line):
         """Build delivery values for each invoice line.

--- a/addons/l10n_tr_nilvera_einvoice_extended/tests/expected_xmls/invoice_basic_export_registered_einvoice.xml
+++ b/addons/l10n_tr_nilvera_einvoice_extended/tests/expected_xmls/invoice_basic_export_registered_einvoice.xml
@@ -126,7 +126,7 @@
     <cbc:TaxExclusiveAmount currencyID="TRY">132.00</cbc:TaxExclusiveAmount>
     <cbc:TaxInclusiveAmount currencyID="TRY">158.40</cbc:TaxInclusiveAmount>
     <cbc:AllowanceTotalAmount currencyID="TRY">18.00</cbc:AllowanceTotalAmount>
-    <cbc:PayableAmount currencyID="TRY">158.40</cbc:PayableAmount>
+    <cbc:PayableAmount currencyID="TRY">132.00</cbc:PayableAmount>
   </cac:LegalMonetaryTotal>
   <cac:InvoiceLine>
     <cbc:ID>1</cbc:ID>


### PR DESCRIPTION
When the invoice's type is "Registered For Export", the total of the invoice which is shown in the cbc:PayableAmount node in XML, has to reflect the VAT deducted amount.
This PR fixes the given issue.

task-5159638

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
