### PR TITLE
[IMP] account: add menu items to do accrual entries

### DIFF
--- a/addons/account/wizard/accrued_orders.py
+++ b/addons/account/wizard/accrued_orders.py
@@ -1,4 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from collections import defaultdict
 from dateutil.relativedelta import relativedelta
 import json
 from odoo import models, fields, api, _, Command
@@ -134,18 +135,24 @@ class AccountAccruedOrdersWizard(models.TransientModel):
 
         self.ensure_one()
         move_lines = []
-        is_purchase = self.env.context.get('active_model') == 'purchase.order'
-        orders = self.env[self.env.context['active_model']].with_company(self.company_id).browse(self.env.context['active_ids'])
+        active_model = self.env.context.get('active_model')
+        if active_model in ['purchase.order.line', 'sale.order.line']:
+            lines = self.env[active_model].with_company(self.company_id).browse(self.env.context['active_ids'])
+            orders = lines.order_id
+        else:
+            orders = self.env[active_model].with_company(self.company_id).browse(self.env.context['active_ids'])
+            lines = orders.order_line.filtered(lambda x: x.product_id)
+        is_purchase = orders._name == 'purchase.order'
 
         if orders.filtered(lambda o: o.company_id != self.company_id):
             raise UserError(_('Entries can only be created for a single company at a time.'))
         if orders.currency_id and len(orders.currency_id) > 1:
             raise UserError(_('Cannot create an accrual entry with orders in different currencies.'))
         orders_with_entries = []
-        fnames = []
         total_balance = 0.0
-        for order in orders:
-            product_lines = order.order_line.filtered(lambda x: x.product_id)
+        amounts_by_perpetual_account = defaultdict(float)
+
+        for order, product_lines in lines.grouped('order_id').items():
             if len(orders) == 1 and product_lines and self.amount and order.order_line:
                 total_balance = self.amount
                 order_line = product_lines[0]
@@ -154,70 +161,64 @@ class AccountAccruedOrdersWizard(models.TransientModel):
                 values = _get_aml_vals(order, self.amount, 0, account.id, label=_('Manual entry'), analytic_distribution=distribution)
                 move_lines.append(Command.create(values))
             else:
