### PR TITLE
[IMP] base: associate `res.device` with sessions

### DIFF
--- a/addons/rpc/tests/test_xmlrpc.py
+++ b/addons/rpc/tests/test_xmlrpc.py
@@ -77,7 +77,15 @@ class TestXMLRPC(common.HttpCase):
         now = datetime.datetime.now()
         ids = self.xmlrpc(
             'res.device.log', 'create',
-            {'session_identifier': "abc", 'first_activity': now, 'revoked': False}
+            {
+                'session_identifier': 'abc',
+                'user_id': self.env.user.id,
+                'ip_address': '',
+                'user_agent': '',
+                'first_activity': now,
+                'last_activity': now,
+                'revoked': False,
+            },
         )
         [r] = self.xmlrpc(
             'res.device.log', 'read',

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -206,6 +206,7 @@ class ResUsers(models.Model):
         help="If specified, this action will be opened at log on for this user, in addition to the standard menu.")
     log_ids = fields.One2many('res.users.log', 'create_uid', string='User log entries')
     device_ids = fields.One2many('res.device', 'user_id', string='User devices')
+    session_ids = fields.One2many('res.session', 'user_id', string='User sessions')
     login_date = fields.Datetime(related='log_ids.create_date', string='Latest Login', readonly=False)
     share = fields.Boolean(compute='_compute_share', compute_sudo=True, string='Share User', store=True,
          help="External user with limited access, created only for the purpose of sharing data.")
@@ -990,8 +991,8 @@ class ResUsers(models.Model):
         return (self.env.user if self.id == self.env.uid else self)._action_revoke_all_devices()
 
     def _action_revoke_all_devices(self):
-        devices = self.env["res.device"].search([("user_id", "=", self.id)])
-        devices.filtered(lambda d: not d.is_current)._revoke()
+        sessions = self.env["res.session"].search([("user_id", "=", self.id)])
+        sessions.filtered(lambda d: not d.is_current)._revoke()
         return {'type': 'ir.actions.client', 'tag': 'reload'}
 
     @api.readonly

--- a/odoo/addons/base/security/base_security.xml
+++ b/odoo/addons/base/security/base_security.xml
@@ -281,7 +281,20 @@
             <field name="perm_unlink" eval="True"/>
         </record>
 
-        <!-- Record Rules For User Devices -->
+        <!-- Record Rules For User Sessions/Devices -->
+        <record id="user_session" model="ir.rule">
+            <field name="name">Users can read only their own sessions</field>
+            <field name="model_id" ref="model_res_session"/>
+            <field name="domain_force">[('user_id', '=', user.id)]</field>
+            <field name="groups" eval="[Command.link(ref('base.group_user'))]"/>
+        </record>
+        <record id="user_session_admin" model="ir.rule">
+            <field name="name">Administrators can read all sessions</field>
+            <field name="model_id" ref="model_res_session"/>
+            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="groups" eval="[Command.link(ref('base.group_system'))]"/>
+        </record>
+
         <record id="user_device" model="ir.rule">
             <field name="name">Users can read only their own devices</field>
             <field name="model_id" ref="model_res_device"/>

--- a/odoo/addons/base/security/ir.model.access.csv
+++ b/odoo/addons/base/security/ir.model.access.csv
@@ -142,6 +142,7 @@ access_res_users_settings_user,res.users.settings,model_res_users_settings,group
 "access_base_partner_merge_automatic_wizard","access.base.partner.merge.automatic.wizard","model_base_partner_merge_automatic_wizard","base.group_partner_manager",1,1,1,0
 "access_ir_profile","ir_profile","model_ir_profile","group_system",1,1,1,1
 "access_base_enable_profiling_wizard","access.base.enable.profiling.wizard","model_base_enable_profiling_wizard","group_system",1,1,1,0
+"access_res_session",access_res_session,base.model_res_session,base.group_user,1,0,0,0
 "access_res_device",access_res_device,base.model_res_device,base.group_user,1,0,0,0
 "access_res_device_log",access_res_device_log,base.model_res_device_log,base.group_user,1,0,0,0
 "access_properties_base_definition_group_system",access_properties_base_definition,base.model_properties_base_definition,base.group_system,1,1,1,1

