### PR TITLE
[IMP] mail: introduce MentionPlugin

### DIFF
--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -434,15 +434,8 @@ export class Message extends Component {
         }
         const editedEl = bodyEl.querySelector(".o-mail-Message-edited");
         editedEl?.replaceChildren(renderToElement("mail.Message.edited"));
-        for (const linkEl of bodyEl.querySelectorAll(".o_channel_redirect")) {
-            const text = linkEl.textContent.substring(1); // remove '#' prefix
-            const icon = linkEl.classList.contains("o_channel_redirect_asThread")
-                ? "fa fa-comments-o"
-                : "fa fa-hashtag";
-            const iconEl = renderToElement("mail.Message.mentionedChannelIcon", { icon });
-            linkEl.replaceChildren(iconEl);
-            linkEl.insertAdjacentText("beforeend", ` ${text}`);
-        }
+        const channelLinks = bodyEl.querySelectorAll("a.o_channel_redirect");
+        this.store.handleValidChannelMention(Array.from(channelLinks));
         for (const el of bodyEl.querySelectorAll(".o_message_redirect")) {
             // only transform links targetting the same database
             if (el.getAttribute("href")?.startsWith(getOrigin())) {

--- a/addons/mail/static/src/core/common/plugin/mention_plugin.js
+++ b/addons/mail/static/src/core/common/plugin/mention_plugin.js
@@ -1,0 +1,61 @@
+import { Plugin } from "@html_editor/plugin";
+import { generateThreadMentionElement } from "@mail/utils/common/format";
+
+export class MentionPlugin extends Plugin {
+    static id = "mention";
+    static dependencies = ["selection", "history"];
+    resources = {
+        selectionchange_handlers: this.detectMentions.bind(this),
+    };
+
+    setup() {
+        super.setup();
+        /** @type {import("models").Store} */
+        this.store = this.services["mail.store"];
+    }
+
+    get MENTION_SELECTORS() {
+        return [
+            {
+                selector: "a.o_channel_redirect",
+                checker: (el) => this.isValidChannelMentionElement(el),
+                validMentionsHandler: (channelLinks) => {
+                    this.store.handleValidChannelMention(channelLinks);
+                    this.dependencies.history.addStep();
+                },
+            },
+        ];
+    }
+
+    async detectMentions(ev) {
+        for (const { selector, checker, validMentionsHandler } of this.MENTION_SELECTORS) {
+            const mentionLinks = Array.from(this.editable.querySelectorAll(selector)) || [];
+            const validMentionLinks = (
+                await Promise.all(
+                    mentionLinks.map(async (el) => ({
+                        el,
+                        isValid: await checker(el),
+                    }))
+                )
+            )
+                .filter(({ isValid }) => isValid)
+                .map(({ el }) => el);
+            validMentionsHandler?.(validMentionLinks);
+        }
+    }
+
+    async isValidChannelMentionElement(el) {
+        if (el.dataset.oeModel !== "discuss.channel") {
+            return false;
+        }
+        const channel = await this.store["discuss.channel"].getOrFetch(Number(el.dataset.oeId));
+        if (!channel) {
+            return false;
+        }
+        const validChannelMention = generateThreadMentionElement(channel);
+        return (
+            validChannelMention.getAttribute("href") === el.getAttribute("href") &&
+            [...validChannelMention.classList].every((cls) => el.classList.contains(cls))
+        );
+    }
+}

--- a/addons/mail/static/src/core/common/plugin/plugin_sets.js
+++ b/addons/mail/static/src/core/common/plugin/plugin_sets.js
@@ -10,6 +10,7 @@ import { TabulationPlugin } from "@html_editor/main/tabulation_plugin";
 import { ToolbarPlugin } from "@html_editor/main/toolbar/toolbar_plugin";
 
 import { MailComposerPlugin } from "@mail/core/common/plugin/mail_composer_plugin";
+import { MentionPlugin } from "@mail/core/common/plugin/mention_plugin";
 
 export const MAIL_CORE_PLUGINS = [
     ...CORE_PLUGINS,
@@ -20,6 +21,7 @@ export const MAIL_CORE_PLUGINS = [
     InlineCodePlugin,
     LinkPlugin,
     MailComposerPlugin,
+    MentionPlugin,
     ShortCutPlugin,
     TabulationPlugin,
 ];

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -9,6 +9,7 @@ import { rpc } from "@web/core/network/rpc";
 import { registry } from "@web/core/registry";
 import { user } from "@web/core/user";
 import { Deferred, Mutex } from "@web/core/utils/concurrency";
+import { renderToElement } from "@web/core/utils/render";
 import { debounce } from "@web/core/utils/timing";
 import { session } from "@web/session";
 import { browser } from "@web/core/browser/browser";
@@ -487,6 +488,20 @@ export class Store extends BaseStore {
             (lastMessageId, message) => Math.max(lastMessageId, message.id),
             0
         );
+    }
+
+    handleValidChannelMention(channelLinks) {
+        for (const linkEl of channelLinks.filter(
+            (el) => !el.querySelector(".fa-comments-o, .fa-hashtag")
+        )) {
+            const text = linkEl.textContent.substring(1); // remove '#' prefix
+            const icon = linkEl.classList.contains("o_channel_redirect_asThread")
+                ? "fa fa-comments-o"
+                : "fa fa-hashtag";
+            const iconEl = renderToElement("mail.Message.mentionedChannelIcon", { icon });
+            linkEl.replaceChildren(iconEl);
+            linkEl.insertAdjacentText("beforeend", ` ${text}`);
+        }
     }
 
     getMentionsFromText(

--- a/addons/mail/static/tests/suggestion/suggestion.test.js
+++ b/addons/mail/static/tests/suggestion/suggestion.test.js
@@ -586,8 +586,28 @@ test("mention a channel thread", async () => {
     await contains(".o-mail-Composer-suggestion:eq(1):has(i.fa-comments-o)", {
         text: "GeneralThreadOne",
     });
+    await click(".o-mail-Composer-suggestion:eq(0)");
+    await contains(
+        ".o-mail-Composer-html.odoo-editor-editable a.o_channel_redirect:has(i.fa-hashtag)",
+        { text: "General" }
+    );
+    await press("Enter");
+    await contains(".o-mail-Message a.o_channel_redirect", {
+        text: "General",
+    });
+    await contains(".o-mail-Composer-html.odoo-editor-editable", { text: "" });
+    await focus(".o-mail-Composer-html.odoo-editor-editable");
+    await htmlInsertText(editor, "#");
+    await contains(".o-mail-Composer-suggestion", { count: 2 });
+    await contains(".o-mail-Composer-suggestion:eq(0):has(i.fa-hashtag)", { text: "General" });
+    await contains(".o-mail-Composer-suggestion:eq(1):has(i.fa-comments-o)", {
+        text: "GeneralThreadOne",
+    });
     await click(".o-mail-Composer-suggestion:eq(1)");
-    await contains(".o-mail-Composer-html.odoo-editor-editable", { text: "#General > ThreadOne" });
+    await contains(
+        ".o-mail-Composer-html.odoo-editor-editable a.o_channel_redirect:has(i.fa-comments-o)",
+        { text: "General > ThreadOne" }
+    );
     await press("Enter");
     await contains(".o-mail-Message a.o_channel_redirect:has(i.fa-comments-o)", {
         text: "General > ThreadOne",


### PR DESCRIPTION
This commit introduces a new MentionPlugin to handle user mentions in the mail composer. The MentionPlugin is responsible for detecting and validating mentions. It listens to selection changes and processes mention elements accordingly.

This commit also moves part of the prepareMessageBody logic to the MentionPlugin, so that we can finally get rid of the prepareMessageBody and get what you see is what you get in the composer.

task-5137057



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
