### PR TITLE
[FIX] sale_project: non-validated timesheets in project sharing preview

### DIFF
--- a/addons/sale_project/views/project_sharing_views.xml
+++ b/addons/sale_project/views/project_sharing_views.xml
@@ -62,6 +62,7 @@
             'active_id_chatter': active_id,
             'delete': false,
             'sale_show_partner_name': true,
+            'is_portal_preview': true,
         }</field>
     </record>
 


### PR DESCRIPTION

### Issue:

Due to this issue, in the project sharing, the customer preview doesn't reflect the actual behaviour of the portal view. It shows non-validated timesheets even if invoicing policy is validated timesheets only.

#### To reproduce:
1- Create a db with sale_project and sale_timesheet_enterprise
2- Configure invoicing policy to validated timesheets only
3- Create a service product:
- Create on Order: Project & Task
- Invoicing policy: Based on Timesheets

4- Create a Quotation for the product and confirm it
5- Open project from smart button
6- Share project with a portal user with Edit access
7- Open tasks, and add two timesheets to the task
8- Open timesheet app, and validate one of the timesheets
9- From project page, click on Customer preview
10- In preview, open the task. You can see both timesheets which is a different behaviour if you view the project using portal user. Using portal user, only validated timesheets are shown.

### Cause:

The timesheets are filtered here to only show validated timesheets:

https://github.com/odoo/enterprise/blob/8223ed0765c6064b88280656a5ab6b13ca9a431f/sale_timesheet_enterprise/models/project_task.py#L73-L91

However, it is filtered only if user is portal. In customer preview the user is still the internal user, as a result the timesheets will not be filtered.

To fix that we can add a context in sharing project action and use it as a check to filter timesheets.

opw-5093339
