### PR TITLE
[FIX] stock: make dashboard card column auto-size

### DIFF
--- a/addons/mrp/views/stock_picking_views.xml
+++ b/addons/mrp/views/stock_picking_views.xml
@@ -49,59 +49,62 @@
                     </div>
                 </div>
             </xpath>
-            <xpath expr='//div[@name="stock_picking"]' position="after">
-                <div t-if="record.code.raw_value == 'mrp_operation'" class="px-2">
-                    <a t-if="!selection_mode" type="object" name="get_mrp_stock_picking_action_picking_type">
-                        <field name="name" class="fw-bold fs-4"/>
-                    </a>
+            <xpath expr='//t[@name="stock_picking"]' position="after">
+                <t t-if="record.code.raw_value == 'mrp_operation'">
+                    <span class="d-flex d-flew-row align-items-baseline px-2">
+                        <a t-if="!selection_mode" type="object" name="get_mrp_stock_picking_action_picking_type">
+                            <field name="name" class="fw-bold fs-4"/>
+                        </a>
+                    </span>
                     <field t-if="selection_mode" name="name" class="fw-bold fs-4"/>
-                    <field name="warehouse_id" class="d-block" groups="stock.group_stock_multi_warehouses"/>
-                    <div t-if="!selection_mode" class="row mt-3">
-                        <div class="col-6">
-                            <button class="btn btn-primary" name="%(mrp_production_action_picking_deshboard)d" type="action" context="{'search_default_filter_confirmed': 1, 'default_picking_type_id': id}">
-                                <span t-if="record.count_mo_todo.raw_value > 0">
-                                    <field name="count_mo_todo"/> To Manufacture
-                                </span>
-                                <span t-else="">Open</span>
-                            </button>
-                        </div>
-                        <div class="col-6 stock-overview-links">
-                            <div t-if="record.count_mo_waiting.raw_value > 0" class="row">
-                                <a class="col-8 offset-4 text-truncate" name="%(mrp_production_action_picking_deshboard)d" type="action" context="{'search_default_waiting': 1}">
-                                    <div class="row">
-                                        <span class="col-6">Waiting</span>
-                                        <field class="col-2 text-end" name="count_mo_waiting"/>
-                                    </div>
-                                </a>
+                    <field name="warehouse_id" class="d-block px-2" groups="stock.group_stock_multi_warehouses"/>
+                    <div class="container-fluid px-2">
+                        <div t-if="!selection_mode" class="row mt-3">
+                            <div class="col">
+                                <button class="btn btn-primary" name="%(mrp_production_action_picking_deshboard)d" type="action" context="{'search_default_filter_confirmed': 1, 'default_picking_type_id': id}">
+                                    <span t-if="record.count_mo_todo.raw_value > 0">
+                                        <field name="count_mo_todo"/> To Manufacture
+                                    </span>
+                                    <span t-else="">Open</span>
+                                </button>
                             </div>
