### PR TITLE
[FIX] hr_recruitment: candidate's related partner's wrong name

### DIFF
--- a/addons/hr_recruitment/models/hr_candidate.py
+++ b/addons/hr_recruitment/models/hr_candidate.py
@@ -117,7 +117,7 @@ class HrCandidate(models.Model):
                 if not candidate.partner_name:
                     raise UserError(_('You must define a Contact Name for this candidate.'))
                 candidate.partner_id = self.env['res.partner'].with_context(default_lang=self.env.lang).find_or_create(candidate.email_from)
-            if candidate.partner_name and (not candidate.partner_id.name or candidate.partner_id.name == candidate.email_from):
+            if candidate.partner_name and (not candidate.partner_id.name or candidate.partner_id.name == candidate.email_normalized):
                 candidate.partner_id.name = candidate.partner_name
             if tools.email_normalize(candidate.email_from) != tools.email_normalize(candidate.partner_id.email):
                 # change email on a partner will trigger other heavy code, so avoid to change the email when

--- a/addons/hr_recruitment/tests/test_recruitment.py
+++ b/addons/hr_recruitment/tests/test_recruitment.py
@@ -201,3 +201,14 @@ class TestRecruitment(TransactionCase):
         application2.action_archive()
         self.env.invalidate_all()
         self.assertEqual(candidate.application_count, 2, 'The applications_count should not change after archiving an application')
+
+    def test_candidate_related_partner_name(self):
+        """
+            Verify that the candidate's related partner's name is correctly set when
+            the email_from is not normalized e.g. it contains uppercase characters.
+        """
+        candidate = self.env['hr.candidate'].create({
+            'partner_name': 'Test Name',
+            'email_from': 'Test@test.com'
+        })
+        self.assertEqual(candidate.partner_id.name, 'Test Name')


### PR DESCRIPTION
Issue:
In this issue, applicant's partner's name is not set correctly, if email contains capital letter.

To reproduce:
1- Create a db with hr_recruitment installed.
2- In Recruitment app, create an application with a capital letter in email address
3- Navigate to contact's form. As you see the display name is set as the email.
4- If you do the same with a lower case email, the display name is set as the name filled in application form

Cause:

Inside `partner_id.find_or_create` the email is normalized: https://github.com/odoo/odoo/blob/88043b84f7a017dfff790deeb64510fc62698c96/addons/mail/models/res_partner.py#L89-L94 And it is used as the partner's name.
Here it is desired if the name is same as email, then we set the partner's name to candidate.partner_name:
https://github.com/odoo/odoo/blob/88043b84f7a017dfff790deeb64510fc62698c96/addons/hr_recruitment/models/hr_candidate.py#L119-L121

However, if the email_from is not normalized intially, the condition will not be taken. As a result the name will remain as email.

opw-5162490
