### PR TITLE
[FIX] purchase: prevent access error in branch companies

### DIFF
--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -520,7 +520,8 @@ class PurchaseOrderLine(models.Model):
         if seller and (seller.product_uom_id or seller.product_tmpl_id.uom_id) != product_uom:
             uom_po_qty = product_id.uom_id._compute_quantity(uom_po_qty, seller.product_uom_id, rounding_method='HALF-UP')
 
-        product_taxes = product_id.supplier_taxes_id.filtered(lambda x: x.company_id in company_id.parent_ids)
+        tax_domain = self.env['account.tax']._check_company_domain(company_id)
+        product_taxes = product_id.supplier_taxes_id.filtered_domain(tax_domain)
         taxes = po.fiscal_position_id.map_tax(product_taxes)
 
         if seller:

--- a/addons/purchase/tests/test_access_rights.py
+++ b/addons/purchase/tests/test_access_rights.py
@@ -1,8 +1,10 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from odoo.addons.account.tests.common import AccountTestInvoicingCommon
-from odoo.tests import Form, tagged
+
+from odoo import Command
 from odoo.exceptions import AccessError
+from odoo.tests import Form, tagged
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 
 
 @tagged('post_install', '-at_install')
@@ -46,6 +48,11 @@ class TestPurchaseInvoice(AccountTestInvoicingCommon):
             'standard_price': 200.0,
             'list_price': 180.0,
             'type': 'service',
+        })
+
+        cls.supplierinfo = cls.env['product.supplierinfo'].create({
+            'partner_id': cls.vendor.id,
+            'product_id': cls.product.id,
         })
 
     def test_create_purchase_order(self):
@@ -135,3 +142,27 @@ class TestPurchaseInvoice(AccountTestInvoicingCommon):
             'uom_id': uom.id,
         })
         self.assertTrue(product, "The default purchase UOM should be in the same category as the sale UOM.")
+
+    def test_prepare_purchase_order_line_from_branch_company(self):
+        """Check that a purchase order line can be created from a nested branch company."""
+        self.env.company.child_ids = [Command.create({
+            'name': "Test Branch",
+            'child_ids': [Command.create({'name': "Nested Branch"})],
+        })]
+        nested_branch = self.env.company.child_ids.child_ids
+        self.purchase_user.write({
+            'company_ids': [Command.set(nested_branch.ids)],
+            'company_id': nested_branch.id,
+        })
+
+        PurchaseOrder = self.env['purchase.order'].with_user(self.purchase_user)
+        order = PurchaseOrder.create({'partner_id': self.vendor.id})
+        nested_branch = nested_branch.with_env(PurchaseOrder.env)
+        product = self.product.with_env(PurchaseOrder.env)
+        supplierinfo = self.supplierinfo.with_env(PurchaseOrder.env)
+
+        self.env.invalidate_all()
+        po_line_vals = PurchaseOrder.order_line._prepare_purchase_order_line(
+            product, 1, product.uom_id, nested_branch, supplierinfo, order,
+        )
+        self.assertTrue(PurchaseOrder.order_line.create(po_line_vals))


### PR DESCRIPTION
Versions
--------
- saas-18.4+

Steps
-----
1. Create a branch company B;
2. create a branch C for the branch company B;
3. change to branch C;
4. create a warehouse;
5. enable dropshipping;
6. add a vendor to a stored product with the Dropship route enabled;
7. log in as a sales user with access to branch C only;
8. add product to a sales order & confirm.

Issue
-----
> Access Error
> Uh-oh! Looks like you have stumbled upon some top-secret records.
> Sorry, Marc Demo (id=5) doesn't have 'read' access to:
> - Companies, YourBranch (res.company: 3)

Cause
-----
The error gets thrown during the `_prepare_purchase_order_line` method, specifically on the line which filters `supplier_taxes_id` using `lambda x: x.company_id in company_id.parent_ids`.

This passes via the field's `convert_to_record` method, which attempts to access the `active` field of the companies to filter out any that are archived[^1].

[^1]: https://github.com/odoo/odoo/blob/5b911a97a3885283d2f21ac30abb96cb10fe39d9/odoo/orm/fields_relational.py#L608-L612

In previous versions, this wasn't an issue, because the `active` field was still present in cache from the `_compute_parent_ids` which is called with `sudo`, but as of saas-18.4, it attempts to refetch these values, leading to the error.

Solution
--------
Instead of using `filtered`, use `filtered_domain` using the result of `account.tax._get_company_domain`.

opw-5112625