### PR TITLE
[FIX] analytic: avoid error updating lines with no distribution

### DIFF
--- a/addons/analytic/models/analytic_line.py
+++ b/addons/analytic/models/analytic_line.py
@@ -236,6 +236,8 @@ class AccountAnalyticLine(models.Model):
                 {line._get_distribution_key(): 100},
                 line.analytic_distribution or {},
             )
+            if not final_distribution:
+                continue
             amount_fname = line._split_amount_fname()
             vals_list = [
                 {amount_fname: line[amount_fname] * percent / 100} | empty_account | {


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

This pull request addresses a bug in Odoo's analytic accounting module. Specifically, when updating analytic lines that have empty distributions, the vals_list[0] ends up being empty. This situation causes an error in the write method, which prevents the system from properly updating analytic lines without distributions.

Current behavior before PR:

Before this fix, attempting to update analytic lines with empty distributions triggers an error in the write method. As a result, operations that involve updating such lines fail, potentially interrupting normal accounting workflows.

Desired behavior after PR is merged:

After merging this PR, the system will first check whether an analytic line has a valid distribution before attempting to update it. Lines with empty distributions will be safely skipped, preventing errors and allowing the rest of the analytic updates to proceed smoothly. This ensures more robust handling of analytic lines and avoids runtime exceptions during updates.


Video: https://app.screencastify.com/watch/03zuCLh984kWun2Q71tK
Odoo Task: https://www.odoo.com/es_ES/my/tasks/5181171

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
