### PR TITLE
[IMP] mail: use link plugin in composer

### DIFF
--- a/addons/mail/static/src/core/common/plugin/plugin_sets.js
+++ b/addons/mail/static/src/core/common/plugin/plugin_sets.js
@@ -1,29 +1,28 @@
-import { CORE_PLUGINS } from "@html_editor/plugin_sets";
-import { ToolbarPlugin } from "@html_editor/main/toolbar/toolbar_plugin";
-import { ShortCutPlugin } from "@html_editor/core/shortcut_plugin";
-import { InlineCodePlugin } from "@html_editor/main/inline_code";
-import { TabulationPlugin } from "@html_editor/main/tabulation_plugin";
-import { HintPlugin } from "@html_editor/main/hint_plugin";
-import { MailComposerPlugin } from "@mail/core/common/plugin/mail_composer_plugin";
 import { ChatGPTTranslatePlugin } from "@html_editor/main/chatgpt/chatgpt_translate_plugin";
+import { ColorPlugin } from "@html_editor/main/font/color_plugin";
+import { CORE_PLUGINS } from "@html_editor/plugin_sets";
+import { FeffPlugin } from "@html_editor/main/feff_plugin";
+import { HintPlugin } from "@html_editor/main/hint_plugin";
+import { InlineCodePlugin } from "@html_editor/main/inline_code";
+import { LinkPlugin } from "@html_editor/main/link/link_plugin";
+import { ShortCutPlugin } from "@html_editor/core/shortcut_plugin";
+import { TabulationPlugin } from "@html_editor/main/tabulation_plugin";
+import { ToolbarPlugin } from "@html_editor/main/toolbar/toolbar_plugin";
 
-export const MAIL_PLUGINS = [
+import { MailComposerPlugin } from "@mail/core/common/plugin/mail_composer_plugin";
+
+export const MAIL_CORE_PLUGINS = [
     ...CORE_PLUGINS,
     ChatGPTTranslatePlugin,
+    ColorPlugin,
+    FeffPlugin,
     HintPlugin,
     InlineCodePlugin,
+    LinkPlugin,
     MailComposerPlugin,
     ShortCutPlugin,
     TabulationPlugin,
-    ToolbarPlugin,
 ];
 
-export const MAIL_SMALL_UI_PLUGINS = [
-    ...CORE_PLUGINS,
-    ChatGPTTranslatePlugin,
-    HintPlugin,
-    InlineCodePlugin,
-    MailComposerPlugin,
-    ShortCutPlugin,
-    TabulationPlugin,
-];
+export const MAIL_PLUGINS = [...MAIL_CORE_PLUGINS, ToolbarPlugin];
+export const MAIL_SMALL_UI_PLUGINS = MAIL_CORE_PLUGINS;

--- a/addons/mail/static/tests/composer/composer.test.js
+++ b/addons/mail/static/tests/composer/composer.test.js
@@ -1640,3 +1640,26 @@ test("send a message end with a space clears the composer", async () => {
     await press("Enter");
     await contains(editor.editable, { text: "Hello", count: 0 });
 });
+
+test.tags("html composer");
+test("parse link correctly in html composer", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_type: "channel",
+        name: "General",
+    });
+    await start();
+    await openDiscuss(channelId);
+    const composerService = getService("mail.composer");
+    composerService.setHtmlComposer();
+    await focus(".o-mail-Composer-html.odoo-editor-editable");
+    const editor = {
+        document,
+        editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
+    };
+    await htmlInsertText(editor, "www.google.com");
+    await contains(editor.editable, { text: "www.google.com", count: 1 });
+    await contains(editor.editable.querySelector("a"), { text: "www.google.com", count: 0 });
+    await htmlInsertText(editor, " ");
+    await contains(editor.editable.querySelector("a"), { text: "www.google.com" });
+});


### PR DESCRIPTION
This commit enables the link plugin in the mail composer so that the link will be properly parsed and hightlighted.

This commit also improves the plugin set and clean up the duplicated plugin lists.

task-5172795
backport - https://github.com/odoo/enterprise/pull/97504

https://github.com/odoo/enterprise/pull/97666

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
