### PR TITLE
[FIX] stock_account: fix zero division error

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -321,7 +321,7 @@ class ProductProduct(models.Model):
                     in_value = move._get_value(at_date=at_date)
                 if lot:
                     lot_qty = move._get_valued_qty(lot)
-                    in_value = in_value * lot_qty / in_qty
+                    in_value = (in_value * lot_qty / in_qty) if in_qty else 0
                     in_qty = lot_qty
                 if quantity < 0 and quantity + in_qty >= 0:
                     positive_qty = quantity + in_qty
@@ -336,7 +336,7 @@ class ProductProduct(models.Model):
                 out_value = out_qty * avco_value
                 if lot:
                     lot_qty = move._get_valued_qty(lot)
-                    out_value = out_value * lot_qty / out_qty
+                    out_value = (out_value * lot_qty / out_qty) if out_qty else 0
                     out_qty = lot_qty
                 avco_total_value -= out_value
                 quantity -= out_qty


### PR DESCRIPTION
The method, _get_valued_qty introduced in this commit:
https://github.com/odoo/odoo/commit/08b62a4bbcc6f9a391b2cc00a621ef4c76100229#diff-ad6229e976ce0bd1592e805b88e9813ac4e3f6fb989d3dfb8dfb8b70af03cd58
because move_lines can have quantity as zero. This is where the value
of in_qty comes from.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
