### PR TITLE
[FIX] stock_account: send Inventory Valuation date as ASCII ISO

### DIFF
--- a/addons/stock_account/static/src/stock_valuation/controller.js
+++ b/addons/stock_account/static/src/stock_valuation/controller.js
@@ -23,7 +23,7 @@ export class StockValuationReportController {
 
     async loadReportData() {
         const kwargs = {
-            date: serializeDate(this.state.date),
+            date: this.state.date.toISODate() || false,
         };
         const res = await this.orm.call(
             "stock_account.stock.valuation.report",
@@ -70,7 +70,7 @@ export class StockValuationReportController {
 
     async setDate(date) {
         this.state.date = date;
-        this.dateAsString = date.toFormat('y-LL-dd HH:mm:ss');
+        this.dateAsString = date.toISO();
         await this.loadReportData();
     }
 


### PR DESCRIPTION
Steps:
- Switch UI language to Arabic.
- Accounting ▸ Review ▸ Inventory Valuation.

Before this commit:
- Crash during RPC with: ValueError: time data '٢٠٢٥-١٠-٢١' does not match format '%Y-%m-%d' (from stock_account.stock.valuation.report._get_report_data)

Cause:
- The client sent the date string with Eastern Arabic digits. Python’s strptime('%Y-%m-%d') only accepts ASCII digits.

with this commit:
When building kwargs for `get_report_values`, serialize the date with `toISODate()` (ASCII `YYYY-MM-DD`).
Replace localized formatting (`toFormat('yyyy-MM-dd')` with `toISODate()` at the call site. This is locale-independent and avoids TZ side effects for pure dates. Keeps existing behavior for empty date (send `false`).

opw-5146684

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
