### PR TITLE
[FIX] stock_account: avoid traceback acceing stock valuation

### DIFF
--- a/addons/stock_account/static/src/stock_valuation/controller.js
+++ b/addons/stock_account/static/src/stock_valuation/controller.js
@@ -1,5 +1,6 @@
 import { reactive } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
+import { serializeDate } from "@web/core/l10n/dates";
 const { DateTime } = luxon;
 
 
@@ -22,7 +23,7 @@ export class StockValuationReportController {
 
     async loadReportData() {
         const kwargs = {
-            date: this.state.date.toFormat("yyyy-MM-dd"),
+            date: serializeDate(this.state.date),
         };
         const res = await this.orm.call(
             "stock_account.stock.valuation.report",


### PR DESCRIPTION
Steps to reproduce the bug:
- activate Arabic language
- Try to open stock valuation

Traceback is triggered:
raise ValueError("time data %r does not match format %r" % ValueError: time data '٢٠٢٥-١٠-٢٢' does not match format '%Y-%m-%d'

opw-5176859