### PR TITLE
[FIX] web: display Tax ID on document layout preview

### DIFF
--- a/addons/web/models/base_document_layout.py
+++ b/addons/web/models/base_document_layout.py
@@ -119,7 +119,7 @@ class BaseDocumentLayout(models.TransientModel):
                 wizard_for_image = wizard
             wizard.logo_primary_color, wizard.logo_secondary_color = wizard.extract_image_primary_secondary_colors(wizard_for_image.logo)
 
-    @api.depends('report_layout_id', 'logo', 'font', 'primary_color', 'secondary_color', 'report_header', 'report_footer', 'layout_background', 'layout_background_image', 'company_details')
+    @api.depends('report_layout_id', 'logo', 'font', 'primary_color', 'secondary_color', 'report_header', 'report_footer', 'layout_background', 'layout_background_image', 'company_details', 'vat')
     def _compute_preview(self):
         """ compute a qweb based preview to display on the wizard """
         styles = self._get_asset_style()
@@ -147,6 +147,7 @@ class BaseDocumentLayout(models.TransientModel):
             'company': self,
             'preview_css': preview_css,
             'is_html_empty': is_html_empty,
+            'forced_vat': self.vat,
         }
 
     @api.onchange('company_id')

--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -849,8 +849,10 @@
         <t t-set="company" t-value="env.company"/>
         <t t-call="web.html_container">
             <t t-set="o" t-value="res_company"/>
+            <t t-set="forced_vat" t-value="company.vat"/>
             <t t-call="web.external_layout">
                 <div class="page">
+                    <br/>
                     <p>This is a sample of an external report.</p>
                 </div>
             </t>


### PR DESCRIPTION
**Steps to reproduce:**
1. Enable debug mode.
2. Go to Settings → Companies → Configure Document Layout.
3. Add a Tax ID and save.
4. Preview the document layout.
5. Print or preview any invoice.

**Observed behavior:**
* Tax ID was missing from the layout preview.
* Tax ID was missing from the external report preview.

**Cause:**
* The Tax ID value was not passed correctly to the templates, so it never
appeared in the rendered layouts or previews.

**Fix:**
* Include the Tax ID in the layout rendering context.
* Adjust layout spacing to prevent overlap in report previews.

opw-5154255