### PR TITLE
[IMP] hr_attendance: add JO overtime ruleset data

### DIFF
--- a/addons/hr_attendance/data/hr_attendance_overtime_ruleset_data.xml
+++ b/addons/hr_attendance/data/hr_attendance_overtime_ruleset_data.xml
@@ -17,5 +17,26 @@
             <field name="rate_combination_mode">sum</field>
             <field name="country_id" ref="base.sa"/>
         </record>
+<!-- JO : Jordan -->
+        <record id="l10n_jo_overtime_ruleset" model="hr.attendance.overtime.ruleset">
+            <field name="name">Jordan Ruleset</field>
+            <field name="rate_combination_mode">sum</field>
+            <field name="country_id" ref="base.jo"/>
+        </record>
+        <record id="l10n_jo_rest_days_overtime_rule" model="hr.attendance.overtime.rule">
+            <field name="name">Rest Days Overtime</field>
+            <field name="ruleset_id" ref="l10n_jo_overtime_ruleset"/>
+            <field name="base_off">timing</field>
+            <field name="amount_rate">1.5</field>
+            <field name="timing_type">non_work_days</field>
+        </record>
+        <record id="l10n_jo_week_days_overtime_rule" model="hr.attendance.overtime.rule">
+            <field name="name">Week Days Overtime</field>
+            <field name="ruleset_id" ref="l10n_jo_overtime_ruleset"/>
+            <field name="base_off">quantity</field>
+            <field name="amount_rate">1.25</field>
+            <field name="quantity_period">day</field>
+            <field name="expected_hours_from_contract" eval="True"/>
+        </record>
     </data>
 </odoo>

--- a/addons/hr_work_entry/data/hr_work_entry_type_data.xml
+++ b/addons/hr_work_entry/data/hr_work_entry_type_data.xml
@@ -1315,6 +1315,24 @@
         <field name="country_id" ref="base.jo"/>
         <field name="amount_rate">1</field>  <!-- Unpaid, but treated in a separate rule -->
     </record>
+    <record id="l10n_jo_work_entry_type_rest_days_overtime" model="hr.work.entry.type">
+        <field name="name">Rest Days Overtime</field>
+        <field name="code">JOROVT</field>
+        <field name="color">4</field>
+        <field name="category" eval="'working_time'"/>
+        <field name="is_extra_hours" eval="True"/>
+        <field name="amount_rate">1.5</field>
+        <field name="country_id" ref="base.jo"/>
+    </record>
+    <record id="l10n_jo_work_entry_type_week_days_overtime" model="hr.work.entry.type">
+        <field name="name">Week Days Overtime</field>
+        <field name="code">JOWOVT</field>
+        <field name="color">4</field>
+        <field name="category" eval="'working_time'"/>
+        <field name="is_extra_hours" eval="True"/>
+        <field name="amount_rate">1.25</field>
+        <field name="country_id" ref="base.jo"/>
+    </record>
 
 <!-- LU : Luxemburg -->
     <record id="l10n_lu_work_entry_type_situational_unemployment" model="hr.work.entry.type">


### PR DESCRIPTION
Before:
- Jordan payroll relied on manual payslip inputs for overtime tracking
- Overtime hours had to be entered manually for each payslip
- No automated overtime calculation based on attendance records

After:
- Introduce a default overtime ruleset tailored for Jordanian companies
- Add two overtime rules:
  - Rest Days Overtime: 1.5x rate for work on non-working days
  - Week Days Overtime: 1.25x rate for daily hours exceeding contract amount
- Add corresponding work entry types to ensure proper association with the ruleset's rules through the appropriate bridge module

Task-5103913
