### PR TITLE
[FIX] hr_work_entry: new version work entry generation

### DIFF
--- a/addons/hr_work_entry/models/hr_employee.py
+++ b/addons/hr_work_entry/models/hr_employee.py
@@ -25,6 +25,14 @@ class HrEmployee(models.Model):
         for employee in self:
             employee.has_work_entries = result.get(employee._origin.id, False)
 
+    def create_version(self, values):
+        new_version = super().create_version(values)
+        new_version.update({
+            'date_generated_from': fields.Datetime.now().replace(hour=0, minute=0, second=0, microsecond=0),
+            'date_generated_to': fields.Datetime.now().replace(hour=0, minute=0, second=0, microsecond=0),
+        })
+        return new_version
+
     def action_open_work_entries(self, initial_date=False):
         self.ensure_one()
         ctx = {'default_employee_id': self.id}

--- a/addons/hr_work_entry/models/hr_version.py
+++ b/addons/hr_work_entry/models/hr_version.py
@@ -427,39 +427,52 @@ class HrVersion(models.Model):
             'date_generated_from': date_start,
             'date_generated_to': date_start,
         })
-        utc = pytz.timezone('UTC')
-        for version in self:
-            version_tz = (version.resource_calendar_id or version.company_id.resource_calendar_id or version.employee_id).tz
-            tz = pytz.timezone(version_tz) if version_tz else pytz.utc
-            version_start = tz.localize(fields.Datetime.to_datetime(version.date_start)).astimezone(utc).replace(tzinfo=None)
-            version_stop = datetime.combine(fields.Datetime.to_datetime(version.date_end or datetime.max.date()),
-                                             datetime.max.time())
-            if version.date_end:
-                version_stop = tz.localize(version_stop).astimezone(utc).replace(tzinfo=None)
-            if date_start > version_stop or date_stop < version_start:
-                continue
-            date_start_work_entries = max(date_start, version_start)
-            date_stop_work_entries = min(date_stop, version_stop)
-            if force:
-                intervals_to_generate[date_start_work_entries, date_stop_work_entries] |= version
-                continue
+        domain_to_nullify = Domain(False)
+        work_entry_null_vals = {field: False for field in self.env["hr.work.entry.regeneration.wizard"]._work_entry_fields_to_nullify()}
 
-            # For each version, we found each interval we must generate
-            # In some cases we do not want to set the generated dates beforehand, since attendance based work entries
-            #  is more dynamic, we want to update the dates within the _get_work_entries_values function
-            last_generated_from = min(version.date_generated_from, version_stop)
-            if last_generated_from > date_start_work_entries:
-                version.date_generated_from = date_start_work_entries
-                intervals_to_generate[date_start_work_entries, last_generated_from] |= version
+        for tz, versions in self.grouped("tz").items():
+            tz = pytz.timezone(tz) if tz else pytz.utc
+            for version in versions:
+                version_start = tz.localize(fields.Datetime.to_datetime(version.date_start)).astimezone(pytz.utc).replace(tzinfo=None)
+                version_stop = tz.localize(datetime.combine(fields.Datetime.to_datetime(version.date_end or date_stop),
+                                                 datetime.max.time())).astimezone(pytz.utc).replace(tzinfo=None)
+                if version_stop < date_start:
+                    continue
+                if version_stop < date_stop:
+                    if version.date_generated_from != version.date_generated_to:
+                        domain_to_nullify |= Domain([
+                            ('version_id', '=', version.id),
+                            ('date', '>', version_stop),
+                            ('date', '<=', date_stop),
+                            ('state', '!=', 'validated'),
+                        ])
+                if date_start > version_stop or date_stop < version_start:
+                    continue
+                date_start_work_entries = max(date_start, version_start)
+                date_stop_work_entries = min(date_stop, version_stop)
+                if force:
+                    intervals_to_generate[date_start_work_entries, date_stop_work_entries] |= version
+                    continue
 
