### PR TITLE
[FIX] html_builder: fix thumbnails for custom social inner snippets

### DIFF
--- a/addons/html_builder/static/src/snippets/snippet_service.js
+++ b/addons/html_builder/static/src/snippets/snippet_service.js
@@ -280,7 +280,7 @@ export class SnippetModel extends Reactive {
         if (!snippetKey) {
             return;
         }
-        return [...this.snippetStructures, ...this.snippetInnerContents].find(
+        return [...this.snippetInnerContents, ...this.snippetStructures].find(
             (snippet) => snippet.name === snippetKey
         );
     }

--- a/addons/website/static/tests/builder/snippet_custom.test.js
+++ b/addons/website/static/tests/builder/snippet_custom.test.js
@@ -1,4 +1,9 @@
-import { createTestSnippets, getSnippetStructure } from "@html_builder/../tests/helpers";
+import {
+    createTestSnippets,
+    getSnippetStructure,
+    getSnippetView,
+    getInnerContent,
+} from "@html_builder/../tests/helpers";
 import { Plugin } from "@html_editor/plugin";
 import { expect, test } from "@odoo/hoot";
 import { animationFrame } from "@odoo/hoot-dom";
@@ -85,4 +90,48 @@ test("Renaming custom snippets don't make an orm call", async () => {
     expect(
         ".o_add_snippet_dialog .o_add_snippet_iframe:iframe .o_custom_snippet_edit>span:contains('new custom name')"
     ).toHaveCount(1);
+});
+
+test("thumbnails are displayed on custom inner snippets even if they have the same name of a snippet structure", async () => {
+    const testSnippetContent = `<section class="s_test" data-snippet="s_test" data-name="test"><p>test snippet</p></section>`;
+    const structureSnippetDesc = {
+        name: "test",
+        groupName: "a",
+        content: testSnippetContent,
+    };
+    const innerContentDesc = {
+        name: "test",
+        content: testSnippetContent,
+        thumbnail: "/website/static/src/img/snippets_thumbs/s_countdown.svg",
+    };
+    const snippets = {
+        snippet_groups: [
+            '<div name="A" data-oe-thumbnail="a.svg" data-oe-snippet-id="123" data-o-snippet-group="a"><section data-snippet="s_snippet_group"></section></div>',
+            '<div name="Custom" data-oe-thumbnail="custom.svg" data-oe-snippet-id="123" data-o-snippet-group="custom"><section data-snippet="s_snippet_group"></section></div>',
+        ],
+        snippet_structure: [getSnippetStructure(structureSnippetDesc)],
+        snippet_content: [getInnerContent(innerContentDesc)],
+        snippet_custom: [],
+    };
+    onRpc("ir.ui.view", "save_snippet", ({ kwargs }) => {
+        const { name, arch, thumbnail_url } = kwargs;
+        const customSnippet = `<div name="${name}" data-oe-type="snippet" data-oe-snippet-id="123" data-o-image-preview="" data-oe-thumbnail="${thumbnail_url}" data-oe-keywords="">${arch}</div>`;
+        snippets.snippet_custom.push(customSnippet);
+        return name;
+    });
+    onRpc("ir.ui.view", "render_public_asset", (args) => getSnippetView(snippets));
+    await setupWebsiteBuilder(
+        `<div class="container">
+            <p>test</p>
+            ${testSnippetContent}
+        </div>`,
+        { snippets }
+    );
+    await contains(":iframe .s_test").click();
+    await contains("div[data-container-title='test'] button.oe_snippet_save").click();
+    await contains(".modal-dialog button.btn-primary").click();
+    await contains("button[data-name='blocks']").click();
+    expect("div.o_snippet[name='Custom test'] div.o_snippet_thumbnail_img").toHaveStyle({
+        "background-image": /url\(.*s_countdown/,
+    });
 });

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -173,7 +173,7 @@
                 <keywords>columns, containers, layouts, large, panels, modules</keywords>
             </t>
             <t t-snippet="website.s_popup" string="Popup" group="content" label="Popup"/>
-            <t t-snippet="website.s_countdown" string="Countdown" t-thumbnail="/website/static/src/img/snippets_thumbs/s_countdown.svg" group="content">
+            <t t-snippet="website.s_countdown" string="Countdown" group="content">
                 <keywords>celebration, launch</keywords>
             </t>
             <t t-snippet="website.s_numbers_charts" string="Numbers Charts" group="content">
@@ -248,7 +248,7 @@
 
             <!-- Keep `s_embed_code` snippet at the very end of the "Content" group -->
             <t t-snippet="website.s_embed_code" string="Embed Code" t-forbid-sanitize="true"
-                t-image-preview="/website/static/src/img/snippets_previews/s_embed_code_preview.png" t-thumbnail="/website/static/src/img/snippets_thumbs/s_embed_code.svg" group="content"/>
+                t-image-preview="/website/static/src/img/snippets_previews/s_embed_code_preview.png" group="content"/>
 
 
             <!-- Images group -->
@@ -379,7 +379,7 @@
             </t>
 
             <!-- Contact & Forms group -->
-            <t t-snippet="website.s_title_form" string="Title - Form" t-forbid-sanitize="form" t-thumbnail="/website/static/src/img/snippets_thumbs/s_website_form.svg" group="contact_and_forms">
+            <t t-snippet="website.s_title_form" string="Title - Form" t-forbid-sanitize="form" group="contact_and_forms">
                 <keywords>contact, collect, submission, input, fields, questionnaire, survey, registration, request</keywords>
             </t>
             <t t-snippet="website.s_opening_hours" string="Opening Hours" group="contact_and_forms"/>
@@ -459,11 +459,9 @@
                 <keywords>social media, fb, feed</keywords>
             </t>
             <t t-set="google_maps_api_key" t-value="request.env['website'].get_current_website().google_maps_api_key"/>
-            <t t-if="debug or not google_maps_api_key" t-snippet="website.s_map" string="Map"
-                t-thumbnail="/website/static/src/img/snippets_thumbs/s_map.svg" group="social"
+            <t t-if="debug or not google_maps_api_key" t-snippet="website.s_map" string="Map" group="social"
                 t-image-preview="/website/static/src/img/snippets_previews/s_map_preview.png"/>
-            <t t-if="debug or google_maps_api_key" t-snippet="website.s_google_map" string="Map"
-                t-thumbnail="/website/static/src/img/snippets_thumbs/s_google_map.svg" group="social"
+            <t t-if="debug or google_maps_api_key" t-snippet="website.s_google_map" string="Map" group="social"
                 t-image-preview="/website/static/src/img/snippets_previews/s_map_preview.png"/>
 
             <!-- Debug group -->


### PR DESCRIPTION
**Description of the Problem**

Custom inner snippets based on `s_facebook_page` and `s_instagram_page` do not display a thumbnail when listed in the “Custom Inner Content” section of the website builder.

**Why the Problem Happens**

Commit [1] introduced the ability to drop the Facebook and Instagram snippets both as inner content and as building blocks, by defining a snippet structure and a snippet inner content with the same name (`s_facebook_page` and `s_instagram_page`). Since commit [2], when a snippet structure and a snippet inner content share the same name, the thumbnail information is stored on both snippets to avoid problems, but this was not done in [1].

In `SnippetModel`, the thumbnail image for custom inner content is retrieved by the method `getSnippetThumbnailURL()`, which relies on `getOriginalSnippet()` to get the snippet object from its name. However, this workflow is not designed to handle cases where an inner content and a building block share the same name. `getOriginalSnippet()` searches for snippets first among `snippetStructures` and then among `snippetInnerContents`. If a name match is found in `snippetStructures`, the method attempts to retrieve the thumbnail URL from there. Since instagram and facebook snippet thumbnails are only defined in `snippetInnerContents`, no thumbnail was found.

**Proposed Solution**

This commit fixes the issue by reversing the search order in `getOriginalSnippet()`, so that `snippetInnerContents` are checked before `snippetStructures`. In this way, it is no more necessary to replicate the thumbnail info on both snippet when the name is shared.

[1]: https://github.com/odoo/odoo/commit/18b1170
[2]: https://github.com/odoo/odoo/commit/a40c360

task-5165956