### PR TITLE
[18.0][FIX] product: Design of catalog kanban

### DIFF
--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -653,7 +653,7 @@ action = {
                     <t t-name="card" class="p-0">
                     <!-- TODO : not getting border when select record -->
                         <div class="d-flex flex-grow-1 m-2">
-                            <div class="p-2 pt-1 d-flex flex-column m-0"
+                            <div class="p-2 pt-1 d-flex flex-column m-0 mw-75"
                                     t-attf-id="product-{{record.id.raw_value}}">
                                 <div class="d-flex">
                                     <field class="mt-1 me-1"
@@ -678,7 +678,7 @@ action = {
                             </div>
                             <field
                                 name="image_128"
-                                class="ms-auto"
+                                class="ms-auto mw-25"
                                 invisible="not image_128"
                                 widget="image"
                                 options="{'size': [55, 55], 'img_class': 'object-fit-contain'}"


### PR DESCRIPTION
With these changes, we ensure that the images will always stay within the kanban card, for example, when there’s an attribute that’s too long.

Before these changes, when an attribute was too long, it was expanding the size of its container and, as a result, pushing the images out of the kanban card.

<img width="1548" height="357" alt="image" src="https://github.com/user-attachments/assets/1661cf6a-6ff7-4ca9-9835-896806734b5e" />

After these changes, the content adjusts to the size of the kanban by applying the overflow: hidden property used by the badge elements.

<img width="1587" height="507" alt="image" src="https://github.com/user-attachments/assets/9bccfe27-1fdb-4093-ad34-82140deab76d" />

cc @Tecnativa TT58797

ping @pedrobaeza @carlosdauden 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
