### PR TITLE
[FIX] web: restore spacing between overlapping calendar events

### DIFF
--- a/addons/web/static/lib/fullcalendar/timegrid/index.global.js
+++ b/addons/web/static/lib/fullcalendar/timegrid/index.global.js
@@ -758,8 +758,9 @@ FullCalendar.TimeGrid = (function (exports, core, internal$1, preact, internal$2
                     let hStyle = (!isMirror && rect) ? this.computeSegHStyle(rect) : { left: 0, right: 0 };
                     let isInset = Boolean(rect) && rect.stackForward > 0;
                     let isShort = Boolean(rect) && (rect.span.end - rect.span.start) < eventShortHeight; // look at other places for this problem
+                    let needsMargin = Boolean(isInset) && rect.thickness < 1 && rect.stackDepth <= rect.stackForward;
                     return (preact.createElement("div", { className: 'fc-timegrid-event-harness' +
-                            (isInset ? ' fc-timegrid-event-harness-inset' : ''), key: forcedKey || instanceId, style: Object.assign(Object.assign({ visibility: isVisible ? '' : 'hidden' }, vStyle), hStyle) },
+                            (isInset ? ' fc-timegrid-event-harness-inset' : ''), key: forcedKey || instanceId, style: Object.assign(Object.assign({ visibility: isVisible ? '' : 'hidden', marginRight: needsMargin ? '20px' : '0' }, vStyle), hStyle) },
                         preact.createElement(TimeColEvent, Object.assign({ seg: seg, isDragging: isDragging, isResizing: isResizing, isDateSelecting: isDateSelecting, isSelected: instanceId === eventSelection, isShort: isShort }, internal$1.getSegMeta(seg, todayRange, nowDate)))));
                 })));
         }


### PR DESCRIPTION
**PROBLEM**
When multiple calendar events overlap in time, the middle event becomes
unclickable if it’s fully contained between two other events. This issue
only occurs when the `hr_homeworking_calendar` module is installed.

**REPRO STEPS**
1. Install hr_homeworking_calendar.
2. create a calendar event from `11:00am` to `12:00pm` and name it "1".
3. create a second calendar event from `11:15am to 11:45pm` and name
it "2".
4. create a third calendar from `11:00am to 12:00pm` and named it "3".
5. attempt to click on the event named "2".

**CAUSE**
FullCalendar rendered overlapping events with the same horizontal
offset and full width. Because of this, the outer events
("1" and "3") visually overlapped and covered the middle event ("2"),
blocking pointer events and making it unclickable.

**SOLUTION**
Introduced a CSS variable `--overlap-gap` on `.o_calendar_renderer`
and applied horizontal margins to `.fc-timegrid-event`. This
slightly reduces each event’s width to create spacing between
overlapping items. The offset prevents elements from fully overlapping,
restoring individual clickability without modifying FullCalendar’s
positioning or layout logic.

opw-4874070

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
