### PR TITLE
[IMP] pos_self_order: add photos of variants within Kiosk

### DIFF
--- a/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.xml
+++ b/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.xml
@@ -9,14 +9,20 @@
              <div class="self_order_attribute_selection row pb-3">
                 <t t-foreach="availableAttributeValue(attribute)" t-as="value" t-key="value.id">
                     <t t-set="valueSelected" t-value="isValueSelected(attribute,value)"/>
-                    <div class="d-flex col-12 col-md-6 col-lg-4">
+                    <div class="d-flex col-12 col-md-6 col-lg-4 position-relative">
                         <button
-                            t-on-click="() => this.selectAttribute(attribute, value)"
+                            t-on-click="() => this.selectAttribute(attribute, value)" style="min-height:105px;"
                             role="button" class="btn btn-light px-3 px-sm-3 py-3 py-sm-3 w-100 d-flex flex-column align-items-start align-items-md-center text-start text-md-center justify-content-center gap-0 border-2 shadow-sm rounded-4"
                             t-attf-class="{{ valueSelected ? 'border-primary': 'border-transparent' }}">
-                            <span t-esc="value.name" class="fs-4"/>
-                            <span t-if="shouldShowPriceExtra(value)" t-esc="formatExtraPrice(value)" class="fs-5  "
-                                 t-att-class="{ 'text-reset opacity-75' : valueSelected, 'text-primary': !valueSelected  }"/>
+                            <div class="d-flex d-inline-flex justify-content-between w-100 align-items-center gap-1">
+                                <div class="text-center d-flex flex-column gap-2 align-items-center w-100">
+                                    <span t-esc="value.name" class="fs-4"/>
+                                </div>
+                                <span t-if="shouldShowPriceExtra(value)" t-esc="formatExtraPrice(value)"
+                                    class="d-block position-absolute badge top-0 end-0 me-3 mt-3 rounded-3 text-bg-primary fw-medium" />
+                                <img  t-if="value.image" t-attf-src="data:image/png;base64,{{value.image}}" class="img-fluid rounded-4" style="max-height:70px; max-width:70px"/>
+                                <div t-if="value.html_color and !value.image" t-attf-style="min-height: 25px; min-width: 25px; background-color: {{value.html_color}}" class="rounded-5"/> 
+                            </div>
                         </button>
                     </div>
                 </t>

--- a/addons/pos_self_order/static/tests/tours/self_order_attribute_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_attribute_tour.js
@@ -94,6 +94,15 @@ registry.category("web_tour.tours").add("self_order_product_info", {
     ],
 });
 
+registry.category("web_tour.tours").add("self_attribute_selector_shows_images", {
+    steps: () => [
+        Utils.clickBtn("Order Now"),
+        ProductPage.clickProduct("Desk Organizer"),
+        ProductPage.attributeHasColorDot("White"),
+        ProductPage.attributeHasImage("Blue"),
+    ],
+});
+
 registry.category("web_tour.tours").add("test_self_order_multi_check_attribute_with_extra_price", {
     steps: () =>
         [

--- a/addons/pos_self_order/static/tests/tours/utils/product_page_util.js
+++ b/addons/pos_self_order/static/tests/tours/utils/product_page_util.js
@@ -90,6 +90,20 @@ export function setupAttribute(attributes, addToCart = true) {
     return steps;
 }
 
+export function attributeHasColorDot(attribute) {
+    return {
+        content: `The ${attribute} has a color dot`,
+        trigger: `div:has(span:contains("${attribute}")) ~ div.rounded-5`,
+    };
+}
+
+export function attributeHasImage(attribute) {
+    return {
+        content: `The ${attribute} has an image`,
+        trigger: `div:has(span:contains("${attribute}")) ~ img.rounded-4`,
+    };
+}
+
 export function verifyIsCheckedAttribute(attribute, values = []) {
     return {
         content: `Select value for attribute ${attribute}`,

--- a/addons/pos_self_order/tests/test_self_order_attribute.py
+++ b/addons/pos_self_order/tests/test_self_order_attribute.py
@@ -146,6 +146,39 @@ class TestSelfOrderAttribute(SelfOrderCommonTest):
 
         self.start_tour(self_route, "self_order_product_info")
 
+    def test_self_order_check_attributes_show_images(self):
+        self.pos_config.write({
+            'self_ordering_default_user_id': self.pos_admin.id,
+            'self_ordering_mode': "mobile",
+            'self_ordering_pay_after': "each",
+            'self_ordering_service_mode': "counter",
+            'available_preset_ids': [Command.clear()],
+        })
+        attributes = self.env['product.attribute'].create([
+            {
+                'name': "Colour",
+                'display_type': "color",
+                'create_variant': "always",
+                'value_ids': [
+                    Command.create({'name': "White", 'default_extra_price': 0, 'html_color': '#FAFAFA'}),
+                    Command.create({'name': "Blue", 'default_extra_price': 2, 'image': b'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+ip1sAAAAASUVORK5CYII='}),
+                ],
+            },
+        ])
+
+        self.env['product.template.attribute.line'].create([
+            {
+                'product_tmpl_id': self.desk_organizer.product_tmpl_id.id,
+                'attribute_id': attr.id,
+                'value_ids': [Command.link(val.id) for val in attr.value_ids],
+            }
+            for attr in attributes
+        ])
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.pos_config.current_session_id.set_opening_control(0, "")
+        self_route = self.pos_config._get_self_order_route()
+        self.start_tour(self_route, "self_attribute_selector_shows_images")
+
     def test_self_order_multi_check_attribute_with_extra_price(self):
         self.pos_config.write({
             'self_ordering_default_user_id': self.pos_admin.id,


### PR DESCRIPTION
Before the images or colors added to variants would be ignored while in the kiosk. Now if they exist they will be shown on the same card as the variant name. Also moved the extra price information from the bottom of the button to next to the name to keep the size of all the buttons consistent.

Task-4537185

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
