### PR TITLE
[REF] mail: message.isTranslatable simplified

### DIFF
--- a/addons/im_livechat/static/src/core/common/message_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/message_model_patch.js
@@ -15,11 +15,11 @@ const messagePatch = {
         }
         return super.canReplyTo(thread);
     },
-    isTranslatable(thread) {
+    get isTranslatable() {
         return (
-            super.isTranslatable(thread) ||
+            super.isTranslatable ||
             (this.store.hasMessageTranslationFeature &&
-                thread?.channel?.channel_type === "livechat" &&
+                this.channel_id?.channel_type === "livechat" &&
                 this.store.self?.main_user_id?.share === false)
         );
     },

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -178,7 +178,7 @@ registerMessageAction("download_files", {
     sequence: 55,
 });
 registerMessageAction("toggle-translation", {
-    condition: ({ message }) => message.isTranslatable(message.thread),
+    condition: ({ message }) => message.isTranslatable,
     icon: ({ message }) =>
         `fa fa-language ${message.showTranslation ? "o-mail-Message-translated" : ""}`,
     name: ({ message }) => (message.showTranslation ? _t("Revert") : _t("Translate")),

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -309,13 +309,13 @@ export class Message extends Record {
         return url(router.stateToUrl({ model: this.thread.model, resId: this.thread.id }));
     }
 
-    isTranslatable(thread) {
+    get isTranslatable() {
         return (
             !this.isEmpty &&
             !this.isBodyEmpty &&
             !this.hasMailNotificationSummary &&
             this.store.hasMessageTranslationFeature &&
-            !["discuss.channel", "mail.box"].includes(thread?.model)
+            !this.channel_id
         );
     }
 

--- a/addons/mail/static/src/discuss/core/common/message_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/message_model_patch.js
@@ -7,6 +7,11 @@ import { patch } from "@web/core/utils/patch";
 const messagePatch = {
     setup() {
         super.setup();
+        this.channel_id = fields.One("discuss.channel", {
+            compute() {
+                return this.thread?.channel;
+            },
+        });
         this.hasEveryoneSeen = fields.Attr(false, {
             /** @this {import("models").Message} */
             compute() {


### PR DESCRIPTION
`message.isTranslatable(thread)` had param `thread` that is useless, as this is deduced from `message.thread`.

This is turned into getter for simpler use of the `isTranslatable` feature on message.

https://github.com/odoo/enterprise/pull/97518