### PR TITLE
[REF] mail: replace `registerMessageRefs` to `useChildRefs` hooks

### DIFF
--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -14,9 +14,6 @@ import { renderToElement } from "@web/core/utils/render";
 import {
     Component,
     onMounted,
-    onPatched,
-    onWillDestroy,
-    onWillUpdateProps,
     toRaw,
     useChildSubEnv,
     useEffect,
@@ -36,7 +33,7 @@ import { getOrigin, url } from "@web/core/utils/urls";
 import { useMessageActions } from "./message_actions";
 import { discussComponentRegistry } from "./discuss_component_registry";
 import { NotificationMessage } from "./notification_message";
-import { useLongPress } from "@mail/utils/common/hooks";
+import { useForwardRefsToParent, useLongPress } from "@mail/utils/common/hooks";
 import { ActionList } from "@mail/core/common/action_list";
 
 /**
@@ -76,10 +73,10 @@ export class Message extends Component {
     };
     static props = [
         "asCard?",
-        "registerMessageRef?",
         "hasActions?",
         "onParentMessageClick?",
         "message",
+        "messageRefs?",
         "previousMessage?",
         "squashed?",
         "thread?",
@@ -110,12 +107,7 @@ export class Message extends Component {
                 predicate: () => !this.isEditing,
             });
         }
-        onWillUpdateProps((nextProps) => {
-            this.props.registerMessageRef?.(this.props.message, null);
-        });
-        onMounted(() => this.props.registerMessageRef?.(this.props.message, this.root));
-        onPatched(() => this.props.registerMessageRef?.(this.props.message, this.root));
-        onWillDestroy(() => this.props.registerMessageRef?.(this.props.message, null));
+        useForwardRefsToParent("messageRefs", (props) => props.message.id, this.root);
         this.hasTouch = hasTouch;
         this.messageBody = useRef("body");
         this.messageActions = useMessageActions({

--- a/addons/mail/static/src/core/common/notification_message.js
+++ b/addons/mail/static/src/core/common/notification_message.js
@@ -1,28 +1,17 @@
-import {
-    Component,
-    onMounted,
-    onPatched,
-    onWillDestroy,
-    onWillUpdateProps,
-    useRef,
-} from "@odoo/owl";
+import { useForwardRefsToParent } from "@mail/utils/common/hooks";
+import { Component, useRef } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 import { escape } from "@web/core/utils/strings";
 
 export class NotificationMessage extends Component {
     static template = "mail.NotificationMessage";
-    static props = ["message", "thread", "registerMessageRef?"];
+    static props = ["message", "messageRefs?", "thread"];
 
     setup() {
         super.setup();
         this.root = useRef("root");
-        onWillUpdateProps((nextProps) => {
-            this.props.registerMessageRef?.(this.props.message, null);
-        });
-        onMounted(() => this.props.registerMessageRef?.(this.props.message, this.root));
-        onPatched(() => this.props.registerMessageRef?.(this.props.message, this.root));
-        onWillDestroy(() => this.props.registerMessageRef?.(this.props.message, null));
+        useForwardRefsToParent("messageRefs", (props) => props.message.id, this.root);
         this.escape = escape;
         this.store = useService("mail.store");
     }

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -23,14 +23,14 @@
                     <div t-if="msg.threadAsFirstUnread?.eq(props.thread) and (prevMsg or props.thread.markedAsUnread)" class="o-mail-Thread-newMessage d-flex align-items-center fw-bold z-1 px-2">
                         <div class="o-mail-Thread-newMessageLine flex-grow-1 border border-danger rounded-start-3 opacity-100 shadow-sm my-1"/><span class="o-ps-1_5 pe-1 bg-danger o-text-white rounded text-uppercase shadow-sm o-xxsmaller">New</span>
                     </div>
-                    <NotificationMessage t-if="msg.isNotification and !msg.notificationHidden" message="msg" thread="props.thread" registerMessageRef="registerMessageRef" />
+                    <NotificationMessage t-if="msg.isNotification and !msg.notificationHidden" message="msg" messageRefs="messageRefs" thread="props.thread"/>
                     <Message
                         t-elif="!msg.isNotification"
                         asCard="props.thread.model === 'mail.box'"
                         className="getMessageClassName(msg)"
                         message="msg"
+                        messageRefs="messageRefs"
                         previousMessage="prevMsg"
-                        registerMessageRef="registerMessageRef"
                         squashed="isSquashed(msg, prevMsg)"
                         onParentMessageClick.bind="() => msg.parent_id and env.messageHighlight?.highlightMessage(msg.parent_id, props.thread)"
                         thread="props.thread"

--- a/addons/mail/static/src/discuss/core/common/thread_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_patch.js
@@ -31,7 +31,7 @@ const threadPatch = {
     applyScrollContextually(thread) {
         if (thread.self_member_id && thread.scrollUnread) {
             if (thread.firstUnreadMessage) {
-                const messageEl = this.refByMessageId.get(thread.firstUnreadMessage.id)?.el;
+                const messageEl = this.messageRefs.get(thread.firstUnreadMessage.id)?.el;
                 if (!messageEl) {
                     return;
                 }

--- a/addons/mail/static/tests/thread/message_highlight.test.js
+++ b/addons/mail/static/tests/thread/message_highlight.test.js
@@ -6,7 +6,7 @@ import {
     start,
     startServer,
 } from "@mail/../tests/mail_test_helpers";
-import { Thread } from "@mail/core/common/thread";
+import { UseForwardRefsToParent } from "@mail/utils/common/hooks";
 import { describe, test } from "@odoo/hoot";
 import { advanceTime, Deferred, tick, waitFor } from "@odoo/hoot-dom";
 import { disableAnimations } from "@odoo/hoot-mock";
@@ -56,11 +56,11 @@ test("can highlight message (slow ref registration)", async () => {
     }
     await pyEnv["discuss.channel"].set_message_pin(channelId, middleMessageId, true);
     let slowRegisterMessageDef;
-    patchWithCleanup(Thread.prototype, {
-        async registerMessageRef(...args) {
+    patchWithCleanup(UseForwardRefsToParent.prototype, {
+        async registerRef(...args) {
             // Ensure scroll is made even when messages are mounted later.
             await slowRegisterMessageDef;
-            return super.registerMessageRef(...args);
+            return super.registerRef(...args);
         },
     });
     await start();


### PR DESCRIPTION
`Thread` and `Message`-like components use a feature alike `useChildRef()` and `useForwardRefToParent()` that works with many refs rather than a single ref, and refs are identified by message id.

Code is copy-pasted between `Message` and `NotificationMessage` components, but also `Thread` has a few different attributes and functions related to this feature, making this feature not as cohesive at it could be.

This commit improves by replacing this code by 2 new hooks:
- `useChildRefs()`, which works somewhat like `useChildRef()` but provides a Map of refs to pass to children.
- `useForwardRefsToParent()`, which works somewhat like `useForwardRefToParent()` but instead of naming the prop and local ref with same name, this hook support 3 params:
1) the prop name to forward the ref to parent refs;
2) a callback that evaluates the key of the refs Map in the parent, which works with mutating props too;
3) a ref that is saved in the refs Map of parent with 2nd callback return value as key

These new hooks makes the code of `registerMessageRefs` of `Thread` and `Message`-like components trivial, with 2 hooks and just using the refs Map in the parent component.