### PR TITLE
[FIX] account: Fix sorting in distribute_delta_amount_smoothly

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -1522,14 +1522,14 @@ class AccountTax(models.Model):
         remaining_errors = nb_of_errors
 
         # Take absolute value of factors and sort them by largest absolute value first
-        factors = [abs(target_factor['factor']) for target_factor in target_factors]
-        factors.sort(reverse=True)
-        sum_of_factors = sum(factors)
+        factors = [(i, abs(target_factor['factor'])) for i, target_factor in enumerate(target_factors)]
+        factors.sort(key=lambda x: x[1], reverse=True)
+        sum_of_factors = sum(x[1] for x in factors)
 
         if sum_of_factors == 0.0:
             return amounts_to_distribute
 
-        for i, factor in enumerate(factors):
+        for i, factor in factors:
             if not remaining_errors:
                 break
 

--- a/addons/account/static/src/helpers/account_tax.js
+++ b/addons/account/static/src/helpers/account_tax.js
@@ -628,15 +628,14 @@ export const accountTaxHelpers = {
         let remaining_errors = nb_of_errors;
 
         // Take absolute value of factors and sort them by largest absolute value first
-        const factors = target_factors.map((x) => Math.abs(x.factor));
-        factors.sort((a, b) => b - a);
-        const sum_of_factors = factors.reduce((a, b) => a + b, 0);
+        const factors = target_factors.map((x, i) => [i, Math.abs(x.factor)]);
+        factors.sort((a, b) => b[1] - a[1]);
+        const sum_of_factors = factors.reduce((sum, x) => sum + x[1], 0.0);
         if (sum_of_factors === 0.0) {
             return amounts_to_distribute;
         }
 
-        for (let i = 0; i < target_factors.length; i++) {
-            const factor = factors[i];
+        for (const [i, factor] of factors) {
             if (remaining_errors === 0) {
                 break;
             }


### PR DESCRIPTION
Before this commit, the factors were sorted and the amounts_to_distribute
were build according this order. However, almost all calls to this
method is zipping target_factors with amounts_to_distribute and both
are no longer in the same order.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
