### PR TITLE
[IMP] sale: adjust margins and paddings in the no-content view

### DIFF
--- a/addons/sale/static/src/js/sale_action_helper/sale_action_helper.xml
+++ b/addons/sale/static/src/js/sale_action_helper/sale_action_helper.xml
@@ -2,12 +2,12 @@
 
 <templates xml:space="preserve">
     <t t-name="sale.SaleActionHelper">
-        <div class="o_view_nocontent flex-wrap pt-5">
+        <div class="o_view_nocontent flex-wrap">
             <div class="container">
                 <div class="o_nocontent_help">
                     <div>
                         <a
-                            class="o_sale_action_preview position-relative overflow-hidden d-inline-block rounded-4"
+                            class="o_sale_action_preview position-relative overflow-hidden d-inline-block mb-2 rounded-4"
                             role="button"
                             t-on-click="this.openVideoPreview"
                         >


### PR DESCRIPTION
This commit removes the `.pt-5` on the wrapping element in the action helper and adds a `.mb-2` under the thumbnail.
This should center the content and allow it to breathe.

task-5156559

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
