### PR TITLE
respect web.base.url for return url

### DIFF
--- a/addons/auth_oauth/controllers/main.py
+++ b/addons/auth_oauth/controllers/main.py
@@ -58,7 +58,7 @@ class OAuthLogin(Home):
         except Exception:
             providers = []
         for provider in providers:
-            return_url = request.httprequest.url_root + 'auth_oauth/signin'
+            return_url = request.env.user.get_base_url() + 'auth_oauth/signin'
             state = self.get_state(provider)
             params = dict(
                 response_type='token',


### PR DESCRIPTION
The problem is the app not respecting web.base.url environment for redirect url, so the app that proxied using tunnel unable to pass public domain from tunnel

Description of the issue/feature this PR addresses:

when app are proxied and tuneling using **cloudflared** for the app to have public domain, it didn't read web.base.url environment and always return http instead of https every oauth google. so google auth always fail

Current behavior before PR:

fix above behavior so google oauth succssessfully via cloudflared tunnel proxy

Desired behavior after PR is merged:

no issue for google oauth when app deployed self hosted and go public using cloudflared tunnel proxy


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
