### PR TITLE
[FIX] website_sale: align datetime picker and restore buttons events

### DIFF
--- a/addons/website_sale/static/src/js/website_sale_utils.js
+++ b/addons/website_sale/static/src/js/website_sale_utils.js
@@ -92,7 +92,10 @@ function updateCartNavBar(data) {
     // Adjust the cart's left column width to accommodate the cart summary (right column). The left
     // column of an empty cart initially takes the full width, but adding products (e.g. via quick 
     // reorder) enables the cart summary on the right.
-    document.querySelector('.oe_cart').classList.toggle('col-lg-7', !!data.cart_quantity);
+    // In some cases (e.g., updating range dates), `cart_quantity` may be undefined.
+    // In that case, we try to get the value from `website_sale.total` instead.
+    // A cart cannot have a total of 0.
+    document.querySelector('.oe_cart').classList.toggle('col-lg-7', !!(data.cart_quantity || data['website_sale.total']));
 
     if (data.cart_ready) {
         document.querySelector("a[name='website_sale_main_button']")?.classList.remove('disabled');


### PR DESCRIPTION
Steps to reproduce:
===================
1. Add a meeting product to the cart with the "Rental" option checked.
2. Go to the cart and change the date range. → The cart layout shifts to the left, and quantity buttons become unclickable.

Cause:
======
Two separate issues caused this behavior:

1. **Layout shift:** When updating the date range, `cart_quantity` can be undefined. The logic that determines whether to toggle the `col-lg-7` class relies on this value. When undefined, it incorrectly assumes the cart is empty and shifts the layout to the left.

2. **Unclickable buttons:** The following line replaces the entire `.js_cart_lines` element: https://github.com/odoo/odoo/blob/abf9bc083c5a219a0b6fc0346dcd2a2cb503e081/addons/website_sale/static/src/js/website_sale_utils.js#L88 This removes all old elements (and their event listeners) and inserts new ones from the server. As a result, interactive buttons (e.g., quantity update) lose their functionality.

Older versions didn't face this issue because they used jQuery event delegation, which automatically handled dynamic elements.

Solution:
=========
1. Use a reliable check for cart emptiness by falling back on `data['website_sale.total']` when `cart_quantity` is undefined,
2. Restart the cart interaction after re-rendering to restore event bindings for clickable buttons.

opw-5167866

related : https://github.com/odoo/enterprise/pull/97715

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
