### PR TITLE
[FIX] iot_drivers: handle error in actions

### DIFF
--- a/addons/iot_drivers/iot_handlers/drivers/serial_base_driver.py
+++ b/addons/iot_drivers/iot_handlers/drivers/serial_base_driver.py
@@ -116,13 +116,12 @@ class SerialDriver(Driver):
             try:
                 self._actions[data['action']](data)
                 time.sleep(self._protocol.commandDelay)
+                self._status = {'status': self.STATUS_CONNECTED, 'message_title': '', 'message_body': ''}
             except Exception:
                 msg = f'An error occurred while performing action "{data}" on "{self.device_name}"'
                 _logger.exception(msg)
                 self._status = {'status': self.STATUS_ERROR, 'message_title': msg, 'message_body': traceback.format_exc()}
-                self._push_status()
-            self._status = {'status': self.STATUS_CONNECTED, 'message_title': '', 'message_body': ''}
-            self.data['status'] = self._status
+            self._push_status()
 
     def action(self, data):
         """Establish a connection with the device if needed and have it perform a specific action.


### PR DESCRIPTION
Before this commit, if an error occurred during the execution of an action, it was catch in the _do_action method. To signal that an error occured, we put "error" in the status of the response. However, before this commit, the status was overriden with a "connected" value right after being set to "error", which led to the frontend thinking everything was fine. This is now solved by only setting one status.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
