### PR TITLE
[IMP] html_editor: facilitate embedded components insert features

### DIFF
--- a/addons/html_editor/static/src/others/embedded_component_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_component_plugin.js
@@ -2,6 +2,7 @@ import { nodeToTree } from "@html_editor/core/history_plugin";
 import { Plugin } from "@html_editor/plugin";
 import { withSequence } from "@html_editor/utils/resource";
 import { memoize } from "@web/core/utils/functions";
+import { renderToElement } from "@web/core/utils/render";
 
 /**
  * This plugin is responsible with providing the API to manipulate/insert
@@ -10,6 +11,7 @@ import { memoize } from "@web/core/utils/functions";
 export class EmbeddedComponentPlugin extends Plugin {
     static id = "embeddedComponents";
     static dependencies = ["history", "protectedNode", "selection"];
+    static shared = ["renderBlueprintToElement"];
     resources = {
         /** Handlers */
         normalize_handlers: withSequence(0, this.normalize.bind(this)),
@@ -34,6 +36,7 @@ export class EmbeddedComponentPlugin extends Plugin {
         this.app = this.config.embeddedComponentInfo.app;
         this.env = this.config.embeddedComponentInfo.env ?? {};
         this.hostToStateChangeManagerMap = new WeakMap();
+        this.hostToOnComponentInsertedMap = new WeakMap();
         this.embeddedComponents = memoize((embeddedComponents = []) => {
             const result = {};
             for (const embedding of embeddedComponents) {
@@ -190,6 +193,12 @@ export class EmbeddedComponentPlugin extends Plugin {
             fiberComplete.call(fiber);
             this.dispatchTo("post_mount_component_handlers");
         };
+        const onComponentInserted = this.extractOnComponentInserted(host);
+        if (onComponentInserted) {
+            // If a pending operation should be executed after the first mount
+            // of an inserted blueprint, add it as the last `onMounted` callback
+            root.node.mounted.push(onComponentInserted);
+        }
         const info = {
             root,
             host,
@@ -263,6 +272,29 @@ export class EmbeddedComponentPlugin extends Plugin {
                 this.deepDestroyComponent(info);
             }
         }
+    }
+
+    /**
+     * @param {String} template blueprint for the embedded Component
+     * @param {Object} [context] rendering context
+     * @param {Function} [onComponentInserted] function to be executed when
+     *        it is first mounted after it was inserted in the DOM. It will not
+     *        be executed if the blueprint is removed from the DOM before the
+     *        first mount nor if the component is mounted again afterwards.
+     * @returns {HTMLElement} host
+     */
+    renderBlueprintToElement(template, context = {}, onComponentInserted = undefined) {
+        const host = renderToElement(template, context);
+        if (onComponentInserted) {
+            this.hostToOnComponentInsertedMap.set(host, onComponentInserted);
+        }
+        return host;
+    }
+
+    extractOnComponentInserted(host) {
+        const onComponentInserted = this.hostToOnComponentInsertedMap.get(host);
+        this.hostToOnComponentInsertedMap.delete(host);
+        return onComponentInserted;
     }
 
     normalize(elem) {

--- a/addons/html_editor/static/src/others/embedded_component_utils.js
+++ b/addons/html_editor/static/src/others/embedded_component_utils.js
@@ -100,9 +100,9 @@ export function useEditableDescendants(host) {
             _restoreSelection = undefined;
         }
     };
-    if (component.env.editorShared?.preserveSelection) {
+    if (component.env.editorShared?.selection) {
         onRendered(() => {
-            _restoreSelection = component.env.editorShared.preserveSelection().restore;
+            _restoreSelection = component.env.editorShared.selection.preserveSelection().restore;
         });
     }
     onMounted(() => {

--- a/addons/html_editor/static/src/others/embedded_components/plugins/embedded_file_plugin/embedded_file_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/embedded_file_plugin/embedded_file_plugin.js
@@ -40,25 +40,23 @@ export class EmbeddedFilePlugin extends FilePlugin {
 
     setupNewFile({ name, env }) {
         if (name === "file") {
-            Object.assign(env, {
-                editorShared: {
-                    setSelectionAfter: (host) => {
-                        try {
-                            const leaf = nextLeaf(host, this.editable);
-                            if (!leaf) {
-                                return;
-                            }
-                            const leafEl = isBlock(leaf) ? leaf : leaf.parentElement;
-                            if (isBlock(leafEl) && leafEl.isContentEditable) {
-                                this.dependencies.selection.setSelection({
-                                    anchorNode: leafEl,
-                                    anchorOffset: 0,
-                                });
-                            }
-                        } catch {
+            Object.assign(env.editorShared, {
+                setSelectionAfter: (host) => {
+                    try {
+                        const leaf = nextLeaf(host, this.editable);
+                        if (!leaf) {
                             return;
                         }
-                    },
+                        const leafEl = isBlock(leaf) ? leaf : leaf.parentElement;
+                        if (isBlock(leafEl) && leafEl.isContentEditable) {
+                            this.dependencies.selection.setSelection({
+                                anchorNode: leafEl,
+                                anchorOffset: 0,
+                            });
+                        }
+                    } catch {
+                        return;
+                    }
                 },
             });
         }

--- a/addons/html_editor/static/src/others/embedded_components/plugins/toggle_block_plugin/toggle_block_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/toggle_block_plugin/toggle_block_plugin.js
@@ -83,7 +83,6 @@ export class ToggleBlockPlugin extends Plugin {
             },
         ],
 
-        mount_component_handlers: this.setupNewToggle.bind(this),
         normalize_handlers: withSequence(Infinity, this.normalize.bind(this)),
 
         delete_backward_overrides: this.handleDeleteBackward.bind(this),
@@ -585,15 +584,5 @@ export class ToggleBlockPlugin extends Plugin {
             selection.isCollapsed &&
             !closestElement(selection.anchorNode, `${toggleSelector} ${titleSelector}`)
         );
-    }
-
-    setupNewToggle({ name, env }) {
-        if (name === "toggleBlock") {
-            Object.assign(env, {
-                editorShared: {
-                    preserveSelection: this.dependencies.selection.preserveSelection,
-                },
-            });
-        }
     }
 }


### PR DESCRIPTION
### Automatically preserve selection in editable descendants

Prior to this work, to make use of the automatic selection restoration feature
hidden in `useEditableDescendants` hook for editable descendants of embedded
components, one had to define a new env property: `editorShared` and populate it
with the selection plugin shared functions. This process was pretty obscure and
is always the same, therefore it makes a lot more sense to automatically
populate the `env` with the selection shared functions.

This work refines the concept of `env.editorShared`: it is now always present
in the `env` of embedded components that are inside an editor, and can be
populated using the `mount_component_handlers` resource. The idea is that a
plugin can assign some of its dependencies in that shared Object for its related
embedded components.

Embedded components using editable descendants will now always have the
`selection` plugin shared functions in `env.editorShared.selection`.

### Introduce renderBlueprintToElement
Prior to this work, it was pretty difficult to execute an operation in a
Plugin related to an embedded Component after inserting the blueprint, because
the Plugin has no way of knowing when the embedded component finishes its async
mount operation.

This work introduces a new shared function `renderBlueprintToElement`, which
allows one to define a callback (associated with the rendered blueprint) which
will be executed after the first mount of its related embedded component when it
was just inserted in the DOM. That function will not be executed if the
blueprint is removed from the DOM before the first mount nor if the component is
mounted again afterwards.

task-5189453