### PR TITLE
[FIX] account: non-deductible product lines account not linked

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3185,7 +3185,7 @@ class AccountMove(models.Model):
         # Collect data to avoid recomputing value unecessarily
         product_lines_before = {
             move: Counter(
-                (line.name, line.price_subtotal, line.tax_ids, line.deductible_amount)
+                (line.name, line.price_subtotal, line.tax_ids, line.deductible_amount, line.account_id)
                 for line in move.line_ids
                 if line.display_type == 'product'
             )
@@ -3198,7 +3198,7 @@ class AccountMove(models.Model):
         to_create = []
         for move in container['records']:
             product_lines_now = Counter(
-                (line.name, line.price_subtotal, line.tax_ids, line.deductible_amount)
+                (line.name, line.price_subtotal, line.tax_ids, line.deductible_amount, line.account_id)
                 for line in move.line_ids
                 if line.display_type == 'product'
             )


### PR DESCRIPTION
When you have a vendor bill with an invoice line linked to a journal item with the display type "non_deductible_product", if you modify the account_id of the invoice line, then the account_id of the linked line should change to have the same value.

How to reproduce?
  1. Create an asset model (Accounting > Configuration > Accounting > Asset Models)
  2. Set the asset_model_id on an account (on the tab "Automation", set "Automate Asset" as "Create in draft" then set the "Asset Model" field with the created asset model
  3. Duplicate the account having the created asset model
  4. Create a vendor bill with an invoice line having:
    - A strictly positive price unit
    - A deductible_amount (Professional %) lower than 100 (this field is hidden by default)
  5. Modify the account_id of the invoice line
  6. Observe the journal items: the line with the non- deductible product should have the same account_id than the invoice line but it's not the case.

task-5156256
