### PR TITLE
[FIX] stock: Prevent global route duplicates on warehouse creation

### DIFF
--- a/addons/stock/models/stock_warehouse.py
+++ b/addons/stock/models/stock_warehouse.py
@@ -396,7 +396,7 @@ class Warehouse(models.Model):
             if raise_if_not_found:
                 raise UserError(_('Can\'t find any generic route %s.', route_name))
             elif data_route and create:
-                route = data_route.copy({'name': data_route.name, 'company_id': company.id, 'rule_ids': False})
+                route = data_route.copy({'name': route_name, 'company_id': company.id, 'rule_ids': False})
         return route
 
     def _get_global_route_rules_values(self):

--- a/addons/stock/tests/test_warehouse.py
+++ b/addons/stock/tests/test_warehouse.py
@@ -704,3 +704,26 @@ class TestWarehouse(TestStockCommon):
         test_warehouse.sequence = 100
         location._compute_warehouse_id()
         self.assertEqual(location.warehouse_id, test_warehouse)
+
+    def test_modified_global_route(self):
+        """ Ensure that _find_or_create_global_route, if called multiple time, only creates the route once
+
+        If a global route was renamed, and has a company setup,
+          then the system would create multiple duplicates with the new name when creating a new warehouse;
+          one duplicate for each call _find_or_create_global_route.
+        """
+        company_2 = self.env["res.company"].create({"name": "Company 2"})
+
+        mto_route = self.warehouse_1.mto_pull_id.route_id
+        mto_route.rule_ids.unlink()  # Quick patch to be able to set a company on the route
+        mto_route.write({"name": "New Name (MTO)", "company_id": self.warehouse_1.company_id.id})
+
+        self.env["stock.warehouse"].with_company(company_2).create({"name": "Warehouse 2", "code": "2"})
+
+        route_sudo = self.env["stock.route"].sudo().with_context(active_test=False)
+        renamed_route_count = route_sudo.search_count([("name", "=", "New Name (MTO)")])
+        self.assertEqual(renamed_route_count, 1)
+
+        new_mto_route = route_sudo.search([("name", "=", "Replenish on Order (MTO)")])
+        self.assertEqual(len(new_mto_route), 1)
+        self.assertEqual(new_mto_route.company_id.id, company_2.id)


### PR DESCRIPTION
In _find_or_create_global_route, use the asked 'route_name' instead of the potentially modified name of `data_route`. This ensures that if '_find_or_create_global_route' is called with the exact same values a new route will not be re-created.

https://github.com/user-attachments/assets/815adf60-aa2d-4699-a79d-f9ad9607cbea

## How to reproduce (in runbot 17.0):
- Enable "Multi-steps Routes"
- Unarchive route "Replenish on Order (MTO)", change the name, set company to "My company (San Francisco)"
- Go to "My Company (Chicago)"
- Create new Warehouse
=> Check all the routes: ~100 MTO routes with the modified name have been created.

OPW-5149842

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
