### PR TITLE
[REM] product: remove double weight assigment

### DIFF
--- a/addons/product/data/product_demo.xml
+++ b/addons/product/data/product_demo.xml
@@ -253,7 +253,6 @@
             <field name="standard_price">800.0</field>
             <field name="list_price">320.0</field>
             <field name="type">consu</field>
-            <field name="weight">0.01</field>
             <field name="uom_id" ref="uom.product_uom_unit"/>
             <field name="default_code">E-COM07</field>
             <field name='weight'>0.330</field>
@@ -279,7 +278,6 @@
             <field name="standard_price">1299.0</field>
             <field name="list_price">1799.0</field>
             <field name="type">consu</field>
-            <field name="weight">0.01</field>
             <field name="uom_id" ref="uom.product_uom_unit"/>
             <field name="default_code">E-COM09</field>
             <field name="description_sale">Minimalist wooden desk for executive use</field>

--- a/addons/stock/data/stock_demo2.xml
+++ b/addons/stock/data/stock_demo2.xml
@@ -12,7 +12,6 @@
             <field name="default_code">FURN_5555</field>
             <field name="name">Cable Management Box</field>
             <field name="is_storable" eval="True"/>
-            <field name="weight">0.01</field>
             <field name="categ_id" ref="product.product_category_office"/>
             <field name="lst_price">100.0</field>
             <field name="standard_price">70.0</field>


### PR DESCRIPTION
Weights were added to the demo data in https://github.com/odoo/odoo/pull/29279.
and some of them already had weight assigned.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
