### PR TITLE
Print a recap of failed tests at the end of the test suite

### DIFF
--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -15,6 +15,7 @@ import signal
 import socket
 import subprocess
 import sys
+import textwrap
 import threading
 import time
 from collections import deque
@@ -677,6 +678,10 @@ class ThreadedServer(CommonServer):
                          else logger.warning if not report.testsRun \
                          else logger.info
                         log("%s when loading database %r", report, db)
+                        for test, errmsg in report.errors:
+                            _logger.info("Error: %s - %s", test, textwrap.shorten(errmsg, width=50))
+                        for test, errmsg in report.failures:
+                            _logger.info("Failed: %s - %s", test, textwrap.shorten(errmsg, width=50))
             self.stop()
             return rc
 

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -2443,17 +2443,13 @@ class HttpCase(TransactionCase):
             # code = ""
             self.assertTrue(browser._wait_ready(ready), 'The ready "%s" code was always falsy' % ready)
 
-            error = False
+            error = None
             try:
                 browser._wait_code_ok(code, timeout, error_checker=error_checker)
             except ChromeBrowserException as chrome_browser_exception:
                 error = chrome_browser_exception
             if error:  # dont keep initial traceback, keep that outside of except
-                if code:
-                    message = 'The test code "%s" failed' % code
-                else:
-                    message = "Some js test failed"
-                self.fail('%s\n\n%s' % (message, error))
+                self.fail(str(error))
 
     def start_tour(self, url_path, tour_name, step_delay=None, **kwargs):
         """Wrapper for `browser_js` to start the given `tour_name` with the

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -306,16 +306,6 @@ class BaseCase(case.TestCase):
     registry: Registry = None
     env: api.Environment = None
     cr: Cursor = None
-    def __init_subclass__(cls):
-        """Assigns default test tags ``standard`` and ``post_install`` to test
-        cases not having them. Also sets a completely unnecessary
-        ``test_module`` attribute.
-        """
-        super().__init_subclass__()
-        if cls.__module__.startswith('odoo.addons.'):
-            if getattr(cls, 'test_tags', None) is None:
-                cls.test_tags = {'standard', 'post_install'}
-            cls.test_module = cls.__module__.split('.')[2]
 
     longMessage = True      # more verbose error message by default: https://www.odoo.com/r/Vmh
     warm = True             # False during warm-up phase (see :func:`warmup`)
@@ -327,13 +317,24 @@ class BaseCase(case.TestCase):
     _registry_readonly_enabled = True
     test_cursor_lock_timeout: int = 20
 
+    @classmethod
+    def __init_subclass__(cls):
+        """Assigns default test tags ``standard`` and ``post_install`` to test
+        cases not having them. Also sets a completely unnecessary
+        ``test_module`` attribute.
+        """
+        super().__init_subclass__()
+        if cls.__module__.startswith('odoo.addons.'):
+            if getattr(cls, 'test_tags', None) is None:
+                cls.test_tags = {'standard', 'post_install'}
+            cls.test_module = cls.__module__.split('.')[2]
+
     def __init__(self, methodName='runTest'):
         super().__init__(methodName)
         self.addTypeEqualityFunc(etree._Element, self.assertTreesEqual)
         self.addTypeEqualityFunc(html.HtmlElement, self.assertTreesEqual)
         if methodName != 'runTest':
             self.test_tags = self.test_tags | set(self.get_method_additional_tags(getattr(self, methodName)))
-
 
     @classmethod
     def _request_handler(cls, s: Session, r: PreparedRequest, /, **kw):


### PR DESCRIPTION
Currently Odoo just logs "X failed, Y errors" at the end of the test suite, and it's up to the developer to hunt down what failed. When running a large number of tests locally, hunting down test failures in the log is a pain in the ass.

This adds a recap listing all the failed tests and a truncated error message, even if it's not enough information for the developer's needs it gives them content to search for.