### PR TITLE
[IMP] hr_holidays: ameliorate kanban list layout

### DIFF
--- a/addons/hr_holidays/static/src/scss/time_off.scss
+++ b/addons/hr_holidays/static/src/scss/time_off.scss
@@ -84,32 +84,13 @@
     width: fit-content;
 }
 
-.o_kanban_renderer {
-    .o_kanban_record.o_hr_holidays_kanban {
-        min-height: 105px;
-        .ribbon {
-            --Ribbon-wrapper-width: 6.7rem;
-            span {
-                --Ribbon-left-position-default: 0.3rem;
-            }
-            & .o_medium {
-                font-size: $font-size-sm !important;
-            }
-        }
-    }
-}
+.o_holidays_view_kanban .o_kanban_renderer {
+    .o_kanban_record:not(.o_kanban_ghost) {
+        --Ribbon-wrapper-height: 5.5rem;
+        --Ribbon-font-size: .72rem;
 
-.o_holidays_view_kanban .o_kanban_renderer{
-
-    .ribbon {
-        --Ribbon-wrapper-width: 6.77rem;
-        height: 5rem;
-        span {
-            --Ribbon-left-position-default: 0.3rem;
-        }
-        & .o_medium {
-            font-size: $font-size-sm !important;
-        }
+        min-height: auto;
+        overflow: hidden;
     }
 
     &.o_kanban_grouped {
@@ -119,48 +100,87 @@
     }
 
     &.o_kanban_ungrouped {
+        --KanbanRecord-width: 100%;
+
         padding: 0px;
-        @media only screen and (max-width:767px) {
+        container-type: inline-size;
+
+        .o_kanban_record:not(.o_kanban_ghost) {
+            margin: 0;
+            border: none;
+            border-bottom: $border-width solid $border-color;
+        }
+
+        @container (max-width: 750px) {
             .o_hr_holidays_kanban {
                 display: none;
             }
         }
-        @media only screen and (min-width:768px){
-            .o_kanban_record:not(.o_kanban_ghost) {
-                width: 100%;
-                max-height: 5.1rem;
-                margin: 0px;
-                justify-content: center;
+
+        @container (max-width: 1150px) {
+            .o_hr_holidays_kanban .o_hr_holidays_button {
+                flex-direction: column;
+                align-items: start;
+                gap: map-get($spacers, 1) !important;
             }
+        }
+
+        @container (min-width: 751px) {
             .o_hr_holidays_kanban_mobile {
-                display: none;
+                display: none !important;
             }
-            .o_holidays_kanban_card {
+            .o_hr_holidays_name {
                 display: flex;
                 flex-direction: column;
-                height: 100%;
-                .o_hr_holidays_value {
-                    display: flex;
-                    flex-direction: row;
-                    .o_hr_holidays_name {
-                        display: flex;
-                        flex-direction: column;
-                        gap: 2;
-                        align-items: baseline;
-                    }
-                    .o_hr_holidays_card {
-                        flex-direction: column;
-                        display: flex;
-                        flex-wrap: wrap;
-                        align-items: baseline;
-                    }
+                gap: 2;
+                align-items: baseline;
+            }
+            .o_hr_holidays_card {
+                flex-direction: column;
+                display: flex;
+                flex-wrap: wrap;
+                align-items: baseline;
+            }
+        }
+    }
+
+    .o_hr_holidays_kanban_mobile {
+        --KanbanRecord__image-width: 40px;
+
+        container-type: inline-size;
+
+        .btn-sm {
+            padding: $btn-padding-y-sm $btn-padding-x-sm;
+        }
+
+        .o_hr_holidays_button {
+            grid-template-columns: 1fr;
+            grid-template-rows: 1fr 1fr;
+            gap: map-get($spacers, 1);
+
+            .btn-primary.oe_kanban_action:where(:last-child), .btn-secondary.oe_kanban_action {
+                grid-area: 2 / 2;
+            }
+
+            .badge {
+                grid-column: -1;
+                align-self: baseline;
+                min-width: fit-content;
+            }
+
+            @container (min-width: 500px) {
+                grid-template-columns: 1fr 1fr 5.5rem;
+                grid-template-rows: 1fr;
+                gap: map-get($spacers, 2);
+                align-items: center;
+
+                .btn-primary.oe_kanban_action:where(:last-child), .btn-secondary.oe_kanban_action {
+                    grid-area: 1 / 2;
                 }
-                .o_hr_holidays_button {
-                    display: flex;
-                    flex-direction: row;
-                    align-items: center;
-                    justify-content: center;
-                    gap: 1;
+
+                .badge {
+                    grid-area: 1 / 3;
+                    align-self: center;
                 }
             }
         }

--- a/addons/hr_holidays/static/src/views/kanban/kanban_renderer.xml
+++ b/addons/hr_holidays/static/src/views/kanban/kanban_renderer.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="hr_holidays.KanbanRenderer">
-        <div class="d-flex flex-column h-100">
+        <div class="d-flex flex-column h-100 w-100">
             <div class="o_timeoff_calendar">
                 <TimeOffDashboard t-if="this.showDashboard" employeeId="this.employeeId"/>
             </div>

--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -422,28 +422,28 @@
                             <widget name="web_ribbon" title="Approved" bg_color="bg-success" invisible="state != 'validate'"/>
                             <aside>
                                 <img t-att-src="'/web/image/hr.employee.public/' + record.employee_id.raw_value + '/avatar_128?unique=' + record.write_date.raw_value"
-                                    class="o_image_64_cover float-start mb-2 me-2" alt="Employee's image"/>
+                                    class="o_image_64_cover float-start rounded border" alt="Employee's image"/>
                             </aside>
                             <main class="h-100">
-                                <div class="justify-content-center o_holidays_kanban_card">
+                                <div class="o_holidays_kanban_card d-flex flex-column justify-content-center h-100 ps-2 pe-3">
                                     <div class="d-flex flex-row">
-                                        <div class="col-12 align-items-center o_hr_holidays_value">
-                                             <div class="col-4 o_hr_holidays_card">
-                                                <field class="fw-bold fs-3 mb-2" name="employee_id"/>
+                                        <div class="col-12 d-flex align-items-center o_hr_holidays_value">
+                                             <div class="col-3 o_hr_holidays_card">
+                                                <field class="fw-bold fs-4 lh-sm" name="employee_id"/>
                                             </div>
                                             <div class="col-2 o_hr_holidays_name">
                                                 <div class="o_hr_holidays_card">
                                                     <field name="work_entry_type_id" class="fw-bold me-1"/>
-                                                    <div class="d-flex flex-wrap">
-                                                    ( <field name="allocation_type"/> )
+                                                    <div class="text-muted">
+                                                        <field name="allocation_type"/>
                                                     </div>
                                                 </div>
                                             </div>
-                                            <div class="col-2 o_hr_holidays_card">
+                                            <div class="col-2 o_hr_holidays_card ps-3">
                                                 <div class="fw-bold d-flex me-1">
                                                     <field name="duration_display"/>
                                                 </div>
-                                                Amount
+                                                <span class="text-muted">Amount</span>
                                             </div>
                                             <div class="col-2 o_hr_holidays_card">
                                                 <div class="fw-bold d-flex gap-1 me-1">
@@ -451,11 +451,11 @@
                                                     /
                                                     <field name="max_leaves" widget="float" digits="[3,2]"/>
                                                 </div>
-                                                <span>
+                                                <span class="text-muted">
                                                     Current balance
                                                 </span>
                                             </div>
-                                            <div class="col-2 o_hr_holidays_button flex-wrap d-flex pe-4 gap-2 justify-content-start">
+                                            <div class="o_hr_holidays_button col-3 d-flex justify-content-start gap-2 ps-5">
                                                 <button
                                                     name="action_approve" type="object" class="btn btn-primary"
                                                     t-if="record.can_approve.raw_value">
@@ -477,43 +477,41 @@
                                 </div>
                             </main>
                         </div>
-                        <div class="o_hr_holidays_kanban_mobile w-100">
-                            <main class="ps-1 d-flex flex-column w-100 gap-1">
-                                <div class="w-100 d-flex flex-row gap-2 align-items-center">
-                                    <field class="fw-bold" name="employee_id" widget="many2one_avatar_employee"/>
-                                    <field class="fw-bold w-100" name="employee_id"/>
-                                    <span
-                                        style="min-width: fit-content;"
-                                        t-attf-class="rounded-pill badge flex-shrink-1 text-bg-{{
-                                            record.state.raw_value == 'validate' ? 'success' :
-                                            ['confirm', 'validate1'].includes(record.state.raw_value) ?
-                                            'warning' : 'danger' }}"
-                                        t-out="record.state.value"/>
-                                </div>
-                                <div class="content d-flex flex-row gap-1 mb-2">
+                        <div class="o_hr_holidays_kanban_mobile d-flex gap-2 w-100">
+                            <aside>
+                                <img t-att-src="'/web/image/hr.employee.public/' + record.employee_id.raw_value + '/avatar_128?unique=' + record.write_date.raw_value"
+                                    class="o_image_40_cover float-start rounded" alt="Employee's image"/>
+                            </aside>
+                            <main class="d-flex flex-column lh-sm">
+                                <field class="fw-bold" name="employee_id"/>
+                                <div class="content d-flex flex-column">
                                     <field name="work_entry_type_id" class="text-muted"/>
-                                    <div class="text-muted">
-                                        (<field name="duration_display"/>)
-                                    </div>
+                                    <div class="text-muted">(<field name="duration_display"/>)</div>
                                 </div>
                             </main>
-                            <bottom class="d-flex justify-content-end gap-2">
+                            <div class="o_hr_holidays_button d-grid align-self-start pt-1">
+                                <span
+                                    t-attf-class="rounded-pill badge text-bg-{{
+                                        record.state.raw_value == 'validate' ? 'success' :
+                                        ['confirm', 'validate1'].includes(record.state.raw_value) ?
+                                        'warning' : 'danger' }}"
+                                    t-out="record.state.value"/>
                                 <button
-                                    name="action_approve" type="object" class="btn btn-sm btn-primary py-0"
+                                    name="action_approve" type="object" class="btn btn-sm btn-primary"
                                     t-if="record.can_approve.raw_value">
                                     Approve
                                 </button>
                                 <button
-                                    name="action_approve" type="object" class="btn btn-sm btn-primary py-0"
+                                    name="action_approve" type="object" class="btn btn-sm btn-primary"
                                     t-if="record.can_validate.raw_value and !record.can_approve.raw_value">
                                     Validate
                                 </button>
                                 <button
-                                    name="action_refuse" type="object" class="btn btn-sm btn-secondary py-0"
+                                    name="action_refuse" type="object" class="btn btn-sm btn-secondary"
                                     t-if="record.can_refuse.raw_value">
                                     Refuse
                                 </button>
-                            </bottom>
+                            </div>
                         </div>
                     </t>
                 </templates>

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -137,18 +137,17 @@
                             <widget name="web_ribbon" title="Approved" bg_color="bg-success" invisible="state != 'validate'"/>
                             <aside>
                                 <img t-att-src="'/web/image/hr.employee.public/' + record.employee_id.raw_value + '/avatar_128'"
-                                    class="o_image_64_cover float-start me-2" alt="Employee's image"/>
+                                    class="o_image_64_cover float-start rounded border" alt="Employee's image"/>
                             </aside>
                             <main class="h-100">
-                                <div class="justify-content-center o_holidays_kanban_card">
+                                <div class="o_holidays_kanban_card d-flex flex-column justify-content-center h-100 ps-2 pe-3">
                                     <div class="d-flex flex-row">
-                                        <div class="col-12 align-items-center o_hr_holidays_value">
-                                            <div class="col-4 o_hr_holidays_card">
-                                                <field class="fw-bold fs-3 mb-2" name="employee_id"/>
+                                        <div class="col-12 d-flex align-items-center o_hr_holidays_value">
+                                            <div class="col-3 o_hr_holidays_card">
+                                                <field class="fw-bold fs-4 lh-sm" name="employee_id"/>
                                             </div>
                                             <div class="col-2 o_hr_holidays_name">
-                                                <field name="work_entry_type_id" class="fw-bold"/>
-                                                <div class="d-flex flex-row">
+                                                <div class="d-flex flex-row fw-bold">
                                                     <t t-set="same_day" t-value="record.request_date_from.raw_value == record.request_date_to.raw_value"/>
                                                     <t t-set="leave_unit" t-value="record.work_entry_type_request_unit.raw_value"/>
                                                     <t t-out="luxon.DateTime.fromISO(record.request_date_from.raw_value).toLocaleString({ month: 'short', day: 'numeric'})"/>
@@ -186,12 +185,15 @@
                                                         <field name="request_hour_to" widget="float_time_selection"/>
                                                     </t>
                                                 </div>
+                                                <field name="work_entry_type_id" class="text-muted"/>
                                             </div>
-                                            <div class="col-2 o_hr_holidays_card">
+                                            <div class="col-2 o_hr_holidays_card ps-3">
                                                 <div class="fw-bold d-flex me-1">
                                                     <field name="duration_display"/>
                                                 </div>
-                                                Amount
+                                                <span class="text-muted">
+                                                    Amount
+                                                </span>
                                             </div>
                                             <div class="col-2 o_hr_holidays_card">
                                                 <div t-if="record.work_entry_type_requires_allocation.raw_value"> <!-- To keep the same space-->
@@ -200,12 +202,17 @@
                                                         /
                                                         <field name="max_leaves" widget="float" digits="[3,2]"/>
                                                     </div>
-                                                    <span>
+                                                    <span class="text-muted">
                                                         Current balance
                                                     </span>
                                                 </div>
                                             </div>
-                                            <div class="col-2 o_hr_holidays_button flex-wrap d-flex pe-4 gap-2 justify-content-start">
+                                            <div class="col-1">
+                                                <button t-if="record.attachment_is_visible and record.supported_attachment_ids_count.raw_value > 0" name="action_documents" type="object" class="btn btn-link text-nowrap">
+                                                    <i class="fa fa-paperclip" title="Attachments" /> <field name="supported_attachment_ids_count" nolabel="1"/>
+                                                </button>
+                                            </div>
+                                            <div class="o_hr_holidays_button col-2 d-flex justify-content-start gap-2">
                                                 <button
                                                     name="action_approve" type="object" class="btn btn-primary"
                                                     t-if="record.can_approve.raw_value">
@@ -227,82 +234,80 @@
                                 </div>
                             </main>
                         </div>
-                        <div class="f-flex flex-row o_hr_holidays_kanban_mobile w-100">
-                            <main>
-                                <div class="flex flex-grow-1 align-items-start mb-1">
-                                    <div class="mb-1 d-flex align-items-center gap-2 hr_leave_kanban_title">
-                                        <field name="employee_id" widget="many2one_avatar_employee"/>
-                                        <field name="employee_id" class="fw-bold w-100"/>
-                                        <span
-                                            style="min-width: fit-content;"
-                                            t-attf-class="rounded-pill badge flex-shrink-1 text-bg-{{
-                                                record.state.raw_value == 'validate' ? 'success' :
-                                                ['confirm', 'validate1'].includes(record.state.raw_value) ?
-                                                'warning' : 'danger' }}"
-                                            t-out="record.state.value"/>
-                                    </div>
-                                    <div class="d-flex flex-row">
-                                        <div id="date_part" class="d-flex flex-row"> <!-- To be override in my_kanban-->
-                                                <t t-set="same_day" t-value="record.request_date_from.raw_value == record.request_date_to.raw_value"/>
-                                                <t t-set="leave_unit" t-value="record.work_entry_type_request_unit.raw_value"/>
-                                                <t t-out="luxon.DateTime.fromISO(record.request_date_from.raw_value).toLocaleString({ month: 'short', day: 'numeric'})"/>
-                                                <t t-if="leave_unit == 'day'">
-                                                    <t t-if="!same_day">
-                                                        <span class="mx-1">–</span>
-                                                        <t t-out="luxon.DateTime.fromISO(record.request_date_to.raw_value).toLocaleString({ month: 'short', day: 'numeric'})"/>
-                                                    </t>
-                                                </t>
-                                                <t t-elif="leave_unit == 'half_day'">
-                                                    <t t-set="same_period" t-value="record.request_date_from_period.raw_value == record.request_date_to_period.raw_value"/>
-                                                    <span class="mx-1">-</span>
-                                                    <t t-out="record.request_date_from_period.value"/>
-                                                    <t t-if="same_day">
-                                                        <t t-if="!same_period">
-                                                            <span class="mx-1">–</span>
-                                                            <t t-out="record.request_date_to_period.value"/>
-                                                        </t>
-                                                    </t>
-                                                    <t t-else="">
-                                                        <span class="mx-1">–</span>
-                                                        <t t-out="luxon.DateTime.fromISO(record.request_date_to.raw_value).toLocaleString({ month: 'short', day: 'numeric'})"/>
-                                                        <span class="mx-1"><t t-out="record.request_date_to_period.value"/></span>
-                                                    </t>
-                                                </t>
-                                                <t t-elif="leave_unit == 'hour'">
-                                                    <span class="mx-1">-</span>
-                                                    <field name="request_hour_from" widget="float_time_selection"/>
+                        <div class="o_hr_holidays_kanban_mobile d-flex gap-2 w-100">
+                            <aside class="hr_leave_kanban_aside">
+                                <img t-att-src="'/web/image/hr.employee.public/' + record.employee_id.raw_value + '/avatar_128'"
+                                    class="o_image_40_cover float-start rounded" alt="Employee's image"/>
+                            </aside>
+                            <main class="d-flex flex-column lh-sm">
+                                <span class="hr_leave_kanban_employee_id"><field name="employee_id" class="fw-bold"/></span>
+                                <div class="d-flex flex-row">
+                                    <div id="date_part" class="d-flex flex-row"> <!-- To be override in my_kanban-->
+                                            <t t-set="same_day" t-value="record.request_date_from.raw_value == record.request_date_to.raw_value"/>
+                                            <t t-set="leave_unit" t-value="record.work_entry_type_request_unit.raw_value"/>
+                                            <t t-out="luxon.DateTime.fromISO(record.request_date_from.raw_value).toLocaleString({ month: 'short', day: 'numeric'})"/>
+                                            <t t-if="leave_unit == 'day'">
+                                                <t t-if="!same_day">
                                                     <span class="mx-1">–</span>
-                                                    <t t-if="!same_day">
-                                                        <t t-out="luxon.DateTime.fromISO(record.request_date_to.raw_value).toLocaleString({ month: 'short', day: 'numeric'})"/>
-                                                        <span class="mx-1">-</span>
-                                                    </t>
-                                                    <field name="request_hour_to" widget="float_time_selection"/>
+                                                    <t t-out="luxon.DateTime.fromISO(record.request_date_to.raw_value).toLocaleString({ month: 'short', day: 'numeric'})"/>
                                                 </t>
-                                        </div>
+                                            </t>
+                                            <t t-elif="leave_unit == 'half_day'">
+                                                <t t-set="same_period" t-value="record.request_date_from_period.raw_value == record.request_date_to_period.raw_value"/>
+                                                <span class="mx-1">-</span>
+                                                <t t-out="record.request_date_from_period.value"/>
+                                                <t t-if="same_day">
+                                                    <t t-if="!same_period">
+                                                        <span class="mx-1">–</span>
+                                                        <t t-out="record.request_date_to_period.value"/>
+                                                    </t>
+                                                </t>
+                                                <t t-else="">
+                                                    <span class="mx-1">–</span>
+                                                    <t t-out="luxon.DateTime.fromISO(record.request_date_to.raw_value).toLocaleString({ month: 'short', day: 'numeric'})"/>
+                                                    <span class="mx-1"><t t-out="record.request_date_to_period.value"/></span>
+                                                </t>
+                                            </t>
+                                            <t t-elif="leave_unit == 'hour'">
+                                                <span class="mx-1">-</span>
+                                                <field name="request_hour_from" widget="float_time_selection"/>
+                                                <span class="mx-1">–</span>
+                                                <t t-if="!same_day">
+                                                    <t t-out="luxon.DateTime.fromISO(record.request_date_to.raw_value).toLocaleString({ month: 'short', day: 'numeric'})"/>
+                                                    <span class="mx-1">-</span>
+                                                </t>
+                                                <field name="request_hour_to" widget="float_time_selection"/>
+                                            </t>
                                     </div>
-                                    <field name="work_entry_type_id" class="text-muted"/>
-                                    <span class="text-muted">
-                                        (<field name="duration_display"/>)
-                                    </span>
                                 </div>
+                                <field name="work_entry_type_id" class="text-muted"/>
+                                <span class="text-muted">
+                                    (<field name="duration_display"/>)
+                                </span>
                             </main>
-                            <bottom class="d-flex justify-content-end gap-2 mt-0">
-                                <button t-if="record.can_approve.raw_value" name="action_approve" type="object" class="btn btn-sm btn-primary py-0"
+                            <button t-if="record.attachment_is_visible and record.supported_attachment_ids_count.raw_value > 0" name="action_documents" type="object" class="btn btn-link me-4 text-nowrap">
+                                <i class="fa fa-paperclip" title="Attachments" /> <field name="supported_attachment_ids_count" nolabel="1"/>
+                            </button>
+                            <div class="o_hr_holidays_button d-grid align-self-start pt-1">
+                                <span
+                                    t-attf-class="badge rounded-pill text-bg-{{
+                                        record.state.raw_value == 'validate' ? 'success' :
+                                        ['confirm', 'validate1'].includes(record.state.raw_value) ?
+                                        'warning' : 'danger' }}"
+                                    t-out="record.state.value"/>
+                                <button t-if="record.can_approve.raw_value" name="action_approve" type="object" class="btn btn-sm btn-primary"
                                     groups="hr_holidays.group_hr_holidays_user">
                                     Approve
                                 </button>
-                                <button t-if="record.can_validate.raw_value and !record.can_approve.raw_value" name="action_approve" type="object" class="btn btn-sm btn-primary py-0"
+                                <button t-if="record.can_validate.raw_value and !record.can_approve.raw_value" name="action_approve" type="object" class="btn btn-sm btn-primary"
                                     groups="hr_holidays.group_hr_holidays_manager">
                                     Validate
                                 </button>
-                                <button t-if="record.can_refuse.raw_value" name="action_refuse" type="object" class="btn btn-sm btn-secondary py-0"
+                                <button t-if="record.can_refuse.raw_value" name="action_refuse" type="object" class="btn btn-sm btn-secondary"
                                     groups="hr_holidays.group_hr_holidays_user">
                                     Refuse
                                 </button>
-                                <button t-if="record.attachment_is_visible and record.supported_attachment_ids_count.raw_value > 0" name="action_documents" type="object" class="btn btn-link btn-sm ps-0 text-danger">
-                                    <i class="fa fa-paperclip"> <field name="supported_attachment_ids_count" nolabel="1"/></i>
-                                </button>
-                            </bottom>
+                            </div>
                         </div>
                     </t>
                 </templates>
@@ -752,16 +757,8 @@
             <xpath expr="//div[@id='date_part']" position="attributes">
                 <attribute name="class" add="w-100 fw-bold" separator=" "/>
             </xpath>
-            <xpath expr="//div[@id='date_part']" position="after">
-                <span
-                    style="min-width: fit-content;"
-                    t-attf-class="rounded-pill badge flex-shrink-1 text-bg-{{
-                    record.state.raw_value == 'validate' ? 'success' :
-                    ['confirm', 'validate1'].includes(record.state.raw_value) ?
-                    'warning' : 'danger' }}"
-                    t-out="record.state.value"/>
-            </xpath>
-            <xpath expr="//div[hasclass('hr_leave_kanban_title')]" position="replace"/>
+            <xpath expr="//span[hasclass('hr_leave_kanban_employee_id')]" position="replace"/>
+            <xpath expr="//aside[hasclass('hr_leave_kanban_aside')]" position="replace"/>
         </field>
     </record>
 


