### PR TITLE
[FIX] stock_account: set SM value using qty in product UoM

### DIFF
--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -251,7 +251,8 @@ class StockMove(models.Model):
             if move.product_id.cost_method == 'fifo':
                 move.value = move.product_id._run_fifo(move._get_valued_qty())
             else:
-                move.value = move.product_id.standard_price * move.quantity
+                qty = move.product_uom._compute_quantity(move.quantity, move.product_id.uom_id, rounding_method='HALF-UP')
+                move.value = move.product_id.standard_price * qty
 
         # Recompute the standard price
         self.env['product.product'].browse(products_to_recompute)._update_standard_price()

--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -2827,3 +2827,28 @@ class TestStockValuation(TestStockValuationBase):
         self.assertEqual(move_out.quantity, 11)
         self.assertEqual(move_out.product_qty, 0.01)
         self.assertEqual(self.product1.qty_available, 0.00)
+
+    def test_stock_move_value_with_different_uom(self):
+        """ Ensure that the stock move value is correctly computed
+        when the move's UoM differs from the product's UoM.
+        """
+        picking = self.env['stock.picking'].create({
+            'picking_type_id': self.picking_type_out.id,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.supplier_location.id,
+            'move_ids': [Command.create({
+                'product_id': self.product1.id,
+                'product_uom': self.env.ref('uom.product_uom_dozen').id,
+                'location_id': self.stock_location.id,
+                'location_dest_id': self.supplier_location.id,
+            })]
+        })
+        self.product1.standard_price = 10
+        self.assertEqual(self.product1.uom_id, self.env.ref('uom.product_uom_unit'))
+        picking.action_confirm()
+        move = picking.move_ids
+        move.quantity = 1
+        move.picked = True
+        picking.button_validate()
+        self.assertEqual(picking.state, 'done')
+        self.assertEqual(move.value, 120, "The move value should match the price in the correct UoM (12 * 10$).")


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product “P1”:
    - UoM: Gram
    - Add a vendor with UoM in Kg
    - Standard price: $10 per Gram

- Create a delivery order:
    - 1 Kg of P1
- Validate the delivery

Problem:
The stock move value is computed as $10 instead of $10,000, which leads to incorrect journal items and stock valuation.

Solution:
Use qty in product's UoM instead of `quantity`
when computing the move value.

opw-5105260
