### PR TITLE
[IMP] mass_mailing(_sms): add mailing preview with desktop/mobile modes

### DIFF
--- a/addons/mass_mailing/__manifest__.py
+++ b/addons/mass_mailing/__manifest__.py
@@ -146,6 +146,8 @@
             'mass_mailing/static/src/xml/mailing_portal_subscription_form.xml',
         ],
         'web.assets_backend': [
+            'mass_mailing/static/src/components/**/*',
+            'mass_mailing/static/src/views/mailing_preview_form_view.js',
             'mass_mailing/static/src/editor/**/*',
             'mass_mailing/static/src/fields/**/*',
             'mass_mailing/static/src/themes/*',

--- a/addons/mass_mailing/models/mailing_list.py
+++ b/addons/mass_mailing/models/mailing_list.py
@@ -2,7 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from markupsafe import Markup
-from random import randint
 
 from odoo import _, api, Command, fields, models, tools
 from odoo.exceptions import UserError

--- a/addons/mass_mailing/models/mailing_trace.py
+++ b/addons/mass_mailing/models/mailing_trace.py
@@ -132,6 +132,12 @@ class MailingTrace(models.Model):
                 values['mail_mail_id_int'] = values['mail_mail_id']
         return super().create(vals_list)
 
+    def action_retry_failed(self):
+        traces = self.filtered(lambda t: t.trace_status in ("error", "cancel", "bounce"))
+        if not traces:
+            return
+        traces.mass_mailing_id.action_retry_failed([("mailing_trace_ids", "in", traces.ids)])
+
     def action_view_contact(self):
         self.ensure_one()
         return {

--- a/addons/mass_mailing/static/src/components/mailing_preview_iframe/mailing_preview_iframe.js
+++ b/addons/mass_mailing/static/src/components/mailing_preview_iframe/mailing_preview_iframe.js
@@ -1,0 +1,112 @@
+import { registry } from "@web/core/registry";
+import { useBus, useService } from "@web/core/utils/hooks";
+import { renderToFragment } from "@web/core/utils/render";
+import { isBrowserSafari } from "@web/core/browser/feature_detection";
+import { useThrottleForAnimation } from "@web/core/utils/timing";
+import { standardFieldProps } from "@web/views/fields/standard_field_props";
+import { Component, onMounted, status, useState, useEffect, useRef } from "@odoo/owl";
+
+export class MailingPreviewIframe extends Component {
+    static template = "mass_mailing.MailingPreviewIframe";
+    static props = {
+        ...standardFieldProps,
+    };
+
+    setup() {
+        this.state = useState(this.env.displayState);
+        this.ui = useService("ui");
+        this.iframeRef = useRef("iframeRef");
+        this.iframeLoaded = Promise.withResolvers();
+
+        onMounted(() => {
+            if (this.iframeRef.el.contentDocument?.readyState === "complete") {
+                this.onIframeLoaded();
+            } else {
+                this.iframeRef.el.addEventListener("load", () => this.onIframeLoaded(), {
+                    once: true,
+                });
+            }
+        });
+
+        useEffect(
+            () => {
+                this.iframeLoaded.promise.then(() => {
+                    this.iframeRef.el?.contentDocument.body.replaceChildren(
+                        this.renderBodyContent()
+                    );
+                });
+            },
+            () => [this.props.record.data.preview_record_ref]
+        );
+
+        useEffect(
+            () => {
+                this.iframeLoaded.promise.then(() => {
+                    this.throttledResize();
+                });
+            },
+            () => [this.state.isMobileMode]
+        );
+
+        useBus(this.ui.bus, "resize", () => {
+            this.iframeLoaded.promise.then(() => {
+                this.throttledResize();
+            });
+        });
+
+        const updateIframeSize = () => {
+            const iframe = this.iframeRef.el;
+            if (this.state.isMobileMode) {
+                // same styling for mobile as we have in 'mass_mailing_iframe'
+                iframe.style.width = "367px";
+                iframe.style.height = "668px";
+                iframe.style.transform = "";
+                iframe.contentDocument.body.scrollTop = 0;
+            } else {
+                iframe.style.width = "140%";
+                iframe.style.height = "140%";
+                iframe.style.transform = `scale(${10 / 14})`;
+                iframe.style.transformOrigin = "top left"
+            }
+        };
+
+        this.throttledResize = useThrottleForAnimation(() => {
+            if (status(this) === "destroyed") {
+                return;
+            }
+            updateIframeSize();
+        });
+    }
+
+    renderHeadContent() {
+        return renderToFragment("mass_mailing.IframeHead", this);
+    }
+
+    renderBodyContent() {
+        return renderToFragment("mass_mailing.MailingPreviewIframeBody", this);
+    }
+
+    onIframeLoaded() {
+        if (status(this) === "destroyed") {
+            return;
+        }
+        this.iframeRef.el?.contentDocument.head.appendChild(this.renderHeadContent());
+        this.iframeRef.el?.contentDocument.body.appendChild(this.renderBodyContent());
+        this.iframeLoaded.resolve();
+    }
+
+    get isBrowserSafari() {
+        return isBrowserSafari();
+    }
+}
+
+export const mailingPreviewIframe = {
+    component: MailingPreviewIframe,
+    supportedTypes: ["html"],
+};
+
+/**
+ * Note: This field does not support switching to another record (e.g. navigation in a standard form view).
+ * It is designed for use in wizards where the record remains constant.
+ */
+registry.category("fields").add("mailing_preview_iframe", mailingPreviewIframe);

--- a/addons/mass_mailing/static/src/components/mailing_preview_iframe/mailing_preview_iframe.xml
+++ b/addons/mass_mailing/static/src/components/mailing_preview_iframe/mailing_preview_iframe.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<templates xml:space="preserve">
+
+    <t t-name="mass_mailing.MailingPreviewIframe">
+        <div class="o_mass_mailing_iframe_wrapper">
+            <div t-att-class="{'o_is_mobile': state.isMobileMode}"
+                 t-attf-style="overflow: hidden;#{!state.isMobileMode? 'height:60vh;' : ''}">
+                <iframe t-ref="iframeRef" t-att-sandbox="this.isBrowserSafari ? 'allow-same-origin allow-scripts' : 'allow-same-origin'"/>
+            </div>
+        </div>
+    </t>
+
+    <t t-name="mass_mailing.MailingPreviewIframeBody">
+        <div style="pointer-events: none;">
+            <t t-out="props.record.data.body_html"/>
+        </div>
+    </t>
+
+</templates>

--- a/addons/mass_mailing/static/src/components/mailing_preview_mode_toggle/mailing_preview_mode_toggle.js
+++ b/addons/mass_mailing/static/src/components/mailing_preview_mode_toggle/mailing_preview_mode_toggle.js
@@ -1,0 +1,26 @@
+import { registry } from "@web/core/registry";
+import { standardWidgetProps } from "@web/views/widgets/standard_widget_props";
+import { Component, useState } from "@odoo/owl";
+
+export class MailingPreviewDisplayModeToggle extends Component {
+    static template = "mass_mailing.MailingPreviewModeToggle";
+    static props = {
+        ...standardWidgetProps,
+    };
+
+    setup() {
+        this.state = useState(this.env.displayState);
+    }
+
+    onTogglePreviewMode(isMobileMode) {
+        this.state.isMobileMode = isMobileMode;
+    }
+}
+
+export const mailingPreviewDisplayModeToggle = {
+    component: MailingPreviewDisplayModeToggle,
+};
+
+registry
+    .category("view_widgets")
+    .add("mailing_preview_display_mode_toggle", mailingPreviewDisplayModeToggle);

--- a/addons/mass_mailing/static/src/components/mailing_preview_mode_toggle/mailing_preview_mode_toggle.xml
+++ b/addons/mass_mailing/static/src/components/mailing_preview_mode_toggle/mailing_preview_mode_toggle.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+
+    <t t-name="mass_mailing.MailingPreviewModeToggle">
+        <div class="d-flex gap-1" t-if="!state.isSmall">
+            <button type="button" class="btn py-0 px-1" t-on-click="() => this.onTogglePreviewMode(false)"
+                    t-att-class="!state.isMobileMode? 'btn-primary' : 'btn-secondary'">
+                <i class="fa fa-desktop" title="Desktop Preview"/>
+            </button>
+            <button type="button" class="btn py-0 px-2" t-on-click="() => this.onTogglePreviewMode(true)"
+                    t-att-class="state.isMobileMode? 'btn-primary' : 'btn-secondary'">
+                <i class="fa fa-lg fa-mobile" title="Mobile Preview"/>
+            </button>
+        </div>
+    </t>
+
+</templates>

--- a/addons/mass_mailing/static/src/views/mailing_preview_form_view.js
+++ b/addons/mass_mailing/static/src/views/mailing_preview_form_view.js
@@ -1,0 +1,30 @@
+import { registry } from "@web/core/registry";
+import { formView } from "@web/views/form/form_view";
+import { useBus, useService } from "@web/core/utils/hooks";
+import { reactive, useSubEnv } from "@odoo/owl";
+import { FormController } from "@web/views/form/form_controller";
+
+class MailingPreviewFormController extends FormController {
+    setup() {
+        super.setup();
+        this.ui = useService("ui");
+        const displayState = reactive({
+            isMobileMode: this.ui.isSmall,
+            isSmall: this.ui.isSmall,
+        });
+
+        useSubEnv({ displayState });
+
+        useBus(this.ui.bus, "resize", () => {
+            displayState.isSmall = this.ui.isSmall;
+            if (displayState.isSmall) {
+                displayState.isMobileMode = true;
+            }
+        });
+    }
+}
+
+registry.category("views").add("mailing_preview_form_view", {
+    ...formView,
+    Controller: MailingPreviewFormController,
+});

--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -71,19 +71,54 @@
                         <button name="action_retry_failed" type="object" invisible="state != 'done' or failed == 0" string="Retry" data-hotkey="y"/>
                         <button name="action_duplicate" type="object" class="btn-secondary" string="Duplicate"
                             data-hotkey="d" invisible="state != 'done'"/>
-                        <button name="action_test" type="object" class="btn-secondary" string="Test" data-hotkey="k"/>
+                        <button name="action_preview" type="object" class="btn-secondary" string="Preview &amp; Test" data-hotkey="k" invisible="is_body_empty"/>
                         <button name="action_cancel" type="object" invisible="state != 'in_queue'" class="btn-secondary" string="Cancel" data-hotkey="x"/>
                         <field name="state" readonly="1" widget="statusbar" statusbar_visible="draft,in_queue,sending,done"/>
                     </header>
                     <div class="alert alert-info o_mass_mailing_alert_message" role="alert"
                             invisible="state not in ['in_queue', 'done'] and sent == 0 and canceled == 0 and scheduled == 0 and failed == 0 and not warning_message">
+                        <div class="o_mails_in_queue" invisible="state != 'in_queue'">
+                            <strong invisible="next_departure_is_past or schedule_type == 'now'">
+                                <span name="next_departure_text">This mailing is scheduled for </span>
+                                <field name="next_departure" class="oe_inline"/>.
+                            </strong>
+                            <strong invisible="not next_departure_is_past or schedule_type == 'now'" class="d-flex align-items-center">
+                                <field name="next_departure_is_past" invisible="1"/>
+                                <span name="refresh_text">This mailing will be sent as soon as possible.</span>
+                                <button name="action_reload" type="object" class="btn btn-link pe-0">
+                                    <u>Refresh <i class="fa fa-refresh ms-1"/></u>
+                                </button>
+                            </strong>
+                            <strong invisible="schedule_type != 'now'" class="d-flex align-items-center">
+                                <field name="next_departure_is_past" invisible="1"/>
+                                <field name="schedule_type" invisible="1"/>
+                                <span name="mailing_schedule_type_now_text">This mailing will be sent as soon as possible.</span>
+                                <button name="action_reload" type="object" class="btn btn-link pe-0">
+                                    <u>Refresh <i class="fa fa-refresh ms-1"/></u>
+                                </button>
+                            </strong>
+                        </div>
+
+                        <div class="o_mails_sent" invisible="sent == 0 and state in ('draft', 'test', 'in_queue')">
+                            <button class="btn btn-link p-0"
+                                    name="action_view_traces_sent"
+                                    type="object">
+                                <strong>
+                                    <field name="sent" class="oe_inline me-2"/>
+                                    <span name="sent">emails have been sent.</span>
+                                </strong>
+                            </button>
+                            <strong class="d-block" invisible="mailing_type == 'mail' or not ab_testing_enabled or state != 'done' or sent != 0 or failed != 0 or canceled != 0">
+                                <span name="ab_test_text">There wasn't enough recipients given to this mailing. </span>
+                            </strong>
+                        </div>
                         <div class="o_mails_canceled" invisible="canceled == 0">
                             <button class="btn btn-link p-0"
                                     name="action_view_traces_canceled"
                                     type="object">
                                 <strong>
                                     <field name="canceled" class="oe_inline me-2"/>
-                                    <span name="canceled_text">emails have been cancelled and will not be sent.</span>
+                                    <span name="canceled_text">emails have been cancelled.</span>
                                 </strong>
                             </button>
                         </div>
@@ -107,51 +142,17 @@
                                 </strong>
                             </button>
                         </div>
-                        <div class="o_mails_sent" invisible="sent == 0 and state in ('draft', 'test', 'in_queue')">
-                            <button class="btn btn-link p-0"
-                                    name="action_view_traces_sent"
-                                    type="object">
-                                <strong>
-                                    <field name="sent" class="oe_inline me-2"/>
-                                    <span name="sent">emails have been sent.</span>
-                                </strong>
-                            </button>
-                            <strong class="d-block" invisible="mailing_type == 'mail' or not ab_testing_enabled or state != 'done' or sent != 0 or failed != 0 or canceled != 0">
-                                <span name="ab_test_text">There wasn't enough recipients given to this mailing. </span>
-                            </strong>
-                        </div>
                         <div class="o_mails_failed" invisible="state != 'done' or failed == 0">
                             <button class="btn btn-link p-0"
                                     name="action_view_traces_failed"
                                     type="object">
                                 <strong>
                                     <field name="failed" class="oe_inline me-2"/>
-                                    <span name="failed_text">emails could not be sent.</span>
+                                    <span name="failed_text">emails failed.</span>
                             </strong>
                             </button>
                         </div>
 
-                        <div class="o_mails_in_queue" invisible="state != 'in_queue'">
-                            <strong invisible="next_departure_is_past or schedule_type == 'now'">
-                                <span name="next_departure_text">This mailing is scheduled for </span>
-                                <field name="next_departure" class="oe_inline"/>.
-                            </strong>
-                            <strong invisible="not next_departure_is_past or schedule_type == 'now'" class="d-flex align-items-center">
-                                <field name="next_departure_is_past" invisible="1"/>
-                                <span name="refresh_text">This mailing will be sent as soon as possible.</span>
-                                <button name="action_reload" type="object" class="btn btn-link pe-0">
-                                    <u>Refresh <i class="fa fa-refresh ms-1"/></u>
-                                </button>
-                            </strong>
-                            <strong invisible="schedule_type != 'now'" class="d-flex align-items-center">
-                                <field name="next_departure_is_past" invisible="1"/>
-                                <field name="schedule_type" invisible="1"/>
-                                <span name="mailing_schedule_type_now_text">This mailing will be sent as soon as possible.</span>
-                                <button name="action_reload" type="object" class="btn btn-link pe-0">
-                                    <u>Refresh <i class="fa fa-refresh ms-1"/></u>
-                                </button>
-                            </strong>
-                        </div>
                         <div invisible="not warning_message">
                             <strong><field name="warning_message"/></strong>
                         </div>
@@ -322,7 +323,7 @@
                                         <field class="o_text_overflow" name="preview" string="Preview Text"
                                             options="{'dynamic_placeholder': true, 'dynamic_placeholder_model_reference_field': 'mailing_model_real'}"
                                             readonly="state in ('sending', 'done')"
-                                            widget="char_emojis" placeholder="e.g. Check it out before it's too late!"/>
+                                            widget="char_emojis" placeholder="This text will appear in inboxes, next to the subject"/>
                                         <field name="email_from" readonly="state in ('sending', 'done')"/>
                                         <label for="reply_to"/>
                                         <div name="reply_to_details">

--- a/addons/mass_mailing/views/mailing_trace_views.xml
+++ b/addons/mass_mailing/views/mailing_trace_views.xml
@@ -19,7 +19,7 @@
                 <filter string="Opened" name="filter_opened" domain="[('trace_status', 'in', ['open', 'reply'])]"/>
                 <filter string="Replied" name="filter_replied" domain="[('trace_status', '=', 'reply')]"/>
                 <filter string="Bounced" name="filter_bounced" domain="[('trace_status', '=', 'bounce')]"/>
-                <filter string="Failed" name="filter_failed" domain="[('trace_status', '=', 'error')]"/>
+                <filter string="Exception" name="filter_error" domain="[('trace_status', '=', 'error')]"/>
                 <filter string="Test Traces" name="filter_is_test_trace" domain="[('is_test_trace', '=', True)]"/>
                 <group>
                     <filter string="State" name="state" domain="[]" context="{'group_by': 'trace_status'}"/>
@@ -59,7 +59,12 @@
         <field name="priority">20</field>
         <field name="arch" type="xml">
             <list string="Mail Traces" create="0">
+                <header>
+                    <button name="action_retry_failed" string="Retry" type="object"/>
+                </header>
                 <field name="mass_mailing_id"/>
+                <field name="model" column_invisible="True"/>
+                <field name="res_id" string="Recipient" widget="many2one_reference" options="{'no_open': True}"/>
                 <field name="email"/>
                 <field name="message_id" optional="hide"/>
                 <field name="sent_datetime"/>

--- a/addons/mass_mailing/wizard/mailing_mailing_test_views.xml
+++ b/addons/mass_mailing/wizard/mailing_mailing_test_views.xml
@@ -1,30 +1,47 @@
 <?xml version="1.0"?>
 <odoo>
 
-        <record model="ir.ui.view" id="view_mail_mass_mailing_test_form">
-            <field name="name">mailing.mailing.test.form</field>
-            <field name="model">mailing.mailing.test</field>
-            <field name="arch" type="xml">
-                <form string="Send a Sample Mail">
-                    <p class="text-muted">
-                        Send a sample mailing for testing purpose to the address below.
-                    </p>
+    <record model="ir.ui.view" id="view_mail_mass_mailing_test_form">
+        <field name="name">mailing.mailing.test.form</field>
+        <field name="model">mailing.mailing.test</field>
+        <field name="arch" type="xml">
+            <form string="Preview &amp; Test" js_class="mailing_preview_form_view">
+                <sheet>
                     <group>
-                        <field name="email_to" placeholder="email1@example.com&#10;email2@example.com"/>
+                        <field name="email_from"/>
+                        <label for="subject" string="Subject"/>
+                        <div class="d-flex">
+                            <field name="subject" class="w-auto me-1 fw-bold"/>
+                            <field name="preview_text" class="text-muted w-auto"/>
+                        </div>
+                        <field name="reply_to"/>
                     </group>
-                    <footer>
-                        <button string="Send test" name="send_mail_test" type="object" class="btn-primary" data-hotkey="q"/>
-                        <button class="btn-secondary" special="cancel" data-hotkey="x"/>
-                    </footer>
-                </form>
-            </field>
-        </record>
+                    <div class="row">
+                        <div class="col-12 col-lg-8 d-flex align-items-center gap-2">
+                            <label for="email_to" string="Send a copy to" class="text-nowrap"/>
+                            <field name="email_to" widget="char" class="border p-1 m-0 w-50"
+                                placeholder="email1@example.com, email2@example.com"/>
+                            <button name="send_mail_test" type="object" string="Send Test" class="btn-secondary text-nowrap"/>
+                        </div>
+                        <div class="col-12 col-lg-4 d-flex align-items-center justify-content-end gap-2">
+                            <widget name="mailing_preview_display_mode_toggle"/>
+                            <field name="preview_record_ref" nolabel="1" class="w-100"
+                                   options="{'hide_model': True, 'no_create': True, 'no_open': True}"
+                                   widget="mail_preview_record_field"/>
+                        </div>
+                    </div>
+                    <field name="body_html" class="w-100" widget="mailing_preview_iframe"/>
+                </sheet>
+                <footer/>
+            </form>
+        </field>
+    </record>
 
-        <record id="action_mail_mass_mailing_test" model="ir.actions.act_window">
-            <field name="name">Mailing Test</field>
-            <field name="res_model">mailing.mailing.test</field>
-            <field name="view_mode">form</field>
-            <field name="target">new</field>
-        </record>
+    <record id="action_mail_mass_mailing_test" model="ir.actions.act_window">
+        <field name="name">Mailing Test</field>
+        <field name="res_model">mailing.mailing.test</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
 
 </odoo>

--- a/addons/mass_mailing_sms/models/mailing_mailing.py
+++ b/addons/mass_mailing_sms/models/mailing_mailing.py
@@ -104,11 +104,11 @@ class MailingMailing(models.Model):
     # BUSINESS / VIEWS ACTIONS
     # --------------------------------------------------
 
-    def action_retry_failed(self):
+    def action_retry_failed(self, extra_domain=None):
         mass_sms = self.filtered(lambda m: m.mailing_type == 'sms')
         if mass_sms:
             mass_sms.action_retry_failed_sms()
-        return super(MailingMailing, self - mass_sms).action_retry_failed()
+        return super(MailingMailing, self - mass_sms).action_retry_failed(extra_domain=extra_domain)
 
     def action_retry_failed_sms(self):
         failed_sms = self.env['sms.sms'].sudo().search([

--- a/addons/test_mass_mailing/models/mailing_models.py
+++ b/addons/test_mass_mailing/models/mailing_models.py
@@ -53,6 +53,7 @@ class MailingTestBlacklist(models.Model):
     _inherit = ['mail.thread.blacklist']
     _order = 'name ASC, id DESC'
     _primary_email = 'email_from'
+    _mailing_enabled = True
 
     name = fields.Char()
     email_from = fields.Char()

--- a/addons/test_mass_mailing/tests/test_mailing.py
+++ b/addons/test_mass_mailing/tests/test_mailing.py
@@ -142,7 +142,7 @@ class TestMassMailing(TestMassMailCommon):
         self.assertEqual(recipients[1].message_bounce, 0)
         self.gateway_mail_trace_bounce(mailing, recipients[1])
         mailing.invalidate_recordset()
-        self.assertMailingStatistics(mailing, expected=5, delivered=4, sent=5, opened=1, clicked=1, bounced=1)
+        self.assertMailingStatistics(mailing, expected=5, delivered=4, sent=5, opened=1, clicked=1, bounced=1, failed=1)
         self.assertEqual(recipients[1].message_bounce, 1)
         self.assertMailTraces([{
             'email': 'test.record.01@test.example.com',

--- a/addons/test_mass_mailing/tests/test_mailing_statistics.py
+++ b/addons/test_mass_mailing/tests/test_mailing_statistics.py
@@ -58,7 +58,8 @@ class TestMailingStatistics(TestMassMailCommon):
         self.assertEqual(mailing.clicked, 3)
         self.assertEqual(mailing.clicks_ratio, 30)
         self.assertEqual(mailing.delivered, 10)
-        self.assertEqual(mailing.failed, 1)
+        # failed = 1 error + 1 bounce
+        self.assertEqual(mailing.failed, 2)
         self.assertEqual(mailing.opened, 4)
         self.assertEqual(mailing.opened_ratio, 40)
         self.assertEqual(mailing.replied, 3)


### PR DESCRIPTION
This commit introduces several improvements:
- Clarifies KPIs to improve readability.
- Adds a new `Retry` button to manually resend only selected failed mails
  instead of retrying all failed mails.
- Introduces a mailing preview with rendered fields and with desktop/mobile
  view modes. This helps to validate final layout before sending.

task-4898430
