### PR TITLE
[FIX] website: correct the format of default values

### DIFF
--- a/addons/website/static/tests/tours/rte.js
+++ b/addons/website/static/tests/tours/rte.js
@@ -7,44 +7,51 @@ import {
 } from "@website/js/tours/tour_utils";
 import { editorsWeakMap, setSelection } from "@html_editor/../tests/tours/helpers/editor";
 
+function installParseltongueAndOpenLangDropdown() {
+    return [
+        ...goToTheme(),
+        {
+            content: "click on Add a language",
+            trigger: "button[data-action-id='addLanguage']",
+            run: "click",
+        }, {
+            content: "confirm leave editor",
+            trigger: ".modal-dialog button.btn-primary",
+            run: "click",
+        }, {
+            content: "type Parseltongue",
+            trigger: 'div[name="lang_ids"] .o_input_dropdown input',
+            run: "edit Parseltongue",
+        }, {
+            content: 'select Parseltongue',
+            trigger: '.dropdown-item:contains(Parseltongue)',
+            run: "click",
+        },
+        {
+            trigger: '.modal-dialog div[name="lang_ids"] .rounded-pill .o_tag_badge_text:contains(Parseltongue)',
+        },
+        {
+            content: "load Parseltongue",
+            trigger: '.modal-footer .btn-primary',
+            run: "click",
+        }, {
+            content: "click language dropdown (2)",
+            trigger: ':iframe .js_language_selector .dropdown-toggle',
+            timeout: 60000,
+            run: "click",
+        },
+        {
+            content: "Check that the language of the page is Parseltongue",
+            trigger: ':iframe html[lang*="pa-GB"]',
+        },
+    ];
+}
+
 registerWebsitePreviewTour('rte_translator', {
     url: '/',
     edition: true,
 }, () => [
-...goToTheme(),
-{
-    content: "click on Add a language",
-    trigger: "button[data-action-id='addLanguage']",
-    run: "click",
-}, {
-    content: "confirm leave editor",
-    trigger: ".modal-dialog button.btn-primary",
-    run: "click",
-}, {
-    content: "type Parseltongue",
-    trigger: 'div[name="lang_ids"] .o_input_dropdown input',
-    run: "edit Parseltongue",
-}, {
-    content: 'select Parseltongue',
-    trigger: '.dropdown-item:contains(Parseltongue)',
-    run: "click",
-},
-{
-    trigger: '.modal-dialog div[name="lang_ids"] .rounded-pill .o_tag_badge_text:contains(Parseltongue)',
-},
-{
-    content: "load Parseltongue",
-    trigger: '.modal-footer .btn-primary',
-    run: "click",
-}, {
-    content: "click language dropdown (2)",
-    trigger: ':iframe .js_language_selector .dropdown-toggle',
-    timeout: 60000,
-    run: "click",
-},
-{
-    trigger: ':iframe html[lang*="pa-GB"]',
-},
+    ...installParseltongueAndOpenLangDropdown(),
 {
     content: "go to english version",
     trigger: ':iframe .o_header_language_selector a[data-url_code="en"]',
@@ -318,3 +325,10 @@ registerWebsitePreviewTour('rte_translator', {
     content: "Check that the editor is not showing translated content (2)",
     trigger: ':iframe body:not(.rte_translator_error)',
 }]);
+
+registerWebsitePreviewTour('multiple_websites_add_language', {
+    url: '/',
+    edition: true,
+}, () => [
+...installParseltongueAndOpenLangDropdown(),
+])

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -296,6 +296,17 @@ class TestUiTranslate(odoo.tests.HttpCase):
         })
         self.start_tour(f"/website/force/{website.id}", 'snippet_dialog_rtl', login='admin')
 
+    def test_multiple_websites_add_language(self):
+        self.env['res.lang'].create({
+            'name': 'Parseltongue',
+            'code': 'pa_GB',
+            'iso_code': 'pa_GB',
+            'url_code': 'pa_GB',
+        })
+        Website = self.env['website']
+        Website.create({'name': 'Website Test'})
+        self.start_tour(self.env['website'].get_client_action_url('/'), 'multiple_websites_add_language', login='admin')
+
 
 @odoo.tests.common.tagged('post_install', '-at_install')
 class TestUi(HttpCaseWithWebsiteUser):

--- a/addons/website/wizard/base_language_install.py
+++ b/addons/website/wizard/base_language_install.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models
+from odoo import api, fields, models, Command
 
 
 class BaseLanguageInstall(models.TransientModel):
@@ -15,7 +15,7 @@ class BaseLanguageInstall(models.TransientModel):
         if website_id:
             if 'website_ids' not in defaults:
                 defaults['website_ids'] = []
-            defaults['website_ids'].append(website_id)
+            defaults['website_ids'].append(Command.link(website_id))
         return defaults
 
     def lang_install(self):


### PR DESCRIPTION
[FIX] website: correct the format of default values
Steps to reproduce the problem:
- On a db with at least two websites installed, enter in edit mode.
- Go to the "Theme" tab.
- Click on "Add a Language".
- Click on "Ok" on the confirmation dialog.

-> Traceback

This commit solves the problem by correctly building the returned value
of the `default_get` method (with `Command`). Note that the problem
appeared since [this commit] as a field (`display_name`) is required
from the websites linked to `base.language.install`.

[this commit]: https://github.com/odoo/odoo/commit/b1489cc89f23779ba0853cfd05b8022bf84f1c78

task-5172747