### PR TITLE
[FIX] website_blog: select archive month by index in the tour

### DIFF
--- a/addons/website_blog/static/tests/tours/blog_tags_with_date.js
+++ b/addons/website_blog/static/tests/tours/blog_tags_with_date.js
@@ -28,7 +28,14 @@ registerWebsitePreviewTour("blog_tags_with_date", {
     }, {
         content: "Select first month",
         trigger: ":iframe select[name=archive]",
-        run: "selectByLabel October",
+        run: function (helpers) {
+            const options = Array.from(this.anchor?.options ?? []);
+            const firstMonthIndex = options.findIndex((option) => option.closest("optgroup"));
+            if (firstMonthIndex === -1) {
+                throw new Error("Expected an option inside an optgroup in the archive select.");
+            }
+            return helpers.selectByIndex(firstMonthIndex, this.anchor);
+        },
     }, {
         content: "Check date filter has been added",
         trigger: ":iframe #o_wblog_posts_loop span>i.fa-calendar-o",


### PR DESCRIPTION
Before this commit the blog_tags_with_date tour tried to select the October option by label. In other locales the month label differs and the tour could not find it, so the tour aborted at that step.

Steps to reproduce:
- Change the website language to one where October has another name.
- Run the blog_tags_with_date preview tour.

The tour now selects the first month option by index, independent of labels.

runbot-233321
