### PR TITLE
[FIX] hr_expense: Cant change Expense Category Cost

### DIFF
--- a/addons/hr_expense/models/product_product.py
+++ b/addons/hr_expense/models/product_product.py
@@ -35,14 +35,12 @@ class ProductProduct(models.Model):
             ])
             for expense_sudo in expenses_sudo:
                 expense_product_sudo = expense_sudo.product_id
-                tax_domain = self.env['account.tax']._check_company_domain(expense_sudo.company_id)
                 product_has_cost = (
                         expense_product_sudo
                         and not expense_sudo.company_currency_id.is_zero(expense_product_sudo.standard_price)
                 )
                 expense_vals = {
                     'product_has_cost': product_has_cost,
-                    'product_has_tax': bool(expense_product_sudo.supplier_taxes_id.filtered_domain(tax_domain)),
                 }
                 if product_has_cost:
                     expense_vals.update({


### PR DESCRIPTION
Steps to reproduce:
- Create 2 companies
- Create a tax one each
- Create an expense category
- Set the 2 taxes as Vendor Taxes
- Select only one of the companies
- Change the cost of the expense category
- Try saving

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
