### PR TITLE
[FIX] point_of_sale: load all pos categories

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -107,6 +107,8 @@
 
             'point_of_sale/static/src/app/utils/html-to-image.js',
             'point_of_sale/static/src/app/services/render_service.js',
+            'point_of_sale/static/src/app/components/category_selector/utils.js',
+
             'point_of_sale/static/tests/unit/**/*',
 
             'point_of_sale/static/src/app/components/odoo_logo/*',

--- a/addons/point_of_sale/models/pos_category.py
+++ b/addons/point_of_sale/models/pos_category.py
@@ -37,12 +37,8 @@ class PosCategory(models.Model):
 
     @api.model
     def _load_pos_data_domain(self, data):
-        domain = []
-        limited_categories = data['pos.config'][0]['limit_categories']
-        if limited_categories:
-            available_category_ids = data['pos.config'][0]['iface_available_categ_ids']
-            domain += [('id', 'in', available_category_ids)]
-        return domain
+        """ Ensure all categories are loaded. """
+        return []
 
     @api.model
     def _load_pos_data_fields(self, config_id):

--- a/addons/point_of_sale/static/src/app/components/category_selector/category_selector.js
+++ b/addons/point_of_sale/static/src/app/components/category_selector/category_selector.js
@@ -1,7 +1,7 @@
 import { Component } from "@odoo/owl";
 import { usePos } from "@point_of_sale/app/hooks/pos_hook";
 import { useService } from "@web/core/utils/hooks";
-import { pick } from "@web/core/utils/objects";
+import { getCategoriesAndSub } from "./utils";
 
 export class CategorySelector extends Component {
     static template = "point_of_sale.CategorySelector";
@@ -13,55 +13,25 @@ export class CategorySelector extends Component {
     }
 
     getCategoriesList(list, allParents, depth) {
-        const categoriesList = [...list];
-        list.forEach((item) => {
-            if (item.id === allParents[depth]?.id && item.child_ids?.length) {
-                categoriesList.push(
-                    ...this.getCategoriesList(item.child_ids, allParents, depth + 1)
-                );
-            }
-        });
-        return categoriesList;
+        // This method is kept for backward compatibility
+        return [];
     }
 
     getCategoriesAndSub() {
-        const { limit_categories, iface_available_categ_ids } = this.pos.config;
-        let rootCategories = this.pos.models["pos.category"].getAll();
-        if (limit_categories && iface_available_categ_ids.length > 0) {
-            rootCategories = iface_available_categ_ids;
-        }
-        rootCategories = rootCategories
-            .filter((category) => !category.parent_id)
-            .sort((a, b) => a.sequence - b.sequence);
-        const selected = this.pos.selectedCategory ? [this.pos.selectedCategory] : [];
-        const allParents = selected.concat(this.pos.selectedCategory?.allParents || []).reverse();
-        return this.getCategoriesList(rootCategories, allParents, 0)
-            .flat(Infinity)
-            .map(this.getChildCategoriesInfo, this);
+        return getCategoriesAndSub(this.pos);
     }
 
     getAncestorsAndCurrent() {
-        const selectedCategory = this.pos.selectedCategory;
-        return selectedCategory
-            ? [undefined, ...selectedCategory.allParents, selectedCategory]
-            : [selectedCategory];
+        // This method is kept for backward compatibility
+        return [];
     }
 
     getChildCategoriesInfo(category) {
-        return {
-            ...pick(category, "id", "name", "color"),
-            imgSrc:
-                this.pos.config.show_category_images && category.has_image
-                    ? `/web/image?model=pos.category&field=image_128&id=${category.id}`
-                    : undefined,
-            isSelected: this.getAncestorsAndCurrent().includes(category),
-            isChildren: this.getChildCategories(this.pos.selectedCategory).includes(category),
-        };
+        // This method is kept for backward compatibility
+        return {};
     }
-
     getChildCategories(selectedCategory) {
-        return selectedCategory
-            ? [...selectedCategory.child_ids]
-            : this.pos.models["pos.category"].filter((category) => !category.parent_id);
+        // This method is kept for backward compatibility
+        return [];
     }
 }

