### PR TITLE
[FIX] web: disabled o_date_item_cell not reflected

### DIFF
--- a/addons/web/static/src/core/datetime/datetime_picker.xml
+++ b/addons/web/static/src/core/datetime/datetime_picker.xml
@@ -30,7 +30,7 @@
                             </t>
                             <t t-else="">
                                 <div
-                                    class="o_date_item_cell o_datetime_button o_center o_cell_md cursor-pointer"
+                                    class="o_date_item_cell o_datetime_button o_center o_cell_md"
                                     t-att-class="{
                                         'o_selected': arInfo.isSelected,
                                         o_select_start: arInfo.isSelectStart,
@@ -38,6 +38,8 @@
                                         o_highlighted: arInfo.isHighlighted,
                                         'o_today fw-bolder text-decoration-underline': itemInfo.includesToday,
                                         [itemInfo.extraClass]: true,
+                                        'opacity-50': !itemInfo.isValid,
+                                        'cursor-pointer': itemInfo.isValid,
                                     }"
                                     t-att-disabled="!itemInfo.isValid"
                                     t-on-pointerenter="() => (state.hoveredDate = itemInfo.range[0])"
@@ -84,6 +86,7 @@
                         o_select_end: arInfo.isSelectEnd,
                         o_highlighted: arInfo.isHighlighted,
                         o_today: itemInfo.includesToday,
+                        'opacity-50': !itemInfo.isValid,
                     }"
                     t-att-disabled="!itemInfo.isValid"
                     t-on-click="() => this.zoomOrSelect(itemInfo)"


### PR DESCRIPTION
In this commit fa3bfb0a696c20ae51cd0f37f737fcf211007c4a, the o_date_item_cell was changed from a button to a div.
This made the style of disabled cells not show that its not unclickable, making it confusing for users.
Solution is to add specific style for the disbaled o_date_item_cell component.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
