### PR TITLE
[IMP] gamification: action_open_badge moved

### DIFF
--- a/addons/gamification/models/gamification_badge_user.py
+++ b/addons/gamification/models/gamification_badge_user.py
@@ -43,6 +43,15 @@ class BadgeUser(models.Model):
 
         return True
 
+    def action_open_badge(self):
+        self.ensure_one()
+        return {
+            'type': 'ir.actions.act_window',
+            'res_model': 'gamification.badge',
+            'view_mode': 'form',
+            'res_id': self.badge_id.id,
+        }
+
     @api.model_create_multi
     def create(self, vals_list):
         for vals in vals_list:

--- a/addons/hr_gamification/models/gamification.py
+++ b/addons/hr_gamification/models/gamification.py
@@ -18,15 +18,6 @@ class GamificationBadgeUser(models.Model):
                 with_context(allowed_company_ids=self.env.user.company_ids.ids).employee_ids:
                 raise ValidationError(_('The selected employee does not correspond to the selected user.'))
 
-    def action_open_badge(self):
-        self.ensure_one()
-        return {
-            'type': 'ir.actions.act_window',
-            'res_model': 'gamification.badge',
-            'view_mode': 'form',
-            'res_id': self.badge_id.id,
-        }
-
 class GamificationBadge(models.Model):
     _inherit = 'gamification.badge'
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Found that method was not in the right module.

Current behavior before PR:

So that method it is use in `gamification` but it was in `hr_gamification` son in order to use it you need to install this last one, as `gamification` does not make sense to depend on `hr_gamification`

Desired behavior after PR is merged:

Now the method it is in the right module and will not affect `hr_gamification` as it depends on `gamification`

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
