### PR TITLE
[FIX] purchase: avoid overwrite of move_type when linking purchase order to an invoice

### DIFF
--- a/addons/purchase/models/account_invoice.py
+++ b/addons/purchase/models/account_invoice.py
@@ -58,8 +58,7 @@ class AccountMove(models.Model):
         new_currency_id = self.currency_id if has_invoice_lines else invoice_vals.get('currency_id')
         del invoice_vals['ref'], invoice_vals['payment_reference']
         del invoice_vals['company_id']  # avoid recomputing the currency
-        if self.move_type == invoice_vals['move_type']:
-            del invoice_vals['move_type'] # no need to be updated if it's same value, to avoid recomputes
+        del invoice_vals['move_type']  # no need to change move_type
         self.update(invoice_vals)
         self.currency_id = new_currency_id
 


### PR DESCRIPTION
### Case 
This PR fixes the case of creating an invoice with a specific move_type(for example in_refund), than this invoice is linked to a purchase order. I discovered the bug while importing an XML Invoice of an in_refund. Importing this Invoice, the move_type become move_type because it is overwritten from the prepare_invoice  data

### Before this PR 
The move_type is overwritten, so the in_refund become in_invoice and it is wrong. 

### After this PR:
The move_type is preserved.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
