### PR TITLE
[REF] im_livechat, *: remove explicit post_install

### DIFF
--- a/addons/crm_livechat/tests/test_chatbot_lead.py
+++ b/addons/crm_livechat/tests/test_chatbot_lead.py
@@ -2,10 +2,8 @@
 
 from odoo import Command
 from odoo.addons.crm_livechat.tests import chatbot_common
-from odoo.tests.common import tagged
 
 
-@tagged("post_install", "-at_install")
 class CrmChatbotCase(chatbot_common.CrmChatbotCase):
 
     def test_chatbot_create_lead_public_user(self):

--- a/addons/crm_livechat/tests/test_crm_lead.py
+++ b/addons/crm_livechat/tests/test_crm_lead.py
@@ -3,10 +3,9 @@
 from odoo import Command
 from odoo.addons.crm.tests.common import TestCrmCommon
 from odoo.addons.mail.tests.common import mail_new_test_user
-from odoo.tests.common import HttpCase, tagged, users
+from odoo.tests.common import HttpCase, users
 
 
-@tagged("post_install", "-at_install")
 class TestLivechatLead(HttpCase, TestCrmCommon):
 
     @classmethod

--- a/addons/crm_livechat/tests/test_discuss_channel_access.py
+++ b/addons/crm_livechat/tests/test_discuss_channel_access.py
@@ -1,10 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.exceptions import AccessError
-from odoo.tests.common import HttpCase, new_test_user, tagged
+from odoo.tests.common import HttpCase, new_test_user
 
 
-@tagged("post_install", "-at_install")
 class TestDiscussChannelAccess(HttpCase):
     def test_access_channel_from_lead(self):
         test_cases = [

--- a/addons/im_livechat/tests/test_call.py
+++ b/addons/im_livechat/tests/test_call.py
@@ -1,9 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.tests.common import tagged, HttpCase, JsonRpcException
+from odoo.tests.common import HttpCase, JsonRpcException
 
 
-@tagged("post_install", "-at_install")
 class TestCall(HttpCase):
     def test_visitor_cannot_start_call(self):
         self.authenticate(None, None)

--- a/addons/im_livechat/tests/test_chatbot_form_ui.py
+++ b/addons/im_livechat/tests/test_chatbot_form_ui.py
@@ -1,11 +1,8 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import tests
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 
 
-@tests.tagged("post_install", "-at_install")
 class TestLivechatChatbotFormUI(HttpCaseWithUserDemo):
     def test_chatbot_steps_sequence_ui(self):
         """ As sequences are *critical* for the chatbot_script script, let us a run a little tour that

--- a/addons/im_livechat/tests/test_chatbot_internals.py
+++ b/addons/im_livechat/tests/test_chatbot_internals.py
@@ -4,13 +4,12 @@ from freezegun import freeze_time
 
 from odoo import Command, fields
 from odoo.addons.im_livechat.tests import chatbot_common
-from odoo.tests.common import JsonRpcException, new_test_user, tagged
+from odoo.tests.common import JsonRpcException, new_test_user
 from odoo.tools.misc import mute_logger
 from odoo.addons.mail.tests.common import freeze_all_time, MailCommon
 from odoo.addons.mail.tools.discuss import Store
 
 
-@tagged("post_install", "-at_install")
 class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
 
     def test_chatbot_duplicate(self):

--- a/addons/im_livechat/tests/test_cors_livechat.py
+++ b/addons/im_livechat/tests/test_cors_livechat.py
@@ -1,9 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.tests import tagged, HttpCase, JsonRpcException
+from odoo.tests import HttpCase, JsonRpcException
 
 
-@tagged("post_install", "-at_install")
 class TestCorsLivechat(HttpCase):
     @classmethod
     def setUpClass(cls):

--- a/addons/im_livechat/tests/test_digest.py
+++ b/addons/im_livechat/tests/test_digest.py
@@ -1,12 +1,9 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.addons.digest.tests.common import TestDigestCommon
 from odoo.tools import mute_logger
-from odoo.tests import tagged
 
 
-@tagged('post_install', '-at_install')
 class TestLiveChatDigest(TestDigestCommon):
 
     @classmethod

--- a/addons/im_livechat/tests/test_discuss_channel.py
+++ b/addons/im_livechat/tests/test_discuss_channel.py
@@ -4,12 +4,11 @@ from freezegun import freeze_time
 from markupsafe import Markup
 
 from odoo import Command, fields
-from odoo.tests import new_test_user, tagged
+from odoo.tests import new_test_user
 from odoo.addons.im_livechat.tests.common import TestImLivechatCommon, TestGetOperatorCommon
 from odoo.addons.mail.tests.common import MailCase
 
 
-@tagged("-at_install", "post_install")
 class TestDiscussChannel(TestImLivechatCommon, TestGetOperatorCommon, MailCase):
     def test_unfollow_from_non_member_does_not_close_livechat(self):
         bob_user = new_test_user(

--- a/addons/im_livechat/tests/test_get_discuss_channel.py
+++ b/addons/im_livechat/tests/test_get_discuss_channel.py
@@ -7,10 +7,9 @@ from unittest.mock import patch, PropertyMock
 from odoo import fields
 from odoo.addons.im_livechat.tests.common import TestImLivechatCommon
 from odoo.addons.mail.tests.common import MailCommon
-from odoo.tests import new_test_user, tagged
+from odoo.tests import new_test_user
 
 
-@tagged("post_install", "-at_install")
 class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
     def test_get_discuss_channel(self):
         """For a livechat with 5 available operators, we open 5 channels 5 times (25 channels total).

--- a/addons/im_livechat/tests/test_get_operator.py
+++ b/addons/im_livechat/tests/test_get_operator.py
@@ -3,14 +3,12 @@
 from datetime import timedelta
 from unittest.mock import patch
 
-import odoo
 from odoo import Command, fields
 from odoo.addons.im_livechat.tests.common import TestGetOperatorCommon
 from odoo.addons.mail.tests.common import MailCommon, freeze_all_time
 from odoo.tests.common import users
 
 
-@odoo.tests.tagged("-at_install", "post_install")
 class TestGetOperator(MailCommon, TestGetOperatorCommon):
     def setUp(self):
         super().setUp()

--- a/addons/im_livechat/tests/test_im_livechat_calls.py
+++ b/addons/im_livechat/tests/test_im_livechat_calls.py
@@ -3,12 +3,10 @@
 from functools import wraps
 from unittest.mock import patch
 
-from odoo.tests.common import tagged
 from odoo.addons.im_livechat.controllers.main import LivechatController
 from odoo.addons.im_livechat.tests.common import TestImLivechatCommon
 
 
-@tagged("post_install", "-at_install")
 class TestImLivechatCalls(TestImLivechatCommon):
     def test_meeting_view(self):
         og_get_session = LivechatController.get_session

--- a/addons/im_livechat/tests/test_im_livechat_channel.py
+++ b/addons/im_livechat/tests/test_im_livechat_channel.py
@@ -1,13 +1,14 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 from datetime import timedelta
 
-from odoo.tests import new_test_user, tagged
+from odoo.tests import new_test_user
 from odoo.exceptions import AccessError, ValidationError
 from odoo.addons.im_livechat.tests.common import TestImLivechatCommon
 from odoo.addons.im_livechat.tests.test_get_operator import TestGetOperator
 from odoo.fields import Command, Datetime
 
 
-@tagged("-at_install", "post_install")
 class TestImLivechatChannel(TestImLivechatCommon, TestGetOperator):
     def test_user_cant_join_livechat_channel(self):
         bob_user = new_test_user(self.env, "bob_user", groups="base.group_user")

--- a/addons/im_livechat/tests/test_im_livechat_report.py
+++ b/addons/im_livechat/tests/test_im_livechat_report.py
@@ -5,10 +5,9 @@ from unittest.mock import patch
 
 from odoo import Command
 from odoo.addons.im_livechat.tests.common import TestImLivechatCommon
-from odoo.tests.common import new_test_user, tagged
+from odoo.tests.common import new_test_user
 
 
-@tagged("post_install", "-at_install")
 class TestImLivechatReport(TestImLivechatCommon):
     def setUp(self):
         super().setUp()

--- a/addons/im_livechat/tests/test_im_livechat_support_page.py
+++ b/addons/im_livechat/tests/test_im_livechat_support_page.py
@@ -1,13 +1,11 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from unittest.mock import patch
 
-import odoo
 from odoo.addons.im_livechat.controllers.main import LivechatController
 from odoo.addons.im_livechat.tests.common import TestGetOperatorCommon
 
-@odoo.tests.tagged("-at_install", "post_install")
+
 class TestImLivechatSupportPage(TestGetOperatorCommon):
     def test_load_modules(self):
         operator = self._create_operator()

--- a/addons/im_livechat/tests/test_js.py
+++ b/addons/im_livechat/tests/test_js.py
@@ -1,8 +1,9 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 import odoo
 from odoo.addons.web.tests.test_js import unit_test_error_checker
 
 
-@odoo.tests.tagged("post_install", "-at_install")
 class ExternalTestSuite(odoo.tests.HttpCase):
     def test_external_livechat(self):
         # webclient external test suite

--- a/addons/im_livechat/tests/test_member_history.py
+++ b/addons/im_livechat/tests/test_member_history.py
@@ -1,10 +1,11 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 from odoo.addons.im_livechat.tests import chatbot_common
 from odoo.exceptions import ValidationError
-from odoo.tests.common import tagged, new_test_user
+from odoo.tests.common import new_test_user
 from odoo.addons.im_livechat.tests.common import TestGetOperatorCommon
 
 
-@tagged("post_install", "-at_install")
 class TestLivechatMemberHistory(TestGetOperatorCommon, chatbot_common.ChatbotCase):
     def test_get_session_create_history(self):
         john = self._create_operator("fr_FR")

--- a/addons/im_livechat/tests/test_message.py
+++ b/addons/im_livechat/tests/test_message.py
@@ -5,13 +5,12 @@ from markupsafe import Markup
 
 from odoo import Command, fields
 from odoo.exceptions import AccessError
-from odoo.tests.common import users, tagged
+from odoo.tests.common import users
 from odoo.addons.mail.tests.common import MailCommon
 from odoo.addons.mail.tools.discuss import Store
 from odoo.addons.im_livechat.tests.chatbot_common import ChatbotCase
 
 
-@tagged('post_install', '-at_install')
 class TestImLivechatMessage(ChatbotCase, MailCommon):
     @classmethod
     def setUpClass(cls):

--- a/addons/im_livechat/tests/test_res_users.py
+++ b/addons/im_livechat/tests/test_res_users.py
@@ -1,8 +1,9 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 from odoo.tests import new_test_user
-from odoo.tests.common import TransactionCase, tagged
+from odoo.tests.common import TransactionCase
 
 
-@tagged("post_install", "-at_install")
 class TestLiveChatResUsers(TransactionCase):
 
     def test_livechat_create_res_users(self):

--- a/addons/im_livechat/tests/test_session_views.py
+++ b/addons/im_livechat/tests/test_session_views.py
@@ -1,10 +1,11 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 from odoo import Command
 from odoo.tests import new_test_user
 from odoo.addons.im_livechat.tests.common import TestImLivechatCommon
-from odoo.tests.common import users, tagged
+from odoo.tests.common import users
 
 
-@tagged("-at_install", "post_install")
 class TestImLivechatSessionViews(TestImLivechatCommon):
     def test_session_history_navigation_back_and_forth(self):
         operator = new_test_user(

--- a/addons/im_livechat/tests/test_transcript.py
+++ b/addons/im_livechat/tests/test_transcript.py
@@ -1,10 +1,10 @@
-from odoo.tests.common import tagged
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 from odoo.tools import mute_logger
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 from odoo.addons.im_livechat.tests.common import TestImLivechatCommon
 
 
-@tagged("-at_install", "post_install")
 class TestImLivechatTranscript(TestImLivechatCommon, HttpCaseWithUserDemo):
     def test_download_transcript(self):
         data = self.make_jsonrpc_request(

--- a/addons/im_livechat/tests/test_upload_attachment.py
+++ b/addons/im_livechat/tests/test_upload_attachment.py
@@ -1,11 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import http
-from odoo.tests.common import tagged, HttpCase
+from odoo.tests.common import HttpCase
 from odoo.tools import mute_logger, file_open
 
 
-@tagged("post_install", "-at_install")
 class TestUploadAttachment(HttpCase):
     def test_visitor_cannot_upload_on_closed_livechat(self):
         self.authenticate(None, None)

--- a/addons/im_livechat/tests/test_user_livechat_username.py
+++ b/addons/im_livechat/tests/test_user_livechat_username.py
@@ -1,9 +1,9 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 from odoo import fields
-from odoo.tests.common import tagged
 from odoo.addons.im_livechat.tests.common import TestGetOperatorCommon
 
 
-@tagged("post_install", "-at_install")
 class TestUserLivechatUsername(TestGetOperatorCommon):
     def test_user_livechat_username_channel_invite_notification(self):
         john = self._create_operator("fr_FR")

--- a/addons/test_discuss_full/tests/test_avatar_card_tour.py
+++ b/addons/test_discuss_full/tests/test_avatar_card_tour.py
@@ -1,12 +1,13 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 from datetime import date, timedelta
 
 from odoo import Command
-from odoo.tests import tagged, users
+from odoo.tests import users
 from odoo.tests.common import HttpCase, new_test_user
 from odoo.addons.mail.tests.common import MailCommon
 
 
-@tagged("post_install", "-at_install")
 class TestAvatarCardTour(MailCommon, HttpCase):
     @classmethod
     def setUpClass(cls):

--- a/addons/test_discuss_full/tests/test_im_livechat_portal.py
+++ b/addons/test_discuss_full/tests/test_im_livechat_portal.py
@@ -1,8 +1,9 @@
-from odoo import Command, tests
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import Command
 from odoo.addons.website_livechat.tests.test_chatbot_ui import TestLivechatChatbotUI
 
 
-@tests.common.tagged("post_install", "-at_install")
 class TestImLivechatPortal(TestLivechatChatbotUI):
     def test_chatbot_redirect_to_portal(self):
         project = self.env["project.project"].create({"name": "Portal Project"})

--- a/addons/test_discuss_full/tests/test_livechat_hr_holidays.py
+++ b/addons/test_discuss_full/tests/test_livechat_hr_holidays.py
@@ -3,11 +3,10 @@
 from dateutil.relativedelta import relativedelta
 
 from odoo import Command, fields
-from odoo.tests.common import HttpCase, tagged
+from odoo.tests.common import HttpCase
 from odoo.addons.mail.tests.common import MailCommon
 
 
-@tagged("post_install", "-at_install")
 class TestLivechatHrHolidays(HttpCase, MailCommon):
     """Tests for bridge between im_livechat and hr_holidays modules."""
 

--- a/addons/test_discuss_full/tests/test_livechat_session_open.py
+++ b/addons/test_discuss_full/tests/test_livechat_session_open.py
@@ -1,9 +1,9 @@
-import odoo
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 from odoo.addons.im_livechat.tests.common import TestImLivechatCommon
 from odoo.tests import new_test_user
 
 
-@odoo.tests.tagged("-at_install", "post_install")
 class TestImLivechatSessions(TestImLivechatCommon):
     def test_livechat_session_open(self):
         new_test_user(

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -11,7 +11,7 @@ from odoo.addons.mail.tools.discuss import Store
 from odoo.tests.common import users, tagged, HttpCase, warmup
 
 
-@tagged('post_install', '-at_install', 'is_query_count')
+@tagged("is_query_count")
 class TestDiscussFullPerformance(HttpCase, MailCommon):
     # Queries for _query_count_init_store (in order):
     #   1: search res_partner (odooot ref exists)

--- a/addons/test_discuss_full/tests/test_performance_inbox.py
+++ b/addons/test_discuss_full/tests/test_performance_inbox.py
@@ -6,7 +6,7 @@ from odoo.addons.mail.tests.common import MailCommon
 from odoo.tests.common import HttpCase, tagged, warmup
 
 
-@tagged("post_install", "-at_install", "is_query_count")
+@tagged("is_query_count")
 class TestInboxPerformance(HttpCase, MailCommon):
     @warmup
     def test_fetch_with_rating_stats_enabled(self):

--- a/addons/website_livechat/tests/test_chatbot_ui.py
+++ b/addons/website_livechat/tests/test_chatbot_ui.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import Command, tests
@@ -7,7 +6,7 @@ from odoo.addons.website_livechat.tests.common import TestLivechatCommon as Test
 from odoo.addons.im_livechat.tests.common import TestGetOperatorCommon
 
 
-@tests.tagged('post_install', '-at_install', 'is_tour')
+@tests.tagged("is_tour")
 class TestLivechatChatbotUICommon(TestGetOperatorCommon, TestWebsiteLivechatCommon, ChatbotCase):
     def setUp(self):
         super().setUp()
@@ -68,7 +67,6 @@ class TestLivechatChatbotUICommon(TestGetOperatorCommon, TestWebsiteLivechatComm
         self.start_tour("/contactus", "website_livechat.chatbot_redirect")
 
 
-@tests.tagged("post_install", "-at_install")
 class TestLivechatChatbotUI(TestLivechatChatbotUICommon):
 
     def _check_complete_chatbot_flow_result(self):
@@ -325,7 +323,6 @@ class TestLivechatChatbotUI(TestLivechatChatbotUICommon):
         self.start_tour("/", "website_livechat.chatbot_continue_tour")
 
 
-@tests.tagged("post_install", "-at_install")
 class TestLivechatChatbotUIMoblie(TestLivechatChatbotUICommon):
     browser_size = '375x667'
 

--- a/addons/website_livechat/tests/test_fw_operator.py
+++ b/addons/website_livechat/tests/test_fw_operator.py
@@ -1,10 +1,11 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 from odoo import Command
-from odoo.tests import HttpCase, tagged
+from odoo.tests import HttpCase
 from odoo.addons.website_livechat.tests.common import TestLivechatCommon
 from odoo.addons.im_livechat.tests.chatbot_common import ChatbotCase
 
 
-@tagged("post_install", "-at_install")
 class TestFwOperator(ChatbotCase, HttpCase, TestLivechatCommon):
     def setUp(self):
         super().setUp()

--- a/addons/website_livechat/tests/test_lazy_frontend_bus.py
+++ b/addons/website_livechat/tests/test_lazy_frontend_bus.py
@@ -1,8 +1,9 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 from odoo import tests
 from odoo.addons.website_livechat.tests.common import TestLivechatCommon
 
 
-@tests.tagged("-at_install", "post_install")
 class TestBusLazyFrontendBus(tests.HttpCase, TestLivechatCommon):
     def test_bus_not_started(self):
         self.start_tour("/", "website_livechat.lazy_frontend_bus")

--- a/addons/website_livechat/tests/test_livechat_basic_flow.py
+++ b/addons/website_livechat/tests/test_livechat_basic_flow.py
@@ -3,14 +3,13 @@
 import datetime
 from freezegun import freeze_time
 
-from odoo import fields, tests, _
+from odoo import fields, _
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 from odoo.addons.mail.tools.discuss import Store
 from odoo.addons.website_livechat.tests.common import TestLivechatCommon
 from odoo.tests.common import new_test_user
 
 
-@tests.tagged('post_install', '-at_install')
 class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
     def test_channel_created_on_user_interaction(self):
         self.start_tour('/', 'im_livechat_request_chat', login=None)
@@ -412,7 +411,6 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
         self.assertEqual(channel_info["livechat_visitor_id"], False)
 
 
-@tests.tagged('post_install', '-at_install')
 class TestLivechatBasicFlowHttpCaseMobile(HttpCaseWithUserDemo, TestLivechatCommon):
     browser_size = '375x667'
     touch_enabled = True

--- a/addons/website_livechat/tests/test_livechat_request.py
+++ b/addons/website_livechat/tests/test_livechat_request.py
@@ -1,12 +1,9 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import tests
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 from odoo.addons.website_livechat.tests.common import TestLivechatCommon
 
 
-@tests.tagged('post_install', '-at_install')
 class TestLivechatRequestHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
     def test_livechat_request_complete_flow(self):
         self._clean_livechat_sessions()

--- a/addons/website_livechat/tests/test_livechat_session_user_changes.py
+++ b/addons/website_livechat/tests/test_livechat_session_user_changes.py
@@ -1,11 +1,9 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import tests
 from odoo.addons.website_livechat.tests.common import TestLivechatCommon
 
 
-@tests.tagged("-at_install", "post_install")
 class TestLivechatSessionUserChanges(tests.HttpCase, TestLivechatCommon):
     def test_livechat_logout_after_chat_start(self):
         self.start_tour("/", "website_livechat_logout_after_chat_start", login="admin")

--- a/addons/website_livechat/tests/test_ui.py
+++ b/addons/website_livechat/tests/test_ui.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import tests, _
@@ -6,7 +5,6 @@ from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 from odoo.addons.website_livechat.tests.common import TestLivechatCommon
 
 
-@tests.tagged('post_install', '-at_install')
 class TestLivechatUI(HttpCaseWithUserDemo, TestLivechatCommon):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
\* = crm_livechat, test_discuss_full, website_livechat

post_install is now the default for all tests, so we can remove the explicit tags.