### PR TITLE
[FIX] pos_self_order: send mail for order confirmation

### DIFF
--- a/addons/pos_self_order/controllers/orders.py
+++ b/addons/pos_self_order/controllers/orders.py
@@ -59,6 +59,9 @@ class PosSelfOrderController(http.Controller):
         if amount_total == 0:
             order_ids._process_saved_order(False)
 
+        if preset_id and preset_id.mail_template_id:
+            order_ids._send_self_order_receipt()
+
         return self._generate_return_values(order_ids, pos_config)
 
     def _get_prefixes(self, device_type):

--- a/addons/pos_self_order/models/pos_order.py
+++ b/addons/pos_self_order/models/pos_order.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+import logging
 
 from odoo import models, fields, api, _
 from odoo.exceptions import UserError
+
+_logger = logging.getLogger(__name__)
 
 
 class PosOrderLine(models.Model):
@@ -67,6 +70,13 @@ class PosOrder(models.Model):
             config.notify_synchronisation(config.current_session_id.id, self.env.context.get('login_number', 0))
             config._notify('ORDER_STATE_CHANGED', {})
 
+    def _send_self_order_receipt(self):
+        if self.email:
+            try:
+                self.action_send_self_order_receipt(self.email, self.preset_id.mail_template_id.id, False, False)
+            except UserError as e:
+                _logger.warning("Error while sending email: %s", e.args[0])
+
     def action_send_self_order_receipt(self, email, mail_template_id, ticket_image, basic_image):
         self.ensure_one()
         self.email = email
@@ -74,7 +84,7 @@ class PosOrder(models.Model):
         if not mail_template:
             raise UserError(_("The mail template with xmlid %s has been deleted.", mail_template_id))
         email_values = {'email_to': email}
-        if self.state == 'paid':
+        if self.state == 'paid' and ticket_image:
             email_values['attachment_ids'] = self._get_mail_attachments(self.name, ticket_image, basic_image)
         mail_template.send_mail(self.id, force_send=True, email_values=email_values)
 

--- a/addons/pos_self_order/static/src/app/models/pos_order.js
+++ b/addons/pos_self_order/static/src/app/models/pos_order.js
@@ -63,4 +63,11 @@ patch(PosOrder.prototype, {
             }
         }
     },
+    serializeForORM(opts = {}) {
+        const data = super.serializeForORM(opts);
+        if (this.email && !data.email) {
+            data.email = this.email;
+        }
+        return data;
+    },
 });

--- a/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
+++ b/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
@@ -116,14 +116,9 @@ export class CartPage extends Component {
     async proceedInfos(state) {
         this.state.fillInformations = false;
         if (state) {
+            this.selfOrder.currentOrder.email =
+                this.selfOrder.currentOrder.partner_id?.email || state.email;
             await this.pay();
-            if (this.selfOrder.currentOrder.preset_id?.mail_template_id) {
-                this.sendReceipt.call({
-                    action: "action_send_self_order_receipt",
-                    destination: state.email,
-                    mail_template_id: this.selfOrder.currentOrder.preset_id.mail_template_id.id,
-                });
-            }
         }
     }
 

--- a/addons/pos_self_order/static/tests/tours/self_order_preset_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_preset_tour.js
@@ -102,3 +102,26 @@ registry.category("web_tour.tours").add("test_slot_limit_orders", {
         CartPage.checkSlotUnavailable("00:00"),
     ],
 });
+
+registry.category("web_tour.tours").add("test_preset_takeaway_email_tour", {
+    steps: () => [
+        Utils.checkIsNoBtn("My Order"),
+        Utils.clickBtn("Order Now"),
+        LandingPage.selectLocation("Takeaway"),
+        ProductPage.clickProduct("Coca-Cola"),
+        Utils.clickBtn("Checkout"),
+        CartPage.checkProduct("Coca-Cola", "2.53", "1"),
+        Utils.clickBtn("Order"),
+        CartPage.fillInput("Name", "Public user"),
+        CartPage.fillInput("Email", "public.user@test.com"),
+        Utils.clickBtn("Continue"),
+        // Waiting for mail to be sent
+        {
+            trigger: "body",
+            run: function () {
+                return new Promise((resolve) => setTimeout(resolve, 500));
+            },
+        },
+        Utils.clickBtn("Ok"),
+    ],
+});

