### PR TITLE
[IMP] orm: domain |, & with bool

### DIFF
--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -317,14 +317,18 @@ class Domain:
 
     def __and__(self, other):
         """Domain & Domain"""
+        if isinstance(other, DomainBool):
+            return other & self
         if isinstance(other, Domain):
-            return DomainAnd.apply([self, other])
+            return DomainAnd.apply((self, other))
         return NotImplemented
 
     def __or__(self, other):
         """Domain | Domain"""
+        if isinstance(other, DomainBool):
+            return other | self
         if isinstance(other, Domain):
-            return DomainOr.apply([self, other])
+            return DomainOr.apply((self, other))
         return NotImplemented
 
     def __invert__(self):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When combining a domain with a boolean, just keep the object instead of creating a new domain. This allows to optimization levels to be kept.

Current behavior before PR:
`domain & Domain.TRUE` creates a new instance.

Desired behavior after PR is merged:
Just return the existing domain.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
