### PR TITLE
[FIX] point_of_sale: Declare property values on product category

### DIFF
--- a/addons/point_of_sale/data/point_of_sale_data.xml
+++ b/addons/point_of_sale/data/point_of_sale_data.xml
@@ -21,6 +21,8 @@
         <record id="product_category_pos" model="product.category">
             <field name="parent_id" ref="product.product_category_1"/>
             <field name="name">PoS</field>
+            <field name="property_stock_valuation_account_id" eval="False"/>
+            <field name="property_valuation">manual_periodic</field>
         </record>
 
         <record id="product_product_tip" model="product.product">


### PR DESCRIPTION
The definition of `product_category_pos` relies on the default values for the fields `property_stock_valuation_account_id` and `property_valuation`. If these defaults are not properly configurated, it can throw a [validation error](https://github.com/odoo/odoo/blob/18.0/addons/stock_account/models/product.py#L997-L1009).

This happens sometimes during upgrades, where the combination of default values stops the creation of new product categories and that breaks the upgrade. To fix that, we can be specific about the value of those fields.