### PR TITLE
[FIX] mass_mailing: fix view online url issue on test mail

### DIFF
--- a/addons/mass_mailing/wizard/mailing_mailing_test.py
+++ b/addons/mass_mailing/wizard/mailing_mailing_test.py
@@ -67,8 +67,8 @@ class TestMassMailing(models.TransientModel):
                 'attachment_ids': [(4, attachment.id) for attachment in mailing.attachment_ids],
                 'auto_delete': False,  # they are manually deleted after notifying the document
                 'mail_server_id': mailing.mail_server_id.id,
-                'model': 'res.users',
-                'res_id': self.env.user.id,
+                'model': record._name,
+                'res_id': record.id,
             }
             mail = self.env['mail.mail'].sudo().create(mail_values)
             mails_sudo |= mail


### PR DESCRIPTION
In the email marketing, when you add "view_online" and dynamic placeholder "object.name", and try doing a test email, it creates a url token for the "view online" with the res_id as the user's id which grabs the record from the mailing_contact with that res_id. So, in case the mailing_contact with the res_id is deleted, the "view_online" gives you error saying record with id "res_id" cannot be find.

Our fix is to search the mailing_contact and grab the id of the first record.

This fix updates the code from this commit: [8a9981e](https://github.com/odoo/odoo/commit/8a9981e78a438ceb53a4fdc0445ebed2170c6624)

opw-5049654