### PR TITLE
[FIX] html_editor: hide toolbar on non-editable elements

### DIFF
--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -240,6 +240,16 @@ export class FormatPlugin extends Plugin {
 
     // @todo phoenix: refactor this method.
     _formatSelection(formatName, { applyStyle, formatProps } = {}) {
+        const deepSelection = this.dependencies.selection.getSelectionData().deepEditableSelection;
+        const anchorElement = deepSelection.anchorNode;
+        const focusElement = deepSelection.focusNode;
+        if (
+            anchorElement === focusElement &&
+            !isContentEditable(anchorElement) &&
+            !closestElement(anchorElement, PROTECTED_QWEB_SELECTOR)
+        ) {
+            return;
+        }
         // note: does it work if selection is in opposite direction?
         const selection = this.dependencies.split.splitSelection();
         if (typeof applyStyle === "undefined") {

--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -389,16 +389,6 @@ export class SelectionPlugin extends Plugin {
             anchorOffset = direction ? range.startOffset : range.endOffset;
             focusOffset = direction ? range.endOffset : range.startOffset;
 
-            [anchorNode, anchorOffset] = normalizeCursorPosition(
-                anchorNode,
-                anchorOffset,
-                direction ? "left" : "right"
-            );
-            [focusNode, focusOffset] = normalizeCursorPosition(
-                focusNode,
-                focusOffset,
-                direction ? "right" : "left"
-            );
             const [startContainer, startOffset, endContainer, endOffset] =
                 direction === DIRECTIONS.RIGHT
                     ? [anchorNode, anchorOffset, focusNode, focusOffset]

--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -18,6 +18,7 @@ import { rpc } from "@web/core/network/rpc";
 import { memoize } from "@web/core/utils/functions";
 import { withSequence } from "@html_editor/utils/resource";
 import { isBlock, closestBlock } from "@html_editor/utils/blocks";
+import { isContentEditable } from "../../utils/dom_info";
 
 /**
  * @typedef {import("@html_editor/core/selection_plugin").EditorSelection} EditorSelection
@@ -460,7 +461,11 @@ export class LinkPlugin extends Plugin {
             // note that data-prevent-closing-overlay also used in color picker but link popover
             // and color picker don't open at the same time so it's ok to query like this
             const popoverEl = document.querySelector("[data-prevent-closing-overlay=true]");
-            if (popoverEl && (!selectionData.documentSelection || popoverEl.contains(selectionData.documentSelection.anchorNode))) {
+            if (
+                popoverEl &&
+                (!selectionData.documentSelection ||
+                    popoverEl.contains(selectionData.documentSelection.anchorNode))
+            ) {
                 return;
             }
             this.overlay.close();
@@ -580,6 +585,12 @@ export class LinkPlugin extends Plugin {
      * @return {HTMLElement}
      */
     getOrCreateLink() {
+        const deepSelection = this.dependencies.selection.getSelectionData().deepEditableSelection;
+        const anchorElement = deepSelection.anchorNode;
+        const focusElement = deepSelection.focusNode;
+        if (anchorElement === focusElement && !isContentEditable(anchorElement)) {
+            return;
+        }
         const selection = this.dependencies.selection.getEditableSelection();
         const linkElement = findInSelection(selection, "a");
         if (linkElement) {

--- a/addons/html_editor/static/src/main/media/icon_plugin.js
+++ b/addons/html_editor/static/src/main/media/icon_plugin.js
@@ -3,7 +3,9 @@ import { Plugin } from "../../plugin";
 import { _t } from "@web/core/l10n/translation";
 import { ColorSelector } from "../font/color_selector";
 import { isZWS } from "@html_editor/utils/dom_info";
-import { nodeSize } from "@html_editor/utils/position";
+import { leftPos, rightPos } from "@html_editor/utils/position";
+import { normalizeCursorPosition } from "@html_editor/utils/selection";
+import { closestElement } from "@html_editor/utils/dom_traversal";
 
 export class IconPlugin extends Plugin {
     static id = "icon";
@@ -129,7 +131,7 @@ export class IconPlugin extends Plugin {
 
     getTargetedIcon() {
         const targetedNodes = this.dependencies.selection.getTargetedNodes();
-        return targetedNodes.find((node) => node.classList?.contains?.("fa"));
+        return targetedNodes.map((node) => closestElement(node, ".fa")).find(Boolean);
     }
 
     isSelectingOnlyIcons(targetedNodes = this.dependencies.selection.getTargetedNodes()) {
@@ -149,12 +151,17 @@ export class IconPlugin extends Plugin {
         const { anchorNode, focusNode } = this.document.getSelection();
         if (this.isSelectingOnlyIcons() && (isZWS(anchorNode) || isZWS(focusNode))) {
             const selectedIcon = this.getSelectedIcon();
+            const [anchorNode, anchorOffset] = normalizeCursorPosition(
+                ...leftPos(selectedIcon),
+                "left"
+            );
+            const [focusNode, focusOffset] = normalizeCursorPosition(...rightPos(selectedIcon));
             this.dependencies.selection.setSelection(
                 {
-                    anchorNode: selectedIcon,
-                    anchorOffset: 0,
-                    focusNode: selectedIcon,
-                    focusOffset: nodeSize(selectedIcon),
+                    anchorNode,
+                    anchorOffset,
+                    focusNode,
+                    focusOffset,
                 },
                 { normalize: false }
             );

--- a/addons/html_editor/static/src/others/qweb_plugin.js
+++ b/addons/html_editor/static/src/others/qweb_plugin.js
@@ -2,7 +2,7 @@ import { Plugin } from "@html_editor/plugin";
 import { closestElement, selectElements } from "@html_editor/utils/dom_traversal";
 import { leftPos, rightPos } from "@html_editor/utils/position";
 import { QWebPicker } from "./qweb_picker";
-import { isElement } from "@html_editor/utils/dom_info";
+import { isElement, PROTECTED_QWEB_SELECTOR } from "@html_editor/utils/dom_info";
 
 const isUnsplittableQWebElement = (node) =>
     isElement(node) &&
@@ -18,8 +18,6 @@ const isUnsplittableQWebElement = (node) =>
             "t-out",
             "t-raw",
         ].some((attr) => node.getAttribute(attr)));
-
-const PROTECTED_QWEB_SELECTOR = "[t-esc], [t-raw], [t-out], [t-field]";
 
 export class QWebPlugin extends Plugin {
     static id = "qweb";
@@ -156,7 +154,7 @@ export class QWebPlugin extends Plugin {
             const qwebNode =
                 selection &&
                 selection.anchorNode &&
-                closestElement(selection.anchorNode, "[t-field],[t-esc],[t-out]");
+                closestElement(selection.anchorNode, PROTECTED_QWEB_SELECTOR);
             if (qwebNode && this.editable.contains(qwebNode)) {
                 // select the whole qweb node
                 const [anchorNode, anchorOffset] = leftPos(qwebNode);

--- a/addons/html_editor/static/src/others/qweb_plugin.js
+++ b/addons/html_editor/static/src/others/qweb_plugin.js
@@ -3,6 +3,7 @@ import { closestElement, selectElements } from "@html_editor/utils/dom_traversal
 import { leftPos, rightPos } from "@html_editor/utils/position";
 import { QWebPicker } from "./qweb_picker";
 import { isElement, PROTECTED_QWEB_SELECTOR } from "@html_editor/utils/dom_info";
+import { normalizeCursorPosition } from "@html_editor/utils/selection";
 
 const isUnsplittableQWebElement = (node) =>
     isElement(node) &&
@@ -157,14 +158,20 @@ export class QWebPlugin extends Plugin {
                 closestElement(selection.anchorNode, PROTECTED_QWEB_SELECTOR);
             if (qwebNode && this.editable.contains(qwebNode)) {
                 // select the whole qweb node
-                const [anchorNode, anchorOffset] = leftPos(qwebNode);
-                const [focusNode, focusOffset] = rightPos(qwebNode);
-                this.dependencies.selection.setSelection({
-                    anchorNode,
-                    anchorOffset,
-                    focusNode,
-                    focusOffset,
-                });
+                const [anchorNode, anchorOffset] = normalizeCursorPosition(
+                    ...leftPos(qwebNode),
+                    "left"
+                );
+                const [focusNode, focusOffset] = normalizeCursorPosition(...rightPos(qwebNode));
+                this.dependencies.selection.setSelection(
+                    {
+                        anchorNode,
+                        anchorOffset,
+                        focusNode,
+                        focusOffset,
+                    },
+                    { normalize: false }
+                );
             }
         }
         const targetNode = ev.target;

--- a/addons/html_editor/static/src/utils/dom_info.js
+++ b/addons/html_editor/static/src/utils/dom_info.js
@@ -829,3 +829,6 @@ export function isRedundantElement(node) {
 
     return true;
 }
+
+// Selector for QWeb-specific attributes
+export const PROTECTED_QWEB_SELECTOR = "[t-esc], [t-raw], [t-out], [t-field]";

--- a/addons/html_editor/static/tests/format/bold.test.js
+++ b/addons/html_editor/static/tests/format/bold.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "@odoo/hoot";
-import { manuallyDispatchProgrammaticEvent, press, queryOne } from "@odoo/hoot-dom";
+import { manuallyDispatchProgrammaticEvent, press } from "@odoo/hoot-dom";
 import { animationFrame, tick } from "@odoo/hoot-mock";
 import { patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { setupEditor, testEditor } from "../_helpers/editor";
@@ -63,24 +63,6 @@ test("should make qweb tag bold (2)", async () => {
         stepFunction: bold,
         contentAfter: `<div>[<p t-field="record.name" contenteditable="false" style="font-weight: bolder;">Test</p>]</div>`,
     });
-});
-
-test("should make qweb tag bold and create a step even with partial selection inside contenteditable false", async () => {
-    const { editor, el } = await setupEditor(
-        `<div><p t-esc="'Test'" contenteditable="false">T[e]st</p></div>`
-    );
-    bold(editor);
-    expect(getContent(el)).toBe(
-        `<div>[<p t-esc="'Test'" contenteditable="false" style="font-weight: bolder;">Test</p>]</div>`
-    );
-    expect(queryOne(`p[contenteditable="false"]`).childNodes.length).toBe(1);
-    const historySteps = editor.shared.history.getHistorySteps();
-    expect(historySteps.length).toBe(2);
-    const lastStep = historySteps.at(-1);
-    expect(lastStep.mutations.length).toBe(1);
-    expect(lastStep.mutations[0].type).toBe("attributes");
-    expect(lastStep.mutations[0].attributeName).toBe("style");
-    expect(lastStep.mutations[0].value).toBe("font-weight: bolder;");
 });
 
 test("should make a whole heading bold after a triple click", async () => {

--- a/addons/html_editor/static/tests/format/bold.test.js
+++ b/addons/html_editor/static/tests/format/bold.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "@odoo/hoot";
-import { manuallyDispatchProgrammaticEvent, press } from "@odoo/hoot-dom";
+import { manuallyDispatchProgrammaticEvent, press, queryOne } from "@odoo/hoot-dom";
 import { animationFrame, tick } from "@odoo/hoot-mock";
 import { patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { setupEditor, testEditor } from "../_helpers/editor";
@@ -432,4 +432,11 @@ test("should not add history step for bold on collapsed selection", async () => 
 
     undo(editor);
     expect(getContent(el)).toBe(`<p>abcd[]</p>`);
+});
+
+test("should not apply bold formatting for partial selection inside contenteditable false", async () => {
+    const { editor, el } = await setupEditor(`<p contenteditable="false">T[e]st</p>`);
+    bold(editor);
+    expect(getContent(el)).toBe(`<p contenteditable="false">T[e]st</p>`);
+    expect(queryOne(`p[contenteditable="false"]`).childNodes.length).toBe(1);
 });

--- a/addons/html_editor/static/tests/icon.test.js
+++ b/addons/html_editor/static/tests/icon.test.js
@@ -166,7 +166,18 @@ test("Can spin an icon", async () => {
 });
 
 test("Can set icon color", async () => {
-    const { el } = await setupEditor(`<p><span class="fa fa-glass">[]</span></p>`);
+    const { el } = await setupEditor('<p><span class="fa fa-glass"></span></p>');
+    expect(getContent(el)).toBe(
+        `<p>\ufeff<span class="fa fa-glass" contenteditable="false">\u200b</span>\ufeff</p>`
+    );
+    setContent(
+        el,
+        `<p>\ufeff<span class="fa fa-glass" contenteditable="false">[]\u200b</span>\ufeff</p>`
+    );
+    await tick();
+    expect(getContent(el)).toBe(
+        `<p>\ufeff[<span class="fa fa-glass" contenteditable="false">\u200b</span>]\ufeff</p>`
+    );
     await waitFor(".o-we-toolbar");
     expect(".o_font_color_selector").toHaveCount(0);
     await click(".o-select-color-foreground");

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -674,6 +674,14 @@ describe("shortcut", () => {
             '<p><a href="http://test.com">li[]nk</a></p>'
         );
     });
+    test("should not create a link via shortcut for partial selection inside contenteditable false", async () => {
+        const { el } = await setupEditor(`<p contenteditable="false">T[e]st</p>`);
+        await press(["ctrl", "k"]);
+        await animationFrame();
+        await click(".o_command_name:first");
+        expect(getContent(el)).toBe('<p contenteditable="false">T[e]st</p>');
+        expect(queryOne(`p[contenteditable="false"]`).childNodes.length).toBe(1);
+    });
 });
 
 describe("link preview", () => {

--- a/addons/html_editor/static/tests/paste.test.js
+++ b/addons/html_editor/static/tests/paste.test.js
@@ -4531,7 +4531,11 @@ describe("onDrop", () => {
                 offset: defTextNode.textContent.length,
             }),
         });
-
+        setSelection({
+            anchorNode: iconElement,
+            anchorOffset: 0,
+        });
+        await animationFrame();
         const dragdata = new DataTransfer();
         await dispatch(iconElement, "dragstart", { dataTransfer: dragdata });
 

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -1263,3 +1263,12 @@ test("dropdown menu should not overflow scroll container", async () => {
     // Font selector should be visible
     expect(fontSelector).toBeVisible();
 });
+
+describe.tags("desktop");
+describe("toolbar visibility on contenteditable false elements", () => {
+    test("should not open toolbar when selected element is contenteditble false", async () => {
+        await setupEditor('<div contenteditable="false"><p>a[bc<strong>def</strong>gh]i</p></div>');
+        await animationFrame();
+        expect(".o-we-toolbar").toHaveCount(0);
+    });
+});


### PR DESCRIPTION
Current behavior before PR:

- Removing formatting on a contenteditable false element infinite loop when removing format.

- The toolbar could appear even when the target element had contenteditable false


Desired behavior after PR is merged:

- Now,the toolbar no longer opens when the selected element is contenteditable false

- The toolbar is now only shown for elements with contenteditable true, except for QWeb and icon elements, where it remains accessible.

task-5265416