### PR TITLE
[FIX] web: use full query for search

### DIFF
--- a/addons/web/static/tests/search/search_bar.test.js
+++ b/addons/web/static/tests/search/search_bar.test.js
@@ -1965,3 +1965,21 @@ test("no crash when search component is destroyed with input", async () => {
     await runAllTimers();
     expect(".o_form_view").toHaveCount(1);
 });
+
+test("search on full query without waiting for display synchronisation", async () => {
+    /* Typically a barcode scan where the dropdown display doesn't have the time to update */
+    const searchBar = await mountWithSearch(SearchBar, {
+        resModel: "partner",
+        searchMenuTypes: [],
+        searchViewId: false,
+    });
+
+    await editSearch("01234");
+    expect(".o-dropdown-item:first").toHaveText("Search Foo for: 01234");
+    await press("5");
+    expect(".o-dropdown-item:first").toHaveText("Search Foo for: 01234");
+    await press("6");
+    expect(".o-dropdown-item:first").toHaveText("Search Foo for: 01234");
+    await keyDown("Enter");
+    expect(searchBar.env.searchModel.domain).toEqual([["foo", "ilike", "0123456"]]);
+});


### PR DESCRIPTION
Issue
-----
When scanning a barcode in the product view, the search is made using only part of the barcode. 

Steps to reproduce
-----
- Open the product view
- Scan a barcode (eg 1234567890)
> The search might only contain 12345678, 123456 or actually the full barcode

Cause
-----
When scanning a barcode, we receive all of the barcode characters followed by newline. When we receive the newline, we select the first item in the dropdown. The problem is that the search input changed but it hasn't been reflected yet in the
items (a rendering is scheduled but hasn't been applied to the DOM yet).

-----
Ticket:
opw-4874425