### PR TITLE
[FIX] crm: fix search_domain for crm stage

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1054,15 +1054,11 @@ class CrmLead(models.Model):
         # - OR ('fold', '=', False): add default columns that are not folded
         # - OR ('team_ids', '=', team_id), ('fold', '=', False) if team_id: add team columns that are not folded
         team_id = self.env.context.get('default_team_id')
-        if team_id:
-            search_domain = ['|', ('id', 'in', stages.ids), '|', ('team_ids', '=', False), ('team_ids', 'in', team_id)]
-        if self.env.context.get('show_user_team_stages'):
-            team_ids = self.env.user.crm_team_ids._ids
-            if team_id:
-                team_ids += (team_id,)
+        team_ids = self.env.user.crm_team_ids._ids if self.env.context.get('show_user_team_stages') else ()
+        team_ids += (team_id,) if team_id else ()
+        search_domain = ['|', ('id', 'in', stages.ids), ('team_ids', '=', False)]
+        if team_ids:
             search_domain = ['|', ('id', 'in', stages.ids), '|', ('team_ids', '=', False), ('team_ids', 'in', team_ids)]
-        else:
-            search_domain = ['|', ('id', 'in', stages.ids), ('team_ids', '=', False)]
 
         # perform search
         stage_ids = stages.sudo()._search(search_domain, order=stages._order)


### PR DESCRIPTION
step to reproduce:
- install crm with sample data
- go to sales -> teams -> "Sales"
- Add a stage and configure it for "sales team" from the stage's cog menu
- back to **Opportunities** page and refresh 

Observation:
- The stage vanishes from the view 

Cause:
- commit [1] adds a if condition in `_read_group_stage_ids` view such that
it overrides previous if condition, hence we lose the intended domain

Fix:
- fix the method and made it simpler

[1] https://github.com/odoo/odoo/commit/7345cbbff6ecb1dcbc508c320e807849167a4f1a
opw-5166128

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
