### PR TITLE
[REF] mail, *: do not send empty ADD or DELETE for many in Store

### DIFF
--- a/addons/im_livechat/tests/test_chatbot_internals.py
+++ b/addons/im_livechat/tests/test_chatbot_internals.py
@@ -206,8 +206,6 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
             channel_data_join = (
                 Store(bus_channel=member_emp._bus_channel()).add(discuss_channel).get_result()
             )
-            channel_data_join["discuss.channel"][0]["invited_member_ids"] = [["ADD", []]]
-            channel_data_join["discuss.channel"][0]["rtc_session_ids"] = [["ADD", []]]
             channel_data_join["discuss.channel"][0]["livechat_outcome"] = "no_agent"
             channel_data_join["discuss.channel"][0]["chatbot"]["currentStep"]["message"] = messages[1].id
             channel_data_join["discuss.channel"][0]["chatbot"]["steps"][0]["message"] = messages[1].id

--- a/addons/mail/models/res_users_settings.py
+++ b/addons/mail/models/res_users_settings.py
@@ -28,7 +28,8 @@ class ResUsersSettings(models.Model):
         if 'volume_settings_ids' in fields_to_format:
             volume_settings = self.volume_settings_ids._discuss_users_settings_volume_format()
             res.pop('volume_settings_ids', None)
-            res['volumes'] = [('ADD', volume_settings)]
+            if volume_settings:
+                res["volumes"] = [("ADD", volume_settings)]
         return res
 
     def set_res_users_settings(self, new_settings):

--- a/addons/mail/tools/discuss.py
+++ b/addons/mail/tools/discuss.py
@@ -517,7 +517,7 @@ class Store:
         def _add_to_store(self, store: "Store", target, key):
             self._sort_recods()
             super()._add_to_store(store, target, key)
-            if not self.only_data:
+            if not self.only_data and (self.records or self.mode == "REPLACE"):
                 rel_val = self._get_id()
                 target[key] = (
                     target[key] + rel_val if key in target and self.mode != "REPLACE" else rel_val

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -456,7 +456,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                     "use_push_to_talk": False,
                     "user_id": {"id": self.users[0].id},
                     "voice_active_duration": 200,
-                    "volumes": [("ADD", [])],
                     "embedded_actions_config_ids": {},
                 },
             },
@@ -661,7 +660,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "group_ids": channel.group_ids.ids,
                 "group_public_id": self.env.ref("base.group_user").id,
                 "id": channel.id,
-                "invited_member_ids": [["ADD", []]],
                 "is_editable": True,
                 "last_interest_dt": last_interest_dt,
                 "member_count": len(self.group_user.all_user_ids),
@@ -669,7 +667,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "message_needaction_counter": 0,
                 "name": "general",
                 "parent_channel_id": False,
-                "rtc_session_ids": [["ADD", []]],
                 "uuid": channel.uuid,
             }
         if channel == self.channel_channel_public_1:
@@ -684,7 +681,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "group_ids": [],
                 "group_public_id": False,
                 "id": channel.id,
-                "invited_member_ids": [["ADD", []]],
                 "is_editable": True,
                 "last_interest_dt": last_interest_dt,
                 "member_count": 5,
@@ -692,7 +688,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "message_needaction_counter": 1,
                 "name": "public channel 1",
                 "parent_channel_id": False,
-                "rtc_session_ids": [["ADD", []]],
                 "uuid": channel.uuid,
             }
         if channel == self.channel_channel_public_2:
@@ -707,7 +702,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "group_ids": [],
                 "group_public_id": False,
                 "id": channel.id,
-                "invited_member_ids": [["ADD", []]],
                 "is_editable": True,
                 "last_interest_dt": last_interest_dt,
                 "member_count": 5,
@@ -715,7 +709,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "message_needaction_counter": 0,
                 "name": "public channel 2",
                 "parent_channel_id": False,
-                "rtc_session_ids": [["ADD", []]],
                 "uuid": channel.uuid,
             }
         if channel == self.channel_channel_group_1:
@@ -754,7 +747,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "group_ids": [],
                 "group_public_id": self.env.ref("base.group_user").id,
                 "id": channel.id,
-                "invited_member_ids": [["ADD", []]],
                 "is_editable": True,
                 "last_interest_dt": last_interest_dt,
                 "member_count": 5,
@@ -762,7 +754,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "message_needaction_counter": 0,
                 "name": "group restricted channel 2",
                 "parent_channel_id": False,
-                "rtc_session_ids": [["ADD", []]],
                 "uuid": channel.uuid,
             }
         if channel == self.channel_group_1:
@@ -776,7 +767,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "fetchChannelInfoState": "fetched",
                 "from_message_id": False,
                 "id": channel.id,
-                "invited_member_ids": [["ADD", []]],
                 "is_editable": True,
                 "last_interest_dt": last_interest_dt,
                 "member_count": 2,
@@ -784,7 +774,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "message_needaction_counter": 0,
                 "name": "",
                 "parent_channel_id": False,
-                "rtc_session_ids": [["ADD", []]],
                 "uuid": channel.uuid,
             }
         if channel == self.channel_chat_1:
@@ -794,14 +783,12 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "default_display_mode": False,
                 "fetchChannelInfoState": "fetched",
                 "id": channel.id,
