### PR TITLE
[IMP] iot_drivers: restart odoo from all protocols

### DIFF
--- a/addons/iot_drivers/controllers/driver.py
+++ b/addons/iot_drivers/controllers/driver.py
@@ -29,9 +29,20 @@ class DriverController(http.Controller):
         We specify in data from which session_id that action is called
         And call the action of specific device
         """
-        if device_identifier == "test_protocol":
-            # Special case for testing if a protocol is working
-            return True
+        if device_identifier == helpers.get_identifier():
+            match data.get('action'):
+                case "restart_odoo":
+                    event_manager.events.append({
+                        'time': time.time(),
+                        'device_identifier': device_identifier,
+                        'owner': session_id,
+                        'status': 'success',
+                    })
+                    time.sleep(2)  # wait for the server to catch the event before restarting
+                    return helpers.odoo_restart()
+                case _:
+                    # Special case for testing if longpolling protocol is working
+                    return True
 
         # If device_identifier is a type of device, we take the first device of this type
         # required for longpolling with community db

--- a/addons/iot_drivers/webrtc_client.py
+++ b/addons/iot_drivers/webrtc_client.py
@@ -79,6 +79,14 @@ class WebRtcClient(Thread):
                         'time': time.time(),
                         'status': 'success',
                     })
+                elif message_type == "restart_odoo":
+                    self.send({
+                        'owner': message['session_id'],
+                        'device_identifier': helpers.get_identifier(),
+                        'time': time.time(),
+                        'status': 'success',
+                    })
+                    await self.event_loop.run_in_executor(None, helpers.odoo_restart)
 
             @channel.on("close")
             def on_close():

--- a/addons/iot_drivers/websocket_client.py
+++ b/addons/iot_drivers/websocket_client.py
@@ -94,6 +94,12 @@ class WebsocketClient(Thread):
                     })
                     helpers.get_odoo_server_url.cache_clear()
                 case 'restart_odoo':
+                    send_to_controller({
+                        'session_id': payload['session_id'],
+                        'iot_box_identifier': helpers.get_identifier(),
+                        'device_identifier': helpers.get_identifier(),
+                        'status': 'success',
+                    })
                     ws.close()
                     helpers.odoo_restart()
                 case 'webrtc_offer':


### PR DESCRIPTION
In order to allow using the `iot_http` service to restart odoo, we updated the action route to accept messages targeting the IoT Box itself, the WebRTC to accept restart actions and the WebSocket to confirm that the restart action was received.

odoo/enterprise#97525
Task: 5169648