### PR TITLE
[FIX] web: safe access currencyIds

### DIFF
--- a/addons/web/static/src/views/pivot/pivot_renderer.js
+++ b/addons/web/static/src/views/pivot/pivot_renderer.js
@@ -105,7 +105,7 @@ export class PivotRenderer extends Component {
             Object.assign(formatOptions, formatter.extractOptions(fieldInfo));
         }
         if (formatType === "monetary") {
-            if (cell.currencyIds.length > 1) {
+            if (cell.currencyIds?.length > 1) {
                 formatOptions.currencyId = user.activeCompany.currency_id;
                 return {
                     rawValue: cell.value,
@@ -113,7 +113,7 @@ export class PivotRenderer extends Component {
                     currencies: cell.currencyIds,
                 };
             }
-            formatOptions.currencyId = cell.currencyIds[0];
+            formatOptions.currencyId = cell.currencyIds?.[0];
         }
         return { value: formatter(cell.value, formatOptions) };
     }


### PR DESCRIPTION
### Issue:

A traceback occurs when opening Timesheets and Planning Analysis.

#### Steps to reproduce:

1. Create a database with `project_timesheet_forecast_sale` installed.
2. Create a project and open the three-dot menu.
3. Click on `Timesheets and Planning Analysis`.

### Cause:

The error occurs because `currencyIds` is undefined. This issue was introduced by #224667.

### Solution:

Add a safe access check for `currencyIds`.

opw-5176269
