### PR TITLE
[REF] mail: removed discuss.channel.member/fetched

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -1428,16 +1428,19 @@ class DiscussChannel(models.Model):
             """, member_query))
             members = cursor_self.env['discuss.channel.member'].browse([r[0] for r in to_update])
             channel2message = members.channel_id._get_last_messages().grouped('channel_id')
+            updated_members_by_channel = defaultdict(cursor_self.env["discuss.channel.member"].browse)
             for member in members:
                 last_message = channel2message[member.channel_id]
                 if member.fetched_message_id != last_message:
                     member.fetched_message_id = last_message
-                    member.channel_id._bus_send('discuss.channel.member/fetched', {
-                        'channel_id': member.channel_id.id,
-                        'id': member.id,
-                        'last_message_id': last_message.id,
-                        'partner_id': cursor_self.env.user.partner_id.id,
-                    })
+                    updated_members_by_channel[member.channel_id] |= member
+            for channel in updated_members_by_channel:
+                store = Store(bus_channel=channel)
+                store.add(updated_members_by_channel[channel], fields=[
+                    Store.One("channel_id", []),
+                    "fetched_message_id",
+                    *cursor_self.env["discuss.channel.member"]._to_store_persona(store.target, [])
+                ]).bus_send()
 
     def channel_set_custom_name(self, name):
         self.ensure_one()

--- a/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
@@ -45,15 +45,6 @@ export class DiscussCoreCommon {
             message.thread.messages.push(message);
             message.thread.transientMessages.push(message);
         });
-        this.busService.subscribe("discuss.channel.member/fetched", (payload) => {
-            const { channel_id, id, last_message_id, partner_id } = payload;
-            this.store["discuss.channel.member"].insert({
-                id,
-                fetched_message_id: { id: last_message_id },
-                partner_id: { id: partner_id },
-                thread: { id: channel_id, model: "discuss.channel" },
-            });
-        });
         this.env.bus.addEventListener("mail.message/delete", ({ detail: { message, notifId } }) => {
             if (message.thread) {
                 const { self_member_id } = message.thread;

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -1,4 +1,4 @@
-import { waitNotifications, waitUntilSubscribe } from "@bus/../tests/bus_test_helpers";
+import { waitUntilSubscribe } from "@bus/../tests/bus_test_helpers";
 
 import { OutOfFocusService } from "@mail/core/common/out_of_focus_service";
 import { LAST_DISCUSS_ACTIVE_ID_LS } from "@mail/core/public_web/discuss_app/discuss_app_model";
@@ -1344,7 +1344,6 @@ test("new message in tab title has precedence over action name", async () => {
             thread_model: "discuss.channel",
         })
     );
-    await waitNotifications(["discuss.channel.member/fetched"]);
     await expect.waitForSteps(["(1) Inbox"]);
 });
 

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
@@ -320,12 +320,25 @@ export class DiscussChannel extends models.ServerModel {
             DiscussChannelMember.write([memberOfCurrentUser.id], {
                 fetched_message_id: lastMessage.id,
             });
-            BusBus._sendone(channel, "discuss.channel.member/fetched", {
-                channel_id: channel.id,
-                id: memberOfCurrentUser.id,
-                last_message_id: lastMessage.id,
-                partner_id: this.env.user.partner_id,
-            });
+            BusBus._sendone(
+                channel,
+                "mail.record/insert",
+                new mailDataHelpers.Store()
+                    .add(
+                        DiscussChannelMember.browse(memberOfCurrentUser.id),
+                        makeKwArgs({
+                            fields: [
+                                mailDataHelpers.Store.one(
+                                    "channel_id",
+                                    makeKwArgs({ as_thread: true, fields: [] })
+                                ),
+                                "fetched_message_id",
+                                ...DiscussChannelMember._to_store_persona([]),
+                            ],
+                        })
+                    )
+                    .get_result()
+            );
         }
     }
 


### PR DESCRIPTION
enterprise PR: https://github.com/odoo/enterprise/pull/97858

This commit refactors the `discuss.channel.member/fetched` bus notification to be a `mail.record/insert` as there is no other logic than inserting channel member data in the store.

task-5177252