### PR TITLE
[FIX] uom: Cap the value of uom.sequence to prevent out of range

### DIFF
--- a/addons/uom/models/uom_uom.py
+++ b/addons/uom/models/uom_uom.py
@@ -57,7 +57,7 @@ class UomUom(models.Model):
                 # Only set a default sequence before the record creation, or on module update if
                 # there is no value.
                 continue
-            uom.sequence = int(uom.relative_factor * 100.0)
+            uom.sequence = min(int(uom.relative_factor * 100.0), 1000)
 
     def _compute_rounding(self):
         """ All Units of Measure share the same rounding precision defined in 'Product Unit'.


### PR DESCRIPTION
The default value of uom.sequence is calculated as uom.relative_factor * 100. If the value of relative_factor is big enough, it can be bigger than what the int column can handle and trigger
```
ERROR: integer out of range
```
So we just cap it at an arbitrary value.

To reproduce:
- Create an uom with relative factor bigger than 2147483647.