### PR TITLE
[FIX] orm: fix the selection properties not working with `filtered_domain`

### DIFF
--- a/odoo/addons/test_orm/tests/test_properties.py
+++ b/odoo/addons/test_orm/tests/test_properties.py
@@ -1225,6 +1225,35 @@ class PropertiesCase(TestPropertiesMixin):
         self.assertEqual(values.get('name'), 'new_selection')
         self.assertEqual(values.get('selection'), [], 'Selection key should be at least an empty array (never False)')
 
+        self.discussion_1.attributes_definition = [
+            {
+                'name': 'option',
+                'type': 'selection',
+                'selection': [['a', 'Label'], ['b', 'Label'], ['c', 'Label']],
+            },
+        ]
+
+        (self.message_1 | self.message_2 | self.message_3).discussion = self.discussion_1
+        (self.message_1 | self.message_2).attributes = [{
+            'value': 'a',
+            'name': 'option',
+        }]
+        self.message_3.attributes = [{
+            'value': 'b',
+            'name': 'option',
+        }]
+        self.assertEqual(
+            (self.message_1 | self.message_2 | self.message_3)
+            .filtered_domain([('attributes.option', '=', 'b')]),
+             self.message_3)
+        self.assertEqual(
+            (self.message_1 | self.message_2 | self.message_3)
+            .filtered_domain([('attributes.option', '=', 'a')]),
+             self.message_1 | self.message_2)
+        self.assertFalse(
+            (self.message_1 | self.message_2 | self.message_3)
+            .filtered_domain([('attributes.option', '=', 'Label')]))
+
     def test_properties_field_separator(self):
         """Test the separator properties."""
         self.message_1.attributes = [

--- a/odoo/orm/fields_properties.py
+++ b/odoo/orm/fields_properties.py
@@ -642,7 +642,7 @@ class Properties(Field):
             raise ValueError(f"Missing property name for {self}")
 
         def get_property(record):
-            property_value = self.__get__(record)
+            property_value = self.__get__(record.with_context(property_selection_get_key=True))
             value = property_value.get(property_name)
             if value:
                 return value
@@ -828,6 +828,8 @@ class Property(abc.Mapping):
             return self.record.env[prop.get('comodel')].browse(prop.get('value'))
 
         if prop.get('type') == 'selection' and prop.get('value'):
+            if self.record.env.context.get('property_selection_get_key'):
+                return next((sel[0] for sel in prop.get('selection') if sel[0] == prop['value']), False)
             return next((sel[1] for sel in prop.get('selection') if sel[0] == prop['value']), False)
 
         if prop.get('type') == 'tags' and prop.get('value'):


### PR DESCRIPTION
Bug
===
The selection properties is not working with `filtered_domain`.
The reason is that the label is used instead of the random name
(when the getter is used in mail template, we show the label).

So we backport the context key added in https://github.com/odoo/odoo/commit/763d83655f1909038b0fdd237529deb87a63f4da
and we use it for `filtered_domain`.

Task-5188957