### PR TITLE
[FIX] point_of_sale: adjust ePos test widget layout in settings views

### DIFF
--- a/addons/point_of_sale/views/pos_config_view.xml
+++ b/addons/point_of_sale/views/pos_config_view.xml
@@ -53,12 +53,12 @@
                         <setting id="other_devices" string="ePos Printer" help="Connect device to your PoS without an IoT Box">
                             <field name="other_devices" />
                             <div class="content-group" invisible="not other_devices">
-                                <div class="row">
+                                <div class="row mb-2">
                                     <div class="col-lg-6">
-                                        <field name="epson_printer_ip" placeholder="Epson Receipt Printer IP Address" />
+                                        <field name="epson_printer_ip" placeholder="Epson Receipt Printer IP Address" class="w-100 pt-1" />
                                     </div>
                                     <div class="col-lg-6">
-                                        <widget name="point_of_sale_test_epos"/>
+                                        <widget name="point_of_sale_test_epos" />
                                     </div>
                                 </div>
                                 <div class="row" invisible="epson_printer_ip in [False, '']">

--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -394,14 +394,16 @@
                                     <field name="pos_other_devices"/>
                                     <div class="row" invisible="not pos_other_devices">
                                         <div class="col-lg-6">
-                                            <field name="pos_epson_printer_ip" placeholder="Epson Receipt Printer IP Address" />
+                                            <field name="pos_epson_printer_ip" placeholder="Epson Receipt Printer IP Address" class="w-100 pt-1" />
                                         </div>
                                         <div class="col-lg-6">
-                                            <widget name="point_of_sale_test_epos"/>
+                                            <widget name="point_of_sale_test_epos" />
                                         </div>
-                                        <div class="row" invisible="pos_epson_printer_ip in [False, '']">
-                                            <label string="Link Cashdrawer" for="pos_iface_cashdrawer" class="col-lg-3 o_light_label"/>
-                                            <field name="pos_iface_cashdrawer"/>
+                                        <div class="col-12 mt-2">
+                                            <div class="row" invisible="pos_epson_printer_ip in [False, '']">
+                                                <label string="Link Cashdrawer" for="pos_iface_cashdrawer" class="col-lg-4 o_light_label"/>
+                                                <field name="pos_iface_cashdrawer" class="col" />
+                                            </div>
                                         </div>
                                     </div>
                                     <div role="alert" class="alert alert-warning" invisible="not pos_iface_print_via_proxy or not pos_other_devices or pos_epson_printer_ip in [False, '']">


### PR DESCRIPTION
- Adjust the display of the ePos test widget and Epson printer IP field in the Point of Sale configuration and settings views for better alignment and spacing.

| View      | Before | After     |
| :---        |    :----:   |          ---: |
| pos_config_view.xml      | <img width="406" height="151" alt="image" src="https://github.com/user-attachments/assets/e2b6f619-62e7-44d8-928b-53ce5401d9a7" />    | <img width="403" height="184" alt="image" src="https://github.com/user-attachments/assets/96a0137d-cc56-4b2e-a322-811e5ad4b130" />  |
| res_config_settings_views   | <img width="535" height="249" alt="image" src="https://github.com/user-attachments/assets/679a1fce-45f3-4378-96bb-077d8cdef2e1" />        | <img width="535" height="218" alt="image" src="https://github.com/user-attachments/assets/efd62f18-a3fc-45f2-9ca2-4132a6b1a1df" />      |

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
