### PR TITLE
[FIX] web_editor: prevent extra breaklines when splitting paragraph

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/enter.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/enter.js
@@ -57,22 +57,10 @@ HTMLElement.prototype.oEnter = function (offset, firstSplit = true) {
         restore = prepareUpdate(this, offset);
     }
 
-    let currentOffset = offset;
     // First split the node in two and move half the children in the clone.
     let splitEl = this.cloneNode(false);
-    while (currentOffset < this.childNodes.length) {
-        const child = this.childNodes[currentOffset];
-        // Handle browser line break behavior: When SHIFT+ENTER is pressed at the end of text
-        // (e.g., `<p>abc[]</p>`), the browser creates two consecutive <br> elements with the
-        // cursor positioned between them. The second <br> makes the line break visible and
-        // gets automatically removed when typing begins. To preserve this line break during
-        // node splitting, we keep the second <br> in the original element.
-        if (child.nodeName === "BR" && child.previousSibling?.nodeName === "BR") {
-            splitEl.appendChild(document.createElement("br"));
-            currentOffset++;
-        } else {
-            splitEl.appendChild(child);
-        }
+    while (offset < this.childNodes.length) {
+        splitEl.appendChild(this.childNodes[offset]);
     }
     if (isBlock(this) || splitEl.hasChildNodes()) {
         this.after(splitEl);

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -2863,8 +2863,15 @@ const priorityRestoreStateRules = [
     [
         // Replace a space by &nbsp; when it was visible thanks to a BR which
         // is now gone.
-        { direction: DIRECTIONS.RIGHT, cType1: CTGROUPS.BR, cType2: CTYPES.SPACE | CTGROUPS.BLOCK },
+        { direction: DIRECTIONS.RIGHT, cType1: CTGROUPS.BR, cType2: CTYPES.SPACE },
         { spaceVisibility: true },
+    ],
+    [
+        // Replace a space by &nbsp; when it was visible thanks to a BR which
+        // is now gone and duplicate a BR which was visible thanks to a second
+        // BR which is now gone.
+        { direction: DIRECTIONS.RIGHT, cType1: CTGROUPS.BR, cType2: CTGROUPS.BLOCK },
+        { spaceVisibility: true, brVisibility: true },
     ],
     [
         // Remove all collapsed spaces when a space is removed.

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
@@ -27,6 +27,10 @@ async function twoDeleteForward(editor) {
     await deleteForward(editor);
 }
 
+const pressEnter = editor => {
+    editor.document.execCommand('insertParagraph');
+};
+
 describe('Editor', () => {
     describe('init', () => {
         describe('No orphan inline elements compatibility mode', () => {
@@ -165,6 +169,42 @@ describe('Editor', () => {
                     contentBefore: '<div contenteditable="false"><a href="" contenteditable="true"><p>abc</p></a></div>',
                     contentAfter: '<div contenteditable="false"><a href="" contenteditable="true">abc</a></div>',
                 });
+            });
+        });
+
+        it('should keep the last line break in the old paragraph (1)', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<div><p>abc<br>[]<br></p></div>',
+                stepFunction: pressEnter,
+                contentAfter: '<div><p>abc<br><br></p><p>[]<br></p></div>',
+            });
+        });
+        it('should keep the last line break in the old paragraph (2)', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: "<div><p>abc<br>[]<br></p></div>",
+                stepFunction: pressEnter,
+                contentAfter: "<div><p>abc<br><br></p><p>[]<br></p></div>",
+            });
+        });
+        it('should keep the last line break in the old paragraph (3)', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: "<div><p>abc<br>[]<br>def</p></div>",
+                stepFunction: pressEnter,
+                contentAfter: "<div><p>abc<br><br></p><p>[]<br>def</p></div>",
+            });
+        });
+        it('should keep the last line break in the old paragraph (4)', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: "<div><p>abc<br>[]<br><br></p></div>",
+                stepFunction: pressEnter,
+                contentAfter: "<div><p>abc<br><br></p><p>[]<br><br></p></div>",
+            });
+        });
+        it('should keep the last line break in the old paragraph (5)', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: "<div><p><br>[]<br></p></div>",
+                stepFunction: pressEnter,
+                contentAfter: "<div><p><br><br></p><p>[]<br></p></div>",
             });
         });
     });


### PR DESCRIPTION
Problem:
When pressing Enter between two line breaks, extra breaklines are inserted unexpectedly.

Cause:
This issue was introduced by commit
59a130457cb2d3b88bcf240f835e405535068eb2. However, the original problem that commit attempted to fix was already properly handled by commit d5590bf8c2d539cbed9a57bcb77b441c71f5ad1c in 18.0.

Solution:
Backport commit d5590bf8c2d539cbed9a57bcb77b441c71f5ad1c to 17.0.

Steps to reproduce:
1. Add several line breaks in a paragraph.
2. Press Enter in the middle to split the paragraph.
3. Observe that extra line breaks appear.

opw-5158234

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
