### PR TITLE
[IMP] pos_stripe: allow refunds of stripe payments

### DIFF
--- a/addons/pos_stripe/static/src/overrides/models/pos_payment.js
+++ b/addons/pos_stripe/static/src/overrides/models/pos_payment.js
@@ -1,0 +1,17 @@
+import { PosPayment } from "@point_of_sale/app/models/pos_payment";
+import { patch } from "@web/core/utils/patch";
+
+patch(PosPayment.prototype, {
+    setup() {
+        super.setup(...arguments);
+        this.uiState = {
+            ...(this.uiState ?? {}),
+            stripePaymentIdToRefund: null,
+        };
+    },
+
+    updateRefundPaymentLine(refundedPaymentLine) {
+        super.updateRefundPaymentLine(refundedPaymentLine);
+        this.uiState.stripePaymentIdToRefund = refundedPaymentLine?.transaction_id;
+    },
+});

--- a/addons/pos_stripe/static/src/overrides/screens/payment_screen.js
+++ b/addons/pos_stripe/static/src/overrides/screens/payment_screen.js
@@ -1,0 +1,26 @@
+import { PaymentScreen } from "@point_of_sale/app/screens/payment_screen/payment_screen";
+import { patch } from "@web/core/utils/patch";
+
+patch(PaymentScreen.prototype, {
+    async addNewPaymentLine(paymentMethod) {
+        if (paymentMethod.use_payment_terminal === "stripe" && this.isRefundOrder) {
+            const refundedOrder = this.currentOrder.lines[0]?.refunded_orderline_id?.order_id;
+            const amountDue = Math.abs(this.currentOrder.getDue());
+            const matchedPaymentLine = refundedOrder?.payment_ids.find(
+                (line) =>
+                    line.payment_method_id.use_payment_terminal === "stripe" &&
+                    line.amount >= amountDue
+            );
+            if (matchedPaymentLine) {
+                const paymentLineAddedSuccessfully = await super.addNewPaymentLine(paymentMethod);
+                if (paymentLineAddedSuccessfully) {
+                    const newPaymentLine = this.paymentLines.at(-1);
+                    newPaymentLine.updateRefundPaymentLine(matchedPaymentLine);
+                }
+                return paymentLineAddedSuccessfully;
+            }
+        }
+
+        return await super.addNewPaymentLine(paymentMethod);
+    },
+});


### PR DESCRIPTION
This commit adds support for refunds via Stripe in POS. Stripe can only refund payments that were originally made using Stripe, either the full or a partial amount. The refunds do not use the payment terminal, instead using the Stripe API to reverse the payments. This means they can potentially take some time to process.

We also add support for the simulated Stripe terminal used for testing, which can be enabled simply by setting the terminal serial number to 'SIMULATOR'. The simulator is documented here:
https://docs.stripe.com/terminal/references/testing#simulated-reader

task-3619615

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
