### PR TITLE
[FIX] tests: catch remain processes

### DIFF
--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -621,6 +621,11 @@ class ThreadedServer(CommonServer):
 
         odoo.sql_db.close_all()
 
+        current_process = psutil.Process()
+        children = current_process.children(recursive=False)
+        for child in children:
+            _logger.info('A child process was found, pid is %s, process may hang', child)
+
         _logger.debug('--')
         logging.shutdown()
 


### PR DESCRIPTION
In some case a process could remain aive at the end of a tests In addition to possible race condition, this can also cause a program to remain stuck at the end of the tests.

This commit proposes to
- catch all remaining processes at the end of a base case.
- log a message if a process is found at the shutdown of the server.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
