### PR TITLE
[IMP] web : Override notification to access to the self

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -1150,12 +1150,21 @@ export function makeActionManager(env, router = _router) {
         const w = browser.open(url, "_blank");
         if (!w || w.closed || typeof w.closed === "undefined") {
             const msg = _t(
-                "A popup window has been blocked. You may need to change your " +
-                    "browser settings to allow popup windows for this page."
+                "A popup window has been blocked. You may need to change your browser settings to allow popup windows for this page. You can also copy the link and paste it in a new tab."
             );
             env.services.notification.add(msg, {
                 sticky: true,
                 type: "warning",
+                buttons: [
+                    {
+                        name: _t("Copy"),
+                        primary: true,
+                        onClick: async () => {
+                            const fullUrl = new URL(url, window.location.origin).href;
+                            navigator.clipboard.writeText(fullUrl);
+                        },
+                    },
+                ],
             });
         }
     }


### PR DESCRIPTION
Before this commit, only on a phone/tablet browser, when we try to open the mobile menu, a generic notification was shown.

After this commit, the notification message is more explicit and tells the user to copy/paste the link in a new tab. with a small button which copy it directly.

In the web module, I just extract the notification message in a function located in a utils object to be able to override it in the pos_self_order module.

task id : 5007465

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
