### PR TITLE
[IMP] mail: link attachments to record in mass mail

### DIFF
--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -1208,7 +1208,10 @@ class MailComposeMessage(models.TransientModel):
                 mail_values['attachment_ids'] = process_record._process_attachments_for_post(
                     decoded_attachments,
                     attachment_ids,
-                    {'model': 'mail.message', 'res_id': 0}
+                    {'model': 'mail.message', 'res_id': 0} if (
+                        not hasattr(record, "_process_attachments_for_post")
+                        or (self.auto_delete and not self.auto_delete_keep_log)
+                    ) else {}  # link to record if kept in chatter, for ease of access
                 )['attachment_ids']
             # comment mode: prepare attachments as a list of IDs, to be processed by MailThread
             else:

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -2882,6 +2882,9 @@ class TestComposerResultsMass(TestMailComposer):
                                   default_template_id=self.template.id)
         ))
         composer = composer_form.save()
+        composer.attachment_ids = self.env['ir.attachment'].sudo().create(
+            self._generate_attachments_data(1, res_model=composer._name, res_id=composer.id)
+        )
         self.assertTrue(composer.reply_to_force_new, 'Should use template reply-to value')
         with self.mock_mail_gateway(mail_unlink_sent=True):
             composer._action_send_mail()
@@ -2907,6 +2910,11 @@ class TestComposerResultsMass(TestMailComposer):
             self.assertEqual(message.subject, 'TemplateSubject %s' % record.name)
             self.assertEqual(message.body, '<p>TemplateBody %s</p>' % record.name)
             self.assertEqual(message.author_id, self.user_employee.partner_id)
+            self.assertEqual(len(message.attachment_ids), 1)
+            self.assertEqual(message.attachment_ids.res_model, record._name)
+            self.assertEqual(message.attachment_ids.res_id, record.id)
+            self.assertEqual(composer.attachment_ids.name, message.attachment_ids.name)
+            self.assertEqual(composer.attachment_ids.datas, message.attachment_ids.datas)
             # post-related fields are void
             self.assertFalse(message.subtype_id)
             self.assertFalse(message.partner_ids)


### PR DESCRIPTION
In [1] the argument to link attachments to messages was that it would automatically clean up the attachments when the message is deleted (typically right after sending). As it originally was kept forever, as we wanted to guarantee that it still exists by the time the email is sent.

However in modern ODOO mass emails can, and often are, logged in the chatter. In that case it is relevant to link the attachments to the record directly so that users can see the attachments in the attachments menu of the chatter.

[1]: https://github.com/odoo/odoo/commit/cf214ed7244207f1fd5d377ab69d85a6441ff665

task-4829625
