### PR TITLE
[FIX] pos_self_order: remove call to resetTableIdentifier

### DIFF
--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -770,7 +770,6 @@ export class SelfOrder extends Reactive {
                 cleanOrders = true;
             } else if (error?.data?.name === "odoo.exceptions.UserError") {
                 message = error.data.message;
-                this.resetTableIdentifier();
             }
         } else if (error instanceof ConnectionLostError) {
             message = _t("Connection lost, please try again later");


### PR DESCRIPTION
Before this commit, there was still a call to the resetTableIdentifier, even though the function had been removed, which could cause errors.

opw-5166737

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
