### PR TITLE
[FIX] spreadsheet: crash on freeze & share with boolean global filter

### DIFF
--- a/addons/spreadsheet/static/src/global_filters/plugins/global_filters_core_view_plugin.js
+++ b/addons/spreadsheet/static/src/global_filters/plugins/global_filters_core_view_plugin.js
@@ -246,7 +246,7 @@ export class GlobalFiltersCoreViewPlugin extends OdooCoreViewPlugin {
         const value = this.getGlobalFilterValue(filter.id);
         switch (filter.type) {
             case "boolean":
-                return [[{ value: value.length ? value.join(", ") : "" }]];
+                return [[{ value: value?.length ? value.join(", ") : "" }]];
             case "text":
                 return [[{ value: value || "" }]];
             case "date": {

--- a/addons/spreadsheet/static/tests/global_filters/global_filters_model.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/global_filters_model.test.js
@@ -1551,6 +1551,22 @@ test("Export from/to global filters for excel", async function () {
     expect(getCell(exportedModel, "C2", sheetId).format).toBe("m/d/yyyy");
 });
 
+test("Export boolean global filters with undefined value for excel", async function () {
+    const { model } = await createSpreadsheetWithPivotAndList();
+    await addGlobalFilter(model, { id: "42", label: "test", type: "boolean" });
+    const filterPlugin = model["handlers"].find(
+        (handler) => handler instanceof GlobalFiltersCoreViewPlugin
+    );
+    const exportData = { styles: [], sheets: [] };
+    filterPlugin.exportForExcel(exportData);
+    const filterSheet = exportData.sheets[0];
+    expect(filterSheet.cells["A1"]).toBe("Filter");
+    expect(filterSheet.cells["A2"]).toBe("test");
+    expect(filterSheet.cells["B1"]).toBe("Value");
+    expect(filterSheet.cells["B2"]).toBe("");
+    model.exportXLSX(); // should not crash
+});
+
 test("Date filter automatic default value for years filter", async function () {
     const label = "This year";
     const { model } = await createSpreadsheetWithPivot();


### PR DESCRIPTION
The method `getFilterDisplayValue` would not handled `undefined` values for boolean global filters, causing crashes when exporting to Excel.

Task: [5188932](https://www.odoo.com/web#id=5188932&cids=1&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