-            last_generated_to = max(version.date_generated_to, version_start)
-            if last_generated_to < date_stop_work_entries:
-                version.date_generated_to = date_stop_work_entries
-                intervals_to_generate[last_generated_to, date_stop_work_entries] |= version
+                # For each version, we found each interval we must generate
+                # In some cases we do not want to set the generated dates beforehand, since attendance based work entries
+                #  is more dynamic, we want to update the dates within the _get_work_entries_values function
+                last_generated_from = min(version.date_generated_from, version_stop)
+                if last_generated_from > date_start_work_entries:
+                    version.date_generated_from = date_start_work_entries
+                    intervals_to_generate[date_start_work_entries, last_generated_from] |= version
+
+                last_generated_to = max(version.date_generated_to, version_start)
+                if last_generated_to < date_stop_work_entries:
+                    version.date_generated_to = date_stop_work_entries
+                    intervals_to_generate[last_generated_to, date_stop_work_entries] |= version
 
         for interval, versions in intervals_to_generate.items():
             date_from, date_to = interval
             vals_list.extend(versions._get_work_entries_values(date_from, date_to))
+
+        work_entries_to_nullify = self.env['hr.work.entry'].search(domain_to_nullify)
+        work_entries_to_nullify.write(work_entry_null_vals)
 
         if not vals_list:
             return self.env['hr.work.entry']

--- a/addons/hr_work_entry/tests/test_work_entry.py
+++ b/addons/hr_work_entry/tests/test_work_entry.py
@@ -358,3 +358,149 @@ class TestWorkEntry(TestWorkEntryBase):
         self.assertEqual(len(half2_entries), 15)  # work entries cover the entire duration
         self.assertTrue(all(entry.duration == 24 for entry in half2_entries))
         self.assertTrue(all(entry.version_id.name == 'FullyFlex Contract' for entry in half2_entries))
