### PR TITLE
[FIX] website: fix missing template error after upgrade to master

### DIFF
--- a/addons/website/views/snippets/s_image_gallery.xml
+++ b/addons/website/views/snippets/s_image_gallery.xml
@@ -81,6 +81,7 @@
     <field name="name">Image gallery 000 XML</field>
     <field name="bundle">web.assets_frontend</field>
     <field name="path">website/static/src/snippets/s_image_gallery/000.xml</field>
+    <field name="active" eval="True"/>
 </record>
 
 </odoo>


### PR DESCRIPTION
After upgrading a database from version 19.0 to master, the “Image Wall” snippet triggers a "Missing template: 'website.gallery.s_image_gallery_mirror.lightbox'" error when clicked.

This occurs because commit d3603dd7c3628302491db65ea59e05b3cf3348bd replaced the `website.s_image_gallery_001_xml` record with `website.s_image_gallery_000_xml`. However, since `website.s_image_gallery_000_xml` was inactive in version 19.0, it remained inactive after the upgrade, leading to the missing template error.

This commit resolves the issue by explicitly reactivating the `website.s_image_gallery_000_xml` record in the master version.

Steps to reproduce:
1. Create a database in version 19.0 and add the Image Wall snippet.
2. Upgrade the database to master.
3. Click the snippet and observe the error: "Missing template: 'website.gallery.s_image_gallery_mirror.lightbox'".

task-5180419
