### PR TITLE
[FIX] mail: html composer styling issues

### DIFF
--- a/addons/mail/static/src/core/common/composer.scss
+++ b/addons/mail/static/src/core/common/composer.scss
@@ -100,7 +100,7 @@
     background-color: var(--mail-Composer-bg, $o-view-background-color);
 }
 
-.o-mail-Composer-inputStyle {
+.o-mail-Composer-inputStyle, .o-mail-Composer-html {
     padding-top: 10px; // carefully crafted to have the text in the middle in chat window
     padding-bottom: 10px;
     padding-left: map-get($spacers, 1);
@@ -126,42 +126,12 @@
     }
 
     .o-mail-Composer.o-isUiSmall & {
-        padding-bottom: 10px;
-    }
-}
-
-.o-mail-Composer-html {
-    padding-top: 10px; // carefully crafted to have the text in the middle in chat window
-    padding-bottom: 10px;
-    padding-left: map-get($spacers, 1);
-    padding-right: map-get($spacers, 1);
-
-    line-height: 1.42857143 !important; // so that input is rounded to 20px = 14px (base font) * 1.42857143 (line-height)
-
-    .o-mail-Composer.o-editing & {
-        padding-left: map-get($spacers, 2);
-        padding-right: map-get($spacers, 2);
-    }
-
-    .o-mail-Composer.o-extended & {
-        padding-left: map-get($spacers, 2) + map-get($spacers, 1);
-        padding-right: map-get($spacers, 2);
-    }
-
-    .o-mail-Composer.o-chatWindow & {
         padding-top: 7px;
         padding-bottom: 7px;
-        padding-left: map-get($spacers, 1) / 2;
-        padding-right: map-get($spacers, 1) / 2;
-    }
-
-    .o-mail-Composer.o-isUiSmall & {
-        padding-top: 10px;
-        padding-bottom: 10px;
     }
 }
 
