### PR TITLE
[FIX] html_editor: prevent traceback when changing GIF shape

### DIFF
--- a/addons/html_editor/static/src/main/media/image_post_process_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_post_process_plugin.js
@@ -26,8 +26,8 @@ export class ImagePostProcessPlugin extends Plugin {
      * @param {Object} newDataset an object containing the modifications to apply
      * @param {Function} [onImageInfoLoaded] can be used to fill
      * newDataset after having access to image info, return true to cancel call
-     * @returns {Function} callback that sets dataURL of the image with the
-     * applied modifications to `img` element
+     * @returns {{ url: string, newDataset: object }} Object containing the image
+     * URL and the updated dataset.
      */
     async _processImage({ img, newDataset = {}, onImageInfoLoaded }) {
         const processContext = {};
@@ -75,7 +75,7 @@ export class ImagePostProcessPlugin extends Plugin {
                 newDataset,
                 processContext
             );
-            return () => this.updateImageAttributes(img, postUrl, postDataset);
+            return { url: postUrl, newDataset: postDataset };
         }
         // Crop
         const container = document.createElement("div");
@@ -232,7 +232,8 @@ export class ImagePostProcessPlugin extends Plugin {
     }
     async getProcessedImageSize(img) {
         const processed = await this._processImage({ img });
-        if (processed.url) {
+        // return undefined if the image is a gif
+        if (!shouldPreventGifTransformation(processed.newDataset)) {
             return getDataURLBinarySize(processed.url);
         }
         return undefined;

--- a/addons/website/static/tests/builder/image_shape.test.js
+++ b/addons/website/static/tests/builder/image_shape.test.js
@@ -43,6 +43,60 @@ test("Should set a shape on an image", async () => {
     );
     expect(":iframe .test-options-target img").toHaveAttribute("data-shape-colors", ";;;;");
 });
+
+test("Should set a shape on a GIF", async () => {
+    // Define the img tag using the specified GIF path.
+    const testGif = `<img
+        src="/web/image/456-test/test.gif"
+        class="img-fluid o_we_custom_image"
+    >`;
+
+    // Set up the website builder with the test GIF.
+    const { getEditor } = await setupWebsiteBuilder(`
+        <div class="test-options-target">
+            ${testGif}
+        </div>
+        `);
+    const editor = getEditor();
+
+    // Click the GIF to activate the image options in the sidebar.
+    await contains(":iframe .test-options-target img").click();
+
+    // Select and apply a shape.
+    await contains("[data-label='Shape'] .dropdown").click();
+    await contains("[data-action-value='html_builder/geometric/geo_shuriken']").click();
+    // Wait for the editor to process the change.
+    await editor.shared.operation.next(() => {});
+
+    const gif = queryFirst(":iframe .test-options-target img");
+
+    // ## Assertions: Verify the shape was applied correctly.
+
+    // 1. The image source should now be an SVG mask, not the original GIF path.
+    expect(gif.src.startsWith("data:image/svg+xml;base64,")).toBe(true);
+
+    // 2. The new MIME type for the element is 'image/svg+xml'.
+    expect(":iframe .test-options-target img").toHaveAttribute("data-mimetype", "image/svg+xml");
+
+    // 3. The system correctly remembers the original source was a GIF.
+    expect(":iframe .test-options-target img").toHaveAttribute(
+        "data-mimetype-before-conversion",
+        "image/gif"
+    );
+
+    // 4. The original source path is preserved in 'data-original-src'.
+    expect(":iframe .test-options-target img").toHaveAttribute(
+        "data-original-src",
+        "/website/static/src/img/snippets_options/header_effect_fade_out.gif"
+    );
+
+    // 5. The shape data attribute is correctly set.
+    expect(":iframe .test-options-target img").toHaveAttribute(
+        "data-shape",
+        "html_builder/geometric/geo_shuriken"
+    );
+});
+
 test("Should change the shape color of an image", async () => {
     const { waitSidebarUpdated } = await setupWebsiteBuilder(
         `<div class="test-options-target">


### PR DESCRIPTION
Steps to reproduce:
===================
1- Add an image of type GIF.
2- Try to change its shape.
→ Traceback occurs.

Cause:
======
The `process` image function can return a callback function when GIF transformation must be skipped:
https://github.com/odoo/odoo/blob/7f95cc6094b914c57b6e36ad072ebb2c9c3b324b/addons/html_editor/static/src/main/media/image_post_process_plugin.js#L78

It can also return an object `{ url, newDataset }`: https://github.com/odoo/odoo/blob/7f95cc6094b914c57b6e36ad072ebb2c9c3b324b/addons/html_editor/static/src/main/media/image_post_process_plugin.js#L224

Only the object case was handled:
https://github.com/odoo/odoo/blob/7f95cc6094b914c57b6e36ad072ebb2c9c3b324b/addons/html_editor/static/src/main/media/image_post_process_plugin.js#L231

As a result, when a function was returned, the image source was set to `null`, because `processed` was a function and didn't have a `url` or `newDataset`, causing a crash here:
https://github.com/odoo/odoo/blob/22c83301337e40699b11621053af627f5bfd505b/addons/html_builder/static/src/plugins/image/image_shape_option_plugin.js#L412

Solution:
=========
Ensure that only the `url` and `dataset` are returned, since the same
function is called elsewhere expecting those values.

opw-5137667
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
