### PR TITLE
[FIX] hr: add assertion to prevent misuse of function

### DIFF
--- a/addons/hr/models/hr_version.py
+++ b/addons/hr/models/hr_version.py
@@ -377,7 +377,10 @@ class HrVersion(models.Model):
         """
         if not self.contract_date_start:
             return False
-        return self.date_start <= date_to and (not self.date_end or self.date_end >= date_from)
+        period_start = date_from or date.min
+        period_end = date_to or date.max
+        contract_end = self.date_end or date.max
+        return period_start <= contract_end and self.date_start <= period_end
 
     def _is_fully_flexible(self):
         """ return True if the version has a fully flexible working calendar """


### PR DESCRIPTION
The assertion was added to prevent the use of the _is_overlapping_period function with null or False dates. Which fixes an exception caused when a payslip's date was false/null.

Related to odoo/enterprise#97013
task-5159666
