### PR TITLE
[FIX] stock_account: take uom in account in product value avco

### DIFF
--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -332,13 +332,13 @@ class StockMove(models.Model):
     def _get_valued_qty(self, lot=None):
         self.ensure_one()
         if self._is_in():
-            return sum(self._get_in_move_lines(lot).mapped('quantity'))
+            return sum(self._get_in_move_lines(lot).mapped('quantity_product_uom'))
         if self._is_out():
-            return sum(self._get_out_move_lines(lot).mapped('quantity'))
+            return sum(self._get_out_move_lines(lot).mapped('quantity_product_uom'))
         if self.is_dropship:
             if lot:
-                return sum(self.move_line_ids.filtered(lambda ml: ml.lot_id == lot).mapped('quantity'))
-            return self.quantity
+                return sum(self.move_line_ids.filtered(lambda ml: ml.lot_id == lot).mapped('quantity_product_uom'))
+            return self.product_qty
         return 0
 
     def _get_manual_value(self, quantity, at_date=None):

--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -2852,3 +2852,13 @@ class TestStockValuation(TestStockValuationBase):
         picking.button_validate()
         self.assertEqual(picking.state, 'done')
         self.assertEqual(move.value, 120, "The move value should match the price in the correct UoM (12 * 10$).")
+
+    def test_product_valuation_scrap_different_uom(self):
+        self.product1.standard_price = 8
+        uom_pack_6 = self.env.ref('uom.product_uom_pack_6')
+        self.product1.uom_ids = uom_pack_6
+        self.product1.categ_id.property_cost_method = 'average'
+        self._make_in_move(self.product1, 10)
+        self.assertEqual(self.product1.total_value, 80)
+        self._make_out_move(self.product1, 1, uom_id=uom_pack_6.id)
+        self.assertEqual(self.product1.total_value, 32)


### PR DESCRIPTION
**Steps to reproduce:**
- Create a storable product.
- Set the category as avco.
- Set the cost to 10
- Set an on hand quantity of 10
- In the Sales tab, add 'pack of 6' to the packagings
- Create a new scrap
- Scrap 1 pack of 6 of this product
- Open reporting/stock and search your product

**Current behavior:**
The value is 90

**Expected behavior:**
It should be 40

**Cause of the issue:**
get_valued_qty does not take into account the uom

opw-5160608