### PR TITLE
[IMP] l10n_us: determine clearing_number label more accurately

### DIFF
--- a/addons/l10n_us/models/res_partner_bank.py
+++ b/addons/l10n_us/models/res_partner_bank.py
@@ -20,13 +20,10 @@ class ResPartnerBank(models.Model):
         required=True
     )
 
-    @api.depends('country_code', 'acc_type')
+    @api.depends('country_code', 'bank_id', 'acc_type')
     def _compute_show_aba_routing(self):
         for bank in self:
-            if bank.country_code == 'US' and bank.acc_type != 'iban':
-                bank.show_aba_routing = True
-            else:
-                bank.show_aba_routing = False
+            bank.show_aba_routing = (bank.bank_id.country_code or bank.country_code) == 'US' and bank.acc_type != 'iban'
 
     @api.constrains('clearing_number')
     def _check_clearing_number_us(self):


### PR DESCRIPTION
Whether to display "Clearing Number" or "ABA/routing" should depend on the country the bank is in, not the country the account holder is in. It's possible to own foreign bank accounts.

We keep the country of the partner as a fallback in case the bank is not set or has an incomplete address.

task-5052996
