### PR TITLE
[FIX] purchase_stock: prevent type mismatch error on valuation report

### DIFF
--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -154,7 +154,7 @@ class StockMove(models.Model):
         value = 0
         aml_ids = set()
         for aml in self.purchase_line_id.invoice_lines:
-            if at_date and fields.Datetime.to_datetime(aml.date) > at_date:
+            if at_date and aml.date > at_date:
                 continue
             if aml.move_id.state != 'posted':
                 continue


### PR DESCRIPTION
Currently, an error occurs when a user attempts to access the stock valuation report for a date beyond today.

**Steps to replicate:**
- Install `stock_account`, `purchase_stock`, `accountant`.
- Go to settings, set `Inventory Cost Method` to Average Cost(AVCO) and Turn on `Lots and Serial Numbers`.
- Go to Products and create a new one with name `test`, set `Track Inventory` - `by lots`.
- On the `Inventory` page turn on `Valuation by Lots/Serial`.
- Open RFQs, Create a new one with test product and Click `Confirm Order` > Click `Receive`.
- Set the Lot name by clicking the `Details` button on the move lines.
- Click `Validate`, go to `Purchase > Orders > Purchase Orders`.
- Select the currently made Purchase Order (It will be in the `Waiting Bills` state) and Click on the `Create bills` Button, Confirm it (it should be in the paid state now).
- Now go to `Accountant > Review > Inventory Evaluation` and select and date ahead of today, the error will occur.

**TL;DR:**
- Install `stock_account, purchase_stock, and accountant`.
- Create a product tracked by lots with AVCO costing and `Valuation by Lots/Serial` enabled.
- Create a Purchase order and receive it (assign a lot), then create and confirm the bill for the same.
- Finally, go to `Accountant > Review > Inventory Valuation`, select a future date — the error occurs.

**Error:**
`TypeError: can't compare datetime.datetime to datetime.date`

**Cause:**
- The error occurs because of recent commit [PR] where `aml.date` is typecasted from `datetime.date` to `datetime.datetime`, but the `at_date` is received as `datetime.date` [1] and this causes the error.
- The `at_date` is converted to `datetime.date` from string at line [2].

**Solution:**
- Now we don't convert `aml.date` to datetime since both `aml.date` [3] and `at_date` [4] are instances of `datetime.date`. Additionally, `account.move` are based on date rather than datetime.

[PR]: https://github.com/odoo/odoo/pull/227567/commits/aec7d3244aa25af626cefd875f021d0d24ce418d

[1]: https://github.com/odoo/odoo/blob/7e0cc5ec686a52b8c1f8270213acac54575ed469/addons/purchase_stock/models/stock_move.py#L157

[2]: https://github.com/odoo/odoo/blob/7e0cc5ec686a52b8c1f8270213acac54575ed469/addons/stock_account/report/stock_valuation_report.py#L32

[3]: https://github.com/odoo/odoo/blob/385d8473952eeaa9dcc7740bacfc2c9cbdc2d1e2/addons/account/models/account_move_line.py#L69-L73

[4]: https://github.com/odoo/odoo/blob/385d8473952eeaa9dcc7740bacfc2c9cbdc2d1e2/addons/stock_account/report/stock_valuation_report.py#L32

sentry-6933268158
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
