### PR TITLE
[FIX] l10n_fr_hr_holidays: missing default reference leave type in setting

### DIFF
--- a/addons/l10n_fr_hr_holidays/data/l10n_fr_hr_holidays_demo.xml
+++ b/addons/l10n_fr_hr_holidays/data/l10n_fr_hr_holidays_demo.xml
@@ -70,7 +70,7 @@
 
     <function model="res.company" name="write">
         <value eval="[ref('base.demo_company_fr')]"/>
-        <value eval="{'l10n_fr_reference_leave_type': [(4, ref('l10n_fr_holiday_status_cl'))]}"/>
+        <value eval="{'l10n_fr_reference_leave_type': ref('l10n_fr_holiday_status_cl')}"/>
     </function>
 
     <function model="res.users" name="write">

--- a/addons/l10n_fr_hr_holidays/views/res_config_settings_views.xml
+++ b/addons/l10n_fr_hr_holidays/views/res_config_settings_views.xml
@@ -13,7 +13,7 @@
                         <field name="l10n_fr_reference_leave_type"
                             class="o_light_label"
                             domain="[('company_id', 'in', [company_id, False])]"
-                            context="{'default_company_id': company_id}"/>
+                            context="{'default_company_id': company_id}" required="company_country_code == 'FR'"/>
                     </setting>
                 </block>
             </block>


### PR DESCRIPTION
**Steps to reproduce:**
- Install l10n_fr_hr_holidays module.
- Go to Time Off > Configuration > Settings.
- Company Paid Time Off field should blank.
- Employee `resource_calendar_id` is not same as company's.
- Create new leave > a validation error will occur.

**Cause:**
- The demo data for 'res.company' did not correctly set the `l10n_fr_reference_leave_type` field.
- 'l10n_fr_reference_leave_type' field should be required.

**Fix:**
- Updated demo record to correctly assign `l10n_fr_reference_leave_type` field.
- Set the `l10n_fr_reference_leave_type` field as required.

Task - 5139488