### PR TITLE
[FIX] sale: apply discount to catalog price for single order line

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -1533,7 +1533,7 @@ class SaleOrderLine(models.Model):
         if len(self) == 1:
             res = {
                 'quantity': self.product_uom_qty,
-                'price': self.price_unit,
+                'price': self.price_unit * (1 - (self.discount or 0.0) / 100.0),
                 'readOnly': (
                     self.order_id._is_readonly()
                     or self.product_id.sale_line_warn == 'block'


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When using the product catalog in sale orders, if a sale order line has a discount applied via the `discount` field, the catalog displays the base `price_unit` instead of the discounted price. This creates an inconsistency between what's shown in the catalog and the actual price in the order line.

Current behavior before PR:

- A sale order line with price_unit=120.00 and discount=15% shows subtotal=102.00 in the order
- The product catalog shows price=120.00 (without discount applied)
- This only happens when `len(self) == 1` in `_get_product_catalog_lines_data()`
- The multi-line case (`elif self:`) correctly calculates the price using pricelist

Desired behavior after PR is merged:

- The product catalog should show price=102.00 (with discount applied)
- Consistency between catalog price and order line subtotal
- The discount field is properly considered in the price calculation for single lines
- Behavior matches the multi-line case where pricelist correctly calculates discounted prices

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
