### PR TITLE
[IMP] crm: change default sales team of the opportunity

### DIFF
--- a/addons/crm/wizard/crm_lead_to_opportunity.py
+++ b/addons/crm/wizard/crm_lead_to_opportunity.py
@@ -104,7 +104,7 @@ class CrmLead2opportunityPartner(models.TransientModel):
         for convert in self:
             convert.user_id = convert.lead_id.user_id if convert.lead_id.user_id else False
 
-    @api.depends('user_id')
+    @api.depends('lead_id', 'user_id')
     def _compute_team_id(self):
         """ When changing the user, also set a team_id or restrict team id
         to the ones user_id is member of. """
@@ -114,6 +114,9 @@ class CrmLead2opportunityPartner(models.TransientModel):
                 continue
             user = convert.user_id
             if convert.team_id and user in convert.team_id.member_ids | convert.team_id.user_id:
+                continue
+            elif user in convert.lead_id.team_id.member_ids | convert.lead_id.team_id.user_id:
+                convert.team_id = convert.lead_id.team_id
                 continue
             team = self.env['crm.team']._get_default_team_id(user_id=user.id, domain=None)
             convert.team_id = team.id

--- a/addons/crm/wizard/crm_lead_to_opportunity_mass.py
+++ b/addons/crm/wizard/crm_lead_to_opportunity_mass.py
@@ -43,7 +43,7 @@ class CrmLead2opportunityPartnerMass(models.TransientModel):
         """Setting a company for each lead in mass mode is not supported."""
         self.commercial_partner_id = False
 
-    @api.depends('user_ids')
+    @api.depends('lead_id', 'user_ids')
     def _compute_team_id(self):
         """ When changing the user, also set a team_id or restrict team id
         to the ones user_id is member of. """
@@ -53,6 +53,9 @@ class CrmLead2opportunityPartnerMass(models.TransientModel):
                 continue
             user = convert.user_id or convert.user_ids and convert.user_ids[0] or self.env.user
             if convert.team_id and user in convert.team_id.member_ids | convert.team_id.user_id:
+                continue
+            elif user in convert.lead_id.team_id.member_ids | convert.lead_id.team_id.user_id:
+                convert.team_id = convert.lead_id.team_id
                 continue
             team = self.env['crm.team']._get_default_team_id(user_id=user.id, domain=None)
             convert.team_id = team.id


### PR DESCRIPTION
This PR uses the team of the lead to pre-fill the team_id field of the opportunity creation form if the salesperson is a member of it.

Previously, the default team of the salesperson was used to pre-fill this field. So if the user completing the form did not notice it, the team of the opportunity was not the same as the one of the lead.

Task-5107580