### PR TITLE
[FIX] project,sale_timesheet: project ratings visibility

### DIFF
--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -178,6 +178,7 @@ class ProjectProject(models.Model):
     can_mark_milestone_as_done = fields.Boolean(compute='_compute_next_milestone_id', groups="project.group_project_milestone", export_string_translation=False)
     is_milestone_deadline_exceeded = fields.Boolean(compute='_compute_next_milestone_id', groups="project.group_project_milestone", export_string_translation=False)
     is_template = fields.Boolean(copy=False, export_string_translation=False)
+    show_ratings = fields.Boolean(compute='_compute_show_ratings', export_string_translation=False)
 
     _project_date_greater = models.Constraint(
         'check(date >= date_start)',
@@ -388,6 +389,18 @@ class ProjectProject(models.Model):
         )
         for project in self:
             project.update_count = update_count_per_project.get(project, 0)
+
+    @api.depends('type_ids.rating_active')
+    def _compute_show_ratings(self):
+        projects_with_rating_active = self.env['project.task.type'].search_fetch(
+            domain=[
+                ('project_ids', 'in', self.ids),
+                ('rating_active', '=', True),
+            ],
+            field_names=['project_ids'],
+        ).project_ids
+        for project in self:
+            project.show_ratings = project in projects_with_rating_active
 
     def _inverse_allow_task_dependencies(self):
         """ Reset state for waiting tasks in the project if the feature is disabled
@@ -1085,6 +1098,7 @@ class ProjectProject(models.Model):
                 'number': f'{int(self.rating_avg) if self.rating_avg.is_integer() else round(self.rating_avg, 1)} / 5',
                 'action_type': 'object',
                 'action': 'action_view_all_rating',
+                'show': self.show_ratings,
                 'sequence': 15,
             })
         if self.env.user.has_group('project.group_project_user'):

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -362,6 +362,7 @@
                 >
                     <field name="allow_milestones"/>
                     <field name="rating_count" />
+                    <field name="show_ratings"/>
                     <field name="privacy_visibility"/>
                     <field name="last_update_color"/>
                     <field name="is_milestone_deadline_exceeded"/>
@@ -432,7 +433,7 @@
                                     <div t-if="record.alias_email.value" class="text-muted text-truncate" t-att-title="record.alias_email.value">
                                         <span class="fa fa-envelope-o me-2" aria-label="Domain Alias" title="Domain Alias"></span><field name="alias_email"/>
                                     </div>
-                                    <div t-if="record.rating_count.raw_value &gt; 0" class="d-flex text-muted">
+                                    <div t-if="record.show_ratings.raw_value and record.rating_count.raw_value &gt; 0" class="d-flex text-muted">
                                         <b class="me-1">
                                             <span class="fa mt4 fa-smile-o fw-bolder text-success" t-if="record.rating_avg.raw_value &gt;= 3.66" title="Average Rating: Happy" role="img" aria-label="Happy face"/>
                                             <span class="fa mt4 fa-meh-o fw-bolder text-warning" t-elif="record.rating_avg.raw_value &gt;= 2.33" title="Average Rating: Neutral" role="img" aria-label="Neutral face"/>

--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -124,7 +124,7 @@
                 <field name="pricing_type" invisible="1"/>
             </xpath>
             <xpath expr="//div[hasclass('o_kanban_manage_reporting')]" position="inside">
-                <div role="menuitem" groups="project.group_project_manager">
+                <div role="menuitem" t-if="record.show_ratings.raw_value" groups="project.group_project_manager">
                    <a name="action_view_all_rating" type="object">
                     Customer Ratings
                     </a>


### PR DESCRIPTION
After this commit, we only show the project ratings if the project uses at least one stage that allows rating.
Reason: as we removed the 'rating_active' field from 'project.project' (v19), we have to rely on task stages to determine if the project should show ratings.

task-5172594

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
