### PR TITLE
[FIX] project: avoid enabling milestones during tour

### DIFF
--- a/addons/project/static/tests/tours/project_update_tour_tests.js
+++ b/addons/project/static/tests/tours/project_update_tour_tests.js
@@ -125,7 +125,6 @@ registry.category("web_tour.tours").add('project_update_tour', {
 }, {
     trigger: ".o_form_button_save",
     run: "click",
-    expectUnloadPage: true,
 }, {
     trigger: "button[name='action_view_tasks']",
     run: "click",

--- a/addons/project/tests/test_project_update_ui.py
+++ b/addons/project/tests/test_project_update_ui.py
@@ -6,5 +6,12 @@ from odoo.tests import HttpCase, tagged
 class TestProjectUpdateUi(HttpCase):
 
     def test_01_project_tour(self):
+        # Enable milestones to avoid a different behavior when running the tour with or without demo data.
+        # Indeed, when we check Milestones on the Settings tab of a newly created project,
+        # we ensure milestones are globally enabled. If the feature was disabled, it causes a full page reload.
+        # The tour step should then have a expectUnloadPage depending on whether milestones are already enabled.
+        # As it is too complicated to determine this value from the tour itself, we avoid this page reload completely.
+        self.env.ref('base.group_user').implied_ids |= self.env.ref('project.group_project_milestone')
+
         self.start_tour("/odoo", 'project_update_tour', login="admin")
         self.start_tour("/odoo", 'project_tour', login="admin")


### PR DESCRIPTION
When running test_01_project_tour, the milestones feature is enabled on one of the projects. When doing so, if the project_milestone global option isn't enabled, it gets enabled automatically.

When such a global feature is enabled while saving a project, the web client executes a reload_context action (see the onRecordSaved override in `@project/views/project_form/project_project_form_controller`). This is why the tour step that clicked on the save button got an `expectUnloadPage: true` attribute.

However, when the demo data are installed, some projects are already created, including projects that have the milestones feature enabled. Therefore, the global option does not get enabled during the tour, and the page does not get reloaded in this case.

With this commit, we enable the global option before running the tour, so that the behavior can be consistent between executions on databases where the demo data are or are not installed.

Runbot-build-error-id: [232962](https://runbot.odoo.com/odoo/runbot.build.error/232962)