### PR TITLE
[FIX] point_of_sale: display product configurator for custom values

### DIFF
--- a/addons/point_of_sale/static/src/app/models/product_template.js
+++ b/addons/point_of_sale/static/src/app/models/product_template.js
@@ -107,7 +107,11 @@ export class ProductTemplate extends Base {
     async _onScaleNotAvailable() {}
 
     isConfigurable() {
-        return this.attribute_line_ids.find((l) => l.product_template_value_ids.length > 1);
+        return this.attribute_line_ids.find(
+            (l) =>
+                l.product_template_value_ids.length > 1 ||
+                l.product_template_value_ids.some((v) => v.is_custom)
+        );
     }
 
     needToConfigure() {

--- a/addons/point_of_sale/static/tests/pos/tours/product_configurator_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_configurator_tour.js
@@ -203,3 +203,16 @@ registry.category("web_tour.tours").add("test_cross_exclusion_attribute_values",
             Chrome.endTour(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_custom_attribute_alone_displayed", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Only Custom"),
+            ProductConfigurator.fillCustomAttribute("Filling"),
+            ProductConfigurator.selectedCustomAttribute("Filling"),
+            Dialog.confirm(),
+            Chrome.endTour(),
+        ].flat(),
+});

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -2999,6 +2999,36 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('test_cross_exclusion_attribute_values')
 
+    def test_custom_attribute_alone_displayed(self):
+        """
+        Tests that if product configurator will be shown if any of the
+        attributes have a free text field, even if there is only one
+        possible selection for every attributes.
+        """
+        attribute_custom = self.env['product.attribute'].create({
+            'name': 'Custom',
+            'display_type': 'radio',
+            'create_variant': 'no_variant',
+        })
+        attribute_value_custom = self.env['product.attribute.value'].create({
+            'name': 'Custom',
+            'attribute_id': attribute_custom.id,
+            'is_custom': True,
+        })
+        self.test_product_1 = self.env['product.template'].create({
+            'name': 'Only Custom',
+            'available_in_pos': True,
+            'list_price': 10.0,
+            'attribute_line_ids': [
+                Command.create({
+                    'attribute_id': attribute_custom.id,
+                    'value_ids': [Command.set([attribute_value_custom.id])],
+                }),
+            ],
+        })
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_custom_attribute_alone_displayed')
+
     def test_preset_customer_selection(self):
         self.preset_delivery = self.env['pos.preset'].create({
             'name': 'Delivery',


### PR DESCRIPTION
**Steps to reproduce:**
- Make a new product, make a single variant with a single value for it
- The variant value should have the Free Text checkbox enabled
- Go to PoS, click on said product
- The product configurator will not be displayed, so there is no way to write on this Free Text field

**Why the fix:**
Before this commit, we did not display the product configurator if all variant attributes were single choice, because it did not make sense to show it just for the user to click on confirm.

But this did not account for the fact that if a Free Text option is enabled, we should still display it, so that the user can write whatever they want on it, even if it is the only option available.

We now display the product configurator in all cases where a Free Text field is present, as we need the customer to be able to fill it, even if it is the only available option.

opw-5133743