--- a/odoo/addons/base/views/res_device_views.xml
+++ b/odoo/addons/base/views/res_device_views.xml
@@ -8,18 +8,20 @@
             <field name="arch" type="xml">
                 <form>
                     <group>
-                        <group>
-                            <field name="user_id"/>
-                            <field name="display_name" string="Name"/>
-                            <field name="ip_address" string="Last IP Address"/>
-                        </group>
-                        <group>
-                            <field name="first_activity"/>
-                            <field name="last_activity"/>
-                        </group>
-                        <group>
-                            <field name="linked_ip_addresses"/>
-                        </group>
+                        <field name="session_identifier"/>
+                        <field name="user_id"/>
+                        <field name="ip_address"/>
+                        <field name="user_agent"/>
+                    </group>
+                    <group>
+                        <field name="first_activity"/>
+                        <field name="last_activity"/>
+                    </group>
+                    <group>
+                        <field name="country"/>
+                        <field name="city"/>
+                        <field name="platform"/>
+                        <field name="browser"/>
                     </group>
                 </form>
             </field>
@@ -30,8 +32,61 @@
             <field name="model">res.device</field>
             <field name="arch" type="xml">
                 <list default_order="last_activity desc">
+                    <field name="session_identifier" optional="hide"/>
                     <field name="user_id"/>
-                    <field name="display_name" string="Name"/>
+                    <field name="first_activity"/>
+                    <field name="last_activity"/>
+                    <field name="ip_address"/>
+                    <field name="country"/>
+                    <field name="city"/>
+                    <field name="platform"/>
+                    <field name="browser"/>
+                    <field name="user_agent" optional="hide"/>
+                </list>
+            </field>
+        </record>
+
+        <record model="ir.ui.view" id="res_session_view_form">
+            <field name="name">res.session.form</field>
+            <field name="model">res.session</field>
+            <field name="arch" type="xml">
+                <form>
+                    <group>
+                        <group>
+                            <field name="session_identifier"/>
+                            <field name="user_id"/>
+                        </group>
+                        <group>
+                            <field name="first_activity"/>
+                            <field name="last_activity"/>
+                        </group>
+                        <field name="device_ids" mode="list">
+                            <list decoration-success="is_current">
+                                <field name="platform"/>
+                                <field name="browser"/>
+                                <field name="country"/>
+                                <field name="city"/>
+                                <field name="ip_address"/>
+                                <field name="first_activity"/>
+                                <field name="last_activity"/>
+                                <field name="user_agent" optional="hide"/>
+                            </list>
+                        </field>
+                    </group>
+                    <footer>
+                        <button string="Close" class="btn-secondary" special="cancel"/>
+                    </footer>
+                </form>
+            </field>
+        </record>
+
+        <record model="ir.ui.view" id="res_session_view_tree">
+            <field name="name">res.session.list</field>
+            <field name="model">res.session</field>
+            <field name="arch" type="xml">
+                <list default_order="last_activity desc">
+                    <field name="session_identifier"/>
+                    <field name="user_id"/>
                     <field name="ip_address"/>
                     <field name="first_activity"/>
                     <field name="last_activity"/>
@@ -42,11 +97,11 @@
             </field>
         </record>
 
-        <record model="ir.ui.view" id="res_device_view_kanban">
-            <field name="name">res.device.kanban</field>
-            <field name="model">res.device</field>
+        <record model="ir.ui.view" id="res_session_view_kanban">
+            <field name="name">res.session.kanban</field>
+            <field name="model">res.session</field>
             <field name="arch" type="xml">
-                <kanban create="0" can_open="0" default_order="is_current desc, last_activity desc">
+                <kanban create="0" can_open="1" default_order="is_current desc, last_activity desc">
                     <field name="id"/>
                     <field name="device_type"/>
                     <field name="last_activity"/>
@@ -81,7 +136,7 @@
             <field name="name">User Devices</field>
             <field name="res_model">res.device</field>
             <field name="path">user-device</field>
-            <field name="view_mode">list,kanban,form</field>
+            <field name="view_mode">list,form</field>
         </record>
         <menuitem action="action_user_device" id="menu_action_user_device" parent="base.menu_security" sequence="10"/>
 

--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -234,7 +234,7 @@
                                         </span>
                                     </div>
                                     <div class="w-md-50 w-lg-75 d-flex flex-column my-auto">
