### PR TITLE
[I18N] l10n_ec: Correct typo in latam Spanish for identification type

### DIFF
--- a/addons/l10n_ec/i18n/es_419.po
+++ b/addons/l10n_ec/i18n/es_419.po
@@ -1489,7 +1489,7 @@ msgstr ""
 #. module: l10n_ec
 #: model:l10n_latam.identification.type,description:l10n_ec.ec_ruc
 msgid "Single Taxpayer Registration"
-msgstr "Registre Unico de Contribuyente"
+msgstr "Registro Unico de Contribuyente"
 
 #. module: l10n_ec
 #: model:account.report.line,name:l10n_ec.tax_report_line_parent_line_report_239


### PR DESCRIPTION
opw-5018450