### PR TITLE
[FIX] spreadsheet: add missing has_searchable_parent_relation method …

### DIFF
--- a/addons/spreadsheet/models/__init__.py
+++ b/addons/spreadsheet/models/__init__.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import ir_model
 from . import ir_http
 from . import res_currency
 from . import res_currency_rate

--- a/addons/spreadsheet/models/ir_model.py
+++ b/addons/spreadsheet/models/ir_model.py
@@ -1,0 +1,21 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models, api
+
+
+class IrModel(models.Model):
+    _inherit = "ir.model"
+
+    @api.readonly
+    @api.model
+    def has_searchable_parent_relation(self, model_names):
+        result = {}
+        for model_name in model_names:
+            model = self.env.get(model_name)
+            if model is None or not model.has_access("read"):
+                result[model_name] = False
+            else:
+                # we consider only stored parent relationships were meant to
+                # be searched
+                result[model_name] = model._parent_store and model._parent_name in model._fields
+        return result


### PR DESCRIPTION
…in community edition

Description of the issue/feature this PR addresses:

To move the missing code from enterprise edition 

Current behavior before PR:

Open a spreadsheet dashboard dropdown in search bar in 19.0 community edition, the traceback message box appeared: 

AttributeError: The method 'ir.model.has_searchable_parent_relation' does not exist

Desired behavior after PR is merged:

No traceback



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