-                            <div t-if="record.count_mo_late.raw_value > 0" class="row">
-                                <a class="col-8 offset-4 text-truncate" name="%(mrp_production_action_picking_deshboard)d" type="action" context="{'search_default_filter_late_mo': 1, 'default_picking_type_id': id}">
-                                    <div class="row">
-                                        <span class="col-6">Late</span>
-                                        <field class="col-2 text-end" name="count_mo_late"/>
-                                    </div>
-                                </a>
-                            </div>
-                            <div t-if="record.count_mo_in_progress.raw_value > 0" class="row">
-                                <a class="col-8 offset-4 text-truncate" name="%(mrp_production_action_picking_deshboard)d" type="action" context="{'search_default_filter_in_progress': 1, 'default_picking_type_id': id}">
-                                    <div class="row">
-                                        <span class="col-6">In Progress</span>
-                                        <field class="col-2 text-end" name="count_mo_in_progress"/>
-                                    </div>
-                                </a>
-                            </div>
-                            <div t-if="record.count_mo_to_close.raw_value > 0" class="row">
-                                <a class="col-8 offset-4 text-truncate" name="%(mrp_production_action_picking_deshboard)d" type="action" context="{'search_default_filter_to_close': 1, 'default_picking_type_id': id}">
-                                    <div class="row">
-                                        <span class="col-6">To Close</span>
-                                        <field class="col-2 text-end" name="count_mo_to_close"/>
-                                    </div>
-                                </a>
+                            <div class="col-auto stock-overview-links px-5">
+                                <div t-if="record.count_mo_waiting.raw_value > 0" class="col-auto">
+                                    <a class="text-truncate" name="%(mrp_production_action_picking_deshboard)d" type="action" context="{'search_default_waiting': 1}">
+                                        <div class="row overflow-hidden">
+                                            <span class="col">Waiting</span>
+                                            <field class="col text-end" name="count_mo_waiting"/>
+                                        </div>
+                                    </a>
+                                </div>
+                                <div t-if="record.count_mo_late.raw_value > 0" class="col-auto">
+                                    <a class="text-truncate" name="%(mrp_production_action_picking_deshboard)d" type="action" context="{'search_default_filter_late_mo': 1, 'default_picking_type_id': id}">
+                                        <div class="row overflow-hidden">
+                                            <span class="col">Late</span>
+                                            <field class="col text-end" name="count_mo_late"/>
+                                        </div>
+                                    </a>
+                                </div>
+                                <div t-if="record.count_mo_in_progress.raw_value > 0" class="col-auto">
+                                    <a class="text-truncate" name="%(mrp_production_action_picking_deshboard)d" type="action" context="{'search_default_filter_in_progress': 1, 'default_picking_type_id': id}">
+                                        <div class="row overflow-hidden">
+                                            <span class="col">In Progress</span>
+                                            <field class="col text-end" name="count_mo_in_progress"/>
+                                        </div>
+                                    </a>
+                                </div>
+                                <div t-if="record.count_mo_to_close.raw_value > 0" class="col-auto">
+                                    <a class="text-truncate" name="%(mrp_production_action_picking_deshboard)d" type="action" context="{'search_default_filter_to_close': 1, 'default_picking_type_id': id}">
+                                        <div class="row overflow-hidden">
+                                            <span class="col">To Close</span>
+                                            <field class="col text-end" name="count_mo_to_close"/>
+                                        </div>
+                                    </a>
+                                </div>
                             </div>
                         </div>
                     </div>
-                    <field t-if="!selection_mode" name="kanban_dashboard_graph" class="mt-auto" graph_type="bar" widget="picking_type_dashboard_graph"/>
-                </div>
+                </t>
             </xpath>
         </field>
     </record>

--- a/addons/repair/views/stock_picking_views.xml
+++ b/addons/repair/views/stock_picking_views.xml
@@ -89,51 +89,54 @@
                         </div>
                     </div>
             </xpath>
-            <xpath expr='//div[@name="stock_picking"]' position="after">
-                <div t-if="record.code.raw_value == 'repair_operation'" class="px-2">
-                    <a t-if="!selection_mode" type="object" name="get_repair_stock_picking_action_picking_type">
-                        <field name="name" class="fw-bold fs-4"/>
-                    </a>
+            <xpath expr='//t[@name="stock_picking"]' position="after">
+                <t t-if="record.code.raw_value == 'repair_operation'">
+                    <span class="d-flex d-flew-row align-items-baseline px-2">
+                        <a t-if="!selection_mode" type="object" name="get_repair_stock_picking_action_picking_type">
+                            <field name="name" class="fw-bold fs-4"/>
+                        </a>
+                    </span>
                     <field t-if="selection_mode" name="name" class="fw-bold fs-4"/>
