### PR TITLE
[FIX] website: fix issue of infinite loading when adding image to grid

### DIFF
--- a/addons/website/static/src/builder/plugins/layout_option/add_element_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/layout_option/add_element_option_plugin.js
@@ -3,6 +3,7 @@ import { resizeGrid, setElementToMaxZindex } from "@html_builder/utils/grid_layo
 import { Plugin } from "@html_editor/plugin";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
+import { onceAllImagesLoaded } from "@website/utils/images";
 
 export class AddElementOptionPlugin extends Plugin {
     static id = "addElementOption";
@@ -88,25 +89,17 @@ export class AddGridElementAction extends BuilderAction {
     async apply({ editingElement: rowEl, params: { mainParam: elementType } }) {
         if (elementType === "image") {
             // Choose an image with the media dialog.
-            let imageEl, imageLoadedPromise;
-            await new Promise((resolve) => {
-                const onClose = this.dependencies.media.openMediaDialog({
-                    onlyImages: true,
-                    noDocuments: true,
-                    save: (selectedImageEl) => {
-                        imageEl = selectedImageEl;
-                        imageLoadedPromise = new Promise((resolve) => {
-                            imageEl.addEventListener("load", () => resolve(), { once: true });
-                        });
-                    },
-                });
-                onClose.then(resolve);
+            let imageEl;
+            await this.dependencies.media.openMediaDialog({
+                onlyImages: true,
+                noDocuments: true,
+                save: (selectedImageEl) => (imageEl = selectedImageEl),
             });
             if (!imageEl) {
                 return;
             }
             // Wait for the image to be loaded.
-            await imageLoadedPromise;
+            await onceAllImagesLoaded(imageEl);
             this.dependencies.addElementOption.addGridElement(rowEl, imageEl, 6, 6, [
                 "o_grid_item_image",
             ]);

--- a/addons/website/static/src/utils/images.js
+++ b/addons/website/static/src/utils/images.js
@@ -12,8 +12,9 @@ export function onceAllImagesLoaded(element) {
         if (imgEl.complete) {
             return; // Already loaded
         }
-        return new Promise((resolve) => {
+        return new Promise((resolve, reject) => {
             imgEl.addEventListener("load", resolve, { once: true });
+            imgEl.addEventListener("error", reject, { once: true });
         });
     });
     return Promise.all(defs);

--- a/addons/website/static/tests/builder/grid_layout.test.js
+++ b/addons/website/static/tests/builder/grid_layout.test.js
@@ -1,7 +1,8 @@
-import { expect, test } from "@odoo/hoot";
-import { contains } from "@web/../tests/web_test_helpers";
-import { defineWebsiteModels, setupWebsiteBuilder } from "./website_helpers";
+import { expect, test, tick, waitFor, waitUntil } from "@odoo/hoot";
+import { contains, onRpc } from "@web/../tests/web_test_helpers";
+import { addPlugin, defineWebsiteModels, setupWebsiteBuilder } from "./website_helpers";
 import { getDragHelper, waitForEndOfOperation } from "@html_builder/../tests/helpers";
+import { Plugin } from "@html_editor/plugin";
 
 defineWebsiteModels();
 
@@ -75,4 +76,38 @@ test("Drag & drop an inner snippet inside a grid item should adjust its height o
     expect(":iframe .btn").toHaveCount(1);
     expect(":iframe .o_grid_item").toHaveClass("g-height-3");
     expect(":iframe .o_grid_mode").toHaveAttribute("data-row-count", "3");
+});
+
+test("Add an image to a grid", async () => {
+    onRpc("ir.attachment", "generate_access_token", () => "dummy-token");
+    onRpc("ir.attachment", "search_read", () => [
+        { image_src: "/website/static/src/img/snippets_demo/s_text_image.jpg" },
+    ]);
+    addPlugin(
+        class extends Plugin {
+            static id = "test";
+            resources = {
+                on_media_dialog_saved_handlers: (el) => waitUntil(() => el[0].complete).then(tick),
+            };
+        }
+    );
+    await setupWebsiteBuilder(
+        `
+        <section>
+            <div class="container">
+                <div class="row o_grid_mode" data-row-count="1">
+                    <div class="o_grid_item g-height-1 g-col-lg-7 col-lg-7" style="grid-area: 1 / 1 / 2 / 8; z-index: 1;">
+                        <p style="height: 50px;">TEST</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+    `
+    );
+    await contains(":iframe .o_grid_mode").click();
+    await contains("button[data-action-id=addGridElement][data-action-param=image]").click();
+    await contains(".o_we_attachment_highlight").click();
+
+    await waitFor(":iframe .o_grid_mode .o_grid_item img");
+    expect(":iframe .o_grid_mode .o_grid_item img").toHaveCount(1);
 });


### PR DESCRIPTION
The action for adding an image was waiting on the  `load` event on the image, but it may have already occurred, thus the promise would never resolve.

With this commit, we do not wait if the img is already `complete`.

Steps to reproduce (non-deterministic):
- Open website builder
- Click on a grid element (for example a "Banner" snippet)
- Click on "Image" in "Add Elements" option
- Add an image (it seems more likely to trigger the bug with a gif)
- Bug: The dialog closes, and an infinite load follows

task-5187071
opw-5167545