### PR TITLE
[FIX] html_editor: fix video url handling for facebook videos

### DIFF
--- a/addons/html_editor/static/src/main/media/media_dialog/video_selector.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/video_selector.js
@@ -144,7 +144,7 @@ export class VideoSelector extends Component {
                     "";
                 if (src) {
                     this.state.urlInput = src;
-                    if (!src.includes("https:") && !src.includes("http:")) {
+                    if (!src.startsWith("https:") && !src.startsWith("http:")) {
                         this.state.urlInput = "https:" + this.state.urlInput;
                     }
                     await this.syncOptionsWithUrl();


### PR DESCRIPTION
This PR improves the changes made in PR #215204.

When embedding facebook videos, the url looks like
`"//facebook.com/plugins/video.php?href=https://www.facebook.com/username/videos/{video_id}/"`
after embedding, so we need to check for "https:" and "http:"
with method `startsWith` instead of `includes`.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
