### PR TITLE
[REV] point_of_sale: use local targetAddressSpace for LNA

### DIFF
--- a/addons/point_of_sale/static/src/app/hardware_proxy/hardware_proxy_service.js
+++ b/addons/point_of_sale/static/src/app/hardware_proxy/hardware_proxy_service.js
@@ -151,7 +151,6 @@ export class HardwareProxy extends EventBus {
             const response = await browser
                 .fetch(`${url}/hw_proxy/hello`, {
                     signal: timeoutController.signal,
-                    targetAddressSpace: "local",
                 })
                 .catch(() => ({}));
             if (response.ok) {


### PR DESCRIPTION
This reverts commit 1a934ae which added the `"targetAddressSpace": local` option to IoT fetch requests. This is because of two reasons:

1. It caused errors on older versions of Chrome that implemented the obsoleted 'Private Network Access' standard.
2. It was not actually required in the first place, it is only needed in situations where a HTTP resource is accessed from HTTPS using a domain that resolves to a local IP. In Odoo we only ever do this for HTTPS -> HTTPS requests, where it works automatically.

task-5157145

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
