### PR TITLE
[FIX] account: access error from public user

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3986,7 +3986,7 @@ class AccountMove(models.Model):
         chains_to_hash = self._get_chains_to_hash(**kwargs)
         grant_secure_group_access = False
         for chain in chains_to_hash:
-            move_hashes = chain['moves']._calculate_hashes(chain['previous_hash'])
+            move_hashes = chain['moves'].sudo()._calculate_hashes(chain['previous_hash'])
             for move, move_hash in move_hashes.items():
                 move.inalterable_hash = move_hash
             # If any secured entries belong to journals without 'hash on post', the user should be granted access rights


### PR DESCRIPTION
Error in backend while public user payment confirmation

Steps:

- Install `website_sale`
- Activate `restrict_mode_hash_table` on sale journal
- From an incognito window, Make an order in ecommerce and pay it
-> we get stucked on 'Your payment has been successfully processed' page
   because of an acces error in the backend

This is because when posting a new move, we either to access or modify
moves we get from `chain['moves']`, however these moves are returned
with `sudo(False)` by `AccountMove._get_chain_info()`.

opw-5128189
