### PR TITLE
[FIX] l10n_ro_edi: Use state for bank instead of state_id

### DIFF
--- a/addons/l10n_ro_edi/models/account_edi_xml_ubl_ciusro.py
+++ b/addons/l10n_ro_edi/models/account_edi_xml_ubl_ciusro.py
@@ -43,11 +43,16 @@ class AccountEdiXmlUbl_Ro(models.AbstractModel):
         address_node = super()._get_address_node(vals)
         partner = vals['partner']
 
-        if partner.state_id:
-            address_node['cbc:CountrySubentity']['_text'] = partner.country_code + '-' + partner.state_id.code
+        if partner._name == 'res.bank':
+            state = partner.state
+        else:
+            state = partner.state_id
+
+        if state:
+            address_node['cbc:CountrySubentity']['_text'] = partner.country_code + '-' + state.code
 
             # Romania requires the CityName to be in the format of "SECTORX" if the address state is in Bucharest.
-            if partner.state_id.code == 'B' and partner.city:
+            if state.code == 'B' and partner.city:
                 address_node['cbc:CityName']['_text'] = get_formatted_sector_ro(partner.city)
 
         return address_node

--- a/addons/l10n_ro_edi/tests/test_xml_ubl_ro.py
+++ b/addons/l10n_ro_edi/tests/test_xml_ubl_ro.py
@@ -154,10 +154,20 @@ class TestUBLRO(TestUBLCommon):
             'street': "Strada Kunst, 3",
         })
 
+        cls.bank = cls.env['res.bank'].create({
+            'name': 'Banca Trimitere EDI Global',
+            'country': cls.env.ref('base.ro').id,
+            'state': cls.env.ref('base.RO_CJ').id,
+            'city': 'Cluj-Napoca',
+            'zip': '400000',
+            'street': 'Strada Global EDI Test',
+        })
+
         cls.env['res.partner.bank'].create({
             'acc_type': 'iban',
             'partner_id': cls.company_data['company'].partner_id.id,
             'acc_number': 'RO98RNCB1234567890123456',
+            'bank_id': cls.bank.id,
         })
 
         cls.partner_a = cls.env['res.partner'].create({


### PR DESCRIPTION
Issue:
When setting up a payment reference and linking a bank to an invoice, sending an E-Factura (SPV) triggers an exception: state_id not defined for res.bank.

Repro Steps:
  1- Create invoice for romanian localization.
  2- Link payment account to invoice.
  3- Add bank to payment account.
  4- Confirm and send invoice with "Send E-Factura SPV" checked.
  Video:
    https://drive.google.com/file/d/1rweJgknjbKrpouJRTQ2cluKHsIXNZtSz/view?usp=drive_link

Cause:
The state field is defined differently for res.bank and res.partner. res.partner uses state_id, while res.bank uses state. The code that retrieves addresses assumes the same field for both, leading to an exception when accessing state for res.bank.

Fix:
The fix checks the type of the input and selects the appropriate field (state or state_id) accordingly.

Test:
Linked the bank in the test suite. The test fails without this fix, confirming the issue is resolved.

opw-5099816

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
