### PR TITLE
[FIX] website: always add plugin with test helper addPlugin and similar

### DIFF
--- a/addons/website/static/tests/builder/preview_mode.test.js
+++ b/addons/website/static/tests/builder/preview_mode.test.js
@@ -1,10 +1,9 @@
 import { Plugin } from "@html_editor/plugin";
-import { after, expect, test } from "@odoo/hoot";
+import { expect, test } from "@odoo/hoot";
 import { xml } from "@odoo/owl";
 import { contains } from "@web/../tests/web_test_helpers";
-import { registry } from "@web/core/registry";
 import { uniqueId } from "@web/core/utils/functions";
-import { addOption, defineWebsiteModels, setupWebsiteBuilder } from "./website_helpers";
+import { addOption, addPlugin, defineWebsiteModels, setupWebsiteBuilder } from "./website_helpers";
 import { BuilderAction } from "@html_builder/core/builder_action";
 
 defineWebsiteModels();
@@ -20,10 +19,7 @@ test("do not update builder if in preview mode", async () => {
             },
         };
     }
-    registry.category("website-plugins").add(pluginId, P);
-    after(() => {
-        registry.category("website-plugins").remove(P);
-    });
+    addPlugin(P);
     addOption({
         selector: ".test-options-target",
         template: xml`<BuilderButton id="'id1'" action="'customAction'">b1</BuilderButton>

--- a/addons/website/static/tests/builder/website_builder/searchbar_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/searchbar_option.test.js
@@ -1,9 +1,12 @@
-import { after, beforeEach, expect, test } from "@odoo/hoot";
+import { beforeEach, expect, test } from "@odoo/hoot";
 import { click } from "@odoo/hoot-dom";
 import { Plugin } from "@html_editor/plugin";
-import { registry } from "@web/core/registry";
 import { contains } from "@web/../tests/web_test_helpers";
-import { defineWebsiteModels, setupWebsiteBuilder } from "@website/../tests/builder/website_helpers";
+import {
+    addPlugin,
+    defineWebsiteModels,
+    setupWebsiteBuilder,
+} from "@website/../tests/builder/website_helpers";
 
 defineWebsiteModels();
 
@@ -39,10 +42,7 @@ class SearchbarTestPlugin extends Plugin {
 }
 
 beforeEach(() => {
-    registry.category("website-plugins").add(SearchbarTestPlugin.id, SearchbarTestPlugin);
-    after(() => {
-        registry.category("website-plugins").remove(SearchbarTestPlugin);
-    });
+    addPlugin(SearchbarTestPlugin);
 });
 
 test("Available 'order by' options are updated after switching search type", async () => {


### PR DESCRIPTION
[FIX] website: always add plugin with test helper addPlugin and similar

The test helper `addPlugin` and other similar helpers added the plugin
with the registry entry `website-plugins`. This entry is not used in
translate mode, thus the plugins added were not present for tests about
translate mode.

To also add the plugin for tests of translate mode, this commit changes
the implementation of `addPlugin` to patch `WebsiteBuilder` instead.
It also changes the implementation of other helpers that were doing the
same things to instead call `addPlugin`.

task-5176469