### PR TITLE
[FIX] account: right company values in gateway failed email

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -6160,9 +6160,14 @@ class AccountMove(models.Model):
     def _routing_check_route(self, message, message_dict, route, raise_exception=True):
         if route[0] == 'account.move' and len(message_dict['attachments']) < 1:
             # Don't create the move if no attachment.
+            company_id = route[2].get('company_id', self.env.company.id)
+            if not isinstance(company_id, int):
+                raise ValueError(_("Default value for 'company_id' for %(record)s is not an integer",
+                                  record=route[4]))
+            journal_alias_company = self.env['res.company'].search([['id', '=', company_id]])
             body = self.env['ir.qweb']._render('account.email_template_mail_gateway_failed', {
-                'company_email': self.env.company.email,
-                'company_name': self.env.company.name,
+                'company_email': journal_alias_company.email or self.env.company.email,
+                'company_name': journal_alias_company.name or self.env.company.name,
             })
             self._routing_create_bounce_email(
                 message_dict['from'], body, message,


### PR DESCRIPTION
A bounce email was introduced in https://github.com/odoo/odoo/pull/168506 , i.e. if an email without an attachment is sent to an incoming email alias for a journal, it will be bounced with an corresponding email template.

But as is, the usage of `'company_email': self.env.company.email` and `'company_name': self.env.company.name` will default to the "main" company (id 1 usually), as during the message routing, that will be the default company in `env`.

This means, that if you have an journal email alias in company B, the email will still render the information of the main company A.

## Proposed fix:

When a journal email alias is created in a standard way, it should have a key:value pair for 'company_id' in the `alias_defaults` field.

We change the routing check logic so that it will try to fetch that value, while defaulting to the main company if there is no explicit company `company_id` key.

This should ensure that the mail gateway failed email renders preferentially renders the company information of the company the mail alias (and accounting journal) belongs to.

OPW-5132806

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
