### PR TITLE
[FIX] account: exclude archived res_partner_bank records when computing duplicate_bank_partner_ids

### DIFF
--- a/addons/account/models/res_partner_bank.py
+++ b/addons/account/models/res_partner_bank.py
@@ -74,8 +74,10 @@ class ResPartnerBank(models.Model):
                   FROM res_partner_bank this
              LEFT JOIN res_partner_bank other ON this.acc_number = other.acc_number
                                              AND this.id != other.id
+                                             AND other.active = TRUE
                  WHERE this.id = ANY(%(ids)s)
                  AND other.partner_id IS NOT NULL
+                   AND this.active = TRUE
                    AND (
                         ((this.company_id = other.company_id) OR (this.company_id IS NULL AND other.company_id IS NULL))
                         OR

--- a/addons/account/tests/test_duplicate_res_partner_bank.py
+++ b/addons/account/tests/test_duplicate_res_partner_bank.py
@@ -49,3 +49,7 @@ class TestDuplicatePartnerBank(SavepointCaseWithUserDemo):
             partner_form.bank_ids.remove(0)
 
         self.assertEqual(len(self.partner_a.bank_ids), 0)
+
+    def test_duplicate_acc_number_inactive_bank_account(self):
+        self.partner_bank_b.active = False
+        self.assertFalse(self.partner_bank_a.duplicate_bank_partner_ids)


### PR DESCRIPTION
If a res_partner_bank record shares an acc_number with other res_partner_bank records, even archived ones, the field duplicate_bank_partner_ids still includes partners from those archived records.

As a result, the contact page shows a banner indicating other partners use the same bank account, even though those res_partner_bank records have been archived.

Steps to reproduce the issue:

1. Create a new bank account which has the same bank account number as another bank account already associated to a partner
2. Assign this new bank account to another partner
3. Archive this new bank account
4. Go to the contact page of the partner (from step 1) which has a bank account with the same bank account number as the new bank account just created
5. A banner will pop up at the top of the contact saying that this partner uses the same bank account as the partner you set on the bank account in step 2

Solution:

Add a condition to the JOIN clause that checks “other.active = TRUE” to ensure that other res_partner_bank records to search for that have the same account number are active.

Also add a condition to the WHERE clause that checks “this.active = TRUE” to ensure that the current res_partner_bank record doing the search is active itself.

opw-4967083