### PR TITLE
[IMP] base*: Improve logging traceability by linking to Odoo records

### DIFF
--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -545,16 +545,6 @@ class BaseAutomation(models.Model):
         for automation in self:
             automation.webhook_uuid = str(uuid4())
 
-    def action_view_webhook_logs(self):
-        self.ensure_one()
-        return {
-            'type': 'ir.actions.act_window',
-            'name': _('Webhook Logs'),
-            'res_model': 'ir.logging',
-            'view_mode': 'list,form',
-            'domain': [('path', '=', "base_automation(%s)" % self.id)],
-        }
-
     def _get_trigger_specific_field(self):
         self.ensure_one()
         match self.trigger:
@@ -592,9 +582,11 @@ class BaseAutomation(models.Model):
             'type': 'server',
             'dbname': self.env.cr.dbname,
             'level': 'INFO',
-            'path': "base_automation(%s)" % self.id,
+            'path': "base_automation/models/base_automation.py",
             'func': '',
-            'line': ''
+            'line': '',
+            'res_model': self._name,
+            'res_id': self.id,
         }
         defaults.update(**values)
         return defaults

--- a/addons/base_automation/views/base_automation_views.xml
+++ b/addons/base_automation/views/base_automation_views.xml
@@ -8,15 +8,6 @@
             <field name="arch" type="xml">
                 <form string="Automation Rule">
                     <sheet>
-                        <div class="oe_button_box" name="button_box">
-                            <button groups="base.group_no_one" invisible="trigger != 'on_webhook'"
-                                type="object"
-                                name="action_view_webhook_logs"
-                                string="Logs"
-                                class="oe_stat_button"
-                                icon="fa-list"
-                            />
-                        </div>
                         <field name="active" invisible="1" />
                         <field name="model_name" invisible="1" force_save="True" />
                         <widget name="web_ribbon" title="Archived" bg_color="bg-danger" invisible="active"/>

--- a/addons/delivery/models/delivery_carrier.py
+++ b/addons/delivery/models/delivery_carrier.py
@@ -367,14 +367,18 @@ class DeliveryCarrier(models.Model):
                 with db_registry.cursor() as cr:
                     env = api.Environment(cr, SUPERUSER_ID, {})
                     IrLogging = env['ir.logging']
-                    IrLogging.sudo().create({'name': 'delivery.carrier',
-                              'type': 'server',
-                              'dbname': db_name,
-                              'level': 'DEBUG',
-                              'message': xml_string,
-                              'path': self.delivery_type,
-                              'func': func,
-                              'line': 1})
+                    IrLogging.sudo().create({
+                        'name': 'delivery.carrier',
+                        'type': 'server',
+                        'dbname': db_name,
+                        'level': 'DEBUG',
+                        'message': xml_string,
+                        'path': self.delivery_type,
+                        'func': func,
+                        'line': 1,
+                        'res_model': self._name,
+                        'res_id': self.id
+                    })
             except psycopg2.Error:
                 pass
 

--- a/addons/web/static/src/views/debug_items.js
+++ b/addons/web/static/src/views/debug_items.js
@@ -416,3 +416,42 @@ export function manageAttachments({ component, env }) {
 }
 
 debugRegistry.category("form").add("manageAttachments", manageAttachments);
