### PR TITLE
[FIX] hr_holidays: add related field on member_of_department

### DIFF
--- a/addons/hr_holidays/report/hr_leave_report_calendar.py
+++ b/addons/hr_holidays/report/hr_leave_report_calendar.py
@@ -37,6 +37,7 @@ class HrLeaveReportCalendar(models.Model):
     is_striked = fields.Boolean('Striked', readonly=True)
 
     is_absent = fields.Boolean(related='employee_id.is_absent')
+    member_of_department = fields.Boolean(related='employee_id.member_of_department')
     leave_manager_id = fields.Many2one(related='employee_id.leave_manager_id')
     leave_id = fields.Many2one(comodel_name='hr.leave', readonly=True, groups='hr_holidays.group_hr_holidays_user')
     is_manager = fields.Boolean("Manager", compute="_compute_is_manager")

--- a/addons/hr_holidays/report/hr_leave_report_calendar.xml
+++ b/addons/hr_holidays/report/hr_leave_report_calendar.xml
@@ -59,7 +59,7 @@
                 <field name="job_id"/>
                 <filter name="my_team" string="My Team" domain="['|', ('employee_id.user_id', '=', uid), ('employee_id.parent_id.user_id', '=', uid)]"/>
                 <filter string="My Department" name="department"
-                        domain="[('employee_id.member_of_department', '=', True)]"
+                        domain="[('member_of_department', '=', True)]"
                         help="My Department"/>
                 <separator/>
                 <filter string="Off Today" name="off_today" domain="[('is_absent', '=', True)]" help="Employees Off Today"/>


### PR DESCRIPTION
Before this commit, the filter `My Department` filter displayed in the `Overview` of Time off app returns an Access Error when the current user has no access to employee app.

This commit adds a related field to do the compute and search on that field in sudo to know if the employees in the Overview are part of the department of the current user.

Steps to reproduce the issue:
============================
1. Install Time off app with demo data
2. Log in as Marc Demo
3. Go to Time Off app > Overview
4. Enable `My Department` filter

Expected Behavior:
-----------------

The gantt view of Time Off Overview should be loaded without any errors.

Current Behavior:
----------------

An Access Error is occurred because the user has not accessed to
`hr.version` model.

runbot-error-233311
