### PR TITLE
[IMP] core: Cleanup SessionStore

### DIFF
--- a/odoo/addons/test_http/utils.py
+++ b/odoo/addons/test_http/utils.py
@@ -50,20 +50,7 @@ class MemorySessionStore(SessionStore):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.__session_store_cls = SessionStore
         self.store = {}
-
-    def generate_key(self):
-        return self.__session_store_cls.generate_key(self)
-
-    def is_valid_session_id(self, sid):
-        return self.__session_store_cls.is_valid_session_id(self, sid)
-
-    def get_session_path(self, sid):
-        return self.__session_store_cls.get_session_path(self, sid)
-
-    def new(self):
-        return self.__session_store_cls.new(self)
 
     def save(self, session):
         self.store[session.sid] = session
@@ -82,10 +69,7 @@ class MemorySessionStore(SessionStore):
                 session.sid = sid
         return session
 
-    def rotate(self, session, env, *, soft=False):
-        self.__session_store_cls.rotate(self, session, env, soft=soft)
-
-    def vacuum(self):
+    def vacuum(self, max_lifetime=None):
         return
 
     def get_missing_session_identifiers(self, identifiers):
@@ -98,9 +82,6 @@ class MemorySessionStore(SessionStore):
                 sid_to_remove.append(sid)
         for sid in sid_to_remove:
             self.store.pop(sid)
-
-    def delete_old_sessions(self, session):
-        return self.__session_store_cls.delete_old_sessions(self, session)
 
 
 # pylint: disable=W0223(abstract-method)


### PR DESCRIPTION
- MemorySessionStore does not need to manually delegates to the class it inherits from, it can just do nothing.
- The generic SessionStore doesn't make much sense, is not typed correctly, and is not leveraged in any way. Just make it standard dynamic instead.

  Keep the `session_cls` param even though it seems completely unused, and technically `session_cls` doesn't even need to be a type however typing a callback with keyword argument support requires a `Protocol` and I can't be arsed, so type it is.
