### PR TITLE
[FIX] sale_stock: prevent error when updating sale order in delivery picking

### DIFF
--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -170,7 +170,7 @@ class StockPicking(models.Model):
 
     def _set_sale_id(self):
         if self.reference_ids and self.sale_id:
-            self.reference_ids.sale_ids = Command.link(self.sale_id)
+            self.reference_ids.sale_ids = [Command.link(self.sale_id.id)]
         else:
             if self.sale_id:
                 self.env['stock.reference'].create({

--- a/addons/sale_stock/tests/test_sale_stock.py
+++ b/addons/sale_stock/tests/test_sale_stock.py
@@ -2283,3 +2283,25 @@ class TestSaleStock(TestSaleStockCommon, ValuationReconciliationTestCommon):
             {'location_id': loc_perso.id, 'location_dest_id': out_location.id, 'quantity': 1},
             {'location_id': stock_location.id, 'location_dest_id': pack_location.id, 'quantity': 1},
         ])
+
+    def test_change_sale_order_in_delivery_picking(self):
+        """Test changing sale order reference in delivery picking."""
+        def create_sale_order():
+            return self.env['sale.order'].create({
+                'partner_id': self.partner_a.id,
+                'order_line': [Command.create({
+                    'name': self.product_a.name,
+                    'product_id': self.product_a.id,
+                    'product_uom_qty': 1,
+                    'price_unit': self.product_a.list_price,
+                })],
+            })
+        so1 = create_sale_order()
+        so2 = create_sale_order()
+
+        so1.action_confirm()
+        picking = so1.picking_ids[0]
+        self.assertEqual(picking.sale_id, so1)
+        picking.sale_id = so2
+        self.assertEqual(picking.sale_id, so2)
+        self.assertFalse(so1.picking_ids)


### PR DESCRIPTION
Currently, an error occurs when user updates the sale order in the delivery picking.

Steps to Reproduce:
 - Install the `sale_stock` and `sale_management` modules.
 - Create a `sale order` and `confirm` it.
-  Click the `Delivery button` on top of the order.
 - In the `Additional Info` tab of the sale order, select any order in `sale order` field and `save`.

`psycopg2.ProgrammingError: can't adapt type 'sale.order'`
`KeyError: <Command.LINK: 4>`

This error occur after [this commit] where, after creating sale order, navigating to its delivery picking, and selecting the same or a different order, an invalid link caused the error[1].

This commit ensures that the sale order is linked correctly to the delivery picking.

[this commit]: https://github.com/odoo/odoo/commit/2713876dbc70d3984e584a9037a2206dcda4e84a#diff-2b9de2e50ff5e1dc0362b825bac2b07623770fb3275b3257ef972f255f3ccb8bR172-R173

[1]- https://github.com/odoo/odoo/blob/d484516bcae1beb767d90d20e1ab294f1e9ae8a9/addons/sale_stock/models/stock.py#L173

sentry-6921046230

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
