### PR TITLE
[FIX] website_sale_product_feed: remove outdated GMC constraint

### DIFF
--- a/addons/website_sale_product_feed/__manifest__.py
+++ b/addons/website_sale_product_feed/__manifest__.py
@@ -2,6 +2,7 @@
 
 {
     'name': "Google Merchant Center",
+    'version': '1.1',
     'category': 'Website/Website',
     'sequence': 50,
     'summary': "Synchronize your products with Google Merchant Center",

--- a/addons/website_sale_product_feed/models/res_config_settings.py
+++ b/addons/website_sale_product_feed/models/res_config_settings.py
@@ -12,8 +12,6 @@ class ResConfigSettings(models.TransientModel):
         group='base.group_user',
     )
 
-    _check_gmc_ecommerce_access = models.Constraint('CHECK (TRUE)', "Disable the constraint")
-
     def set_values(self):
         """Override to pre-populate the website feeds if none already exists."""
         super().set_values()

--- a/addons/website_sale_product_feed/models/website.py
+++ b/addons/website_sale_product_feed/models/website.py
@@ -12,6 +12,9 @@ class Website(models.Model):
         ),
     )
 
+    # The second version of GMC no longer mandates public access to the eCommerce.
+    _check_gmc_ecommerce_access = models.Constraint('CHECK (TRUE)', "Constraint disabled")
+
     def _populate_product_feeds(self):
         """Populate product feeds for the website with default values."""
         for website in self:


### PR DESCRIPTION
Initially, a constraint was added to ensure the eCommerce site was publicly accessible, allowing Google to access the feed without requiring authentication.

However, the updated version of GMC no longer relies on this constraint. Instead, it uses an access token to authorize feed access.

A previous attempt ([^1]) to remove this constraint targeted the wrong model. This commit corrects that mistake.

[^1]: https://github.com/odoo/odoo/pull/225536

