### PR TITLE
[FIX] core: inline `_WHATWG_C0_CONTROL_OR_SPACE`

### DIFF
--- a/odoo/tools/urls.py
+++ b/odoo/tools/urls.py
@@ -1,6 +1,5 @@
 import re
 import urllib.parse
-from urllib.parse import _WHATWG_C0_CONTROL_OR_SPACE
 
 __all__ = ['urljoin']
 
@@ -63,7 +62,7 @@ def urljoin(base: str, extra: str) -> str:
     if e_path:
         # prevent urljoin("/", "\\example.com/") to resolve as absolute to "//example.com/" in a browser redirect
         # https://github.com/mozilla-firefox/firefox/blob/5e81b64f4ed88b610eb332e103744d68ee8b6c0d/netwerk/base/nsStandardURL.cpp#L2386-L2388
-        e_path = e_path.lstrip('/\\' + _WHATWG_C0_CONTROL_OR_SPACE)
+        e_path = e_path.lstrip('/\\\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f ')
         path = f'{path}/{e_path}'
 
     # normalize: foo//bar -> foo/bar


### PR DESCRIPTION
This is a private variable of the stdlib, it was added in Python 3.12 (python/cpython#102508) and only backported to 3.11.4 (python/cpython#104575) and 3.10.12 (python/cpython#104592) so is not necessarily available in versions of 3.10 and 3.11 clients might be running. So embed the content into the file directly to avoid depending on the stdlib. Not to mention the concept of C0 is not exactly novel or mutable.

Also inline it in its sole use, there's no reason to have multiple string literals and a runtime concatenation.

Fixes #230990
