### PR TITLE
[IMP] web: edit date and datetime fields with operation

### DIFF
--- a/addons/web/static/src/core/datetime/datetimepicker_service.js
+++ b/addons/web/static/src/core/datetime/datetimepicker_service.js
@@ -204,7 +204,10 @@ export const datetimePickerService = {
                  * @param {Event} ev
                  */
                 function onInputChange(ev) {
-                    updateValueFromInputs();
+                    const abort = updateValueFromInputs();
+                    if (abort) {
+                        return;
+                    }
                     inputsChanged[ev.target === getInput(1) ? 1 : 0] = true;
                     if (!isOpen() || inputsChanged.every(Boolean)) {
                         saveAndClose();
@@ -232,7 +235,10 @@ export const datetimePickerService = {
                 function onInputKeydown(ev) {
                     if (ev.key == "Enter" && ev.ctrlKey) {
                         ev.preventDefault();
-                        updateValueFromInputs();
+                        const abort = updateValueFromInputs();
+                        if (abort) {
+                            return;
+                        }
                         return open(ev.target === getInput(1) ? 1 : 0);
                     }
                     switch (ev.key) {
@@ -389,8 +395,15 @@ export const datetimePickerService = {
                 }
 
                 function updateValueFromInputs() {
+                    const inputs = getInputs();
+                    const updated = params.onWillParseValues?.(
+                        inputs.map((input) => input && input.value)
+                    );
+                    if (updated) {
+                        return true;
+                    }
                     const values = zipWith(
-                        getInputs(),
+                        inputs,
                         ensureArray(pickerProps.value),
                         (el, currentValue) => {
                             if (!el || el.tagName?.toLowerCase() !== "input") {
@@ -467,7 +480,10 @@ export const datetimePickerService = {
                 const popover = createPopover(DateTimePickerPopover, {
                     useBottomSheet: isBottomSheet(),
                     async onClose() {
-                        updateValueFromInputs();
+                        const abort = updateValueFromInputs();
+                        if (abort) {
+                            return;
+                        }
                         setFocusClass(null);
                         restoreTargetMargin?.();
                         restoreTargetMargin = null;

--- a/addons/web/static/src/core/l10n/dates.js
+++ b/addons/web/static/src/core/l10n/dates.js
@@ -77,7 +77,7 @@ const normalizeFormatTable = {
     X: "HH:mm:ss",
 };
 
-const smartDateUnits = {
+export const smartDateUnits = {
     d: "days",
     m: "months",
     w: "weeks",
@@ -304,8 +304,7 @@ function parseSmartDateInput(value) {
         const dayname = term.slice(1);
         if (Object.hasOwn(smartWeekdays, dayname) || dayname === "week_start") {
             const { weekStart } = localization;
-            const weekdayNumber =
-                dayname === "week_start" ? weekStart : smartWeekdays[dayname];
+            const weekdayNumber = dayname === "week_start" ? weekStart : smartWeekdays[dayname];
             let weekdayOffset =
                 ((weekdayNumber - weekStart + 7) % 7) - ((now.weekday - weekStart + 7) % 7);
             if (operator == "+" || operator == "-") {

--- a/addons/web/static/src/model/relational_model/operation.js
+++ b/addons/web/static/src/model/relational_model/operation.js
@@ -1,7 +1,95 @@
+import { smartDateUnits } from "@web/core/l10n/dates";
+import { localization } from "@web/core/l10n/localization";
+import { escapeRegExp } from "@web/core/utils/strings";
 export class Operation {
+    static supportedOperators = [];
+    static parse() {}
+    /**
+     * @param {string} operator
+     * @param {*} operand
+     */
     constructor(operator, operand) {
         this.operator = operator;
         this.operand = operand;
+        if (!this.constructor.supportedOperators.includes(this.operator)) {
+            throw new Error(`Operator ${this.operator} not supported on ${this.constructor.name}`);
+        }
+        this.setup();
+    }
+
+    setup() {}
+
+    toString() {
+        return `${this.operator} ${this.operand}`;
+    }
+}
+
+export class DateTimeOperation extends Operation {
+    static supportedOperators = ["+", "-"];
+    static dateTimeUnits = Object.keys(smartDateUnits).join();
+
+    static parse(operation) {
+        if (!operation) {
+            return false;
+        }
+        const regex = new RegExp(
+            `^(?<operator>[+\\-])\\s*=\\s*(?<amount>\\d+)\\s*(?<unit>[${DateTimeOperation.dateTimeUnits}])?$`
+        );
+        const match = operation.match(regex);
+        if (match?.groups) {
+            const amount = match.groups.amount;
+            const unit = match.groups.unit || "d";
+            const operand = {
+                amount: parseInt(amount, 10),
+                unit,
+            };
+            const operator = match.groups.operator;
+            return new DateTimeOperation(operator, operand);
+        }
+        return false;
+    }
+
+    setup() {
+        this.amount = this.operand.amount;
+        this.unit = this.operand.unit;
+        this.luxonUnit = smartDateUnits[this.unit];
+    }
+
+    compute(value) {
+        if (!value) {
+            return;
+        }
+        const delta = { [this.luxonUnit]: this.amount };
+        return this.operator === "+" ? value.plus(delta) : value.minus(delta);
+    }
+
+    toString() {
+        return `${this.operator} ${this.amount} ${this.luxonUnit}`;
+    }
+}
+
+export class ArithmeticOperation extends Operation {
+    static supportedOperators = ["+", "-", "/", "*"];
+
+    static parse(operation, parseValueFn) {
+        if (!operation) {
+            return false;
+        }
+        if (typeof parseValueFn !== "function") {
+            return false;
+        }
+        const regex = new RegExp(
+            `^(?<operator>[+\\-*/])\\s*=\\s*(?<operand>-?\\d+(?:[${escapeRegExp(
+                localization.decimalPoint
+            )}]\\d+)?)$`
+        );
+        const match = operation.match(regex);
+        if (match?.groups) {
+            const operand = parseValueFn(match.groups.operand);
+            const operator = match.groups.operator;
+            return new ArithmeticOperation(operator, operand);
+        }
+        return false;
     }
 
     compute(value) {

--- a/addons/web/static/src/views/fields/datetime/datetime_field.js
+++ b/addons/web/static/src/views/fields/datetime/datetime_field.js
@@ -9,6 +9,7 @@ import { exprToBoolean } from "@web/core/utils/strings";
 import { FIELD_WIDTHS } from "@web/views/list/column_width_hook";
 import { formatDate, formatDateTime } from "../formatters";
 import { standardFieldProps } from "../standard_field_props";
+import { DateTimeOperation } from "@web/model/relational_model/operation";
 
 const { DateTime } = luxon;
 
@@ -168,6 +169,21 @@ export class DateTimeField extends Component {
             },
             onChange: () => {
                 this.state.range = this.isRange(this.state.value);
+            },
+            onWillParseValues: (values) => {
+                const parsedValues = values.map((value) => DateTimeOperation.parse(value));
+                const toUpdate = {};
+                if (parsedValues[0]) {
+                    toUpdate[this.startDateField] = parsedValues[0];
+                }
+                if (parsedValues[1]) {
+                    toUpdate[this.endDateField] = parsedValues[1];
+                }
+                if (Object.keys(toUpdate).length) {
+                    this.props.record.update(toUpdate);
+                    return true;
+                }
+                return false;
             },
             onClose: () => {
                 this.picker.activeInput = "";

--- a/addons/web/static/src/views/fields/parsers.js
+++ b/addons/web/static/src/views/fields/parsers.js
@@ -3,7 +3,7 @@ import { localization } from "@web/core/l10n/localization";
 import { evaluateExpr } from "@web/core/py_js/py";
 import { registry } from "@web/core/registry";
 import { escapeRegExp } from "@web/core/utils/strings";
-import { Operation } from "@web/model/relational_model/operation";
+import { ArithmeticOperation } from "@web/model/relational_model/operation";
 
 // -----------------------------------------------------------------------------
 // Helpers
@@ -24,21 +24,6 @@ function evaluateMathematicalExpression(expr, context = {}) {
         safeEvalString += v;
     }
     return evaluateExpr(safeEvalString, context);
-}
-
-function parseOperation(value, parseValueFn) {
-    const regex = new RegExp(
-        `^(?<operator>[+\\-*/])\\s*=\\s*(?<operand>-?\\d+(?:[${escapeRegExp(
-            localization.decimalPoint
-        )}]\\d+)?)$`
-    );
-    const match = value.match(regex);
-    if (match?.groups) {
-        const operand = parseValueFn(match.groups.operand);
-        const operator = match.groups.operator;
-        return new Operation(operator, operand);
-    }
-    return false;
 }
 
 /**
@@ -86,8 +71,8 @@ export class InvalidNumberError extends Error {}
  * @returns {number} a float
  */
 export function parseFloat(value, { allowOperation = false } = {}) {
-    const operation = allowOperation ? parseOperation(value, parseFloat) : null;
-    if (operation instanceof Operation) {
+    const operation = allowOperation ? ArithmeticOperation.parse(value, parseFloat) : null;
+    if (operation) {
         return operation;
     }
     const thousandsSepRegex = localization.thousandsSep || "";
@@ -140,8 +125,8 @@ export function parseFloatTime(value) {
  * @returns {number} an integer
  */
 export function parseInteger(value, { allowOperation = false } = {}) {
-    const operation = allowOperation ? parseOperation(value, parseInteger) : null;
-    if (operation instanceof Operation) {
+    const operation = allowOperation ? ArithmeticOperation.parse(value, parseInteger) : null;
+    if (operation) {
         return operation;
     }
     const thousandsSepRegex = localization.thousandsSep || "";
@@ -198,8 +183,8 @@ export function parsePercentage(value) {
  * @returns {number}
  */
 export function parseMonetary(value, { allowOperation = false } = {}) {
-    const operation = allowOperation ? parseOperation(value, parseMonetary) : null;
-    if (operation instanceof Operation) {
+    const operation = allowOperation ? ArithmeticOperation.parse(value, parseMonetary) : null;
+    if (operation) {
         return operation;
     }
     value = value.trim();

--- a/addons/web/static/src/views/list/list_confirmation_dialog.xml
+++ b/addons/web/static/src/views/list/list_confirmation_dialog.xml
@@ -47,7 +47,7 @@
                                     <td style="pointer-events: none;">
                                         <span t-if="isValueEmpty(field)">None</span>
                                         <span t-elif="isValueOperation(field)" t-att-name="field.name">
-                                            <t t-out="field.label + ' ' + props.changes[field.name].operator + ' ' + props.changes[field.name].operand"></t>
+                                            <t t-out="field.label"></t> <t t-esc="props.changes[field.name]"></t>
                                         </span>
                                         <Field t-else="" name="field.name" record="props.record" type="field.widget" readonly="true" fieldInfo="field.fieldNode"/>
                                     </td>
@@ -58,8 +58,14 @@
                     <div t-if="showTip" class="alert alert-info d-flex align-items-center mt-3">
                         <i class="fa fa-lightbulb-o fa-lg me-4"></i>
                         <div class="text-muted">
-                            <div>Use the operators "+=", "-=", "*=" and "/=" to update the current value.</div>
-                            <div>For example, if the value is "1" and you enter "+=2", it will be updated to "3".</div>
+                            <t t-if="showNumberTip">
+                                <div>Use the operators "+=", "-=", "*=" and "/=" to update the current value.</div>
+                                <div>For example, if the value is "1" and you enter "+=2", it will be updated to "3".</div>
+                            </t>
+                            <t t-elif="showDateTip">
+                                <div t-esc="dateTip"/>
+                                <div t-esc="dateTipExample"/>
+                            </t>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
This commit introduces support for applying relative date/time
operations on datetime field.
With this feature, a record can be updated according to a specified
operation.
The operation should be like :
[operator]=[amount][unit]
with:
operator: - | +
amount: integer
unit: d (days), w (weeks), m (months), y (years)
    H (hours), M (minutes), S (seconds)

task~5156124