-                                        <field name="device_ids" mode="kanban" class="w-sm-75 w-md-100 w-lg-75 w-xl-50 o_base_devices_kanban_view"/>
+                                        <field name="session_ids" mode="kanban" class="w-sm-75 w-md-100 w-lg-75 w-xl-50 o_base_devices_kanban_view"/>
                                         <div>
                                             <button name="action_revoke_all_devices" type="object" string="Log out from all devices" class="btn btn-secondary h-100"/>
                                         </div>
@@ -497,7 +497,7 @@
                                         </span>
                                     </div>
                                     <div class="w-lg-75 d-flex flex-column my-auto">
-                                        <field name="device_ids" mode="kanban" class="w-lg-75 o_base_devices_kanban_view"/>
+                                        <field name="session_ids" mode="kanban" class="w-lg-75 o_base_devices_kanban_view"/>
                                         <div>
                                             <button name="action_revoke_all_devices" type="object" string="Log out from all devices" class="btn btn-secondary h-100"/>
                                         </div>

--- a/odoo/addons/test_http/tests/test_device.py
+++ b/odoo/addons/test_http/tests/test_device.py
@@ -24,8 +24,10 @@ class TestDevice(TestHttpBase):
     def setUp(self):
         super().setUp()
 
-        self.Device = self.env['res.device']
+        self.Session = self.env['res.session']
+        self.DeviceLine = self.env['res.device']
         self.DeviceLog = self.env['res.device.log']
+
         self.DeviceLog.search([]).unlink()
 
         self.user_admin = self.env.ref('base.user_admin')
@@ -49,26 +51,25 @@ class TestDevice(TestHttpBase):
             }
         with freeze_time(time), \
             patch.dict(odoo.tools.config.options, {'proxy_mode': bool(ip)}):
-            res = self.url_open(url=endpoint, headers=headers)
-        return res
+            return self.url_open(url=endpoint, headers=headers)
 
     def info_trace(self, trace):
         return {
-            'elapsed_time': trace['last_activity'] - trace['first_activity'],
-            'platform': trace['platform'],
-            'browser': trace['browser'],
             'ip_address': trace['ip_address'],
+            'user_agent': trace['user_agent'],
+            'elapsed_time': trace['last_activity'] - trace['first_activity'],
         }
 
-    def get_devices_logs(self, user=None):
+    def get_devices(self, user=None):
+        self.DeviceLog.flush_model()
+        self.DeviceLine.invalidate_model()
+        self.Session.invalidate_model()
+
         domain = [('user_id', '=', user.id)] if user else []
-        devices = self.Device.search(domain)
-        logs = self.DeviceLog.search([
-            ('session_identifier', 'in', devices.mapped('session_identifier')),
-            ('platform', 'in', devices.mapped('platform')),
-            ('browser', 'in', devices.mapped('browser'))
-        ])
-        return devices, logs
+        session_ids = self.Session.search(domain)
+        device_ids = session_ids.device_ids  # To have the order `last_activity desc`
+        device_log_ids = self.DeviceLog.search(domain)
+        return session_ids, device_ids, device_log_ids
 
     # --------------------
     # DETECTION
@@ -78,7 +79,8 @@ class TestDevice(TestHttpBase):
         session = self.authenticate(self.user_admin.login, self.user_admin.login)
         self.hit('2024-01-01 08:00:00', '/test_http/greeting-public')
 
-        devices, logs = self.get_devices_logs(self.user_admin)
+        sessions, devices, logs = self.get_devices(self.user_admin)
+        self.assertEqual(len(sessions), 1)
         self.assertEqual(len(devices), 1)
         self.assertEqual(len(logs), 1)
         self.assertEqual(len(session['_trace']), 1)
@@ -87,31 +89,36 @@ class TestDevice(TestHttpBase):
         session = self.authenticate(self.user_admin.login, self.user_admin.login)
         self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0')
 
-        devices, logs = self.get_devices_logs(self.user_admin)
+        sessions, devices, logs = self.get_devices(self.user_admin)
+        self.assertEqual(len(sessions), 1)
         self.assertEqual(len(devices), 1)
         self.assertEqual(len(logs), 1)
         self.assertEqual(len(session['_trace']), 1)
 
     def test_detection_user_public(self):
-        self.authenticate(None, None)
+        session = self.authenticate(None, None)
         self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0')
 
