### PR TITLE
[FIX] web: align close icon on badges

### DIFF
--- a/addons/web/static/src/core/tags_list/badge_tag.xml
+++ b/addons/web/static/src/core/tags_list/badge_tag.xml
@@ -7,8 +7,8 @@
                 <div class="o_tag_badge_text o_badge_text" t-out="this.props.text"/>
             </t>
             <t t-if="this.props.onDelete">
-                <a class="o_delete d-flex align-items-center opacity-100-hover ps-1 opacity-75" href="#" tabindex="-1" aria-label="Delete" data-tooltip="Delete" t-on-click.stop.prevent="() => this.props.onDelete()">
-                    <i class="oi oi-close align-text-center"/>
+                <a class="o_delete ps-1 opacity-75 opacity-100-hover" href="#" tabindex="-1" aria-label="Delete" data-tooltip="Delete" t-on-click.stop.prevent="() => this.props.onDelete()">
+                    <i class="oi oi-close"/>
                 </a>
             </t>
         </span>

--- a/addons/web/static/src/core/tags_list/tags_list.xml
+++ b/addons/web/static/src/core/tags_list/tags_list.xml
@@ -40,7 +40,7 @@
                 <a
                     t-if="tag.onDelete"
                     t-on-click.stop.prevent="(ev) => tag.onDelete and tag.onDelete(ev)"
-                    class="o_delete d-flex align-items-center opacity-100-hover"
+                    class="o_delete opacity-100-hover"
                     t-att-class="{
                             'btn btn-link position-relative py-0 px-1 text-danger opacity-0': tag.img,
                             'ps-1 opacity-75': !tag.img
@@ -49,7 +49,7 @@
                     aria-label="Delete"
                     tabIndex="-1"
                     href="#">
-                        <i class="oi oi-close align-text-top"/>
+                        <i class="oi oi-close"/>
                 </a>
             </span>
         </t>

--- a/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.scss
+++ b/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.scss
@@ -40,6 +40,10 @@
             @include o-text-overflow(inline-block);
             max-width: var(--Tag-max-width, 200px);
         }
+
+        .o_delete {
+            line-height: normal;
+        }
     }
 }
 


### PR DESCRIPTION
This commit fixes the vertical alignment of the `oi-close` icon on `badge_tag.xml` and `tags_list.xml`.

task-5072923

| Browser | Before | After |
|--------|--------|--------|
| Safari | <img width="348" height="39" alt="image" src="https://github.com/user-attachments/assets/68ff3890-e295-4a8b-b26b-b806e2e49ba8" /> | <img width="364" height="42" alt="image" src="https://github.com/user-attachments/assets/6bda8604-9a2f-4cf8-bd8a-21c0de9a441b" /> |
| Chrome | <img width="362" height="37" alt="image" src="https://github.com/user-attachments/assets/1b2bc4aa-5a08-4b89-ac78-be3d307f5be8" /> | <img width="368" height="40" alt="image" src="https://github.com/user-attachments/assets/f8377eab-6d9c-4647-be95-a41e6e9900f9" /> |
| Firefox | <img width="350" height="39" alt="image" src="https://github.com/user-attachments/assets/b3f382ca-abe0-4a53-bb36-4468c9bf8983" /> | <img width="360" height="43" alt="image" src="https://github.com/user-attachments/assets/783f2994-daa5-4bbe-bf8a-f0658207fe03" /> |

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
