### PR TITLE
[FIX] test_main_flows: incorrect navigation / breadcrumb

### DIFF
--- a/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
+++ b/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
@@ -1162,7 +1162,7 @@ stepUtils.autoExpandMoreButtons(true),
 },
 {
     isActive: ["mobile"],
-    trigger: ".o_back_button",
+    trigger: "div.o_breadcrumb:contains('Tasks') .o_back_button",
     content: _t('Back to the sale order'),
     tooltipPosition: "bottom",
     run: "click",


### PR DESCRIPTION
Depending on scheduling / machine load, it's possible for the "Back to the sale order" step to run before the "Back to the task" step's effect have completed, and thus trigger on the exact same breadcrumb, leading to *not* returning to the SO and on to not finding the `order_line` field and a failure on the next step.

Fix this specific instance of breadcrumb confusion by checking that the breadcrumb label is the one we expect as precondition.

https://runbot.odoo.com/odoo/runbot.build.error/231766
