### PR TITLE
[FIX] website: configurator dropdown working on iOS safari


### DIFF
--- a/addons/website/static/src/client_actions/configurator/configurator.js
+++ b/addons/website/static/src/client_actions/configurator/configurator.js
@@ -187,7 +187,7 @@ export class DescriptionScreen extends Component {
             }
         }, () => [this.state.selectedType, this.state.selectedIndustry]);
 
-        this.dropdownSafariHack = false;
+        this.safariHackFocusedOutDropdown = null;
     }
 
     onMounted() {
@@ -359,35 +359,30 @@ export class DescriptionScreen extends Component {
             this.props.navigate(ROUTES.paletteSelectionScreen);
         }
     }
+    onConfiguratorScreenFocusin(ev) {
+        // On safari, hide the previously focused out dropdown if focusin is
+        // outside of it
+        if (isBrowserSafari() && this.safariHackFocusedOutDropdown) {
+            if (ev.target.closest(".dropdown") !== this.safariHackFocusedOutDropdown) {
+                window.Dropdown.getOrCreateInstance(this.safariHackFocusedOutDropdown).hide();
+            }
+            this.safariHackFocusedOutDropdown = null;
+        }
+    }
     /**
      * Hide the dropdown once the focus isn't contained within it anymore.
      *
      * @param {FocusEvent} ev
      */
     onDropdownFocusout(ev) {
-        if (this.dropdownSafariHack) {
+        // On safari, we are missing relatedTarget because we can't focus on a
+        // button, so we delay dropdown hiding to focusin of next element
+        if (isBrowserSafari()) {
+            this.safariHackFocusedOutDropdown = ev.currentTarget;
             return;
         }
         if (ev.relatedTarget?.closest(".dropdown") !== ev.currentTarget) {
             window.Dropdown.getOrCreateInstance(ev.currentTarget).hide();
-        }
-    }
-    // Because of focus problems with safari on buttons, we need to block the focusout
-    // until the pointer is up.
-    onDropdownPointerDown() {
-        if (isBrowserSafari()) {
-            this.dropdownSafariHack = true;
-        }
-    }
-    onDropdownPointerUp(ev) {
-        if (!isBrowserSafari()) {
-            return;
-        }
-        const dropdown = ev.currentTarget;
-        this.dropdownSafariHack = false;
-        const active = document.activeElement;
-        if (!active || !dropdown.contains(active)) {
-            window.Dropdown.getOrCreateInstance(dropdown).hide();
         }
     }
 

--- a/addons/website/static/src/client_actions/configurator/configurator.xml
+++ b/addons/website/static/src/client_actions/configurator/configurator.xml
@@ -24,15 +24,14 @@
 </t>
 
 <t t-name="website.Configurator.DescriptionScreen">
-    <div class="o_configurator_screen h-100 d-flex flex-column o_description_screen">
+    <div class="o_configurator_screen h-100 d-flex flex-column o_description_screen"
+         t-on-focusin="onConfiguratorScreenFocusin">
         <div class="o_configurator_screen_content d-flex h-100 flex-grow-1">
             <div class="container align-self-center">
                 <div class="o_configurator_typing_text d-inline d-md-block mb-md-2 mb-lg-4 o_configurator_show">
                     <span>I want </span>
                     <div t-attf-class="dropdown o_configurator_type_dd d-inline-block {{state.selectedType ? 'o_step_completed' : 'o_step_todo show'}}"
-                         t-on-focusout="onDropdownFocusout"
-                         t-on-pointerdown="onDropdownPointerDown"
-                         t-on-pointerup="onDropdownPointerUp">
+                         t-on-focusout="onDropdownFocusout">
                         <button id="selectTypeToggle"
                                 class="o_btn_reset w-100 px-2"
                                 data-bs-toggle="dropdown"
@@ -85,9 +84,7 @@
                 <div t-if="state.selectedType and state.selectedIndustry" class="o_configurator_typing_text d-inline d-md-block mb-md-2 mb-lg-4 o_configurator_show">
                     <span>with the main objective to </span>
                     <div t-attf-class="dropdown d-inline-block o_configurator_purpose_dd {{state.selectedPurpose ? 'o_step_completed' : 'o_step_todo'}}"
-                         t-on-focusout="onDropdownFocusout"
-                         t-on-pointerdown="onDropdownPointerDown"
-                         t-on-pointerup="onDropdownPointerUp">
+                         t-on-focusout="onDropdownFocusout">
                         <button id="selectPurposeToggle"
                                 class="o_btn_reset w-100 px-2"
                                 data-bs-toggle="dropdown"


### PR DESCRIPTION

Scenario:

- go to /website/configurator on safari iOS (ipad, iphone, …)
- configure the website

Result: the dropdown are not selecting a value

Cause: 7a291d59909b2ee57111ddec35a20a2302291f29 fixed the issue on
desktop safari by using pointerdown and pointerup handler, and handling
the dropdown hiding in the pointerup. This work since events happen in
order:

pointerdown -> focusout -> pointerup -> focusin

But on iOS safari the order is:

pointerdown -> pointerup -> focusout -> focusin

that is not taken into account by the fix.

Fix: change the safari fix to close the dropdown on a focusin on another
element following a focusout of a dropdown.

opw-5129288
