### PR TITLE
[FIX] website_blog: fix faketime build for blog tour

### DIFF
--- a/addons/website_blog/static/tests/tours/blog_tags_with_date.js
+++ b/addons/website_blog/static/tests/tours/blog_tags_with_date.js
@@ -28,7 +28,7 @@ registerWebsitePreviewTour("blog_tags_with_date", {
     }, {
         content: "Select first month",
         trigger: ":iframe select[name=archive]",
-        run: "selectByLabel October",
+        run: "selectByLabel January",
     }, {
         content: "Check date filter has been added",
         trigger: ":iframe #o_wblog_posts_loop span>i.fa-calendar-o",

--- a/addons/website_blog/tests/test_ui.py
+++ b/addons/website_blog/tests/test_ui.py
@@ -74,32 +74,31 @@ class TestWebsiteBlogUi(odoo.tests.HttpCase, TestWebsiteBlogCommon):
         Blog1 = Blog.create({'name': 'Nature'})
         Blog2 = Blog.create({'name': 'Space'})
 
+        blog_tag = self.env.ref('website_blog.blog_tag_5', raise_if_not_found=False)
+        if not blog_tag:
+            blog_tag = self.env['blog.tag'].create({'name': "discovery"})
+
         # Create first blog post (Feb 2025)
-        blog_post_1 = Post.create({
+        Post.create({
             'name': 'First Blog Post',
             'blog_id': Blog1.id,
             'author_id': self.env.user.id,
             'is_published': True,
+            'tag_ids': [(4, blog_tag.id)],
             'published_date': datetime(2025, 2, 10, 12, 0, 0),
         })
 
         # Create second blog post (Jan 2025)
-        blog_post_2 = Post.create({
+        Post.create({
             'name': 'Second Blog Post',
             'blog_id': Blog2.id,
             'author_id': self.env.user.id,
             'is_published': True,
+            'tag_ids': [(4, blog_tag.id)],
             'published_date': datetime(2025, 1, 15, 14, 30, 0),
         })
 
         self.env.ref("website_blog.opt_blog_sidebar_show").active = True
         self.env.ref("website_blog.opt_blog_post_sidebar").active = True
         self.start_tour("/blog", "blog_sidebar_with_date_and_tag", login="admin")
-
-        blog_tag = self.env.ref('website_blog.blog_tag_5', raise_if_not_found=False)
-        if not blog_tag:
-            blog_tag = self.env['blog.tag'].create({'name': "discovery"})
-        blog_post_1.write({'tag_ids': [(4, blog_tag.id)]})
-        blog_post_2.write({'tag_ids': [(4, blog_tag.id)]})
-
         self.start_tour("/blog", "blog_tags_with_date", login="admin")


### PR DESCRIPTION
he blog_tags_with_date tour used a static month value ("October") that relied on the current date and time, which could cause failures in future months when the expected tag no longer matched.

This commit keeps the blog post publish date fixed to avoid time-dependent inconsistencies and prevent future test breakages

[1]: https://github.com/odoo/odoo/pull/231328

runbot-233321