### PR TITLE
[FIX] web: adapt test following offsetParent fix in Chrome 140

### DIFF
--- a/addons/web/static/tests/core/resizable_panel.test.js
+++ b/addons/web/static/tests/core/resizable_panel.test.js
@@ -88,9 +88,11 @@ test("handles resize handle at start in fixed position", async () => {
             x: window.innerWidth - 200,
         },
     });
-    expect(resizablePanelEl).toHaveRect({
-        width: 100 + queryRect(".o_resizable_panel_handle").width / 2,
-    });
+    const panelExpectedWidth = 100 + queryRect(".o_resizable_panel_handle").width / 2;
+    expect(queryRect(resizablePanelEl).width).toBeWithin(
+        panelExpectedWidth,
+        panelExpectedWidth + 1
+    );
 });
 
 test("resizing the window adapts the panel", async () => {


### PR DESCRIPTION
In Chrome 140, a fix [^0] has been applied regarding the `offsetParent` property with a fixed position element.

Due to this fix, a resizable panel's test failed by 1px. As this difference doesn't have a real functional impact, we adapted the test to accept both the pre/post fix values.

Note: that it is also related to a clarification [^1] in the CSS spec [^2].

[^0]: https://chromium-review.googlesource.com/c/chromium/src/+/6774502
[^1]: https://github.com/w3c/csswg-drafts/issues/12352
[^2]: https://drafts.csswg.org/cssom-view/#dom-htmlelement-offsetparent
