### PR TITLE
[FIX] base_setup: nightly documentation links test

### DIFF
--- a/addons/base_setup/tests/test_res_config_doc_links.py
+++ b/addons/base_setup/tests/test_res_config_doc_links.py
@@ -2,8 +2,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import re
+
+from odoo.release import ALPHA, url, version, version_info
 from odoo.tests import HttpCase, tagged
-from odoo.release import url, version
 
 
 @tagged('-standard', 'external', 'post_install', '-at_install') # nightly is not a real tag
@@ -34,6 +35,10 @@ class TestResConfigDocLinks(HttpCase):
     def test_02_setting_nodes_documentation_links(self):
         links_regex = re.compile(r"<setting .* documentation=\"(\S+)\"")
 
+        version_ = (
+            version.replace('~', '-') if ALPHA not in version_info else 'master'
+        )
+
         checked_links = set()
         for link in self._extract_links_from_settings_view(links_regex, self.settings_view):
             if not link.startswith("http"):
@@ -41,7 +46,7 @@ class TestResConfigDocLinks(HttpCase):
                 if link in checked_links:
                     continue
                 self._check_link(
-                    f"{url}/documentation/{version if 'alpha' not in version else 'master'}{link}")
+                    f"{url}/documentation/{version_}{link}")
                 checked_links.add(link)
 
     def _check_link(self, link):


### PR DESCRIPTION
> AssertionError: 404 != 200 : The following link is broken: 'https://www.odoo.com/documentation/19.1a1/applications/marketing/sms_marketing/pricing/pricing_and_faq.html'


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
