### PR TITLE
[FIX] website_sale_collect: Don't forcecreate delivery carrier

### DIFF
--- a/addons/website_sale_collect/data/delivery_carrier_data.xml
+++ b/addons/website_sale_collect/data/delivery_carrier_data.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo noupdate="1">
 
-    <record id="carrier_pick_up_in_store" model="delivery.carrier">
+    <record id="carrier_pick_up_in_store" model="delivery.carrier" forcecreate="0">
         <field name="name">Pick up in store</field>
         <field name="delivery_type">in_store</field>
         <field name="product_id" ref="website_sale_collect.product_pick_up_in_store"/>

--- a/addons/website_sale_collect/models/delivery_carrier.py
+++ b/addons/website_sale_collect/models/delivery_carrier.py
@@ -44,8 +44,15 @@ class DeliveryCarrier(models.Model):
                 vals['integration_level'] = 'rate'
 
                 # Set the default warehouses and publish if one is found.
+                if 'company_id' in vals:
+                    company_id = vals.get('company_id')
+                else:
+                    company_id = (
+                        self.env['product.product'].browse(vals.get('product_id')).company_id.id
+                        or self.env.company.id
+                    )
                 warehouses = self.env['stock.warehouse'].search(
-                    [('company_id', 'in', self.env.company.id)]
+                    [('company_id', 'in', company_id)]
                 )
                 vals.update({
                     'warehouse_ids': [Command.set(warehouses.ids)],


### PR DESCRIPTION
The record `carrier_pick_up_in_store` will get assigned the product `product_pick_up_in_store`. Since the warehouses are linked based[^1] on the env company, if it doesn't match that of the product it will throw an error[^2] because of that mismatch.

To reproduce:
- Change the company of `product_pick_up_in_store` to one other than the active.
- Delete the delivery carrier `carrier_pick_up_in_store`
- Upgrade the module.

**[FIX] website_sale_collect: Use right company for warehouses**

While creating a delivery carrier the warehouses are linked using the env
company. While using multi-company, you might select another company from the
active ones rather than the one from env. This will trigger a validation error
because the warehouses will be filtered by the wrong company. Same case if the
company is left empty.

To reproduce:
- Create a delivery method selecting pick up in store, leaving the company empty.
- It will still link the warehouses from the active company.

- Activate a second company in the multi-company menu.
- Create a delivery carrier, selecting pick up in store and the second company.
- The warehouses will be linked to the first company, triggering a validation
error.
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
[^1]:https://github.com/odoo/odoo/blob/9900375bc0bac2754150fd8cd6a1e45ecad8da83/addons/website_sale_collect/models/delivery_carrier.py#L47-L49
[^2]:https://github.com/odoo/odoo/blob/9900375bc0bac2754150fd8cd6a1e45ecad8da83/addons/website_sale_collect/models/delivery_carrier.py#L33-L38