### PR TITLE
[IMP] mail: adapt test to use discuss.channel model

### DIFF
--- a/addons/mail/static/tests/core/common/store_service.test.js
+++ b/addons/mail/static/tests/core/common/store_service.test.js
@@ -78,4 +78,8 @@ test("store.insert different PY model having same JS model", async () => {
     expect(Boolean(store["mail.thread"].get({ id: 1, model: "discuss.channel" }))).toBe(true);
     expect(Boolean(store["mail.thread"].get({ id: 2, model: "discuss.channel" }))).toBe(true);
     expect(Boolean(store["mail.thread"].get({ id: 3, model: "discuss.channel" }))).toBe(true);
+    expect(store["discuss.channel"].records).toHaveLength(3); // 3 channels
+    expect(Boolean(store["discuss.channel"].get(1))).toBe(true);
+    expect(Boolean(store["discuss.channel"].get(2))).toBe(true);
+    expect(Boolean(store["discuss.channel"].get(3))).toBe(true);
 });


### PR DESCRIPTION
This commit updates the test for inserting the PY model to take the discuss.channel model into account.