-        devices, logs = self.get_devices_logs()
+        sessions, devices, logs = self.get_devices(self.user_admin)
+        self.assertEqual(len(sessions), 0)
         self.assertEqual(len(devices), 0)
         self.assertEqual(len(logs), 0)
+        self.assertEqual(len(session['_trace']), 0)
 
     def test_detection_device_readonly_then_no_readonly(self):
         session = self.authenticate(self.user_admin.login, self.user_admin.login)
         self.hit('2024-01-01 08:00:00', '/test_http/greeting-public')
 
-        devices, logs = self.get_devices_logs(self.user_admin)
+        sessions, devices, logs = self.get_devices(self.user_admin)
+        self.assertEqual(len(sessions), 1)
         self.assertEqual(len(devices), 1)
         self.assertEqual(len(logs), 1)
         self.assertEqual(len(session['_trace']), 1)
 
         self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0')
 
-        devices, logs = self.get_devices_logs(self.user_admin)
+        sessions, devices, logs = self.get_devices(self.user_admin)
+        self.assertEqual(len(sessions), 1)
         self.assertEqual(len(devices), 1)
         self.assertEqual(len(logs), 1)
         self.assertEqual(len(session['_trace']), 1)
@@ -120,7 +127,8 @@ class TestDevice(TestHttpBase):
         session = self.authenticate(self.user_admin.login, self.user_admin.login)
         self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0')
 
-        devices, logs = self.get_devices_logs(self.user_admin)
+        sessions, devices, logs = self.get_devices(self.user_admin)
+        self.assertEqual(len(sessions), 1)
         self.assertEqual(len(devices), 1)
         self.assertEqual(len(logs), 1)
         self.assertEqual(len(session['_trace']), 1)
@@ -128,7 +136,8 @@ class TestDevice(TestHttpBase):
 
         self.hit('2024-01-01 08:30:00', '/test_http/greeting-public?readonly=0')
 
-        devices, logs = self.get_devices_logs(self.user_admin)
+        sessions, devices, logs = self.get_devices(self.user_admin)
+        self.assertEqual(len(sessions), 1)
         self.assertEqual(len(devices), 1)
         self.assertEqual(len(logs), 1)
         self.assertEqual(len(session['_trace']), 1)
@@ -136,7 +145,8 @@ class TestDevice(TestHttpBase):
 
         self.hit('2024-01-01 09:00:00', '/test_http/greeting-public?readonly=0')
 
-        devices, logs = self.get_devices_logs(self.user_admin)
+        sessions, devices, logs = self.get_devices(self.user_admin)
+        self.assertEqual(len(sessions), 1)
         self.assertEqual(len(devices), 1)
         self.assertEqual(len(logs), 2)
         self.assertEqual(len(session['_trace']), 1)
@@ -144,7 +154,8 @@ class TestDevice(TestHttpBase):
 
         self.hit('2024-01-01 10:00:00', '/test_http/greeting-public?readonly=0')
 
-        devices, logs = self.get_devices_logs(self.user_admin)
+        sessions, devices, logs = self.get_devices(self.user_admin)
+        self.assertEqual(len(sessions), 1)
         self.assertEqual(len(devices), 1)
         self.assertEqual(len(logs), 3)
         self.assertEqual(len(session['_trace']), 1)
@@ -155,35 +166,37 @@ class TestDevice(TestHttpBase):
 
         self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0', headers={'User-Agent': USER_AGENT_linux_chrome})
 
-        devices, logs = self.get_devices_logs(self.user_admin)
+        sessions, devices, logs = self.get_devices(self.user_admin)
+        self.assertEqual(len(sessions), 1)
         self.assertEqual(len(devices), 1)
         self.assertEqual(len(logs), 1)
         self.assertEqual(len(session['_trace']), 1)
-        self.assertEqual(self.info_trace(session['_trace'][0])['platform'], 'linux')
-        self.assertEqual(self.info_trace(session['_trace'][0])['browser'], 'chrome')
+        self.assertEqual(self.info_trace(session['_trace'][0])['user_agent'], USER_AGENT_linux_chrome)
 
         self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0', headers={'User-Agent': USER_AGENT_linux_firefox})
 
