### PR TITLE
[FIX] html_builder: fix visually-hidden text causing scrollbar in Chrome

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_list.scss
+++ b/addons/html_builder/static/src/core/building_blocks/builder_list.scss
@@ -1,3 +1,8 @@
+table .visually-hidden {
+    position: static !important;
+    display: inline-block;
+}
+
 .bl-dropdown-toggle:disabled {
     cursor: default;
     border: 1px solid #00000088;


### PR DESCRIPTION
This is a known issue [1] in bootstrap, which displays an unexpected
scrollbar when we have a visually-hidden text in the table. The issue
occurs in Chrome, Edge and Safari, but does not in Firefox.

**Steps to see the issue:**
- Open website and start editing
- Drop a table of content
- Drop inside of the ToC a donation snippet
- Click on the donation amounts form

=> A scrollbar appears.
The visually-hidden spans are present since [2], but the problem couldn't be
seen until commit [3] removed the `overflow: hidden` style.

[1]: https://github.com/twbs/bootstrap/issues/41554
[2]: https://github.com/odoo/odoo/commit/faafb913a0af5c4bfa7d207e09bbea0d97125aed
[3]: https://github.com/odoo/odoo/commit/10156c10b09dc502a40253d64e2505e817a520bf

task-5169275