### PR TITLE
[FIX] mrp: allow creating an orderpoint for a kit in another company

### DIFF
--- a/addons/mrp/models/stock_warehouse.py
+++ b/addons/mrp/models/stock_warehouse.py
@@ -312,10 +312,14 @@ class Orderpoint(models.Model):
     @api.constrains('product_id')
     def check_product_is_not_kit(self):
         domain = [
-            '|', ('product_id', 'in', self.product_id.ids),
-                 '&', ('product_id', '=', False),
-                      ('product_tmpl_id', 'in', self.product_id.product_tmpl_id.ids),
-            ('type', '=', 'phantom'),
+            '&',
+                '|', ('product_id', 'in', self.product_id.ids),
+                    '&', ('product_id', '=', False),
+                        ('product_tmpl_id', 'in', self.product_id.product_tmpl_id.ids),
+                ('type', '=', 'phantom'),
+                '|',
+                    ('company_id', 'in', self.company_id.ids),
+                    ('company_id', '=', False),
         ]
         if self.env['mrp.bom'].search_count(domain, limit=1):
             raise ValidationError(_("A product with a kit-type bill of materials can not have a reordering rule."))

--- a/addons/mrp/tests/test_replenish.py
+++ b/addons/mrp/tests/test_replenish.py
@@ -152,3 +152,15 @@ class TestMrpReplenish(TestMrpCommon):
         lead_days_date = datetime.strptime(
             loads(repl_info.json_lead_days)['lead_days_date'], '%m/%d/%Y').date()
         self.assertEqual(lead_days_date, fields.Date.today() + timedelta(days=365))
+
+    def test_orderpoint_with_kit_bom_in_another_company(self):
+        """Test that an orderpoint can be created for a product
+        having a kit-type BoM defined in another company.
+        """
+        self.assertEqual(self.bom_2.type, 'phantom')
+        self.assertEqual(self.bom_2.company_id, self.env.company)
+        company_2 = self.env['res.company'].create({'name': 'Company 2'})
+        orderpoint = self.env['stock.warehouse.orderpoint'].with_company(company_2).create({
+            'product_id': self.bom_2.product_id.id,
+        })
+        self.assertEqual(orderpoint.company_id, company_2)


### PR DESCRIPTION
Steps to reproduce:
- Create a storable product "P1"
  - Add a kit BoM restricted to Company A
- Switch to Company B
- Try to create an orderpoint for "P1" in Company B

Issue:
A validation error is raised:
"A product with a kit-type bill of materials cannot have a reordering rule."

Cause:
The check did not consider the company of the BoM, so kit BoMs defined in other companies incorrectly blocked orderpoint creation.

Solution:
Add the company condition in the BoM search domain to ensure that only BoMs belonging to the same company (or global ones) are considered.

opw-5158491
