### PR TITLE
[FIX] web: add required prop to the model field selector widget

### DIFF
--- a/addons/web/static/src/views/fields/dynamic_widget/dynamic_model_field_selector_char.js
+++ b/addons/web/static/src/views/fields/dynamic_widget/dynamic_model_field_selector_char.js
@@ -17,6 +17,7 @@ export class DynamicModelFieldSelectorChar extends CharField {
         resModel: { type: String, optional: true },
         onlySearchable: { type: Boolean, optional: true },
         followRelations: { type: Boolean, optional: true },
+        required: { type: Boolean, optional: true },
     };
 
     /**
@@ -87,6 +88,7 @@ export const dynamicModelFieldSelectorChar = {
         return {
             followRelations: options.follow_relations ?? true,
             onlySearchable: exprToBoolean(options.only_searchable),
+            required: dynamicInfo.required,
             resModel: options.model,
         };
     },

--- a/addons/web/static/tests/views/fields/dynamic_model_field_selector_char.test.js
+++ b/addons/web/static/tests/views/fields/dynamic_model_field_selector_char.test.js
@@ -1,0 +1,40 @@
+import { expect, test } from "@odoo/hoot";
+import { waitFor } from "@odoo/hoot-dom";
+import { contains, defineModels, fields, models, mountView } from "@web/../tests/web_test_helpers";
+
+class Partner extends models.Model {
+    char = fields.Char();
+    model_name = fields.Char();
+
+    _records = [
+        { id: 1, char: "", model_name: "partner" },
+        { id: 2, char: "", model_name: "partner" },
+    ];
+
+    _views = {
+        form: /* xml */ `
+            <form>
+                <field name="char" widget="DynamicModelFieldSelectorChar" required="id == 1" readonly="id == 2" options="{'model': 'model_name'}"/>
+            </form>
+        `,
+    };
+}
+
+defineModels([Partner]);
+
+test("Dynamic model field selector char - required layout", async () => {
+    await mountView({ type: "form", resModel: "partner", resId: 1 });
+    await waitFor(".o_model_field_selector");
+    expect(".o_model_field_selector_warning").toHaveCount(1);
+    await contains(".o_model_field_selector_value").click();
+    await contains(".o_model_field_selector_popover_item button:contains('Char')").click();
+    await waitFor(".o_model_field_selector_value:contains('Char')");
+    expect(".o_model_field_selector_warning").toHaveCount(0);
+});
+
+test("Dynamic model field selector char - readonly layout", async () => {
+    await mountView({ type: "form", resModel: "partner", resId: 2 });
+    await waitFor(".o_model_field_selector");
+    expect(".o_model_field_selector_warning").toHaveCount(0);
+    expect(".o_model_field_selector").toHaveClass("o_read_mode");
+});


### PR DESCRIPTION
Purpose:
--------
Fields with the "Dynamic Model Field Selector" widget and the required attr do not appear as required (eg. in base/ir_actions_views).

The prop "required" is passed to the model field selector, but this prop is not defined on the field widget.

Task-5109721