### PR TITLE
[FIX] website_event: translatable "Select a Date" for slots


### DIFF
--- a/addons/website_event/static/src/interactions/website_event_slot_details.js
+++ b/addons/website_event/static/src/interactions/website_event_slot_details.js
@@ -1,4 +1,5 @@
 import { deserializeDateTime } from "@web/core/l10n/dates";
+import { _t } from "@web/core/l10n/translation";
 import { Interaction } from "@web/public/interaction";
 import { registry } from "@web/core/registry";
 import { rpc } from "@web/core/network/rpc";
@@ -38,7 +39,7 @@ export class SlotDetails extends Interaction {
             "t-out": () => this.selectedSlotDatetime,
         },
         ".o_wevent_selected_slot_title": {
-            "t-out": () => this.selectedSlotId ? "Selected Date: " : "Select a Date: ",
+            "t-out": () => this.selectedSlotId ? _t("Selected Date:") : _t("Select a Date:"),
         },
     };
 


### PR DESCRIPTION
Scenario:

- adds slots to an event
- register to that event with another language

Result: "Selected Date" or "Select a Date" is not translated or
translatable.

Fix: wrap those JS strings with _t function.

opw-5167911
