### PR TITLE
[FIX] base: no debug asset path for binaries

### DIFF
--- a/odoo/addons/base/models/assetsbundle.py
+++ b/odoo/addons/base/models/assetsbundle.py
@@ -143,8 +143,9 @@ class AssetsBundle(object):
         return self.external_assets + response
 
     def get_link(self, asset_type):
-        unique = self.get_version(asset_type) if not self.is_debug_assets else 'debug'
-        extension = asset_type if self.is_debug_assets else f'min.{asset_type}'
+        use_debug = self.is_debug_assets and not self.has_binary
+        unique = self.get_version(asset_type) if not use_debug else 'debug'
+        extension = asset_type if use_debug else f'min.{asset_type}'
         return self.get_asset_url(unique=unique, extension=extension)
 
     def get_version(self, asset_type):


### PR DESCRIPTION
When [1] introduced binary assets, the fact that the path generated by `t-call-assets="..." t-binary="True"` would include `/debug/` was overseen.
Because of this, when such a `t-call-assets` is used, the generated link does not reach a recognized URL.

This commit neutralizes the debug mode when generating the links to binary assets.

[1]: https://github.com/odoo/odoo/commit/a5c02da5c24bfc85b3bbb7d1410d489d3c7185b8

task-5170716
