### PR TITLE
[IMP] fleet: update status bar of vehicle contracts

### DIFF
--- a/addons/fleet/models/fleet_vehicle_log_contract.py
+++ b/addons/fleet/models/fleet_vehicle_log_contract.py
@@ -49,7 +49,7 @@ class FleetVehicleLogContract(models.Model):
          ('open', 'Running'),
          ('expired', 'Expired'),
          ('closed', 'Cancelled')
-        ], 'Status', default='open',
+        ], 'Status', default='futur',
         help='Choose whether the contract is still valid or not',
         tracking=True,
         copy=False)
@@ -102,23 +102,33 @@ class FleetVehicleLogContract(models.Model):
                 record.days_left = -1
                 record.expires_today = False
 
+    def _update_state(self):
+        date_today = fields.Date.today()
+        future_contracts, running_contracts, expired_contracts = self.env[self._name], self.env[self._name], self.env[self._name]
+        for contract in self.filtered(lambda c: c.start_date and c.state != 'closed'):
+            if date_today < contract.start_date:
+                future_contracts |= contract
+            elif not contract.expiration_date or contract.start_date <= date_today <= contract.expiration_date:
+                running_contracts |= contract
+            else:
+                expired_contracts |= contract
+        future_contracts.action_draft()
+        running_contracts.action_open()
+        expired_contracts.action_expire()
+
     def write(self, vals):
-        res = super(FleetVehicleLogContract, self).write(vals)
+        res = super().write(vals)
         if 'start_date' in vals or 'expiration_date' in vals:
-            date_today = fields.Date.today()
-            future_contracts, running_contracts, expired_contracts = self.env[self._name], self.env[self._name], self.env[self._name]
-            for contract in self.filtered(lambda c: c.start_date and c.state != 'closed'):
-                if date_today < contract.start_date:
-                    future_contracts |= contract
-                elif not contract.expiration_date or contract.start_date <= date_today <= contract.expiration_date:
-                    running_contracts |= contract
-                else:
-                    expired_contracts |= contract
-            future_contracts.action_draft()
-            running_contracts.action_open()
-            expired_contracts.action_expire()
+            self._update_state()
         if vals.get('expiration_date') or vals.get('user_id'):
             self.activity_reschedule(['fleet.mail_act_fleet_contract_to_renew'], date_deadline=vals.get('expiration_date'), new_user_id=vals.get('user_id'))
+        return res
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        res = super().create(vals_list)
+        for contract in res:
+            contract._update_state()
         return res
 
     def action_close(self):
@@ -132,6 +142,10 @@ class FleetVehicleLogContract(models.Model):
 
     def action_expire(self):
         self.write({'state': 'expired'})
+
+    def action_reactivate(self):
+        self.write({'state': 'futur'})
+        self._update_state()
 
     @api.model
     def scheduler_manage_contract_expiration(self):

--- a/addons/fleet/views/fleet_vehicle_cost_views.xml
+++ b/addons/fleet/views/fleet_vehicle_cost_views.xml
@@ -7,7 +7,11 @@
             <form string="Contract logs">
                 <field name="company_id" invisible="1"/>
                 <header>
-                    <field name="state" widget="statusbar" options="{'clickable': '1'}"/>
+                    <button name="action_close" string="Cancel" type="object" class="btn-secondary" invisible="state == 'closed'"/>
+                    <button name="action_reactivate" string="Reactivate" type="object" class="btn-secondary" invisible="state != 'closed'"/>
+                    <field name="state" widget="statusbar" statusbar_visible="futur,open" invisible="state in ('expired', 'closed')"/>
+                    <field name="state" widget="statusbar" statusbar_visible="futur,open,expired" invisible="state != 'expired'"/>
+                    <field name="state" widget="statusbar" statusbar_visible="futur,open,closed" invisible="state != 'closed'"/>
                 </header>
                 <sheet>
                     <field name="active" invisible="1"/>


### PR DESCRIPTION
Only show cancelled or expired states of vehicle contract when the contract is in that state. Also make the status bar non clickable and rely on automatic state updates based on the contract start and expiration dates.

Since the state can no longer be changed by clicking on the status bar, this meant that the state should be correct at all times, this lead to a change where the state is computed upon creation (previously, it would go to the default state regardless of the contract start and expiration dates). Also buttons were added to allow the user to manually cancel and reactivate contracts.

Task-ID: 5176374

[Related PR](https://github.com/odoo/enterprise/pull/98141)