### PR TITLE
[FIX] mass_mailing: Limit name field to it's container

### DIFF
--- a/addons/mass_mailing/views/mailing_list_views.xml
+++ b/addons/mass_mailing/views/mailing_list_views.xml
@@ -155,7 +155,7 @@
                         <!-- Card when the Kanban view is not grouped -->
                         <div class="o_mailing_list_kanban_ungrouped d-flex gap-1 flex-row justify-content-between align-items-center flex-wrap">
                             <div class="col-lg-3 col-sm-6 col-12 py-0 my-auto">
-                                <span class="d-inline-block text-truncate fs-2 fw-normal lh-sm" t-att-title="record.name.value">
+                                <span class="d-inline-block w-100 text-truncate fs-2 fw-normal lh-sm" t-att-title="record.name.value">
                                     <field name="name"/>
                                 </span>
                             </div>


### PR DESCRIPTION
Issue:
When you create a long name for your maling list, the name overflows over the other fields in the view.

Repro:
Go to marketing -> mailing lists -> create a fairly long name -> notice name overflows in the view.

Cause:
Small bootstrap issue, name field not limited to it's container.

Fix:
Added a simple w-100 to limit the field to 100% of it's container.

opw-5153270

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
