### PR TITLE
[FIX] stock, mrp: don’t clean reservations for Kit products

### DIFF
--- a/addons/mrp/models/stock_quant.py
+++ b/addons/mrp/models/stock_quant.py
@@ -9,3 +9,6 @@ class StockQuant(models.Model):
     def _check_kits(self):
         if self.sudo().product_id.filtered("is_kits"):
             raise UserError(_('You should update the components quantity instead of directly updating the quantity of the kit product.'))
+
+    def _should_bypass_product(self, product=False, location=False, reserved_quantity=0, lot_id=False, package_id=False, owner_id=False):
+        return super()._should_bypass_product(product, location, reserved_quantity, lot_id, package_id, owner_id) or (product and product.is_kits)

--- a/addons/mrp/tests/__init__.py
+++ b/addons/mrp/tests/__init__.py
@@ -4,6 +4,7 @@ from . import test_bom
 from . import test_byproduct
 from . import test_cancel_mo
 from . import test_order
+from . import test_quant
 from . import test_stock
 from . import test_stock_report
 from . import test_warehouse_multistep_manufacturing

--- a/addons/mrp/tests/test_quant.py
+++ b/addons/mrp/tests/test_quant.py
@@ -1,0 +1,55 @@
+from odoo import Command
+from odoo.exceptions import UserError
+
+from odoo.addons.mrp.tests.common import TestMrpCommon
+
+
+class TestMrpQuant(TestMrpCommon):
+
+    def test_kit_product_reservation_flow(self):
+        """Test that kit products are not cleaned"""
+
+        product_kit = self.env['product.product'].create({
+            'name': 'This product will be a kit',
+            'type': 'consu',
+            'is_storable': True
+        })
+
+        delivery = self.env['stock.picking'].create({
+            'location_id': self.location_1.id,
+            'location_dest_id': self.warehouse_1.lot_stock_id.id,
+            'picking_type_id': self.picking_type_out,
+            'move_line_ids': [Command.create({
+                'product_id': product_kit.id,
+                'quantity_product_uom': 1,
+                'location_dest_id': self.warehouse_1.lot_stock_id.id,
+            })]
+        })
+
+        delivery.action_confirm()
+        self.env['mrp.bom'].create({
+            'product_tmpl_id': product_kit.product_tmpl_id.id,
+            'product_id': product_kit.id,
+            'product_qty': 1,
+            'type': 'phantom',  # type kit
+        })
+
+        # Force recomputation of is_kits, since it's currently not recomputed automatically when BOM is created
+        product_kit._compute_is_kits()
+        delivery.move_ids_without_package.quantity = 1
+        product_normal = self.env['product.product'].create({
+            'name': 'Normal Product Test',
+            'type': 'consu',
+            'is_storable': True
+        })
+
+        # Should work without error
+        product_normal.action_open_quants()
+
+        # Ensure it's raise an error if we try to update quantity of kit product directly
+        with self.assertRaises(UserError, msg="You should update the components quantity instead of directly updating the quantity of the kit product."):
+            self.env['stock.quant']._update_available_quantity(
+                product_kit,
+                self.warehouse_1.lot_stock_id,
+                10,
+            )

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -1157,7 +1157,8 @@ class StockQuant(models.Model):
                 del reserved_move_lines[(product, location, lot, package, owner)]
 
         for (product, location, lot, package, owner), reserved_quantity in reserved_move_lines.items():
-            if location.should_bypass_reservation():
+            if location.should_bypass_reservation() or\
+                self.env['stock.quant']._should_bypass_product(product, location, reserved_quantity, lot, package, owner):
                 continue
             else:
                 self.env['stock.quant']._update_reserved_quantity(product, location, reserved_quantity, lot_id=lot, package_id=package, owner_id=owner)
@@ -1539,6 +1540,9 @@ class StockQuant(models.Model):
                 result_package_id))
         moves = self.env['stock.move'].create(move_vals)
         moves._action_done()
+
+    def _should_bypass_product(self, product=False, location=False, reserved_quantity=0, lot_id=False, package_id=False, owner_id=False):
+        return False
 
 
 class StockQuantPackage(models.Model):


### PR DESCRIPTION
Since this commit: 766ec99

We try to clean reservations because, for some reason, there could be a discrepancy between the sum of “stock.move.line” and the quantity/reserved quantity on “stock.quant”.
However, there are cases where a user creates a storable product, updates its quantity, and then uses it in a “stock.move.line”, confirms it, and later changes the product type to a kit. So, when trying to clean the reservations for these “stock.move.line”, a user error occurs because the system attempts to create a quant for a kit-type product: https://github.com/odoo/odoo/blob/c07778bbce4311c142bd8e2ce3013998d4f126ae/addons/mrp/models/stock_quant.py#L6-L11 As a result, each time users try to access the quant list, clean_reservation is triggered, causing a user error that prevents them from modifying the quantity of any quant.

Solution:
For kits, we can skip cleaning their quant to avoid unnecessary errors.

This is a manual forward-port of #200595

opw-4625002
opw-4624008
opw-4621175
opw-4625465
opw-4621504
opw-4623523
opw-4621508
opw-4623329
opw-4629386
opw-5179369