### PR TITLE
[FIX] packaging: exclude iot_box_builder files from rpm

### DIFF
--- a/setup/rpm/odoo.spec
+++ b/setup/rpm/odoo.spec
@@ -108,6 +108,7 @@ EOF
 %pycached %exclude %{python3_sitelib}/doc/cla/stats.py
 %pycached %exclude %{python3_sitelib}/setup/*.py
 %exclude %{python3_sitelib}/setup/odoo
+%exclude %{python3_sitelib}/setup/iot_box_builder/
 
 %changelog
 * %{build_date} Christophe Monniez <moc@odoo.com> - %{version}-%{release}


### PR DESCRIPTION
Those files are not needed in the package.
