### PR TITLE
[FIX] partner_autocomplete: show placeholder in res_partner_many2one widget

### DIFF
--- a/addons/partner_autocomplete/static/src/xml/partner_autocomplete.xml
+++ b/addons/partner_autocomplete/static/src/xml/partner_autocomplete.xml
@@ -47,7 +47,7 @@
                 onSelect.bind="onSelect"
                 onChange.bind="onChange"
                 input="inputRef"
-                placeholder="placeholder || ''"
+                placeholder="props.placeholder || ''"
             />
         </xpath>
     </t>


### PR DESCRIPTION
**Issue:**
Fields using the res_partner_many2one widget with a placeholder do not display the placeholder text.

**Steps to reproduce:**
1. Install `contacts` module
2. Go to Contacts
3. Create new 'Individual' contact
4. Notice just below the name, Related Company field placeholder is not visible.

**Cause:**
Props are not passed correctly in PartnerAutoComplete component

**Solution:**
Use the correct prop reference (props.placeholder) when passing the placeholder to the PartnerAutoComplete component, ensuring it is properly rendered.

opw-5153125