### PR TITLE
[FIX] mail: fix 'discard on pressing escape' test

### DIFF
--- a/addons/mail/static/tests/discuss_app/inbox.test.js
+++ b/addons/mail/static/tests/discuss_app/inbox.test.js
@@ -86,6 +86,7 @@ test("reply: discard on pressing escape", async () => {
     await contains(".o-mail-Composer-suggestionList .o-open", { count: 0 });
     await contains(".o-mail-Composer");
     await click(".o-mail-Composer-input").catch(() => {});
+    await contains(".o-mail-Composer.o-focused");
     triggerHotkey("Escape");
     await contains(".o-mail-Composer", { count: 0 });
 });


### PR DESCRIPTION
Before this commit, test "discard on pressing escape" failed non-deterministically with the following error:

```
Failed to find 0 of ".o-mail-Composer" (Timeout of 3 seconds). Found 1 instead.
```

This happens at the very last step of the test: we click on composer of message to have the focus, so that we can then press ESCAPE and discard the editing of message and thus remove the composer.

The issue happens because while we click on composer, we don't await the composer being logically focused, which is necessary for the good working of the ESCAPE feature to discard the message editing.

This commit fixes the issue by awaiting the composer is logically focused after click on composer, so that pressing ESCAPE is properly expected to cancel the editing and thus remove the composer.

Fix runbot-error-233394