### PR TITLE
[IMP] web,project: fallback on project manager top bar configuration

### DIFF
--- a/addons/project/models/__init__.py
+++ b/addons/project/models/__init__.py
@@ -17,6 +17,7 @@ from . import project_collaborator
 from . import project_update
 from . import res_config_settings
 from . import res_partner
+from . import res_users_settings
 from . import res_users
 from . import digest_digest
 from . import ir_ui_menu

--- a/addons/project/models/res_users_settings.py
+++ b/addons/project/models/res_users_settings.py
@@ -1,0 +1,36 @@
+from odoo import models
+
+
+class ResUsersSettings(models.Model):
+    _inherit = 'res.users.settings'
+
+    def get_embedded_actions_settings(self):
+        embedded_actions_settings_dict = super().get_embedded_actions_settings()
+        res_model = self.env.context.get('res_model')
+        res_id = self.env.context.get('res_id')
+        if not (res_model == 'project.project' and res_id):
+            return embedded_actions_settings_dict
+
+        project_manager = self.env['project.project'].browse(res_id).user_id
+        if self.user_id == project_manager:
+            return embedded_actions_settings_dict
+
+        user_configs = self.env['res.users.settings.embedded.action'].search(
+            domain=[
+                ('user_setting_id', '=', self.id),
+                ('res_model', '=', res_model),
+                ('res_id', '=', res_id),
+            ],
+        )
+        manager_configs_sudo = self.env['res.users.settings.embedded.action'].sudo().search(
+            domain=[
+                ('user_setting_id', '=', project_manager.sudo().res_users_settings_id.id),
+                ('res_model', '=', res_model),
+                ('res_id', '=', res_id),
+                ('action_id', 'not in', user_configs.action_id.ids),
+            ],
+        )
+        if manager_configs_sudo:
+            embedded_actions_settings_dict.update(manager_configs_sudo.copy({'user_setting_id': self.id})._embedded_action_settings_format())
+
+        return embedded_actions_settings_dict

--- a/addons/project/tests/test_project_config.py
+++ b/addons/project/tests/test_project_config.py
@@ -8,6 +8,8 @@ class TestProjectConfig(TestProjectCommon):
     def setUpClass(cls):
         super(TestProjectConfig, cls).setUpClass()
         cls.Settings = cls.env["res.config.settings"]
