### PR TITLE
[FIX] spreadsheet: getter should not throw outside of evaluation

### DIFF
--- a/addons/spreadsheet/static/src/pivot/odoo_pivot.js
+++ b/addons/spreadsheet/static/src/pivot/odoo_pivot.js
@@ -369,7 +369,11 @@ export class OdooPivot {
             case "float":
                 return "#,##0.00";
             case "monetary":
-                return this.getters.getCompanyCurrencyFormat() || "#,##0.00";
+                try {
+                    return this.getters.getCompanyCurrencyFormat() || "#,##0.00";
+                } catch {
+                    return "#,##0.00";
+                }
             case "date":
             case "datetime": {
                 const timeAdapter = pivotTimeAdapter(granularity);

--- a/addons/spreadsheet/static/tests/pivots/model/pivot_plugin.test.js
+++ b/addons/spreadsheet/static/tests/pivots/model/pivot_plugin.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "@odoo/hoot";
+import { describe, expect, test, Deferred } from "@odoo/hoot";
 import { animationFrame, mockDate } from "@odoo/hoot-mock";
 import {
     defineSpreadsheetActions,
@@ -12,7 +12,6 @@ import {
     patchWithCleanup,
     serverState,
 } from "@web/../tests/web_test_helpers";
-import { Deferred } from "@web/core/utils/concurrency";
 
 import {
     addGlobalFilter,
@@ -1106,6 +1105,7 @@ test("PIVOT formulas with monetary measure are correctly formatted at evaluation
                     <field name="pognon" type="measure"/>
                 </pivot>`,
     });
+    await animationFrame();
     expect(getEvaluatedCell(model, "B3").format).toBe("#,##0.00[$€]");
 });
 
@@ -2314,4 +2314,33 @@ test("Pivot headers day of week are still correct after updating the locale's we
     });
     await waitForDataLoaded(model);
     expect(getEvaluatedGrid(model, "A22:A24")).toEqual([["Sunday"], ["Wednesday"], ["Thursday"]]);
+});
+
+test("`getPivotCellFromPosition` should not throw on missing company default currency", async function () {
+    const { model } = await createSpreadsheetWithPivot({
+        mockRPC: async function (route, args) {
+            if (args.method === "get_company_currency_for_spreadsheet") {
+                return false;
+            }
+        },
+        arch: /* xml */ `
+            <pivot>
+                <field name="foo" type="col"/>
+                <field name="bar" type="row"/>
+                <field name="pognon" type="measure"/>
+            </pivot>`,
+    });
+    const sheetId = model.getters.getActiveSheetId();
+    const [pivotId] = model.getters.getPivotIds();
+    updatePivot(model, pivotId, {
+        sortedColumn: {
+            domain: [],
+            order: "desc",
+            measure: "pognon:avg",
+        },
+    });
+    await animationFrame();
+    expect(() => {
+        model.getters.getPivotCellFromPosition({ sheetId, col: 0, row: 0 });
+    }).not.toThrow();
 });

--- a/addons/spreadsheet/static/tests/public_spreadsheet/freeze.test.js
+++ b/addons/spreadsheet/static/tests/public_spreadsheet/freeze.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "@odoo/hoot";
+import { animationFrame, describe, expect, test } from "@odoo/hoot";
 import { registries } from "@odoo/o-spreadsheet";
 import { createSpreadsheetWithChart } from "@spreadsheet/../tests/helpers/chart";
 import {
@@ -124,6 +124,7 @@ test("computed format is exported", async function () {
             `,
     });
     setCellContent(model, "A1", '=PIVOT.VALUE(1,"pognon:avg")');
+    await animationFrame();
     expect(getCell(model, "A1").format).toBe(undefined);
     expect(getEvaluatedCell(model, "A1").format).toBe("#,##0.00[$€]");
     const data = await freezeOdooData(model);


### PR DESCRIPTION
Some getters are (too) tied with the evaluation and sometimes take the liberty to throw evaluation-related errors.
This can only work if the said getter is called exclusively in the within the context of the evaluation (which has a splendid try/catch statement to this effect).

Issues start to appear when we start using the said getters outside the evaluation and this is what happens.

Since https://github.com/odoo/o-spreadsheet/issues/6083, we call the getter `getPivotCellFromPosition` which in specific cases call `getCompanyCurrencyFormat` and the latter will throw errors when starting and RPC. However, its effect was hidden by the sortcut added in https://github.com/odoo/odoo/pull/151725.

The effect could only be seen in a version history action where we did not provide a default currency to the model config.

This commit fixes the symptom but not the original cause: having getters that throw and are not handled in the components life-cycle. Such getters should probably disappear in a future refactoring.

Task-5187293

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
