### PR TITLE
[FIX] point_of_sale: check LNA support for fetch

### DIFF
--- a/addons/point_of_sale/static/src/app/hardware_proxy/hardware_proxy_service.js
+++ b/addons/point_of_sale/static/src/app/hardware_proxy/hardware_proxy_service.js
@@ -34,6 +34,11 @@ export class HardwareProxy extends EventBus {
             },
             [this.connectionInfo]
         );
+
+        browser.navigator.permissions
+            ?.query({ name: "local-network-access" })
+            .then(() => (this.useLocalFetch = true))
+            .catch(() => (this.useLocalFetch = false));
     }
 
     setConnectionInfo(info) {
@@ -151,7 +156,7 @@ export class HardwareProxy extends EventBus {
             const response = await browser
                 .fetch(`${url}/hw_proxy/hello`, {
                     signal: timeoutController.signal,
-                    targetAddressSpace: "local",
+                    targetAddressSpace: this.useLocalFetch ? "local" : undefined,
                 })
                 .catch(() => ({}));
             if (response.ok) {


### PR DESCRIPTION
Enterprise PR: https://github.com/odoo/enterprise/pull/97266

In odoo/odoo#231014 we added the `targetAddressSpace` argument to `fetch` requests to prepare for the Local Network Access feature that will be enabled by default from Chrome 142. Unfortunately, it seems that adding this option breaks the `fetch` request in older versions of Chrome that are implementing the Private Network Access spec.

To fix this we detect if the permission is available in the browser, and only set the option if this is the case.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
