### PR TITLE
[FIX] auth_passkey: add data to test_passkey_demo

### DIFF
--- a/addons/auth_passkey/tests/test_passkey_demo.py
+++ b/addons/auth_passkey/tests/test_passkey_demo.py
@@ -449,6 +449,7 @@ class PasskeyTestTours(PasskeyTest):
     def test_passkey_backend(self):
         # All these tests rely on each other but had to be split up to patch different methods.
         self.env['ir.config_parameter'].sudo().set_param('web.base.url', self.passkeys['test-yubikey']['host'])
+        self.admin_user.tz = 'UTC'  # workaround to fix timezone not being set so you are unable to click any buttons on the profile page
         self.admin_user.auth_passkey_key_ids.unlink()
         with self.patch_start_registration(self.passkeys['test-yubikey']['registration']['challenge']):
             self.start_tour("/odoo?debug=tests", 'passkeys_tour_registration', login="admin")


### PR DESCRIPTION
We need to define timezone of the admin user for no demo tests, similar to how it is done in [saas-18.3](https://github.com/odoo/odoo/blob/9900375bc0bac2754150fd8cd6a1e45ecad8da83/addons/auth_passkey/tests/test_passkey_demo.py#L456): 

[Runbot error - 229872](https://runbot.odoo.com/odoo/error/229872)





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
