### PR TITLE
[FIX] sale,stock,purchase,test_sale_product_configurators: fix warning visibility

### DIFF
--- a/addons/purchase/models/account_invoice.py
+++ b/addons/purchase/models/account_invoice.py
@@ -122,6 +122,9 @@ class AccountMove(models.Model):
 
     @api.depends('partner_id.name', 'partner_id.purchase_warn_msg', 'invoice_line_ids.product_id.purchase_line_warn_msg', 'invoice_line_ids.product_id.display_name')
     def _compute_purchase_warning_text(self):
+        if not self.env.user.has_group('purchase.group_warning_purchase'):
+            self.purchase_warning_text = ''
+            return
         for move in self:
             if move.move_type != 'in_invoice':
                 move.purchase_warning_text = ''
@@ -515,7 +518,7 @@ class AccountMoveLine(models.Model):
     is_downpayment = fields.Boolean()
     purchase_line_id = fields.Many2one('purchase.order.line', 'Purchase Order Line', ondelete='set null', index='btree_not_null', copy=False)
     purchase_order_id = fields.Many2one('purchase.order', 'Purchase Order', related='purchase_line_id.order_id', readonly=True)
-    purchase_line_warn_msg = fields.Text(related='product_id.purchase_line_warn_msg')
+    purchase_line_warn_msg = fields.Text(compute='_compute_purchase_line_warn_msg')
 
     def _copy_data_extend_business_fields(self, values):
         # OVERRIDE to copy the 'purchase_line_id' field as well.
@@ -540,3 +543,9 @@ class AccountMoveLine(models.Model):
         if self.purchase_line_id and not self.analytic_distribution:
             vals |= self.purchase_line_id.analytic_distribution or {}
         return vals
+
+    @api.depends('product_id.purchase_line_warn_msg')
+    def _compute_purchase_line_warn_msg(self):
+        has_group = self.env.user.has_group('purchase.group_warning_purchase')
+        for line in self:
+            line.purchase_line_warn_msg = line.product_id.purchase_line_warn_msg if has_group else ""

--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -285,6 +285,9 @@ class PurchaseOrder(models.Model):
 
     @api.depends('partner_id.name', 'partner_id.purchase_warn_msg', 'order_line.purchase_line_warn_msg')
     def _compute_purchase_warning_text(self):
+        if not self.env.user.has_group('purchase.group_warning_purchase'):
+            self.purchase_warning_text = ''
+            return
         for order in self:
             warnings = OrderedSet()
             if partner_msg := order.partner_id.purchase_warn_msg:

--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -84,7 +84,7 @@ class PurchaseOrderLine(models.Model):
     )
     product_template_attribute_value_ids = fields.Many2many(related='product_id.product_template_attribute_value_ids', readonly=True)
     product_no_variant_attribute_value_ids = fields.Many2many('product.template.attribute.value', string='Product attribute values that do not create variants', ondelete='restrict')
-    purchase_line_warn_msg = fields.Text(related='product_id.purchase_line_warn_msg')
+    purchase_line_warn_msg = fields.Text(compute='_compute_purchase_line_warn_msg')
 
     @api.depends('product_qty', 'price_unit', 'tax_ids', 'discount')
     def _compute_amount(self):
@@ -158,6 +158,12 @@ class PurchaseOrderLine(models.Model):
             )
         else:
             return self.invoice_lines
+
+    @api.depends('product_id.purchase_line_warn_msg')
+    def _compute_purchase_line_warn_msg(self):
+        has_warning_group = self.env.user.has_group('purchase.group_warning_purchase')
+        for line in self:
+            line.purchase_line_warn_msg = line.product_id.purchase_line_warn_msg if has_warning_group else ""
 
     @api.depends('product_id', 'product_id.type')
     def _compute_qty_received_method(self):

--- a/addons/purchase/tests/test_purchase.py
+++ b/addons/purchase/tests/test_purchase.py
@@ -902,6 +902,8 @@ class TestPurchase(AccountTestInvoicingCommon):
                 'product_id': product_with_warning2.id,
             },
         ])
