### PR TITLE
[IMP] web, *: improve checkbox styling and focus state

### DIFF
--- a/addons/purchase/views/res_partner_views.xml
+++ b/addons/purchase/views/res_partner_views.xml
@@ -8,16 +8,12 @@
             <field name="priority">36</field>
             <field name="arch" type="xml">
                 <group name="purchase" position="inside">
-                    <div name="receipt_reminder" colspan="2" class="o_checkbox_optional_field" groups='purchase.group_send_reminder'>
-                        <div class="o_cell o_wrap_label text-break text-900">
-                            <label for="receipt_reminder_email"/>
-                        </div>
-                        <div class="o_cell o_wrap_input text-break d-flex gap-2">
-                            <field name="receipt_reminder_email"/>
-                            <div invisible="not receipt_reminder_email">
-                                <field name="reminder_date_before_receipt" class="oe_inline"/>
-                                <span> day(s) before</span>
-                            </div>
+                    <label for="receipt_reminder_email" string="Receipt Reminder" groups='purchase.group_send_reminder'/>
+                    <div class="o_checkbox_optional_field" groups='purchase.group_send_reminder'>
+                        <field name="receipt_reminder_email" nolabel="1"/>
+                        <div invisible="not receipt_reminder_email">
+                            <field name="reminder_date_before_receipt" class="oe_inline" nolabel="1"/>
+                            <span> day(s) before</span>
                         </div>
                     </div>
                     <field name="property_purchase_currency_id" options="{'no_create': True, 'no_open': True}" groups='base.group_multi_currency'/>

--- a/addons/web/static/src/scss/bootstrap_overridden.scss
+++ b/addons/web/static/src/scss/bootstrap_overridden.scss
@@ -289,9 +289,11 @@ $kbd-box-shadow: 0px 1px 1px rgba($o-black, 0.2), inset 0px -1px 1px 1px rgba($o
 // Input
 $input-bg: $o-input-bg !default;
 $input-focus-border-color: $o-brand-primary !default;
+$form-check-input-border: 1px solid $o-form-check-input-border-color !default;
 $form-check-input-checked-color: $o-brand-lightsecondary !default;
 $form-check-input-checked-border-color: $o-brand-primary !default;
 $form-check-input-checked-bg-color: $o-brand-primary !default;
+$form-check-input-focus-box-shadow: 0 0 0 .25rem rgba($o-action, .25) !default;
 $form-switch-checked-color: $white !default;
 $form-switch-focus-color: mix($o-success, $input-bg) !default;
 

--- a/addons/web/static/src/scss/bootstrap_review_backend.scss
+++ b/addons/web/static/src/scss/bootstrap_review_backend.scss
@@ -277,6 +277,22 @@ $-o-bg-colors-custom: null;
     margin-bottom: var(--alert-margin-bottom, $alert-margin-bottom);
 }
 
+// Checkboxes and Radios - transitions and animations
+// ============================================================================
+.form-check-input {
+    transition: background-color 250ms ease, border-color 200ms ease;
+}
+
+.form-check-input[type="checkbox"]:checked {
+    background-size: 100% 100%;
+    animation: check-grow 300ms ease-in-out;
+}
+
+@keyframes check-grow {
+    from { background-size: 0 0; }
+    to { background-size: 100% 100%; }
+}
+
 // Switches
 // ============================================================================
 .form-switch {

--- a/addons/web/static/src/scss/primary_variables.scss
+++ b/addons/web/static/src/scss/primary_variables.scss
@@ -161,6 +161,7 @@ $o-btn-custom: (
 
 
 // Forms
+$o-form-check-input-border-color: $o-gray-300 !default;
 
 // o-inputs
 $o-input-padding-y: 2px !default;


### PR DESCRIPTION
*: purchase, website

Before this commit, checkboxes had no micro-interactions, and used the primary color for the focus state instead of the action color.

This commit adds a micro-interaction for better visual feedback, and updates the focus state to use the action color. It also improves alignment in a vendor form in purchase module.

requires: https://github.com/odoo/enterprise/pull/97340

task-5136827


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
