### PR TITLE
[FIX] point_of_sale: ePOS cashdrawer blocked when IoT disconnected

### DIFF
--- a/addons/point_of_sale/static/src/app/hardware_proxy/hardware_proxy_service.js
+++ b/addons/point_of_sale/static/src/app/hardware_proxy/hardware_proxy_service.js
@@ -191,10 +191,11 @@ export class HardwareProxy extends EventBus {
         return this.message("log", { arguments: [...arguments] });
     }
     async openCashbox(action = false) {
+        const isPrinterConnected = ["connected", "init"].includes(this.connectionInfo.status) || this.pos.config.epson_printer_ip;
         if (
             this.pos.config.iface_cashdrawer &&
             this.printer &&
-            ["connected", "init"].includes(this.connectionInfo.status)
+            isPrinterConnected
         ) {
             this.printer.openCashbox();
             if (action) {


### PR DESCRIPTION
Steps to reproduce:
1. Configure a POS to use an ePOS printer with the cashdrawer enabled.
2. Also configure the POS to use an IoT box with a dummy device, e.g. '[Shop] Scale'. The important thing is that the IoT box is not reachable when the POS opens, so the dummy devices work well for this.
3. Open the POS, make an order and go to payment, then click 'Open cashbox'.

Expected behaviour: The cashdrawer opens
Actual behaviour: Nothing happens

task-5059502

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
