### PR TITLE
[IMP] point_of_sale: improve config and ui for categories

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -683,6 +683,18 @@ class PosConfig(models.Model):
             self._update_preparation_printers_menuitem_visibility()
         return result
 
+    def link_category_form_pos(self, category):
+        self.ensure_one()
+        category = self.env['pos.category'].browse(category.id).exists()
+        if not category:
+            return
+
+        if self.iface_available_categ_ids and category not in self.iface_available_categ_ids.ids:
+            self.sudo().write({
+                'iface_available_categ_ids': [(4, category.id)],
+            })
+            return
+
     def _preprocess_x2many_vals_from_settings_view(self, vals):
         """ From the res.config.settings view, changes in the x2many fields always result to an array of link commands or a single set command.
             - As a result, the items that should be unlinked are not properly unlinked.

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -2137,7 +2137,11 @@ export class PosStore extends WithLazyGetterTrap {
                         this.action.doAction({
                             type: "ir.actions.act_window_close",
                         });
+                        this.reloadData(true);
                     },
+                },
+                additionalContext: {
+                    pos_session_id: this.session.id,
                 },
             }
         );

--- a/addons/point_of_sale/views/pos_category_view.xml
+++ b/addons/point_of_sale/views/pos_category_view.xml
@@ -7,7 +7,7 @@
             <form string="Pos Product Categories">
                 <sheet>
                     <field name="image_512" widget="image" class="oe_avatar"/>
-                    <div class="oe_title">
+                    <div class="oe_title row">
                         <h1>
                             <field name="name" class="o_text_overflow" placeholder="e.g. Soft Drinks" required="True"/>
                         </h1>
@@ -38,8 +38,9 @@
             <list string="Product Product Categories">
                 <field name="sequence" widget="handle"/>
                 <field name="display_name" string="PoS Product Category"/>
-                <field name="parent_id" optional="hide"/>
-                <field name="color" widget="color_picker" optional="hide"/>
+                <field name="parent_id"/>
+                <field name="pos_config_ids" widget="many2many_tags"/>
+                <field name="color" widget="color_picker"/>
             </list>
         </field>
     </record>
@@ -49,14 +50,26 @@
         <field name="model">pos.category</field>
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile">
+                <field name="parent_id" />
                 <templates>
                     <t t-name="card" class="row g-0">
+                        <main class="col ms-4 justify-content-between">
+                            <div class="d-flex gap-2 align-items-center">
+                                <field name="color" widget="color_picker"/>
+                                <field name="name" class="fw-bolder fs-5"/>
+                            </div>
+                            <div class="category-extras">
+                                <div class="d-inline-flex gap-2" t-if="record.parent_id.raw_value">
+                                    <div class="p-0">
+                                        <span>Parent category:</span>
+                                    </div>
+                                    <field name="parent_id" />
+                                </div>
+                            </div>
+                        </main>
                         <aside class="col-4">
                             <field name="image_128" widget="image" alt="Category" options="{'size': [100, 100], 'img_class': 'h-100'}"/>
                         </aside>
-                        <main class="col ms-4">
-                            <field name="name" class="fw-bolder fs-5"/>
-                        </main>
                     </t>
                 </templates>
             </kanban>

--- a/addons/pos_restaurant/views/pos_category_view.xml
+++ b/addons/pos_restaurant/views/pos_category_view.xml
@@ -7,7 +7,7 @@
         <field name="arch" type="xml">
             <xpath expr="//div[@name='available_between']" position="after">
                 <group>
-                    <field name="course_id" class="o_text_overflow" options="{'no_create_edit': True}"/>
+                    <field name="course_id" class="o_text_overflow" options="{'no_create_edit': True}" placeholder="No default"/>
                 </group>
             </xpath>
         </field>

--- a/addons/pos_self_order/models/pos_category.py
+++ b/addons/pos_self_order/models/pos_category.py
@@ -1,14 +1,11 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models, fields
+from odoo import models
 
 
 class PosCategory(models.Model):
     _inherit = "pos.category"
-
-
-    pos_config_ids = fields.Many2many('pos.config', string='Linked PoS Configurations')
 
     def _can_return_content(self, field_name=None, access_token=None):
         if field_name in ["image_128", "image_512"]:


### PR DESCRIPTION
**Functional**

- Removed the restriction of deleting pos categories while sessions are open and replaced it with a restriction on removing categories which are used by POS. If the category is not in use by any POS deleting it will have no side-effects.

- Moved the definition of pos_config_ids from the pos_self_order override of the pos.category to the base class in point_of_sale so it can be always accessed, not only when the self_order is installed.

- Creating a new product from a POS session with a category which is not displayed on the current POS session will automatically add the category to the POS session config and reload the data to show the new products. This way when a user creates a new product, it will always show up on their POS from where they created the product.

**Design (Categories)**

- [Form View] For a better design will align the category title with the rest of the fields on the form view. Also added a placeholder on the pos_restaurant course field.

- [Kanban] Improved the kanban view to show the color, parent category and course if they are present directly on the card.

- [List] Made the parent category and color display by default. Added the points of sale where the category is used to the list

Task - 5172551

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
