### PR TITLE
[IMP] hr: moving Mitchell Admin to demo data

### DIFF
--- a/addons/hr/data/hr_data.xml
+++ b/addons/hr/data/hr_data.xml
@@ -190,16 +190,6 @@
             <field name="country_id" ref="base.be"/>
         </record>
 
-        <!-- Employee -->
-        <record id="employee_admin" model="hr.employee" forcecreate="0">
-            <field name="name" eval="obj(ref('base.partner_admin')).name" model="res.partner"/>
-            <field name="department_id" ref="dep_administration"/>
-            <field name="user_id" ref="base.user_admin"/>
-            <field name="address_id" ref="base.main_partner"/>
-            <field name="image_1920" eval="obj(ref('base.partner_admin')).image_1920" model="res.partner"/>
-            <field name="structure_type_id" ref="hr.structure_type_employee"/>
-        </record>
-
         <!-- Contract-related subtypes for messaging / Chatter -->
         <record id="mt_contract_pending" model="mail.message.subtype">
             <field name="name">To Renew</field>

--- a/addons/hr/data/hr_demo.xml
+++ b/addons/hr/data/hr_demo.xml
@@ -12,6 +12,15 @@
                 (4, ref('hr.group_hr_manager'))]"/>
         </record>
 
+        <record id="employee_admin" model="hr.employee">
+            <field name="name" eval="obj(ref('base.partner_admin')).name" model="res.partner"/>
+            <field name="user_id" ref="base.user_admin"/>
+            <field name="department_id" ref="dep_administration"/>
+            <field name="address_id" ref="base.main_partner"/>
+            <field name="image_1920" eval="obj(ref('base.partner_admin')).image_1920" model="res.partner"/>
+            <field name="structure_type_id" ref="hr.structure_type_employee"/>
+        </record>
+
         <!-- Resource Calendar -->
         <record id="resource_calendar_std_20h" model="resource.calendar">
             <field name="name">Standard 20 hours/week</field>

--- a/addons/hr/tests/__init__.py
+++ b/addons/hr/tests/__init__.py
@@ -19,3 +19,4 @@ from . import test_hr_contract_versions
 from . import test_flexible_resource_calendar
 from . import test_multiple_bank_accounts
 from . import test_hr_org_chart
+from . import test_utils

--- a/addons/hr/tests/test_utils.py
+++ b/addons/hr/tests/test_utils.py
@@ -1,0 +1,16 @@
+def get_admin_employee(env, additional_values=None):
+    """ Get `hr.employee_admin` or create it if it doesn't exist (singleton). """
+    additional_values = additional_values or {}
+    admin_employee = env.ref('hr.employee_admin', raise_if_not_found=False)
+    if admin_employee:
+        admin_employee.write(additional_values)
+        return admin_employee
+    return env['hr.employee'].create({
+        'name': 'Mitchell Admin',
+        'user_id': env.ref('base.user_admin').id,
+        'department_id': env.ref('hr.dep_administration').id,
+        'address_id': env.ref('base.main_partner').id,
+        'structure_type_id': env.ref('hr.structure_type_employee').id,
+        'company_id': env.ref('base.main_company').id,
+        **additional_values,
+    })

--- a/addons/hr_expense/tests/test_expenses_tour.py
+++ b/addons/hr_expense/tests/test_expenses_tour.py
@@ -1,8 +1,14 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo.tests import tagged, HttpCase
+from odoo.addons.hr.tests.test_utils import get_admin_employee
 
 
 @tagged('post_install', '-at_install')
 class TestExpensesTour(HttpCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.admin_employee = get_admin_employee(cls.env)
+
     def test_tour_expenses(self):
         self.start_tour("/odoo", "hr_expense_test_tour", login="admin")

--- a/addons/hr_holidays/tests/common.py
+++ b/addons/hr_holidays/tests/common.py
@@ -7,6 +7,7 @@ from odoo.addons.mail.tests.common import mail_new_test_user
 from odoo.tests import common
 from odoo.tests.common import TransactionCase
 from odoo.fields import Datetime
+from odoo.addons.hr.tests.test_utils import get_admin_employee
 
 
 class TestHrHolidaysCommon(common.TransactionCase):
@@ -36,6 +37,8 @@ class TestHrHolidaysCommon(common.TransactionCase):
             'request_unit': 'day',
             'company_id': cls.company.id,
         })
