### PR TITLE
[FIX] crm: fix stages update for crm lead with multiple teams

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -318,7 +318,7 @@ class Lead(models.Model):
     @api.depends('team_id', 'type')
     def _compute_stage_id(self):
         for lead in self:
-            if not lead.stage_id:
+            if not lead.stage_id or (lead.team_id and lead.stage_id.team_id and lead.team_id != lead.stage_id.team_id):
                 lead.stage_id = lead._stage_find(domain=[('fold', '=', False)]).id
 
     @api.depends('user_id')

--- a/addons/crm/tests/test_crm_lead.py
+++ b/addons/crm/tests/test_crm_lead.py
@@ -587,6 +587,41 @@ class TestCRMLead(TestCrmCommon):
         self.assertEqual(lead.probability, 100.0)
         self.assertEqual(lead.stage_id, self.stage_gen_won)  # generic won stage has lower sequence than team won stage
 
+    def test_crm_lead_stages_with_multiple_possible_teams(self):
+        """ Test lead stage is properly set when switching between multiple teams. """
+        self.sales_team_2 = self.env['crm.team'].create({
+            'name': 'Test Sales Team 2',
+            'company_id': False,
+            'user_id': self.user_sales_manager.id,
+        })
+        self.sales_team_2_m1 = self.env['crm.team.member'].create({
+            'user_id': self.user_sales_leads.id,
+            'crm_team_id': self.sales_team_2.id,
+        })
+
+        user_teams = self.env['crm.team'].search([
+            ('crm_team_member_all_ids.user_id', '=', self.user_sales_leads.id),
+        ])
+        self.assertIn(self.sales_team_1, user_teams)
+        self.assertIn(self.sales_team_2, user_teams)
+
+        self.stage_team2_1 = self.env['crm.stage'].create({
+            'name': 'New (T2)',
+            'team_id': self.sales_team_2.id,
+        })
+
+        lead = self.env['crm.lead'].with_user(self.user_sales_leads).create({
+            'name': 'Test',
+            'contact_name': 'Test Contact',
+            'team_id': self.sales_team_1.id,
+        })
+        self.assertEqual(lead.team_id, self.sales_team_1)
+        self.assertEqual(lead.stage_id, self.stage_team1_1)
+
+        lead.team_id = self.sales_team_2
+        self.assertEqual(lead.team_id, self.sales_team_2)
+        self.assertEqual(lead.stage_id, self.stage_team2_1)
+
     @users('user_sales_manager')
     def test_crm_lead_unlink_calendar_event(self):
         """ Test res_id / res_model is reset (and hide document button in calendar


### PR DESCRIPTION
**Steps to reproduce:**
- Install CRM and set the Leads configuration setting
- Go to CRM > Configuration > Sales Teams
- Create two Sales Teams
- Go to CRM > Configuration > Stages
- Create multiple stages specific to each team
- Make the current user belong to both teams
- Go to CRM > Leads
- Create a new lead (stage is assigned here)
- Change its Sales Team
- Lead stage is not updated according to the team

**Issue:**
The `stage_id` of `crm.lead` is never updated after it is set. This means that changing the related team will not modify the possible stages of the lead (even if it should not be available to the current team).

**Fix:**
Check if the team of the lead is the same as the one of its current stage during `_compute_stage_id`.

opw-4901009

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
