### PR TITLE
[FIX] mail: prevent traceback when copying invitation link from pip window

### DIFF
--- a/addons/mail/static/src/discuss/call/common/pip_service.js
+++ b/addons/mail/static/src/discuss/call/common/pip_service.js
@@ -56,6 +56,9 @@ export const callPipService = {
             get isNativePipAvailable() {
                 return Boolean(window.documentPictureInPicture);
             },
+            get pipWindow() {
+                return pipWindow;
+            },
             state,
             closePip,
             openPip,

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.js
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.js
@@ -189,8 +189,18 @@ export class ChannelInvitation extends Component {
     }
 
     async onClickCopy(ev) {
-        await navigator.clipboard.writeText(this.props.thread.invitationLink);
-        this.notification.add(_t("Link copied!"), { type: "success" });
+        let notification = _t("Invitation link copied!");
+        let type = "success";
+        const clipboard = this.env.inDiscussCallView?.isPip
+            ? this.rtc.pipService.pipWindow?.navigator.clipboard
+            : navigator.clipboard;
+        try {
+            await clipboard.writeText(this.props.thread.invitationLink);
+        } catch {
+            notification = _t("Invitation link copy failed (Permission denied?)!");
+            type = "danger";
+        }
+        this.notification.add(notification, { type });
     }
 
     async onClickInvite() {


### PR DESCRIPTION
**Current behavior before PR:**
Attempting to copy the invitation link from the Picture-in-Picture (PIP) window results in a traceback error, indicating that the document is not focused.

**Desired behavior after PR is merged:**
Copying the invitation link from the PIP (Picture-in-Picture) window no longer triggers a traceback error and successfully copies the link to the user's clipboard.

task-[5149370](https://www.odoo.com/odoo/project/1519/tasks/5149370)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
