### PR TITLE
[FIX] point_of_sale: always show test epos button

### DIFF
--- a/addons/point_of_sale/static/src/backend/test_epos/test_epos.js
+++ b/addons/point_of_sale/static/src/backend/test_epos/test_epos.js
@@ -53,7 +53,11 @@ export class TestEPos extends Component {
                     ? data.epson_printer_ip
                     : data.pos_epson_printer_ip;
             if (!printer_ip) {
-                throw new Error("No printer IP configured");
+                this.notification.add(
+                    _t("Please configure a valid ePoS url in order to test the printer"),
+                    { type: "danger" }
+                );
+                return;
             }
             const url = window.location.protocol + "//" + printer_ip;
             this.address = url + "/cgi-bin/epos/service.cgi?devid=local_printer";

--- a/addons/point_of_sale/views/pos_config_view.xml
+++ b/addons/point_of_sale/views/pos_config_view.xml
@@ -58,7 +58,7 @@
                                         <field name="epson_printer_ip" placeholder="Epson Receipt Printer IP Address" />
                                     </div>
                                     <div class="col-lg-6">
-                                        <widget name="point_of_sale_test_epos" invisible="epson_printer_ip in [False, '']"/>
+                                        <widget name="point_of_sale_test_epos"/>
                                     </div>
                                 </div>
                                 <div class="row" invisible="epson_printer_ip in [False, '']">

--- a/addons/point_of_sale/views/pos_printer_view.xml
+++ b/addons/point_of_sale/views/pos_printer_view.xml
@@ -16,7 +16,7 @@
                     </group>
                     <group>
                         <div style="display:flex; justify-content:flex-end; align-items:flex-start; height:100%;">
-                            <widget name="point_of_sale_test_epos" invisible="printer_type != 'epson_epos' or epson_printer_ip in [False, '']"/>
+                            <widget name="point_of_sale_test_epos" invisible="printer_type != 'epson_epos'"/>
                         </div>
                     </group>
                 </group>

--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -397,7 +397,7 @@
                                             <field name="pos_epson_printer_ip" placeholder="Epson Receipt Printer IP Address" />
                                         </div>
                                         <div class="col-lg-6">
-                                            <widget name="point_of_sale_test_epos" invisible="pos_epson_printer_ip in [False, '']"/>
+                                            <widget name="point_of_sale_test_epos"/>
                                         </div>
                                         <div class="row" invisible="pos_epson_printer_ip in [False, '']">
                                             <label string="Link Cashdrawer" for="pos_iface_cashdrawer" class="col-lg-3 o_light_label"/>


### PR DESCRIPTION
Currently it is only visible if the epos ip is set, but if the user
1) Opens the settings
2) Sets the epos ip
3) Doesn't defocus and clicks on "Save"

He never gets to see the test button.
This PR makes the "test" button for epos printers always visible in the PoS settings if the "epos" setting is activated.
If the ip is not set it displays a notification asking to set it

