### PR TITLE
[FIX] web: remove non-breaking spaces in signatures

### DIFF
--- a/addons/web/static/src/core/signature/name_and_signature.js
+++ b/addons/web/static/src/core/signature/name_and_signature.js
@@ -140,7 +140,8 @@ export class NameAndSignature extends Component {
      * @returns {string} cleaned name
      */
     getCleanedName() {
-        const text = this.props.signature.name;
+        // This replaces non-breaking spaces with breaking spaces
+        const text = this.props.signature.name.replace(/ /g, " ");
         if (this.props.signatureType === "initial" && text) {
             return (
                 text

--- a/addons/web/static/tests/core/name_and_signature.test.js
+++ b/addons/web/static/tests/core/name_and_signature.test.js
@@ -112,3 +112,21 @@ test("test name_and_signature widget update signmode with onSignatureChange prop
     await contains(".o_web_sign_draw_button").click();
     expect(currentSignMode).toBe("draw");
 });
+
+test("test name_and_signature widget with non-breaking spaces", async function () {
+   const props = {
+       signature: { name: "Non Breaking Spaces" },
+   };
+   const res = await mountWithCleanup(NameAndSignature, { props });
+   expect(res.getCleanedName()).toBe("Non Breaking Spaces");
+});
+
+
+test("test name_and_signature widget with non-breaking spaces and initials mode", async function () {
+   const props = {
+       signature: { name: "Non Breaking Spaces" },
+       signatureType: "initial",
+   };
+   const res = await mountWithCleanup(NameAndSignature, { props });
+   expect(res.getCleanedName()).toBe("N.B.S.");
+});


### PR DESCRIPTION
Before this commit:
Names containing a non-breaking space would break the generated svg
file.
This is because the inserted '&nbsp' is not valid XML.
This also broke the initials signature generation.

After this commit:
The getCleanedName method actually returns the cleaned name and the
signature svg files is correct.

Related ticket:
opw-4927425
