### PR TITLE
[FIX] pos_self_order: wrong order on confirmation screen, incorrect receipt after refresh

### DIFF
--- a/addons/pos_self_order/static/src/app/data_service_options.js
+++ b/addons/pos_self_order/static/src/app/data_service_options.js
@@ -12,6 +12,14 @@ patch(DataServiceOptions.prototype, {
                 key: "uuid",
                 condition: (record) => false,
             },
+            "pos.payment": {
+                key: "uuid",
+                condition: (record) => false,
+            },
+            "pos.payment.method": {
+                key: "id",
+                condition: (record) => false,
+            },
         };
     },
 });

--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -705,7 +705,6 @@ export class SelfOrder extends Reactive {
                 order_access_tokens: accessTokens,
                 table_identifier: tableIdentifier,
             });
-            this.selectedOrderUuid = null;
             const result = this.models.loadData(data);
             const openOrder = result["pos.order"]?.find((o) => o.state === "draft");
             if (openOrder && this.router.activeSlot !== "confirmation") {


### PR DESCRIPTION
This PR contains 2 small fixes for mobile self order:

- **[FIX] pos_self_order: wrong order on confirmation screen**

  Steps to reproduce:
  1. Configure a Self Order POS to use QR menu + ordering
  2. In the mobile menu, make an order and confirm
  3. The confirmation screen shows order S001, pay at the counter
  4. In the POS, pay and validate the order
  5. In the mobile menu, make another order and confirm
  
  Expected behaviour:
  - The confirmation screen shows order S002, pay at the counter
  
  Actual behaviour:
  - The confirmation screen shows order S001, already paid
  
  The cause of this is that `selectedOrderUuid` is cleared whenever the
  `getUserDataFromServer` method is called, even if the server doesn't
  return an order to replace it with. The self order service then tries
  to find the current order and takes the previously paid order instead of
  the new order.
  
  To fix this, we simply don't clear `selectedOrderUuid`. It will still be
  overwritten if the server does return new order data.


- **[FIX] pos_self_order: incorrect receipt after refresh**

  Steps to reproduce:
  1. Configure a Self Order POS to use QR menu + ordering
  2. Make an order in the mobile menu
  3. Pay and validate the order in the POS using the 'Card' payment method
  4. Go to 'My Orders' in the mobile menu, and download the receipt
  5. Observe the correct 'Card' payment line is shown on the receipt
  6. Refresh the page
  7. Download the receipt again
  
  Expected behaviour:
  - The downloaded receipt is the same as the first one, with the 'Card'
    payment line.
  
  Actual behaviour:
  - The downloaded receipt has no payment lines, so it just shows a
    negative 'Change' line at the end.
  
  The cause of this issue is that the payment lines and payment methods
  used to render the receipt were not being persisted in the indexed DB.
  The fix is simply to add these models to the data service options so
  that they also get saved locally.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
