### PR TITLE
[IMP] mail: action panel definition available to all discuss actions

### DIFF
--- a/addons/crm_livechat/static/src/core/thread_actions.js
+++ b/addons/crm_livechat/static/src/core/thread_actions.js
@@ -7,17 +7,23 @@ import { _t } from "@web/core/l10n/translation";
 import { usePopover } from "@web/core/popover/popover_hook";
 
 registerThreadAction("create-lead", {
+    actionPanelClose: ({ action }) => action.popover?.close(),
     actionPanelComponent: LivechatCommandDialog,
     actionPanelComponentProps: ({ action }) => ({
-        close: () => action.close(),
+        close: () => action.actionPanelClose(),
         commandName: "lead",
         placeholderText: _t("e.g. Product pricing"),
         title: _t("Create Lead"),
         icon: "fa fa-handshake-o",
     }),
-    close: ({ action }) => action.popover?.close(),
+    actionPanelOpen({ owner, thread }) {
+        this.popover?.open(owner.root.el.querySelector(`[name="${this.id}"]`), {
+            thread,
+            ...this.actionPanelComponentProps,
+        });
+    },
+    actionPanelOuterClass: "bg-100",
     condition: false, // managed by ThreadAction patch
-    panelOuterClass: "bg-100",
     icon: "fa fa-handshake-o",
     name: _t("Create Lead"),
     sequence: 10,
@@ -25,16 +31,9 @@ registerThreadAction("create-lead", {
     setup({ owner }) {
         if (!owner.env.inChatWindow) {
             this.popover = usePopover(LivechatCommandDialog, {
-                onClose: () => this.close(),
-                popoverClass: this.panelOuterClass,
+                onClose: () => this.actionPanelClose(),
+                popoverClass: this.actionPanelOuterClass,
             });
         }
-    },
-    toggle: true,
-    open({ owner, thread }) {
-        this.popover?.open(owner.root.el.querySelector(`[name="${this.id}"]`), {
-            thread,
-            ...this.actionPanelComponentProps,
-        });
     },
 });

--- a/addons/hr/static/src/core/web/thread_actions.js
+++ b/addons/hr/static/src/core/web/thread_actions.js
@@ -9,7 +9,7 @@ registerThreadAction("open-hr-profile", {
         !owner.isDiscussSidebarChannelActions,
     icon: "fa fa-fw fa-id-card",
     name: _t("Open Profile"),
-    open: async ({ store, thread }) =>
+    onSelected: async ({ store, thread }) =>
         store.env.services.action.doAction({
             type: "ir.actions.act_window",
             res_id: thread.correspondent.partner_id?.employeeId,

--- a/addons/im_livechat/static/src/core/web/discuss_content_patch.js
+++ b/addons/im_livechat/static/src/core/web/discuss_content_patch.js
@@ -4,7 +4,7 @@ import { patch } from "@web/core/utils/patch";
 patch(DiscussContent.prototype, {
     actionPanelAutoOpenFn() {
         if (!this.threadActions.activeAction) {
-            this.threadActions.actions.find((a) => a.id === "livechat-info")?.open();
+            this.threadActions.actions.find((a) => a.id === "livechat-info")?.actionPanelOpen();
         }
         super.actionPanelAutoOpenFn();
     },

--- a/addons/im_livechat/static/src/core/web/thread_actions.js
+++ b/addons/im_livechat/static/src/core/web/thread_actions.js
@@ -7,24 +7,23 @@ import { joinChannelAction } from "@mail/discuss/core/web/thread_actions";
 
 registerThreadAction("livechat-info", {
     actionPanelComponent: LivechatChannelInfoList,
+    actionPanelOuterClass: "o-livechat-ChannelInfoList bg-inherit",
     condition: ({ channel, owner }) =>
         channel?.channel_type === "livechat" && !owner.isDiscussSidebarChannelActions,
-    panelOuterClass: "o-livechat-ChannelInfoList bg-inherit",
     icon: "fa fa-fw fa-info",
     name: _t("Information"),
     sequence: 10,
     sequenceGroup: 7,
-    toggle: true,
 });
 registerThreadAction("livechat-status", {
     actionPanelComponent: LivechatChannelInfoList,
+    actionPanelOuterClass: "o-livechat-ChannelInfoList bg-inherit",
     condition: ({ channel, owner }) =>
         channel?.channel_type === "livechat" && !channel.livechat_end_dt && !owner.isDiscussContent,
     dropdown: true,
     dropdownMenuClass: "p-0",
     dropdownTemplate: "im_livechat.LivechatStatusSelection",
     dropdownTemplateParams: ({ thread }) => ({ livechatThread: thread }),
-    panelOuterClass: "o-livechat-ChannelInfoList bg-inherit",
     icon: ({ channel, store }) => {
         const btn = store.livechatStatusButtons.find(
             (btn) => btn.status === channel.livechat_status
@@ -41,11 +40,10 @@ registerThreadAction("livechat-status", {
     nameClass: "fst-italic small",
     sequence: ({ owner }) => (owner.isDiscussSidebarChannelActions ? 10 : 5),
     sequenceGroup: ({ owner }) => (owner.isDiscussSidebarChannelActions ? 5 : 7),
-    toggle: true,
 });
 
 patch(joinChannelAction, {
-    async open({ channel, store, thread }) {
+    async onSelected({ channel, store, thread }) {
         if (channel.livechat_status === "need_help") {
             const hasJoined = await store.env.services.orm.call(
                 "discuss.channel",
@@ -59,7 +57,7 @@ patch(joinChannelAction, {
                 );
             }
         } else {
-            super.open(...arguments);
+            super.onSelected(...arguments);
         }
     },
 });

--- a/addons/im_livechat/static/src/embed/common/thread_actions.js
+++ b/addons/im_livechat/static/src/embed/common/thread_actions.js
@@ -9,7 +9,7 @@ registerThreadAction("restart", {
         thread?.chatbot?.canRestart && !owner.isDiscussSidebarChannelActions,
     icon: "fa fa-fw fa-refresh",
     name: _t("Restart Conversation"),
-    open: ({ owner, thread }) => {
+    onSelected: ({ owner, thread }) => {
         thread.chatbot.restart();
         owner.props.chatWindow.open({ focus: true });
     },

--- a/addons/mail/static/src/core/common/chat_window.js
+++ b/addons/mail/static/src/core/common/chat_window.js
@@ -59,7 +59,7 @@ export class ChatWindow extends Component {
         this.isMobileOS = isMobileOS();
 
         useChildSubEnv({
-            closeActionPanel: () => this.threadActions.activeAction?.close(),
+            closeActionPanel: () => this.threadActions.activeAction?.actionPanelClose(),
             messageHighlight: this.messageHighlight,
         });
     }
@@ -106,7 +106,7 @@ export class ChatWindow extends Component {
     onKeydown(ev) {
         const chatWindow = toRaw(this.props.chatWindow);
         if (ev.key === "Escape" && this.threadActions.activeAction) {
-            this.threadActions.activeAction.close();
+            this.threadActions.activeAction.actionPanelClose();
             ev.stopPropagation();
             return;
         }
@@ -149,7 +149,7 @@ export class ChatWindow extends Component {
             this.ui.isSmall ||
             this.state.editingName ||
             this.props.chatWindow.actionsDisabled ||
-            isEventHandled(ev, "ThreadAction.onSelected")
+            isEventHandled(ev, "Action.onSelected")
         ) {
             return;
         }

--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -64,7 +64,7 @@
         </div>
         <div t-if="!props.chatWindow.folded or ui.isSmall" class="d-flex flex-column h-100 overflow-auto o-scrollbar-thin position-relative bg-inherit" t-att-class="{ 'opacity-50': state.editingName }" t-ref="content">
             <t name="thread content">
-                <div t-if="threadActions.activeAction?.actionPanelComponentCondition" class="h-100" t-attf-class="{{ threadActions.activeAction.panelOuterClass }}">
+                <div t-if="threadActions.activeAction?.actionPanelComponentCondition" class="h-100" t-attf-class="{{ threadActions.activeAction.actionPanelOuterClass }}">
                     <t t-component="threadActions.activeAction.actionPanelComponent" t-props="{ ...threadActions.activeAction.actionPanelComponentProps, thread }"/>
                 </div>
                 <t t-elif="thread">

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -1,15 +1,14 @@
-import { toRaw, useComponent, useState } from "@odoo/owl";
+import { toRaw } from "@odoo/owl";
 
 import { _t } from "@web/core/l10n/translation";
 import { download } from "@web/core/network/download";
 import { registry } from "@web/core/registry";
 import { discussComponentRegistry } from "./discuss_component_registry";
 import { Deferred } from "@web/core/utils/concurrency";
-import { Action, ACTION_TAGS, UseActions } from "@mail/core/common/action";
+import { Action, ACTION_TAGS, useAction, UseActions } from "@mail/core/common/action";
 import { useEmojiPicker } from "@web/core/emoji_picker/emoji_picker";
 import { QuickReactionMenu } from "@mail/core/common/quick_reaction_menu";
 import { isMobileOS } from "@web/core/browser/feature_detection";
-import { useService } from "@web/core/utils/hooks";
 
 const { DateTime } = luxon;
 
@@ -20,11 +19,7 @@ export const messageActionsRegistry = registry.category("mail.message/actions");
 /** @typedef {import("models").Message} Message */
 /** @typedef {import("models").Thread} Thread */
 /**
- * @typedef {Object} MessageActionSpecificDefinition
- * @property {boolean|(comp: Component) => boolean} [condition=true]
- */
-/**
- * @typedef {ActionDefinition & MessageActionSpecificDefinition} MessageActionDefinition
+ * @typedef {ActionDefinition} MessageActionDefinition
  */
 /**
  * @param {string} id
@@ -239,18 +234,5 @@ class UseMessageActions extends UseActions {
  * @param {Thread|() => Thread} [thread] when set, the thread the message is being viewed
  */
 export function useMessageActions({ message, thread } = {}) {
-    const component = useComponent();
-    const transformedActions = messageActionsRegistry
-        .getEntries()
-        .map(
-            ([id, definition]) =>
-                new MessageAction({ owner: component, id, definition, message, thread })
-        );
-    for (const action of transformedActions) {
-        action.setup();
-    }
-    const state = useState(
-        new UseMessageActions(component, transformedActions, useService("mail.store"))
-    );
-    return state;
+    return useAction(messageActionsRegistry, UseMessageActions, MessageAction, { message, thread });
 }

--- a/addons/mail/static/src/core/common/thread_actions.js
+++ b/addons/mail/static/src/core/common/thread_actions.js
@@ -1,32 +1,19 @@
-import { useSubEnv, useComponent, useState } from "@odoo/owl";
+import { useSubEnv } from "@odoo/owl";
 
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { SearchMessagesPanel } from "@mail/core/common/search_messages_panel";
-import { markEventHandled } from "@web/core/utils/misc";
-import { Action, ACTION_TAGS, UseActions } from "@mail/core/common/action";
+import { Action, ACTION_TAGS, useAction, UseActions } from "@mail/core/common/action";
 import { MeetingChat } from "@mail/discuss/call/common/meeting_chat";
-import { useService } from "@web/core/utils/hooks";
 
 export const threadActionsRegistry = registry.category("mail.thread/actions");
 
 /** @typedef {import("@odoo/owl").Component} Component */
 /** @typedef {import("@mail/core/common/action").ActionDefinition} ActionDefinition */
 /** @typedef {import("models").Thread} Thread */
-/**
- * @typedef {Object} ThreadActionSpecificDefinition
- * @property {Component} [actionPanelComponent]
- * @property {(Component) => Object} [actionPanelComponentProps]
- * @property {(Component) => void} [close]
- * @property {boolean|(comp: Component) => boolean} [condition=true]
- * @property {string|(comp: Component) => string} [nameClass]
- * @property {(comp: Component) => void} [open]
- * @property {(comp: Component) => string} [panelOuterClass]
- * @property {boolean} [toggle]
- */
 
 /**
- * @typedef {ActionDefinition & ThreadActionSpecificDefinition} ThreadActionDefinition
+ * @typedef {ActionDefinition} ThreadActionDefinition
  */
 
 /**
@@ -41,7 +28,7 @@ registerThreadAction("fold-chat-window", {
     condition: ({ owner }) => owner.props.chatWindow && !owner.isDiscussSidebarChannelActions,
     icon: "oi oi-fw oi-minus",
     name: ({ owner }) => (!owner.props.chatWindow?.isOpen ? _t("Open") : _t("Fold")),
-    open: ({ owner }) => owner.toggleFold(),
+    onSelected: ({ owner }) => owner.toggleFold(),
     displayActive: ({ owner }) => !owner.props.chatWindow?.isOpen,
     sequence: 99,
     sequenceQuick: 20,
@@ -54,7 +41,7 @@ registerThreadAction("rename-thread", {
         !owner.isDiscussSidebarChannelActions,
     icon: "fa fa-fw fa-pencil",
     name: _t("Rename Thread"),
-    open: ({ owner }) => (owner.state.editingName = true),
+    onSelected: ({ owner }) => (owner.state.editingName = true),
     sequence: 30,
     sequenceGroup: 20,
 });
@@ -62,18 +49,18 @@ registerThreadAction("close", {
     condition: ({ owner }) => owner.props.chatWindow && !owner.isDiscussSidebarChannelActions,
     icon: "oi fa-fw oi-close",
     name: _t("Close Chat Window (ESC)"),
-    open: ({ owner }) => owner.close(),
+    onSelected: ({ owner }) => owner.close(),
     sequence: 100,
     sequenceQuick: 10,
 });
 registerThreadAction("search-messages", {
     actionPanelComponent: SearchMessagesPanel,
+    actionPanelOuterClass: "o-mail-SearchMessagesPanel bg-inherit",
     condition: ({ owner, thread }) =>
         ["discuss.channel", "mail.box"].includes(thread?.model) &&
         (!owner.props.chatWindow || owner.props.chatWindow.isOpen) &&
         !owner.isDiscussSidebarChannelActions,
     hotkey: "f",
-    panelOuterClass: "o-mail-SearchMessagesPanel bg-inherit",
     icon: "oi oi-fw oi-search",
     name: ({ action }) => (action.isActive ? _t("Close Search") : _t("Search Messages")),
     sequence: 20,
@@ -81,27 +68,25 @@ registerThreadAction("search-messages", {
     setup: ({ action }) =>
         useSubEnv({
             searchMenu: {
-                open: () => action.open(),
+                open: () => action.actionPanelOpen(),
                 close: () => {
                     if (action.isActive) {
-                        action.close();
+                        action.actionPanelClose();
                     }
                 },
             },
         }),
-    toggle: true,
 });
 registerThreadAction("meeting-chat", {
     actionPanelComponent: MeetingChat,
+    actionPanelOuterClass: "bg-100 border border-secondary",
     badge: ({ thread }) => thread.isUnread,
     badgeIcon: ({ thread }) => !thread.importantCounter && "fa fa-circle text-700",
     badgeText: ({ thread }) => thread.importantCounter || undefined,
     condition: ({ owner }) => owner.env.inMeetingView,
     icon: "fa fa-fw fa-comments",
     name: _t("Chat"),
-    panelOuterClass: "bg-100 border border-secondary",
     sequence: 30,
-    toggle: true,
     tags: ({ thread }) => {
         const tags = [];
         if (thread.importantCounter) {
@@ -112,8 +97,6 @@ registerThreadAction("meeting-chat", {
 });
 
 export class ThreadAction extends Action {
-    /** Determines whether this is a popover linked to this action. */
-    popover = null;
     /** @type {() => Thread} */
     threadFn;
 
@@ -130,101 +113,10 @@ export class ThreadAction extends Action {
         const thread = this.threadFn();
         return Object.assign(super.params, { channel: thread?.channel, thread });
     }
-
-    /** Optional component that is used as action panel of this component, i.e. when action is active. */
-    get actionPanelComponent() {
-        return this.definition.actionPanelComponent;
-    }
-
-    /** Condition to display the action panel component of this action. */
-    get actionPanelComponentCondition() {
-        return this.isActive && this.actionPanelComponent && this.condition && !this.popover;
-    }
-
-    /** Props to pass to the action panel component of this action. */
-    get actionPanelComponentProps() {
-        return this.definition.actionPanelComponentProps?.call(this, this.params);
-    }
-
-    /** Closes this action. */
-    close() {
-        if (this.toggle) {
-            this.owner.threadActions.activeAction = this.owner.threadActions.actionStack.pop();
-        }
-        this.definition.close?.call(this, this.params);
-    }
-
-    /** States whether this action is currently active. */
-    get isActive() {
-        return this.id === this.owner.threadActions.activeAction?.id;
-    }
-
-    /** ClassName on name of this action */
-    get nameClass() {
-        return typeof this.definition.nameClass === "function"
-            ? this.definition.nameClass.call(this, this.params)
-            : this.definition.nameClass;
-    }
-
-    /**
-     * @override
-     * @param {MouseEvent} [ev]
-     * @param {object} [param0]
-     * @param {boolean} [param0.keepPrevious] Whether the previous action
-     * should be kept so that closing the current action goes back
-     * to the previous one.
-     * */
-    onSelected(ev, { keepPrevious } = {}) {
-        if (ev) {
-            markEventHandled(ev, "ThreadAction.onSelected");
-        }
-        if (this.toggle && this.isActive) {
-            this.close();
-        } else {
-            this.open({ keepPrevious });
-        }
-    }
-
-    /**
-     * Opens this action.
-     *
-     * @param {object} [param0]
-     * @param {boolean} [param0.keepPrevious] Whether the previous action
-     * should be kept so that closing the current action goes back
-     * to the previous one.
-     * */
-    open({ keepPrevious } = {}) {
-        if (this.toggle) {
-            if (this.owner.threadActions.activeAction) {
-                if (keepPrevious) {
-                    this.owner.threadActions.actionStack.push(
-                        this.owner.threadActions.activeAction
-                    );
-                } else {
-                    this.owner.threadActions.activeAction.close();
-                }
-            }
-            this.owner.threadActions.activeAction = this;
-        }
-        this.definition.open?.call(this, this.params);
-    }
-
-    get panelOuterClass() {
-        return typeof this.definition.panelOuterClass === "function"
-            ? this.definition.panelOuterClass.call(this, this.params)
-            : this.definition.panelOuterClass;
-    }
-
-    /** Determines whether this action is a one time effect or can be toggled (on or off). */
-    get toggle() {
-        return this.definition.toggle;
-    }
 }
 
 class UseThreadActions extends UseActions {
     ActionClass = ThreadAction;
-    actionStack = [];
-    activeAction = null;
 }
 
 /**
@@ -232,12 +124,5 @@ class UseThreadActions extends UseActions {
  * @param {Thread|() => Thread} thread
  */
 export function useThreadActions({ thread } = {}) {
-    const component = useComponent();
-    const transformedActions = threadActionsRegistry
-        .getEntries()
-        .map(([id, definition]) => new ThreadAction({ owner: component, id, definition, thread }));
-    for (const action of transformedActions) {
-        action.setup();
-    }
-    return useState(new UseThreadActions(component, transformedActions, useService("mail.store")));
+    return useAction(threadActionsRegistry, UseThreadActions, ThreadAction, { thread });
 }

--- a/addons/mail/static/src/core/public_web/discuss_content.js
+++ b/addons/mail/static/src/core/public_web/discuss_content.js
@@ -47,7 +47,7 @@ export class DiscussContent extends Component {
         }
         if (this.store.discuss.isMemberPanelOpenByDefault) {
             if (!this.threadActions.activeAction) {
-                memberListAction.open();
+                memberListAction.actionPanelOpen();
             } else if (this.threadActions.activeAction === memberListAction) {
                 return; // no-op (already open)
             } else {

--- a/addons/mail/static/src/core/public_web/discuss_content.xml
+++ b/addons/mail/static/src/core/public_web/discuss_content.xml
@@ -71,7 +71,7 @@
                             <t name="thread"><Thread thread="thread" t-key="thread.localId" jumpPresent="state.jumpThreadPresent"/></t>
                             <Composer t-if="thread.model !== 'mail.box' or thread.composer.replyToMessage" t-key="thread.localId" composer="thread.composer" autofocus="true" onDiscardCallback="() => (thread.composer.replyToMessage = undefined)" onPostCallback.bind="() => this.state.jumpThreadPresent++" dropzoneRef="root" type="thread.composer.replyToMessage ? (thread.composer.replyToMessage.isNote ? 'note' : 'message') : undefined"/>
                         </div>
-                        <div t-if="threadActions.activeAction?.actionPanelComponentCondition" t-attf-class="{{ threadActions.activeAction.panelOuterClass }}" class="o-mail-DiscussContent-panelContainer o-mail-discussSidebarBgColor h-100 border-start border-secondary flex-shrink-0">
+                        <div t-if="threadActions.activeAction?.actionPanelComponentCondition" t-attf-class="{{ threadActions.activeAction.actionPanelOuterClass }}" class="o-mail-DiscussContent-panelContainer o-mail-discussSidebarBgColor h-100 border-start border-secondary flex-shrink-0">
                             <t t-component="threadActions.activeAction.actionPanelComponent" thread="thread" t-props="threadActions.activeAction.actionPanelComponentProps"/>
                         </div>
                     </t>

--- a/addons/mail/static/src/core/web/thread_actions.js
+++ b/addons/mail/static/src/core/web/thread_actions.js
@@ -6,7 +6,8 @@ registerThreadAction("mark-all-read", {
     condition: ({ owner, thread }) =>
         thread?.id === "inbox" && !owner.isDiscussSidebarChannelActions,
     disabledCondition: ({ thread }) => thread.isEmpty,
-    open: ({ store }) => store.env.services.orm.silent.call("mail.message", "mark_all_as_read"),
+    onSelected: ({ store }) =>
+        store.env.services.orm.silent.call("mail.message", "mark_all_as_read"),
     sequence: 1,
     name: _t("Mark all read"),
 });
@@ -14,7 +15,7 @@ registerThreadAction("unstar-all", {
     condition: ({ owner, thread }) =>
         thread?.id === "starred" && !owner.isDiscussSidebarChannelActions,
     disabledCondition: ({ thread }) => thread.isEmpty,
-    open: ({ store }) => store.unstarAll(),
+    onSelected: ({ store }) => store.unstarAll(),
     sequence: 2,
     name: _t("Unstar all"),
 });

--- a/addons/mail/static/src/discuss/call/common/call_actions.js
+++ b/addons/mail/static/src/discuss/call/common/call_actions.js
@@ -1,9 +1,7 @@
-import { Action, ACTION_TAGS, UseActions } from "@mail/core/common/action";
-import { useComponent, useState } from "@odoo/owl";
+import { Action, ACTION_TAGS, useAction, UseActions } from "@mail/core/common/action";
 import { isMobileOS } from "@web/core/browser/feature_detection";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
-import { useService } from "@web/core/utils/hooks";
 import { QuickVoiceSettings } from "./quick_voice_settings";
 import { QuickVideoSettings } from "./quick_video_settings";
 import { attClassObjectToString } from "@mail/utils/common/format";
@@ -343,9 +341,5 @@ class UseCallActions extends UseActions {
  * @param {Thread|() => Thread} thread
  */
 export function useCallActions({ thread } = {}) {
-    const component = useComponent();
-    const transformedActions = callActionsRegistry
-        .getEntries()
-        .map(([id, definition]) => new CallAction({ owner: component, id, definition, thread }));
-    return useState(new UseCallActions(component, transformedActions, useService("mail.store")));
+    return useAction(callActionsRegistry, UseCallActions, CallAction, { thread });
 }

--- a/addons/mail/static/src/discuss/call/common/meeting.js
+++ b/addons/mail/static/src/discuss/call/common/meeting.js
@@ -54,14 +54,14 @@ export class Meeting extends Component {
                 openChat: () =>
                     this.threadActions.actions
                         .find((action) => action.id === "meeting-chat")
-                        ?.open(),
+                        ?.actionPanelOpen(),
             },
         });
         this.threadActions = useThreadActions({ thread: () => this.thread });
         this.messageHighlight = useMessageScrolling();
         this.messageSearch = useMessageSearch(this.thread);
         useChildSubEnv({
-            closeActionPanel: () => this.threadActions.activeAction?.close(),
+            closeActionPanel: () => this.threadActions.activeAction?.actionPanelClose(),
             messageHighlight: this.messageHighlight,
             messageSearch: this.messageSearch,
         });

--- a/addons/mail/static/src/discuss/call/common/meeting.xml
+++ b/addons/mail/static/src/discuss/call/common/meeting.xml
@@ -6,7 +6,7 @@
                 <div class="o-mail-Meeting-callContainer h-100 flex-grow-1 o-min-width-0" t-att-class="{'d-none': ui.isSmall and threadActions.activeAction?.actionPanelComponentCondition, 'pb-0': ui.isSmall}">
                     <Call hasOverlay="false" isPip="props.isPip"/>
                 </div>
-                <div t-if="threadActions.activeAction?.actionPanelComponentCondition" t-attf-class="{{ threadActions.activeAction.panelOuterClass }}" class="o-mail-DiscussContent-panelContainer o-mail-discussSidebarBgColor h-100 border-start border-secondary flex-shrink-0 rounded-2" t-att-class="{ 'w-100': ui.isSmall }">
+                <div t-if="threadActions.activeAction?.actionPanelComponentCondition" t-attf-class="{{ threadActions.activeAction.actionPanelOuterClass }}" class="o-mail-DiscussContent-panelContainer o-mail-discussSidebarBgColor h-100 border-start border-secondary flex-shrink-0 rounded-2" t-att-class="{ 'w-100': ui.isSmall }">
                     <t t-component="threadActions.activeAction.actionPanelComponent" t-props="threadActions.activeAction.actionPanelComponentProps" thread="thread"/>
                 </div>
             </div>

--- a/addons/mail/static/src/discuss/call/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/call/common/thread_actions.js
@@ -10,7 +10,7 @@ registerThreadAction("call", {
     icon: "fa fa-fw fa-phone",
     name: ({ thread }) =>
         thread.rtc_session_ids.length > 0 ? _t("Join the Call") : _t("Start Call"),
-    open: ({ channel, store }) => store.rtc.toggleCall(channel),
+    onSelected: ({ channel, store }) => store.rtc.toggleCall(channel),
     sequence: 10,
     sequenceQuick: 30,
     tags: [ACTION_TAGS.SUCCESS, ACTION_TAGS.JOIN_LEAVE_CALL],
@@ -23,7 +23,7 @@ registerThreadAction("camera-call", {
         thread.rtc_session_ids.length > 0
             ? _t("Join the Call with Camera")
             : _t("Start Video Call"),
-    open: ({ channel, store }) => store.rtc.toggleCall(channel, { camera: true }),
+    onSelected: ({ channel, store }) => store.rtc.toggleCall(channel, { camera: true }),
     sequence: 5,
     sequenceQuick: ({ owner }) => (owner.env.inDiscussApp ? 25 : 35),
     tags: [ACTION_TAGS.SUCCESS, ACTION_TAGS.JOIN_LEAVE_CALL],
@@ -39,12 +39,11 @@ registerThreadAction("call-settings", {
     name: _t("Call Settings"),
     sequence: 20,
     sequenceGroup: 30,
-    toggle: true,
 });
 registerThreadAction("disconnect", {
     condition: ({ channel, owner, store }) =>
         store.rtc.selfSession?.in(channel?.rtc_session_ids) && owner.isDiscussSidebarChannelActions,
-    open: ({ channel, store }) => store.rtc.toggleCall(channel),
+    onSelected: ({ channel, store }) => store.rtc.toggleCall(channel),
     icon: "fa fa-fw fa-phone",
     name: _t("Disconnect"),
     sequence: 30,

--- a/addons/mail/static/src/discuss/core/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/common/thread_actions.js
@@ -23,20 +23,9 @@ class ChannelActionDialog extends Component {
 }
 
 registerThreadAction("notification-settings", {
+    actionPanelClose: ({ action }) => action.popover?.close(),
     actionPanelComponent: NotificationSettings,
-    condition: ({ channel, owner, store }) =>
-        channel && store.self_partner && (!owner.props.chatWindow || owner.props.chatWindow.isOpen),
-    setup({ owner }) {
-        if (!owner.props.chatWindow) {
-            this.popover = usePopover(NotificationSettings, {
-                onClose: () => this.close(),
-                position: "bottom-end",
-                fixedPosition: true,
-                popoverClass: this.panelOuterClass,
-            });
-        }
-    },
-    open({ owner, store, thread }) {
+    actionPanelOpen({ owner, store, thread }) {
         if (owner.isDiscussSidebarChannelActions || owner.env.inMeetingView) {
             store.env.services.dialog?.add(ChannelActionDialog, {
                 title: thread.name,
@@ -50,16 +39,26 @@ registerThreadAction("notification-settings", {
             });
         }
     },
-    close: ({ action }) => action.popover?.close(),
+    actionPanelOuterClass: "bg-100 border border-secondary",
+    condition: ({ channel, owner, store }) =>
+        channel && store.self_partner && (!owner.props.chatWindow || owner.props.chatWindow.isOpen),
+    setup({ owner }) {
+        if (!owner.props.chatWindow) {
+            this.popover = usePopover(NotificationSettings, {
+                onClose: () => this.actionPanelClose(),
+                position: "bottom-end",
+                fixedPosition: true,
+                popoverClass: this.actionPanelOuterClass,
+            });
+        }
+    },
     icon: ({ channel }) =>
         channel.self_member_id?.mute_until_dt
             ? "fa fa-fw text-danger fa-bell-slash"
             : "fa fa-fw fa-bell",
     name: _t("Notification Settings"),
-    panelOuterClass: "bg-100 border border-secondary",
     sequence: 10,
     sequenceGroup: 30,
-    toggle: true,
 });
 registerThreadAction("attachments", {
     actionPanelComponent: AttachmentPanel,
@@ -71,21 +70,12 @@ registerThreadAction("attachments", {
     name: _t("Attachments"),
     sequence: 10,
     sequenceGroup: 10,
-    toggle: true,
 });
 registerThreadAction("invite-people", {
+    actionPanelClose: ({ action }) => action.popover?.close(),
     actionPanelComponent: ChannelInvitation,
-    actionPanelComponentProps: ({ action }) => ({ close: () => action.close() }),
-    close: ({ action }) => action.popover?.close(),
-    condition: ({ channel, owner }) =>
-        channel && (!owner.props.chatWindow || owner.props.chatWindow.isOpen),
-    panelOuterClass: ({ owner }) =>
-        `o-discuss-ChannelInvitation ${
-            owner.props.chatWindow ? "bg-inherit" : ""
-        } bg-100 border border-secondary`,
-    icon: "oi oi-fw oi-user-plus",
-    name: _t("Invite People"),
-    open({ owner, store, thread }) {
+    actionPanelComponentProps: ({ action }) => ({ close: () => action.actionPanelClose() }),
+    actionPanelOpen({ owner, store, thread }) {
         if (owner.isDiscussSidebarChannelActions) {
             store.env.services.dialog?.add(ChannelActionDialog, {
                 title: thread.name,
@@ -103,47 +93,53 @@ registerThreadAction("invite-people", {
             });
         }
     },
+    actionPanelOuterClass: ({ owner }) =>
+        `o-discuss-ChannelInvitation ${
+            owner.props.chatWindow ? "bg-inherit" : ""
+        } bg-100 border border-secondary`,
+    condition: ({ channel, owner }) =>
+        channel && (!owner.props.chatWindow || owner.props.chatWindow.isOpen),
+    icon: "oi oi-fw oi-user-plus",
+    name: _t("Invite People"),
     sequence: ({ owner }) => (owner.isDiscussSidebarChannelActions ? 20 : 10),
     sequenceGroup: 20,
     setup({ owner }) {
         if (!owner.props.chatWindow && !owner.env.inMeetingView) {
             this.popover = usePopover(ChannelInvitation, {
-                onClose: () => this.close(),
-                popoverClass: this.panelOuterClass,
+                onClose: () => this.actionPanelClose(),
+                popoverClass: this.actionPanelOuterClass,
             });
         }
     },
-    toggle: true,
 });
 registerThreadAction("member-list", {
-    actionPanelComponent: ChannelMemberList,
-    actionPanelComponentProps: ({ owner }) => ({
-        openChannelInvitePanel({ keepPrevious } = {}) {
-            owner.threadActions.actions
-                .find(({ id }) => id === "invite-people")
-                ?.open({ keepPrevious });
-        },
-    }),
-    condition: ({ owner, thread }) =>
-        thread?.hasMemberList &&
-        (!owner.props.chatWindow || owner.props.chatWindow.isOpen) &&
-        !owner.isDiscussSidebarChannelActions,
-    panelOuterClass: "o-discuss-ChannelMemberList bg-inherit",
-    icon: "oi oi-fw oi-users",
-    name: _t("Members"),
-    close: ({ owner, store }) => {
+    actionPanelClose: ({ owner, store }) => {
         if (owner.env.inDiscussApp) {
             store.discuss.isMemberPanelOpenByDefault = false;
         }
     },
-    open: ({ owner, store }) => {
+    actionPanelComponent: ChannelMemberList,
+    actionPanelComponentProps: ({ actions }) => ({
+        openChannelInvitePanel({ keepPrevious } = {}) {
+            actions.actions
+                .find(({ id }) => id === "invite-people")
+                ?.actionPanelOpen({ keepPrevious });
+        },
+    }),
+    actionPanelOpen: ({ owner, store }) => {
         if (owner.env.inDiscussApp) {
             store.discuss.isMemberPanelOpenByDefault = true;
         }
     },
+    actionPanelOuterClass: "o-discuss-ChannelMemberList bg-inherit",
+    condition: ({ owner, thread }) =>
+        thread?.hasMemberList &&
+        (!owner.props.chatWindow || owner.props.chatWindow.isOpen) &&
+        !owner.isDiscussSidebarChannelActions,
+    icon: "oi oi-fw oi-users",
+    name: _t("Members"),
     sequence: 30,
     sequenceGroup: 10,
-    toggle: true,
 });
 registerThreadAction("mark-read", {
     condition: ({ channel, owner }) =>
@@ -151,17 +147,19 @@ registerThreadAction("mark-read", {
         channel.self_member_id.message_unread_counter > 0 &&
         !channel.self_member_id.mute_until_dt &&
         owner.isDiscussSidebarChannelActions,
-    open: ({ owner }) => owner.thread.markAsRead(),
+    onSelected: ({ owner }) => owner.thread.markAsRead(),
     icon: "fa fa-fw fa-check",
     name: _t("Mark Read"),
     sequence: 10,
     sequenceGroup: 20,
 });
 registerThreadAction("delete-thread", {
+    actionPanelClose: ({ action }) => action.popover?.close(),
     actionPanelComponent: DeleteThreadDialog,
     actionPanelComponentProps({ action }) {
-        return { close: () => action.close() };
+        return { close: () => action.actionPanelClose() };
     },
+    actionPanelOuterClass: "bg-100",
     condition({ owner, store, thread }) {
         return (
             thread?.parent_channel_id &&
@@ -169,13 +167,10 @@ registerThreadAction("delete-thread", {
             !owner.isDiscussContent
         );
     },
-    panelOuterClass: "bg-100",
     icon: "fa fa-fw fa-trash",
     iconLarge: "fa fa-fw fa-lg fa-trash",
     name: _t("Delete Thread"),
-    close: ({ action }) => action.popover?.close(),
-    toggle: true,
-    open: ({ owner, store, thread }) => {
+    actionPanelOpen: ({ owner, store, thread }) => {
         if (owner.isDiscussSidebarChannelActions) {
             store.env.services.dialog?.add(ChannelActionDialog, {
                 title: thread.name,

--- a/addons/mail/static/src/discuss/core/web/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/web/thread_actions.js
@@ -6,7 +6,7 @@ import { _t } from "@web/core/l10n/translation";
 export const joinChannelAction = {
     condition: ({ channel, thread }) =>
         channel && !channel.self_member_id && !["chat", "group"].includes(channel.channel_type),
-    open: ({ channel, store }) =>
+    onSelected: ({ channel, store }) =>
         store.env.services.orm.call("discuss.channel", "add_members", [[channel.id]], {
             partner_ids: [store.self.id],
         }),
@@ -25,7 +25,7 @@ registerThreadAction("expand-discuss", {
         !owner.isDiscussSidebarChannelActions,
     icon: "fa fa-fw fa-expand",
     name: _t("Open in Discuss"),
-    open({ owner, store, thread }) {
+    onSelected({ owner, store, thread }) {
         store.env.services.action.doAction(
             {
                 type: "ir.actions.client",
@@ -42,7 +42,7 @@ registerThreadAction("expand-discuss", {
 });
 registerThreadAction("advanced-settings", {
     condition: ({ channel, owner }) => channel && owner.isDiscussSidebarChannelActions,
-    open: ({ channel, store }) => {
+    onSelected: ({ channel, store }) => {
         store.env.services.action.doAction({
             type: "ir.actions.act_window",
             res_model: "discuss.channel",

--- a/addons/mail/static/src/discuss/message_pin/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/message_pin/common/thread_actions.js
@@ -7,11 +7,11 @@ import { _t } from "@web/core/l10n/translation";
 
 registerThreadAction("pinned-messages", {
     actionPanelComponent: PinnedMessagesPanel,
+    actionPanelOuterClass: "o-discuss-PinnedMessagesPanel bg-inherit",
     condition: ({ channel, owner }) =>
         channel &&
         (!owner.props.chatWindow || owner.props.chatWindow.isOpen) &&
         !owner.isDiscussSidebarChannelActions,
-    panelOuterClass: "o-discuss-PinnedMessagesPanel bg-inherit",
     icon: "fa fa-fw fa-thumb-tack",
     name: ({ action }) => (action.isActive ? _t("Hide Pinned Messages") : _t("Pinned Messages")),
     sequence: 20,
@@ -19,14 +19,13 @@ registerThreadAction("pinned-messages", {
     setup() {
         useChildSubEnv({
             pinMenu: {
-                open: () => this.open(),
+                open: () => this.actionPanelOpen(),
                 close: () => {
                     if (this.isActive) {
-                        this.close();
+                        this.actionPanelClose();
                     }
                 },
             },
         });
     },
-    toggle: true,
 });


### PR DESCRIPTION
Before this commit, action panel definition was a feature only available in thread actions.

This commit moves definition to all actions, to move closer to same feature-set to all discuss actions.

Summary of the changes:
1. `panelOuterClass` has been renamed to `actionPanelOuterClass`
2. `toggle` has been removed (always set for action panel)
3. `open` and `close` renamed to respectively `actionPanelOpen` and `actionPanelClose`.
4. `open` is specific to actions with action panel. Other actions must use `onSelected` like other discuss action definitions.

Functionally this commit makes no change: action panel is still only used by thread actions. Future commits will make use of action panel for the composer pickers and will also make further improvements to code around action panels.