-                # create a virtual order that will allow to recompute the qty delivered/received (and dependancies)
-                # without actually writing anything on the real record (field is computed and stored)
-                o = order.new(origin=order)
-                if is_purchase:
-                    o.order_line.with_context(accrual_entry_date=self.date)._compute_qty_received()
-                    o.order_line.with_context(accrual_entry_date=self.date)._compute_qty_invoiced()
-                else:
-                    o.order_line.with_context(accrual_entry_date=self.date)._compute_qty_delivered()
-                    o.order_line.with_context(accrual_entry_date=self.date)._compute_qty_invoiced()
-                    o.order_line.with_context(accrual_entry_date=self.date)._compute_untaxed_amount_invoiced()
-                    o.order_line.with_context(accrual_entry_date=self.date)._compute_qty_to_invoice()
-                lines = o.order_line.filtered(
+                accrual_entry_date = self.env.context.get('accrual_entry_date', self.date)
+                order_lines = lines.with_context(accrual_entry_date=accrual_entry_date).filtered(
                     # We only want non-comment lines (no sections, notes, ...) and include all lines
                     # for purchase orders but exclude downpayment lines for sales orders.
                     lambda l: not l.display_type and not l.is_downpayment and
+                    l.id in order.order_line.ids and
                     fields.Float.compare(
-                        l.qty_to_invoice,
+                        l.amount_to_invoice_at_date,
                         0,
                         precision_rounding=l.product_uom_id.rounding,
                     ) != 0
                 )
-                for order_line in lines:
+                for order_line in order_lines:
+                    product = order_line.product_id
                     if is_purchase:
-                        account = self._get_computed_account(order, order_line.product_id, is_purchase)
+                        expense_account, stock_variation_account = self._get_product_expense_and_stock_var_accounts(product)
+                        account = stock_variation_account if stock_variation_account else self._get_computed_account(order, order_line.product_id, is_purchase)
                         if any(tax.price_include for tax in order_line.tax_ids):
                             # As included taxes are not taken into account in the price_unit, we need to compute the price_subtotal
+                            qty_to_invoice = order_line.qty_received_at_date - order_line.qty_invoiced_at_date
                             price_subtotal = order_line.tax_ids.compute_all(
                                 order_line.price_unit,
                                 currency=order_line.order_id.currency_id,
-                                quantity=order_line.qty_to_invoice,
+                                quantity=qty_to_invoice,
                                 product=order_line.product_id,
                                 partner=order_line.order_id.partner_id)['total_excluded']
                         else:
-                            price_subtotal = order_line.qty_to_invoice * order_line.price_unit
+                            price_subtotal = order_line.amount_to_invoice_at_date
                         amount_currency = order_line.currency_id.round(price_subtotal)
                         amount = order.currency_id._convert(amount_currency, self.company_id.currency_id, self.company_id)
-                        fnames = ['qty_to_invoice', 'qty_received', 'qty_invoiced', 'invoice_lines']
                         label = _(
                             '%(order)s - %(order_line)s; %(quantity_billed)s Billed, %(quantity_received)s Received at %(unit_price)s each',
                             order=order.name,
                             order_line=_ellipsis(order_line.name, 20),
-                            quantity_billed=order_line.qty_invoiced,
-                            quantity_received=order_line.qty_received,
+                            quantity_billed=order_line.qty_invoiced_at_date,
+                            quantity_received=order_line.qty_received_at_date,
                             unit_price=formatLang(self.env, order_line.price_unit, currency_obj=order.currency_id),
                         )
                     else:
-                        account = self._get_computed_account(order, order_line.product_id, is_purchase)
-                        amount_currency = order_line.untaxed_amount_to_invoice
+                        expense_account, stock_variation_account = self._get_product_expense_and_stock_var_accounts(product)
+                        account = self._get_computed_account(order, product, is_purchase)
+                        amount_currency = order_line.amount_to_invoice_at_date
                         amount = order.currency_id._convert(amount_currency, self.company_id.currency_id, self.company_id)
-                        fnames = ['qty_to_invoice', 'untaxed_amount_to_invoice', 'qty_invoiced', 'qty_delivered', 'invoice_lines']
                         label = _(
                             '%(order)s - %(order_line)s; %(quantity_invoiced)s Invoiced, %(quantity_delivered)s Delivered at %(unit_price)s each',
                             order=order.name,
                             order_line=_ellipsis(order_line.name, 20),
-                            quantity_invoiced=order_line.qty_invoiced,
-                            quantity_delivered=order_line.qty_delivered,
+                            quantity_invoiced=order_line.qty_invoiced_at_date,
+                            quantity_delivered=order_line.qty_delivered_at_date,
                             unit_price=formatLang(self.env, order_line.price_unit, currency_obj=order.currency_id),
                         )
+                        if expense_account and stock_variation_account:
+                            label += " (*)"
+                            amounts_by_perpetual_account[expense_account, stock_variation_account] += amount
                     distribution = order_line.analytic_distribution if order_line.analytic_distribution else {}
                     values = _get_aml_vals(order, amount, amount_currency, account.id, label=label, analytic_distribution=distribution)
                     move_lines.append(Command.create(values))
                     total_balance += amount
-                # must invalidate cache or o can mess when _create_invoices().action_post() of original order after this
-                order.order_line.invalidate_model(fnames)
 
         if not self.company_id.currency_id.is_zero(total_balance):
             # globalized counterpart for the whole orders selection
@@ -230,6 +231,18 @@ class AccountAccruedOrdersWizard(models.TransientModel):
                 for account_id, distribution in line.analytic_distribution.items():
                     analytic_distribution.update({account_id : analytic_distribution.get(account_id, 0) + distribution*ratio})
             values = _get_aml_vals(orders, -total_balance, 0.0, self.account_id.id, label=_('Accrued total'), analytic_distribution=analytic_distribution)
+            move_lines.append(Command.create(values))
+
+        for (expense_account, stock_variation_account), amount in amounts_by_perpetual_account.items():
+            if amount == 0:
+                continue
+            if amount > 0:
+                label = _('(*) Goods Delivered not Invoiced (perpetual valuation)')
+            else:
+                label = _('(*) Goods Invoiced not Delivered (perpetual valuation)')
+            values = _get_aml_vals(orders, amount, 0.0, stock_variation_account.id, label=label)
+            move_lines.append(Command.create(values))
+            values = _get_aml_vals(orders, -amount, 0.0, expense_account.id, label=label)
             move_lines.append(Command.create(values))
 
         move_type = _('Expense') if is_purchase else _('Revenue')
@@ -276,3 +289,7 @@ class AccountAccruedOrdersWizard(models.TransientModel):
             'view_mode': 'list,form',
             'domain': [('id', 'in', (move | reverse_move).ids)],
         }
