### PR TITLE
[IMP] point_of_sale: improve config and ui for categories

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -667,6 +667,18 @@ class PosConfig(models.Model):
                 vals['name'] = _("%s (copy)", config.name)
         return vals_list
 
+    def link_category_form_pos(self, category):
+        self.ensure_one()
+        category = self.env['pos.category'].browse(category.id).exists()
+        if not category:
+            return
+
+        if self.iface_available_categ_ids and category not in self.iface_available_categ_ids.ids:
+            self.sudo().write({
+                'iface_available_categ_ids': [(4, category.id)],
+            })
+            return
+
     def _preprocess_x2many_vals_from_settings_view(self, vals):
         """ From the res.config.settings view, changes in the x2many fields always result to an array of link commands or a single set command.
             - As a result, the items that should be unlinked are not properly unlinked.

--- a/addons/point_of_sale/models/product_product.py
+++ b/addons/point_of_sale/models/product_product.py
@@ -8,6 +8,23 @@ class ProductProduct(models.Model):
     _inherit = ['product.product', 'pos.load.mixin']
 
     @api.model
+    def create(self, vals_list):
+        new_product = super().create(vals_list)
+        pos_session_id = self.env.context.get('pos_session_id')
+        if pos_session_id and new_product.product_tmpl_id.pos_categ_ids:
+            session = self.env['pos.session'].browse(pos_session_id)
+            config = session.config_id
+
+            # Check if any of the categories is already in the pos
+            if config.iface_available_categ_ids and not set(config.iface_available_categ_ids).intersection(new_product.product_tmpl_id.pos_categ_ids):
+                # Add the first chosen category to the POS by default
+                category = new_product.product_tmpl_id.pos_categ_ids[0]
+                if category not in config.iface_available_categ_ids:
+                    config.link_category_form_pos(category)
+
+        return new_product
+
+    @api.model
     def _load_pos_data_domain(self, data, config):
         return [('product_tmpl_id', 'in', [p['id'] for p in data['product.template']])]
 

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -2082,7 +2082,22 @@ export class PosStore extends WithLazyGetterTrap {
             {
                 props: {
                     resId: product?.id,
-                    onSave: (record) => {
+                    onSave: async (record) => {
+                        if (
+                            record.evalContext.pos_categ_ids.length &&
+                            !this.config.iface_available_categ_ids.some((categ) =>
+                                record.evalContext.pos_categ_ids.includes(categ)
+                            )
+                        ) {
+                            await this.data.read("pos.category", [
+                                record.evalContext.pos_categ_ids[0],
+                            ]);
+                            await this.data.read(
+                                "pos.config",
+                                [this.config.id],
+                                ["iface_available_categ_ids"]
+                            );
+                        }
                         this.data.read("product.template", [record.evalContext.id]);
                         this.data.searchRead("product.product", [
                             ["product_tmpl_id", "=", record.evalContext.id],
@@ -2094,6 +2109,7 @@ export class PosStore extends WithLazyGetterTrap {
                 },
                 additionalContext: {
                     taxes_readonly: orderContainsProduct,
+                    pos_session_id: this.session.id,
                 },
             }
         );

--- a/addons/point_of_sale/static/src/scss/pos_dashboard.scss
+++ b/addons/point_of_sale/static/src/scss/pos_dashboard.scss
@@ -37,3 +37,10 @@
     overflow-y: auto;
   }
 }
+
+.small_color_picker .o_colorlist_toggler {
+    width: 18px !important;
+    height: 18px !important;
+    min-width: 18px !important;
+    min-height: 18px !important;
+}

--- a/addons/point_of_sale/views/pos_category_view.xml
+++ b/addons/point_of_sale/views/pos_category_view.xml
@@ -7,7 +7,7 @@
             <form string="Pos Product Categories">
                 <sheet>
                     <field name="image_512" widget="image" class="oe_avatar"/>
-                    <div class="oe_title">
+                    <div class="oe_title row">
                         <h1>
                             <field name="name" class="o_text_overflow" placeholder="e.g. Soft Drinks" required="True"/>
                         </h1>
@@ -35,11 +35,12 @@
         <field name="name">pos.category.list</field>
         <field name="model">pos.category</field>
         <field name="arch" type="xml">
-            <list string="Product Product Categories">
+            <list string="Product Product Categories" multi_edit="1">
                 <field name="sequence" widget="handle"/>
                 <field name="display_name" string="PoS Product Category"/>
-                <field name="parent_id" optional="hide"/>
-                <field name="color" widget="color_picker" optional="hide"/>
+                <field name="parent_id"/>
+                <field name="pos_config_ids" widget="many2many_tags"/>
+                <field name="color" widget="color_picker"/>
             </list>
         </field>
     </record>
@@ -49,14 +50,28 @@
         <field name="model">pos.category</field>
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile">
+                <field name="parent_id" />
                 <templates>
                     <t t-name="card" class="row g-0">
-                        <aside class="col-4">
-                            <field name="image_128" widget="image" alt="Category" options="{'size': [100, 100], 'img_class': 'h-100'}"/>
-                        </aside>
-                        <main class="col ms-4">
-                            <field name="name" class="fw-bolder fs-5"/>
+                        <main class="col-10 pe-2">
+                            <div class="d-flex mb-1 h5">
+                                <field name="color" class="small_color_picker me-2" style="pointer-events: none;" widget="color_picker"/>
+                                <field name="name" class="text-truncate"/>
+                            </div>
+                            <div class="category-extras d-flex flex-column">
+                                <div class="row gap-1" t-if="record.parent_id.raw_value">
+                                    <div class="pe-0 col-auto">
+                                        <span>Parent category:</span>
+                                    </div>
+                                    <div class="text-truncate col ps-0">
+                                        <field name="parent_id"/>
+                                    </div>
+                                </div>
+                            </div>
                         </main>
+                        <aside class="col-2">
+                            <field name="image_128" widget="image" alt="Category" options="{'img_class': 'o_image_64_contain mw-100'}"/>
+                        </aside>
                     </t>
                 </templates>
             </kanban>

--- a/addons/pos_restaurant/views/pos_category_view.xml
+++ b/addons/pos_restaurant/views/pos_category_view.xml
@@ -7,7 +7,7 @@
         <field name="arch" type="xml">
             <xpath expr="//div[@name='available_between']" position="after">
                 <group>
-                    <field name="course_id" class="o_text_overflow" options="{'no_create_edit': True}"/>
+                    <field name="course_id" class="o_text_overflow" options="{'no_create_edit': True}" placeholder="No default"/>
                 </group>
             </xpath>
         </field>
@@ -21,6 +21,24 @@
             <field name="parent_id" position="after">
                 <field name="course_id"/>
             </field>
+        </field>
+    </record>
+
+    <record id="pos_restaurant_pos_category_kanban_view" model="ir.ui.view">
+        <field name="name">pos.restaurant.pos.category.kanban</field>
+        <field name="model">pos.category</field>
+        <field name="inherit_id" ref="point_of_sale.view_pos_category_kanban"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[hasclass('category-extras')]" position="inside">
+                <div class="gap-1 row" t-if="record.course_id.raw_value">
+                    <div class="pe-0 col-auto">
+                        <span>Course:</span>
+                    </div>
+                    <div class="col text-truncate ps-0">
+                        <field name="course_id" class="col-auto"/>
+                    </div>
+                </div>
+            </xpath>
         </field>
     </record>
 </odoo>

--- a/addons/pos_self_order/models/pos_category.py
+++ b/addons/pos_self_order/models/pos_category.py
@@ -1,14 +1,11 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models, fields
+from odoo import models
 
 
 class PosCategory(models.Model):
     _inherit = "pos.category"
-
-
-    pos_config_ids = fields.Many2many('pos.config', string='Linked PoS Configurations')
 
     def _can_return_content(self, field_name=None, access_token=None):
         if field_name in ["image_128", "image_512"]:


### PR DESCRIPTION
**Functional**

- Removed the restriction of deleting pos categories while sessions are open and replaced it with a restriction on removing categories which are used by POS. If the category is not in use by any POS deleting it will have no side-effects.

- Moved the definition of pos_config_ids from the pos_self_order override of the pos.category to the base class in point_of_sale so it can be always accessed, not only when the self_order is installed.

- Creating a new product from a POS session with a category which is not displayed on the current POS session will automatically add the category to the POS session config and reload the data to show the new products. This way when a user creates a new product, it will always show up on their POS from where they created the product.

**Design (Categories)**

- [Form View] For a better design will align the category title with the rest of the fields on the form view. Also added a placeholder on the pos_restaurant course field.

- [Kanban] Improved the kanban view to show the color, parent category and course if they are present directly on the card.

- [List] Made the parent category and color display by default. Added the points of sale where the category is used to the list

Task - 5172551

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
