### PR TITLE
[REF] mail: remove explicit post_install

### DIFF
--- a/addons/mail/tests/discuss/test_avatar_acl.py
+++ b/addons/mail/tests/discuss/test_avatar_acl.py
@@ -2,10 +2,8 @@
 
 from odoo import fields, Command
 from odoo.tests import HttpCase
-from odoo.tests.common import tagged
 
 
-@tagged("post_install", "-at_install")
 class TestAvatarAcl(HttpCase):
     def get_avatar_url(self, record, add_token=False):
         access_token = ""

--- a/addons/mail/tests/discuss/test_discuss_action.py
+++ b/addons/mail/tests/discuss/test_discuss_action.py
@@ -3,7 +3,7 @@ from odoo.tests import HttpCase, tagged
 from odoo.addons.mail.tests.common import MailCommon
 
 
-@tagged("post_install", "-at_install", "discuss_action")
+@tagged("discuss_action")
 class TestDiscussAction(HttpCase, MailCommon):
     def test_go_back_to_thread_from_breadcrumbs(self):
         self.start_tour(

--- a/addons/mail/tests/discuss/test_discuss_attachment_controller.py
+++ b/addons/mail/tests/discuss/test_discuss_attachment_controller.py
@@ -5,7 +5,7 @@ from odoo.addons.mail.tests.common_controllers import MailControllerAttachmentCo
 from odoo.tools.misc import file_open
 
 
-@odoo.tests.tagged("-at_install", "post_install", "mail_controller")
+@odoo.tests.tagged("mail_controller")
 class TestDiscussAttachmentController(MailControllerAttachmentCommon):
     def test_attachment_allowed_upload_public_channel(self):
         """Test access to upload an attachment on an allowed upload public channel"""

--- a/addons/mail/tests/discuss/test_discuss_binary_controller.py
+++ b/addons/mail/tests/discuss/test_discuss_binary_controller.py
@@ -2,7 +2,7 @@ from odoo.addons.mail.tests.common_controllers import MailControllerBinaryCommon
 from odoo.tests import tagged
 
 
-@tagged("-at_install", "post_install", "mail_controller")
+@tagged("mail_controller")
 class TestDiscussBinaryController(MailControllerBinaryCommon):
 
     @classmethod

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -14,11 +14,10 @@ from odoo.addons.mail.tests.common import mail_new_test_user
 from odoo.addons.mail.tests.common import MailCommon
 from odoo.addons.mail.tools.discuss import Store
 from odoo.exceptions import ValidationError
-from odoo.tests import HttpCase, tagged, users
+from odoo.tests import HttpCase, users
 from odoo.tools import html_escape, mute_logger
 
 
-@tagged("post_install", "-at_install")
 class TestChannelInternals(MailCommon, HttpCase):
 
     @classmethod

--- a/addons/mail/tests/discuss/test_discuss_channel_access.py
+++ b/addons/mail/tests/discuss/test_discuss_channel_access.py
@@ -5,11 +5,9 @@ from psycopg2.errors import UniqueViolation
 from odoo.addons.mail.tests.common import mail_new_test_user
 from odoo.addons.mail.tests.common import MailCommon
 from odoo.exceptions import AccessError, UserError
-from odoo.tests.common import tagged
 from odoo.tools import mute_logger
 
 
-@tagged("post_install", "-at_install")
 class TestDiscussChannelAccess(MailCommon):
     @classmethod
     def setUpClass(cls):

--- a/addons/mail/tests/discuss/test_discuss_channel_as_guest.py
+++ b/addons/mail/tests/discuss/test_discuss_channel_as_guest.py
@@ -5,7 +5,7 @@ from odoo.tests.common import tagged
 from odoo.addons.base.tests.common import HttpCaseWithUserPortal, HttpCaseWithUserDemo
 
 
-@tagged("post_install", "-at_install", "is_tour")
+@tagged("is_tour")
 class TestMailPublicPage(HttpCaseWithUserPortal, HttpCaseWithUserDemo):
     """Checks that the invite page redirects to the channel and that all
     modules load correctly on the welcome and channel page when authenticated as various users"""

--- a/addons/mail/tests/discuss/test_discuss_channel_invite.py
+++ b/addons/mail/tests/discuss/test_discuss_channel_invite.py
@@ -4,11 +4,10 @@ from itertools import product
 
 from odoo.addons.mail.tests.common import MailCommon
 from odoo.exceptions import UserError
-from odoo.tests import HttpCase, new_test_user, tagged
+from odoo.tests import HttpCase, new_test_user
 from odoo.tools.misc import hash_sign
 
 
-@tagged("-at_install", "post_install")
 class TestDiscussChannelInvite(HttpCase, MailCommon):
     def test_01_invite_by_email_flow(self):
         bob = new_test_user(self.env, "bob", groups="base.group_user", email="bob@test.com")

--- a/addons/mail/tests/discuss/test_discuss_channel_member.py
+++ b/addons/mail/tests/discuss/test_discuss_channel_member.py
@@ -1,11 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.addons.mail.tests.common import MailCommon
-from odoo.exceptions import AccessError, UserError, ValidationError
-from odoo.tests.common import new_test_user, tagged
+from odoo.exceptions import AccessError, ValidationError
+from odoo.tests.common import new_test_user
 
 
-@tagged("post_install", "-at_install")
 class TestDiscussChannelMember(MailCommon):
     @classmethod
     def setUpClass(cls):

--- a/addons/mail/tests/discuss/test_discuss_mail_presence.py
+++ b/addons/mail/tests/discuss/test_discuss_mail_presence.py
@@ -9,13 +9,12 @@ except ImportError:
 
 from itertools import product
 
-from odoo.tests import tagged, new_test_user
+from odoo.tests import new_test_user
 from odoo.addons.bus.tests.common import WebsocketCase
 from odoo.addons.mail.tests.common import MailCommon, freeze_all_time
 from odoo.addons.bus.models.bus import channel_with_db, json_dump
 
 
-@tagged("post_install", "-at_install")
 class TestMailPresence(WebsocketCase, MailCommon):
     def _receive_presence(self, requested_by, target, has_token=False):
         self.env["mail.presence"].search([]).unlink()

--- a/addons/mail/tests/discuss/test_discuss_message_update_controller.py
+++ b/addons/mail/tests/discuss/test_discuss_message_update_controller.py
@@ -2,7 +2,7 @@ from odoo.addons.mail.tests.common_controllers import MailControllerUpdateCommon
 from odoo.tests import tagged
 
 
-@tagged("-at_install", "post_install", "mail_controller")
+@tagged("mail_controller")
 class TestDiscussMessageUpdateController(MailControllerUpdateCommon):
 
     def test_message_update_guest_as_owner(self):

--- a/addons/mail/tests/discuss/test_discuss_reaction_controller.py
+++ b/addons/mail/tests/discuss/test_discuss_reaction_controller.py
@@ -2,7 +2,7 @@ from odoo.addons.mail.tests.common_controllers import MailControllerReactionComm
 from odoo.tests import tagged
 
 
-@tagged("-at_install", "post_install", "mail_controller")
+@tagged("mail_controller")
 class TestMessageReactionController(MailControllerReactionCommon):
 
     def test_message_reaction_public_channel(self):

--- a/addons/mail/tests/discuss/test_discuss_res_role.py
+++ b/addons/mail/tests/discuss/test_discuss_res_role.py
@@ -1,9 +1,9 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 from odoo.addons.mail.tests.common import mail_new_test_user
 from odoo.addons.mail.tests.test_res_role import TestResRole
-from odoo.tests.common import tagged
 
 
-@tagged("-at_install", "post_install")
 class TestDiscussResRole(TestResRole):
     def test_only_mention_by_role_when_channel_is_accessible(self):
         self.authenticate("admin", "admin")

--- a/addons/mail/tests/discuss/test_discuss_sub_channels.py
+++ b/addons/mail/tests/discuss/test_discuss_sub_channels.py
@@ -6,11 +6,10 @@ from datetime import datetime, timedelta
 from freezegun import freeze_time
 from unittest.mock import patch
 
-from odoo.tests.common import HttpCase, new_test_user, tagged
+from odoo.tests.common import HttpCase, new_test_user
 from odoo.exceptions import UserError, ValidationError
 
 
-@tagged("post_install", "-at_install")
 class TestDiscussSubChannels(HttpCase):
     def test_01_gc_unpin_outdated_sub_channels(self):
         parent = self.env["discuss.channel"].create({"name": "General"})

--- a/addons/mail/tests/discuss/test_discuss_thread_controller.py
+++ b/addons/mail/tests/discuss/test_discuss_thread_controller.py
@@ -1,8 +1,10 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 from odoo.addons.mail.tests.common_controllers import MailControllerThreadCommon, MessagePostSubTestData
 from odoo.tests import tagged
 
 
-@tagged("-at_install", "post_install", "mail_controller")
+@tagged("mail_controller")
 class TestDiscussThreadController(MailControllerThreadCommon):
 
     def test_internal_channel_message_post_access(self):

--- a/addons/mail/tests/discuss/test_guest.py
+++ b/addons/mail/tests/discuss/test_guest.py
@@ -1,9 +1,9 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 from odoo import fields
 from odoo.addons.mail.tests.common import MailCase
-from odoo.tests.common import tagged
 
 
-@tagged("post_install", "-at_install")
 class TestGuest(MailCase):
 
     def test_updating_guest_name_linked_to_multiple_channels(self):

--- a/addons/mail/tests/discuss/test_guest_feature.py
+++ b/addons/mail/tests/discuss/test_guest_feature.py
@@ -1,12 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import json
-from odoo.tests import tagged
 from odoo.addons.bus.tests.common import WebsocketCase
 from odoo.addons.mail.tests.common import MailCommon
 
 
-@tagged("post_install", "-at_install")
 class TestGuestFeature(WebsocketCase, MailCommon):
     def test_mark_as_read_as_guest(self):
         guest = self.env["mail.guest"].create({"name": "Guest"})

--- a/addons/mail/tests/discuss/test_load_messages.py
+++ b/addons/mail/tests/discuss/test_load_messages.py
@@ -1,10 +1,10 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import odoo.tests
 from odoo import Command
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 
 
-@odoo.tests.tagged('post_install', '-at_install')
 class TestLoadMessages(HttpCaseWithUserDemo):
     def test_01_mail_message_load_order_tour(self):
         partner_admin = self.env.ref('base.partner_admin')

--- a/addons/mail/tests/discuss/test_message_controller.py
+++ b/addons/mail/tests/discuss/test_message_controller.py
@@ -11,7 +11,7 @@ from odoo.http import STATIC_CACHE_LONG
 from odoo import Command, fields
 
 
-@odoo.tests.tagged("-at_install", "post_install", "mail_controller")
+@odoo.tests.tagged("mail_controller")
 class TestMessageController(HttpCaseWithUserDemo):
     @classmethod
     def setUpClass(cls):

--- a/addons/mail/tests/discuss/test_rtc.py
+++ b/addons/mail/tests/discuss/test_rtc.py
@@ -11,7 +11,7 @@ from odoo.tests.common import HttpCase, new_test_user, tagged, users
 from odoo.tools.misc import mute_logger
 
 
-@tagged("RTC", "post_install", "-at_install")
+@tagged("RTC")
 class TestChannelRTC(MailCommon, HttpCase):
 
     @users('employee')

--- a/addons/mail/tests/discuss/test_toggle_upload.py
+++ b/addons/mail/tests/discuss/test_toggle_upload.py
@@ -1,13 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from requests.exceptions import HTTPError
-
 from odoo import Command, http
-from odoo.tests.common import tagged, HttpCase
-from odoo.tools import file_open, mute_logger
+from odoo.tests.common import HttpCase
+from odoo.tools import file_open
 
 
-@tagged("post_install", "-at_install")
 class TestToggleUpload(HttpCase):
     def test_upload_allowed(self):
         self.authenticate(None, None)

--- a/addons/mail/tests/discuss/test_ui.py
+++ b/addons/mail/tests/discuss/test_ui.py
@@ -1,11 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import odoo.tests
 from odoo import Command
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo, new_test_user
 
 
-@odoo.tests.tagged('post_install', '-at_install')
 class TestUi(HttpCaseWithUserDemo):
 
     def test_01_mail_tour(self):

--- a/addons/mail/tests/test_discuss_tools.py
+++ b/addons/mail/tests/test_discuss_tools.py
@@ -2,11 +2,10 @@
 
 from odoo.addons.mail.tools.discuss import Store
 from odoo.addons.mail.tests.common import mail_new_test_user
-from odoo.tests import tagged, TransactionCase
+from odoo.tests import TransactionCase
 from odoo.tests.common import new_test_user
 
 
-@tagged("post_install", "-at_install")
 class TestDiscussTools(TransactionCase):
     """Test class for discuss tools."""
 

--- a/addons/mail/tests/test_font_to_img.py
+++ b/addons/mail/tests/test_font_to_img.py
@@ -4,11 +4,10 @@
 from io import BytesIO
 from PIL import Image
 
-from odoo.tests.common import HttpCase, tagged
+from odoo.tests.common import HttpCase
 from odoo.tools.misc import file_open
 
 
-@tagged("-at_install", "post_install")
 class TestFontToImg(HttpCase):
 
     def test_font_to_img(self):

--- a/addons/mail/tests/test_ir_websocket.py
+++ b/addons/mail/tests/test_ir_websocket.py
@@ -8,13 +8,12 @@ try:
 except ImportError:
     ws = None
 
-from odoo.tests import new_test_user, tagged
+from odoo.tests import new_test_user
 from odoo.addons.bus.tests.common import WebsocketCase
 from odoo.addons.bus.models.bus import channel_with_db, json_dump
 from odoo.addons.mail.models.mail_presence import AWAY_TIMER
 
 
-@tagged("-at_install", "post_install")
 class TestIrWebsocket(WebsocketCase):
     def test_notify_on_status_change(self):
         bob = new_test_user(self.env, login="bob_user", groups="base.group_user")

--- a/addons/mail/tests/test_link_preview.py
+++ b/addons/mail/tests/test_link_preview.py
@@ -11,7 +11,7 @@ from odoo.addons.mail.tools import link_preview
 from odoo.tests.common import tagged
 
 
-@tagged("mail_link_preview", "mail_message", "post_install", "-at_install")
+@tagged("mail_link_preview", "mail_message")
 class TestLinkPreview(MailCommon):
 
     @classmethod

--- a/addons/mail/tests/test_mail_activity.py
+++ b/addons/mail/tests/test_mail_activity.py
@@ -5,7 +5,7 @@ from odoo.addons.mail.tests.common_activity import ActivityScheduleCase
 from odoo.tests import tagged, HttpCase
 
 
-@tagged("mail_activity", "-at_install", "post_install")
+@tagged("mail_activity")
 class TestMailActivityChatter(HttpCase):
 
     @classmethod
@@ -38,7 +38,7 @@ class TestMailActivityChatter(HttpCase):
         )
 
 
