### PR TITLE
[REF] core: Rework purpose and usage of Field._sequence

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -111,9 +111,6 @@ class AccountAccount(models.Model):
         depends_context=('uid',),  # To avoid cache pollution between sudo / non-sudo uses of the field
         default=lambda self: self.env.company)
     code_mapping_ids = fields.One2many(comodel_name='account.code.mapping', inverse_name='account_id')
-    # Ensure `code_mapping_ids` is written before `company_ids` so we don't trigger the `_ensure_code_is_unique`
-    # constraint when writing multiple code mappings and multiple companies in the same call to `write`.
-    code_mapping_ids.write_sequence = 19
     tag_ids = fields.Many2many(
         comodel_name='account.account.tag',
         relation='account_account_account_tag',

--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -17,6 +17,7 @@ import odoo.sql_db
 import odoo.tools.sql
 import odoo.tools.translate
 from odoo import api, tools
+from odoo.tools import OrderedSet
 from odoo.tools.convert import convert_file, IdRef, ConvertMode as LoadMode
 
 from . import db as modules_db
@@ -191,6 +192,10 @@ def load_module_graph(
             # updated by this module because it's not marked as 'to upgrade/to install'.
             model_names = registry.descendants(model_names, '_inherit', '_inherits')
             models_to_check |= set(model_names) & models_updated
+        elif update_module and package.state == 'to remove':
+            # All model extended should be check because ir.model / ir.model.fields should
+            # be update without the extention and constraints too
+            models_to_check |= set(model_names)
 
         if update_operation:
             # Can't put this line out of the loop: ir.module.module will be
@@ -332,6 +337,7 @@ def load_modules(
     install_modules: Collection[str] = (),
     reinit_modules: Collection[str] = (),
     new_db_demo: bool = False,
+    models_to_check: OrderedSet[str] | None = None,
 ) -> None:
     """ Load the modules for a registry object that has just been created.  This
         function is part of Registry.new() and should not be used anywhere else.
@@ -343,9 +349,10 @@ def load_modules(
         :param reinit_modules: A collection of module names to reinitialize.
         :param new_db_demo: Whether to install demo data for new database. Defaults to ``False``
     """
-    initialize_sys_path()
+    if models_to_check is None:
+        models_to_check = OrderedSet()
 
-    models_to_check: set[str] = set()
+    initialize_sys_path()
 
     with registry.cursor() as cr:
         # prevent endless wait for locks on schema changes (during online
@@ -536,11 +543,8 @@ def load_modules(
                 cr.commit()
                 _logger.info('Reloading registry once more after uninstalling modules')
                 registry = Registry.new(
-                    cr.dbname, update_module=update_module
+                    cr.dbname, update_module=update_module, models_to_check=models_to_check,
                 )
-                cr.transaction.reset()
-                registry.check_tables_exist(cr)
-                cr.commit()
                 return
 
         # STEP 5.5: Verify extended fields on every model
@@ -555,7 +559,9 @@ def load_modules(
             cr.execute("""SELECT DISTINCT model FROM ir_model_fields WHERE state = 'manual'""")
             models_to_check.update(model_name for model_name, in cr.fetchall() if model_name in registry)
         if models_to_check:
-            registry.init_models(cr, list(models_to_check), {'models_to_check': True, 'update_custom_fields': True})
+            # Doesn't check model that didn't exist anymore, it may happen during uninstallation
+            models_to_check = [model for model in models_to_check if model in registry]
+            registry.init_models(cr, models_to_check, {'models_to_check': True, 'update_custom_fields': True})
 
         # STEP 6: verify custom views on every model
         if update_module:

--- a/odoo/orm/model_classes.py
+++ b/odoo/orm/model_classes.py
@@ -428,7 +428,7 @@ def _setup(model_cls: type[BaseModel], env: Environment):
     model_cls._setup_done__ = True
 
     for field in model_cls._fields.values():
-        field.prepare_setup()
+        field._setup_done = False
 
     # 5. determine and validate rec_name
     if model_cls._rec_name:
@@ -529,6 +529,15 @@ def _setup_fields(model_cls: type[BaseModel], env: Environment):
 
     for name in bad_fields:
         pop_field(model_cls, name)
+
+    # set _sequence to order field with write_sequence + natural order of _fields
+    field_indexes = {
+        field: index for index, field in enumerate(sorted(
+            model_cls._fields.values(), key=lambda f: f.write_sequence,
+        ))
+    }
+    for field in model_cls._fields.values():
+        field._sequence = field_indexes[field]
 
 
 def _add_manual_models(env: Environment):

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -3843,7 +3843,7 @@ class BaseModel(metaclass=MetaModel):
             # Monetary fields need their corresponding currency field in cache
             # for rounding values. X2many fields must be written last, because
             # they flush other fields when deleting lines.
-            for field, value in sorted(field_values, key=lambda item: item[0].write_sequence):
+            for field, value in sorted(field_values):
                 field.write(self, value)
 
             # determine records depending on new values
@@ -4309,9 +4309,10 @@ class BaseModel(metaclass=MetaModel):
             records.modified(self._fields, create=True)
 
             if other_fields:
+                other_fields = sorted(other_fields)
                 # discard default values from context for other fields
                 others = records.with_context(clean_context(self.env.context))
-                for field in sorted(other_fields, key=attrgetter('_sequence')):
+                for field in other_fields:
                     field.create([
                         (other, data['stored'][field.name])
                         for other, data in zip(others, data_list)
@@ -5441,7 +5442,7 @@ class BaseModel(metaclass=MetaModel):
             raise ValueError("Invalid field %r on model %r" % (e.args[0], self._name))
 
         # convert monetary fields after other columns for correct value rounding
-        for field, value in sorted(field_values, key=lambda item: item[0].write_sequence):
+        for field, value in sorted(field_values):
             value = field.convert_to_cache(value, self, validate)
             field._update_cache(self, value)
 

--- a/odoo/orm/registry.py
+++ b/odoo/orm/registry.py
@@ -138,6 +138,7 @@ class Registry(Mapping[str, type["BaseModel"]]):
         upgrade_modules: Collection[str] = (),
         reinit_modules: Collection[str] = (),
         new_db_demo: bool | None = None,
+        models_to_check: set[str] | None = None,
     ) -> Registry:
         """Create and return a new registry for the given database name.
 
@@ -192,6 +193,7 @@ class Registry(Mapping[str, type["BaseModel"]]):
                     install_modules=install_modules,
                     reinit_modules=reinit_modules,
                     new_db_demo=new_db_demo,
+                    models_to_check=models_to_check,
                 )
             except Exception:
                 reset_modules_state(db_name)


### PR DESCRIPTION
`Field._sequence` was previously only used during the _create() method
for X2many fields. The `write_sequence` attribute served a similar
purpose, but was applied exclusively during the `write`/`new` method.

This commit modifies the Field._sequence behavior to properly account
for `write_sequence` and the natural order of `_fields`. It is now
used within `create`, `write`, and `_update_cache` to enforce a
complete and deterministic ordering of fields.

The Field class is also made sortable to simplify related code.
Note that it decrease the performance of the loading of the registry by
0.2 % which is negligeable.