### PR TITLE
[IMP] *: group imported invoice lines by tax

### DIFF
--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -65,6 +65,7 @@ class AccountTestInvoicingCommon(ProductCommon):
         super().setUpClass()
 
         cls.maxDiff = None
+        cls._set_extract_single_line_per_tax(cls.env.company)
         cls.company_data = cls.collect_company_accounting_data(cls.env.company)
         cls.product_category.with_company(cls.env.company).write({
             'property_account_income_categ_id': cls.company_data['default_account_revenue'].id,
@@ -255,6 +256,8 @@ class AccountTestInvoicingCommon(ProductCommon):
                 create_values['country_id'] = country.id
             if 'currency_id' not in create_values:
                 create_values['currency_id'] = country.currency_id.id
+        if 'extract_single_line_per_tax' in cls.env['res.company']._fields and 'extract_single_line_per_tax' not in create_values:
+            create_values['extract_single_line_per_tax'] = False
         company = super()._create_company(**create_values)
         cls._use_chart_template(company, cls.chart_template)
         # if the currency_id was defined explicitly (or via the country), it should override the one from the coa
@@ -920,6 +923,11 @@ class AccountTestInvoicingCommon(ProductCommon):
         )
         discount_wizard.action_apply_discount()
         return discount_wizard
+
+    @classmethod
+    def _set_extract_single_line_per_tax(cls, company):
+        if 'extract_single_line_per_tax' in company._fields:
+            company.extract_single_line_per_tax = False
 
     # -------------------------------------------------------------------------
     # Assertions

--- a/addons/account_edi_ubl_cii/__manifest__.py
+++ b/addons/account_edi_ubl_cii/__manifest__.py
@@ -24,6 +24,7 @@ Pro rules and show the errors.
     'depends': ['account'],
     'data': [
         'data/cii_22_templates.xml',
+        'views/account_move_views.xml',
         'views/account_tax_views.xml',
         'views/res_partner_views.xml',
     ],

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -1,6 +1,7 @@
 from lxml import etree
+from collections import defaultdict
 
-from odoo import _, models, Command
+from odoo import _, api, models, Command
 from odoo.tools import html2plaintext
 from odoo.tools.float_utils import float_is_zero, float_round
 from odoo.addons.account.tools import dict_to_xml
@@ -1159,6 +1160,17 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         )
         invoice_line_vals, line_logs = self._import_lines(invoice, tree, './{*}' + line_tag, document_type=invoice.move_type, tax_type=invoice.journal_id.type, qty_factor=qty_factor)
         rounding_line_vals, rounding_logs = self._import_rounding_amount(invoice, tree, './{*}LegalMonetaryTotal/{*}PayableRoundingAmount', document_type=invoice.move_type, qty_factor=qty_factor)
