### PR TITLE
[FIX] project: hide full composer button

### DIFF
--- a/addons/project/static/src/project_sharing/chatter/chatter_patch.js
+++ b/addons/project/static/src/project_sharing/chatter/chatter_patch.js
@@ -13,6 +13,7 @@ patch(Chatter.prototype, {
         this.orm = useService("orm");
         useSubEnv({
             projectSharingId: this.props.projectSharingId,
+            inFrontendPortalChatter: true,
         });
     },
 


### PR DESCRIPTION
Steps to reproduce:
===
- Create a project.
- Share the project with access to edit rights to the portal user.
- Log in as the portal user.
- Open the shared project and then open a task.
- Click on the expand button in the chat.

Issue:
===
A traceback occurs when trying to expand the chatter in a project sharing task.

Cause:
===
`inFrontendPortalChatter` not being set in `useSubEnv` is the reason for button appearance, and we don't have the necessary composer for it to render in the project sharing bundle.

Fix:
===
Define missing `inFrontendPortalChatter` to hide the expand chatter composer action as it was not meant to be available in the portal/front-end.

task-5049129