### PR TITLE
[IMP] core/netsvc: silence warning on Jammy images

### DIFF
--- a/odoo/netsvc.py
+++ b/odoo/netsvc.py
@@ -14,6 +14,7 @@ import traceback
 import warnings
 
 import werkzeug.serving
+from pkg_resources import PkgResourcesDeprecationWarning
 
 from . import release
 from . import sql_db
@@ -206,6 +207,15 @@ def init_logger():
     # This warning is triggered library only during the python precompilation which does not occur on readonly filesystem
     warnings.filterwarnings("ignore", r'invalid escape sequence', category=DeprecationWarning, module=".*vobject")
     warnings.filterwarnings("ignore", r'invalid escape sequence', category=SyntaxWarning, module=".*vobject")
+
+    # jammy's pdfminer has a broken version (the distribution returns
+    # `-VERSION-`, the code has a version of `__VERSION__`), which triggers
+    # these warnings when trying to check the version of something else (ldap):
+    #
+    # - the first signals a fallback after failing to parse the above as a `Version`
+    # - the second signals the use of the `LegacyVersion`... as fallback
+    warnings.filterwarnings("ignore", r'.*-VERSION-', category=PkgResourcesDeprecationWarning, module="pkg_resources")
+    warnings.filterwarnings("ignore", r'.*\bLegacyVersion\b', category=DeprecationWarning, module="pkg_resources")
     from .tools.translate import resetlocale
     resetlocale()
 


### PR DESCRIPTION
Apparently on jammy the pdfminer package returns nonsensical versions (the distribution for `pdfminer.six` yields `-VERSION-`, and inside the python code the `__version__` is `__VERSION__`).

When trying to look up the distribution for the (invalid as a distribution name) `ldap`, as a fallback `pkg_resources` parses every package on the sys.path before returning a lookup failure. Doing so, it encounters `pdfminer` fails to parse its version as a `Version`, warns that that is deprecated, then parses it using the more lenient `LegacyVersion` and warns that this is also deprecated.

Since this is a packaging issue in just jammy and we can't really do anything about it, just sweep the issue under the rug.

https://runbot.odoo.com/odoo/error/163677
