### PR TITLE
[IMP] l10n_tr_nilvera{,_einvoice}: translate Nilvera error descriptions

### DIFF
--- a/addons/l10n_tr_nilvera/const.py
+++ b/addons/l10n_tr_nilvera/const.py
@@ -1,0 +1,38 @@
+from odoo.tools.translate import LazyTranslate
+
+_lt = LazyTranslate(__name__)
+
+NILVERA_ERROR_CODE_MESSAGES = {
+    # 404 errors
+    3000: _lt("Tag for the Recipient Not Found"),
+    3001: _lt("Tag for the Sender Not Found"),
+    3017: _lt("You do not have a package with this code"),
+    3030: _lt("API Not Found"),
+
+    # 409 errors
+    1000: _lt("The sent Tax Identification Number (TIN) does not match the company"),
+    1001: _lt("Nilvera UUID (ETTN) is already registered in the system"),
+    1004: _lt("This e-invoice has been previously added"),
+    1005: _lt("The e-invoice series has been used before"),
+    1015: _lt("The record has been added before"),
+
+    # 422 errors
+    2000: _lt("You do not have sufficient credits"),
+    2004: _lt("Record generation unsuccessful"),
+    2015: _lt("Schema/Schematron error"),
+    2024: _lt("The document scenario must be e-Archive"),
+    2025: _lt("The recipient is an e-invoice taxpayer. The e-Archive invoice cannot be sent"),
+    2051: _lt("The Sender is not an e-Invoice Payer"),
+    2052: _lt("Buyer's Alias is Not in Use"),
+    2053: _lt("The Buyer Became an e-Invoice Taxpayer"),
+    2054: _lt("The Buyer is Not an E-Invoice Payer"),
+    2057: _lt("An Error Occurred While Fetching E-Invoice Labels"),
+    2059: _lt("E-Invoice Scenario Must Be Public"),
+    2060: _lt("Invoice Scenario Must Be e-Archive Invoice"),
+    2061: _lt("e-Invoice Scenario Should Not Be Public"),
+    2063: _lt("Since the Invoice Scenario is an e-Archive Invoice, it cannot be sent to the e-Invoice sender"),
+    2065: _lt("e-Invoice Serial Field Cannot Be Blank"),
+    2075: _lt("Your Credit Package Has Expired"),
+    2078: _lt("Your Credit Package Does Not Have Enough Credit"),
+    2100: _lt("Series and Document Year Mismatch"),
+}

--- a/addons/l10n_tr_nilvera_einvoice/models/account_move.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_move.py
@@ -5,6 +5,7 @@ from urllib.parse import quote, urlencode, urlparse
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 from odoo.tools import SQL
+from odoo.addons.l10n_tr_nilvera.const import NILVERA_ERROR_CODE_MESSAGES
 from odoo.addons.l10n_tr_nilvera.lib.nilvera_client import _get_nilvera_client
 
 MOVE_TYPE_CATEGORY_MAP = {
@@ -345,9 +346,12 @@ class AccountMove(models.Model):
         response_json = response.json()
         if errors := response_json.get('Errors'):
             msg += _("The invoice couldn't be sent due to the following errors:\n")
+
             for error in errors:
-                msg += "%s - %s: %s\n" % (error.get('Code'), error.get('Description'), error.get('Detail'))
-                error_codes.append(error.get('Code'))
+                code = error.get('Code')
+                description = NILVERA_ERROR_CODE_MESSAGES.get(code, error.get('Description'))
+                msg += "\n%s - %s:\n%s\n" % (code, description, error.get('Detail'))
+                error_codes.append(code)
 
         return msg, error_codes
 


### PR DESCRIPTION
Before this commit:
- Nilvera errors were shown exactly as received from the API, which was in
Turkish and could be confusing for non-Turkish users.

After this commit:
- The error descriptions have been translated. Error details remain in
Turkish, as they are dynamic and reliably translated at this stage.

task-5003543
