### PR TITLE
[FIX] pos_sale: Manage products paid on ecommerce in the POS

### DIFF
--- a/addons/pos_sale/models/sale_order.py
+++ b/addons/pos_sale/models/sale_order.py
@@ -24,7 +24,7 @@ class SaleOrder(models.Model):
     @api.model
     def _load_pos_data_fields(self, config_id):
         return ['name', 'state', 'user_id', 'order_line', 'partner_id', 'pricelist_id', 'fiscal_position_id', 'amount_total', 'amount_untaxed', 'amount_unpaid',
-            'picking_ids', 'partner_shipping_id', 'partner_invoice_id', 'date_order', 'write_date']
+            'picking_ids', 'partner_shipping_id', 'partner_invoice_id', 'date_order', 'write_date', 'amount_paid']
 
     def _count_pos_order(self):
         for order in self:
@@ -42,12 +42,12 @@ class SaleOrder(models.Model):
             'domain': [('id', 'in', linked_orders.ids)],
         }
 
-    @api.depends('order_line', 'amount_total', 'order_line.invoice_lines.parent_state', 'order_line.invoice_lines.price_total', 'order_line.pos_order_line_ids')
+    @api.depends('transaction_ids.state', 'transaction_ids.amount', 'order_line', 'amount_total', 'order_line.invoice_lines.parent_state', 'order_line.invoice_lines.price_total', 'order_line.pos_order_line_ids')
     def _compute_amount_unpaid(self):
         for sale_order in self:
             total_invoice_paid = sum(sale_order.order_line.filtered(lambda l: not l.display_type).mapped('invoice_lines').filtered(lambda l: l.parent_state != 'cancel').mapped('price_total'))
             total_pos_paid = sum(sale_order.order_line.filtered(lambda l: not l.display_type).mapped('pos_order_line_ids.price_subtotal_incl'))
-            sale_order.amount_unpaid = sale_order.amount_total - (total_invoice_paid + total_pos_paid)
+            sale_order.amount_unpaid = max(sale_order.amount_total - total_invoice_paid - total_pos_paid - sale_order.amount_paid, 0.0)
 
     @api.depends('order_line.pos_order_line_ids')
     def _compute_amount_to_invoice(self):

