### PR TITLE
[REF] mail: simplify props to LinkPreview component 

### DIFF
--- a/addons/mail/static/src/core/common/link_preview.js
+++ b/addons/mail/static/src/core/common/link_preview.js
@@ -7,16 +7,12 @@ import { useService } from "@web/core/utils/hooks";
 
 /**
  * @typedef {Object} Props
- * @property {import("models").LinkPreview} linkPreview
- * @property {import("models").Message} [message]
- * @property {Boolean} [gifPaused]
- * @property {function} [delete] Function bound to the delete button
- * @property {function} [deleteAll] Function bound to the delete all button
+ * @property {import("models").MessageLinkPreview} messageLinkPreview
  * @extends {Component<Props, Env>}
  */
 export class LinkPreview extends Component {
     static template = "mail.LinkPreview";
-    static props = ["linkPreview", "delete?", "deleteAll?", "gifPaused?", "message?"];
+    static props = ["messageLinkPreview"];
     static components = { Gif };
 
     setup() {
@@ -34,12 +30,14 @@ export class LinkPreview extends Component {
         );
     }
 
+    get linkPreview() {
+        return this.props.messageLinkPreview.link_preview_id;
+    }
+
     onClick() {
         this.dialogService.add(LinkPreviewConfirmDelete, {
-            linkPreview: this.props.linkPreview,
-            delete: this.props.delete,
-            deleteAll: this.props.deleteAll,
             LinkPreview,
+            messageLinkPreview: this.props.messageLinkPreview,
         });
     }
 

--- a/addons/mail/static/src/core/common/link_preview.xml
+++ b/addons/mail/static/src/core/common/link_preview.xml
@@ -2,39 +2,33 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.LinkPreview">
-        <t t-if="props.linkPreview.isCard">
-            <t t-call="mail.LinkPreviewCard"/>
-        </t>
-        <t t-if="props.linkPreview.isVideo">
-            <t t-call="mail.LinkPreviewVideo"/>
-        </t>
-        <t t-if="props.linkPreview.isImage">
-            <t t-call="mail.LinkPreviewImage"/>
-        </t>
+        <t t-if="linkPreview.isCard" t-call="mail.LinkPreviewCard"/>
+        <t t-if="linkPreview.isVideo" t-call="mail.LinkPreviewVideo"/>
+        <t t-if="linkPreview.isImage" t-call="mail.LinkPreviewImage"/>
     </t>
 
     <t t-name="mail.LinkPreviewCard">
         <div class="o-mail-LinkPreviewCard card position-relative w-100 mb-2 rounded bg-view shadow-sm overflow-hidden" t-att-class="{ 'me-2': env.inChatter }" t-attf-class="{{ className }}">
             <div class="row g-0 flex-row-reverse h-100">
-                <div class="col min-w-0" t-att-class="{ 'd-flex align-items-center': !props.linkPreview.og_description }">
+                <div class="col min-w-0" t-att-class="{ 'd-flex align-items-center': !linkPreview.og_description }">
                     <div class="px-3 py-2">
-                        <h6 class="card-title mb-0 me-2" t-attf-class="{{ props.linkPreview.og_description ? 'text-truncate' : 'overflow-hidden' }}">
-                            <a t-att-href="props.linkPreview.source_url" target="_blank" t-out="props.linkPreview.og_title"/>
+                        <h6 class="card-title mb-0 me-2" t-attf-class="{{ linkPreview.og_description ? 'text-truncate' : 'overflow-hidden' }}">
+                            <a t-att-href="linkPreview.source_url" target="_blank" t-out="linkPreview.og_title"/>
                         </h6>
-                        <span t-if="props.linkPreview.og_site_name" t-out="props.linkPreview.og_site_name"/>
-                        <p t-if="props.linkPreview.og_description" class="o-mail-LinkPreviewCard-description card-text mb-0 mt-2 text-muted small overflow-hidden" t-out="props.linkPreview.og_description"/>
+                        <span t-if="linkPreview.og_site_name" t-out="linkPreview.og_site_name"/>
+                        <p t-if="linkPreview.og_description" class="o-mail-LinkPreviewCard-description card-text mb-0 mt-2 text-muted small overflow-hidden" t-out="linkPreview.og_description"/>
                     </div>
                 </div>
                 <div class="o-mail-LinkPreviewCard-imageLinkWrap col-4 d-block">
-                    <a t-att-href="props.linkPreview.source_url" target="_blank">
-                        <img t-if="props.linkPreview.og_image" class="w-100 h-100 object-fit-cover" t-att-src="props.linkPreview.og_image" t-att-alt="props.linkPreview.og_title" t-on-load="onImageLoaded"/>
+                    <a t-att-href="linkPreview.source_url" target="_blank">
+                        <img t-if="linkPreview.og_image" class="w-100 h-100 object-fit-cover" t-att-src="linkPreview.og_image" t-att-alt="linkPreview.og_title" t-on-load="onImageLoaded"/>
                         <span t-else="" class="d-flex align-items-center justify-content-center w-100 h-100 bg-100 text-300">
                             <i class="fa fa-camera fa-2x"/>
                         </span>
                     </a>
                 </div>
             </div>
-            <t t-if="props.delete" t-call="mail.LinkPreview.aside">
+            <t t-call="mail.LinkPreview.aside">
                 <t t-set="className" t-value="'fa fa-stack p-0 opacity-75 opacity-100-hover'"/>
             </t>
         </div>
@@ -42,44 +36,44 @@
 
     <t t-name="mail.LinkPreviewImage">
         <div class="o-mail-LinkPreviewImage position-relative mb-2 rounded" t-att-class="{ 'me-2': env.inChatter }" t-attf-class="{{ className }}">
-            <a t-if="props.linkPreview.imageUrl" t-att-href="props.linkPreview.imageUrl" target="_blank">
-                <Gif t-if="props.linkPreview.isGif" paused="props.gifPaused" class="'h-auto w-auto rounded'" src="props.linkPreview.imageUrl" onLoad.bind="onImageLoaded"/>
-                <img t-else="" class="h-auto w-auto rounded" t-att-src="props.linkPreview.imageUrl" t-on-load="onImageLoaded"/>
+            <a t-if="linkPreview.imageUrl" t-att-href="linkPreview.imageUrl" target="_blank">
+                <Gif t-if="linkPreview.isGif" paused="props.messageLinkPreview.gifPaused" class="'h-auto w-auto rounded'" src="linkPreview.imageUrl" onLoad.bind="onImageLoaded"/>
+                <img t-else="" class="h-auto w-auto rounded" t-att-src="linkPreview.imageUrl" t-on-load="onImageLoaded"/>
             </a>
-            <t t-if="props.delete" t-call="mail.LinkPreview.aside">
+            <t t-call="mail.LinkPreview.aside">
                 <t t-set="className" t-value="'btn btn-sm btn-dark mt-2 me-2 rounded opacity-75 opacity-100-hover'"/>
             </t>
         </div>
     </t>
 
     <t t-name="mail.LinkPreviewVideo">
-        <div class="o-mail-LinkPreviewVideo card position-relative w-100 mb-2 rounded bg-view shadow-sm overflow-hidden" t-att-data-provider="props.linkPreview.videoProvider" t-att-class="{ 'me-2': env.inChatter, 'o-mail-LinkPreviewVideo-embed': props.linkPreview.videoURL, 'o-mail-LinkPreviewVideo-started': state.startVideo }" t-attf-class="{{ className }}">
+        <div class="o-mail-LinkPreviewVideo card position-relative w-100 mb-2 rounded bg-view shadow-sm overflow-hidden" t-att-data-provider="linkPreview.videoProvider" t-att-class="{ 'me-2': env.inChatter, 'o-mail-LinkPreviewVideo-embed': linkPreview.videoURL, 'o-mail-LinkPreviewVideo-started': state.startVideo }" t-attf-class="{{ className }}">
             <div class="row g-0 flex-row-reverse">
-                <div class="col min-w-0" t-att-class="{ 'd-flex align-items-center': !props.linkPreview.og_description }">
+                <div class="col min-w-0" t-att-class="{ 'd-flex align-items-center': !linkPreview.og_description }">
                     <div class="d-flex flex-column gap-1 px-3 py-2 bg-view">
-                        <p t-if="props.linkPreview.og_site_name" class="mb-0 card-text text-muted smaller overflow-hidden" t-out="props.linkPreview.og_site_name"></p>
-                        <h6 class="o-mail-LinkPreviewVideo-title card-title mb-0 me-2" t-attf-class="{{ props.linkPreview.og_description ? 'text-truncate' : 'o-mail-LinkPreviewVideo-hasDescription overflow-hidden' }}">
-                            <a t-att-href="props.linkPreview.source_url" target="_blank" t-esc="props.linkPreview.og_title"/>
+                        <p t-if="linkPreview.og_site_name" class="mb-0 card-text text-muted smaller overflow-hidden" t-out="linkPreview.og_site_name"></p>
+                        <h6 class="o-mail-LinkPreviewVideo-title card-title mb-0 me-2" t-attf-class="{{ linkPreview.og_description ? 'text-truncate' : 'o-mail-LinkPreviewVideo-hasDescription overflow-hidden' }}">
+                            <a t-att-href="linkPreview.source_url" target="_blank" t-esc="linkPreview.og_title"/>
                         </h6>
-                        <p t-if="props.linkPreview.og_description" class="o-mail-LinkPreviewVideo-description o-mail-LinkPreviewVideo-hasDescription card-text mb-0 text-muted small overflow-hidden" t-out="props.linkPreview.og_description"></p>
+                        <p t-if="linkPreview.og_description" class="o-mail-LinkPreviewVideo-description o-mail-LinkPreviewVideo-hasDescription card-text mb-0 text-muted small overflow-hidden" t-out="linkPreview.og_description"></p>
                     </div>
                 </div>
-                <div t-if="!props.linkPreview.videoURL" class="col-4 d-block">
-                    <a t-att-href="props.linkPreview.source_url" target="_blank"><t t-call="mail.LinkPreviewVideo.preview"/></a>
+                <div t-if="!linkPreview.videoURL" class="col-4 d-block">
+                    <a t-att-href="linkPreview.source_url" target="_blank"><t t-call="mail.LinkPreviewVideo.preview"/></a>
                 </div>
             </div>
-            <div t-if="props.linkPreview.videoURL" class="o-mail-LinkPreviewVideo-container">
+            <div t-if="linkPreview.videoURL" class="o-mail-LinkPreviewVideo-container">
                 <div t-if="!state.videoLoaded" class="o-mail-LinkPreviewVideo-videoWrap h-100 w-100" t-on-click="() => state.startVideo = true"><t t-call="mail.LinkPreviewVideo.preview"/></div>
-                <iframe t-if="state.startVideo" t-att-src="props.linkPreview.videoURL" class="h-100 w-100" t-att-class="{'d-none': !state.videoLoaded}" allow="autoplay" frameborder="0" allowFullScreen="true" t-ref="video"/>
+                <iframe t-if="state.startVideo" t-att-src="linkPreview.videoURL" class="h-100 w-100" t-att-class="{'d-none': !state.videoLoaded}" allow="autoplay" frameborder="0" allowFullScreen="true" t-ref="video"/>
             </div>
-            <t t-if="props.delete" t-call="mail.LinkPreview.aside">
+            <t t-call="mail.LinkPreview.aside">
                 <t t-set="className" t-value="'fa fa-stack p-0 opacity-75 opacity-100-hover'"/>
             </t>
         </div>
     </t>
 
     <t t-name="mail.LinkPreview.aside">
-        <div t-if="props.message?.allowsEdition" class="position-absolute top-0 end-0 small">
+        <div t-if="props.messageLinkPreview.message_id?.allowsEdition" class="position-absolute top-0 end-0 small">
             <button t-attf-class="{{ className }}" class="o-mail-LinkPreview-aside btn" aria-label="Remove" t-on-click="onClick">
                 <i class="fa fa-times"/>
             </button>
@@ -87,9 +81,9 @@
     </t>
 
     <t t-name="mail.LinkPreviewVideo.preview">
-        <div  class="o-mail-LinkPreviewVideo-overlay position-relative h-100 rounded-bottom" t-att-class="{'bg-dark': !props.linkPreview.og_image}">
-            <img t-if="props.linkPreview.og_image" class="img-fluid h-100 object-fit-cover" t-att-src="props.linkPreview.og_image" t-att-alt="props.linkPreview.og_title" t-on-load="onImageLoaded"/>
-            <i t-elif="props.linkPreview.videoURL" class="fa fa-television fa-8x position-absolute top-50 start-50 translate-middle"/>
+        <div  class="o-mail-LinkPreviewVideo-overlay position-relative h-100 rounded-bottom" t-att-class="{'bg-dark': !linkPreview.og_image}">
+            <img t-if="linkPreview.og_image" class="img-fluid h-100 object-fit-cover" t-att-src="linkPreview.og_image" t-att-alt="linkPreview.og_title" t-on-load="onImageLoaded"/>
+            <i t-elif="linkPreview.videoURL" class="fa fa-television fa-8x position-absolute top-50 start-50 translate-middle"/>
             <span t-else="" class="d-flex align-items-center justify-content-center w-100 h-100 bg-100 text-300">
                 <i class="fa fa-camera fa-2x"/>
             </span>
@@ -97,7 +91,7 @@
                 <div t-if="!state.startVideo" class="o-mail-LinkPreviewVideo-play btn btn-lg rounded transition-base">
                     <i class="fa fa-play"/>
                 </div>
-                <div t-elif="!props.linkPreview.og_image" class="spinner-border text-muted"/>
+                <div t-elif="!linkPreview.og_image" class="spinner-border text-muted"/>
             </div>
         </div>
     </t>

--- a/addons/mail/static/src/core/common/link_preview_confirm_delete.js
+++ b/addons/mail/static/src/core/common/link_preview_confirm_delete.js
@@ -14,7 +14,7 @@ import { useService } from "@web/core/utils/hooks";
  */
 export class LinkPreviewConfirmDelete extends Component {
     static components = { Dialog };
-    static props = ["linkPreview", "delete", "deleteAll?", "close", "LinkPreview"];
+    static props = ["LinkPreview", "messageLinkPreview", "close"];
     static template = "mail.LinkPreviewConfirmDelete";
 
     setup() {
@@ -22,17 +22,13 @@ export class LinkPreviewConfirmDelete extends Component {
         this.store = useService("mail.store");
     }
 
-    get message() {
-        return this.props.linkPreview.message_id;
-    }
-
     onClickOk() {
-        this.props.delete();
+        this.props.messageLinkPreview.hide();
         this.props.close();
     }
 
     onClickDeleteAll() {
-        this.props.deleteAll?.();
+        this.props.messageLinkPreview.message_id.hideAllLinkPreviews();
         this.props.close();
     }
 

--- a/addons/mail/static/src/core/common/link_preview_confirm_delete.xml
+++ b/addons/mail/static/src/core/common/link_preview_confirm_delete.xml
@@ -3,10 +3,10 @@
     <t t-name="mail.LinkPreviewConfirmDelete">
         <Dialog size="'md'" title.translate="Confirmation" modalRef="modalRef">
             <p class="mx-3 mb-3">Do you really want to delete this preview?</p>
-            <t t-component="props.LinkPreview" linkPreview="props.linkPreview"/>
+            <t t-component="props.LinkPreview" messageLinkPreview="props.messageLinkPreview"/>
             <t t-set-slot="footer">
                 <button class="btn btn-danger me-2" t-on-click="onClickOk">Delete</button>
-                <button t-if="props.deleteAll" class="btn btn-outline-danger me-2" t-on-click="onClickDeleteAll">Delete all previews</button>
+                <button t-if="props.messageLinkPreview.hasDeleteAll" class="btn btn-outline-danger me-2" t-on-click="onClickDeleteAll">Delete all previews</button>
                 <button class="btn btn-secondary me-2" t-on-click="onClickCancel">Cancel</button>
             </t>
         </Dialog>

--- a/addons/mail/static/src/core/common/message_link_preview_list.xml
+++ b/addons/mail/static/src/core/common/message_link_preview_list.xml
@@ -3,14 +3,7 @@
     <t t-name="mail.MessageLinkPreviewList">
         <div class="o-mail-LinkPreviewList d-flex flex-column mt-2" t-att-class="{ 'me-2 pe-4': env.inChatWindow and !env.alignedRight, 'ms-2 ps-4': env.inChatWindow and env.alignedRight }">
             <div class="d-flex flex-grow-1 flex-wrap">
-                <t t-if="props.messageLinkPreviews.length > 1">
-                    <t t-foreach="props.messageLinkPreviews" t-as="messageLinkPreview" t-key="messageLinkPreview.id">
-                        <LinkPreview linkPreview="messageLinkPreview.link_preview_id" delete.bind="messageLinkPreview.hide" deleteAll.bind="messageLinkPreview.message_id.hideAllLinkPreviews" gifPaused="messageLinkPreview.gifPaused" message="messageLinkPreview.message_id"/>
-                    </t>
-                </t>
-                <t t-else="">
-                   <LinkPreview linkPreview="props.messageLinkPreviews[0].link_preview_id" delete.bind="props.messageLinkPreviews[0].hide" gifPaused="props.messageLinkPreviews[0].gifPaused" message="props.messageLinkPreviews[0].message_id"/>
-                </t>
+                <LinkPreview t-foreach="props.messageLinkPreviews" t-as="messageLinkPreview" t-key="messageLinkPreview.id" messageLinkPreview="messageLinkPreview"/>
             </div>
         </div>
     </t>

--- a/addons/mail/static/src/core/common/message_link_preview_model.js
+++ b/addons/mail/static/src/core/common/message_link_preview_model.js
@@ -13,6 +13,10 @@ export class MessageLinkPreview extends Record {
         return !this.message_id.thread?.isFocused;
     }
 
+    get hasDeleteAll() {
+        return this.message_id.message_link_preview_ids.length > 1;
+    }
+
     hide() {
         rpc("/mail/link_preview/hide", { message_link_preview_ids: [this.id] });
     }


### PR DESCRIPTION
The component was named LinkPreview but is actually linked quite heavily to message link preview, i.e. the instance of link preview on a mail message, as shown by the many props that are deduced from message link preview object.

This commit simplifies the component by passing message link preview rather than link preview, so that now only 1 prop is provided.