### PR TITLE
[IMP] html_editor: center translate button

### DIFF
--- a/addons/html_editor/static/src/main/chatgpt/language_selector.xml
+++ b/addons/html_editor/static/src/main/chatgpt/language_selector.xml
@@ -25,7 +25,7 @@
         <button class="btn btn-light" name="translate" t-att-title="props.title"
             t-att-disabled="props.isDisabled" t-on-click="onClick">
             <!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
-            <svg class="oe-language-icon" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+            <svg class="oe-language-icon d-flex" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
                 viewBox="796 796 200 200" enable-background="new 796 796 200 200" xml:space="preserve">
             <g>
                 <path d="M973.166,818.5H818.833c-12.591,0-22.833,10.243-22.833,22.833v109.333c0,12.59,10.243,22.833,22.833,22.833h154.333


### PR DESCRIPTION
This PR centers the translate button's icon in the toolbar, which was previously offset downward.

task-5095689

| Before | After |
|--------|--------|
| <img width="116" height="50" alt="Screenshot 2025-10-20 at 10 49 07" src="https://github.com/user-attachments/assets/3768d20c-e56b-4e63-a655-644360cd04df" /> | <img width="111" height="45" alt="Screenshot 2025-10-20 at 10 49 30" src="https://github.com/user-attachments/assets/b7e864a0-ac8d-4425-b012-d17ee21530bf" /> |

PR-ent: https://github.com/odoo/enterprise/pull/97090

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
