### PR TITLE
[FIX] cloud_storage: avoid uploading document attachments to the cloud

### DIFF
--- a/addons/cloud_storage/models/ir_attachment.py
+++ b/addons/cloud_storage/models/ir_attachment.py
@@ -88,4 +88,8 @@ class CloudStorageAttachment(models.Model):
     def _get_cloud_storage_unsupported_models(self):
         # Some models may use their attachments' data in the business code
         # We should avoid those attachments to be uploaded to the cloud storage
-        return list(self.env.registry.descendants(['mail.thread.main.attachment'], '_inherit', '_inherits'))
+        models = self.env.registry.descendants(['mail.thread.main.attachment'], '_inherit', '_inherits')
+        if 'documents.mixin' in self.env:
+            models.update(self.env.registry.descendants(['documents.mixin'], '_inherit'))
+            models.add('documents.document')
+        return list(models)


### PR DESCRIPTION
Some models' attachments will automatically become document attachments which may be used in business code of documents. This commit avoids uploading these attachments to the cloud storage.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
