### PR TITLE
[FIX] base: res_lang _create_lang grouping

### DIFF
--- a/odoo/addons/base/models/res_lang.py
+++ b/odoo/addons/base/models/res_lang.py
@@ -206,6 +206,14 @@ class ResLang(models.Model):
                 format = format.replace(pattern, replacement)
             return str(format)
 
+        def fix_grouping(grouping):
+            grouping = str(grouping).replace(' ', '')
+
+            if grouping in self._fields['grouping'].get_values(self.env):
+                return grouping
+
+            return '[3,0]'
+
         conv = locale.localeconv()
         lang_info = {
             'code': lang,
@@ -216,7 +224,7 @@ class ResLang(models.Model):
             'time_format' : fix_datetime_format(locale.nl_langinfo(locale.T_FMT)),
             'decimal_point' : fix_xa0(str(conv['decimal_point'])),
             'thousands_sep' : fix_xa0(str(conv['thousands_sep'])),
-            'grouping': str(conv.get('grouping') or '[3,0]'),
+            'grouping': fix_grouping(conv.get('grouping')),
         }
         try:
             return self.create(lang_info)


### PR DESCRIPTION
When `conv.get('grouping')` returns a valid list the format will be `'[x, y, z]'` which is not a valid format. This will make the test `test_lazy_translation` fail.

The reason the test doesn't fail on runbot is because runbot uses the `C` local which make the code always fallback on the `or '[3,0]'` and by doing so hides the issue.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
