### PR TITLE
HTML Editor Performance Optimisation - Reduce number of layout calculation

### DIFF
--- a/addons/html_editor/static/src/core/base_container_plugin.js
+++ b/addons/html_editor/static/src/core/base_container_plugin.js
@@ -164,9 +164,10 @@ export class BaseContainerPlugin extends Plugin {
      * oe_unbreakable) => it stays unsplittable.
      */
     isCandidateForBaseContainerAllowUnsplittable(element) {
-        const predicates = new Set(this.getResource("invalid_for_base_container_predicates"));
-        predicates.delete(this.isUnsplittablePredicate);
-        for (const predicate of predicates) {
+        for (const predicate of this.getResource("invalid_for_base_container_predicates")) {
+            if (predicate === this.isUnsplittablePredicate) {
+                continue;
+            }
             if (predicate(element)) {
                 return false;
             }
@@ -182,9 +183,11 @@ export class BaseContainerPlugin extends Plugin {
      * compute childNodes multiple times in more complex operations.
      */
     shallowIsCandidateForBaseContainer(element) {
-        const predicates = new Set(this.getResource("invalid_for_base_container_predicates"));
-        predicates.delete(this.hasNonPhrasingContentPredicate);
+        const predicates = this.getResource("invalid_for_base_container_predicates");
         for (const predicate of predicates) {
+            if (predicate === this.hasNonPhrasingContentPredicate) {
+                continue;
+            }
             if (predicate(element)) {
                 return false;
             }

--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -457,7 +457,12 @@ export class SelectionPlugin extends Plugin {
         const documentSelection =
             selection?.anchorNode && selection?.focusNode
                 ? Object.freeze({
-                      isCollapsed: selection.isCollapsed,
+                      get isCollapsed() {
+                          if (this.collapsed === undefined) {
+                              this.collapsed = selection.isCollapsed;
+                          }
+                          return this.collapsed;
+                      },
                       anchorNode: selection.anchorNode,
                       anchorOffset: selection.anchorOffset,
                       focusNode: selection.focusNode,
@@ -1037,7 +1042,10 @@ export class SelectionPlugin extends Plugin {
 
         const closestNonEditable = (node) => closestElement(node, (el) => !el.isContentEditable);
         // If selection includes a non-editable element, focusing editor will move cursor to different position.
-        if (!closestNonEditable(editableSelection.anchorNode) && !closestNonEditable(editableSelection.focusNode)) {
+        if (
+            !closestNonEditable(editableSelection.anchorNode) &&
+            !closestNonEditable(editableSelection.focusNode)
+        ) {
             // Manualy focusing the editable is necessary to avoid some non-deterministic error in the HOOT unit tests.
             this.editable.focus({ preventScroll: true });
         }

--- a/addons/html_editor/static/src/utils/blocks.js
+++ b/addons/html_editor/static/src/utils/blocks.js
@@ -44,7 +44,7 @@ const blockTagNames = [
     "TH",
 ];
 
-const computedStyles = new WeakMap();
+const computedStyleDisplayCache = new WeakMap();
 
 /**
  * Return true if the given node is a block-level element, false otherwise.
@@ -69,14 +69,15 @@ export function isBlock(node) {
     if (!node.isConnected) {
         return blockTagNames.includes(tagName);
     }
-    // We won't call `getComputedStyle` more than once per node.
-    let style = computedStyles.get(node);
-    if (!style) {
-        style = node.ownerDocument.defaultView.getComputedStyle(node);
-        computedStyles.set(node, style);
+    // We won't call `getComputedStyle(node).display` more than once per node.
+    let display = computedStyleDisplayCache.get(node);
+    if (display === undefined) {
+        const style = node.ownerDocument.defaultView.getComputedStyle(node);
+        display = style.display;
+        computedStyleDisplayCache.set(node, display);
     }
-    if (style.display) {
-        return !style.display.includes("inline") && style.display !== "contents";
+    if (display) {
+        return !display.includes("inline") && display !== "contents";
     }
     return blockTagNames.includes(tagName);
 }


### PR DESCRIPTION
The goal of this PR is to improve the performance of the HTML Editor by  
reducing the number of times layout or style recalculations are needed.

[FIX] html_editor: make isCollapsed lazy
==========
The goal of this commit is to make `isCollapsed` lazy. Currently, when
calling `getSelectionData`, `selection.isCollapsed` is evaluated,
which can trigger a layout recalculation.

We now make it lazy and evaluate it only when necessary. This change
helps avoid the cost of layout recalculations (few ms) in many situations.


[FIX] html_editor: cache style.display in isBlock
========
This commit ensures that calls to `getComputedStyle(node).display` in the
`isBlock` utility are properly cached. Currently, each call triggers a
style recalculation, which can be costly.

Solution: we cache the `display` value itself, not the entire return
value of `getComputedStyle`.

[FIX] html_editor: imp perf in base_container_plugin
======
This commit aims to improve performance. Using a `Set` only to remove a
callback from a list is quite expensive compared to using a simple `if`
check during the list iteration.