### PR TITLE
[FIX] pos_self_order: missing bypass_search_access on attachment field

### DIFF
--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -64,12 +64,14 @@ class PosConfig(models.Model):
         'ir.attachment',
         string="Add images",
         help="Image to display on the self order screen",
+        bypass_search_access=True,
     )
     self_ordering_image_background_ids = fields.Many2many(
         'ir.attachment',
         string="Set background image",
         help="Image to be displayed in the background",
         relation="pos_self_order_background_rels",
+        bypass_search_access=True,
     )
     self_ordering_default_user_id = fields.Many2one(
         "res.users",


### PR DESCRIPTION
Follow-up of 8e5fde2a462e, we should set `bypass_search_access` on `ir.attachment` many2many fields.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