--- a/addons/pos_self_order/tests/__init__.py
+++ b/addons/pos_self_order/tests/__init__.py
@@ -11,3 +11,4 @@ from . import test_self_order_common
 from . import test_webmanifest
 from . import test_self_order_sequence
 from . import test_self_order_preset
+from . import test_takeaway_preset_mail

--- a/addons/pos_self_order/tests/test_takeaway_preset_mail.py
+++ b/addons/pos_self_order/tests/test_takeaway_preset_mail.py
@@ -1,0 +1,21 @@
+import odoo.tests
+from odoo.addons.mail.tests.common import MailCase
+from odoo.addons.pos_self_order.tests.test_self_order_preset import TestSelfOrderPreset
+
+
+@odoo.tests.tagged('post_install', '-at_install')
+class TestTakeawayMail(MailCase, TestSelfOrderPreset):
+
+    def test_preset_takeaway_email_tour(self):
+        self.preset_takeaway.mail_template_id = self.env.ref('pos_self_order.takeout_email_template')
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.pos_config.current_session_id.set_opening_control(0, "")
+        self_route = self.pos_config._get_self_order_route()
+
+        with self.mock_mail_gateway():
+            self.start_tour(self_route, "test_preset_takeaway_email_tour")
+        self.assertEqual("Public user", self.env["pos.order"].search([], limit=1, order="id desc").floating_order_name)
+
+        # Message is posted and mail is sent on time
+        self.assertEqual(len(self._new_mails), 1)
+        self.assertEqual(self._new_mails.subject, "Your BarTest receipt")


### PR DESCRIPTION
When using the takeout preset with the self order, we're supposed to send a confirmation email to the customer. Currently, this mail does not get sent.

Steps to reproduce:
-------------------
* Open the Restaurant config, make it only use the takeout preset
  (by default) and enable self ordering + QR
* Log out
* Open the mobile menu
* Make an order
* Fill out the information for takeout (slot, name, mail) and continue
* Check the mails
> Nothing being sent

Cause:
------------
The email is supposed to be sent after entering the takeout informations and selecting the button "continue".
https://github.com/odoo/odoo/blob/aec27a7b4fbf6826842e7b5945ef0d5670bc0603/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js#L131-L135

The call to the db is made here:
https://github.com/odoo/odoo/blob/aec27a7b4fbf6826842e7b5945ef0d5670bc0603/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js#L156-L162
Which utlimately resolves in calling:
https://github.com/odoo/odoo/blob/aec27a7b4fbf6826842e7b5945ef0d5670bc0603/addons/point_of_sale/static/src/app/services/data_service.js#L526

This uses the call_kw route which requires the user to be connected.
https://github.com/odoo/odoo/blob/aec27a7b4fbf6826842e7b5945ef0d5670bc0603/addons/web/controllers/dataset.py#L28-L29

However the usecase we describe is mainly used by non connected users. If a user is not connected we will never call `action_send_self_order_receipt` which sends the email.

Why the fix:
------------
We do not want to use a public route to send the email. What we want is to send the email directly from the backend when the order is created.

In order to achieve this we need to send the email given by the customer when sending the order. To do that we need to override `serializeForORM` as the email is a computed field.

Currently we cannot send the receipt by email as we cannot render it from the backend. This is currently a limitation but does not induce a stepback compared to using a public route as the route to send the email would usually be executed before the payment of the order, in which case we didn't sent a receipt.

opw-5164546