### PR TITLE
[FIX] mail: correct discuss header alignment below XL screen size

### DIFF
--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -22,7 +22,6 @@
                     'o-chatWindow mx-2 my-1': env.inChatWindow,
                     'mb-2': env.inChatWindow and !props.composer.message,
                     'o-discussApp pt-1 ps-2 pe-4 pb-2': env.inDiscussApp,
-                    'ps-xl-3': env.inDiscussApp and !ui.isSmall,
                 }" t-attf-class="{{ props.className }}">
             <FileUploader t-if="allowUpload" multiUpload="isMultiUpload" onUploaded.bind="(data) => { attachmentUploader.uploadData(data) }">
                 <t t-set-slot="toggler">

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -18,7 +18,7 @@
             >
                 <div class="o-mail-Message-jumpTarget position-absolute top-0 pe-none"/>
                 <div t-if="props.asCard and isMobileOS" class="position-absolute end-0 z-1 m-n2"><t t-call="mail.Message.actions"/></div>
-                <div class="o-mail-Message-core position-relative d-flex flex-shrink-0 bg-inherit" t-att-class="{ 'ps-xl-2': env.inDiscussApp and !ui.isSmall }">
+                <div class="o-mail-Message-core position-relative d-flex flex-shrink-0 bg-inherit">
                     <div class="o-mail-Message-sidebar d-flex flex-shrink-0 align-items-center flex-column bg-inherit" t-att-class="{ 'align-items-start': !isAlignedRight, 'o-inChatWindow': env.inChatWindow }">
                         <t t-if="!props.squashed">
                             <div class="o-mail-Message-avatarContainer position-relative bg-inherit rounded-3" t-att-class="getAvatarContainerAttClass()">

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -101,7 +101,7 @@
 </t>
 
 <t t-name="mail.Thread.startMessage">
-    <div class="pt-4" t-att-class="{ 'px-3': env.inChatWindow, 'px-2 ps-xl-3': env.inDiscussApp, 'px-2': env.inMeetingChat }">
+    <div class="pt-4" t-att-class="{ 'px-3': env.inChatWindow, 'px-2': env.inDiscussApp or env.inMeetingChat }">
         <div class="d-flex align-items-center gap-2" t-att-class="{
             'mt-2 mb-1': !props.thread.parent_channel_id,
             'mt-1': props.thread.parent_channel_id,

--- a/addons/mail/static/src/core/public_web/discuss_content.xml
+++ b/addons/mail/static/src/core/public_web/discuss_content.xml
@@ -4,7 +4,7 @@
 <t t-name="mail.DiscussContent">
     <t t-set="partitionedActions" t-value="threadActions.partition"/>
     <div class="o-mail-DiscussContent d-flex flex-column h-100 w-100 overflow-auto o-scrollbar-thin" t-ref="root">
-        <div class="o-mail-DiscussContent-header py-2 ps-2 ps-xl-3 pe-3 d-flex flex-shrink-0 align-items-center border-bottom border-secondary gap-1 z-1 flex-grow-0" t-ref="header">
+        <div class="o-mail-DiscussContent-header py-2 ps-3 d-flex flex-shrink-0 align-items-center border-bottom border-secondary gap-1 z-1 flex-grow-0" t-ref="header">
             <t t-if="thread">
                 <div t-if="showThreadAvatar" class="o-mail-DiscussContent-threadAvatar position-relative align-self-center align-items-center bg-inherit">
                     <img class="rounded-2 object-fit-cover" t-att-src="thread.parent_channel_id?.avatarUrl ?? thread.avatarUrl" alt="Thread Image"/>


### PR DESCRIPTION
Before this commit, The header of the Discuss app had the avatar too close to the sidebar of Discuss app, which looked off and also makes it misaligned with avatars in message list and composer.

This comes from a specific style to reduce initial padding below large screen, which was mismatched between discuss header and other items in message list. The intended design was to have enough space between discuss sidebar and message list so that this doesn't feel too crowded and fatiguing to see.

This was an issue in the past, but now Discuss app is visually fine even with reduced spacing in large screen. This commit removes all the large-screen specific extra spacing, which fixes the issue as it's easier to match the spacing between all of them.

<img width="775" height="908" alt="Screenshot 2025-10-15 at 12 55 06" src="https://github.com/user-attachments/assets/2dedd04d-3949-4586-9325-844313476194" />
