### PR TITLE
[FIX] sale_project: non-validated timesheets in project sharing preview

### DIFF
--- a/addons/sale_project/views/project_sharing_views.xml
+++ b/addons/sale_project/views/project_sharing_views.xml
@@ -62,6 +62,7 @@
             'active_id_chatter': active_id,
             'delete': false,
             'sale_show_partner_name': true,
+            'is_portal_preview': true,
         }</field>
     </record>
 


### PR DESCRIPTION
Issue:

Due to this issue, in the project sharing, the customer preview doesn't reflect the actual behaviour of the portal view. It shows non-validated timesheets even if invoicing policy is validated timesheets only.

To reproduce:

Cause:

Fix:

opw-5155281

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
