### PR TITLE
[FIX] pos_sale: Correctly update qty_invoiced

### DIFF
--- a/addons/pos_sale/models/sale_order.py
+++ b/addons/pos_sale/models/sale_order.py
@@ -91,7 +91,7 @@ class SaleOrderLine(models.Model):
             if all(picking.state == 'done' for picking in pos_lines.order_id.picking_ids):
                 sale_line.qty_delivered += sum((self._convert_qty(sale_line, pos_line.qty, 'p2s') for pos_line in pos_lines if sale_line.product_id.type != 'service'), 0)
 
-    @api.depends('pos_order_line_ids.qty')
+    @api.depends('pos_order_line_ids.qty', 'pos_order_line_ids.order_id.state')
     def _compute_qty_invoiced(self):
         super()._compute_qty_invoiced()
         for sale_line in self:

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -1647,6 +1647,82 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         self.main_pos_config.open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_selected_partner_quotation_loading', login="accountman")
 
+    def test_backend_settle_refund(self):
+        """Make sure that sale orders settled in PoS and refunded in the backend get their invoiced quantity updated correctly."""
+
+        product_a = self.env['product.product'].create({
+            'name': 'Product A',
+            'available_in_pos': True,
+            'lst_price': 10.0,
+            'taxes_id': [],
+        })
+
+        partner_test = self.env['res.partner'].create({'name': 'Test Partner'})
+
+        sale_order = self.env['sale.order'].create({
+            'partner_id': partner_test.id,
+            'order_line': [(0, 0, {
+                'product_id': product_a.id,
+                'name': product_a.name,
+                'product_uom_qty': 1,
+                'product_uom': product_a.uom_id.id,
+                'price_unit': product_a.lst_price,
+            })],
+        })
+        sale_order.action_confirm()
+        self.main_pos_config.open_ui()
+        current_session = self.main_pos_config.current_session_id
+
+        pos_order = {
+           'amount_paid': 10,
+           'amount_return': 0,
+           'amount_tax': 0,
+           'amount_total': 10,
+           'date_order': fields.Datetime.to_string(fields.Datetime.now()),
+           'fiscal_position_id': False,
+           'to_invoice': True,
+           'partner_id': partner_test.id,
+           'pricelist_id': self.main_pos_config.available_pricelist_ids[0].id,
+           'lines': [[0,
+             0,
+             {'discount': 0,
+              'pack_lot_ids': [],
+              'price_unit': 10,
+              'product_id': product_a.id,
+              'price_subtotal': 10,
+              'price_subtotal_incl': 10,
+              'sale_order_line_id': sale_order.order_line[0].id,
+              'sale_order_origin_id': sale_order.id,
+              'qty': 1,
+              'tax_ids': []}]],
+           'name': 'Order 00044-003-0014',
+           'session_id': current_session.id,
+           'sequence_number': self.main_pos_config.journal_id.id,
+           'payment_ids': [[0,
+             0,
+             {'amount': 10,
+              'name': fields.Datetime.now(),
+              'payment_method_id': self.main_pos_config.payment_method_ids[0].id}]],
+           'user_id': self.env.uid,
+           'uuid': str(uuid4()),
+            }
+
+        data = self.env['pos.order'].sync_from_ui([pos_order])
+        self.assertEqual(sale_order.order_line.qty_invoiced, 1)
+        pos_order_id = data['pos.order'][0]['id']
+        pos_order_record = self.env['pos.order'].browse(pos_order_id)
+        refund_action = pos_order_record.refund()
+        refund = self.env['pos.order'].browse(refund_action['res_id'])
+        payment_context = {"active_ids": refund.ids, "active_id": refund.id}
+        refund_payment = self.env['pos.make.payment'].with_context(**payment_context).create({
+            'amount': refund.amount_total,
+            'payment_method_id': self.bank_payment_method.id,
+        })
+
+        self.env.flush_all()
+        refund_payment.with_context(**payment_context).check()
+        self.assertEqual(sale_order.order_line.qty_invoiced, 0)
+
     def test_ecommerce_paid_order_is_hidden_in_pos(self):
         """
         Tests that a Sale Order fully paid via a payment.transaction (eCommerce)


### PR DESCRIPTION
When doing a refund of a POS order linked to a SO in the backend, the
qty_invoiced on the SO line is not updated correctly.

Steps to reproduce:
-------------------
* Create a SO with 1 quantity of any product
* Settle the SO in the PoS
* Refund the PoS order from the backend not from the PoS interface
* Check the qty_invoiced on the SO line
> Observation: The qty_invoiced is still 1

Why the fix:
------------
The method _compute_qty_invoiced was not triggered when the refunding
order was paid. So we need to add a new dependency on the function.

Note:
-----------
In the test we need to flush all before doing the payment of the refund,
because if we do not do it, the _compute_qty_invoiced method would be
called during the payment. But that is not the case outside of the test.
This is just to ensure that the test fails correctly without the fix.

opw-4991405