### PR TITLE
[FIX] web: tests - allow custom responses in onRpc

### DIFF
--- a/addons/web/static/tests/_framework/mock_server/mock_server.js
+++ b/addons/web/static/tests/_framework/mock_server/mock_server.js
@@ -536,9 +536,7 @@ export class MockServer {
         // Set default routes
         this._onRoute(["/web/action/load"], this.loadAction);
         this._onRoute(["/web/action/load_breadcrumbs"], this.loadActionBreadcrumbs);
-        this._onRoute(["/web/bundle/<string:bundle_name>"], this.loadBundle, {
-            pure: true,
-        });
+        this._onRoute(["/web/bundle/<string:bundle_name>"], this.loadBundle);
         this._onRoute(["/web/dataset/call_kw", "/web/dataset/call_kw/<path:path>"], this.callKw, {
             final: true,
         });
@@ -548,15 +546,9 @@ export class MockServer {
             { final: true }
         );
         this._onRoute(["/web/dataset/resequence"], this.resequence);
-        this._onRoute(["/web/image/<string:model>/<int:id>/<string:field>"], this.loadImage, {
-            pure: true,
-        });
-        this._onRoute(["/web/webclient/load_menus/<string:unique>"], this.loadMenus, {
-            pure: true,
-        });
-        this._onRoute(["/web/webclient/translations/<string:unique>"], this.loadTranslations, {
-            pure: true,
-        });
+        this._onRoute(["/web/image/<string:model>/<int:id>/<string:field>"], this.loadImage);
+        this._onRoute(["/web/webclient/load_menus/<string:unique>"], this.loadMenus);
+        this._onRoute(["/web/webclient/translations/<string:unique>"], this.loadTranslations);
 
         // Add routes from "mock_rpc" registry
         const mockRpcEntries = registry.category("mock_rpc").getEntries();
@@ -801,7 +793,7 @@ export class MockServer {
                     error = err instanceof Error ? err : new Error(err);
                 }
                 if (final || error || (result !== null && result !== undefined)) {
-                    if (pure) {
+                    if (pure || result instanceof Response) {
                         jsonRpcParams = null;
                     }
                     break;

--- a/addons/web/static/tests/mock_server/mock_server.test.js
+++ b/addons/web/static/tests/mock_server/mock_server.test.js
@@ -151,15 +151,15 @@ defineModels([Partner, Bar, Foo]);
  *  kwargs: Record<string, any>;
  *  [key: string]: any;
  * }} params
- * @returns
  */
-const ormRequest = async (params) => {
-    const response = await fetch(`/web/dataset/call_kw/${params.model}/${params.method}`, {
+function fetchCallKw(params) {
+    return fetch(`/web/dataset/call_kw/${params.model}/${params.method}`, {
         method: "POST",
         headers: {
             "Content-Type": "application/json",
         },
         body: JSON.stringify({
+            id: nextJsonRpcId++,
             jsonrpc: "2.0",
             method: "call",
             params: {
@@ -169,6 +169,19 @@ const ormRequest = async (params) => {
             },
         }),
     });
+}
+
+/**
+ * @param {{
+ *  model: string;
+ *  method: string;
+ *  args: any[];
+ *  kwargs: Record<string, any>;
+ *  [key: string]: any;
+ * }} params
+ */
+const ormRequest = async (params) => {
+    const response = await fetchCallKw(params);
     const { error, result } = await response.json();
     if (error) {
         console.error(error);
@@ -186,6 +199,7 @@ const JSON_RPC_BASIC_PARAMS = {
         ["Content-Type"]: "application/json",
     },
 };
+let nextJsonRpcId = 0;
 
 describe.current.tags("headless");
 
@@ -316,6 +330,13 @@ test("rpc: calls on mock server", async () => {
     ).rejects.toThrow(
         `Cannot find a definition for model "fake.model": could not get model from server environment`
     );
+});
+
+test("performRPC: custom response", async () => {
+    const customResponse = new Response("{}", { status: 418 });
+    onRpc(() => customResponse);
+    await makeMockServer();
+    await expect(fetchCallKw({})).resolves.toBe(customResponse);
 });
 
 test("performRPC: search with active_test=false", async () => {


### PR DESCRIPTION
Before this commit, when an 'onRpc' handler would return a 'Response' object, it would still be wrapped in a JSON-RPC payload (under the 'result' key) if the "content-type" header specified that it was a JSON-RPC.

However, if a 'Response' object is returned by the handler, it usually means that the response should be that object as-is, as it was created with the desired final parameters.

This commit ensures that 'Response' values are returned as they are, instead of being wrapped in a JSON-RPC payload object.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
