### PR TITLE
[IMP] web: list: use sendBeacon to save urgently

### DIFF
--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -224,6 +224,7 @@ export class ListController extends Component {
                 onAskMultiSaveConfirmation: this.onAskMultiSaveConfirmation.bind(this),
                 onWillSetInvalidField: this.onWillSetInvalidField.bind(this),
             },
+            useSendBeaconToSaveUrgently: true,
         };
     }
 

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -1,4 +1,4 @@
-import { expect, getFixture, test } from "@odoo/hoot";
+import { expect, getFixture, mockSendBeacon, test } from "@odoo/hoot";
 import {
     clear,
     click,
@@ -15781,9 +15781,17 @@ test(`Auto save: save on closing tab/browser`, async () => {
 });
 
 test(`Auto save: save on closing tab/browser (pending changes)`, async () => {
-    onRpc("foo", "web_save", ({ args }) => {
-        expect.step("web_save");
-        expect(args).toEqual([[1], { foo: "test" }]);
+    const sendBeaconDeferred = new Deferred();
+    mockSendBeacon((_, blob) => {
+        expect.step("sendBeacon");
+        blob.text().then((r) => {
+            const { params } = JSON.parse(r);
+            if (params.method === "web_save" && params.model === "foo") {
+                expect(params.args).toEqual([[1], { foo: "test" }]);
+            }
+            sendBeaconDeferred.resolve();
+        });
+        return true;
     });
 
     await mountView({
@@ -15794,12 +15802,16 @@ test(`Auto save: save on closing tab/browser (pending changes)`, async () => {
     await contains(`.o_data_cell`).click();
     await contains(`.o_data_cell [name=foo] input`).edit("test", { confirm: false });
 
-    await unload();
-    await animationFrame();
-    expect.verifySteps(["web_save"]);
+    const [event] = await unload();
+    await sendBeaconDeferred;
+    expect.verifySteps(["sendBeacon"]);
+    expect(event.defaultPrevented).toBe(false);
 });
 
 test(`Auto save: save on closing tab/browser (invalid field)`, async () => {
+    mockSendBeacon(() => {
+        expect.step("sendBeacon"); // should not be called
+    });
     onRpc("foo", "web_save", () => {
         expect.step("save"); // should not be called
     });
@@ -15828,9 +15840,18 @@ test(`Auto save: save on closing tab/browser (onchanges + pending changes)`, asy
 
     const deferred = new Deferred();
     onRpc("foo", "onchange", () => deferred);
-    onRpc("foo", "web_save", ({ args }) => {
-        expect.step("web_save");
-        expect(args).toEqual([[1], { int_field: 2021 }]);
+
+    const sendBeaconDeferred = new Deferred();
+    mockSendBeacon((_, blob) => {
+        expect.step("sendBeacon");
+        blob.text().then((r) => {
+            const { params } = JSON.parse(r);
+            if (params.method === "web_save" && params.model === "foo") {
+                expect(params.args).toEqual([[1], { int_field: 2021 }]);
+            }
+            sendBeaconDeferred.resolve();
+        });
+        return true;
     });
 
     await mountView({
@@ -15847,8 +15868,8 @@ test(`Auto save: save on closing tab/browser (onchanges + pending changes)`, asy
     await contains(`.o_data_cell [name="int_field"] input`).edit("2021", { confirm: "blur" });
 
     await unload();
-    await animationFrame();
-    expect.verifySteps(["web_save"]);
+    await sendBeaconDeferred;
+    expect.verifySteps(["sendBeacon"]);
 });
 
 test(`Auto save: save on closing tab/browser (onchanges)`, async () => {
@@ -15860,9 +15881,18 @@ test(`Auto save: save on closing tab/browser (onchanges)`, async () => {
 
     const deferred = new Deferred();
     onRpc("foo", "onchange", () => deferred);
-    onRpc("foo", "web_save", ({ args }) => {
-        expect.step("web_save");
-        expect(args).toEqual([[1], { foo: "test", int_field: 2021 }]);
+
+    const sendBeaconDeferred = new Deferred();
+    mockSendBeacon((_, blob) => {
+        expect.step("sendBeacon");
+        blob.text().then((r) => {
+            const { params } = JSON.parse(r);
+            if (params.method === "web_save" && params.model === "foo") {
+                expect(params.args).toEqual([[1], { foo: "test", int_field: 2021 }]);
+            }
+            sendBeaconDeferred.resolve();
+        });
+        return true;
     });
 
     await mountView({
@@ -15880,8 +15910,8 @@ test(`Auto save: save on closing tab/browser (onchanges)`, async () => {
     await contains(`.o_data_cell [name="foo"] input`).edit("test", { confirm: "blur" });
 
     await unload();
-    await animationFrame();
-    expect.verifySteps(["web_save"]);
+    await sendBeaconDeferred;
+    expect.verifySteps(["sendBeacon"]);
 });
 
 test.tags("desktop");


### PR DESCRIPTION
In form views, we faced the issue that sometimes, when closing the browser, changes weren't properly saved (despite being valid). This especially happened when the payload was large (e.g. a lot of changes in an html field), or on specific devices, or on slow networks... PR [1] fixed the issue by using sendBeacon instead of a regular xhr, as sendBeacon provides an API that guarantees to reach the server. More details are available in [1].

However, we only applied that sendBeacon strategy in form views, which were the most likely to be exposed to the issue. Recently [2], we improved the kanban quick create feature and started using sendBeacon as well, thus only leaving the list (among the 3 major views) as not using sendBeacon.

As the similar situation could occur in lists as well, this commit thus enables it there.

Note that sendBeacon is only used when closing the browser while there're pending changes in the UI. In other times, we still use classical xhr.

[1] https://github.com/odoo/odoo/pull/149944
[2] https://github.com/odoo/odoo/pull/228632

Task~3537838

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
