### PR TITLE
[IMP] mail: move offlineMembers to channel model

### DIFF
--- a/addons/mail/static/src/discuss/core/common/channel_member_list.js
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.js
@@ -34,7 +34,7 @@ export class ChannelMemberList extends Component {
 
     get offlineSectionText() {
         return _t("Offline - %(offline_count)s", {
-            offline_count: this.props.thread.offlineMembers.length,
+            offline_count: this.props.thread.channel.offlineMembers.length,
         });
     }
 

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.xml
@@ -12,12 +12,12 @@
                     <t t-foreach="props.thread.onlineMembers" t-as="member" t-key="member.id" t-call="discuss.channel_member"/>
                 </div>
             </t>
-            <t name="offlineMembers" t-if="props.thread.offlineMembers.length > 0">
+            <t name="offlineMembers" t-if="props.thread.channel.offlineMembers.length > 0">
                 <t t-call="discuss.ChannelMemberList.section">
                     <t t-set="sectionName" t-value="offlineSectionText"/>
                 </t>
                 <div class="d-flex flex-column bg-inherit gap-1">
-                    <t t-foreach="props.thread.offlineMembers" t-as="member" t-key="member.id" t-call="discuss.channel_member">
+                    <t t-foreach="props.thread.channel.offlineMembers" t-as="member" t-key="member.id" t-call="discuss.channel_member">
                         <t t-set="offline" t-value="1"/>
                     </t>
                 </div>

--- a/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
@@ -14,6 +14,19 @@ export class DiscussChannel extends Record {
             }
         },
     });
+    offlineMembers = fields.Many("discuss.channel.member", {
+        compute() {
+            return this._computeOfflineMembers().sort(
+                (m1, m2) => this.store.sortMembers(m1, m2) // FIXME: sort are prone to infinite loop (see test "Display livechat custom name in typing status")
+            );
+        },
+    });
+    /** @returns {import("models").ChannelMember[]} */
+    _computeOfflineMembers() {
+        return this.channel_member_ids.filter(
+            (member) => !this.store.onlineMemberStatuses.includes(member.im_status)
+        );
+    }
     thread = fields.One("mail.thread", {
         compute() {
             return { id: this.id, model: "discuss.channel" };

--- a/addons/mail/static/src/discuss/core/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_model_patch.js
@@ -198,13 +198,6 @@ const threadPatch = {
                     .sort((m1, m2) => this.store.sortMembers(m1, m2)); // FIXME: sort are prone to infinite loop (see test "Display livechat custom name in typing status")
             },
         });
-        this.offlineMembers = fields.Many("discuss.channel.member", {
-            compute() {
-                return this._computeOfflineMembers().sort(
-                    (m1, m2) => this.store.sortMembers(m1, m2) // FIXME: sort are prone to infinite loop (see test "Display livechat custom name in typing status")
-                );
-            },
-        });
         this.otherTypingMembers = fields.Many("discuss.channel.member", {
             /** @this {import("models").Thread} */
             compute() {
@@ -229,12 +222,6 @@ const threadPatch = {
             },
         });
         this.typingMembers = fields.Many("discuss.channel.member", { inverse: "threadAsTyping" });
-    },
-    /** @returns {import("models").ChannelMember[]} */
-    _computeOfflineMembers() {
-        return this.channel?.channel_member_ids.filter(
-            (member) => !this.store.onlineMemberStatuses.includes(member.im_status)
-        );
     },
     get areAllMembersLoaded() {
         return this.member_count === this.channel?.channel_member_ids.length;


### PR DESCRIPTION
This commit move the offlineMembers field to discuss.channel model.

PR enterprise: https://github.com/odoo/enterprise/pull/97089