+
+        cls.admin_employee = get_admin_employee(cls.env)
 
         # Test users to use through the various tests
         cls.user_hruser = mail_new_test_user(cls.env, login='armande', groups='base.group_user,hr_holidays.group_hr_holidays_user')

--- a/addons/hr_holidays/tests/test_holidays_flow.py
+++ b/addons/hr_holidays/tests/test_holidays_flow.py
@@ -85,7 +85,7 @@ class TestHolidaysFlow(TestHrHolidaysCommon):
             Allocations = self.env['hr.leave.allocation']
             HolidaysStatus = self.env['hr.leave.type']
 
-            self.env.ref('hr.employee_admin').tz = "Europe/Brussels"
+            self.admin_employee.tz = "Europe/Brussels"
 
             holiday_status_paid_time_off = self.env['hr.leave.type'].create({
                 'name': 'Paid Time Off',
@@ -108,7 +108,7 @@ class TestHolidaysFlow(TestHrHolidaysCommon):
                     'name': 'Paid Time off for Admin',
                     'holiday_status_id': holiday_status_paid_time_off.id,
                     'number_of_days': 20,
-                    'employee_id': self.ref('hr.employee_admin'),
+                    'employee_id': self.admin_employee.id,
                     'state': 'confirm',
                     'date_from': time.strftime('%Y-%m-01'),
                 }
@@ -194,8 +194,8 @@ class TestHolidaysFlow(TestHrHolidaysCommon):
             self.assertEqual(hol2.state, 'refuse',
                             'hr_holidays: hr_user should not be able to reset a refused leave request')
 
-            employee_id = self.ref('hr.employee_admin')
-            # cl can be of maximum 20 days for employee_admin
+            employee_id = self.admin_employee.id
+            # cl can be of maximum 20 days for admin_emp
             hol3_status = holiday_status_paid_time_off.with_context(employee_id=employee_id)
             # I assign the dates in the holiday request for 1 day
             hol3 = Requests.create({
@@ -219,11 +219,11 @@ class TestHolidaysFlow(TestHrHolidaysCommon):
         # Print the HR Holidays(Summary Employee) Report through the wizard
         ctx = {
             'model': 'hr.employee',
-            'active_ids': [self.ref('hr.employee_admin')]
+            'active_ids': [self.admin_employee.id]
         }
         data_dict = {
             'date_from': datetime.today().strftime('%Y-%m-01'),
-            'emp': [(6, 0, [self.ref('hr.employee_admin')])],
+            'emp': [(6, 0, [self.admin_employee.id])],
             'holiday_type': 'Approved'
         }
         self.env.company.external_report_layout_id = self.env.ref('web.external_layout_standard').id
@@ -247,7 +247,7 @@ class TestHolidaysFlow(TestHrHolidaysCommon):
             'name': 'Paid Time off for David',
             'holiday_status_id': holiday_status_paid_time_off.id,
             'number_of_days': 20,
-            'employee_id': self.ref('hr.employee_admin'),
+            'employee_id': self.admin_employee.id,
             'state': 'confirm',
             'date_from': time.strftime('%Y-%m-01'),
             'date_to': time.strftime('%Y-12-31'),
@@ -258,7 +258,7 @@ class TestHolidaysFlow(TestHrHolidaysCommon):
             'holiday_status_id': holiday_status_paid_time_off.id,
             'request_date_from': date.today() + relativedelta(day=11),
             'request_date_to': date.today() + relativedelta(day=10),
-            'employee_id': self.ref('hr.employee_admin'),
+            'employee_id': self.admin_employee.id,
         }
         with mute_logger('odoo.sql_db'), self.assertRaises(IntegrityError):
             self.env['hr.leave'].create(leave_vals)
@@ -268,7 +268,7 @@ class TestHolidaysFlow(TestHrHolidaysCommon):
             'holiday_status_id': holiday_status_paid_time_off.id,
             'request_date_from': date.today() + relativedelta(day=10),
             'request_date_to': date.today() + relativedelta(day=11),
-            'employee_id': self.ref('hr.employee_admin'),
+            'employee_id': self.admin_employee.id,
         }
         leave = self.env['hr.leave'].create(leave_vals)
 

--- a/addons/hr_holidays/tests/test_holidays_mail.py
+++ b/addons/hr_holidays/tests/test_holidays_mail.py
@@ -22,7 +22,7 @@ class TestHolidaysMail(TestHrHolidaysCommon, MailCase):
     def test_email_sent_when_approved(self):
         """ Testing leave request flow: limited type of leave request """
         with freeze_time('2022-01-15'):
-            self.env.ref('hr.employee_admin').tz = "Europe/Brussels"
+            self.admin_employee.tz = "Europe/Brussels"
 
             holiday_status_paid_time_off = self.env['hr.leave.type'].create({
                 'name': 'Paid Time Off',
@@ -49,7 +49,7 @@ class TestHolidaysMail(TestHrHolidaysCommon, MailCase):
                     'name': 'Paid Time off for Mitchell',
                     'holiday_status_id': holiday_status_paid_time_off.id,
                     'number_of_days': 20,
-                    'employee_id': self.ref('hr.employee_admin'),
+                    'employee_id': self.admin_employee.id,
                     'state': 'confirm',
                     'date_from': time.strftime('%Y-%m-01'),
                 },
@@ -60,12 +60,12 @@ class TestHolidaysMail(TestHrHolidaysCommon, MailCase):
                 'holiday_status_id': holiday_status_paid_time_off.id,
                 'request_date_from': date.today() + relativedelta(day=2),
                 'request_date_to': date.today() + relativedelta(day=3),
-                'employee_id': self.ref('hr.employee_admin'),
+                'employee_id': self.admin_employee.id,
             }
             leave = self.env['hr.leave'].create(leave_vals)
             leave.action_approve()
             with self.mock_mail_gateway():
                 leave.action_approve()
-                admin_emails = self._new_mails.filtered(lambda x: x.partner_ids.employee_ids.id == self.ref('hr.employee_admin'))
+                admin_emails = self._new_mails.filtered(lambda x: x.partner_ids.employee_ids.id == self.admin_employee.id)
                 self.assertEqual(len(admin_emails), 1, "Mitchell Admin should receive an email")
                 self.assertTrue("has been accepted" in admin_emails.preview)

--- a/addons/hr_holidays/tests/test_hr_holidays_tour.py
+++ b/addons/hr_holidays/tests/test_hr_holidays_tour.py
@@ -4,6 +4,7 @@ from freezegun import freeze_time
 
 from odoo.tests import HttpCase
 from odoo.tests.common import tagged
+from odoo.addons.hr.tests.test_utils import get_admin_employee
 
 from datetime import date
 
@@ -16,7 +17,7 @@ class TestHrHolidaysTour(HttpCase):
         admin_user.write({
             'email': 'mitchell.admin@example.com',
         })
-        admin_employee = admin_user.employee_id
+        admin_employee = get_admin_employee(self.env)
         HRLeave = self.env['hr.leave']
         date_from = date(2022, 1, 17)
         date_to = date(2022, 1, 18)

--- a/addons/hr_holidays/tests/test_hr_leave_type_tour.py
+++ b/addons/hr_holidays/tests/test_hr_leave_type_tour.py
@@ -1,12 +1,12 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from freezegun import freeze_time
+from datetime import date
 
 from odoo import Command
 from odoo.tests import HttpCase
 from odoo.tests.common import tagged
-
-from datetime import date
+from odoo.addons.hr.tests.test_utils import get_admin_employee
 
 
 @tagged('post_install', '-at_install')
@@ -35,7 +35,7 @@ class TestHrLeaveTypeTour(HttpCase):
         admin_user.write({
             'email': 'mitchell.admin@example.com',
         })
-        admin_employee = admin_user.employee_id
+        admin_employee = get_admin_employee(self.env)
         HRLeave = self.env['hr.leave']
         date_from = date(2022, 1, 17)
         date_to = date(2022, 1, 18)

--- a/addons/hr_holidays/tests/test_time_off_allocation_tour.py
+++ b/addons/hr_holidays/tests/test_time_off_allocation_tour.py
@@ -1,8 +1,10 @@
 from odoo.tests import HttpCase, tagged
+from odoo.addons.hr.tests.test_utils import get_admin_employee
 
 
 @tagged("post_install", "-at_install")
 class TestTimeOffAllocationTour(HttpCase):
 
     def test_time_off_allocation_warning_tour(self):
+        self.admin_employee = get_admin_employee(self.env)
         self.start_tour("/", "time_off_allocation_warning_tour", login="admin")

--- a/addons/hr_holidays/tests/test_time_off_card_tour.py
+++ b/addons/hr_holidays/tests/test_time_off_card_tour.py
@@ -1,4 +1,5 @@
 from odoo.tests import HttpCase, tagged, users
+from odoo.addons.hr.tests.test_utils import get_admin_employee
 
 @tagged('post_install', '-at_install')
 class TestTimeOffCardTour(HttpCase):
@@ -11,8 +12,9 @@ class TestTimeOffCardTour(HttpCase):
             'requires_allocation': True,
             'allocation_validation_type': 'no_validation',
         })
