### PR TITLE
[FIX] pos_self_order: fix table sharing between devices

### DIFF
--- a/addons/pos_self_order/controllers/orders.py
+++ b/addons/pos_self_order/controllers/orders.py
@@ -174,7 +174,7 @@ class PosSelfOrderController(http.Controller):
         table = pos_config.env["restaurant.table"].search([('identifier', '=', table_identifier)], limit=1)
         domain = False
 
-        if not table_identifier:
+        if not table_identifier or pos_config.self_ordering_pay_after == 'each':
             domain = [(False, '=', True)]
         else:
             domain = ['&', '&',

--- a/addons/pos_self_order/static/tests/tours/self_order_mobile_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_mobile_tour.js
@@ -409,3 +409,29 @@ registry.category("web_tour.tours").add("test_mobile_self_order_preparation_chan
             Utils.clickBtn("Ok"),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_self_order_table_sharing-each_mode", {
+    steps: () =>
+        [
+            Utils.checkIsNoBtn("My Order"),
+            Utils.clickBtn("Order Now"),
+            ProductPage.clickProduct("Coca-Cola"),
+            ProductPage.clickProduct("Fanta"),
+            Utils.clickBtn("Checkout"),
+            CartPage.checkProduct("Fanta", "2.53", "1"),
+            CartPage.checkProduct("Coca-Cola", "2.53", "1"),
+            Utils.clickBtn("Order"),
+            ConfirmationPage.isShown(),
+            Utils.clickBtn("Ok"),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_self_order_table_sharing-meal_mode", {
+    steps: () =>
+        [
+            Utils.checkIsNoBtn("My Order"),
+            Utils.clickBtn("Order Now"),
+            Utils.clickBtn("Checkout"),
+            CartPage.checkProduct("Coca-Cola", "2.20", "1"),
+        ].flat(),
+});


### PR DESCRIPTION
Before this commit orders were always shared between multiple devices
using the same QR code. This could lead to issues when multiple
customers were using self-ordering at the same table, as they could
see and modify each other's orders.

When multiple devices are used for self-ordering with the same QR code,
there is now two mode possible:

- Pay after each: orders are not shared, and the table isn't linked to
  the order when synchronizing. Instead the table number is in the
  floating order name.

- Pay after meal: orders are shared, and the table is linked to the
  order when synchronizing. That's means that multiple devices can add
  products to the same order.

taskId: 5187089