### PR TITLE
[FIX] hr: access error on users also employees w/o employee rights

### DIFF
--- a/addons/hr/views/res_users.xml
+++ b/addons/hr/views/res_users.xml
@@ -229,6 +229,9 @@
                 <xpath expr="//group[@name='other_calendar_preferences']" position="inside">
                     <field name="work_location_id" string="Main Work Location" invisible="not employee_id or share"/>
                 </xpath>
+                <xpath expr="//page[@name='calendar']" position="attributes">
+                    <attribute name="groups">hr.group_hr_user</attribute>
+                </xpath>
             </field>
         </record>
     </data>


### PR DESCRIPTION
Steps to reproduce : switch Marc Demo as "Administrator" + ensure we has no "Employees" rights, connect as him and try to open his user form view (Settings / Users / Users) it crashed with: "You do not have enough rights to access the field "version_id" on Employee (hr.employee). Please contact your system administrator."

Reason : a hidden Many2one field linking to hr.employee model, thus when the view is loaded this field causes an access to the model employee , given the current user doesn't have the rights , it causes an error.
Fix : made the calendar page invisible for people with no hr rights , because there is a same view that can be accessed through the preference menu that contains the user's own info , otherwise , even with admin rights , if he doesn't have employee rights he is not concerned with the content of the calendar page of his or other user's form view. so it should be hidden from him.

Fix : made the calendar page visible only for target users , in our case , users part of the following group : "hr.group_hr_user"

task-5173101

