### PR TITLE
[16.0][FIX] product: show seller_ids related to the same product variant

### DIFF
--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -87,6 +87,28 @@ class ProductProduct(models.Model):
     image_256 = fields.Image("Image 256", compute='_compute_image_256')
     image_128 = fields.Image("Image 128", compute='_compute_image_128')
     can_image_1024_be_zoomed = fields.Boolean("Can Image 1024 be zoomed", compute='_compute_can_image_1024_be_zoomed')
+    seller_ids = fields.One2many(
+        comodel_name="product.supplierinfo",
+        inverse_name="product_id",
+        string="Vendors",
+        compute="_compute_variant_seller_ids",
+        store=False,
+    )
+
+    @api.depends('product_tmpl_id.seller_ids', 'seller_ids')
+    def _compute_variant_seller_ids(self):
+        """ Filter seller_ids for each variant 
+        to show only those that match the variant or apply globally. """
+
+        for product in self:
+            seller_ids = product.product_tmpl_id.seller_ids
+            filtered_seller_ids = seller_ids.filtered(
+                lambda s: s.product_id and s.product_id == product
+            )
+            if filtered_seller_ids:
+                product.seller_ids = filtered_seller_ids 
+            else:
+                product.seller_ids = seller_ids
 
     @api.depends('image_variant_1920', 'image_variant_1024')
     def _compute_can_image_variant_1024_be_zoomed(self):

--- a/addons/product/tests/test_seller.py
+++ b/addons/product/tests/test_seller.py
@@ -43,7 +43,7 @@ class TestSeller(TransactionCase):
         company_b = self.env['res.company'].create({
             'name': 'Saucisson Inc.',
         })
-        self.product_consu.write({'seller_ids': [
+        self.product_consu.product_tmpl_id.write({'seller_ids': [
             (0, 0, {'partner_id': self.asustec.id, 'product_code': 'A', 'company_id': company_a.id}),
             (0, 0, {'partner_id': self.asustec.id, 'product_code': 'B', 'company_id': company_b.id}),
             (0, 0, {'partner_id': self.asustec.id, 'product_code': 'NO', 'company_id': False}),
@@ -150,7 +150,7 @@ class TestSeller(TransactionCase):
             'partner_id': self.camptocamp.id,
             'product_id': self.product_consu.id,
         }])
-        self.assertEqual(vendors, self.product_consu.seller_ids,
+        self.assertEqual(vendors.filtered('product_id'), self.product_consu.seller_ids,
             "Sellers of a product should be listed in the product's seller_ids")
         vendors.write({'product_id': False})
         self.assertEqual(vendors, self.product_consu.seller_ids,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
We see lines for unrelated variant whether we see our concerned one among them.


Current behavior before PR:
We can see lines of seller ids having no product variants this is ok, but if variants are set better to display the concerned one.


Desired behavior after PR is merged:
Filter seller_ids for each variant to show only those that match the variant or apply globally by ignoring the filter if the variant field has no value set.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
