### PR TITLE
[IMP] mail: more alignment in search and check access

### DIFF
--- a/addons/mail/tests/test_mail_message.py
+++ b/addons/mail/tests/test_mail_message.py
@@ -22,6 +22,13 @@ class TestMailMessage(common.MailCommon):
         self.env["mail.message"].unstar_all()
         self.assertNotIn(self.env.user.partner_id, message.starred_partner_ids)
 
+    def test_mail_message_inexisting_access(self):
+        user = new_test_user(self.env, login="Bob", email="bob@test.com")
+        inexisting_message = self.env['mail.message'].with_user(user).browse(-434264)
+        self.assertFalse(inexisting_message.exists())
+        self.assertTrue(inexisting_message.browse().has_access('read'))
+        self.assertFalse(inexisting_message.has_access('read'))
+
     def test_unlink_failure_message_notify_author(self):
         recipient = new_test_user(self.env, login="Bob", email="invalid_email_addr")
         with self.mock_mail_gateway():

--- a/addons/portal/controllers/thread.py
+++ b/addons/portal/controllers/thread.py
@@ -82,8 +82,7 @@ class PortalThreadController(ThreadController):
                     portal_data={"portal_partner": portal_partner, "portal_thread": thread}
                 )
             # Non-employee see only messages with not internal subtype (aka, no internal logs)
-            if not request.env.user._is_internal():
-                domain = Message._get_search_domain_share() & domain
+            domain = Message._get_search_domain_share() & domain
             Message = request.env["mail.message"].sudo()
         res = Message._message_fetch(domain, **(fetch_params or {}))
         messages = res.pop("messages")

--- a/addons/test_mail/tests/test_mail_activity.py
+++ b/addons/test_mail/tests/test_mail_activity.py
@@ -529,6 +529,7 @@ class TestActivitySystray(TestActivityCommon, HttpCase):
 
         # if not assigned -> should filter out
         self.env.invalidate_all()
+        self.env.transaction.clear_access_cache()
         self.test_activities_removed.write({'user_id': self.user_admin.id})
         test_with_removed = self.env['mail.activity'].search([
             ('id', 'in', self.test_activities.ids),


### PR DESCRIPTION
Align and document mail permission checks.

Followup and cleaning notably of odoo/odoo#244194 (recent work on read and search
coherency), as well as continuation of cleaning introduced notably with odoo/odoo#112126
and odoo/odoo#134677 .

Contains notably
 * use _check_access in _search overrides of message and activity, allowing to have
   code defined once, lessening incoherence between reading and searching;
 * continue adding defensive code against non existing records;
 * simplify 'share' domain on message (domain specific for portal users, limiting access
   to non internal messages);
 * various code and docstring updates;

Task-5238007
