### PR TITLE
[FIX] point_of_sale: set qty to combo lines on adding a note

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/customer_note_button/customer_note_button.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/customer_note_button/customer_note_button.js
@@ -44,12 +44,18 @@ export class OrderlineNoteButton extends Component {
         }
         const saved_quantity = selectedOrderline.qty - quantity_with_note;
         if (saved_quantity > 0 && quantity_with_note > 0) {
-            await this.pos.addLineToCurrentOrder({
+            const newLine = await this.pos.addLineToCurrentOrder({
                 product_id: selectedOrderline.product_id,
                 qty: quantity_with_note,
                 note: payload,
             });
+            newLine.combo_line_ids.forEach((child) => {
+                child.qty = quantity_with_note;
+            });
             selectedOrderline.qty = saved_quantity;
+            selectedOrderline.combo_line_ids.forEach((child) => {
+                child.qty = saved_quantity;
+            });
         } else {
             this.props.setter(selectedOrderline, payload);
         }

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -22,6 +22,7 @@ import {
 import { registry } from "@web/core/registry";
 import * as Numpad from "@point_of_sale/../tests/tours/utils/numpad_util";
 import { delay } from "@odoo/hoot-dom";
+import * as TextInputPopup from "@point_of_sale/../tests/tours/utils/text_input_popup_util";
 
 const ProductScreen = { ...ProductScreenPos, ...ProductScreenResto };
 
@@ -806,5 +807,44 @@ registry.category("web_tour.tours").add("test_reload_order_line_removed", {
             refresh(),
             FloorScreen.clickTable("5"),
             inLeftSide(Order.hasLine({ productName: "Coca-Cola", quantity: 1 })),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_combo_children_qty_updated_with_note", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickDisplayedProduct("Office Combo"),
+            combo.select("Combo Product 2"),
+            combo.select("Combo Product 4"),
+            combo.select("Combo Product 6"),
+            Dialog.confirm(),
+            ProductScreen.clickOrderButton(),
+            ProductScreen.clickNumpad("3"),
+            ProductScreen.clickInternalNoteButton(),
+            TextInputPopup.inputText("test note"),
+            Dialog.confirm(),
+            combo.select("Combo Product 2"),
+            combo.select("Combo Product 4"),
+            combo.select("Combo Product 6"),
+            Dialog.confirm(),
+            Order.doesNotHaveLine({
+                productName: "Office Combo",
+                quantity: 1,
+                internalNote: "test note",
+            }),
+            Order.hasLine({ productName: "Combo Product 2", quantity: 1 }),
+            Order.hasLine({ productName: "Combo Product 4", quantity: 1 }),
+            Order.hasLine({ productName: "Combo Product 6", quantity: 1 }),
+            Order.hasLine({
+                productName: "Office Combo",
+                quantity: 2,
+                internalNote: "test note",
+            }),
+            Order.hasLine({ productName: "Combo Product 2", quantity: 2 }),
+            Order.hasLine({ productName: "Combo Product 4", quantity: 2 }),
+            Order.hasLine({ productName: "Combo Product 6", quantity: 2 }),
         ].flat(),
 });

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -554,3 +554,9 @@ class TestFrontend(TestFrontendCommon):
             if PoS gets reloaded, the order line gets back
         """
         self.start_pos_tour('test_reload_order_line_removed')
+
+    def test_combo_children_qty_updated_with_note(self):
+        setup_product_combo_items(self)
+        self.pos_config.write({'printer_ids': False})
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_combo_children_qty_updated_with_note')


### PR DESCRIPTION
**Steps to reproduce:**
- Go to the restaurant
- Select a table, click on a combo and order it
- Add quantity to the ordered combo and add a note to it
- Select the desired combo options in the popup
- The combos' children lines' qty are not updated and are either too much or 1

**Why the fix:**
When we add a note to an orderline that has qty that has not been sent to the kitchen, we split the line in 2 lines, one with everything that has been sent to the kitchen and one with everything that has not been sent and the note we just added.

This implementation didn't account for the combos, so the combo_line_ids' qty were never updated and stayed as is in the original line, and were set as 1 in the new line.

We now update the children lines' qty at the same time as the parent lines.

This behavior will need to change with the changes made in version  18.3, as this version introduces the possibility of having the same child line multiple times in the same combo, like 2 of the same burger in a single combo.
Another problem is there is currently a bug in 18.3 preventing us from correctly changing the qty of a combo's children by changing the parent's qty if the same item is ordered twice (the qty will still be set to the parent's qty instead of being multiplied). So this will need to be changed once this reaches 18.3

opw-5164102