### PR TITLE
[FIX] account: Reverse charge taxes are never price-included

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -1071,7 +1071,9 @@ class AccountTax(models.Model):
                 add_tax_amount_to_results(tax, tax_amount)
 
         def prepare_tax_extra_data(tax, **kwargs):
-            if special_mode == 'total_included':
+            if tax.has_negative_factor:
+                price_include = False
+            elif special_mode == 'total_included':
                 price_include = True
             elif special_mode == 'total_excluded':
                 price_include = False

--- a/addons/account/static/src/helpers/account_tax.js
+++ b/addons/account/static/src/helpers/account_tax.js
@@ -298,7 +298,9 @@ export const accountTaxHelpers = {
 
         function prepare_tax_extra_data(tax, kwargs = {}) {
             let price_include;
-            if (special_mode === "total_included") {
+            if (tax.has_negative_factor) {
+                price_include = false;
+            } else if (special_mode === "total_included") {
                 price_include = true;
             } else if (special_mode === "total_excluded") {
                 price_include = false;

--- a/addons/account/views/account_tax_views.xml
+++ b/addons/account/views/account_tax_views.xml
@@ -186,7 +186,7 @@
                                 <group name="advanced_booleans">
                                     <field name="price_include" invisible="1"/>
                                     <field name="price_include_override"
-                                           invisible="amount_type == 'group'"
+                                           invisible="amount_type == 'group' or has_negative_factor"
                                            placeholder="Default"
                                     />
                                     <field name="include_base_amount" invisible="amount_type == 'group'"/>


### PR DESCRIPTION
After this commit, you no longer can set a custom "price_include_override" on a tax using the UI. Even if you do, the tax engine forces such tax to be price-excluded.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
