### PR TITLE
[IMP] l10n_ph: add Philippines group menuitem

### DIFF
--- a/addons/l10n_ph/__manifest__.py
+++ b/addons/l10n_ph/__manifest__.py
@@ -16,6 +16,7 @@
     'auto_install': ['account'],
     'data': [
         'data/account_tax_report_data.xml',
+        'data/menuitem_data.xml',
         'wizard/generate_2307_wizard_views.xml',
         'views/account_move_views.xml',
         'views/account_payment_views.xml',

--- a/addons/l10n_ph/data/menuitem_data.xml
+++ b/addons/l10n_ph/data/menuitem_data.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <menuitem id="account_reports_ph_statements_menu" name="Philippines" parent="account.menu_finance_reports" sequence="6" groups="account.group_account_readonly"/>
+</odoo>


### PR DESCRIPTION
# Description

[IMP] l10n_ph: add Philippines reporting menu in /Accounting/Reporting

Introduce a dedicated "Philippines" group under the Finance

Reporting section.

This provides a centralized location for Philippine-specific

accounting reports (such as Book of Accounts), improving

navigation and user experience for users managing Philippine

localizations.

[Enterprise-odoo/enterprise#97448](vscode-file://vscode-app/usr/share/codium/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

task-4509282