### PR TITLE
[FIX] point_of_sale: load special products assigned to current company

### DIFF
--- a/addons/point_of_sale/models/product_template.py
+++ b/addons/point_of_sale/models/product_template.py
@@ -100,7 +100,7 @@ class ProductTemplate(models.Model):
 
         special_products = config._get_special_products().filtered(
                     lambda product: not product.sudo().company_id
-                                    or product.sudo().company_id == self.company_id
+                                    or product.sudo().company_id == self.env.company
                 )
         products += special_products.product_tmpl_id
         if config.tip_product_id:


### PR DESCRIPTION
### Problem

When assigning a special product to a company, the product will not be loaded when accessed from a PoS config of the same company.

The issue occurs because `product.sudo().company_id == self.company_id` fails as `self` is an empty recordset.

### Steps to Reproduce on Runbot
* Add a company to the special PoS product.
* Access a PoS config on the same company.
* Reload data.
* The product will not be loaded.

opw-5157959
