### PR TITLE
[FIX] account: Use payment reference instead of customer one

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5949,7 +5949,7 @@ class AccountMove(models.Model):
             # No eligible method could be found; we can't generate the QR-code
             return None
 
-        unstruct_ref = self.ref if self.ref else self.name
+        unstruct_ref = self.payment_reference or self.name
         rslt = self.partner_bank_id.build_qr_code_base64(self.amount_residual, unstruct_ref, self.payment_reference, self.currency_id, self.partner_id, qr_code_method, silent_errors=silent_errors)
 
         # We only set qr_code_method after generating the url; otherwise, it

--- a/addons/l10n_ch/report/swissqr_report.py
+++ b/addons/l10n_ch/report/swissqr_report.py
@@ -11,7 +11,7 @@ class ReportSwissQR(models.AbstractModel):
 
         qr_code_urls = {}
         for invoice in docs:
-            qr_code_urls[invoice.id] = invoice.partner_bank_id.build_qr_code_base64(invoice.amount_residual, invoice.ref or invoice.name, invoice.payment_reference, invoice.currency_id, invoice.partner_id, qr_method='ch_qr', silent_errors=False)
+            qr_code_urls[invoice.id] = invoice.partner_bank_id.build_qr_code_base64(invoice.amount_residual, invoice.payment_reference or invoice.name, invoice.payment_reference, invoice.currency_id, invoice.partner_id, qr_method='ch_qr', silent_errors=False)
 
         return {
             'doc_ids': docids,


### PR DESCRIPTION
The aim of this commit is replacing the usage of
customer reference for the free communication
in EPC SEPA QR Code for the payment reference.

task-5122875

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
