### PR TITLE
[FIX] account: compute journal items when line_ids added via Studio

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -741,7 +741,8 @@ class AccountPayment(models.Model):
                 if k in self._fields and self._fields[k].store and k in pay.move_id._fields and pay.move_id._fields[k].store:
                     to_write[k] = v
 
-            if 'line_ids' not in vals_list[i]:
+            # Check if line_ids is empty or not provided
+            if not vals_list[i].get('line_ids'):
                 to_write['line_ids'] = [
                     Command.create(line_vals)
                     for line_vals in pay._prepare_move_line_default_vals(


### PR DESCRIPTION
**Steps to reproduce:**
1. Install the Accounting and Studio modules.
2. Create a payment in draft state.
3. Add the `line_ids` field to the payment form view using Studio.
4. Save the payment.

**Observed behavior:**
* A journal entry was created, but its journal items (`line_ids`) were not computed.
* The payment stayed in draft with empty journal items.
* The normal flow (without the field added) worked correctly.

**Cause:**
* The create method only checked whether `line_ids` was missing from `vals`. When Studio adds the field to the form, it appears in `vals` even when empty. As a result, the condition failed and journal items were not generated.

**Fix:**
* Check both if `line_ids` is missing and if it is empty.
* Always compute journal items when none are explicitly provided.
* Keep existing behavior for custom journal item creation.

opw-5030072
