### PR TITLE
[FIX] point_of_sale: undefined user_id opening session w/ different user

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -163,6 +163,7 @@ class PosSession(models.Model):
         data[0]['_has_cash_move_perm'] = self.env.user.has_group('account.group_account_invoice')
         data[0]['_has_available_products'] = self._pos_has_valid_product()
         data[0]['_pos_special_products_ids'] = self.env['pos.config']._get_special_products().ids
+        data[0]['user_id'] = self.env.uid
         return {
             'data': data,
             'fields': fields


### PR DESCRIPTION
This commit fixes an undefined `user_id` on the pos session when trying to start a payment with a Six terminal from another user than the one that started the session.

Before this commit:

- open a pos session with Mitchell Admin,
- check the value of `pos.session.user_id` (it will be `2`),
- open another tab and connect as Marc Demo,
- check the value of `pos.session.user_id` again: it should be `6`, but instead is `undefined`.

After this commit:

`pos.session.user_id` is set to the right `user_id` while loading pos data.

opw-5055977