### PR TITLE
[FIX] l10n_sa_edi: keep sign of tax base for exempt line

### DIFF
--- a/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py
+++ b/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py
@@ -446,7 +446,7 @@ class AccountEdiXmlUBL21Zatca(models.AbstractModel):
             'tax_subtotal_vals': [{
                 'currency': invoice.currency_id,
                 'currency_dp': invoice.currency_id.decimal_places,
-                'taxable_amount': abs(vals['base_amount_currency']),
+                'taxable_amount': vals['base_amount_currency'] if vals['tax_amount'] == 0 else abs(vals['base_amount_currency']),
                 'tax_amount': abs(vals['tax_amount_currency']),
                 'percent': vals['_tax_category_vals_']['percent'],
                 'tax_category_vals': vals['_tax_category_vals_'],


### PR DESCRIPTION
Adding a negative line with 0% tax on an invoice will make the validation succeed with a warning

Steps to reproduce (with a SA company setup):

- Create an invoice
- Add a negative line with 0% tax
- Confirm and send to Zatca

Issue:

The following warning can be observed in chatter

[202] BR-O-08 : [BR-O-08]-In a VAT
breakdown (BG-23) where the VAT category code (BT-118) is ' Not subject to VAT' the VAT category taxable amount (BT-116) shall equal the sum of Invoice line net amounts (BT-131) minus the sum of Document level allowance amounts (BT-92) plus the sum of Document level charge amounts (BT-99) where the VAT category codes (BT-151, BT-95, BT-102) are 'Not subject to VAT'.

This occurs because in the e-invoice, the tax base is transmitted in absolute value

opw-5072577