### PR TITLE
[IMP] web, *: make calendar swipe transition smoother

### DIFF
--- a/addons/calendar/static/tests/attendee_calendar_views.test.js
+++ b/addons/calendar/static/tests/attendee_calendar_views.test.js
@@ -117,7 +117,7 @@ test("Linked record rendering", async () => {
         res_model_id: modelId,
     });
     await mountView({ type: "calendar", resModel: "calendar.event", arch });
-    expect(".o_calendar_renderer .fc-view").toHaveCount(1);
+    expect(".o_calendar_renderer .o_calendar_current .fc-view").toHaveCount(1);
 
     await changeScale("week");
     await clickEvent(eventId);

--- a/addons/hr_homeworking_calendar/static/src/calendar/common/calendar_common_renderer.js
+++ b/addons/hr_homeworking_calendar/static/src/calendar/common/calendar_common_renderer.js
@@ -105,7 +105,7 @@ patch(AttendeeCalendarCommonRenderer.prototype, {
         const showLine = ["week", "month"].includes(this.props.model.scale);
         let worklocation = this.props.model.worklocations[parsedDate];
         const workLocationSetForCurrentUser =
-            multiCalendar ?
+            multiCalendar && worklocation ?
             Object.keys(worklocation).some(key => worklocation[key].some(wlItem => wlItem.userId === user.userId)
             ) : worklocation?.userId === user.userId;
 

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -24,7 +24,7 @@ import {
 } from "@odoo/owl";
 
 import { ActionSwiper } from "@web/core/action_swiper/action_swiper";
-import { hasTouch, isMobileOS } from "@web/core/browser/feature_detection";
+import { isMobileOS } from "@web/core/browser/feature_detection";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
 import { _t } from "@web/core/l10n/translation";
@@ -112,7 +112,6 @@ export class Message extends Component {
             });
         }
         useForwardRefsToParent("messageRefs", (props) => props.message.id, this.root);
