### PR TITLE
[FIX] point_of_sale: allow merging lines with same discount & unit_price

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -350,8 +350,8 @@ export class PosOrderline extends PosOrderlineAccounting {
             orderline.getNote() === this.getNote() &&
             this.getProduct().id === orderline.getProduct().id &&
             this.isPosGroupable() &&
-            // don't merge discounted orderlines
-            this.getDiscount() === 0 &&
+            this.getDiscount() === orderline.getDiscount() &&
+            this.price_type === orderline.price_type &&
             this.currency.isZero(
                 this.currency.round(price) -
                     this.currency.round(order_line_price) -

--- a/addons/point_of_sale/static/tests/unit/models/pos_order_line.test.js
+++ b/addons/point_of_sale/static/tests/unit/models/pos_order_line.test.js
@@ -248,6 +248,16 @@ test("[canBeMergedWith]: Base test", async () => {
     // Test with same note
     line2.setNote("Test note");
     expect(line1.canBeMergedWith(line2)).toBe(true);
+    // Test with discount applied
+    line1.setDiscount(10.0);
+    expect(line1.canBeMergedWith(line2)).toBe(false);
+    // Test with same discount
+    line2.setDiscount(10.0);
+    expect(line1.canBeMergedWith(line2)).toBe(true);
+    // Test with different price unit
+    line2.price_unit = line1.price_unit + 1;
+    line2.price_type = "manual";
+    expect(line1.canBeMergedWith(line2)).toBe(false);
     // Test to merge lines
     line1.merge(line2);
     expect(line1.qty).toBe(5);


### PR DESCRIPTION
Only allow merging lines if they have the same discount and unit price.

Before this commit, you were able to merge lines with different discounts or unit prices only if the source order contained the line with the discount/price change. It was not working the other way which was inconsistent.

task-id: 5189949


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