+        cls.user_settings_project_manager = cls.env['res.users.settings']._find_or_create_for_user(cls.user_projectmanager)
+        cls.user_settings_project_user = cls.env['res.users.settings']._find_or_create_for_user(cls.user_projectuser)
 
     def test_project_stages_feature_enable_views(self):
         """Check that the Gantt, Calendar and Activities views are
@@ -17,3 +19,108 @@ class TestProjectConfig(TestProjectCommon):
         menu_ids = set([self.env.ref('project.menu_projects').id, self.env.ref('project.menu_projects_config').id])
         menu_loaded = set(self.env['ir.ui.menu']._load_menus_blacklist())
         self.assertTrue(menu_ids.issubset(menu_loaded), "The menu project and menu projects config should be loaded")
+
+    def test_copy_project_manager_embedded_config_as_default(self):
+        """
+        Test that when a user gets the embedded actions configs of a projet, he gets the configs of
+        the project manager as default if he has no personal configuration yet for a particular action.
+        The configs he gets should also be copied in its user's settings.
+        """
+        project = self.env['project.project'].create({
+            'name': 'Test Project',
+            'user_id': self.user_projectmanager.id,
+        })
+        project_action = self.env['ir.actions.act_window'].create({
+            'name': 'Test Project Action',
+            'res_model': 'project.project',
+        })
+        # Create the embedded action config for the project manager
+        project_manager_config = self.env['res.users.settings.embedded.action'].create({
+            'user_setting_id': self.user_settings_project_manager.id,
+            'action_id': project_action.id,
+            'res_model': 'project.project',
+            'res_id': project.id,
+            'embedded_actions_order': 'false,3,2,1',
+            'embedded_actions_visibility': '1,2,3',
+            'embedded_visibility': True,
+        })
+
+        # The project user has no personal configuration yet
+        self.assertFalse(self.user_settings_project_user.embedded_actions_config_ids)
+        # He should get the project manager configuration as default
+        project_user_config = self.user_settings_project_user.with_context(
+            res_model='project.project',
+            res_id=project.id,
+        ).get_embedded_actions_settings()
+        self.assertDictEqual(
+            project_user_config[f'{project_action.id}+{project.id}'],
+            {
+                'embedded_actions_order': [False, 3, 2, 1],
+                'embedded_actions_visibility': [1, 2, 3],
+                'embedded_visibility': True,
+            },
+        )
+
+        # Check that the config has indeed been copied for the project user
+        project_user_config = self.user_settings_project_user.embedded_actions_config_ids
+        self.assertEqual(len(project_user_config), 1, 'There should be one embedded action setting created.')
+        self.assertEqual(project_user_config.action_id, project_manager_config.action_id, 'The action should match the one set in the project manager config.')
+        self.assertEqual(project_user_config.res_id, project_manager_config.res_id, 'The res_id should match the one set in the project manager config.')
+        self.assertEqual(project_user_config.res_model, project_manager_config.res_model, 'The res_model should match the one set in the project manager config.')
+        self.assertEqual(project_user_config.embedded_actions_order, project_manager_config.embedded_actions_order, 'The embedded actions order should match the one set in the project manager config.')
+        self.assertEqual(project_user_config.embedded_actions_visibility, project_manager_config.embedded_actions_visibility, 'The embedded actions visibility should match the one set in the project manager config.')
+        self.assertEqual(project_user_config.embedded_visibility, project_manager_config.embedded_visibility, 'The embedded visibility should match the one set in the project manager config.')
+
+    def test_no_copy_project_manager_embedded_config_as_default(self):
+        """
+        Test that when a user gets the embedded actions configs of a projet, he does not get the configs of
+        the project manager as default if he already has a personal configuration for some actions.
+        """
+        project = self.env['project.project'].create({
+            'name': 'Test Project',
+            'user_id': self.user_projectmanager.id,
+        })
+        project_action = self.env['ir.actions.act_window'].create({
+            'name': 'Test Project Action',
+            'res_model': 'project.project',
+        })
+        # Create the embedded action config for the project manager
+        self.env['res.users.settings.embedded.action'].create({
+            'user_setting_id': self.user_settings_project_manager.id,
+            'action_id': project_action.id,
+            'res_model': 'project.project',
+            'res_id': project.id,
+            'embedded_actions_order': 'false,3,2,1',
+            'embedded_actions_visibility': '1,2,3',
+            'embedded_visibility': True,
+        })
+        # The project user already has a personal configuration
+        user_config = self.env['res.users.settings.embedded.action'].create({
+            'user_setting_id': self.user_settings_project_user.id,
+            'action_id': project_action.id,
+            'res_model': 'project.project',
+            'res_id': project.id,
+            'embedded_actions_order': 'false,1,2,3',
+            'embedded_actions_visibility': '2,3',
+            'embedded_visibility': False,
+        })
+        self.assertEqual(len(self.user_settings_project_user.embedded_actions_config_ids), 1)
+
+        # He should get his personal configuration as default
+        project_user_config = self.user_settings_project_user.with_context(
+            res_model='project.project',
+            res_id=project.id,
+        ).get_embedded_actions_settings()
+        self.assertDictEqual(
+            project_user_config[f'{project_action.id}+{project.id}'],
+            {
+                'embedded_actions_order': [False, 1, 2, 3],
+                'embedded_actions_visibility': [2, 3],
+                'embedded_visibility': False,
+            },
+        )
+
+        # Check that no new config has been created for the project user
+        project_user_config = self.user_settings_project_user.embedded_actions_config_ids
+        self.assertEqual(len(project_user_config), 1, 'There should still be only one embedded action setting created.')
+        self.assertEqual(project_user_config, user_config, 'The existing user config should be unchanged.')

--- a/addons/web/static/src/search/control_panel/control_panel.js
+++ b/addons/web/static/src/search/control_panel/control_panel.js
@@ -40,9 +40,10 @@ const STICKY_CLASS = "o_mobile_sticky";
  */
 
 class EmbeddedActionsConfigHandler {
-    constructor(parentActionId, currentActiveId, ormService) {
+    constructor(parentActionId, currentActiveId, parentResModel, ormService) {
         this.parentActionId = parentActionId;
         this.currentActiveId = currentActiveId;
+        this.parentResModel = parentResModel;
         this.embeddedActionsKey = `${this.parentActionId}+${this.currentActiveId || ""}`;
         this.embeddedActionsConfig = user.settings.embedded_actions_config_ids || {};
         this.orm = ormService;
@@ -71,9 +72,12 @@ class EmbeddedActionsConfigHandler {
     }
 
     async fetchEmbeddedActionsConfig() {
-        return await this.orm.call("res.users.settings", "get_embedded_actions_settings", [
-            user.settings.id,
-        ]);
+        return await this.orm.call(
+            "res.users.settings",
+            "get_embedded_actions_settings",
+            [user.settings.id],
+            { context: { res_model: this.parentResModel, res_id: this.currentActiveId } }
+        );
     }
 
     updateEmbeddedActionsConfig(newSettings) {
@@ -139,6 +143,7 @@ export class ControlPanel extends Component {
         this.embeddedActionsConfigHandler = new EmbeddedActionsConfigHandler(
             parentActionId,
             currentActiveId,
+            this.currentEmbeddedAction?.parent_res_model,
             this.orm
         );
 

--- a/addons/web/static/tests/webclient/actions/embedded_action.test.js
+++ b/addons/web/static/tests/webclient/actions/embedded_action.test.js
@@ -676,3 +676,25 @@ test("custom embedded action loaded first", async () => {
         message: "'Favorite Ponies' view should be loaded",
     });
 });
+
+test("test get_embedded_actions_settings rpc args", async () => {
+    onRpc("res.users.settings", "get_embedded_actions_settings", ({ args, kwargs }) => {
+        expect(args.length).toBe(1, {
+            message: "Should have one positional argument, which is the id of the user setting.",
+        });
+        expect(args[0]).toBe(1, { message: "The id of the user setting should be 1." });
+        expect(kwargs.context.res_id).toBe(5, {
+            message: "The context should contain the res_id passed to the action.",
+        });
+        expect(kwargs.context.res_model).toBe("partner", {
+            message: "The context should contain the res_model passed to the action.",
+        });
+        expect.step("get_embedded_actions_settings");
+    });
+    await mountWithCleanup(WebClient);
+    await getService("action").doAction(1, {
+        additionalContext: { active_id: 5 },
+    });
+    await contains(".o_control_panel_navigation > button > i.fa-sliders").click();
+    expect.verifySteps(["get_embedded_actions_settings"]);
+});


### PR DESCRIPTION
If the current user doesn't have a top bar configuration yet for a given project, we fallback on the top bar configuration of the project manager to show the actions.

task-5072899

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
