### PR TITLE
[IMP] html_builder, website: remove unnecessary image data in DOM

### DIFF
--- a/addons/website/static/tests/builder/image_test_helpers.js
+++ b/addons/website/static/tests/builder/image_test_helpers.js
@@ -2,7 +2,7 @@ import { before, globals } from "@odoo/hoot";
 import { contains, onRpc, patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { ImagePositionOverlay } from "@html_builder/plugins/image/image_position_overlay";
 
-function onRpcReal(route) {
+export function onRpcReal(route) {
     onRpc(route, () => globals.fetch.call(window, route));
 }
 


### PR DESCRIPTION
Steps to see the issue:
- Add a shape to an image
- Remove it

=> Image element in the DOM still has some data related to the shape.
We shoud remove it.

task-5172640