### PR TITLE
[IMP] iot_drivers: avoid auto register event for terminals

### DIFF
--- a/addons/iot_drivers/driver.py
+++ b/addons/iot_drivers/driver.py
@@ -63,7 +63,7 @@ class Driver(Thread):
 
         # Make response available to /event route or websocket
         # printers handle their own events (low on paper, etc.)
-        if self.device_type != "printer":
+        if self.device_type not in ["printer", "payment"]:
             event_manager.device_changed(self, response)
 
     def _check_if_action_is_duplicate(self, action_unique_id):

--- a/addons/iot_drivers/event_manager.py
+++ b/addons/iot_drivers/event_manager.py
@@ -51,25 +51,20 @@ class EventManager:
         :param Driver device: actual device class
         :param dict data: data returned by the device (optional)
         """
-        if data:
-            # Notify via websocket
-            send_to_controller({
-                **device.data,
-                'session_id': data.get('action_args', {}).get('session_id', ''),
-                'iot_box_identifier': helpers.get_identifier(),
-                'device_identifier': device.device_identifier,
-                **data,
-            })
-        else:
-            data = request.params.get('data', {}) if request else {}
+        data = data or request.params.get('data', {}) if request else {}
 
         # Make notification available to longpolling event route
         event = {
             **device.data,
             'device_identifier': device.device_identifier,
-            'time': time.time(),
             **data,
         }
+        send_to_controller({
+            **event,
+            'session_id': data.get('action_args', {}).get('session_id', ''),
+            'iot_box_identifier': helpers.get_identifier(),
+            **data,
+        })
         self.events.append(event)
         for session in self.sessions:
             session_devices = self.sessions[session]['devices']


### PR DESCRIPTION
As for printers that can send event whenever they want, payment terminals handle event themselves.

We then removed auto event registering for payment terminals.

odoo/enterprise#97617