### PR TITLE
[FIX] account: fix iframe selection for invoice_html

### DIFF
--- a/addons/account/static/src/interactions/account_sidebar.js
+++ b/addons/account/static/src/interactions/account_sidebar.js
@@ -17,7 +17,7 @@ export class AccountSidebar extends Sidebar {
 
     start() {
         super.start();
-        this.invoiceHTMLEl = document.querySelector("iframe");
+        this.invoiceHTMLEl = document.getElementById('invoice_html');
         const iframeDoc = this.invoiceHTMLEl.contentDocument || this.invoiceHTMLEl.contentWindow.document;
         if (iframeDoc.readyState === 'complete') {
             this.updateIframeSize();


### PR DESCRIPTION
Support the possibility of multiple iframes being present on the invoice preview page.

Steps to reproduce
-----
1. Add a map block to the nav bar of the website.
2. Go to accounting and find an invoice.
3. Click preview and receive a traceback.

Cause
-----
The use of querySelector works if there is only one iframe element, but map blocks are also iframe elements so adding one with the website editor can cause the wrong iframe to be selected with querySelector.

Solution
-----
The iframe element that needs to be selected already has an id, so updating querySelector to getElementById resolves the issue.

opw-ticket 5170640
