### PR TITLE
[REF] discuss: call tests with mocked network layer

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call.xml
+++ b/addons/mail/static/src/discuss/call/common/call.xml
@@ -51,7 +51,7 @@
                     </div>
                 </div>
                 <div t-if="hasCallNotifications" class="position-absolute d-flex flex-column-reverse start-0 bottom-0" t-att-class="{ 'ps-5 pb-5': rtc.state.isFullscreen, 'ps-2 pb-2': !rtc.state.isFullscreen }">
-                    <span class="text-bg-800 shadow-lg rounded-1 m-1" t-att-class="{ 'p-4 fs-4': rtc.state.isFullscreen, 'p-2': !rtc.state.isFullscreen }" t-foreach="rtc.notifications.values()" t-as="notification" t-key="notification.id" t-esc="notification.text"/>
+                    <span class="o-discuss-Call-notification text-bg-800 shadow-lg rounded-1 m-1" t-att-class="{ 'p-4 fs-4': rtc.state.isFullscreen, 'p-2': !rtc.state.isFullscreen }" t-foreach="rtc.notifications.values()" t-as="notification" t-key="notification.id" t-esc="notification.text"/>
                 </div>
                 <div class="o-discuss-Call-layoutActions position-absolute bottom-0 end-0">
                     <ActionList actions="layoutActions" inline="true"/>