+
+    @api.model
+    def _get_product_expense_and_stock_var_accounts(self, product):
+        return (False, False)

--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from datetime import datetime, time
 from dateutil.relativedelta import relativedelta
 from pytz import UTC
@@ -60,6 +61,20 @@ class PurchaseOrderLine(models.Model):
     qty_received_manual = fields.Float("Manual Received Qty", digits='Product Unit', copy=False)
     qty_to_invoice = fields.Float(compute='_compute_qty_invoiced', string='To Invoice Quantity', store=True, readonly=True,
                                   digits='Product Unit')
+
+    # Same than `qty_received` and `qty_to_invoice` but non-stored and depending of the context.
+    qty_received_at_date = fields.Float(
+        string="Received",
+        compute='_compute_qty_received_at_date',
+        digits='Product Unit'
+    )
+    qty_invoiced_at_date = fields.Float(
+        string="Billed",
+        compute='_compute_qty_invoiced_at_date',
+        digits='Product Unit'
+    )
+
+    amount_to_invoice_at_date = fields.Float(string='Amount', compute='_compute_amount_to_invoice_at_date')
 
     partner_id = fields.Many2one('res.partner', related='order_id.partner_id', string='Partner', readonly=True, store=True, index='btree_not_null')
     currency_id = fields.Many2one(related='order_id.currency_id', string='Currency')
@@ -137,16 +152,10 @@ class PurchaseOrderLine(models.Model):
 
     @api.depends('invoice_lines.move_id.state', 'invoice_lines.quantity', 'qty_received', 'product_uom_qty', 'order_id.state')
     def _compute_qty_invoiced(self):
+        invoiced_quantities = self._prepare_qty_invoiced()
         for line in self:
-            # compute qty_invoiced
-            qty = 0.0
-            for inv_line in line._get_invoice_lines():
-                if inv_line.move_id.state not in ['cancel'] or inv_line.move_id.payment_state == 'invoicing_legacy':
-                    if inv_line.move_id.move_type == 'in_invoice':
-                        qty += inv_line.product_uom_id._compute_quantity(inv_line.quantity, line.product_uom_id)
-                    elif inv_line.move_id.move_type == 'in_refund':
-                        qty -= inv_line.product_uom_id._compute_quantity(inv_line.quantity, line.product_uom_id)
-            line.qty_invoiced = qty
+            if not line.qty_invoiced or line in invoiced_quantities:
+                line.qty_invoiced = invoiced_quantities[line]
 
             # compute qty_to_invoice
             if line.order_id.state == 'purchase':
@@ -157,11 +166,35 @@ class PurchaseOrderLine(models.Model):
             else:
                 line.qty_to_invoice = 0
 
+    @api.depends('qty_invoiced')
+    @api.depends_context('accrual_entry_date')
+    def _compute_qty_invoiced_at_date(self):
+        if not self._date_in_the_past():
+            for line in self:
+                line.qty_invoiced_at_date = line.qty_invoiced
+            return
+        invoiced_quantities = self._prepare_qty_invoiced()
+        for line in self:
+            line.qty_invoiced_at_date = invoiced_quantities[line]
+
+    def _prepare_qty_invoiced(self):
+        # Compute qty_invoiced
+        invoiced_qties = defaultdict(float)
+        for line in self:
+            for inv_line in line._get_invoice_lines():
+                if inv_line.move_id.state not in ['cancel'] or inv_line.move_id.payment_state == 'invoicing_legacy':
+                    if inv_line.move_id.move_type == 'in_invoice':
+                        invoiced_qties[line] += inv_line.product_uom_id._compute_quantity(inv_line.quantity, line.product_uom_id)
+                    elif inv_line.move_id.move_type == 'in_refund':
+                        invoiced_qties[line] -= inv_line.product_uom_id._compute_quantity(inv_line.quantity, line.product_uom_id)
+        return invoiced_qties
+
     def _get_invoice_lines(self):
         self.ensure_one()
         if self.env.context.get('accrual_entry_date'):
+            accrual_date = fields.Date.from_string(self.env.context['accrual_entry_date'])
             return self.invoice_lines.filtered(
-                lambda l: l.move_id.invoice_date and l.move_id.invoice_date <= self.env.context['accrual_entry_date']
+                lambda l: l.move_id.invoice_date and l.move_id.invoice_date <= accrual_date
             )
         else:
             return self.invoice_lines
