### PR TITLE
[FIX] html_editor,...: improve perf with setAttribute

### DIFF
--- a/addons/html_builder/static/src/core/builder_content_editable_plugin.js
+++ b/addons/html_builder/static/src/core/builder_content_editable_plugin.js
@@ -1,4 +1,5 @@
 import { Plugin } from "@html_editor/plugin";
+import { setAttribute } from "@html_editor/utils/dom";
 import { registry } from "@web/core/registry";
 
 export class BuilderContentEditablePlugin extends Plugin {
@@ -20,7 +21,7 @@ export class BuilderContentEditablePlugin extends Plugin {
     };
 
     setup() {
-        this.editable.setAttribute("contenteditable", false);
+        setAttribute(this.editable, "contenteditable", "false");
     }
 
     filterContentEditable(contentEditableEls) {

--- a/addons/html_editor/static/src/core/content_editable_plugin.js
+++ b/addons/html_editor/static/src/core/content_editable_plugin.js
@@ -1,5 +1,6 @@
 import { isArtificialVoidElement } from "@html_editor/core/selection_plugin";
 import { Plugin } from "@html_editor/plugin";
+import { setAttribute } from "@html_editor/utils/dom";
 import { selectElements } from "@html_editor/utils/dom_traversal";
 import { withSequence } from "@html_editor/utils/resource";
 
@@ -22,7 +23,7 @@ export class ContentEditablePlugin extends Plugin {
         const toDisableSelector = this.getResource("force_not_editable_selector").join(",");
         const toDisableEls = toDisableSelector ? [...selectElements(root, toDisableSelector)] : [];
         for (const toDisable of toDisableEls) {
-            toDisable.setAttribute("contenteditable", "false");
+            setAttribute(toDisable, "contenteditable", "false");
         }
         const toEnableSelector = this.getResource("force_editable_selector").join(",");
         let filteredContentEditableEls = toEnableSelector
@@ -48,7 +49,7 @@ export class ContentEditablePlugin extends Plugin {
                     continue;
                 }
                 if (!contentEditableEl.matches(toDisableSelector)) {
-                    contentEditableEl.setAttribute("contenteditable", true);
+                    setAttribute(contentEditableEl, "contenteditable", "true");
                 }
             }
         }

--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -7,6 +7,7 @@ import {
     makeContentsInline,
     removeClass,
     removeStyle,
+    setAttribute,
     splitTextNode,
     unwrapContents,
     wrapInlinesInBlocks,
@@ -498,7 +499,7 @@ export class DomPlugin extends Plugin {
                 continue;
             }
             if (attr.name !== "class" || ignoredClasses.size === 0) {
-                target.setAttribute(attr.name, attr.value);
+                setAttribute(target, attr.name, attr.value);
             } else {
                 const classes = [...source.classList];
                 for (const className of classes) {

--- a/addons/html_editor/static/src/core/history_plugin.js
+++ b/addons/html_editor/static/src/core/history_plugin.js
@@ -4,7 +4,7 @@ import { childNodes, descendants, getCommonAncestor } from "../utils/dom_travers
 import { hasTouch } from "@web/core/browser/feature_detection";
 import { withSequence } from "@html_editor/utils/resource";
 import { Deferred } from "@web/core/utils/concurrency";
-import { toggleClass } from "@html_editor/utils/dom";
+import { setAttribute, toggleClass } from "@html_editor/utils/dom";
 import { omit, pick } from "@web/core/utils/objects";
 import { trackOccurrences, trackOccurrencesPair } from "../utils/tracking";
 
@@ -1551,6 +1551,7 @@ export class HistoryPlugin extends Plugin {
                 await revertOperation();
                 const def = new Deferred();
                 const revertSavePoint = this.makeSavePoint();
+                this.stageSelection();
                 revertOperation = async () => {
                     await def;
                     revertSavePoint();
@@ -1682,7 +1683,7 @@ export class HistoryPlugin extends Plugin {
 
         // if attributeValue is falsy but not null, we still need to apply it
         if (attributeValue !== null) {
-            node.setAttribute(attributeName, attributeValue);
+            setAttribute(node, attributeName, attributeValue);
         } else {
             node.removeAttribute(attributeName);
         }
@@ -1803,7 +1804,7 @@ export class HistoryPlugin extends Plugin {
             }
 
             for (const node of this._onKeyupResetContenteditableNodes) {
-                node.setAttribute("contenteditable", false);
+                setAttribute(node, "contenteditable", "false");
             }
         }
     }
@@ -1814,7 +1815,7 @@ export class HistoryPlugin extends Plugin {
             this._onKeyupResetContenteditableNodes.length
         ) {
             for (const node of this._onKeyupResetContenteditableNodes) {
-                node.setAttribute("contenteditable", true);
+                setAttribute(node, "contenteditable", "true");
             }
             this._onKeyupResetContenteditableNodes = [];
         }

--- a/addons/html_editor/static/src/core/protected_node_plugin.js
+++ b/addons/html_editor/static/src/core/protected_node_plugin.js
@@ -1,3 +1,4 @@
+import { setAttribute } from "@html_editor/utils/dom";
 import { Plugin } from "../plugin";
 import { isProtecting, isUnprotecting } from "../utils/dom_info";
 import { childNodes } from "../utils/dom_traversal";
@@ -171,10 +172,10 @@ export class ProtectedNodePlugin extends Plugin {
         // functions of the editor are allowed to work (and how) in that
         // editable part (none?) => should be enforced.
         if (protecting) {
-            elem.setAttribute("contenteditable", "false");
+            setAttribute(elem, "contenteditable", "false");
             this.protectDescendants(elem);
         } else {
-            elem.setAttribute("contenteditable", "true");
+            setAttribute(elem, "contenteditable", "true");
             this.unProtectDescendants(elem);
         }
     }

--- a/addons/html_editor/static/src/core/sanitize_plugin.js
+++ b/addons/html_editor/static/src/core/sanitize_plugin.js
@@ -1,5 +1,6 @@
 import { selectElements } from "@html_editor/utils/dom_traversal";
 import { Plugin } from "../plugin";
+import { setAttribute } from "@html_editor/utils/dom";
 
 /**
  * @typedef { Object } SanitizeShared
@@ -43,10 +44,10 @@ export class SanitizePlugin extends Plugin {
             el.contentEditable = el.matches(".o-contenteditable-true");
         }
         for (const el of selectElements(element, "[data-oe-role]")) {
-            el.setAttribute("role", el.dataset.oeRole);
+            setAttribute(el, "role", el.dataset.oeRole);
         }
         for (const el of selectElements(element, "[data-oe-aria-label]")) {
-            el.setAttribute("aria-label", el.dataset.oeAriaLabel);
+            setAttribute(el, "aria-label", el.dataset.oeAriaLabel);
         }
     }
 

--- a/addons/html_editor/static/src/main/hint_plugin.js
+++ b/addons/html_editor/static/src/main/hint_plugin.js
@@ -1,6 +1,6 @@
 import { Plugin } from "@html_editor/plugin";
 import { isEmptyBlock, isProtected } from "@html_editor/utils/dom_info";
-import { removeClass } from "@html_editor/utils/dom";
+import { removeClass, setAttribute } from "@html_editor/utils/dom";
 import { selectElements } from "@html_editor/utils/dom_traversal";
 import { closestBlock } from "../utils/blocks";
 
@@ -69,7 +69,7 @@ export class HintPlugin extends Plugin {
 
     makeHint(el, text) {
         this.dispatchTo("make_hint_handlers", el);
-        el.setAttribute("o-we-hint-text", text);
+        setAttribute(el, "o-we-hint-text", text);
         el.classList.add("o-we-hint");
     }
 

--- a/addons/html_editor/static/src/main/media/media_plugin.js
+++ b/addons/html_editor/static/src/main/media/media_plugin.js
@@ -17,6 +17,7 @@ import { withSequence } from "@html_editor/utils/resource";
 import { closestElement } from "@html_editor/utils/dom_traversal";
 import { fuzzyLookup } from "@web/core/utils/search";
 import { FORMATTABLE_TAGS } from "@html_editor/utils/formatting";
+import { setAttribute } from "@html_editor/utils/dom";
 
 /**
  * @typedef { Object } MediaShared
@@ -134,10 +135,12 @@ export class MediaPlugin extends Plugin {
             if (isProtected(el) || isProtecting(el)) {
                 continue;
             }
-            el.setAttribute(
+            setAttribute(
+                el,
                 "contenteditable",
                 el.hasAttribute("contenteditable") ? el.getAttribute("contenteditable") : "false"
             );
+
             // Do not update the text if it's already OK to avoid recording a
             // mutation on Firefox. (Chrome filters them out.)
             if (isIconElement(el) && el.textContent !== "\u200B") {

--- a/addons/html_editor/static/src/utils/dom.js
+++ b/addons/html_editor/static/src/utils/dom.js
@@ -321,3 +321,16 @@ export function fixNonEditableFirstChild(editable, node, baseContainerNodeName) 
         node.before(firstBaseContainer);
     }
 }
+
+/**
+ * This function allows you to update an element's attribute if it is a new value.
+ * It avoids recalculating the layout if the value is the same.
+ * @param {HTMLElement} element
+ * @param {string} attribute
+ * @param {string} value
+ */
+export function setAttribute(element, attribute, value) {
+    if (element.getAttribute(attribute) !== value) {
+        element.setAttribute(attribute, value);
+    }
+}

--- a/addons/mail/static/src/utils/common/format.js
+++ b/addons/mail/static/src/utils/common/format.js
@@ -1,3 +1,4 @@
+import { setAttribute } from "@html_editor/utils/dom";
 import { htmlEscape, markup } from "@odoo/owl";
 
 import { router } from "@web/core/browser/router";
@@ -314,15 +315,15 @@ export function getNonEditableMentions(body) {
     }
     // for mentioned partner
     for (const mention of doc.body.querySelectorAll(".o_mail_redirect")) {
-        mention.setAttribute("contenteditable", false);
+        setAttribute(mention, "contenteditable", false);
     }
     // for mentioned channel
     for (const mention of doc.body.querySelectorAll(".o_channel_redirect")) {
-        mention.setAttribute("contenteditable", false);
+        setAttribute(mention, "contenteditable", false);
     }
     // for special mentions
     for (const mention of doc.body.querySelectorAll(".o-discuss-mention")) {
-        mention.setAttribute("contenteditable", false);
+        setAttribute(mention, "contenteditable", false);
     }
     return markup(doc.body.innerHTML);
 }

--- a/addons/website/static/src/builder/plugins/form/form_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/form/form_option_plugin.js
@@ -43,6 +43,7 @@ import { FormOption } from "./form_option";
 import { isSmallInteger } from "@html_builder/utils/utils";
 import { localization } from "@web/core/l10n/localization";
 import { formatDate } from "@web/core/l10n/dates";
+import { setAttribute } from "@html_editor/utils/dom";
 
 const { DateTime } = luxon;
 
@@ -663,7 +664,11 @@ export class FormOptionPlugin extends Plugin {
                     for (const el of inputsInDependencyContainer) {
                         conditionValueList.push({
                             value: el.value,
-                            textContent: inputsInDependencyContainer.length === 1 ? el.value : dependencyContainerEl.querySelector(`label[for="${el.id}"]`).textContent,
+                            textContent:
+                                inputsInDependencyContainer.length === 1
+                                    ? el.value
+                                    : dependencyContainerEl.querySelector(`label[for="${el.id}"]`)
+                                          .textContent,
                         });
                     }
                     if (!inputContainerEl.dataset.visibilityCondition) {
@@ -1083,7 +1088,7 @@ export class FormToggleRecaptchaLegalAction extends BuilderAction {
         const legalEl = renderToElement("website.s_website_form_recaptcha_legal", {
             labelWidth: labelWidth,
         });
-        legalEl.setAttribute("contentEditable", true);
+        setAttribute(legalEl, "contentEditable", "true");
         el.querySelector(".s_website_form_submit").insertAdjacentElement("beforebegin", legalEl);
     }
     clean({ editingElement: el }) {

--- a/addons/website/static/src/core/website_edit_service.js
+++ b/addons/website/static/src/core/website_edit_service.js
@@ -5,6 +5,7 @@ import { Interaction } from "@web/public/interaction";
 import { patch } from "@web/core/utils/patch";
 import { setupIgnoreDOMMutations } from "@website/js/content/auto_hide_menu";
 import { omit } from "@web/core/utils/objects";
+import { setAttribute } from "@html_editor/utils/dom";
 
 export function buildEditableInteractions(builders) {
     const result = [];
@@ -226,7 +227,7 @@ registry.category("services").add("website_edit", {
                     insert(...args) {
                         const el = args[0];
                         super.insert(...args);
-                        el.setAttribute("contenteditable", "false");
+                        setAttribute(el, "contenteditable", "false");
                     },
                 }),
                 patch(publicInteractions.constructor.prototype, {


### PR DESCRIPTION
..., mail, website, html_builder

The goal of this commit is to improve performance when using `setAttribute`. Using the native `setAttribute` causes a layout recalculation sometimes it is used, even when the same value is set. A good example is the `contenteditable` attribute, it will trigger a layout recalculation even when the value is the same. We are therefore introducing the `setAttribute` utility, which checks that the value is different before applying it.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
