### PR TITLE
[FIX] web: Hoot - fix early manual run

### DIFF
--- a/addons/web/static/lib/hoot/core/runner.js
+++ b/addons/web/static/lib/hoot/core/runner.js
@@ -841,6 +841,7 @@ export class Runner {
     }
 
     manualStart() {
+        this._canStartDef ||= Promise.withResolvers();
         this._canStartDef.resolve(true);
     }
 
@@ -1880,7 +1881,7 @@ export class Runner {
     async _setupStart() {
         this._startTime = $now();
         if (this.config.manual) {
-            this._canStartDef = Promise.withResolvers();
+            this._canStartDef ||= Promise.withResolvers();
         }
 
         // Config log


### PR DESCRIPTION
Before this commit, in manual mode, "Run" could be clicked before the assets finished loading (and so, before the test runner was properly "ready"). This caused a crash because it tried to resolve a promise that did not exist yet.

Steps to reproduce:
- Go to test URL (manual)
- Click "Run" as soon as the button is visible (probably via a script to make sure the click is fast enough)

This commit fixes that by adding failsafes around that promise, effecitvely allowing to click "Run" early on.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
