### PR TITLE
[FIX] l10n_ar_website_sale: update Argentinian no-tax price on website

### DIFF
--- a/addons/l10n_ar_website_sale/models/product_template.py
+++ b/addons/l10n_ar_website_sale/models/product_template.py
@@ -47,8 +47,6 @@ class ProductTemplate(models.Model):
         combination_info = super()._get_additionnal_combination_info(
             product_or_template, quantity, uom, date, website
         )
-        pricelist_prices = request.pricelist._compute_price_rule(self, 1.0)
-
         if (
             website
             and website.company_id.country_code == 'AR'
@@ -60,11 +58,8 @@ class ProductTemplate(models.Model):
             mapped_taxes = request.fiscal_position.map_tax(product_taxes)
 
             # Compute price per unit of product or template
-            unit_price = (
-                pricelist_prices[self.id][0]
-                if product_or_template._name == 'product.template'
-                else product_or_template.lst_price
-            )
+            pricelist_prices = request.pricelist._compute_price_rule(product_or_template, quantity)
+            unit_price = pricelist_prices[product_or_template.id][0]
 
             # Compute the tax-excluded value
             total_excluded_value = mapped_taxes.compute_all(


### PR DESCRIPTION
Versions
--------
- saas-18.4+

Steps
-----
1. Have a company with Argentinian localization;
2. in Website settings, enable "Display Price without National Taxes";
3. add a quantity-based fixed price on the website's pricelist;
4. go to a product page where the fixed price can be applied;
5. increase quantity so the fixed price should apply.

Issue
-----
The price without national taxes isn't getting updated.

Cause
-----
In the `_get_additional_combination_info` override, the given `quantity` gets ignored, as well as the pricelist price for product variants, instead defaulting to their `lst_price`.

Solution
--------
Pass the quantity to `_compute_price_rule`, and use the result for both templates & variants.

opw-5040056