### PR TITLE
[FIX] html_editor: properly clean listener of `load` in AutoResizeImage

### DIFF
--- a/addons/html_editor/static/src/main/media/media_dialog/image_selector.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/image_selector.js
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "@odoo/owl";
+import { useRef, useState } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
 import { rpc } from "@web/core/network/rpc";
 import { KeepLast } from "@web/core/utils/concurrency";
@@ -18,14 +18,6 @@ export class AutoResizeImage extends Attachment {
         this.state = useState({
             loaded: false,
         });
-
-        useEffect(
-            () => {
-                this.image.el.addEventListener("load", () => this.onImageLoaded());
-                return this.image.el.removeEventListener("load", () => this.onImageLoaded());
-            },
-            () => []
-        );
     }
 
     async onImageLoaded() {

--- a/addons/html_editor/static/src/main/media/media_dialog/image_selector.xml
+++ b/addons/html_editor/static/src/main/media/media_dialog/image_selector.xml
@@ -4,7 +4,7 @@
         <RemoveButton t-if="props.isRemovable" model="props.model" remove="() => this.remove()"/>
         <div class="o_we_media_dialog_img_wrapper" t-att-class="{ 'bg-light': props.unselectable }">
              <t t-set="unselectable_attachment_title">You can not use this image in a field</t>
-             <img t-ref="auto-resize-image" class="o_we_attachment_highlight img img-fluid w-100" t-att-class="{ 'opacity-25': props.unselectable}" t-att-src="props.src" t-att-alt="props.altDescription" loading="lazy" t-att-title="props.unselectable ? unselectable_attachment_title : props.title"/>
+             <img t-ref="auto-resize-image" class="o_we_attachment_highlight img img-fluid w-100" t-att-class="{ 'opacity-25': props.unselectable}" t-att-src="props.src" t-att-alt="props.altDescription" loading="lazy" t-att-title="props.unselectable ? unselectable_attachment_title : props.title" t-on-load="onImageLoaded"/>
              <a t-if="props.author" class="o_we_media_author position-absolute start-0 bottom-0 end-0 text-truncate text-center text-primary fs-6 bg-white-50" t-att-href="props.authorLink" target="_blank" t-esc="props.author"/>
         </div>
         <span t-if="props.isOptimized" class="badge position-absolute bottom-0 end-0 m-1 text-bg-success">Optimized</span>


### PR DESCRIPTION
In `AutoResizeImage`, a listener for the load of an image was made with a `useEffect`, but it was not correctly cleaning. It should return a function that remove the listener not directly call `removeListener`, and it should remove the same listener that was added.

This commit uses the `t-on-load` in the template instead.

task-5190618