### PR TITLE
[FIX] website_sale: Correct class for card layout

### DIFF
--- a/addons/website_sale/views/product_tile_templates.xml
+++ b/addons/website_sale/views/product_tile_templates.xml
@@ -39,7 +39,7 @@
     </t>
 
     <form
-        t-attf-class="oe_product_cart d-flex {{ptavs_classes}}"
+        t-attf-class="oe_product_cart h-100 d-flex {{ptavs_classes}}"
         t-att-data-publish="product.website_published and 'on' or 'off'"
         role="article"
         t-att-aria-label="product.name"


### PR DESCRIPTION
**Issue:**
The issue occurs when selecting the card layout on the website shop page — the height of all cards changes. In version 18.4, it worked as expected, but in version 19.0, one class "h-100" was missing, which caused the issue.

**Solution:**
I have added the class "h-100" again to fix the problem.

**Steps to Reproduce:**

Create a demo database.

Install the website_sale module.

Go to the Shop page and click Edit.

Select the Card Layout option.

The issue can also be reproduced on the runbot.

**Before Fix:**
<img width="1151" height="811" alt="Before" src="https://github.com/user-attachments/assets/0e20dfb6-0ae7-4372-ac6a-c960b77700eb" />

**After Fix**

<img width="1176" height="649" alt="After_fix" src="https://github.com/user-attachments/assets/e5209bb0-ded8-40e9-ac16-21e5514a72b2" />

[OPW:5150748](https://www.odoo.com/odoo/project/70/tasks/5150748?debug=1)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
