### PR TITLE
[IMP] l10n_in_edi: store logs for edi, eway-bill requests.

### DIFF
--- a/addons/l10n_in/models/__init__.py
+++ b/addons/l10n_in/models/__init__.py
@@ -7,6 +7,7 @@ from . import account_payment
 from . import account_tax
 from . import company
 from . import iap_account
+from . import ir_logging
 from . import product_template
 from . import port_code
 from . import res_config_settings

--- a/addons/l10n_in/models/ir_logging.py
+++ b/addons/l10n_in/models/ir_logging.py
@@ -1,0 +1,21 @@
+from odoo import models
+
+
+class IrLogging(models.Model):
+    _inherit = 'ir.logging'
+
+    def _l10n_in_log_message(self, func: str, name: str, path: str, request: dict, response: dict, error_found: bool = False):
+        # if error is found, then log request and response as message.
+        if error_found:
+            message = f"Request:\n{request}\n\nResponse:\n{response}"
+        else:
+            message = response
+        self.env['ir.logging'].create({
+            'func': func,
+            'message': message,
+            'name': name,
+            'path': path,
+            'level': 'INFO',
+            'type': 'server',
+            'line': ' ',
+        })

--- a/addons/l10n_in/models/res_partner.py
+++ b/addons/l10n_in/models/res_partner.py
@@ -136,6 +136,14 @@ class ResPartner(models.Model):
                 '/iap/l10n_in_reports/1/public/search',
                 "l10n_in.endpoint"
             )
+            self.env['ir.logging']._l10n_in_log_message(
+                func='action_l10n_in_verify_gstin_status',
+                name=f'{self._name}({self.id})',
+                path='/l10n_in_reports/1/public/search',
+                request=params,
+                response=response,
+                error_found=bool(response.get('error')),
+            )
         except AccessError:
             raise UserError(_("Unable to connect with GST network"))
         if response.get('error') and any(e.get('code') == 'no-credit' for e in response['error']):

--- a/addons/l10n_in_edi/models/res_company.py
+++ b/addons/l10n_in_edi/models/res_company.py
@@ -58,6 +58,14 @@ class ResCompany(models.Model):
                 "/iap/l10n_in_edi/1/authenticate",
                 "l10n_in_edi.endpoint"
             )
+            self.env['ir.logging']._l10n_in_log_message(
+                func='_l10n_in_edi_authenticate',
+                name=f'{self._name}({self.id})',
+                path='/l10n_in_edi/1/authenticate',
+                request=params,
+                response=response,
+                error_found=bool(response.get('error')),
+            )
         except AccessError as e:
             return {
                 "error": [{

--- a/addons/l10n_in_edi/views/account_move_views.xml
+++ b/addons/l10n_in_edi/views/account_move_views.xml
@@ -38,6 +38,15 @@
                         groups="base.group_no_one"
                         string="Download EDI JSON"/>
             </xpath>
+             <xpath expr="//div[@name='button_box']" position="inside">
+                <button name="action_view_l10n_in_edi_logs"
+                    type="object"
+                    groups="base.group_no_one"
+                    string="View logs"
+                    class="oe_stat_button"
+                    invisible="country_code != 'IN'"
+                    icon="fa-list"/>
+            </xpath>
             <xpath expr="//div[@name='journal_div']" position="after">
                 <field name="l10n_in_edi_status" invisible="not l10n_in_edi_status or state == 'draft'"/>
             </xpath>

--- a/addons/l10n_in_ewaybill/tools/ewaybill_api.py
+++ b/addons/l10n_in_ewaybill/tools/ewaybill_api.py
@@ -103,6 +103,14 @@ class EWayBillApi:
                 fields.Datetime.now()
                 + timedelta(hours=6, minutes=00, seconds=00)
             )
+        self.env['ir.logging']._l10n_in_log_message(
+            func='_ewaybill_authenticate',
+            name=f'{self.company}',
+            path='/l10n_in_edi_ewaybill/1/authenticate',
+            request=params,
+            response=response,
+            error_found=bool(response and response.get("status_cd") == "1"),
+        )
 
     def _ewaybill_make_transaction(self, operation_type, json_payload):
         """

--- a/addons/l10n_in_ewaybill/views/l10n_in_ewaybill_views.xml
+++ b/addons/l10n_in_ewaybill/views/l10n_in_ewaybill_views.xml
@@ -54,6 +54,14 @@
                     </div>
                 </div>
                 <sheet>
+                    <div name="button_box" class="oe_button_box">
+                        <button name="action_view_l10n_in_ewaybill_logs"
+                                string="View logs"
+                                type="object"
+                                class="oe_stat_button"
+                                groups="base.group_no_one"
+                                icon="fa-list"/>
+                    </div>
                     <div class="oe_title">
                         <h1 invisible="not name">
                             <field name="name" readonly="1"/>

--- a/addons/l10n_in_ewaybill_irn/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill_irn/models/l10n_in_ewaybill.py
@@ -153,4 +153,12 @@ class L10nInEwaybill(models.Model):
                 })
             if response.get('error'):
                 raise EWayBillError(response)
+        self.env['ir.logging']._l10n_in_log_message(
+            func='_ewaybill_generate_by_irn',
+            name=f'{self._name}({self.id})',
+            path='/l10n_in_edi/1/get_ewaybill_by_irn',
+            request=json_payload,
+            response=response,
+            error_found=bool(response.get('error')),
+        )
         return response


### PR DESCRIPTION
After this PR:
- Logs related to a particular invoice for EDI or E-waybill are visible to administrator through a technical smart button.

- If request fails, then both request and response are logged, otherwise only response is logged.

Task: 4896516

Related PR (enterprise): https://github.com/odoo/enterprise/pull/97336