### PR TITLE
[FIX] web: blacklist attendance Onboarding menu in clickbot

### DIFF
--- a/addons/web/static/src/webclient/clickbot/clickbot.js
+++ b/addons/web/static/src/webclient/clickbot/clickbot.js
@@ -16,6 +16,7 @@ const BLACKLISTED_MENUS = [
     "base.menu_third_party", // Open a new tab
     "event.menu_event_registration_desk", // there's no way to come back from this menu (tablet mode)
     "hr_attendance.menu_action_open_form", // same here (tablet mode)
+    "hr_attendance.menu_hr_attendance_onboarding", // same here (tablet mode)
     "mrp_workorder.menu_mrp_workorder_root", // same here (tablet mode)
     "pos_enterprise.menu_point_kitchen_display_root", // conditional menu that may leads to frontend
 ];


### PR DESCRIPTION
This commit blacklists the attendance Onboarding menu in clickbot since that menu redirects the user to kiosk app which is a custom app for tablet mode and so the clickbot cannot go back in backend when it enters in the kiosk.
