### PR TITLE
[IMP] account_edi_ubl_cii: use code ZZZ instead of 30 if no bank

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -156,7 +156,14 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         return vals
 
     def _get_invoice_payment_means_vals_list(self, invoice):
-        payment_means_code, payment_means_name = (30, 'credit transfer') if invoice.move_type == 'out_invoice' else (57, 'standing agreement')
+        if invoice.move_type == 'out_invoice':
+            if invoice.partner_bank_id:
+                payment_means_code, payment_means_name = (30, 'credit transfer')
+            else:
+                payment_means_code, payment_means_name = ('ZZZ', 'mutually defined')
+        else:
+            payment_means_code, payment_means_name = (57, 'standing agreement')
+
         # in Denmark payment code 30 is not allowed. we hardcode it to 1 ("unknown") for now
         # as we cannot deduce this information from the invoice
         if invoice.partner_id.country_code == 'DK':


### PR DESCRIPTION
Backport of commit 026743fb2627edeada5ae2a517b64bf05ae921ae .

To generate a valid BIS3 format, if we put 30 - credit transfer as payment means, we need to have a bank account set. If it's not the case, it will raise an error. We improve the usability by changing that code to ZZZ - mutually defined if no bank account is provided to the invoice.

This should improve the onboarding flow when no bank account is set yet.

task-None
