### PR TITLE
[FIX] website: prevent traceback when adding a field in extra info form

### DIFF
--- a/addons/website/static/src/builder/plugins/form/form_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/form/form_option_plugin.js
@@ -441,10 +441,15 @@ export class FormOptionPlugin extends Plugin {
         const field = getCustomField("char", _t("Custom Text"));
         field.formatInfo = getDefaultFormat(formEl);
         const fieldEl = renderField(field);
-        const locationEl = formEl.querySelector(
+        let locationEl = formEl.querySelector(
             ".s_website_form_submit, .s_website_form_recaptcha"
         );
-        locationEl.insertAdjacentElement("beforebegin", fieldEl);
+        if (!locationEl) {
+            locationEl = formEl.querySelector(".s_website_form_rows");
+            locationEl.insertAdjacentElement("beforeend", fieldEl);
+        } else {
+            locationEl.insertAdjacentElement("beforebegin", fieldEl);
+        }
         this.dependencies.builderOptions.setNextTarget(fieldEl);
     }
     addFieldAfterField(fieldEl) {


### PR DESCRIPTION
Steps to reproduce:
===================
1. Add an element to the cart.
2. Enable the “Extra Info” step.
3. Try to add a field in the “Extra Info” form. → Traceback occurs.

Cause:
======
In previous versions, the “Extra Info” form contained a submit button, and when adding a new field, the code attempted to insert it relative to that button.

Starting from version 19.0, this button was removed and replaced by the common “Confirm” button used in other checkout steps. As a result, the element used to determine the field insertion location (`locationEl`) was `null`, causing a crash when trying to insert a new field.

Solution:
=========
If no target element is found, the field is now inserted relative to the last element of the form instead, preventing the traceback.

opw-5160322
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
