### PR TITLE
[FIX] purchase: compare PO/invoice price_unit with product price prec.

### DIFF
--- a/addons/purchase/models/account_invoice.py
+++ b/addons/purchase/models/account_invoice.py
@@ -6,6 +6,7 @@ import time
 from markupsafe import Markup
 
 from odoo import api, fields, models, Command, _
+from odoo.tools import float_compare
 
 _logger = logging.getLogger(__name__)
 
@@ -237,6 +238,7 @@ class AccountMove(models.Model):
         matched_inv_lines = []
         try:
             start_time = time.time()
+            precision = self.env["decimal.precision"].precision_get("Product Price")
             for invoice_line in invoice_lines:
                 # There are no purchase order lines left. We are done matching.
                 if not purchase_lines:
@@ -250,10 +252,10 @@ class AccountMove(models.Model):
                     # The lists are sorted by unit price descendingly.
                     # When the unit price of the purchase line is lower than the unit price of the invoice line,
                     # we cannot get a match anymore.
-                    if purchase_line.price_unit < invoice_line.price_unit:
+                    if float_compare(purchase_line.price_unit, invoice_line.price_unit, precision_digits=precision) < 0:
                         break
 
-                    if (invoice_line.price_unit == purchase_line.price_unit
+                    if (float_compare(invoice_line.price_unit, purchase_line.price_unit, precision_digits=precision) == 0
                             and invoice_line.quantity <= purchase_line.product_qty - purchase_line.qty_invoiced):
                         # The current purchase line is a possible match for the current invoice line.
                         # We calculate the name match ratio and continue with other possible matches.

--- a/addons/purchase/tests/test_purchase_invoice.py
+++ b/addons/purchase/tests/test_purchase_invoice.py
@@ -771,6 +771,35 @@ class TestInvoicePurchaseMatch(TestPurchaseToInvoiceCommon):
         for line in po.order_line:
             self.assertTrue(line in invoice_lines.purchase_line_id)
 
+    def test_subset_match_from_edi_partial_po_within_precision(self):
+        """A line of the invoice totally matches a 1-line purchase order despite
+        a slight unit price difference due to decimal precision issues
+        """
+        po = self.init_purchase(confirm=True, products=[self.product_order])
+        invoice = self.init_invoice('in_invoice', partner=self.partner_a, products=[self.product_order, self.service_order])
+
+        # Simulate a slight difference in unit_price due to decimal precision issues
+        # for example when when receiving an invoice in XML or OCR
+        po_line = po.order_line[0]
+        invoice_line = invoice.line_ids[0]
+        precision_error = 0.0000001
+        query_string = f"""
+            UPDATE account_move_line
+            SET price_unit = {po_line.price_unit + precision_error}
+            WHERE id = {invoice_line.id}
+        """
+        invoice_line.env.cr.execute(query_string)
+        invoice_line.invalidate_model(['price_unit'], flush=False)
+
+        invoice._find_and_set_purchase_orders(
+            ['my_match_reference'], invoice.partner_id.id, invoice.amount_total, from_ocr=False)
+
+        self.assertTrue(invoice.id in po.invoice_ids.ids)
+        invoice_lines = invoice.line_ids.filtered(lambda l: l.price_unit)
+        self.assertEqual(len(invoice_lines), 2)
+        for line in po.order_line:
+            self.assertTrue(line in invoice_lines.purchase_line_id)
+
     def test_subset_match_from_edi_partial_inv(self):
         """An invoice totally matches some purchase order line
         """


### PR DESCRIPTION
Fixes Task 5213234

Issue:
In AccountMove method _find_matching_po_and_inv_lines (called when looking for
a subset match of EDI invoice lines with PO lines), the price_unit of a
purchase.order.line is compared to the price_unit of an invoice line.
However, currently the comparisons do not take into account the precision to be
applied to product prices.
In some cases, the invoice line price_unit differs from the price_unit in a PO
line, but by less than the "Product Price" precision. With the current
comparisons this leads to not matching the lines.
This has prevented matching some invoices received via Peppol for at least one
big customer (see Task-5213234)

Steps to reproduce:
- Create an XML document for an EDI UBL invoice with 2 lines; the first line
  has a price_unit 113.57 euros (for example) 
- Create a PO with a reference matching the invoice, and one PO line with a
  price_unit matching the price_unit of the first invoice line (113.57 euros)
- Upload the XML invoice and create a bill from it; during the creation of the
  account.move.line, the price_unit gets a value which is slightly different
  from 113.57 (113.57000000000001) (due to python rounding ?)
- Result: no link is established between the PO and the invoice.

This fix makes sure that the "Product Price" precision is used when comparing
the invoice line price_unit with a PO line price_unit.

opw-5213234

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
