### PR TITLE
[FIX] mail{,_test}: fix mail inbox crash due to mutli-company access issue

### DIFF
--- a/addons/mail/models/mail_notification.py
+++ b/addons/mail/models/mail_notification.py
@@ -123,8 +123,9 @@ class MailNotification(models.Model):
     def _filtered_for_web_client(self):
         """Returns only the notifications to show on the web client."""
         def _filter_unimportant_notifications(notif):
+            # sudo: 'mail.notification' - to check partner_share for all recipients of message regardless of company in multi-company setup
             if notif.notification_status in ['bounce', 'exception', 'canceled'] \
-                    or notif.res_partner_id.partner_share:
+                    or notif.sudo().res_partner_id.partner_share:
                 return True
             subtype = notif.mail_message_id.subtype_id
             return not subtype or subtype.track_recipients
@@ -139,5 +140,6 @@ class MailNotification(models.Model):
                 ["failure_type", "notification_status", "notification_type"], load=False
             )[0]
             data["message"] = Store.one(notif.mail_message_id, only_id=True)
-            data["persona"] = Store.one(notif.res_partner_id, fields=["name"])
+            # sudo: 'mail.notification' - to show all recipients of message regardless of company in multi-company setup
+            data["persona"] = Store.one(notif.sudo().res_partner_id, fields=["name"])
             store.add(notif, data)

--- a/addons/test_mail/tests/test_mail_multicompany.py
+++ b/addons/test_mail/tests/test_mail_multicompany.py
@@ -353,6 +353,16 @@ class TestMultiCompanyControllers(TestMailMCCommon, HttpCase):
                     self.assertEqual(result["mail.thread"][0]["hasReadAccess"], has_r)
                     self.assertEqual(result["mail.thread"][0]["canPostOnReadonly"], can_post)
 
+        record.with_user(self.user_admin).message_post(
+            body='Hello!',
+            message_type='comment',
+            subtype_xmlid='mail.mt_comment',
+            partner_ids=self.partner_employee_c2.ids,
+        )
+        self.authenticate(self.user_employee_c2.login, self.user_employee_c2.login)
+        messages = self.make_jsonrpc_request("/mail/inbox/messages")
+        self.assertEqual(len(messages['data']['mail.message']), 1)
+
     def test_redirect_to_records(self):
         """ Test mail/view redirection in MC environment, notably cids being
         added in redirect if user has access to the record. """


### PR DESCRIPTION
### Issue:

Due to this bug, user's inbox can crash and become inaccessible by another user.

#### Steps to reproduce:
1- Create a db with two companies and sale installed with demo data.
2- Demo user should only have access to company A
3- Demo user preference should be handle in Odoo
4- Admin should access both companies
5- Create a partner called partner_b with company set to company B
6- Using admin create a SO in company B, with the partner_b
7- Send a message (not internal note) in SO chatter, and mention Demo user
8- Login using Demo user
9- Open discuss app. As you see the inbox is not accessible anymore.

### Cause:

This is caused because Demo user doesn't have read access to partner_b. This cause issue in adding notification for partner_b.
https://github.com/odoo/odoo/blob/6e262e8cf7666216305a04f92c213578452fd652/addons/mail/models/mail_message.py#L1042-L1064

opw-5089738