-.o-mail-Composer-input {
+.o-mail-Composer-input, .o-mail-Composer-html {
     max-height: Min(400px, 60vh);
     resize: none;
 

--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -296,45 +296,46 @@ $o-mail-utilities: map-merge(
 // see `@mixin button-variant`, this is the implementation without requiring `.btn` classname
 @mixin o-mention-variant(
     $background,
-    $border,
+    $outline,
     $color: color-contrast($background),
     $hover-background: if($color == $color-contrast-light, shade-color($background, $btn-hover-bg-shade-amount), tint-color($background, $btn-hover-bg-tint-amount)),
-    $hover-border: if($color == $color-contrast-light, shade-color($border, $btn-hover-border-shade-amount), tint-color($border, $btn-hover-border-tint-amount)),
+    $hover-outline: if($color == $color-contrast-light, shade-color($outline, $btn-hover-border-shade-amount), tint-color($outline, $btn-hover-border-tint-amount)),
     $hover-color: color-contrast($hover-background),
     $active-background: if($color == $color-contrast-light, shade-color($background, $btn-active-bg-shade-amount), tint-color($background, $btn-active-bg-tint-amount)),
-    $active-border: if($color == $color-contrast-light, shade-color($border, $btn-active-border-shade-amount), tint-color($border, $btn-active-border-tint-amount)),
+    $active-outline: if($color == $color-contrast-light, shade-color($outline, $btn-active-border-shade-amount), tint-color($outline, $btn-active-border-tint-amount)),
     $active-color: color-contrast($active-background),
     $disabled-background: $background,
-    $disabled-border: $border,
+    $disabled-outline: $outline,
     $disabled-color: color-contrast($disabled-background)
 ) {
     color: #{$color} !important;
     background-color: #{$background};
-    border-color: #{$border};
+    outline-color: #{$outline};
     &:hover {
         color: #{$hover-color};
         background-color: #{$hover-background};
-        border-color: #{$hover-border};
+        outline-color: #{$hover-outline};
     }
     &:focus {
-        box-shadow: #{to-rgb(mix($color, $border, 15%))};
+        box-shadow: #{to-rgb(mix($color, $outline, 15%))};
     }
     &:active {
         color: #{$active-color};
         background-color: #{$active-background};
-        border-color: #{$active-border};
+        outline-color: #{$active-outline};
     }
     &:disabled {
         color: #{$disabled-color};
         background-color: #{$disabled-background};
-        border-color: #{$disabled-border};
+        outline-color: #{$disabled-outline};
     }
 }
 
 a.o_mail_redirect, a.o_channel_redirect, a.o-discuss-mention, a.o_message_redirect_transformed {
     border-radius: $btn-border-radius-sm;
-    padding: 0rem 0.1875rem;
-    border: 1px solid;
+    padding: 0rem 0.1rem;
+    margin: 0rem 0.0875rem;
+    outline: 1px solid;
     font-weight: $font-weight-bold;
     display: inline-block;
 }

--- a/addons/mail/static/tests/inline/convert_inline.test.js
+++ b/addons/mail/static/tests/inline/convert_inline.test.js
@@ -1501,7 +1501,7 @@ describe("Should not convert blacklisted class to inline styles", () => {
         classToStyle(editable, getCSSRules(editable.ownerDocument));
 
         expect(editable).toHaveInnerHTML(
-            `<a contenteditable="false" href="#" class="o_mail_redirect" style="text-decoration: none; border-style: solid; padding: 0rem 0.1875rem; box-sizing: border-box; overflow-wrap: unset;"> @Marc Demo </a> Testing!`,
+            `<a contenteditable="false" href="#" class="o_mail_redirect" style="text-decoration: none; padding: 0rem 0.1rem; margin: 0rem 0.0875rem; box-sizing: border-box; overflow-wrap: unset;">@Marc Demo</a> Testing!`,
             {
                 message: "blacklisted class styles should remain unconverted",
             }
@@ -1517,7 +1517,7 @@ describe("Should not convert blacklisted class to inline styles", () => {
         editable.innerHTML = `<a contenteditable="false" href="#" class="o_mail_redirect test-style">@Marc Demo</a> Testing!`;
         classToStyle(editable, getCSSRules(editable.ownerDocument));
         expect(editable).toHaveInnerHTML(
-            `<a contenteditable="false" href="#" class="o_mail_redirect test-style" style="text-decoration: none; border-style: solid; padding: 0rem 0.1875rem; box-sizing: border-box; background-color: yellow; overflow-wrap: unset;"> @Marc Demo </a> Testing!`,
+            `<a contenteditable="false" href="#" class="o_mail_redirect test-style" style="text-decoration: none; padding: 0rem 0.1rem; margin: 0rem 0.0875rem; box-sizing: border-box; background-color: yellow; overflow-wrap: unset;"> @Marc Demo </a> Testing!`,
             { message: "styles marked !important should override blacklisted class restrictions" }
         );
     });
@@ -1531,7 +1531,7 @@ describe("Should not convert blacklisted class to inline styles", () => {
         editable.innerHTML = `<a contenteditable="false" href="#" class="o_mail_redirect test-color">@Marc Demo</a> Testing!`;
         classToStyle(editable, getCSSRules(editable.ownerDocument));
         expect(editable).toHaveInnerHTML(
-            `<a contenteditable="false" href="#" class="o_mail_redirect test-color" style="text-decoration: none; border-style: solid; padding: 0rem 0.1875rem; box-sizing: border-box; overflow-wrap: unset;"> @Marc Demo </a> Testing!`,
+            `<a contenteditable="false" href="#" class="o_mail_redirect test-color" style="text-decoration: none; padding: 0rem 0.1rem; margin: 0rem 0.0875rem; box-sizing: border-box; overflow-wrap: unset;"> @Marc Demo </a> Testing!`,
             {
                 message:
                     "should ignore styles from lower specificity class in favor of blacklisted class",


### PR DESCRIPTION
This commit fixes several HTML composer styling issues:

  - The HTML composer html did not align vertically with the text area when the chat window is in small UI mode.

  - The mention/redirect links had a border and causing slight layout shifts when applied to the composer. This is now fixed by using outline instead of border.

  - The maximum height of the HTML composer was not constrained on small screens, causing it to overflow the screen. This is now fixed by using a max-height relative to the viewport height.

task-5022254

after:
<img width="435" height="346" alt="image" src="https://github.com/user-attachments/assets/cfd309d6-f6a4-4d7c-8694-2a86504193e7" />
<img width="454" height="782" alt="image" src="https://github.com/user-attachments/assets/6ce924b6-9df7-4831-890d-59ec37ea18c9" />

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
