### PR TITLE
[FIX] html_editor: more complete check for internal and frontend urls

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -101,7 +101,7 @@ async function fetchInternalMetaData(url) {
             const html_parser = new window.DOMParser();
             const doc = html_parser.parseFromString(content, "text/html");
             const internalUrlMetaData = await rpc("/html_editor/link_preview_internal", {
-                preview_url: urlParsed.pathname,
+                preview_url: urlParsed.href,
             });
 
             internalUrlMetaData["favicon"] = doc.querySelector("link[rel~='icon']");

--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -1,3 +1,4 @@
+import { session } from "@web/session";
 import { _t } from "@web/core/l10n/translation";
 import { Component, useState, onMounted, useRef } from "@odoo/owl";
 import { useAutofocus, useService } from "@web/core/utils/hooks";
@@ -221,7 +222,10 @@ export class LinkPopover extends Component {
             if (icon) {
                 this.state.previewIcon.value = icon;
             }
-        } else if (window.location.hostname !== url.hostname) {
+        } else if (
+            window.location.hostname !== url.hostname &&
+            !new RegExp(`^https?://${session.db}\\.odoo\\.com(/.*)?$`).test(url.origin)
+        ) {
             // Preview pages from current website only. External website will
             // most of the time raise a CORS error. To avoid that error, we
             // would need to fetch the page through the server (s2s), involving

--- a/addons/html_editor/tests/test_controller.py
+++ b/addons/html_editor/tests/test_controller.py
@@ -7,6 +7,8 @@ import json
 import odoo.tests
 from odoo.tests.common import HttpCase, new_test_user
 from odoo.tools.json import scriptsafe as json_safe
+from unittest.mock import patch
+from odoo.addons.mail.tools import link_preview
 
 
 @odoo.tests.tagged('-at_install', 'post_install')
@@ -154,12 +156,28 @@ class TestController(HttpCase):
 
     def test_05_internal_link_preview(self):
         self.authenticate(self.admin, self.admin)
+
+        def _get_full_url(pathname):
+            return f"{self.base_url()}{pathname}"
+
+        def _patched_get_link_preview_from_url(url):
+            if url == _get_full_url("/page-with-description"):
+                return {
+                    'og_description': 'Mocked page description',
+                }
+            elif url == _get_full_url("/page-without-description") or url == _get_full_url("/shop/category/1"):
+                return {
+                    'og_description': None,
+                }
+            else:
+                return False
+
         # retrieve metadata of an record without customerized link_preview_name but with display_name
         response_without_preview_name = self.url_open(
             '/html_editor/link_preview_internal',
             data=json_safe.dumps({
                 "params": {
-                    "preview_url": f"/odoo/users/{self.portal_user.id}",
+                    "preview_url": _get_full_url(f"/odoo/users/{self.portal_user.id}"),
                 }
             }),
             headers=self.headers
@@ -172,7 +190,7 @@ class TestController(HttpCase):
             '/html_editor/link_preview_internal',
             data=json_safe.dumps({
                 "params": {
-                    "preview_url": "/odoo/actionInvalid/1",
+                    "preview_url": _get_full_url("/odoo/actionInvalid/1"),
                 }
             }),
             headers=self.headers
@@ -185,7 +203,7 @@ class TestController(HttpCase):
             '/html_editor/link_preview_internal',
             data=json_safe.dumps({
                 "params": {
-                    "preview_url": "/odoo/users/9999",
+                    "preview_url": _get_full_url("/odoo/users/9999"),
                 }
             }),
             headers=self.headers
@@ -194,24 +212,67 @@ class TestController(HttpCase):
         self.assertTrue('error_msg' in response_wrong_record.text)
 
         # retrieve metadata of a url not directing to a record
-        response_not_record = self.url_open(
-            '/html_editor/link_preview_internal',
-            data=json_safe.dumps({
-                "params": {
-                    "preview_url": "/odoo/users",
-                }
-            }),
-            headers=self.headers
-        )
-        self.assertEqual(200, response_not_record.status_code)
-        self.assertTrue('other_error_msg' in response_not_record.text)
+        with patch.object(link_preview, 'get_link_preview_from_url', side_effect=_patched_get_link_preview_from_url):
+            # Check metadata for a URL that points to a valid frontend page with
+            # a page description set
+            response_page_with_desc = self.url_open(
+                '/html_editor/link_preview_internal',
+                data=json_safe.dumps({
+                    "params": {
+                        "preview_url": _get_full_url("/page-with-description"),
+                    }
+                }),
+                headers=self.headers
+            )
+            self.assertEqual(200, response_page_with_desc.status_code)
+            self.assertTrue('"description": "Mocked page description"' in response_page_with_desc.text)
+
+            # Check metadata for a URL that points to a valid frontend page with
+            # no page description set
+            response_page_without_desc = self.url_open(
+                '/html_editor/link_preview_internal',
+                data=json_safe.dumps({
+                    "params": {
+                        "preview_url": _get_full_url("/page-without-description"),
+                    }
+                }),
+                headers=self.headers
+            )
+            self.assertEqual(200, response_page_without_desc.status_code)
+            self.assertTrue('"result": {}' in response_page_without_desc.text)
+
+            response_page_without_desc = self.url_open(
+                '/html_editor/link_preview_internal',
+                data=json_safe.dumps({
+                    "params": {
+                        "preview_url": _get_full_url("/shop/category/1"),
+                    }
+                }),
+                headers=self.headers
+            )
+            self.assertEqual(200, response_page_without_desc.status_code)
+            self.assertTrue('"result": {}' in response_page_without_desc.text)
+            self.assertFalse('error_msg' in response_page_without_desc.text)
+
+            # Check metadata for a URL that points to an invalid/unknown page
+            invalid_page = self.url_open(
+                '/html_editor/link_preview_internal',
+                data=json_safe.dumps({
+                    "params": {
+                        "preview_url": _get_full_url("/invalid-page"),
+                    }
+                }),
+                headers=self.headers
+            )
+            self.assertEqual(200, invalid_page.status_code)
+            self.assertTrue('"result": {}' in invalid_page.text)
 
         # Attempt to retrieve metadata for path format `odoo/<model>/<record_id>`
         response_model_record = self.url_open(
             '/html_editor/link_preview_internal',
             data=json_safe.dumps({
                 "params": {
-                    "preview_url": f"/odoo/res.users/{self.portal_user.id}",
+                    "preview_url": _get_full_url(f"/odoo/res.users/{self.portal_user.id}"),
                 }
             }),
             headers=self.headers
@@ -225,7 +286,7 @@ class TestController(HttpCase):
             '/html_editor/link_preview_internal',
             data=json_safe.dumps({
                 "params": {
-                    "preview_url": "/odoo/mail.thread/1",
+                    "preview_url": _get_full_url("/odoo/mail.thread/1"),
                 }
             }),
             headers=self.headers


### PR DESCRIPTION
Cherry pick of two commits from 18.4

Commit 1: 379d324

Previously, the link popover did not support frontend website pages
(e.g., /contactus, /shop, etc.).

Steps to reproduce:
- Enter edit mode.
- Click on a link to a frontend page, such as "Contact Us".
- An error was thrown in the browser console.
- Also, the link popover did not show the page description (even if it
  existed).

This commit:
- Fixes the error that occurred in the browser console.
- Adds support for frontend website pages in the link popover.
- Displays the page description in the linkpopover, if available.
  (The page description refers to the SEO field that can be set via:
  Site > This Page > Optimize SEO > Description)

Commit 2: b8908f3

Before this commit: the condition to check if an url is internal is not complete
as the user could user the odoo instance domain instead of the real domain. The
check if an internal url is a frontend one is rather naive as there are cases
where the url ends with a number but actually not leading to a record.

Reproduction for the second use case:
1. create a link with frontend url for example `/shop/category/16`
2. click on the link, when it loads the preview, a warning pops up

After this commit, the cases explained above are included.

task-4971829



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
