### PR TITLE
[FIX] stock: prevent error when horizon days field is empty

### DIFF
--- a/addons/stock/static/src/views/search/stock_orderpoint_search_panel.js
+++ b/addons/stock/static/src/views/search/stock_orderpoint_search_panel.js
@@ -19,7 +19,7 @@ export class StockOrderpointSearchPanel extends SearchPanel {
     }
 
     async applyGlobalHorizonDays(ev) {
-        this.globalHorizonDays.value = Math.max(parseInt(ev.target.value), 0);
+        this.globalHorizonDays.value = Math.max(parseInt(ev.target.value || 0), 0);
         await this.env.searchModel.applyGlobalHorizonDays(this.globalHorizonDays.value);
     }
 }


### PR DESCRIPTION
Currently, an error occurs when the Horizon days field was cleared in the Replenishment view by the user.

**Step to Reproduce:**
- Install the `purchase_stock` module.
- Create a new product and set the Minimum Quantity in the reordering rule (e.g., 5).
- Update the In Hand Quantity to a value greater than the minimum (e.g., 10).
- Go to Inventory > Operations > Replenishment.
- In the Horizon section on the left panel, clear the days field.

**Cause:**
When the Horizon days field is cleared, **NaN** value is assigned to the context as `global_horizon_days` at [1]. As a result, the `get_horizon_days()` method returns **None**, which later triggers an error at [2] when performing date computation.

**Error:**
`TypeError- unsupported operand type(s) for +: 'NoneType' and 'int'`

**Fix:**
This commit handles the issue by defaulting the Horizon days value to 0, when the input is empty.

[1] - https://github.com/odoo/odoo/blob/e7aeef2fca0897e5240b087e2c3b95291ed6d568/addons/stock/static/src/views/search/stock_orderpoint_search_panel.js#L21-L24
[2] - https://github.com/odoo/odoo/blob/e7aeef2fca0897e5240b087e2c3b95291ed6d568/addons/stock/models/stock_orderpoint.py#L816

sentry-6936562315