-                    <field class="d-block"  name="warehouse_id"  groups="stock.group_stock_multi_warehouses"/>
-                    <div t-if="!selection_mode" class="row mt-3">
-                        <div class="col-6">
-                            <button class="btn btn-primary" name="get_repair_stock_picking_action_picking_type" context="{'search_default_ready': 1}" type="object">
-                                <span t-if="record.count_repair_ready.raw_value > 0">
-                                    <field name="count_repair_ready"/> To Repair
-                                </span>
-                                <span t-else="">Open</span>
-                            </button>
-                        </div>
-                        <div class="col-6 stock-overview-links">
-                            <div t-if="record.count_repair_late.raw_value > 0" class="row">
-                                <a class="col-8 offset-4 text-truncate" name="get_repair_stock_picking_action_picking_type" context="{'search_default_filter_late': 1}" type="object">
-                                    <div class="row">
-                                        <span class="col-6">Late</span>
-                                        <field class="col-2 text-end" name="count_repair_late"/>
-                                    </div>
-                                </a>
+                    <field name="warehouse_id" class="d-block px-2" groups="stock.group_stock_multi_warehouses"/>
+                    <div class="container-fluid px-2">
+                        <div t-if="!selection_mode" class="row mt-3">
+                            <div class="col">
+                                <button class="btn btn-primary" name="get_repair_stock_picking_action_picking_type" context="{'search_default_ready': 1}" type="object">
+                                    <span t-if="record.count_repair_ready.raw_value > 0">
+                                        <field name="count_repair_ready"/> To Repair
+                                    </span>
+                                    <span t-else="">Open</span>
+                                </button>
                             </div>
-                            <div t-if="record.count_repair_confirmed.raw_value > 0" class="row">
-                                <a class="col-8 offset-4 text-truncate" name="get_repair_stock_picking_action_picking_type" context="{'search_default_filter_confirmed': 1}" type="object">
-                                    <div class="row">
-                                        <span class="col-6">Confirmed</span>
-                                        <field class="col-2 text-end" name="count_repair_confirmed"/>
-                                    </div>
-                                </a>
-                            </div>
-                            <div t-if="record.count_repair_under_repair.raw_value > 0" class="row">
-                                <a class="col-8 offset-4 text-truncate" name="get_repair_stock_picking_action_picking_type" context="{'search_default_filter_under_repair': 1}" type="object">
-                                    <div class="row">
-                                        <span class="col-6">Under Repair</span>
-                                        <field class="col-2 text-end" name="count_repair_under_repair"/>
-                                    </div>
-                                </a>
+                            <div class="col-auto stock-overview-links px-5">
+                                <div t-if="record.count_repair_late.raw_value > 0" class="row overflow-hidden">
+                                    <a class="text-truncate" name="get_repair_stock_picking_action_picking_type" context="{'search_default_filter_late': 1}" type="object">
+                                        <div class="row">
+                                            <span class="col">Late</span>
+                                            <field class="col text-end" name="count_repair_late"/>
+                                        </div>
+                                    </a>
+                                </div>
+                                <div t-if="record.count_repair_confirmed.raw_value > 0" class="row overflow-hidden">
+                                    <a class="text-truncate" name="get_repair_stock_picking_action_picking_type" context="{'search_default_filter_confirmed': 1}" type="object">
+                                        <div class="row">
+                                            <span class="col">Confirmed</span>
+                                            <field class="col text-end" name="count_repair_confirmed"/>
+                                        </div>
+                                    </a>
+                                </div>
+                                <div t-if="record.count_repair_under_repair.raw_value > 0" class="row overflow-hidden">
+                                    <a class="text-truncate" name="get_repair_stock_picking_action_picking_type" context="{'search_default_filter_under_repair': 1}" type="object">
+                                        <div class="row">
+                                            <span class="col">Under Repair</span>
+                                            <field class="col text-end" name="count_repair_under_repair"/>
+                                        </div>
+                                    </a>
+                                </div>
                             </div>
                         </div>
                     </div>
-                    <field t-if="!selection_mode" class="mt-auto" name="kanban_dashboard_graph" graph_type="bar" widget="picking_type_dashboard_graph"/>
-                </div>
+                </t>
             </xpath>
         </field>
     </record>

--- a/addons/stock/static/src/scss/stock_overview.scss
+++ b/addons/stock/static/src/scss/stock_overview.scss
@@ -12,8 +12,11 @@
         margin-left: 4px;
         margin-right: 4px;
     }
