### PR TITLE
[FIX] core: allow opening several temporary directories

### DIFF
--- a/odoo/orm/environments.py
+++ b/odoo/orm/environments.py
@@ -584,7 +584,7 @@ class Transaction:
         self.cache = Cache(self)
 
         # temporary directories (managed in odoo.tools.file_open_temporary_directory)
-        self.__file_open_tmp_paths = ()  # type: ignore # noqa: PLE0237
+        self.__file_open_tmp_paths = []  # type: ignore # noqa: PLE0237
 
     def flush(self) -> None:
         """ Flush pending computations and updates in the transaction. """

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -229,7 +229,7 @@ def file_path(file_path: str, filter_ext: tuple[str, ...] = ('',), env: Environm
         addons_paths = list(map(os.path.dirname, module.__path__))
     else:
         root_path = os.path.abspath(config.root_path)
-        temporary_paths = env.transaction._Transaction__file_open_tmp_paths if env else ()
+        temporary_paths = env.transaction._Transaction__file_open_tmp_paths if env else []
         addons_paths = [*odoo.addons.__path__, root_path, *temporary_paths]
 
     for addons_dir in addons_paths:
@@ -305,13 +305,12 @@ def file_open_temporary_directory(env: Environment):
     :param env: environment for which the temporary directory is created.
     :return: the absolute path to the created temporary directory
     """
-    assert not env.transaction._Transaction__file_open_tmp_paths, 'Reentrancy is not implemented for this method'
     with tempfile.TemporaryDirectory() as module_dir:
         try:
-            env.transaction._Transaction__file_open_tmp_paths = (module_dir,)
+            env.transaction._Transaction__file_open_tmp_paths.append(module_dir)
             yield module_dir
         finally:
-            env.transaction._Transaction__file_open_tmp_paths = ()
+            env.transaction._Transaction__file_open_tmp_paths.remove(module_dir)
 
 
 #----------------------------------------------------------


### PR DESCRIPTION
Before this commit, only one temporary directory can be opened concurrently, which prevents for example nested temporary directories.

This commit removes this limitation by adapting the __file_open_tmp_paths variable, which is now an array where we store opened temporary folders. It also adds tests about file_open(temporary_directory) methods.