### PR TITLE
[FIX] point_of_sale : Fix combo lines quantity update

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -24,6 +24,7 @@ export class PosOrderline extends PosOrderlineAccounting {
         this.uiState = {
             hasChange: true,
             savedQuantity: 0,
+            oldQty: this.qty,
         };
     }
 
@@ -230,7 +231,7 @@ export class PosOrderline extends PosOrderlineAccounting {
     // product's unity of measure properties. Quantities greater than zero will not get
     // rounded to zero
     setQuantity(quantity, keep_price) {
-        const oldQty = this.qty;
+        this.uiState.oldQty = this.qty;
         if (this.order_id.preset_id?.is_return) {
             quantity = -Math.abs(quantity);
         }
@@ -303,7 +304,7 @@ export class PosOrderline extends PosOrderlineAccounting {
         }
         for (const comboLine of this.combo_line_ids) {
             // If each combo contains 2 qty of a product, we wanna keep this ratio after setting the new quantity on the parent product.
-            comboLine.setQuantity((comboLine.qty / oldQty || 1) * quantity, true);
+            comboLine.setQuantity((comboLine.qty / this.uiState.oldQty || 1) * quantity, true);
         }
         return true;
     }

--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/orderline_note_button/orderline_note_button.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/orderline_note_button/orderline_note_button.js
@@ -48,6 +48,9 @@ export class NoteButton extends Component {
                 note: payload,
             });
             selectedOrderline.qty = saved_quantity;
+            for (const line of selectedOrderline.combo_line_ids) {
+                line.setQuantity(line.uiState.oldQty);
+            }
         } else {
             this.setOrderlineNote(payload);
         }

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1070,7 +1070,7 @@ export class PosStore extends WithLazyGetterTrap {
                     price_unit: comboItem.price_unit,
                     price_type: "automatic",
                     order_id: order,
-                    qty: comboItem.qty,
+                    qty: comboItem.qty * values.qty,
                     attribute_value_ids: comboItem.attribute_value_ids?.map((attr) => [
                         "link",
                         attr,

--- a/addons/point_of_sale/static/tests/unit/components/orderline_note_button.test.js
+++ b/addons/point_of_sale/static/tests/unit/components/orderline_note_button.test.js
@@ -1,0 +1,54 @@
+import { expect, test } from "@odoo/hoot";
+import { setupPosEnv, dialogActions } from "../utils";
+import { definePosModels } from "../data/generate_model_definitions";
+import { mountWithCleanup } from "@web/../tests/web_test_helpers";
+import { click } from "@odoo/hoot-dom";
+import { InternalNoteButton } from "@point_of_sale/app/screens/product_screen/control_buttons/orderline_note_button/orderline_note_button";
+import { OrderSummary } from "@point_of_sale/app/screens/product_screen/order_summary/order_summary";
+
+definePosModels();
+
+test("orderline_note_button.js", async () => {
+    const store = await setupPosEnv();
+    const order = store.addNewOrder();
+    const productTmplCombo = store.models["product.template"].get(7);
+
+    const productComboSteps = [
+        () => click("#article_product_8"), // Wood Chair 1/2
+        () => click("#article_product_8"), // Wood Chair 2/2
+        () => click("#article_product_10"), // Wood desk
+        () => click(".confirm"), // Confirm combo configuration
+    ];
+    const lineAction = async () =>
+        await store.addLineToCurrentOrder({
+            product_tmpl_id: productTmplCombo,
+            qty: 1,
+        });
+    const line = await dialogActions(lineAction, productComboSteps);
+    expect(order.lines[0].qty).toBe(1);
+    expect(order.lines[1].qty).toBe(1);
+    expect(order.lines[2].qty).toBe(2);
+    const orderSummary = await mountWithCleanup(OrderSummary, { props: {} });
+    orderSummary._setValue(4);
+    expect(order.lines[0].qty).toBe(4);
+    expect(order.lines[1].qty).toBe(4);
+    expect(order.lines[2].qty).toBe(8);
+    const comp = await mountWithCleanup(InternalNoteButton, { props: { label: "" } });
+    await comp.setChanges(line, '[{"1":"Test","colorIndex":0}]');
+    order.updateLastOrderChange();
+    orderSummary._setValue(9);
+
+    const noteAction = async () => await comp.setChanges(line, '[{"2":"Test","colorIndex":0}]');
+    await dialogActions(noteAction, productComboSteps);
+    // Check quantity
+    expect(order.lines[0].qty).toBe(4);
+    expect(order.lines[1].qty).toBe(4);
+    expect(order.lines[2].qty).toBe(8);
+    expect(order.lines[3].qty).toBe(5);
+    expect(order.lines[4].qty).toBe(5);
+    expect(order.lines[5].qty).toBe(10);
+
+    // Check notes (only on parent lines)
+    expect(order.lines[0].note).toBe('[{"1":"Test","colorIndex":0}]');
+    expect(order.lines[3].note).toBe('[{"2":"Test","colorIndex":0}]');
+});


### PR DESCRIPTION
Before this commit when a combo product was added to the the order, if a note was added and then the product was ordered. And after we change the quantity of this product and the note, the combo children lines were not updated correctly.

After this commit, the combo children lines quantities are correctly updated when the parent line quantity is changed.

Step to reproduce :

1. Add a combo item to the order line in Point of Sale (Restaurant).
2. Add a Note to the main order line and place the order(Send to Kitchen).
3. Now increase the quantity of the main order line and update the note as well.
4. A popup appears to select the combo again make your selection. You'll notice that a new order line is added.
5. However, in the previous order line, the main product quantity is reverted back to the original quantity, but the combo item order line quantity is not reverted, resulting in an inconsistency.

Task id : 5163287
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
