### PR TITLE
[FIX] point_of_sale: show the product variant inventory in info popup

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
@@ -41,7 +41,7 @@
                     <t t-if="currentOrder?.fiscal_position_id" t-esc="currentOrder.fiscal_position_id.display_name" />
                     <t t-else="">Tax</t>
                 </button>
-                <button t-if="this.displayProductInfoBtn()" class="btn btn-secondary btn-lg py-5" t-on-click="() => this.pos.onProductInfoClick(currentOrder.getSelectedOrderline().product_id.product_tmpl_id)">
+                <button t-if="this.displayProductInfoBtn()" class="btn btn-secondary btn-lg py-5" t-on-click="() => this.pos.onProductInfoClick(currentOrder.getSelectedOrderline().product_id.product_tmpl_id, currentOrder.getSelectedOrderline().product_id)">
                     <i class="fa fa-info-circle me-1" role="img" aria-label="Product Info" title="Product Info" /> Info
                 </button>
                 <button t-if="this.pos.cashier._role != 'minimal'" class="btn btn-secondary btn-lg py-5" t-on-click="() => this.pos.onDeleteOrder(this.pos.getOrder())">

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -661,8 +661,8 @@ export class PosStore extends WithLazyGetterTrap {
             return "flex-row-reverse justify-content-between m-1";
         }
     }
-    async onProductInfoClick(productTemplate) {
-        const info = await this.getProductInfo(productTemplate, 1);
+    async onProductInfoClick(productTemplate, productProduct = false) {
+        const info = await this.getProductInfo(productTemplate, 1, 0, productProduct);
         this.dialog.add(ProductInfoPopup, { info: info, productTemplate: productTemplate });
     }
     getProductPriceFormatted(productTemplate) {

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -1082,3 +1082,29 @@ registry.category("web_tour.tours").add("test_preset_customer_selection", {
             Chrome.endTour(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_product_info_product_inventory", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+
+            inLeftSide([
+                ...scan_barcode("product_variant_0"),
+                ...ProductScreen.clickControlButton("Info"),
+                {
+                    trigger: ".section-inventory-body :contains(100)",
+                },
+                Dialog.confirm("Close"),
+            ]),
+
+            inLeftSide([
+                ...scan_barcode("product_variant_1"),
+                ...ProductScreen.clickControlButton("Info"),
+                {
+                    trigger: ".section-inventory-body :contains(200)",
+                },
+                Dialog.confirm("Close"),
+            ]),
+        ].flat(),
+});

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -2927,6 +2927,36 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('test_preset_customer_selection')
 
+    def test_product_info_product_inventory(self):
+        """ Test that the product variant inventory info is correctly displayed in the POS. """
+        size_attribute = self.env['product.attribute'].create({
+            'name': 'Size',
+            'value_ids': [
+                Command.create({'name': 'Small'}),
+                Command.create({'name': 'Large'})
+            ],
+            'create_variant': 'always',
+        })
+
+        product_template = self.env['product.template'].create({
+            'name': 'Test Product',
+            'available_in_pos': True,
+            'is_storable': True,
+            'attribute_line_ids': [
+                Command.create({
+                    'attribute_id': size_attribute.id,
+                    'value_ids': [Command.link(id) for id in size_attribute.value_ids.ids]
+                })
+            ]
+        })
+
+        for variant in range(len(product_template.product_variant_ids)):
+            self.env['stock.quant']._update_available_quantity(product_template.product_variant_ids[variant], self.main_pos_config.warehouse_id.lot_stock_id, (variant + 1) * 100)
+            product_template.product_variant_ids[variant].write({'barcode': f'product_variant_{variant}'})
+
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_product_info_product_inventory')
+
     def test_add_money_button_with_different_decimal_separator(self):
         """
         Tests that the buttons such as +10 or +50 work even in languages such as


### PR DESCRIPTION
Before this commit, when a product template had several variants, opening the product info while a specific variant was selected would not display the inventory information of the selected variant.

opw-5161698

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
