### PR TITLE
[FIX] mail: correct composer height when editing message

### DIFF
--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -100,7 +100,7 @@ export class Message extends Component {
         this.escape = escape;
         this.popover = usePopover(this.constructor.components.Popover, { position: "top" });
         this.state = useState({
-            isEditing: false,
+            isEditing: false, // @deprecated
             isHovered: false,
             isClicked: false,
             expandOptions: false,
@@ -129,12 +129,6 @@ export class Message extends Component {
             message: this.props.message,
             alignedRight: this.isAlignedRight,
         });
-        useEffect(
-            (editingMessage) => {
-                this.state.isEditing = this.props.message.eq(editingMessage);
-            },
-            () => [this.props.messageEdition?.editingMessage]
-        );
         onMounted(() => {
             if (this.shadowBody.el) {
                 this.shadowRoot = this.shadowBody.el.attachShadow({ mode: "open" });
@@ -212,12 +206,16 @@ export class Message extends Component {
         );
         useEffect(
             () => {
-                if (!this.state.isEditing) {
+                if (!this.isEditing) {
                     this.prepareMessageBody(this.messageBody.el);
                 }
             },
-            () => [this.state.isEditing, this.message.body]
+            () => [this.isEditing, this.message.body]
         );
+    }
+
+    get isEditing() {
+        return this.props.message.eq(this.props.messageEdition?.editingMessage);
     }
 
     get attClass() {
@@ -244,7 +242,7 @@ export class Message extends Component {
                 this.props.message
             ),
             "o-actionMenuMobileOpen": this.state.actionMenuMobileOpen,
-            "o-editing": this.state.isEditing,
+            "o-editing": this.isEditing,
         };
     }
 

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -69,11 +69,11 @@
                                    'flex-row-reverse': isAlignedRight,
                                    }"
                         >
-                            <div class="o-mail-Message-content o-min-width-0" t-att-class="{ 'w-100': state.isEditing, 'opacity-50': message.isPending, 'pt-1': message.is_note }">
-                                <div class="o-mail-Message-textContent position-relative d-flex" t-att-class="{ 'w-100': state.isEditing }">
+                            <div class="o-mail-Message-content o-min-width-0" t-att-class="{ 'w-100': isEditing, 'opacity-50': message.isPending, 'pt-1': message.is_note }">
+                                <div class="o-mail-Message-textContent position-relative d-flex" t-att-class="{ 'w-100': isEditing }">
                                     <t t-if="message.message_type === 'notification' and message.body" t-call="mail.Message.bodyAsNotification" name="bodyAsNotification"/>
-                                    <t t-if="message.isEmpty or (message.message_type !== 'notification' and !message.is_transient and (message.hasTextContent or message.subtype_description or state.isEditing or message.edited))">
-                                        <LinkPreviewList t-if="!state.isEditing and message.linkPreviewSquash" linkPreviews="message.link_preview_ids" deletable="false"/>
+                                    <t t-if="message.isEmpty or (message.message_type !== 'notification' and !message.is_transient and (message.hasTextContent or message.subtype_description or isEditing or message.edited))">
+                                        <LinkPreviewList t-if="!isEditing and message.linkPreviewSquash" linkPreviews="message.link_preview_ids" deletable="false"/>
                                         <t t-else="">
                                             <div t-if="message.bubbleColor and !props.squashed" class="o-mail-Message-bubbleTail position-absolute d-flex" t-att-style="isAlignedRight ? 'right: -4px; transform: rotateY(180deg);' : 'left: -4px;'" t-att-class="{
                                                 'o-blue': message.bubbleColor === 'blue',
@@ -86,7 +86,7 @@
                                                 </svg>
                                             </div>
                                             <div class="position-relative overflow-x-auto overflow-y-hidden d-inline-block text-body" t-att-class="{
-                                                'w-100': state.isEditing,
+                                                'w-100': isEditing,
                                                 'shadow-sm': message.bubbleColor,
                                                 'o-rounded-bubble': message.bubbleColor and props.squashed,
                                                 'o-rounded-bottom-bubble': message.bubbleColor and !props.squashed,
@@ -105,14 +105,14 @@
                                                 <MessageInReply t-if="message.parentMessage" message="message" onClick="props.onParentMessageClick"/>
                                                 <div class="position-relative text-break o-mail-Message-body" t-att-class="{
                                                             'p-1': message.is_note,
-                                                            'fs-1': !state.isEditing and !env.inChatter and message.onlyEmojis,
+                                                            'fs-1': !isEditing and !env.inChatter and message.onlyEmojis,
                                                             'mb-0': !message.is_note,
-                                                            'py-2': !message.is_note and !state.isEditing,
-                                                            'pt-2 pb-1': !message.is_note and state.isEditing,
+                                                            'py-2': !message.is_note and !isEditing,
+                                                            'pt-2 pb-1': !message.is_note and isEditing,
                                                             'o-note': message.is_note,
                                                             'o-rounded-bubble': props.squashed,
-                                                            'align-self-start o-rounded-end-bubble o-rounded-bottom-bubble': !state.isEditing and !message.is_note and !props.squashed,
-                                                            'flex-grow-1': state.isEditing,
+                                                            'align-self-start o-rounded-end-bubble o-rounded-bottom-bubble': !isEditing and !message.is_note and !props.squashed,
+                                                            'flex-grow-1': isEditing,
                                                             }" t-ref="body">
                                                     <i t-if="message.isEmpty" class="text-muted opacity-75" t-esc="message.inlineBody"/>
                                                     <Composer t-elif="props.message.eq(props.messageEdition?.editingMessage)" autofocus="true" composer="message.composer" onDiscardCallback.bind="exitEditMode" onPostCallback.bind="exitEditMode" mode="'compact'" sidebar="false"/>
@@ -160,7 +160,7 @@
 </t>
 
 <t t-name="mail.Message.actions">
-    <div t-if="props.hasActions and message.hasActions and !state.isEditing and !env.inChatter?.disabled" class="o-mail-Message-actions d-print-none d-flex align-items-start"
+    <div t-if="props.hasActions and message.hasActions and !isEditing and !env.inChatter?.disabled" class="o-mail-Message-actions d-print-none d-flex align-items-start"
         t-att-class="{
             'start-0': isAlignedRight,
             'mx-1': !isMobileOS,


### PR DESCRIPTION
Before this commit, when editing a message longer than ~30 characters, the composer would be bigger than necessary.

This happens because the height of the composer is assigned in a `useEffect` which gets executed before the `useEffect` that sets the message in "edit" mode.
This results in the width of the textarea to be the size of the message, rather than the full width of the thread, and thus to have a bigger `scrollHeight`:
<img width="454" height="136" alt="Pasted image 20251017143022" src="https://github.com/user-attachments/assets/a14ba961-d986-4862-b513-b11768564c8c" />
_(At this point the composer height is set)_

This commit fixes the issue by replacing `useEffect` with a getter to ensure the height calculation happens when the DOM is in the correct state.

task-4661400