### PR TITLE
[FIX] l10n_it_edi_withholding: checks shouldn't consider ENASARCO as withholding

### DIFF
--- a/addons/l10n_it_edi_withholding/models/account_move.py
+++ b/addons/l10n_it_edi_withholding/models/account_move.py
@@ -183,7 +183,7 @@ class AccountMove(models.Model):
     def _l10n_it_edi_export_taxes_check(self):
         # EXTENDS l10n_it_edi
         errors = super()._l10n_it_edi_export_taxes_check()
-        for kind_code, kind_desc in (('withholding', _('Withholding')), ('pension_fund', _('Pension Fund'))):
+        for kind_code, kind_desc in (('withholding_no_enasarco', _('Withholding')), ('pension_fund', _('Pension Fund'))):
             errors.update(self._l10n_it_edi_check_lines_for_tax_kind(kind_code, kind_desc, min_len=0))
         return errors
 

--- a/addons/l10n_it_edi_withholding/tests/__init__.py
+++ b/addons/l10n_it_edi_withholding/tests/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import test_account_move_send
 from . import test_withholding

--- a/addons/l10n_it_edi_withholding/tests/test_account_move_send.py
+++ b/addons/l10n_it_edi_withholding/tests/test_account_move_send.py
@@ -1,0 +1,20 @@
+from odoo.tests import tagged
+from odoo.addons.l10n_it_edi.tests.test_account_move_send import TestItAccountMoveSend
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestItWithholdingAccountMoveSend(TestItAccountMoveSend):
+
+    def test_enasarco_no_warnings(self):
+        self.proxy_user.edi_mode = 'demo'
+        ref = self.env['account.chart.template'].with_company(self.proxy_user.company_id).ref
+        self.partner_a.write({
+            "l10n_it_codice_fiscale": "PERTLELPALQZRTSN",
+            'country_id': self.env.ref('base.it').id,
+            'street': 'Test street',
+            'city': 'Test town',
+            'zip': '32121',
+        })
+        invoice = self.init_invoice(partners=self.partner_a, taxes=ref('22v') | ref('23vwo') | ref('enasarcov'))
+        wizard = self.create_send_and_print(invoice, sending_methods=['l10n_it_edi'])
+        self.assertFalse(wizard.alerts)

--- a/addons/l10n_it_edi_withholding/tests/test_withholding.py
+++ b/addons/l10n_it_edi_withholding/tests/test_withholding.py
@@ -5,7 +5,7 @@ import datetime
 from collections import namedtuple
 
 from odoo import fields
-from odoo.tests import tagged
+from odoo.tests import tagged, Form
 from odoo.exceptions import ValidationError
 from odoo.addons.l10n_it_edi.tests.common import TestItEdi
 
@@ -164,6 +164,35 @@ class TestWithholdingAndPensionFundTaxes(TestItEdi):
             'payment_amount': 801.6,
         }
         return namedtuple('ClientInvoice', data.keys())(**data)
+
+    def test_withholding_tax_change(self):
+        tax_form = Form(self.env['account.tax'])
+        name = "Test Withholding"
+
+        tax_form.name = name
+        tax_form.amount = -2.00
+        tax_form.l10n_it_withholding_type = 'RT01'
+        tax_form.l10n_it_withholding_reason = False
+        with self.assertRaises(ValidationError):
+            tax_form.save()
+
+        tax_form.l10n_it_withholding_reason = "A"
+        tax = tax_form.save()
+        self.assertRecordValues(tax, [{
+            'name': name,
+            'amount': -2.00,
+            'l10n_it_withholding_type': 'RT01',
+            'l10n_it_withholding_reason': 'A',
+        }])
+
+        tax_form.l10n_it_withholding_type = False
+        tax = tax_form.save()
+        self.assertRecordValues(tax, [{
+            'name': name,
+            'amount': -2.00,
+            'l10n_it_withholding_type': False,
+            'l10n_it_withholding_reason': False,
+        }])
 
     def test_withholding_tax_constraints(self):
         with self.assertRaises(ValidationError):


### PR DESCRIPTION
In the Italian localization, we validate that each invoice line has at most one tax per kind (VAT, withholding, pension fund).

In Italy, a product cannot have more than one VAT tax. Also, the FatturaPA XML structure only allows global declarations for withholding and pension fund taxes — on the line level, it can only specify if those taxes apply, not which ones. To reflect this, we enforce one tax per kind per line. This validation was broken and recently fixed.

However, ENASARCO is a special case: it acts both as a withholding and a pension fund tax. We added the Withholding flag recently (odoo/odoo#226968). In realistic cases (e.g., a line with VAT + withholding 23% RIT AG + ENASARCO), the validation fails and the user gets a blocking error in account.move.send.

Since ENASARCO already has dedicated support through the AltriDatiGestionali tag on the line, we allow it to pass the check as if it were only a pension fund, restoring the previous behavior before we added the withholding flag.

Some validation added and fields clear up in the tax editing phase, preventing invalid cases.

Ticket [link](https://www.odoo.com/odoo/project.task/5154223)
opw-5154223