### PR TITLE
[FIX] account: keep analytic lines when posting vendor bills

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1676,7 +1676,7 @@ class AccountMoveLine(models.Model):
                                 body=msg,
                                 tracking_value_ids=tracking_value_ids
                             )
-            if not self.env.context.get('skip_analytic_sync'):
+            if 'analytic_line_ids' in vals:
                 self.filtered(lambda l: l.parent_state == 'draft').analytic_line_ids.with_context(skip_analytic_sync=True).unlink()
 
         return result

--- a/addons/account/tests/test_account_analytic.py
+++ b/addons/account/tests/test_account_analytic.py
@@ -1062,6 +1062,29 @@ class TestAccountAnalyticAccount(AccountTestInvoicingCommon, AnalyticCommon):
         journal_entry.action_post()
         self.assertTrue(self.get_analytic_lines(journal_entry))
 
+    def test_analytic_lines_on_post(self):
+        """
+        In some cases (e.g. when there is a purchase lock, the journal has autocheck_on_post=False),
+        when the move state is changed to post, write is first triggered for dependencies while the move
+        state is still 'draft'. In these cases, the analytic lines created should not be deleted.
+        """
+        in_invoice = self.env['account.move'].create([{
+            'move_type': 'in_invoice',
+            'partner_id': self.partner_a.id,
+            'date': '2017-01-01',
+            'invoice_date': '2017-01-01',
+            'invoice_line_ids': [
+                Command.create({
+                    'product_id': self.product_a.id,
+                    'price_unit': 100.0,
+                    'analytic_distribution': {self.analytic_account_1.id: 100},
+                }),
+            ],
+        }])
+        in_invoice.company_id.purchase_lock_date = '2017-01-31'
+        in_invoice.action_post()
+        self.assertTrue(self.get_analytic_lines(in_invoice))
+
     def test_multicurrency_different_rounding_analytic_line(self):
         """If using a foreign currency, the rounding of the analytic_line amount should the one from the company currency"""
         foreign_currency = self.env['res.currency'].create({


### PR DESCRIPTION
To reproduce:
1. Ensure Analytic Accounting is activated in the accounting settings
2. Uncheck the option Auto-Check on Post in the Vendor Bills journal
3. Create a vendor bill and set analytic accounts in at least one line
4. Post the vendor bill
5. Go to Accounting > Analytic Items
6. No analytic item was created for the vendor bill

In some cases, such as when the vendor bill journal has `Auto-check on Post` disabled or a there is a lock date set, the analytic items are not created when posting the move, even if analytic accounts were set on the move lines.

Cause:
In #222196, a check is performed when writing an account.move.line, which unlinks analytic lines created for draft moves. However, this condition is too general, and if additional writes happen in between the analytic line creation and changing the move state to `posted`, the analytic lines are deleted.

Solution:
The unlinking on analytic lines should only be performed if `analytic_line_ids` are in vals.

opw-5053179,opw-5154394
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
