### PR TITLE
[FIX] purchase: Fix purchase warning text

### DIFF
--- a/addons/purchase/models/account_invoice.py
+++ b/addons/purchase/models/account_invoice.py
@@ -128,7 +128,7 @@ class AccountMove(models.Model):
                 continue
             warnings = OrderedSet()
             if partner_msg := move.partner_id.purchase_warn_msg:
-                warnings.add(move.partner_id.name + ' - ' + partner_msg)
+                warnings.add((move.partner_id.name or move.partner_id.display_name) + ' - ' + partner_msg)
             for product in move.invoice_line_ids.product_id:
                 if product_msg := product.purchase_line_warn_msg:
                     warnings.add(product.display_name + ' - ' + product_msg)

--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -288,7 +288,7 @@ class PurchaseOrder(models.Model):
         for order in self:
             warnings = OrderedSet()
             if partner_msg := order.partner_id.purchase_warn_msg:
-                warnings.add(order.partner_id.name + ' - ' + partner_msg)
+                warnings.add((order.partner_id.name or order.partner_id.display_name) + ' - ' + partner_msg)
             for line in order.order_line:
                 if product_msg := line.purchase_line_warn_msg:
                     warnings.add(line.product_id.display_name + ' - ' + product_msg)


### PR DESCRIPTION
When creating a purchase order for a partner without a name, a traceback occurs.

Steps to reproduce the error:

- Install purchase with demo data
- Enable purchase warning from settings
- Open `Azure Interior` Contact > In Contact, Add Contact > Type: invoice >
Save & close
- Add warning in newly created contact
- Create a purchase order with the newly created partner and create an invoice with the newly created partner

Traceback:
`TypeError: unsupported operand type(s) for +: 'bool' and 'str'`

https://github.com/odoo/odoo/blob/96887e0b9e7a9b01482b9dc1fcf99040e9de6b2c/addons/purchase/models/purchase_order.py#L298
https://github.com/odoo/odoo/blob/96887e0b9e7a9b01482b9dc1fcf99040e9de6b2c/addons/purchase/models/account_invoice.py#L131

Here, `partner_id.name` is `False`, which leads to string concatenation with a boolean in purchase warning messages and results in the above traceback.

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
