### PR TITLE
[IMP] pos_adyen: add referenced refund support

### DIFF
--- a/addons/pos_adyen/static/src/app/models/pos_payment.js
+++ b/addons/pos_adyen/static/src/app/models/pos_payment.js
@@ -2,6 +2,25 @@ import { PosPayment } from "@point_of_sale/app/models/pos_payment";
 import { patch } from "@web/core/utils/patch";
 
 patch(PosPayment.prototype, {
+    setup() {
+        super.setup(...arguments);
+        this.uiState = {
+            ...(this.uiState ?? {}),
+            adyenRefundTransactionId: null,
+            adyenRefundTransactionTimestamp: null,
+        };
+    },
+
+    updateRefundPaymentLine(refundedPaymentLine) {
+        super.updateRefundPaymentLine(refundedPaymentLine);
+        if (refundedPaymentLine) {
+            this.uiState.adyenRefundTransactionTimestamp = refundedPaymentLine.create_date
+                .toUTC()
+                .toISO();
+            this.uiState.adyenRefundTransactionId = refundedPaymentLine.transaction_id;
+        }
+    },
+
     setTerminalServiceId(id) {
         this.terminalServiceId = id;
     },

--- a/addons/pos_adyen/static/tests/tours/adyen_tour.js
+++ b/addons/pos_adyen/static/tests/tours/adyen_tour.js
@@ -3,6 +3,7 @@ import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
 import * as FeedbackScreen from "@point_of_sale/../tests/pos/tours/utils/feedback_screen_util";
 import * as PaymentScreen from "@point_of_sale/../tests/pos/tours/utils/payment_screen_util";
 import * as ProductScreen from "@point_of_sale/../tests/pos/tours/utils/product_screen_util";
+import * as TicketScreen from "@point_of_sale/../tests/pos/tours/utils/ticket_screen_util";
 import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
 import { registry } from "@web/core/registry";
 const response_from_adyen_on_pos_webhook = (session, ServiceID) => ({
@@ -56,8 +57,7 @@ const response_from_adyen_on_pos_webhook = (session, ServiceID) => ({
                 },
             },
             Response: {
-                AdditionalResponse:
-                    "useless=true&metadata.pos_hmac=ba6c62413839eb32030a3ee6400af4d367b8fb889b54ea85dffcb5a13625c318",
+                AdditionalResponse: "useless=true&metadata.pos_hmac=dummy_hmac",
                 Result: "Success",
             },
             SaleData: {
@@ -70,7 +70,40 @@ const response_from_adyen_on_pos_webhook = (session, ServiceID) => ({
     },
 });
 
-registry.category("web_tour.tours").add("PosAdyenTour", {
+const adyenWebhookStep = (isRefund = false) => ({
+    content: "Waiting for Adyen payment to be processed",
+    trigger: `.electronic_status:contains('${
+        isRefund ? "Refund in process" : "Waiting for card"
+    }')`,
+    run: async function () {
+        const payment_terminal =
+            posmodel.getPendingPaymentLine("adyen").payment_method_id.payment_terminal;
+        // The fact that we are shown the `Waiting for card` status means that the
+        // request for payment has been sent to the adyen server ( in this case the mocked server )
+        // and the server replied with an `ok` response.
+        // As such, this is the time when we wait to receive the notification from adyen on the webhook
+        // The simplest way to mock this notification is to send it ourselves here.
+
+        // ==> pretend to be adyen and send the notification to the POS
+        const resp = await fetch("/pos_adyen/notification", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify(
+                response_from_adyen_on_pos_webhook(
+                    posmodel.config.current_session_id.id,
+                    payment_terminal.most_recent_service_id
+                )
+            ),
+        });
+        if (!resp.ok) {
+            throw new Error("Failed to notify Adyen webhook");
+        }
+    },
+});
+
+registry.category("web_tour.tours").add("PosAdyenPaymentTour", {
     steps: () =>
         [
             Chrome.startPoS(),
@@ -78,37 +111,28 @@ registry.category("web_tour.tours").add("PosAdyenTour", {
             ProductScreen.addOrderline("Desk Pad"),
             ProductScreen.clickPayButton(),
             PaymentScreen.clickPaymentMethod("Adyen"),
-            {
-                content: "Waiting for Adyen payment to be processed",
-                trigger: ".electronic_status:contains('Waiting for card')",
-                run: async function () {
-                    const payment_terminal =
-                        posmodel.getPendingPaymentLine("adyen").payment_method_id.payment_terminal;
-                    // The fact that we are shown the `Waiting for card` status means that the
-                    // request for payment has been sent to the adyen server ( in this case the mocked server )
-                    // and the server replied with an `ok` response.
-                    // As such, this is the time when we wait to receive the notification from adyen on the webhook
-                    // The simplest way to mock this notification is to send it ourselves here.
+            adyenWebhookStep(),
+            FeedbackScreen.isShown(),
+        ].flat(),
+});
 
-                    // ==> pretend to be adyen and send the notification to the POS
-                    const resp = await fetch("/pos_adyen/notification", {
-                        method: "POST",
-                        headers: {
-                            "Content-Type": "application/json",
-                        },
-                        body: JSON.stringify(
-                            response_from_adyen_on_pos_webhook(
-                                posmodel.config.current_session_id.id,
-                                payment_terminal.most_recent_service_id
-                            )
-                        ),
-                    });
-                    if (!resp.ok) {
-                        throw new Error("Failed to notify Adyen webhook");
-                    }
-                },
-            },
-
+registry.category("web_tour.tours").add("PosAdyenRefundTour", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.addOrderline("Desk Pad"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Adyen"),
+            adyenWebhookStep(),
+            FeedbackScreen.isShown(),
+            FeedbackScreen.clickNextOrder(),
+            ProductScreen.clickRefund(),
+            TicketScreen.selectOrder("001"),
+            TicketScreen.confirmRefund(),
+            PaymentScreen.clickPaymentMethod("Adyen"),
+            PaymentScreen.clickRefundButton(),
+            adyenWebhookStep(true),
             FeedbackScreen.isShown(),
         ].flat(),
 });

--- a/addons/pos_adyen/tests/test_basic.py
+++ b/addons/pos_adyen/tests/test_basic.py
@@ -1,16 +1,22 @@
+import re
 from requests import Response
 from unittest.mock import patch
-from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCommon
+
+from odoo import Command
+from odoo.exceptions import ValidationError
+from odoo.tools import hmac
 from odoo.tests.common import tagged
+from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCommon
+
 
 @tagged('post_install', '-at_install')
 class TestAdyenPoS(TestPointOfSaleHttpCommon):
-    def test_adyen_basic_order(self):
+    def setUp(self):
+        super().setUp()
         self.main_pos_config.write({
             "payment_method_ids": [
-                (0, 0, {
+                Command.create({
                     "name": "Adyen",
-                    "use_payment_terminal": True,
                     "adyen_api_key": "my_adyen_api_key",
                     "adyen_terminal_identifier": "my_adyen_terminal",
                     "adyen_test_mode": False,
@@ -20,15 +26,58 @@ class TestAdyenPoS(TestPointOfSaleHttpCommon):
                 }),
             ],
         })
+
+    def mock_adyen_post(self, url, headers, json, **kwargs):
+        response = Response()
+        response._content = b"{}"
+
+        if url != "https://terminal-api-live.adyen.com/async":
+            response.status_code = 404
+            return response
+        self.assertEqual(headers.get("x-api-key"), "my_adyen_api_key")
+
+        message = json["SaleToPOIRequest"]
+        self.assertEqual(message["MessageHeader"]["POIID"], "my_adyen_terminal")
+        if "PaymentRequest" in message:
+            expected_hash = self.get_expected_hash(message["MessageHeader"]["ServiceID"], message["PaymentRequest"]["SaleData"]["SaleTransactionID"]["TransactionID"])
+            received_hash = self.parse_received_hash(message["PaymentRequest"]["SaleData"]["SaleToAcquirerData"])
+
+            self.assertEqual(received_hash, expected_hash)
+            self.assertEqual(message["PaymentRequest"]["PaymentTransaction"]["AmountsReq"]["Currency"], "USD")
+            self.assertEqual(message["PaymentRequest"]["PaymentTransaction"]["AmountsReq"]["RequestedAmount"], 1.98)
+        elif "ReversalRequest" in message:
+            self.assertEqual(message["ReversalRequest"]["ReversalReason"], "MerchantCancel")
+            self.assertEqual(message["ReversalRequest"]["ReversedAmount"], 1.98)
+            pass
+        else:
+            raise ValidationError("Unexpected Adyen request received")
+
+        response.status_code = 200
+        return response
+
+    def get_expected_hash(self, service_id, transaction_id):
+        return hmac(
+            env=self.env,
+            scope='pos_adyen_payment',
+            message=(f"{self.main_pos_config.name} (ID: {self.main_pos_config.id})", service_id, "my_adyen_terminal", transaction_id)
+        )
+
+    def parse_received_hash(self, sale_to_acquirer_data):
+        hash_regex = r"metadata\.pos_hmac=(.+)"
+        match = re.search(hash_regex, sale_to_acquirer_data)
+        self.assertIsNotNone(match, "POS HMAC could not be parsed from request to Adyen")
+        return match and match[1]
+
+    def test_adyen_basic_order(self):
         self.main_pos_config.with_user(self.pos_user).open_ui()
 
-        def post(url, **kwargs):
-            # TODO: check that the data passed by pos to adyen is correct
-            response = Response()
-            response.status_code = 200
-            response._content = "ok".encode()
-            return response
+        with patch('odoo.addons.pos_adyen.models.pos_payment_method.requests.post', self.mock_adyen_post), \
+             patch('odoo.addons.pos_adyen.controllers.main.consteq', lambda a, b: a == "dummy_hmac"):
+            self.start_pos_tour('PosAdyenPaymentTour')
 
-        with patch('odoo.addons.pos_adyen.models.pos_payment_method.requests.post', post), \
-             patch('odoo.addons.pos_adyen.controllers.main.consteq', lambda a,b: True):
-            self.start_pos_tour('PosAdyenTour')
+    def test_adyen_refund_order(self):
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+
+        with patch('odoo.addons.pos_adyen.models.pos_payment_method.requests.post', self.mock_adyen_post), \
+             patch('odoo.addons.pos_adyen.controllers.main.consteq', lambda a, b: a == "dummy_hmac"):
+            self.start_pos_tour('PosAdyenRefundTour')

--- a/addons/pos_stripe/static/src/overrides/screens/payment_screen.js
+++ b/addons/pos_stripe/static/src/overrides/screens/payment_screen.js
@@ -5,7 +5,7 @@ patch(PaymentScreen.prototype, {
     async addNewPaymentLine(paymentMethod) {
         if (paymentMethod.use_payment_terminal === "stripe" && this.isRefundOrder) {
             const refundedOrder = this.currentOrder.lines[0]?.refunded_orderline_id?.order_id;
-            const amountDue = Math.abs(this.currentOrder.getDue());
+            const amountDue = Math.abs(this.currentOrder.remainingDue);
             const matchedPaymentLine = refundedOrder?.payment_ids.find(
                 (line) =>
                     line.payment_method_id.use_payment_terminal === "stripe" &&


### PR DESCRIPTION
This commit adds support to reverse previously made Adyen transactions, either partially or in full. This is done through the payment terminal but the customer does not need to present their card again, the original transaction is simply voided.

It also improves the existing test and adds a new test for the refund flow.

task-3619617

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
