### PR TITLE
[IMP] mail: user info selector in avatar card

### DIFF
--- a/addons/hr/static/tests/m2x_avatar_employee.test.js
+++ b/addons/hr/static/tests/m2x_avatar_employee.test.js
@@ -54,7 +54,7 @@ test("many2one in list view", async () => {
     // click on first employee avatar
     await contains(".o_data_cell .o_m2o_avatar > img:eq(0)").click();
     await waitFor(".o_avatar_card");
-    expect(".o_card_user_infos > span").toHaveText("Mario");
+    expect(".o-mail-avatar-card-name").toHaveText("Mario");
     expect(".o_card_user_infos > a").toHaveText("Mario@partner.com");
     expect(".o_avatar_card_buttons button:eq(0)").toHaveText("Send message");
     await contains(".o_avatar_card_buttons button:eq(0)").click();
@@ -63,7 +63,7 @@ test("many2one in list view", async () => {
 
     // click on second employee
     await contains(".o_data_cell .o_m2o_avatar > img:eq(1)").click();
-    expect(".o_card_user_infos span").toHaveText("Luigi");
+    expect(".o-mail-avatar-card-name").toHaveText("Luigi");
     expect(".o_avatar_card").toHaveCount(1);
     expect(".o_avatar_card_buttons button:eq(0)").toHaveText("Send message");
     await contains(".o_avatar_card_buttons button:eq(0)").click();
@@ -72,9 +72,9 @@ test("many2one in list view", async () => {
 
     // click on third employee (same as first)
     await contains(".o_data_cell .o_m2o_avatar > img:eq(2)").click();
-    expect(".o_card_user_infos span").toHaveText("Mario");
+    expect(".o-mail-avatar-card-name").toHaveText("Mario");
     expect(".o_avatar_card").toHaveCount(1);
-    expect(".o_card_user_infos span:eq(0)").toHaveText("Mario");
+    expect(".o-mail-avatar-card-name").toHaveText("Mario");
     expect(".o_card_user_infos > a").toHaveText("Mario@partner.com");
     expect(".o_avatar_card_buttons button:eq(0)").toHaveText("Send message");
     await contains(".o_avatar_card_buttons button:eq(0)").click();
@@ -263,7 +263,7 @@ test("many2one in form view", async () => {
     // Clicking on first employee's avatar
     await contains(".o_field_many2many_avatar_employee .o_tag .o_m2m_avatar:eq(0)").click();
     await waitFor(".o_avatar_card");
-    expect(".o_card_user_infos > span").toHaveText("Mario");
+    expect(".o-mail-avatar-card-name").toHaveText("Mario");
     expect(".o_card_user_infos > a").toHaveText("Mario@partner.com");
     expect(".o_avatar_card_buttons button:eq(0)").toHaveText("Send message");
     await contains(".o_avatar_card_buttons button:eq(0)").click();
@@ -272,7 +272,7 @@ test("many2one in form view", async () => {
 
     // Clicking on second employee's avatar
     await contains(".o_field_many2many_avatar_employee .o_tag .o_m2m_avatar:eq(1)").click();
-    expect(".o_card_user_infos span").toHaveText("Luigi");
+    expect(".o-mail-avatar-card-name").toHaveText("Luigi");
     expect(".o_avatar_card").toHaveCount(1);
     expect(".o_avatar_card_buttons button:eq(0)").toHaveText("Send message");
     await contains(".o_avatar_card_buttons button:eq(0)").click();
@@ -314,10 +314,7 @@ test("many2one with hr group widget in form view", async () => {
     );
     await contains(".o_field_many2many_avatar_employee .o_tag .o_m2m_avatar:eq(0)").click();
     await contains(".o_field_many2many_avatar_employee .o_tag .o_m2m_avatar:eq(1)").click();
-    expect.verifySteps([
-        `read hr.employee ${employeeId_1}`,
-        `read hr.employee ${employeeId_2}`,
-    ]);
+    expect.verifySteps([`read hr.employee ${employeeId_1}`, `read hr.employee ${employeeId_2}`]);
 });
 
 test("many2one widget in list view", async () => {
@@ -358,7 +355,7 @@ test("many2one widget in list view", async () => {
     // Clicking on first employee's avatar
     await contains(".o_data_cell .o_m2m_avatar:eq(0)").click();
     await waitFor(".o_avatar_card");
-    expect(".o_card_user_infos > span").toHaveText("Mario");
+    expect(".o-mail-avatar-card-name").toHaveText("Mario");
     expect(".o_card_user_infos > a").toHaveText("Mario@partner.com");
     expect(".o_avatar_card_buttons button:eq(0)").toHaveText("Send message");
     await contains(".o_avatar_card_buttons button:eq(0)").click();
@@ -367,7 +364,7 @@ test("many2one widget in list view", async () => {
 
     // Clicking on second employee's avatar
     await contains(".o_data_cell .o_m2m_avatar:eq(1)").click();
-    expect(".o_card_user_infos span").toHaveText("Yoshi");
+    expect(".o-mail-avatar-card-name").toHaveText("Yoshi");
     expect(".o_avatar_card").toHaveCount(1);
     expect(".o_avatar_card_buttons button:eq(0)").toHaveText("Send message");
     await contains(".o_avatar_card_buttons button:eq(0)").click();
@@ -434,7 +431,7 @@ test("many2many in kanban view", async () => {
     // Clicking on first employee's avatar
     await contains(".o_kanban_record img.o_m2m_avatar:eq(1)").click();
     await waitFor(".o_avatar_card");
-    expect(".o_card_user_infos > span").toHaveText("Mario");
+    expect(".o-mail-avatar-card-name").toHaveText("Mario");
     expect(".o_card_user_infos > a").toHaveText("Mario@partner.com");
     expect(".o_avatar_card_buttons button:eq(0)").toHaveText("Send message");
     await contains(".o_avatar_card_buttons button:eq(0)").click();
@@ -443,7 +440,7 @@ test("many2many in kanban view", async () => {
 
     // Clicking on second employee's avatar
     await contains(".o_kanban_record img.o_m2m_avatar:eq(0)").click();
-    expect(".o_card_user_infos span").toHaveText("Luigi");
+    expect(".o-mail-avatar-card-name").toHaveText("Luigi");
     expect(".o_avatar_card").toHaveCount(1);
     expect(".o_avatar_card_buttons button:eq(0)").toHaveText("Send message");
     await contains(".o_avatar_card_buttons button:eq(0)").click();
@@ -486,13 +483,13 @@ test("many2many: click on an employee not associated with a user", async () => {
     // Clicking on first employee's avatar (employee with no user)
     await contains(".o_field_many2many_avatar_employee .o_tag .o_m2m_avatar:eq(0)").click();
     await waitFor(".o_avatar_card");
-    expect(".o_card_user_infos > span").toHaveText("Mario");
+    expect(".o-mail-avatar-card-name").toHaveText("Mario");
     expect(".o_card_user_infos > a").toHaveText("Mario@partner.com");
     expect(".o_avatar_card_buttons button:eq(0)").toHaveText("View Profile");
 
     // Clicking on second employee's avatar (employee with user)
     await contains(".o_field_many2many_avatar_employee .o_tag .o_m2m_avatar:eq(1)").click();
-    expect(".o_card_user_infos span").toHaveText("Luigi");
+    expect(".o-mail-avatar-card-name").toHaveText("Luigi");
     expect(".o_avatar_card").toHaveCount(1);
     expect(".o_avatar_card_buttons button:eq(0)").toHaveText("Send message");
     await contains(".o_avatar_card_buttons button:eq(0)").click();

--- a/addons/mail/static/src/core/web/recipients_popover.xml
+++ b/addons/mail/static/src/core/web/recipients_popover.xml
@@ -11,7 +11,7 @@
                         />
                     </span>
                     <div class="d-flex flex-column o_card_user_infos overflow-hidden">
-                        <span class="fw-bold" t-out="name"/>
+                        <span class="o-mail-avatar-card-name fw-bold" t-out="name"/>
                         <a t-if="email" t-attf-href="mailto:{{email}}" t-att-title="email" class="text-truncate">
                             <i class="fa fa-fw fa-envelope me-1"/><t t-out="email"/>
                         </a>

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -272,7 +272,7 @@ test("Click on avatar opens its partner chat window", async () => {
     await contains(".o-mail-Message-sidebar .o-mail-Message-avatarContainer img");
     await click(".o-mail-Message-sidebar .o-mail-Message-avatarContainer img");
     await contains(".o_avatar_card");
-    await contains(".o_card_user_infos > span", { text: "testPartner" });
+    await contains(".o-mail-avatar-card-name", { text: "testPartner" });
     await contains(".o_card_user_infos > a", { text: "test@partner.com" });
     await contains(".o_card_user_infos > a", { text: "+45687468" });
 });

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -1058,7 +1058,7 @@ test("open author avatar card", async () => {
     await contains(".o-mail-DiscussContent .o-mail-Message-avatarContainer img");
     await click(".o-mail-DiscussContent .o-mail-Message-avatarContainer img");
     await contains(".o_avatar_card");
-    await contains(".o_card_user_infos > span", { text: "Demo" });
+    await contains(".o-mail-avatar-card-name", { text: "Demo" });
     await contains(".o_card_user_infos > a", { text: "demo@example.com" });
     await contains(".o_card_user_infos > a", { text: "+5646548" });
 });
@@ -1532,7 +1532,7 @@ test("avatar card from author should be opened after clicking on their avatar", 
     expect(".o-mail-Message-avatarContainer:first").toHaveClass("cursor-pointer");
     await click(".o-mail-Message-avatar");
     await contains(".o_avatar_card");
-    await contains(".o_card_user_infos > span", { text: "Partner_2" });
+    await contains(".o-mail-avatar-card-name", { text: "Partner_2" });
     await contains(".o_card_user_infos > a", { text: "partner2@mail.com" });
     await contains(".o_card_user_infos > a", { text: "+15968415" });
 });
@@ -1558,7 +1558,7 @@ test("avatar card from author should be opened after clicking on their name", as
     await openFormView("res.partner", partnerId);
     await click(".o-mail-Message-author", { text: "Demo" });
     await contains(".o_avatar_card");
-    await contains(".o_card_user_infos > span", { text: "Demo" });
+    await contains(".o-mail-avatar-card-name", { text: "Demo" });
     await contains(".o_card_user_infos > a", { text: "demo@example.com" });
     await contains(".o_card_user_infos > a", { text: "+5646548" });
 });

--- a/addons/mail/static/tests/scheduled_message/scheduled_message.test.js
+++ b/addons/mail/static/tests/scheduled_message/scheduled_message.test.js
@@ -142,13 +142,13 @@ test("avatar card from author should be opened after clicking on their name or a
     await start();
     await openFormView("res.partner", partnerId);
     await click(".o-mail-Scheduled-Message .o-mail-Message-author", { text: "Demo" });
-    await contains(".o_card_user_infos > span", { text: "Demo" });
+    await contains(".o-mail-avatar-card-name", { text: "Demo" });
     await contains(".o_card_user_infos > a", { text: "demo@example.com" });
     await contains(".o_card_user_infos > a", { text: "+5646548" });
     await click(".o-mail-Message-date");
     await contains(".o_card_user_infos", { count: 0 });
     await click(".o-mail-Message-avatar");
-    await contains(".o_card_user_infos > span", { text: "Demo" });
+    await contains(".o-mail-avatar-card-name", { text: "Demo" });
 });
 
 test("Read more of a scheduled message", async () => {

--- a/addons/mail/static/tests/web/fields/many2many_avatar_user.test.js
+++ b/addons/mail/static/tests/web/fields/many2many_avatar_user.test.js
@@ -313,7 +313,7 @@ test("avatar card preview", async () => {
     // Open card
     await click(".o_m2o_avatar > img");
     await contains(".o_avatar_card");
-    await contains(".o_card_user_infos > span", { text: "Mario" });
+    await contains(".o-mail-avatar-card-name", { text: "Mario" });
     await contains(".o_card_user_infos > a", { text: "Mario@odoo.test" });
     await contains(".o_card_user_infos > a", { text: "+78786987" });
     // Close card
@@ -362,7 +362,7 @@ test("avatar card preview (partner_id field)", async () => {
     // Open card
     await click(".o_m2o_avatar > img");
     await contains(".o_avatar_card");
-    await contains(".o_card_user_infos > span", { text: "Mario" });
+    await contains(".o-mail-avatar-card-name", { text: "Mario" });
     await contains(".o_card_user_infos > a", { text: "Mario@odoo.test" });
     await contains(".o_card_user_infos > a", { text: "+78786987" });
     // Close card
@@ -403,7 +403,7 @@ test("many2one_avatar_user widget in list view", async () => {
     await contains(".o_data_cell .o_many2one a", { count: 0 });
     await click(".o_data_cell .o_m2o_avatar > img");
     await contains(".o_avatar_card");
-    await contains(".o_card_user_infos > span", { text: "Mario" });
+    await contains(".o-mail-avatar-card-name", { text: "Mario" });
     await contains(".o_card_user_infos > a", { text: "Mario@partner.com" });
     await contains(".o_card_user_infos > a", { text: "+45687468" });
 });
@@ -425,7 +425,7 @@ test("many2many_avatar_user widget in form view", async () => {
     });
     await click(".o_field_many2many_avatar_user .o_avatar img");
     await contains(".o_avatar_card");
-    await contains(".o_card_user_infos > span", { text: "Mario" });
+    await contains(".o-mail-avatar-card-name", { text: "Mario" });
     await contains(".o_card_user_infos > a", { text: "Mario@partner.com" });
     await contains(".o_card_user_infos > a", { text: "+45687468" });
 });

--- a/addons/resource_mail/static/tests/many2many_avatar_resource.test.js
+++ b/addons/resource_mail/static/tests/many2many_avatar_resource.test.js
@@ -115,7 +115,7 @@ test("many2many_avatar_resource widget in form view", async () => {
 
     // 2. Clicking on human resource's avatar with no user associated
     await click(".many2many_tags_avatar_field_container .o_tag img:first");
-    await contains(".o_card_user_infos span", { text: "Marie" });
+    await contains(".o-mail-avatar-card-name", { text: "Marie" });
     await contains(
         ".o_avatar_card",
         { count: 1 },
@@ -128,7 +128,7 @@ test("many2many_avatar_resource widget in form view", async () => {
     );
     // 3. Clicking on human resource's avatar with one user associated
     await click(queryAll(".many2many_tags_avatar_field_container .o_tag img")[1]);
-    await contains(".o_card_user_infos span", { text: "Pierre" });
+    await contains(".o-mail-avatar-card-name", { text: "Pierre" });
     await contains(
         ".o_avatar_card",
         { count: 1 },
@@ -185,7 +185,7 @@ test("many2many_avatar_resource widget in list view", async () => {
     await contains(".o_avatar_card", { count: 0 });
     // 2. Clicking on human resource's avatar with no user associated
     await click(tagMarie);
-    await contains(".o_card_user_infos span", { text: "Marie" });
+    await contains(".o-mail-avatar-card-name", { text: "Marie" });
     await contains(
         ".o_avatar_card",
         { count: 1 },
@@ -198,7 +198,7 @@ test("many2many_avatar_resource widget in list view", async () => {
     );
     // 3. Clicking on human resource's avatar with one user associated
     await click(tagPierre);
-    await contains(".o_card_user_infos span", { text: "Pierre" });
+    await contains(".o-mail-avatar-card-name", { text: "Pierre" });
     await contains(
         ".o_avatar_card",
         { count: 1 },
@@ -272,7 +272,7 @@ test("many2many_avatar_resource widget in kanban view", async () => {
     await contains(".o_avatar_card", { count: 0 });
     // 2. Clicking on human resource's avatar with no user associated
     await click(tagMarie);
-    await contains(".o_card_user_infos span", { text: "Marie" });
+    await contains(".o-mail-avatar-card-name", { text: "Marie" });
     await contains(
         ".o_avatar_card",
         { count: 1 },
@@ -285,7 +285,7 @@ test("many2many_avatar_resource widget in kanban view", async () => {
     );
     // 3. Clicking on human resource's avatar with one user associated
     await click(tagPierre);
-    await contains(".o_card_user_infos span", { text: "Pierre" });
+    await contains(".o-mail-avatar-card-name", { text: "Pierre" });
     await contains(
         ".o_avatar_card",
         { count: 1 },

--- a/addons/resource_mail/static/tests/many2one_avatar_resource.test.js
+++ b/addons/resource_mail/static/tests/many2one_avatar_resource.test.js
@@ -156,7 +156,7 @@ test("many2one_avatar_resource widget in kanban view", async () => {
     await contains(".o_avatar_card", { count: 0 });
     // 2. Clicking on human resource's avatar with no user associated
     await click(".o_kanban_record:nth-of-type(2) .o_m2o_avatar > img");
-    await contains(".o_card_user_infos span", { text: "Marie" });
+    await contains(".o-mail-avatar-card-name", { text: "Marie" });
     await contains(
         ".o_avatar_card",
         { count: 1 },
@@ -169,7 +169,7 @@ test("many2one_avatar_resource widget in kanban view", async () => {
     );
     // 3. Clicking on human resource's avatar with one user associated
     await click(".o_kanban_record:nth-of-type(3) .o_m2o_avatar > img");
-    await contains(".o_card_user_infos span", { text: "Pierre" });
+    await contains(".o-mail-avatar-card-name", { text: "Pierre" });
     await contains(
         ".o_avatar_card",
         { count: 1 },


### PR DESCRIPTION
Update the user info selector in avatar card tests to use the class names.

This will simplify future changes to the avatar card. The tests will be less likely to break if the structure of the avatar card changes, as long as the class names remain the same.

pre task of task-4107790
https://github.com/odoo/enterprise/pull/97219

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
