### PR TITLE
[IMP] hr_attendance: print badge in attendance onboarding

### DIFF
--- a/addons/hr_attendance/static/src/components/new_employee_dialog/new_employee_dialog.js
+++ b/addons/hr_attendance/static/src/components/new_employee_dialog/new_employee_dialog.js
@@ -25,16 +25,19 @@ export class NewEmployeeDialog extends Component {
             badgeId: "",
             value: null,
             searchName: "",
+            employeeHasBadge: false,
         });
     }
 
     onSelectEmployee(emp) {
         this.state.searchName = emp?.name ?? "";
+        this.state.badgeId = "";
         if( this.state.searchName == ""){
             this.state.value = null;
         }
         else{
             this.state.value = emp;
+            this.state.employeeHasBadge = false;
         }
     }
 
@@ -85,7 +88,7 @@ export class NewEmployeeDialog extends Component {
             this.notification.add(_t("Badge assigned successfully!"), {
                 type: "success",
             });
-            this.props.close();
+            this.state.employeeHasBadge = true;
         } else {
             this.notification.add( _t("Error: ") + _t(data?.message),{
                 type: "danger",

--- a/addons/hr_attendance/static/src/components/new_employee_dialog/new_employee_dialog.xml
+++ b/addons/hr_attendance/static/src/components/new_employee_dialog/new_employee_dialog.xml
@@ -12,7 +12,7 @@
                 </div>
                 <div class="mb-3">
                     <label class="form-label">Select Employee Without Badge</label>
-                    <div class="o_select_employee">
+                    <div class="o_select_employee align-items-start">
                         <div class="o_select_employee_display form-control">
                             <img t-if="state.value" class="d-flex rounded" t-attf-src="/web/image/hr.employee.public/{{state.value.id}}/avatar_128"/>
                             <div class="o_select_employee_option p-0">
@@ -20,7 +20,23 @@
                             </div>
                         </div>
                         <input type="text" t-model="state.badgeId" class="form-control" placeholder="Enter Badge Number"/>
-                        <button class="btn btn-primary" style="min-width: fit-content;" t-on-click="onSetBadge">Set the Badge</button>
+                        <div class="d-flex flex-column gap-2">
+                            <button class="btn btn-primary"
+                                style="min-width: max-content;"
+                                t-on-click="onSetBadge">
+                                Set the Badge
+                            </button>                            
+                            <a
+                                title="Print"
+                                role="button"
+                                class="btn btn-secondary w-100"
+                                t-att-href="`/hr_attendance/print_badge?employee_id=${state.value?.id}&amp;token=${props.token}`"
+                                target="_self"
+                                t-if="state.value and state.employeeHasBadge"
+                            >
+                                Print It
+                            </a>
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
The attendance onboarding page allowed the creation of badges for employees, but to actually print the badge, the user had to do the following:

- Exit the onboarding page
- Go to the employees page
- Find the user
- Go to the settings tab
- Click on the "Print Badge" link at the bottom of the page

This was very tedious especially if it had to be done for multiple employees at a time, this commit adds a button in the onboarding page to print the badge after setting it to improve the onboarding process.

The reason why it wasn't done by calling the "hr.hr_employee_print_badge" report action directly is that the onboarding page is in kiosk mode whose environment doesn't have the action service. To circumvent this, an HTTP endpoint was added to the controller. Calling said endpoint downloads the badge pdf. A button is then added which directly calls said endpoint with the appropriate arguments.

Task-5160112
