### PR TITLE
[FIX] pos_sale: fix paid order in ecommerce

### DIFF
--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -1592,7 +1592,6 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         })
         provider = self.env['payment.provider'].create({
             'name': 'Test',
-            'code': 'custom',
         })
         transaction = self.env['payment.transaction'].create({
             'provider_id': provider.id,
@@ -1623,14 +1622,6 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
             'name': 'Product A',
             'available_in_pos': True,
             'lst_price': 10.0,
-        })
-        sale_order = self.env['sale.order'].create({
-            'partner_id': partner_1.id,
-            'order_line': [(0, 0, {
-                'product_id': product_a.id,
-                'product_uom_qty': 2,
-                'price_unit': product_a.lst_price
-            })]
         })
         sale_order = self.env['sale.order'].create({
             'partner_id': partner_1.id,


### PR DESCRIPTION
The code of the payment provider is not relevant to the test_ecommerce_paid_order_is_hidden_in_pos test, and pos_sale doesn't have payment_custom in the dependencies. It caused tests to fail so I removed it.

Runbot Build Error-233461

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
