### PR TITLE
[IMP] html_builder, website: rework tooltips, labels and options

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_button.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_button.js
@@ -14,6 +14,7 @@ export class BuilderButton extends Component {
         ...clickableBuilderComponentProps,
 
         title: { type: String, optional: true },
+        titleActive: { type: String, optional: true },
         label: { type: String, optional: true },
         iconImg: { type: String, optional: true },
         iconImgAlt: { type: String, optional: true },
@@ -28,6 +29,7 @@ export class BuilderButton extends Component {
 
     static defaultProps = {
         type: "secondary",
+        titleActive: "",
     };
 
     setup() {

--- a/addons/html_builder/static/src/core/building_blocks/builder_button.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_button.xml
@@ -13,7 +13,7 @@
             t-att-data-attribute-action="info.attributeAction"
             t-att-data-attribute-action-value="info.attributeActionValue"
             t-att-class="className"
-            t-att-title="props.title"
+            t-att-title="(state.isActive and props.titleActive) or props.title"
             t-att-aria-label="props.title"
             t-on-click="() => this.onClick()"
             t-on-pointerenter="() => this.onPointerEnter(props.id)"

--- a/addons/html_builder/static/src/core/building_blocks/builder_text_input_base.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_text_input_base.js
@@ -13,6 +13,7 @@ export const textInputBasePassthroughProps = {
     classes: { type: String, optional: true },
     inputClasses: { type: String, optional: true },
     prefix: { type: String, optional: true },
+    prefixIcon: { type: String, optional: true },
 };
 
 export class BuilderTextInputBase extends Component {

--- a/addons/html_builder/static/src/core/building_blocks/builder_text_input_base.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_text_input_base.xml
@@ -13,6 +13,7 @@
         t-att-data-attribute-action="info.attributeAction"
         t-att-data-attribute-action-value="info.attributeActionValue">
         <span t-if="props.prefix" class="o-hb-input-prefix" t-out="props.prefix"/>
+        <i t-if="props.prefixIcon" role="img" t-att-class="'o-hb-input-prefix ' + props.prefixIcon"/> 
         <input
             t-ref="inputRef"
             type="text"

--- a/addons/html_builder/static/src/plugins/background_option/background_option.xml
+++ b/addons/html_builder/static/src/plugins/background_option/background_option.xml
@@ -9,7 +9,8 @@
         <t t-if="props.withImages">
             <BuilderButton
                 action="'toggleBgImage'"
-                title.translate="Image"
+                title.translate="Add a background image"
+                titleActive.translate="Remove the background image"
                 preview="false"
                 className="'ms-auto fa fa-fw fa-camera px-2'"
                 id="'toggle_bg_image_id'"
@@ -17,11 +18,12 @@
             <t t-if="props.withShapes">
                 <BuilderButton
                     action="'toggleBgShape'"
+                    title.translate="Add a background shape"
+                    titleActive.translate="Remove the background shape"
                     preview="false"
                     id="'toggle_bg_shape_id'"
                     iconImg="'/html_builder/static/img/options/bg_shape.svg'"
                     className="'px-2'"
-                    title.translate="Shape"
                 />
             </t>
         </t>

--- a/addons/html_builder/static/src/plugins/image/image_format_option.xml
+++ b/addons/html_builder/static/src/plugins/image/image_format_option.xml
@@ -14,7 +14,7 @@
             </t>
         </BuilderSelect>
     </BuilderRow>
-    <BuilderRow label.translate="Quality" t-if="state.showQuality and state.formats.length" level="this.props.level">
+    <BuilderRow label.translate="Quality" tooltip.translate="Increase for more detail, decrease for speed" t-if="state.showQuality and state.formats.length" level="this.props.level">
         <BuilderRange
             action="'setImageQuality'"
             min="0"

--- a/addons/html_builder/static/src/plugins/rating_option.xml
+++ b/addons/html_builder/static/src/plugins/rating_option.xml
@@ -12,11 +12,11 @@
             <BuilderSelectItem action="'setIcons'" actionParam="'custom'">Custom</BuilderSelectItem>
         </BuilderSelect>
     </BuilderRow>
-    <BuilderRow label.translate="&#8985; Active">
+    <BuilderRow label.translate="Active" level="1">
         <BuilderColorPicker applyTo="'.s_rating_active_icons'" styleAction="'color'" enabledTabs="['solid', 'custom']"/>
         <BuilderButton action="'customIcon'" actionParam="'customActiveIcon'" preview="false"><i class="fa fa-fw fa-refresh me-1"/> Replace Icon</BuilderButton>
     </BuilderRow>
-    <BuilderRow label.translate="&#8985; Inactive">
+    <BuilderRow label.translate="Inactive" level="1">
         <BuilderColorPicker applyTo="'.s_rating_inactive_icons'" styleAction="'color'" enabledTabs="['solid', 'custom']"/>
         <BuilderButton action="'customIcon'" actionParam="'customInactiveIcon'" preview="false"><i class="fa fa-fw fa-refresh me-1"/> Replace Icon</BuilderButton>
     </BuilderRow>

--- a/addons/html_builder/static/src/plugins/shadow_option.xml
+++ b/addons/html_builder/static/src/plugins/shadow_option.xml
@@ -14,9 +14,9 @@
             <BuilderColorPicker actionParam="'color'"  enabledTabs="['solid', 'custom']"/>
         </BuilderRow>
 
-        <BuilderRow label.translate="Offset (X, Y)" level="1">
-            <BuilderNumberInput actionParam="'offsetX'" unit="'px'"/>
-            <BuilderNumberInput actionParam="'offsetY'" unit="'px'"/>
+        <BuilderRow label.translate="Offset" tooltip.translate="Horizontal and Vertical offset" level="1">
+            <BuilderNumberInput actionParam="'offsetX'" unit="'px'" prefixIcon="'oi oi-arrows-h'"/>
+            <BuilderNumberInput actionParam="'offsetY'" unit="'px'" prefixIcon="'oi oi-arrows-v'"/>
         </BuilderRow>
 
         <BuilderRow label.translate="Blur" level="1">

--- a/addons/html_builder/static/tests/shadow_option.test.js
+++ b/addons/html_builder/static/tests/shadow_option.test.js
@@ -29,7 +29,7 @@ test("edit box-shadow with ShadowOption", async () => {
     expect(queryAllTexts(".hb-row .hb-row-label")).toEqual([
         "Shadow",
         "Color",
-        "Offset (X, Y)",
+        "Offset",
         "Blur",
         "Spread",
     ]);
@@ -59,7 +59,7 @@ test("edit box-shadow with ShadowOption", async () => {
     expect(queryAllTexts(".hb-row .hb-row-label")).toEqual([
         "Shadow",
         "Color",
-        "Offset (X, Y)",
+        "Offset",
         "Blur",
         "Spread",
     ]);

--- a/addons/test_website/static/tests/tours/form.js
+++ b/addons/test_website/static/tests/tours/form.js
@@ -17,7 +17,7 @@ registerWebsitePreviewTour(
             trigger: ":iframe .s_website_form .s_website_form_input[name=name]",
             run: "click",
         },
-        ...changeOptionInPopover("Field", "Visibility", "Visible only if"),
+        ...changeOptionInPopover("Field", "Visibility Rule", "Visible only if"),
         {
             content: "Open model selector",
             trigger: "button[id='hidden_condition_record_opt']:contains('Test Tag')",

--- a/addons/website/static/src/builder/plugins/carousel_bottom_controllers_option.xml
+++ b/addons/website/static/src/builder/plugins/carousel_bottom_controllers_option.xml
@@ -14,7 +14,7 @@
     <xpath expr="//BuilderRow[@label.translate=&quot;Indicators&quot;]/BuilderSelect" position="attributes">
         <attribute name="action">"toggleControllers"</attribute>
     </xpath>
-    <xpath expr="//BuilderSelect" position="replace">
+    <xpath expr="//BuilderRow[@label.translate=&quot;Control&quot;]/BuilderSelect" position="replace">
         <BuilderSelect applyTo="'.o_horizontal_controllers_row'">
             <BuilderSelectItem classAction="'justify-content-between'">Default</BuilderSelectItem>
             <BuilderSelectItem classAction="'justify-content-between flex-row-reverse'" >Reversed</BuilderSelectItem>

--- a/addons/website/static/src/builder/plugins/carousel_option.xml
+++ b/addons/website/static/src/builder/plugins/carousel_option.xml
@@ -5,15 +5,19 @@
     <BuilderRow label.translate="Slide">
         <BuilderButton type="'success'" title.translate="Add Slide"  action="'addSlide'">Add Slide</BuilderButton>
     </BuilderRow>
+    
     <BuilderRow label.translate="Style">
         <BuilderSelect>
-            <BuilderSelectItem classAction="''">Classic</BuilderSelectItem>
-            <BuilderSelectItem classAction="'s_carousel_controllers_indicators_outside'">Indicators outside</BuilderSelectItem>
+            <BuilderSelectItem classAction="''">Regular</BuilderSelectItem>
+            <BuilderSelectItem classAction="'carousel-dark'">Inverted colors</BuilderSelectItem>
         </BuilderSelect>
     </BuilderRow>
 
-    <BuilderRow label.translate="Invert colors" level="1">
-        <BuilderCheckbox classAction="'carousel-dark'"/>
+    <BuilderRow label.translate="Control" level="1">
+        <BuilderSelect>
+            <BuilderSelectItem classAction="''">Indicators Inside</BuilderSelectItem>
+            <BuilderSelectItem classAction="'s_carousel_controllers_indicators_outside'">Indicators Outside</BuilderSelectItem>
+        </BuilderSelect>
     </BuilderRow>
 
     <BuilderRow label.translate="Arrows" level="1">
@@ -51,7 +55,7 @@
     </BuilderRow>
 
     <t t-if="isActiveItem('auto_after_first_hover') || isActiveItem('auto_always')">
-        <BuilderRow label.translate="Speed" level="1">
+        <BuilderRow label.translate="Timespan" level="1">
             <BuilderNumberInput dataAttributeAction="'bsInterval'"
                 default="10"
                 unit="'s'"

--- a/addons/website/static/src/builder/plugins/content_width_option.xml
+++ b/addons/website/static/src/builder/plugins/content_width_option.xml
@@ -4,9 +4,9 @@
 <t t-name="website.ContentWidthOption">
     <BuilderRow label.translate="Content Width">
         <BuilderButtonGroup action="'setContainerWidth'">
-            <BuilderButton actionParam="'o_container_small'"><Img src="'/website/static/src/img/snippets_options/content_width_small.svg'" /></BuilderButton>
-            <BuilderButton actionParam="'container'"><Img src="'/website/static/src/img/snippets_options/content_width_normal.svg'" /></BuilderButton>
-            <BuilderButton actionParam="'container-fluid'"><Img src="'/website/static/src/img/snippets_options/content_width_full.svg'" /></BuilderButton>
+            <BuilderButton actionParam="'o_container_small'" title.translate="Thin"><Img src="'/website/static/src/img/snippets_options/content_width_small.svg'" /></BuilderButton>
+            <BuilderButton actionParam="'container'" title.translate="Regular"><Img src="'/website/static/src/img/snippets_options/content_width_normal.svg'" /></BuilderButton>
+            <BuilderButton actionParam="'container-fluid'" title.translate="Full-width"><Img src="'/website/static/src/img/snippets_options/content_width_full.svg'" /></BuilderButton>
         </BuilderButtonGroup>
     </BuilderRow>
 </t>

--- a/addons/website/static/src/builder/plugins/form/form_option.xml
+++ b/addons/website/static/src/builder/plugins/form/form_option.xml
@@ -306,9 +306,9 @@
     <BuilderRow label.translate="Error Message" level="1" t-if="isActiveItem('error_message_opt')">
         <BuilderTextInput placeholder.translate="Write custom error message" id="'error_message_input_opt'" dataAttributeAction="'errorMessage'"/>
     </BuilderRow>
-    <BuilderRow label.translate="Visibility">
+    <BuilderRow label.translate="Visibility Rule">
         <BuilderSelect preview="false" action="'setVisibility'">
-            <BuilderSelectItem actionValue="'visible'" classAction="''">Always Visible</BuilderSelectItem>
+            <BuilderSelectItem actionValue="'visible'" classAction="''">None</BuilderSelectItem>
             <BuilderSelectItem actionValue="'hidden'" classAction="'s_website_form_field_hidden'">Hidden</BuilderSelectItem>
             <BuilderSelectItem id="'hidden_if_opt'" actionValue="'conditional'" classAction="'s_website_form_field_hidden_if d-none'">Visible only if</BuilderSelectItem>
         </BuilderSelect>

--- a/addons/website/static/src/builder/plugins/layout_option/grid_column_option.xml
+++ b/addons/website/static/src/builder/plugins/layout_option/grid_column_option.xml
@@ -2,9 +2,9 @@
 <templates xml:space="preserve">
 
 <t t-name="website.GridColumnsOption">
-    <BuilderRow t-if="this.state.isGridMode" label.translate="Padding (Y, X)">
-        <BuilderNumberInput action="'setGridColumnsPadding'" actionParam="'--grid-item-padding-y'" unit="'px'"/>
-        <BuilderNumberInput action="'setGridColumnsPadding'" actionParam="'--grid-item-padding-x'" unit="'px'"/>
+    <BuilderRow t-if="this.state.isGridMode" label.translate="Padding" tooltip.translate="Vertical and Horizontal padding">
+        <BuilderNumberInput action="'setGridColumnsPadding'" actionParam="'--grid-item-padding-y'" unit="'px'" prefixIcon="'oi oi-arrows-v'"/>
+        <BuilderNumberInput action="'setGridColumnsPadding'" actionParam="'--grid-item-padding-x'" unit="'px'" prefixIcon="'oi oi-arrows-h'"/>
     </BuilderRow>
 </t>
 

--- a/addons/website/static/src/builder/plugins/layout_option/spacing_option.xml
+++ b/addons/website/static/src/builder/plugins/layout_option/spacing_option.xml
@@ -2,9 +2,9 @@
 <templates xml:space="preserve">
 
 <t t-name="website.SpacingOption">
-    <BuilderRow label.translate="Spacing (Y, X)" level="props.level" applyTo="props.applyTo">
-        <BuilderNumberInput action="'setGridSpacing'" actionParam="'row-gap'" unit="'px'" default="0" />
-        <BuilderNumberInput action="'setGridSpacing'" actionParam="'column-gap'" unit="'px'" default="0" max="60"/>
+    <BuilderRow label.translate="Spacing" tooltip.translate="Vertical and Horizontal spacing" level="props.level" applyTo="props.applyTo">
+        <BuilderNumberInput action="'setGridSpacing'" actionParam="'row-gap'" unit="'px'" default="0" prefixIcon="'oi oi-arrows-v'"/>
+        <BuilderNumberInput action="'setGridSpacing'" actionParam="'column-gap'" unit="'px'" default="0" max="60" prefixIcon="'oi oi-arrows-h'"/>
     </BuilderRow>
 </t>
 

--- a/addons/website/static/src/builder/plugins/options/animate_option.xml
+++ b/addons/website/static/src/builder/plugins/options/animate_option.xml
@@ -63,7 +63,7 @@
             </BuilderSelect>
         </BuilderRow>
         <!-- Intensity -->
-        <BuilderRow label.translate="Intensity" level="1" t-if="state.showIntensity">
+        <BuilderRow label.translate="Intensity" tooltip.translate="Adjust how strong the animation effect is" level="1" t-if="state.showIntensity">
             <BuilderRange
                 action="'setAnimateIntensity'"
                 preview="false"
@@ -99,7 +99,7 @@
                     <BuilderSelectItem actionValue="'image_mirror_blur'" id="'hover_effect_mirror_blur_opt'">Mirror Blur</BuilderSelectItem>
                 </BuilderSelect>
             </BuilderRow>
-            <BuilderRow label.translate="Intensity" level="2">
+            <BuilderRow label.translate="Intensity" tooltip.translate="Adjust how strong the hover effect is" level="2">
                 <BuilderRange action="'setHoverEffectIntensity'"
                     t-if="this.isActiveItems(['hover_effect_zoom_in_opt', 'hover_effect_zoom_out_opt', 'hover_effect_mirror_blur_opt', 'hover_effect_dolly_zoom_opt'])"
                     preview="false" min="1" max="100" step="1" displayRangeValue="true"/>

--- a/addons/website/static/src/builder/plugins/options/background_option.xml
+++ b/addons/website/static/src/builder/plugins/options/background_option.xml
@@ -4,10 +4,12 @@
 <t t-name="website.WebsiteBackgroundOption" t-inherit="html_builder.BackgroundOption">
     <xpath expr="//BuilderButton[@action=&quot;'toggleBgImage'&quot;]" position="after">
         <t t-if="props.withVideos">
-            <BuilderButton title.translate="Video"
-                className="'fa fa-fw fa-film px-2'"
-                preview="false"
+            <BuilderButton
                 action="'toggleBgVideo'"
+                title.translate="Add a background video"
+                titleActive.translate="Remove the background video"
+                preview="false"
+                className="'fa fa-fw fa-film px-2'"
                 id="'toggle_bg_video_id'"
             />
         </t>

--- a/addons/website/static/src/builder/plugins/options/image_gallery_option.xml
+++ b/addons/website/static/src/builder/plugins/options/image_gallery_option.xml
@@ -30,6 +30,51 @@
         </BuilderSelect>
     </BuilderRow>
 
+    <t t-if="this.state.isSlideShow">
+        <BuilderRow label.translate="Style">
+            <BuilderSelect applyTo="'.carousel'">
+                <BuilderSelectItem classAction="''">Regular</BuilderSelectItem>
+                <BuilderSelectItem classAction="'carousel-dark'">Inverted colors</BuilderSelectItem>
+            </BuilderSelect>
+        </BuilderRow>
+
+        <BuilderRow label.translate="Control" level="1">
+            <BuilderSelect>
+                <BuilderSelectItem classAction="''">Classic</BuilderSelectItem>
+                <BuilderSelectItem classAction="'s_image_gallery_controllers_indicators_outside'">Indicators outside</BuilderSelectItem>
+                <BuilderSelectItem classAction="'s_image_gallery_controllers_outside'">Outside, center</BuilderSelectItem>
+                <BuilderSelectItem classAction="'s_image_gallery_controllers_outside s_image_gallery_controllers_outside_arrows_left'">Outside, at right</BuilderSelectItem>
+                <BuilderSelectItem classAction="'s_image_gallery_controllers_outside s_image_gallery_controllers_outside_arrows_right'">Outside, at left</BuilderSelectItem>
+            </BuilderSelect>
+        </BuilderRow>
+
+        <BuilderRow label.translate="Arrows" level="1">
+            <BuilderSelect>
+                <BuilderSelectItem classAction="'s_image_gallery_arrows_default'">Default</BuilderSelectItem>
+                <BuilderSelectItem classAction="'s_image_gallery_arrows_boxed'">Boxed</BuilderSelectItem>
+                <BuilderSelectItem classAction="'s_image_gallery_arrows_rounded'">Rounded</BuilderSelectItem>
+                <BuilderSelectItem classAction="'s_image_gallery_arrows_hidden'">Hidden</BuilderSelectItem>
+            </BuilderSelect>
+        </BuilderRow>
+
+        <BuilderRow label.translate="Indicators" level="1">
+            <BuilderSelect action="'indicatorsStyle'">
+                <BuilderSelectItem actionParam="'s_image_gallery_indicators_bars'">Bars</BuilderSelectItem>
+                <BuilderSelectItem actionParam="'s_image_gallery_indicators_dots'">Dots</BuilderSelectItem>
+                <BuilderSelectItem actionParam="'s_image_gallery_indicators_numbers'">Numbers</BuilderSelectItem>
+                <BuilderSelectItem actionParam="'s_image_gallery_indicators_squared'" id="'indicators_squared_opt'">Squared Miniatures</BuilderSelectItem>
+                <BuilderSelectItem actionParam="'s_image_gallery_indicators_rounded'" id="'indicators_rounded_opt'">Rounded Miniatures</BuilderSelectItem>
+                <BuilderSelectItem actionParam="'s_image_gallery_indicators_hidden'">Hidden</BuilderSelectItem>
+            </BuilderSelect>
+        </BuilderRow>
+
+        <BuilderRow label.translate="Outline" level="2" t-if="isActiveItem('indicators_squared_opt') || isActiveItem('indicators_rounded_opt')">
+            <BuilderCheckbox classAction="'s_image_gallery_indicators_outline'"/>
+        </BuilderRow>
+    </t>
+
+    <t t-call="website.ImagePopUpOption"/>
+
     <BuilderContext applyTo="'.carousel'">
         <BuilderRow label.translate="Transition">
             <BuilderSelect >
@@ -48,7 +93,7 @@
         </BuilderRow>
 
         <t t-if="isActiveItem('auto_after_first_hover') || isActiveItem('auto_always')">
-            <BuilderRow label.translate="Speed" level="1">
+            <BuilderRow label.translate="Timespan" level="1">
                 <BuilderNumberInput dataAttributeAction="'bsInterval'"
                     default="10"
                     unit="'s'"
@@ -60,46 +105,6 @@
             </BuilderRow>
         </t>
     </BuilderContext>
-
-    <BuilderRow label.translate="Style" t-if="this.state.isSlideShow">
-        <BuilderSelect>
-            <BuilderSelectItem classAction="''">Classic</BuilderSelectItem>
-            <BuilderSelectItem classAction="'s_image_gallery_controllers_indicators_outside'">Indicators outside</BuilderSelectItem>
-            <BuilderSelectItem classAction="'s_image_gallery_controllers_outside'">Outside, center</BuilderSelectItem>
-            <BuilderSelectItem classAction="'s_image_gallery_controllers_outside s_image_gallery_controllers_outside_arrows_left'">Outside, at right</BuilderSelectItem>
-            <BuilderSelectItem classAction="'s_image_gallery_controllers_outside s_image_gallery_controllers_outside_arrows_right'">Outside, at left</BuilderSelectItem>
-        </BuilderSelect>
-    </BuilderRow>
-
-    <BuilderRow label.translate="Invert colors" level="1" t-if="this.state.isSlideShow">
-        <BuilderCheckbox applyTo="'.carousel'" classAction="'carousel-dark'"/>
-    </BuilderRow>
-
-    <BuilderRow label.translate="Arrows" level="1" t-if="this.state.isSlideShow">
-        <BuilderSelect>
-            <BuilderSelectItem classAction="'s_image_gallery_arrows_default'">Default</BuilderSelectItem>
-            <BuilderSelectItem classAction="'s_image_gallery_arrows_boxed'">Boxed</BuilderSelectItem>
-            <BuilderSelectItem classAction="'s_image_gallery_arrows_rounded'">Rounded</BuilderSelectItem>
-            <BuilderSelectItem classAction="'s_image_gallery_arrows_hidden'">Hidden</BuilderSelectItem>
-        </BuilderSelect>
-     </BuilderRow>
-
-    <BuilderRow label.translate="Indicators" level="1" t-if="this.state.isSlideShow">
-        <BuilderSelect action="'indicatorsStyle'">
-            <BuilderSelectItem actionParam="'s_image_gallery_indicators_bars'">Bars</BuilderSelectItem>
-            <BuilderSelectItem actionParam="'s_image_gallery_indicators_dots'">Dots</BuilderSelectItem>
-            <BuilderSelectItem actionParam="'s_image_gallery_indicators_numbers'">Numbers</BuilderSelectItem>
-            <BuilderSelectItem actionParam="'s_image_gallery_indicators_squared'" id="'indicators_squared_opt'">Squared Miniatures</BuilderSelectItem>
-            <BuilderSelectItem actionParam="'s_image_gallery_indicators_rounded'" id="'indicators_rounded_opt'">Rounded Miniatures</BuilderSelectItem>
-            <BuilderSelectItem actionParam="'s_image_gallery_indicators_hidden'">Hidden</BuilderSelectItem>
-        </BuilderSelect>
-     </BuilderRow>
-
-    <BuilderRow label.translate="Outline" level="2" t-if="isActiveItem('indicators_squared_opt') || isActiveItem('indicators_rounded_opt')">
-        <BuilderCheckbox classAction="'s_image_gallery_indicators_outline'"/>
-    </BuilderRow>
-
-    <t t-call="website.ImagePopUpOption"/>
 
     <BuilderContext applyTo="'img'">
         <BorderConfigurator label.translate="Border"/>

--- a/addons/website/static/src/builder/plugins/options/parallax_option.xml
+++ b/addons/website/static/src/builder/plugins/options/parallax_option.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="website.ParallaxOption">
-    <BuilderRow t-if="isActiveItem('toggle_bg_image_id') and !isActiveItem('toggle_bg_video_id')" label.translate="Scroll Effect" level="2" preview="false">
+    <BuilderRow t-if="isActiveItem('toggle_bg_image_id') and !isActiveItem('toggle_bg_video_id')" label.translate="Scroll Effect" tooltip.translate="Select a motion style for scrolling" level="2" preview="false">
         <BuilderSelect action="'setParallaxType'">
             <BuilderSelectItem actionValue="'none'">None</BuilderSelectItem>
             <BuilderSelectItem actionValue="'fixed'">Fixed</BuilderSelectItem>
@@ -13,32 +13,26 @@
         </BuilderSelect>
     </BuilderRow>
     <BuilderContext preview="false">
-        <BuilderRow t-if="isActiveItem('parallax_top_opt')" level="3" label.translate="Intensity">
-            <BuilderRange
+        <BuilderRow level="3" label.translate="Intensity" tooltip.translate="Adjust how strong the scroll effect appears" >
+            <BuilderRange t-if="isActiveItem('parallax_top_opt')"
                 dataAttributeAction="'scrollBackgroundRatio'"
                 min="0.15"
                 max="3"
                 step="0.15"
             />
-        </BuilderRow>
-        <BuilderRow t-if="isActiveItem('parallax_bottom_opt')" level="3" label.translate="Intensity">
-            <BuilderRange
+            <BuilderRange t-if="isActiveItem('parallax_bottom_opt')" 
                 dataAttributeAction="'scrollBackgroundRatio'"
                 min="-0.15"
                 max="-3"
                 step="0.15"
             />
-        </BuilderRow>
-        <BuilderRow t-if="isActiveItem('parallax_zoom_in_opt')" level="3" label.translate="Intensity">
-            <BuilderRange
+            <BuilderRange t-if="isActiveItem('parallax_zoom_in_opt')"
                 dataAttributeAction="'scrollBackgroundRatio'"
                 min="0.05"
                 max="0.95"
                 step="0.05"
             />
-        </BuilderRow>
-        <BuilderRow t-if="isActiveItem('parallax_zoom_out_opt')" level="3" label.translate="Intensity">
-            <BuilderRange
+            <BuilderRange t-if="isActiveItem('parallax_zoom_out_opt')"
                 dataAttributeAction="'scrollBackgroundRatio'"
                 min="0.15"
                 max="3"

--- a/addons/website/static/src/builder/plugins/options/scroll_button_option.xml
+++ b/addons/website/static/src/builder/plugins/options/scroll_button_option.xml
@@ -19,6 +19,12 @@
     </BuilderRow>
 
     <t t-if="this.isActiveItem('scroll_button_opt')">
+        <BuilderRow label.translate="Animation" level="1" applyTo="':scope > .o_scroll_button'">
+            <BuilderSelect>
+                <BuilderSelectItem classAction="''">None</BuilderSelectItem>
+                <BuilderSelectItem classAction="'anim-heartbeat'">Heartbeat</BuilderSelectItem>
+            </BuilderSelect>
+        </BuilderRow>
         <BuilderRow label.translate="Colors" level="1" applyTo="':scope > .o_scroll_button'">
             <BuilderColorPicker styleAction="'background-color'"/>
             <BuilderColorPicker styleAction="'color'"/>

--- a/addons/website/static/src/builder/plugins/options/scroll_button_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/scroll_button_option_plugin.js
@@ -32,9 +32,11 @@ class ScrollButtonManager {
             "rounded-circle",
             "align-items-center",
             "justify-content-center",
+            "o_cc",
+            "o_cc4",
             "mx-auto",
-            "bg-primary",
-            "o_not_editable"
+            "o_not_editable",
+            "anim-heartbeat"
         );
         anchor.href = "#";
         anchor.contentEditable = "false";

--- a/addons/website/static/src/builder/plugins/options/table_of_content_option.xml
+++ b/addons/website/static/src/builder/plugins/options/table_of_content_option.xml
@@ -21,7 +21,7 @@
             <BuilderButton icon="'fa-long-arrow-right'" title.translate="Right" actionParam="'right'"/>
         </BuilderButtonGroup>
     </BuilderRow>
-    <BuilderRow label.translate="Sticky">
+    <BuilderRow label.translate="Sticky" tooltip.translate="Keep this element fixed while scrolling">
         <BuilderCheckbox classAction="'s_table_of_content_navbar_sticky'" preview="false"/>
     </BuilderRow>
 </t>

--- a/addons/website/static/src/builder/plugins/options/visibility_option.xml
+++ b/addons/website/static/src/builder/plugins/options/visibility_option.xml
@@ -2,10 +2,10 @@
 <templates xml:space="preserve">
 
 <t t-name="website.DeviceVisibility">
-    <BuilderButton className="'o-hb-btn-has-img-icon btn-danger-color-active'" action="'toggleDeviceVisibility'" actionParam="'no_desktop'" preview="false">
+    <BuilderButton className="'o-hb-btn-has-img-icon btn-danger-color-active'" action="'toggleDeviceVisibility'" actionParam="'no_desktop'" preview="false" title.translate="Hide on Desktop" titleActive.translate="Show on Desktop">
 		<Img src="'/html_builder/static/img/options/desktop_invisible.svg'" style="'width: 12px'"/>
 	</BuilderButton>
-    <BuilderButton className="'o-hb-btn-has-img-icon btn-danger-color-active'" action="'toggleDeviceVisibility'" actionParam="'no_mobile'" preview="false">
+    <BuilderButton className="'o-hb-btn-has-img-icon btn-danger-color-active'" action="'toggleDeviceVisibility'" actionParam="'no_mobile'" preview="false" title.translate="Hide on Mobile" titleActive.translate="Show on Mobile">
 		<Img src="'/html_builder/static/img/options/mobile_invisible.svg'" style="'width: 12px'" />
 	</BuilderButton>
 </t>

--- a/addons/website/static/src/builder/plugins/theme/theme_button_option.xml
+++ b/addons/website/static/src/builder/plugins/theme/theme_button_option.xml
@@ -35,17 +35,17 @@
                 buttonIcon="'fa-trash'"
                 buttonTitle.translate="Reset to Default Font Family"/>
         </BuilderRow>
-        <BuilderRow label.translate="Padding" action="'customizeWebsiteVariable'">
-            <BuilderNumberInput title.translate="Y" actionParam="'btn-padding-y'" unit="'px'" saveUnit="'rem'"/>
-            <BuilderNumberInput title.translate="X" actionParam="'btn-padding-x'" unit="'px'" saveUnit="'rem'"/>
+        <BuilderRow label.translate="Padding" tooltip.translate="Vertical and Horizontal padding" action="'customizeWebsiteVariable'">
+            <BuilderNumberInput actionParam="'btn-padding-y'" unit="'px'" saveUnit="'rem'" prefixIcon="'oi oi-arrows-v'"/>
+            <BuilderNumberInput actionParam="'btn-padding-x'" unit="'px'" saveUnit="'rem'" prefixIcon="'oi oi-arrows-h'"/>
             <t t-set-slot="collapse">
-                <BuilderRow label.translate="Small" level="1">
-                    <BuilderNumberInput title.translate="Y" actionParam="'btn-padding-y-sm'" unit="'px'" saveUnit="'rem'"/>
-                    <BuilderNumberInput title.translate="X" actionParam="'btn-padding-x-sm'" unit="'px'" saveUnit="'rem'"/>
+                <BuilderRow label.translate="Small" tooltip.translate="Vertical and Horizontal padding" level="1">
+                    <BuilderNumberInput actionParam="'btn-padding-y-sm'" unit="'px'" saveUnit="'rem'" prefixIcon="'oi oi-arrows-v'"/>
+                    <BuilderNumberInput actionParam="'btn-padding-x-sm'" unit="'px'" saveUnit="'rem'" prefixIcon="'oi oi-arrows-h'"/>
                 </BuilderRow>
-                <BuilderRow label.translate="Large" level="1">
-                    <BuilderNumberInput title.translate="Y" actionParam="'btn-padding-y-lg'" unit="'px'" saveUnit="'rem'"/>
-                    <BuilderNumberInput title.translate="X" actionParam="'btn-padding-x-lg'" unit="'px'" saveUnit="'rem'"/>
+                <BuilderRow label.translate="Large" tooltip.translate="Vertical and Horizontal padding" level="1">
+                    <BuilderNumberInput actionParam="'btn-padding-y-lg'" unit="'px'" saveUnit="'rem'" prefixIcon="'oi oi-arrows-v'"/>
+                    <BuilderNumberInput actionParam="'btn-padding-x-lg'" unit="'px'" saveUnit="'rem'" prefixIcon="'oi oi-arrows-h'"/>
                 </BuilderRow>
             </t>
         </BuilderRow>

--- a/addons/website/static/src/builder/plugins/theme/theme_tab.xml
+++ b/addons/website/static/src/builder/plugins/theme/theme_tab.xml
@@ -87,17 +87,17 @@
 
 <t t-name="website.ThemeInputOption">
     <BuilderContext preview="false">
-        <BuilderRow label.translate="Padding" action="'customizeWebsiteVariable'">
-            <BuilderNumberInput title.translate="Y" actionParam="'input-padding-y'" unit="'px'" saveUnit="'rem'"/>
-            <BuilderNumberInput title.translate="X" actionParam="'input-padding-x'" unit="'px'" saveUnit="'rem'"/>
+        <BuilderRow label.translate="Padding" tooltip.translate="Vertical and Horizontal padding" action="'customizeWebsiteVariable'">
+            <BuilderNumberInput actionParam="'input-padding-y'" unit="'px'" saveUnit="'rem'" prefixIcon="'oi oi-arrows-v'"/>
+            <BuilderNumberInput actionParam="'input-padding-x'" unit="'px'" saveUnit="'rem'" prefixIcon="'oi oi-arrows-h'"/>
             <t t-set-slot="collapse">
-                <BuilderRow label.translate="Small" level="1">
-                    <BuilderNumberInput title.translate="Y" actionParam="'input-padding-y-sm'" unit="'px'" saveUnit="'rem'"/>
-                    <BuilderNumberInput title.translate="X" actionParam="'input-padding-x-sm'" unit="'px'" saveUnit="'rem'"/>
+                <BuilderRow label.translate="Small" tooltip.translate="Vertical and Horizontal padding" level="1">
+                    <BuilderNumberInput actionParam="'input-padding-y-sm'" unit="'px'" saveUnit="'rem'" prefixIcon="'oi oi-arrows-v'"/>
+                    <BuilderNumberInput actionParam="'input-padding-x-sm'" unit="'px'" saveUnit="'rem'" prefixIcon="'oi oi-arrows-h'"/>
                 </BuilderRow>
-                <BuilderRow label.translate="Large" level="1">
-                    <BuilderNumberInput title.translate="Y" actionParam="'input-padding-y-lg'" unit="'px'" saveUnit="'rem'"/>
-                    <BuilderNumberInput title.translate="X" actionParam="'input-padding-x-lg'" unit="'px'" saveUnit="'rem'"/>
+                <BuilderRow label.translate="Large" tooltip.translate="Vertical and Horizontal padding" level="1">
+                    <BuilderNumberInput actionParam="'input-padding-y-lg'" unit="'px'" saveUnit="'rem'" prefixIcon="'oi oi-arrows-v'"/>
+                    <BuilderNumberInput actionParam="'input-padding-x-lg'" unit="'px'" saveUnit="'rem'" prefixIcon="'oi oi-arrows-h'"/>
                 </BuilderRow>
             </t>
         </BuilderRow>

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -2212,7 +2212,6 @@ span.list-inline-item.o_add_language:last-child {
     display: flex;
     width: 50px;
     height: 50px;
-    animation: o-anim-heartbeat 2.6s ease-in-out 1s infinite;
 
     &, &:hover {
         text-decoration: none;
@@ -2220,19 +2219,26 @@ span.list-inline-item.o_add_language:last-child {
     &:focus {
         outline: none;
     }
+    
+}
+
+.anim-heartbeat {
+    animation: o-anim-heartbeat 2.6s ease-in-out 1s infinite;
+    opacity: 0.8;
+
     &:hover {
         animation-iteration-count: 1;
     }
-}
-
-// Attention keeper for the "scroll down" top-banner button
-@keyframes o-anim-heartbeat {
-    0%, 14%, 35% {
-        transform: scale(1);
-    }
-    7%, 21% {
-        transform: scale(1.3);
-        background-color: rgba(map-get($theme-colors, 'primary'), 0.8);
+    // Attention keeper for the "scroll down" top-banner button
+    @keyframes o-anim-heartbeat {
+        0%, 14%, 35% {
+            transform: scale(1);
+            opacity: 0.8;
+        }
+        7%, 21% {
+            transform: scale(1.3);
+            opacity: 1;
+        }
     }
 }
 

--- a/addons/website/static/tests/builder/options/grid_column_option.test.js
+++ b/addons/website/static/tests/builder/options/grid_column_option.test.js
@@ -16,11 +16,11 @@ import {
 
 defineWebsiteModels();
 
-test("Using the Padding (Y, X) option should display a padding preview", async () => {
+test("Using the Padding option should display a padding preview", async () => {
     await setupWebsiteBuilderWithSnippet("s_banner", { loadIframeBundles: true });
     await contains(":iframe .s_banner .o_grid_item").click();
-    await waitFor("[data-label='Padding (Y, X)'] input");
-    await click(queryAll("[data-label='Padding (Y, X)'] input")[0]);
+    await waitFor("[data-label='Padding'] input");
+    await click(queryAll("[data-label='Padding'] input")[0]);
     await edit(20);
     const def = new Deferred();
     expect(queryFirst(":iframe .s_banner .o_grid_item")).toHaveClass("o_we_padding_highlight");
@@ -35,8 +35,8 @@ test("Using the Padding (Y, X) option should display a padding preview", async (
 test("Cloning a block with a padding preview should not make the preview appear on the clone", async () => {
     await setupWebsiteBuilderWithSnippet("s_banner", { loadIframeBundles: true });
     await contains(":iframe .s_banner .o_grid_item").click();
-    await waitFor("[data-label='Padding (Y, X)'] input");
-    await click(queryAll("[data-label='Padding (Y, X)'] input")[0]);
+    await waitFor("[data-label='Padding'] input");
+    await click(queryAll("[data-label='Padding'] input")[0]);
     expect(":iframe .s_banner .o_grid_item").toHaveCount(4);
     await edit(20);
     await click("[data-container-title='Box'] .oe_snippet_clone");

--- a/addons/website/static/tests/builder/options/spacing_option.test.js
+++ b/addons/website/static/tests/builder/options/spacing_option.test.js
@@ -8,25 +8,25 @@ import {
 
 defineWebsiteModels();
 
-test("Use the 'Spacing (Y, X)' option", async () => {
+test("Use the 'Spacing' option", async () => {
     await setupWebsiteBuilderWithSnippet("s_banner", { loadIframeBundles: true });
     await contains(":iframe .s_banner").click();
     expect(":iframe .s_banner .row").toHaveStyle({ "row-gap": "0px" });
     expect(":iframe .s_banner .row").toHaveStyle({ "column-gap": "0px" });
 
-    await contains("[data-label='Spacing (Y, X)'] [data-action-param='row-gap'] input").edit(10);
+    await contains("[data-label='Spacing'] [data-action-param='row-gap'] input").edit(10);
     expect(":iframe .s_banner .row").toHaveStyle({ "row-gap": "10px" });
     expect(":iframe .s_banner .row").toHaveStyle({ "column-gap": "0px" });
 
-    await contains("[data-label='Spacing (Y, X)'] [data-action-param='column-gap'] input").edit(20);
+    await contains("[data-label='Spacing'] [data-action-param='column-gap'] input").edit(20);
     expect(":iframe .s_banner .row").toHaveStyle({ "row-gap": "10px" });
     expect(":iframe .s_banner .row").toHaveStyle({ "column-gap": "20px" });
 });
 
-test("Using the 'Spacing (Y, X)' option should display a grid preview", async () => {
+test("Using the 'Spacing' option should display a grid preview", async () => {
     await setupWebsiteBuilderWithSnippet("s_banner", { loadIframeBundles: true });
     await contains(":iframe .s_banner").click();
-    await contains("[data-label='Spacing (Y, X)'] input").click();
+    await contains("[data-label='Spacing'] input").click();
     await edit(20);
     expect(":iframe .o_we_grid_preview").toHaveCount(1);
 
@@ -45,7 +45,7 @@ test("Cloning a block with a grid preview should not make the preview appear on 
     await setupWebsiteBuilderWithSnippet("s_banner", { loadIframeBundles: true });
     await contains(":iframe .s_banner").click();
     expect(":iframe .s_banner").toHaveCount(1);
-    await contains("[data-label='Spacing (Y, X)'] input").click();
+    await contains("[data-label='Spacing'] input").click();
     await edit(20);
     await contains("[data-container-title='Block'] .oe_snippet_clone").click();
     expect(":iframe .s_banner").toHaveCount(2);
@@ -62,7 +62,7 @@ test("Saving a block with a grid preview should not save the preview", async () 
     await setupWebsiteBuilderWithSnippet("s_banner", { loadIframeBundles: true });
     await contains(":iframe .s_banner").click();
     expect(":iframe .s_banner").toHaveCount(1);
-    await contains("[data-label='Spacing (Y, X)'] input").click();
+    await contains("[data-label='Spacing'] input").click();
     await edit(20);
 
     await contains(".o-snippets-top-actions [data-action='save']").click();

--- a/addons/website/static/tests/builder/website_builder/carousel.test.js
+++ b/addons/website/static/tests/builder/website_builder/carousel.test.js
@@ -112,13 +112,13 @@ test("Test Carousel Option (s_carousel)", async () => {
     expect(carouselEl).toHaveAttribute("data-bs-ride", "true");
     expect(carouselEl).toHaveAttribute("data-bs-interval", "10000");
 
-    // Editing the Speed
+    // Editing the Timespan
 
-    await contains(".hb-row[data-label='Speed'] input").edit("3");
+    await contains(".hb-row[data-label='Timespan'] input").edit("3");
     expect(carouselEl).toHaveAttribute("data-bs-ride", "true");
     expect(carouselEl).toHaveAttribute("data-bs-interval", "3000");
 
-    await contains(".hb-row[data-label='Speed'] input").edit("0");
+    await contains(".hb-row[data-label='Timespan'] input").edit("0");
     expect(carouselEl).toHaveAttribute("data-bs-ride", "true");
     expect(carouselEl).toHaveAttribute("data-bs-interval", "1000");
 
@@ -169,13 +169,13 @@ test("Test Carousel Option (s_image_gallery)", async () => {
     expect(carouselEl).toHaveAttribute("data-bs-ride", "true");
     expect(carouselEl).toHaveAttribute("data-bs-interval", "10000");
 
-    // Editing the Speed
+    // Editing the Timespan
 
-    await contains(".hb-row[data-label='Speed'] input").edit("3");
+    await contains(".hb-row[data-label='Timespan'] input").edit("3");
     expect(carouselEl).toHaveAttribute("data-bs-ride", "true");
     expect(carouselEl).toHaveAttribute("data-bs-interval", "3000");
 
-    await contains(".hb-row[data-label='Speed'] input").edit("0");
+    await contains(".hb-row[data-label='Timespan'] input").edit("0");
     expect(carouselEl).toHaveAttribute("data-bs-ride", "true");
     expect(carouselEl).toHaveAttribute("data-bs-interval", "1000");
 

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -11,7 +11,7 @@ import { stepUtils } from "@web_tour/tour_utils";
 import { editorsWeakMap } from "@html_editor/../tests/tours/helpers/editor";
 
 // Visibility possible values:
-const VISIBLE = "Always Visible";
+const VISIBLE = "None";
 const CONDITIONALVISIBILITY = "Visible only if";
 
 const NB_NON_ESSENTIAL_REQUIRED_FIELDS_IN_DEFAULT_FORM = 2;
@@ -109,7 +109,7 @@ const addField = function (
             content: "Wait for field to load",
             trigger: `:iframe .s_website_form_field[data-type="${name}"],:iframe .s_website_form_input[name="${name}"]`, //custom or existing field
         },
-        ...changeOptionInPopover("Field", "Visibility", display.visibility),
+        ...changeOptionInPopover("Field", "Visibility Rule", display.visibility),
     ];
     let testText = ":iframe .s_website_form_field";
     if (display.condition) {
@@ -246,11 +246,11 @@ registerWebsitePreviewTour(
         },
         ...addCustomField("char", "text", "Conditional Visibility Check 1", false),
         ...addCustomField("char", "text", "Conditional Visibility Check 2", false),
-        ...changeOptionInPopover("Field", "Visibility", "Visible only if"),
+        ...changeOptionInPopover("Field", "Visibility Rule", "Visible only if"),
         ...selectButtonByData("Your Name", "[data-action-value='Conditional Visibility Check 1']"),
         ...addCustomField("char", "text", "Conditional Visibility Check 2", false),
         ...selectFieldByLabel("Conditional Visibility Check 1"),
-        ...changeOptionInPopover("Field", "Visibility", "Visible only if"),
+        ...changeOptionInPopover("Field", "Visibility Rule", "Visible only if"),
         {
             content: "Open list of the visibility selector of Conditional Visibility Check 1",
             trigger: ".o_customize_tab button:contains('Your Name')",
@@ -264,7 +264,7 @@ registerWebsitePreviewTour(
         },
         ...addCustomField("char", "text", "Conditional Visibility Check 3", false),
         ...addCustomField("char", "text", "Conditional Visibility Check 4", false),
-        ...changeOptionInPopover("Field", "Visibility", "Visible only if"),
+        ...changeOptionInPopover("Field", "Visibility Rule", "Visible only if"),
         ...selectButtonByData("Your Name", "[data-action-value='Conditional Visibility Check 3']"),
         {
             content:
@@ -275,11 +275,11 @@ registerWebsitePreviewTour(
         },
         {
             content: "Check that the conditional visibility of the renamed field is removed",
-            trigger: ".o_customize_tab [data-label='Visibility'] button:contains('Always Visible')",
+            trigger: ".o_customize_tab [data-label='Visibility Rule'] button:contains('None')",
         },
         ...addCustomField("char", "text", "Conditional Visibility Check 5", false),
         ...addCustomField("char", "text", "Conditional Visibility Check 6", false),
-        ...changeOptionInPopover("Field", "Visibility", "Visible only if"),
+        ...changeOptionInPopover("Field", "Visibility Rule", "Visible only if"),
         {
             content:
                 "Change the label of 'Conditional Visibility Check 6' and change it to 'Conditional Visibility Check 5'",
@@ -319,7 +319,7 @@ registerWebsitePreviewTour(
         ...selectFieldByLabel("dependent"),
         {
             content: "Open the select",
-            trigger: ".o_customize_tab button:contains('Always Visible')",
+            trigger: ".o_customize_tab [data-label='Visibility Rule'] button:contains('None')",
             run: "click",
         },
         {
@@ -381,7 +381,7 @@ registerWebsitePreviewTour(
                 ":has(.checkbox:has(label:contains('Wiko Stairway')):has(input[type='checkbox'][required]))",
         },
         // Check conditional visibility for the relational fields
-        ...changeOptionInPopover("Field", "Visibility", "Visible only if"),
+        ...changeOptionInPopover("Field", "Visibility Rule", "Visible only if"),
         ...selectButtonByData("Your Name", "[data-action-value='recipient_ids']"),
         ...selectButtonByText("Is equal to", "Is not equal to"),
         {
@@ -640,7 +640,7 @@ registerWebsitePreviewTour(
         },
         ...addCustomField("char", "text", "field C", false),
         ...selectFieldByLabel("field B"),
-        ...changeOptionInPopover("Field", "Visibility", "Visible only if"),
+        ...changeOptionInPopover("Field", "Visibility Rule", "Visible only if"),
         {
             content: "Verify that the default comparator should be set",
             trigger: ".o_customize_tab #hidden_condition_opt:not(:empty)",
@@ -727,7 +727,7 @@ registerWebsitePreviewTour(
             trigger:
                 '.options-container-header span[title=\'The field "subject" is mandatory for the action "Send an E-mail".\'] > button.fa-trash[disabled]',
         },
-        ...changeOptionInPopover("Field", "Visibility", "Visible only if"),
+        ...changeOptionInPopover("Field", "Visibility Rule", "Visible only if"),
         ...selectButtonByData("Your Name", "[data-action-value='Philippe of Belgium']"),
         ...selectButtonByText("Is equal to", "Is set"),
         {
@@ -741,7 +741,7 @@ registerWebsitePreviewTour(
                 ':iframe .s_website_form_field.s_website_form_required:has(label:contains("Your Message"))',
             run: "click",
         },
-        ...changeOptionInPopover("Field", "Visibility", "Visible only if"),
+        ...changeOptionInPopover("Field", "Visibility Rule", "Visible only if"),
         ...selectButtonByData("Your Name", "[data-action-value='Philippe of Belgium']"),
         ...selectButtonByText("Is equal to", "Is set"),
 
@@ -770,7 +770,7 @@ registerWebsitePreviewTour(
                 ':iframe .s_website_form_field.s_website_form_model_required:has(label:contains("Subject"))',
             run: "click",
         },
-        ...changeOptionInPopover("Field", "Visibility", "Always Visible"),
+        ...changeOptionInPopover("Field", "Visibility Rule", "None"),
         {
             content: "Empty the default value of the 'Subject' field",
             trigger: "[data-label='Default Value'] input",
@@ -782,7 +782,7 @@ registerWebsitePreviewTour(
                 ':iframe .s_website_form_field.s_website_form_required:has(label:contains("Your Message"))',
             run: "click",
         },
-        ...changeOptionInPopover("Field", "Visibility", "Always Visible"),
+        ...changeOptionInPopover("Field", "Visibility Rule", "None"),
         // This step is to ensure select fields are properly cleaned before
         // exiting edit mode
         {


### PR DESCRIPTION
Tooltip on options can now display a different text whether the option
is active or not. This enable to be more descriptive by displaying
"add" or "remove" instead of "toggle".

Enable to display an icon at the start of a builder input in order to
help the user understand what it correspond to without requiring an
tooltip (before, this was limited to text).

Multiple tooltips and labels were changed for a better understanding.

Some options were changed / reordered for better consistency.

task-5169192