### PR TITLE
[FIX] account: fix totals onchange with product and unit price

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2617,6 +2617,18 @@ class AccountMove(models.Model):
         elif 'invoice_line_ids' in field_names:
             values = {key: val for key, val in values.items() if key != 'line_ids'}
             fields_spec = {key: val for key, val in fields_spec.items() if key != 'line_ids'}
+            # When product_id and price_unit are in values, values is reordered to make sure
+            # that product_id is before price_unit because product_id is triggering an onchange
+            # of price_unit that could override the one defined here if the product_id is set
+            # after price_unit
+            invoice_line_ids = values.get('invoice_line_ids')
+            for invoice_line_idx, invoice_line in enumerate(invoice_line_ids):
+                if (len(invoice_line) == 3 and invoice_line[0] == 1 and isinstance(invoice_line[2], dict) and
+                    'product_id' in invoice_line[2] and 'price_unit' in invoice_line[2]
+                ):
+                    if isinstance(invoice_line, tuple):
+                        invoice_line_ids[invoice_line_idx] = invoice_line = list(invoice_line)
+                    invoice_line[2] = dict(sorted(invoice_line[2].items(), key=lambda item: item[0] != 'product_id'))
         return super().onchange(values, field_names, fields_spec)
 
     # -------------------------------------------------------------------------

--- a/addons/account/tests/test_invoice_tax_totals.py
+++ b/addons/account/tests/test_invoice_tax_totals.py
@@ -996,3 +996,27 @@ class TestTaxTotals(AccountTestInvoicingCommon):
             })
             move.invoice_cash_rounding_id = cash_rounding
             self.assertEqual(move.tax_totals['amount_total'], 120)
+
+    def test_multiple_onchange_product_and_price(self):
+        """
+        This test checks that the totals are computed correctly when an onchange is executed
+        with "price_unit" before "product_id" in the values.
+        This test covers a UI issue where the totals were not updated when the price was changed,
+        then the product and finally the price again.
+        The issue was only occuring between the change of value and the next save.
+        That's why the test is using the onchange method directly instead of using a Form.
+        """
+        invoice = self.init_invoice('out_invoice', products=self.product_a)
+        self.assertEqual(invoice.tax_totals['amount_untaxed'], 1000.0)
+        self.assertEqual(invoice.tax_totals['amount_total'], 1150.0)
+        # The onchange is executed directly to simulate the following flow:
+        # 1) unit price is changed to any value
+        # 2) product is changed to "Product B"
+        # 3) unit price is changed to 2000.0
+        results = invoice.onchange(
+            {'invoice_line_ids': [Command.update(invoice.invoice_line_ids[0].id, {'price_unit': 2000.0, 'product_id': self.product_b.id})]},
+            ['invoice_line_ids'],
+            {"invoice_line_ids": {}, 'tax_totals': {}}
+        )
+        self.assertEqual(results['value']['tax_totals']['amount_untaxed'], 2000.0)
+        self.assertEqual(results['value']['tax_totals']['amount_total'], 2600.0)


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting

- Create an invoice with an invoice line
- Save the invoice

- Change the unit price => The totals should change
- Change the product => The unit price and the totals should change
- Change the unit price again

**Issue:**
After this point, the totals don't change anymore, even if the unit price is changed several times.
Only saving the form will adapt the totals correctly.

**Cause:**
When changing the unit price the first time, a "price_unit "key is added in the onchange values.
When changing the product, a "product_id" key is added after the price key.
Changing the product triggers an onchange of the price with the price of the new product.
However, when the price is changed again, as the "price_unit" key already exists, it's reused and its position is still before "product_id" key even if it should be computed after.
This order results in the use of the price of the second product instead of the one entered manually when computing the "tax_totals".

**Solution:**
If "product_id" and "price_unit" are the values of the onchange method, the list of values is reordered to make sure that "product_id" is computed first.

opw-5012125




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
