### PR TITLE
[FIX] point_of_sale: allow searching product with dynamic attribute

### DIFF
--- a/addons/point_of_sale/static/src/app/models/product_template.js
+++ b/addons/point_of_sale/static/src/app/models/product_template.js
@@ -310,5 +310,13 @@ export class ProductTemplate extends Base {
     get canBeDisplayed() {
         return this.active && this.available_in_pos;
     }
+
+    get searchString() {
+        const fields = ["name", "default_code", "barcode"];
+        return fields
+            .map((field) => this[field] || "")
+            .filter(Boolean)
+            .join(" ");
+    }
 }
 registry.category("pos_available_models").add(ProductTemplate.pythonModel, ProductTemplate);

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -2725,10 +2725,12 @@ export class PosStore extends WithLazyGetterTrap {
 
     getProductsBySearchWord(searchWord, products) {
         const words = unaccent(searchWord.toLowerCase(), false);
-        const matches = products.filter((p) =>
-            p.product_variant_ids.some((variant) =>
-                unaccent(variant.searchString, false).toLowerCase().includes(words)
-            )
+        const matches = products.filter(
+            (p) =>
+                unaccent(p.searchString, false).toLowerCase().includes(words) ||
+                p.product_variant_ids.some((variant) =>
+                    unaccent(variant.searchString, false).toLowerCase().includes(words)
+                )
         );
 
         return this.sortByWordIndex(matches, words);

--- a/addons/point_of_sale/static/tests/pos/tours/product_configurator_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_configurator_tour.js
@@ -6,6 +6,7 @@ import * as combo from "@point_of_sale/../tests/pos/tours/utils/combo_popup_util
 import * as Order from "@point_of_sale/../tests/generic_helpers/order_widget_util";
 import { inLeftSide } from "@point_of_sale/../tests/pos/tours/utils/common";
 import { registry } from "@web/core/registry";
+import { negateStep } from "@point_of_sale/../tests/generic_helpers/utils";
 
 registry.category("web_tour.tours").add("ProductConfiguratorTour", {
     steps: () =>
@@ -107,6 +108,10 @@ registry.category("web_tour.tours").add("PosProductWithDynamicAttributes", {
         [
             Chrome.startPoS(),
             Dialog.confirm("Open Register"),
+            ProductScreen.searchProduct("Non Existing Product"),
+            ProductScreen.productIsDisplayed("Dynamic Product").map(negateStep),
+            ProductScreen.searchProduct("Dynamic Product"),
+            ProductScreen.productIsDisplayed("Dynamic Product"),
             ProductScreen.clickDisplayedProduct("Dynamic Product"),
             ProductConfigurator.pickRadio("Test 1"),
             Dialog.confirm(),


### PR DESCRIPTION
Before this commit, it was not possible to search a product that had a dynamic attribute configured on its template, since no product variant was created yet.

opw-5188725

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
