### PR TITLE
[FIX] l10n_es_edi_verifactu: removed unnecessary chatter

### DIFF
--- a/addons/l10n_es_edi_verifactu/views/l10n_es_edi_verifactu_document_views.xml
+++ b/addons/l10n_es_edi_verifactu/views/l10n_es_edi_verifactu_document_views.xml
@@ -25,7 +25,6 @@
                             </group>
                         </group>
                     </sheet>
-                    <chatter/>
                 </form>
             </field>
         </record>


### PR DESCRIPTION
The system will crash with error when user clicks on expand button.

**Steps to produce:**
- Install `l10n_es_edi_verifactu and l10n_es_edi_facturae` with demo data.
- Switched to ES company.
- Go to any invoice and click send > continue.
- Open veri*fectu tab > click on record > click on expand button.

**Traceback:**
```py
  File '/home/odoo/odoo19/community/odoo/http.py', line 2341, in _serve_db
    return service_model.retrying(serve_func, env=self.env)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File '/home/odoo/odoo19/community/odoo/service/model.py', line 184, in retrying
    result = func()
             ^^^^^^
  File '/home/odoo/odoo19/community/odoo/http.py', line 2388, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File '/home/odoo/odoo19/community/odoo/http.py', line 2609, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File '/home/odoo/odoo19/community/odoo/addons/base/models/ir_http.py', line 357, in _dispatch
    result = endpoint(**request.params)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File '/home/odoo/odoo19/community/odoo/http.py', line 791, in route_wrapper
    result = endpoint(self, *args, **params_ok)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File '/home/odoo/odoo19/community/addons/mail/tools/discuss.py', line 36, in wrapper
    return func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File '/home/odoo/odoo19/community/addons/mail/controllers/webclient.py', line 26, in mail_data
    return self._process_request(fetch_params, context=context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File '/home/odoo/odoo19/community/addons/mail/controllers/webclient.py', line 33, in _process_request
    self._process_request_loop(store, fetch_params)
  File '/home/odoo/odoo19/community/addons/mail/controllers/discuss/channel.py', line 23, in _process_request_loop
    super()._process_request_loop(store, fetch_params)
  File '/home/odoo/odoo19/community/addons/mail/controllers/webclient.py', line 45, in _process_request_loop
    self._process_request_for_all(store, name, params)
  File '/home/odoo/odoo19/community/addons/mail/controllers/discuss/channel.py', line 35, in _process_request_for_all
    super()._process_request_for_all(store, name, params)
  File '/home/odoo/odoo19/community/addons/mail/controllers/webclient.py', line 59, in _process_request_for_all
    thread = self._get_thread_with_access(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File '/home/odoo/odoo19/community/addons/mail/controllers/thread.py', line 51, in _get_thread_with_access
    return request.env[thread_model]._get_thread_with_access(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'l10n_es_edi_verifactu.document' object has no attribute '_get_thread_with_access'
```

**Cause:**
- `l10n_es_edi_verifactu.document` does not inherits ['mail.thread', 'mail.activity.mixin'] and used chatter in it's form view.

- In this PR, removed `<chatter/>` from view.

**sentry-6792833694**

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