--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -102,7 +102,7 @@ function hasTurn(iceServers) {
  * establish a connection with other call participants with the SFU when possible, and still handle
  * peer-to-peer for the participants who did not manage to establish a SFU connection.
  */
-class Network {
+export class Network {
     /** @type {import("@mail/discuss/call/common/peer_to_peer").PeerToPeer} */
     p2p;
     /** @type {import("@mail/../lib/odoo_sfu/odoo_sfu").SfuClient} */

--- a/addons/mail/static/src/discuss/call/common/rtc_session_model.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_session_model.js
@@ -1,6 +1,16 @@
 import { fields, Record } from "@mail/core/common/record";
 import { Deferred } from "@web/core/utils/concurrency";
 
+/**
+ * @typedef {object} SessionInfo
+ * @property {boolean} [isSelfMuted]
+ * @property {boolean} [isDeaf]
+ * @property {boolean} [isTalking]
+ * @property {boolean} [isRaisingHand]
+ * @property {boolean} [isCameraOn]
+ * @property {boolean} [isScreenSharingOn]
+ */
+
 export class RtcSession extends Record {
     static _name = "discuss.channel.rtc.session";
     static id = "id";

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -1,14 +1,17 @@
 import {
     click,
     contains,
+    createVideoStream,
     defineMailModels,
     listenStoreFetch,
     mockGetMedia,
+    makeMockRtcNetwork,
     openDiscuss,
     patchUiSize,
     SIZES,
     start,
     startServer,
+    streams,
     triggerEvents,
     waitStoreFetch,
 } from "@mail/../tests/mail_test_helpers";
@@ -858,4 +861,165 @@ test("should not show context menu on participant card when not in a call", asyn
         ".o-discuss-CallParticipantCard[title='Awesome Partner'] .o-discuss-CallParticipantCard-contextButton"
     );
     await contains(".o-discuss-CallContextMenu");
+});
+
+test("all streams are properly closed when abruptly disconnected", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    const env = await start();
+    const rtc = env.services["discuss.rtc"];
+    await openDiscuss(channelId);
+    await click("[title='Start Call']");
+    await contains(".o-discuss-Call");
+    const audioStream = streams.at(-1);
+    expect(audioStream.getTracks()[0].readyState).toBe("live");
+    await click("[title='Turn camera on']");
+    await contains(".o-discuss-CallParticipantCard video");
+    const cameraStream = streams.at(-1);
+    expect(cameraStream.getTracks()[0].readyState).toBe("live");
+    await click("[title='Share Screen']");
+    await contains(".o-mail-DiscussSidebarCallParticipants-status:contains('LIVE')");
+    const screenStream = streams.at(-1);
+    expect(screenStream.getTracks()[0].readyState).toBe("live");
+    expect(streams.length).toBe(3);
+    pyEnv["discuss.channel.rtc.session"].unlink([rtc.selfSession.id]);
+    await contains(".o-discuss-Call", { count: 0 });
+    expect(audioStream.getTracks()[0].readyState).toBe("ended");
+    expect(cameraStream.getTracks()[0].readyState).toBe("ended");
+    expect(screenStream.getTracks()[0].readyState).toBe("ended");
+});
+
+test("Leaving a call should close all the streams", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    await start();
+    await openDiscuss(channelId);
+    await click("[title='Start Call']");
+    await contains(".o-discuss-Call");
+    await click("[title='Turn camera on']");
+    await contains(".o-discuss-CallParticipantCard video");
+    await click("[title='Share Screen']");
+    await contains(".o-discuss-CallParticipantCard.o-inset");
+    expect(streams.length).toBe(3);
+    expect(streams[0].getTracks()[0].readyState).toBe("live");
+    expect(streams[1].getTracks()[0].readyState).toBe("live");
+    expect(streams[2].getTracks()[0].readyState).toBe("live");
+    await triggerEvents(".o-discuss-Call-mainCards", ["mousemove"]); // show overlay
+    await click(".o-discuss-CallActionList button[aria-label='Disconnect']");
+    await contains(".o-discuss-Call", { count: 0 });
+    expect(streams[0].getTracks()[0].readyState).toBe("ended");
+    expect(streams[1].getTracks()[0].readyState).toBe("ended");
+    expect(streams[2].getTracks()[0].readyState).toBe("ended");
+});
+
+test("all streams are properly closed when requesting new ones and tuning the features off", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    await start();
+    await openDiscuss(channelId);
+    await click("[title='Start Call']");
+    await contains(".o-discuss-Call");
+    const audioStream = streams.at(-1);
+    expect(audioStream.getTracks()[0].readyState).toBe("live");
+    await click("[title='Turn camera on']");
+    await contains(".o-discuss-CallParticipantCard video");
+    const cameraStream1 = streams.at(-1);
+    expect(cameraStream1.getTracks()[0].readyState).toBe("live");
+    await click("[title='Stop camera']");
+    await contains(".o-discuss-CallParticipantCard video", { count: 0 });
+    await click("[title='Turn camera on']");
+    await contains(".o-discuss-CallParticipantCard video");
+    const cameraStream2 = streams.at(-1);
+    expect(cameraStream1.getTracks()[0].readyState).toBe("ended");
+    expect(cameraStream2.getTracks()[0].readyState).toBe("live");
+    await click("[title='Stop camera']");
+    await contains(".o-discuss-CallParticipantCard video", { count: 0 });
+    await click("[title='Share Screen']");
+    await contains(".o-discuss-CallParticipantCard video");
+    await contains(".o-mail-DiscussSidebarCallParticipants-status:contains('LIVE')");
+    const screenStream = streams.at(-1);
+    expect(screenStream.getTracks()[0].readyState).toBe("live");
+    await triggerEvents(".o-discuss-Call-mainCards", ["mousemove"]); // show overlay
+    await click("[title='Stop Sharing Screen']");
+    expect(screenStream.getTracks()[0].readyState).toBe("ended");
+});
+
+test("Show connecting state on cards", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    const channelMemberId = pyEnv["discuss.channel.member"].create({
+        channel_id: channelId,
+        partner_id: pyEnv["res.partner"].create({ name: "Bob" }),
+    });
+    const env = await start();
+    const network = await makeMockRtcNetwork({ env, channelId });
+    const bobRemote = network.makeMockRemote(channelMemberId);
+    await openDiscuss(channelId);
+    await click("[title='Join Call']");
+    await contains(".o-discuss-CallParticipantCard[title='Bob']");
+    await bobRemote.updateConnectionState("connecting");
+    await contains(".o-discuss-CallParticipantCard[title='Bob'] .fa-exclamation-triangle");
+    await bobRemote.updateConnectionState("connected");
+    await contains("span[data-connection-state='connected']");
+});
+
+test("Can see raised hands from other call participants", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    const channelMemberId = pyEnv["discuss.channel.member"].create({
+        channel_id: channelId,
+        partner_id: pyEnv["res.partner"].create({ name: "Bob" }),
+    });
+    const env = await start();
+    const network = await makeMockRtcNetwork({ env, channelId });
+    const bobRemote = network.makeMockRemote(channelMemberId);
+    await openDiscuss(channelId);
+    await click("[title='Join Call']");
+    await contains(".o-discuss-CallParticipantCard[title='Bob']");
+    await bobRemote.updateConnectionState("connected");
+    await bobRemote.updateInfo({ isRaisingHand: true });
+    await contains(".o-discuss-CallParticipantCard[title='Bob'] .fa-hand-paper-o");
+    await contains(".o-discuss-Call-notification:contains('Bob raised their hand')");
+});
+
+test("Can see videos from other call participants", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    const channelMemberId = pyEnv["discuss.channel.member"].create({
+        channel_id: channelId,
+        partner_id: pyEnv["res.partner"].create({ name: "Bob" }),
+    });
+    const env = await start();
+    const network = await makeMockRtcNetwork({ env, channelId });
+    const bobRemote = network.makeMockRemote(channelMemberId);
+    await openDiscuss(channelId);
+    await click("[title='Join Call']");
+    await contains(".o-discuss-CallParticipantCard[title='Bob']");
+    await bobRemote.updateConnectionState("connected");
+    await bobRemote.updateUpload("screen", createVideoStream().getVideoTracks()[0]);
+    await contains(".o-discuss-CallParticipantCard[title='Bob'] video");
+});
+
+test("show all participants on other user stops screen share", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    const channelMemberId = pyEnv["discuss.channel.member"].create({
+        channel_id: channelId,
+        partner_id: pyEnv["res.partner"].create({ name: "Streamer" }),
+    });
+    const env = await start();
+    const network = await makeMockRtcNetwork({ env, channelId });
+    const streamerRemote = network.makeMockRemote(channelMemberId);
+    await openDiscuss(channelId);
+    await click("[title='Join Call']");
+    await streamerRemote.updateConnectionState("connected");
+    await contains(".o-discuss-CallParticipantCard-avatar", { count: 2 });
+    await streamerRemote.updateUpload("screen", createVideoStream().getVideoTracks()[0]);
+    await contains(".o-discuss-CallParticipantCard-avatar", { count: 2 });
+    await contains(".o-discuss-CallParticipantCard video");
+    await click(".o-discuss-CallParticipantCard[title='Streamer'] video");
+    await contains(".o-discuss-CallParticipantCard-avatar");
+    await contains(".o-discuss-CallParticipantCard video");
+    await streamerRemote.updateUpload("screen", null);
+    await contains(".o-discuss-CallParticipantCard-avatar", { count: 2 });
 });


### PR DESCRIPTION
- Add a Mock for the network layer of calls (`rtcService.network`),
which allows for the testing of features that depend on network events,
without using online tests (which would require local network access in
the test environment).

- Improve the stream testing API, so tests for stream
cleanup are also added, which guards against memory leaks that could
be caused if streams aren't properly closed and the associated lingering
OS/browser level media indicators (eg: webcam activity light).

- Add a test for https://github.com/odoo/odoo/pull/230287 now that it's
possible to test such features.