### PR TITLE
[IMP] hr_expense: make name not required if draft expense

### DIFF
--- a/addons/hr_expense/tests/test_expenses_mail_import.py
+++ b/addons/hr_expense/tests/test_expenses_mail_import.py
@@ -2,7 +2,7 @@
 
 from odoo.addons.hr_expense.tests.common import TestExpenseCommon
 from odoo.tests import tagged
-from odoo.exceptions import UserError
+from odoo.exceptions import ValidationError
 
 
 @tagged('-at_install', 'post_install')
@@ -227,4 +227,4 @@ class TestExpensesMailImport(TestExpenseCommon):
         }
 
         expense = self.env['hr.expense'].message_new(message)
-        self.assertRaisesRegex(UserError, r"You can not submit an expense without a category\.", expense.action_submit)
+        self.assertRaisesRegex(ValidationError, "Select a category to proceed.", expense.action_submit)

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -20,7 +20,7 @@
                     <!--  Optional -->
                     <field name="department_id" optional="hide" readonly="True"/>
                     <field name="date" optional="show" readonly="not is_editable"/>
-                    <field name="product_id" optional="show" readonly="not is_editable" required="1"/>
+                    <field name="product_id" optional="show" readonly="not is_editable"/>
                     <field name="payment_mode" optional="show" readonly="not is_editable"/>
                     <field name="activity_ids" widget="list_activity" optional="show"/>
                     <field name="analytic_distribution" widget="analytic_distribution"
@@ -189,7 +189,7 @@
 
                             <label for="product_id"/>
                             <div>
-                                <field name="product_id" required="1" readonly="not is_editable"
+                                <field name="product_id" readonly="not is_editable"
                                     context="{
                                         'default_type': 'service',
                                         'default_can_be_expensed': 1,
@@ -210,7 +210,7 @@
                             <div invisible="not product_has_cost">
                                 <div class="o_row">
                                     <field name="quantity" class="oe_inline" readonly="not is_editable"/>
-                                    <field name="product_uom_id" required="1" force_save="1"
+                                    <field name="product_uom_id" force_save="1"
                                            options="{'no_open': True, 'no_create': True}" groups="uom.group_uom"
                                            readonly="not is_editable" widget="many2one_uom"/>
                                 </div>
@@ -285,7 +285,7 @@
                     </div>
                 </sheet>
                 <div class="o_attachment_preview o_center_attachment"/>
-                <chatter/>
+                <chatter reload_on_attachment="True"/>
                 </form>
             </field>
         </record>


### PR DESCRIPTION
Enable the uploading of expense attachment on the form view even if the required fields "name" and "product_id" aren't provided yet. We therefore make these fields not required if the expense is in draft state.

task-4684825
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