+        group_warning_purchase = self.env.ref('purchase.group_warning_purchase')
+        self.env.user.group_ids.implied_ids = [Command.link(group_warning_purchase.id)]
         purchase_order2.button_confirm()
         purchase_order2.action_create_invoice()
         invoice = Form(purchase_order2.invoice_ids[0])
@@ -914,6 +916,13 @@ class TestPurchase(AccountTestInvoicingCommon):
         self.assertEqual(purchase_order.purchase_warning_text, '\n'.join(expected_warnings))
         self.assertEqual(purchase_order2.purchase_warning_text, '\n'.join(expected_warnings_for_purchase_order2))
         self.assertEqual(invoice.purchase_warning_text, '\n'.join(expected_warnings_for_purchase_order2))
+
+        # without warning group, there should be no warning
+        self.env.user.group_ids.implied_ids = [Command.unlink(group_warning_purchase.id)]
+        self.assertEqual(purchase_order.purchase_warning_text, '')
+        self.assertEqual(purchase_order2.purchase_warning_text, '')
+        invoice = Form(purchase_order2.invoice_ids[0])
+        self.assertEqual(invoice.purchase_warning_text, '')
 
     def test_bill_in_purchase_matching_individual(self):
         """

--- a/addons/sale/models/account_move.py
+++ b/addons/sale/models/account_move.py
@@ -50,6 +50,9 @@ class AccountMove(models.Model):
 
     @api.depends('partner_id.name', 'partner_id.sale_warn_msg', 'invoice_line_ids.product_id.sale_line_warn_msg', 'invoice_line_ids.product_id.display_name')
     def _compute_sale_warning_text(self):
+        if not self.env.user.has_group('sale.group_warning_sale'):
+            self.sale_warning_text = ''
+            return
         for move in self:
             if move.move_type != 'out_invoice':
                 move.sale_warning_text = ''

--- a/addons/sale/models/account_move_line.py
+++ b/addons/sale/models/account_move_line.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _, fields, models
+from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 from odoo.tools import float_compare, float_is_zero
 
@@ -14,7 +14,13 @@ class AccountMoveLine(models.Model):
         'sale_order_line_invoice_rel',
         'invoice_line_id', 'order_line_id',
         string='Sales Order Lines', readonly=True, copy=False)
-    sale_line_warn_msg = fields.Text(related='product_id.sale_line_warn_msg')
+    sale_line_warn_msg = fields.Text(compute='_compute_sale_line_warn_msg')
+
+    @api.depends('product_id.sale_line_warn_msg')
+    def _compute_sale_line_warn_msg(self):
+        has_warning_group = self.env.user.has_group('sale.group_warning_sale')
+        for line in self:
+            line.sale_line_warn_msg = line.product_id.sale_line_warn_msg if has_warning_group else ""
 
     def _copy_data_extend_business_fields(self, values):
         # OVERRIDE to copy the 'sale_line_ids' field as well.

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -809,6 +809,9 @@ class SaleOrder(models.Model):
 
     @api.depends('partner_id.name', 'partner_id.sale_warn_msg', 'order_line.sale_line_warn_msg')
     def _compute_sale_warning_text(self):
+        if not self.env.user.has_group('sale.group_warning_sale'):
+            self.sale_warning_text = ''
+            return
         for order in self:
             warnings = OrderedSet()
             if partner_msg := order.partner_id.sale_warn_msg:
@@ -2138,9 +2141,10 @@ class SaleOrder(models.Model):
             **kwargs,
         )
         res = super()._get_product_catalog_order_data(products, **kwargs)
+        has_warning_group = self.env.user.has_group('sale.group_warning_sale')
         for product in products:
             res[product.id]['price'] = pricelist.get(product.id)
-            if product.sale_line_warn_msg:
+            if product.sale_line_warn_msg and has_warning_group:
                 res[product.id]['warning'] = product.sale_line_warn_msg
         return res
 

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -305,7 +305,7 @@ class SaleOrderLine(models.Model):
         related='company_id.tax_calculation_rounding_method',
         string='Tax calculation rounding method', readonly=True)
     company_price_include = fields.Selection(related="company_id.account_price_include")
-    sale_line_warn_msg = fields.Text(related='product_id.sale_line_warn_msg')
+    sale_line_warn_msg = fields.Text(compute='_compute_sale_line_warn_msg')
 
     #=== COMPUTE METHODS ===#
 
@@ -499,6 +499,12 @@ class SaleOrderLine(models.Model):
         for line in self:
             if not line.product_uom_id or (line.product_id.uom_id.id != line.product_uom_id.id):
                 line.product_uom_id = line.product_id.uom_id
+
+    @api.depends('product_id.sale_line_warn_msg')
+    def _compute_sale_line_warn_msg(self):
+        has_warning_group = self.env.user.has_group('sale.group_warning_sale')
+        for line in self:
+            line.sale_line_warn_msg = line.product_id.sale_line_warn_msg if has_warning_group else ""
 
     @api.depends('product_id', 'product_id.uom_id', 'product_id.uom_ids')
     def _compute_allowed_uom_ids(self):

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -721,6 +721,8 @@ class TestSaleOrder(SaleCommon):
             },
         ])
 
+        group_warning_sale = self.env.ref('sale.group_warning_sale')
+        self.group_user.implied_ids = [Command.link(group_warning_sale.id)]
         sale_order2.action_confirm()
         sale_order2._create_invoices()
         invoice = Form(sale_order2.invoice_ids[0])
@@ -734,6 +736,13 @@ class TestSaleOrder(SaleCommon):
         self.assertEqual(sale_order.sale_warning_text, '\n'.join(expected_warnings))
         self.assertEqual(sale_order2.sale_warning_text, '\n'.join(expected_warnings_for_sale_order2))
         self.assertEqual(invoice.sale_warning_text, '\n'.join(expected_warnings_for_sale_order2))
+
+        # without warning group, there should be no warning
+        self.group_user.implied_ids = [Command.unlink(group_warning_sale.id)]
+        self.assertEqual(sale_order.sale_warning_text, '')
+        self.assertEqual(sale_order2.sale_warning_text, '')
+        invoice = Form(sale_order2.invoice_ids[0])
+        self.assertEqual(invoice.sale_warning_text, '')
 
     def test_sale_order_unit_price_recompute_on_product_change(self):
         """Ensure price_unit is correctly recomputed when the product is

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -994,6 +994,9 @@ class StockPicking(models.Model):
 
     @api.depends('partner_id.name', 'partner_id.parent_id.name')
     def _compute_picking_warning_text(self):
