### PR TITLE
[FIX] discuss: reduce memory usage during stream tests

### DIFF
--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -11,7 +11,6 @@ import {
     SIZES,
     start,
     startServer,
-    streams,
     triggerEvents,
     waitStoreFetch,
 } from "@mail/../tests/mail_test_helpers";
@@ -39,8 +38,9 @@ import { isMobileOS } from "@web/core/browser/feature_detection";
 describe.current.tags("desktop");
 defineMailModels();
 
+let streams = [];
 beforeEach(() => {
-    mockGetMedia();
+    streams = mockGetMedia();
 });
 
 test("basic rendering", async () => {


### PR DESCRIPTION
Before this commit, since https://github.com/odoo/odoo/pull/231222, the streams used for tests were unnecessarily realistic.

- The audio stream was running with an oscillator, it is now an empty  idle stream. This may also fix an issue where if the `oscillator.start` function crashes, the stream wouldn't be added to the stream list and not be closed.
- The video stream was playing at 1fps, it now uses the default of canvas.captureStream which does not generate new frames if the canvas does not change.

The commit also makes the `mockGetMedia` return the streams that it manages instead of using an exported global variable, which may cause issues as hoot retains the reference to window.