-        devices, logs = self.get_devices_logs(self.user_admin)
+        sessions, devices, logs = self.get_devices(self.user_admin)
+        self.assertEqual(len(sessions), 1)
         self.assertEqual(len(devices), 2)
         self.assertEqual(len(logs), 2)
         self.assertEqual(len(session['_trace']), 2)
-        self.assertEqual(self.info_trace(session['_trace'][1])['platform'], 'linux')
-        self.assertEqual(self.info_trace(session['_trace'][1])['browser'], 'firefox')
+        self.assertEqual(self.info_trace(session['_trace'][1])['user_agent'], USER_AGENT_linux_firefox)
 
     def test_detection_device_according_to_ipaddress(self):
         session = self.authenticate(self.user_admin.login, self.user_admin.login)
         self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0')
 
-        devices, logs = self.get_devices_logs(self.user_admin)
+        sessions, devices, logs = self.get_devices(self.user_admin)
+        self.assertEqual(len(sessions), 1)
         self.assertEqual(len(devices), 1)
         self.assertEqual(len(logs), 1)
         self.assertEqual(len(session['_trace']), 1)
 
         self.hit('2024-01-01 08:00:01', '/test_http/greeting-public?readonly=0', ip=TEST_IP)
 
-        devices, logs = self.get_devices_logs(self.user_admin)
-        self.assertEqual(len(devices), 1)
+        sessions, devices, logs = self.get_devices(self.user_admin)
+        self.assertEqual(len(sessions), 1)
+        self.assertEqual(len(devices), 2)
         self.assertEqual(len(logs), 2)
         self.assertEqual(len(session['_trace']), 2)
         self.assertNotEqual(self.info_trace(session['_trace'][0])['ip_address'], TEST_IP)
@@ -197,24 +210,26 @@ class TestDevice(TestHttpBase):
         self.hit('2024-01-01 08:00:00', '/test_http/greeting-user?readonly=0')
 
         self.hit('2024-01-01 08:00:00', '/test_http/greeting-user?readonly=0', headers={'session_id': session.sid}, ip=TEST_IP)
-        devices, logs = self.get_devices_logs(self.user_internal)
-        self.assertEqual(len(devices), 1)
-        self.assertEqual(len(logs), 2)
-        self.assertEqual(len(self.user_internal.device_ids), 1)
+        self.assertEqual(len(self.user_internal.session_ids), 1)
+        self.assertEqual(len(self.user_internal.session_ids.device_ids), 2)
 
     def test_detection_devices_according_to_time_useragent(self):
         self.authenticate(self.user_admin.login, self.user_admin.login)
         self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0', headers={'User-Agent': USER_AGENT_linux_chrome})
-        self.assertEqual(len(self.user_admin.device_ids), 1)
+        self.assertEqual(len(self.user_admin.session_ids), 1)
+        self.assertEqual(len(self.user_admin.session_ids.device_ids), 1)
 
         self.hit('2024-01-01 09:00:00', '/test_http/greeting-public?readonly=0', headers={'User-Agent': USER_AGENT_linux_chrome})
-        self.assertEqual(len(self.user_admin.device_ids), 1)
+        self.assertEqual(len(self.user_admin.session_ids), 1)
+        self.assertEqual(len(self.user_admin.session_ids.device_ids), 1)
 
         self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0', headers={'User-Agent': USER_AGENT_linux_firefox})
-        self.assertEqual(len(self.user_admin.device_ids), 2)
+        self.assertEqual(len(self.user_admin.session_ids), 1)
+        self.assertEqual(len(self.user_admin.session_ids.device_ids), 2)
 
         self.hit('2024-01-01 09:00:00', '/test_http/greeting-public?readonly=0', headers={'User-Agent': USER_AGENT_linux_firefox})
-        self.assertEqual(len(self.user_admin.device_ids), 2)
+        self.assertEqual(len(self.user_admin.session_ids), 1)
+        self.assertEqual(len(self.user_admin.session_ids.device_ids), 2)
 
     def test_detection_devices_according_to_user_or_admin(self):
         self.authenticate(self.user_admin.login, self.user_admin.login)
@@ -224,26 +239,24 @@ class TestDevice(TestHttpBase):
         self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0')
         self.hit('2024-01-01 09:00:00', '/test_http/greeting-public?readonly=0')
 
