### PR TITLE
[FIX] payment_flutterwave: fix function call error in token flow

### DIFF
--- a/addons/payment_flutterwave/static/src/js/payment_form.js
+++ b/addons/payment_flutterwave/static/src/js/payment_form.js
@@ -15,7 +15,7 @@ odoo.define('payment_flutterwave.payment_form', require => {
          * @param {object} processingValues - The processing values of the transaction
          * @return {undefined}
          */
-        _processTokenPayment: (provider_code, tokenId, processingValues) => {
+        _processTokenPayment: function (provider_code, tokenId, processingValues) {
             if (provider_code === 'flutterwave' && processingValues.auth_redirect_form_html) {
                 // Append the redirect form to the body
                 const $redirectForm = $(processingValues.auth_redirect_form_html).attr(


### PR DESCRIPTION
Steps:
- Run `_processTokenPayment` method for flow other then flutterwave for the token flow.
- or simply trigger super call from that method.

Issue:
- Error is thrown, `this._super` is not a function.

Cause:
- Arrow function caused loss of `this` context, making `_super` undefined.

Fix:
- Replaced arrow function with a normal function to correctly bind `this`
