### PR TITLE
[IMP] web: ace: qweb: add token for attributes that should not be cha…

### DIFF
--- a/addons/web/static/lib/ace/mode-qweb.js
+++ b/addons/web/static/lib/ace/mode-qweb.js
@@ -4,9 +4,18 @@ define("ace/mode/qweb_highlight_rules", ["require", "exports", "module", "ace/li
     var oop = require("../lib/oop");
     var XmlHighlightRules = require("./xml_highlight_rules").XmlHighlightRules;
 
-    var QWebHighlightRules = function () {
+    var QWebHighlightRules = function (options) {
         XmlHighlightRules.call(this);
         const xmlRules = this.$rules;
+
+        const attributes_display_custom = [];
+        if (options?.readonlyAttributes) {
+            const attrRegx = options.readonlyAttributes.join("|");
+            attributes_display_custom.push({
+                regex: `(${attrRegx})(=)(\\s*)(")([^"]*)(")`,
+                token: ["entity.other.attribute-name.xml.odoo_attr_readonly", "keyword.operator.attribute-equals.xml.odoo_attr_readonly", "text.odoo_attr_readonly", "string.attribute-value.xml.start.odoo_attr_readonly", "string.attribute-value.xml.code.odoo_attr_readonly", "string.attribute-value.xml.end.odoo_attr_readonly"],
+            })
+        }
 
         const tagRegex = xmlRules.attributes[0].regex;
 
@@ -14,6 +23,8 @@ define("ace/mode/qweb_highlight_rules", ["require", "exports", "module", "ace/li
             xmlRules,
             {
                 attributes: [{
+                    include: "attributes_display_custom",
+                }, {
                     include: "attributes_odoo",
                 }, {
                     include: "attributes_qweb",
@@ -22,6 +33,8 @@ define("ace/mode/qweb_highlight_rules", ["require", "exports", "module", "ace/li
                 }, {
                     include: "attributes_sample",
                 }],
+
+                attributes_display_custom,
 
                 attributes_odoo: [{
                     token: ["entity.other.attribute-name.xml.odoo", "keyword.operator.attribute-equals.xml", "text", "string.attribute-value.xml.start", "string.attribute-value.xml.code", "string.attribute-value.xml.end"],
@@ -102,15 +115,105 @@ define("ace/mode/qweb",["require","exports","module","ace/lib/oop","ace/lib/lang
     var oop = require("../lib/oop");
     var lang = require("../lib/lang");
     var TextMode = require("./text").Mode;
+    var TokenIterator = require("ace/token_iterator").TokenIterator;
     var QWebHighlightRules = require("./qweb_highlight_rules").QWebHighlightRules;
     var XmlBehaviour = require("./behaviour/xml").XmlBehaviour;
     var XmlFoldMode = require("./folding/xml").FoldMode;
     var WorkerClient = require("../worker/worker_client").WorkerClient;
+    const AceRange = require("ace/range").Range;
 
-    var Mode = function() {
-       this.HighlightRules = QWebHighlightRules;
-       this.$behaviour = new XmlBehaviour();
-       this.foldingRules = new XmlFoldMode();
+    function* getTokensInRange(session, range) {
+        const tokenIterator = new TokenIterator(session, range.start.row, range.start.column);
+        while (true) {
+            const token = tokenIterator.getCurrentToken();
+            if (!token) {
+                return;
+            }
+            const tRange = tokenIterator.getCurrentTokenRange();
+            if (!intersects(range, tRange, false)) {
+                return;
+            }
+            if (!intersects(range, tRange)) {
+                yield { ...token, tokenRange: tRange, edge: true };
+            } else {
+                yield { ...token, tokenRange: tRange };
+            }
+            tokenIterator.stepForward();
+        }
+    }
+
+    // See issue https://github.com/ajaxorg/ace/issues/5877
+    function intersects(r1, r2, exludeEnd=true) {
+        if (exludeEnd) {
+            r1 = new AceRange(r1.start.row, r1.start.column, r1.end.row, r1.end.column - 1)
+            r2 = new AceRange(r2.start.row, r2.start.column, r2.end.row, r2.end.column - 1)
+        }
+        return r1.intersects(r2)
+    }
+
+    function getOrphansReadonlyAttributesFromTokens(tokens) {
+        const readOnlys = [];
+        let currentTagRo = null;
+        for (const token of tokens) {
+            if (!token || token.edge) {
+                continue;
+            }
+            if (token.type === "meta.tag.punctuation.tag-open.xml") {
+                if (currentTagRo) {
+                    readOnlys.push(currentTagRo);
+                }
+                currentTagRo = [];
+            }
+            if (token.type === "meta.tag.punctuation.tag-close.xml") {
+                currentTagRo = null;
+            }
+            if (token.type?.includes(".odoo_attr_readonly")) {
+                (currentTagRo || readOnlys).push(token);
+            }
+        }
+        if (currentTagRo) {
+            readOnlys.push(currentTagRo);
+        }
+        return readOnlys.flat();
+    }
+
+    var Mode = function(options) {
+        this.HighlightRules = QWebHighlightRules;
+        this.$behaviour = new XmlBehaviour();
+
+        const highlightRulesConfig = {
+            ...(this.$highlightRuleConfig || {}),
+            ...(options.highlightRulesConfig || {}),
+        };
+        if (highlightRulesConfig.readonlyAttributes?.length) {
+            this.$highlightRuleConfig = {...highlightRulesConfig };
+            this.$behaviour.add("readonly_attr", "insertion", (state, action, editor, session, text) => {
+                const range = editor.getSelectionRange();
+                const tokensInRange = [...getTokensInRange(session, range)];
+
+                // do not insert anything if we are writing over an orphan readonly attribute
+                if (getOrphansReadonlyAttributesFromTokens(tokensInRange).length) {
+                    editor.selection.setSelectionRange(new AceRange(range.start.row, range.start.column, range.start.row, range.start.column));
+                    return { text: "" }
+                }
+
+                // Make sure we insert a space before a readonly attribute
+                const lastToken = tokensInRange.at(-1);
+                if (lastToken?.edge && !text.endsWith(" ") && lastToken?.type?.includes(".odoo_attr_readonly")) {
+                    return { text: text + " ", selection: [text.length, text.length] };
+                }
+            });
+
+            this.$behaviour.add("readonly_attr", "deletion", (state, action, editor, session, range) => {
+                // Cancels a deletion if we are deleting orphans readonly attributes
+                const tokensInRange = [...getTokensInRange(session, range)];
+                if (getOrphansReadonlyAttributesFromTokens(tokensInRange).length) {
+                    return new AceRange(range.start.row, range.start.column, range.start.row, range.start.column);
+                }
+            });
+        }
+
+        this.foldingRules = new XmlFoldMode();
     };
 
     oop.inherits(Mode, TextMode);

--- a/addons/web/static/src/core/code_editor/code_editor.js
+++ b/addons/web/static/src/core/code_editor/code_editor.js
@@ -10,6 +10,7 @@ export class CodeEditor extends Component {
             optional: true,
             validate: (mode) => CodeEditor.MODES.includes(mode),
         },
+        modeOptions: { type: Object, optional: true },
         value: { validate: (v) => typeof v === "string", optional: true },
         readonly: { type: Boolean, optional: true },
         onChange: { type: Function, optional: true },
@@ -152,7 +153,7 @@ export class CodeEditor extends Component {
                     });
                     sessions[sessionId] = session;
                 }
-                session.setMode(mode ? `ace/mode/${mode}` : "");
+                session.setMode(this.aceMode);
                 this.aceEditor.setSession(session);
             },
             () => [this.props.sessionId, this.props.mode, this.props.value]
@@ -176,5 +177,16 @@ export class CodeEditor extends Component {
                 });
             });
         }
+    }
+
+    get aceMode() {
+        const mode = this.props.mode;
+        if (mode) {
+            return {
+                path: `ace/mode/${mode}`,
+                ...(this.props.modeOptions || {}),
+            };
+        }
+        return "";
     }
 }

--- a/addons/web/static/tests/core/code_editor.test.js
+++ b/addons/web/static/tests/core/code_editor.test.js
@@ -1,7 +1,7 @@
 import { expect, test } from "@odoo/hoot";
 import { queryAll, queryAllTexts, queryOne } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
-import { Component, markup, useState, xml } from "@odoo/owl";
+import { Component, markup, reactive, useState, xml } from "@odoo/owl";
 import {
     contains,
     editAce,
@@ -12,6 +12,7 @@ import {
 } from "@web/../tests/web_test_helpers";
 
 import { CodeEditor } from "@web/core/code_editor/code_editor";
+import { pick } from "@web/core/utils/objects";
 import { debounce } from "@web/core/utils/timing";
 
 preloadBundle("web.ace_lib");
@@ -351,4 +352,72 @@ test("code editor can take an initial cursor position", async () => {
             value: "new\nvalue",
         },
     ]);
+});
+
+test("qweb mode readonly attributes", async () => {
+    class Parent extends Component {
+        static components = { CodeEditor };
+        static template = xml`<CodeEditor maxLines="10" mode="props.state.mode" value="props.state.value" modeOptions="props.state.modeOptions" initialCursorPosition="props.state.initialCursorPosition"/>`;
+        static props = ["*"];
+    }
+
+    const initialValue = `
+        <form lock-id="0" name="some_name" >
+        <div />
+        </form>
+        `.replace(/^\s*/gm, ""); // simple dedent;
+
+    const state = reactive({
+        value: initialValue,
+        mode: "qweb",
+        modeOptions: {
+            highlightRulesConfig: {
+                readonlyAttributes: ["lock-id"],
+            },
+        },
+        initialCursorPosition: { column: 17, row: 0 },
+    });
+
+    await mountWithCleanup(Parent, {
+        props: { state },
+    });
+    await animationFrame();
+    const editor = window.ace.edit(queryOne(".ace_editor"));
+    expect(document.activeElement).toBe(editor.textInput.getElement());
+
+    expect(".ace_editor .ace_odoo_attr_readonly").toHaveCount(5);
+
+    for (let i = 0; i < 'lock-id="0"'.length; i++) {
+        editor.commands.commands.backspace.exec(editor);
+    }
+    await animationFrame();
+    expect(editor.getValue()).toBe(initialValue);
+    expect(pick(editor.getSelection().getRange(), "start", "end")).toEqual({
+        start: {
+            row: 0,
+            column: 6,
+        },
+        end: {
+            row: 0,
+            column: 6,
+        },
+    });
+
+    editor.commands.commands.insertstring.exec(editor, 'lol="5"');
+    expect(editor.getValue()).toBe(
+        `
+        <form lol="5" lock-id="0" name="some_name" >
+        <div />
+        </form>
+        `.replace(/^\s*/gm, "")
+    );
+
+    editor.getSelection().selectLine();
+    editor.commands.commands.backspace.exec(editor);
+    expect(editor.getValue()).toBe(
+        `
+        <div />
+        </form>
+        `.replace(/^\s*/gm, "")
+    );
 });


### PR DESCRIPTION
…nged

This commit introduces two things:
- In the mode-qweb ace module that handles qweb XML A feature is added to pass a list of attributes that should not be removed if the parent tag is not removed at the same time.
Behaviors are added to make sure inserting or deleting in or around those readonly attribute do not modify them, at least in a best effort case.
- Options are now passable to the Ace edition mode via the CodeEditor This allows to make the feature described above parametrable.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