-                "invited_member_ids": [["ADD", []]],
                 "is_editable": True,
                 "last_interest_dt": last_interest_dt,
                 "member_count": 2,
                 "message_needaction_counter_bus_id": bus_last_id,
                 "message_needaction_counter": 0,
                 "name": "Ernest Employee, test14",
-                "rtc_session_ids": [["ADD", []]],
                 "uuid": channel.uuid,
             }
         if channel == self.channel_chat_2:
@@ -811,14 +798,12 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "default_display_mode": False,
                 "fetchChannelInfoState": "fetched",
                 "id": channel.id,
-                "invited_member_ids": [["ADD", []]],
                 "is_editable": True,
                 "last_interest_dt": last_interest_dt,
                 "member_count": 2,
                 "message_needaction_counter_bus_id": bus_last_id,
                 "message_needaction_counter": 0,
                 "name": "Ernest Employee, test15",
-                "rtc_session_ids": [["ADD", []]],
                 "uuid": channel.uuid,
             }
         if channel == self.channel_chat_3:
@@ -828,14 +813,12 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "default_display_mode": False,
                 "fetchChannelInfoState": "fetched",
                 "id": channel.id,
-                "invited_member_ids": [["ADD", []]],
                 "is_editable": True,
                 "last_interest_dt": last_interest_dt,
                 "member_count": 2,
                 "message_needaction_counter_bus_id": bus_last_id,
                 "message_needaction_counter": 0,
                 "name": "Ernest Employee, test2",
-                "rtc_session_ids": [["ADD", []]],
                 "uuid": channel.uuid,
             }
         if channel == self.channel_chat_4:
@@ -845,14 +828,12 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "default_display_mode": False,
                 "fetchChannelInfoState": "fetched",
                 "id": channel.id,
-                "invited_member_ids": [["ADD", []]],
                 "is_editable": True,
                 "last_interest_dt": last_interest_dt,
                 "member_count": 2,
                 "message_needaction_counter_bus_id": bus_last_id,
                 "message_needaction_counter": 0,
                 "name": "Ernest Employee, test3",
-                "rtc_session_ids": [["ADD", []]],
                 "uuid": channel.uuid,
             }
         if channel == self.channel_livechat_1:
@@ -865,7 +846,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "description": False,
                 "fetchChannelInfoState": "fetched",
                 "id": channel.id,
-                "invited_member_ids": [["ADD", []]],
                 "is_editable": True,
                 "last_interest_dt": last_interest_dt,
                 "livechat_end_dt": False,
@@ -882,7 +862,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "message_needaction_counter": 0,
                 "name": "test1 Ernest Employee",
                 "requested_by_operator": False,
-                "rtc_session_ids": [["ADD", []]],
                 "uuid": channel.uuid,
             }
         if channel == self.channel_livechat_2:
@@ -895,7 +874,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "description": False,
                 "fetchChannelInfoState": "fetched",
                 "id": channel.id,
-                "invited_member_ids": [["ADD", []]],
                 "is_editable": True,
                 "last_interest_dt": last_interest_dt,
                 "livechat_end_dt": False,
@@ -912,7 +890,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "message_needaction_counter": 0,
                 "name": "Visitor Ernest Employee",
                 "requested_by_operator": False,
-                "rtc_session_ids": [["ADD", []]],
                 "uuid": channel.uuid,
             }
         return {}

--- a/addons/website_livechat/tests/test_livechat_basic_flow.py
+++ b/addons/website_livechat/tests/test_livechat_basic_flow.py
@@ -214,7 +214,6 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
                         "description": False,
                         "fetchChannelInfoState": "fetched",
                         "id": channel.id,
-                        "invited_member_ids": [("ADD", [])],
                         "is_editable": True,
                         "last_interest_dt": fields.Datetime.to_string(channel.last_interest_dt),
                         "livechat_channel_id": self.livechat_channel.id,
@@ -231,7 +230,6 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
                         "message_needaction_counter_bus_id": 0,
                         "name": f"Visitor #{self.visitor.id} El Deboulonnator",
                         "requested_by_operator": False,
-                        "rtc_session_ids": [("ADD", [])],
                         "uuid": channel.uuid,
                     }
                 ),
@@ -334,7 +332,6 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
                     "default_display_mode": False,
                     "fetchChannelInfoState": "fetched",
                     "id": channel.id,
-                    "invited_member_ids": [("ADD", [])],
                     "is_editable": False,
                     "last_interest_dt": fields.Datetime.to_string(channel.last_interest_dt),
                     "livechat_end_dt": fields.Datetime.to_string(agent_left_dt),
@@ -344,7 +341,6 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
                     "message_needaction_counter_bus_id": 0,
                     "name": f"Visitor #{self.visitor.id} El Deboulonnator",
                     "requested_by_operator": False,
-                    "rtc_session_ids": [("ADD", [])],
                     "uuid": channel.uuid,
                 },
             )


### PR DESCRIPTION
Sending empty fields is useful for standard fields, as an empty value will clear the existing value in JS.

But for many fields, empty ADD or empty DELETE will not do anything, it's useless to send them.

Similarly to other fields, empty REPLACE are still useful though.

task-4717333