### PR TITLE
[FIX] mail: let text url regex contain commas and end with dots

### DIFF
--- a/addons/link_tracker/models/mail_render_mixin.py
+++ b/addons/link_tracker/models/mail_render_mixin.py
@@ -10,7 +10,7 @@ from werkzeug import urls
 
 from odoo import api, models, tools
 from odoo.addons.link_tracker.tools.html import find_links_with_urls_and_labels
-from odoo.tools.mail import is_html_empty, URL_SKIP_PROTOCOL_REGEX, TEXT_URL_REGEX
+from odoo.tools.mail import is_html_empty, text_url_replace, URL_SKIP_PROTOCOL_REGEX, TEXT_URL_REGEX
 
 
 class MailRenderMixin(models.AbstractModel):
@@ -86,6 +86,6 @@ class MailRenderMixin(models.AbstractModel):
             link = self.env['link.tracker'].search_or_create([create_vals])
             if link.short_url:
                 # Ensures we only replace the same link and not a subpart of a longer one, multiple times if applicable
-                content = re.sub(re.escape(original_url) + r'(?![\w@:%.+&~#=/-])', link.short_url, content)
+                content = text_url_replace(original_url, link.short_url, content)
 
         return content

--- a/addons/link_tracker/tests/test_mail_render_mixin.py
+++ b/addons/link_tracker/tests/test_mail_render_mixin.py
@@ -227,7 +227,10 @@ This is a link: https://www.worldcommunitygrid.org
 This is another: {self.base_url}/odoo?debug=1&more=2
 A third: {self.base_url}
 A forth: {self.base_url}
-And a last, with question mark: https://boinc.berkeley.edu/forum_thread.php?id=14544&postid=106833"""
+One with question mark: https://boinc.berkeley.edu/forum_thread.php?id=14544&postid=106833&options=2,3. Ok.
+One with commas and dots without query: https://boinc.berkeley.edu/options/2,3/view, Should work too.
+One with many end dots: https://boinc.berkeley.edu/other_options/2,3/view...
+"""
 
         expected_pattern = re.compile(
             rf"""
@@ -235,7 +238,10 @@ This is a link: {self.base_url}/r/\w+
 This is another: {self.base_url}/r/\w+
 A third: {self.base_url}/r/(\w+)
 A forth: {self.base_url}/r/(\w+)
-And a last, with question mark: {self.base_url}/r/(\w+)"""
+One with question mark: {self.base_url}/r/(\w+)\. Ok\.
+One with commas and dots without query: {self.base_url}/r/(\w+), Should work too\.
+One with many end dots: {self.base_url}/r/(\w+)\.
+"""
         )
         with self.allow_requests(all_requests=True):  # Creating link will query url to infer title
             new_content = self.env["mail.render.mixin"]._shorten_links_text(content, {})

--- a/addons/mass_mailing_sms/models/sms_sms.py
+++ b/addons/mass_mailing_sms/models/sms_sms.py
@@ -4,7 +4,7 @@
 import re
 
 from odoo import fields, models
-from odoo.tools.mail import TEXT_URL_REGEX
+from odoo.tools.mail import text_url_replace, TEXT_URL_REGEX
 
 
 class SmsSms(models.Model):
@@ -28,6 +28,6 @@ class SmsSms(models.Model):
             body = sms.body
             for url in set(re.findall(TEXT_URL_REGEX, body)):
                 if url.startswith(sms.get_base_url() + '/r/'):
-                    body = re.sub(re.escape(url) + r'(?![\w@:%.+&~#=/-])', url + f'/s/{sms.id}', body)
+                    body = text_url_replace(url, url + f'/s/{sms.id}', body)
             res[sms.id] = body
         return res

--- a/addons/mass_mailing_sms/static/src/components/sms_widget/fields_sms_widget.js
+++ b/addons/mass_mailing_sms/static/src/components/sms_widget/fields_sms_widget.js
@@ -8,7 +8,7 @@ import { SmsWidget } from "@sms/components/sms_widget/fields_sms_widget";
 
 import { onWillStart } from "@odoo/owl";
 
-const TEXT_URL_REGEX = /https?:\/\/[\w@:%.+&~#=/-]+(?:\?\S+)?/g;  // from tools.mail.TEXT_URL_REGEX
+const TEXT_URL_REGEX = /https?:\/\/([\w@:%+&~#=/-]|[.,][^\s](?!$))+(?:\?(?:[^\s.,]|[.,][^\s](?!$))+)?/g;  // from tools.mail.TEXT_URL_REGEX
 
 /**
  * Patch to provide extra characters count information to

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -473,7 +473,10 @@ def html_sanitize(src, silent=True, sanitize_tags=True, sanitize_attributes=Fals
 
 URL_SKIP_PROTOCOL_REGEX = r'mailto:|tel:|sms:'
 URL_REGEX = rf'''(\bhref=['"](?!{URL_SKIP_PROTOCOL_REGEX})([^'"]+)['"])'''
-TEXT_URL_REGEX = r'https?://[\w@:%.+&~#=/-]+(?:\?\S+)?'
+TEXT_URL_ALLOWED_GROUP = r'[\w@:%+&~#=/-]|[.,][^\s](?!$)'  # defines what characters can be inside a URL
+TEXT_URL_REGEX = r'https?://'  # scheme
+TEXT_URL_REGEX += rf'(?:{TEXT_URL_ALLOWED_GROUP})+'  # domain + path
+TEXT_URL_REGEX += r'(?:\?(?:[^\s.,]|[.,][^\s](?!$))+)?'  # query parameters
 # retrieve inner content of the link
 HTML_TAG_URL_REGEX = URL_REGEX + r'([^<>]*>([^<>]+)<\/)?'
 HTML_TAGS_REGEX = re.compile('<.*?>')
@@ -949,6 +952,11 @@ def url_domain_extract(url):
     if company_hostname and '.' in company_hostname:
         return '.'.join(company_hostname.split('.')[-2:])  # remove subdomains
     return False
+
+
+def text_url_replace(original_url, new_url, text):
+    """Replace an url with another inside some arbitrary text. Avoids matching sub-urls."""
+    return re.sub(re.escape(original_url) + rf'(?!{TEXT_URL_ALLOWED_GROUP})', new_url, text)
 
 def email_escape_char(email_address):
     """ Escape problematic characters in the given email address string"""


### PR DESCRIPTION
Currently a valid url like: `https://www.odoo.com/1,2,3/test`

Will only be matched up to the first comma: `https://www.odoo.com/1`

As we use commas quite often for tag urls, they should be supported.

Additionally one should be able to write: "For more info, go to `https://www.odoo.com/`." without the url containing a random dot.

We can assume commas and dots should only be matched if they're not followed by spaces or the end of the line.

task-4876650