-        devices, logs = self.get_devices_logs()
-        self.assertEqual(len(devices), 2)
-        self.assertEqual(len(logs), 4)
-        self.assertEqual(len(self.user_admin.device_ids), 1)
-        self.assertEqual(len(self.user_internal.device_ids), 1)
+        self.assertEqual(len(self.user_admin.session_ids), 1)
+        self.assertEqual(len(self.user_admin.session_ids.device_ids), 1)
+        self.assertEqual(len(self.user_internal.session_ids), 1)
+        self.assertEqual(len(self.user_internal.session_ids.device_ids), 1)
 
-        devices_from_admin = self.Device.with_user(self.user_admin).search([])
-        devices_from_internal = self.Device.with_user(self.user_internal).search([])
-        self.assertEqual(len(devices_from_admin), 2)
-        self.assertEqual(len(devices_from_internal), 1)
+        sessions_seen_from_admin = self.Session.with_user(self.user_admin).search([])
+        sessions_seen_from_internal = self.Session.with_user(self.user_internal).search([])
+        self.assertEqual(len(sessions_seen_from_admin), 2)
+        self.assertEqual(len(sessions_seen_from_admin.device_ids), 2)
+        self.assertEqual(len(sessions_seen_from_internal), 1)
+        self.assertEqual(len(sessions_seen_from_internal.device_ids), 1)
 
     def test_differentiate_computer_and_mobile(self):
         self.authenticate(self.user_admin.login, self.user_admin.login)
         self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0', headers={'User-Agent': USER_AGENT_linux_chrome})
         self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0', headers={'User-Agent': USER_AGENT_android_chrome})
 
-        devices, logs = self.get_devices_logs(self.user_admin)
-        self.assertEqual(len(devices), 2)
-        self.assertEqual(len(logs), 2)
-
+        devices = self.user_admin.session_ids.device_ids
         laptop_device = devices.filtered(lambda device: device.device_type == 'computer')
         mobile_device = devices.filtered(lambda device: device.device_type == 'mobile')
         self.assertEqual(len(laptop_device), 1)
@@ -255,11 +268,10 @@ class TestDevice(TestHttpBase):
         self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0', ip='192.0.2.42')
         self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0', ip='191.0.1.41')
 
-        devices, _ = self.get_devices_logs(self.user_admin)
-        self.assertEqual(len(devices), 1)
-        self.assertIn('193.0.3.43', devices.linked_ip_addresses)
-        self.assertIn('192.0.2.42', devices.linked_ip_addresses)
-        self.assertIn('191.0.1.41', devices.linked_ip_addresses)
+        self.assertCountEqual(
+            self.user_admin.session_ids.device_ids.mapped('ip_address'),
+            ['193.0.3.43', '192.0.2.42', '191.0.1.41'],
+        )
 
     def test_retrieve_linked_ip_addresses_according_to_devices(self):
         self.authenticate(self.user_admin.login, self.user_admin.login)
@@ -267,14 +279,11 @@ class TestDevice(TestHttpBase):
         self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0', headers={'User-Agent': USER_AGENT_linux_chrome}, ip='192.0.2.42')
         self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0', headers={'User-Agent': USER_AGENT_linux_firefox}, ip='191.0.1.41')
 
-        devices, _ = self.get_devices_logs(self.user_admin)
-        self.assertEqual(len(devices), 2)
+        devices = self.user_admin.session_ids.device_ids
         device_chrome = devices.filtered(lambda device: device.browser == 'chrome')
         device_firefox = devices.filtered(lambda device: device.browser == 'firefox')
-        self.assertIn('193.0.3.43', device_chrome.linked_ip_addresses)
-        self.assertIn('192.0.2.42', device_chrome.linked_ip_addresses)
-        self.assertNotIn('191.0.1.41', device_chrome.linked_ip_addresses)
-        self.assertIn('191.0.1.41', device_firefox.linked_ip_addresses)
+        self.assertCountEqual(device_chrome.mapped('ip_address'), ['193.0.3.43', '192.0.2.42'])
+        self.assertCountEqual(device_firefox.mapped('ip_address'), ['191.0.1.41'])
 
     def test_detection_no_trace_mechanism(self):
         session = self.authenticate(self.user_admin.login, self.user_admin.login)
@@ -282,20 +291,24 @@ class TestDevice(TestHttpBase):
         odoo.http.root.session_store.save(session)
         res = self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0')
         self.assertEqual(res.status_code, 200)
