### PR TITLE
[FIX] html_editor: patch classes in footer so xpath of inherited applies

### DIFF
--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -180,7 +180,13 @@ export function changeOptionInPopover(blockName, optionName, elementName, search
     steps.push(
         clickOnElement(
             `${elementName} in the ${optionName} option`,
-            `.o_popover div.o-dropdown-item:contains("${elementName}"), .o_popover span.o-dropdown-item:contains("${elementName}"), .o_popover ${elementName}`
+            [
+                `.o_popover div.o-dropdown-item:contains("${elementName}")`,
+                `.o_popover span.o-dropdown-item:contains("${elementName}")`,
+                `.o_popover div.o-dropdown-item[title="${elementName}"]`,
+                `.o_popover span.o-dropdown-item[title="${elementName}"]`,
+                `.o_popover ${elementName}`,
+            ].join(", ")
         )
     );
     return steps;
@@ -745,7 +751,7 @@ export function clickToolbarButton(elementName, selector, button, expand = false
         selectFullText(`${elementName}`, selector),
         {
             content: `Click on the ${button} from toolbar`,
-            trigger: `.o-we-toolbar button[title="${button}"]`,
+            trigger: `.o-we-toolbar button[title="${button}"], .o-we-toolbar button[name="${button}"]`,
             run: "click",
         },
     ];

--- a/addons/website/static/tests/tours/mega_footer.js
+++ b/addons/website/static/tests/tours/mega_footer.js
@@ -1,0 +1,44 @@
+import {
+    changeOptionInPopover,
+    clickOnEditAndWaitEditMode,
+    clickOnSave,
+    clickOnSnippet,
+    clickToolbarButton,
+    registerWebsitePreviewTour,
+} from "@website/js/tours/tour_utils";
+
+registerWebsitePreviewTour(
+    "mega_footer",
+    {
+        url: "/",
+        edition: true,
+    },
+    () => [
+        {
+            content: "Mark the current footer (to tell when it is gone)",
+            trigger: ":iframe footer",
+            run() {
+                this.anchor.ownerDocument
+                    .querySelector("footer #footer p")
+                    .classList.add("if_this_is_here_this_is_the_old_footer");
+            },
+        },
+        ...clickOnSnippet({ id: "o_footer", name: "Footer" }),
+        ...changeOptionInPopover("Footer", "Template", "Mega"),
+        {
+            content: "Check that the footer has been replaced",
+            trigger: ":iframe footer:not(:has(.if_this_is_here_this_is_the_old_footer))",
+        },
+        ...clickToolbarButton(
+            "copyright and company name text",
+            ".o_footer_copyright span",
+            "bold" // could be any edit in that span
+        ),
+        ...clickOnSave(),
+        ...clickOnEditAndWaitEditMode(),
+        {
+            content: "The company name at the bottom of the footer has the new content",
+            trigger: ":iframe .o_footer_copyright span strong",
+        },
+    ]
+);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -722,3 +722,6 @@ class TestUi(HttpCaseWithWebsiteUser):
         # It should go in edit mode if we are not on the FR page even if FR is
         # available
         self.start_tour('/', 'alt_a_edit', login='admin')
+
+    def test_mega_footer(self):
+        self.start_tour('/', 'mega_footer', login='admin')


### PR DESCRIPTION
The new footer templates had xpath selectors that were breaking in
case the user changed some things in the footer. This is caused by
a different order of evaluation after the copy is made to save the
customized website view.

This commit patches the view to add the class on which the xpath relies
so that it is always present, thus the xpath always apply.

Steps to reproduce:
- Open website builder (on an new db)
- Click on the footer
- Change "Template" to "Mega" (or "Mega Columns", or "Mega Links")
- Click on "Company Name" in the footer, and edit the text
- Save
- Bug: save fails because an xpath does not apply

Commit adding "Mega": 2132835bad8f66d6bf87097db3539cc1354e0392
Commit adding "Mega Columns": 6295f19e383cdf6c01b819ff9b5116249f2a214a
Commit adding "Mega Links": ce8d86214f42615e2252349b708ad27998eeeacf

task-5181309