### PR TITLE
[FIX] point_of_sale: configurable product access rights issue

### DIFF
--- a/addons/point_of_sale/models/product_template.py
+++ b/addons/point_of_sale/models/product_template.py
@@ -349,7 +349,7 @@ class ProductTemplate(models.Model):
         while not tax_to_use and company:
             tax_to_use = self.taxes_id.filtered(lambda tax: tax.company_id.id == company.id)
             if not tax_to_use:
-                company = company.parent_id
+                company = company.sudo().parent_id
         taxes = tax_to_use.compute_all(price, config.currency_id, quantity, self)
         grouped_taxes = {}
         for tax in taxes['taxes']:


### PR DESCRIPTION
**Issue:**
In POS, clicking on a tax-free, inventory-tracked, configurable product as a non-admin user can throw an Access Rights error when trying to access it on a branch company's POS config.

**Steps to reproduce:**
- Configure a branching company on a parent company
- Create a new POS restaurant on the child company
- Create a configurable product that has no taxes associated with it
  and add it to a POS category so that it can be chosen from the
  POS screen
- On a non-admin POS user, try to click that product 🐛

**Before this commit:**
The user will get an Access Rights error.

**After this commit:**
The configurator dialog will load successfully.

opw-5145176