-@tagged("-at_install", "post_install", "mail_activity")
+@tagged("mail_activity")
 class TestMailActivityIntegrity(ActivityScheduleCase):
 
     def test_mail_activity_type_master_data(self):

--- a/addons/mail/tests/test_mail_composer.py
+++ b/addons/mail/tests/test_mail_composer.py
@@ -264,7 +264,7 @@ class TestMailComposerRendering(TestMailComposer):
         )
 
 
-@tagged("mail_composer", "-at_install", "post_install")
+@tagged("mail_composer")
 class TestMailComposerUI(MailCommon, HttpCase):
 
     def test_mail_composer_test_tour(self):

--- a/addons/mail/tests/test_mail_message.py
+++ b/addons/mail/tests/test_mail_message.py
@@ -4,7 +4,7 @@ from odoo.addons.mail.tests import common
 from odoo.tests import new_test_user, tagged
 
 
-@tagged("-at_install", "post_install", "mail_message")
+@tagged("mail_message")
 class TestMailMessage(common.MailCommon):
     def test_unlink_failure_message_notify_author(self):
         recipient = new_test_user(self.env, login="Bob", email="invalid_email_addr")

--- a/addons/mail/tests/test_mail_message_translate.py
+++ b/addons/mail/tests/test_mail_message_translate.py
@@ -37,7 +37,7 @@ def mock_response(fun):
 
 
 # Google Cloud Translation Documentation: https://cloud.google.com/translate/docs/reference/api-overview?hl=en
