### PR TITLE
[FIX] account: allow to group by "sent" on invoices

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -626,6 +626,7 @@ class AccountMove(models.Model):
         ],
         string='Sent',
         compute='compute_move_sent_values',
+        search='_search_move_sent_values',
     )
     invoice_user_id = fields.Many2one(
         string='Salesperson',
@@ -798,6 +799,14 @@ class AccountMove(models.Model):
     def compute_move_sent_values(self):
         for move in self:
             move.move_sent_values = 'sent' if move.is_move_sent else 'not_sent'
+
+    def _search_move_sent_values(self, operator, value):
+        if operator in ('=', '!='):
+            if value == 'sent':
+                return [('is_move_sent', operator, True)]
+            if value == 'not_sent':
+                return [('is_move_sent', operator, False)]
+        raise NotImplementedError
 
     def _compute_payment_reference(self):
         for move in self.filtered(lambda m: (

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -4873,3 +4873,20 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             untaxed_amount=invoice.amount_tax,
         )
         self.assertEqual(discounted_amount, 52.95)
+
+    def test_search_move_sent_values(self):
+        # Create a partner to only get invoices from this test
+        partner = self.env['res.partner'].create({
+            'name': 'Test Partner',
+        })
+
+        invoice_sent = self.init_invoice('out_invoice', products=self.product_a, partner=partner, post=True)
+        invoice_sent._generate_and_send()
+
+        invoice_not_sent = self.init_invoice('out_invoice', products=self.product_a, partner=partner, post=True)
+
+        res = self.env['account.move'].search([('partner_id', '=', partner.id), ('move_sent_values', '=', 'sent')])
+        self.assertEqual(invoice_sent, res)
+
+        res = self.env['account.move'].search([('partner_id', '=', partner.id), ('move_sent_values', '=', 'not_sent')])
+        self.assertEqual(invoice_not_sent, res)


### PR DESCRIPTION
### Issue:
The groups "Sent" and "Not Sent" display all the invoices.

### Steps to reproduce:
- Go in Accounting > Customer > Invoices
- Create a custom GroupBy with "Sent"
- Unfold the groups: all invoices appear in each group

### Cause:
`web_read_group` returns the groups with their length and the domain corresponding. When unfolding `web_search_read` uses the given domain to get the records to display.

Here the issue comes from the domain returned, it contains `['move_sent_values', '=', 'sent']`, but `move_sent_values` is a computed field that doesn't have a `_search` method so the domain doesn't filter on this field.

### Solution:
Add the method `_search_move_sent_values` to search on `is_move_sent`.

opw-5164650