### PR TITLE
[REF] rating: refactored sending rating stats

### DIFF
--- a/addons/rating/models/mail_message.py
+++ b/addons/rating/models/mail_message.py
@@ -38,32 +38,7 @@ class MailMessage(models.Model):
 
     def _to_store_defaults(self, target):
         # sudo: mail.message - guest and portal user can receive rating of accessible message
-        return super()._to_store_defaults(target) + [
-            Store.One("rating_id", sudo=True),
-            "record_rating",
-        ]
-
-    def _to_store(self, store: Store, fields, **kwargs):
-        super()._to_store(store, [f for f in fields if f != "record_rating"], **kwargs)
-        if "record_rating" in fields:
-            for records in self._records_by_model_name().values():
-                if (
-                    issubclass(self.pool[records._name], self.pool["rating.mixin"])
-                    and records._has_field_access(records._fields["rating_avg"], 'read')
-                ):
-                    all_stats = {}
-                    if records._allow_publish_rating_stats():
-                        all_stats = records._rating_get_stats_per_record()
-                    record_fields = [
-                        "rating_avg",
-                        "rating_count",
-                        Store.Attr(
-                            "rating_stats",
-                            lambda record, all_stats=all_stats: all_stats.get(record.id),
-                            predicate=lambda record: record._allow_publish_rating_stats(),
-                        ),
-                    ]
-                    store.add(records, record_fields, as_thread=True)
+        return super()._to_store_defaults(target) + [Store.One("rating_id", sudo=True)]
 
     def _is_empty(self):
         return super()._is_empty() and not self.rating_id


### PR DESCRIPTION
This commit removes the message `_to_store` override in `rating`. The `_to_store` was called only in the when posting a review, so this commit moves the addition to the store of the rating stats in the message post flow.

task-4676469
