### PR TITLE
[FIX] l10n_latam_check: improve ref in search view

### DIFF
--- a/addons/l10n_latam_check/views/l10n_latam_check_view.xml
+++ b/addons/l10n_latam_check/views/l10n_latam_check_view.xml
@@ -35,7 +35,7 @@
         <field name="name">account.check.search</field>
         <field name="model">l10n_latam.check</field>
         <field name="mode">primary</field>
-        <field name="inherit_id" ref="view_account_payment_search"/>
+        <field name="inherit_id" ref="l10n_latam_check.view_account_payment_search"/>
         <field name="arch" type="xml">
             <filter name="checks_on_hand" position="replace"/>
             <filter name="checks_voided" position="replace"/>


### PR DESCRIPTION
Description of the Issue/Feature this PR Addresses:
To eliminate the risk of XML ID collisions. Using an unqualified external ID in a ref attribute can cause Odoo to load a view from an unintended module if the XML IDs are duplicated.

Current Behavior Before PR:
The search view uses an unqualified XML ID in the ref attribute, which relies on global resolution and can resolve to the wrong view.

Desired Behavior After PR is Merged:
The ref attribute uses the fully qualified external ID `l10n_latam_check.view_account_payment_search.` This ensures deterministic view loading by explicitly linking the reference to the correct view within the l10n_latam_check module.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
