### PR TITLE
[FIX] hr_recruitment: email applications without company

### DIFF
--- a/addons/hr_recruitment/models/hr_job.py
+++ b/addons/hr_recruitment/models/hr_job.py
@@ -282,7 +282,7 @@ class HrJob(models.Model):
             defaults.update({
                 'job_id': self.id,
                 'department_id': self.department_id.id,
-                'company_id': self.department_id.company_id.id if self.department_id else self.company_id.id,
+                'company_id': self.department_id.company_id.id or self.company_id.id,
                 'user_id': self.user_id.id,
             })
         return values

--- a/addons/hr_recruitment/tests/test_recruitment_process.py
+++ b/addons/hr_recruitment/tests/test_recruitment_process.py
@@ -141,3 +141,49 @@ class TestRecruitmentProcess(TestHrCommon):
         # Make sure the applicant are created in the right company
         applicant = self.env['hr.applicant'].search([('email_from', 'ilike', 'Richard_Anderson@yahoo.com')], limit=1)
         self.assertEqual(applicant.company_id, other_company, 'Applicant should be created in the right company')
+
+    def test_email_application_department_with_no_company(self):
+        """
+        Test that applicants created from incoming emails are assigned the job's company when the job's department
+        has no company set.
+        """
+        mystery_company = self.env["res.company"].create({"name": "Mystery Company"})
+        _mail_alias_domain = self.env["mail.alias.domain"].create(
+            {
+                "company_ids": [(4, mystery_company.id)],
+                "name": "test.example.com",
+            }
+        )
+        alias = self.env["mail.alias"].create(
+            {
+                "alias_domain_id": mystery_company.alias_domain_id.id,
+                "alias_name": "mystery_job",
+                "alias_model_id": self.env["ir.model"]._get_id("hr.job"),
+            }
+        )
+
+        mystery_department = self.env["hr.department"].create({"name": "Mystery Department", "company_id": False})
+        mystery_job = self.env["hr.job"].create(
+            {
+                "name": "Mystery Job",
+                "company_id": mystery_company.id,
+                "department_id": mystery_department.id,
+                "alias_id": alias.id,
+            }
+        )
+
+        email = f"""MIME-Version: 1.0
+Message-ID: <verymysteriousapplication>
+From: Applicant <test@example.com>
+To: {mystery_job.alias_id.display_name}
+Subject: Job Application
+Content-Type: text/plain; charset="UTF-8"
+
+I want to work for you!"""
+
+        applicant_from_email = self.env["mail.thread"].message_process("hr.applicant", email)
+        applicant = self.env["hr.applicant"].browse(applicant_from_email)
+        self.assertEqual(
+            applicant.department_id, mystery_department, "Applicant should be assigned to the right department"
+        )
+        self.assertEqual(applicant.company_id, mystery_company, "Applicant should be created in the right company")


### PR DESCRIPTION
When an applicant applied to a job position with a company_id and department_id, but the department itself had no company_id set, the application would have company_id set to False rather than the company_id from the job position. This caused bunch of issues such as the inability to add a recruiter or interviewers to the application.The bug seems to come from the default values created in the method `_alias_get_creation_values` on the job position, which sets the default company_id to the department's company_id when the job has a department that can result in False when the department exists but has no company set.

task-5184275

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
