### PR TITLE
[FIX] mass_mailing: prevent error on selecting mail template

### DIFF
--- a/addons/mass_mailing/views/snippets/mass_mailing_footer_snippets.xml
+++ b/addons/mass_mailing/views/snippets/mass_mailing_footer_snippets.xml
@@ -12,7 +12,7 @@
             <div class="row">
                 <div class="col-md pb4 col">
                     <p class="mb-0" style="text-align: center">
-                        <font style="color:white;">© <t t-out="datetime.datetime.now().year"/> <t t-out="company_id.name or user.company_id.name"/>, All Rights Reserved</font>
+                        <font style="color:white;">© <t t-out="datetime.datetime.now().year"/> <t t-out="company_id.name"/>, All Rights Reserved</font>
                     </p>
                 </div>
             </div>

--- a/addons/mass_mailing/views/snippets/mass_mailing_headers_snippets.xml
+++ b/addons/mass_mailing/views/snippets/mass_mailing_headers_snippets.xml
@@ -6,8 +6,8 @@
                 <div class="col-md-4 pt16 pb16">
                     <div class="o_not_editable">
                         <a t-att-href="(company_id.website) or '#'" style="text-decoration:none;float:none;" target="_blank">
-                            <img class="o_b64_image_to_save o_editable_media"
-                                t-att-src="image_data_uri(company_id.logo if company_id.logo else user.company_id.logo)" style="height:auto;max-width:100%;" />
+                            <img t-if="company_id.logo or user_id.company_id.logo" class="o_b64_image_to_save o_editable_media"
+                                t-att-src="image_data_uri(company_id.logo if company_id.logo else user_id.company_id.logo)" style="height:auto;max-width:100%;" />
                         </a>
                     </div>
                 </div>
@@ -27,8 +27,8 @@
                 <div class="col-md-6" style="text-align: center;">
                     <div class="o_not_editable">
                         <a t-att-href="(company_id.website) or '#'" style="text-decoration:none;" target="_blank">
-                            <img class="py-4 o_b64_image_to_save o_editable_media"
-                                t-att-src="image_data_uri(company_id.logo if company_id.logo else user.company_id.logo)" style="height:auto;max-width:100%;"/>
+                            <img t-if="company_id.logo or user_id.company_id.logo" class="py-4 o_b64_image_to_save o_editable_media"
+                                t-att-src="image_data_uri(company_id.logo if company_id.logo else user_id.company_id.logo)" style="height:auto;max-width:100%;"/>
                         </a>
                     </div>
                 </div>
@@ -46,8 +46,8 @@
                 <div class="col-md-6" style="text-align: center;">
                     <div class="o_not_editable">
                         <a t-att-href="(company_id.website) or '#'" style="text-decoration:none;" target="_blank">
-                            <img class="py-4 o_b64_image_to_save o_editable_media"
-                                t-att-src="image_data_uri(company_id.logo if company_id.logo else user.company_id.logo)" style="height:auto;max-width:100%;"/>
+                            <img t-if="company_id.logo or user_id.company_id.logo" class="py-4 o_b64_image_to_save o_editable_media"
+                                t-att-src="image_data_uri(company_id.logo if company_id.logo else user_id.company_id.logo)" style="height:auto;max-width:100%;"/>
                         </a>
                     </div>
                 </div>


### PR DESCRIPTION
Currently, an error occurs when a user selects a mail template after removing their company logo.

**Steps to replicate**
* Install `mass_mailing`
* Companies > YourCompany > Remove company logo
* Email Marketing > New > Start From Scratch

**Error:**
```
`QwebError:
Error while rendering the template:
    KeyError: 'user'
    Template: mass_mailing.s_mail_block_header_social
    Reference: 805
    Path: /t/section/div/div/div[1]/div/a/img
    Element: <img class='o_b64_image_to_save o_editable_media' t-att-src='image_data_uri(company_id.logo if company_id.logo else user.company_id.logo)'...`
```

**Root cause:**
* This error occurs because [1] tries to access `user` after the company logo is removed. As shown in [2], `user` isn’t in values but exists in `env` or as `user_id` ,causing a key error and a qweb exception.
* The template change that introduced this behavior was made after commit [3].

**Solution:**
* Show the logo only if at least one is available, similar to the approach in `18.4` [4]. Without this condition, the template fails when both the selected company and the user's default company are the same and have no logo. This leads to a type error at [5] because accessing the logo through the user returns `False`, and a boolean is not subscriptable.

[1]:
https://github.com/odoo/odoo/blob/d484516bcae1beb767d90d20e1ab294f1e9ae8a9/addons/mass_mailing/views/snippets/mass_mailing_headers_snippets.xml#L9-L10 
[2]:
https://drive.google.com/file/d/1XwASk3CGcfkVk7sifuqZE7t_QtCZpuRU/view?usp=sharing 
[3]:
https://github.com/odoo/odoo/commit/b6e51609807bdb771f305ba289aafe3e2b9b26b6#diff-8f450b28258a6e33b353e751dcb8c71e5ac6c93743efe6eea35a8744d9f7d6b5 
[4]:
https://github.com/odoo/odoo/blob/3a712861be1e3536e593a94e741457840da46907/addons/mass_mailing/views/snippets_themes.xml#L90 
[5]:
https://github.com/odoo/odoo/blob/d484516bcae1beb767d90d20e1ab294f1e9ae8a9/odoo/tools/image.py#L562

sentry-6923986938
