### PR TITLE
[FIX] orm: fix hierarchy operators with parent_path

### DIFF
--- a/odoo/addons/test_new_api/security/ir.model.access.csv
+++ b/odoo/addons/test_new_api/security/ir.model.access.csv
@@ -1,5 +1,5 @@
 "id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
-access_category,test_new_api_category,test_new_api.model_test_new_api_category,base.group_system,1,1,1,1
+access_category,test_new_api_category,test_new_api.model_test_new_api_category,base.group_user,1,1,1,1
 access_decimal_precision_test_all,decimal.precision.test,model_decimal_precision_test,base.group_system,1,1,1,1
 access_discussion,test_new_api_discussion,test_new_api.model_test_new_api_discussion,base.group_user,1,1,1,1
 access_message,test_new_api_message,test_new_api.model_test_new_api_message,base.group_user,1,1,1,1

--- a/odoo/addons/test_new_api/tests/test_new_fields.py
+++ b/odoo/addons/test_new_api/tests/test_new_fields.py
@@ -3921,10 +3921,11 @@ class TestMagicFields(TransactionCase):
         self.assertTrue(field.store)
 
 
-class TestParentStore(TransactionCase):
+class TestParentStore(TransactionCaseWithUserDemo):
 
-    def setUp(self):
-        super(TestParentStore, self).setUp()
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
         # make a tree of categories:
         #   0
         #  /|\
@@ -3933,7 +3934,7 @@ class TestParentStore(TransactionCase):
         #   4 5 6
         #      /|\
         #     7 8 9
-        Cat = self.env['test_new_api.category']
+        Cat = cls.env['test_new_api.category']
         cat0 = Cat.create({'name': '0'})
         cat1 = Cat.create({'name': '1', 'parent': cat0.id})
         cat2 = Cat.create({'name': '2', 'parent': cat0.id})
@@ -3944,8 +3945,8 @@ class TestParentStore(TransactionCase):
         cat7 = Cat.create({'name': '7', 'parent': cat6.id})
         cat8 = Cat.create({'name': '8', 'parent': cat6.id})
         cat9 = Cat.create({'name': '9', 'parent': cat6.id})
-        self._cats = Cat.concat(cat0, cat1, cat2, cat3, cat4,
-                                cat5, cat6, cat7, cat8, cat9)
+        cls._cats = Cat.concat(cat0, cat1, cat2, cat3, cat4,
+                               cat5, cat6, cat7, cat8, cat9)
 
     def cats(self, *indexes):
         """ Return the given categories. """
@@ -3983,7 +3984,6 @@ class TestParentStore(TransactionCase):
 
     def test_base_compute(self):
         """ Check the tree structure after computation from scratch. """
-        self.cats()._parent_store_compute()
         self.assertChildOf(self.cats(0), self.cats(0, 1, 2, 3, 4, 5, 6, 7, 8, 9))
         self.assertChildOf(self.cats(1), self.cats(1))
         self.assertChildOf(self.cats(2), self.cats(2))
@@ -4099,10 +4099,45 @@ class TestParentStore(TransactionCase):
         self.assertEqual(self.cats(8).depth, 2)
         self.assertEqual(self.cats(9).depth, 2)
 
+        # warmup
+        self.cats().create({'name': 'warmup'})
         # add a new node: one query to INSERT, one query to UPDATE parent_path
         with self.assertQueryCount(2):
             cat = self.cats().create({'name': '10', 'parent': self.cats(6).id})
             self.assertEqual(cat.depth, 2)
+
+    def test_with_ir_rule_behavior(self):
+        self.env['ir.rule'].create({
+            'name': 'category rule',
+            'model_id': self.env['ir.model']._get('test_new_api.category').id,
+            'domain_force': str([('id', 'in', self.cats(3).ids)]),
+        })
+
+        # Ensure that we don't have access to inaccessible records
+        self.assertEqual(
+            self.cats().with_user(self.user_demo).search([('id', 'child_of', self.cats(3).ids)]),
+            self.cats(3),
+        )
+        self.assertEqual(
+            self.cats().with_user(self.user_demo).search([('id', 'parent_of', self.cats(3).ids)]),
+            self.cats(3),
+        )
+
+        Dis = self.env['test_new_api.discussion'].with_user(self.user_demo)
+        dis_0, dis_3, dis_5, dis_7 = Dis.create([
+            {'name': 'A', 'categories': self.cats(0)},
+            {'name': 'B', 'categories': self.cats(3)},
+            {'name': 'C', 'categories': self.cats(5)},
+            {'name': 'D', 'categories': self.cats(7)},
+        ])
+        self.assertEqual(
+            Dis.search([('categories', 'child_of', self.cats(3).ids)]),
+            dis_3 + dis_5 + dis_7,
+        )
+        self.assertEqual(
+            Dis.search([('categories', 'parent_of', self.cats(3).ids)]),
+            dis_0 + dis_3,
+        )
 
 
 class TestRequiredMany2one(TransactionCase):

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -1371,7 +1371,7 @@ def _operator_hierarchy(condition, model):
     if isinstance(result, Domain):
         if field.name == 'id':
             return result
-        return DomainCondition(field.name, 'any', result)
+        return DomainCondition(field.name, 'in', comodel_sudo._search(result))
     return DomainCondition(field.name, 'in', result)
 
 


### PR DESCRIPTION
We introduced a regression in https://github.com/odoo/odoo/pull/170009 for 'child_of'/'parent_of' operators on relational fields: With a domain leaf like `[('X2X', 'child_of', ids)]` where the X2X comodel has `_parent_store=True`, we don't take into account inaccessible children from the current user. That's incorrect, and we already fixed this behavior in ae038904face6766d93695dcaa9b07346d05282a, but the test added targeted 'res.partner' which has `_parent_store=False`.

Fix it by using a `_search()` on the sudoed comodel instead of the 'any' operator. In 19.0 we should use 'any!' operator instead.