-}
 
-.stock-overview-links {
-    height: 5.5rem;
+    // ensure graphs stay aligned to bottom
+    .container-fluid {
+        flex: 1 0 auto;
+        display: flex;
+        flex-flow: column nowrap;
+    }
 }

--- a/addons/stock/views/stock_picking_type_views.xml
+++ b/addons/stock/views/stock_picking_type_views.xml
@@ -227,64 +227,69 @@
                         </div>
                     </t>
                     <t t-name="card">
-                        <div t-if="record.show_picking_type.raw_value" name="stock_picking" class="px-2">
-                            <a t-if="!selection_mode" type="object" name="get_stock_picking_action_picking_type">
-                                <field class="fw-bold fs-4" name="name"/>
-                            </a>
+                        <t t-if="record.show_picking_type.raw_value" name="stock_picking">
+                            <span class="d-flex d-flew-row align-items-baseline px-2">
+                                <a t-if="!selection_mode" type="object" name="get_stock_picking_action_picking_type">
+                                    <field class="fw-bold fs-4" name="name"/>
+                                </a>
+                            </span>
                             <field t-if="selection_mode" class="fw-bold fs-4" name="name"/>
-                            <field name="warehouse_id" class="d-block" groups="stock.group_stock_multi_warehouses"/>
-                            <div t-if="!selection_mode" class="row mt-3">
-                                <div class="col-6">
-                                    <button class="btn btn-primary" name="get_action_picking_tree_ready" type="object">
-                                        <span t-if="record.count_picking_ready.raw_value > 0">
-                                            <field name="count_picking_ready"/>
-                                            <t t-if="record.code.raw_value === 'incoming'"> To Receive</t>
-                                            <t t-elif="record.code.raw_value === 'outgoing'" name="outgoing_label"> To Deliver</t>
-                                            <t t-else=""> To Process</t>
-                                        </span>
-                                        <span t-else="">Open</span>
-                                    </button>
-                                </div>
-                                <div class="col-6 stock-overview-links">
-                                    <div t-if="record.count_picking_waiting.raw_value > 0" class="row">
-                                        <a class="col-8 offset-4 pe-0 text-truncate" name="get_action_picking_tree_waiting" type="object">
-                                            <div class="row">
-                                                <span class="col-6">Waiting</span>
-                                                <field class="col-2 text-end" name="count_picking_waiting"/>
-                                            </div>
-                                        </a>
+                            <field name="warehouse_id" class="d-block px-2" groups="stock.group_stock_multi_warehouses"/>
+                            <div class="container-fluid px-2">
+                                <div t-if="!selection_mode" class="row mt-3">
+                                    <div class="col">
+                                        <button class="btn btn-primary" name="get_action_picking_tree_ready" type="object">
+                                            <span t-if="record.count_picking_ready.raw_value > 0">
+                                                <field name="count_picking_ready"/>
+                                                <t t-if="record.code.raw_value === 'incoming'"> To Receive</t>
+                                                <t t-elif="record.code.raw_value === 'outgoing'" name="outgoing_label"> To Deliver</t>
+                                                <t t-else=""> To Process</t>
+                                            </span>
+                                            <span t-else="">Open</span>
+                                        </button>
                                     </div>
+                                    <div class="col-auto stock-overview-links px-5">
+                                        <div t-if="record.count_picking_waiting.raw_value > 0" class="col-auto">
+                                            <a class="pe-0 text-truncate" name="get_action_picking_tree_waiting" type="object">
+                                                <div class="row overflow-hidden">
+                                                    <span class="col">Waiting</span>
+                                                    <field class="col text-end" name="count_picking_waiting"/>
+                                                </div>
+                                            </a>
+                                        </div>
 
