### PR TITLE
FW port of SEPA check QR code structured ref + NL Cases

### DIFF
--- a/addons/account/tests/test_structured_reference.py
+++ b/addons/account/tests/test_structured_reference.py
@@ -6,6 +6,7 @@ from odoo.addons.account.tools import (
     is_valid_structured_reference_fi,
     is_valid_structured_reference_no_se,
     is_valid_structured_reference_si,
+    is_valid_structured_reference_nl,
     is_valid_structured_reference_iso,
     is_valid_structured_reference,
 )
@@ -101,6 +102,37 @@ class StructuredReferenceTest(TransactionCase):
         self.assertFalse(is_valid_structured_reference_si("SI01 25-20-"))
         self.assertFalse(is_valid_structured_reference_si("SI01"))
 
+    def test_structured_reference_nl(self):
+        # Accepts 7 digits
+        self.assertTrue(is_valid_structured_reference_nl('1234567'))
+
+        # Accepts 9 digits
+        self.assertTrue(is_valid_structured_reference_nl('271234567'))
+
+        # Accepts 14 digits
+        self.assertTrue(is_valid_structured_reference_nl('42234567890123'))
+
+        # Accepts 16 digits
+        self.assertTrue(is_valid_structured_reference_nl('5000056789012345'))
+
+        # Accepts particular chase (check = 11 or 10)
+        self.assertTrue(is_valid_structured_reference_nl('0123456788'))  # Check of 123456788 == 11 then check = 0
+        self.assertTrue(is_valid_structured_reference_nl('123456789107'))  # Check of 23456789107 == 10 then check = 1
+
+        # Accepts spaces
+        self.assertTrue(is_valid_structured_reference_nl('5 000 0567 8901 2345'))
+        self.assertTrue(is_valid_structured_reference_nl('   5000056789012345   '))
+
+        # Check the length
+        self.assertFalse(is_valid_structured_reference_nl('123456'))
+        self.assertFalse(is_valid_structured_reference_nl('12345678'))
+        self.assertFalse(is_valid_structured_reference_nl('123456789012345'))
+        self.assertFalse(is_valid_structured_reference_nl('12345678901234567'))
+        # Check the checksum
+        self.assertFalse(is_valid_structured_reference_nl('4000056789012345'))
+        # Check the entire string
+        self.assertFalse(is_valid_structured_reference_nl('5000056789012345-OTHER-RANDOM-STUFF'))
+
     def test_structured_reference(self):
         # Accepts references in structured format
         self.assertTrue(is_valid_structured_reference(' RF18 5390 0754 7034 '))  # ISO
@@ -109,12 +141,14 @@ class StructuredReferenceTest(TransactionCase):
         self.assertTrue(is_valid_structured_reference('2023 0000 98'))  # FI
         self.assertTrue(is_valid_structured_reference('1234 5678 97'))  # NO-SE
         self.assertTrue(is_valid_structured_reference("SI01 25-20-85"))  # SI
+        self.assertTrue(is_valid_structured_reference('5000056789012345'))  # NL
         # Accept references in unstructured format
         self.assertTrue(is_valid_structured_reference(' RF18539007547034'))  # ISO
         self.assertTrue(is_valid_structured_reference(' 020343057642'))  # BE
         self.assertTrue(is_valid_structured_reference('2023000098'))  # FI
         self.assertTrue(is_valid_structured_reference('1234567897'))  # NO-SE
         self.assertTrue(is_valid_structured_reference("  SI01 25  - 2 0-85  "))  # SI
+        self.assertTrue(is_valid_structured_reference('5 000 0567 8901 2345'))  # NL
         # Validates with zero's added in front
         self.assertTrue(is_valid_structured_reference('RF18000000000539007547034'))  # ISO
         self.assertTrue(is_valid_structured_reference('00000000002023000098'))  # FI
@@ -126,9 +160,11 @@ class StructuredReferenceTest(TransactionCase):
         self.assertFalse(is_valid_structured_reference('2023/0000/98'))  # FI
         self.assertFalse(is_valid_structured_reference('1234/5678/97'))  # NO-SE
         self.assertFalse(is_valid_structured_reference("0519123584503"))  # SI
+        self.assertFalse(is_valid_structured_reference('(5)000 0567 8901 2345'))  # NL
         # Does not validate invalid checksum
         self.assertFalse(is_valid_structured_reference('RF17539007547034'))  # ISO
         self.assertFalse(is_valid_structured_reference('020343057641'))  # BE
         self.assertFalse(is_valid_structured_reference('2023000095'))  # FI
         self.assertFalse(is_valid_structured_reference('1234567898'))  # NO-SE
         self.assertFalse(is_valid_structured_reference("SI01 19-1235-84504"))  # SI
