### PR TITLE
[FIX] l10n_tr_nilvera_einvoice: skip PDF attachment for ubl_tr

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice/models/account_move_send.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_move_send.py
@@ -223,3 +223,13 @@ class AccountMoveSend(models.AbstractModel):
                     invoice._l10n_tr_nilvera_submit_einvoice(xml_file, customer_alias)
                 else:   # E-Archive
                     invoice._l10n_tr_nilvera_submit_earchive(xml_file)
+
+    @api.model
+    def _postprocess_invoice_ubl_xml(self, invoice, invoice_data):
+        # EXTENDS account_edi_ubl_cii
+        # Nilvera rejects XMLs with the PDF attachment.
+
+        if invoice_data['invoice_edi_format'] == 'ubl_tr':
+            return
+
+        return super()._postprocess_invoice_ubl_xml(invoice, invoice_data)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses:
Nilvera rejects E-Invoices if the PDF attachment of the invoice is included in the XML payload.

## Current behavior before PR:
When an e-invoice XML is generated, it correctly follows the UBL 2.1 standard, which includes the PDF as an attachment. However, when the user later tries to send this XML to the Nilvera integration, the request fails because Nilvera does not expect the PDF attachment in the payload.

## Desired behavior after PR is merged:
After this fix, if the Customer's e-invoice format is set to **Türkiye (UBL TR 1.2)**, the PDF attachment will be skipped during the XML generation to ensure compatibility with Nilvera.

task-5169400

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
