### PR TITLE
[FIX] mail: ensure only one expander for fullComposer signature

### DIFF
--- a/addons/html_editor/static/src/main/signature.xml
+++ b/addons/html_editor/static/src/main/signature.xml
@@ -1,5 +1,9 @@
 <templates>
     <t t-name="html_editor.Signature">
-        <div t-att-class="signatureClass" t-out="signature"/>
+        <div
+            t-att-class="signatureClass"
+            t-att-data-o-mail-quote="dataMailQuote or '1'"
+            t-out="signature"
+        />
     </t>
 </templates>

--- a/addons/html_editor/static/tests/signature.test.js
+++ b/addons/html_editor/static/tests/signature.test.js
@@ -27,7 +27,7 @@ test("apply 'Signature' command", async () => {
     await press("enter");
     await tick();
     expect(getContent(el)).toBe(
-        `<p>ab</p><div class="o-signature-container"><h1>Hello[]</h1></div><p>cd</p>`
+        `<p>ab</p><div class="o-signature-container" data-o-mail-quote="1"><h1>Hello[]</h1></div><p>cd</p>`
     );
 });
 
@@ -38,7 +38,7 @@ test("undo a 'Signature' command", async () => {
     await press("enter");
     await tick();
     expect(getContent(el)).toBe(
-        `<p>abtest</p><div class="o-signature-container"><h1>Hello[]</h1></div><p>cd</p>`
+        `<p>abtest</p><div class="o-signature-container" data-o-mail-quote="1"><h1>Hello[]</h1></div><p>cd</p>`
     );
 
     undo(editor);

--- a/addons/mail/static/tests/mock_server/mock_models/res_partner.js
+++ b/addons/mail/static/tests/mock_server/mock_models/res_partner.js
@@ -272,6 +272,7 @@ export class ResPartner extends webModels.ResPartner {
                             "display_name",
                             "isAdmin",
                             "notification_type",
+                            "signature",
                             "user",
                         ].includes(field)
                 ),
@@ -313,6 +314,9 @@ export class ResPartner extends webModels.ResPartner {
                 }
                 if (fields.includes("notification_type")) {
                     data.notification_preference = mainUser.notification_type;
+                }
+                if (fields.includes("signature")) {
+                    data.signature = mainUser.signature;
                 }
             }
             store.add(this.browse(partner.id), data);

--- a/addons/mail/static/tests/mock_server/mock_models/res_users.js
+++ b/addons/mail/static/tests/mock_server/mock_models/res_users.js
@@ -44,6 +44,7 @@ export class ResUsers extends webModels.ResUsers {
                             "isAdmin",
                             "name",
                             "notification_type",
+                            "signature",
                             "user",
                         ],
                     })


### PR DESCRIPTION
**Steps to reproduce:**
- Go to the current user preferences
- Go to its signature field
- The current state should be something like:
```
--
Mitchell Admin
```
- Apply bold formatting on the text
- Save the changes
- Refresh
- Remove the bold formatting
- Press enter between the two lines (at the end of `--`)
- Save the changes
- Go to the Contact app
- Select any record
- Go to its chatter
- Click on `Send Message` and then the `Full Composer` expand button
- Send the mail
- In the chatter multiple `Read More` are added for the same signature

(I think it can appears in multiple operations,
this is just an example related to the `<strong>`
element becoming `<span>` on removal)

**Issue:**
Playing with the html editor on the signature field can break the `tag_quote` flow due to the added elements.

**Fix:**
Explicitly add `"data-o-mail-quote"` to the signature container which is added when opening the `fullComposer`.
It could also be an issue related to the html_editor but this seems cleaner to fix it here.

This issue was fixed in 19.0 in a similar way by adding a common div around the signature and adding the same attribute.

related: https://github.com/odoo/odoo/commit/6eb55c42158b08652c4c533bf56b5333c162bd3a

opw-5149505
