### PR TITLE
[FIX] point_of_sale: display error for tracking_number search

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -373,6 +373,8 @@ class PosOrder(models.Model):
                        AND MOD(session_id, 10) = %s
                     )""", '% _____-___-__' + value[1:], int(value[0]))
                 return [('id', 'in', sql)]
+            else:
+                raise UserError(_("The search on Order Number only supports up to 3 digits."))
 
         raise NotImplementedError(_("Unsupported search operation"))
 

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -2705,6 +2705,8 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
         self.assertEqual(order.pos_reference, f'Order {session_id.id:05d}-003-0001', "Should find the correct order")
         order = self.env['pos.order'].search([('tracking_number', 'ilike', '03')])
         self.assertEqual(len(order), 0, "Should not find any order with the tracking number")
+        with self.assertRaises(UserError):
+            self.env['pos.order'].search([('tracking_number', 'ilike', '1234')])
 
     def test_refunded_order_has_uuid(self):
         """ Test that a refunded order has a uuid generated. """


### PR DESCRIPTION
**Steps to reproduce:**
- Go to PoS>Orders
- Search by Order Number and input at least 4 characters
- A traceback will appear

**Why the fix:**
In 18.0, we do not support long search for the tracking_number, as it is not how we search for it.
The way it works now is that depending on the length of the input, we search one way or another.
If the input is 1 or 2 digits long, we search for those in the tracking number. If it's 3, we search for the last 2 digits in the tracking number, but the first input digit will be to search for the session_id.
This is why we do not support inputs longer than 3 digits.

To prevent this, we introduce a friendlier userError, as to inform the user that this is not possible, instead of a full traceback.

This error was introduced when the function was changed in 36b5842 as a fallback was not implemented if the input was longer than 3 characters.

The way we search for the tracking number is different in later versions, so the bug and the function itself are not there anymore.

opw-5142216