### PR TITLE
[FIX] account: Fix management of manual_tax_amounts

### DIFF
--- a/addons/account/static/src/helpers/account_tax.js
+++ b/addons/account/static/src/helpers/account_tax.js
@@ -928,6 +928,12 @@ export const accountTaxHelpers = {
                 const manual_field = `manual_${total_field}`;
                 if (base_line[manual_field] !== null) {
                     tax_details[total_field] = base_line[manual_field];
+                    if (suffix === "_currency" && rate) {
+                        tax_details.total_excluded = roundPrecision(
+                            tax_details[total_field] / rate,
+                            company.currency_id.rounding
+                        );
+                    }
                 }
 
                 for (const tax_data of tax_details.taxes_data) {
@@ -1277,6 +1283,8 @@ export const accountTaxHelpers = {
 
                     let excluded_target_amount;
                     if (base_line[excluded_manual_field] !== null) {
+                        excluded_target_amount = base_line[excluded_manual_field];
+                    } else if (suffix === "" && base_line.manual_total_excluded_currency !== null) {
                         excluded_target_amount = excluded_rounded_amount;
                     } else {
                         excluded_target_amount = excluded_raw_amount;
@@ -1292,6 +1300,12 @@ export const accountTaxHelpers = {
                         values[tax_base_raw_field] = tax_data[tax_base_raw_field];
 
                         if (tax_base_rounded_field in current_manual_tax_amounts) {
+                            values[tax_base_target_field] =
+                                current_manual_tax_amounts[tax_base_rounded_field];
+                        } else if (
+                            suffix === "" &&
+                            "base_amount_currency" in current_manual_tax_amounts
+                        ) {
                             values[tax_base_target_field] = tax_data[tax_base_rounded_field];
                         } else {
                             values[tax_base_target_field] = tax_data[tax_base_raw_field];
@@ -1302,31 +1316,38 @@ export const accountTaxHelpers = {
                         values[tax_base_target_field] = excluded_target_amount;
                     }
 
-                    const tax_tax_rounded_field = `tax_amount${suffix}`;
-                    const tax_tax_raw_field = `raw_${tax_tax_rounded_field}`;
-                    const tax_tax_target_field = `target_${tax_tax_rounded_field}`;
+                    const tax_rounded_field = `tax_amount${suffix}`;
+                    const tax_raw_field = `raw_${tax_rounded_field}`;
+                    const tax_target_field = `target_${tax_rounded_field}`;
 
-                    values[tax_tax_rounded_field] = 0.0;
-                    values[tax_tax_raw_field] = 0.0;
-                    values[tax_tax_target_field] = 0.0;
+                    values[tax_rounded_field] = 0.0;
+                    values[tax_raw_field] = 0.0;
+                    values[tax_target_field] = 0.0;
                 }
             }
 
             // Tax amount.
             if (tax_data) {
+                const reverse_charge_sign = tax_data.is_reverse_charge ? -1 : 1;
                 const values = values_per_grouping_key[grouping_key];
                 for (const suffix of ["_currency", ""]) {
-                    const tax_tax_rounded_field = `tax_amount${suffix}`;
-                    const tax_tax_raw_field = `raw_${tax_tax_rounded_field}`;
-                    const tax_tax_target_field = `target_${tax_tax_rounded_field}`;
+                    const tax_rounded_field = `tax_amount${suffix}`;
+                    const tax_raw_field = `raw_${tax_rounded_field}`;
+                    const tax_target_field = `target_${tax_rounded_field}`;
 
-                    values[tax_tax_rounded_field] += tax_data[tax_tax_rounded_field];
-                    values[tax_tax_raw_field] += tax_data[tax_tax_raw_field];
+                    values[tax_rounded_field] += tax_data[tax_rounded_field];
+                    values[tax_raw_field] += tax_data[tax_raw_field];
 
-                    if (tax_tax_rounded_field in current_manual_tax_amounts) {
-                        values[tax_tax_target_field] += tax_data[tax_tax_rounded_field];
+                    if (tax_rounded_field in current_manual_tax_amounts) {
+                        values[tax_target_field] +=
+                            reverse_charge_sign * current_manual_tax_amounts[tax_rounded_field];
+                    } else if (
+                        suffix === "" &&
+                        "tax_amount_currency" in current_manual_tax_amounts
+                    ) {
+                        values[tax_target_field] = tax_data[tax_rounded_field];
                     } else {
-                        values[tax_tax_target_field] += tax_data[tax_tax_raw_field];
+                        values[tax_target_field] += tax_data[tax_raw_field];
                     }
                 }
                 values.taxes_data.push(tax_data);

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1569,7 +1569,7 @@ class PosOrderLine(models.Model):
                 self.price_subtotal = taxes['total_excluded']
                 self.price_subtotal_incl = taxes['total_included']
 
-    @api.depends('order_id', 'order_id.fiscal_position_id')
+    @api.depends('order_id', 'order_id.fiscal_position_id', 'tax_ids')
     def _get_tax_ids_after_fiscal_position(self):
         for line in self:
             line.tax_ids_after_fiscal_position = line.order_id.fiscal_position_id.map_tax(line.tax_ids)


### PR DESCRIPTION
The 'manual_tax_amounts' were not well managed in the aggregators when the amount expressed in foreign currency was specified but not the amounts expressed in company currency. In that case, we were taking the raw amount instead of the rate applied on the manual amount in foreign currency.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
