### PR TITLE
[IMP] tests: allow to test specific test for all modules

### DIFF
--- a/addons/web/tests/test_js.py
+++ b/addons/web/tests/test_js.py
@@ -139,6 +139,18 @@ class HOOTCommon(odoo.tests.HttpCase):
         self._test_params = [('-', '-@web/core/autocomplete,-@web/core/autocomplete2')]
         self.assertEqual(self.get_hoot_filters(), '&id=69a6561d&id=cb246db5')
 
+
+@odoo.tests.tagged('hoot', 'post_install', '-at_install')
+class HootSuite(QunitCommon, HOOTCommon, odoo.tests.CrossModule):
+    def test_js(self, modules):
+        print(self._test_params)
+        print(modules)
+
+    def test_js_mobile(self, modules):
+        print(self._test_params)
+        print(modules)
+
+
 @odoo.tests.tagged('post_install', '-at_install')
 class WebSuite(QunitCommon, HOOTCommon):
 

--- a/addons/web/tests/test_js.py
+++ b/addons/web/tests/test_js.py
@@ -140,17 +140,6 @@ class HOOTCommon(odoo.tests.HttpCase):
         self.assertEqual(self.get_hoot_filters(), '&id=69a6561d&id=cb246db5')
 
 
-@odoo.tests.tagged('hoot', 'post_install', '-at_install')
-class HootSuite(QunitCommon, HOOTCommon, odoo.tests.CrossModule):
-    def test_js(self, modules):
-        print(self._test_params)
-        print(modules)
-
-    def test_js_mobile(self, modules):
-        print(self._test_params)
-        print(modules)
-
-
 @odoo.tests.tagged('post_install', '-at_install')
 class WebSuite(QunitCommon, HOOTCommon):
 
@@ -211,6 +200,20 @@ class WebSuite(QunitCommon, HOOTCommon):
                     if RE_ONLY.search(fp.read().decode('utf-8')):
                         self.fail("`QUnit.only()` or `QUnit.debug()` used in file %r" % asset['url'])
 
+    def _get_canonical_tags_params(self, log=None):
+        result = super()._get_canonical_tags_params(log)
+        if self._testMethodName == 'test_unit_desktop' and log:
+            message = log.msg
+            if log.args:
+                message = log.msg % log.args
+            if '[HOOT] Test "@' in message:
+                match = re.search(r'\[HOOT\] Test "(@([^/]+)/[^"]+)"', message)
+                if match:
+                    # module = match.group(2)
+                    test = match.group(1)
+                    # result['module'] = module
+                    result['params'] = test
+        return result
 
 @odoo.tests.tagged('post_install', '-at_install')
 class MobileWebSuite(QunitCommon, HOOTCommon):

--- a/odoo/addons/base/tests/test_tests_tags.py
+++ b/odoo/addons/base/tests/test_tests_tags.py
@@ -418,32 +418,33 @@ class TestSelectorSelection(TransactionCase):
 
     def test_selector_parser_parameters(self):
         tags = ','.join([
-            ':FakeClassA[@web/test]',
-            '-/web:FakeClassA[@web/test/x]',
-        ])
-        tags = TagsSelector(tags, available_modules=['base', 'mail', 'web'])
-        class FakeClassA(TransactionCase, CrossModule):
-            pass
-
-        fc = FakeClassA()
-        tags.check(fc)
-        self.assertEqual(fc._test_params, [('+', '@web/test'), ('-', '@web/test/x')])
-
-
-    def test_selector_parser_cross_module_parameters(self):
-        tags = ','.join([
             '/base:FakeClassA[failfast=0,filter=-livechat]',
             #'/base:FakeClassA[filter=[-barecode,-stock_x]]',
             '/other[notForThisClass]',
             '-/base:FakeClassA[arg1,arg2]',
         ])
         tags = TagsSelector(tags)
+
         class FakeClassA(TransactionCase):
             pass
 
         fc = FakeClassA()
         tags.check(fc)
         self.assertEqual(fc._test_params, [('+', 'failfast=0,filter=-livechat'), ('-', 'arg1,arg2')])
