### PR TITLE
[IMP] website_sale: Products snippet sorting

### DIFF
--- a/addons/website_sale/models/website_snippet_filter.py
+++ b/addons/website_sale/models/website_snippet_filter.py
@@ -1,6 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from collections import Counter
 from functools import partial
 
 from odoo import _, api, fields, models
@@ -186,6 +185,7 @@ class WebsiteSnippetFilter(models.Model):
             [('website_published', '=', True)] if self.env.user._is_public() or self.env.user._is_portal() else [],
             website.website_domain(),
             [('company_id', 'in', [False, website.company_id.id])],
+            [('sale_ok', '=', True)],
             search_domain or [],
         ])
         products = handler(website, limit, domain, **kwargs)
@@ -201,20 +201,12 @@ class WebsiteSnippetFilter(models.Model):
             ('state', '=', 'sale'),
         ], limit=8, order='date_order DESC')
         if sale_orders:
+            sold_products = sale_orders.order_line.product_id
             if self.env.context.get('hide_variants'):
-                sold_products = Counter(
-                    sol.product_id.product_tmpl_id.product_variant_id
-                    for sol in sale_orders.order_line
-                )
-            else:
-                sold_products = Counter(sol.product_id for sol in sale_orders.order_line)
+                sold_products = sold_products.product_tmpl_id.product_variant_id
             if sold_products:
-                domain = Domain(domain) & Domain('id', 'in', [p.id for p, _ in sold_products.most_common(limit)])
-                products = self.env['product.product'].with_context(
-                    display_default_code=False,
-                ).search(domain, limit=limit)
-                products = products.sorted(key=sold_products.get, reverse=True)
-        return products
+                products = sold_products.filtered_domain(domain)[:limit]
+        return products.with_context(display_default_code=False)
 
     def _get_products_latest_viewed(self, website, limit, domain, **kwargs):
         products = self.env['product.product']

--- a/addons/website_sale/templates/snippets/product_snippet_template_data.xml
+++ b/addons/website_sale/templates/snippets/product_snippet_template_data.xml
@@ -20,6 +20,7 @@
                     role="article"
                     t-att-aria-label="product.display_name"
                     t-att-data-add2cart-rerender="data.get('_add2cart_rerender')"
+                    t-att-data-publish="product.website_published and 'on' or 'off'"
                 >
                     <!-- Image -->
                     <div t-attf-class="oe_product_image position-relative flex-grow-0 overflow-hidden">


### PR DESCRIPTION
**Purpose:**
The products snippet deserves a few improvements to be more usable.

**Pecification:**
- Remove the delivery products from the list
- Mute unpublished products for admins, same as in shop page
- Fix the sort of the recently sold products to show latest sold first. Currently, it sorts by amount sold.

Task-5167692

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