+        if not self.env.user.has_group('stock.group_warning_stock'):
+            self.picking_warning_text = ''
+            return
         for picking in self:
             text = ''
             if partner_msg := picking.partner_id.picking_warn_msg:

--- a/addons/test_sale_product_configurators/tests/test_sale_product_configurator.py
+++ b/addons/test_sale_product_configurators/tests/test_sale_product_configurator.py
@@ -190,6 +190,8 @@ class TestProductConfiguratorUi(HttpCase, TestProductConfiguratorCommon):
                 (6, 0, [office_chair.product_tmpl_id.id, self.product_product_conf_chair.id])
             ]
         })
+
+        self.salesman.group_ids += self.env.ref('sale.group_warning_sale')
         self.product_product_conf_chair.sale_line_warn_msg = 'sold'
         self.product_product_custo_desk.optional_product_ids = [
             (4, self.product_product_conf_chair.id)


### PR DESCRIPTION
    
Step to reproduce:
- install purchase
- go to setting -> (enable) warning
- create a new products and add purchase warning
- now disable the warning from setting
- create a PO with that product

Observation:
- warning is visible, even though we disabled the setting

Cause:
- After commit [1] , once a warning is set on a product, it is displayed on
document regardless of the warning setting.

[1]:https://github.com/odoo/odoo/commit/1e13520ca9bb18deba85110ce9362ac2adb55904

Fix:
- Fix the computes of warning message to run only,
when the warning setting is enabled
    
opw-5156107



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
