### PR TITLE
[FIX] pos_self_order: display correct order number and price on confi…

### DIFF
--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -673,7 +673,9 @@ export class SelfOrder extends Reactive {
                 order_access_tokens: accessTokens,
                 table_identifier: tableIdentifier,
             });
-            this.selectedOrderUuid = null;
+            if (this.router.activeSlot !== "confirmation") {
+                this.selectedOrderUuid = null;
+            }
             const result = this.models.connectNewData(data);
             const openOrder = result["pos.order"]?.find((o) => o.state === "draft");
             if (openOrder && this.router.activeSlot !== "confirmation") {


### PR DESCRIPTION
…rmation

**Steps to reproduce:**
- Have a self order with the mobile setting (QR menu + self ordering)
- Make a purchase, confirm it in the orders in the regular PoS
- Make another purchase
- The order number did not increase and "Pay X at the counter" is not displayed

**Why the fix:**
Before this commit, on the confirmation page, we displayed the self order's current order, which was not correctly set in the case of a mobile self order.

This is why we had the same order number (tracking_number) on the confirmation page. This is also why we did not display the "Pay X at the counter" part of the page, as the wrong order was chosen.

With the current flow, the selectedOrderUuid was set to null after an rpc call, and was only set back if there was an open order and the current screen was different from confirmation.
In this case, we had neither, because the current screen was confirmation and the function did not return any open order, as they are only considered open if they are older than the order we are currently working with.

So with this, the selectedOrderUuid was set to null, just to stay like this. We then used the fallback in the currentOrder's getter (which works fine with the kiosk but not on mobile, and that's why it only works in kiosk), which gave us the wrong order (the last paid order).

Right now, we do not set the selectedOrderUuid to null in the case where the current screen is the confirmation screen, as this seems to be the only issue we have with it.

I couldn't find a way to test this, as we need to confirm the order from the regular PoS, then go back to the self order
and make another sale.

opw-5112561