-        devices, logs = self.get_devices_logs(self.user_admin)
+
+        sessions, devices, logs = self.get_devices(self.user_admin)
+        self.assertEqual(len(sessions), 0)
         self.assertEqual(len(devices), 0)
         self.assertEqual(len(logs), 0)
+        self.assertEqual(len(session['_trace']), 0)
 
     def test_detection_device_default_order(self):
         self.authenticate(self.user_admin.login, self.user_admin.login)
         self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0', headers={'User-Agent': USER_AGENT_linux_chrome})
         self.hit('2024-01-01 10:00:00', '/test_http/greeting-public?readonly=0', headers={'User-Agent': USER_AGENT_linux_firefox})
         self.hit('2024-01-01 09:00:00', '/test_http/greeting-public?readonly=0', headers={'User-Agent': USER_AGENT_android_chrome})
-        devices, _ = self.get_devices_logs(self.user_admin)
+
+        devices = self.user_admin.session_ids.device_ids
         self.assertEqual(
             list(zip(devices.mapped('platform'), devices.mapped('browser'))),
             [('linux', 'firefox'), ('android', 'chrome'), ('linux', 'chrome')],
-            "By default, devices should be found from the most recent to the least recent (according to their last activity)."
+            "By default, devices should be found from the most recent to the least recent (according to their last activity).",
         )
 
     # --------------------
@@ -311,11 +324,10 @@ class TestDevice(TestHttpBase):
         res = self.hit('2024-01-01 08:00:00', '/test_http/greeting-user?readonly=0')
         self.assertNotIn('/web/login', res.url)
 
-        user_internal_device = self.user_internal.device_ids
-        self.assertEqual(len(user_internal_device), 1)
-        self.assertEqual(user_internal_device.revoked, False)
+        user_internal_session = self.user_internal.session_ids
+        self.assertEqual(len(user_internal_session), 1)
 
-        user_internal_device._revoke()
+        user_internal_session._revoke()
 
         res = self.hit('2024-01-01 08:00:01', '/test_http/greeting-user?readonly=0')
         self.assertIn('/web/login', res.url)
@@ -324,7 +336,7 @@ class TestDevice(TestHttpBase):
         session = self.authenticate(self.user_internal.login, self.user_internal.login)
         self.hit('2024-01-01 08:00:00', '/test_http/greeting-user?readonly=0')
 
-        self.user_internal.device_ids._revoke()
+        self.user_internal.session_ids._revoke()
 
         res = self.hit('2024-01-01 08:00:00', '/test_http/greeting-user?readonly=0', headers={'session_id': session.sid})
         self.assertIn('/web/login', res.url)
@@ -338,12 +350,19 @@ class TestDevice(TestHttpBase):
         self.hit('2024-01-01 09:00:00', '/test_http/greeting-user?readonly=0', headers={'User-Agent': USER_AGENT_linux_chrome})
         self.hit('2024-01-01 08:00:00', '/test_http/greeting-user?readonly=0', headers={'User-Agent': USER_AGENT_linux_firefox})
 
-        devices, logs = self.get_devices_logs(self.user_admin)
+        sessions, devices, logs = self.get_devices(self.user_admin)
+        self.assertEqual(len(sessions), 2)
         self.assertEqual(len(devices), 3)
         self.assertEqual(len(logs), 5)
-        self.assertEqual(len(self.user_admin.device_ids), 3)
 
-        self.user_admin.device_ids.filtered(lambda device: 'firefox' in device.browser)._revoke()
+        self.user_admin.session_ids.filtered(
+            lambda session: any(device.browser == 'firefox' for device in session.device_ids),
+        )._revoke()
+
+        sessions, devices, logs = self.get_devices(self.user_admin)
+        self.assertEqual(len(sessions), 1)
+        self.assertEqual(len(devices), 1)
+        self.assertEqual(len(logs), 5)
 
         res = self.hit('2024-01-01 08:00:30', '/test_http/greeting-user?readonly=0', headers={'User-Agent': USER_AGENT_linux_firefox})
         self.assertIn('/web/login', res.url)
@@ -358,6 +377,8 @@ class TestDevice(TestHttpBase):
                 'session_identifier': odoo.http.root.session_store.generate_key(),
                 'user_id': session.uid,
                 'revoked': False,
