### PR TITLE
[REF] mail: make user inherit partner (JS)

### DIFF
--- a/addons/mail/static/src/core/common/@types/models.d.ts
+++ b/addons/mail/static/src/core/common/@types/models.d.ts
@@ -56,7 +56,7 @@ declare module "models" {
     export interface ResLang extends ResLangClass {}
     export interface ResPartner extends ResPartnerClass {}
     export interface ResRole extends ResRoleClass {}
-    export interface ResUsers extends ResUsersClass {}
+    export interface ResUsers extends ResUsersClass, ResPartner {}
     export interface Settings extends SettingsClass {}
     export interface Thread extends ThreadClass {}
     export interface Volume extends VolumeClass {}

--- a/addons/mail/static/src/core/common/res_partner_model.js
+++ b/addons/mail/static/src/core/common/res_partner_model.js
@@ -94,6 +94,7 @@ export class ResPartner extends Record {
     });
     /** @type {string|undefined} */
     previousPresencechannel;
+    user_ids = fields.Many("res.users", { inverse: "partner_id" });
     write_date = fields.Datetime();
 
     _computeDisplayName() {

--- a/addons/mail/static/src/core/common/res_users_model.js
+++ b/addons/mail/static/src/core/common/res_users_model.js
@@ -2,30 +2,19 @@ import { fields, Record } from "@mail/core/common/record";
 
 export class ResUsers extends Record {
     static _name = "res.users";
+    static _inherits = { "res.partner": "partner_id" };
     static id = "id";
 
     /** @type {number} */
     id;
     company_id = fields.One("res.company");
     /** @type {string} */
-    get email() {
-        return this.partner_id?.email;
-    }
-    /** @type {string} */
     im_status;
     /** @type {boolean} */
     is_admin;
-    /** @type {string} */
-    get name() {
-        return this.partner_id?.name;
-    }
     /** @type {"email" | "inbox"} */
     notification_type;
-    partner_id = fields.One("res.partner");
-    /** @type {string} */
-    get phone() {
-        return this.partner_id?.phone;
-    }
+    partner_id = fields.One("res.partner", { inverse: "user_ids" });
     /** @type {boolean} false when the user is an internal user, true otherwise */
     share;
     /** @type {ReturnType<import("@odoo/owl").markup>|string|undefined} */

--- a/addons/mail/static/src/model/make_store.js
+++ b/addons/mail/static/src/model/make_store.js
@@ -66,6 +66,14 @@ export function makeStore(env, { localRegistry } = {}) {
                             if (Model._.parentFields.has(name)) {
                                 const parentFieldName = Model._.parentFields.get(name);
                                 const parentRecordFullProxy = recordFullProxy[parentFieldName];
+                                if (!parentRecordFullProxy) {
+                                    const ParentModel =
+                                        Models[Model._.fieldsTargetModel.get(parentFieldName)];
+                                    if (isMany(ParentModel, name)) {
+                                        return [];
+                                    }
+                                    return;
+                                }
                                 return Reflect.get(parentRecordFullProxy, name);
                             }
                             recordFullProxy = record._.downgradeProxy(record, recordFullProxy);

--- a/addons/mail/static/tests/core/record.test.js
+++ b/addons/mail/static/tests/core/record.test.js
@@ -1444,3 +1444,24 @@ test("shadowed fields, getters and functions are not inherited", async () => {
     expect(thread.getName()).toBe("Thread: General");
     expect(thread.channel.getName()).toBe("Channel: undefined");
 });
+
+test("accessing fields through empty _inherits parent returns empty values", async () => {
+    (class Partner extends Record {
+        static id = "id";
+        id;
+        name;
+        users = fields.Many("User", { inverse: "partner" });
+        partners = fields.Many("Partner");
+    }).register(localRegistry);
+    (class User extends Record {
+        static id = "id";
+        static _inherits = { Partner: "partner" };
+        id;
+        partner = fields.One("Partner", { inverse: "users" });
+    }).register(localRegistry);
+    const store = await start();
+    const user = store.User.insert({ id: 1 });
+    expect(user.partner).toBe(undefined);
+    expect(user.name).toBe(undefined);
+    expect(user.partners).toHaveLength(0);
+});


### PR DESCRIPTION
Now that _inherits is supported in JS models too, user should inherit partner in JS to match what is done in python.

This will avoid creating getters explicitly on users for all partner fields (or having to access these fields through the partner relation explicitly).

task-5173010