### PR TITLE
[IMP] purchase: improve filters in purchase analysis

### DIFF
--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -63,7 +63,7 @@ class PurchaseOrderLine(models.Model):
 
     partner_id = fields.Many2one('res.partner', related='order_id.partner_id', string='Partner', readonly=True, store=True, index='btree_not_null')
     currency_id = fields.Many2one(related='order_id.currency_id', string='Currency')
-    date_order = fields.Datetime(related='order_id.date_order', string='Order Date', readonly=True)
+    date_order = fields.Datetime(related='order_id.date_order', string='Order Deadline', readonly=True)
     date_approve = fields.Datetime(related="order_id.date_approve", string='Confirmation Date', readonly=True)
     tax_calculation_rounding_method = fields.Selection(
         related='company_id.tax_calculation_rounding_method',

--- a/addons/purchase/report/purchase_report.py
+++ b/addons/purchase/report/purchase_report.py
@@ -15,7 +15,7 @@ class PurchaseReport(models.Model):
     _auto = False
     _order = 'date_order desc, price_total desc'
 
-    date_order = fields.Datetime('Order Date', readonly=True)
+    date_order = fields.Datetime('Order Deadline', readonly=True)
     state = fields.Selection([
         ('draft', 'Draft RFQ'),
         ('sent', 'RFQ Sent'),

--- a/addons/purchase/report/purchase_report_views.xml
+++ b/addons/purchase/report/purchase_report_views.xml
@@ -53,8 +53,11 @@
             <search string="Purchase Orders">
                 <filter string="Requests for Quotation" name="quotes" domain="[('state','in',('draft','sent'))]"/>
                 <filter string="Purchase Orders" name="orders" domain="[('state','!=','draft'), ('state','!=','sent'), ('state','!=','cancel')]"/>
-                <filter string="Confirmation Date Last Year" name="later_than_a_year_ago" domain="[('date_approve', '&gt;=', 'today -1y')]"/>
+                <separator/>
                 <filter name="filter_date_order" date="date_order"/>
+                <filter name="order_date_last_year" string="Order Deadline: Last 365 Days"
+                        domain="[('date_order', '&gt;=', 'today -365d')]" invisible="1"/>
+                <separator/>
                 <filter name="filter_date_approve" date="date_approve" default_period="month"/>
                 <field name="partner_id"/>
                 <field name="product_id"/>
@@ -74,7 +77,7 @@
                     <filter string="Status" name="status" context="{'group_by':'state'}"/>
                     <filter string="Company" name="company" context="{'group_by':'company_id'}" groups="base.group_multi_company"/>
                     <separator/>
-                    <filter string="Order Date" name="order_month" context="{'group_by': 'date_order:month'}"/>
+                    <filter name="order_month" context="{'group_by': 'date_order:month'}"/>
                     <filter string="Confirmation Date" name="group_date_approve_month" context="{'group_by': 'date_approve:month'}"/>
                 </group>
             </search>
@@ -89,7 +92,7 @@
         <field name="view_id"></field>  <!-- force empty -->
         <field name="context">{
                 'search_default_orders': 1,
-                'search_default_filter_date_approve': 1}</field>
+                'search_default_order_date_last_year': 1}</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 No Purchase Analysis

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -438,7 +438,9 @@
                     <filter name="not_acknowledged" string="Not Acknowledged" domain="[('state', '=', 'purchase'), ('acknowledged', '=', False)]"/>
                     <filter name="late_receipt" string="Late Receipts" domain="[('is_late', '=', True)]"/>
                     <separator/>
-                    <filter name="order_date" string="Order Date" date="date_order"/>
+                    <filter name="order_date" date="date_order"/>
+                    <separator/>
+                    <filter name="filter_date_approve" date="date_approve" default_period="month"/>
                     <filter invisible="1" string="My Activities" name="filter_activities_my"
                         domain="[('activity_user_id', '=', uid)]"/>
                     <separator invisible="1"/>
@@ -455,7 +457,8 @@
                     <group>
                         <filter string="Vendor" name="vendor" domain="[]" context="{'group_by': 'partner_id'}"/>
                         <filter string="Buyer" name="representative" domain="[]" context="{'group_by': 'user_id'}"/>
-                        <filter string="Order Date" name="order_date" domain="[]" context="{'group_by': 'date_order'}"/>
+                        <filter name="order_date" domain="[]" context="{'group_by': 'date_order'}"/>
+                        <filter name="group_date_approve_month" context="{'group_by': 'date_approve:month'}"/>
                     </group>
                 </search>
             </field>
@@ -479,8 +482,9 @@
                     <filter name="not_invoiced" string="Waiting Bills" domain="[('invoice_status', '=', 'to invoice')]" help="Purchase orders that include lines not invoiced."/>
                     <filter name="invoiced" string="Bills Received" domain="[('invoice_status', '=', 'invoiced')]" help="Purchase orders that have been invoiced."/>
                     <separator/>
-                    <filter name="order_date" string="Order Date" date="date_order"/>
+                    <filter name="order_date" date="date_order"/>
                     <separator/>
+                    <filter name="filter_date_approve" date="date_approve" default_period="month"/>
                     <filter invisible="1" string="My Activities" name="filter_activities_my"
                         domain="[('activity_user_id', '=', uid)]"/>
                     <separator invisible="1"/>
@@ -497,7 +501,8 @@
                     <group>
                         <filter string="Vendor" name="vendor" domain="[]" context="{'group_by': 'partner_id'}"/>
                         <filter string="Buyer" name="representative" domain="[]" context="{'group_by': 'user_id'}"/>
-                        <filter string="Order Date" name="order_date" domain="[]" context="{'group_by': 'date_order'}"/>
+                        <filter name="order_date" domain="[]" context="{'group_by': 'date_order'}"/>
+                        <filter name="group_date_approve_month" context="{'group_by': 'date_approve:month'}"/>
                     </group>
                 </search>
             </field>
@@ -801,7 +806,7 @@
                     <filter string="Status" name="purchase_state" domain="[('state', '=', 'purchase')]"/>
                     <separator/>
                     <filter name="filter_date_order" date="date_order" default_period="month"/>
-                    <filter name="order_date_last_year" string="Order Date: Last 365 Days"
+                    <filter name="order_date_last_year" string="Order DeadLine: Last 365 Days"
                         domain="[
                             ('date_order', '>', 'today -1y')
                         ]" invisible="1"/>
@@ -809,8 +814,7 @@
                         <filter name="groupby_supplier" string="Vendor" domain="[]" context="{'group_by' : 'partner_id'}" />
                         <filter name="groupby_product" string="Product" domain="[]" context="{'group_by' : 'product_id'}" />
                         <filter string="Order Reference" name="order_reference" domain="[]" context="{'group_by' :'order_id'}"/>
-                        <separator/>
-                        <filter string="Order Date" name="group_by_date_order" context="{'group_by': 'date_order'}"/>
+                        <filter name="group_by_date_order" context="{'group_by': 'date_order'}"/>
                     </group>
                 </search>
             </field>


### PR DESCRIPTION
This PR adds some improvements to the filters in purchase analysis and purchase orders as follows:

- renames the filter `Order Date` to `Order Deadline`.
- in purchase analysis, it changes the default filter from `Purchase Orders OR Confirmation Date <this month>` to be
`Purchase Order AND Order Deadline: Last 365 days`.
- in purchase analysis, it removes the filters `Confirmation Date Last Year`.
- in purchase orders, it adds the filter `Confirmation Date`.

Task-5182961