### PR TITLE
[FIX] spreadsheet: add missing has_searchable_parent_relation method …

### DIFF
--- a/addons/spreadsheet/models/__init__.py
+++ b/addons/spreadsheet/models/__init__.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import ir_model
 from . import ir_http
 from . import res_currency
 from . import res_currency_rate

--- a/addons/spreadsheet/models/ir_model.py
+++ b/addons/spreadsheet/models/ir_model.py
@@ -1,0 +1,21 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models, api
+
+
+class IrModel(models.Model):
+    _inherit = "ir.model"
+
+    @api.readonly
+    @api.model
+    def has_searchable_parent_relation(self, model_names):
+        result = {}
+        for model_name in model_names:
+            model = self.env.get(model_name)
+            if model is None or not model.has_access("read"):
+                result[model_name] = False
+            else:
+                # we consider only stored parent relationships were meant to
+                # be searched
+                result[model_name] = model._parent_store and model._parent_name in model._fields
+        return result

--- a/addons/spreadsheet/tests/__init__.py
+++ b/addons/spreadsheet/tests/__init__.py
@@ -3,6 +3,7 @@
 from . import test_currency
 from . import test_currency_rate
 from . import test_display_names
+from . import test_ir_model
 from . import test_locale
 from . import test_session_info
 from . import test_utils

--- a/addons/spreadsheet/tests/test_ir_model.py
+++ b/addons/spreadsheet/tests/test_ir_model.py
@@ -1,0 +1,12 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests.common import TransactionCase
+
+
+class SpreadsheetIrModel(TransactionCase):
+
+    def test_has_searchable_parent_not_stored(self):
+        self.assertEqual(self.env['ir.model'].has_searchable_parent_relation(['res.users']), {'res.users': False})
+
+    def test_has_searchable_parent_stored(self):
+        self.assertEqual(self.env['ir.model'].has_searchable_parent_relation(['ir.ui.menu']), {'ir.ui.menu': True})


### PR DESCRIPTION
…in community edition

`has_searchable_parent_relation` is used to manage operators in global filters domains since http://github.com/odoo/odoo/pull/215217.

The method was not moved in community accordingly.

Task-5189262

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
