### PR TITLE
[PERF] product: improve "add to products" in pav

### DIFF
--- a/addons/product/models/product_template_attribute_line.py
+++ b/addons/product/models/product_template_attribute_line.py
@@ -207,9 +207,9 @@ class ProductTemplateAttributeLine(models.Model):
         ptav_to_unlink = ProductTemplateAttributeValue
         for ptal in self:
             ptav_to_activate = ProductTemplateAttributeValue
-            remaining_pav = ptal.value_ids
+            remaining_pav = set(ptal.value_ids.ids)
             for ptav in ptal.product_template_value_ids:
-                if ptav.product_attribute_value_id not in remaining_pav:
+                if ptav.product_attribute_value_id.id not in remaining_pav:
                     # Remove values that existed but don't exist anymore, but
                     # ignore those that are already archived because if they are
                     # archived it means they could not be deleted previously.
@@ -217,36 +217,32 @@ class ProductTemplateAttributeLine(models.Model):
                         ptav_to_unlink += ptav
                 else:
                     # Activate corresponding values that are currently archived.
-                    remaining_pav -= ptav.product_attribute_value_id
+                    remaining_pav.remove(ptav.product_attribute_value_id.id)
                     if not ptav.ptav_active:
                         ptav_to_activate += ptav
 
-            for pav in remaining_pav:
-                # The previous loop searched for archived values that belonged to
-                # the current line, but if the line was deleted and another line
-                # was recreated for the same attribute, we need to expand the
-                # search to those with matching `attribute_id`.
-                # While not ideal for peformance, this search has to be done at
-                # each step to exclude the values that might have been activated
-                # at a previous step. Since `remaining_pav` will likely be a
-                # small list in all use cases, this is an acceptable trade-off.
-                ptav = ProductTemplateAttributeValue.search([
+            ptav_groups = ProductTemplateAttributeValue._read_group([
                     ('ptav_active', '=', False),
                     ('product_tmpl_id', '=', ptal.product_tmpl_id.id),
                     ('attribute_id', '=', ptal.attribute_id.id),
-                    ('product_attribute_value_id', '=', pav.id),
-                ], limit=1)
-                if ptav:
-                    ptav.write({'ptav_active': True, 'attribute_line_id': ptal.id})
-                    # If the value was marked for deletion, now keep it.
-                    ptav_to_unlink -= ptav
-                else:
-                    # create values that didn't exist yet
-                    ptav_to_create.append({
-                        'product_attribute_value_id': pav.id,
-                        'attribute_line_id': ptal.id,
-                        'price_extra': pav.default_extra_price,
-                    })
+                    ('product_attribute_value_id', 'in', list(remaining_pav)),
+                ], groupby=["product_attribute_value_id"], aggregates=["id:recordset"])
+
+            for pav, ptav in ptav_groups:
+                ptav = ptav[0]
+                ptav.write({'ptav_active': True, 'attribute_line_id': ptal.id})
+                # If the value was marked for deletion, now keep it.
+                ptav_to_unlink -= ptav
+                remaining_pav.remove(pav.id)
+
+            remaining_pav = self.env['product.attribute.value'].sudo().browse(sorted(remaining_pav))
+
+            for pav in remaining_pav:
+                ptav_to_create.append({
+                    'product_attribute_value_id': pav.id,
+                    'attribute_line_id': ptal.id,
+                    'price_extra': pav.default_extra_price,
+                })
             # Handle active at each step in case a following line might want to
             # re-use a value that was archived at a previous step.
             ptav_to_activate.write({'ptav_active': True})


### PR DESCRIPTION
opw-4876370

Issue:

A customer who uses many attribute values complained that the "add to products" button on product attribute values in their database was really slow (8 minutes or so). 

Upon investigation I found parts of the involved functions used iteration over a set of records, which proved notably slower to psql searches. 

Fix:

Replacing the code with what I believe is equivalent operations making use of the `search` method to filter through the sets much quicker. 

Behaviour after fix:

The process takes 2-3 minutes when running this commit on the aforementioned database, but it's still a major improvement compared to the previous time.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
