### PR TITLE
[FIX] bus: websocket worker incorrectly detects user changes

### DIFF
--- a/addons/bus/models/ir_websocket.py
+++ b/addons/bus/models/ir_websocket.py
@@ -58,6 +58,8 @@ class IrWebsocket(models.AbstractModel):
                 .with_context(active_test=False)
                 .search([("id", "in", [int(p[1]) for p in presences if p[0] == "res.partner"])])
             )
+        if self.env.user and not self.env.user._is_public():
+            channels.append((self.env.user.partner_id, "presence"))
         return channels
 
     def _build_bus_channel_list(self, channels):

--- a/addons/bus/static/src/workers/websocket_worker.js
+++ b/addons/bus/static/src/workers/websocket_worker.js
@@ -33,7 +33,7 @@ export const WEBSOCKET_CLOSE_CODES = Object.freeze({
     RECONNECTING: 4003,
 });
 /** @deprecated worker version is now retrieved from `session.websocket_worker_bundle` */
-export const WORKER_VERSION = "17.0-2";
+export const WORKER_VERSION = "17.0-3";
 const MAXIMUM_RECONNECT_DELAY = 60000;
 
 /**
@@ -255,9 +255,10 @@ export class WebsocketWorker {
             this.isWaitingForNewUID = false;
             this.currentUID = uid;
         }
-        if ((this.currentUID !== uid && isCurrentUserKnown) || this.currentDB !== db) {
+        this.currentDB ||= db;
+        if ((this.currentUID !== uid && isCurrentUserKnown) || (db && this.currentDB !== db)) {
             this.currentUID = uid;
-            this.currentDB = db;
+            this.currentDB = db || this.currentDB;
             if (this.websocket) {
                 this.websocket.close(WEBSOCKET_CLOSE_CODES.CLEAN);
             }

--- a/addons/bus/static/tests/bus_tests.js
+++ b/addons/bus/static/tests/bus_tests.js
@@ -228,11 +228,15 @@ QUnit.test("Websocket disconnects upon user log out", async () => {
     const firstTabEnv = await makeTestEnv();
     firstTabEnv.services["bus_service"].start();
     await waitForBusEvent(firstTabEnv, "connect");
-    // second tab connects to the worker after disconnection: user_id
-    // is now false.
-    patchWithCleanup(session, { user_id: false });
+    patchWithCleanup(session, { db: undefined });
+    // second tab connects to the worker, ommiting the DB name. Consider same DB.
     const env2 = await makeTestEnv();
     env2.services["bus_service"].start();
+    await waitForBusEvent(firstTabEnv, "disconnect", { received: false });
+    // third tab connects to the worker after disconnection: user_id is now false.
+    patchWithCleanup(session, { user_id: false });
+    const env3 = await makeTestEnv();
+    env3.services["bus_service"].start();
     await waitForBusEvent(firstTabEnv, "disconnect");
 });
 

--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -880,7 +880,7 @@ class WebsocketConnectionHandler:
     # Latest version of the websocket worker. This version should be incremented
     # every time `websocket_worker.js` is modified to force the browser to fetch
     # the new worker bundle.
-    _VERSION = "17.0-2"
+    _VERSION = "17.0-3"
 
     @classmethod
     def websocket_allowed(cls, request):

--- a/addons/mail/models/discuss/ir_websocket.py
+++ b/addons/mail/models/discuss/ir_websocket.py
@@ -53,6 +53,7 @@ class IrWebsocket(models.AbstractModel):
         elif guest := self.env["mail.guest"]._get_guest_from_context():
             # sudo - mail.guest: guest can access their own channels.
             self_discuss_channels = guest.sudo().channel_ids
+            channels.append((guest, "presence"))
         partner_domain = [
             ("id", "in", [int(p[1]) for p in presences if p[0] == "res.partner"]),
             ("channel_ids", "in", self_discuss_channels.ids),


### PR DESCRIPTION
The websocket worker holds a single WebSocket connection per browser. Clients pass the current user ID and DB name, which the worker uses to detect login/logout. Some pages omit the DB name, causing the worker to incorrectly mark the user as changed. This clears previous channels, which may never be added back.

This is particularly noticeable with presence channels: the user's own channel can be lost, preventing them from receiving their own presence updates (e.g. when another browser closes, the user cannot see they are disconnected and cannot correct the value).

The user's own presence channel should be added server-side, so the first subscription immediately returns the user presence and the DB should not be taken into account if ommited.

task-5096212

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
