### PR TITLE
[FIX] mail: prevent duplicate deaf icon in sidebar call participant status

### DIFF
--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
@@ -78,8 +78,7 @@
                     <t t-set="session" t-value="session"/>
                 </t>
                 <t t-else="">
-                    <span t-if="session.is_muted" class="p-1 fa opacity-75" t-att-class="rtc.callActions.find(a => a.id === 'mute').icon"/>
-                    <span t-if="session.is_deaf" class="p-1 fa opacity-75" t-att-class="rtc.callActions.find(a => a.id === 'deafen').icon"/>
+                    <span t-if="session.is_muted or session.is_deaf" class="p-1 fa opacity-75" t-att-class="rtc.callActions.find(a => a.id === 'mute').icon"/>
                     <span t-if="session.is_screen_sharing_on" class="o-live bg-danger o-text-white rounded">LIVE</span>
                 </t>
             </div>

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -1023,3 +1023,20 @@ test("show all participants on other user stops screen share", async () => {
     await streamerRemote.updateUpload("screen", null);
     await contains(".o-discuss-CallParticipantCard-avatar", { count: 2 });
 });
+
+test("discuss sidebar call participant shows appropriate status icon", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    await start();
+    await openDiscuss(channelId);
+    await click("[title='Start Call']");
+    await contains(".o-discuss-Call");
+    await click("button[title='Mute']");
+    await contains(".o-mail-DiscussSidebarCallParticipants-status .fa-microphone-slash");
+    await click("button[title='Voice Settings']");
+    await click(".dropdown-menu button:contains('Deafen')");
+    await contains(".o-mail-DiscussSidebarCallParticipants-status .fa-deaf");
+    await contains(".o-mail-DiscussSidebarCallParticipants-status .fa-microphone-slash", {
+        count: 0,
+    });
+});


### PR DESCRIPTION
**Current behavior before PR:**
The PR #228657 combined the mute and deafen actions into a single "mute"
action handling both states, As a result, when a user was both
muted and deafened during a call, two identical deaf icons were shown
in the participant status area (in sidebar).

**Steps to reproduce:**
1. Start a call
2. Click the Mute button
3. Open Voice Settings dropdown
4. Click Deafen button
5. Observe two deaf icons in the sidebar participant status

**Desired behavior after PR is merged:**
Only one deaf icon is shown when the user is deafened, since the deaf state already implies being muted.

**Before:**
<img width="387" height="113" alt="image" src="https://github.com/user-attachments/assets/65be3365-0c7a-4d97-9260-1f440ce09c70" />

**After:**
<img width="385" height="119" alt="image" src="https://github.com/user-attachments/assets/bd83fe67-d4b2-4756-9445-5f48ef3a8b5e" />

task-[5166621](https://www.odoo.com/odoo/project/1519/tasks/5166621)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
