### PR TITLE
[FIX] website_blog, web: use empty alt on author's avatar

### DIFF
--- a/addons/web/models/ir_qweb_fields.py
+++ b/addons/web/models/ir_qweb_fields.py
@@ -76,7 +76,7 @@ class IrQwebFieldImage(models.AbstractModel):
 
         if options.get('alt-field') and options['alt-field'] in record and record[options['alt-field']]:
             alt = escape(record[options['alt-field']])
-        elif options.get('alt'):
+        elif options.get('alt') is not None:
             alt = options['alt']
         else:
             alt = escape(record.display_name)
@@ -101,7 +101,7 @@ class IrQwebFieldImage(models.AbstractModel):
 
         img = ['<img']
         for name, value in atts.items():
-            if value:
+            if value is not None:
                 img.append(' ')
                 img.append(escape(name))
                 img.append('="')

--- a/addons/website_blog/views/website_blog_components.xml
+++ b/addons/website_blog/views/website_blog_components.xml
@@ -140,7 +140,7 @@
         <div t-if="blog_post.author_avatar"
              t-field="blog_post.author_avatar"
              style="line-height:1"
-             t-options='{"widget": "image", "class": "rounded-circle " + "o_wblog_author_avatar me-1" if hide_date else  "o_wblog_author_avatar_date me-2"}' />
+             t-options='{"widget": "image", "alt": "", "class": "rounded-circle " + "o_wblog_author_avatar me-1" if hide_date else  "o_wblog_author_avatar_date me-2"}' />
         <div t-att-class="not hide_date and 'small fw-bold'" style="line-height:1">
             <span t-if="editable" t-field="blog_post.author_id" t-options='{ "widget": "contact", "fields": ["name"]}'/>
             <span t-else="" t-out="blog_post.author_name"/>


### PR DESCRIPTION
On blog posts, the `alt` attribute on the author's avatar is the title of the post. It doesn't make sense and should be empty as it is a decorative image (see [W3C WAI]).
We could consider writing the author's name in the alt, but as it is already written right next to the avatar, the image should be considered decorative.

To make the empty alt appear after QWeb rendering, `IrQwebFieldImage.record_to_html` must be adapted to allow empty strings as values.

[W3C WAI]: https://www.w3.org/WAI/tutorials/images/decorative/

task-5187019