### PR TITLE
[FIX] point_of_sale: small fixes for blackbox integration

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1687,9 +1687,17 @@ export class PosStore extends WithLazyGetterTrap {
             this.printOptions
         );
         if (!printBillActionTriggered) {
-            order.nb_print = order.nb_print ? order.nb_print + 1 : 1;
-            if (order.isSynced && result) {
-                await this.data.write("pos.order", [order.id], { nb_print: order.nb_print });
+            if (result) {
+                const count = order.nb_print ? order.nb_print + 1 : 1;
+                if (order.isSynced) {
+                    const wasDirty = order.isDirty();
+                    await this.data.write("pos.order", [order.id], { nb_print: count });
+                    if (!wasDirty) {
+                        order._dirty = false;
+                    }
+                } else {
+                    order.nb_print = count;
+                }
             }
         } else if (!order.nb_print) {
             order.nb_print = 0;

--- a/addons/point_of_sale/static/src/app/utils/order_payment_validation.js
+++ b/addons/point_of_sale/static/src/app/utils/order_payment_validation.js
@@ -109,7 +109,9 @@ export default class OrderPaymentValidation {
         if ((await this.askBeforeValidation()) === false) {
             return false;
         }
-        await this._askForCustomerIfRequired();
+        if ((await this._askForCustomerIfRequired()) === false) {
+            return false;
+        }
         this.pos.numberBuffer.capture();
         if (!this.checkCashRoundingHasBeenWellApplied()) {
             return false;

--- a/addons/pos_restaurant/views/res_config_settings_views.xml
+++ b/addons/pos_restaurant/views/res_config_settings_views.xml
@@ -26,7 +26,7 @@
                 </setting>
             </block>
             <div id="tip_product" position="after">
-                <div invisible="not pos_module_pos_restaurant or not pos_iface_tipproduct">
+                <div invisible="not pos_module_pos_restaurant or not pos_iface_tipproduct or country_code == 'BE'">
                     <field name="pos_set_tip_after_payment" class="oe_inline"/>
                     <label class="fw-normal" for="pos_set_tip_after_payment" string="Add tip after payment"/>
                 </div>


### PR DESCRIPTION
- Don't display the setting `pos_set_tip_after_payment` for belgian company.
- Correctly wait for customer to be choosen before validating the order.
- Before this commit, after doing `await this.data.write("pos.order", [order.id], { nb_print: order.nb_print });` the order was marked as dirty. This was causing issue for the next `sync_from_ui` causing this order to be resynced and then send twice to the blackbox.

task-id: 5011427


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