### PR DESCRIPTION
This PR enhances the kanban view layout for Time Off and Allocations by:
- optimizing spacing
- avoiding text overlap
- preventing ribbon from covering buttons
- improving the mobile layout
- always showing the attachments button (previously it was only shown on mobile)

task-5072771

| Before | After |
|--------|--------|
| <img width="414" height="896" alt="mobile-before" src="https://github.com/user-attachments/assets/dfcab16b-08a9-407e-8bf1-b4b135648053" /> | <img width="654" height="1416" alt="All-Time-Off-03-18-2026_10_10_AM" src="https://github.com/user-attachments/assets/a4096e99-9789-44a1-a90b-3f98163808d3" /> |
| <img width="820" height="961" alt="tablet-before" src="https://github.com/user-attachments/assets/2a67e342-f293-4cf2-994c-747116082eb9" /> | <img width="2048" height="1962" alt="All-Time-Off-03-18-2026_10_11_AM" src="https://github.com/user-attachments/assets/3de1f259-cae3-4106-b12d-8f21e525a9fc" /> |
| <img width="1646" height="1035" alt="desktop-before" src="https://github.com/user-attachments/assets/24d2b131-0f14-4f87-9682-ee635a5f9673" /> | <img width="3380" height="2096" alt="All-Time-Off-03-18-2026_10_12_AM" src="https://github.com/user-attachments/assets/3e98639f-8ac7-4f8f-8daa-7e3b5ee012da" />  |







---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
