### PR TITLE
[IMP] account_reports: negative amounts format

### DIFF
--- a/addons/l10n_us_account/models/template_us.py
+++ b/addons/l10n_us_account/models/template_us.py
@@ -89,6 +89,7 @@ class AccountChartTemplate(models.AbstractModel):
                 'income_account_id': 'account_account_us_income',
                 'account_sale_tax_id': default_sales_tax,
                 'account_purchase_tax_id': default_purchase_tax,
+                'negative_format_reports': 'parenthesis',
             },
         }
 


### PR DESCRIPTION
https://github.com/odoo/enterprise/pull/97637 allows the user to choose how to display the negative amounts in the reports, either " (negative_amount) "  - common US formatting - or " - negative_amount ".

If the country is US the (negative_amount) format will be selected by default.

The choice is available in the settings and is company specific.

task-5118741
