### PR TITLE
[FIX] tools/pdf: Asking for an attribute that might not exist

### DIFF
--- a/odoo/tools/pdf/__init__.py
+++ b/odoo/tools/pdf/__init__.py
@@ -115,12 +115,15 @@ def _unwrapping_get(self, key, default=None):
 
 DictionaryObject.get = _unwrapping_get
 
-# Make sure all the correct delimiters are included
-# https://github.com/py-pdf/pypdf/commit/8c542f331828c5839fda48442d89b8ac5d3984ac
-NameObject.renumber_table.update({
-    **{chr(i): f"#{i:02X}".encode() for i in b"#()<>[]{}/%"},
-    **{chr(i): f"#{i:02X}".encode() for i in range(33)},
-})
+
+if hasattr(NameObject, 'renumber_table'):
+    # Make sure all the correct delimiters are included
+    # We will make this change only if pypdf has the renumber_table attribute
+    # https://github.com/py-pdf/pypdf/commit/8c542f331828c5839fda48442d89b8ac5d3984ac
+    NameObject.renumber_table.update({
+        **{chr(i): f"#{i:02X}".encode() for i in b"#()<>[]{}/%"},
+        **{chr(i): f"#{i:02X}".encode() for i in range(33)},
+    })
 
 
 if hasattr(PdfWriter, 'write_stream'):


### PR DESCRIPTION
On Python 3.10, we require PyPDF2==1.26.0 that doesn't have this attribute.

For now, we should ignore it.

Description of the issue/feature this PR addresses:

We cannot start Odoo in Python 3.10

Current behavior before PR:

On https://github.com/odoo/odoo/commit/daf7c285bc82fb875e59c2bc50471d6d7b3aa903 it was added a fix, but it was breaking python3.10 installation.

Desired behavior after PR is merged:

Odoo works in Python 3.10.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
