### PR TITLE
[FIX] point_of_sale: access error unlinking partner

### DIFF
--- a/addons/point_of_sale/models/res_partner.py
+++ b/addons/point_of_sale/models/res_partner.py
@@ -74,5 +74,5 @@ class ResPartner(models.Model):
 
     @api.ondelete(at_uninstall=False)
     def _unlink_if_pos_no_orders(self):
-        if any(self.mapped('pos_order_ids')):
+        if self.sudo().pos_order_ids:
             raise ValidationError(_('You cannot delete a customer that has point of sales orders. You can archive it instead.'))


### PR DESCRIPTION
Versions affected 18 (and any where the fw port has been deployed)

A user with no point of sale or inventory permissions wouldn't be able to delete contacts anymore since commit 082b7d3

Steps to reproduce:

- In runbot, strip demo user permissions so he doesn't have inventory or point of sale access.
- Go to a contact and try to delete it.
- An **Access Error** error raises, as that user doesn't have `pos.order` permissions and the new unlink check is trying to check if the partner has related orders.

(anyway, maybe the right approach would be to set an `ondelete='restrict'` in the `partner_id` field of `pos.order`)

cc @moduon MT-12281

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
