### PR TITLE
[FIX] html_editor: fix error on delete without selection

### DIFF
--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -1126,7 +1126,7 @@ export class ListPlugin extends Plugin {
 
     adjustListPaddingOnDelete() {
         const selection = this.document.getSelection();
-        if (!selection.isCollapsed) {
+        if (!selection.isCollapsed || !selection.anchorNode) {
             return;
         }
         const listItem = closestElement(selection.anchorNode);


### PR DESCRIPTION
If the selection of the document is not set and the user presses the delete key, the delete handler of the list plugin throws an error.

Steps to reproduce (in 19.0, where the issue was discovered):
- Open website builder
- Drop the video inner snippet in the header
- Double-click & drag from the video to just outside the video
- Click once on the video
- Press "delete"
- Bug: Traceback

task-5186954