### PR TITLE
[FIX] website_sale: product mail action redirect to shop page

### DIFF
--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -936,7 +936,7 @@ class ProductTemplate(models.Model):
     def _get_access_action(self, access_uid=None, force_website=False):
         """ Instead of the classic form view, redirect to website if it is published. """
         self.ensure_one()
-        if force_website or self.website_published:
+        if force_website or (self.website_published and self.env.user.share):
             return {
                 "type": "ir.actions.act_url",
                 "url": self.website_url,


### PR DESCRIPTION
### Issue:
Mail action redirects only to shop page, even though the user has internal access to the product page.

#### To reproduce:
1- Create a db with website_sale installed.
2- Create a product and publish it.
3- In the product page chatter, send a message to an internal user
4- In received email, click on `View Product` button
5- As you see the shop page opens

This is reproduced after #202555

Inside `_get_access_action`, if the product is published, we are returning `website_url`. We can add a check to do that only if user is portal or public.

opw-5155281

