### PR TITLE
[FIX] ImportError in urls.py: _WHATWG_C0_CONTROL_OR_SPACE missing

### DIFF
--- a/odoo/tools/urls.py
+++ b/odoo/tools/urls.py
@@ -1,7 +1,12 @@
 import re
 import urllib.parse
-from urllib.parse import _WHATWG_C0_CONTROL_OR_SPACE
 
+try:
+    # For Python ≤3.10
+    from urllib.parse import _WHATWG_C0_CONTROL_OR_SPACE
+except ImportError:
+    # For Python 3.11+ (constant removed)
+    _WHATWG_C0_CONTROL_OR_SPACE = re.compile(r"[\x00-\x20]")
 __all__ = ['urljoin']
 
 


### PR DESCRIPTION
Closes #230990

Description of the issue/feature this PR addresses:
- In Python 3.11+, urllib3 stopped relying on its internal _WHATWG_C0_CONTROL_OR_SPACE constant directly in newer releases

Current behavior before PR:
- As described by #230990 

Desired behavior after PR is merged:
- Using Python 3.11+ should not throw a _WHATWG_C0_CONTROL_OR_SPACE missing error



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
