### PR TITLE
[FIX] calendar: do not add activity feedback to description

### DIFF
--- a/addons/calendar/models/mail_activity.py
+++ b/addons/calendar/models/mail_activity.py
@@ -28,23 +28,6 @@ class MailActivity(models.Model):
         }
         return action
 
-    def _action_done(self, feedback=False, attachment_ids=False):
-        events = self.calendar_event_id
-        # To avoid the feedback to be included in the activity note (due to the synchronization in event.write
-        # that updates the related activity note each time the event description is updated),
-        # when the activity is written as a note in the chatter in _action_done (leading to duplicate feedback),
-        # we call super before updating the description. As self is deleted in super, we load the related events before.
-        messages, activities = super(MailActivity, self)._action_done(feedback=feedback, attachment_ids=attachment_ids)
-        if feedback:
-            for event in events:
-                description = event.description
-                description = '%s<br />%s' % (
-                    description if not tools.is_html_empty(description) else '',
-                    _('Feedback: %(feedback)s', feedback=tools.plaintext2html(feedback)) if feedback else '',
-                )
-                event.write({'description': description})
-        return messages, activities
-
     def unlink_w_meeting(self):
         events = self.mapped('calendar_event_id')
         res = self.unlink()


### PR DESCRIPTION
When marking a calendar.event activity as done, one can submit a feedback. Currently, that feedback is logged in the chatter, and is also appended at the end of the meeting's description.

As this field is synchronized with external calendars, this may lead to notification / meeting updates. However, this should serve an internal purpose instead, and should not be shared to attendees in that way.

Therefore, simply remove this behavior. The feedback will still be found in the note in the chatter.

Task-5143141