### PR TITLE
[FIX] l10n_es_edi_tbai: regime_key 08 for Canarias

### DIFF
--- a/addons/l10n_es_edi_tbai/models/l10n_es_edi_tbai_document.py
+++ b/addons/l10n_es_edi_tbai/models/l10n_es_edi_tbai_document.py
@@ -439,6 +439,10 @@ class L10n_Es_Edi_TbaiDocument(models.Model):
             **self._get_regime_code_value(values['taxes'], values['is_simplified']),
             **self._get_refunded_values(values),
         }
+        # Regime key override for Canarias/Ceuta/Melilla and no_sujeto_loc
+        if values['partner'] and values['partner'].country_id.code == 'ES' and values['partner'].state_id.code in ('TF', 'GC', 'CE', 'ME'):
+            if any(t.l10n_es_type == 'no_sujeto_loc' for t in values['taxes']):
+                sale_values.update({'regime_key': ['08']})
 
         if not values['partner'] or not values['partner']._l10n_es_is_foreign() or values["is_simplified"]:
             sale_values.update(**self._get_importe_desglose_es_partner(values['base_lines'], values['is_refund']))


### PR DESCRIPTION
We check that if the partner is from Canary Islands and we put a no sujeto por reglas de localizacion
tax (so for services) we put the 08 key.

opw-5099749

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
