### PR TITLE
[FIX] point_of_sale: show cashier name on receipt regardless of preset

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml
@@ -16,7 +16,7 @@
                 <div t-if="order.company.email" t-esc="order.company.email" />
                 <div t-if="order.company.website" t-esc="order.company.website" />
                 <div t-if="order.config.receipt_header" style="white-space:pre-line" t-esc="order.config.receipt_header" />
-                <div t-if="order?.getCashierName() and (!order.preset_id or order.preset_id.identification === 'name')" class="cashier">
+                <div t-if="order?.getCashierName()" class="cashier">
                     <div>--------------------------------</div>
                     <div>Served by: <t t-esc="order.getCashierName()" /></div>
                 </div>

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -550,6 +550,20 @@ registry.category("web_tour.tours").add("RestaurantPresetTakeoutTour", {
         ].flat(),
 });
 
+registry.category("web_tour.tours").add("RestaurantPresetEatInTour", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            FloorScreen.clickTable("4"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola", true),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.cashierNameExists("A simple PoS man!"),
+        ].flat(),
+});
+
 registry.category("web_tour.tours").add("test_combo_preparation_receipt_layout", {
     steps: () =>
         [

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -595,6 +595,14 @@ class TestFrontend(TestFrontendCommon):
         expected_time = datetime(2025, 2, 12, 14, 40)
         self.assertEqual(order.preset_time, expected_time, f"The preset time should be {expected_time}, but got {order.preset_time}")
 
+    def test_restaurant_preset_eatin_tour(self):
+        self.pos_config.write({
+            'use_presets': True,
+            'default_preset_id': self.env.ref('pos_restaurant.pos_takein_preset', False).id,
+        })
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('RestaurantPresetEatInTour', login="pos_user")
+
     def test_combo_preparation_receipt_layout(self):
         setup_product_combo_items(self)
         pos_printer = self.env['pos.printer'].create({


### PR DESCRIPTION
Currently cashier name is only shown if no preset is shown or if the present identification is set on name.

Steps tot reproduce:
--------------------
* Open restaurant
* Make sure you use the Eat in preset
* Place an order and pay it
> Observation: On the receipt the "Served by:" indication is not shown.

Why the fix:
------------
The cashier/server information should not depend on the preset used.

opw-5154347