### PR TITLE
[FIX] website_slides: fix review edition

### DIFF
--- a/addons/website_slides/static/src/js/portal_rating_composer.js
+++ b/addons/website_slides/static/src/js/portal_rating_composer.js
@@ -9,15 +9,19 @@ RatingPopupComposer.include({
             (this.options.default_message_id && "/slides/mail/update_comment");
     },
     _reloadRatingPopupComposer: function () {
-        this._super(...arguments);
         if (this.options.res_model !== "slide.channel") {
-            return;
+            return this._super(...arguments);
         }
         const reviewEl = document.querySelector("#review-tab");
         if (reviewEl) {
             reviewEl.textContent = this.rating_count
                 ? _t("Reviews (%s)", this.rating_count)
                 : _t("Reviews");
+        }
+        const editedMessage = this.options["mail.message"]?.[0];
+        // Only update the modal when editing the logged user message
+        if (!editedMessage || this.options.partner_id === editedMessage.author?.id) {
+            return this._super(...arguments);
         }
     },
 });

--- a/addons/website_slides/static/tests/tours/slides_course_reviews_admin.js
+++ b/addons/website_slides/static/tests/tours/slides_course_reviews_admin.js
@@ -1,0 +1,90 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+
+const messageOfOtherUserSelector =
+    "#chatterRoot:shadow .o-mail-Message:has(.o-mail-Message-textContent:contains('Other user review'))";
+
+/**
+ * This tour tests that editing the comment of another user (as admin)
+ * doesn't alter the behavior of the "Edit review" button:
+ * admins will edit their own review and not another one's they've just edited.
+ */
+registry.category("web_tour.tours").add("course_reviews_admin", {
+    url: "/slides",
+    steps: () => [
+        {
+            trigger: "a:contains(Basics of Gardening - Test)",
+            run: "click",
+            expectUnloadPage: true,
+        },
+        {
+            trigger: "a[id=review-tab]",
+            run: "click",
+        },
+        {
+            content: "Display contextual menu of the rating message of another user",
+            trigger: messageOfOtherUserSelector,
+            run: `hover && click ${messageOfOtherUserSelector} [title='Expand']`,
+        },
+        {
+            content: 'Click on "edit" action of the contextual menu of the rating message',
+            trigger: `#chatterRoot:shadow .o-dropdown-item:contains('edit')`,
+            run: "click",
+        },
+        {
+            content: "Update the content of the message",
+            trigger: "#chatterRoot:shadow .o-mail-Message .o-mail-Composer textarea",
+            run: "edit Other user review edited",
+        },
+        {
+            content:
+                "Update the Review tab name to detect later when the review is saved (see below)",
+            trigger: "body",
+            async run() {
+                document.getElementById("review-tab").textContent = "Review";
+            },
+        },
+        {
+            content: "Click on save",
+            trigger: "#chatterRoot:shadow a[data-type=save]",
+            run: "click",
+        },
+        {
+            content:
+                "Wait the review to be completely saved by checking that the review tab name has been updated",
+            trigger: "#review-tab:contains('Reviews (2)')",
+        },
+        {
+            content: 'Click on the "edit review" button to edit the logged user review',
+            trigger: ".o_rating_popup_composer_text:contains(Edit Review)",
+            run: "click",
+        },
+        {
+            content:
+                "Check that the modal displays the message of the logged user and not the one we've just modified",
+            trigger: "div.o_portal_chatter_composer_body textarea:value(Admin review)",
+        },
+        {
+            content: "Select 5 stars for the admin review",
+            trigger: ".modal.modal_shown .modal-body i.fa.fa-star-o:eq(3)",
+            run: "click",
+        },
+        {
+            content: "Update admin review",
+            trigger: "div.o_portal_chatter_composer textarea:value(Admin review)",
+            run: "edit Admin review2",
+        },
+        {
+            content: "Post admin review",
+            trigger:
+                ".modal.modal_shown.show button.o_portal_chatter_composer_btn:contains(Update review)",
+            run: "click",
+        },
+        {
+            content: "Check that the admin message and review have been updated",
+            trigger:
+                "#chatterRoot:shadow .o-mail-Message:contains(Admin review2) .o_website_rating_static[title='5 stars on 5']",
+        },
+    ],
+});

--- a/addons/website_slides/tests/test_ui_wslides.py
+++ b/addons/website_slides/tests/test_ui_wslides.py
@@ -198,6 +198,28 @@ class TestUi(TestUICommon):
 
         self.start_tour('/slides', 'course_reviews', login=user_demo.login)
 
+    def test_course_reviews_elearning_admin(self):
+        user_demo = self.user_demo
+        user_demo.write({
+            'karma': 10,
+            'groups_id': [(6, 0, (self.env.ref('base.group_user') | self.env.ref('website_slides.group_website_slides_officer')).ids)]
+        })
+        self.channel._action_add_members(user_demo.partner_id)
+        self.channel.with_user(user_demo).message_post(
+            body="Other user review",
+            message_type="comment",
+            rating_value="3",
+            subtype_xmlid="mail.mt_comment"
+        )
+        self.channel.with_user(self.user_admin).message_post(
+            body="Admin review",
+            message_type="comment",
+            rating_value="1",
+            subtype_xmlid="mail.mt_comment"
+        )
+
+        self.start_tour('/slides', 'course_reviews_admin', login=self.user_admin.login)
+
     def test_course_reviews_reaction_public(self):
         password = "Pl1bhD@2!kXZ"
         manager = self.user_admin


### PR DESCRIPTION
How to reproduce:
- Log as Mitchell Admin
- Edit Marc Demo review using the contextual edit button
- Click on save to update the review
- Click on the button "Edit Review" on the top

The review modals opens with the message of Marc Demo instead of the message of Mitchell Admin. The fix ensures you always edit your review message when clicking on "Edit review" button.

Note: this is only possible with admin user as other users cannot edit messages of other users. So unfortunately, we had to create a new tours as we can't add steps to test_course_reviews_elearning_officer (not running as admin). An alternative would have been to extend test_fullscreen_slide_text_highlights and rename it.

Task-5170310