### PR TITLE
[IMP] purchase_stock: make the forecast column smaller in PO

### DIFF
--- a/addons/purchase_stock/views/purchase_views.xml
+++ b/addons/purchase_stock/views/purchase_views.xml
@@ -28,8 +28,8 @@
             </xpath>
             <xpath expr="//page/field[@name='order_line']/list/field[@name='product_qty']" position="after">
                 <field name="forecasted_issue" column_invisible="True"/>
-                <button type="object" name="action_product_forecast_report" title="Forecast Report" icon="fa-area-chart" invisible="not id or not forecasted_issue or not is_storable" class="text-danger"/>
-                <button type="object" name="action_product_forecast_report" title="Forecast Report" icon="fa-area-chart" invisible="not id or forecasted_issue or not is_storable"/>
+                <button type="object" name="action_product_forecast_report" title="Forecast Report" icon="fa-area-chart" invisible="not id or not forecasted_issue or not is_storable" class="text-danger" width="20px"/>
+                <button type="object" name="action_product_forecast_report" title="Forecast Report" icon="fa-area-chart" invisible="not id or forecasted_issue or not is_storable" width="20px"/>
             </xpath>
             <xpath expr="//div[@name='date_planned_div']" position="inside">
                 <div>


### PR DESCRIPTION
The new size is consistent with SO lines.

Task: 5164117

Description of the issue/feature this PR addresses:

Current behavior before PR:

<img width="1245" height="181" alt="Screenshot from 2025-10-22 14-01-00" src="https://github.com/user-attachments/assets/ed496bb3-14d3-45e6-95a0-ba6d637a42cf" />
<img width="1245" height="181" alt="Screenshot from 2025-10-22 14-01-12" src="https://github.com/user-attachments/assets/037a21a5-2818-4056-a41e-7ced42b008b1" />


Desired behavior after PR is merged:

<img width="1245" height="181" alt="Screenshot from 2025-10-22 14-01-36" src="https://github.com/user-attachments/assets/d8b4292f-8310-4acd-8522-7057fafed3f5" />
<img width="1245" height="181" alt="Screenshot from 2025-10-22 14-01-38" src="https://github.com/user-attachments/assets/b976242e-e418-4808-b19b-97f36bf61548" />



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