+
+    def test_selector_parser_cross_module_parameters(self):
+        tags = ','.join([
+            ':FakeClassA[@web/test]',
+            '-/web:FakeClassA[@web/test/x]',
+        ])
+        tags = TagsSelector(tags, available_modules=['base', 'mail', 'web'])
+
+        class FakeClassA(TransactionCase, CrossModule):
+            pass
+
+        fc = FakeClassA()
+        tags.check(fc)
+        self.assertEqual(fc._test_params, [('+', '@web/test'), ('-', '@web/test/x')])
 
     def test_negative_parameters_translate(self):
         tags = TagsSelector('.test_negative_parameters_translate')

--- a/odoo/addons/base/tests/test_tests_tags.py
+++ b/odoo/addons/base/tests/test_tests_tags.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.tests.common import TransactionCase, tagged, BaseCase
+from odoo.tests.common import TransactionCase, tagged, BaseCase, CrossModule
 from odoo.tests.tag_selector import TagsSelector
 
 
@@ -221,7 +221,6 @@ class TestSelector(TransactionCase):
         tags = TagsSelector('/module.method')
         self.assertEqual({('standard', 'module', None, 'method', None), }, tags.include)  # all in module
 
-
 @tagged('nodatabase')
 class TestSelectorSelection(TransactionCase):
     def test_selector_selection(self):
@@ -379,7 +378,59 @@ class TestSelectorSelection(TransactionCase):
         tags = TagsSelector(__file__)
         self.assertTrue(tags.check(no_tags_obj), 'Test should its absolute file path')
 
+    def test_selector_cross_module_selection(self):
+        class TestLintingCrossModule(TransactionCase, CrossModule):
+            def test_linting(self, modules):
+                pass
+
+        tags = TagsSelector('/base:TestLintingCrossModule', available_modules=['base', 'mail', 'web'])
+        instance = TestLintingCrossModule('test_linting')
+        self.assertTrue(tags.check(instance), "The cross module test should be selected by its class and module")
+        self.assertEqual(instance._test_modules, ['base'])
+
+        tags = TagsSelector(':TestLintingCrossModule', available_modules=['base', 'mail', 'web'])
+        self.assertTrue(tags.check(instance), "The cross module test should be selected by its class")
+        self.assertEqual(instance._test_modules, ['base', 'mail', 'web'])
+
+        tags = TagsSelector('/mail:TestLintingCrossModule', available_modules=['base', 'mail', 'web'])
+        self.assertTrue(tags.check(instance), "The cross module test should be selected by its class and another module")
+        self.assertEqual(instance._test_modules, ['mail'])
+
+        tags = TagsSelector('/mail', available_modules=['base', 'mail', 'web'])
+        self.assertTrue(tags.check(instance), "The cross module test should be selected any module")
+        self.assertEqual(instance._test_modules, ['mail'])
+
+        tags = TagsSelector('/mail,-:TestLintingCrossModule', available_modules=['base', 'mail', 'web'])
+        self.assertFalse(tags.check(instance), "The cross module test should not be selected if explicilty blacklisted by its class")
+
+        self.assertEqual(instance.__module__.split('.')[2], 'base', "Ensure that module is define in base for following checks")
+
+        tags = TagsSelector(':TestLintingCrossModule,-/base', available_modules=['base', 'mail', 'web'])
+        self.assertTrue(tags.check(instance), "The cross module test should be selected by its class even when declaring module is blacklisted")
+        self.assertEqual(instance._test_modules, ['mail', 'web'])
+
+        tags = TagsSelector(':TestLintingCrossModule,-/base,-/web,-/mail ', available_modules=['base', 'mail', 'web'])
+        self.assertFalse(tags.check(instance), "The cross module test should not be selected by its class if the module list is empty")
+
+        tags = TagsSelector(':TestLintingCrossModule,-/base,-/web.test_linting,-/mail.test_other ', available_modules=['base', 'mail', 'web'])
+        self.assertTrue(tags.check(instance), "The cross module test should be selected for mail")
+        self.assertEqual(instance._test_modules, ['mail'])
+
     def test_selector_parser_parameters(self):
