### PR TITLE
[FIX] purchase: prevent deletion of UoM when it is in use

### DIFF
--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -31,7 +31,7 @@ class PurchaseOrderLine(models.Model):
         digits='Discount',
         store=True, readonly=False)
     taxes_id = fields.Many2many('account.tax', string='Taxes', context={'active_test': False})
-    product_uom = fields.Many2one('uom.uom', string='Unit of Measure', domain="[('category_id', '=', product_uom_category_id)]")
+    product_uom = fields.Many2one('uom.uom', string='Unit of Measure', domain="[('category_id', '=', product_uom_category_id)]", ondelete='restrict')
     product_uom_category_id = fields.Many2one(related='product_id.uom_id.category_id')
     product_id = fields.Many2one('product.product', string='Product', domain=[('purchase_ok', '=', True)], change_default=True, index='btree_not_null', ondelete='restrict')
     product_type = fields.Selection(related='product_id.type', readonly=True)


### PR DESCRIPTION
When a user deletes the UoM used in a purchase order line and then tries to confirm the purchase order.

Steps to reproduce:
---
- Install `purchase_stock` module(without demo)
- Create a New PO > Add a product in Line (with UoM=Units)
- Remove UoM in order line and select `Dozen` in it > Save
- Settings > Units of Measure Categories > Open `Units` > Remove `Dozen`
- Orders  > Requests for Quotation > Open PO > `Confirm Order`

Traceback:
---
`ValueError: Expected singleton: uom.uom()`
`AssertionError: precision_rounding must be positive, got 0.0`

This error occurs because, after the UoM is deleted, the `product_uom` field becomes empty, which leads to an error.

Solution:
---
This commit resolves the error by restricting the deletion of a UoM when it is still in use.

sentry-6746792383

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
