### PR TITLE
[FIX] html_builder, website: no o_editable on non-translatable nodes

### DIFF
--- a/addons/html_builder/static/src/core/core_plugins.js
+++ b/addons/html_builder/static/src/core/core_plugins.js
@@ -24,6 +24,7 @@ import { RemovePlugin } from "./remove_plugin";
 import { SavePlugin } from "./save_plugin";
 import { SaveSnippetPlugin } from "./save_snippet_plugin";
 import { SetupEditorPlugin } from "./setup_editor_plugin";
+import { CoreSetupEditorPlugin } from "./core_setup_editor_plugin";
 import { VersionControlPlugin } from "./version_control_plugin";
 import { VisibilityPlugin } from "./visibility_plugin";
 import { FieldChangeReplicationPlugin } from "./field_change_replication_plugin";
@@ -68,6 +69,7 @@ export const CORE_PLUGINS = [
     DisableSnippetsPlugin,
     MediaWebsitePlugin,
     SetupEditorPlugin,
+    CoreSetupEditorPlugin,
     SavePlugin,
     VisibilityPlugin,
     DropZoneSelectorPlugin,

--- a/addons/html_builder/static/src/core/core_setup_editor_plugin.js
+++ b/addons/html_builder/static/src/core/core_setup_editor_plugin.js
@@ -1,0 +1,8 @@
+import { Plugin } from "@html_editor/plugin";
+
+export class CoreSetupEditorPlugin extends Plugin {
+    static id = "core_setup_editor_plugin";
+    resources = {
+        o_editable_selectors: "[data-oe-model]",
+    };
+}

--- a/addons/html_builder/static/src/core/setup_editor_plugin.js
+++ b/addons/html_builder/static/src/core/setup_editor_plugin.js
@@ -8,7 +8,6 @@ export class SetupEditorPlugin extends Plugin {
     resources = {
         clean_for_save_handlers: this.cleanForSave.bind(this),
         closest_savable_providers: withSequence(10, (el) => el.closest(".o_editable")),
-        o_editable_selectors: "[data-oe-model]",
         unremovable_node_predicates: (node) => node.classList?.contains("o_editable"),
     };
 

--- a/addons/website/static/src/builder/plugins/translate_setup_editor_plugin.js
+++ b/addons/website/static/src/builder/plugins/translate_setup_editor_plugin.js
@@ -1,0 +1,8 @@
+import { Plugin } from "@html_editor/plugin";
+
+export class TranslateSetupEditorPlugin extends Plugin {
+    static id = "translate_setup_editor_plugin";
+    resources = {
+        o_editable_selectors: "[data-oe-model][data-oe-translation-source-sha]",
+    };
+}

--- a/addons/website/static/src/builder/website_builder.js
+++ b/addons/website/static/src/builder/website_builder.js
@@ -5,6 +5,7 @@ import { DisableSnippetsPlugin } from "@html_builder/core/disable_snippets_plugi
 import { OperationPlugin } from "@html_builder/core/operation_plugin";
 import { SavePlugin } from "@html_builder/core/save_plugin";
 import { SetupEditorPlugin } from "@html_builder/core/setup_editor_plugin";
+import { TranslateSetupEditorPlugin } from "./plugins/translate_setup_editor_plugin";
 import { VisibilityPlugin } from "@html_builder/core/visibility_plugin";
 import { removePlugins } from "@html_builder/utils/utils";
 import { closestElement } from "@html_editor/utils/dom_traversal";
@@ -42,6 +43,7 @@ const TRANSLATION_PLUGINS = [
     DisableSnippetsPlugin,
     SavePlugin,
     SetupEditorPlugin,
+    TranslateSetupEditorPlugin,
     VisibilityPlugin,
     PopupVisibilityPlugin,
     SaveTranslationPlugin,

--- a/addons/website/static/tests/builder/translation.test.js
+++ b/addons/website/static/tests/builder/translation.test.js
@@ -129,6 +129,19 @@ test("only have translation editors on deepest nodes", async () => {
     expect(":iframe .o_editable .o_editable").toHaveAttribute("contenteditable", "true");
 });
 
+test("only [data-oe-model] not o_editable in translation", async () => {
+    await setupSidebarBuilderForTranslation({
+        websiteContent: `
+            <div data-oe-model="test"><section>${getTranslateEditable({
+                inWrap: "Hello",
+            })}</section></div>
+        `,
+    });
+    expect(":iframe [data-oe-model='test']").not.toHaveClass("o_editable");
+    expect(":iframe .container").not.toHaveAttribute("contenteditable");
+    expect(":iframe .container span.o_editable").toHaveAttribute("contenteditable", "true");
+});
+
 test("404 page in translate mode", async () => {
     patchWithCleanup(EditWebsiteSystrayItem.prototype, {
         setup() {


### PR DESCRIPTION
Scenario:

- install second language on website
- add mega menu item to menu
- translate full span (from first to last letter)
- save

Result: nothing is saved

Cause:

The mega menu is in a node with [data-oe-model] attribute that receives
the o_editable class from SetupEditorPlugin. Its content is in a
`section > .container` that receives contenteditable="true" from
BuilderContentEditablePlugin.

Because the container zone is contenteditable, the editor allows to
select outside of <span data-oe-translation-…/> elements and when we
replace the whole content, the node is removed because it is an empty
SPAN and we lose the translation reference, so the translation are lost
when saved.

Fix:

There is already a code that disable wrapping editable since
d4f8aebea8cc7eba1517575302e072e0d5e2e406. This was not taking this case
where the content is not in '.o_editable' but in '.o_editable section >
.container'.

With this fix, we only add o_editable class to nodes that matches
[data-oe-model][data-oe-translation-source-sha].

opw-5045798
opw-5159026