### PR TITLE
[REF] mail: rename MentionPlugin

### DIFF
--- a/addons/mail/static/src/views/web/fields/html_composer_message_field/html_composer_message_field.js
+++ b/addons/mail/static/src/views/web/fields/html_composer_message_field/html_composer_message_field.js
@@ -3,7 +3,7 @@ import { isEmpty } from "@html_editor/utils/dom_info";
 import { registry } from "@web/core/registry";
 import { useBus } from "@web/core/utils/hooks";
 import { HtmlMailField, htmlMailField } from "../html_mail_field/html_mail_field";
-import { MentionPlugin } from "./mention_plugin";
+import { MailFullComposerSuggestionPlugin } from "./mail_full_composer_suggestion_plugin";
 import { ContentExpandablePlugin } from "./content_expandable_plugin";
 import { fillEmpty } from "@html_editor/utils/dom";
 import { markup } from "@odoo/owl";
@@ -39,7 +39,7 @@ export class HtmlComposerMessageField extends HtmlMailField {
 
     getConfig() {
         const config = super.getConfig(...arguments);
-        config.Plugins = [...config.Plugins, MentionPlugin];
+        config.Plugins = [...config.Plugins, MailFullComposerSuggestionPlugin];
         if (this.props.record.data.composition_comment_option === "reply_all") {
             config.Plugins.push(ContentExpandablePlugin);
         }

--- a/addons/mail/static/src/views/web/fields/html_composer_message_field/mail_full_composer_suggestion_plugin.js
+++ b/addons/mail/static/src/views/web/fields/html_composer_message_field/mail_full_composer_suggestion_plugin.js
@@ -4,8 +4,8 @@ import { router } from "@web/core/browser/router";
 import { renderToElement } from "@web/core/utils/render";
 import { url } from "@web/core/utils/urls";
 
-export class MentionPlugin extends Plugin {
-    static id = "mention";
+export class MailFullComposerSuggestionPlugin extends Plugin {
+    static id = "mail_full_composer_suggestion";
     static dependencies = ["overlay", "dom", "history", "input", "selection"];
 
     resources = {

--- a/addons/mail/static/tests/html_editor/editor_plugin_dependencies.test.js
+++ b/addons/mail/static/tests/html_editor/editor_plugin_dependencies.test.js
@@ -1,10 +1,10 @@
 import { InputPlugin } from "@html_editor/core/input_plugin";
-import { MentionPlugin } from "@mail/views/web/fields/html_composer_message_field/mention_plugin";
+import { MailFullComposerSuggestionPlugin } from "@mail/views/web/fields/html_composer_message_field/mail_full_composer_suggestion_plugin";
 import { describe, expect, test } from "@odoo/hoot";
 
 describe("Implicit plugin dependencies", () => {
     test("position as an implicit dependency", async () => {
-        for (const P of [MentionPlugin]) {
+        for (const P of [MailFullComposerSuggestionPlugin]) {
             // input dependency through the "beforeinput_handlers" and
             // "input_handlers" resources. This dependency was added because the
             // plugin is heavily dependent on inputs handling and will appear


### PR DESCRIPTION
Rename MentionPlugin to MailFullComposerSuggestionPlugin to better reflect its purpose in the full composer context.

This gives a chance to free the "mention" id for a more generic mention plugin that would be introduced later.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
