### PR TITLE
[FIX] sale_stock: Remove duplicate product name from delivery slip

### DIFF
--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -29,7 +29,8 @@ class StockMove(models.Model):
         for move in self:
             if move.sale_line_id and not move.description_picking_manual:
                 sale_line_id = move.sale_line_id.with_context(lang=move.sale_line_id.order_id.partner_id.lang)
-                move.description_picking = (sale_line_id._get_sale_order_line_multiline_description_variants() + '\n' + move.description_picking).strip()
+                description_picking = move.description_picking if move.description_picking != move.product_id.display_name else ""
+                move.description_picking = (sale_line_id._get_sale_order_line_multiline_description_variants() + '\n' + description_picking).strip()
 
     def _action_synch_order(self):
         sale_order_lines_vals = []


### PR DESCRIPTION
****Behavior:****
**Current:**
When creating a quotation with a product that has a free text attribute. The stock move and delivery slip show the product name another time in the description.

This is caused because the XML template checks if the description differs from the product name (which is the default) before rendering. However for products with free text attribute, the description contains both the duplicate name aswell as the custom value of the attribute, which slips through the template check and causes the name to appear twice.

**Expected:**
We want the picking description to appear only when it has been set. So an additional check ensuring the description differs from the product name was added before it is merged with the free text attribute.

**Steps to reproduce:**
- Create an attribute with a free text value.
- Create a product with the said attribute
- Create a quotation containing the product
- Confirm the quotation
- Open the related delivery order
- You should observe that the name of the product is duplicated
- If you try to print the delivery slip you should observe the same thing.

opw-5118725