-        this.hasTouch = hasTouch;
         this.messageBody = useRef("body");
         this.messageActions = useMessageActions({
             message: () => this.message,

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.Message">
-        <ActionSwiper onRightSwipe="hasTouch() and props.thread?.eq(store.inbox) ? { action: () => this.message.setDone(), bgColor: 'bg-success', icon: 'fa-check-circle' } : undefined">
+        <ActionSwiper onRightSwipe="props.thread?.eq(store.inbox) ? { action: () => this.message.setDone(), bgColor: 'bg-success', icon: 'fa-check-circle' } : undefined">
             <t t-set="dummy" t-value="computeActions()"/>
             <div class="o-mail-Message position-relative rounded-0 bg-inherit"
                 t-att-data-starred="message.starred"

--- a/addons/microsoft_calendar/static/tests/microsoft_calendar.test.js
+++ b/addons/microsoft_calendar/static/tests/microsoft_calendar.test.js
@@ -121,5 +121,5 @@ test(`component is destroyed while sync microsoft calendar`, async () => {
 
     deferred.resolve();
     await animationFrame();
-    expect.verifySteps(["search_read"]);
+    await expect.waitForSteps(["search_read"]);
 });

--- a/addons/web/static/src/core/action_swiper/action_swiper.scss
+++ b/addons/web/static/src/core/action_swiper/action_swiper.scss
@@ -2,11 +2,8 @@
     position: relative;
     touch-action: pan-y;
 }
-.o_actionswiper_target_container {
+.o_actionswiper_target_container.o_actionswiper_transition_enabled {
     transition: transform 0.4s;
-}
-.o_actionswiper_swiping {
-    transition: none;
 }
 .o_actionswiper_right_swipe_area {
     /*rtl:ignore*/

--- a/addons/web/static/src/core/action_swiper/action_swiper.xml
+++ b/addons/web/static/src/core/action_swiper/action_swiper.xml
@@ -1,19 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="web.ActionSwiper">
-        <t t-if="props.onRightSwipe || props.onLeftSwipe">
-            <div class="o_actionswiper" t-on-touchend="_onTouchEndSwipe" t-on-touchmove="_onTouchMoveSwipe" t-on-touchstart="_onTouchStartSwipe" t-ref="root">
+        <t t-if="localizedProps">
+            <div class="o_actionswiper" t-on-touchstart="_onTouchStartSwipe" t-ref="root">
                 <div class="o_actionswiper_overflow_container position-relative overflow-hidden">
-                    <div class="o_actionswiper_target_container" t-ref="targetContainer" t-att-style="state.containerStyle" t-att-class="{ o_actionswiper_swiping: state.isSwiping }">
+                    <div class="o_actionswiper_target_container" t-ref="targetContainer">
                         <t t-slot="default"/>
-                        <t t-if="localizedProps.onRightSwipe and (localizedProps.onRightSwipe.icon or localizedProps.onRightSwipe.bgColor)">
-                            <div t-att-style="'max-width: ' + swipedDistance + 'px;'" class="o_actionswiper_right_swipe_area position-absolute overflow-hidden w-100 h-100 d-flex align-items-center justify-content-center rounded-end" t-att-class="localizedProps.onRightSwipe.bgColor">
-                                <span><i class="fa fa-2x" t-att-class="localizedProps.onRightSwipe.icon"/></span>
+                        <t t-if="localizedProps.onRightSwipe">
+                            <div t-ref="leftPanel" class="o_actionswiper_right_swipe_area position-absolute overflow-hidden w-100 h-100">
+                                <t t-if="this.props.animationType === 'forwards'">
+                                    <t t-if="localizedProps.onRightSwipe.slot" t-component="localizedProps.onRightSwipe.slot.component" t-props="localizedProps.onRightSwipe.slot.props" />
+                                </t>
+                                <div t-else="" class="h-100 w-100 d-flex align-items-center justify-content-center rounded-end" t-att-class="localizedProps.onRightSwipe.bgColor">
+                                    <i class="fa fa-2x" t-att-class="localizedProps.onRightSwipe.icon"/>
+                                </div>
                             </div>
                         </t>
-                        <t t-if="localizedProps.onLeftSwipe and (localizedProps.onLeftSwipe.icon or localizedProps.onLeftSwipe.bgColor)">
-                            <div t-att-style="'max-width: ' + -swipedDistance + 'px;'" class="o_actionswiper_left_swipe_area position-absolute overflow-hidden w-100 h-100 d-flex align-items-center justify-content-center rounded-start" t-att-class="localizedProps.onLeftSwipe.bgColor">
-                                <span><i class="fa fa-2x" t-att-class="localizedProps.onLeftSwipe.icon"/></span>
+                        <t t-if="localizedProps.onLeftSwipe">
+                            <div t-ref="rightPanel" class="o_actionswiper_left_swipe_area position-absolute overflow-hidden w-100 h-100">
+                                <t t-if="this.props.animationType === 'forwards'">
+                                    <t t-if="localizedProps.onLeftSwipe.slot" t-component="localizedProps.onLeftSwipe.slot.component" t-props="localizedProps.onLeftSwipe.slot.props" />
+                                </t>
+                                <div t-else="" class="h-100 w-100 d-flex align-items-center justify-content-center rounded-start" t-att-class="localizedProps.onLeftSwipe.bgColor">
+                                    <i class="fa fa-2x" t-att-class="localizedProps.onLeftSwipe.icon"/>
+                                </div>
                             </div>
                         </t>
                     </div>

--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.xml
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.CalendarCommonRenderer">
-        <div class="o_calendar_widget" t-att-class="{ o_multi_create_mode: this.props.model.hasMultiCreate }" t-ref="fullCalendar" />
+        <div class="o_calendar_widget" t-att-class="{ o_multi_create_mode: this.props.model.hasMultiCreate, 'o_calendar_current': !this.props.isDisabled }" t-ref="fullCalendar" />
     </t>
 
     <t t-name="web.CalendarCommonRenderer.event">

--- a/addons/web/static/src/views/calendar/calendar_controller.js
+++ b/addons/web/static/src/views/calendar/calendar_controller.js
@@ -21,6 +21,7 @@ import { MultiSelectionButtons } from "@web/views/view_components/multi_selectio
 import { getLocalYearAndWeek } from "@web/core/l10n/dates";
 
 import { Component, reactive, useState } from "@odoo/owl";
+import { hasTouch } from "@web/core/browser/feature_detection";
 
 const { DateTime } = luxon;
 
@@ -105,6 +106,7 @@ export class CalendarController extends Component {
             domain: this.props.domain,
             fields: this.props.fields,
             date: this.props.state?.date,
+            loadSurroundings: hasTouch()
         };
     }
 
@@ -148,17 +150,17 @@ export class CalendarController extends Component {
     }
 
     get weekHeader() {
-        const { rangeStart, rangeEnd } = this.model;
-        if (rangeStart.year != rangeEnd.year) {
-            return `${rangeStart.toFormat("MMMM")} ${rangeStart.year} - ${rangeEnd.toFormat(
+        const { start, end } = this.model.visibleRange;
+        if (start.year != end.year) {
+            return `${start.toFormat("MMMM")} ${start.year} - ${end.toFormat(
                 "MMMM"
-            )} ${rangeEnd.year}`;
-        } else if (rangeStart.month != rangeEnd.month) {
-            return `${rangeStart.toFormat("MMMM")} - ${rangeEnd.toFormat("MMMM")} ${
-                rangeStart.year
+            )} ${end.year}`;
+        } else if (start.month != end.month) {
+            return `${start.toFormat("MMMM")} - ${end.toFormat("MMMM")} ${
+                start.year
             }`;
         }
-        return `${rangeStart.toFormat("MMMM")} ${rangeStart.year}`;
+        return `${start.toFormat("MMMM")} ${start.year}`;
     }
 
     get currentMonth() {
@@ -166,7 +168,7 @@ export class CalendarController extends Component {
     }
 
     get currentWeek() {
-        return getLocalYearAndWeek(this.model.rangeStart).week;
+        return getLocalYearAndWeek(this.model.visibleRange.start).week;
     }
 
     get rendererProps() {
@@ -407,7 +409,7 @@ export class CalendarController extends Component {
         return this.model.unlinkRecords(ids);
     }
 
-    async setDate(move) {
+    setDate(move) {
         let date = null;
         switch (move) {
             case "next":
@@ -423,7 +425,7 @@ export class CalendarController extends Component {
                 }
                 break;
         }
-        await this.model.load({ date });
+        this.model.load({ date });
     }
 
     get scales() {

--- a/addons/web/static/src/views/calendar/calendar_controller.scss
+++ b/addons/web/static/src/views/calendar/calendar_controller.scss
@@ -36,6 +36,17 @@ $o-cw-filter-avatar-size: 20px;
             }
         }
     }
+
+    .o_actionswiper_right_swipe_area, .o_actionswiper_left_swipe_area {
+        max-width: unset !important;
+        .o_calendar_widget {
+            width: 100%;
+        }
+    }
+
+    .o_actionswiper, .o_actionswiper_overflow_container , .o_actionswiper_target_container {
+        height: 100%;
+    }
 }
 
 .o_calendar_sidebar_container {

--- a/addons/web/static/src/views/calendar/calendar_model.js
+++ b/addons/web/static/src/views/calendar/calendar_model.js
@@ -75,6 +75,8 @@ export class CalendarModel extends Model {
         }
         browser.localStorage.setItem(this.storageKey, this.meta.scale);
         const data = { ...this.data };
+        // notify with basic data to render a simple calendar before updating them
+        this.notify();
         await this.keepLast.add(this.updateData(data));
         this.data = data;
         this.notify();
@@ -194,6 +196,18 @@ export class CalendarModel extends Model {
     }
     get defaultFilterLabel() {
         return _t("Undefined");
+    }
+    get visibleRange() {
+        if (this.meta.loadSurroundings) {
+            return {
+                start: this.rangeStart.plus({[`${this.scale}s`]: 1}),
+                end: this.rangeEnd.minus({[`${this.scale}s`]: 1}),
+            }
+        }
+        return {
+            start: this.rangeStart,
+            end: this.rangeEnd,
+        }
     }
 
     //--------------------------------------------------------------------------
@@ -419,6 +433,12 @@ export class CalendarModel extends Model {
     async updateData(data) {
         data.range = this.computeRange();
         let unusualDaysProm;
+        if (this.meta.loadSurroundings) {
+            data.range = {
+                start: data.range.start.minus({[`${this.scale}s`]: 1}),
+                end: data.range.end.plus({[`${this.scale}s`]: 1}),
+            }
+        }
         if (this.meta.showUnusualDays) {
             unusualDaysProm = this.loadUnusualDays(data).then((unusualDays) => {
                 data.unusualDays = unusualDays;

--- a/addons/web/static/src/views/calendar/calendar_renderer.js
+++ b/addons/web/static/src/views/calendar/calendar_renderer.js
@@ -1,4 +1,5 @@
 import { ActionSwiper } from "@web/core/action_swiper/action_swiper";
+import { TOUCH_SELECTION_THRESHOLD } from "@web/views/utils";
 import { CalendarCommonRenderer } from "./calendar_common/calendar_common_renderer";
 import { CalendarYearRenderer } from "./calendar_year/calendar_year_renderer";
 
@@ -31,29 +32,40 @@ export class CalendarRenderer extends Component {
         if (this.props.model.scale === "year") {
             return {
                 model: this.props.model,
+                initialDate: this.props.model.date,
                 isWeekendVisible: this.props.isWeekendVisible,
                 createRecord: this.props.createRecord,
                 editRecord: this.props.editRecord,
                 deleteRecord: this.props.deleteRecord,
             };
         }
-        return this.props;
+        return {
+            ...this.props,
+            initialDate: this.props.model.date,
+        };
     }
     get calendarKey() {
         return `${this.props.model.scale}_${this.props.model.date.valueOf()}`;
     }
     get actionSwiperProps() {
         return {
-            onLeftSwipe: this.env.isSmall
-                ? { action: () => this.props.setDate("next") }
-                : undefined,
-            onRightSwipe: this.env.isSmall
-                ? { action: () => this.props.setDate("previous") }
-                : undefined,
-            animationOnMove: false,
+            onLeftSwipe: this.getSwiperProps("next"),
+            onRightSwipe: this.getSwiperProps("previous"),
             animationType: "forwards",
-            swipeDistanceRatio: 6,
-            swipeInvalid: () => Boolean(document.querySelector(".o_event.fc-mirror")),
+            enabledDuration: TOUCH_SELECTION_THRESHOLD
+        };
+    }
+    getSwiperProps(direction) {
+        return {
+            action: () => this.props.setDate(direction),
+            slot: {
+                component: this.concreteRenderer,
+                props: {
+                    ...this.concreteRendererProps,
+                    initialDate: this.props.model.date[direction === "next" ? "plus" : "minus"]({[`${this.props.model.scale}s`]: 1}),
+                    isDisabled: true
+                },
+            },
         };
     }
 }

--- a/addons/web/static/src/views/calendar/calendar_renderer.xml
+++ b/addons/web/static/src/views/calendar/calendar_renderer.xml
@@ -3,11 +3,10 @@
 
     <t t-name="web.CalendarRenderer">
         <div class="o_calendar_renderer h-100 flex-grow-1">
-            <ActionSwiper t-props="actionSwiperProps">
+            <ActionSwiper t-props="actionSwiperProps" t-key="calendarKey">
                 <t
                     t-component="concreteRenderer"
                     t-props="concreteRendererProps"
-                    t-key="calendarKey"
                 />
             </ActionSwiper>
         </div>

--- a/addons/web/static/src/views/calendar/calendar_year/calendar_year_renderer.xml
+++ b/addons/web/static/src/views/calendar/calendar_year/calendar_year_renderer.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.CalendarYearRenderer">
-        <div class="o_calendar_widget overflow-y-auto" t-ref="root">
+        <div class="o_calendar_widget overflow-y-auto" t-att-class="{'o_calendar_current': !this.props.isDisabled}" t-ref="root">
             <div class="fc-view-container">
                 <div class="fc fc-dayGridYear-view d-flex flex-wrap justify-content-evenly gap-3 px-2 py-3">
                     <t t-foreach="months" t-as="month" t-key="month">

--- a/addons/web/static/src/views/kanban/kanban_record.js
+++ b/addons/web/static/src/views/kanban/kanban_record.js
@@ -14,7 +14,7 @@ import { fileTypeMagicWordMap } from "@web/views/fields/image/image_field";
 import { ViewButton } from "@web/views/view_button/view_button";
 import { useViewCompiler } from "@web/views/view_compiler";
 import { Widget } from "@web/views/widgets/widget";
-import { getFormattedValue } from "../utils";
+import { TOUCH_SELECTION_THRESHOLD, getFormattedValue } from "../utils";
 import { KANBAN_CARD_ATTRIBUTE, KANBAN_MENU_ATTRIBUTE } from "./kanban_arch_parser";
 import { KanbanCompiler } from "./kanban_compiler";
 import { KanbanCoverImageDialog } from "./kanban_cover_image_dialog";
@@ -182,7 +182,7 @@ export class KanbanRecord extends Component {
     static template = "web.KanbanRecord";
 
     setup() {
-        this.LONG_TOUCH_THRESHOLD = this.props.canResequence ? 600 : 400;
+        this.LONG_TOUCH_THRESHOLD = this.props.canResequence ? 600 : TOUCH_SELECTION_THRESHOLD;
         this.evaluateBooleanExpr = evaluateBooleanExpr;
         this.action = useService("action");
         this.dialog = useService("dialog");

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -14,6 +14,7 @@ import { AGGREGATABLE_FIELD_TYPES, combineModifiers } from "@web/model/relationa
 import { Field, getPropertyFieldInfo } from "@web/views/fields/field";
 import { getTooltipInfo } from "@web/views/fields/field_tooltip";
 import {
+    TOUCH_SELECTION_THRESHOLD,
     computeAggregatedValue,
     getClassNameFromDecoration,
     getFormattedValue,
@@ -104,7 +105,6 @@ export class ListRenderer extends Component {
     static recordRowTemplate = "web.ListRenderer.RecordRow";
     static groupRowTemplate = "web.ListRenderer.GroupRow";
     static useMagicColumnWidths = true;
-    static LONG_TOUCH_THRESHOLD = 400;
     static components = {
         DropdownItem,
         Field,
@@ -2204,7 +2204,7 @@ export class ListRenderer extends Component {
             this.longTouchTimer = browser.setTimeout(() => {
                 this.toggleRecordSelection(record);
                 this.resetLongTouchTimer();
-            }, this.constructor.LONG_TOUCH_THRESHOLD);
+            }, TOUCH_SELECTION_THRESHOLD);
         }
     }
 
@@ -2213,7 +2213,7 @@ export class ListRenderer extends Component {
      */
     onRowTouchEnd(_record) {
         const elapsedTime = Date.now() - this.touchStartMs;
-        if (elapsedTime < this.constructor.LONG_TOUCH_THRESHOLD) {
+        if (elapsedTime < TOUCH_SELECTION_THRESHOLD) {
             this.resetLongTouchTimer();
         }
     }

--- a/addons/web/static/src/views/utils.js
+++ b/addons/web/static/src/views/utils.js
@@ -4,6 +4,8 @@ import { unique } from "@web/core/utils/arrays";
 import { exprToBoolean } from "@web/core/utils/strings";
 import { combineModifiers } from "@web/model/relational_model/utils";
 
+export const TOUCH_SELECTION_THRESHOLD = 400;
+
 export const X2M_TYPES = ["one2many", "many2many"];
 const NUMERIC_TYPES = ["integer", "float", "monetary"];
 

--- a/addons/web/static/src/webclient/settings_form_view/settings/settings_page.js
+++ b/addons/web/static/src/webclient/settings_form_view/settings/settings_page.js
@@ -2,6 +2,7 @@ import { ActionSwiper } from "@web/core/action_swiper/action_swiper";
 
 import { Component, useState, useRef, useEffect } from "@odoo/owl";
 import { browser } from "@web/core/browser/browser";
+import { Deferred } from "@web/core/utils/concurrency";
 
 export class SettingsPage extends Component {
     static template = "web.SettingsPage";
@@ -47,6 +48,8 @@ export class SettingsPage extends Component {
 
                 const { scrollTop } = this.scrollMap[currentTab] || 0;
                 settingsEl.scrollTop = scrollTop;
+                this.scrollToSelectedTab();
+                this.tabChangeProm?.resolve();
             },
             () => [this.settingsRef.el, this.state.selectedTab]
         );
@@ -70,15 +73,15 @@ export class SettingsPage extends Component {
             this.getCurrentIndex() !== this.props.modules.length - 1
         );
     }
-    async onRightSwipe(prom) {
+    onRightSwipe() {
+        this.tabChangeProm = new Deferred();
         this.state.selectedTab = this.props.modules[this.getCurrentIndex() - 1].key;
-        await prom;
-        this.scrollToSelectedTab();
+        return this.tabChangeProm;
     }
-    async onLeftSwipe(prom) {
+    onLeftSwipe() {
+        this.tabChangeProm = new Deferred();
         this.state.selectedTab = this.props.modules[this.getCurrentIndex() + 1].key;
-        await prom;
-        this.scrollToSelectedTab();
+        return this.tabChangeProm;
     }
 
     scrollToSelectedTab() {

--- a/addons/web/static/src/webclient/settings_form_view/settings/settings_page.xml
+++ b/addons/web/static/src/webclient/settings_form_view/settings/settings_page.xml
@@ -15,15 +15,13 @@
                 </div>
             </div>
             <ActionSwiper
-                    onRightSwipe = " hasRightSwipe() ? {
+                    onRightSwipe="hasRightSwipe() ? {
                         action: onRightSwipe.bind(this),
                     } : undefined"
-                    onLeftSwipe = " hasLeftSwipe() ? {
+                    onLeftSwipe="hasLeftSwipe() ? {
                         action: onLeftSwipe.bind(this),
                     } : undefined"
-                    animationOnMove="false"
-                    animationType="'forwards'"
-                    swipeDistanceRatio="6">
+                    animationType="'forwards'">
                 <div class="settings" t-ref="settings">
                     <t t-slot="NoContentHelper" t-if="props.slots['NoContentHelper'].isVisible"/>
                     <t t-slot="default" selectedTab="state.selectedTab"/>

--- a/addons/web/static/tests/core/action_swiper.test.js
+++ b/addons/web/static/tests/core/action_swiper.test.js
@@ -2,8 +2,8 @@
 
 import { beforeEach, expect, test } from "@odoo/hoot";
 import { hover, queryFirst } from "@odoo/hoot-dom";
-import { advanceTime, animationFrame, mockTouch } from "@odoo/hoot-mock";
-import { Component, onPatched, xml } from "@odoo/owl";
+import { mockTouch } from "@odoo/hoot-mock";
+import { Component, xml } from "@odoo/owl";
 import {
     contains,
     defineParams,
@@ -13,9 +13,15 @@ import {
     swipeRight,
 } from "@web/../tests/web_test_helpers";
 import { ActionSwiper } from "@web/core/action_swiper/action_swiper";
+import { browser } from "@web/core/browser/browser";
 import { Deferred } from "@web/core/utils/concurrency";
 
-beforeEach(() => mockTouch(true));
+beforeEach(() => {
+    mockTouch(true);
+    patchWithCleanup(ActionSwiper, {
+       animationLength: 0, 
+    })
+});
 
 // Tests marked as will fail on browsers that don't support
 // TouchEvent by default. It might be an option to activate on some browser.
@@ -27,6 +33,28 @@ test("render only its target if no props is given", async () => {
         static template = xml`
                 <div class="d-flex">
                     <ActionSwiper>
+                        <div class="target-component"/>
+                    </ActionSwiper>
+                </div>
+            `;
+    }
+    await mountWithCleanup(Parent);
+    expect("div.o_actionswiper").toHaveCount(0);
+    expect("div.target-component").toHaveCount(1);
+});
+
+test("render only its target on non-touch devices", async () => {
+    mockTouch(false);
+    // mockTouch(false) don't work well with hasTouch() because browser.ontouchstart is null
+    patchWithCleanup(browser, {
+        ontouchstart: undefined
+    })
+    class Parent extends Component {
+        static props = ["*"];
+        static components = { ActionSwiper };
+        static template = xml`
+                <div class="d-flex">
+                    <ActionSwiper onLeftSwipe="{action: () => {}, icon: 'fa-circle', bgColor: 'bg-warning'}">
                         <div class="target-component"/>
                     </ActionSwiper>
                 </div>
@@ -141,7 +169,6 @@ test("can perform actions by swiping to the right", async () => {
         },
     });
     await dragHelper.drop();
-    await animationFrame();
     expect(targetContainer.style.transform).not.toInclude("translateX", {
         message: "target does not have a translate value",
     });
@@ -266,11 +293,9 @@ test("invert the direction of swipes when language is rtl", async () => {
     await mountWithCleanup(Parent);
     // Touch ends once the half of the distance has been crossed to the left
     await swipeLeft(".o_actionswiper");
-    await advanceTime(500);
     // In rtl languages, actions are permuted
     expect.verifySteps(["onRightSwipe"]);
     await swipeRight(".o_actionswiper");
-    await advanceTime(500);
     // In rtl languages, actions are permuted
     expect.verifySteps(["onLeftSwipe"]);
 });
@@ -390,7 +415,6 @@ test("swiping when the swiper contains scrollable areas", async () => {
             "the swiper has swiped to the right because the scrollable element couldn't scroll anymore to the left",
     });
     await dragHelper.drop();
-    await advanceTime(500);
     expect.verifySteps(["onRightSwipe"]);
 
     dragHelper = await contains(largeText).drag({
@@ -436,7 +460,6 @@ test("swiping when the swiper contains scrollable areas", async () => {
             "the swiper has swiped to the left because the scrollable element couldn't scroll anymore to the right",
     });
     await dragHelper.drop();
-    await advanceTime(500);
     expect.verifySteps(["onLeftSwipe"]);
 });
 
@@ -538,7 +561,6 @@ test("preventing swipe on scrollable areas when language is rtl", async () => {
             "the swiper has swiped to the right because the scrollable element couldn't scroll anymore to the left",
     });
     await dragHelper.drop();
-    await advanceTime(500);
     // In rtl languages, actions are permuted
     expect.verifySteps(["onLeftSwipe"]);
     // LEFT => RIGHT trigger
@@ -590,63 +612,14 @@ test("preventing swipe on scrollable areas when language is rtl", async () => {
             "the swiper has swiped to the left because the scrollable element couldn't scroll anymore to the right",
     });
     await dragHelper.drop();
-    await advanceTime(500);
 
     // In rtl languages, actions are permuted
     expect.verifySteps(["onRightSwipe"]);
 });
 
