### PR TITLE
[FIX] sale_project: prevent error when creating sale order for project

### DIFF
--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -269,7 +269,7 @@ class SaleOrder(models.Model):
         project = self.env['project.project'].browse(self.env.context.get('create_for_project_id'))
         task = self.env['project.task'].browse(self.env.context.get('create_for_task_id'))
         if project or task:
-            service_sol = next((sol for sol in created_records.order_line if sol.is_service), False)
+            service_sol = next((sol for sol in created_records.order_line if sol.is_service), self.env['sale.order.line'])
             if project and not project.sale_line_id:
                 project.sale_line_id = service_sol
                 if not project.reinvoiced_sale_order_id:

--- a/addons/sale_project/tests/test_sale_project.py
+++ b/addons/sale_project/tests/test_sale_project.py
@@ -1854,3 +1854,25 @@ class TestSaleProject(TestSaleProjectCommon):
             so.project_ids.allow_milestones,
             'The generated project should have the "Allow Milestones" setting enabled, as one of the products has invoice policy based on milestones.',
         )
+
+    def test_sale_order_creation_without_service_product_for_project(self):
+        """Test that a sale order is created for a project using a non-service product"""
+        self.project_global.partner_id = self.partner
+        action_dict = self.project_global.with_context(
+            create_for_project_id=self.project_global.id,
+            default_project_id=self.project_global.id,
+            default_partner_id=self.partner.id
+        ).action_view_sos()
+
+        self.product_milestone.type = 'consu'
+        sale_order = self.env['sale.order'].with_context(action_dict['context']).create({
+            'order_line': [Command.create({
+                'product_id': self.product_milestone.id,
+                'product_uom_qty': 1,
+            })],
+        })
+
+        self.assertEqual(sale_order.project_id, self.project_global)
+        self.assertEqual(sale_order.partner_id, self.partner)
+        self.assertFalse(self.project_global.sale_line_id)
+        self.assertEqual(self.project_global.reinvoiced_sale_order_id, sale_order)


### PR DESCRIPTION
Currently, an error occurs when creating a sale order for a project.

**Steps to Reproduce:**
 - Install the `sale_project` module.
 - Go to `Project` and, in the `list view`, create a `project` and `set a customer`.
 - Click the `Sales Order` button in the header.
 - Save the `sale order` without adding `any product` or by adding a `non-service product`.

**Error:**
`AttributeError: 'bool' object has no attribute 'order_id'`

This error occurs, when user creating a sale order for a project without adding a service product, then 
service sol becomes empty [1], which raises an error here [2] when trying to access the sale order.

This commit ensures that if there is no service sol, empty sol is taken in the service sol.

[1]- https://github.com/odoo/odoo/blob/3121577430cdfa485af4d69792745a6f9c2ffe2f/addons/sale_project/models/sale_order.py#L272

[2]- https://github.com/odoo/odoo/blob/3121577430cdfa485af4d69792745a6f9c2ffe2f/addons/sale_project/models/sale_order.py#L276

sentry-6948584510

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