--- a/addons/point_of_sale/static/src/app/components/category_selector/utils.js
+++ b/addons/point_of_sale/static/src/app/components/category_selector/utils.js
@@ -1,0 +1,79 @@
+import { pick } from "@web/core/utils/objects";
+
+export function getCategoriesAndSub(pos) {
+    const displayableCategories = getDisplayableCategories(pos);
+    const selectedCategory = pos.selectedCategory;
+    const displayableCategoriesSet = new Set(displayableCategories);
+    const rootCategories = displayableCategories
+        .filter(
+            (category) => !category.parent_id || !displayableCategoriesSet.has(category.parent_id)
+        )
+        .sort((a, b) => a.sequence - b.sequence);
+    const selected = selectedCategory ? [selectedCategory] : [];
+    const allParents = selected
+        .concat(getAllParents(selectedCategory, displayableCategoriesSet))
+        .reverse();
+    return getCategoriesList(rootCategories, allParents, displayableCategoriesSet, 0)
+        .flat(Infinity)
+        .map((cat) => getChildCategoriesInfo(pos, cat, rootCategories, displayableCategoriesSet));
+}
+
+function getCategoriesList(list, allParents, displayableCategoriesSet, depth) {
+    const categoriesList = [...list];
+    list.forEach((item) => {
+        if (item.id === allParents[depth]?.id) {
+            const children = getChildren(item, displayableCategoriesSet);
+            if (children.length) {
+                categoriesList.push(
+                    ...getCategoriesList(children, allParents, displayableCategoriesSet, depth + 1)
+                );
+            }
+        }
+    });
+    return categoriesList;
+}
+
+function getDisplayableCategories(pos) {
+    const { limit_categories, iface_available_categ_ids } = pos.config;
+    if (limit_categories && iface_available_categ_ids.length > 0) {
+        return iface_available_categ_ids;
+    }
+    return pos.models["pos.category"].getAll();
+}
+
+export function getAncestorsAndCurrent(selectedCategory, displayableCategoriesSet) {
+    return selectedCategory
+        ? [selectedCategory, ...getAllParents(selectedCategory, displayableCategoriesSet)]
+        : [];
+}
+
+function getAllParents(category, displayableCategoriesSet) {
+    return category?.allParents.filter((cat) => displayableCategoriesSet.has(cat)) || [];
+}
+
+function getChildren(category, displayableCategoriesSet) {
+    return (
+        category.child_ids
+            ?.filter((child) => displayableCategoriesSet.has(child))
+            .sort((a, b) => a.sequence - b.sequence) || []
+    );
+}
+
+export function getChildCategoriesInfo(pos, category, rootCategories, displayableCategoriesSet) {
+    const selectedCategory = pos.selectedCategory;
+
+    return {
+        ...pick(category, "id", "name", "color"),
+        imgSrc:
+            pos.config.show_category_images && category.has_image
+                ? `/web/image?model=pos.category&field=image_128&id=${category.id}`
+                : undefined,
+        isSelected: getAncestorsAndCurrent(selectedCategory, displayableCategoriesSet).includes(
+            category
+        ),
+        isChildren: (selectedCategory
+            ? getChildren(selectedCategory, displayableCategoriesSet)
+            : rootCategories
+        ).includes(category),
+    };
+}