-@tagged("post_install", "-at_install", "mail_message")
+@tagged("mail_message")
 class TestTranslationController(HttpCaseWithUserDemo):
     @classmethod
     def setUpClass(cls):

--- a/addons/mail/tests/test_mail_presence.py
+++ b/addons/mail/tests/test_mail_presence.py
@@ -3,11 +3,10 @@
 from datetime import datetime, timedelta
 from freezegun import freeze_time
 
-from odoo.tests import HttpCase, tagged, new_test_user
+from odoo.tests import HttpCase, new_test_user
 from ..models.mail_presence import PRESENCE_OUTDATED_TIMER
 
 
-@tagged("-at_install", "post_install")
 class TestMailPresence(HttpCase):
     def test_bus_presence_auto_vacuum(self):
         user = new_test_user(self.env, login="bob_user")

--- a/addons/mail/tests/test_mail_template.py
+++ b/addons/mail/tests/test_mail_template.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from markupsafe import Markup
 from unittest.mock import patch
@@ -473,7 +472,7 @@ class TestMailTemplateReset(MailCommon):
         self.assertEqual(mail_template.with_context(lang='fr_FR').name, 'Mail: Test Mail Template FR')
 
 
-@tagged("mail_template", "-at_install", "post_install")
+@tagged("mail_template")
 class TestMailTemplateUI(HttpCase):
 
     def test_mail_template_dynamic_placeholder_tour(self):
