### PR TITLE
[FIX] hr: adapt company domain

### DIFF
--- a/addons/hr/models/hr_export_mixin.py
+++ b/addons/hr/models/hr_export_mixin.py
@@ -27,7 +27,7 @@ class HrExportMixin(models.AbstractModel):
     def _get_company_domain(self):
         domain = Domain('id', 'in', self.env.companies.ids)
         if restriction := self._country_restriction():
-            domain &= Domain('country_id.code', '=', restriction)
+            domain &= Domain('partner_id.country_id.code', '=', restriction)
         return domain
 
     period_start = fields.Date('Period Start', compute='_compute_period_dates', store=True, readonly=False)


### PR DESCRIPTION
As the country_id field on the company is computed and not searcheable, this commit adapts the domain to search for the country of the associated partner.

task-5096037

X-original-commit: 64fa9e4

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
