### PR TITLE
[FIX] base: show button switch to language only when no using this language

### DIFF
--- a/odoo/addons/base/wizard/base_language_install.py
+++ b/odoo/addons/base/wizard/base_language_install.py
@@ -26,6 +26,7 @@ class BaseLanguageInstall(models.TransientModel):
     first_lang_id = fields.Many2one('res.lang',
                                     compute='_compute_first_lang_id',
                                     help="Used when the user only selects one language and is given the option to switch to it")
+    first_lang_code = fields.Char(related='first_lang_id.code', string='Language Code')
 
     def _compute_first_lang_id(self):
         self.first_lang_id = False

--- a/odoo/addons/base/wizard/base_language_install_views.xml
+++ b/odoo/addons/base/wizard/base_language_install_views.xml
@@ -17,7 +17,8 @@
                     </div>
                     <footer>
                         <button name="reload" string="Close" type="object" class="btn-primary" data-hotkey="q"/>
-                        <button name="switch_lang" type="object" class="btn-primary ms-1" data-hotkey="w">
+                        <button name="switch_lang" type="object" class="btn-primary ms-1" data-hotkey="w"
+                                invisible="context.get('lang') == first_lang_code">
                             Switch to <field name="first_lang_id" readonly="True" options="{'no_open': True}"/> &amp; Close
                         </button>
                     </footer>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
show button switch to language only when no using this language
<img width="3700" height="1350" alt="截图 2025-10-18 19-55-45" src="https://github.com/user-attachments/assets/a8ea889b-eb8f-47a5-8776-179bd881fb5e" />
<img width="3700" height="1350" alt="截图 2025-10-18 19-55-55" src="https://github.com/user-attachments/assets/8721d3a4-95d9-4167-9ee4-e27a2142876b" />

**Current behavior before PR:**
I develop odoo in Chinese language. Sometimes I change the po files, I need to reload the Chinese language to load the latest translations. While I am using the Chinese, so it do not need to ask me to switch to Chinese.

**Desired behavior after PR is merged:**
show button switch to language only when not using this language



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