@@ -481,7 +480,7 @@ class TestMailTemplateUI(HttpCase):
         self.start_tour('/odoo?debug=1', 'mail_template_dynamic_placeholder_tour', login='admin')
 
 
-@tagged("mail_template", "-at_install", "post_install")
+@tagged("mail_template")
 class TestTemplateConfigRestrictEditor(MailCommon):
 
     def test_switch_icp_value(self):
@@ -503,7 +502,7 @@ class TestTemplateConfigRestrictEditor(MailCommon):
         self.assertTrue(self.user_employee.has_group('mail.group_mail_template_editor'))
 
 
-@tagged("mail_template", "-at_install", "post_install")
+@tagged("mail_template")
 class TestSearchTemplateCategory(MailCommon):
 
     @classmethod

--- a/addons/mail/tests/test_res_role.py
+++ b/addons/mail/tests/test_res_role.py
@@ -2,10 +2,9 @@
 
 from odoo import Command
 from odoo.addons.mail.tests.common import MailCommon, mail_new_test_user
-from odoo.tests.common import HttpCase, tagged
+from odoo.tests.common import HttpCase
 
 
-@tagged("-at_install", "post_install")
 class TestResRole(MailCommon, HttpCase):
     def test_post_mention_role(self):
         """Test mention with role"""

