### PR TITLE
[IMP] hr: Add Display name to export mixin

### DIFF
--- a/addons/hr/models/hr_export_mixin.py
+++ b/addons/hr/models/hr_export_mixin.py
@@ -103,4 +103,9 @@ class HrExportEmployeeMixin(models.AbstractModel):
 
     export_id = fields.Many2one('hr.export.mixin', required=True, index=True, ondelete='cascade')
     company_id = fields.Many2one(related='export_id.company_id', store=True, readonly=True)
-    employee_id = fields.Many2one('hr.employee', required=True, ondelete='cascade', check_company=True)
+    employee_id = fields.Many2one('hr.employee', required=True, domain="[('company_id', '=', company_id)]", ondelete='cascade', check_company=True)
+
+    _uniq_employee = models.Constraint(
+        'unique (employee_id,export_id)',
+        "An Emplyee can be imported only once!",
+    )

--- a/addons/hr/views/hr_export_mixin_views.xml
+++ b/addons/hr/views/hr_export_mixin_views.xml
@@ -31,6 +31,7 @@
                 </header>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
+                        <field name="display_name" invisible="1"/>
                         <button name="action_open_employees"
                                 type="object"
                                 class="oe_stat_button"


### PR DESCRIPTION
In order to make display names available in a proper way, the mixin has to include the display_name field so that it can be recomputed correctly. This commit adds the display name. 
See: odoo/enterprise#97586
task:5163668

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
