### PR TITLE
[FIX] orm: consider timezone for conversion to datetime in domains

### DIFF
--- a/odoo/addons/test_orm/tests/test_domain.py
+++ b/odoo/addons/test_orm/tests/test_domain.py
@@ -705,8 +705,13 @@ class TestDomainOptimize(TransactionCase):
             "Timezone should have no effect on datetime"
         )
         self.assertEqual(
+            Domain('moment', '>=', '2024-07-02').optimize(model),
+            Domain('moment', '>=', datetime(2024, 7, 1, 22)),
+            "Date should consider timezone of the user"
+        )
+        self.assertEqual(
             Domain('moment', '>=', '2024-01-02').optimize(model),
-            Domain('moment', '>=', datetime(2024, 1, 1, 22)),
+            Domain('moment', '>=', datetime(2024, 1, 1, 23)),
             "Date should consider timezone of the user"
         )
 

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -1566,7 +1566,7 @@ def _value_to_datetime(value, env, iso_only=False):
             tz = None
         elif (tz := env.tz) != pytz.utc:
             # get the tzinfo (without LMT)
-            tz = tz.localize(datetime.now()).tzinfo
+            tz = tz.localize(datetime.combine(value, time.min)).tzinfo
         else:
             tz = None
         value = datetime.combine(value, time.min, tz)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When casting a date to a datetime during conversion of domains, we should take the DST of the date instead of now.

Current behavior before PR:
`[('dt_field', '>', '2022-01-01')]` uses the DST of now which may or may not be +1h.

Desired behavior after PR is merged:
`[('dt_field', '>', '2022-01-01')]` would use the DST of the given date.


runbot.build.error/232914

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
