### PR TITLE
[FIX] hr_work_entry: fix leave interval filter

### DIFF
--- a/addons/hr_work_entry/models/hr_version.py
+++ b/addons/hr_work_entry/models/hr_version.py
@@ -318,6 +318,9 @@ class HrVersion(models.Model):
                 for leave_interval in [(l[0], l[1], interval[2]) for l in leaves_over_interval]:
                     leave_entry_type = version._get_interval_leave_work_entry_type(leave_interval, leaves, bypassing_work_entry_type_codes)
                     interval_leaves = [leave for leave in leaves if leave[2].work_entry_type_id.id == leave_entry_type.id]
+                    if not interval_leaves:
+                        # Maybe the computed leave type is not found. In that case, we use all leaves
+                        interval_leaves = leaves
                     interval_start = leave_interval[0].astimezone(pytz.utc).replace(tzinfo=None)
                     interval_stop = leave_interval[1].astimezone(pytz.utc).replace(tzinfo=None)
                     version_vals += [dict([


### PR DESCRIPTION
This filter was not necessary and was causing some issues in l10n_BE as the work entry type can change depending on various reasons. If it changed, the leave_id would not be copied to the new work entry.

task-5103485

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
