### PR TITLE
[IMP] sale_stock: remove customer reference from picking origin

### DIFF
--- a/addons/sale_stock/models/sale_order_line.py
+++ b/addons/sale_stock/models/sale_order_line.py
@@ -387,7 +387,7 @@ class SaleOrderLine(models.Model):
 
             line_uom = line.product_uom
             quant_uom = line.product_id.uom_id
-            origin = f'{line.order_id.name} - {line.order_id.client_order_ref}' if line.order_id.client_order_ref else line.order_id.name
+            origin = line.order_id.name
             product_qty, procurement_uom = line_uom._adjust_uom_quantities(product_qty, quant_uom)
             procurements += line._create_procurements(product_qty, procurement_uom, origin, values)
         if procurements:


### PR DESCRIPTION
The origin field reliably tracks related orders, but including the customer reference caused issues:
- The delivery slip displayed the customer reference twice.
- Updating the customer reference in a sale order did not update the origin, making it unreliable for tracking.

This change removes the customer reference from the origin, while keeping it structured for related orders.

opw-5134111