### PR TITLE
[FIX] point_of_sale: prevent making PoS order invoice draft

### DIFF
--- a/addons/point_of_sale/models/account_move.py
+++ b/addons/point_of_sale/models/account_move.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models, api
+from odoo import fields, models, api, _
+from odoo.exceptions import UserError
 
 
 class AccountMove(models.Model):
@@ -82,6 +83,10 @@ class AccountMove(models.Model):
     def _compute_tax_totals(self):
         return super(AccountMove, self.with_context(linked_to_pos=bool(self.sudo().pos_order_ids)))._compute_tax_totals()
 
+    def button_draft(self):
+        if self.sudo().pos_order_ids:
+            raise UserError(_("You cannot reset to draft an invoice linked to a POS order. You must refund the order or create a credit note instead."))
+        return super().button_draft()
 
 
 class AccountMoveLine(models.Model):

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -841,6 +841,10 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
         self.assertAlmostEqual(
             invoice.amount_total, self.pos_order_pos1.amount_total, places=2, msg="Invoice not correct")
 
+        # It should no be possible to make the invoice draft
+        with self.assertRaises(UserError):
+            invoice.button_draft()
+
         # I close the session to generate the journal entries
         current_session.action_pos_session_closing_control()
 


### PR DESCRIPTION
Before this commit, it was possible to set the invoice of a PoS order to draft, which could prevent closing the session since unposted invoices block the session closing.

This commit prevents that by raising a user error suggesting to refund the order or create a credit note instead.

opw-5079889

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
