### PR TITLE
[IMP] website: improve Google Fonts GDPR compliance with cookies bar

### DIFF
--- a/addons/website/static/src/builder/plugins/font/add_font_dialog.js
+++ b/addons/website/static/src/builder/plugins/font/add_font_dialog.js
@@ -51,7 +51,7 @@ export class AddFontDialog extends Component {
         valid: true,
         loading: false,
         googleFontFamily: undefined,
-        googleServe: true,
+        googleServe: !this.env.services.website.currentWebsite.cookies_bar,
         uploadedFontName: undefined,
         uploadedFonts: [],
         uploadedFontFaces: undefined,

--- a/addons/website/static/src/builder/plugins/font/add_font_dialog.xml
+++ b/addons/website/static/src/builder/plugins/font/add_font_dialog.xml
@@ -50,7 +50,7 @@
                     </div>
                     <label class="col-form-label col-md-4" for="google_font_serve">
                         Serve font from Google servers
-                        <sup class="text-info" title="To comply with some local regulations">
+                        <sup class="text-info" title="Use Google’s servers for fonts. It may impact GDPR compliance">
                             <a target="_blank" href="https://www.odoo.com/forum/help-1/how-to-use-google-fonts-and-respecting-german-requirements-214049">?</a>
                         </sup>
                     </label>

--- a/addons/website/static/src/services/website_service.js
+++ b/addons/website/static/src/services/website_service.js
@@ -276,6 +276,7 @@ export const websiteService = {
                             name: {},
                             language_ids: {},
                             default_lang_id: { fields: { code: {} } },
+                            cookies_bar: {},
                         },
                     })
                 ).records;

--- a/addons/website/views/res_config_settings_views.xml
+++ b/addons/website/views/res_config_settings_views.xml
@@ -215,7 +215,7 @@
                         </setting>
                         <setting
                             id="website_cookies_bar_setting"
-                            help="Display a customizable cookies bar on your website"
+                            help="Display a customizable cookies bar on your website. Please ensure your site is GDPR-compliant (e.g. Google Fonts usage)."
                             documentation="/applications/websites/website/configuration/cookies_bar.html"
                         >
                             <field name="website_cookies_bar"/>


### PR DESCRIPTION
__Current behavior before commit:__
When the cookies bar is installed, Google fonts are still loaded from Google servers by default, which may violate GDPR requirements.

See the PR adding the "Serve from Google"[1] option for more details.

__Description of the change:__
If the cookies bar is enabled, it likely means that the website needs to be GDPR compliant. In this case the "Serve from Google" option is disabled by default when adding a new Google Font, preventing it from being served from Google servers.
The tooltip and setting help text are also updated to clarify GDPR implications.

[1]: https://github.com/odoo/odoo/pull/101129

task-5111612