### PR TITLE
[FIX] project: make sure to not use enterprise fields

### DIFF
--- a/addons/project/static/src/views/project_task_calendar/project_task_calendar_model.js
+++ b/addons/project/static/src/views/project_task_calendar/project_task_calendar_model.js
@@ -5,6 +5,15 @@ import { CalendarModel } from '@web/views/calendar/calendar_model';
 import { ProjectTaskModelMixin } from "../project_task_model_mixin";
 
 export class ProjectTaskCalendarModel extends ProjectTaskModelMixin(CalendarModel) {
+    get tasksToPlanDomain() {
+        const projectId = this.meta.context.default_project_id;
+        const domain = [['date_deadline', '=', false]];
+        if (projectId) {
+            domain.push(['project_id', '=', projectId]);
+        }
+        return domain;
+    }
+
     /**
      * @override
      */
@@ -73,7 +82,7 @@ export class ProjectTaskCalendarModel extends ProjectTaskModelMixin(CalendarMode
         );
         domain = Domain.and([
             domain,
-            [['planned_date_begin', '=', false], ['date_deadline', '=', false], ['project_id', '=', projectId]],
+            this.tasksToPlanDomain,
         ]);
         return await this.orm.webSearchRead(this.resModel, domain.toList(this.meta.context), {
             specification: this.tasksToPlanSpecification,


### PR DESCRIPTION
Before this commit, when the user with just Odoo community version tries to go to tasks calendar of a project, he will get a traceback saying `planning_date_begin` field does not exist in `project.task` model. The reason is because that field only exist when `project_enterprise` module is installed.

This commit makes sure we only use that field when project_enterprise is installed.

Closes #228178