### PR TITLE
[FIX] pos_event: prioritize global answers on identification questions

### DIFF
--- a/addons/pos_event/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/pos_event/static/src/app/screens/product_screen/product_screen.js
@@ -58,6 +58,9 @@ patch(ProductScreen.prototype, {
             return;
         }
 
+        const globalIdentificationAnswers = {};
+        const identificationQuestionTypes = ["name", "email", "phone", "company_name"];
+
         const { globalSimpleChoice, globalTextAnswer } = Object.entries(result.byOrder).reduce(
             (acc, [questionId, answer]) => {
                 const question = this.pos.models["event.question"].get(parseInt(questionId));
@@ -68,6 +71,12 @@ patch(ProductScreen.prototype, {
                     acc.globalSimpleChoice[questionId] = answer;
                 } else if (answer) {
                     acc.globalTextAnswer[questionId] = answer;
+                    if (
+                        identificationQuestionTypes.includes(question.question_type) &&
+                        !(question.question_type in globalIdentificationAnswers)
+                    ) {
+                        globalIdentificationAnswers[question.question_type] = answer;
+                    }
                 }
 
                 return acc;
@@ -85,11 +94,17 @@ patch(ProductScreen.prototype, {
             });
 
             for (const registration of data) {
-                const userData = {};
+                // Global answers have precedence for identification question types.
+                const userData = { ...globalIdentificationAnswers };
                 for (const [questionId, answer] of Object.entries(registration)) {
                     const question = this.pos.models["event.question"].get(parseInt(questionId));
 
-                    if (!question) {
+                    if (
+                        !question ||
+                        !answer ||
+                        !identificationQuestionTypes.includes(question.question_type) ||
+                        question.question_type in userData
+                    ) {
                         continue;
                     }
 


### PR DESCRIPTION
When pos_event was added, a difference in behavior with the existing registration flow in website_event was missed. When answering an 'identification question' (name, email, phone, company_type) with the 'once per order' enabled, the values should be used and propagated directly on the created event.registration records, with precedence over other answers given to individual questions (not once per order)

STEPS
=====

1. Create a new event with name, email questions, once per order ticked.
2. Go to POS (reload data if needed)
3. Register and answer both questions
4. Continue the pos flow until both registrations are created
5. Go to backend > your event > registrations
6. You can see that even if the answers are propagated in the o2m field registration_answer_ids, which is expected, the attendee's name and attendee's email fields are empty. They should contain the values of step 3.

FIX
===

Align the website_event flow and precedence of OPO questions over
individual answers in pos_event. Now, the first non-null answer of an OPO
question will be used for each of the question_type values listed above,
if any, over answers to individual questions.

Also align the fact that after OPO answers, precedence should be given
to the first non-null answer to a given question type for identification
questions, and not the last as it is currently.

Task-4919080
