### PR TITLE
[FIX] web: properly disable write action on x2many fields

### DIFF
--- a/addons/web/static/src/views/fields/relational_utils.js
+++ b/addons/web/static/src/views/fields/relational_utils.js
@@ -101,13 +101,13 @@ export function useActiveActions({
         // We need to take care of tags "control" and "create" to set create stuff
         result.create = !readonly && evalAction("create");
         result.createEdit = !readonly && result.create && crudOptions.createEdit; // always a boolean
-        result.edit = crudOptions.edit;
+        result.edit = crudOptions.edit; // always a boolean
         result.delete = !readonly && evalAction("delete");
+        result.write = (isMany2Many || !readonly) && evalAction("write");
 
         if (isMany2Many) {
             result.link = !readonly && evalAction("link");
             result.unlink = !readonly && evalAction("unlink");
-            result.write = evalAction("write");
         }
 
         if (result.unlink || (!isMany2Many && result.delete)) {
@@ -123,7 +123,7 @@ export function useActiveActions({
     // Define eval functions
     const evals = {};
     for (const actionName of STANDARD_ACTIVE_ACTIONS) {
-        let evalFn = () => actionName !== "write";
+        let evalFn = () => true;
         if (!isNull(crudOptions[actionName])) {
             const action = crudOptions[actionName];
             evalFn = (evalContext) => Boolean(action && new Domain(action).contains(evalContext));
@@ -911,8 +911,12 @@ export function useOpenX2ManyRecord({
         let deleteButtonLabel = undefined;
         const isDuplicate = !!record;
 
-        const params = { activeFields, fields, readonly };
-        params.mode = params.readonly ? "readonly" : "edit";
+        const params = { activeFields, fields };
+        if (isMany2Many) {
+            params.mode = activeActions.write ? "edit" : "readonly";
+        } else {
+            params.mode = readonly || !activeActions.write ? "readonly" : "edit";
+        }
         if (record) {
             const { delete: canDelete, onDelete } = activeActions;
             deleteRecord = viewMode === "kanban" && canDelete ? () => onDelete(record) : null;

--- a/addons/web/static/src/views/fields/x2many/x2many_field.js
+++ b/addons/web/static/src/views/fields/x2many/x2many_field.js
@@ -190,7 +190,7 @@ export class X2ManyField extends Component {
             archInfo,
             list: this.list,
             openRecord: this.openRecord.bind(this),
-            readonly: this.props.readonly,
+            readonly: this.props.readonly || !this.activeActions.write,
         };
 
         if (this.props.viewMode === "kanban") {

--- a/addons/web/static/tests/views/fields/one2many_field.test.js
+++ b/addons/web/static/tests/views/fields/one2many_field.test.js
@@ -3662,6 +3662,56 @@ test("one2many kanban: conditional create/delete actions", async () => {
     });
 });
 
+test("one2many kanban: conditional write action", async () => {
+    Partner._records[0].p = [2, 4];
+
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        arch: `
+            <form>
+                <field name="bar"/>
+                <field name="p" options="{'write': [('bar', '=', True)]}">
+                    <kanban>
+                        <templates>
+                            <t t-name="card">
+                                <field name="name"/>
+                                <field name="bar" widget="boolean_toggle"/>
+                            </t>
+                        </templates>
+                    </kanban>
+                    <form>
+                        <field name="name"/>
+                        <field name="foo"/>
+                    </form>
+                </field>
+            </form>`,
+        resId: 1,
+    });
+
+    expect(".o_kanban_record:first span").toHaveText("second record");
+    expect(".o_field_widget[name=bar]:first input").toBeChecked();
+
+    // bar is initially true -> edit action is available
+    expect(".o_kanban_record:first .o_field_widget[name=bar] input").toBeEnabled();
+    expect(".o-kanban-button-new").toHaveCount(1); // can create
+    await contains(".o_kanban_record:first").click();
+    expect(".o_dialog .o_form_renderer").toHaveClass("o_form_editable");
+    await contains(".o_dialog .o_field_widget[name=name] input").edit("second record edited");
+    await contains(".modal .o_form_button_save").click();
+    expect(".o_kanban_record:first span").toHaveText("second record edited");
+
+    // set bar false -> edit action is no longer available
+    await contains('.o_field_widget[name="bar"] input').click();
+    expect(".o_kanban_record:first .o_field_widget[name=bar] input").not.toBeEnabled();
+    expect(".o-kanban-button-new").toHaveCount(1); // can still create
+    await contains(".o_kanban_record:first").click();
+    expect(".o_dialog .o_form_renderer").toHaveClass("o_form_readonly");
+    expect(".o_dialog .o_form_button_save").toHaveCount(0);
+    await contains(".modal .o_form_button_cancel").click();
+    expect(".o_dialog").toHaveCount(0);
+});
+
 test.tags("desktop");
 test("editable one2many list, pager is updated on desktop", async () => {
     Turtle._records.push({ id: 4, turtle_foo: "stephen hawking" });


### PR DESCRIPTION
Before this commit, specifying the `edit` or `write` crud options on an x2many field didn't work. The `edit` action was overruled by the view mode (true iff the record datapoint is in edition), and the `write` action wasn't correctly honored in x2many. This commit ensures the `write` action is taken into account. In master, we'll rationalize this to merge `edit` and `write` in a single action.

Task~5160367

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
