### PR TITLE
[FIX] account: force demo install in l10n standalone test

### DIFF
--- a/addons/account/tests/test_account_all_l10n.py
+++ b/addons/account/tests/test_account_all_l10n.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 
+from odoo.modules.loading import force_demo
 from odoo.tests import standalone
 
 
@@ -13,6 +14,7 @@ def test_all_l10n(env):
     As the module install is not yet fully transactional, the modules will
     remain installed after the test.
     """
+    force_demo(env.cr)
     assert env.ref('base.module_account').demo, "Need the demo to test with data"
     l10n_mods = env['ir.module.module'].search([
         ('name', 'like', 'l10n%'),


### PR DESCRIPTION
In later versions, we improve the testing suite to avoid having to install demo data in order to reduce the testing time. In order to keep the testing configuration simple across versions, we force the installation of demo data instead of only asserting that demo is installed before launching the script.

