### PR TITLE
[IMP] html_builder, website: reset crop after shape removal

### DIFF
--- a/addons/html_builder/static/src/plugins/image/image_shape_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/image_shape_option_plugin.js
@@ -5,6 +5,7 @@ import { getShapeURL } from "@html_builder/plugins/image/image_helpers";
 import {
     activateCropper,
     createDataURL,
+    cropperDataFields,
     loadImage,
     loadImageInfo,
     isGif,
@@ -407,6 +408,18 @@ export class SetImageShapeAction extends BuilderAction {
     static dependencies = ["imageShapeOption"];
     async load({ editingElement: img, value: shapeId }) {
         const params = { shape: shapeId };
+        // A crop is applied to the image at the same time as certain shapes,
+        // which is why we reset the crop here or when the shape is removed.
+        // However, we don’t reset it when the crop was applied intentionally.
+        // In that case, there are crop values; otherwise, there are none,
+        // only a 'data-aspect-ratio'.
+        if (
+            !shapeId &&
+            img.dataset.aspectRatio &&
+            !cropperDataFields.some((field) => field in img.dataset)
+        ) {
+            params["aspectRatio"] = undefined;
+        }
         // todo nby: re-read the old option method `setImgShape` and be sure all the logic is in there
         return this.dependencies.imageShapeOption.loadShape(img, params);
     }

--- a/addons/website/static/tests/builder/image_shape.test.js
+++ b/addons/website/static/tests/builder/image_shape.test.js
@@ -523,3 +523,21 @@ describe("toggle ratio", () => {
         expect(`:iframe .test-options-target img`).not.toHaveAttribute("src", croppedSrc);
     });
 });
+
+test("Should reset crop when removing shape with ratio", async () => {
+    const { waitSidebarUpdated } = await setupWebsiteBuilder(`
+        <div class="test-options-target">
+            ${testImg}
+        </div>
+    `);
+
+    await contains(":iframe .test-options-target img").click();
+    await contains("[data-label='Shape'] .dropdown").click();
+    await contains("[data-action-value='html_builder/geometric/geo_shuriken']").click();
+    await waitSidebarUpdated();
+    expect(`:iframe .test-options-target img`).toHaveAttribute("data-aspect-ratio");
+    // Remove the shape.
+    await contains("[data-action-id='setImageShape']").click();
+    await waitSidebarUpdated();
+    expect(`:iframe .test-options-target img`).not.toHaveAttribute("data-aspect-ratio");
+});


### PR DESCRIPTION
Steps to reproduce:

- Enter website edit mode.
- Drag and drop a snippet containing an image onto the page.
- Click the image.
- Apply a shape that enforces a 1/1 ratio with stretch disabled (e.g the
first one).
- Remove the shape with the close button.

Before this commit, removing the shape kept data-aspect-ratio at 1/1,
so the picture stayed cropped or distorted.

After this commit, removing the shape clears the crop dataset when no
manual crop values exist, restoring the original proportions.

task-5170195