+        admin_employee = get_admin_employee(self.env)
         self.env['hr.leave.allocation'].create({
-            'employee_id': self.env.user.employee_id.id,
+            'employee_id': admin_employee.id,
             'holiday_status_id': leave_type.id,
             'allocation_type': 'regular',
             'type_request_unit': 'half_day',

--- a/addons/pos_hr/tests/test_frontend.py
+++ b/addons/pos_hr/tests/test_frontend.py
@@ -11,16 +11,23 @@ class TestPosHrHttpCommon(TestPointOfSaleHttpCommon):
         super().setUpClass()
 
         cls.env.user.group_ids += cls.env.ref('hr.group_hr_user')
+        cls.env.user.group_ids |= cls.env.ref('hr.group_hr_manager')
+        payroll_user_group = cls.env.ref("hr_payroll.group_hr_payroll_user", raise_if_not_found=False)
+        if payroll_user_group:
+            cls.env.user.group_ids |= payroll_user_group
 
         cls.main_pos_config.write({"module_pos_hr": True})
 
         # Admin employee
-        cls.admin = cls.env.ref("hr.employee_admin").sudo().copy({
+        cls.admin = cls.env['hr.employee'].create({
             "date_version": '2000-01-01',
             "company_id": cls.env.company.id,
             "user_id": cls.pos_admin.id,
             "name": "Mitchell Admin",
             "pin": False,
+            'department_id': cls.env.ref('hr.dep_administration').id,
+            'address_id': cls.env.ref('base.main_partner').id,
+            'structure_type_id': cls.env.ref('hr.structure_type_employee').id,
         })
 
         # Managers

--- a/addons/sale_timesheet/tests/test_sale_timesheet_ui.py
+++ b/addons/sale_timesheet/tests/test_sale_timesheet_ui.py
@@ -4,6 +4,7 @@
 import logging
 
 from odoo.tests import HttpCase, tagged
+from odoo.addons.hr.tests.test_utils import get_admin_employee
 
 _logger = logging.getLogger(__name__)
 
@@ -28,9 +29,8 @@ class TestSaleTimesheetUi(HttpCase):
 
         # Enable the "Milestones" feature to be able to create milestones on this tour.
         cls.env.ref('base.group_user').sudo().implied_ids |= cls.env.ref('project.group_project_milestone')
-
-        admin = cls.env.ref('base.user_admin')
-        admin.employee_id.hourly_cost = 75
+        cls.admin_employee = get_admin_employee(cls.env)
+        cls.admin_employee.hourly_cost = 75
 
     def test_ui(self):
         self.env['product.pricelist'].with_context(active_test=False).search([]).unlink()

--- a/odoo/addons/test_main_flows/tests/test_flow.py
+++ b/odoo/addons/test_main_flows/tests/test_flow.py
@@ -2,6 +2,7 @@
 from odoo import Command
 from odoo.addons.account.tests.common import AccountTestMockOnlineSyncCommon
 from odoo.tools import mute_logger
+from odoo.addons.hr.tests.test_utils import get_admin_employee
 
 import logging
 import odoo.tests
@@ -16,6 +17,8 @@ class BaseTestUi(AccountTestMockOnlineSyncCommon):
         self.env.ref('base.user_admin').write({
             'email': 'mitchell.admin@example.com',
         })
+        self.admin_employee = get_admin_employee(self.env)
+
         # Enable Buy and Manufacture routes to be selectable on the product form.
         self.env.ref('purchase_stock.route_warehouse0_buy').write({
             'product_selectable': True,


### PR DESCRIPTION
## Purpose
The default administrator employee (in master data) sometimes can get annoying, making it difficult to code easy features. Moreover, almost all the fields of this employee are empty, and the user can easily create its own Administrator employee by clicking the "Create Employee" button from the Admin User View.

## Solution
Moving the admin employee to the demo data.

[enterprise#97864](https://github.com/odoo/enterprise/pull/97864)
[upgrade#8806](https://github.com/odoo/upgrade/pull/8806)
[task-5138634](https://www.odoo.com/odoo/all-tasks/5138634)