--- a/addons/mail/tests/test_res_users.py
+++ b/addons/mail/tests/test_res_users.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import datetime, timedelta
@@ -14,7 +13,7 @@ from odoo.tests import RecordCapturer, tagged, users
 from odoo.tools import mute_logger
 
 
-@tagged('-at_install', 'post_install', 'mail_tools', 'res_users')
+@tagged('mail_tools', 'res_users')
 class TestNotifySecurityUpdate(MailCommon):
 
     @users('employee')
@@ -51,7 +50,8 @@ class TestNotifySecurityUpdate(MailCommon):
             subject='Security Update: Password Changed',
         )
 
-@tagged('-at_install', 'post_install', 'mail_tools', 'res_users')
+
+@tagged('mail_tools', 'res_users')
 class TestUser(MailCommon):
 
     @classmethod
@@ -180,7 +180,7 @@ class TestUser(MailCommon):
         )
 
 
-@tagged('-at_install', 'post_install', 'res_users')
+@tagged('res_users')
 class TestUserTours(HttpCaseWithUserDemo):
 
     def test_user_modify_own_profile(self):
@@ -205,7 +205,6 @@ class TestUserTours(HttpCaseWithUserDemo):
         self.assertEqual(self.user_demo.notification_type, "inbox")
 
 
-@tagged("post_install", "-at_install")
 class TestUserSettings(MailCommon):
 
     @skip('Crashes in post_install, probably because other modules force creation through inverse (e.g. voip)')

--- a/addons/mail/tests/test_uninstall.py
+++ b/addons/mail/tests/test_uninstall.py
@@ -1,10 +1,8 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.tests import tagged, TransactionCase
+from odoo.tests import TransactionCase
 
 
-@tagged('-at_install', 'post_install')
 class TestMailUninstall(TransactionCase):
     def test_unlink_model(self):
         model = self.env['ir.model'].create({


### PR DESCRIPTION
post_install is now the default for all tests, so we can remove the explicit tags.