-test("swipeInvalid prop prevents swiping", async () => {
-    expect.assertions(2);
-
-    class Parent extends Component {
-        static props = ["*"];
-        static components = { ActionSwiper };
-        static template = xml`
-                <div class="d-flex">
-                    <ActionSwiper onRightSwipe = "{
-                        action: () => this.onRightSwipe(),
-                        icon: 'fa-circle',
-                        bgColor: 'bg-warning',
-                    }" swipeInvalid = "swipeInvalid">
-                        <div class="target-component" style="width: 200px; height: 80px">Test</div>
-                    </ActionSwiper>
-                </div>
-            `;
-        onRightSwipe() {
-            expect.step("onRightSwipe");
-        }
-        swipeInvalid() {
-            expect.step("swipeInvalid");
-            return true;
-        }
-    }
-    await mountWithCleanup(Parent);
-    const targetContainer = queryFirst(".o_actionswiper_target_container");
-    // Touch ends once the half of the distance has been crossed
-    await swipeRight(".o_actionswiper");
-
-    expect(targetContainer.style.transform).not.toInclude("translateX", {
-        message: "target doesn't have translateX after action is performed",
-    });
-    expect.verifySteps(["swipeInvalid"]);
-});
-
-test("action should be done before a new render", async () => {
-    let executingAction = false;
-    const prom = new Deferred();
-
-    patchWithCleanup(ActionSwiper.prototype, {
-        setup() {
-            super.setup();
-            onPatched(() => {
-                if (executingAction) {
-                    expect.step("ActionSwiper patched");
-                }
-            });
-        },
-    });
-
+test("an async action is awaited before being executed", async () => {
+const prom = new Deferred();
+    
     class Parent extends Component {
         static props = [];
         static components = { ActionSwiper };
@@ -663,16 +636,15 @@ test("action should be done before a new render", async () => {
             `;
 
         async onRightSwipe() {
-            await animationFrame();
+            expect.step("action started")
+            await prom;
             expect.step("action done");
-            prom.resolve();
         }
     }
 
     await mountWithCleanup(Parent);
     await swipeRight(".o_actionswiper");
-    executingAction = true;
-    await prom;
-    await animationFrame();
-    expect.verifySteps(["action done", "ActionSwiper patched"]);
+    expect.verifySteps(["action started"]);
+    prom.resolve();
+    await expect.waitForSteps(["action done"]);
 });

--- a/addons/web/static/tests/views/calendar/calendar_common_renderer.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_common_renderer.test.js
@@ -15,6 +15,7 @@ import { CallbackRecorder } from "@web/search/action_hook";
 
 const FAKE_PROPS = {
     model: FAKE_MODEL,
+    initialDate: FAKE_MODEL.date,
     createRecord() {},
     deleteRecord() {},
     editRecord() {},

--- a/addons/web/static/tests/views/calendar/calendar_year_renderer.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_year_renderer.test.js
@@ -13,6 +13,7 @@ import { CalendarYearRenderer } from "@web/views/calendar/calendar_year/calendar
 
 const FAKE_PROPS = {
     model: FAKE_MODEL,
+    initialDate: FAKE_MODEL.date,
     createRecord() {},
     deleteRecord() {},
     editRecord() {},

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -88,6 +88,7 @@ import { KanbanRenderer } from "@web/views/kanban/kanban_renderer";
 import { kanbanView } from "@web/views/kanban/kanban_view";
 import { ViewButton } from "@web/views/view_button/view_button";
 import { AnimatedNumber } from "@web/views/view_components/animated_number";
+import { TOUCH_SELECTION_THRESHOLD } from "@web/views/utils";
 import { WebClient } from "@web/webclient/webclient";
 
 const { IrAttachment } = webModels;
@@ -8400,7 +8401,7 @@ test("selection can be enabled by long touch", async () => {
     });
     expect(".o_selection_box").toHaveCount(0);
     await drag(".o_kanban_record:nth-of-type(2)");
-    await advanceTime(400);
+    await advanceTime(TOUCH_SELECTION_THRESHOLD);
     expect(".o_selection_box").toHaveCount(1);
 });
 
@@ -8422,7 +8423,7 @@ test("selection can be enabled by long touch with drag & drop enabled", async ()
     });
     expect(".o_selection_box").toHaveCount(0);
     const { drop } = await drag(".o_kanban_record:nth-of-type(1)");
-    await advanceTime(400);
+    await advanceTime(TOUCH_SELECTION_THRESHOLD);
     expect(".o_selection_box").toHaveCount(0, {
         message: "touch delay is longer when drag & drop is enabled",
     });


### PR DESCRIPTION
This commit reworks entirely the ActionSwiper component with the 'forwards' animationType. This has been done to create a more engaging animation, with the content area being moved following the user's finger on the screen.

The commit also allows to set custom content in surrounding areas, such as a preview of the item nearby that replaces the current content with the animation is done. This is used to create a continued experience in the calendar, showing other instances of the calendar arround the current period being visible instead of a blank screen. By default, no content is set (settings app for example).

By improving the 'forwards' animation with a more natural UX, the props associated with a fixed swipable experience has be removed. It is also no longer useful to support a custom distance ratio before expecting the content to change, so the dedicated props has been dropped as well.

task-4800846