### PR TITLE
[IMP] l10n_sa: change the label and help of delivery_date

### DIFF
--- a/addons/l10n_sa/i18n_extra/ar.po
+++ b/addons/l10n_sa/i18n_extra/ar.po
@@ -546,3 +546,15 @@ msgstr "إشعار المدين"
 #: model_terms:ir.ui.view,arch_db:l10n_sa.l10n_sa_report_invoice_document
 msgid "هذا المستند ليس مستنداً قانونياً"
 msgstr "هذا المستند ليس مستنداً قانونياً"
+
+#. module: l10n_sa
+#: model_terms:ir.ui.view,arch_db:l10n_sa.view_move_form_inherit_l10n_sa
+msgid ""
+"Date when the supply of the goods and services is performed. In case of "
+"multiple deliveries, you should take the date of the latest one."
+msgstr "تاريخ تنفيذ توريد السلع والخدمات. في حالة وجود عمليات تسليم متعددة، يجب أخذ تاريخ آخر عملية تسليم."
+
+#. module: l10n_sa
+#: model_terms:ir.ui.view,arch_db:l10n_sa.view_move_form_inherit_l10n_sa
+msgid "Supply Date"
+msgstr "تاريخ التوريد"

--- a/addons/l10n_sa/i18n_extra/l10n_sa.pot
+++ b/addons/l10n_sa/i18n_extra/l10n_sa.pot
@@ -549,3 +549,15 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:l10n_sa.l10n_sa_report_invoice_document
 msgid "هذا المستند ليس مستنداً قانونياً"
 msgstr ""
+
+#. module: l10n_sa
+#: model_terms:ir.ui.view,arch_db:l10n_sa.view_move_form_inherit_l10n_sa
+msgid ""
+"Date when the supply of the goods and services is performed. In case of "
+"multiple deliveries, you should take the date of the latest one."
+msgstr ""
+
+#. module: l10n_sa
+#: model_terms:ir.ui.view,arch_db:l10n_sa.view_move_form_inherit_l10n_sa
+msgid "Supply Date"
+msgstr ""

--- a/addons/l10n_sa/views/account_move_views.xml
+++ b/addons/l10n_sa/views/account_move_views.xml
@@ -9,6 +9,26 @@
                 <group name="sale_info_group" position="inside">
                     <field name="l10n_sa_reason" invisible="not l10n_sa_show_reason" readonly="state != 'draft'"/>
                 </group>
+                <xpath expr="//field[@name='delivery_date']" position="attributes">
+                    <attribute name="invisible" add="country_code == 'SA'" separator=" or "/>
+                </xpath>
+                <xpath expr="//field[@name='delivery_date']" position="after">
+                    <field name="delivery_date"
+                           string="Supply Date"
+                           invisible="not show_delivery_date or country_code != 'SA'"
+                           readonly="state != 'draft'"
+                           help="Date when the supply of the goods and services is performed. In case of multiple deliveries, you should take the date of the latest one."/>
+                </xpath>
+                <xpath expr="//group[@id='other_tab_group']/group/field[@name='delivery_date']" position="attributes">
+                    <attribute name="invisible" add="country_code == 'SA'" separator=" or "/>
+                </xpath>
+                <xpath expr="//group[@id='other_tab_group']/group/field[@name='delivery_date']" position="after">
+                    <field name="delivery_date"
+                           string="Supply Date"
+                           invisible="not show_delivery_date or country_code != 'SA'"
+                           readonly="state != 'draft'"
+                           help="Date when the supply of the goods and services is performed. In case of multiple deliveries, you should take the date of the latest one."/>
+                </xpath>
             </field>
         </record>
     </data>


### PR DESCRIPTION
Renamed the standard delivery_date field label to "Supply Date" on Saudi account move entries. In addition, added help text explaining its role in ZATCA VAT due liability recognition.

task-4922130
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
