### PR TITLE
[IMP] web: preload Odoo UI icons font on the frontend just like the FA

### DIFF
--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -41,6 +41,7 @@
       </xpath>
       <xpath expr="//head/link[last()]" position="after">
         <t t-call-assets="web.fontawesome" t-binary="True"/>
+        <t t-call-assets="web.odoo_ui_icons" t-binary="True"/>
         <t t-call-assets="web.assets_frontend" t-js="false"/>
       </xpath>
       <xpath expr="//head/script[@id='web.layout.odooscript']" position="after">


### PR DESCRIPTION
Commit [1] improved the loading and preloading of the FontAwesome font, increasing its cache time to 1 year and allowing to invalidate it directly when changed, for the frontend (a follow-up is being made for the rest).

In the process of improving the page speed score and hopefully slightly increase performance as well, this commit now forces the preload of the Odoo UI icons font (with the same system). Indeed, commit [1] already improved the caching system of that font too but the font was previously not preloaded.

Note that preloading FontAwesome is done since [2], a long time ago (not sure Odoo UI icons already existed at the time). Adding preload for Odoo UI icons was not very relevant before because the frontend does not use those much and they cannot be used by website users. However, this became less true: it is more and more used in frontend layouts and it is now used to patch some FontAwesome icons (e.g. twitter -> X), see [3].

[1]: https://github.com/odoo/odoo/commit/a5c02da5c24bfc85b3bbb7d1410d489d3c7185b8
[2]: https://github.com/odoo/odoo/commit/f25b0aae39fd3a92c2f22f146eaffedfd6a4db9c
[3]: https://github.com/odoo/odoo/commit/23ffe210a3307db3d0dd642744a9e13cab732222

Related to task-5046274
