### PR TITLE
[IMP] l10n_es: remove count_rows usage

### DIFF
--- a/addons/l10n_es/data/mod115.xml
+++ b/addons/l10n_es/data/mod115.xml
@@ -30,15 +30,14 @@
                         <field name="name">[01] Nº of recipients</field>
                         <field name="name@es">[01] Nº de perceptores</field>
                         <field name="code">aeat_mod_115_01</field>
-                        <field name="groupby">partner_id</field>
-                        <field name="foldable" eval="True"/>
                         <field name="expression_ids">
                             <record id="mod_115_casilla_01_balance" model="account.report.expression">
                                 <field name="label">balance</field>
-                                <field name="engine">domain</field>
-                                <field name="formula" eval="['|', '|', '|', ('tax_tag_ids', '=', 'mod115[02]'), ('tax_tag_ids', '=', 'mod115[03]'), ('tax_tag_ids', '=', 'mod115[02]'), ('tax_tag_ids', '=', 'mod115[03]')]"/>
+                                <field name="engine">custom</field>
+                                <field name="formula">_report_custom_engine_number_of_recipients</field>
                                 <field name="subformula">count_rows</field>
                                 <field name="figure_type">integer</field>
+                                <field name="auditable" eval="True"/>
                             </record>
                         </field>
                     </record>


### PR DESCRIPTION
We want to remove all count_rows since it's the only thing that uses next_groupby which will allow us to remove it as an argument from the engines functions.

task-5145246

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
