### PR TITLE
[IMP] website: apply bg-color on 'connections' shape

### DIFF
--- a/addons/html_builder/static/src/@types/plugins.d.ts
+++ b/addons/html_builder/static/src/@types/plugins.d.ts
@@ -25,7 +25,7 @@ declare module "plugins" {
     import { snippet_preview_dialog_bundles, snippet_preview_dialog_stylesheets_handlers } from "@html_builder/snippets/add_snippet_dialog";
     import { background_shape_target_providers } from "@html_builder/plugins/background_option/background_shape_option_plugin";
     import { mark_color_level_selector_params } from "@html_builder/plugins/background_option/background_option_plugin";
-    import { is_movable_selector } from "@html_builder/core/move_plugin";
+    import { is_movable_selector, on_move_handlers } from "@html_builder/core/move_plugin";
     import { content_editable_selectors, content_not_editable_selectors } from "@html_builder/core/builder_content_editable_plugin";
     import { builder_actions, BuilderActionsShared } from "@html_builder/core/builder_actions_plugin";
     import { so_content_addition_selector, so_snippet_addition_selector } from "@html_builder/core/dropzone_selector_plugin";
@@ -79,6 +79,7 @@ declare module "plugins" {
         on_element_out_dropzone_handlers: on_element_out_dropzone_handlers;
         on_element_over_dropzone_handlers: on_element_over_dropzone_handlers;
         on_mobile_preview_clicked: on_mobile_preview_clicked;
+        on_moved_handlers: on_moved_handlers;
         on_prepare_drag_handlers: on_prepare_drag_handlers;
         on_removed_handlers: on_removed_handlers;
         on_restore_containers_handlers: on_restore_containers_handlers;

--- a/addons/html_builder/static/src/core/move_plugin.js
+++ b/addons/html_builder/static/src/core/move_plugin.js
@@ -262,6 +262,7 @@ export class MovePlugin extends Plugin {
                 this.overlayTarget
             );
         }
+        this.dispatchTo("on_moved_handlers", { movedEl: this.overlayTarget, siblingEl });
 
         // Scroll to the element.
         if (!this.noScroll && !isElementInViewport(this.overlayTarget)) {

--- a/addons/html_builder/static/src/core/move_plugin.js
+++ b/addons/html_builder/static/src/core/move_plugin.js
@@ -19,6 +19,10 @@ import { localization } from "@web/core/l10n/localization";
  *     noScroll?: boolean;
  * }[]} is_movable_selector
  */
