### PR TITLE
[FIX] l10n_es_edi_verifactu: removed unnecessary chatter

### DIFF
--- a/addons/l10n_es_edi_verifactu/views/l10n_es_edi_verifactu_document_views.xml
+++ b/addons/l10n_es_edi_verifactu/views/l10n_es_edi_verifactu_document_views.xml
@@ -25,7 +25,6 @@
                             </group>
                         </group>
                     </sheet>
-                    <chatter/>
                 </form>
             </field>
         </record>


### PR DESCRIPTION
The system will crash with error when user clicks on expand button.

**Error:**
`AttributeError: 'l10n_es_edi_verifactu.document' object has no attribute '_get_thread_with_access'`

**Cause:**
- `l10n_es_edi_verifactu.document` does not inherits ['mail.thread', 'mail.activity.mixin'] and used chatter in it's form view.

- In this PR, removed `<chatter/>` from view.

Already fixed for master here: https://github.com/odoo/odoo/pull/231477

**sentry-6792833694**

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
