### PR TITLE
[FIX] html_editor: removeFormat to clear text color classes from list

### DIFF
--- a/addons/html_editor/static/tests/list/color_list.test.js
+++ b/addons/html_editor/static/tests/list/color_list.test.js
@@ -7,6 +7,7 @@ import {
     toggleUnorderedList,
 } from "../_helpers/user_actions";
 import { execCommand } from "../_helpers/userCommands";
+import { unformat } from "../_helpers/format";
 
 test("should apply color to completely selected list item", async () => {
     await testEditor({
@@ -164,6 +165,62 @@ test("should remove color from partially selected list item", async () => {
         stepFunction: (editor) => execCommand(editor, "removeFormat"),
         contentAfter:
             '<ol><li style="color: rgb(255, 0, 0);">ab<font class="o_default_color">[cd]</font>ef</li></ol>',
+    });
+});
+
+test("should remove color from fully selected list item with nested list", async () => {
+    await testEditor({
+        contentBefore: unformat(`
+            <ol>
+                <li class="text-o-color-1">
+                    <p>[abc</p>
+                    <ol class="o_default_color">
+                        <li class="text-o-color-1">def</li>
+                    </ol>
+                </li>
+                <li class="text-o-color-1">ghi]</li>
+            </ol>
+        `),
+        stepFunction: (editor) => execCommand(editor, "removeFormat"),
+        contentAfterEdit: unformat(`
+            <ol>
+                <li>
+                    <p>[abc</p>
+                    <ol>
+                        <li>def</li>
+                    </ol>
+                </li>
+                <li>ghi]</li>
+            </ol>
+        `),
+    });
+});
+
+test("should remove color from partially selected text inside list item", async () => {
+    await testEditor({
+        contentBefore: unformat(`
+            <ol>
+                <li class="text-o-color-1">
+                    <p>abc</p>
+                    <ol class="o_default_color">
+                        <li class="text-o-color-1">d[e]f</li>
+                    </ol>
+                </li>
+            </ol>
+        `),
+        stepFunction: (editor) => execCommand(editor, "removeFormat"),
+        contentAfterEdit: unformat(`
+            <ol>
+                <li class="text-o-color-1">
+                    <p>abc</p>
+                    <ol class="o_default_color">
+                        <li class="text-o-color-1">
+                            d<font class="o_default_color">[e]</font>f
+                        </li>
+                    </ol>
+                </li>
+            </ol>
+        `),
     });
 });
 


### PR DESCRIPTION
### Steps to reproduce:

- Open the Todo and create a new list.
- Type some text and press `Ctrl + A` to select all.
- Apply a text color class using the color picker.
- Remove formatting from the selected content.

### Description of the issue/feature this PR addresses:

- When color was applied through classes inside list items and removeFormat was triggered, color classes were not removed.

### Desired behavior after PR is merged:

- All text color styles and classes are removed when using `removeFormat`.

task-5166472

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
