### PR TITLE
[FIX] mrp: Use work center availability to compute total expected workorder duration

### DIFF
--- a/addons/mrp/tests/test_procurement.py
+++ b/addons/mrp/tests/test_procurement.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from datetime import timedelta
+from freezegun import freeze_time
 
 from odoo import Command, fields
 from odoo.tests import Form
@@ -980,6 +981,7 @@ class TestProcurement(TestMrpCommon):
         self.assertRecordValues(mo.move_raw_ids, expected_vals)
         self.assertRecordValues(mo.picking_ids.move_ids, expected_vals)
 
+    @freeze_time("2025-11-3")
     def test_consecutive_pickings(self):
         """ Test that when we generate several procurements for a product in a raw
             we do not create demand for the same quantities several times """
@@ -1040,17 +1042,17 @@ class TestProcurement(TestMrpCommon):
                     'location_dest_id': self.env.ref('stock.stock_location_customers').id,
                     'name': 'picking move',
                     'product_id': product_1.id,
-                    'product_uom_qty': 15,
+                    'product_uom_qty': 8,
                     'product_uom': self.uom_unit.id,
                 })],
             })
             picking.action_confirm()
             if not mo:
                 mo = self.env['mrp.production'].search([('product_id', '=', product_1.id)])
-            self.assertEqual(delta_hours(mo.date_finished - mo.date_start), i * 15)
+            self.assertEqual(delta_hours(mo.date_finished - mo.date_start), i * 24)
 
         # Check the generated MO
-        self.assertEqual(mo.product_qty, 45)
+        self.assertEqual(mo.product_qty, 24)
 
     def test_update_mo_producing_qty_with_mtso_rule_and_some_available_stock(self):
         """
@@ -1100,3 +1102,4 @@ class TestProcurement(TestMrpCommon):
         })
         update_quantity_wizard.change_prod_qty()
         self.assertEqual(replenishment.product_uom_qty, 7)
+        self.assertEqual(mo.product_qty, 24)


### PR DESCRIPTION
**Issue**
The scheduled end date of a manufacturing order incorrectly assumes that the work center operates 24 hours a day.

**Steps to reproduce**
1. Create a manufacturing order with:
   - A work order with an expected duration of 1440 minutes.
   - A work center configured to work 8 hours per day.
2. Observe that the scheduled end date is computed as if the work center operates 24h/day resulting in an end date 1 day instead of 4 after the starting date.

**Cause**
The [`date_finish` computation](https://github.com/odoo/odoo/blob/680085b55728dcb000e7bb4277bb83b0e4e2ce91/addons/mrp/models/mrp_production.py#L745C1-L746C105)
does not take into account neither the work center’s calendar nor the workorder dependency when estimating the duration.

**Solution**
Use [`_get_first_available_slot`](https://github.com/odoo/odoo/blob/5d75037d4f81d71a50394c3d390c420967766731/addons/mrp/models/mrp_workcenter.py#L332) to consider workcenter availability, inspired from when a [workorder is planned](https://github.com/odoo/odoo/blob/5d75037d4f81d71a50394c3d390c420967766731/addons/mrp/models/mrp_workorder.py#L527) and implements a topological sort to acknoledge the wo dependencies.
**Additionnal note**
- To make the change minimal, if a workcenter of at least one workorder is unavailable, just fallback on the previous computation.
- This commit use assertAlmostEqual for the same reason than https://github.com/odoo/odoo/commit/e6c958ca226bd8ef7e518243c93e40b92b9b5919

opw-5084120