### PR TITLE
[FIX] l10n_tr_nilvera_einvoice: fix test

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice/tests/test_tr_nilvera_mocked_requests.py
+++ b/addons/l10n_tr_nilvera_einvoice/tests/test_tr_nilvera_mocked_requests.py
@@ -139,7 +139,9 @@ class TestTRNilveraMockedRequests(TestUBLTRCommon):
         _, invoice = self._generate_invoice_xml(self.einvoice_partner, include_invoice=True)
 
         invoices_data = {
-            invoice: {**invoice.read()[0], 'extra_edis': {'tr_nilvera'}}
+            invoice: {
+                **self.env['account.move.send']._get_default_sending_settings(invoice),
+            }
         }
 
         with patch('odoo.addons.l10n_tr_nilvera_einvoice.models.account_move.AccountMove._l10n_tr_nilvera_submit_einvoice') as mock_submit_einvoice, \


### PR DESCRIPTION
In the `test_which_service_to_call` test, we are calling
`_call_web_service_before_invoice_pdf_render` with invoice_data.
But invoice_data is just a dict with `invoice.read()` and
the extra key extra_edis.

Instead of manually building invoice_data, we should call
`_get_default_sending_settings`, which is meant to be used
in the base `account.move.send` flow.

Why this fix? Because by not calling `_get_default_sending_settings`,
we risk changing the expected invoice_data format used in
`_call_web_service_before_invoice_pdf_render`, which could lead to KeyErrors.

Spotted while developing https://github.com/odoo/enterprise/pull/80590,
the test failed, raising the ['invoice_edi_format'] key error.

no-task