-                                    <div t-if="record.count_picking_late.raw_value > 0" class="row">
-                                        <a class="col-8 offset-4 pe-0 text-truncate" name="get_action_picking_tree_late" type="object">
-                                            <div class="row">
-                                                <span class="col-6">Late</span>
-                                                <field class="col-2 text-end" name="count_picking_late"/>
-                                            </div>
-                                        </a>
-                                    </div>
+                                        <div t-if="record.count_picking_late.raw_value > 0" class="col-auto">
+                                            <a class="pe-0 text-truncate" name="get_action_picking_tree_late" type="object">
+                                                <div class="row overflow-hidden">
+                                                    <span class="col">Late</span>
+                                                    <field class="col text-end" name="count_picking_late"/>
+                                                </div>
+                                            </a>
+                                        </div>
 
-                                    <div t-if="record.count_picking_backorders.raw_value > 0" class="row" name="picking_type_backorder_count">
-                                        <a class="col-8 offset-4 pe-0 text-truncate" name="get_action_picking_tree_backorder" type="object">
-                                            <div class="row">
-                                                <span class="col-6">Back Orders</span>
-                                                <field class="col-2 text-end" name="count_picking_backorders"/>
-                                            </div>
-                                        </a>
-                                    </div>
+                                        <div t-if="record.count_picking_backorders.raw_value > 0" class="col-auto" name="picking_type_backorder_count">
+                                            <a class="pe-0 text-truncate" name="get_action_picking_tree_backorder" type="object">
+                                                <div class="row overflow-hidden">
+                                                    <span class="col">Back Orders</span>
+                                                    <field class="col text-end" name="count_picking_backorders"/>
+                                                </div>
+                                            </a>
+                                        </div>
 
-                                    <div t-if="record.count_move_ready.raw_value > 0" class="row">
-                                        <a class="col-8 offset-4 pe-0 text-truncate" name="get_action_picking_type_ready_moves" type="object">
-                                            <div class="row">
-                                                <span class="col-6">Operations</span>
-                                                <field class="col-2 text-end" name="count_move_ready"/>
-                                            </div>
-                                        </a>
+                                        <div t-if="record.count_move_ready.raw_value > 0" class="col-auto">
+                                            <a class="pe-0 text-truncate" name="get_action_picking_type_ready_moves" type="object">
+                                                <div class="row overflow-hidden">
+                                                    <span class="col">Operations</span>
+                                                    <field class="col text-end" name="count_move_ready"/>
+                                                </div>
+                                            </a>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
-                            <field t-if="!selection_mode" name="kanban_dashboard_graph" class="mt-auto" graph_type="bar" widget="picking_type_dashboard_graph"/>
-                        </div>
+                        </t>
+                            <field t-if="!selection_mode" name="kanban_dashboard_graph" class="px-2" graph_type="bar" widget="picking_type_dashboard_graph"/>
+                        <!-- </div> -->
                     </t>
                 </templates>
             </kanban>

--- a/addons/stock_picking_batch/views/stock_picking_wave_views.xml
+++ b/addons/stock_picking_batch/views/stock_picking_wave_views.xml
@@ -120,10 +120,10 @@
             </xpath>
             <xpath expr="//div[@name='picking_type_backorder_count']" class="row" position="after">
                 <div class="row">
-                    <a class="col-8 offset-4 text-truncate" name="action_wave" type="object">
+                    <a class="text-truncate" name="action_wave" type="object">
                         <div t-if="record.count_picking_wave.raw_value > 0"  class="row">
-                            <span class="col-6">Waves</span>
-                            <field name="count_picking_wave" class="col-2 text-end"/>
+                            <span class="col">Waves</span>
+                            <field name="count_picking_wave" class="col text-end"/>
                         </div>
                     </a>
                 </div>


### PR DESCRIPTION
The current hardcoded column values for the Inventory Overview kanban card links make it so if the text or the number exceeds the width, the text will overlap with each other. In some cases, this resulted in translations overlapping with single digit numbers.

This commit relaxs the design to make the columns dynamically resize on their own based on the lengths of these texts so that this overlap no longer happens. Note that this means:
- the column will go under the buttons in the card view in smaller windows and/or when the text is long and/or when grouping by Type of Operation in some cases
- the card now has more similar behavior to the overview in accounting for the sizing of this column

Task: 5155629

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
