### PR TITLE
[FIX] mass_mailing: prevent crash when fieldHTML in modal

### DIFF
--- a/addons/mass_mailing/static/tests/mass_mailing_html_field.test.js
+++ b/addons/mass_mailing/static/tests/mass_mailing_html_field.test.js
@@ -7,6 +7,7 @@ import {
     onRpc,
     clickSave,
     patchWithCleanup,
+    contains,
 } from "@web/../tests/web_test_helpers";
 import { click, queryOne, waitFor } from "@odoo/hoot-dom";
 import { defineMailModels } from "@mail/../tests/mail_test_helpers";
@@ -152,5 +153,42 @@ describe("field HTML", () => {
 
         // assert that tElement style has inline attibute
         expect(tElement).toHaveAttribute("data-oe-t-inline", "true");
+    });
+
+    test("builder in modal -- owl reconciliation iframe unload", async () => {
+        // Related to ad-hoc fix where in modal, some editor's popovers
+        // get to be spawned before the modal in the DOM and in OWL
+        // When those popovers are killed, OWL tries to reconcile its element List
+        // in OverlayContainer, displaces the node that contains the iframe
+        // and the editor subsequently crashes
+        class SomeModel extends models.Model {
+            _name = "some.model"
+            mailing_ids = fields.One2many({relation: "mailing.mailing"});
+
+            _records = [{
+                id: 1,
+                mailing_ids: [1],
+            }]
+        }
+
+        Mailing._views["form"] = mailViewArch;
+        defineModels([SomeModel]);
+        const arch = `<form><field name="mailing_ids"> <list><field name="display_name" /></list> </field></form>`
+        await mountView({
+            type: "form",
+            resModel: "some.model",
+            arch,
+            resId: 1,
+        });
+        await contains(".o_data_cell").click();
+        await waitFor(".o_dialog");
+        await contains(".o_dialog [data-name='event']").click();
+        await waitFor(".o_dialog .o_mass_mailing-builder_sidebar", { timeout: 1000 });
+        await contains(".o_dialog :iframe p", { timeout: 1000}).click();
+        await waitFor(".o_dialog .o_mass_mailing-builder_sidebar .options-container-header:contains(Text)");
+        const overlayOptionsSelect = ".o-main-components-container .o-overlay-container .o_overlay_options"
+        await waitFor(overlayOptionsSelect + ":has(button[title='Move up'])");
+        await contains(".o_dialog :iframe img").click();
+        await waitFor(overlayOptionsSelect + ":not(:has(button[title='Move up']))");
     });
 });


### PR DESCRIPTION
Have a mass mailing html field in a modal
click on some text then on some image

Before this commit there was a crash. This was because some overlays use a sequence lower that the dialog they are related to. Hence, when the OverlayContainer reconciled its Owl list of element, the dialog got displaced, making the iframe unloading The Editor crashed subsequently, tryng to access the iframe's defaultView which did not exist anymore after unloading the iframe

After this commit, this use case doesn't happen any more. This is really ad-hoc Owl cannot be fixed to account for iframes in that situation the web framework could do more to stack overlays in order to avoid this.

related to task-5182993

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
