### PR TITLE
[CLN] website_event_*: clean the slots registration button

### DIFF
--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -3,7 +3,6 @@ import werkzeug
 
 from ast import literal_eval
 from collections import Counter
-from datetime import datetime
 from werkzeug.exceptions import NotFound
 
 from odoo import fields, http, _
@@ -220,15 +219,6 @@ class WebsiteEventController(http.Controller):
         urls = lazy(event._get_event_resource_urls)
         return {
             'event': event,
-            'slots': event.event_slot_ids.filtered(
-                        lambda s: s.start_datetime > datetime.now()
-                        and any(
-                            availability is None or availability > 0
-                            for availability in event._get_seats_availability([
-                                (s, ticket) for ticket in event.event_ticket_ids or [False]
-                            ])
-                        )
-                    ).grouped('date'),
             'main_object': event,
             'range': range,
             'google_url': lazy(lambda: urls.get('google_url')),

--- a/addons/website_event/views/event_templates_page_registration.xml
+++ b/addons/website_event/views/event_templates_page_registration.xml
@@ -236,7 +236,7 @@
                 </small>
                 <div class="card bg-transparent py-3 px-2 px-md-3">
                     <!-- Up to the next 3 closest dates -->
-                    <t t-set="slots_to_preview" t-value="dict(list(slots.items())[:3])"/>
+                    <t t-set="slots_to_preview" t-value="dict(list(event.event_open_slot_ids.grouped('date').items())[:3])"/>
                     <t t-if="slots_to_preview">
                         <div class="row">
                             <div t-foreach="slots_to_preview" t-as="date" class="col d-flex flex-column align-items-start gap-1 pb-2">
@@ -710,6 +710,7 @@
                         </ul>
                     </nav>
                     <div class="o_wevent_slot_dates row px-2">
+                        <t t-set="slots" t-value="event.event_open_slot_ids.grouped('date')"/>
                         <div t-foreach="slots" t-as="date" t-attf-class="o_wevent_slot_date col col-sm-6 col-lg-4 px-3 pb-4">
                             <time t-out="date" class="text-nowrap pe-5 me-5" t-options="{'widget': 'date', 'format': 'full'}"/>
                             <div class="d-flex flex-wrap gap-2">


### PR DESCRIPTION
This PR cleans this [fix](). Using a compute field of the event model is a more sustainable solution than adding the slots to the context of the page containing the registration button. As this last one is added to the page from a layout, it is easily possible to forget to add the slots in the new pages. This solution removes the slots in the context as all pages containing the register button have an event, which now contains the available slots.

Task-5083175