### PR TITLE
[IMP] mail: snappy open/fold discuss sidebar category

### DIFF
--- a/addons/im_livechat/static/src/core/web/discuss_sidebar_category_patch.js
+++ b/addons/im_livechat/static/src/core/web/discuss_sidebar_category_patch.js
@@ -11,7 +11,7 @@ const DiscussSidebarCategoryPatch = {
         if (
             this.store.has_access_livechat &&
             this.category.livechat_channel_id &&
-            this.category.open
+            this.category.is_open
         ) {
             actions.push({
                 onSelect: () => {

--- a/addons/mail/models/res_users_settings.py
+++ b/addons/mail/models/res_users_settings.py
@@ -6,9 +6,6 @@ from odoo import api, fields, models
 class ResUsersSettings(models.Model):
     _inherit = 'res.users.settings'
 
-    is_discuss_sidebar_category_channel_open = fields.Boolean(string="Is discuss sidebar category channel open?", default=True)
-    is_discuss_sidebar_category_chat_open = fields.Boolean(string="Is discuss sidebar category chat open?", default=True)
-
     # RTC
     push_to_talk_key = fields.Char(string="Push-To-Talk shortcut", help="String formatted to represent a key with modifiers following this pattern: shift.ctrl.alt.key, e.g: truthy.1.true.b")
     use_push_to_talk = fields.Boolean(string="Use the push to talk feature", default=False)

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app_model_patch.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app_model_patch.js
@@ -24,7 +24,6 @@ const discussAppPatch = {
                     id: "channels",
                     name: _t("Channels"),
                     sequence: 10,
-                    serverStateKey: "is_discuss_sidebar_category_channel_open",
                 };
             },
             eager: true,
@@ -46,7 +45,6 @@ const discussAppPatch = {
             id: "chats",
             name: _t("Direct messages"),
             sequence: 30,
-            serverStateKey: "is_discuss_sidebar_category_chat_open",
         };
     },
 };

--- a/addons/mail/static/src/discuss/core/public_web/discuss_core_public_web_service.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_core_public_web_service.js
@@ -14,22 +14,6 @@ export class DiscussCorePublicWeb {
         this.store = services["mail.store"];
         this.busService = services.bus_service;
         this.notificationService = services.notification;
-        try {
-            this.sidebarCategoriesBroadcast = new browser.BroadcastChannel(
-                "discuss_core_public_web.sidebar_categories"
-            );
-            this.sidebarCategoriesBroadcast.addEventListener(
-                "message",
-                ({ data: { id, open } }) => {
-                    const category = this.store.DiscussAppCategory.get(id);
-                    if (category) {
-                        category.open = open;
-                    }
-                }
-            );
-        } catch {
-            // BroadcastChannel API is not supported (e.g. Safari < 15.4), so disabling it.
-        }
         this.busService.subscribe("discuss.channel/joined", async (payload) => {
             const { data, channel_id, invited_by_user_id: invitedByUserId } = payload;
             this.store.insert(data);
@@ -73,15 +57,6 @@ export class DiscussCorePublicWeb {
                 }
             }
         );
-    }
-
-    /**
-     * Send the state of a category to the other tabs.
-     *
-     * @param {import("models").DiscussAppCategory} category
-     */
-    broadcastCategoryState(category) {
-        this.sidebarCategoriesBroadcast?.postMessage({ id: category.id, open: category.open });
     }
 }
 

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
@@ -159,7 +159,7 @@ export class DiscussSidebarChannel extends Component {
         if (sub.eq(this.store.discuss.thread)) {
             return true;
         }
-        if (!this.thread.discussAppCategory.open) {
+        if (!this.thread.discussAppCategory.is_open) {
             return false;
         }
         if (
@@ -226,11 +226,7 @@ export class DiscussSidebarCategory extends Component {
     }
 
     toggle() {
-        if (this.store.channels.status === "fetching") {
-            return;
-        }
-        this.category.open = !this.category.open;
-        this.discusscorePublicWebService.broadcastCategoryState(this.category);
+        this.category.is_open = !this.category.is_open;
     }
 }
 

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -10,7 +10,7 @@
 
     <t t-name="mail.DiscussSidebarCategories.category">
         <DiscussSidebarCategory category="category"/>
-        <t t-if="category.open">
+        <t t-if="category.is_open">
             <DiscussSidebarChannel t-foreach="filteredThreads(category.threads)" t-as="thread" t-key="thread.localId" thread="thread"/>
         </t>
         <DiscussSidebarChannel t-elif="store.discuss.thread?.in(category.threads)" thread="store.discuss.thread"/>
@@ -35,25 +35,23 @@
             <button class="o-mail-DiscussSidebarCategory-toggler btn btn-link text-reset flex-grow-1 d-flex p-0 text-start" t-att-class="{ 'align-items-baseline o-gap-0_5': !store.discuss.isSidebarCompact, 'align-items-center justify-content-center border-0 o-compact gap-1': store.discuss.isSidebarCompact }" t-on-click="() => this.toggle()" name="toggler">
                 <t t-if="store.discuss.isSidebarCompact">
                     <i class="o-mail-DiscussSidebarCategory-chevronCompact position-absolute fa-fw o-xsmaller o-mt-0_5" t-att-class="{
-                        'oi oi-chevron-down': category.open,
-                        'oi oi-chevron-right': !category.open,
+                        'oi oi-chevron-down': category.is_open,
+                        'oi oi-chevron-right': !category.is_open,
                     }"/>
                     <span class="rounded p-1"><i t-if="store.channels.status === 'fetching'" class="fa fa-fw fa-circle-o-notch fa-spin"/><i t-else="" class="fa-fw fa-lg" t-att-class="category.icon ?? 'fa fa-user'"/></span>
                 </t>
                 <t t-else="">
                     <span t-if="store.channels.status === 'fetching'" class="o-visible-short-delay"><i class="o-mail-DiscussSidebarCategory-icon o-xxsmaller fa fa-fw fa-circle-o-notch fa-spin opacity-50 o-mt-0_5"/></span>
-                    <i t-else="" class="o-mail-DiscussSidebarCategory-icon o-xsmaller fa-fw position-absolute ms-n3 align-self-center o-mt-0_5" t-att-class="category.open ? 'oi oi-chevron-down' : 'oi oi-chevron-right'"/>
+                    <i t-else="" class="o-mail-DiscussSidebarCategory-icon o-xsmaller fa-fw position-absolute ms-n3 align-self-center o-mt-0_5" t-att-class="category.is_open ? 'oi oi-chevron-down' : 'oi oi-chevron-right'"/>
                     <span class="o-mail-DiscussSidebarCategory-title text-break smaller"
-                        t-att-class="{
-                            'fs-bold': category.open,
-                        }"
+                        t-att-class="{ 'fs-bold': category.is_open }"
                     >
                         <t t-esc="category.name"/>
                     </span>
                 </t>
             </button>
             <t t-if="actions.length and !store.discuss.isSidebarCompact" t-call="mail.DiscussSidebarCategory.actions"/>
-            <div t-if="!category.open and category.threadsWithCounter.length > 0" class="o-mail-DiscussSidebar-badge shadow-sm badge rounded-pill o-discuss-badge fw-bold" t-att-class="{ 'position-absolute o-compact': store.discuss.isSidebarCompact, 'me-1': !store.discuss.isSidebarCompact }">
+            <div t-if="!category.is_open and category.threadsWithCounter.length > 0" class="o-mail-DiscussSidebar-badge shadow-sm badge rounded-pill o-discuss-badge fw-bold" t-att-class="{ 'position-absolute o-compact': store.discuss.isSidebarCompact, 'me-1': !store.discuss.isSidebarCompact }">
                 <t t-esc="category.threadsWithCounter.length"/>
             </div>
         </div>
@@ -91,7 +89,7 @@
                 <t t-else="" t-call="mail.DiscussSidebarChannel.main"/>
                 <ul t-if="subChannels.length > 0" class="o-mail-DiscussSidebarChannel-subChannelList list-unstyled position-relative flex-grow-1 my-0 d-flex flex-column">
                     <t t-foreach="subChannels" t-as="sub" t-key="sub.localId">
-                        <DiscussSidebarSubchannel t-if="showThread(sub)" thread="sub" isFirst="sub_first or !thread.discussAppCategory.open"/>
+                        <DiscussSidebarSubchannel t-if="showThread(sub)" thread="sub" isFirst="sub_first or !thread.discussAppCategory.is_open"/>
                     </t>
                 </ul>
             </t>

--- a/addons/mail/static/tests/mail_test_helpers.js
+++ b/addons/mail/static/tests/mail_test_helpers.js
@@ -79,6 +79,7 @@ import { ResUsersSettingsVolumes } from "./mock_server/mock_models/res_users_set
 import { Network } from "@mail/discuss/call/common/rtc_service";
 import { UPDATE_EVENT } from "@mail/discuss/call/common/peer_to_peer";
 import { SoundEffects } from "@mail/core/common/sound_effects_service";
+import { DISCUSS_SIDEBAR_CATEGORY_FOLDED_LS } from "@mail/discuss/core/public_web/discuss_app_category_model";
 
 export * from "./mail_test_helpers_contains";
 
@@ -767,6 +768,18 @@ function convertChatHubParam(param) {
 
 export function setupChatHub({ opened = [], folded = [] } = {}) {
     browser.localStorage.setItem(CHAT_HUB_KEY, toChatHubData(opened, folded));
+}
+
+export function setDiscussSidebarCategoryFoldState(categoryId, val) {
+    if (val) {
+        localStorage.setItem(`${DISCUSS_SIDEBAR_CATEGORY_FOLDED_LS}${categoryId}`, val);
+    } else {
+        localStorage.removeItem(`${DISCUSS_SIDEBAR_CATEGORY_FOLDED_LS}${categoryId}`);
+    }
+}
+
+export function isDiscussSidebarCategoryFolded(categoryId) {
+    return localStorage.getItem(`${DISCUSS_SIDEBAR_CATEGORY_FOLDED_LS}${categoryId}`) === "true";
 }
 
 export function assertChatHub({ opened = [], folded = [] }) {

--- a/addons/mail/static/tests/mock_server/mock_models/res_users_settings.js
+++ b/addons/mail/static/tests/mock_server/mock_models/res_users_settings.js
@@ -1,4 +1,4 @@
-import { fields, getKwArgs, webModels } from "@web/../tests/web_test_helpers";
+import { getKwArgs, webModels } from "@web/../tests/web_test_helpers";
 import { ensureArray } from "@web/core/utils/arrays";
 import { patch } from "@web/core/utils/patch";
 
@@ -8,9 +8,6 @@ import { patch } from "@web/core/utils/patch";
  */
 
 export class ResUsersSettings extends webModels.ResUsersSettings {
-    is_discuss_sidebar_category_channel_open = fields.Generic({ default: true });
-    is_discuss_sidebar_category_chat_open = fields.Generic({ default: true });
-
     /**
      * @param {number} guest_id
      * @param {number} partner_id

--- a/addons/mail/tests/test_res_users.py
+++ b/addons/mail/tests/test_res_users.py
@@ -247,8 +247,7 @@ class TestUserSettings(MailCommon):
     @users('employee')
     def test_set_res_users_settings_should_send_notification_on_bus(self):
         settings = self.user_employee.res_users_settings_id
-        settings.is_discuss_sidebar_category_chat_open = False
-        settings.is_discuss_sidebar_category_channel_open = False
+        settings.channel_notifications = False
 
         with self.assertBus(
                 [(self.cr.dbname, 'res.partner', self.partner_employee.id)],
@@ -256,17 +255,17 @@ class TestUserSettings(MailCommon):
                     'type': 'res.users.settings',
                     'payload': {
                         'id': settings.id,
-                        'is_discuss_sidebar_category_chat_open': True,
+                        'channel_notifications': "no_notif",
                     },
                 }]):
-            settings.set_res_users_settings({'is_discuss_sidebar_category_chat_open': True})
+            settings.set_res_users_settings({'channel_notifications': "no_notif"})
 
     @users('employee')
     def test_set_res_users_settings_should_set_settings_properly(self):
         settings = self.user_employee.res_users_settings_id
-        settings.set_res_users_settings({'is_discuss_sidebar_category_chat_open': True})
+        settings.set_res_users_settings({'channel_notifications': "no_notif"})
         self.assertEqual(
-            settings.is_discuss_sidebar_category_chat_open,
-            True,
-            "category state should be updated correctly"
+            settings.channel_notifications,
+            "no_notif",
+            "channel_notifications state should be updated correctly"
         )

--- a/addons/mail/views/res_users_settings_views.xml
+++ b/addons/mail/views/res_users_settings_views.xml
@@ -24,10 +24,6 @@
                         <h1><field name="user_id" readonly="id != False"/></h1>
                     </div>
                     <group name="discuss_user_settings">
-                        <group string="Discuss sidebar">
-                            <field name="is_discuss_sidebar_category_channel_open"/>
-                            <field name="is_discuss_sidebar_category_chat_open"/>
-                        </group>
                         <group string="Voice">
                             <field name="use_push_to_talk"/>
                             <field name="push_to_talk_key" placeholder="e.g. true.true..f" invisible="not use_push_to_talk"/>

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -448,8 +448,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "settings": {
                     "channel_notifications": False,
                     "id": self.env["res.users.settings"]._find_or_create_for_user(self.users[0]).id,
-                    "is_discuss_sidebar_category_channel_open": True,
-                    "is_discuss_sidebar_category_chat_open": True,
                     "livechat_expertise_ids": [],
                     "livechat_lang_ids": [],
                     "livechat_username": False,


### PR DESCRIPTION
Before this commit, discuss sidebar categories had their state saved on the server.

Saving on server is not that useful and causes more harm than benefits:

- more LOCs than a local storage solution
- race condition on state coming late due to network

This commit improves UI/UX by saving the category fold state in local storage.

Part of Task-5003012
