### PR TITLE
[IMP] project: Assign team members to project roles

### DIFF
--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -1429,15 +1429,12 @@ class ProjectProject(models.Model):
             for key, value in self.env.context.items()
             if key.startswith('default_') and key.removeprefix('default_') in self._get_template_default_context_whitelist()
         } | values
-        project = self.with_context(copy_from_template=True, copy_from_project_template=True).copy(default=default)
+        context = {
+            'copy_from_template': True,
+            'copy_from_project_template': self.id,
+        }
+        if role_to_users_mapping is not None:
+            context['role_to_users_mapping'] = {entry.role_id.id: entry.user_ids.ids for entry in role_to_users_mapping if entry.user_ids}
+        project = self.with_context(**context).copy(default=default)
         project.message_post(body=self.env._("Project created from template %(name)s.", name=self.name))
-
-        # Tasks dispatching using project roles
-        if role_to_users_mapping and (mapping := role_to_users_mapping.filtered(lambda entry: entry.user_ids)):
-            for new_task in project.task_ids:
-                for entry in mapping:
-                    if entry.role_id in new_task.role_ids:
-                        new_task.user_ids |= entry.user_ids
-
-        project.task_ids.role_ids = False
         return project

--- a/addons/project/models/project_role.py
+++ b/addons/project/models/project_role.py
@@ -14,6 +14,14 @@ class ProjectRole(models.Model):
     name = fields.Char(required=True, translate=True)
     color = fields.Integer(default=_get_default_color)
     sequence = fields.Integer(export_string_translation=False)
+    user_ids = fields.Many2many(
+        'res.users',
+        'project_role_res_users_rel',
+        'project_role_id',
+        'res_users_id',
+        string='Team Members',
+        domain=lambda self: [('all_group_ids', '=', self.env.ref('project.group_project_user').id)],
+    )
 
     def copy_data(self, default=None):
         vals_list = super().copy_data(default=default)

--- a/addons/project/models/res_users.py
+++ b/addons/project/models/res_users.py
@@ -6,6 +6,15 @@ class ResUsers(models.Model):
 
     favorite_project_ids = fields.Many2many('project.project', 'project_favorite_user_rel', 'user_id', 'project_id',
                                             string='Favorite Projects', export_string_translation=False, copy=False)
+    project_role_ids = fields.Many2many(
+        'project.role',
+        'project_role_res_users_rel',
+        'res_users_id',
+        'project_role_id',
+        string='Project Roles',
+        export_string_translation=False,
+        copy=False,
+    )
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/project/views/project_role_views.xml
+++ b/addons/project/views/project_role_views.xml
@@ -7,6 +7,7 @@
             <list editable="bottom" multi_edit="1">
                 <field name="sequence" widget="handle"/>
                 <field name="name" placeholder="e.g. Developer"/>
+                <field name="user_ids" widget="many2many_avatar_user"/>
                 <field name="color" widget="color_picker" optional="show"/>
             </list>
         </field>
@@ -22,6 +23,7 @@
                     <group>
                         <field name="active" invisible="1"/>
                         <field name="name"/>
+                        <field name="user_ids" widget="many2many_avatar_user"/>
                         <field name="color" widget="color_picker"/>
                     </group>
                 </sheet>
@@ -54,7 +56,11 @@
         <field name="arch" type="xml">
             <search>
                 <field name="name"/>
+                <field name="user_ids"/>
                 <filter name="archived" string="Archived" domain="[('active', '=', False)]"/>
+                <group>
+                    <filter name="groupby_team_members" string="Team Members" context="{'group_by': 'user_ids'}"/>
+                </group>
             </search>
         </field>
     </record>

--- a/addons/project/wizard/project_template_create_wizard.xml
+++ b/addons/project/wizard/project_template_create_wizard.xml
@@ -26,6 +26,7 @@
                     <list create="0" delete="0" no_open="1" editable="bottom">
                         <field name="role_id" force_save="1" readonly="1" options="{'no_open': True}"/>
                         <field name="user_ids" widget="many2many_avatar_user" options="{'no_open': True, 'no_quick_create': True}"/>
+                        <field name="role_user_ids" column_invisible="1"/> <!-- Needed to compute the domain of user_ids -->
                     </list>
                 </field>
                 <footer>


### PR DESCRIPTION
## [IMP] project: add team members field in project role model 

This commit adds user_ids field in project.role model to allow the user
to define the default users per project role.

## [IMP] project: only allow to select project user from project role in template wizard

This commit adds a domain to the user_ids field in the wizard used to
create a project from a project template to only display the users set
on the project role. If no default users for a role is defined then all
project users will be selectable.

## [IMP] project: override copy of tasks when copy from project template

Before this commit, after duplicating the project template to create a
new project, we do extra stuff on tasks generated in that project based
on the task templates stored in the project template, the problem is the
order of task_ids field for project template and project cannot be
guarantee. To make sure, the order is guarantee, the process on tasks
should be done in copy method to correctly compare the task template
with the task created by that template.

This commit moves the changes made on the tasks generated in the copy to
make sure the order is preserved when we need to use zip function to
have task template and the task created based on that template at each
iteration.

task-5139714