+                'ip_address': TEST_IP,
+                'user_agent': USER_AGENT_linux_chrome,
                 'first_activity': datetime.now(),
                 'last_activity': datetime.now(),
             })
@@ -367,33 +388,23 @@ class TestDevice(TestHttpBase):
         with freeze_time('2025-01-01 08:00:00'):
             self._create_device_log_for_user(session, 10)
 
-        devices, logs = self.get_devices_logs(self.user_admin)
-        self.assertEqual(len(devices), 10)
-        self.assertEqual(len(logs), 10)
-        self.assertEqual(len(self.user_admin.device_ids), 10)
-
         session = self.authenticate(self.user_internal.login, self.user_internal.login)
         with freeze_time('2025-01-01 08:00:00'):
             self._create_device_log_for_user(session, 10)
 
-        devices, logs = self.get_devices_logs(self.user_internal)
-        self.assertEqual(len(devices), 10)
-        self.assertEqual(len(logs), 10)
-        self.assertEqual(len(self.user_internal.device_ids), 10)
+        self.assertEqual(len(self.user_admin.session_ids), 10)
+        self.assertEqual(len(self.user_internal.session_ids), 10)
+
+        odoo.http.root.session_store.store.clear()
 
         # Update all device logs
         with freeze_time('2025-02-01 08:00:00'), patch.object(self.cr, 'commit', lambda: ...):
             self.DeviceLog.sudo()._ResDeviceLog__update_revoked()
         self.DeviceLog.flush_model()  # Because write on ``res.device.log`` and so we have new values in cache
-        self.Device.invalidate_model()  # Because it depends on the ``res.device.log`` model (updated in database)
+        self.Session.invalidate_model()  # Because it depends on the ``res.device.log`` model (updated in database)
 
-        devices, _ = self.get_devices_logs(self.user_admin)
-        self.assertEqual(len(devices), 0)  # No file exist on the filesystem (``revoked`` equals to ``True``)
-        self.assertEqual(len(self.user_admin.device_ids), 0)
-
-        devices, _ = self.get_devices_logs(self.user_internal)
-        self.assertEqual(len(devices), 0)
-        self.assertEqual(len(self.user_internal.device_ids), 0)
+        self.assertEqual(len(self.user_admin.session_ids), 0)
+        self.assertEqual(len(self.user_internal.session_ids), 0)
 
     # --------------------
     # SPECIFIC USE CASE
@@ -416,3 +427,20 @@ class TestDevice(TestHttpBase):
         # This means that the device logic will not create a session file
         # (because we are not passing in the `_update_device` logic).
         self.assertFalse(session['_trace'])
+
+    def test_keep_user_reference_after_user_deletion(self):
+        self.authenticate(self.user_internal.login, self.user_internal.login)
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public')
+
+        sessions, devices, logs = self.get_devices(self.user_internal)
+        self.assertEqual(len(sessions), 1)
+        self.assertEqual(len(devices), 1)
+        self.assertEqual(len(logs), 1)
+        # `user_id` field must be a recordset
+        self.assertEqual(sessions.user_id, self.user_internal)
+        self.assertEqual(devices.user_id, self.user_internal)
+        self.assertEqual(logs.user_id, self.user_internal.id)
+
+        self.user_internal.unlink()
+
+        self.assertEqual(logs.user_id, self.user_internal.id)

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -499,7 +499,7 @@ class BaseCase(case.TestCase):
             httprequest=Mock(host='localhost'),
             db=self.env.cr.dbname,
             env=self.env,
-            session=DotDict(odoo.http.get_default_session(), debug='1'),
+            session=DotDict(odoo.http.get_default_session(), debug='1', sid=''),
         )
         try:
             self.env.flush_all()


### PR DESCRIPTION
Before this commit, a record of the `res.device` model represents a device.
This meant that it was possible to have multiple devices for the same session.
The user would therefore see several devices even though only one session was
active.

From a security point of view, this is fine.
But from a purely usage point of view, someone without technical knowledge would
find it difficult to understand what was happening (and would just see a bunch
of devices).

The aim of this commit is to simplify the `res.device` model for the user
without losing any information.

A record in the `res.session` model represents a session (identified by the last
active device for that session for reasons of simplicity and display).

The `res.device` model makes it possible to find all
the devices linked to the session and thus provide the information to those who
want it.