### PR TITLE
[I18N] l10n_latam_base: fix VAT translation

### DIFF
--- a/addons/l10n_latam_base/i18n/es_419.po
+++ b/addons/l10n_latam_base/i18n/es_419.po
@@ -161,4 +161,4 @@ msgstr "Tipo"
 #. module: l10n_latam_base
 #: model:l10n_latam.identification.type,name:l10n_latam_base.it_vat
 msgid "VAT"
-msgstr "IVA"
+msgstr "ID Fiscal"


### PR DESCRIPTION

### Description of the issue/feature this PR addresses:

Bad translation in Spanish LATAM (es_419.po)  for VAT the generic name receive for the document types.
 
### Current behavior before PR:

Will show IVA as the document type name

### Desired behavior after PR is merged:

Now will show "ID Fiscal" instead


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
