### PR TITLE
[FIX] core: default to declared icon for a module

### DIFF
--- a/odoo/modules/module.py
+++ b/odoo/modules/module.py
@@ -380,9 +380,15 @@ def get_module_icon(module: str) -> str:
     """ Get the path to the module's icon. Invalid module names are accepted. """
     manifest = Manifest.for_addon(module, display_warning=False)
     if manifest and 'icon' in manifest.__dict__:
+        # we have a value in the cached property
         return manifest.icon
-    try:
+    fpath = ''
+    if manifest:
+        fpath = manifest.raw_value('icon') or ''
+        fpath = fpath.lstrip('/')
+    if not fpath:
         fpath = f"{module}/static/description/icon.png"
+    try:
         tools.file_path(fpath)
         return "/" + fpath
     except FileNotFoundError:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The `get_module_icon` function is used in multiple places allowing to
default to the standard icon if none is found. First, if the module
already has a checked icon as a cached property, just return it.
Afterwards, read the raw value from the manifest as the icon to check,
we were checking only the default location so the cached value
effectively ignored what was defined in the manifest.

Current behavior before PR:
'icon' attribute is ignored in the manifest.

Desired behavior after PR is merged:
Check the icon defined in the manifest before defaulting to the default icon location.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
