### PR TITLE
[IMP] point_of_sale: increase contrast between disabled/enabled buttons

### DIFF
--- a/addons/point_of_sale/static/src/scss/pos.scss
+++ b/addons/point_of_sale/static/src/scss/pos.scss
@@ -29,8 +29,14 @@ select > option {
 
 .btn-secondary {
     --btn-bg: #F4F4F4;
-    --btn-border-color: #F4F4F4;
+    --btn-border-color: #cccccc;
     --btn-color: #{$o-gray-900};
+    --btn-disabled-bg: var(--btn-bg);
+    --btn-disabled-color: #{$o-gray-700};
+    --btn-disabled-border-color: var(--btn-border-color);
+    &:disabled, &.disabled {
+        filter: saturate(0);
+    }
 }
 
 .bg-secondary {


### PR DESCRIPTION
Before this PR there was a contrast issue between disabled and active secondary buttons in the action dialog.
This was due to a customization where the `btn-secondary`'s default background color was lightened.

To fix this, we used the same lighter background color for disabled `.btn-secondary`, reduced the opacity of its text and desaturated tho whole button for whenever there is color such as the "reward" button. This way we can distinguish between the two states.

A border was added to `.btn-secondary` in order to make the button more visible in light-challenging situations (in broad daylight for example).

task-5186928

| Before | After |
| ------------- | ------------- |
| <img width="1002" height="647" alt="Screenshot 2025-11-06 at 13 17 27" src="https://github.com/user-attachments/assets/cc63d6e1-8587-427e-b5cd-de99e96df8c0" />|<img width="1004" height="645" alt="Screenshot 2025-11-06 at 12 58 07" src="https://github.com/user-attachments/assets/f199fd94-1223-4c6b-869b-e8d66d99bc82" /> |



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
