### PR TITLE
[FIX] website: loader progress bar color

### DIFF
--- a/addons/website/static/src/components/website_loader/website_loader.scss
+++ b/addons/website/static/src/components/website_loader/website_loader.scss
@@ -34,7 +34,6 @@
     }
     .o_website_loader_progress {
         --progress-height: 0.5rem;
-        --progress-bar-bg: black;
     }
     .o_website_loader_check {
         @keyframes loaderCheck {


### PR DESCRIPTION
This commits changes the website loader progress bar color, from black to `$primary`. This provides a better contrast in dark mode as well as better consistency.

task-5170115

| Before | After |
|--------|--------|
| <img width="1920" height="1186" alt="image" src="https://github.com/user-attachments/assets/cd9525cf-b9d6-40dd-9ffb-ed0027020ab5" /> | <img width="1920" height="1172" alt="image" src="https://github.com/user-attachments/assets/3f7d9a4b-4a3e-4fbd-a1be-826c898466cd" /> | 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
