### PR TITLE
[FIX] account: invalid literal for int() with base 10: ''

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1074,7 +1074,7 @@ class AccountMoveLine(models.Model):
             if line.display_type == 'product' or not line.move_id.is_invoice(include_receipts=True):
                 related_distribution = line._related_analytic_distribution()
                 root_plans = self.env['account.analytic.account'].browse(
-                    list({int(account_id) for ids in related_distribution for account_id in ids.split(',')})
+                    list({int(account_id) for ids in related_distribution for account_id in ids.split(',') if account_id.strip()})
                 ).exists().root_plan_id
 
                 arguments = frozendict(line._get_analytic_distribution_arguments(root_plans))

--- a/doc/cla/individual/amriwicahyo.md
+++ b/doc/cla/individual/amriwicahyo.md
@@ -1,0 +1,15 @@
+Indonesia, 2025-10-23
+
+Falinwa Group agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Amri Wicahyo <amriwicahyo95@gmail.com> https://github.com/amriwicahyo
+
+List of contributors:
+
+Amri Wicahyo <amriwicahyo95@gmail.com> https://github.com/amriwicahyo


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
ValueError: invalid literal for int() with base 10: ''
Current behavior before PR:
ValueError: invalid literal for int() with base 10: ''
Desired behavior after PR is merged:
not giving valueerror



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
