### PR TITLE
[FIX] hr_holidays: fix test test_tour_mandatory_days_in_hebrew

### DIFF
--- a/addons/hr_holidays/static/src/tours/hr_holidays_tour.js
+++ b/addons/hr_holidays/static/src/tours/hr_holidays_tour.js
@@ -8,6 +8,10 @@ const leaveType = "NotLimitedHR";
 const leaveDateFrom = "01/17/2022";
 const leaveDateTo = "01/17/2022";
 const description = 'Days off';
+const todayDate = () => {
+    return new Date().toISOString().slice(0, 10);
+};
+
 
 registry.category("web_tour.tours").add('hr_holidays_tour', {
     url: '/web',
@@ -116,13 +120,13 @@ registry.category("web_tour.tours").add("hr_leave_mandatory_days_hebrew_tour", {
             run: "click",
         },
         {
-            trigger: 'td[data-date="2025-11-11"]',
-            content: "Verify that the date has the hr_mandatory_day class.",
+            trigger: '.o_calendar_renderer',
+            content: "Verify that the today has the hr_mandatory_day class.",
             run: () => {
-                const td = document.querySelector('td[data-date="2025-11-11"]');
+                const td = document.querySelector(`td[data-date="${todayDate()}"]`);
                 if (!td?.classList.contains("hr_mandatory_day")) {
                     console.error(
-                        "The date 2025-11-11 does not have the hr_mandatory_day class."
+                        `Today ${todayDate()} does not have the hr_mandatory_day class.`
                     );
                 }
             },

--- a/addons/hr_holidays/tests/test_hr_holidays_tour.py
+++ b/addons/hr_holidays/tests/test_hr_holidays_tour.py
@@ -1,6 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from datetime import datetime
 from freezegun import freeze_time
 
 from odoo.tests import HttpCase
@@ -51,7 +50,6 @@ class TestHrHolidaysTour(HttpCase):
         admin_user.lang = "sr@latin"
         self.start_tour("/web", "hr_holidays_launch", login="admin")
 
-    @freeze_time('2025-11-11')
     def test_tour_mandatory_days_in_hebrew(self):
         """Run the UI tour in Hebrew to check mandatory days display."""
         # Force Hebrew language for the user
@@ -59,10 +57,11 @@ class TestHrHolidaysTour(HttpCase):
         self.env.ref("base.lang_he_IL").active = True
         admin_user.lang = "he_IL"
 
+        today = date.today()
         self.env['hr.leave.mandatory.day'].create({
             'name': 'Madatory Day',
-            'start_date': datetime(2025, 11, 11),
-            'end_date': datetime(2025, 11, 11),
+            'start_date': today,
+            'end_date': today,
             'color': 1,
         })
         self.start_tour(


### PR DESCRIPTION
**Issue:**
The test case test_tour_mandatory_days_in_hebrew fails for nightly faketime builds that test 'next year' because of hardcoded dates.

**Solution:**
Instead of checking for static dates, now we are checking if today is mandatory or not.

runbot error:233323