### PR TITLE
[FIX] account: Prevent deletion of accounts used by other companies

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -1104,7 +1104,7 @@ class AccountAccount(models.Model):
 
     @api.ondelete(at_uninstall=False)
     def _unlink_except_contains_journal_items(self):
-        if self.env['account.move.line'].search_count([('account_id', 'in', self.ids)], limit=1):
+        if self.env['account.move.line'].sudo().search_count([('account_id', 'in', self.ids)], limit=1):
             raise UserError(_('You cannot perform this action on an account that contains journal items.'))
 
     @api.ondelete(at_uninstall=False)

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -98,7 +98,7 @@ class AccountMoveLine(models.Model):
         inverse='_inverse_account_id',
         index=False,  # covered by account_move_line_account_id_date_idx defined in init()
         auto_join=True,
-        ondelete="cascade",
+        ondelete="restrict",
         domain="[('deprecated', '=', False), ('account_type', '!=', 'off_balance')]",
         check_company=True,
         tracking=True,


### PR DESCRIPTION
In a multi-company environment, accounts can be shared. A Python constraint prevents deleting an account if it has journal items in the current company. However, this check was missing when an account only contained journal items belonging to other shared companies.

This commit fixes the issue by:

1.  Updating the `ondelete` attribute of the `account_id` field on `account.move.line` to cascade the restriction at the database level.
2.  Updating the existing Python constraint on `account.account` to enforce this logic in stable versions without a module update (this will be removed in the master branch).

task-5158966

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
