### PR TITLE
[IMP]account_peppol: Manage reception transfer across odoo databases

### DIFF
--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -345,10 +345,6 @@ class AccountEdiProxyClientUser(models.Model):
             peppol_state_translated = dict(company._fields['account_peppol_proxy_state'].selection)[company.account_peppol_proxy_state]
             raise UserError(
                 _('Cannot register a user with a %s application', peppol_state_translated))
-
-        edi_identification = self._get_proxy_identification(company, 'peppol')
-        self._check_company_on_peppol(company, edi_identification)
-
         self._call_peppol_proxy(
             endpoint='/api/peppol/1/register_sender_as_receiver',
             params={
@@ -362,6 +358,10 @@ class AccountEdiProxyClientUser(models.Model):
         company.account_peppol_proxy_state = 'smp_registration'
 
         self.env.ref('account_peppol.ir_cron_peppol_get_participant_status')._trigger(at=fields.Datetime.now() + timedelta(hours=1))
+
+    def _peppol_send_recovery_mail(self):
+        self.ensure_one()
+        self._call_peppol_proxy(endpoint='/api/peppol/1/send_user_transfer_email')
 
     def _peppol_deregister_participant(self):
         self.ensure_one()

--- a/addons/account_peppol/views/res_config_settings_views.xml
+++ b/addons/account_peppol/views/res_config_settings_views.xml
@@ -9,19 +9,15 @@
                 <div id="account_peppol" class="col-12 o_setting_box">
                     <div class="o_setting_right_pane border-0">
                         <div invisible="account_peppol_proxy_state not in ('sender', 'receiver', 'smp_registration')">
-                            Your Peppol ID <field name="account_peppol_edi_identification" class="oe_inline o_form_label" readonly="1"/> <field name="account_peppol_proxy_state" class="oe_inline o_form_label text-lowercase" readonly="1"/> invoices and credit notes.
+                            <p>
+                                You are sending your e-invoices via Odoo with this Peppol ID
+                                <field name="account_peppol_edi_identification" class="oe_inline o_form_label" readonly="1"/>
+                                But you are registered with another Odoo database for eInvoice reception.
+                            </p>
                         </div>
                         <div invisible="account_peppol_proxy_state != 'rejected'">
                             You registration has been rejected, the reason has been sent to you via email.
                             Please contact our support if you need further assistance.
-                        </div>
-
-                        <!-- The participant registered as a sender: display register as a receiver button, email, migration key field -->
-                        <div class="row" invisible="account_peppol_proxy_state not in ('sender', 'smp_registration', 'receiver')">
-                            <label string="Primary contact email"
-                                   for="account_peppol_contact_email"
-                                   class="col-lg-3 o_light_label"/>
-                            <field name="account_peppol_contact_email" required="account_peppol_proxy_state in ('sender', 'smp_registration', 'receiver')"/>
                         </div>
 
                         <!-- The participant is waiting to be registered on the SMP -->
@@ -38,14 +34,6 @@
                                     Your registration should be activated within a day.
                                 </p>
                             </div>
-                        </div>
-
-                        <!-- Optional: field related to registering as a receiver -->
-                        <div invisible="account_peppol_proxy_state != 'sender'" groups="base.group_no_one">
-                            <p colspan="2" class="mt-4 mb-2">
-                                I want to migrate my existing Peppol connection to Odoo (optional):
-                            </p>
-                            <field name="account_peppol_migration_key"/>
                         </div>
 
                         <div class="mt-4"

--- a/addons/account_peppol/wizard/peppol_registration.py
+++ b/addons/account_peppol/wizard/peppol_registration.py
@@ -109,11 +109,6 @@ class PeppolRegistration(models.TransientModel):
                     'message': _("The endpoint number might not be correct. "
                                 "Please check if you entered the right identification number."),
                 }
-            if not wizard.smp_registration:
-                peppol_warnings['company_on_another_smp'] = {
-                    'message': _("Your company is already registered on another Access Point for receiving invoices."
-                                 "We will register you as a sender only.")
-                }
             wizard.peppol_warnings = peppol_warnings or False
 
     @api.depends('peppol_eas', 'peppol_endpoint')


### PR DESCRIPTION
### Summary

Previously, when a user attempted to **register as a Peppol receiver** while already registered through a different Odoo database, the system would raise a **User Error**.  
The user had to **manually deregister** and **re-register** from the desired database.

---

### New Behavior (After This Commit)

With this update:
- The system **detects existing Peppol registrations** across databases.  
- Instead of raising an error, it now **sends an automated email** to the user with a **secure transfer link**.  
- This allows the user to **migrate their Peppol connection** to the current database seamlessly.

---
###  Flow Overview

```text
            ┌────────────────────────────┐
            │  User initiates Peppol     │
            │  registration (becomes     │
            │  sender)                   │
            └────────────┬───────────────┘
                         │
                         ▼
          ┌──────────────────────────────┐
          │  Check existing registration  │
          └────────────┬─────────────────┘
                       │
        ┌──────────────┴──────────────┐
        ▼                             ▼
┌─────────────────────┐       ┌──────────────────────────────┐
│ User NOT registered │       │ User ALREADY registered      |
│ in any Odoo DB      │       
└────────────┬────────┘       └──────────────┬───────────────┘
             │                               │
             ▼                               ▼
 ┌──────────────────────────┐      ┌──────────────────────────────┐
 │ Proceed with normal      │      │ Send email with transfer link│
 │ registration flow        │      │ to the user                  │
 └──────────────────────────┘      └──────────────┬───────────────┘
                                                  │
                                                  ▼
                                     ┌──────────────────────────────┐
                                     │ User clicks transfer link    
                                     │                                                                              
                                     └──────────────┬───────────────┘
                                                    │
                                                    ▼
                                     ┌──────────────────────────────┐
                                     │ Peppol connection migrated 
                                     └──────────────────────────────┘


```
---
iap pr- https://github.com/odoo/iap-apps/pull/1236
task- 5023252
