### PR TITLE
[FIX] mail: handle response on uploading encrypted pdf file

### DIFF
--- a/addons/mail/tests/discuss/test_discuss_attachment_controller.py
+++ b/addons/mail/tests/discuss/test_discuss_attachment_controller.py
@@ -79,4 +79,7 @@ class TestDiscussAttachmentController(MailControllerAttachmentCommon):
             ownership_token = attachment._get_ownership_token()
             url = f'/mail/attachment/pdf_first_page/{attachment.id}?access_token={ownership_token}'
             response = self.url_open(url)
-            self.assertEqual(response.status_code, 415)
+            # Depending on the environment, the response status_code may vary:
+            # - 200 if PyPDF2 and PyCryptodome are installed (PDF successfully parsed)
+            # - 415 if those libs are missing (PDF cannot be processed)
+            self.assertIn(response.status_code, [415, 200])


### PR DESCRIPTION
The `test_first_page_access_of_mail_attachment_pdf` test is failing on `runbot`.

**Error:**
```
FAIL: TestDiscussAttachmentController.test_first_page_access_of_mail_attachment_pdf Traceback (most recent call last):
  File '/data/build/odoo/addons/mail/tests/discuss/test_discuss_attachment_controller.py', line 82, in test_first_page_access_of_mail_attachment_pdf
    self.assertEqual(response.status_code, 415)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: 200 != 415
```

**Root cause:**
The test expects a `415 status code` when accessing the first page of `encrypted` 
PDFs. When `PyPDF2` and `PyCryptodome` are installed, the response 
returns `200`, causing the `assertion` to `fail`.

**Fix:**
Update the test to accept both `415` and `200` as valid status codes.

This commit fixes test failures caused by https://github.com/odoo/odoo/pull/230713

runbot-233411