### PR TITLE
[FIX] setup: update Python version in IoT Builder

### DIFF
--- a/setup/iot_box_builder/iot_box_builder.py
+++ b/setup/iot_box_builder/iot_box_builder.py
@@ -21,8 +21,8 @@ logger.addHandler(handler)
 
 IOTBOX_IMAGE = "iotbox.img"
 IOTBOX_VERSION = datetime.now().strftime('%Y.%m.%0d')
-RASPI_IMAGE = "2024-11-19-raspios-bookworm-armhf-lite.img.xz"
-RASPI_IMAGE_URl = f"https://downloads.raspberrypi.com/raspios_lite_armhf/images/raspios_lite_armhf-2024-11-19/{RASPI_IMAGE}"
+RASPI_IMAGE = "2025-10-01-raspios-trixie-armhf-lite.img.xz"
+RASPI_IMAGE_URl = f"https://downloads.raspberrypi.com/raspios_lite_armhf/images/raspios_lite_armhf-2025-10-02/{RASPI_IMAGE}"
 NGROK_TGZ = "ngrok-v3-stable-linux-arm.tgz"
 NGROK_URL = f"https://bin.equinox.io/c/bNyj1mQVY4c/{NGROK_TGZ}"
 BUILD_DIR = "/iot_build"


### PR DESCRIPTION
Currently the builder uses the python version 3.11.2 incompatible with our Odoo python requirement for 19.1 (Python >= 3.12)

This leads to Odoo being unable to start in the 19.1 version.

This PR updates the rpi os used by the builder to the latest release. Based on the following link, this Rasbian version is based on Debian Trixie which uses Python 3.13 by default.

https://downloads.raspberrypi.com/raspios_lite_armhf/release_notes.txt

