### PR TITLE
[FIX] website: add versioning for GallerySlider interaction

### DIFF
--- a/addons/website/static/src/interactions/carousel/carousel_slider.js
+++ b/addons/website/static/src/interactions/carousel/carousel_slider.js
@@ -1,9 +1,13 @@
 import { Interaction } from "@web/public/interaction";
+import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
 import { registry } from "@web/core/registry";
 
 export class CarouselSlider extends Interaction {
     static selector = ".carousel";
     dynamicContent = {
+        _root: {
+            "t-on-slid.bs.carousel": this.onSlidCarousel,
+        },
         "img": {
             "t-on-load": this.computeMaxHeight,
         },
@@ -15,11 +19,26 @@ export class CarouselSlider extends Interaction {
                 "min-height": this.maxHeight ? `${this.maxHeight}px` : "",
             }),
         },
+        ".carousel-indicators button, .carousel-indicators li": {
+            "t-on-pointerdown": (ev) => {
+                const toLoadEl = this.carouselItemEls.at(ev.currentTarget.dataset.bsSlideTo);
+                this.prefetchImages([toLoadEl]);
+            },
+            "t-on-keydown": (ev) => {
+                const hotkey = getActiveHotkey(ev);
+                if (["space", "enter"].includes(hotkey)) {
+                    const toLoadEl = this.carouselItemEls.at(ev.currentTarget.dataset.bsSlideTo);
+                    this.prefetchImages([toLoadEl]);
+                }
+            },
+        },
     };
     carouselOptions = undefined;
 
     setup() {
         this.maxHeight = undefined;
+        this.carouselInnerEl = this.el.querySelector(".carousel-inner");
+        this.carouselItemEls = [...this.carouselInnerEl.querySelectorAll(".carousel-item")];
     }
 
     start() {
@@ -27,6 +46,18 @@ export class CarouselSlider extends Interaction {
         this.updateContent();
         const carouselBS = window.Carousel.getOrCreateInstance(this.el, this.carouselOptions);
         this.registerCleanup(() => carouselBS.dispose());
+
+        // Preload first items only when carousel is on screen
+        const observer = new IntersectionObserver((entries) => {
+            entries.forEach((entry) => {
+                if (entry.isIntersecting) {
+                    this.loadItemsToAppear();
+                    observer.unobserve(this.el);
+                }
+            });
+        });
+        observer.observe(this.el);
+        this.registerCleanup(() => observer.unobserve(this.el));
     }
 
     computeMaxHeight() {
@@ -42,6 +73,74 @@ export class CarouselSlider extends Interaction {
                 this.maxHeight = height;
             }
             itemEl.classList.toggle("active", isActive);
+        }
+    }
+
+    /**
+     * Handles the 'slid' event of the carousel. Called *after* a slide
+     * transition.
+     *
+     * @param {Event} ev The Bootstrap Carousel slid event.
+     */
+    onSlidCarousel(ev) {
+        this.loadItemsToAppear(); // Preload future items after a slide
+    }
+
+    /**
+     * Loads images of the carousel-item necessary for both 'prev' and 'next'
+     * animations. Loads images for items that are about to become visible.
+     *
+     * @param {number} [nbItemsToLoad=1] The number of items to preload on each
+     * side.
+     */
+    loadItemsToAppear(nbItemsToLoad = 1) {
+        const index = this.carouselItemEls.findIndex((el) => el.classList.contains("active"));
+        const activeItemIndex = index >= 0 ? index : 0;
+
+        // Load "Next" items: nbItemsToLoad items after the active element
+        const nextEndIndex = Math.min(
+            activeItemIndex + nbItemsToLoad + 1,
+            this.carouselItemEls.length
+        );
+        const nextItemElsToLoad = this.carouselItemEls.slice(activeItemIndex, nextEndIndex);
+
+        // load "Prev" items : nbItemsToLoad items before the active element
+        // (circular wrapping)
+        // if currentIndex is 0, then the nbItemsToLoad items are the last
+        // elements of the carousel
+        let prevItemElsToLoad = [];
+        if (activeItemIndex - nbItemsToLoad < 0) {
+            const wrapAmount = Math.abs(activeItemIndex - nbItemsToLoad);
+            prevItemElsToLoad = this.carouselItemEls
+                .slice(this.carouselItemEls.length - wrapAmount, this.carouselItemEls.length)
+                .concat(this.carouselItemEls.slice(0, activeItemIndex))
+                .reverse();
+        } else {
+            prevItemElsToLoad = this.carouselItemEls
+                .slice(activeItemIndex - nbItemsToLoad, activeItemIndex)
+                .reverse();
+        }
+
+        this.prefetchImages(nextItemElsToLoad.concat(prevItemElsToLoad));
+    }
+    /**
+     * Replaces loading from `lazy` to `eager` for all images of the given
+     * carousel slides. This forces the browser to load the images immediately.
+     * The goal is to avoid the flicker (mainly on Firefox) when the carousel
+     * slides.
+     *
+     * @param {HTMLElement[]} toLoadEls
+     */
+    prefetchImages(toLoadEls) {
+        for (const carouselItemEl of toLoadEls) {
+            const imageEls = carouselItemEl.querySelectorAll("img[loading='lazy']");
+            for (const imageEl of imageEls) {
+                // Note that we remove the attribute with the goal of forcing it
+                // to the "eager" value. Removing the attribute is better so
+                // that the attribute is not saved as eager in edit mode (the
+                // lazy value is auto added on page rendering).
+                imageEl.removeAttribute("loading");
+            }
         }
     }
 }

