### PR TITLE
[FIX] pos_self_order: Pay button shows in mobile menu

### DIFF
--- a/addons/pos_online_payment_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_online_payment_self_order/static/src/app/services/self_order_service.js
@@ -25,6 +25,15 @@ patch(SelfOrder.prototype, {
             }
         });
     },
+    hasPaymentMethod() {
+        if (
+            this.config.self_ordering_mode === "mobile" &&
+            this.config.self_order_online_payment_method_id
+        ) {
+            return true;
+        }
+        return super.hasPaymentMethod();
+    },
     getOnlinePaymentUrl(
         { id: order_id, access_token: order_access_token, config_id: order_pos_config_id },
         exitRoute = true

--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -285,7 +285,10 @@ export class SelfOrder extends Reactive {
         this.printKioskChanges(access_token);
     }
     hasPaymentMethod() {
-        return this.models["pos.payment.method"].getAll().length > 0;
+        return (
+            this.config.self_ordering_mode === "kiosk" &&
+            this.models["pos.payment.method"].getAll().length > 0
+        );
     }
 
     async confirmOrder() {


### PR DESCRIPTION
Steps to reproduce:
1. Configure a Self Order POS to use QR menu + ordering
2. Open the mobile menu and make an order
3. Pay and validate the order in the POS
4. Try to make another order in the mobile menu

Expected behaviour:
- The 'Order' button shows, which takes the user to the confirmation screen without paying.

Actual behaviour:
- The 'Pay' button shows, and clicking it causes an error.

This bug was introduced with odoo/odoo#229921. This PR made the self order always load all payment methods it had loaded, assuming that they would only come from the backend which filters them correctly. However, there was an oversight due to the fact that additional payment methods need to be loaded in Mobile ordering in order to render the order receipt correctly.

The fix is to re-introduce some checks on the frontend, to make sure the 'Pay' button only shows when intended.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
