### PR TITLE
[FIX] discuss: prevent invalid fields overrides in tests

### DIFF
--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -1337,9 +1337,6 @@ export class StoreMany extends StoreRelation {
         target[key] = (previous_value || []).concat(rel_val);
     }
     _get_id() {
-        if (!this.records || !this.records.length) {
-            return [];
-        }
         const res = [];
 
         if (this.records._name === "mail.message.reaction") {


### PR DESCRIPTION
Before this commit, the mock server would send incorrect store commands
because their mode was not preserved if the value was falsy.
For example, an empty ADD would behave as a replace, overriding the
value instead of leaving it unchanged.

This caused indeterministic test crashes as these commands could
corrupt data depending on the order in which they were applied.

https://runbot.odoo.com/odoo/error/231613