### PR TITLE
[FIX] stock_account: put half package tracked prod in another package

### DIFF
--- a/addons/stock_account/models/stock_move_line.py
+++ b/addons/stock_account/models/stock_move_line.py
@@ -87,7 +87,7 @@ class StockMoveLine(models.Model):
 
     def _action_done(self):
         for line in self:
-            if not line.lot_id and not line.lot_name and line.product_id.lot_valuated:
+            if not line.lot_id and not line.lot_name and line.product_id.lot_valuated and line.quantity:
                 raise UserError(_("Lot/Serial number is mandatory for product valuated by lot"))
         return super()._action_done()
 

--- a/addons/stock_account/tests/test_lot_valuation.py
+++ b/addons/stock_account/tests/test_lot_valuation.py
@@ -811,3 +811,33 @@ class TestLotValuation(TestStockValuationCommon):
                 with picking_form.move_ids_without_package.edit(0) as mv:
                     mv.quantity = 5.0
         self.assertEqual(in_move.quantity, 2)
+
+    def test_lot_valuation_no_error_no_quantity(self):
+        """
+        Checks that an empty move line with no lot and a product valued by lot does not trigger the
+        no lot error
+        """
+        move = self.env['stock.move'].create({
+            'name': 'in move name',
+            'product_id': self.product1.id,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
+            'product_uom': self.uom_unit.id,
+            'product_uom_qty': 2,
+            'price_unit': 2,
+            'picked': True,
+            'picking_type_id': self.picking_type_in.id,
+            'move_line_ids': [Command.create({
+                'product_id': self.product1.id,
+                'location_id': self.supplier_location.id,
+                'location_dest_id': self.stock_location.id,
+                'product_uom_id': self.uom_unit.id,
+                'quantity': 2.0,
+                'picked': True,
+                'lot_id': self.lot1.id,
+            })for sml in range(2)],
+        })
+        move.move_line_ids[1].quantity = 0
+        move.move_line_ids[1].lot_id = False
+        move._action_done()
+        self.assertEqual(move.quantity, 2)


### PR DESCRIPTION
**Problem:**
With a valued by lot/SN product,
assigning a partial barcode move line to a new package will trigger 
a lot error when validating even if there is a lot on the line.

**Steps to reproduce:**
- Create product tracked by lot and valued by lot/SN.
- Set on on hand quantity of 100 in stock with a package that 
you create and a lot that you create.
- Create an internal transfer for 100 of this product.
- Mark it as to do.
- Open it in barcode.
- Scan stock.
- Scan the package.
- Edit the line to quantity of 50.
- Scan any other empty package already existing to set 
it as the delivery package.
- Validate.
- On the incomplete transfer widget, also click on validate.

**Current behavior:**
An error 'Lot/Serial number is mandatory for product valuated by lot'
is triggered even though there is a lot on the line.

**Cause of the issue:**
When _assignEmptyPackage() is called to assign the new package, 
it calls shouldsplitline() which returns true because line.qty_done is 
smaller thant line.reserved_uom_qty
https://github.com/odoo/enterprise/blob/931779b845291e1dc7efdea91d91bdfa5ab703d6/stock_barcode/static/src/models/barcode_picking_model.js#L949-52
Therefore, splitLine() is called and a new line is created with
no package and no lot.

Then, when we validate, _action_done() is called on the move which calls
_action_done() on the move lines.
https://github.com/odoo/odoo/blob/30189db8a47e69038242a68706cfdfe6c152e779/addons/stock/models/stock_move.py#L2065
In the stock_account override, the error is raised for the line newly created
because it has no lot_id and no lot_name.
https://github.com/odoo/odoo/blob/30189db8a47e69038242a68706cfdfe6c152e779/addons/stock_account/models/stock_move_line.py#L90-L91

opw-5028008