### PR TITLE
[IMP] base: improve customizable of res_partner form

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -270,6 +270,22 @@ class ResPartner(models.Model):
     is_company = fields.Boolean(string='Is a Company', default=False, compute="_compute_is_company", store=True,
         help="Check if the contact is a company, otherwise it is a person")
     is_public = fields.Boolean(compute='_compute_is_public', compute_sudo=True)
+    is_address_readonly = fields.Boolean(
+        compute="_compute_contact_type",
+        help="If true, the address fields are readonly.",
+    )
+    is_individual = fields.Boolean(
+        compute="_compute_contact_type", help="If true, the partner name is splitted."
+    )
+    can_be_parent = fields.Boolean(
+        compute="_compute_contact_type",
+        search="_search_can_be_parent",
+        help="If true, the partner is available as parent.",
+    )
+    can_be_child = fields.Boolean(
+        compute="_compute_contact_type",
+        help="If true, the partner_id field is available.",
+    )
     industry_id: ResPartnerIndustry = fields.Many2one('res.partner.industry', 'Industry')
     company_id: ResCompany = fields.Many2one('res.company', 'Company', index=True)
     color = fields.Integer(string='Color Index', default=0)
@@ -339,6 +355,26 @@ class ResPartner(models.Model):
     @api.depends('name', 'user_ids.share', 'image_128', 'is_company', 'type')
     def _compute_avatar_128(self):
         super()._compute_avatar_128()
