### PR TITLE
[FIX] bus: implement application level connection checks

### DIFF
--- a/addons/bus/static/tests/helpers/mock_websocket.js
+++ b/addons/bus/static/tests/helpers/mock_websocket.js
@@ -76,6 +76,10 @@ export function patchWebsocketWorkerWithCleanup(params = {}) {
         WebSocket: function () {
             return new WebSocketMock();
         },
+        // Browser can't be imported in the worker bundle, but intervals should
+        // be cleared during tests.
+        setInterval: browser.setInterval.bind(browser),
+        clearInterval: browser.clearInterval.bind(browser),
     });
     websocketWorker = websocketWorker || new WebsocketWorker();
     patchWithCleanup(websocketWorker, params);

--- a/addons/bus/static/tests/websocket_worker_tests.js
+++ b/addons/bus/static/tests/websocket_worker_tests.js
@@ -1,9 +1,10 @@
 /** @odoo-module */
 
-import { WEBSOCKET_CLOSE_CODES } from "@bus/workers/websocket_worker";
 import { patchWebsocketWorkerWithCleanup } from "@bus/../tests/helpers/mock_websocket";
+import { WEBSOCKET_CLOSE_CODES } from "@bus/workers/websocket_worker";
 
 import { nextTick, patchWithCleanup } from "@web/../tests/helpers/utils";
+import { Deferred } from "@web/core/utils/concurrency";
 
 QUnit.module("Websocket Worker");
 
@@ -91,4 +92,33 @@ QUnit.test("notification event is broadcasted", async function (assert) {
     );
 
     assert.verifySteps(["broadcast notification"]);
+});
+
+QUnit.test("check connection health during inactivity", async (assert) => {
+    let restartIntervalDef = null;
+    const worker = patchWebsocketWorkerWithCleanup({
+        _restartConnectionCheckInterval() {
+            if (restartIntervalDef) {
+                assert.step("_restartConnectionCheckInterval");
+                restartIntervalDef.resolve();
+                restartIntervalDef = null;
+            }
+        },
+    });
+    restartIntervalDef = new Deferred();
+    worker._start();
+    await restartIntervalDef;
+    assert.verifySteps(["_restartConnectionCheckInterval"]);
+    restartIntervalDef = new Deferred();
+    worker.websocket.dispatchEvent(
+        new MessageEvent("message", {
+            data: JSON.stringify([{ id: 70, message: { type: "foo" } }]),
+        })
+    );
+    await restartIntervalDef;
+    assert.verifySteps(["_restartConnectionCheckInterval"]);
+    restartIntervalDef = new Deferred();
+    worker._sendToServer({ event_name: "foo" });
+    await restartIntervalDef;
+    assert.verifySteps(["_restartConnectionCheckInterval"]);
 });

--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -880,7 +880,7 @@ class WebsocketConnectionHandler:
     # Latest version of the websocket worker. This version should be incremented
     # every time `websocket_worker.js` is modified to force the browser to fetch
     # the new worker bundle.
-    _VERSION = "17.0-1"
+    _VERSION = "17.0-2"
 
     @classmethod
     def websocket_allowed(cls, request):
@@ -1010,6 +1010,9 @@ class WebsocketConnectionHandler:
             # worker version.
             websocket.disconnect(CloseCode.CLEAN, "OUTDATED_VERSION")
         for message in websocket.get_messages():
+            if message == b'\x00':
+                # Ignore internal sentinel message used to detect dead/idle connections.
+                continue
             with WebsocketRequest(db, httprequest, websocket) as req:
                 try:
                     req.serve_websocket_message(message)


### PR DESCRIPTION
When a TCP connection is not closed cleanly, it can take minutes to detect a closed WebSocket connection. During this time, no messages are received. This can happen in slow or unstable network conditions.

Browsers do not expose WebSocket ping/pong mechanisms. To detect dead connections quickly, periodic application level messages are sent if no messages were either sent or received within a minute.

This approach ensures quicker detection compared to relying on the OS TCP timeout, which is typically set to a high value.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
