### PR TITLE
[IMP] stock, product{,_barcodelookup}: allow the user to disable the barcodelookup

### DIFF
--- a/addons/product/models/res_config_settings.py
+++ b/addons/product/models/res_config_settings.py
@@ -9,6 +9,7 @@ class ResConfigSettings(models.TransientModel):
     group_uom = fields.Boolean("Units of Measure & Packagings", implied_group='uom.group_uom')
     group_product_variant = fields.Boolean("Variants", implied_group='product.group_product_variant')
     module_loyalty = fields.Boolean("Promotions, Coupons, Gift Card & Loyalty Program")
+    module_product_barcodelookup = fields.Boolean("Barcode Database")
     group_product_pricelist = fields.Boolean("Pricelists",
         implied_group='product.group_product_pricelist')
     product_weight_in_lbs = fields.Selection([

--- a/addons/product/views/res_config_settings_views.xml
+++ b/addons/product/views/res_config_settings_views.xml
@@ -15,6 +15,14 @@
                         </setting>
                     </block>
                 </xpath>
+                <setting id="module_auth_oauth" position="after">
+                    <setting id="process_barcode_lookup_setting" string="Barcode Database" documentation="https://www.barcodelookup.com/api-documentation">
+                        <field name="module_product_barcodelookup" widget="upgrade_boolean"/>
+                        <span id="barcodelookup_description" class="text-muted">
+                            Create products by scanning using <a href="https://www.barcodelookup.com" target="_blank">barcodelookup.com</a>
+                        </span>
+                    </setting>
+                </setting>
             </field>
         </record>
 </odoo>

--- a/addons/stock/models/res_config_settings.py
+++ b/addons/stock/models/res_config_settings.py
@@ -84,6 +84,16 @@ class ResConfigSettings(models.TransientModel):
         if self.stock_text_confirmation and self.stock_confirmation_type == 'sms':
             self.module_stock_sms = True
 
+    @api.onchange('module_product_barcodelookup')
+    def onchange_module_product_barcodelookup(self):
+        if not self.module_product_barcodelookup:
+            self.module_stock_barcode_barcodelookup = False
+
+    @api.onchange('module_stock_barcode_barcodelookup')
+    def onchange_module_stock_barcode_barcodelookup(self):
+        if self.module_stock_barcode_barcodelookup:
+            self.module_product_barcodelookup = True
+
     @api.onchange('group_stock_adv_location')
     def onchange_adv_location(self):
         if self.group_stock_adv_location and not self.group_stock_multi_locations:

--- a/addons/stock/views/res_config_settings_views.xml
+++ b/addons/stock/views/res_config_settings_views.xml
@@ -48,7 +48,7 @@
                                 <field name="module_stock_barcode" widget="upgrade_boolean"/>
                             </setting>
                             <setting id="process_stock_barcodelookup" string="Stock Barcode Database" help="" documentation="https://www.barcodelookup.com/api-documentation">
-                                <field name="module_stock_barcode_barcodelookup" placeholder="e.g. d7vctmiv2rwgenebha8bxq7irooudn"/>
+                                <field name="module_stock_barcode_barcodelookup" widget="upgrade_boolean"/>
                                 <span class="text-muted">
                                     Create products easily by scanning using <a href="https://www.barcodelookup.com" target="_blank">barcodelookup.com</a> in barcode.
                                 </span>


### PR DESCRIPTION
### Issue:

Currently, the `product_barcodelookup` feature is disabled only when no API key is configured:
https://github.com/odoo/enterprise/blob/86937d9c974125d60f6e2e9dc6bf0b048e20e489/product_barcodelookup/models/product_template.py#L199-L203 https://github.com/odoo/enterprise/blob/86937d9c974125d60f6e2e9dc6bf0b048e20e489/product_barcodelookup/tools/barcode_lookup_service.py#L7-L11 
However, for SaaS users, the API key is hardcoded, which makes it impossible to disable the feature without uninstalling the module.

### Improvement:

The purpose of this commit is to add a boolean setting that allows users to explicitly disable the barcode lookup feature by proposing to uninstall the module for them.

Enterprise: https://github.com/odoo/enterprise/pull/97936

opw-5096468
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
