### PR TITLE
[CLN] website: remove duplicate height utility classes

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -925,25 +925,9 @@ table.table_desc tr td {
 }
 
 .o_full_screen_height {
-    display: flex;
-    flex-direction: column;
-    justify-content: space-around;
-    min-height: 100vh !important;
     // See JS: this is overridden for multiple reasons, including the fact that
     // Arc browser does not support this correctly at the moment.
     min-height: 100svh !important;
-}
-.o_half_screen_height {
-    @extend .o_full_screen_height;
-    min-height: 55vh !important;
-}
-
-// TODO remove cover_full and cover_mid classes (kept for compatibility for now)
-.cover_full {
-    @extend .o_full_screen_height;
-}
-.cover_mid {
-    @extend .o_half_screen_height;
 }
 
 // Allows custom border radius without contents overflowing.


### PR DESCRIPTION
Remove redundant `o_full_screen_height` and related height utility classes from the website SCSS, as they are already defined in `html_editor` SCSS.

This cleanup avoids duplication and ensures consistent styling across modules.

task-[5123275](https://www.odoo.com/odoo/project/974/tasks/5123275)