### PR TITLE
[FIX] #232233 :the title of the phone field in the form view of the u…

### DIFF
--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -143,7 +143,7 @@
                                     <field name="email" placeholder="Email" class="w-75"  invisible="login == email"/>
                                 </h5>
                                 <h5 name="h5_phone" class="d-flex align-items-baseline mb-0">
-                                    <i class="fa fa-fw fa-phone me-1 text-primary" title="Email"/>
+                                    <i class="fa fa-fw fa-phone me-1 text-primary" title="Phone"/>
                                     <field name="phone" placeholder="Phone" class="w-75"/>
                                 </h5>
                             </div>


### PR DESCRIPTION
…sers is displayed as email

Description of the issue/feature this PR addresses: In Odoo 19, the phone field label in the user form view was incorrectly displayed as “Email” instead of “Phone”.

Current behavior before PR: The phone field in the user form view showed the wrong title — “Email”.

Desired behavior after PR is merged: The phone field now correctly displays the title “Phone” in the user form view.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