+/**
+ * @typedef {((arg: { movedEl: HTMLElement, siblingEl: HTMLElement }) => void)[]} on_moved_handlers
+ * Called after an element was moved.
+ */
 export class MovePlugin extends Plugin {
     static id = "move";
     static dependencies = ["visibility"];

--- a/addons/html_builder/static/src/plugins/background/background_color_option.xml
+++ b/addons/html_builder/static/src/plugins/background/background_color_option.xml
@@ -1,6 +1,6 @@
 <templates>
 <!-- TODO: handle bg_color_opt-->
 <t t-name="html_builder.BackgroundColorWidgetOption">
-    <BuilderColorPicker title.translate="Color" styleAction="'background-color'"/>
+    <BuilderColorPicker title.translate="Color" styleAction="'background-color'" action="'handleBgColorChanged'"/>
 </t>
 </templates>

--- a/addons/html_builder/static/src/plugins/background_option/background_shape_option.js
+++ b/addons/html_builder/static/src/plugins/background_option/background_shape_option.js
@@ -12,8 +12,12 @@ export class BackgroundShapeOption extends BaseOptionComponent {
         super.setup();
         this.backgroundShapePlugin = this.dependencies.backgroundShapeOption;
         this.toRatio = toRatio;
+        this.shapePositionCache = this.extractShapePositionsFromCSS();
         this.state = useDomState((editingElement) => {
             const shapeData = this.backgroundShapePlugin.getShapeData(editingElement);
+            this.currentColors = shapeData.colors;
+            this.currentFlip = shapeData.flip;
+            this.injectShapeColorStyles(editingElement);
             const shapeInfo = this.backgroundShapePlugin.getBackgroundShapes()[shapeData.shape];
             return {
                 hasShape: !!shapeInfo,
@@ -28,6 +32,223 @@ export class BackgroundShapeOption extends BaseOptionComponent {
     }
     getShapeStyleUrl(shapeId) {
         return this.backgroundShapePlugin.getShapeStyleUrl(shapeId);
+    }
+    getShapeClass(shapePath) {
+        return `o_${shapePath.replaceAll("/", "_")}`;
+    }
+
+    /**
+     * Extracts background-position values for all shapes directly from CSS
+     * rules. This avoids the need to create temporary DOM elements.
+     *
+     * @returns {Map<string, string>} Map of shape class names to
+     * background-position values
+     */
+    extractShapePositionsFromCSS() {
+        const positions = new Map();
+        const injectedStyleId = "shape-selector-custom-colors";
+
+        for (const styleSheet of document.styleSheets) {
+            // Skip cross-origin stylesheets
+            if (styleSheet.href && new URL(styleSheet.href).origin !== location.origin) {
+                continue;
+            }
+            // Skip the injected shape color stylesheet
+            if (styleSheet.ownerNode?.id === injectedStyleId) {
+                continue;
+            }
+            for (const rule of styleSheet.cssRules) {
+                // Look for rules like
+                // ".o_we_shape.o_html_builder_Connections_01"
+                if (rule.selectorText?.includes(".o_we_shape.o_")) {
+                    const match = rule.selectorText.match(/\.o_we_shape\.(o_[a-zA-Z0-9_]+)/);
+                    if (match && rule.style.backgroundPosition) {
+                        positions.set(match[1], rule.style.backgroundPosition);
+                    }
+                }
+            }
+        }
+
+        return positions;
+    }
+
+    /**
+     * Injects CSS to override shape background-image URLs with current colors
+     * and applies flip transformations.
+     * This allows the shape selector to show shapes with the user's selected
+     * colors and flip.
+     */
+    injectShapeColorStyles(editingElement) {
+        const styleId = "shape-selector-custom-colors";
+        let styleEl = document.getElementById(styleId);
+
+        if (!styleEl) {
+            styleEl = document.createElement("style");
+            styleEl.id = styleId;
+            document.head.appendChild(styleEl);
+        }
+
+        // Build CSS rules for each shape
+        const cssRules = [];
+        const computedColors = { classic: {}, connection: {} };
+        for (const group of Object.values(this.getBackgroundShapeGroups())) {
+            for (const subgroup of Object.values(group.subgroups)) {
+                for (const [shapePath] of Object.entries(subgroup.shapes)) {
+                    const result = this.getShapeUrlWithColors(
+                        editingElement,
+                        shapePath,
+                        computedColors
+                    );
+                    if (!result.hasChanges) {
+                        continue;
+                    }
+                    const shapeClass = this.getShapeClass(shapePath);
+                    const flipPosition = this.getFlipBackgroundPosition(shapePath);
+
+                    const rule = `
+                        .o_we_shape_btn_content .o_we_shape.${shapeClass} {
+                            background-image: url("${result.url}") !important;
+                            ${
+                                flipPosition
+                                    ? `background-position: ${flipPosition} !important;`
+                                    : ""
+                            }
+                            }
+                            `;
+                    cssRules.push(rule);
+                }
+            }
+        }
+
+        styleEl.textContent = cssRules.join("\n");
+    }
+
+    /**
+     * Generates a shape URL with current colors and flip applied.
+     * Uses getImplicitColors to compute the correct colors for each shape.
+     *
+     * @param {string} editingElement - The editing Element
+     * @param {string} shapePath - The shape path
+     * @param {Object} computedColors - Cache object with classic and connection
+     * colors
+     * @returns {Object} Object with `url`, `hasChanges` flag, and
+     * brighterColor`
+     */
+    getShapeUrlWithColors(editingElement, shapePath, computedColors) {
+        const defaultUrl = this.getShapeStyleUrl(shapePath);
+
+        if (!defaultUrl) {
+            return { url: "", hasChanges: false };
+        }
+        const innerUrl = defaultUrl.replace(/^url\((['"]?)(.*?)\1\)$/, "$2");
+        const url = new URL(innerUrl, window.location.origin);
+        const defaultParams = new URLSearchParams(url.search);
+        let hasChanges = false;
+        const colorCache = shapePath.includes("html_builder/Connections/")
+            ? computedColors.connection
+            : computedColors.classic;
+
+        let allColorsCached = true;
+        for (const colorName of defaultParams.keys()) {
+            if (!colorCache[colorName]) {
+                allColorsCached = false;
+                break;
+            }
+        }
+
+        if (allColorsCached) {
+            for (const [colorName, colorValue] of Object.entries(colorCache)) {
+                if (defaultParams.has(colorName)) {
+                    const currentValue = defaultParams.get(colorName);
+                    if (currentValue !== colorValue) {
+                        defaultParams.set(colorName, colorValue);
+                        hasChanges = true;
+                    }
+                }
+            }
+        } else {
+            if (this.backgroundShapePlugin.getImplicitColors && editingElement) {
+                const implicitColors = this.backgroundShapePlugin.getImplicitColors(
+                    editingElement,
+                    shapePath,
+                    this.currentColors || {}
+                );
+                for (const [colorName, colorValue] of Object.entries(implicitColors)) {
+                    if (defaultParams.has(colorName)) {
+                        colorCache[colorName] = colorValue;
+                        const currentValue = defaultParams.get(colorName);
+                        if (currentValue !== colorValue) {
+                            defaultParams.set(colorName, colorValue);
+                            hasChanges = true;
+                        }
+                    }
+                }
+            }
+        }
+
+        if (this.currentFlip && this.currentFlip.length > 0) {
+            defaultParams.set("flip", this.currentFlip.sort().join(""));
+            hasChanges = true;
+        }
+
+        return {
+            url: `/html_editor/shape/${encodeURIComponent(
+                shapePath
+            )}.svg?${defaultParams.toString()}`,
+            hasChanges,
+        };
+    }
+    /**
+     * Converts a CSS background-position value to a percentage.
+     * Handles both numeric values and keywords like "left", "center", "right",
+     * "top", "bottom".
+     *
+     * @param {string} position - The position value (e.g., "50%", "center",
+     * "left", "100px")
+     * @param {boolean} isVertical - Whether this is a vertical position
+     * (affects keyword mapping)
+     * @returns {number} The position as a percentage (0-100)
+     */
+    _convertPositionToPercent(position, isVertical = false) {
+        position = position.trim();
+        const keywordMap = isVertical
+            ? { top: 0, center: 50, bottom: 100 }
+            : { left: 0, center: 50, right: 100 };
+        return keywordMap[position];
+    }
+
+    /**
+     * Calculates the background-position value to apply flip transformations
+     * for a given shape. Uses pre-extracted CSS positions to avoid DOM
+     * manipulation.
+     *
+     * @param {string} shapePath - The path of the shape
+     * (e.g., "html_builder/Connections/01")
+     * @returns {string} The flipped background-position
+     */
+    getFlipBackgroundPosition(shapePath) {
+        if (!this.currentFlip || this.currentFlip.length === 0) {
+            return null;
+        }
+        const shapeClass = this.getShapeClass(shapePath);
+        const bgPosition = this.shapePositionCache.get(shapeClass);
+        const positions = bgPosition.split(" ");
+        const firstTerm = positions[0];
+        const secondTerm = positions[1];
+
+        let xPos, yPos;
+        // Check if first term is a vertical-only keyword
+        if (firstTerm === "top" || firstTerm === "bottom") {
+            xPos = this._convertPositionToPercent(secondTerm || "center", false);
+            yPos = this._convertPositionToPercent(firstTerm, true);
+        } else {
+            xPos = this._convertPositionToPercent(firstTerm, false);
+            yPos = this._convertPositionToPercent(secondTerm || "center", true);
+        }
+
+        xPos = this.currentFlip.includes("x") ? 100 - xPos : xPos;
+        yPos = this.currentFlip.includes("y") ? 100 - yPos : yPos;
+        return `${xPos}% ${yPos}%`;
     }
 }
 

--- a/addons/html_builder/static/src/plugins/shape/shape_selector.scss
+++ b/addons/html_builder/static/src/plugins/shape/shape_selector.scss
@@ -60,6 +60,9 @@
         button, div {
             height: 50px;
         }
+        .o_we_shape {
+            background-color: rgba(27, 27, 27, 0.2);
+        }
     }
 
     .o-hb-img-shape-btn {

--- a/addons/html_builder/static/tests/background_shape_color.test.js
+++ b/addons/html_builder/static/tests/background_shape_color.test.js
@@ -1,0 +1,267 @@
+import { addBuilderOption, setupHTMLBuilder } from "@html_builder/../tests/helpers";
+import { BackgroundOption } from "@html_builder/plugins/background_option/background_option";
+import { expect, test, describe } from "@odoo/hoot";
+import { animationFrame, queryOne } from "@odoo/hoot-dom";
+import { contains } from "@web/../tests/web_test_helpers";
+
+describe.current.tags("desktop");
+
+function getShapeTestCSS() {
+    return `
+        /* CSS Variables for theme colors */
+        :root {
+            --o-color-1: #3aadaa;
+            --o-color-2: #7c6576;
+            --o-color-3: #dd7777;
+            --o-color-4: #383e45;
+            --o-color-5: #f0f0f0;
+
+            --o-cc1-bg: #3aadaa;
+            --o-cc2-bg: #7c6576;
+            --o-cc3-bg: #dd7777;
+            --o-cc4-bg: #383e45;
+            --o-cc5-bg: #f0f0f0;
+        }
+
+        .o_cc5 {
+            background-color: var(--o-cc5-bg);
+        }
+
+        /* Base shape styles - required for positioning and layout */
+        .o_we_shape {
+            position: absolute !important;
+            top: 0;
+            right: 0;
+            bottom: 0;
+            left: 0;
+            display: block;
+            overflow: hidden;
+            pointer-events: none;
+        }
+
+        /* Connections shapes */
+        .o_we_shape.o_html_builder_Connections_01 {
+            background-image: url("/html_editor/shape/html_builder/Connections/01.svg?c5=%23383e45");
+            background-position: 50% 100%;
+            background-size: 100% auto;
+            background-repeat: no-repeat;
+        }
+
+        .o_we_shape.o_html_builder_Connections_02 {
+            background-image: url("/html_editor/shape/html_builder/Connections/02.svg?c5=%23383e45");
+            background-position: 50% 100%;
+            background-size: 100% auto;
+            background-repeat: no-repeat;
+        }
+
+        /* Non-connection shapes used in tests */
+        .o_we_shape.o_html_builder_Blobs_02 {
+            background-image: url("/html_editor/shape/html_builder/Blobs/02.svg?c1=%23383e45");
+            background-position: 50% 50%;
+            background-size: 100% 100%;
+            background-repeat: no-repeat;
+        }
+
+        .o_we_shape.o_html_builder_Containers_01 {
+            background-image: url("/html_editor/shape/html_builder/Containers/01.svg?c5=%23383e45");
+            background-position: 50% 100%;
+            background-size: 100% auto;
+            background-repeat: no-repeat;
+        }
+
+        .o_we_shape.o_html_builder_Bold_16 {
+            background-image: url("/html_editor/shape/html_builder/Bold/16.svg?c5=%23383e45");
+            background-position: 50% 100%;
+            background-size: 100% auto;
+            background-repeat: no-repeat;
+        }
+    `;
+}
+
+test("Connections shape takes neighbor element's background color", async () => {
+    addBuilderOption(
+        class TestBackgroundOption extends BackgroundOption {
+            static selector = "section";
+            static props = {
+                ...BackgroundOption.props,
+                withColors: { type: Boolean, optional: true },
+                withImages: { type: Boolean, optional: true },
+                withColorCombinations: { type: Boolean, optional: true },
+            };
+            static defaultProps = {
+                withColors: true,
+                withImages: true,
+                withShapes: true,
+                withColorCombinations: false,
+            };
+        }
+    );
+
+    await setupHTMLBuilder(
+        `
+        <section id="section1" style="background-color: rgb(255, 0, 0);" data-snippet="s_snippet">
+            Section 1
+        </section>
+        <section id="section2" style="background-color: rgb(0, 0, 255);" data-snippet="s_snippet">
+            Section 2
+        </section>
+    `,
+        {
+            styleContent: getShapeTestCSS(),
+        }
+    );
+
+    await contains(":iframe #section1").click();
+    await contains("[data-label='Shape'] button").click();
+    await animationFrame();
+    await contains(
+        "button[data-action-id='setBackgroundShape'][data-action-value='html_builder/Connections/01']"
+    ).click();
+    await animationFrame();
+    expect(":iframe #section1 .o_we_shape").toHaveCount(1);
+    const shapeData = JSON.parse(queryOne(":iframe #section1").dataset.oeShapeData);
+    expect(shapeData.shape).toBe("html_builder/Connections/01");
+    expect(shapeData.colors.c5).toBe("#0000ff");
+});
+
+test("Flipped Connections shape takes previous element's background color", async () => {
+    addBuilderOption(
+        class TestBackgroundOption extends BackgroundOption {
+            static selector = "section";
+            static props = {
+                ...BackgroundOption.props,
+                withColors: { type: Boolean, optional: true },
+                withImages: { type: Boolean, optional: true },
+                withColorCombinations: { type: Boolean, optional: true },
+            };
+            static defaultProps = {
+                withColors: true,
+                withImages: true,
+                withShapes: true,
+                withColorCombinations: false,
+            };
+        }
+    );
+
+    await setupHTMLBuilder(
+        `
+        <section id="section1" style="background-color: rgb(255, 0, 0);" data-snippet="s_snippet">
+            Section 1
+        </section>
+        <section id="section2" style="background-color: rgb(0, 0, 255);" data-snippet="s_snippet">
+            Section 2
+        </section>
+    `,
+        {
+            styleContent: getShapeTestCSS(),
+        }
+    );
+
+    await contains(":iframe #section2").click();
+    await contains("[data-label='Shape'] button").click();
+    await animationFrame();
+    await contains(
+        "button[data-action-id='setBackgroundShape'][data-action-value='html_builder/Connections/01']"
+    ).click();
+    await animationFrame();
+    await contains("button[data-action-id='flipShape'][data-action-param='y']").click();
+    expect(":iframe #section2 .o_we_shape").toHaveCount(1);
+    const shapeData = JSON.parse(queryOne(":iframe #section2").dataset.oeShapeData);
+    expect(shapeData.shape).toBe("html_builder/Connections/01");
+    expect(shapeData.colors.c5).toBe("#ff0000");
+    expect(shapeData.flip.includes("y")).toBe(true);
+});
+
+test("Connections shape uses contrasting color when neighbor has same background", async () => {
+    addBuilderOption(
+        class TestBackgroundOption extends BackgroundOption {
+            static selector = "section";
+            static props = {
+                ...BackgroundOption.props,
+                withColors: { type: Boolean, optional: true },
+                withImages: { type: Boolean, optional: true },
+                withColorCombinations: { type: Boolean, optional: true },
+            };
+            static defaultProps = {
+                withColors: true,
+                withImages: true,
+                withShapes: true,
+                withColorCombinations: false,
+            };
+        }
+    );
+
+    await setupHTMLBuilder(
+        `
+        <section id="section1" style="background-color: rgb(255, 0, 0);" data-snippet="s_snippet">
+            Section 1
+        </section>
+        <section id="section2" style="background-color: rgb(255, 0, 0);" data-snippet="s_snippet">
+            Section 2
+        </section>
+    `,
+        {
+            styleContent: getShapeTestCSS(),
+        }
+    );
+
+    await contains(":iframe #section1").click();
+    await contains("[data-label='Shape'] button").click();
+    await animationFrame();
+    await contains(
+        "button[data-action-id='setBackgroundShape'][data-action-value='html_builder/Connections/01']"
+    ).click();
+    await animationFrame();
+    expect(":iframe #section1 .o_we_shape").toHaveCount(1);
+    const shapeData = JSON.parse(queryOne(":iframe #section1").dataset.oeShapeData);
+    expect(shapeData.shape).toBe("html_builder/Connections/01");
+    expect(shapeData.colors.c5).toBe("#f0f0f0");
+});
+
+test("Non-Connections shapes are not affected by neighbor color changes", async () => {
+    addBuilderOption(
+        class TestBackgroundOption extends BackgroundOption {
+            static selector = "section";
+            static props = {
+                ...BackgroundOption.props,
+                withColors: { type: Boolean, optional: true },
+                withImages: { type: Boolean, optional: true },
+                withColorCombinations: { type: Boolean, optional: true },
+            };
+            static defaultProps = {
+                withColors: true,
+                withImages: true,
+                withShapes: true,
+                withColorCombinations: false,
+            };
+        }
+    );
+
+    await setupHTMLBuilder(
+        `
+        <section id="section1" style="background-color: rgb(255, 0, 0);" data-snippet="s_snippet"
+                 data-oe-shape-data='{"shape":"html_builder/Blobs/02","colors":{"c1":"#ffff00"},"flip":[],"showOnMobile":false,"shapeAnimationSpeed":"0"}'>
+            <div class="o_we_shape o_html_builder_Blobs_02"></div>
+            Section 1
+        </section>
+        <section id="section2" style="background-color: rgb(0, 0, 255);" data-snippet="s_snippet">
+            Section 2
+        </section>
+    `,
+        {
+            styleContent: getShapeTestCSS(),
+        }
+    );
+
+    const section1 = queryOne(":iframe #section1");
+    const initialShapeData = JSON.parse(section1.dataset.oeShapeData);
+    expect(initialShapeData.shape).toBe("html_builder/Blobs/02");
+    expect(initialShapeData.colors.c1).toBe("#ffff00");
+    await contains(":iframe #section2").click();
+    await contains(".o_we_color_preview").click();
+    await contains("[data-color='o_cc3']").click();
+    await animationFrame();
+    const updatedShapeData = JSON.parse(section1.dataset.oeShapeData);
+    expect(updatedShapeData.shape).toBe("html_builder/Blobs/02");
+    expect(updatedShapeData.colors.c1).toBe("#ffff00");
+});

--- a/addons/html_builder/static/tests/background_shape_color.test.js
+++ b/addons/html_builder/static/tests/background_shape_color.test.js
@@ -1,4 +1,10 @@
-import { addBuilderOption, setupHTMLBuilder } from "@html_builder/../tests/helpers";
+import {
+    addBuilderOption,
+    setupHTMLBuilder,
+    waitForEndOfOperation,
+    confirmAddSnippet,
+    getSnippetStructure,
+} from "@html_builder/../tests/helpers";
 import { BackgroundOption } from "@html_builder/plugins/background_option/background_option";
 import { expect, test, describe } from "@odoo/hoot";
 import { animationFrame, queryOne } from "@odoo/hoot-dom";
@@ -264,4 +270,219 @@ test("Non-Connections shapes are not affected by neighbor color changes", async 
     const updatedShapeData = JSON.parse(section1.dataset.oeShapeData);
     expect(updatedShapeData.shape).toBe("html_builder/Blobs/02");
     expect(updatedShapeData.colors.c1).toBe("#ffff00");
+});
+
+test("Connections shape color updates when neighbor background color changes", async () => {
+    addBuilderOption(
+        class TestBackgroundOption extends BackgroundOption {
+            static selector = "section";
+            static props = {
+                ...BackgroundOption.props,
+                withColors: { type: Boolean, optional: true },
+                withImages: { type: Boolean, optional: true },
+                withColorCombinations: { type: Boolean, optional: true },
+            };
+            static defaultProps = {
+                withColors: true,
+                withImages: true,
+                withShapes: true,
+                withColorCombinations: false,
+            };
+        }
+    );
+
+    await setupHTMLBuilder(
+        `
+        <section id="section1" style="background-color: rgb(255, 0, 0);" data-snippet="s_snippet"
+                 data-oe-shape-data='{"shape":"html_builder/Connections/01","colors":{"c5":"#0000ff"},"flip":[],"showOnMobile":false,"shapeAnimationSpeed":"0"}'>
+            <div class="o_we_shape o_html_builder_Connections_01"></div>
+            Section 1
+        </section>
+        <section id="section2" style="background-color: rgb(0, 0, 255);" data-snippet="s_snippet">
+            Section 2
+        </section>
+    `,
+        {
+            styleContent: getShapeTestCSS(),
+        }
+    );
+
+    await contains(":iframe #section2").click();
+    await contains(".o_we_color_preview").click();
+    await contains("[data-color='o_cc5']").click();
+    await animationFrame();
+    const shapeData = JSON.parse(queryOne(":iframe #section1").dataset.oeShapeData);
+    expect(shapeData.shape).toBe("html_builder/Connections/01");
+    expect(shapeData.colors.c5).toBe("#f0f0f0");
+});
+
+test("Connections shape color updates when snippet is dropped next to it", async () => {
+    addBuilderOption(
+        class TestBackgroundOption extends BackgroundOption {
+            static selector = "section";
+            static props = {
+                ...BackgroundOption.props,
+                withColors: { type: Boolean, optional: true },
+                withImages: { type: Boolean, optional: true },
+                withColorCombinations: { type: Boolean, optional: true },
+            };
+            static defaultProps = {
+                withColors: true,
+                withImages: true,
+                withShapes: true,
+                withColorCombinations: false,
+            };
+        }
+    );
+
+    await setupHTMLBuilder(
+        `
+        <section id="section1" style="background-color: rgb(255, 0, 0);" data-snippet="s_snippet"
+                 data-oe-shape-data='{"shape":"html_builder/Connections/01","colors":{"c5":"#0000ff"},"flip":[],"showOnMobile":false,"shapeAnimationSpeed":"0"}'>
+            <div class="o_we_shape o_html_builder_Connections_01" style='background-image: url("/html_editor/shape/html_builder/Connections/01.svg?c5=%230000ff")'></div>
+            Section 1
+        </section>
+        <section id="section2" style="background-color: rgb(0, 0, 255);" data-snippet="s_snippet">
+            Section 2
+        </section>
+    `,
+        {
+            styleContent: getShapeTestCSS(),
+            snippets: {
+                snippet_groups: [
+                    '<div name="A" data-oe-thumbnail="a.svg" data-oe-snippet-id="123" data-o-snippet-group="a"><section data-snippet="s_snippet_group"></section></div>',
+                ],
+                snippet_structure: [
+                    getSnippetStructure({
+                        name: "Test",
+                        groupName: "a",
+                        content: `<section class="s_test" data-snippet="s_test" data-name="Test" style ="background-color: rgb(0,255,0); height: 19px;">
+                <div class="test_a"></div>
+                </section>`,
+                    }),
+                ],
+            },
+        }
+    );
+
+    const initialShapeData = JSON.parse(queryOne(":iframe #section1").dataset.oeShapeData);
+    expect(initialShapeData.shape).toBe("html_builder/Connections/01");
+    expect(initialShapeData.colors.c5).toBe("#0000ff");
+    await contains(":iframe #section1").click();
+    await contains("[data-action-param='y']").click();
+    await contains("#blocks-tab").click();
+    const section1 = queryOne(":iframe #section1");
+    const { moveTo, drop } = await contains(
+        ".o-snippets-menu #snippet_groups .o_snippet_thumbnail"
+    ).drag();
+    await moveTo(section1);
+    await drop();
+    await confirmAddSnippet();
+    await waitForEndOfOperation();
+    const updatedShapeData = JSON.parse(queryOne(":iframe #section1").dataset.oeShapeData);
+    expect(updatedShapeData.shape).toBe("html_builder/Connections/01");
+    expect(updatedShapeData.colors.c5).toBe("#00ff00");
+});
+
+test("Connections shape color updates when adjacent snippet is removed", async () => {
+    addBuilderOption(
+        class TestBackgroundOption extends BackgroundOption {
+            static selector = "section";
+            static props = {
+                ...BackgroundOption.props,
+                withColors: { type: Boolean, optional: true },
+                withImages: { type: Boolean, optional: true },
+                withColorCombinations: { type: Boolean, optional: true },
+            };
+            static defaultProps = {
+                withColors: true,
+                withImages: true,
+                withShapes: true,
+                withColorCombinations: false,
+            };
+        }
+    );
+
+    await setupHTMLBuilder(
+        `
+        <section id="section1" style="background-color: rgb(255, 0, 0);" data-snippet="s_snippet"
+                 data-oe-shape-data='{"shape":"html_builder/Connections/01","colors":{"c5":"#00ff00"},"flip":[],"showOnMobile":false,"shapeAnimationSpeed":"0"}'>
+            <div class="o_we_shape o_html_builder_Connections_01"></div>
+            Section 1
+        </section>
+        <section id="section2" style="background-color: rgb(0, 255, 0);" data-snippet="s_snippet">
+            Section 2
+        </section>
+        <section id="section3" style="background-color: rgb(0, 0, 255);" data-snippet="s_snippet">
+            Section 3
+        </section>
+    `,
+        {
+            styleContent: getShapeTestCSS(),
+        }
+    );
+
+    const initialShapeData = JSON.parse(queryOne(":iframe #section1").dataset.oeShapeData);
+    expect(initialShapeData.shape).toBe("html_builder/Connections/01");
+    expect(initialShapeData.colors.c5).toBe("#00ff00");
+    await contains(":iframe #section2").click();
+    await contains(".oe_snippet_remove").click();
+    await animationFrame();
+    const updatedShapeData = JSON.parse(queryOne(":iframe #section1").dataset.oeShapeData);
+    expect(updatedShapeData.shape).toBe("html_builder/Connections/01");
+    expect(updatedShapeData.colors.c5).toBe("#0000ff");
+});
+
+test("Multiple Connections shapes update when middle section color changes", async () => {
+    addBuilderOption(
+        class TestBackgroundOption extends BackgroundOption {
+            static selector = "section";
+            static props = {
+                ...BackgroundOption.props,
+                withColors: { type: Boolean, optional: true },
+                withImages: { type: Boolean, optional: true },
+                withColorCombinations: { type: Boolean, optional: true },
+            };
+            static defaultProps = {
+                withColors: true,
+                withImages: true,
+                withShapes: true,
+                withColorCombinations: false,
+            };
+        }
+    );
+
+    await setupHTMLBuilder(
+        `
+        <section id="section1" style="background-color: rgb(255, 0, 0);" data-snippet="s_snippet"
+                 data-oe-shape-data='{"shape":"html_builder/Connections/01","colors":{"c5":"#00ff00"},"flip":[],"showOnMobile":false,"shapeAnimationSpeed":"0"}'>
+            <div class="o_we_shape o_html_builder_Connections_01"></div>
+            Section 1
+        </section>
+        <section id="section2" style="background-color: rgb(0, 255, 0);" data-snippet="s_snippet">
+            Section 2
+        </section>
+        <section id="section3" style="background-color: rgb(0, 0, 255);" data-snippet="s_snippet"
+                 data-oe-shape-data='{"shape":"html_builder/Connections/01","colors":{"c5":"#00ff00"},"flip":[],"showOnMobile":false,"shapeAnimationSpeed":"0"}'>
+            <div class="o_we_shape o_html_builder_Connections_01"></div>
+            Section 3
+        </section>
+    `,
+        {
+            styleContent: getShapeTestCSS(),
+        }
+    );
+
+    await contains(":iframe #section3").click();
+    await contains("[data-action-param='y']").click();
+    await contains(":iframe #section2").click();
+    await contains(".o_we_color_preview").click();
+    await contains("[data-color='o_cc5']").click();
+    await animationFrame();
+    const updatedShape1Data = JSON.parse(queryOne(":iframe #section1").dataset.oeShapeData);
+    const updatedShape3Data = JSON.parse(queryOne(":iframe #section3").dataset.oeShapeData);
+    expect(updatedShape1Data.shape).toBe("html_builder/Connections/01");
+    expect(updatedShape3Data.shape).toBe("html_builder/Connections/01");
+    expect(updatedShape1Data.colors.c5).toBe("#f0f0f0");
+    expect(updatedShape3Data.colors.c5).toBe("#f0f0f0");
 });

--- a/addons/website/static/src/builder/plugins/customize_website_plugin.js
+++ b/addons/website/static/src/builder/plugins/customize_website_plugin.js
@@ -889,7 +889,7 @@ export class CustomizeWebsiteVariableAction extends BuilderAction {
 
 export class CustomizeWebsiteColorAction extends BuilderAction {
     static id = "customizeWebsiteColor";
-    static dependencies = ["customizeWebsite"];
+    static dependencies = ["customizeWebsite", "backgroundShapeOption"];
     setup() {
         this.preview = false;
         this.dependencies.customizeWebsite.withCustomHistory(this);
@@ -912,6 +912,7 @@ export class CustomizeWebsiteColorAction extends BuilderAction {
         return getCSSVariableValue(color, style);
     }
     async apply({
+        editingElement,
         params: { mainParam: color, colorType, gradientColor, combinationColor, nullValue },
         value,
     }) {
@@ -946,6 +947,13 @@ export class CustomizeWebsiteColorAction extends BuilderAction {
                 { [color]: value },
                 { colorType, combinationColor, resetCcOnEmpty: true, nullValue }
             );
+        }
+        if (["menu-custom", "footer-custom"].includes(color)) {
+            if (color === "menu-custom") {
+                this.document.querySelector("main").style.paddingTop = "";
+                this.document.querySelector("header").style.transform = "";
+            }
+            this.dependencies.backgroundShapeOption.handleBgColorChanged(editingElement, value);
         }
         setBuilderCSSVariables(getHtmlStyle(this.document));
     }

--- a/addons/website/static/tests/builder/background_shape_header.test.js
+++ b/addons/website/static/tests/builder/background_shape_header.test.js
@@ -1,0 +1,104 @@
+import { expect, test, describe } from "@odoo/hoot";
+import { animationFrame, queryOne } from "@odoo/hoot-dom";
+import { contains, defineModels, models, onRpc } from "@web/../tests/web_test_helpers";
+import {
+    defineWebsiteModels,
+    setupWebsiteBuilder,
+} from "@website/../tests/builder/website_helpers";
+
+describe.current.tags("desktop");
+
+function getShapeTestCSS() {
+    return `
+        /* CSS Variables for theme colors */
+        :root {
+            --o-color-1: #3aadaa;
+            --o-color-2: #7c6576;
+            --o-color-3: #dd7777;
+            --o-color-4: #383e45;
+            --o-color-5: #f0f0f0;
+            --o-cc1-bg: #3aadaa;
+            --o-cc2-bg: #7c6576;
+            --o-cc3-bg: #dd7777;
+            --o-cc4-bg: #383e45;
+            --o-cc5-bg: #f0f0f0;
+        }
+        
+        body {
+            margin: 0;
+        }
+        /* Base shape styles - required for positioning and layout */
+        .o_we_shape {
+            position: absolute !important;
+            top: 0;
+            right: 0;
+            bottom: 0;
+            left: 0;
+            display: block;
+            overflow: hidden;
+            pointer-events: none;
+        }
+        /* Connections shapes */
+        .o_we_shape.o_html_builder_Connections_01 {
+            background-image: url("/html_editor/shape/html_builder/Connections/01.svg?c5=%23383e45");
+            background-position: 50% 100%;
+            background-size: 100% auto;
+            background-repeat: no-repeat;
+        }
+        .o_we_shape.o_html_builder_Connections_02 {
+            background-image: url("/html_editor/shape/html_builder/Connections/02.svg?c5=%23383e45");
+            background-position: 50% 100%;
+            background-size: 100% auto;
+            background-repeat: no-repeat;
+        }
+    `;
+}
+
+test("Connections shape updates when header color changes", async () => {
+    class WebsiteAssets extends models.Model {
+        _name = "website.assets";
+        make_scss_customization(location, changes) {}
+    }
+    defineWebsiteModels();
+    defineModels([WebsiteAssets]);
+    onRpc("/website/theme_customize_bundle_reload", async (request) => "");
+    await setupWebsiteBuilder(
+        `
+        <main>
+            <section id="section1" style="background-color: rgb(0, 0, 255);"'>
+                <div class="container">
+                    Section 1
+                </div>
+            </section>
+        </main>
+    `,
+        {
+            headerContent: `<header id="top" data-anchor="true" data-name="Header" style="background-color: rgb(255, 0, 0);">
+                <div class="container">
+                    <nav>Header Content</nav>
+                </div>
+            </header>`,
+            styleContent: getShapeTestCSS(),
+        }
+    );
+
+    await contains(":iframe #section1").click();
+    await contains("[data-label='Shape'] button").click();
+    await animationFrame();
+    await contains(
+        "button[data-action-id='setBackgroundShape'][data-action-value='html_builder/Connections/01']"
+    ).click();
+    await animationFrame();
+    await contains("[data-action-param='y']").click();
+    await animationFrame();
+    const ShapeData = JSON.parse(queryOne(":iframe #section1").dataset.oeShapeData);
+    expect(ShapeData.colors.c5).toBe("#ff0000");
+    await animationFrame();
+    await contains(":iframe header").click();
+    await animationFrame();
+    await contains("[data-label='Background'] .o_we_color_preview").click();
+    await contains("[data-color='o_cc3']").click();
+    await animationFrame();
+    const updatedShapeData = JSON.parse(queryOne(":iframe #section1").dataset.oeShapeData);
+    expect(updatedShapeData.colors.c5).toBe("#dd7777");
+});

--- a/addons/website/static/tests/tours/default_shape_gets_palette_colors.js
+++ b/addons/website/static/tests/tours/default_shape_gets_palette_colors.js
@@ -17,6 +17,11 @@ registerWebsitePreviewTour(
             name: "Text - Image",
             groupName: "Content",
         }),
+        ...insertSnippet({
+            id: "s_banner",
+            name: "Banner",
+            groupName: "Intro",
+        }),
         ...clickOnSnippet({
             id: "s_text_image",
             name: "Text - Image",


### PR DESCRIPTION
This commit enhances the "Connections" background shapes by automatically applying the background color of
adjacent snippets to ensure seamless transitions.

Key improvements include:

- Dynamic Background Color: When a "Connections" shape is added, its background color is determined by the following snippet's background, ensuring visual continuity. If the shape is flipped upside down, its background color is then determined by the previous snippet' background.

- Improved Preview Handling: Previews of "Connections" shapes now reflect the current background color and flip state, avoiding flickering caused by mismatched previews.

- Automatic Updates: When a snippet's background color changes, adjacent "Connections" shapes automatically update their colors. This eliminates the need for manual adjustments, aligning the visual style seamlessly. Those changes are also triggered when snippets are added or deleted next to "Connections" shapes.

task-4280426