### PR TITLE
[FIX] point_of_sale: respect product image configuration in combo product also

### DIFF
--- a/addons/point_of_sale/static/src/app/store/combo_configurator_popup/combo_configurator_popup.xml
+++ b/addons/point_of_sale/static/src/app/store/combo_configurator_popup/combo_configurator_popup.xml
@@ -22,7 +22,8 @@
                                 productId="product.id"
                                 product="product"
                                 comboExtraPrice="formattedComboPrice(combo_item)"
-                                imageUrl="product.getImageUrl()"
+                                color="product.color || product.pos_categ_ids?.at(-1)?.color"
+                                imageUrl="pos.config.show_product_images and product.getImageUrl()"
                                 onClick="(ev) => this.onClickProduct({ product, combo_item }, ev)" />
                         </label>
                     </div>

--- a/addons/point_of_sale/static/tests/tours/pos_combo_tour.js
+++ b/addons/point_of_sale/static/tests/tours/pos_combo_tour.js
@@ -254,3 +254,28 @@ registry.category("web_tour.tours").add("test_combo_disallowLineQuantityChange_2
             Order.hasTotal("47.33"),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_combo_item_image_display", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Office Combo"),
+            combo.checkImgAndSelect("Combo Product 2", true),
+            combo.checkImgAndSelect("Combo Product 4", true),
+            combo.checkImgAndSelect("Combo Product 6", true),
+            Dialog.confirm(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_combo_item_image_not_display", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            ProductScreen.clickDisplayedProduct("Office Combo"),
+            combo.checkImgAndSelect("Combo Product 2", false),
+            combo.checkImgAndSelect("Combo Product 4", false),
+            combo.checkImgAndSelect("Combo Product 6", false),
+            Dialog.confirm(),
+        ].flat(),
+});

--- a/addons/point_of_sale/static/tests/tours/utils/combo_popup_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/combo_popup_util.js
@@ -32,3 +32,15 @@ export function isConfirmationButtonDisabled() {
         trigger: `.modal ${confirmationButtonTrigger}[disabled]`,
     };
 }
+
+export function checkImgAndSelect(productName, checkImg = false) {
+    const productArticleSelector = productTrigger(productName);
+    const withImg = `${productArticleSelector}:has(.product-img)`;
+    const withoutImg = `${productArticleSelector}:not(:has(.product-img))`;
+    const trigger = `.modal ${checkImg ? withImg : withoutImg}`;
+    return {
+        content: `Check image & select combo item ${productName}`,
+        trigger: trigger,
+        run: "click",
+    };
+}

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -2,6 +2,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import logging
+import base64
+import io
+
+from PIL import Image
 from contextlib import contextmanager
 from unittest.mock import patch
 from odoo import Command, api
@@ -16,6 +20,13 @@ from odoo.exceptions import UserError
 from odoo.addons.point_of_sale.models.pos_config import PosConfig
 
 _logger = logging.getLogger(__name__)
+
+
+def _create_image(color: int | str = 0, dims=(1920, 1080), format='JPEG'):
+    f = io.BytesIO()
+    Image.new('RGB', dims, color).save(f, format)
+    f.seek(0)
+    return base64.b64encode(f.read())
 
 
 class TestPointOfSaleHttpCommon(AccountTestInvoicingHttpCommon):
@@ -1566,6 +1577,27 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'ProductComboChangePricelist', login="pos_user")
+
+    def test_combo_item_image_display(self):
+        """ when `show_product_images` is enabled, verify combo item product images should appear in the POS UI. When disabled, the UI should not display
+            the product image for combo items.
+        """
+
+        setup_product_combo_items(self)
+        image = _create_image(color="orange")
+
+        for combo in self.office_combo.combo_ids:
+            for item in combo.combo_item_ids:
+                item.product_id.image_1920 = image
+
+        # Case 1: Images ON → images must be visible in combo items
+        self.main_pos_config.show_product_images = True
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'test_combo_item_image_display', login="pos_user")
+
+        # Case 2: Images OFF → product images should not be shown
+        self.main_pos_config.show_product_images = False
+        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'test_combo_item_image_not_display', login="pos_user")
 
     def test_cash_rounding_payment(self):
         """Verify than an error popup is shown if the payment value is more precise than the rounding method"""


### PR DESCRIPTION
Before this commit:
====================
In POS, when product images were configured to be hidden, the setting was correctly applied to normal products. However, in the combo product configurator, product images were still displayed, causing inconsistency with the configured behavior.

After this commit:
======================
The combo product configurator now respects the product image visibility configuration, ensuring consistent behavior across all product types in the POS interface.

Task-5163955