+
+    @api.depends("is_company", "type", "parent_id")
+    def _compute_contact_type(self):
+        for partner in self:
+            partner.is_address_readonly = not (
+                partner.is_company
+                or not partner.parent_id
+                or partner.type not in ["contact"]
+            )
+            partner.is_individual = not partner.is_company and partner.type in [
+                "contact",
+                "other",
+            ]
+
+            partner.can_be_parent = partner.is_company
+            partner.can_be_child = not partner.is_company
+
+    @api.model
+    def _search_can_be_parent(self, operator, value):
+        return [("is_company", operator, value)]
 
     def _compute_avatar(self, avatar_field, image_field):
         partners_with_internal_user = self.filtered(

--- a/odoo/addons/base/tests/test_res_partner.py
+++ b/odoo/addons/base/tests/test_res_partner.py
@@ -1161,3 +1161,63 @@ class TestPartnerCategory(TransactionCase):
         result = self.env['res.partner.category'].name_search('buggy_test')
         self.assertEqual(len(result), 1)
         self.assertEqual(result, [(category.id, category.display_name)])
+
+
+@tagged('res_partner')
+class TestResPartnerUi(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.ResPartner = cls.env["res.partner"]
+
+        cls.Partner_company = cls.ResPartner.create(
+            {"name": "Company Partner", "is_company": True, "type": "contact"}
+        )
+        cls.Partner_contact = cls.ResPartner.create(
+            {"name": "Individual Partner", "is_company": False, "type": "contact"}
+        )
+        cls.Partner_child = cls.ResPartner.create(
+            {
+                "name": "Child Partner",
+                "is_company": False,
+                "type": "contact",
+                "parent_id": cls.Partner_company.id,
+            }
+        )
+        cls.Partner_other = cls.ResPartner.create(
+            {"name": "Other Partner", "is_company": False, "type": "other"}
+        )
+        cls.Partner_invoice = cls.ResPartner.create(
+            {"name": "Invoice Partner", "is_company": False, "type": "invoice"}
+        )
+        cls.Partner_delivery = cls.ResPartner.create(
+            {"name": "Shipping Partner", "is_company": False, "type": "delivery"}
+        )
+
+    def test_is_address_readonly(self):
+        self.assertFalse(self.Partner_company.is_address_readonly)
+        self.assertFalse(self.Partner_contact.is_address_readonly)
+        self.assertTrue(self.Partner_child.is_address_readonly)
+        self.assertFalse(self.Partner_invoice.is_address_readonly)
+        self.assertFalse(self.Partner_delivery.is_address_readonly)
+
+    def test_is_individual_types(self):
+        self.assertFalse(self.Partner_company.is_individual)
+        self.assertTrue(self.Partner_contact.is_individual)
+        self.assertTrue(self.Partner_other.is_individual)
+        self.assertFalse(self.Partner_invoice.is_individual)
+        self.assertFalse(self.Partner_delivery.is_individual)
+
+    def test_can_be_parent(self):
+        self.assertTrue(self.Partner_company.can_be_parent)
+        self.assertFalse(self.Partner_contact.can_be_parent)
+        self.assertFalse(self.Partner_other.can_be_parent)
+        self.assertFalse(self.Partner_invoice.can_be_parent)
+        self.assertFalse(self.Partner_delivery.can_be_parent)
+
+    def test_can_be_child(self):
+        self.assertFalse(self.Partner_company.can_be_child)
+        self.assertTrue(self.Partner_contact.can_be_child)
+        self.assertTrue(self.Partner_other.can_be_child)
+        self.assertTrue(self.Partner_invoice.can_be_child)
+        self.assertTrue(self.Partner_delivery.can_be_child)

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -43,15 +43,16 @@
                     <field name="image_1920" widget='image' class="oe_avatar" options='{"preview_image": "avatar_128"}'/>
                     <div class="oe_title">
                         <h1>
-                            <field id="contact" name="name" default_focus="1" placeholder="e.g. Lumber Inc or Brandon Freeman"  required="type == 'contact'"/>
+                            <field id="contact" name="name" default_focus="1" placeholder="e.g. Lumber Inc or Brandon Freeman" required="is_individual or is_company"/>
                         </h1>
                         <field name="parent_id"
                             widget="res_partner_many2one"
                             placeholder="Company Name..."
-                            domain="[('parent_id', '=', False)]" context="{'show_vat': True, 'default_user_id': user_id}"/>
+                            domain="[('can_be_parent', '=', True)]" context="{'show_vat': True, 'default_user_id': user_id}"
+                            invisible="not can_be_child"/> 
                     </div>
                     <group>
-                        <field name="function" placeholder="e.g. Sales Director"/>
+                        <field name="function" placeholder="e.g. Sales Director" invisible="not is_individual"/>
                         <field name="email" widget="email" required="True"/>
                         <field name="phone" widget="phone" options="{'enable_sms': false}"/>
                     </group>
@@ -131,8 +132,8 @@
                             <field name="image_1920" widget="contact_image" options="{'preview_image': 'avatar_128', 'size': [130,130], 'img_class': 'rounded border'}"/>
                             <field name="avatar_128" invisible="1"/> <!-- Needed in contact_image widget -->
                             <div class="d-flex flex-column flex-grow-1">
-                                <h1 class="mb-0 w-75">
-                                    <field options="{'line_breaks': False}" widget="text" class="text-break d-block" name="name" default_focus="1" placeholder="Name (company or person)" required="type == 'contact'"/>
+                                <h1 class="mb-0 w-md-75">
+                                    <field options="{'line_breaks': False}" widget="text" class="text-break d-block" name="name" default_focus="1" placeholder="Name (company or person)" required="is_individual or is_company"/>
                                 </h1>
                                 <div class="d-flex align-items-baseline w-md-50">
                                     <i class="fa fa-fw me-1 fa-building text-primary" title="Company"/>
@@ -155,6 +156,18 @@
                     </div>
                     <group>
                         <group>
+                            <field name="parent_id"
+                                widget="res_partner_many2one"
+                                placeholder="Company Name..."
+                                string="Company"
+                                domain="[('is_company', '=', True)]"
+                                context="{'default_is_company': True, 'default_user_id': user_id, 'show_address': False}"
+                                invisible="((is_company and not parent_id) or company_name) and company_name != ''"/>
+                            <div colspan="2" class="d-flex gap-2" invisible="not company_name or company_name == '' or is_company">
+                                <label for="company_name" class="fw-bold text-nowrap"/>
+                                <field name="company_name"/>
+                                <button name="create_company" icon="fa-plus-square" string="Create" type="object" class="oe_edit_only btn-link text-nowrap"/>
+                            </div>
                             <span class="o_form_label o_td_label o_address_type" name="address_name">
                                 <field name="type_address_label" readonly="1" class="fw-bold"/>
                             </span>
@@ -174,7 +187,7 @@
                             <field name="vat" placeholder="e.g. BE0477472701"/>
                         </group>
                         <group>
-                            <field name="function" placeholder="e.g. Sales Director"/>
+                            <field name="function" placeholder="e.g. Sales Director" invisible="not is_individual"/>
                             <field name="website" string="Website" widget="url" placeholder="e.g. https://www.odoo.com"/>
                             <field name="lang" invisible="active_lang_count &lt;= 1"/>
                             <field name="category_id" widget="many2many_tags" options="{'color_field': 'color', 'on_tag_click': 'edit_color'}"
@@ -240,7 +253,7 @@
                                             <field name="image_1920" widget="contact_image" nolabel="1" options="{'preview_image': 'avatar_128', 'size': [100,100], 'img_class': 'rounded border'}"/>
                                             <div class="flex-grow-1">
                                                 <h3>
-                                                    <field name="name" class="d-block" string="Name" default_focus="1" required="type == 'contact'" placeholder="e.g. Brandon Freeman"/>
+                                                    <field name="name" class="d-block" string="Name" default_focus="1" required="is_individual or is_company" placeholder="e.g. Brandon Freeman"/>
                                                 </h3>
                                                 <div class="row flex-row">
                                                     <div class="d-flex align-items-baseline">
@@ -251,14 +264,14 @@
                                                         <i class="fa fa-fw me-1 fa-phone text-primary" title="Phone"/>
                                                         <field name="phone" widget="phone" class="w-100" placeholder="Phone"/>
                                                     </div>
-                                                    <div invisible="type != 'contact'" class="d-flex align-items-baseline">
+                                                    <div invisible="not is_individual" class="d-flex align-items-baseline">
                                                         <i class="fa fa-fw me-1 fa-suitcase text-primary" title="Position"/>
                                                         <field name="function" placeholder="Job title"/>
                                                     </div>
                                                 </div>
                                             </div>
                                         </div>
-                                        <group invisible="type == 'contact'" name="other_info">
+                                        <group invisible="is_address_readonly" name="other_info">
                                             <group>
                                                 <span class="o_form_label o_td_label o_address_type">
                                                     <field name="type_address_label" readonly="1" class="fw-bold"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The current contact UI is partly inconsistent regarding the child/parent behavior and also it is not flexible extensible regarding new contact types like "Home office Contact", which is a "Contact" but has a different Address, and also an "Delivery Address" is in my opinion not an individual, but neigther a company.

Therefore I suggest to de-couple the different topics and add new variables. These variables can be customized by overwriting the
"_compute_contact_type" method according to the users needs.

e.g. you could add a new individual type "home office contact" which is an individual, but also has an editable address.
By changing can_be_child to True on Company contacts, you could create multi-level company structures.

In this patch, the current behavior is not changed, but gives better possibilities for customizations.

Current behavior before PR:
The forms are hardly customizable regarding new contact types.

Desired behavior after PR is merged:

The UI can be more customizable and using is_address_readonly, is_individual, can_be_parent and can_be_child instead of linking the type directly.

see also: https://github.com/odoo/odoo/pull/209101


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
