### PR TITLE
[FIX] l10n_tr_nilvera_einvoice_extended: prevent branch tax duplicates

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice_extended/__init__.py
+++ b/addons/l10n_tr_nilvera_einvoice_extended/__init__.py
@@ -6,16 +6,19 @@ _logger = logging.getLogger(__name__)
 
 
 def _l10n_tr_nilvera_einvoice_extended_post_init(env):
-    """Existing companies that have the Turkish Chart of Accounts set"""
-    tr_companies = env["res.company"].search([("chart_template", "=", "tr")], order="parent_path")
+    """Existing none branch companies that have the Turkish Chart of Accounts set"""
+    tr_companies = env["res.company"].search([("chart_template", "=", "tr"), ("parent_id", "=", False)], order="parent_path")
     for company in tr_companies:
-        chart_template = env["account.chart.template"].with_company(company)
-        chart_template._load_data({
-            "l10n_tr_nilvera_einvoice_extended.account.tax.code": chart_template._get_tr_withholding_account_tax_code(),
+        ChartTemplate = env["account.chart.template"].with_company(company)
+        data = {
+            "l10n_tr_nilvera_einvoice_extended.account.tax.code": ChartTemplate._get_tr_withholding_account_tax_code(),
             "account.tax": {
                 xml_id: data
-                for xml_id, data in chart_template._get_tr_withholding_account_tax().items()
+                for xml_id, data in ChartTemplate._get_tr_withholding_account_tax().items()
                 if not env.ref(f"account.{company.id}_{xml_id}", raise_if_not_found=False)
             },
-        })
-        chart_template._load_translations(companies=company)
+        }
+        ChartTemplate._deref_account_tags("tr", data["account.tax"])
+        ChartTemplate._pre_reload_data(company, {}, data)
+        ChartTemplate._load_data(data)
+        ChartTemplate._load_translations(companies=company)


### PR DESCRIPTION
Adds parent_id check on the domain to ensure taxes are only loaded for root companies. This prevents duplicate tax creation on branch (child) companies when initializing tax templates.

task-5176333
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
