### PR TITLE
[FIX] website_livechat: only cancel pending chat requests

### DIFF
--- a/addons/website_livechat/models/im_livechat_channel.py
+++ b/addons/website_livechat/models/im_livechat_channel.py
@@ -17,8 +17,12 @@ class Im_LivechatChannel(models.Model):
             discuss_channel_vals['livechat_visitor_id'] = visitor_sudo.id
             # As chat requested by the visitor, delete the chat requested by an operator if any to avoid conflicts between two flows
             # TODO DBE : Move this into the proper method (open or init mail channel)
-            chat_request_channel = self.env['discuss.channel'].sudo().search([('livechat_visitor_id', '=', visitor_sudo.id), ('livechat_active', '=', True)])
-            for discuss_channel in chat_request_channel:
+            pending_chats_domain = [
+                ("is_pending_chat_request", "=", True),
+                ("livechat_visitor_id", "=", visitor_sudo.id),
+                ("livechat_active", "=", True),
+            ]
+            for discuss_channel in self.env["discuss.channel"].sudo().search(pending_chats_domain):
                 operator = discuss_channel.livechat_operator_id
                 operator_name = operator.user_livechat_username or operator.name
                 discuss_channel._close_livechat_session(cancel=True, operator=operator_name)

--- a/addons/website_livechat/tests/test_livechat_request.py
+++ b/addons/website_livechat/tests/test_livechat_request.py
@@ -48,10 +48,18 @@ class TestLivechatRequestHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
                                                    ('livechat_active', '=', True)])
 
         # Check that the chat request has been canceled.
-        chat_request.invalidate_recordset()
         self.assertEqual(chat_request.livechat_active, False, "The livechat request must be inactive as the visitor started himself a livechat session.")
         self.assertEqual(len(channel), 1)
         self.assertEqual(channel.livechat_operator_id, self.operator.partner_id, "Operator for active livechat session must be Michel Operator")
+
+        self._clean_livechat_sessions()
+        self.visitor.with_user(self.operator_b).sudo().action_send_chat_request()
+        chat_request = self.env["discuss.channel"].search(
+            [("livechat_visitor_id", "=", self.visitor.id), ("livechat_active", "=", True)]
+        )
+        chat_request.is_pending_chat_request = False  # Customer already accessed the chat.
+        self.url_open(url=self.open_chat_url, json=self.open_chat_params)
+        self.assertTrue(chat_request.livechat_active)
 
     def _common_chat_request_flow(self):
         self.visitor.with_user(self.operator).sudo().action_send_chat_request()


### PR DESCRIPTION
The website livechat module allows agents to start conversations with customers, but conversations are only displayed on the next navigation.

Previously, pending chat requests were canceled whenever a customer opened a new live chat. The search condition for pending chats was too broad: it did not consider who started the conversation or whether it was already ongoing.

As a result, ongoing chats could be unintentionally canceled. Customers could have multiple conversations (e.g. on different devices).

This change ensures that only pending chat requests are canceled, leaving ongoing chats intact.

task-5186567

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
