### PR TITLE
[FIX] core: fix limit_time_real_cron 0

### DIFF
--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -474,8 +474,7 @@ class ThreadedServer(CommonServer):
                 if getattr(thread, 'start_time', None):
                     thread_execution_time = time.time() - thread.start_time
                     thread_limit_time_real = config['limit_time_real']
-                    if (getattr(thread, 'type', None) == 'cron' and
-                            config['limit_time_real_cron'] and config['limit_time_real_cron'] > 0):
+                    if (getattr(thread, 'type', None) == 'cron' and config['limit_time_real_cron'] >= 0):
                         thread_limit_time_real = config['limit_time_real_cron']
                     if thread_limit_time_real and thread_execution_time > thread_limit_time_real:
                         _logger.warning(


### PR DESCRIPTION
setting limit_time_real_cron to 0 should not limit the cron job time in multi-thread mode.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
