### PR TITLE
[FIX] web: load set polyfill when indedex_db is used

### DIFF
--- a/addons/web/__manifest__.py
+++ b/addons/web/__manifest__.py
@@ -369,6 +369,7 @@ This module provides the core of the Odoo Web Client.
             'web/static/src/env.js',
             'web/static/src/session.js',
             'web/static/src/core/utils/transitions.scss',
+            'web/static/src/polyfills/set.js',  # polyfill for addons/web/static/src/core/utils/indexed_db.js
             'web/static/src/core/**/*',
             ('remove', 'web/static/src/core/emoji_picker/emoji_data.js'), # always lazy-loaded
         ],


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Old browsers crashing for Odoo 19.0 after logging into backend
```
TypeError: this._tables.difference is not a function\n    at request.onsuccess (http://.../web/assets/d7f7d1b/web.assets_web.min.js:4763:464)
```


Current behavior before PR:
Polyfill for Set difference() is only loaded in web.assets_frontend_minimal and not loaded after login since 2d56c0930f824ae9a8fd33c376e1dd9f34900ffa


Desired behavior after PR is merged:
Polyfill for Set difference() is also loaded in backend and the User can use Odoo.

References:
https://www.odoo.com/de_DE/forum/hilfe-1/error-code-new-to-odoo-278378
https://www.odoo.com/de_DE/forum/hilfe-1/there-is-an-error-please-solve-this-error-282526

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

Info @wt-io-it
