### PR TITLE
[IMP] UI frontend : Product and payment screens

### DIFF
--- a/addons/point_of_sale/static/src/app/components/category_selector/category_selector.js
+++ b/addons/point_of_sale/static/src/app/components/category_selector/category_selector.js
@@ -60,4 +60,19 @@ export class CategorySelector extends Component {
             ? [...selectedCategory.child_ids]
             : this.pos.models["pos.category"].filter((category) => !category.parent_id);
     }
+
+    getAllSelected() {
+        return this.getAncestorsAndCurrent().filter(Boolean).length === 0;
+    }
+    hasParent() {
+        const selectedCategory = this.pos.selectedCategory;
+        return !!(selectedCategory && selectedCategory.parent_id);
+    }
+    isAncestorOrSelected(category) {
+        const selected = this.pos.selectedCategory;
+        if (!selected) {
+            return false;
+        }
+        return category.id === selected.id || selected.allParents.some((p) => p.id === category.id);
+    }
 }

--- a/addons/point_of_sale/static/src/app/components/category_selector/category_selector.scss
+++ b/addons/point_of_sale/static/src/app/components/category_selector/category_selector.scss
@@ -13,5 +13,6 @@
 
 .category-button {
     --btn-border-color: #{$o-gray-200};
+    border-width: 2px;
     height: 4rem;
 }

--- a/addons/point_of_sale/static/src/app/components/category_selector/category_selector.xml
+++ b/addons/point_of_sale/static/src/app/components/category_selector/category_selector.xml
@@ -4,8 +4,12 @@
         <div t-attf-class="{{this.pos.config.show_category_images ? 'category-list' : 'product-list'}} d-grid gap-1 gap-lg-2 p-2">
             <t t-foreach="this.getCategoriesAndSub()" t-as="category" t-key="category.id">
                 <button t-on-click="() => this.pos.setSelectedCategory(category.id)"
-                    t-attf-class="o_colorlist_item_color_{{!category.isSelected and !category.isChildren ? 'transparent_': ''}}{{category.color or 'none'}}"
-                    t-att-class="{'opacity-50': !category.isChildren and !category.isSelected, 'justify-content-center': ui.isSmall}"
+                    t-attf-class="o_colorlist_item_color_{{category.color or 'none'}}"
+                    t-att-class="{
+                        'border-0': category.isChildren and !this.isAncestorOrSelected(category), 
+                        'opacity-75 border-0': !category.isChildren and !category.isSelected,
+                        'justify-content-center': ui.isSmall
+                    }"
                     class="category-button p-1 btn btn-light d-flex justify-content-center align-items-center rounded-3">
                     <img t-if="category.imgSrc and !ui.isSmall" t-att-src="category.imgSrc"
                         class="category-img-thumb h-100 rounded-3 object-fit-cover"

--- a/addons/point_of_sale/static/src/app/components/numpad/numpad.js
+++ b/addons/point_of_sale/static/src/app/components/numpad/numpad.js
@@ -23,8 +23,13 @@ export const DECIMAL = {
     get value() {
         return localization.decimalPoint;
     },
+    class: "o_colorlist_item_numpad_color_6",
 };
-export const BACKSPACE = { value: "Backspace", text: "⌫" };
+export const BACKSPACE = {
+    value: "Backspace",
+    text: "⌫",
+    class: "o_colorlist_item_numpad_color_1",
+};
 export const ZERO = { value: "0" };
 export const SWITCHSIGN = { value: "-", text: "+/-" };
 export const DEFAULT_LAST_ROW = [SWITCHSIGN, ZERO, DECIMAL];

--- a/addons/point_of_sale/static/src/app/components/order_display/order_display.js
+++ b/addons/point_of_sale/static/src/app/components/order_display/order_display.js
@@ -2,7 +2,6 @@ import { Component, useEffect, useRef } from "@odoo/owl";
 import { CenteredIcon } from "@point_of_sale/app/components/centered_icon/centered_icon";
 import { Orderline } from "@point_of_sale/app/components/orderline/orderline";
 import { formatCurrency } from "@web/core/currency";
-import { _t } from "@web/core/l10n/translation";
 import { TagsList } from "@web/core/tags_list/tags_list";
 
 // This methods is service-less, see PoS knowledges for more information
