### PR TITLE
[FIX] base_import: support multiple import templates

### DIFF
--- a/addons/base_import/static/src/import_action/import_action.xml
+++ b/addons/base_import/static/src/import_action/import_action.xml
@@ -50,8 +50,8 @@
                             Excel files are recommended as formatting is automatic.
                         </p>
                         <div class="mt16 mb4">Need Help?</div>
-                        <div t-foreach="importTemplates" t-as="template" t-key="template">
-                            <a class="btn btn-outline-primary mb32 mt8" t-att-href="template.template" aria-label="Download" data-tooltip="Download">
+                        <div t-foreach="importTemplates" t-as="template" t-key="template.template">
+                            <a class="btn btn-outline-primary mb8 mt8" t-att-href="template.template" aria-label="Download" data-tooltip="Download">
                                 <i class="fa fa-download"/> <span><t t-esc="template.label"/></span>
                             </a>
                         </div>

--- a/addons/base_import/static/tests/import_action_tests.js
+++ b/addons/base_import/static/tests/import_action_tests.js
@@ -315,6 +315,7 @@ QUnit.module("Base Import Tests", (hooks) => {
 
     QUnit.test("Import view: UI before file upload", async function (assert) {
         const templateURL = "/myTemplateURL.xlsx";
+        const secondTemplateURL = "/mySecondTemplateURL.xlsx";
 
         await createImportAction({
             "partner/get_import_templates": (route, args) => {
@@ -324,6 +325,10 @@ QUnit.module("Base Import Tests", (hooks) => {
                         label: "Some Import Template",
                         template: templateURL,
                     },
+                    {
+                        label: "Another Import Template",
+                        template: secondTemplateURL,
+                    }
                 ]);
             },
             "base_import.import/create": (route, args) => {
@@ -334,13 +339,27 @@ QUnit.module("Base Import Tests", (hooks) => {
 
         assert.containsOnce(target, ".o_import_action", "import view is displayed");
         assert.strictEqual(
-            target.querySelector(".o_nocontent_help .btn-outline-primary").textContent,
+            target.querySelectorAll(".o_nocontent_help .btn-outline-primary").length,
+            2,
+            "there are two import template buttons"
+        )
+        assert.strictEqual(
+            target.querySelectorAll(".o_nocontent_help .btn-outline-primary")[0].textContent,
             " Some Import Template"
         );
         assert.strictEqual(
-            target.querySelector(".o_nocontent_help .btn-outline-primary").href,
+            target.querySelectorAll(".o_nocontent_help .btn-outline-primary")[0].href,
             window.location.origin + templateURL,
-            "button has the right download url"
+            "1st button has the right download url"
+        );
+        assert.strictEqual(
+            target.querySelectorAll(".o_nocontent_help .btn-outline-primary")[1].textContent,
+            " Another Import Template"
+        );
+        assert.strictEqual(
+            target.querySelectorAll(".o_nocontent_help .btn-outline-primary")[1].href,
+            window.location.origin + secondTemplateURL,
+            "2nd button has the right download url"
         );
         assert.verifySteps(["partner/get_import_templates", "base_import.import/create"]);
         // Contains invisible mobile buttons


### PR DESCRIPTION
Import templates are defined on models to allow developpers to provide
sample import files to users. These templates are fetched by the client
as an array of objects of the form {label: string, template: string},
where label is the label to display and template the URL of the file.

The iteration on `importTemplates` goes through this list, and if more
than one element is present in it, the t-key for both elements will be
the same (`[[object Object]]`), leading to a crash of the client
action's template.

This commit uses the 'template' url as the key, as it should be unique
(the label is less trustworthy, as it is translatable).

It also slightly changes the styling, as having an mb32 between multiple
buttons looked rather bad.