+        self.assertFalse(is_valid_structured_reference('6000056789012345'))  # NL

--- a/addons/account/tools/structured_reference.py
+++ b/addons/account/tools/structured_reference.py
@@ -69,6 +69,45 @@ def is_valid_structured_reference_no_se(reference):
     return no_se_ref and luhn.is_valid(ref)
 
 
+def is_valid_structured_reference_nl(reference):
+    """ Generates a valid Dutch structured payment reference (betalingskenmerk)
+        by ensuring it follows the correct format.
+
+        Valid reference lengths:
+        - 7 digits: Simple reference with no check digit.
+        - 9-14 digits: Includes a check digit and a length code.
+        - 16 digits: Contains only a check digit, commonly used for wire transfers.
+
+        :param reference: the reference to check
+        :return: True if reference is a structured reference, False otherwise
+    """
+    sanitized_reference = sanitize_structured_reference(reference)
+
+    if re.fullmatch(r'\d{7}', sanitized_reference):
+        return True
+
+    if not re.fullmatch(r'\d{9,16}', sanitized_reference):
+        return False
+
+    if len(sanitized_reference) == 15:
+        return False
+
+    check, reference_to_check = sanitized_reference[0], sanitized_reference[1:]
+    weigths = [2, 4, 8, 5, 10, 9, 7, 3, 6, 1]
+    reference_to_check = reference_to_check.zfill(16)[::-1]
+
+    total = sum(
+        int(digit) * weigths[index % len(weigths)]
+        for index, digit in enumerate(reference_to_check)
+    )
+    computed_check = 11 - (total % 11)
+    if computed_check == 11:
+        computed_check = 0
+    elif computed_check == 10:
+        computed_check = 1
+
+    return computed_check == int(check)
+
 def is_valid_structured_reference_si(reference):
     """ Validates a Slovenian structured reference using Model 01 (SI01).
 
@@ -126,5 +165,6 @@ def is_valid_structured_reference(reference):
         is_valid_structured_reference_fi(reference) or
         is_valid_structured_reference_no_se(reference) or
         is_valid_structured_reference_si(reference) or
+        is_valid_structured_reference_nl(reference) or
         is_valid_structured_reference_iso(reference)
     )

--- a/addons/account_qr_code_sepa/models/res_bank.py
+++ b/addons/account_qr_code_sepa/models/res_bank.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from odoo import models, fields, api, _
+from odoo.addons.account.tools import is_valid_structured_reference, sanitize_structured_reference
 
 
 class ResPartnerBank(models.Model):
@@ -8,7 +9,12 @@ class ResPartnerBank(models.Model):
 
     def _get_qr_vals(self, qr_method, amount, currency, debtor_partner, free_communication, structured_communication):
         if qr_method == 'sct_qr':
-            comment = (free_communication or '') if not structured_communication else ''
+            if structured_communication and is_valid_structured_reference(structured_communication):
+                structured_communication = sanitize_structured_reference(structured_communication)
+                comment = ''
+            else:
+                structured_communication = ''
+                comment = free_communication or ''
 
             qr_code_vals = [
                 'BCD',                                                  # Service Tag
@@ -20,7 +26,7 @@ class ResPartnerBank(models.Model):
                 self.sanitized_acc_number,                              # Account Number of the Beneficiary
                 currency.name + str(amount),                            # Currency + Amount of the Transfer in EUR
                 '',                                                     # Purpose of the Transfer
-                (structured_communication or '')[:36],                  # Remittance Information (Structured)
+                structured_communication,                               # Remittance Information (Structured)
                 comment[:141],                                          # Remittance Information (Unstructured) (can't be set if there is a structured one)
                 '',                                                     # Beneficiary to Originator Information
             ]


### PR DESCRIPTION
[SEE THIS PR](https://github.com/odoo/odoo/pull/200922)

[IMP] account: Check NL structured reference

The aim of this commit is implementing a new function to check
the structured reference for the Netherlands. Even if dutch
people can use the ISO format, they can still use the NL format.

no task id

[FIX] account_qr_code_sepa: Don't fill structured communication with unstructured communication

This commit ensures that unstructured communication
is not mistakenly used as structured communication
in the QR code values.

To achieve this, we use is_valid_structured_reference,
a simple validation approach that checks all available
is_valid_structured_reference functions. While this
method may lead to occasional false positives, we
consider this trade-off acceptable.

opw-4575004


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
