### PR TITLE
[IMP] html_builder, website: allow media resize via slider

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_number_input.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_number_input.js
@@ -1,5 +1,6 @@
 import { convertNumericToUnit, getHtmlStyle } from "@html_editor/utils/formatting";
-import { Component } from "@odoo/owl";
+import { Component, useState } from "@odoo/owl";
+import { effect } from "@web/core/utils/reactive";
 import {
     basicContainerBuilderComponentProps,
     useInputBuilderComponent,
@@ -49,8 +50,14 @@ export class BuilderNumberInput extends Component {
         });
         this.commit = commit;
         this.preview = preview;
-        this.state = state;
-
+        this.domState = state;
+        this.state = useState({});
+        effect(
+            ({ value }) => {
+                this.state.showUnit = value?.length > 0;
+            },
+            [state]
+        );
         this.inputRef = useChildRef();
         this.debouncedCommitValue = useInputDebouncedCommit(this.inputRef);
     }
@@ -159,7 +166,24 @@ export class BuilderNumberInput extends Component {
     }
 
     get displayValue() {
-        return this.formatRawValue(this.state.value);
+        return this.formatRawValue(this.domState.value);
+    }
+
+    updateUnitVisibility(value) {
+        if (value === "") {
+            this.state.showUnit = false;
+        } else {
+            const numericValue = Number(value);
+            this.state.showUnit = !Number.isNaN(numericValue);
+        }
+    }
+
+    onChange(e) {
+        this.updateUnitVisibility(e.target.value);
+    }
+
+    onInput(e) {
+        this.updateUnitVisibility(e.target.value);
     }
 
     onKeydown(e) {

--- a/addons/html_builder/static/src/core/building_blocks/builder_number_input.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_number_input.xml
@@ -12,8 +12,10 @@
             commit="commit"
             preview="preview"
             onKeydown.bind="onKeydown"
+            onInput.bind="onInput"
+            onChange.bind="onChange"
             >
-            <span class="o-hb-input-field-unit" t-out="props.unit"/>
+            <span class="o-hb-input-field-unit" t-out="props.unit" t-if="!props.placeholder or state.showUnit"/>
         </BuilderTextInputBase>
     </BuilderComponent>
 </t>

--- a/addons/html_builder/static/src/core/building_blocks/builder_text_input_base.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_text_input_base.js
@@ -25,6 +25,8 @@ export class BuilderTextInputBase extends Component {
         commit: { type: Function },
         preview: { type: Function },
         onFocus: { type: Function, optional: true },
+        onInput: { type: Function, optional: true },
+        onChange: { type: Function, optional: true },
         onKeydown: { type: Function, optional: true },
         value: { type: [String, { value: null }], optional: true },
     };
@@ -45,11 +47,13 @@ export class BuilderTextInputBase extends Component {
         this.isEditing = false;
         const normalizedDisplayValue = this.props.commit(ev.target.value);
         ev.target.value = normalizedDisplayValue;
+        this.props.onChange?.(ev);
     }
 
     onInput(ev) {
         this.isEditing = true;
         this.props.preview(ev.target.value);
+        this.props.onInput?.(ev);
     }
 
     onFocus(ev) {

--- a/addons/html_builder/static/src/plugins/image/image_tool_option.js
+++ b/addons/html_builder/static/src/plugins/image/image_tool_option.js
@@ -3,6 +3,7 @@ import { ImageShapeOption } from "@html_builder/plugins/image/image_shape_option
 import { ImageFilterOption } from "@html_builder/plugins/image/image_filter_option";
 import { ImageFormatOption } from "@html_builder/plugins/image/image_format_option";
 import { ImageTransformOption } from "./image_transform_option";
+import { MediaSizeOption } from "./media_size_option";
 
 export class ImageToolOption extends BaseOptionComponent {
     static template = "html_builder.ImageToolOption";
@@ -11,6 +12,7 @@ export class ImageToolOption extends BaseOptionComponent {
         ImageFilterOption,
         ImageFormatOption,
         ImageTransformOption,
+        MediaSizeOption,
     };
     static selector = "img";
     static exclude = "[data-oe-type='image'] > img";

--- a/addons/html_builder/static/src/plugins/image/image_tool_option.xml
+++ b/addons/html_builder/static/src/plugins/image/image_tool_option.xml
@@ -25,16 +25,7 @@
     </BuilderRow>
     <ImageFilterOption />
     <t t-if="!state.isGridMode">
-        <BuilderRow label.translate="Size">
-            <BuilderSelect styleAction="'width'">
-                <BuilderSelectItem styleActionValue="''" title.translate="Resize Default">Default</BuilderSelectItem>
-                <BuilderSelectItem styleActionValue="'100%'" title.translate="Resize Full">100%</BuilderSelectItem>
-                <BuilderSelectItem styleActionValue="'75%'" title.translate="Resize 75%">75%</BuilderSelectItem>
-                <BuilderSelectItem styleActionValue="'50%'" title.translate="Resize Half">50%</BuilderSelectItem>
-                <BuilderSelectItem styleActionValue="'25%'" title.translate="Resize Quarter">25%</BuilderSelectItem>
-                <BuilderSelectItem styleActionValue="'10%'" title.translate="Resize 10%">10%</BuilderSelectItem>
-            </BuilderSelect>
-        </BuilderRow>
+        <MediaSizeOption/>
     </t>
     <ImageFormatOption />
 </t>

--- a/addons/html_builder/static/src/plugins/image/image_tool_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/image_tool_option_plugin.js
@@ -2,6 +2,7 @@ import { cropperDataFieldsWithAspectRatio, loadImage } from "@html_editor/utils/
 import { registry } from "@web/core/registry";
 import { Plugin } from "@html_editor/plugin";
 import { ImageToolOption } from "./image_tool_option";
+import { VideoSizeOption } from "./video_size_option";
 import { isImageCorsProtected } from "@html_editor/utils/image";
 import { withSequence } from "@html_editor/utils/resource";
 import {
@@ -41,6 +42,7 @@ class ImageToolOptionPlugin extends Plugin {
             withSequence(REPLACE_MEDIA, ReplaceMediaOption),
             withSequence(IMAGE_TOOL, ImageToolOption),
             withSequence(ALIGNMENT_STYLE_PADDING, ImageAndFaOption),
+            withSequence(IMAGE_TOOL, VideoSizeOption),
         ],
         builder_actions: {
             CropImageAction,

--- a/addons/html_builder/static/src/plugins/image/media_size_option.js
+++ b/addons/html_builder/static/src/plugins/image/media_size_option.js
@@ -1,0 +1,5 @@
+import { BaseOptionComponent } from "@html_builder/core/utils";
+
+export class MediaSizeOption extends BaseOptionComponent {
+    static template = "html_builder.MediaSizeOption";
+}

--- a/addons/html_builder/static/src/plugins/image/media_size_option.xml
+++ b/addons/html_builder/static/src/plugins/image/media_size_option.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+<t t-name="html_builder.MediaSizeOption">
+    <BuilderRow label.translate="Size">
+        <div style="width: 45%;">
+            <BuilderRange
+                action="'mediaSizeSlider'"
+                min="5"
+                max="100"
+                step="1"
+                unit="'%'"
+            />
+        </div>
+        <div style="width: 40%;">
+            <BuilderNumberInput
+                action="'mediaSizeText'"
+                placeholder.translate="auto"
+                default="null"
+                unit="'%'"
+                min="5"
+                max="100"
+            />
+        </div>
+        <BuilderButton
+            title.translate="Auto"
+            action="'setMediaSizeAuto'">
+            <i class="fa fa-fw fa-expand" />
+        </BuilderButton>
+    </BuilderRow>
+</t>
+
+</templates>

--- a/addons/html_builder/static/src/plugins/image/media_size_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/media_size_option_plugin.js
@@ -1,0 +1,80 @@
+import { BuilderAction } from "@html_builder/core/builder_action";
+import { Plugin } from "@html_editor/plugin";
+import { registry } from "@web/core/registry";
+
+class MediaSizeOptionPlugin extends Plugin {
+    static id = "MediaSizeOptionPlugin";
+    resources = {
+        builder_actions: {
+            MediaSizeSliderAction,
+            MediaSizeTextAction,
+            SetMediaSizeAutoAction,
+        },
+    };
+}
+
+function setWidth(getAction, editingElement, value) {
+    getAction("styleAction").apply({
+        editingElement,
+        params: {
+            mainParam: "width",
+        },
+        value: value,
+    });
+}
+
+export class MediaSizeSliderAction extends BuilderAction {
+    static id = "mediaSizeSlider";
+    static dependencies = ["builderActions"];
+    getValue({ editingElement }) {
+        // If width is not set or set to "auto", we arbitrarily set the slider
+        // to 99%. 99% seems preferable to 100% because it allows the user to
+        // set 100% by acting on the slider. If "auto" was set as 100% instead
+        // of 99%, if the user dragged the slider towards the right, the preview
+        // mechanism would prevent 100% from being set, and the setting would
+        // stay at "auto".
+        const width = editingElement.style.width;
+        if (width === "auto" || width === "") {
+            return "99%";
+        }
+        return width;
+    }
+    apply({ editingElement, value }) {
+        setWidth(this.dependencies.builderActions.getAction, editingElement, value);
+    }
+}
+
+export class MediaSizeTextAction extends BuilderAction {
+    static id = "mediaSizeText";
+    static dependencies = ["builderActions"];
+    getValue({ editingElement }) {
+        // If width is set to "auto", we return an empty string to display the
+        // BuilderNumberInput placeholder text.
+        const width = editingElement.style.width;
+        return width === "auto" ? "" : width;
+    }
+    apply({ editingElement, value }) {
+        if (!value || value === "") {
+            setWidth(this.dependencies.builderActions.getAction, editingElement, "auto");
+            return;
+        }
+        setWidth(this.dependencies.builderActions.getAction, editingElement, value);
+    }
+}
+
+export class SetMediaSizeAutoAction extends BuilderAction {
+    static id = "setMediaSizeAuto";
+    static dependencies = ["builderActions"];
+    isApplied({ editingElement }) {
+        // The "Auto" button is active when width is auto or not set
+        return editingElement.style.width === "auto" || editingElement.style.width === "";
+    }
+    apply({ editingElement }) {
+        setWidth(this.dependencies.builderActions.getAction, editingElement, "auto");
+    }
+    clean({ editingElement }) {
+        setWidth(this.dependencies.builderActions.getAction, editingElement, "100%");
+    }
+}
+
+registry.category("builder-plugins").add(MediaSizeOptionPlugin.id, MediaSizeOptionPlugin);

--- a/addons/html_builder/static/src/plugins/image/video_size_option.js
+++ b/addons/html_builder/static/src/plugins/image/video_size_option.js
@@ -1,0 +1,15 @@
+import { BaseOptionComponent, useDomState } from "@html_builder/core/utils";
+import { MediaSizeOption } from "./media_size_option";
+
+export class VideoSizeOption extends BaseOptionComponent {
+    static template = "html_builder.VideoSizeOption";
+    static components = { MediaSizeOption };
+    static selector = ".media_iframe_video";
+    static name = "videoSizeOption";
+    setup() {
+        super.setup();
+        this.state = useDomState((editingElement) => ({
+            isGridMode: editingElement.closest(".o_grid_mode, .o_grid"),
+        }));
+    }
+}

--- a/addons/html_builder/static/src/plugins/image/video_size_option.xml
+++ b/addons/html_builder/static/src/plugins/image/video_size_option.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+<t t-name="html_builder.VideoSizeOption">
+    <MediaSizeOption t-if="!state.isGridMode"/>
+</t>
+
+</templates>

--- a/addons/mass_mailing/static/src/builder/options/image_tool_option.xml
+++ b/addons/mass_mailing/static/src/builder/options/image_tool_option.xml
@@ -16,7 +16,7 @@
             <attribute name="withAnimatedShapes">false</attribute>
         </xpath>
         <xpath expr="//ImageTransformOption" position="replace"/>
-        <xpath expr="//BuilderRow[@label.translate=&quot;Size&quot;]" position="attributes">
+        <xpath expr="//MediaSizeOption" position="attributes">
             <attribute name="t-if">massMailingState.isImgFluid</attribute>
         </xpath>
     </t>

--- a/addons/website/static/src/builder/plugins/image/image_tool_option.xml
+++ b/addons/website/static/src/builder/plugins/image/image_tool_option.xml
@@ -1,7 +1,7 @@
 <templates>
     <t t-inherit="html_builder.ImageToolOption" t-inherit-mode="extension">
         <!-- Hide the image "Size" option when card cover width control is available -->
-        <xpath expr="//BuilderRow[@label.translate='Size']" position="attributes">
+        <xpath expr="//MediaSizeOption" position="attributes">
             <attribute name="t-if">!this.env.getEditingElement().closest('.o_card_img_wrapper')</attribute>
         </xpath>
     </t>

--- a/addons/website/static/tests/builder/image_size.test.js
+++ b/addons/website/static/tests/builder/image_size.test.js
@@ -1,5 +1,5 @@
 import { expect, test } from "@odoo/hoot";
-import { waitFor } from "@odoo/hoot-dom";
+import { animationFrame, clear, edit, press, waitFor } from "@odoo/hoot-dom";
 import { contains } from "@web/../tests/web_test_helpers";
 import { defineWebsiteModels, setupWebsiteBuilder } from "./website_helpers";
 import { testImg, testImgSrc, testGifImg, testGifImgSrc } from "./image_test_helpers";
@@ -59,4 +59,213 @@ test("the GIF background image should NOT show its size", async () => {
     await contains(":iframe .test-options-target section").click();
     await waitSidebarUpdated();
     expect(`[data-label="Image"] [title="Size"]`).toHaveCount(0);
+});
+
+test("images can be resized by slider, text input and button", async () => {
+    const { waitSidebarUpdated } = await setupWebsiteBuilder(`
+        <div class="test-options-target">
+            ${testImg}
+        </div>
+    `);
+    await contains(":iframe .test-options-target img").click();
+    await waitSidebarUpdated();
+    expect(".options-container [data-action-id='mediaSizeSlider'] input").toHaveValue(99);
+    expect(".options-container [data-action-id='mediaSizeText'] input").toHaveValue("");
+    expect(
+        ".options-container [data-action-id='mediaSizeText'] .o-hb-input-field-unit"
+    ).toHaveCount(0);
+    expect(".options-container button[data-action-id='setMediaSizeAuto']").toHaveClass("active");
+
+    await contains(".options-container [data-action-id='mediaSizeText'] input").click();
+    await edit("3");
+    await animationFrame();
+    //min width is clipped to 5%
+    expect(":iframe .test-options-target img").toHaveStyle(
+        { width: "5% !important" },
+        { inline: true }
+    );
+
+    await contains(".options-container [data-action-id='mediaSizeText'] input").click();
+    await edit("110");
+    await animationFrame();
+    //max width is clipped to 100%
+    expect(":iframe .test-options-target img").toHaveStyle(
+        { width: "100% !important" },
+        { inline: true }
+    );
+
+    await contains(":iframe .test-options-target img").click();
+    await waitSidebarUpdated();
+    await contains(".options-container [data-action-id='mediaSizeText'] input").click();
+    await edit("50");
+    await press("Enter");
+    await animationFrame();
+    expect(":iframe .test-options-target img").toHaveStyle(
+        { width: "50% !important" },
+        { inline: true }
+    );
+
+    await contains(":iframe .test-options-target img").click();
+    await waitSidebarUpdated();
+    await contains(".options-container button[data-action-id='setMediaSizeAuto']").click();
+    await animationFrame();
+    expect(":iframe .test-options-target img").toHaveStyle(
+        { width: "auto !important" },
+        { inline: true }
+    );
+    expect(".options-container [data-action-id='mediaSizeText'] input").toHaveValue("");
+    expect(
+        ".options-container [data-action-id='mediaSizeText'] .o-hb-input-field-unit"
+    ).toHaveCount(0);
+    expect(".options-container button[data-action-id='setMediaSizeAuto']").toHaveClass("active");
+
+    await contains(":iframe .test-options-target img").click();
+    await waitSidebarUpdated();
+    await contains(".options-container [data-action-id='mediaSizeSlider'] input").click();
+    await edit("65");
+    await waitSidebarUpdated();
+    expect(":iframe .test-options-target img").toHaveStyle(
+        { width: "65% !important" },
+        { inline: true }
+    );
+    expect(".options-container [data-action-id='mediaSizeText'] input").toHaveValue("65");
+    expect(
+        ".options-container [data-action-id='mediaSizeText'] .o-hb-input-field-unit"
+    ).toHaveCount(1);
+    expect(".options-container button[data-action-id='setMediaSizeAuto']").not.toHaveClass(
+        "active"
+    );
+
+    await contains(":iframe .test-options-target img").click();
+    await waitSidebarUpdated();
+    await contains(".options-container [data-action-id='mediaSizeText'] input").click();
+    await clear();
+    await press("Enter");
+    await waitSidebarUpdated();
+    expect(":iframe .test-options-target img").toHaveStyle(
+        { width: "auto !important" },
+        { inline: true }
+    );
+    expect(".options-container [data-action-id='mediaSizeText'] input").toHaveValue("");
+    expect(
+        ".options-container [data-action-id='mediaSizeText'] .o-hb-input-field-unit"
+    ).toHaveCount(0);
+    expect(".options-container button[data-action-id='setMediaSizeAuto']").toHaveClass("active");
+});
+
+test("videos can be resized by slider, text input and button", async () => {
+    const { waitSidebarUpdated } = await setupWebsiteBuilder(`
+        <figure class="figure">
+            <div data-oe-expression="//www.youtube.com/embed/G8b4UZIcTfg?rel=0&amp;autoplay=0" class="figure-img media_iframe_video">
+                <iframe src="//www.youtube.com/embed/G8b4UZIcTfg?rel=0&amp;autoplay=0"></iframe>
+            </div>
+        </figure>
+    `);
+    await contains(":iframe .media_iframe_video").click();
+    await waitSidebarUpdated();
+    expect(".options-container [data-action-id='mediaSizeSlider'] input").toHaveValue(99);
+    expect(".options-container [data-action-id='mediaSizeText'] input").toHaveValue("");
+    expect(
+        ".options-container [data-action-id='mediaSizeText'] .o-hb-input-field-unit"
+    ).toHaveCount(0);
+    expect(".options-container button[data-action-id='setMediaSizeAuto']").toHaveClass("active");
+
+    await contains(".options-container [data-action-id='mediaSizeText'] input").click();
+    await edit("3");
+    await animationFrame();
+    //min width is clipped to 5%
+    expect(":iframe .media_iframe_video").toHaveStyle({ width: "5% !important" }, { inline: true });
+
+    await contains(".options-container [data-action-id='mediaSizeText'] input").click();
+    await edit("110");
+    await animationFrame();
+    //max width is clipped to 100%
+    expect(":iframe .media_iframe_video").toHaveStyle(
+        { width: "100% !important" },
+        { inline: true }
+    );
+
+    await contains(":iframe .media_iframe_video").click();
+    await waitSidebarUpdated();
+    await contains(".options-container [data-action-id='mediaSizeText'] input").click();
+    await edit("50");
+    await press("Enter");
+    await animationFrame();
+    expect(":iframe .media_iframe_video").toHaveStyle(
+        { width: "50% !important" },
+        { inline: true }
+    );
+
+    await contains(":iframe .media_iframe_video").click();
+    await waitSidebarUpdated();
+    await contains(".options-container button[data-action-id='setMediaSizeAuto']").click();
+    await animationFrame();
+    expect(":iframe .media_iframe_video").toHaveStyle(
+        { width: "auto !important" },
+        { inline: true }
+    );
+    expect(".options-container [data-action-id='mediaSizeText'] input").toHaveValue("");
+    expect(
+        ".options-container [data-action-id='mediaSizeText'] .o-hb-input-field-unit"
+    ).toHaveCount(0);
+    expect(".options-container button[data-action-id='setMediaSizeAuto']").toHaveClass("active");
+
+    await contains(":iframe .media_iframe_video").click();
+    await waitSidebarUpdated();
+    await contains(".options-container [data-action-id='mediaSizeSlider'] input").click();
+    await edit("65");
+    await waitSidebarUpdated();
+    expect(":iframe .media_iframe_video").toHaveStyle(
+        { width: "65% !important" },
+        { inline: true }
+    );
+    expect(".options-container [data-action-id='mediaSizeText'] input").toHaveValue("65");
+    expect(
+        ".options-container [data-action-id='mediaSizeText'] .o-hb-input-field-unit"
+    ).toHaveCount(1);
+    expect(".options-container button[data-action-id='setMediaSizeAuto']").not.toHaveClass(
+        "active"
+    );
+
+    await contains(":iframe .media_iframe_video").click();
+    await waitSidebarUpdated();
+    await contains(".options-container [data-action-id='mediaSizeText'] input").click();
+    await clear();
+    await press("Enter");
+    await waitSidebarUpdated();
+    expect(":iframe .media_iframe_video").toHaveStyle(
+        { width: "auto !important" },
+        { inline: true }
+    );
+    expect(".options-container [data-action-id='mediaSizeText'] input").toHaveValue("");
+    expect(
+        ".options-container [data-action-id='mediaSizeText'] .o-hb-input-field-unit"
+    ).toHaveCount(0);
+    expect(".options-container button[data-action-id='setMediaSizeAuto']").toHaveClass("active");
+});
+
+test("media resize bar does not appear in grid mode", async () => {
+    const { waitSidebarUpdated } = await setupWebsiteBuilder(`
+        <div class="container">
+            <div class="row o_grid_mode" data-row-count="6">
+                <div class="image-test o_grid_item g-height-5 g-col-lg-5 col-lg-5" data-name="Block" style="z-index: 1; grid-area: 2 / 6 / 7 / 11;">
+                    <img src="/web/image/website.s_masonry_block_default_image_1" class="img img-fluid mx-auto" alt="" loading="lazy" data-mimetype="image/webp">
+                </div>
+                <div class="video-test o_grid_item g-height-5 g-col-lg-5 col-lg-5" data-name="Block" style="z-index: 1; grid-area: 2 / 1 / 7 / 6;">
+                    <div data-oe-expression="//www.youtube.com/embed/G8b4UZIcTfg?rel=0&amp;autoplay=0" class="mx-auto media_iframe_video">
+                        <div class="css_editable_mode_display"></div>
+                        <div class="media_iframe_video_size"></div>
+                        <iframe loading="lazy" frameborder="0" allowfullscreen="allowfullscreen" src="//www.youtube.com/embed/G8b4UZIcTfg?rel=0&amp;autoplay=0"></iframe>
+                    </div>
+                </div>
+            </div>
+        </div>
+    `);
+    await contains(":iframe .image-test img").click();
+    await waitSidebarUpdated();
+    expect(".options-container [data-label='Size']").toHaveCount(0);
+
+    await contains(":iframe .video-test .media_iframe_video").click();
+    await waitSidebarUpdated();
+    expect(".options-container [data-label='Size']").toHaveCount(0);
 });

--- a/addons/website/static/tests/builder/website_builder/background_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/background_option.test.js
@@ -425,6 +425,7 @@ test("change background size", async () => {
     expect(heightInput).toHaveValue("");
 
     await contains(heightInput).edit("0");
+    await animationFrame();
     expect(heightInput).toHaveValue("1", { message: "minimum value is 1" });
     expect(section).toHaveStyle("background-size: 100px 1px");
 
@@ -438,6 +439,7 @@ test("change background size", async () => {
     expect(section).toHaveStyle("background-size: auto");
 
     await contains(widthInput).edit("0");
+    await animationFrame();
     expect(widthInput).toHaveValue("1", { message: "minimum value is 1" });
     expect(section).toHaveStyle("background-size: 1px");
 });


### PR DESCRIPTION
Previously, users could resize images only by selecting from a fixed set of options, and videos were not resizable.

This commit introduces `MediaSizeOption`, which provides a more flexible way to resize both images and videos. Users can now:
- Adjust size using a slider,
- Enter a custom width percentage manually,
- Set the size to "auto" by clicking a button.

task-4600541

