### PR TITLE
[FIX] pos_loyalty: prevent adding unwanted product

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/models/pos_store.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_store.js
@@ -100,16 +100,6 @@ patch(PosStore.prototype, {
                         (reward.reward_type !== "product" ||
                             (reward.reward_type == "product" && !reward.multi_product))
                     ) {
-                        if (
-                            (reward.reward_type == "product" &&
-                                reward.program_id.applies_on !== "both") ||
-                            (reward.program_id.applies_on == "both" && reward.reward_product_qty)
-                        ) {
-                            this.addLineToCurrentOrder({
-                                product_id: reward.reward_product_id,
-                                qty: reward.reward_product_qty || 1,
-                            });
-                        }
                         order._applyReward(reward, coupon_id);
                         changed = true;
                     }

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_reward_button_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_reward_button_tour.js
@@ -39,6 +39,9 @@ registry.category("web_tour.tours").add("PosLoyaltyFreeProductTour", {
             ProductScreen.clickDisplayedProduct("Desk Organizer", true, "2.00"),
             ProductScreen.clickDisplayedProduct("Desk Organizer"),
             PosLoyalty.hasRewardLine("Free Product - Desk Organizer", "-5.10", "1.00"),
+            ProductScreen.clickNumpad("9"),
+            ProductScreen.selectedOrderlineHas("Desk Organizer", "9.00"),
+            PosLoyalty.hasRewardLine("Free Product - Desk Organizer", "-15.30", "3.00"),
             ProductScreen.clickNumpad("⌫"),
             ProductScreen.selectedOrderlineHas("Desk Organizer", "0.00"),
             ProductScreen.clickDisplayedProduct("Desk Organizer", true, "1.00"),
@@ -83,10 +86,11 @@ registry.category("web_tour.tours").add("PosLoyaltyFreeProductTour", {
             ProductScreen.clickDisplayedProduct("Magnetic Board"),
             ProductScreen.selectedOrderlineHas("Magnetic Board", "2.00"),
             ProductScreen.clickDisplayedProduct("Magnetic Board"),
+            ProductScreen.selectedOrderlineHas("Magnetic Board", "3.00"),
             PosLoyalty.hasRewardLine("Free Product - Whiteboard Pen", "-3.20", "1.00"),
             PosLoyalty.isRewardButtonHighlighted(false),
 
-            PosLoyalty.orderTotalIs("9.14"),
+            PosLoyalty.orderTotalIs("5.94"),
             PosLoyalty.finalizeOrder("Cash", "10"),
 
             // Promotion: 2 items of shelves, get desk_pad/monitor_stand free
@@ -150,6 +154,7 @@ registry.category("web_tour.tours").add("test_loyalty_free_product_rewards_2", {
             Chrome.startPoS(),
             Dialog.confirm("Open Register"),
 
+            ProductScreen.clickDisplayedProduct("Desk Organizer"),
             ProductScreen.clickDisplayedProduct("Desk Organizer"),
             ProductScreen.clickDisplayedProduct("Desk Organizer"),
             PosLoyalty.hasRewardLine("Free Product - Desk Organizer", "-5.10", "1.00"),

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -414,7 +414,7 @@ class TestUi(TestPointOfSaleHttpCommon):
                 'product_ids': self.desk_organizer,
                 'reward_point_amount': 1,
                 'reward_point_mode': 'order',
-                'minimum_qty': 2,
+                'minimum_qty': 3,
             })],
             'reward_ids': [(0, 0, {
                 'reward_type': 'product',


### PR DESCRIPTION
After commit https://github.com/odoo/odoo/commit/b86dd8f0674f02a14f4aaa10db39bd4a1e8270f1, an extra order line could be added unintentionally. For example, in a "Buy X Get Y" loyalty program, if you add the product and press 3x on the numpad, the system would incorrectly add 3x + 1 products to the order.

Moreover, the fix introduced in the above commit was not correct according to the program logic. For instance, if the configuration is set to "Grant: 1 credit per order" with a minimum quantity of 2, and the reward is for one point, then when ordering 2 products, one of them should indeed be free. The previous fix changed this intended behavior, resulting in incorrect reward application.

opw-5151979

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
