### PR TITLE
[FIX] stock: use original move line quantity to avoid extra empty lot lines

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -2248,7 +2248,7 @@ Please change the quantity done or the rounding precision of your unit of measur
     def _set_quantity_done_prepare_vals(self, qty):
         res = []
         for ml in self.move_line_ids:
-            ml_qty = ml.quantity
+            ml_qty = ml._origin.quantity or ml.quantity
             if float_is_zero(qty, precision_rounding=self.product_uom.rounding):
                 res.append((2, ml.id))
                 continue


### PR DESCRIPTION
Issue Before This Commit:
=======================
When a user updates `qty_producing` in a subcontracting MO, it creates new move lines with empty lots or serials, even though the required quantity is already available in existing `reserved move lines`. This requires the user to manually reassign lots/serials; otherwise, validating the picking raises a UserError of `missing Lot/Serial numbers`.

Steps to Reproduce:
=======================
- Install the `mrp_subcontracting` and `Purchase` module.
- Create product1 with Vendor1. Create product2 with lot tracking and set it `Resupply  Subcontractor on order` in Inventory.
- Create a BOM for product1, with product2 as a component (quantity 10) and subcontractor Vendor1.
- Create and confirm a purchase order for product1 (quantity 10) with Vendor1.
- Go to Resupply → Supply Product2, deliver 100 units of Product2 to Vendor1 using lot-01, then validate the picking.
- Go to the source PO → Receipt → Record Component. Observe that the move line is created with 100 units from lot-01
- Set qty_producing to 2 → the current component line updates to 20 quantity.
- Increase qty_producing by 1 → a new line is created with empty lot, even though the existing line already has 100 quantity of the same lot.

Cause of the issue:
=======================
When `qty_producing` is updated in the subcontracting MO wizard, the `_set_quantity_done_prepare_vals` method recalculates quantities based on the already modified move line quantity instead of referencing its original `reserved quantity`.This causes incorrect comparisons on subsequent updates, leading to the creation of new move lines with empty lots even when sufficient quantity already exists in the existing move line.

With This Commit:
=======================
`_set_quantity_done_prepare_vals` method now uses `ml._origin.quantity or ml.quantity`. ` _origin.quantity` ensures the reserved quantity of existing move lines is counted, while `ml.quantity` handles newly created lines without an origin. This prevents unnecessary move lines with empty lots when sufficient quantity already exists in existing reserved lines, eliminating manual reassignment and avoiding UserError on picking validation.

opw-5116273