### PR TITLE
[FIX] account_peppol: Fix Peppol test - company registry not computed

### DIFF
--- a/addons/account_peppol/tests/test_peppol_messages.py
+++ b/addons/account_peppol/tests/test_peppol_messages.py
@@ -430,7 +430,7 @@ class TestPeppolMessage(TestAccountMoveSendCommon, MailCommon):
         peppol_partner = self.env['res.partner'].create({
             'name': 'Peppol partner',
             'country_id': self.env.ref('base.be').id,
-            'vat': 'BE0477472701',
+            'company_registry': '0477472701',
         })
         self.assertRecordValues(peppol_partner, [{
             'peppol_verification_state': 'not_verified',


### PR DESCRIPTION
This commits fixes test we previously added [1].
In Belgium, the Company Registry (0208) and the VAT number (9925) can be computed from each other (`0208:0400000000` <-> `9925:BE0400000000`). 
[This compute](https://github.com/odoo/odoo/blob/0d8aadb2db7f10d439e10f222ec0ab6dcfab3672/addons/l10n_be/models/res_partner.py#L13) is actually only available in l10n_be, while the test rely on it to deduce the expected EAS, and therefore fails on single Apps builds.

[1]: https://github.com/odoo/odoo/pull/230880
[runbot-error-233343](https://runbot.odoo.com/odoo/runbot.build.error/233343)