@@ -176,11 +209,30 @@ class PurchaseOrderLine(models.Model):
 
     @api.depends('qty_received_method', 'qty_received_manual')
     def _compute_qty_received(self):
+        received_qties = self._prepare_qty_received()
+        for line in self:
+            if not line.qty_received or line in received_qties:
+                line.qty_received = received_qties[line]
+
+    @api.depends('qty_received')
+    @api.depends_context('accrual_entry_date')
+    def _compute_qty_received_at_date(self):
+        if not self._date_in_the_past():
+            for line in self:
+                line.qty_received_at_date = line.qty_received
+            return
+        received_quantities = self._prepare_qty_received()
+        for line in self:
+            line.qty_received_at_date = received_quantities[line]
+
+    def _prepare_qty_received(self):
+        received_qties = defaultdict(float)
         for line in self:
             if line.qty_received_method == 'manual':
-                line.qty_received = line.qty_received_manual or 0.0
+                received_qties[line] = line.qty_received_manual or 0.0
             else:
-                line.qty_received = 0.0
+                received_qties[line] = 0.0
+        return received_qties
 
     @api.onchange('qty_received')
     def _inverse_qty_received(self):
@@ -208,6 +260,12 @@ class PurchaseOrderLine(models.Model):
                 line.selected_seller_id = seller.id if seller else False
             else:
                 line.selected_seller_id = False
+
+    @api.depends('price_unit', 'qty_invoiced_at_date', 'qty_received_at_date')
+    @api.depends_context('accrual_entry_date')
+    def _compute_amount_to_invoice_at_date(self):
+        for line in self:
+            line.amount_to_invoice_at_date = (line.qty_received_at_date - line.qty_invoiced_at_date) * line.price_unit
 
     @api.model_create_multi
     def create(self, vals_list):
@@ -590,6 +648,13 @@ class PurchaseOrderLine(models.Model):
         to order user's time zone, convert to UTC time.
         """
         return self.order_id.get_order_timezone().localize(datetime.combine(date, time(12))).astimezone(UTC).replace(tzinfo=None)
+
+    @api.model
+    def _date_in_the_past(self):
+        if not 'accrual_entry_date' in self.env.context:
+            return False
+        accrual_date = fields.Date.from_string(self.env.context['accrual_entry_date'])
+        return accrual_date < fields.Date.today()
 
     def _update_date_planned(self, updated_date):
         self.date_planned = updated_date

--- a/addons/purchase/tests/test_accrued_purchase_orders.py
+++ b/addons/purchase/tests/test_accrued_purchase_orders.py
@@ -91,7 +91,7 @@ class TestAccruedPurchaseOrders(AccountTestInvoicingCommon):
         move.action_post()
 
         with self.assertRaises(UserError):
-            self.wizard.create_entries()
+            self.wizard.with_context(accrual_entry_date='2020-01-30').create_entries()
 
     def test_multi_currency_accrued_order(self):
         # 5 qty of each product billeable
@@ -173,15 +173,15 @@ class TestAccruedPurchaseOrders(AccountTestInvoicingCommon):
         res = self.env['account.move'].search(self.wizard.create_entries()['domain']).line_ids
         self.assertRecordValues(res, [
             # reverse move lines
-            {'account_id': self.account_expense.id, 'debit': 5000.0, 'credit': 0.0},
-            {'account_id': self.alt_exp_account.id, 'debit': 1000.0, 'credit': 0.0},
-            {'account_id': self.account_revenue.id, 'debit': 0.0, 'credit': 6000.0},
+            {'account_id': self.account_expense.id, 'debit': 10000.0, 'credit': 0.0},
+            {'account_id': self.alt_exp_account.id, 'debit': 2000.0, 'credit': 0.0},
+            {'account_id': self.account_revenue.id, 'debit': 0.0, 'credit': 12000.0},
             # move lines
-            {'account_id': self.account_expense.id, 'debit': 0.0, 'credit': 5000.0},
-            {'account_id': self.alt_exp_account.id, 'debit': 0.0, 'credit': 1000.0},
-            {'account_id': self.account_revenue.id, 'debit': 6000.0, 'credit': 0.0},
+            {'account_id': self.account_expense.id, 'debit': 0.0, 'credit': 10000.0},
+            {'account_id': self.alt_exp_account.id, 'debit': 0.0, 'credit': 2000.0},
+            {'account_id': self.account_revenue.id, 'debit': 12000.0, 'credit': 0.0},
         ])
-    
+
     def test_error_when_different_currencies_accrued(self):
         """
         Tests that if two Purchase Orders with different currencies are selected for Accrued Expense Entry, 

