### PR TITLE
[REM] calendar: remove useless portal attendee ACL and ir.rule

### DIFF
--- a/addons/calendar/security/calendar_security.xml
+++ b/addons/calendar/security/calendar_security.xml
@@ -16,13 +16,6 @@
             <field eval="[(4,ref('base.group_user'))]" name="groups"/>
         </record>
 
-        <record id="calendar_attendee_rule_my" model="ir.rule">
-            <field name="name">Own attendees</field>
-            <field ref="model_calendar_attendee" name="model_id"/>
-            <field name="domain_force">[(1, '=', 1)]</field>
-            <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
-        </record>
-
         <record id="calendar_event_rule_private" model="ir.rule">
             <field ref="model_calendar_event" name="model_id"/>
             <field name="name">Private events</field>

--- a/addons/calendar/security/ir.model.access.csv
+++ b/addons/calendar/security/ir.model.access.csv
@@ -1,5 +1,4 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_calendar_attendee_portal,calendar.attendee_portal,model_calendar_attendee,base.group_portal,0,0,0,0
 access_calendar_attendee_employee,calendar.attendee_employee,model_calendar_attendee,base.group_user,1,1,1,1
 access_calendar_attendee_employee_delete_wizard,calendar.attendee_employee_delete_wizard,model_calendar_popover_delete_wizard,base.group_user,1,1,1,1
 access_calendar_alarm,calendar.alarm,model_calendar_alarm,base.group_user,1,1,1,1


### PR DESCRIPTION
If the ACL is set to `0,0,0,0`
there is no need to add an ACL in the first place.

If there is no ACL on `calendar.attendee` for portal, there is no need for a record rule.
