### PR TITLE
[FIX] stock: recompute move state when splitting a picking

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -2186,6 +2186,7 @@ Please change the quantity done or the rounding precision of your unit of measur
         new_product_qty = self.product_id.uom_id._compute_quantity(max(0, self.product_qty - qty), self.product_uom, round=False)
         new_product_qty = float_round(new_product_qty, precision_digits=self.env['decimal.precision'].precision_get('Product Unit of Measure'))
         self.with_context(do_not_unreserve=True).write({'product_uom_qty': new_product_qty})
+        self._recompute_state()
         return new_move_vals
 
     def _post_process_created_moves(self):

--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -7063,3 +7063,31 @@ class StockMove(TransactionCase):
         delivery.move_ids.picked = True
         delivery.move_ids.quantity = 5
         self.assertTrue(delivery.move_ids.picked)
+
+    def test_move_state_after_split(self):
+        """Test that move states are correctly recomputed after splitting a picking."""
+        picking = self.env['stock.picking'].create({
+            'picking_type_id': self.env.ref('stock.picking_type_out').id,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.supplier_location.id,
+            'move_ids': [Command.create({
+                'name': 'move_test',
+                'product_id': self.product.id,
+                'product_uom_qty': 10,
+                'location_id': self.stock_location.id,
+                'location_dest_id': self.supplier_location.id,
+            })]
+        })
+        self.env['stock.quant']._update_available_quantity(self.product, self.stock_location, 10)
+        picking.action_confirm()
+        self.assertEqual(picking.move_ids.state, 'assigned')
+        picking.move_ids.quantity = 4
+        self.assertEqual(picking.move_ids.state, 'partially_available')
+        picking.action_split_transfer()
+        self.assertEqual(len(picking.move_ids), 1)
+        self.assertEqual(picking.move_ids.product_uom_qty, 4)
+        self.assertEqual(picking.move_ids.state, 'assigned')
+        backorder = picking.backorder_ids
+        self.assertEqual(backorder.move_ids.product_uom_qty, 6)
+        self.assertEqual(backorder.move_ids.quantity, 6)
+        self.assertEqual(backorder.move_ids.state, 'assigned')


### PR DESCRIPTION
Steps to reproduce:
- Create a storable product “P1”
  - Update its quantity to 10
- Create a delivery picking with 10 units of P1
- Confirm → The picking is in “Ready” state and the move is “Available”

- Update the “Quantity” of P1 to 6 units in the picking

→ The move state is recomputed to “Partially Available”, since the demanded quantity exceeds the quantity done.
https://github.com/odoo/odoo/blob/18.0/addons/stock/models/stock_move.py#L2207-L2208

- Split the picking

Problem:
A new picking is created with 4 units in quantity and its move is “Available”, but the original move with 6 units does not have its state recomputed.

opw-5173374
