### PR TITLE
[FIX] sale_stock_margin: recompute purchase_price when pricelist changes after cancel

### DIFF
--- a/addons/sale_stock_margin/models/sale_order_line.py
+++ b/addons/sale_stock_margin/models/sale_order_line.py
@@ -12,12 +12,14 @@ class SaleOrderLine(models.Model):
         line_ids_to_pass = set()
         for line in self:
             product = line.product_id.with_company(line.company_id)
-            if not line.has_valued_move_ids():
+            # Filter out cancelled moves to ensure purchase price is recomputed when changing pricelist after order cancellation
+            valid_moves = line.move_ids.filtered(lambda m: m.state != 'cancel')
+            if not valid_moves or not line.has_valued_move_ids():
                 line_ids_to_pass.add(line.id)
             elif line.product_id and line.product_id.categ_id.property_cost_method != 'standard':
                 # don't overwrite any existing value unless non-standard cost method
                 qty_from_delivery = line.qty_delivered if line.product_id.invoice_policy == 'order' else line.qty_to_invoice
-                purch_price = product._compute_average_price(0, line.product_uom_qty or qty_from_delivery, line.move_ids.with_company(line.company_id))
+                purch_price = product._compute_average_price(0, line.product_uom_qty or qty_from_delivery, valid_moves.with_company(line.company_id))
                 if line.product_uom != product.uom_id:
                     purch_price = product.uom_id._compute_price(purch_price, line.product_uom)
                 line.purchase_price = line._convert_to_sol_currency(


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Issue: The purchase_price field in sale order lines is not recomputed when changing the pricelist to a different currency after a sales order has been confirmed, cancelled, and set back to quotation state.

This causes incorrect cost calculations and margin reporting when users need to modify the currency/pricelist of a previously confirmed order that was later cancelled and reset to draft.

Affected modules: sale_stock_margin

Versions affected: 16.0, 17.0, 18.0 (confirmed on 18.0)

**Current behavior before PR:**
When a sales order goes through the following workflow:

Create a sales order with a pricelist in USD
Add a product line (e.g., purchase_price shows $100.00 USD)
Confirm the order (stock moves are created)
Cancel the order (stock moves are set to state 'cancel' but remain in move_ids)
Set the order back to quotation state
Change the pricelist to one with a different currency (e.g., EUR)
Result: The purchase_price remains in the original currency (USD) instead of being converted to the new currency (EUR).

Root cause: The _compute_purchase_price() method in sale_stock_margin checks if move_ids exist to determine whether to use stock-based costing or fall back to the standard price from sale_margin. However, cancelled moves are still present in move_ids, causing the method to skip the currency conversion that should happen when no valid (non-cancelled) moves exist.


**Desired behavior after PR is merged:**
After following the same workflow:

Create a sales order with a pricelist in USD
Add a product line (purchase_price shows $100.00 USD)
Confirm the order
Cancel the order
Set the order back to quotation state
Change the pricelist to EUR
Expected result: The purchase_price is automatically recomputed and converted to the new currency (e.g., shows €92.00 EUR based on the exchange rate).

How it works: The method now filters out cancelled stock moves before checking if valued moves exist. If only cancelled moves are present, the computation is delegated to the parent sale_margin module, which properly handles currency conversion using _convert_to_sol_currency().


Video Demostration
From runbot of today (10/21/2025)
https://drive.google.com/file/d/1KExSzOYHAmMc10b3u_Xy5B1nWkkYOBqy/view


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
