### PR TITLE
[FIX] sale: don't skip super on validation post-process

### DIFF
--- a/addons/sale/models/payment_transaction.py
+++ b/addons/sale/models/payment_transaction.py
@@ -83,10 +83,9 @@ class PaymentTransaction(models.Model):
         )._post_process()
 
         for done_tx in self.filtered(lambda tx: tx.state == 'done'):
-            confirmed_orders = done_tx._check_amount_and_confirm_order()
-            if done_tx.operation == 'validation':
-                continue
-            (done_tx.sale_order_ids - confirmed_orders)._send_payment_succeeded_for_order_mail()
+            if done_tx.operation != 'validation':
+                confirmed_orders = done_tx._check_amount_and_confirm_order()
+                (done_tx.sale_order_ids - confirmed_orders)._send_payment_succeeded_for_order_mail()
 
             auto_invoice = str2bool(
                 self.env['ir.config_parameter'].sudo().get_param('sale.automatic_invoice')


### PR DESCRIPTION
Versions
--------
- 18.0+

Issue
-----
`super` isn't called on `_post_process` for confirmed validation transactions.

Cause
-----
A fix that prevented the sending of mail for validation transactions added a `continue` in a loop, which skips over the `super` call in the loop.

Solution
--------
Instead of `continue`, add an `if` check to see if we want to send mail.