### PR TITLE
[FIX] tools/pdf: patch NameObject only in PyPDF2 2.x and more

### DIFF
--- a/odoo/tools/pdf/__init__.py
+++ b/odoo/tools/pdf/__init__.py
@@ -117,10 +117,11 @@ DictionaryObject.get = _unwrapping_get
 
 # Make sure all the correct delimiters are included
 # https://github.com/py-pdf/pypdf/commit/8c542f331828c5839fda48442d89b8ac5d3984ac
-NameObject.renumber_table.update({
-    **{chr(i): f"#{i:02X}".encode() for i in b"#()<>[]{}/%"},
-    **{chr(i): f"#{i:02X}".encode() for i in range(33)},
-})
+if hasattr(NameObject, 'renumber_table'):
+    NameObject.renumber_table.update({
+        **{chr(i): f"#{i:02X}".encode() for i in b"#()<>[]{}/%"},
+        **{chr(i): f"#{i:02X}".encode() for i in range(33)},
+    })
 
 
 if hasattr(PdfWriter, 'write_stream'):


### PR DESCRIPTION
The attribute `renumber_table` was only added in PyPDF2 2.10.8, and is absent from 1.26.0, which is the versions used in Odoo for Python 3.10 or less

https://github.com/py-pdf/pypdf/commit/fb8be4065bfb26ec3bec71d8c6d65b3be3a2034f
