### PR TITLE
[FIX] website_sale: TypeError in DynamicSnippetCategory when accessing SIZE_CONFIG[nodeData.size].span

### DIFF
--- a/addons/website_sale/static/src/snippets/s_dynamic_snippet_categories/dynamic_snippet_category.js
+++ b/addons/website_sale/static/src/snippets/s_dynamic_snippet_categories/dynamic_snippet_category.js
@@ -27,7 +27,7 @@ export class DynamicSnippetCategory extends DynamicSnippet {
         const colSpanTwo = colsCount !== 1 && (nodeData.size !== 'small' || colsCount === 5);
         // Pass custom data to the template.
         nodeData.customTemplateData = JSON.stringify({
-            size: SIZE_CONFIG[nodeData.size].span,
+            size: SIZE_CONFIG[nodeData.size]?.span,
             alignmentClass: ALIGNMENT_CLASSES_MAPPING[nodeData.alignment],
             buttonText: nodeData.button,
             colSpanTwo: colSpanTwo,


### PR DESCRIPTION
Cause: 
SIZE_CONFIG[nodeData.size] can be undefined in some snippet configurations, causing a TypeError when accessing .span.

Steps to reproduce: 
1) Install website_sale with demo data, 
2) Visit page url `/website/demo/snippets` and check the browser console for the error.

Solution: 
Use optional chaining (SIZE_CONFIG[nodeData.size]?.span) to safely access the property and prevent the frontend crash.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
