### PR TITLE
[FIX] hr_recruitment: exclude inactive (non-running) activities from Job counters

### DIFF
--- a/addons/hr_recruitment/models/hr_job.py
+++ b/addons/hr_recruitment/models/hr_job.py
@@ -118,6 +118,7 @@ class HrJob(models.Model):
               AND act.date_deadline <= %(today)s::date AND app.active
               AND app.job_id IN %(job_ids)s
               AND sta.hired_stage IS NOT TRUE
+              AND COALESCE(act.active, TRUE) = TRUE
             GROUP BY app.job_id, act_state
         """, {
             'today': fields.Date.context_today(self),


### PR DESCRIPTION
On the Recruitment dashboard (Jobs kanban), the counters for “Late Activities” and “Today’s Activities” may not decrease after an activity is marked as done, even though completed activities no longer appear in the applicant list.

Root cause:
`_compute_activities` aggregates counts from `mail_activity` using the deadline and job filters but does not exclude non-running (inactive/archived) activities. If an activity is not unlinked and becomes inactive (`active = FALSE`), it still matches `date_deadline <= today` and is counted.

Steps to reproduce:
1. Open Recruitment
2. Pick any job and schedule an activity with Due date is Today (also try Yesterday for “Late”).
3. Mark the activity as Done. the number of activities today or late will not decrease

opw-5123947


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