+        tags = ','.join([
+            ':FakeClassA[@web/test]',
+            '-/web:FakeClassA[@web/test/x]',
+        ])
+        tags = TagsSelector(tags, available_modules=['base', 'mail', 'web'])
+        class FakeClassA(TransactionCase, CrossModule):
+            pass
+
+        fc = FakeClassA()
+        tags.check(fc)
+        self.assertEqual(fc._test_params, [('+', '@web/test'), ('-', '@web/test/x')])
+
+
+    def test_selector_parser_cross_module_parameters(self):
         tags = ','.join([
             '/base:FakeClassA[failfast=0,filter=-livechat]',
             #'/base:FakeClassA[filter=[-barecode,-stock_x]]',
@@ -423,5 +474,5 @@ class TestTestClass(BaseCase):
     def test_canonical_tag(self):
         self.assertEqual(self.canonical_tag, '/base/tests/test_tests_tags.py:TestTestClass.test_canonical_tag')
 
-    def get_log_metadata(self):
+    def get_log_metadata(self, _log):
         self.assertEqual(self.log_metadata['canonical_tag'], '/base/tests/test_tests_tags.py:TestTestClass.test_canonical_tag')

--- a/odoo/netsvc.py
+++ b/odoo/netsvc.py
@@ -81,7 +81,7 @@ class PostgreSQLHandler(logging.Handler):
                 metadata = {}
                 if modules.module.current_test:
                     with contextlib.suppress(Exception):
-                        metadata['test'] = modules.module.current_test.get_log_metadata()
+                        metadata['test'] = modules.module.current_test.get_log_metadata(record)
 
                 if metadata:
                     cr.execute("""

--- a/odoo/tests/case.py
+++ b/odoo/tests/case.py
@@ -250,19 +250,42 @@ class TestCase(_TestCase):
 
     @property
     def canonical_tag(self):
+        return self.get_canonical_tag()
+
+    def _make_canonical_tag(self=None, tag='', module=None, test_class=None, test_method=None, params=None):
+        if module:
+            tag = f'{tag}/{module}'
+        if test_class:
+            tag = f'{tag}:{test_class}'
+        if test_method:
+            tag = f'{tag}.{test_method}'
+        if params:
+            tag = f'{tag}[{params}]'
+        return tag
+
+    def _get_canonical_tags_params(self, log):
         module = self.__module__
         for prefix in ('odoo.addons.', 'odoo.upgrade.'):
             if module.startswith(prefix):
                 module = module[len(prefix):]
 
         module = module.replace('.', '/')
-        return f'/{module}.py:{self.__class__.__name__}.{self._testMethodName}'
+        module = f'{module}.py'
 
-    def get_log_metadata(self):
-        metadata = {
-            'canonical_tag': self.canonical_tag,
+        return {
+            'module': module,
+            'test_class': self.__class__.__name__,
+            'test_method': self._testMethodName,
+            'params': None,
         }
-        return metadata
+
+    def get_canonical_tag(self, log=None):
+        return self._make_canonical_tag(**self._get_canonical_tags_params(log))
+
+    def get_log_metadata(self, _log):
+        return {
+            'canonical_tag': self.get_canonical_tag(_log),
+        }
 
 
 class _SubTest(TestCase):

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -923,6 +923,15 @@ class BaseCase(case.TestCase):
                 additional_tags.append('is_query_count')
         return additional_tags
 
+
+class CrossModule(case.TestCase):
+    _cross_module = True
+    _test_modules = []
+
+    def _callTestMethod(self, method):
+        method(self._test_modules)
+
+
 class Like:
     """
         A string-like object comparable to other strings but where the substring

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -931,6 +931,11 @@ class CrossModule(case.TestCase):
     def _callTestMethod(self, method):
         method(self._test_modules)
 
+    def _get_canonical_tags_params(self, log=None):
+        result = super()._get_canonical_tags_params(log)
+        result['module'] = None
+        return result
+
 
 class Like:
     """

--- a/odoo/tests/loader.py
+++ b/odoo/tests/loader.py
@@ -95,8 +95,9 @@ def make_suite(module_names, position='at_install'):
     :param list[str] module_names: modules to load tests from
     :param str position: "at_install" or "post_install"
     """
-    config_tags = TagsSelector(tools.config['test_tags'])
-    position_tag = TagsSelector(position)
+    available_modules = module_names if position == 'post_install' else None
+    config_tags = TagsSelector(tools.config['test_tags'], available_modules)
+    position_tag = TagsSelector(position, available_modules)
     tests = (
         t
         for module_name in module_names

--- a/odoo/tests/tag_selector.py
+++ b/odoo/tests/tag_selector.py
@@ -19,14 +19,15 @@ class TagsSelector(object):
                                 (?:\[(.*)\])?               # parameters
                                 $''', re.VERBOSE)  # [-][tag][/module][:class][.method][[params]]
 
-    def __init__(self, spec):
+    def __init__(self, spec, available_modules=None):
         """ Parse the spec to determine tags to include and exclude. """
         parts = re.split(r',(?![^\[]*\])', spec)  # split on all comma not inside [] (not followed by ])
         filter_specs = [t.strip() for t in parts if t.strip()]
         self.exclude = set()
         self.include = set()
         self.parameters = OrderedSet()
-
+        self.available_modules = available_modules and set(available_modules)
+        self.has_include = False
         for filter_spec in filter_specs:
             match = self.filter_spec_re.match(filter_spec)
             if not match:
@@ -51,11 +52,18 @@ class TagsSelector(object):
                 is_exclude = False
 
             if is_include:
+                self.has_include = True  # this is important for tags like /nonexistingmodule,-test_x
+
+            if is_include and module and self.available_modules and module not in self.available_modules:
+                _logger.info("Module '%s' in tag selector not in the list of installed modules %s", module, available_modules)
+                continue
+
+            if is_include:
                 self.include.add(test_filter)
             if is_exclude:
                 self.exclude.add(test_filter)
 
-        if (self.exclude or self.parameters) and not self.include:
+        if (self.exclude or self.parameters) and not self.has_include:
             self.include.add(('standard', None, None, None, None))
 
     def check(self, test):
@@ -76,29 +84,63 @@ class TagsSelector(object):
         test_module_path = test_module_path.replace('.', '/') + '.py'
 
         test._test_params = []
+        included_modules = set()
+        excluded_modules = set()
+
+        cross_module_test = hasattr(test, '_cross_module')
+
+        if cross_module_test and not self.available_modules:
+            _logger.debug("Skipping test '%s' because no available modules found.", test)
+            return False
 
         def _is_matching(test_filter):
             (tag, module, klass, method, file_path) = test_filter
             if tag and tag not in test_tags:
                 return False
-            elif file_path and not file_path.endswith(test_module_path):
+            if file_path and not file_path.endswith(test_module_path):
                 return False
-            elif not file_path and module and module != test_module:
+            if not file_path and module and module != test_module and not cross_module_test:
                 return False
-            elif klass and klass != test_class:
+            if klass and klass != test_class:
                 return False
-            elif method and test_method and method != test_method:
+            if method and test_method and method != test_method:  # noqa: SIM103
                 return False
             return True
 
-        if any(_is_matching(test_filter) for test_filter in self.exclude):
+        match_include = False
+        for test_filter in self.include:
+            if _is_matching(test_filter):
+                match_include = True
+                if cross_module_test:
+                    test_filter_module = test_filter[1]
+                    if test_filter_module:
+                        included_modules.add(test_filter_module)
+                    else:
+                        included_modules |= self.available_modules
+                else:
+                    break
+
+        if not match_include:
             return False
 
-        if not any(_is_matching(test_filter) for test_filter in self.include):
-            return False
-        
+        for test_filter in self.exclude:
+            if _is_matching(test_filter):
+                if cross_module_test:
+                    test_filter_module = test_filter[1]
+                    if test_filter_module:
+                        excluded_modules.add(test_filter_module)
+                    else:
+                        return False
+                else:
+                    return False
+
         for test_filter, parameter in self.parameters:
             if _is_matching(test_filter):
                 test._test_params.append(parameter)
+
+        test._test_modules = sorted(included_modules - excluded_modules)
+
+        if cross_module_test and not test._test_modules:  # noqa: SIM103
+            return False
 
         return True


### PR DESCRIPTION
Some tests are ran as part of a specific module even if they are testing many modules (js tests, liniting, ...).

If running --test-tags /project, the js tests are not ran meaning that to run all tests we may need to do something like
    --test-tags /project,/web:WebSuite[@account],/web:MobileWebSuite[@account],..

This is nor practical, nor intuitive and lead to the /web module taking a lot of time.

The proposed solution would behave somehoe like the test /web:WebSuite was defined in all modules.

A parameter will be given to the test with the list of module to test when executed. An alternative solution could be to run it once per module but some experiments where done for that and the overhead can be massive in some cases, mainly when the test spawns a subprocess (chrome, pylint, ...)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
