### PR TITLE
[IMP] html_builder: allow creation of anchors on cards and columns

### DIFF
--- a/addons/html_builder/static/src/core/anchor/anchor_plugin.js
+++ b/addons/html_builder/static/src/core/anchor/anchor_plugin.js
@@ -4,11 +4,12 @@ import { browser } from "@web/core/browser/browser";
 import { _t } from "@web/core/l10n/translation";
 import { markup } from "@odoo/owl";
 import { AnchorDialog } from "./anchor_dialog";
-import { getElementsWithOption } from "@html_builder/utils/utils";
+import { getElementsWithOption, getSnippetName } from "@html_builder/utils/utils";
 
-const anchorSelector = ":not(p).oe_structure > *, :not(p)[data-oe-type=html] > *";
+const anchorSelector =
+    ":not(p).oe_structure > *, :not(p)[data-oe-type=html] > *, .row > *, .s_card";
 const anchorExclude =
-    ".modal *, .oe_structure .oe_structure *, [data-oe-type=html] .oe_structure *, .s_popup";
+    ".modal *, .oe_structure .oe_structure *, [data-oe-type=html] .oe_structure *, .s_popup, .carousel *";
 
 export function canHaveAnchor(element) {
     return element.matches(anchorSelector) && !element.matches(anchorExclude);
@@ -63,8 +64,8 @@ export class AnchorPlugin extends Plugin {
     }
 
     createAnchor(element) {
-        const titleEls = element.querySelectorAll("h1, h2, h3, h4, h5, h6");
-        const title = titleEls.length > 0 ? titleEls[0].innerText : element.dataset.name;
+        const title =
+            element.querySelector("h1, h2, h3, h4, h5, h6")?.innerText || getSnippetName(element);
         const anchorName = this.formatAnchor(title);
 
         let n = "";

--- a/addons/website/static/tests/builder/custom_tab/container_buttons.test.js
+++ b/addons/website/static/tests/builder/custom_tab/container_buttons.test.js
@@ -189,6 +189,22 @@ test("Use the sidebar 'create anchor' buttons", async () => {
         <section class="third" data-name="Dummy Section" data-snippet="s_dummy">
             <p>test<p>
         </section>
+        <section class="fourth">
+            <p>test<p>
+            <div class="row">
+                <div>column</div>
+            </div>
+        </section>
+        <section class="fifth carousel">
+            <p>test<p>
+            <div class="row">
+                <div>column</div>
+            </div>
+        </section>
+        <section class="sixth">
+            <p>test<p>
+            <div class="s_card" data-name="Card">card</div>
+        </section>
     `;
     await setupWebsiteBuilder(websiteContent);
     const anchorSelector =
@@ -241,6 +257,36 @@ test("Use the sidebar 'create anchor' buttons", async () => {
     await contains(".o_dialog button:contains('Remove')").click();
     expect(":iframe section.third").not.toHaveAttribute("id");
     expect(":iframe section.third").not.toHaveAttribute("data-anchor");
+
+    await contains(notificationCloseSelector).click();
+    // Column without title nor data-name should use the default name for column
+    await contains(":iframe section.fourth div.row div").click();
+    await animationFrame();
+    await contains(
+        ".o_customize_tab .options-container > div:contains('Column') button.oe_snippet_anchor"
+    ).click();
+    await animationFrame();
+    expect(queryText(notificationContentSelector)).toInclude("#Column");
+    await contains(notificationCloseSelector).click();
+    expect(":iframe section.fourth div.row div").toHaveAttribute("id", "Column");
+
+    // Column in carousel does not allow anchor
+    await contains(":iframe section.fifth div.row div").click();
+    await animationFrame();
+    expect(
+        ".o_customize_tab .options-container > div:contains('Column') button.oe_snippet_anchor"
+    ).toHaveCount(0);
+
+    // Card outside a column also support anchor
+    await contains(":iframe section.sixth div").click();
+    await animationFrame();
+    await contains(
+        ".o_customize_tab .options-container > div:contains('Card') button.oe_snippet_anchor"
+    ).click();
+    await animationFrame();
+    expect(queryText(notificationContentSelector)).toInclude("#Card");
+    await contains(notificationCloseSelector).click();
+    expect(":iframe section.sixth div").toHaveAttribute("id", "Card");
 });
 
 test("Clicking on the options container title selects the corresponding element", async () => {


### PR DESCRIPTION
This commit allows user to create anchors on cards and columns (like there is on sections).

To achieve this, the selector used to tell whether an anchor is allowed is extended to accept children of `.row`. The name used as fallback if there is no title is changed to support the cases where the name of the block is not given in its dataset, by using the same function that give the name in the sidebar.

task-5179852