### PR TITLE
[FIX] html_editor: scope list item selector to editor headers only

### DIFF
--- a/addons/html_editor/static/src/main/list/list.scss
+++ b/addons/html_editor/static/src/main/list/list.scss
@@ -1,9 +1,12 @@
-li p {
-    margin-bottom: 0px;
-}
+[contenteditable="true"] {
+    li p {
+        margin-bottom: 0;
+    }
 
-li * {
-    color: inherit;
+    // Invalidate `--heading-color` when under colored element in editable
+    :where([style*="color:"]) {
+        --heading-color: none;
+    }
 }
 
 // Checklist


### PR DESCRIPTION
Problem:
The CSS selector `li *` was applied globally, affecting all list content on pages where the editor is loaded — including frontend content outside the editor.

Cause:
The selector was not scoped to the editor context, so its styling leaked into non-editor elements.

Solution:
Restrict the `li *` selector to apply only within headers inside the editor to prevent unwanted global styling.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
