### PR TITLE
[FIX] website_sale: performance issue ProductVariantPreview

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -372,6 +372,7 @@
     </template>
 
     <template id="product_variant_preview">
+        <!-- If gap-1 is changed make sure to update the margin in product_variant_preview.js -->
         <div
             t-attf-class="o_wsale_attribute_previewer d-flex align-items-center gap-1 flex-nowrap overflow-hidden {{
                 'show_on_hover' if product_ptavs[0]['ptav'].attribute_id.preview_variants == 'hover' and layout_mode != 'list' else ''


### PR DESCRIPTION
Description
=======

This commit aims to reduce performance issues related to the `ProductVariantPreview` interaction. Editing the `/shop` page with the **"Products Design"** option caused severe slowdowns and noticeable lag.

🧩 Problem
=======

`ProductVariantPreview` uses `offsetWidth` to calculate the container size for variants and the size of the circles representing them. This is needed to determine how many variants can be displayed based on available space.

Every call to `offsetWidth` after a DOM change (for example, adding a class) triggers a layout recalculation, which is expensive
(around **6–7 ms** per call). The cost grows quickly since each `ProductVariantPreview` instance performs this for every circle, resulting in dozens or hundreds of layout recalculations.

💡 Solution
=======

1. The variant previewer was changed to target the entirety product grid instead of each single variant previewer, reducing the number of interactions per page to only 1.

2. Batch layout recalculations using `requestAnimationFrame`, given that now all container sizes are computed at the same time.

This reduces the total to just **two layout recalculations**.

🔁 How to reproduce
=======

1. Go to `/shop` with several visible products with many variants.
2. Switch to **edit mode**.
3. Preview the **"Products Design"** option (hover over elements).

Before this commit:
=======
- The UI was extremely slow and laggy.
- A single preview took **700 ms+**.
- Performance degraded with more products and variants.

After this commit:
=======
- The interface is **much faster**.
- Worst-case preview time is around **120 ms**.
- The number of variants no longer impacts performance.

Additional PRs related to `html_editor` and `html_builder` are in
progress and should further reduce the duration by **30–40 ms**.