### PR TITLE
[IMP] iot: deprecade iot subscription logic

### DIFF
--- a/addons/iot_drivers/connection_manager.py
+++ b/addons/iot_drivers/connection_manager.py
@@ -90,13 +90,13 @@ class ConnectionManager(Thread):
 
     def _poll_pairing_result(self):
         result = self._call_iot_proxy()
-        if all(key in result for key in ['url', 'token', 'db_uuid', 'enterprise_code']):
-            self._connect_to_server(result['url'], result['token'], result['db_uuid'], result['enterprise_code'])
+        if all(key in result for key in ['url', 'token', 'db_uuid']):
+            self._connect_to_server(result['url'], result['token'], result['db_uuid'])
 
-    def _connect_to_server(self, url, token, db_uuid, enterprise_code):
+    def _connect_to_server(self, url, token, db_uuid):
         self.new_database_url = url
         # Save DB URL and token
-        helpers.save_conf_server(url, token, db_uuid, enterprise_code)
+        helpers.save_conf_server(url, token, db_uuid)
         # Send already detected devices and IoT Box info to the database
         manager._send_all_devices()
         # Switch git branch before restarting, this avoids restarting twice

--- a/addons/iot_drivers/controllers/homepage.py
+++ b/addons/iot_drivers/controllers/homepage.py
@@ -90,7 +90,6 @@ class IotBoxOwlHomePage(http.Controller):
     def clear_credential(self):
         system.update_conf({
             'db_uuid': '',
-            'enterprise_code': '',
         })
         helpers.odoo_restart(0)
         return json.dumps({
@@ -164,7 +163,6 @@ class IotBoxOwlHomePage(http.Controller):
 
         return json.dumps({
             'db_uuid': system.get_conf('db_uuid'),
-            'enterprise_code': system.get_conf('enterprise_code'),
             'ip': system.get_ip(),
             'identifier': IOT_IDENTIFIER,
             'mac_address': system.get_mac_address(),
@@ -272,10 +270,9 @@ class IotBoxOwlHomePage(http.Controller):
         }
 
     @route.iot_route('/iot_drivers/save_credential', type="jsonrpc", methods=['POST'], cors='*')
-    def save_credential(self, db_uuid, enterprise_code):
+    def save_credential(self, db_uuid):
         system.update_conf({
             'db_uuid': db_uuid,
-            'enterprise_code': enterprise_code,
         })
         helpers.odoo_restart(0)
         return {
@@ -322,9 +319,9 @@ class IotBoxOwlHomePage(http.Controller):
             try:
                 if len(token.split('|')) == 4:
                     # Old style token with pipe separators (pre v18 DB)
-                    url, token, db_uuid, enterprise_code = token.split('|')
+                    url, token, db_uuid = token.split('|')[:3]
                     configuration = helpers.parse_url(url)
-                    helpers.save_conf_server(configuration["url"], token, db_uuid, enterprise_code)
+                    helpers.save_conf_server(configuration["url"], token, db_uuid)
                 else:
                     # New token using query params (v18+ DB)
                     configuration = helpers.parse_url(token)

--- a/addons/iot_drivers/static/src/app/components/dialog/CredentialDialog.js
+++ b/addons/iot_drivers/static/src/app/components/dialog/CredentialDialog.js
@@ -15,13 +15,12 @@ export class CredentialDialog extends Component {
         this.state = useState({ waitRestart: false });
         this.form = useState({
             db_uuid: this.store.base.db_uuid,
-            enterprise_code: "",
         });
     }
 
     async connectToServer() {
         try {
-            if (!this.form.db_uuid || !this.form.enterprise_code) {
+            if (!this.form.db_uuid) {
                 return;
             }
 
@@ -71,7 +70,6 @@ export class CredentialDialog extends Component {
                 </div>
                 <div class="d-flex flex-column gap-2 mt-3">
                     <input type="text" class="form-control" placeholder="Database UUID" t-model="form.db_uuid"/>
-                    <input type="text" class="form-control" placeholder="Odoo contract number" t-model="form.enterprise_code"/>
                 </div>
             </t>
             <t t-set-slot="footer">

--- a/addons/iot_drivers/tools/certificate.py
+++ b/addons/iot_drivers/tools/certificate.py
@@ -65,20 +65,17 @@ def get_certificate_end_date():
 
 
 def download_odoo_certificate(retry=0):
-    """Send a request to Odoo with customer db_uuid and enterprise_code
-    to get a true certificate
-    """
+    """Send a request to Odoo with customer db_uuid to get a true certificate"""
     if IS_TEST:
         _logger.info("Skipping certificate download in test mode.")
         return None
     db_uuid = system.get_conf('db_uuid')
-    enterprise_code = system.get_conf('enterprise_code')
     if not db_uuid:
         return None
     try:
         response = requests.post(
             'https://www.odoo.com/odoo-enterprise/iot/x509',
-            json={'params': {'db_uuid': db_uuid, 'enterprise_code': enterprise_code}},
+            json={'params': {'db_uuid': db_uuid}},
             timeout=95,  # let's encrypt library timeout
         )
         response.raise_for_status()

--- a/addons/iot_drivers/tools/helpers.py
+++ b/addons/iot_drivers/tools/helpers.py
@@ -102,20 +102,18 @@ def require_db(function):
     return wrapper
 
 
-def save_conf_server(url, token, db_uuid, enterprise_code, db_name=None):
+def save_conf_server(url, token, db_uuid, db_name=None):
     """
     Save server configurations in odoo.conf
     :param url: The URL of the server
     :param token: The token to authenticate the server
     :param db_uuid: The database UUID
-    :param enterprise_code: The enterprise code
     :param db_name: The database name
     """
     system.update_conf({
         'remote_server': url,
         'token': token,
         'db_uuid': db_uuid,
-        'enterprise_code': enterprise_code,
         'db_name': db_name,
     })
     get_odoo_server_url.cache_clear()
@@ -281,7 +279,6 @@ def disconnect_from_server():
         'token': '',
         'db_uuid': '',
         'db_name': '',
-        'enterprise_code': '',
         'screen_orientation': '',
         'browser_url': '',
         'iot_handlers_etag': '',


### PR DESCRIPTION
Note: needs to be merged after the https://github.com/odoo/internal/pull/3858 otherwise iot pairing / certificate generation won't work

Currently we are only providing the ssl certificates to the iot users if they are on trial (free certificate first 30 days) or they have an enterprise code in their db.

The issue here is that if the iot box doesn't get a new certificate after a trial period they will experience a lot of issues in Point Of Sale where a lot of requests rely on local network and ssl certificates.

This PR removes the logic around the enterprise code for the generation of the certificates. Now we always generate a certificate as long as the database has a valid db_uuid registered on our servers.

Related Enterprise PR: https://github.com/odoo/enterprise/pull/97880
Related internal PR: https://github.com/odoo/internal/pull/3858