### PR TITLE
[FIX] mail: correct "is talking" color in call menu with dark theme

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_menu.dark.scss
+++ b/addons/mail/static/src/discuss/call/common/call_menu.dark.scss
@@ -1,0 +1,3 @@
+.o-discuss-CallMenu-buttonContent {
+    --discuss-talkingColor: #{rgba(darken($o-enterprise-action-color, 5%), .75)};
+}


### PR DESCRIPTION
Before this commit, call menu "is talking" outline color had the wrong color in dark theme.

This happens because it uses the color of white theme, which is a light green that works in white theme but in dark theme this is using a darker green color. To make this dark green color, call UI elements override the color. The call menu UI was not overriding the color in dark theme, even though it had code to deal with it.

This commit fixes the issue by adding the override of "is talking" color in call menu in dark theme, to have intended color like other call UI elements with "is talking".

Before
<img width="958" height="381" alt="Screenshot 2025-10-15 at 12 34 51" src="https://github.com/user-attachments/assets/c8cd7a18-fff0-49e4-a26a-9b191b364111" />


After
<img width="958" height="422" alt="Screenshot 2025-10-15 at 12 33 41" src="https://github.com/user-attachments/assets/d8d6d635-4d0c-40c0-b343-71ca0fd75eb2" />
