### PR TITLE
[FIX] spreadsheet: fix global filter cell value conversion

### DIFF
--- a/addons/spreadsheet/static/src/global_filters/helpers.js
+++ b/addons/spreadsheet/static/src/global_filters/helpers.js
@@ -157,7 +157,7 @@ const SET_OPERATORS_BEHAVIORS = {
         return new Domain([[fieldPath, domainOperator, false]]);
     },
     toCellValue(getters, filter, filterValue) {
-        return { value: filterValue.operator === "set" };
+        return [[{ value: filterValue.operator === "set" }]];
     },
 };
 
@@ -175,7 +175,7 @@ const FILTERS_BEHAVIORS = {
                 );
             },
             toCellValue(getters, filter, filterValue) {
-                return { value: filterValue.strings.join(", ") };
+                return [[{ value: filterValue.strings.join(", ") }]];
             },
         },
         {
@@ -188,7 +188,7 @@ const FILTERS_BEHAVIORS = {
                 return new Domain([[fieldPath, filterValue.operator, filterValue.strings]]);
             },
             toCellValue(getters, filter, filterValue) {
-                return { value: filterValue.strings.join(", ") };
+                return [[{ value: filterValue.strings.join(", ") }]];
             },
         },
         {
@@ -203,7 +203,7 @@ const FILTERS_BEHAVIORS = {
                 );
             },
             toCellValue(getters, filter, filterValue) {
-                return { value: filterValue.strings.join(", ") };
+                return [[{ value: filterValue.strings.join(", ") }]];
             },
         },
         SET_OPERATORS_BEHAVIORS,
@@ -242,7 +242,7 @@ const FILTERS_BEHAVIORS = {
                 );
             },
             toCellValue(getters, filter, filterValue) {
-                return { value: filterValue.strings.join(", ") };
+                return [[{ value: filterValue.strings.join(", ") }]];
             },
         },
         SET_OPERATORS_BEHAVIORS,
@@ -270,7 +270,7 @@ const FILTERS_BEHAVIORS = {
                 return new Domain([[fieldPath, filterValue.operator, filterValue.selectionValues]]);
             },
             toCellValue(getters, filter, filterValue) {
-                return { value: filterValue.selectionValues.join(", ") };
+                return [[{ value: filterValue.selectionValues.join(", ") }]];
             },
         },
     ],
@@ -292,9 +292,8 @@ const FILTERS_BEHAVIORS = {
                 return new Domain([[fieldPath, filterValue.operator, filterValue.targetValue]]);
             },
             toCellValue(getters, filter, filterValue) {
-                return {
-                    value: filterValue.targetValue !== undefined ? filterValue.targetValue : "",
-                };
+                const value = filterValue.targetValue !== undefined ? filterValue.targetValue : "";
+                return [[{ value }]];
             },
         },
         {

--- a/addons/spreadsheet/static/tests/global_filters/global_filters_model.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/global_filters_model.test.js
@@ -1712,6 +1712,38 @@ test("Export boolean global filters with undefined value for excel", async funct
     expect(filterSheet.cells["A2"]).toBe("test");
     expect(filterSheet.cells["B1"]).toBe("Value");
     expect(filterSheet.cells["B2"]).toBe("");
+
+    model.exportXLSX(); // should not crash
+});
+
+test("Export relational global filter for excel", async function () {
+    const { model } = await createSpreadsheetWithPivotAndList();
+    await addGlobalFilter(model, {
+        id: "1",
+        label: "test relation in",
+        type: "relation",
+        defaultValue: { operator: "in", ids: [1, 2] },
+    });
+    await addGlobalFilter(model, {
+        id: "2",
+        label: "test relation ilike",
+        type: "relation",
+        defaultValue: { operator: "ilike", strings: ["hello", "world"] },
+    });
+
+    const filterPlugin = model["handlers"].find(
+        (handler) => handler instanceof GlobalFiltersCoreViewPlugin
+    );
+    const exportData = { styles: [], sheets: [], formats: {} };
+    filterPlugin.exportForExcel(exportData);
+    const filterSheet = exportData.sheets[0];
+
+    expect(filterSheet.cells["A2"]).toBe("test relation in");
+    expect(filterSheet.cells["B2"]).toBe("1, 2");
+
+    expect(filterSheet.cells["A3"]).toBe("test relation ilike");
+    expect(filterSheet.cells["B3"]).toBe("hello, world");
+
     model.exportXLSX(); // should not crash
 });
 


### PR DESCRIPTION
The helper `getFilterCellValue` would sometime returning POJOS, sometimes a matrix of POJOs. This made the excel export crash, as it expected a matrix.

Task: [5153124](https://www.odoo.com/web#id=5153124&cids=1&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