--- a/addons/website/static/src/snippets/s_image_gallery/002.scss
+++ b/addons/website/static/src/snippets/s_image_gallery/002.scss
@@ -130,8 +130,30 @@
         }
 
         .carousel-indicators {
+            $-mask-margin: 3rem;
+            $-left-mask-gradient: transparent, #000 $-mask-margin;
+            $-right-mask-gradient: #000 calc(100% - #{$-mask-margin}), transparent;
+
             align-items: center;
             min-width: 0;
+            overflow: auto hidden; // Force hidden on Y for mobile.
+            justify-content: flex-start;
+            flex-wrap: nowrap;
+            scrollbar-width: none;
+
+            & > button {
+                flex-shrink: 0;
+            }
+
+            &.o_faded_left {
+                mask: linear-gradient(to right, $-left-mask-gradient);
+            }
+            &.o_faded_right {
+                mask: linear-gradient(to right, $-right-mask-gradient);
+            }
+            &.o_faded_left.o_faded_right {
+                mask: linear-gradient(to right, $-left-mask-gradient, $-right-mask-gradient);
+            }
         }
 
         .carousel-control-prev, .carousel-control-next {

--- a/addons/website/static/src/snippets/s_image_gallery/gallery_slider.js
+++ b/addons/website/static/src/snippets/s_image_gallery/gallery_slider.js
@@ -3,8 +3,15 @@ import { registry } from "@web/core/registry";
 
 import { isVisible } from "@html_editor/utils/dom_info";
 
+/**
+ * This interaction is kept for compatibility with snippets dropped before 18.0.
+ * If you have to update or extend the GallerySlider, you are probably looking
+ * for GallerySlider001.
+ * @deprecated
+ **/
 export class GallerySlider extends Interaction {
-    static selector = ".o_slideshow";
+    // TODO in master: use `.o_slideshow:not([data-vjs])`
+    static selector = ".o_slideshow:not([data-vcss]), .o_slideshow[data-vcss='001']";
     dynamicContent = {
         ".carousel": {
             "t-on-slide.bs.carousel": this.onSlideCarousel,
@@ -100,7 +107,7 @@ export class GallerySlider extends Interaction {
     }
 
     hide() {
-        for (let i = 0; i < this.liEls?.length; i++) {
+        for (let i = 0; i < this.liEls.length; i++) {
             this.liEls[i].classList.toggle("d-none", i < this.page * this.nbPerPage || i >= (this.page + 1) * this.nbPerPage);
         }
         if (this.prevEl) {
@@ -108,7 +115,7 @@ export class GallerySlider extends Interaction {
                 this.prevEl.remove();
             } else {
                 this.prevEl.classList.remove("d-none");
-                this.indicatorEl.insertAdjacentElement("afterbegin", this.prevEl);
+                this.insert(this.prevEl, this.indicatorEl, "afterbegin");
             }
         }
         if (this.nextEl) {
@@ -116,7 +123,7 @@ export class GallerySlider extends Interaction {
                 this.nextEl.remove();
             } else {
                 this.nextEl.classList.remove("d-none");
-                this.insert(this.nextEl, this.indicatorEl, "beforeend")
+                this.insert(this.nextEl, this.indicatorEl, "beforeend");
             }
         }
     }

--- a/addons/website/static/src/snippets/s_image_gallery/gallery_slider_001.js
+++ b/addons/website/static/src/snippets/s_image_gallery/gallery_slider_001.js
@@ -1,0 +1,67 @@
+import { registry } from "@web/core/registry";
+import { Interaction } from "@web/public/interaction";
+
+export class GallerySlider001 extends Interaction {
+    // TODO in master: use `.o_slideshow[data-vjs='001']`
+    static selector = ".o_slideshow[data-vcss='002']";
+    dynamicContent = {
+        ".carousel": {
+            "t-on-slide.bs.carousel": this.onSlideCarousel,
+        },
+        ".carousel-indicators": {
+            "t-on-scroll": this.checkScrollableIndicators,
+            "t-att-class": () => ({
+                o_faded_left: this.canScrollLeft,
+                o_faded_right: this.canScrollRight,
+            }),
+        },
+    };
+
+    setup() {
+        this.carouselEl = this.el.classList.contains("carousel")
+            ? this.el
+            : this.el.querySelector(".carousel");
+        this.indicatorsWrapperEl = this.carouselEl?.querySelector(".carousel-indicators");
+
+        if (this.indicatorsWrapperEl) {
+            this.indicatorEls = this.indicatorsWrapperEl.querySelectorAll("[data-bs-slide-to]");
+            const isRTL = !!this.el.closest(".o_rtl, [dir='rtl']");
+            const nbIndicators = this.indicatorEls.length - 1;
+            const index = { left: isRTL ? nbIndicators : 0, right: isRTL ? 0 : nbIndicators };
+            this.leftIndicatorEl = this.indicatorEls.item(index.left);
+            this.rightIndicatorEl = this.indicatorEls.item(index.right);
+
+            this.checkScrollableIndicators();
+        }
+    }
+    /**
+     * Checks whether the indicators container is scrollable to the left or/and
+     * to the right because there are more items.
+     */
+    checkScrollableIndicators() {
+        const containerRect = this.indicatorsWrapperEl.getBoundingClientRect();
+        const leftIndicatorRect = this.leftIndicatorEl.getBoundingClientRect();
+        const rightIndicatorRect = this.rightIndicatorEl.getBoundingClientRect();
+        this.canScrollLeft = leftIndicatorRect.left < containerRect.left;
+        this.canScrollRight = rightIndicatorRect.right > containerRect.right;
+    }
+
+    onSlideCarousel(ev) {
+        if (this.indicatorEls.length) {
+            const nextActiveIndicatorEl = this.indicatorEls.item(ev.to);
+            // Scroll the indicators to center the active one.
+            this.indicatorsWrapperEl.scrollTo({
+                left:
+                    nextActiveIndicatorEl.offsetLeft +
+                    nextActiveIndicatorEl.offsetWidth / 2 -
+                    this.indicatorsWrapperEl.offsetWidth / 2,
+                behavior: "smooth",
+            });
+        }
+    }
+}
+
+registry.category("public.interactions").add("website.gallery_slider_001", GallerySlider001);
+registry
+    .category("public.interactions.edit")
+    .add("website.gallery_slider_001", { Interaction: GallerySlider001 });

--- a/addons/website/static/tests/interactions/snippets/gallery_slider.test.js
+++ b/addons/website/static/tests/interactions/snippets/gallery_slider.test.js
@@ -9,7 +9,7 @@ import { advanceTime } from "@odoo/hoot-mock";
 
 import { onceAllImagesLoaded } from "@website/utils/images";
 
-setupInteractionWhiteList("website.gallery_slider");
+setupInteractionWhiteList(["website.gallery_slider", "website.gallery_slider_001"]);
 
 describe.current.tags("interaction_dev");
 


### PR DESCRIPTION
## [FIX] website: add versioning for GallerySlider interaction
    
    The GallerySlider interaction (and its edit mode counterpart) is not up
    to date: the logic is still written for old snippets (before [9042b1c],
    so before 18.0).
    
    In the meantime, the pagination for the indicators was lost, meaning
    that if you add too many images, the indicators will have less and less
    space.
    
    Steps to reproduce:
    - Drop an Image Gallery snippet
    - Set the indicators to squared or rounded miniatures
    - Add 15 or more images
    => All the indicators are crammed into the same line.
    
    With this commit, we deprecate the old `GallerySlider` interaction and
    create a `GallerySlider001` for the snippets dropped since 18.0.
    For the indicators, instead of a pagination, we now use a horizontal
    scrolling container which centers on the active indicator.
    
[9042b1c]: https://github.com/odoo/odoo/commit/9042b1c 

## [FIX] website: preload available carousel images
    
    As images are lazy loaded, it means that in the context of a carousel or
    an image gallery, they only start loading once the user clicks either on
    its indicator or on the previous / next button (or after completing an
    auto-slide). While Chrome seems to optimize that to make it seemless, on
    Firefox this causes the carousel slide to appear blank for a moment
    before the image suddenly pops up, as the sliding animation arrives to
    its end.
    In effect, this causes a flicker and a feeling that the carousels, and
    especially the gallery, is extremely laggy.
    
    To mitigate that while trying to keep the advantages of image lazy
    loading, this commit partially backports [08d837e], which loads the
    images of the next and the previous carousel items.
    
    Additionally, we prefetch the target images on pointerdown / keydown on
    an indicator. That may seem like too small of a difference to be
    interesting, but it actually gives a little bit of time between the
    pointerdown and pointerup (which triggers the slide event) to start
    loading the images, which with a correct connexion already goes a long
    way towards mitigating the laggy feeling.
    
[08d837e]: https://github.com/odoo/odoo/commit/08d837e70f28a84a9bd97974f5d15d387a42b7c0
    
task-5245513