### PR TITLE
[FIX] mail: copy attachments when copying templates

### DIFF
--- a/addons/test_mail/tests/test_mail_template.py
+++ b/addons/test_mail/tests/test_mail_template.py
@@ -80,18 +80,6 @@ class TestMailTemplate(TestMailTemplateCommon):
         self.assertEqual(action.name, 'Send Mail (%s)' % self.test_template.name)
         self.assertEqual(action.binding_model_id.model, 'mail.test.lang')
 
-    def test_template_copy(self):
-        """ Test copying template, notably for attachments management """
-        template = self.test_template
-        self.assertEqual(template.attachment_ids.mapped("res_id"), [template.id] * 2)
-        copy = template.copy()
-        self.assertEqual(template.attachment_ids, copy.attachment_ids)
-        self.assertEqual(
-            template.attachment_ids.mapped("res_id"), [copy.id] * 2,
-            "Updated res_id, seems strange"
-        )
-        self.assertEqual(copy.attachment_ids.mapped("res_id"), [copy.id] * 2)
-
     @mute_logger('odoo.addons.mail.models.mail_mail')
     @users('employee')
     def test_template_schedule_email(self):
@@ -242,10 +230,10 @@ class TestMailTemplateLanguages(TestMailTemplateCommon):
         self.assertEqual(len(mails_sudo), 100)
         for idx, (mail, record) in enumerate(zip(mails_sudo, self.test_records_batch)):
             self.assertEqual(sorted(mail.attachment_ids.mapped('name')), ['first.txt', 'second.txt'])
-            self.assertEqual(mail.attachment_ids.mapped("res_id"), [self.test_template_wreports.id] * 2)
+            self.assertEqual(mail.attachment_ids.mapped("res_id"), [template.id] * 2)
             self.assertEqual(mail.attachment_ids.mapped("res_model"), [template._name] * 2)
-            self.assertEqual(mail.email_cc, self.test_template.email_cc)
-            self.assertEqual(mail.email_to, self.test_template.email_to)
+            self.assertEqual(mail.email_cc, template.email_cc)
+            self.assertEqual(mail.email_to, template.email_to)
             self.assertEqual(mail.recipient_ids, self.partner_2 | self.user_admin.partner_id)
             if idx >= 50:
                 self.assertEqual(mail.subject, f'EnglishSubject for {record.name}')


### PR DESCRIPTION
Copying tmeplates should copy their attachments. Otherwise they are
shared, which means

  * wrong res_id: ACL check on attachments relies on a specific
    template, as res_model / res_id is used in access check;
  * propagated changes: changing one attachment changes it on all
    duplicated templates;

If custom rules on templates are implemented, this means notably
ACL issues when accessing attachments. It is not the case in standard
Odoo 17 as everyone can read templates but this notably changes in
future versions of Odoo.

While being there, also fix 'default' usage in copy override. User
given values should not be erased by default computation of name.

Task-5128863