### PR TITLE
[FIX] product: prevent deletion of combo choices linked to products

### DIFF
--- a/addons/product/models/product_combo.py
+++ b/addons/product/models/product_combo.py
@@ -77,3 +77,10 @@ class ProductCombo(models.Model):
         templates = self.env['product.template'].sudo().search([('combo_ids', 'in', self.ids)])
         templates._check_company(fnames=['combo_ids'])
         self.combo_item_ids._check_company(fnames=['product_id'])
+
+    @api.ondelete(at_uninstall=False)
+    def _unlink_product_combo(self):
+        templates = self.env['product.template'].search([('combo_ids', 'in', self.ids)])
+        if templates:
+            products = ", ".join(templates.mapped('name'))
+            raise ValidationError(_("You can't delete combo choice(s) as it is used in the following products: %(products)s", products=products))

--- a/addons/product/tests/test_product_combo.py
+++ b/addons/product/tests/test_product_combo.py
@@ -146,3 +146,13 @@ class TestProductCombo(ProductCommon):
             combo_in_company_a.write({
                 'company_id': False,
             })
+
+    def test_unlink_combo_choices(self):
+        combo = self.env['product.combo'].create({
+            'name': "Test combo",
+            'combo_item_ids': [Command.create({'product_id': self.product.id})],
+        })
+        self._create_product(type='combo', combo_ids=[Command.link(combo.id)])
+
+        with self.assertRaises(ValidationError):
+            combo.unlink()


### PR DESCRIPTION
When combo choices associated with products are deleted and
the user attempts to load sample data in the Furniture PoS, a traceback occurs.

Steps to reproduce the error:
- Install ``point_of_sale`` module without demo data
- Go to Point of Sale > Click on Furniture > Open Register > Load Sample > Close register
- Go to Point of Sale > Products > Combo choices > Delete all combo choices
- Go to Settings > Restrict Categories > Unset all categories > Save
- Go to Point of Sale > Dashboard > Furniture > Open Register > Load Sample

Traceback:
```py
ParseError: while parsing /home/odoo/src/odoo/19.0/addons/product/data/product_demo.xml:905
A combo product must contain at least 1 combo choice.
```

https://github.com/odoo/odoo/blob/c81e50d3b8f0ffc0297c97b06afd77e2c92ad508/addons/point_of_sale/models/pos_config.py#L1025
When clicking Load Sample button in the Furniture PoS,
the ``_load_onboarding_furniture_demo_data`` method loads the ``data/product_demo.xml`` file.
If the combo choices linked to products have been deleted,
loading the following record triggers the above traceback.

https://github.com/odoo/odoo/blob/c81e50d3b8f0ffc0297c97b06afd77e2c92ad508/addons/product/data/product_demo.xml#L664-L671

Solution:
Restrict deletion of combo choices if they are linked to any products.

sentry-6943167929

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
