### PR TITLE
[IMP] tests: allow to test specific test for all modules

### DIFF
--- a/addons/web/tests/test_js.py
+++ b/addons/web/tests/test_js.py
@@ -139,6 +139,18 @@ class HOOTCommon(odoo.tests.HttpCase):
         self._test_params = [('-', '-@web/core/autocomplete,-@web/core/autocomplete2')]
         self.assertEqual(self.get_hoot_filters(), '&id=69a6561d&id=cb246db5')
 
+
+@odoo.tests.tagged('hoot', 'post_install', '-at_install')
+class HootSuite(QunitCommon, HOOTCommon, odoo.tests.CrossModule):
+    def test_js(self, modules):
+        print(self._test_params)
+        print(modules)
+
+    def test_js_mobile(self, modules):
+        print(self._test_params)
+        print(modules)
+
+
 @odoo.tests.tagged('post_install', '-at_install')
 class WebSuite(QunitCommon, HOOTCommon):
 

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -928,6 +928,15 @@ class BaseCase(case.TestCase):
                 additional_tags.append('is_query_count')
         return additional_tags
 
+
+class CrossModule(case.TestCase):
+    _cross_module = True
+    _test_modules = []
+
+    def _callTestMethod(self, method):
+        method(self._test_modules)
+
+
 class Like:
     """
         A string-like object comparable to other strings but where the substring

--- a/odoo/tests/loader.py
+++ b/odoo/tests/loader.py
@@ -95,7 +95,8 @@ def make_suite(module_names, position='at_install'):
     :param list[str] module_names: modules to load tests from
     :param str position: "at_install" or "post_install"
     """
-    config_tags = TagsSelector(tools.config['test_tags'])
+    available_modules = module_names if position == 'post_install' else None
+    config_tags = TagsSelector(tools.config['test_tags'], available_modules)
     position_tag = TagsSelector(position)
     tests = (
         t


### PR DESCRIPTION
Some tests are ran as part of a specific module even if they are testing many modules (js tests, liniting, ...).

If running --test-tags /project, the js tests are not ran meaning that to run all tests we may need to do something like
    --test-tags /project,/web:WebSuite[@account],/web:MobileWebSuite[@account],..

This is nor practical, nor intuitive and lead to the /web module taking a lot of time.

The proposed solution would behave somehoe like the test /web:WebSuite was defined in all modules.

A parameter will be given to the test with the list of module to test when executed. An alternative solution could be to run it once per module but some experiments where done for that and the overhead can be massive in some cases, mainly when the test spawns a subprocess (chrome, pylint, ...)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
