### PR TITLE
[IMP] mail: remove console errors from sound effect HOOT url failing

### DIFF
--- a/addons/mail/static/src/core/common/sound_effects_service.js
+++ b/addons/mail/static/src/core/common/sound_effects_service.js
@@ -47,7 +47,7 @@ export class SoundEffects {
         if (!soundEffect.audio) {
             const audio = new browser.Audio();
             const ext = audio.canPlayType("audio/ogg; codecs=vorbis") ? ".ogg" : ".mp3";
-            audio.src = url(soundEffect.path + ext);
+            this._setAudioSrc(audio, url(soundEffect.path + ext));
             soundEffect.audio = audio;
         }
         if (!soundEffect.audio.paused) {
@@ -57,6 +57,10 @@ export class SoundEffects {
         soundEffect.audio.loop = loop;
         soundEffect.audio.volume = volume ?? soundEffect.defaultVolume ?? 1;
         Promise.resolve(soundEffect.audio.play()).catch(() => {});
+    }
+    /** To be patched in tests to use data-src */
+    _setAudioSrc(audio, srcPath) {
+        audio.src = srcPath;
     }
     /**
      * Resets the audio to the start of the track and pauses it.

--- a/addons/mail/static/tests/mail_test_helpers.js
+++ b/addons/mail/static/tests/mail_test_helpers.js
@@ -78,6 +78,7 @@ import { ResUsersSettings } from "./mock_server/mock_models/res_users_settings";
 import { ResUsersSettingsVolumes } from "./mock_server/mock_models/res_users_settings_volumes";
 import { Network } from "@mail/discuss/call/common/rtc_service";
 import { UPDATE_EVENT } from "@mail/discuss/call/common/peer_to_peer";
+import { SoundEffects } from "@mail/core/common/sound_effects_service";
 
 export * from "./mail_test_helpers_contains";
 
@@ -358,6 +359,11 @@ export async function start(options) {
         env = getMockEnv() || (await makeMockEnv({}));
     }
     env.testEnv = true;
+    patchWithCleanup(SoundEffects.prototype, {
+        _setAudioSrc(audio, srcPath) {
+            audio["data-src"] = srcPath;
+        },
+    });
     await mountWithCleanup(WebClient, { env, target });
     await loadEmoji();
     return Object.assign(env, { ...options?.env, target });


### PR DESCRIPTION
Sound effects are played a lot in discuss tests, especially in discuss call tests, and each of them show an error in HOOT dev tools. While this doesn't reach server src for actual audio as the src is replaced by fake HOOT urlPath, this still displays an error in dev tools because this still attempts to make a network call.

This commit reduces significantly the noise in dev tool logs of HOOT discuss tests by silenting the sound effect play errors, by patching `audio.src` to `audio['data-src']` so that this doesn't trigger the implicit fetch of `audio.src`. Replacing `src` by `data-src` is already a technique used to get similar results in all OWL templates in HOOT.