### PR TITLE
[FIX] l10n_sa_edi: prevent error when tax_data is missing

### DIFF
--- a/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py
+++ b/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py
@@ -81,7 +81,7 @@ class AccountEdiXmlUbl_21Zatca(models.AbstractModel):
             return True
 
         def tax_grouping_function(base_line, tax_data):
-            tax = tax_data['tax']
+            tax = tax_data and tax_data['tax']
 
             # Ignore withholding taxes
             if tax and tax.l10n_sa_is_retention:


### PR DESCRIPTION
Before this commit, if the tax_data was missing, it would raise a traceback during the electronic invoice generation.

opw-5193614

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
