### PR TITLE
[IMP] mail: remove unused prop 'messageActions' from Thread component

### DIFF
--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -50,7 +50,6 @@ export class Thread extends Component {
         "scrollRef?",
         "showEmptyMessage?",
         "showJumpPresent?",
-        "messageActions?",
     ];
     static defaultProps = {
         jumpPresent: 0,
@@ -58,7 +57,6 @@ export class Thread extends Component {
         showDates: true,
         showEmptyMessage: true,
         showJumpPresent: true,
-        messageActions: true,
     };
     static template = "mail.Thread";
 

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -35,7 +35,7 @@
                         onParentMessageClick.bind="() => msg.parent_id and env.messageHighlight?.highlightMessage(msg.parent_id, props.thread)"
                         thread="props.thread"
                         isFirstMessage="msg_first"
-                        hasActions="props.messageActions and !msg.eq(props.thread.from_message_id)"
+                        hasActions="!msg.eq(props.thread.from_message_id)"
                         showDates="props.showDates"
                     />
                 </t>


### PR DESCRIPTION
This was added by https://github.com/odoo/odoo/pull/127380 In order to be used in https://github.com/odoo/enterprise/pull/41951 in same task, but was merged with no use.

So this prop has been officially useless for at least 2 years.

This commit removes it, to simplify thread props.