@@ -29,10 +28,6 @@ export class OrderDisplay extends Component {
 
     formatCurrency(amount) {
         return formatCurrency(amount, this.order.currency.id);
-    }
-
-    emptyCartText() {
-        return _t("Start adding products");
     }
 
     get comboSortedLines() {

--- a/addons/point_of_sale/static/src/app/components/order_display/order_display.xml
+++ b/addons/point_of_sale/static/src/app/components/order_display/order_display.xml
@@ -43,7 +43,6 @@
         </t>
         <t t-elif="props.mode !== 'receipt'">
             <div t-if="!props.slots?.emptyCart" class="d-flex flex-column align-items-center justify-content-center flex-grow-1 rounded-3 gap-3">
-                <CenteredIcon icon="'fa-shopping-cart fa-4x'" text="emptyCartText()" class="'h-unset'"/>
                 <t t-slot="details"/>
             </div>
             <t t-else="" t-slot="emptyCart" />

--- a/addons/point_of_sale/static/src/app/components/popups/number_popup/number_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/number_popup/number_popup.js
@@ -21,7 +21,7 @@ export class NumberPopup extends Component {
         close: Function,
     };
     static defaultProps = {
-        title: _t("Confirm?"),
+        title: _t("Amount of guests"),
         startingValue: "",
         isValid: () => true,
         formatDisplayedValue: (x) => x,

--- a/addons/point_of_sale/static/src/app/components/popups/number_popup/number_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/number_popup/number_popup.xml
@@ -12,11 +12,16 @@
             <div t-if="props.feedback(this.state.buffer)" class="p-2 mx-auto mt-n2 mb-2" t-esc="props.feedback(this.state.buffer)" />
             <Numpad buttons="props.buttons"/>
             <t t-set-slot="footer">
-                <div class="d-flex flex-grow-1 justify-content-center">
-                    <button t-att-disabled="!props.isValid(state.buffer)" class="btn btn-primary btn-lg lh-lg me-2" tabindex="1" t-on-click="confirm">
-                        <t t-esc="confirmButtonLabel"/>
+                <div class="d-flex flex-grow-1 justify-content-center w-100">
+                    <button t-att-disabled="!props.isValid(state.buffer)"
+                        class="btn btn-primary btn-lg lh-lg o-default-button me-2 flex-fill"
+                        tabindex="1"
+                        t-on-click="confirm">
+                        Confirm
                     </button>
-                    <button class="btn btn-secondary btn-lg lh-lg" tabindex="1" t-on-click="cancel">
+                    <button class="btn btn-secondary btn-lg lh-lg o-default-button flex-fill"
+                        tabindex="1"
+                        t-on-click="cancel">
                         Discard
                     </button>
                 </div>

--- a/addons/point_of_sale/static/src/app/components/popups/preset_slots_popup/preset_slots_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/preset_slots_popup/preset_slots_popup.xml
@@ -55,7 +55,7 @@
                 </div>
             </div>
             <t t-set-slot="footer">
-                <button class="btn btn-secondary" t-on-click="() => this.props.close()">Discard</button>
+                <button class="btn btn-primary" t-on-click="() => this.props.close()">Continue</button>
             </t>
         </Dialog>
     </t>

--- a/addons/point_of_sale/static/src/app/components/popups/product_configurator_popup/product_configurator_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/product_configurator_popup/product_configurator_popup.js
@@ -241,11 +241,7 @@ export class ProductConfiguratorPopup extends Component {
         const info = this.props.productTemplate.getTaxDetails();
         const name = this.props.productTemplate.display_name;
         const total = this.env.utils.formatCurrency(info?.raw_total_included_currency || 0.0);
-        const taxName = info?.taxes_data[0]?.name || "";
-        const taxAmount = this.env.utils.formatCurrency(
-            info?.taxes_data[0]?.raw_tax_amount_currency || 0.0
-        );
-        return `${name} | ${total} | VAT: ${taxName} (= ${taxAmount})`;
+        return `${name} | ${total}`;
     }
     get showInfoBanner() {
         return this.props.productTemplate.is_storable;

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -377,6 +377,9 @@ export class PaymentScreen extends Component {
             this.validateOrder(false);
         }
     }
+    async clickTableGuests() {
+        this.pos.setCustomerCount();
+    }
 }
 
 registry.category("pos_pages").add("PaymentScreen", {

--- a/addons/point_of_sale/static/src/scss/pos.scss
+++ b/addons/point_of_sale/static/src/scss/pos.scss
@@ -190,6 +190,17 @@ select > option {
         $-color: adjust-color(nth($o-colors, $size), $lightness: -40%, $saturation: -15%);
         @include o-print-color($-bg, background-color, bg-opacity);
         @include o-print-color($-color, color, text-opacity);
+        border-color: #{darken(nth($o-colors, $size), 20%)};
+        &:hover {
+            border-color: #{darken(nth($o-colors, $size), 20%)};
+        }
+    }
+
+    .o_colorlist_item_wo_border_color_#{$size - 1} {
+        $-bg: adjust-color(nth($o-colors, $size), $lightness: 25%, $saturation: 15%);
+        $-color: adjust-color(nth($o-colors, $size), $lightness: -40%, $saturation: -15%);
+        @include o-print-color($-bg, background-color, bg-opacity);
+        @include o-print-color($-color, color, text-opacity);
     }
 }
 

--- a/addons/point_of_sale/static/tests/pos/tours/utils/chrome_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/chrome_util.js
@@ -91,7 +91,7 @@ export function doCashMove(amount, reason) {
         })),
         {
             isActive: ["mobile"],
-            trigger: ".o-overlay-item:nth-child(2) .modal-footer button:contains('Ok')",
+            trigger: ".o-overlay-item:nth-child(2) .modal-footer button:contains('Confirm')",
             run: "click",
         },
         Dialog.confirm(),

