### PR TITLE
[FIX] l10n_in: wrong default timezone in company working schedule

### DIFF
--- a/addons/l10n_in/models/company.py
+++ b/addons/l10n_in/models/company.py
@@ -30,3 +30,9 @@ class ResCompany(models.Model):
     def action_update_state_as_per_gstin(self):
         self.ensure_one()
         self.partner_id.action_update_state_as_per_gstin()
+
+    def _prepare_resource_calendar_values(self):
+        vals = super()._prepare_resource_calendar_values()
+        if self.country_id and self.country_id.code == 'IN':
+            vals['tz'] = 'Asia/Kolkata'
+        return vals


### PR DESCRIPTION
steps to reproduce:
- Install l10n_in_hr_payroll module.
- Open Payroll/Employee > Configuration > Working Schedule for the Indian
  company.
- 'Standard 40 hours/week' shows timezone as Europe/Brussels.

cause:
- The '_prepare_resource_calendar_values' method in res.company did not set a
timezone, and default value (Europe/Brussels) is set.

fix:
- Inherit '_prepare_resource_calendar_values' to set the timezone to
Asia/Kolkata for companies with country code 'IN'.

task - 5156782