### PR TITLE
[FIX] sale: keep product line easily editable on draft orders

### DIFF
--- a/addons/sale/static/src/js/sale_product_field.js
+++ b/addons/sale/static/src/js/sale_product_field.js
@@ -67,8 +67,6 @@ export class SaleOrderLineProductField extends ProductLabelSectionAndNoteField {
         this.isInternalUpdate = false;
         this.wasCombo = false;
         let isMounted = false;
-        this.isInternalUpdate = false;
-        this.wasCombo = false;
         useEffect(value => {
             if (!isMounted) {
                 isMounted = true;
@@ -172,7 +170,7 @@ export class SaleOrderLineProductField extends ProductLabelSectionAndNoteField {
         }
         return {
             ...p,
-            canOpen: this.props.canOpen || !this.props.readonly || this.isProductClickable,
+            canOpen: this.props.canOpen && (!this.props.readonly || this.isProductClickable),
             update: (value) => {
                 this.isInternalUpdate = true;
                 this.wasCombo = this.isCombo;

--- a/addons/sale/static/src/js/tours/tour_utils.js
+++ b/addons/sale/static/src/js/tours/tour_utils.js
@@ -62,9 +62,11 @@ function clickSomewhereElse() {
 }
 
 function checkSOLDescriptionContains(productName, text) {
-    // currently must be called after exiting the edit mode on the SOL
-    // TODO in the future: handle edit mode and look directly into the textarea value
-    let trigger = `.o_field_product_label_section_and_note_cell:contains("${productName}")`;
+    // TODO in the future: look directly into the textarea value
+    let trigger = '.o_field_product_label_section_and_note_cell';
+    if (productName) {
+        trigger = `${trigger}:has(:contains("${productName}"), input:value("${productName}"))`;
+    }
     if (text) {
         trigger = `${trigger} textarea`;
     }


### PR DESCRIPTION
Versions
--------
- saas-18.3+

Steps
-----
1. Create a sales order;
2. add a product that doesn't have an extra description;
3. save & exit view;
4. go back to view;
5. add a description or change the product on the line.

Issue
-----
Clicking on the product field opens the product record instead of edit mode.

Cause
-----
It opens the product record because the `canOpen` property is set to `true`. As this is the default value, and isn't getting changed anywhere, the line will always open the product record outside of edit mode.

Solution
--------
Instead of using OR, check `props.canOpen` AND additional checks.

opw-5172115