### PR TITLE
[FIX] html_editor: rename "Default" to "Default font" in toolbar

### DIFF
--- a/addons/html_editor/static/src/main/font/font_family_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_family_plugin.js
@@ -8,7 +8,7 @@ import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 
 export const defaultFontFamily = {
     name: "Default system font",
-    nameShort: "Default",
+    nameShort: "Default font",
     fontFamily: false,
 };
 export const fontFamilyItems = [
@@ -18,12 +18,12 @@ export const fontFamilyItems = [
     { name: "Tahoma (sans-serif)", nameShort: "Tahoma", fontFamily: "Tahoma, sans-serif" },
     {
         name: "Trebuchet MS (sans-serif)",
-        nameShort: "Trebuchet",
+        nameShort: "Trebuchet MS",
         fontFamily: '"Trebuchet MS", sans-serif',
     },
     {
         name: "Courier New (monospace)",
-        nameShort: "Courier",
+        nameShort: "Courier New",
         fontFamily: '"Courier New", monospace',
     },
 ];

--- a/addons/html_editor/static/tests/format/font_family.test.js
+++ b/addons/html_editor/static/tests/format/font_family.test.js
@@ -58,7 +58,7 @@ test("should overide fontFamily on the selected characters", async () => {
 test("should change the font family of a few characters", async () => {
     const { el } = await setupEditor("<p>ab[cde]fg</p>");
     await expandToolbar();
-    expect(queryOne(".btn[name='font_family']").textContent).toBe("Default");
+    expect(queryOne(".btn[name='font_family']").textContent).toBe("Default font");
     await click(".btn[name='font_family']");
     await waitFor(".o_font_family_selector_menu");
     await click(".o_font_family_selector_menu .o-dropdown-item:nth-child(2)");
@@ -71,7 +71,7 @@ test("should change the font family of a few characters", async () => {
 test("should undo and redo the font family changes", async () => {
     const { editor, el } = await setupEditor("<p>ab[cde]fg</p>");
     await expandToolbar();
-    expect(queryOne(".btn[name='font_family']").textContent).toBe("Default");
+    expect(queryOne(".btn[name='font_family']").textContent).toBe("Default font");
     await click(".btn[name='font_family']");
     await waitFor(".o_font_family_selector_menu");
     await click(".o_font_family_selector_menu .o-dropdown-item:nth-child(2)");
@@ -92,8 +92,8 @@ test("should remove font family on the selected content using remove format", as
     await expandToolbar();
     expect(queryOne(".btn[name='font_family']").textContent).toBe("Arial");
     await click(".btn[title='Remove Format']");
-    await waitFor(".btn[name='font_family']:contains('Default')");
-    expect(queryOne(".btn[name='font_family']").textContent).toBe("Default");
+    await waitFor(".btn[name='font_family']:contains('Default font')");
+    expect(queryOne(".btn[name='font_family']").textContent).toBe("Default font");
     expect(getContent(el)).toBe("<p>ab[cde]fg</p>");
 });
 
@@ -107,14 +107,14 @@ test("should remove font family on the selected content using Default font famil
     await waitFor(".o_font_family_selector_menu");
     await click(".o_font_family_selector_menu .o-dropdown-item:first-child");
     await animationFrame();
-    expect(queryOne(".btn[name='font_family']").textContent).toBe("Default");
+    expect(queryOne(".btn[name='font_family']").textContent).toBe("Default font");
     expect(getContent(el)).toBe("<p>ab[cde]fg</p>");
 });
 
 test("should contain the 5 available font + default", async () => {
     await setupEditor("<p>ab[cde]fg</p>");
     await expandToolbar();
-    expect(queryOne(".btn[name='font_family']").textContent).toBe("Default");
+    expect(queryOne(".btn[name='font_family']").textContent).toBe("Default font");
     await click(".btn[name='font_family']");
     await animationFrame();
     await waitFor(".o_font_family_selector_menu");


### PR DESCRIPTION
Description of the issue:

- Renamed `Default` to `Default font` for better clarity in the toolbar.

task-5156110

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
