### PR TITLE
[FIX] account_peppol: fix view inheritance

### DIFF
--- a/addons/account_peppol/views/res_partner_views.xml
+++ b/addons/account_peppol/views/res_partner_views.xml
@@ -4,7 +4,7 @@
         <field name="name">res.partner.form.account.peppol</field>
             <field name="model">res.partner</field>
             <field name="priority">20</field>
-            <field name="inherit_id" ref="base.view_partner_form"/>
+            <field name="inherit_id" ref="account_edi_ubl_cii.view_partner_property_form"/>
             <field name="arch" type="xml">
             <data>
                 <xpath expr="//field[@name='ubl_cii_format']" position="before">
@@ -43,7 +43,7 @@
     <record id="res_partner_view_tree" model="ir.ui.view">
         <field name="name">res.partner.tree.inherit</field>
         <field name="model">res.partner</field>
-        <field name="inherit_id" ref="base.view_partner_tree"/>
+        <field name="inherit_id" ref="account_edi_ubl_cii.res_partner_view_tree"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='ubl_cii_format']" position="after">
                 <field name="peppol_eas" string="Peppol EAS" optional="hide"/>


### PR DESCRIPTION
Currently the following views inherit from `base.view_partner_tree`:
- `res_partner_form_account_peppol`
- `res_partner_view_tree`

The views mentioned about contain xpath expressions based on the
`ubl_cii_format` field. But the view in `base` does not include
the field yet. It is added in module `account_edi_ubl_cii`.

This commit changes the inheritance to be from the equivalent views in
`account_edi_ubl_cii` instead.

Otherwise there is an error in a test when upgrading from 16.0 to 17.0
with the backported `account_peppol` to 16.0.

task-4925169