### PR TITLE
[IMP] html_editor, web, website: export color picker tabs

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/color_picker_theme_tab.js
+++ b/addons/html_builder/static/src/core/building_blocks/color_picker_theme_tab.js
@@ -2,7 +2,7 @@ import { Component } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-class ColorPickerThemeTab extends Component {
+export class ColorPickerThemeTab extends Component {
     static template = "html_builder.ColorPickerThemeTab";
     static props = {
         onColorClick: Function,

--- a/addons/html_editor/static/src/main/font/color_picker_gradient_tab.js
+++ b/addons/html_editor/static/src/main/font/color_picker_gradient_tab.js
@@ -15,7 +15,7 @@ const DEFAULT_GRADIENT_COLORS = [
     "linear-gradient(135deg, rgb(255, 222, 202) 0%, rgb(202, 115, 69) 100%)",
 ];
 
-class ColorPickerGradientTab extends Component {
+export class ColorPickerGradientTab extends Component {
     static template = "html_editor.ColorPickerGradientTab";
     static components = { GradientPicker };
     static props = {

--- a/addons/web/static/src/core/color_picker/tabs/color_picker_custom_tab.js
+++ b/addons/web/static/src/core/color_picker/tabs/color_picker_custom_tab.js
@@ -4,7 +4,7 @@ import { registry } from "@web/core/registry";
 import { isColorGradient } from "@web/core/utils/colors";
 import { CustomColorPicker } from "../custom_color_picker/custom_color_picker";
 
-class ColorPickerCustomTab extends Component {
+export class ColorPickerCustomTab extends Component {
     static template = "web.ColorPickerCustomTab";
     static components = { CustomColorPicker };
     static props = {

--- a/addons/web/static/src/core/color_picker/tabs/color_picker_solid_tab.js
+++ b/addons/web/static/src/core/color_picker/tabs/color_picker_solid_tab.js
@@ -2,7 +2,7 @@ import { Component } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-class ColorPickerSolidTab extends Component {
+export class ColorPickerSolidTab extends Component {
     static template = "web.ColorPickerSolidTab";
     static props = {
         colorPickerNavigation: Function,


### PR DESCRIPTION
Since the [1] color picker tabs are plugable, and so, in order to be able to patch them, we'd need to export them. This commit exports them all at once.

[1]: https://github.com/odoo/odoo/commit/edc9d5bb9582db704ed02051ee4adb3801ddfaa9