### PR TITLE
[FIX] web: display new calendar event after creation

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_controller.js
+++ b/addons/web/static/src/views/calendar/calendar_controller.js
@@ -244,6 +244,7 @@ export class CalendarController extends Component {
             viewId: this.model.quickCreateFormViewId,
             title: _t("New Event"),
             context,
+            onRecordSaved: () => this.model.load(),
         };
     }
 


### PR DESCRIPTION
Before this commit, creating a new event in the calendar view using the quick create dialog did not display the new event upon saving.

This commit resolves the issue by reloading the calendar view model after saving the new record.


