### PR TITLE
[FIX] account : Fix the invoice preview when stripe is enabled

### DIFF
--- a/addons/account/static/src/interactions/account_sidebar.js
+++ b/addons/account/static/src/interactions/account_sidebar.js
@@ -17,7 +17,7 @@ export class AccountSidebar extends Sidebar {
 
     start() {
         super.start();
-        this.invoiceHTMLEl = document.querySelector("iframe");
+        this.invoiceHTMLEl = document.querySelector("iframe#invoice_html");
         const iframeDoc = this.invoiceHTMLEl.contentDocument || this.invoiceHTMLEl.contentWindow.document;
         if (iframeDoc.readyState === 'complete') {
             this.updateIframeSize();


### PR DESCRIPTION
Before this commit:

- when stripe is enabled, the invoiceHTMLEl is set to the stripe iframe instead of the invoice one leading to a crash.

after this commit:

- the invoice iframe is correctly retrieved by using it's ID.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
