### PR TITLE
[FIX] hw_drivers: fit pdf report format printing w/ ghostcript

### DIFF
--- a/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_W.py
+++ b/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_W.py
@@ -115,7 +115,7 @@ class PrinterDriver(Driver):
             printer = self.device_name
 
             args = [
-                "-dPrinted", "-dBATCH", "-dNOPAUSE", "-dNOPROMPT",
+                "-dPrinted", "-dBATCH", "-dNOPAUSE", "-dNOPROMPT", "-dPDFFitPage",
                 "-q",
                 "-sDEVICE#mswinpr2",
                 f'-sOutputFile#%printer%{printer}',


### PR DESCRIPTION
When printing a landscape report using a Virtual IoT Box, we end up printing a portrait page cropped.

This commit adds the "pdf fit page" argument to ensure the page printed follows the report orientation.

opw-5051809
Task: 5149706