### PR TITLE
[FIX] html_editor, web, website_sale: upload hi-res images via front-end

### DIFF
--- a/addons/html_editor/models/ir_qweb_fields.py
+++ b/addons/html_editor/models/ir_qweb_fields.py
@@ -531,6 +531,9 @@ class IrQwebFieldImage(models.AbstractModel):
             return None
 
     def load_remote_url(self, url):
+        if url.startswith('data:'):
+            logger.debug("Cannot load binary data url %r", url)
+            return None
         try:
             # should probably remove remote URLs entirely:
             # * in fields, downloading them without blowing up the server is a

--- a/addons/html_editor/static/src/fields/x2many_field/x2many_media_viewer.js
+++ b/addons/html_editor/static/src/fields/x2many_field/x2many_media_viewer.js
@@ -96,7 +96,7 @@ export class X2ManyMediaViewer extends X2ManyField {
                     );
 
                     // WebP format
-                    const webpData = canvas.toDataURL("image/webp", 0.75).split(",")[1];
+                    const webpData = canvas.toDataURL("image/webp").split(",")[1];
                     const [resizedId] = await this.orm.call("ir.attachment", "create_unique", [
                         [
                             {
@@ -113,7 +113,7 @@ export class X2ManyMediaViewer extends X2ManyField {
                     referenceId = referenceId || resizedId;
 
                     // JPEG format for compatibility
-                    const jpegData = canvas.toDataURL("image/jpeg", 0.75).split(",")[1];
+                    const jpegData = canvas.toDataURL("image/jpeg").split(",")[1];
                     await this.orm.call("ir.attachment", "create_unique", [
                         [
                             {
@@ -133,7 +133,7 @@ export class X2ManyMediaViewer extends X2ManyField {
                 const ctx = canvas.getContext("2d");
                 ctx.drawImage(image, 0, 0, image.width, image.height);
 
-                const webpData = canvas.toDataURL("image/webp", 0.75).split(",")[1];
+                const webpData = canvas.toDataURL("image/webp").split(",")[1];
                 attachment.datas = webpData;
                 attachment.mimetype = "image/webp";
                 attachment.name = attachment.name.replace(/\.[^/.]+$/, ".webp");

--- a/addons/html_editor/static/src/main/media/image_post_process_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_post_process_plugin.js
@@ -12,7 +12,7 @@ import {
 import { Plugin } from "../../plugin";
 import { getAffineApproximation, getProjective } from "@html_editor/utils/perspective_utils";
 
-export const DEFAULT_IMAGE_QUALITY = "75";
+export const DEFAULT_IMAGE_QUALITY = "92";
 
 /**
  * @typedef { Object } ImagePostProcessShared

--- a/addons/html_editor/static/src/main/media/image_save_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_save_plugin.js
@@ -164,11 +164,11 @@ export class ImageSavePlugin extends Plugin {
                     canvas.height
                 );
                 altData[size] = {
-                    "image/jpeg": canvas.toDataURL("image/jpeg", 0.75).split(",")[1],
+                    "image/jpeg": canvas.toDataURL("image/jpeg").split(",")[1],
                 };
                 if (size !== originalSize) {
                     altData[size]["image/webp"] = canvas
-                        .toDataURL("image/webp", 0.75)
+                        .toDataURL("image/webp")
                         .split(",")[1];
                 }
             }

--- a/addons/html_editor/static/src/main/media/media_dialog/upload_progress_toast/upload_service.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/upload_progress_toast/upload_service.js
@@ -147,7 +147,7 @@ export const uploadService = {
                                 ctx.fillStyle = "rgb(255, 255, 255)";
                                 ctx.fillRect(0, 0, canvas.width, canvas.height);
                                 ctx.drawImage(image, 0, 0);
-                                const altDataURL = canvas.toDataURL("image/jpeg", 0.75);
+                                const altDataURL = canvas.toDataURL("image/jpeg");
                                 await rpc(
                                     "/html_editor/attachment/add_data",
                                     {

--- a/addons/web/static/src/views/fields/image/image_field.js
+++ b/addons/web/static/src/views/fields/image/image_field.js
@@ -167,7 +167,7 @@ export class ImageField extends Component {
             const ctx = canvas.getContext("2d");
             ctx.drawImage(image, 0, 0);
 
-            info.data = canvas.toDataURL("image/webp", 0.75).split(",")[1];
+            info.data = canvas.toDataURL("image/webp").split(",")[1];
             info.type = "image/webp";
             info.name = info.name.replace(/\.[^/.]+$/, ".webp");
         }
@@ -177,7 +177,7 @@ export class ImageField extends Component {
             image.src = `data:image/webp;base64,${info.data}`;
             await new Promise((resolve) => image.addEventListener("load", resolve));
             const originalSize = Math.max(image.width, image.height);
-            const smallerSizes = [1024, 512, 256, 128].filter((size) => size < originalSize);
+            const smallerSizes = [1920, 1024, 512, 256, 128].filter((size) => size < originalSize);
             let referenceId = undefined;
             for (const size of [originalSize, ...smallerSizes]) {
                 const ratio = size / originalSize;
@@ -208,7 +208,7 @@ export class ImageField extends Component {
                             datas:
                                 size === originalSize
                                     ? info.data
-                                    : canvas.toDataURL("image/webp", 0.75).split(",")[1],
+                                    : canvas.toDataURL("image/webp").split(",")[1],
                             res_id: referenceId,
                             res_model: "ir.attachment",
                             mimetype: "image/webp",
@@ -222,7 +222,7 @@ export class ImageField extends Component {
                         {
                             name: info.name.replace(/\.webp$/, ".jpg"),
                             description: "format: jpeg",
-                            datas: canvas.toDataURL("image/jpeg", 0.75).split(",")[1],
+                            datas: canvas.toDataURL("image/jpeg").split(",")[1],
                             res_id: resizedId,
                             res_model: "ir.attachment",
                             mimetype: "image/jpeg",

--- a/addons/website/static/tests/builder/image_size.test.js
+++ b/addons/website/static/tests/builder/image_size.test.js
@@ -17,7 +17,7 @@ test("the image should show its size", async () => {
     const selector = `[data-container-title="Image"] [title="Size"]`;
     await waitFor(selector);
     const size = parseFloat(document.querySelector(selector).innerHTML);
-    expectAround(size, 20.1);
+    expectAround(size, 22.8);
 });
 
 test("the background image should show its size", async () => {
@@ -31,7 +31,7 @@ test("the background image should show its size", async () => {
     const selector = `[data-label="Image"] [title="Size"]`;
     await waitFor(selector);
     const size = parseFloat(document.querySelector(selector).innerHTML);
-    expectAround(size, 20.1);
+    expectAround(size, 22.8);
 });
 
 function expectAround(value, expected, delta = 0.2) {

--- a/addons/website_sale/static/src/website_builder/product_page_option_plugin.js
+++ b/addons/website_sale/static/src/website_builder/product_page_option_plugin.js
@@ -239,7 +239,7 @@ export class BaseProductPageAction extends BuilderAction {
         imgEl.src = imageEl.src;
         await new Promise((resolve) => imgEl.addEventListener("load", resolve));
         const originalSize = Math.max(imgEl.width, imgEl.height);
-        const smallerSizes = [1024, 512, 256, 128].filter((size) => size < originalSize);
+        const smallerSizes = [1920, 1024, 512, 256, 128].filter((size) => size < originalSize);
         const extension = attachment.name.match(/\.(jpe?|pn)g$/i)?.[0] ?? ".jpeg";
         const webpName = attachment.name.replace(extension, ".webp");
         const format = extension.substr(1).toLowerCase().replace(/^jpg$/, "jpeg");
@@ -269,7 +269,7 @@ export class BaseProductPageAction extends BuilderAction {
                     {
                         name: webpName,
                         description: size === originalSize ? "" : `resize: ${size}`,
-                        datas: canvas.toDataURL("image/webp", 0.75).split(",")[1],
+                        datas: canvas.toDataURL("image/webp").split(",")[1],
                         res_id: referenceId,
                         res_model: "ir.attachment",
                         mimetype: "image/webp",
@@ -288,7 +288,7 @@ export class BaseProductPageAction extends BuilderAction {
                     {
                         name: attachment.name,
                         description: `format: ${format}`,
-                        datas: canvas.toDataURL(mimetype, 0.75).split(",")[1],
+                        datas: canvas.toDataURL(mimetype).split(",")[1],
                         res_id: resizedId,
                         res_model: "ir.attachment",
                         mimetype: mimetype,
@@ -317,7 +317,7 @@ export class ProductPageImageGridColumnsAction extends BaseProductPageAction {
 }
 export class ProductReplaceMainImageAction extends BaseProductPageAction {
     static id = "productReplaceMainImage";
-    static dependencies = [...super.dependencies, "media_website"];
+    static dependencies = [...super.dependencies, "media", "media_website"];
     setup() {
         super.setup();
         this.reload = false;
@@ -327,7 +327,33 @@ export class ProductReplaceMainImageAction extends BaseProductPageAction {
         const image = productDetailMainEl.querySelector(
             `[data-oe-model="${this.model}"][data-oe-field=image_1920] img`
         );
-        this.dependencies.media_website.replaceMedia(image);
+        this.dependencies.media.openMediaDialog({
+            multiImages: false,
+            visibleTabs: ["IMAGES"],
+            node: productDetailMainEl,
+            save: (imgEl, selectedMedia) => {
+                const attachment = selectedMedia[0];
+                if (["image/gif", "image/svg+xml"].includes(attachment.mimetype)) {
+                    image.src = attachment.image_src;
+                    return;
+                }
+                const originalSize = Math.max(imgEl.width, imgEl.height);
+                const ratio = Math.min(originalSize, 1920) / originalSize;
+                const canvas = document.createElement("canvas");
+                canvas.width = parseInt(imgEl.width * ratio);
+                canvas.height = parseInt(imgEl.height * ratio);
+                const ctx = canvas.getContext("2d")
+                ctx.fillStyle = "transparent";
+                ctx.fillRect(0, 0, canvas.width, canvas.height);
+                ctx.drawImage(imgEl, 0, 0);
+                image.src = canvas.toDataURL("image/webp");
+                const { model, productProductID: productID, productTemplateID: templateID } = this;
+                const resID = parseInt(model === "product.product" ? productID : templateID);
+                this.services.orm.write(model, [resID], {
+                    image_1920: image.src.split(",")[1],
+                });
+            },
+        });
     }
 }
 


### PR DESCRIPTION
Versions
--------
- 19.0+

Steps
-----
1. Have a browser open with a side-bar or that isn't full-screen;
2. open website editor on a product page;
3. enable zoom-on-click;
4. replace the main image;
5. save changes;
6. click on the new image to zoom in;
7. download the image.

Issue
-----
The image is too small & low quality.

Cause
-----
The `this.dependencies.media_website.replaceMedia(image)` call is meant to be used along with an html editor widget to select size & quality. As we have a custom widget to handle product images, the image that ends up getting uploaded is one that's been optimized for the current viewport size.

Solution
--------
Replace the `replaceMedia` call with custom logic similar to that used for extra media, drawing the image to a `canvas` element, and then saving it as the product's `image_1920` field.

Additionally, enable extra media to get saved as in 1920 size, and remove the hardcoded `0.75` image quality value, as a value this low easily leads to visible compression artifacts.

opw-5088032