### PR TITLE
[FIX] api_doc: Hide api_key and generate key link

### DIFF
--- a/addons/api_doc/__manifest__.py
+++ b/addons/api_doc/__manifest__.py
@@ -52,6 +52,10 @@ the methods over HTTP, with examples in various programming languages.
             'api_doc/static/src/**/*.xml',
             'api_doc/static/src/**/*.js',
             'api_doc/static/src/doc_client.css',
+            ('remove', 'api_doc/static/src/api_action.js'),
+        ],
+        'web.assets_backend': [
+            'api_doc/static/src/api_action.js',
         ],
     },
     'bootstrap': True,

--- a/addons/api_doc/static/src/api_action.js
+++ b/addons/api_doc/static/src/api_action.js
@@ -1,0 +1,12 @@
+import { _t } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+
+registry.category("actions").add("doc_api_key_wizard", () => {
+    return {
+        type: "ir.actions.act_window",
+        name: _t("API Key Wizard"),
+        res_model: "res.users.apikeys.description",
+        views: [[false, "form"]],
+        target: "new",
+    }
+});

--- a/addons/api_doc/static/src/components/doc_modal_api_key.js
+++ b/addons/api_doc/static/src/components/doc_modal_api_key.js
@@ -30,4 +30,8 @@ export class ApiKeyModal extends Component {
     cancel() {
         this.env.modelStore.showApiKeyModal = false;
     }
+
+    async openAPIKeyForm() {
+        window.open(`${window.location.origin}/odoo/action-doc_api_key_wizard`, "_blank");
+    }
 }

--- a/addons/api_doc/static/src/components/doc_modal_api_key.xml
+++ b/addons/api_doc/static/src/components/doc_modal_api_key.xml
@@ -3,14 +3,17 @@
 
 <t t-name="web.DocApiKeyModal">
     <div class="modal-bg d-flex flex-nowrap justify-content-center align-items-center">
-        <div class="modal p-3 d-flex flex-nowrap flex-column mb-2" style="height: 14rem; width: 25rem" t-ref="modalRef">
+        <div class="modal h-auto p-3 d-flex flex-nowrap flex-column mb-2" style="width: 25rem" t-ref="modalRef">
             <h2 class="mb-2">API key</h2>
 
-            <p>To try the API, please insert your API key here</p>
+            <p class="mb-1">To try the API, please insert your API key here</p>
+            <a href="#" t-on-click="openAPIKeyForm">Generate a new API key here</a>
             <input
-                class="mt-1"
-                type="text"
+                class="mt-2 w-100"
+                type="password"
+                name="api-key"
                 autocorrect="off"
+                autocomplete="one-time-code"
             />
 
             <div class="d-flex flex-nowrap flex-content-between mt-2">

--- a/addons/api_doc/static/src/doc_client.js
+++ b/addons/api_doc/static/src/doc_client.js
@@ -14,7 +14,7 @@ export class DocClient extends Component {
         DocModel,
         ApiKeyModal,
         SearchModal,
-    };t
+    };
     static props = {};
 
     setup() {


### PR DESCRIPTION
This commit sets the field type of the api key setting as password to hide it from the user.

It also adds a link in the api key dialog to open the api key page in the backend and let the user create an api key more easily.

Task: 5039248

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
