### PR TITLE
[FIX] html_editor: correct bold detection inside blockquote in blog

### DIFF
--- a/addons/html_editor/static/src/utils/dom_info.js
+++ b/addons/html_editor/static/src/utils/dom_info.js
@@ -46,7 +46,11 @@ export function isEmptyTextNode(node) {
  */
 export function isBold(node) {
     const fontWeight = +getComputedStyle(closestElement(node)).fontWeight;
-    return fontWeight > 500 || fontWeight > +getComputedStyle(closestBlock(node)).fontWeight;
+    const referenceElement = closestElement(
+        node,
+        (el) => isBlock(el) || +getComputedStyle(el).fontWeight !== fontWeight
+    );
+    return fontWeight > 500 || fontWeight > +getComputedStyle(referenceElement).fontWeight;
 }
 
 /**


### PR DESCRIPTION
Problem:
The bold check inside a blockquote in Website Blog is incorrect.

Cause:
`isBold` checks if the node’s computed font weight is higher than `500` or if the `closestBlock` has a different weight than the node. However, this is wrong when an ancestor (that is not a block) has a different font weight — that ancestor should also be considered in the check.

Solution:
Instead of comparing with the `closestBlock`, find the closest ancestor that has a different computed font weight and use it for the bold check.

Steps to reproduce:
1. Go to a blog post.
2. Select text inside a blockquote that is already bold.
3. Click the bold button → bold is removed.
4. Click the bold button again → text is not bold (incorrect).

task-2906482


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
