### PR TITLE
[FIX] website_event: regex gets incorrect event id

### DIFF
--- a/addons/website_event/static/src/website_builder/event_page_option_plugin.js
+++ b/addons/website_event/static/src/website_builder/event_page_option_plugin.js
@@ -64,7 +64,7 @@ export class DisplaySubMenuAction extends BuilderAction {
         if (!isEventPage) {
             return 0;
         }
-        const objectIds = this.currentWebsiteUrl.match(/\d+(?![-\w])/);
+        const objectIds = this.currentWebsiteUrl.match(/\d+(?=\/|$)/);
         return parseInt(objectIds[0]) | 0;
     }
 


### PR DESCRIPTION
The website event page extracts the event id from urls that are formatted like "/event/[title]-[id]/" by matching the first number not followed by a word character. Languages like Korean however will have their title percent-encoded like "%EC%82%AC%EC", causing the regex to miss the true ID and return the wrong one.

Steps to Reproduce:

1. Create an event with a Korean title eg "모든 행사".
2. Go to the website view and click on edit.
3. You'll see that the regex grabs a wrong id.

This fix is for adapting this commit https://github.com/odoo/odoo/commit/d16b0a8e303047997a0d4764f55bb7f1c214d47b to the use of plugins over snippets in 18.4 and onwards.

opw-5095411