### PR TITLE
[FIX] stock_sms : updated condition for required field

### DIFF
--- a/addons/stock_sms/views/res_config_settings_views.xml
+++ b/addons/stock_sms/views/res_config_settings_views.xml
@@ -13,7 +13,7 @@
                 <div class="row mt16" invisible="stock_confirmation_type != 'sms' or not stock_text_confirmation">
                     <field name="stock_sms_confirmation_template_id"
                         class="oe_inline"
-                        required="stock_confirmation_type == 'sms'"
+                        required="stock_text_confirmation and stock_confirmation_type == 'sms'"
                         context="{'default_model': 'stock.picking'}"/>
                 </div>
                 <widget name="iap_buy_more_credits" service_name="sms" invisible="stock_confirmation_type != 'sms' or not stock_text_confirmation"/>


### PR DESCRIPTION
Due to this [commit](https://github.com/odoo/odoo/commit/889848aa65b474c3f495e65b75409068b6ef172a),
The field ```stock_sms_confirmation_template_id``` is visible only when ```stock_confirmation_type``` is set to sms and ```stock_text_confirmation``` is set to True.

However, the field ```stock_sms_confirmation_template_id``` is marked as required whenever ```stock_confirmation_type``` is set to sms, regardless of whether ```stock_text_confirmation``` is enabled.

As a result, when saving the record with ```stock_text_confirmation``` unchecked, the required field ```stock_sms_confirmation_template_id``` remains invisible and unset — which causes a missing required field error during record save.

Steps to reproduce: [Video](https://drive.google.com/file/d/1cpL6ie2zSDgW5mYGqOH5h-CpzxppXzFi/view)
1. go to settings - inventory - shipping
2. check Text Confirmation , set stock_confirmation_type = sms
3. uncheck Text confirmation
4.  save the changes
-  To fix this issue, need to just add condition of ```stock_text_confirmation```

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
