### PR TITLE
[IMP] hw_posbox_homepage: certificate status message

### DIFF
--- a/addons/hw_posbox_homepage/static/src/app/Homepage.js
+++ b/addons/hw_posbox_homepage/static/src/app/Homepage.js
@@ -94,21 +94,20 @@ export class Homepage extends Component {
             <div class="d-flex mb-4 flex-column align-items-center justify-content-center">
                 <h4 class="text-center m-0">IoT Box - <t t-esc="state.data.hostname" /></h4>
             </div>
-            <div t-if="!this.store.advanced and !state.data.is_certificate_ok" class="alert alert-warning" role="alert">
+            <div t-if="!state.data.is_certificate_ok and state.data.server_status !== 'Not Configured'" class="alert alert-warning" role="alert">
                 <p class="m-0 fw-bold">
                     This IoT Box doesn't have a valid certificate.
                 </p>
-                <small>
+                <small t-if="state.data.certificate_details === 'ERR_SSL_CERT_DOWNLOAD'">
                     The IoT Box should get a certificate automatically when paired with a database. If it doesn't, 
                     try to restart it.
                 </small>
+                <small t-else="" t-esc="state.data.certificate_details" />
             </div>
-            <div t-if="this.store.advanced" t-att-class="'alert ' + (state.data.is_certificate_ok === true ? 'alert-info' : 'alert-warning')" role="alert">
+            <div t-if="this.store.advanced and state.data.is_certificate_ok" class="alert alert-info" role="alert">
                 <p class="m-0 fw-bold">HTTPS Certificate</p>
                 <small>
-                    <t t-if="state.data.is_certificate_ok === true">Status: </t>
-                    <t t-else="">Error Code: </t>
-                    <t t-esc="state.data.certificate_details" />
+                    Status: <t t-esc="state.data.certificate_details" />
                 </small>
             </div>
             <SingleData name="'Name'" value="state.data.hostname" icon="'fa-id-card'">


### PR DESCRIPTION
We improved the certificate status warning displayed on the homepage to avoid having to check the logs to know what went wrong while downloading the SSL certificate.