### PR TITLE
[FIX] calendar: check access rights with active user

### DIFF
--- a/addons/calendar/models/calendar_attendee.py
+++ b/addons/calendar/models/calendar_attendee.py
@@ -66,15 +66,15 @@ class Attendee(models.Model):
                 values['email'] = email[0] if email else ''
                 values['common_name'] = values.get("common_name")
         attendees = super().create(vals_list)
-        attendees.event_id.check_access_rights('write')
-        attendees.event_id.check_access_rule('write')
+        attendees.event_id.with_user(self.env.uid).check_access_rights('write')
+        attendees.event_id.with_user(self.env.uid).check_access_rule('write')
         attendees._subscribe_partner()
         return attendees
 
     def write(self, vals):
         attendees = super().write(vals)
-        self.event_id.check_access_rights('write')
-        self.event_id.check_access_rule('write')
+        self.event_id.with_user(self.env.uid).check_access_rights('write')
+        self.event_id.with_user(self.env.uid).check_access_rule('write')
         return attendees
 
     def unlink(self):

--- a/addons/calendar/models/calendar_attendee.py
+++ b/addons/calendar/models/calendar_attendee.py
@@ -66,15 +66,15 @@ class Attendee(models.Model):
                 values['email'] = email[0] if email else ''
                 values['common_name'] = values.get("common_name")
         attendees = super().create(vals_list)
-        attendees.event_id.with_user(self.env.uid).check_access_rights('write')
-        attendees.event_id.with_user(self.env.uid).check_access_rule('write')
+        attendees.event_id.with_user(self.env.uid_origin).check_access_rights('write')
+        attendees.event_id.with_user(self.env.uid_origin).check_access_rule('write')
         attendees._subscribe_partner()
         return attendees
 
     def write(self, vals):
         attendees = super().write(vals)
-        self.event_id.with_user(self.env.uid).check_access_rights('write')
-        self.event_id.with_user(self.env.uid).check_access_rule('write')
+        self.event_id.with_user(self.env.uid_origin).check_access_rights('write')
+        self.event_id.with_user(self.env.uid_origin).check_access_rule('write')
         return attendees
 
     def unlink(self):

--- a/doc/cla/individual/hassan510-cmd.md
+++ b/doc/cla/individual/hassan510-cmd.md
@@ -1,0 +1,11 @@
+Egypt, 2025-10-15
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Hassan Mahmoud Hassan hassanmahmoud607@gmail.com https://github.com/hassan510-cmd

--- a/doc/cla/individual/hassan510-cmd.md
+++ b/doc/cla/individual/hassan510-cmd.md
@@ -8,4 +8,4 @@ declaration.
 
 Signed,
 
-Hassan Mahmoud Hassan hassanmahmoud607@gmail.com https://github.com/hassan510-cmd
+Hassan Mahmoud Hassan <55447090+hassan510-cmd@users.noreply.github.com> https://github.com/hassan510-cmd


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Access right issue while validate `hr.leave`

Current behavior before PR:
<img width="812" height="380" alt="image" src="https://github.com/user-attachments/assets/09c2daac-0a92-4bb2-9cc7-32fd65f01056" />

On October 7th, a new update was added to Odoo, which caused the current issue.
This update makes the system verify the edit permissions of the user linked to the leave request - which has been changed through context in the provided image line 1094 - , rather than the currently active user.
As a result, all portal users no longer have edit permissions.
This behavior was confirmed when submitting a leave request on behalf of an internal user or admin.
<img width="1600" height="871" alt="image" src="https://github.com/user-attachments/assets/895bd996-f7cf-48bd-8612-97cc67894230" />


Desired behavior after PR is merged:
I’ve resolved the issue by changing the permission check to use the currently active user instead of the user linked to the leave request.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
