### PR TITLE
[FIX] analytic: Add support for updating the analytic.project_plan system parameter

### DIFF
--- a/addons/analytic/models/__init__.py
+++ b/addons/analytic/models/__init__.py
@@ -7,3 +7,4 @@ from . import analytic_line
 from . import analytic_mixin
 from . import analytic_distribution_model
 from . import res_config_settings
+from . import ir_config_parameter

--- a/addons/analytic/models/ir_config_parameter.py
+++ b/addons/analytic/models/ir_config_parameter.py
@@ -1,0 +1,28 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models, _
+from odoo.exceptions import UserError
+
+
+class IrConfigParameter(models.Model):
+
+    _inherit = 'ir.config_parameter'
+
+    def write(self, vals):
+        ''' When this paramater is changed, dynamic fields needs to be recomputed '''
+        param = self.filtered(lambda x: x.key == 'analytic.project_plan')
+        if not param:
+            return super().write(vals)
+        old_plan_id = param.value
+        new_plan_id = vals.get('value')
+        if not (
+            new_plan_id
+            and str(new_plan_id).isnumeric()
+            and (plan := self.env['account.analytic.plan'].browse(int(new_plan_id)))
+            and (plan_field := plan._find_plan_column())
+        ):
+            raise UserError(_('The value for %s must be the ID to a valid analytic plan that is not a subplan', param.key))
+        res = super().write(vals)
+        self.env['account.analytic.plan'].browse(int(old_plan_id))._sync_plan_column()
+        plan_field.unlink()
+        return res

--- a/addons/analytic/tests/test_analytic_account.py
+++ b/addons/analytic/tests/test_analytic_account.py
@@ -349,3 +349,9 @@ class TestAnalyticAccount(TransactionCase):
             plan_1_col: self.analytic_account_1.id,
             plan_2_col: False,
         }])
+
+    def test_change_sys_param(self):
+        ''' Test if changing project_plan param updates dynamic fields on account.analytic.line '''
+        self.env['ir.config_parameter'].set_param('analytic.project_plan', self.analytic_plan_2.id)
+        self.analytic_account_1.write({'company_id': self.company_data.id})
+        self.analytic_account_1._check_company_consistency()


### PR DESCRIPTION
A field on `account.analytic.line` is created for every plan using the `id` of the plan to make the names unique, like `x_plan{id}_id`. The plan that has the ID of the `analytic.project_plan` parameter does not get a dynamic field, it uses `account_id`. If you change the system parameter for analytic.project_plan, the plan with the corresponding value will now use `account_id,` and the plan that corresponds to the previous default value will have no corresponding field on `account.analytic.line`.

So, when the project plan system parameter changes, the dynamic fields that are created for each analytic plan (apart from the project one) do not get updated.

Steps:

1. Set the `analytic.project_plan` system parameter to a value other than `1`
2. Enable `Analytic Accounting` setting under `Accounting > Analytic`
3. Create a sales order with a service product that creates a project.
4. Confirm sales order
5. Traceback: `ValueError: Invalid field account.analytic.line.x_plan1_id in leaf 'x_plan1_id', 'in', [23])`


We now extend the write method on `ir.config_parameter` so that when the value of the analytic.project_plan is changed the dynamic fields on `account.analytic.line` are properly added and removed. This solution always creates a field for the previous value and deletes a field for the new value so that no plan ever has two fields referencing it.  

Ticket [link](https://www.odoo.com/odoo/project.task/5069381)
opw-5069381
