### PR TITLE
[PERF] orm: skip nary optimization if nothing changed

### DIFF
--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -654,6 +654,15 @@ class DomainNary(Domain):
         children = self._flatten(child._optimize(model, level) for child in self.children)
         size = len(children)
         if size > 1:
+            # nary-optimizations are independent of the level, so if BASIC was
+            # performed and all children are exactly the same, there is no need
+            # to try to merge them again
+            if (
+                level > OptimizationLevel.BASIC
+                and len(self.children) == size
+                and all(map(operator.is_, self.children, children))
+            ):
+                return self
             # sort children in order to ease their grouping by field and operator
             children.sort(key=_optimize_nary_sort_key)
             # run optimizations until some merge happens


### PR DESCRIPTION
If we already did BASIC optimizations, children are sorted and merged. In the following levels, if the children remain exactly the same objects, there is no need to try to merge them because the optimization is independent from the level.

Skipping these, we can gain up to 15% when optimizing complex domains.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
