### PR TITLE
[FIX] mrp: prevent move from being picked when qty to consume is updated

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -313,7 +313,8 @@ class StockMove(models.Model):
 
     @api.onchange('product_uom_qty', 'product_uom')
     def _onchange_product_uom_qty(self):
-        if self.product_uom and self.raw_material_production_id and self.has_tracking == 'none':
+        if self.product_uom and self.raw_material_production_id and self.has_tracking == 'none'\
+            and self.state not in ('draft', 'cancel', 'done'):
             mo = self.raw_material_production_id
             new_qty = float_round((mo.qty_producing - mo.qty_produced) * self.unit_factor, precision_rounding=self.product_uom.rounding)
             self.quantity = new_qty
@@ -321,7 +322,8 @@ class StockMove(models.Model):
     @api.onchange('quantity', 'product_uom', 'picked')
     def _onchange_quantity(self):
         if self.raw_material_production_id and self.product_uom and \
-           float_compare(self.product_uom_qty, self.quantity, precision_rounding=self.product_uom.rounding) != 0:
+            not float_is_zero(self.quantity, precision_rounding=self.product_uom.rounding) and \
+            float_compare(self.product_uom_qty, self.quantity, precision_rounding=self.product_uom.rounding) != 0:
             self.manual_consumption = True
             self.picked = True
 

--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -1823,11 +1823,19 @@ class TestBoM(TestMrpCommon):
             move_raw.product_uom_qty = 1
             move_raw.product_uom = uom_dozen
         mo_2 = mo_form.save()
+        self.assertEqual(mo_2.state, 'draft')
         mo_2.action_confirm()
+        self.assertEqual(mo_2.state, 'confirmed')
         self.assertRecordValues(mo_2.move_raw_ids, [
             {'product_id': component_1.id, 'product_uom_qty': 2, 'product_uom': uom_dozen.id},
             {'product_id': component_2.id, 'product_uom_qty': 1, 'product_uom': uom_dozen.id}
         ])
+        mo_form = Form(mo_2)
+        with mo_form.move_raw_ids.edit(0) as move_raw:
+            move_raw.quantity = 5
+        with mo_form.move_raw_ids.edit(1) as move_raw:
+            move_raw.quantity = 5
+        mo_2 = mo_form.save()
 
         # Updates the BoM by set the second BoM line's quantity to 2.
         bom_form = Form(bom)


### PR DESCRIPTION
Steps to reproduce the issue:
- Create a storable product “P1” with the following BoM:
    - Component: - 1 unit of C1
- Update the quantity on hand of C1 to 10 units
- Create a manufacturing order to produce one unit of P1
- Confirm the order → The quantity of C1 is reserved, and the produced quantity of P1 is 0 (expected behavior)

- Update the component's quantity to consume (C1) to 2
- The consumed quantity is set to 0 and the move marked as picked
- Try to reserve the quantities again

Problem:
Since the move is picked, the
new quantity cannot be reserved.

Solution:
Prevent the move from being marked as picked when the consumed quantity is zero.

opw-5152592

