### PR TITLE
[FIX] repair: allow serial number only after save

### DIFF
--- a/addons/repair/views/repair_views.xml
+++ b/addons/repair/views/repair_views.xml
@@ -166,7 +166,8 @@
                                     invisible="not show_details_visible or has_tracking != 'serial'"
                                     optional="hide"
                                     context="{'default_company_id': company_id, 'default_product_id': product_id}"
-                                    domain="[('product_id','=',product_id)]"/>
+                                    domain="[('product_id','=',product_id)]"
+                                    readonly="not id"/>
                                 <button type="object" name="action_product_forecast_report" title="Forecast Report" icon="fa-area-chart" column_invisible="parent.state != 'draft'" invisible="forecast_availability &lt; 0 and repair_line_type == 'add'"/>
                                 <button type="object" name="action_product_forecast_report" title="Forecast Report" icon="fa-area-chart text-danger" column_invisible="parent.state != 'draft'" invisible="forecast_availability &gt;= 0 or repair_line_type != 'add'"/>
                                 <button name="action_show_details" type="object" icon="fa-list" width="0.1" title="Details"


### PR DESCRIPTION
When creating a repair order, if you add a line and assign a serial
number before saving the line, the serial number is removed when saving.

Steps to reproduce:
- Create a repair order and save it.
- Add a repair line with a product tracked by serial number.
- Without saving the repair order, add a serial number on the line.
- Save the repair order.
- You will notice that the serial number is no longer assigned to the
repair line.

This PR fixes the issue by making the serial number field read-only
until the repair line is saved.

opw-5156267