### PR TITLE
[FIX] l10n_fr_hr_holidays: missing default reference leave type in setting

### DIFF
--- a/addons/l10n_fr_hr_holidays/views/res_config_settings_views.xml
+++ b/addons/l10n_fr_hr_holidays/views/res_config_settings_views.xml
@@ -13,7 +13,7 @@
                         <field name="l10n_fr_reference_leave_type"
                             class="o_light_label"
                             domain="[('company_id', 'in', [company_id, False])]"
-                            context="{'default_company_id': company_id}"/>
+                            context="{'default_company_id': company_id}" required="company_country_code == 'FR'"/>
                     </setting>
                 </block>
             </block>


### PR DESCRIPTION
steps to reproduce:
-Install l10n_fr_hr_holidays module.
-Go to Time Off > Configuration > Settings.
-Company Paid Time Off field should blank.
-Employee working schedule calendar is not same as company's. 
-Create new leave > a validation error will occur.

cause:
-'l10n_fr_reference_leave_type' field should be required.

fix:
-Set the 'l10n_fr_reference_leave_type' field as required.

task - 5139488
