### PR TITLE
[FIX] html_editor: make the checkbox in the link popover visible

### DIFF
--- a/addons/html_editor/static/src/main/link/link_popover.scss
+++ b/addons/html_editor/static/src/main/link/link_popover.scss
@@ -19,6 +19,10 @@
         }
     }
 
+    .form-check-input {
+        --border-color: var(--#{$prefix}dark-border-subtle) !important;
+    }
+
     .form-control:focus, .form-select:focus, .form-check-input:focus {
         border-color: $input-focus-border-color !important;
         box-shadow: 0 0 0 $focus-ring-width rgba($input-focus-border-color, $focus-ring-opacity);


### PR DESCRIPTION
In dark mode the checkbox in the link popover wasn't visible due
to the same popover background and checkbox border colors.
Steps to see the issue:
- Set dark mode as the preferred theme
- Open Website and start editing
- Click on any link
- Click on the "Edit Link" pen icon
- Click on the "Advanced Mode" gear icon

=> The checkbox borders aren't visible

task-5155669
