### PR TITLE
[PERF] sale_project: index `reinvoiced_sale_order_id`

### DIFF
--- a/addons/sale_project/models/project_project.py
+++ b/addons/sale_project/models/project_project.py
@@ -42,7 +42,7 @@ class ProjectProject(models.Model):
     partner_id = fields.Many2one(compute="_compute_partner_id", store=True, readonly=False)
     display_sales_stat_buttons = fields.Boolean(compute='_compute_display_sales_stat_buttons', export_string_translation=False)
     sale_order_state = fields.Selection(related='sale_order_id.state', export_string_translation=False)
-    reinvoiced_sale_order_id = fields.Many2one('sale.order', string='Sales Order', groups='sales_team.group_sale_salesman', copy=False, domain="[('partner_id', '=', partner_id)]",
+    reinvoiced_sale_order_id = fields.Many2one('sale.order', string='Sales Order', groups='sales_team.group_sale_salesman', copy=False, domain="[('partner_id', '=', partner_id)]", index='btree_not_null',
         help="Products added to stock pickings, whose operation type is configured to generate analytic costs, will be re-invoiced in this sales order if they are set up for it.",
     )
 


### PR DESCRIPTION
This commit adds an index on `project.project.
reinvoiced_sale_order_id`, because the search in `sale.order. _compute_project_ids` might not be selective enough based on `sale_order_id`, which is a related field using `sale_line_id`. Since it's related, there is only a where clause on `sale_line_id IS NOT NULL`, which might not be selective enough and leads to a Seq. Scan of the `project_project` table.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
