### PR TITLE
[FIX] account_edi_ubl_cii: fix empty child name in e-invoice docs

### DIFF
--- a/addons/account_edi_ubl_cii/data/cii_22_templates.xml
+++ b/addons/account_edi_ubl_cii/data/cii_22_templates.xml
@@ -107,7 +107,7 @@
                 xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100"
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
                 <!-- Contact. -->
-                <ram:Name t-out="partner.display_name"/>
+                <ram:Name t-out="partner.display_name if partner.name else partner.commercial_partner_id.display_name"/>
                 <ram:SpecifiedLegalOrganization t-if="specified_legal_organization_val">
                     <ram:ID t-att-schemeID="str('0002')"
                             t-out="specified_legal_organization_val"/>

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -147,7 +147,7 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         return {
             'partner': partner,
             'party_identification_vals': self.with_context(ubl_partner_role=role)._get_partner_party_identification_vals_list(partner.commercial_partner_id),
-            'party_name_vals': [{'name': partner.display_name}],
+            'party_name_vals': [{'name': partner.display_name if partner.name else partner.commercial_partner_id.display_name}],
             'postal_address_vals': self._get_partner_address_vals(partner),
             'party_tax_scheme_vals': self._get_partner_party_tax_scheme_vals_list(partner.commercial_partner_id, role),
             'party_legal_entity_vals': self._get_partner_party_legal_entity_vals_list(partner.commercial_partner_id),


### PR DESCRIPTION
**Steps to reproduce:**
- Install Contacts, Accounting and l10n_de
- Switch to a German company (e.g. DE Company)

- Go to Contacts
- Create a German contact with "XRechnung CIUS" as electronic format
- For this contact, create an "Invoice Address" without "Contact Name"

- Create an invoice with the invoice address as customer
- Confirm the invoice
- Generate "XRechnung" via "Send & Print" button

**Issue:**
In the generated ULB XML and in factur-x.xml file embedded in the PDF, the customer name contains the mention "Invoice Address", which doesn't appear on the PDF of the invoice.

**Cause:**
The used invoice address has no name, so its "display_name" is build from the name of the parent contact and the type of the child contact (i.e. Invoice Address).

**Solution:**
Only use "display_name" of a contact if "name" is set. Otherwise fall back on "display_name" of the commercial partner.

opw-5159291




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
