### PR TITLE
[FIX] im_livechat: 'busy' live chat agents should be available

### DIFF
--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -162,7 +162,7 @@ class Im_LivechatChannel(models.Model):
         counts = {}
         if livechat_channels := self.filtered(lambda c: c.max_sessions_mode == "limited"):
             possible_users = users if users is not None else livechat_channels.user_ids
-            limited_users = possible_users.filtered(lambda user: "online" in user.im_status)
+            limited_users = possible_users.filtered(lambda user: "online" in user.im_status or "busy" in user.im_status)
             counts = {
                 (partner, livechat_channels): count
                 for (partner, livechat_channels, count) in self.env["discuss.channel"]._read_group(
@@ -178,7 +178,7 @@ class Im_LivechatChannel(models.Model):
 
         def is_available(user, channel):
             return (
-                "online" in user.im_status
+                ("online" in user.im_status or "busy" in user.im_status)
                 and (
                     channel.max_sessions_mode == "unlimited"
                     or counts.get((user.partner_id, channel), 0) < channel.max_sessions

--- a/addons/im_livechat/tests/test_get_operator.py
+++ b/addons/im_livechat/tests/test_get_operator.py
@@ -405,6 +405,23 @@ class TestGetOperator(MailCommon, TestGetOperatorCommon):
                 livechat_channels[1]: operator,
             },
         )
+        operator.manual_im_status = "busy"
+        self.assertEqual(
+            livechat_channels._get_available_operators_by_livechat_channel(operator),
+            {
+                livechat_channels[0]: self.env["res.users"],
+                livechat_channels[1]: operator,
+            },
+        )
+        operator.manual_im_status = False
+        operator.presence_ids.status = "away"
+        self.assertEqual(
+            livechat_channels._get_available_operators_by_livechat_channel(operator),
+            {
+                livechat_channels[0]: self.env["res.users"],
+                livechat_channels[1]: self.env["res.users"],
+            },
+        )
         operator.presence_ids.status = "offline"
         self.assertEqual(
             livechat_channels._get_available_operators_by_livechat_channel(operator),


### PR DESCRIPTION
Before this commit, when a human agent had the IM status "busy", the agent was not considered available for live chat.

The "busy" feature is intended only to not receive notification and to show to others we are busy, but is not meant to disable availabily as a live chat operator.

The issue happens because availability of the operator required the "online" IM status, which ignored "busy" that was added recently.

Note that "away" is considered as not available for operator: the "away" IM status can be set manually by user but also can be triggered automatically when agent is away for a long time, and in these cases users already expect to not be considered as available live chat agents. This behavior is kept in this commit.

opw-5150332