--- a/addons/purchase/tests/test_purchase_downpayment.py
+++ b/addons/purchase/tests/test_purchase_downpayment.py
@@ -89,8 +89,7 @@ class TestPurchaseDownpayment(TestPurchaseToInvoiceCommon):
 
     def test_downpayment_in_accrued_expense_entry(self):
         """Check that the downpayment is not included in the accrued expense entry"""
-        po = self.init_purchase(confirm=False, products=[self.product_order])
-        po.button_confirm()
+        po = self.init_purchase(confirm=True, products=[self.product_order])
 
         self.init_invoice('in_invoice', amounts=[1600.00], post=True)
 
@@ -106,8 +105,11 @@ class TestPurchaseDownpayment(TestPurchaseToInvoiceCommon):
             active_ids=po.ids,
         ).create({
             'account_id': self.company_data['default_account_expense'].id,
-            'date': '2025-01-01',
+            'date': fields.Date.today(),
         })
+
+        # Receive 1 qty to have something to accrual.
+        po.order_line.qty_received = 1
 
         self.assertRecordValues(self.env['account.move'].search(accrued_wizard.create_entries()['domain']).line_ids, [
             # reverse move lines

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -147,6 +147,7 @@ class SaleOrderLine(models.Model):
     linked_line_ids = fields.One2many(
         string="Linked Order Lines", comodel_name='sale.order.line', inverse_name='linked_line_id',
     )
+    categ_id = fields.Many2one(related='product_id.categ_id')
     # Uniquely identifies this sale order line before the record is saved in the DB, i.e. before the
     # record has an `id`.
     virtual_id = fields.Char()
@@ -287,6 +288,18 @@ class SaleOrderLine(models.Model):
         compute='_compute_amount_to_invoice',
         compute_sudo=True,  # ensure same access as `untaxed_amount_to_invoice`
     )
+    amount_to_invoice_at_date = fields.Float(string='Amount', compute='_compute_amount_to_invoice_at_date')
+
+    # Same than `qty_delivered` and `qty_invoiced` but non-stored and depending of the context.
+    qty_delivered_at_date = fields.Float(
+        string="Delivered",
+        compute='_compute_qty_delivered_at_date',
+        digits='Product Unit')
+    qty_invoiced_at_date = fields.Float(
+        string="Invoiced",
+        compute='_compute_qty_invoiced_at_date',
+        digits='Product Unit')
+
     # Technical field holding custom data for the taxes computation engine.
     extra_tax_data = fields.Json()
 
@@ -876,11 +889,31 @@ class SaleOrderLine(models.Model):
             take their concerned so lines, compute and set the `qty_delivered` field, and call super with the remaining
             records.
         """
+        delivered_qties = self._prepare_qty_delivered()
+        for so_line in self:
+            if not so_line.qty_delivered or so_line in delivered_qties:
+                so_line.qty_delivered = delivered_qties[so_line]
+
+    @api.depends('qty_delivered')
+    @api.depends_context('accrual_entry_date')
+    def _compute_qty_delivered_at_date(self):
+        if not self._date_in_the_past():
+            # Avoid useless compute if we don't look in the past.
+            for line in self:
+                line.qty_delivered_at_date = line.qty_delivered
+            return
+        delivered_qties = self._prepare_qty_delivered()
+        for line in self:
+            line.qty_delivered_at_date = delivered_qties[line]
+
+    def _prepare_qty_delivered(self):
         # compute for analytic lines
+        delivered_qties = defaultdict(float)
         lines_by_analytic = self.filtered(lambda sol: sol.qty_delivered_method == 'analytic')
         mapping = lines_by_analytic._get_delivered_quantity_by_analytic([('amount', '<=', 0.0)])
         for so_line in lines_by_analytic:
-            so_line.qty_delivered = mapping.get(so_line.id or so_line._origin.id, 0.0)
+            delivered_qties[so_line] = mapping.get(so_line.id or so_line._origin.id, 0.0)
+        return delivered_qties
 
     def _get_downpayment_state(self):
         self.ensure_one()
@@ -897,8 +930,8 @@ class SaleOrderLine(models.Model):
         return ''
 
     def _get_delivered_quantity_by_analytic(self, additional_domain):
-        """ Compute and write the delivered quantity of current SO lines, based on their related
-            analytic lines.
+        """ Compute and return the delivered quantity of current SO lines,
+            based on their related analytic lines.
             :param additional_domain: domain to restrict AAL to include in computation (required since timesheet is an AAL with a project ...)
         """
         result = defaultdict(float)
@@ -937,15 +970,34 @@ class SaleOrderLine(models.Model):
         a refund made would automatically decrease the invoiced quantity, then there is a risk of reinvoicing
         it automatically, which may not be wanted at all. That's why the refund has to be created from the SO
         """
+        invoiced_quantities = self._prepare_qty_invoiced()
         for line in self:
-            qty_invoiced = 0.0
+            if not line.qty_invoiced or line in invoiced_quantities:
+                line.qty_invoiced = invoiced_quantities[line]
+
+    @api.depends('qty_invoiced')
+    @api.depends_context('accrual_entry_date')
+    def _compute_qty_invoiced_at_date(self):
+        if not self._date_in_the_past():
+            # Avoid useless compute if we don't look in the past.
+            for line in self:
+                line.qty_invoiced_at_date = line.qty_invoiced
+            return
+        invoiced_quantities = self._prepare_qty_invoiced()
+        for line in self:
+            line.qty_invoiced_at_date = invoiced_quantities[line]
+
+    def _prepare_qty_invoiced(self):
+        invoiced_qties = defaultdict(float)
+        for line in self:
             for invoice_line in line._get_invoice_lines():
                 if invoice_line.move_id.state != 'cancel' or invoice_line.move_id.payment_state == 'invoicing_legacy':
+                    invoice_qty = invoice_line.product_uom_id._compute_quantity(invoice_line.quantity, line.product_uom_id)
                     if invoice_line.move_id.move_type == 'out_invoice':
-                        qty_invoiced += invoice_line.product_uom_id._compute_quantity(invoice_line.quantity, line.product_uom_id)
+                        invoiced_qties[line] += invoice_qty
                     elif invoice_line.move_id.move_type == 'out_refund':
-                        qty_invoiced -= invoice_line.product_uom_id._compute_quantity(invoice_line.quantity, line.product_uom_id)
-            line.qty_invoiced = qty_invoiced
+                        invoiced_qties[line] -= invoice_qty
+        return invoiced_qties
 
     @api.depends('invoice_lines.move_id.state', 'invoice_lines.quantity')
     def _compute_qty_invoiced_posted(self):
@@ -967,8 +1019,9 @@ class SaleOrderLine(models.Model):
     def _get_invoice_lines(self):
         self.ensure_one()
         if self.env.context.get('accrual_entry_date'):
+            accrual_date = fields.Date.from_string(self.env.context['accrual_entry_date'])
             return self.invoice_lines.filtered(
-                lambda l: l.move_id.invoice_date and l.move_id.invoice_date <= self.env.context['accrual_entry_date']
+                lambda l: l.move_id.invoice_date and l.move_id.invoice_date <= accrual_date
             )
         else:
             return self.invoice_lines
@@ -1139,6 +1192,12 @@ class SaleOrderLine(models.Model):
                 line.amount_to_invoice = unit_price_total * qty_to_invoice
             else:
                 line.amount_to_invoice = 0.0
+
+    @api.depends('price_unit', 'qty_invoiced_at_date', 'qty_delivered_at_date')
+    @api.depends_context('accrual_entry_date')
+    def _compute_amount_to_invoice_at_date(self):
+        for line in self:
+            line.amount_to_invoice_at_date = (line.qty_delivered_at_date - line.qty_invoiced_at_date) * line.price_unit
 
     @api.depends('order_id.partner_id', 'product_id')
     def _compute_analytic_distribution(self):
@@ -1647,6 +1706,13 @@ class SaleOrderLine(models.Model):
                 round=False,
             )
         return amount
+
+    @api.model
+    def _date_in_the_past(self):
+        if not 'accrual_entry_date' in self.env.context:
+            return False
+        accrual_date = fields.Date.from_string(self.env.context['accrual_entry_date'])
+        return accrual_date < fields.Date.today()
 
     def has_valued_move_ids(self):
         return self.move_ids

--- a/addons/sale/tests/test_accrued_sale_orders.py
+++ b/addons/sale/tests/test_accrued_sale_orders.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo import fields
 from odoo.exceptions import UserError
 from odoo.fields import Command
 from odoo.tests import freeze_time, tagged
@@ -73,16 +74,23 @@ class TestAccruedSaleOrders(TestSaleCommon):
             'active_ids': cls.sale_order.ids,
         }).create({
             'account_id': cls.account_expense.id,
+            'date': fields.Date.today(),
         })
 
     def test_accrued_order(self):
+        # self.wizard = self.wizard.with_context(accrual_entry_date=fields.Date.today())
+        self.wizard.date = fields.Date.today()
         # nothing to invoice : no entries to be created
         with self.assertRaises(UserError):
             self.wizard.create_entries()
 
         # 5 qty of each product invoiceable
         self.sale_order.order_line.qty_delivered = 5
-        self.assertRecordValues(self.env['account.move'].search(self.wizard.create_entries()['domain']).line_ids, [
+        # Call accrual wizard at today date because calling in the past will
+        # re-compute delivred and invoiced quantities for this date and thus
+        # generate nothing since there was no delivered quantity at this time.
+        account_move = self.env['account.move'].search(self.wizard.create_entries()['domain'])
+        self.assertRecordValues(account_move.line_ids, [
             # reverse move lines
             {'account_id': self.account_revenue.id, 'debit': 5000, 'credit': 0},
             {'account_id': self.alt_inc_account.id, 'debit': 1000, 'credit': 0},
@@ -95,10 +103,8 @@ class TestAccruedSaleOrders(TestSaleCommon):
 
         # delivered products invoiced, nothing to invoice left
         invoices = self.sale_order._create_invoices()
-        invoices.invoice_date = self.wizard.date
         invoices.action_post()
         with self.assertRaises(UserError):
-            self.env['account.move.line']._invalidate_cache()
             self.wizard.create_entries()
         self.assertTrue(self.wizard.display_amount)
 

--- a/addons/sale/wizard/account_accrued_orders_wizard_views.xml
+++ b/addons/sale/wizard/account_accrued_orders_wizard_views.xml
@@ -10,4 +10,13 @@
         <field name="target">new</field>
     </record>
 
+    <record id="action_accrued_revenue_entry_sale_order_line" model="ir.actions.act_window">
+        <field name="name">Accrued Revenue Entry</field>
+        <field name="res_model">account.accrued.orders.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="binding_model_id" ref="sale.model_sale_order_line"/>
+        <field name="group_ids" eval="[(4, ref('account.group_account_user'))]"/>
+        <field name="target">new</field>
+    </record>
+
 </odoo>

--- a/addons/sale_stock/models/sale_order_line.py
+++ b/addons/sale_stock/models/sale_order_line.py
@@ -196,6 +196,8 @@ class SaleOrderLine(models.Model):
     def _compute_qty_delivered(self):
         super(SaleOrderLine, self)._compute_qty_delivered()
 
+    def _prepare_qty_delivered(self):
+        delivered_qties = super()._prepare_qty_delivered()
         for line in self:  # TODO: maybe one day, this should be done in SQL for performance sake
             if line.qty_delivered_method == 'stock_move':
                 qty = 0.0
@@ -208,7 +210,8 @@ class SaleOrderLine(models.Model):
                     if move.state != 'done':
                         continue
                     qty -= move.product_uom._compute_quantity(move.quantity, line.product_uom_id, rounding_method='HALF-UP')
-                line.qty_delivered = qty
+                delivered_qties[line] = qty
+        return delivered_qties
 
     @api.model_create_multi
     def create(self, vals_list):
@@ -311,7 +314,8 @@ class SaleOrderLine(models.Model):
                     triggering_rule_ids.append(move.rule_id.id)
                     seen_wh_ids.add(move.warehouse_id.id)
         if self.env.context.get('accrual_entry_date'):
-            moves = moves.filtered(lambda r: fields.Date.context_today(r, r.date) <= self.env.context['accrual_entry_date'])
+            accrual_date = fields.Date.from_string(self.env.context['accrual_entry_date'])
+            moves = moves.filtered(lambda r: fields.Date.context_today(r, r.date) <= accrual_date)
 
         for move in moves:
             if not move._is_dropshipped_returned() and (

--- a/addons/sale_stock/wizard/__init__.py
+++ b/addons/sale_stock/wizard/__init__.py
@@ -1,5 +1,5 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import accrued_orders
 from . import stock_rules_report
 from . import stock_return_picking

--- a/addons/sale_stock/wizard/accrued_orders.py
+++ b/addons/sale_stock/wizard/accrued_orders.py
@@ -1,0 +1,17 @@
+from odoo import models, api
+
+
+class AccountAccruedOrdersWizard(models.TransientModel):
+    _inherit = 'account.accrued.orders.wizard'
+
+    @api.model
+    def _get_product_expense_and_stock_var_accounts(self, product):
+        self.ensure_one()
+        res = super()._get_product_expense_and_stock_var_accounts(product)
+        if product.is_storable and product.valuation == 'real_time':
+            product_accounts = product._get_product_accounts()
+            expense_account = product_accounts.get('expense')
+            stock_variation_account = product_accounts.get('stock_variation')
+            if expense_account and stock_variation_account:
+                return (expense_account, stock_variation_account)
+        return res

--- a/addons/sale_timesheet/models/sale_order_line.py
+++ b/addons/sale_timesheet/models/sale_order_line.py
@@ -70,11 +70,15 @@ class SaleOrderLine(models.Model):
     @api.depends('analytic_line_ids.project_id', 'project_id.pricing_type')
     def _compute_qty_delivered(self):
         super()._compute_qty_delivered()
+
+    def _prepare_qty_delivered(self):
+        delivered_qties = super()._prepare_qty_delivered()
         lines_by_timesheet = self.filtered(lambda sol: sol.qty_delivered_method == 'timesheet')
         domain = lines_by_timesheet._timesheet_compute_delivered_quantity_domain()
         mapping = lines_by_timesheet.sudo()._get_delivered_quantity_by_analytic(domain)
         for line in lines_by_timesheet:
-            line.qty_delivered = mapping.get(line.id or line._origin.id, 0.0)
+            delivered_qties[line] = mapping.get(line.id or line._origin.id, 0.0)
+        return delivered_qties
 
     def _timesheet_compute_delivered_quantity_domain(self):
         """ Hook for validated timesheet in addionnal module """

--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, _


### PR DESCRIPTION
*: account, pos_sale, purchase, purchase_mrp, purchase_stock, sale,
sale_mrp, sale_project, sale_stock, sale_timesheet, stock_account

This commit modifies `sale.order.line` and `purchase.order.line` models
to work with the new accrual reports.

List of changes made:

## Split compute methods
The `purchase.order.line` has two fields, `qty_received` and
`qty_invoiced`, and we would like to be able to know what was those
fields value in the past at a given date. The `sale.order.line` has also
two fields in the same situation, `qty_delivered` and `qty_invoiced`.

Currently, those fields are computed and stored, thus we need a
computed non-stored version of those fields to be able to re-compute
their value depending of the context (so, we can pass the accrual date
into the context.) The non-stored version of those fields have the same
name with the suffix "at_date" (eg.: `qty_invoiced_at_date`.)

To achieve that, we move all the compute code outside of the compute
method to have a method we can call from both fields' compute.
For example, we have now a method named `_prepare_qty_delivered` which
returns the `qty_delivered` value for the SO lines, and both
`_compute_qty_delivered` and `_compute_qty_delivered_at_date` use it.

## "at_date" fields
Those new computed stored fields use the `accrual_entry_date` context
key to compute their value at this date.
This key was already there in the code and already used by the accrual
wizard but before, it was always an actual date object, now it can be a
string (when pass in the context from the client side) and thus needs to
be parsed.

A field `amount_to_invoice_at_date` was also added, both for PO line and
SO line, and this field is simply the difference between the
delivered/received quantity and the invoiced quantity times the price
unit. It is used by the accrual views (see enterprise PR) and the
accrual wizard.
About this field, note that we make the choice to declare it a a `Float`
field and not a `Monetary` field. While a monetary field was our first
option, we figured out it adds complexity while hacking *hum* patching
the `_read_group` method to be able to sum those non-stored computed
fields (again, see entreprise PR for more information.)

## Perpetual valuation
When using the Accrued Orders Wizard, if an order's product uses the
perpetual valuation (needs an expense account and a stock variation
account), addition account moves will be generated for the expense
account and the stock variation account and related product will be
marked by an asterisk (*).

[task-5075455](https://www.odoo.com/odoo/966/tasks/5075455)
Enterprise PR: odoo/enterprise#97151