### PR TITLE
[FIX] mail: specify border-color to avoid runbot failures

### DIFF
--- a/addons/mail/static/tests/inline/html_mail_field.test.js
+++ b/addons/mail/static/tests/inline/html_mail_field.test.js
@@ -124,11 +124,15 @@ test("HtmlMail add icon and save inline html", async function () {
         `.test-icon-inline .note-editable .fa {
             color: rgb(55,65,81) !important;
             background-color: rgb(249,250,251) !important;
-        }`
+        }
+        p, img {
+            border-color: #ff0000 !important;
+        }
+        `
     );
     onRpc("web_save", ({ args }) => {
         expect(args[1].body).toBe(
-            `<p style="border-radius:0px;border-style:none;padding:0px;margin:0px 0 16px 0;box-sizing:border-box;border-left-color:#374151;border-bottom-color:#374151;border-right-color:#374151;border-top-color:#374151;border-left-width:0px;border-bottom-width:0px;border-right-width:0px;border-top-width:0px;"><span style="display: inline-block; width: 14px; height: 14px; vertical-align: text-bottom;" class="oe_unbreakable "><img width="14" height="14" src="/web_editor/font_to_img/61440/rgb(55%2C65%2C81)/rgb(249%2C250%2C251)/14x14" data-class="fa fa-glass" data-style="null" style="border-radius:0px;border-style:none;padding:0px;border-left-color:#374151;border-bottom-color:#374151;border-right-color:#374151;border-top-color:#374151;border-left-width:0px;border-bottom-width:0px;border-right-width:0px;border-top-width:0px;box-sizing: border-box; line-height: 14px; width: 14px; height: 14px; vertical-align: unset; margin: 0px;"></span>first</p>`
+            `<p style="border-radius:0px;border-style:none;padding:0px;margin:0px 0 16px 0;box-sizing:border-box;border-left-width:0px;border-bottom-width:0px;border-right-width:0px;border-top-width:0px;border-left-color:#ff0000;border-bottom-color:#ff0000;border-right-color:#ff0000;border-top-color:#ff0000;"><span style="display: inline-block; width: 14px; height: 14px; vertical-align: text-bottom;" class="oe_unbreakable "><img width="14" height="14" src="/web_editor/font_to_img/61440/rgb(55%2C65%2C81)/rgb(249%2C250%2C251)/14x14" data-class="fa fa-glass" data-style="null" style="border-radius:0px;border-style:none;padding:0px;border-left-width:0px;border-bottom-width:0px;border-right-width:0px;border-top-width:0px;border-left-color:#ff0000;border-bottom-color:#ff0000;border-right-color:#ff0000;border-top-color:#ff0000;box-sizing: border-box; line-height: 14px; width: 14px; height: 14px; vertical-align: unset; margin: 0px;"></span>first</p>`
         );
         expect.step("web_save");
     });


### PR DESCRIPTION
Problem:
Runbot build fails due to different resulting `border-color` values.

Cause:
The default `border-color` can change depending on the environment, leading to non-deterministic behavior.

Solution:
Specify the `border-color` explicitly to ensure consistent results.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
