### PR TITLE
[FIX] payment_paypal: update currencies list

### DIFF
--- a/addons/payment_paypal/const.py
+++ b/addons/payment_paypal/const.py
@@ -2,12 +2,13 @@
 
 # ISO 4217 codes of currencies supported by PayPal
 # See https://developer.paypal.com/docs/reports/reference/paypal-supported-currencies/.
-# Last seen on: 22 September 2022.
+# Also see https://developer.paypal.com/api/nvp-soap/currency-codes/.
+# Last seen on: 16 October 2025.
 SUPPORTED_CURRENCIES = (
     'AUD',
     'BRL',
     'CAD',
-    'CNY',
+    # 'CNY', # Only for Chinese PayPal accounts; to be added manually from interface.
     'CZK',
     'DKK',
     'EUR',


### PR DESCRIPTION
## Versions
17.0+

## Issue
No payment is possible with PayPal for invoices expressed in Chinese currency.

## Steps to reproduce
**`account` app required**
- Enable "CNY" currency via `Invoicing / Configuration / Accounting / Currencies`;
- Install, setup and publish PayPal payment provider;
- Move to the Invoice app:
  - Create a new invoice in "CNY" currency for any customer with at least 1 product;
  - Confirm and click on the preview button:
    - Click on the "Pay now" button then "Pay" button of the wizard.

## Cause
"CNY" currency is only supported for Chinese accounts and for transactions occurring in China. PayPal says:
> Please note that Chinese Renminbi (CNY) is supported as a payment currency (buyer currency) or settlement currency (holding currency) only for in-country PayPal accounts. If the settlement account is based outside of China, PayPal will convert the funds into the account’s primary currency using the applicable currency conversion rate, which includes a spread or fee.


opw-5071893