### PR TITLE
[FIX] mail: Store extra_fields shared list mutation

### DIFF
--- a/addons/mail/tools/discuss.py
+++ b/addons/mail/tools/discuss.py
@@ -421,7 +421,7 @@ class Store:
             """Returns a new relation with the given records instead of the field name."""
             assert self.field_name and self.records is None
             assert not self.dynamic_fields or calling_record
-            extra_fields = self.kwargs.get("extra_fields", [])
+            extra_fields = list(self.kwargs.get("extra_fields", []))
             if self.dynamic_fields:
                 extra_fields += self.dynamic_fields(calling_record)
             params = {


### PR DESCRIPTION
Before this commit, the `extra_fields` kwarg of Store.Relation would be mutated in place, causing unexpected behavior where the `dynamic_fields` of a record would be used for others.

This commit fixes the shared list mutation issue by making a copy of the `extra_fields` and appending to that.