### PR TITLE
[FIX] iot_drivers: missing time in event

### DIFF
--- a/addons/iot_drivers/event_manager.py
+++ b/addons/iot_drivers/event_manager.py
@@ -57,6 +57,7 @@ class EventManager:
         event = {
             **device.data,
             'device_identifier': device.device_identifier,
+            'time': time.time(),
             **data,
         }
         send_to_controller({


### PR DESCRIPTION
In odoo/odoo#232282, `time` was removed from registered events, leading to `KeyError` when trying to fetch longpolling events.
