### PR TITLE
[FIX] web: Repetition of error while switching tabs

### DIFF
--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -478,7 +478,7 @@ export class FormController extends Component {
 
     beforeVisibilityChange() {
         if (document.visibilityState === "hidden" && this.formInDialog === 0) {
-            return this.model.root.save();
+            return this.model.root.save({ onError: this.onSaveError.bind(this) });
         }
     }
 


### PR DESCRIPTION
On a form view, when there is a validation error and the user switches browser tabs multiple times,
the dialog with the validation error keep popping multiple times causing the page to have multiple
dialogs on top of one another.
This commit solves this issue by preventing the form controller from creating multiple dialogs in
case of a save error.

task-5180610




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
