### PR TITLE
[FIX] purchase: Update billing status on PO when there are only 'cancelled' bills

### DIFF
--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -62,7 +62,7 @@ class PurchaseOrder(models.Model):
                     float_is_zero(line.qty_to_invoice, precision_digits=precision)
                     for line in order.order_line.filtered(lambda l: not l.display_type)
                 )
-                and order.invoice_ids
+                and order.invoice_ids.filtered(lambda x: x.state not in 'cancel')
             ):
                 order.invoice_status = 'invoiced'
             else:


### PR DESCRIPTION
Version: 17.0+

Issue:
When we have cancelled vendor bills linked to purchase orders with products with control policy "On received quantities", the billing status is not correctly reflected.

Purpose of this PR:
To correctly reflect the billing status on purchase orders that have only linked cancelled vendor bills

Steps to reproduce on Runbot:
install stock and purchase
create product with control policy On received quantities create purchase order with product
create bill separately and use Auto complete to select the purchase order view the purchase order billing status
cancel bill
purchase order's billing status remains "Fully Billed" -- expected to be "Waiting for Bills"

opw-5170592