--- a/addons/pos_restaurant/static/src/app/screens/payment_screen/payment_screen.xml
+++ b/addons/pos_restaurant/static/src/app/screens/payment_screen/payment_screen.xml
@@ -23,8 +23,16 @@
     </t>
     <t t-name="pos_restaurant.PaymentScreenDue" t-inherit="point_of_sale.PaymentScreenDue" t-inherit-mode="extension">
         <xpath expr="//section[hasclass('paymentlines-container')]" position="inside">
-            <div t-if="currentOrder.getCustomerCount() > 1" class="message text-center fs-2">
+            <div t-if="currentOrder.getCustomerCount() > 1" class="message text-center fs-1">
                 <PriceFormatter price="this.env.utils.formatCurrency(currentOrder.amountPerGuest())" /> / Guest
+                <button class="btn rounded-lg p" t-on-click="clickTableGuests" style="background-color: #ced4da;">
+                    <span class="text-black fs-4 fw-bolder" t-esc="currentOrder?.getCustomerCount() || 0"/>
+                </button>
+            </div>
+            <div class="fs-2 text-center">
+            2: <PriceFormatter price="this.env.utils.formatCurrency(currentOrder.amountPerGuest(2))" /> <span class="me-4">/ Guest</span>
+            3: <PriceFormatter price="this.env.utils.formatCurrency(currentOrder.amountPerGuest(3))" /> <span class="me-4">/ Guest</span>
+            4: <PriceFormatter price="this.env.utils.formatCurrency(currentOrder.amountPerGuest(4))" /> <span class="me-4">/ Guest</span>
             </div>
         </xpath>
     </t>

--- a/addons/pos_sale/static/tests/tours/test_taxes_downpayment.js
+++ b/addons/pos_sale/static/tests/tours/test_taxes_downpayment.js
@@ -40,8 +40,8 @@ export function addDownPayment(percentage, soNth, downPaymentType) {
         steps.push(clickDownPaymentNumpad(num));
     }
     steps.push({
-        content: "Select 'OK'",
-        trigger: ".modal-dialog button.btn-primary:contains('OK')",
+        content: "Select 'Confirm'",
+        trigger: ".modal-dialog button.btn-primary:contains('Confirm')",
         run: "click",
     });
     return steps;

--- a/addons/pos_sale/static/tests/tours/utils/pos_sale_utils.js
+++ b/addons/pos_sale/static/tests/tours/utils/pos_sale_utils.js
@@ -63,7 +63,7 @@ export function downPaymentFirstOrder(amount) {
             run: "click",
         },
         Numpad.click(amount),
-        Dialog.confirm("Ok"),
+        Dialog.confirm("Confirm"),
     ];
 }
 

--- a/addons/pos_sale/static/tests/unit/services/pos_store.test.js
+++ b/addons/pos_sale/static/tests/unit/services/pos_store.test.js
@@ -83,7 +83,7 @@ describe("onClickSaleOrder", () => {
         await waitFor(".modal-title:contains('Down Payment')");
         await click(".modal-body .numpad .numpad-button[value='+50']");
         await new Promise((resolve) => setTimeout(resolve, 50));
-        await click(".modal-footer .btn:contains('Ok')");
+        await click(".modal-footer .btn:contains('Confirm')");
         await promiseResult;
 
         const currentOrder = store.getOrder();
@@ -137,7 +137,7 @@ describe("onClickSaleOrder", () => {
         await waitFor(".modal-title:contains('Down Payment')");
         await click(".modal-body .numpad .numpad-button[value='+50']");
         await new Promise((resolve) => setTimeout(resolve, 50));
-        await click(".modal-footer .btn:contains('Ok')");
+        await click(".modal-footer .btn:contains('Confirm')");
         await promiseResult;
 
         const currentOrder = store.getOrder();


### PR DESCRIPTION
After this commit, the cart on the left side of the product screen is removed.
- Category cards have now border when selected.
- The VAT summary on the product with attributes is now removed.
- On the payment screen, there is now a small light grey button under the price summary to set the number of guests at any moment.
- Small change on the preset time slot button.

Task : 5145441

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