+
+    def test_work_entry_version_changed_after_generation(self):
+        """
+        When you generate work entries for a version, and you add a new version to the employee starting during the period of already generated work entries,
+        The previous version work entries date generation to should be updated to the new version date and new work entries should be generated.
+        Previous ones should be deleted
+        """
+        calendar_40h = self.env['resource.calendar'].create({
+            'name': '40h Calendar',
+            'tz': 'Europe/Brussels',
+            'hours_per_day': 8,
+            'attendance_ids': [(5, 0, 0),
+               (0, 0, {'name': 'Monday Morning', 'dayofweek': '0', 'hour_from': 7, 'hour_to': 11, 'day_period': 'morning'}),
+               (0, 0, {'name': 'Monday Afternoon', 'dayofweek': '0', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'}),
+               (0, 0, {'name': 'Tuesday Morning', 'dayofweek': '1', 'hour_from': 7, 'hour_to': 11, 'day_period': 'morning'}),
+               (0, 0, {'name': 'Tuesday Afternoon', 'dayofweek': '1', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'}),
+               (0, 0, {'name': 'Wednesday Morning', 'dayofweek': '2', 'hour_from': 7, 'hour_to': 11, 'day_period': 'morning'}),
+               (0, 0, {'name': 'Wednesday Afternoon', 'dayofweek': '2', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'}),
+               (0, 0, {'name': 'Thursday Morning', 'dayofweek': '3', 'hour_from': 7, 'hour_to': 11, 'day_period': 'morning'}),
+               (0, 0, {'name': 'Thursday Afternoon', 'dayofweek': '3', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'}),
+               (0, 0, {'name': 'Friday Morning', 'dayofweek': '4', 'hour_from': 7, 'hour_to': 11, 'day_period': 'morning'}),
+               (0, 0, {'name': 'Friday Afternoon', 'dayofweek': '4', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'})
+            ]
+        })
+        calendar_35h = self.env['resource.calendar'].create({
+            'name': '35h Calendar',
+            'tz': 'Europe/Brussels',
+            'hours_per_day': 7,
+            'attendance_ids': [(5, 0, 0),
+                (0, 0, {'name': 'Monday Morning', 'dayofweek': '0', 'hour_from': 7, 'hour_to': 11, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Monday Afternoon', 'dayofweek': '0', 'hour_from': 13, 'hour_to': 16, 'day_period': 'afternoon'}),
+                (0, 0, {'name': 'Tuesday Morning', 'dayofweek': '1', 'hour_from': 7, 'hour_to': 11, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Tuesday Afternoon', 'dayofweek': '1', 'hour_from': 13, 'hour_to': 16, 'day_period': 'afternoon'}),
+                (0, 0, {'name': 'Wednesday Morning', 'dayofweek': '2', 'hour_from': 7, 'hour_to': 11, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Wednesday Afternoon', 'dayofweek': '2', 'hour_from': 13, 'hour_to': 16, 'day_period': 'afternoon'}),
+                (0, 0, {'name': 'Thursday Morning', 'dayofweek': '3', 'hour_from': 7, 'hour_to': 11, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Thursday Afternoon', 'dayofweek': '3', 'hour_from': 13, 'hour_to': 16, 'day_period': 'afternoon'}),
+                (0, 0, {'name': 'Friday Morning', 'dayofweek': '4', 'hour_from': 7, 'hour_to': 11, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Friday Afternoon', 'dayofweek': '4', 'hour_from': 13, 'hour_to': 16, 'day_period': 'afternoon'})
+            ]
+        })
+
+        # first version with a 40h calendar
+        employee = self.env['hr.employee'].create({
+            'name': 'Test',
+            'resource_calendar_id': calendar_40h.id,
+            'date_version': datetime(2025, 1, 1),
+            'contract_date_start': datetime(2025, 1, 1),
+        })
+        employee.generate_work_entries(datetime(2025, 1, 1), datetime(2025, 1, 31))
+        work_entries = self.env['hr.work.entry'].search([('employee_id', '=', employee.id)])
+        self.assertEqual(len(work_entries), 23, "23 attendance")
+        self.assertEqual(sum(work_entries.mapped("duration")), 184, "23 * 8h")
+
+        # new version with a different calendar (35h) set in the tier of the month
+        employee.create_version({
+            'resource_calendar_id': calendar_35h.id,
+            'date_version': datetime(2025, 1, 10),
+        })
+        employee.generate_work_entries(datetime(2025, 1, 1), datetime(2025, 1, 31))
+        work_entries = self.env['hr.work.entry'].search([('employee_id', '=', employee.id)])
+        self.assertEqual(len(work_entries), 23, "23 attendance")
+        self.assertEqual(sum(work_entries.mapped("duration")), 168, "7 * 8h + 16 * 7h")
+
+        # new version with a different calendar (40h) set in the second tier of the month
+        employee.create_version({
+            'resource_calendar_id': calendar_40h.id,
+            'date_version': datetime(2025, 1, 20),
+        })
+        employee.generate_work_entries(datetime(2025, 1, 1), datetime(2025, 1, 31))
+        work_entries = self.env['hr.work.entry'].search([('employee_id', '=', employee.id)])
+        self.assertEqual(len(work_entries), 23, "23 attendance")
+        self.assertEqual(sum(work_entries.mapped("duration")), 178, "7 * 8h + 6 * 7h + 10 * 8h")
+
+    def test_work_entry_version_changed_after_generation2(self):
+        """
+        When you generate work entries for a version, and you add a new version to the employee starting during the period of already generated work entries,
+        The previous version work entries date generation to should be updated to the new version date and new work entries should be generated.
+        Previous ones should be deleted
+        """
+        calendar_40h = self.env['resource.calendar'].create({
+            'name': '40h Calendar',
+            'tz': 'Europe/Brussels',
+            'hours_per_day': 8,
+            'attendance_ids': [(5, 0, 0),
+               (0, 0, {'name': 'Monday Morning', 'dayofweek': '0', 'hour_from': 7, 'hour_to': 11, 'day_period': 'morning'}),
+               (0, 0, {'name': 'Monday Afternoon', 'dayofweek': '0', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'}),
+               (0, 0, {'name': 'Tuesday Morning', 'dayofweek': '1', 'hour_from': 7, 'hour_to': 11, 'day_period': 'morning'}),
+               (0, 0, {'name': 'Tuesday Afternoon', 'dayofweek': '1', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'}),
+               (0, 0, {'name': 'Wednesday Morning', 'dayofweek': '2', 'hour_from': 7, 'hour_to': 11, 'day_period': 'morning'}),
+               (0, 0, {'name': 'Wednesday Afternoon', 'dayofweek': '2', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'}),
+               (0, 0, {'name': 'Thursday Morning', 'dayofweek': '3', 'hour_from': 7, 'hour_to': 11, 'day_period': 'morning'}),
+               (0, 0, {'name': 'Thursday Afternoon', 'dayofweek': '3', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'}),
+               (0, 0, {'name': 'Friday Morning', 'dayofweek': '4', 'hour_from': 7, 'hour_to': 11, 'day_period': 'morning'}),
+               (0, 0, {'name': 'Friday Afternoon', 'dayofweek': '4', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'})
+            ]
+        })
+        calendar_35h = self.env['resource.calendar'].create({
+            'name': '35h Calendar',
+            'tz': 'Europe/Brussels',
+            'hours_per_day': 7,
+            'attendance_ids': [(5, 0, 0),
+                (0, 0, {'name': 'Monday Morning', 'dayofweek': '0', 'hour_from': 7, 'hour_to': 11, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Monday Afternoon', 'dayofweek': '0', 'hour_from': 13, 'hour_to': 16, 'day_period': 'afternoon'}),
+                (0, 0, {'name': 'Tuesday Morning', 'dayofweek': '1', 'hour_from': 7, 'hour_to': 11, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Tuesday Afternoon', 'dayofweek': '1', 'hour_from': 13, 'hour_to': 16, 'day_period': 'afternoon'}),
+                (0, 0, {'name': 'Wednesday Morning', 'dayofweek': '2', 'hour_from': 7, 'hour_to': 11, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Wednesday Afternoon', 'dayofweek': '2', 'hour_from': 13, 'hour_to': 16, 'day_period': 'afternoon'}),
+                (0, 0, {'name': 'Thursday Morning', 'dayofweek': '3', 'hour_from': 7, 'hour_to': 11, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Thursday Afternoon', 'dayofweek': '3', 'hour_from': 13, 'hour_to': 16, 'day_period': 'afternoon'}),
+                (0, 0, {'name': 'Friday Morning', 'dayofweek': '4', 'hour_from': 7, 'hour_to': 11, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Friday Afternoon', 'dayofweek': '4', 'hour_from': 13, 'hour_to': 16, 'day_period': 'afternoon'})
+            ]
+        })
+
+        # first version with a 40h calendar
+        employee = self.env['hr.employee'].create({
+            'name': 'Test',
+            'resource_calendar_id': calendar_40h.id,
+            'date_version': datetime(2025, 1, 1),
+            'contract_date_start': datetime(2025, 1, 1),
+        })
+        employee.generate_work_entries(datetime(2025, 1, 1), datetime(2025, 1, 31))
+        work_entries = self.env['hr.work.entry'].search([('employee_id', '=', employee.id)])
+        self.assertEqual(len(work_entries), 23, "23 attendance")
+        self.assertEqual(sum(work_entries.mapped("duration")), 184, "23 * 8h")
+
+        # new version with a different calendar (40h) set in the tier of the month
+        employee.create_version({
+            'resource_calendar_id': calendar_40h.id,
+            'date_version': datetime(2025, 1, 20),
+        })
+        employee.generate_work_entries(datetime(2025, 1, 1), datetime(2025, 1, 31))
+        work_entries = self.env['hr.work.entry'].search([('employee_id', '=', employee.id)])
+        self.assertEqual(len(work_entries), 23, "23 attendance")
+        self.assertEqual(sum(work_entries.mapped("duration")), 184, "13 * 8h + 10 * 8h")
+
+        # new version with a different calendar (35h) set in the second tier of the month
+        employee.create_version({
+            'resource_calendar_id': calendar_35h.id,
+            'date_version': datetime(2025, 1, 10),
+        })
+        employee.generate_work_entries(datetime(2025, 1, 1), datetime(2025, 1, 31))
+        work_entries = self.env['hr.work.entry'].search([('employee_id', '=', employee.id)])
+        self.assertEqual(len(work_entries), 23, "23 attendance")
+        self.assertEqual(sum(work_entries.mapped("duration")), 178, "7 * 8h + 6 * 7h + 10 * 8h")


### PR DESCRIPTION
Problem
----------
When we create a new version with a new working schedule, it will generate correct work entries (because no one was generated for this version before) But it will not remove the previous one for the other previous versions.

Solution
----------
Nullify work entries if outside the valid period of the version if they were already created before.

task-5065139
