### PR TITLE
[FIX] hr_holidays: fix supporting files visibility

### DIFF
--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -364,7 +364,7 @@
                             <field name="name" readonly="state != 'confirm'" widget="text" nolabel="1" colspan="2" placeholder="No description provided" />
                         </group>
                         <group>
-                            <field name="supported_attachment_ids" widget="many2many_binary" nolabel="1" invisible="state not in ('confirm', 'validate1')" />
+                            <field name="supported_attachment_ids" widget="many2many_binary" nolabel="1" invisible="not leave_type_support_document or state not in ('confirm', 'validate1')" />
                         </group>
                     </div>
                     <div class="o_hr_leave_column col_right col-md-6 col-12">


### PR DESCRIPTION
issue:
- Field to attach documents is always visible when applying for time off regardless of whether we have allowed supporting documents in "time off types" or not


<img width="641" height="505" alt="image" src="https://github.com/user-attachments/assets/0ec26822-5284-474f-b791-4b2b8e5eb9cc" />

<img width="511" height="265" alt="image" src="https://github.com/user-attachments/assets/ea546067-ac62-4e25-9a70-bbd86c053109" />


cause:
- In commit [1], there was a change, which resulted to this issue

[1] https://github.com/odoo/odoo/commit/944c11e61abead4f5157a7a7cb7b1f536bc14411

fix:
- `supported_attachment_ids` now also depends on whether uploading files in a time off is supported or not


opw-5144399

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
