### PR TITLE
[FIX] hr_contract: show unusual days of the past

### DIFF
--- a/addons/hr_contract/models/hr_employee.py
+++ b/addons/hr_contract/models/hr_employee.py
@@ -204,7 +204,7 @@ class Employee(models.Model):
         if not employee_contracts:
             return super()._get_unusual_days(date_from, date_to)
 
-        selected_contracts = employee_contracts.filtered(lambda c: c.state == 'open')
+        selected_contracts = employee_contracts.filtered(lambda c: c.state in ('open', 'close'))
 
         if not selected_contracts:
             selected_contracts = max(employee_contracts, key=lambda c: (c.create_date, c.id))


### PR DESCRIPTION
Since changes made in https://github.com/odoo/odoo/pull/212959, we don't see anymore the week-end and banck holidays before the start date of your current contract.

As the goal of the initial commit was to prevent to use the contracts in state 'new', we add the contracts 'exppired' that are contracts of the past that really give information of the working hours.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