+
+        if (
+            'extract_single_line_per_tax' in invoice.company_id._fields  # defined in account_invoice_extract
+            and invoice.company_id.extract_single_line_per_tax
+            # We also need to check if group_invoice_lines is not in context in the case the setting is True
+            # but the user wants to ungroup lines, then group_invoice_lines will be set to False in context
+            and 'group_invoice_lines' not in invoice.env.context
+        ) or invoice.env.context.get('group_invoice_lines'):
+            # group amls with the same tax id into one aml, with the total amount
+            invoice_line_vals = self._get_lines_vals_group_by_tax(invoice_line_vals, invoice.partner_id, invoice_values['invoice_date'], invoice.currency_id)
+
         line_vals = allowance_charges_line_vals + invoice_line_vals + rounding_line_vals
 
         invoice_values = {
@@ -1168,6 +1180,49 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         invoice.write(invoice_values)
         logs += partner_logs + currency_logs + line_logs + allowance_charges_logs + rounding_logs
         return logs
+
+    @api.model
+    def _get_lines_vals_group_by_tax(self, lines_vals, partner_id, date, currency):
+        """
+        This method group the lines in lines_vals by tax.
+        lines_vals can either be a list of vals dict(s) to create lines
+        :param lines_vals: list of dict
+        :param partner_id: the partner of the move related to the lines
+        :param date: the date of the move in str format
+        :param currency: the currency of the move related to lines
+        :return: a list of dict vals line grouped by tax
+        """
+        # group amls with same tax id into one aml, with the total amount
+        taxes = dict()
+        line_vals_to_group = defaultdict(list)
+        for line in lines_vals:
+            if currency.is_zero(line.get('price_unit', 0.0)):
+                continue
+            line_tax_ids = line.get('tax_ids', [])
+            tax_ref = str(line_tax_ids)
+            if 'Command' in tax_ref:
+                # unhandled, we don't group
+                return lines_vals
+            tax_ids = taxes.get(tax_ref)
+            if tax_ids is None:
+                taxes[tax_ref] = tax_ids = self.env['account.tax'].browse(line_tax_ids)
+            dates = (False, False)
+            if line.get('deferred_start_date') and line.get('deferred_end_date'):
+                dates = (line['deferred_start_date'], line['deferred_end_date'])
+            line_vals_to_group[tax_ids, dates].append(line)
+
+        return [{
+            'name': " - ".join(
+                [partner_id.name or _("Unknown partner"), date] + (tax_ids.mapped('name') or [_("Untaxed")])),
+            'price_unit': sum(
+                line.get('price_unit') * line.get('quantity', 0.0) - line.get('price_unit') * line.get('quantity', 0.0) * line.get('discount', 0.0) / 100
+                for line in lines
+            ),
+            'quantity': 1,
+            'tax_ids': tax_ids.ids,
+            'deferred_start_date': deferred_start_date,
+            'deferred_end_date': deferred_end_date,
+        } for (tax_ids, (deferred_start_date, deferred_end_date)), lines in line_vals_to_group.items()]
 
     def _get_tax_nodes(self, tree):
         tax_nodes = tree.findall('.//{*}Item/{*}ClassifiedTaxCategory/{*}Percent')

--- a/addons/account_edi_ubl_cii/views/account_move_views.xml
+++ b/addons/account_edi_ubl_cii/views/account_move_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record model="ir.actions.server" id="action_group_lines_by_tax">
+            <field name="name">(Un)Group lines by tax</field>
+            <field name="model_id" ref="account.model_account_move"/>
+            <field name="group_ids" eval="[(4, ref('account.group_account_invoice'))]"/>
+            <field name="binding_model_id" ref="account.model_account_move"/>
+            <field name="state">code</field>
+            <field name="binding_view_types">form</field>
+            <field name="code">
+                if records:
+                    records.action_group_ungroup_lines_by_tax()
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/addons/purchase_edi_ubl_bis3/models/__init__.py
+++ b/addons/purchase_edi_ubl_bis3/models/__init__.py
@@ -1,2 +1,3 @@
+from . import account_move
 from . import purchase_edi_xml_ubl_bis3
 from . import purchase_order

--- a/addons/purchase_edi_ubl_bis3/models/account_move.py
+++ b/addons/purchase_edi_ubl_bis3/models/account_move.py
@@ -1,0 +1,12 @@
+from odoo import _, models
+from odoo.exceptions import UserError
+
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    def _check_move_for_group_ungroup_lines_by_tax(self):
+        # Extends account.move
+        super()._check_move_for_group_ungroup_lines_by_tax()
+        if any(line.purchase_order_id for line in self.line_ids):
+            raise UserError(_("You can only (un)group lines of an invoice not linked to a purchase order"))


### PR DESCRIPTION
[IMP] *: group imported invoice lines by tax

modules: account_edi_ubl_cii, l10n_account_edi_ubl_cii_tests, l10n_dk_oioubl, purchase_edi_ubl_bis_3

Most of the time, an accountant that imports a bill don't need to see every line. What's useful to him is to see what amount is linked to what tax.

task-5047859

