### PR TITLE
[IMP] mail, *: shorten discuss channel typedef

### DIFF
--- a/addons/im_livechat/static/src/core/common/@types/models.d.ts
+++ b/addons/im_livechat/static/src/core/common/@types/models.d.ts
@@ -25,14 +25,6 @@ declare module "models" {
     export interface DataResponse {
         chatbot_step: ChatbotStep;
     }
-    export interface DiscussChannel {
-        composerHidden: Readonly<boolean>;
-        livechat_conversation_tag_ids: LivechatConversationTag[];
-        livechat_end_dt: import("luxon").DateTime;
-        livechat_operator_id: ResPartner;
-        livechatVisitorMember: ChannelMember;
-        open_chat_window: true|undefined;
-    }
     export interface Message {
         chatbotStep: ChatbotStep;
     }

--- a/addons/im_livechat/static/src/core/public_web/@types/models.d.ts
+++ b/addons/im_livechat/static/src/core/public_web/@types/models.d.ts
@@ -6,11 +6,6 @@ declare module "models" {
     export interface DiscussAppCategory {
         livechat_channel_id: LivechatChannel;
     }
-    export interface DiscussChannel {
-        appAsLivechats: DiscussApp;
-        country_id: Country;
-        livechat_channel_id: LivechatChannel;
-    }
     export interface LivechatChannel {
         appCategory: DiscussAppCategory;
         threads: Thread[];

--- a/addons/im_livechat/static/src/core/web/@types/models.d.ts
+++ b/addons/im_livechat/static/src/core/web/@types/models.d.ts
@@ -1,13 +1,4 @@
 declare module "models" {
-    export interface DiscussChannel {
-        hasFetchedLivechatSessionData: boolean;
-        livechat_expertise_ids: LivechatExpertise[];
-        livechat_note: ReturnType<import("@odoo/owl").markup>|string;
-        livechat_outcome: "no_answer"|"no_agent"|"no_failure"|"escalated"|undefined;
-        livechat_status: "in_progress"|"waiting"|"need_help"|undefined;
-        livechatNoteText: string|undefined;
-        livechatStatusLabel: Readonly<string>;
-    }
     export interface LivechatChannel {
         join: (param0: { notify: boolean }) => Promise<void>;
         joinTitle: Readonly<string>;

--- a/addons/im_livechat/static/src/embed/common/@types/models.d.ts
+++ b/addons/im_livechat/static/src/embed/common/@types/models.d.ts
@@ -1,17 +1,4 @@
 declare module "models" {
-    export interface DiscussChannel {
-        _prevComposerDisabled: boolean;
-        _toggleChatbot: boolean;
-        chatbot: Chatbot;
-        chatbotTypingMessage: Message;
-        hasWelcomeMessage: Readonly<boolean>;
-        isLastMessageFromCustomer: Readonly<boolean>;
-        livechat_operator_id: ResPartner;
-        livechatWelcomeMessage: Message;
-        readyToSwapDeferred: Deferred;
-        requested_by_operator: boolean;
-        storeAsActiveLivechats: Store;
-    }
     export interface Message {
         disableChatbotAnswers: boolean;
     }

--- a/addons/mail/static/src/chatter/web/@types/models.d.ts
+++ b/addons/mail/static/src/chatter/web/@types/models.d.ts
@@ -3,9 +3,6 @@ declare module "models" {
 
     export interface ScheduledMessage extends ScheduledMessageClass {}
 
-    export interface DiscussChannel {
-        scheduledMessages: ScheduledMessage[];
-    }
     export interface Store {
         "mail.scheduled.message": StaticMailRecord<ScheduledMessage, typeof ScheduledMessageClass>;
     }

--- a/addons/mail/static/src/core/public_web/@types/models.d.ts
+++ b/addons/mail/static/src/core/public_web/@types/models.d.ts
@@ -3,10 +3,6 @@ declare module "models" {
 
     export interface DiscussApp extends DiscussAppClass {}
 
-    export interface DiscussChannel {
-        autoOpenChatWindowOnNewMessage: Readonly<boolean>;
-        inChathubOnNewMessage: Readonly<boolean>;
-    }
     export interface Store {
         action_discuss_id: number|undefined;
         discuss: DiscussApp;

--- a/addons/mail/static/src/core/web/@types/models.d.ts
+++ b/addons/mail/static/src/core/web/@types/models.d.ts
@@ -8,13 +8,6 @@ declare module "models" {
         markAsDoneAndScheduleNext: () => Promise<ActionDescription>;
         remove: (param0: { broadcast: boolean }) => void;
     }
-    export interface DiscussChannel {
-        activities: Activity[];
-        isDisplayedInDiscussAppDesktop: boolean;
-        recipients: Follower[];
-        recipientsCount: number|undefined;
-        recipientsFullyLoaded: Readonly<boolean>;
-    }
     export interface Message {
         canForward: (thread: Thread) => boolean;
         canReplyAll: (thread: Thread) => boolean;

--- a/addons/mail/static/src/discuss/call/common/@types/models.d.ts
+++ b/addons/mail/static/src/discuss/call/common/@types/models.d.ts
@@ -9,20 +9,6 @@ declare module "models" {
         rtc_inviting_session_id: RtcSession;
         rtcSession: RtcSession;
     }
-    export interface DiscussChannel {
-        activeRtcSession: RtcSession;
-        cancelRtcInvitationTimeout: number|undefined;
-        focusStack: RtcSession[];
-        hadSelfSession: boolean;
-        lastSessionIds: Set<number>;
-        promoteFullscreen: typeof CALL_PROMOTE_FULLSCREEN[keyof CALL_PROMOTE_FULLSCREEN];
-        rtc_session_ids: RtcSession[];
-        showCallView: Readonly<boolean>;
-        useCameraByDefault: null;
-        videoCount: number;
-        videoCountNotSelf: number;
-        visibleCards: CardData[];
-    }
     export interface MailGuest {
         currentRtcSession: RtcSession;
     }

--- a/addons/mail/static/src/discuss/core/common/@types/models.d.ts
+++ b/addons/mail/static/src/discuss/core/common/@types/models.d.ts
@@ -3,58 +3,8 @@ declare module "models" {
     import { DiscussChannel as DiscussChannelClass } from "@mail/discuss/core/common/discuss_channel_model";
 
     export interface ChannelMember extends ChannelMemberClass {}
-    export interface DiscussChannel extends DiscussChannelClass {}
+    export interface DiscussChannel extends DiscussChannelClass, Thread {}
 
-    export interface DiscussChannel {
-        allowCalls: Readonly<boolean>;
-        allowDescription: Readonly<boolean>;
-        allowedToLeaveChannelTypes: Readonly<string[]>;
-        allowedToUnpinChannelTypes: Readonly<string[]>;
-        areAllMembersLoaded: Readonly<boolean>;
-        avatar_cache_key: string;
-        canLeave: Readonly<boolean>;
-        canUnpin: Readonly<boolean>;
-        channel: DiscussChannel;
-        channel_member_ids: ChannelMember[];
-        channel_name_member_ids: ChannelMember[];
-        channel_type: string;
-        correspondent: ChannelMember;
-        correspondentCountry: Country;
-        correspondents: Readonly<ChannelMember[]>;
-        default_display_mode: "video_full_screen"|undefined;
-        fetchChannelInfoDeferred: Deferred<Thread|undefined>;
-        fetchChannelInfoState: "not_fetched"|"fetching"|"fetched";
-        firstUnreadMessage: Message;
-        group_ids: ResGroups[];
-        hasMemberList: Readonly<boolean>;
-        hasOtherMembersTyping: boolean;
-        hasSeenFeature: boolean;
-        hasSelfAsMember: Readonly<boolean>;
-        invitationLink: Readonly<unknown|string>;
-        invited_member_ids: ChannelMember[];
-        isChatChannel: Readonly<boolean>;
-        last_interest_dt: import("luxon").DateTime;
-        lastInterestDt: import("luxon").DateTime;
-        lastMessageSeenByAllId: undefined|number;
-        lastSelfMessageSeenByEveryone: Message;
-        markedAsUnread: boolean;
-        markingAsRead: boolean;
-        member_count: number|undefined;
-        membersThatCanSeen: Readonly<ChannelMember[]>;
-        name: string;
-        offlineMembers: ChannelMember[];
-        onlineMembers: ChannelMember[];
-        openChannel: () => boolean;
-        otherTypingMembers: ChannelMember[];
-        scrollUnread: boolean;
-        self_member_id: ChannelMember;
-        showCorrespondentCountry: Readonly<boolean>;
-        showUnreadBanner: Readonly<boolean>;
-        toggleBusSubscription: boolean;
-        typesAllowingCalls: Readonly<string[]>;
-        typingMembers: ChannelMember[];
-        unknownMembersCount: Readonly<number>;
-    }
     export interface MailGuest {
         channelMembers: ChannelMember[];
     }
@@ -65,6 +15,7 @@ declare module "models" {
         hasSomeoneFetched: boolean|undefined;
         hasSomeoneSeen: boolean|undefined;
         isMessagePreviousToLastSelfMessageSeenByEveryone: boolean;
+        showSeenIndicator: (thread: Thread) => boolean;
         threadAsFirstUnread: Thread;
     }
     export interface ResPartner {

--- a/addons/mail/static/src/discuss/core/public_web/@types/models.d.ts
+++ b/addons/mail/static/src/discuss/core/public_web/@types/models.d.ts
@@ -5,23 +5,10 @@ declare module "models" {
 
     export interface DiscussApp {
         allCategories: DiscussAppCategory[];
-        channels: DiscussAppCategory;
-        chats: DiscussAppCategory;
+        channelCategory: DiscussAppCategory;
+        chatCategory: DiscussAppCategory;
         computeChatCategory: () => object;
         unreadChannels: Thread[];
-    }
-    export interface DiscussChannel {
-        appAsUnreadChannels: DiscussApp;
-        categoryAsThreadWithCounter: DiscussAppCategory;
-        discussAppCategory: DiscussAppCategory;
-        displayInSidebar: boolean;
-        from_message_id: Message;
-        hasSubChannelFeature: Readonly<boolean>;
-        isBusSubscribed: boolean;
-        lastSubChannelLoaded: Thread|null;
-        loadSubChannelsDone: boolean;
-        parent_channel_id: Thread;
-        sub_channel_ids: Thread[];
     }
     export interface Message {
         linkedSubChannel: Thread;

--- a/addons/mail/static/src/discuss/message_pin/common/@types/models.d.ts
+++ b/addons/mail/static/src/discuss/message_pin/common/@types/models.d.ts
@@ -1,8 +1,4 @@
 declare module "models" {
-    export interface DiscussChannel {
-        pinnedMessages: Message[];
-        pinnedMessagesState: 'loaded'|'loading'|'error'|undefined;
-    }
     export interface Message {
         pin: () => Deferred<boolean>;
         pinned_at: import("luxon").DateTime;

--- a/addons/portal/static/src/chatter/frontend/@types/models.d.ts
+++ b/addons/portal/static/src/chatter/frontend/@types/models.d.ts
@@ -2,9 +2,6 @@ declare module "models" {
     export interface Composer {
         portalComment: boolean;
     }
-    export interface DiscussChannel {
-        hasReadAccess: boolean|undefined;
-    }
     export interface Thread {
         hasReadAccess: boolean|undefined;
     }

--- a/addons/project/static/src/core/web/@types/models.d.ts
+++ b/addons/project/static/src/core/web/@types/models.d.ts
@@ -1,7 +1,4 @@
 declare module "models" {
-    export interface DiscussChannel {
-        collaborator_ids: ResPartner[];
-    }
     export interface Thread {
         collaborator_ids: ResPartner[];
     }

--- a/addons/website_livechat/static/src/common/@types/models.d.ts
+++ b/addons/website_livechat/static/src/common/@types/models.d.ts
@@ -1,7 +1,4 @@
 declare module "models" {
-    export interface DiscussChannel {
-        livechat_visitor_id: WebsiteVisitor;
-    }
     export interface Thread {
         livechat_visitor_id: WebsiteVisitor;
     }


### PR DESCRIPTION
Since recent changes, thread fields and methods are automatically accessible from the `DiscussChannel` model. This update refines the type definitions to reflect that:

- `DiscussChannel` now inherits from the Thread interface, removing duplication of fields.
- Getters and methods from `Thread` are also inherited in the typedefs, following the recent code changes that made them accessible.

*: im_livechat, portal, project, website_livechat.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
