### PR TITLE
[IMP] website: improve performance in website module

### DIFF
--- a/addons/website/models/assets.py
+++ b/addons/website/models/assets.py
@@ -331,13 +331,13 @@ class WebsiteAssets(models.AbstractModel):
         if self.env.user.has_group('website.group_website_designer'):
             self = self.sudo()
         website = self.env['website'].get_current_website()
-        res = self.env["ir.attachment"].search([("url", op, custom_url)])
+        res = self.env["ir.attachment"].search([("url", op, custom_url), ("website_id", "=", website.id)])
         # It is guaranteed that the attachment we are looking for has a website_id.
         # When we serve an attachment we normally serve the ones which have the right website_id
         # or no website_id at all (which means "available to all websites", of
         # course if they are marked "public"). But this does not apply in this
         # case of customized asset files.
-        return res.with_context(website_id=website.id).filtered(lambda x: x.website_id == website)
+        return res
 
     @api.model
     def _get_custom_asset(self, custom_url):

--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -114,8 +114,19 @@ class IrHttp(models.AbstractModel):
         return len(rewrites)
 
     def _get_rewrites(self, website_id):
-        domain = [('redirect_type', 'in', ('308', '404')), '|', ('website_id', '=', False), ('website_id', '=', website_id)]
-        return  {x.url_from: x for x in self.env['website.rewrite'].sudo().search(domain)}
+        domain = (
+            Domain('redirect_type', 'in', ('308', '404'))
+            & Domain('website_id', 'in', [False, website_id])
+        )
+        cache = self.env.cr.cache.setdefault('website_rewrites_cache', {})
+        rewrites = cache.get(website_id)
+        if rewrites is None:
+            rewrites = {
+                rewrite.url_from: rewrite.sudo(False)
+                for rewrite in self.env['website.rewrite'].sudo().search(domain)
+            }
+            cache[website_id] = rewrites
+        return rewrites
 
     def _generate_routing_rules(self, modules, converters):
         if not request:
@@ -126,9 +137,13 @@ class IrHttp(models.AbstractModel):
         rewrites = self._get_rewrites(website_id)
         self._rewrite_len.__cache__.add_value(self, website_id, cache_value=len(rewrites))
 
+        if not rewrites:
+            yield from super()._generate_routing_rules(modules, converters)
+            return
+
         for url, endpoint in super()._generate_routing_rules(modules, converters):
-            if url in rewrites:
-                rewrite = rewrites[url]
+            rewrite = rewrites.get(url)
+            if rewrite:
                 url_to = rewrite.url_to
                 if rewrite.redirect_type == '308':
                     logger.debug('Add rule %s for %s' % (url_to, website_id))


### PR DESCRIPTION
## Purpose

This PR improves the performance of several hot paths in the Website module by introducing lightweight, per-request caches and by moving certain filters and lookups to faster SQL or in-memory operations.

## Key improvements

### Faster attachment resolution
_get_custom_attachment() now applies the website_id filter directly at the SQL level, avoiding Python-side filtering and leveraging database indexes for faster lookups.

### Cached AI snippet placeholder conversions
html_text_processor.py introduces a per-request cache for placeholder computations used by AI snippet generation. Repeated conversions now reuse prior results, cutting redundant tree parsing.

### Cached rewrite mappings
ir_http now builds and stores rewrite mappings in request._website_rewrites_cache. Repeated rewrite lookups during a single request no longer hit the database, and routing generation short-circuits when no rewrites exist.

[H>A]

task-5175985
