### PR TITLE
[FIX] discuss: prevent race condition crash during peer to peer offer

### DIFF
--- a/addons/mail/static/src/discuss/call/common/peer_to_peer.js
+++ b/addons/mail/static/src/discuss/call/common/peer_to_peer.js
@@ -530,6 +530,7 @@ export class PeerToPeer extends EventTarget {
                     peer = this._createPeer(id, { sequence: payload.sequence });
                 }
                 if (
+                    !peer.connection ||
                     INVALID_ICE_CONNECTION_STATES.has(peer.connection.iceConnectionState) ||
                     peer.connection.signalingState === "have-remote-offer"
                 ) {


### PR DESCRIPTION
Before this commit, since https://github.com/odoo/odoo/pull/205198,
the handling of an offer can be arbitrarily delayed by the `acceptOffer`
callback.

This could lead to a traceback when the reference to `peer` is stale by
the time the event is handled.
