### PR TITLE
[FIX] website: create test menu for edit_menus_delete_parent

### DIFF
--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -656,6 +656,12 @@ class TestUi(HttpCaseWithWebsiteUser):
 
     def test_website_edit_menus_delete_parent(self):
         website = self.env['website'].browse(1)
+        self.env['website.menu'].create({
+            'name': 'Test Child Menu',
+            'url': '/test-child',
+            'website_id': website.id,
+            'parent_id': website.menu_id.id,
+        })
         menu_tree = self.env['website.menu'].get_tree(website.id)
 
         parent_menu = menu_tree['children'][0]['fields']


### PR DESCRIPTION
Description
- The test was failing because the default "Contact us" menu was removed
  In commit https://github.com/odoo/odoo/pull/223724. 

Fix
- Created a test menu to ensure the test has two menus to work with.

runbot-233330


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
