### PR TITLE
19.0 general profile fixes mmha

### DIFF
--- a/odoo/tools/profiler.py
+++ b/odoo/tools/profiler.py
@@ -279,9 +279,9 @@ class MemoryCollector(_BasePeriodicCollector):
         })
 
     def stop(self):
+        super().stop()
         _lock.release()
         tracemalloc.stop()
-        super().stop()
 
     def post_process(self):
         for i, entry in enumerate(self._entries):

--- a/odoo/tools/profiler.py
+++ b/odoo/tools/profiler.py
@@ -129,10 +129,10 @@ class Collector:
     def progress(self, entry=None, frame=None):
         """ Checks if the limits were met and add to the entries"""
         if self.profiler.entry_count_limit \
-            and self.profiler.entry_count() >= self.profiler.entry_count_limit:
+            and self.profiler.counter >= self.profiler.entry_count_limit:
             self.profiler.end()
             return
-
+        self.profiler.counter += 1
         self.add(entry=entry,frame=frame)
 
     def _get_stack_trace(self, frame=None):
@@ -557,6 +557,7 @@ class Profiler:
         self.entry_count_limit = int(self.params.get("entry_count_limit",0)) # the limit could be set using a smarter way
         self.done = False
         self.exit_stack = ExitStack()
+        self.counter = 0
 
         if db is ...:
             # determine database from current thread


### PR DESCRIPTION
Multiple fixes for the Profiler.

Issues:
- Python throws cannot join current thread when using the entry count with memory and traces async profilers.
- The periodic profilers were waiting the full amount of the sleep before ending.
- When using the entry_count, the memory profiler was throwing a non serializable object error
- Sometimes the memory collector throws an error that the tracemalloc needs to be started so that it collects.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