+
+//------------------------------------------------------------------------------
+// Manage Debug logs
+//------------------------------------------------------------------------------
+
+export function manageIrLogging({ component, env }) {
+    const resId = component.model.root.resId;
+    if (!resId) {
+        return null; // No record
+    }
+    const description = _t("Logging");
+    return {
+        type: "item",
+        description,
+        callback: () => {
+            env.services.action.doAction({
+                res_model: "ir.logging",
+                name: description,
+                views: [
+                    [false, "list"],
+                    [false, "form"],
+                ],
+                type: "ir.actions.act_window",
+                domain: [
+                    ["res_model", "=", component.props.resModel],
+                    ["res_id", "=", resId],
+                ],
+                context: {
+                    default_res_model: component.props.resModel,
+                    default_res_id: resId,
+                },
+            });
+        },
+        sequence: 160,
+        section: "record",
+    };
+}
+
+debugRegistry.category("form").add("manageIrLogging", manageIrLogging);

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -1118,7 +1118,7 @@ class IrActionsServer(models.Model):
                 cr.execute("""
                     INSERT INTO ir_logging(create_date, create_uid, type, dbname, name, level, message, path, line, func, res_model, res_id)
                     VALUES (NOW() at time zone 'UTC', %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-                """, (self.env.uid, 'server', self.env.cr.dbname, __name__, level, message, "action", action.id, action.name, action.id, action._name))
+                """, (self.env.uid, 'server', self.env.cr.dbname, __name__, level, message, "action", action.id, action.name, action._name, action.id))
 
         eval_context = super(IrActionsServer, self)._get_eval_context(action=action)
         model_name = action.model_id.sudo().model

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -1116,9 +1116,9 @@ class IrActionsServer(models.Model):
         def log(message, level="info"):
             with self.pool.cursor() as cr:
                 cr.execute("""
-                    INSERT INTO ir_logging(create_date, create_uid, type, dbname, name, level, message, path, line, func)
-                    VALUES (NOW() at time zone 'UTC', %s, %s, %s, %s, %s, %s, %s, %s, %s)
-                """, (self.env.uid, 'server', self.env.cr.dbname, __name__, level, message, "action", action.id, action.name))
+                    INSERT INTO ir_logging(create_date, create_uid, type, dbname, name, level, message, path, line, func, res_model, res_id)
+                    VALUES (NOW() at time zone 'UTC', %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                """, (self.env.uid, 'server', self.env.cr.dbname, __name__, level, message, "action", action.id, action.name, action.id, action._name))
 
         eval_context = super(IrActionsServer, self)._get_eval_context(action=action)
         model_name = action.model_id.sudo().model

--- a/odoo/addons/base/models/ir_logging.py
+++ b/odoo/addons/base/models/ir_logging.py
@@ -32,6 +32,8 @@ class IrLogging(models.Model):
     path = fields.Char(required=True)
     func = fields.Char(string='Function', required=True)
     line = fields.Char(required=True)
+    res_model = fields.Char(string="Related Model Name", help="Model name of the object from which the logging originates, if applicable")
+    res_id = fields.Integer(string="Resource ID", help="Database ID of record from which the logging originates, if applicable")
 
     def init(self):
         super(IrLogging, self).init()

--- a/odoo/addons/base/views/ir_logging_views.xml
+++ b/odoo/addons/base/views/ir_logging_views.xml
@@ -17,6 +17,8 @@
                         <field name="path" />
                         <field name="line" />
                         <field name="func" />
+                        <field name="res_model"/>
+                        <field name="res_id"/>
                         <field name="message" />
                     </group>
                 </sheet>
@@ -48,6 +50,8 @@
                     <field name="name" />
                     <field name="level" />
                     <field name="message" />
+                    <field name="res_model"/>
+                    <field name="res_id"/>
                     <group>
                         <filter string="Database" name="database" domain="[]" context="{'group_by': 'dbname'}" />
                         <filter string="Level" name="group_by_level" domain="[]" context="{'group_by': 'level'}" />


### PR DESCRIPTION
Adds `res_model` and `res_id` fields to `ir.logging` to establish a direct, explicit link between a log entry and the Odoo record it pertains to (e.g., during external API calls).

Previously, this relation was established indirectly by injecting record information as a string into the `path` field, requiring manual filtering.

This improvement:
- Simplifies Log Retrieval: Replaces string matching with standard relational fields.
- Enhances Usability: Allows developers to instantly jump to related log entries via the debug menu, bypassing the need to navigate to the logging menu and apply filters.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