--- a/addons/pos_sale/static/src/overrides/components/control_buttons/control_buttons.js
+++ b/addons/pos_sale/static/src/overrides/components/control_buttons/control_buttons.js
@@ -10,6 +10,7 @@ patch(ControlButtons.prototype, {
             ["state", "!=", "cancel"],
             ["invoice_status", "!=", "invoiced"],
             ["currency_id", "=", this.pos.currency.id],
+            ["amount_unpaid", ">", 0],
         ];
         if (this.pos.get_order()?.get_partner()) {
             domain = [

--- a/addons/pos_sale/static/src/overrides/models/pos_store.js
+++ b/addons/pos_sale/static/src/overrides/models/pos_store.js
@@ -84,6 +84,13 @@ patch(PosStore.prototype, {
         let userWasAskedAboutLoadedLots = false;
         let previousProductLine = null;
 
+        // Add a down payment for transactions that were already done online
+        if (sale_order.amount_paid > 0) {
+            if (!(await this.loadDownPaymentProduct())) {
+                return;
+            }
+            this.addDownPaymentProductOrderlineToOrder(sale_order, -sale_order.amount_paid, false);
+        }
         const converted_lines = await this.data.call("sale.order.line", "read_converted", [
             sale_order.order_line.map((l) => l.id),
         ]);
@@ -185,17 +192,19 @@ patch(PosStore.prototype, {
             }
         }
     },
+    prepareSoBaseLineForTaxesComputationExtraValues(so, soLine) {
+        const extraValues = { currency_id: so.currency_id || this.company.currency_id };
+        return {
+            ...extraValues,
+            quantity: soLine.product_uom_qty,
+            tax_ids: soLine.tax_ids,
+            partner_id: so.partner_id,
+            product_id: soLine.product_id,
+            extra_tax_data: soLine.extra_tax_data,
+        };
+    },
     async downPaymentSO(sale_order, isPercentage) {
-        if (!this.config.down_payment_product_id && this.config.raw.down_payment_product_id) {
-            await this.data.read("product.product", [this.config.raw.down_payment_product_id]);
-        }
-        if (!this.config.down_payment_product_id) {
-            this.dialog.add(AlertDialog, {
-                title: _t("No down payment product"),
-                body: _t(
-                    "It seems that you didn't configure a down payment product in your point of sale. You can go to your point of sale configuration to choose one."
-                ),
-            });
+        if (!(await this.loadDownPaymentProduct())) {
             return;
         }
         const payload = await makeAwaitable(this.dialog, NumberPopup, {
@@ -216,8 +225,27 @@ patch(PosStore.prototype, {
         if (!payload) {
             return;
         }
-        const userValue = parseFloat(payload);
-        let proposed_down_payment = userValue;
+
+        const amount = parseFloat(payload);
+        this.addDownPaymentProductOrderlineToOrder(sale_order, amount, isPercentage);
+    },
+    async loadDownPaymentProduct() {
+        if (!this.config.down_payment_product_id && this.config.raw.down_payment_product_id) {
+            await this.data.read("product.product", [this.config.raw.down_payment_product_id]);
+        }
+        if (!this.config.down_payment_product_id) {
+            this.dialog.add(AlertDialog, {
+                title: _t("No down payment product"),
+                body: _t(
+                    "It seems that you didn't configure a down payment product in your point of sale. You can go to your point of sale configuration to choose one."
+                ),
+            });
+            return false;
+        }
+        return true;
+    },
+    addDownPaymentProductOrderlineToOrder(sale_order, amount, isPercentage) {
+        let proposed_down_payment = amount;
         if (isPercentage) {
             const down_payment_tax = this.models["account.tax"].get(
                 this.config.down_payment_product_id.taxes_id
@@ -226,7 +254,7 @@ patch(PosStore.prototype, {
                 !down_payment_tax || down_payment_tax.price_include
                     ? sale_order.amount_unpaid
                     : sale_order.amount_untaxed;
-            proposed_down_payment = (percentageBase * userValue) / 100;
+            proposed_down_payment = (percentageBase * amount) / 100;
         }
         if (proposed_down_payment > sale_order.amount_unpaid) {
             this.dialog.add(AlertDialog, {
@@ -308,6 +336,16 @@ patch(PosStore.prototype, {
             }
         }
         for (const down_payment_line of down_payment_line_to_create) {
+            const matchedSaleOrderLines = [];
+            for (const line of sale_order.order_line.filter((soLine) => !soLine.display_type)) {
+                if (
+                    !line.product_id ||
+                    line.product_id.id === this.config.down_payment_product_id?.id
+                ) {
+                    continue;
+                }
+                matchedSaleOrderLines.push(line);
+            }
             this.addLineToCurrentOrder({
                 pos: this,
                 order: this.get_order(),
@@ -316,18 +354,12 @@ patch(PosStore.prototype, {
                 price_unit: down_payment_line.price,
                 price_type: "automatic",
                 sale_order_origin_id: sale_order,
-                down_payment_details: down_payment_line.tab
-                    .filter(
-                        (line) =>
-                            line.product_id &&
-                            line.product_id.id !== this.config.down_payment_product_id.id
-                    )
-                    .map((line) => ({
-                        product_name: line.product_id.display_name,
-                        product_uom_qty: line.product_uom_qty,
-                        price_unit: line.price_unit,
-                        total: line.price_total,
-                    })),
+                down_payment_details: matchedSaleOrderLines.map((line) => ({
+                    product_name: line.product_id.display_name,
+                    product_uom_qty: line.product_uom_qty,
+                    price_unit: line.price_unit,
+                    total: line.price_total,
+                })),
                 tax_ids: [["link", ...down_payment_line.tax_ids]],
             });
         }

--- a/addons/pos_sale/static/tests/tours/pos_sale_tour.js
+++ b/addons/pos_sale/static/tests/tours/pos_sale_tour.js
@@ -539,3 +539,23 @@ registry.category("web_tour.tours").add("test_selected_partner_quotation_loading
             ProductScreen.selectedOrderlineHas("Product B", "2.00"),
         ].flat(),
 });
+registry.category("web_tour.tours").add("test_ecommerce_paid_order_is_hidden_in_pos", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("A Test Partner 1"),
+            PosSale.checkOrdersListEmpty(),
+        ].flat(),
+});
+registry.category("web_tour.tours").add("test_ecommerce_unpaid_order_is_shown_in_pos", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("A Test Partner 1"),
+            PosSale.checkOrdersListNotEmpty(),
+        ].flat(),
+});

--- a/addons/pos_sale/static/tests/tours/utils/pos_sale_utils.js
+++ b/addons/pos_sale/static/tests/tours/utils/pos_sale_utils.js
@@ -85,3 +85,13 @@ export function selectedOrderLinesHasLots(productName, lots) {
     const lotSteps = lots.reduce((acc, serial, i) => acc.concat(getSerialStep(i, serial)), []);
     return [...ProductScreen.selectedOrderlineHas(productName), ...lotSteps];
 }
+
+export function checkOrdersListNotEmpty() {
+    return [
+        ...ProductScreen.clickControlButton("Quotation/Order"),
+        {
+            content: "Check that the orders list is not empty",
+            trigger: ".o_data_row",
+        },
+    ];
+}

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -1645,3 +1645,76 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         })
         self.main_pos_config.open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_selected_partner_quotation_loading', login="accountman")
+
+    def test_ecommerce_paid_order_is_hidden_in_pos(self):
+        """
+        Tests that a Sale Order fully paid via a payment.transaction (eCommerce)
+        does not appear in the list of orders fetched by the Point of Sale.
+        """
+        partner_1 = self.env['res.partner'].create({'name': 'A Test Partner 1', 'email': 'test.customer@example.com'})
+        product_a = self.env['product.product'].create({
+            'name': 'Product A',
+            'available_in_pos': True,
+            'lst_price': 10.0,
+        })
+        sale_order = self.env['sale.order'].create({
+            'partner_id': partner_1.id,
+            'order_line': [(0, 0, {
+                'product_id': product_a.id,
+                'product_uom_qty': 2,
+                'price_unit': product_a.lst_price
+            })]
+        })
+        provider = self.env['payment.provider'].create({
+            'name': 'Test',
+        })
+        transaction = self.env['payment.transaction'].create({
+            'provider_id': provider.id,
+            'payment_method_id': self.env.ref('payment.payment_method_unknown').id,
+            'amount': sale_order.amount_total,
+            'currency_id': sale_order.currency_id.id,
+            'partner_id': sale_order.partner_id.id,
+            'sale_order_ids': [(6, 0, [sale_order.id])],
+        })
+        transaction._set_done()
+        sale_order.invalidate_recordset(['transaction_ids'])
+
+        self.assertEqual(
+            sale_order.amount_unpaid, 0.0,
+            "The amount_unpaid for the SO should be 0 after a successful transaction."
+        )
+        self.main_pos_config.open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_ecommerce_paid_order_is_hidden_in_pos', login="accountman")
+
+    def test_ecommerce_unpaid_order_is_shown_in_pos(self):
+        """
+        Tests that a Sale Order fully paid via a payment.transaction (eCommerce)
+        does not appear in the list of orders fetched by the Point of Sale.
+        """
+        partner_1 = self.env['res.partner'].create({'name': 'A Test Partner 1', 'email': 'test.customer@example.com'})
+        product_a = self.env['product.product'].create({
+            'name': 'Product A',
+            'available_in_pos': True,
+            'lst_price': 10.0,
+        })
+        sale_order = self.env['sale.order'].create({
+            'partner_id': partner_1.id,
+            'order_line': [(0, 0, {
+                'product_id': product_a.id,
+                'product_uom_qty': 2,
+                'price_unit': product_a.lst_price
+            })]
+        })
+        sale_order = self.env['sale.order'].create({
+            'partner_id': partner_1.id,
+            'order_line': [(0, 0, {
+                'product_id': product_a.id,
+                'product_uom_qty': 2,
+                'price_unit': product_a.lst_price
+            })]
+        })
+        self.assertEqual(
+            sale_order.amount_unpaid, sale_order.amount_total,
+            "The amount_unpaid for the SO should not be 0 if there are no transactions."
+        )
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_ecommerce_unpaid_order_is_shown_in_pos', login="accountman")


### PR DESCRIPTION
Before, if you paid for something on the website with ecommerce, it would create a sale order with a transaction linked to it, but no invoice. So in the POS the order would show up in the Quotation/Order menu, but the POS didn't have any reference on the payment, so you would have to create another duplicate payment.

Now the amount_paid (which is the amount already paid in transactions) is taken into account when calculating what's left to pay in the POS. So anytime you open a sale order in the POS it should create a down payment line for anything already paid on the website (the same as we were already doing for invoices).

Also to avoid double payments, now the sale orders which have been already paid in full, even if they are not invoiced yet, will not show up in the POS. The invoice can still be created normally from the Sale app in Odoo.

Task-5187602
Original Task-5138081

Backport-[#230809](https://github.com/odoo/odoo/pull/230809)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
