### PR TITLE
[FIX] pos_online_payment: sync partner after adding online payment line

### DIFF
--- a/addons/point_of_sale/static/tests/tours/utils/payment_screen_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/payment_screen_util.js
@@ -344,7 +344,7 @@ export function clickPartnerButton() {
         },
         {
             content: "partner screen is shown",
-            trigger: `.modal ${PartnerList.clickPartner().trigger}`,
+            trigger: `${PartnerList.clickPartner().trigger}`,
         },
     ];
 }

--- a/addons/pos_online_payment/models/pos_payment.py
+++ b/addons/pos_online_payment/models/pos_payment.py
@@ -20,7 +20,7 @@ class PosPayment(models.Model):
             pm_id = vals['payment_method_id']
             if pm_id not in online_account_payments_by_pm:
                 online_account_payments_by_pm[pm_id] = set()
-            online_account_payments_by_pm[pm_id].add(vals.get('online_account_payment_id'))
+            online_account_payments_by_pm[pm_id].add(vals.get('online_account_payment_id') or None)
 
         opms_read_id = self.env['pos.payment.method'].search_read(['&', ('id', 'in', list(online_account_payments_by_pm.keys())), ('is_online_payment', '=', True)], ["id"])
         opms_id = {opm_read_id['id'] for opm_read_id in opms_read_id}

--- a/addons/pos_online_payment/static/src/overrides/pos_overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_online_payment/static/src/overrides/pos_overrides/components/payment_screen/payment_screen.js
@@ -115,6 +115,7 @@ patch(PaymentScreen.prototype, {
                         return false;
                     }
 
+                    await this.pos.syncAllOrders({ orders: [this.currentOrder] });
                     onlinePaymentLine.set_payment_status("waiting");
                     this.currentOrder.select_paymentline(onlinePaymentLine);
                     const onlinePaymentData = {
@@ -231,13 +232,13 @@ patch(PaymentScreen.prototype, {
         }
 
         if (isInvoiceRequested) {
-            if (!orderJSON[0].raw.account_move) {
+            if (!orderJSON[0].account_move) {
                 this.dialog.add(AlertDialog, {
                     title: _t("Invoice could not be generated"),
                     body: _t("The invoice could not be generated."),
                 });
             } else {
-                await this.invoiceService.downloadPdf(orderJSON[0].raw.account_move);
+                await this.invoiceService.downloadPdf(orderJSON[0].account_move);
             }
         }
 

--- a/addons/pos_online_payment/static/tests/tours/online_payment_tour.js
+++ b/addons/pos_online_payment/static/tests/tours/online_payment_tour.js
@@ -58,3 +58,23 @@ registry.category("web_tour.tours").add("OnlinePaymentErrorsTour", {
             Dialog.confirm(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_selected_customer_after_adding_payment_sync", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.addOrderline("Letter Tray", "10"),
+            ProductScreen.selectedOrderlineHas("Letter Tray", "10.0"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.totalIs("48.0"),
+            PaymentScreen.emptyPaymentlines("48.0"),
+            PaymentScreen.clickPaymentMethod("Online payment"),
+            PaymentScreen.selectedPaymentlineHas("Online payment", "48.0"),
+            PaymentScreen.clickPartnerButton(),
+            PaymentScreen.clickCustomer("A simple PoS man!"),
+            PaymentScreen.validateButtonIsHighlighted(true),
+            PaymentScreen.clickValidate(),
+            Dialog.is("Scan to Pay"),
+        ].flat(),
+});

--- a/addons/pos_online_payment/tests/test_frontend.py
+++ b/addons/pos_online_payment/tests/test_frontend.py
@@ -330,6 +330,15 @@ class TestUi(TestPointOfSaleHttpCommon, OnlinePaymentCommon):
             session.action_pos_session_close()
             self.assertEqual(session.state, 'closed')
 
+    def test_selected_customer_after_adding_payment_sync(self):
+        """ Test that the selected customer is kept after adding an online payment."""
+        self.pos_config.with_user(self.pos_admin).open_ui()
+        self.start_pos_tour('test_selected_customer_after_adding_payment_sync', login="pos_admin")
+        order = self.pos_config.current_session_id.order_ids.sorted(lambda o: o.id, reverse=True)[0]
+        self.assertEqual(order.partner_id.name, "A simple PoS man!", "The selected customer was not kept after adding an online payment.")
+        self.assertEqual(order.state, "draft", "The order should still be in draft state.")
+        self.assertEqual(len(order.payment_ids), 0, "There should be no payment line in the order.")
+
     @classmethod
     def tearDownClass(cls):
         # Restore company values after the tests


### PR DESCRIPTION
Before this commit, if a partner was selected after adding an online payment line, the partner was not synced after completing the online payment.

opw-5098127


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
