### PR TITLE
[PERF] analytic: optimize analytic distribution widget

### DIFF
--- a/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.js
+++ b/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.js
@@ -284,7 +284,9 @@ export class AnalyticDistribution extends Component {
                 // company domain might be required here
                 domain: [["root_plan_id", "=", account.planId]],
             };
-            values[fieldName] =  account?.accountId || false;
+            values[fieldName] = account?.accountId
+                ? [account.accountId, account.accountDisplayName]
+                : false;
         });
         // Percentage field
         recordFields['percentage'] = {
@@ -301,10 +303,9 @@ export class AnalyticDistribution extends Component {
             values[name] = this.props.record.data[name] * values['percentage'];
             // Currency field
             if (currency_field) {
-                // TODO: check web_read network request
                 const { string, name, type, relation } = this.props.record.fields[currency_field];
                 recordFields[currency_field] = { name, string, type, relation, invisible: true };
-                values[currency_field] = this.props.record.data[currency_field][0];
+                values[currency_field] = [this.props.record.data[currency_field][0], ""];
             }
         }
         return {


### PR DESCRIPTION
Currently opening the analytic distrubtion popup on an invoice line creates N network requests per account set on the line.

Steps to reproduce
-----
1. Edit the analytic distribution on an invoice line and add a lot of accounts
2. Open the popup again
3. A lot of web_read requests are made

Issue
-----
The display_name for the account and currency is not being passed to the field values in recordProps(), resulting in another fetch when each Field element is rendered.

Solution
-----
Pass account.accountDisplayName. The display name for the currency is actually not initially loaded by the client, but since that field is invisible, we can safely use an empty string.

opw-5106219