### PR TITLE
[IMP] point_of_sale: test button for epos printers

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -83,6 +83,7 @@
             'point_of_sale/static/src/backend/pos_payment_provider_cards/*',
             'point_of_sale/static/src/app/hooks/hooks.js',
             'point_of_sale/static/src/backend/many2many_placeholder_list_view/*',
+            'point_of_sale/static/src/backend/test_epos/*',
         ],
         "web.assets_web_dark": [
             'point_of_sale/static/src/scss/pos_dashboard.dark.scss',

--- a/addons/point_of_sale/static/src/app/utils/printer/epson_printer.js
+++ b/addons/point_of_sale/static/src/app/utils/printer/epson_printer.js
@@ -67,6 +67,7 @@ export class EpsonPrinter extends BasePrinter {
             const res = await fetch(this.address, {
                 method: "POST",
                 body: img,
+                signal: AbortSignal.timeout(15000),
             });
             const body = await res.text();
             const parser = new DOMParser();

--- a/addons/point_of_sale/static/src/backend/test_epos/test_epos.js
+++ b/addons/point_of_sale/static/src/backend/test_epos/test_epos.js
@@ -1,0 +1,94 @@
+import { Component } from "@odoo/owl";
+import { registry } from "@web/core/registry";
+import { standardWidgetProps } from "@web/views/widgets/standard_widget_props";
+import { _t } from "@web/core/l10n/translation";
+import { useService } from "@web/core/utils/hooks";
+
+const EPSON_ERRORS = {
+    DeviceNotFound: _t(
+        "Check the printer configuration for the 'Device ID' setting.\nIt should be set to: 'local_printer'"
+    ),
+    EPTR_AUTOMATICAL: _t(
+        "Continuous printing of high-density printing caused a printing error. Please retry later"
+    ),
+    EPTR_COVER_OPEN: _t("Printer cover is open, please close it before printing"),
+    EPTR_CUTTER: _t("The cutter has a foreign matter, please check the cutter mechanism"),
+    EPTR_MECHANICAL: _t("Mechanical error, please check the printer"),
+    EPTR_REC_EMPTY: _t("The paper is empty, please load paper into the printer"),
+    EPTR_UNRECOVERABLE: _t("Low voltage unrecoverable error occured, please check the printer"),
+    EX_BADPORT: _t("The device is not connected, please check the printer power / connection"),
+    EX_TIMEOUT: _t("Timeout occured, please try again"),
+};
+
+export class TestEPos extends Component {
+    static template = `point_of_sale.TestEPosButton`;
+    static props = {
+        ...standardWidgetProps,
+    };
+
+    setup() {
+        super.setup();
+        this.notification = useService("notification");
+    }
+
+    _getReceipt() {
+        return `
+        <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+            <s:Body>
+                <epos-print xmlns="http://www.epson-pos.com/schemas/2011/03/epos-print">
+                    <feed line="1" />
+                    <text align="center">This is a test receipt&#10;</text>
+                    <feed line="3" />
+                    <cut type="feed" />
+                </epos-print>
+            </s:Body>
+        </s:Envelope>`;
+    }
+
+    async onClick() {
+        try {
+            const data = this.props.record.data;
+            const printer_ip =
+                data.epson_printer_ip !== undefined
+                    ? data.epson_printer_ip
+                    : data.pos_epson_printer_ip;
+            if (!printer_ip) {
+                throw new Error("No printer IP configured");
+            }
+            const url = window.location.protocol + "//" + printer_ip;
+            this.address = url + "/cgi-bin/epos/service.cgi?devid=local_printer";
+            // Parse response
+            const result = await fetch(this.address, {
+                method: "POST",
+                body: this._getReceipt(),
+                signal: AbortSignal.timeout(15000),
+            });
+            const body = await result.text();
+            const parser = new DOMParser();
+            const parsedBody = parser.parseFromString(body, "application/xml");
+            const response = parsedBody.querySelector("response");
+            const success = response.getAttribute("success") === "true";
+            const errorCode = response.getAttribute("code");
+            if (!success || errorCode !== "") {
+                const errorMessage =
+                    EPSON_ERRORS[errorCode] ||
+                    _t("Failed to print a test receipt. Check your printer.");
+                this.notification.add(errorMessage, { type: "warning" });
+            } else {
+                this.notification.add(_t("Succesfully printed a test receipt"), { type: "info" });
+            }
+        } catch {
+            this.notification.add(
+                _t(
+                    "Failed to reach the printer. Check the configured url. Make sure that the printer is online and you are on the same network."
+                ),
+                { type: "danger" }
+            );
+        }
+    }
+}
+
+export const TestEPosWidget = {
+    component: TestEPos,
+};
+registry.category("view_widgets").add("point_of_sale_test_epos", TestEPosWidget);

--- a/addons/point_of_sale/static/src/backend/test_epos/test_epos_button.xml
+++ b/addons/point_of_sale/static/src/backend/test_epos/test_epos_button.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="point_of_sale.TestEPosButton">
+        <button type="button"
+                class="btn btn-secondary"
+                data-tooltip="Test"
+                aria-label="Test"
+                t-on-click.stop="onClick">
+            Test
+        </button>
+    </t>
+
+</templates>

--- a/addons/point_of_sale/views/pos_config_view.xml
+++ b/addons/point_of_sale/views/pos_config_view.xml
@@ -53,12 +53,19 @@
                         <setting id="other_devices" string="ePos Printer" help="Connect device to your PoS without an IoT Box">
                             <field name="other_devices" />
                             <div class="content-group" invisible="not other_devices">
-                                <field name="epson_printer_ip" placeholder="Epson Receipt Printer IP Address" />
-                                <div class="row" invisible="epson_printer_ip in [False, '']">
-                                    <div class="col-lg-5 o_light_label">
-                                        <label string="Cashdrawer" for="iface_cashdrawer"/>
+                                <div class="row">
+                                    <div class="col-lg-6">
+                                        <field name="epson_printer_ip" placeholder="Epson Receipt Printer IP Address" />
                                     </div>
-                                    <div class="col-lg-7">
+                                    <div class="col-lg-6">
+                                        <widget name="point_of_sale_test_epos" invisible="epson_printer_ip in [False, '']"/>
+                                    </div>
+                                </div>
+                                <div class="row" invisible="epson_printer_ip in [False, '']">
+                                    <div class="col-lg-6 o_light_label">
+                                        <label string="Link Cashdrawer" for="iface_cashdrawer"/>
+                                    </div>
+                                    <div class="col-lg-6">
                                         <field name="iface_cashdrawer"/>
                                     </div>
                                 </div>

--- a/addons/point_of_sale/views/pos_printer_view.xml
+++ b/addons/point_of_sale/views/pos_printer_view.xml
@@ -5,6 +5,7 @@
         <field name="arch" type="xml">
             <form string="POS Printer">
                 <sheet>
+                <group>
                     <group>
                         <field name="company_id" invisible="1" />
                         <field name="name" />
@@ -13,6 +14,12 @@
                         <field name="proxy_ip" invisible="printer_type != 'iot'"/>
                         <field name="product_categories_ids" />
                     </group>
+                    <group>
+                        <div style="display:flex; justify-content:flex-end; align-items:flex-start; height:100%;">
+                            <widget name="point_of_sale_test_epos" invisible="printer_type != 'epson_epos' or epson_printer_ip in [False, '']"/>
+                        </div>
+                    </group>
+                </group>
                 </sheet>
             </form>
         </field>

--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -392,10 +392,15 @@
                             <block title="Connected Devices" id="pos_connected_devices_section">
                                 <setting id="pos_other_devices" string="ePos Printer" help="Connect device to your PoS without an IoT Box" documentation="/applications/sales/point_of_sale/configuration/epos_ssc.html">
                                     <field name="pos_other_devices"/>
-                                    <div class="content-group" invisible="not pos_other_devices">
-                                        <field name="pos_epson_printer_ip" placeholder="Epson Receipt Printer IP Address" />
+                                    <div class="row" invisible="not pos_other_devices">
+                                        <div class="col-lg-6">
+                                            <field name="pos_epson_printer_ip" placeholder="Epson Receipt Printer IP Address" />
+                                        </div>
+                                        <div class="col-lg-6">
+                                            <widget name="point_of_sale_test_epos" invisible="pos_epson_printer_ip in [False, '']"/>
+                                        </div>
                                         <div class="row" invisible="pos_epson_printer_ip in [False, '']">
-                                            <label string="Cashdrawer" for="pos_iface_cashdrawer" class="col-lg-3 o_light_label"/>
+                                            <label string="Link Cashdrawer" for="pos_iface_cashdrawer" class="col-lg-3 o_light_label"/>
                                             <field name="pos_iface_cashdrawer"/>
                                         </div>
                                     </div>


### PR DESCRIPTION
This PR adds a test button to all the views in point of sale where the epos printer can be configured (pos config / res config and preparation printer)

When clicked a test receipt is printed on the epos printer or else an error is shown like "no paper" / "failed to reach printer" etc.

Finally it adds a timeout of 15s to Epos printing which isn't there now

Task-5153542
