### PR TITLE
[IMP] cloud_storage: disable cloud storage for chats with ai agents

### DIFF
--- a/addons/cloud_storage/static/src/core/common/attachment_upload_service_patch.js
+++ b/addons/cloud_storage/static/src/core/common/attachment_upload_service_patch.js
@@ -85,6 +85,7 @@ patch(AttachmentUploadService.prototype, {
 
     async _upload(thread, composer, file, options, tmpId, tmpURL) {
         if (
+            !thread.channel?.ai_agent_id && // ai_agent (enterprise) does not support url files
             session.cloud_storage_min_file_size !== undefined &&
             file.size > session.cloud_storage_min_file_size &&
             !session.cloud_storage_unsupported_models.includes(thread.model)

--- a/addons/cloud_storage/static/src/core/common/composer_patch.js
+++ b/addons/cloud_storage/static/src/core/common/composer_patch.js
@@ -4,8 +4,10 @@ import { patch } from "@web/core/utils/patch";
 import { session } from "@web/session";
 
 patch(Composer.prototype, {
-    setup() {
-        super.setup();
-        this.cloudStorageUsable = session.cloud_storage_min_file_size !== undefined;
+    get cloudStorageUsable() {
+        return (
+            !this.thread?.channel?.ai_agent_id && // ai_agent (enterprise) does not support url files
+            session.cloud_storage_min_file_size !== undefined
+        );
     },
 });


### PR DESCRIPTION
Purpose:
--------
The related enterprise PR introduces the ability to upload files when chatting with ai agents. This feature is not available with attachments of type url. This commit disables cloud storage when chatting with an ai agent. Changes have been done in the cloud_storage module to avoid a bridge module.

Task-5031785