--- a/addons/point_of_sale/static/tests/pos/tours/utils/preparation_receipt_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/preparation_receipt_util.js
@@ -48,7 +48,6 @@ export function checkPreparationTicketData(
     opts = {
         visibleInDom: [],
         invisibleInDom: [],
-        lineOrder: [],
         type: "new", // can be "new", "cancelled" or "noteUpdate"
     }
 ) {
@@ -56,6 +55,12 @@ export function checkPreparationTicketData(
         const ticket = generatePreparationReceiptElement(opts.type || "new");
         const lines = ticket.querySelectorAll(".orderline");
         const lineNames = [];
+
+        if (data.length !== lines.length) {
+            throw new Error(
+                `Ticket data mismatch: expected ${data.length} lines, but printed ${lines.length}.`
+            );
+        }
 
         let idx = 0;
         for (const line of lines) {
@@ -65,15 +70,15 @@ export function checkPreparationTicketData(
             const attrs = domAttrs.map((c) => c.innerHTML).filter(Boolean);
             const values = data[idx];
 
-            if (values.qty != qty) {
-                throw new Error(
-                    `Ticket data mismatch for ${name}: expected ${values.qty}, got ${qty}`
-                );
-            }
-
             if (values.name != name) {
                 throw new Error(
                     `Ticket data mismatch for ${name}: expected ${values.name}, got ${name}, maybe lines ordering ?`
+                );
+            }
+
+            if (values.qty != qty) {
+                throw new Error(
+                    `Ticket data mismatch for ${name}: expected ${values.qty}, got ${qty}`
                 );
             }
 

--- a/addons/point_of_sale/static/tests/unit/category_selector.test.js
+++ b/addons/point_of_sale/static/tests/unit/category_selector.test.js
@@ -1,0 +1,374 @@
+import { expect, test, describe, beforeEach } from "@odoo/hoot";
+import { getCategoriesAndSub } from "@point_of_sale/app/components/category_selector/utils";
+
+class MockCategory {
+    constructor(props = {}) {
+        for (const [key, value] of Object.entries(props)) {
+            this[key] = value;
+        }
+    }
+
+    get allParents() {
+        // TODO avoid mock >= 18.3
+        const parents = [];
+        let parent = this.parent_id;
+
+        if (!parent) {
+            return parents;
+        }
+
+        while (parent) {
+            parents.unshift(parent);
+            parent = parent.parent_id;
+        }
+
+        return parents.reverse();
+    }
+}
+
+class FakePos {
+    categories = [];
+    config = {};
+    selectedCategory = null;
+
+    constructor() {
+        this.models = {
+            "pos.category": {
+                getAll: () => this.categories,
+            },
+        };
+    }
+}
+
+// Helper functions
+function assertCategory(category, expected) {
+    expect(category.id).toBe(expected.id);
+    expect(category.name).toBe(expected.name);
+    expect(category.isChildren).toBe(expected.isChildren);
+    expect(category.isSelected).toBe(expected.isSelected);
+}
+
+function assertCategories(categories, expectedCategories) {
+    expect(categories.length).toBe(expectedCategories.length);
+    expectedCategories.forEach((expected, index) => {
+        assertCategory(categories[index], expected);
+    });
+}
+
+describe("Without restricted categories", () => {
+    describe("Without child categories", () => {
+        beforeEach(() => {
+            this.pos = new FakePos();
+            this.food = new MockCategory({ id: 1, name: "Food", parent_id: null, sequence: 1 });
+            this.drinks = new MockCategory({ id: 2, name: "Drinks", parent_id: null, sequence: 2 });
+            this.pos.categories = [this.drinks, this.food]; // Intentionally unsorted
+        });
+
+        test("return root categories sorted by sequence", () => {
+            const categories = getCategoriesAndSub(this.pos);
+            assertCategories(categories, [
+                { id: 1, name: "Food", isChildren: true, isSelected: false },
+                { id: 2, name: "Drinks", isChildren: true, isSelected: false },
+            ]);
+        });
+
+        test("mark category as selected", () => {
+            this.pos.selectedCategory = this.drinks;
+            const categories = getCategoriesAndSub(this.pos);
+
+            assertCategories(categories, [
+                { id: 1, name: "Food", isChildren: false, isSelected: false },
+                { id: 2, name: "Drinks", isChildren: false, isSelected: true },
+            ]);
+        });
+
+        test("update selection state when switching between categories", () => {
+            this.pos.selectedCategory = this.drinks;
+            getCategoriesAndSub(this.pos);
+
+            this.pos.selectedCategory = this.food;
+            const categories = getCategoriesAndSub(this.pos);
+
+            assertCategories(categories, [
+                { id: 1, name: "Food", isChildren: false, isSelected: true },
+                { id: 2, name: "Drinks", isChildren: false, isSelected: false },
+            ]);
+        });
+
+        test("reset to default state when category is unselected", () => {
+            this.pos.selectedCategory = this.food;
+            getCategoriesAndSub(this.pos);
+
+            this.pos.selectedCategory = null;
+            const categories = getCategoriesAndSub(this.pos);
+
+            assertCategories(categories, [
+                { id: 1, name: "Food", isChildren: true, isSelected: false },
+                { id: 2, name: "Drinks", isChildren: true, isSelected: false },
+            ]);
+        });
+    });
+
+    describe('With child categories"', () => {
+        beforeEach(() => {
+            this.pos = new FakePos();
+
+            // Food hierarchy: Food > Burger > Best Burger
+            this.food = new MockCategory({ id: 1, name: "Food", parent_id: null, sequence: 1 });
+            this.burger = new MockCategory({
+                id: 2,
+                name: "Burger",
+                parent_id: this.food,
+                sequence: 2,
+            });
+            this.bestBurger = new MockCategory({
+                id: 3,
+                name: "Best Burger",
+                parent_id: this.burger,
+                sequence: 3,
+            });
+            this.food.child_ids = [this.burger];
+            this.burger.child_ids = [this.bestBurger];
+
+            // Drinks hierarchy: Drinks > [Soft, Cocktail]
+            this.drinks = new MockCategory({ id: 4, name: "Drinks", parent_id: null, sequence: 4 });
+            this.soft = new MockCategory({
+                id: 6,
+                name: "Soft",
+                parent_id: this.drinks,
+                sequence: 6,
+            });
+            this.cocktail = new MockCategory({
+                id: 5,
+                name: "Cocktail",
+                parent_id: this.drinks,
+                sequence: 7,
+            });
+            this.drinks.child_ids = [this.cocktail, this.soft];
+
+            this.pos.categories = [
+                this.food,
+                this.burger,
+                this.bestBurger,
+                this.drinks,
+                this.cocktail, //Unsorted on purpose
+                this.soft,
+            ];
+        });
+
+        test("return only root categories when no category is selected", () => {
+            const categories = getCategoriesAndSub(this.pos);
+
+            assertCategories(categories, [
+                { id: 1, name: "Food", isChildren: true, isSelected: false },
+                { id: 4, name: "Drinks", isChildren: true, isSelected: false },
+            ]);
+        });
+
+        test("show immediate children when root category is selected", () => {
+            this.pos.selectedCategory = this.food;
+            const categories = getCategoriesAndSub(this.pos);
+
+            assertCategories(categories, [
+                { id: 1, name: "Food", isChildren: false, isSelected: true },
+                { id: 4, name: "Drinks", isChildren: false, isSelected: false },
+                { id: 2, name: "Burger", isChildren: true, isSelected: false },
+            ]);
+        });
+
+        test("show parent categories when second-level category is selected", () => {
+            this.pos.selectedCategory = this.burger;
+            const categories = getCategoriesAndSub(this.pos);
+
+            assertCategories(categories, [
+                { id: 1, name: "Food", isChildren: false, isSelected: true },
+                { id: 4, name: "Drinks", isChildren: false, isSelected: false },
+                { id: 2, name: "Burger", isChildren: false, isSelected: true },
+                { id: 3, name: "Best Burger", isChildren: true, isSelected: false },
+            ]);
+        });
+
+        test("show parent categories when third-level category is selected", () => {
+            this.pos.selectedCategory = this.bestBurger;
+            const categories = getCategoriesAndSub(this.pos);
+
+            assertCategories(categories, [
+                { id: 1, name: "Food", isChildren: false, isSelected: true },
+                { id: 4, name: "Drinks", isChildren: false, isSelected: false },
+                { id: 2, name: "Burger", isChildren: false, isSelected: true },
+                { id: 3, name: "Best Burger", isChildren: false, isSelected: true },
+            ]);
+        });
+
+        test("show children sorted by sequence when parent is selected", () => {
+            this.pos.selectedCategory = this.drinks;
+            const categories = getCategoriesAndSub(this.pos);
+
+            // Soft (sequence: 6) should come before Cocktail (sequence: 7)
+            assertCategories(categories, [
+                { id: 1, name: "Food", isChildren: false, isSelected: false },
+                { id: 4, name: "Drinks", isChildren: false, isSelected: true },
+                { id: 6, name: "Soft", isChildren: true, isSelected: false },
+                { id: 5, name: "Cocktail", isChildren: true, isSelected: false },
+            ]);
+        });
+
+        test("switch to different category", () => {
+            this.pos.selectedCategory = this.cocktail;
+            const categories = getCategoriesAndSub(this.pos);
+
+            assertCategories(categories, [
+                { id: 1, name: "Food", isChildren: false, isSelected: false },
+                { id: 4, name: "Drinks", isChildren: false, isSelected: true },
+                { id: 6, name: "Soft", isChildren: false, isSelected: false },
+                { id: 5, name: "Cocktail", isChildren: false, isSelected: true },
+            ]);
+        });
+    });
+});
+
+describe("With restricted categories", () => {
+    describe("Without child categories", () => {
+        beforeEach(() => {
+            this.pos = new FakePos();
+            this.food = new MockCategory({ id: 1, name: "Food", parent_id: null, sequence: 1 });
+            this.drinks = new MockCategory({ id: 2, name: "Drinks", parent_id: null, sequence: 3 });
+            this.hiddenRoot = new MockCategory({
+                id: 3,
+                name: "Hidden",
+                parent_id: null,
+                sequence: 1,
+            });
+
+            this.pos.categories = [this.drinks, this.food, this.hiddenRoot]; //All categories are loaded
+            this.pos.config.limit_categories = true;
+            this.pos.config.iface_available_categ_ids = [this.drinks, this.food];
+        });
+
+        test("return only restricted categories", () => {
+            const categories = getCategoriesAndSub(this.pos);
+            assertCategories(categories, [
+                { id: 1, name: "Food", isChildren: true, isSelected: false },
+                { id: 2, name: "Drinks", isChildren: true, isSelected: false },
+            ]);
+        });
+
+        test("select category", () => {
+            this.pos.selectedCategory = this.drinks;
+            const categories = getCategoriesAndSub(this.pos);
+            assertCategories(categories, [
+                { id: 1, name: "Food", isChildren: false, isSelected: false },
+                { id: 2, name: "Drinks", isChildren: false, isSelected: true },
+            ]);
+        });
+    });
+
+    describe("With sub categories", () => {
+        beforeEach(() => {
+            this.pos = new FakePos();
+            this.food = new MockCategory({ id: 1, name: "Food", parent_id: null, sequence: 1 });
+            this.foodHidden = new MockCategory({
+                id: 99,
+                name: "foodHidden",
+                parent_id: this.food,
+                sequence: 1,
+            });
+            this.food.child_ids = [this.foodHidden];
+
+            this.drinks = new MockCategory({ id: 2, name: "Drinks", parent_id: null, sequence: 3 });
+            this.soft = new MockCategory({
+                id: 6,
+                name: "Soft",
+                parent_id: this.drinks,
+                sequence: 6,
+            });
+            this.cocktail = new MockCategory({
+                id: 5,
+                name: "Cocktail",
+                parent_id: this.drinks,
+                sequence: 7,
+            });
+
+            this.drinkHidden = new MockCategory({
+                id: 93,
+                name: "drinkHidden",
+                parent_id: this.drinks,
+                sequence: 1,
+            });
+
+            this.drinks.child_ids = [this.cocktail, this.soft, this.drinkHidden];
+
+            this.pos.categories = [
+                this.drinks,
+                this.food,
+                this.soft,
+                this.cocktail,
+                this.drinkHidden,
+                this.foodHidden,
+            ]; //All categories are loaded
+            this.pos.config.limit_categories = true;
+            this.pos.config.iface_available_categ_ids = [
+                this.drinks,
+                this.food,
+                this.soft,
+                this.cocktail,
+            ];
+        });
+
+        test("show only restricted sub categories", () => {
+            assertCategories(getCategoriesAndSub(this.pos), [
+                { id: 1, name: "Food", isChildren: true, isSelected: false },
+                { id: 2, name: "Drinks", isChildren: true, isSelected: false },
+            ]);
+
+            //select food (the hidden cat is not displayed)
+            this.pos.selectedCategory = this.food;
+            assertCategories(getCategoriesAndSub(this.pos), [
+                { id: 1, name: "Food", isChildren: false, isSelected: true },
+                { id: 2, name: "Drinks", isChildren: false, isSelected: false },
+            ]);
+
+            //select drink (the hidden cat is not displayed)
+            this.pos.selectedCategory = this.drinks;
+            assertCategories(getCategoriesAndSub(this.pos), [
+                { id: 1, name: "Food", isChildren: false, isSelected: false },
+                { id: 2, name: "Drinks", isChildren: false, isSelected: true },
+                { id: 6, name: "Soft", isChildren: true, isSelected: false },
+                { id: 5, name: "Cocktail", isChildren: true, isSelected: false },
+            ]);
+        });
+
+        test("show third level category as root if the second level category is hidden", () => {
+            this.superDrink = new MockCategory({
+                id: 999,
+                name: "Super cocktail",
+                parent_id: this.cocktail,
+                sequence: 999,
+            });
+            this.cocktail.child_ids = [this.superDrink];
+
+            //cocktail is not available
+            this.pos.config.iface_available_categ_ids = [
+                this.food,
+                this.drinks,
+                this.soft,
+                this.superDrink,
+            ];
+
+            this.pos.categories.push(this.superDrink);
+
+            assertCategories(getCategoriesAndSub(this.pos), [
+                { id: 1, name: "Food", isChildren: true, isSelected: false },
+                { id: 2, name: "Drinks", isChildren: true, isSelected: false },
+                { id: 999, name: "Super cocktail", isChildren: true, isSelected: false },
+            ]);
+            this.pos.selectedCategory = this.drinks;
+            assertCategories(getCategoriesAndSub(this.pos), [
+                { id: 1, name: "Food", isChildren: false, isSelected: false },
+                { id: 2, name: "Drinks", isChildren: false, isSelected: true },
+                { id: 999, name: "Super cocktail", isChildren: false, isSelected: false },
+                { id: 6, name: "Soft", isChildren: true, isSelected: false },
+            ]);
+        });
+    });
+});

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -2706,9 +2706,10 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
         self.main_pos_config.open_ui()
         loaded_data = self.main_pos_config.current_session_id.load_data([])
-        category_id = [category['id'] for category in loaded_data['pos.category']]
-        self.assertNotIn(children_categs[0].id, category_id, "Child category is unavailable and shouldn't appear in the POS")
-        self.assertIn(children_categs[1].id, category_id, "Child category is available and should appear in the POS")
+        category_ids = [category['id'] for category in loaded_data['pos.category']]
+        self.assertIn(parent_categ.id, category_ids)
+        self.assertIn(children_categs[0].id, category_ids)
+        self.assertIn(children_categs[1].id, category_ids)
 
     def test_pos_order_shipping_date(self):
         self.env['res.partner'].create({

--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -449,7 +449,9 @@ export class SelfOrder extends Reactive {
     }
 
     initData() {
-        this.productCategories = this.models["pos.category"].getAll();
+        this.productCategories = this.config.iface_available_categ_ids.length
+            ? this.config.iface_available_categ_ids
+            : this.models["pos.category"].getAll();
         this.productByCategIds = this.models["product.template"].getAllBy("pos_categ_ids");
 
         const excludedProductTemplateIds = new Set(


### PR DESCRIPTION
Since this PR https://github.com/odoo/odoo/pull/225658, if the POS category of a combo item product was not listed under the restricted categories but was assigned to a preparation printer, the item would not be printed by the preparation printer.

A test was already present to check this, but the validation method was incorrect  (test_restricted_categories_combo_product)

This commit ensures that all POS categories are loaded, preventing any category from being missed.

Enterprise PR: https://github.com/odoo/enterprise/pull/97333


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
