### PR TITLE
[18.0][IMP] sale_pdf_quote_builder: Defensively test sale.order state names.

### DIFF
--- a/addons/sale_pdf_quote_builder/tests/test_pdf_quote_builder.py
+++ b/addons/sale_pdf_quote_builder/tests/test_pdf_quote_builder.py
@@ -99,9 +99,8 @@ class TestPDFQuoteBuilder(BaseUsersCommon, SaleManagementCommon):
             new_form_fields[3]: "",  # datetime missing
             new_form_fields[4]: "1.0",  # float
             new_form_fields[5]: "1",  # integer
-            new_form_fields[6]: "Quotation",  # selection
+            new_form_fields[6]: dict(self.sale_order._fields['state'].selection)['draft'],  # selection
             new_form_fields[7]: "$\xa0725.00",  # monetary
-
             new_form_fields[8]: f"{sol_1.display_name}, {sol_2.display_name}",  # one2many
             new_form_fields[9]: f"{self.sale_order.company_id.display_name}",  # many2one
             new_form_fields[10]: f"{self.sale_order.company_id.display_name}",  # many2many
@@ -145,9 +144,8 @@ class TestPDFQuoteBuilder(BaseUsersCommon, SaleManagementCommon):
             'datetime_test': "12/21/2121 13:21:12",
             'float_test': "4.99",
             'integer_test': "0",
-            'selection_test': "Quotation",
+            'selection_test': dict(self.sale_order._fields['state'].selection)['draft'],
             'monetary_test': self.sale_order.currency_id.format(720.01),
-
             'one2many_test': f"{sol_1.display_name}, {sol_2.display_name}",
             'many2one_test': self.sale_order.company_id.display_name,
             'many2many_test': "test tax1, test tax2",


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

This ensures that `sale_pdf_quote_builder` tests pass even if a third party module that renames `sale.order` `state` selections has been installed.

### Current behavior before PR:

Tests fail.

### Desired behavior after PR is merged:

Tests pass.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
