### PR TITLE
[FIX] website_hr_recruitment: allow portal users to filter jobs by department

### DIFF
--- a/addons/website_hr_recruitment/security/ir.model.access.csv
+++ b/addons/website_hr_recruitment/security/ir.model.access.csv
@@ -3,3 +3,4 @@ access_hr_job_public_public,hr.job.public,hr.model_hr_job,base.group_public,1,0,
 access_hr_job_public_portal,hr.job.public,hr.model_hr_job,base.group_portal,1,0,0,0
 access_hr_job_public_employee,hr.job.public,hr.model_hr_job,base.group_user,1,0,0,0
 access_hr_department_public,hr.department.public,hr.model_hr_department,base.group_public,1,0,0,0
+access_hr_department_portal,hr.department.public,hr.model_hr_department,base.group_portal,1,0,0,0


### PR DESCRIPTION
## Issue:
Filtering by Department on the Jobs page as a Portal user raised a Forbidden Error

## Cause:
Portal users lacked access rights on hr.department, even though public users have it

## Steps to reproduce:
You need a portal user and a published job position in a department (you can use demo data)
- Open the Website > Jobs page as Admin
- Edit > Customize > Enable Department filter > Save
- Login with Portal User
- Access the jobs page and set a Department filter

opw-4948838