### PR TITLE
[IMP] web: list: allow so specify min/max widths in arch

### DIFF
--- a/addons/web/static/src/views/list/column_width_hook.js
+++ b/addons/web/static/src/views/list/column_width_hook.js
@@ -106,6 +106,37 @@ export const FIELD_WIDTHS = Object.freeze({
     text: [80, 1200],
 });
 
+/**
+ * @typedef {Object} Widths
+ * @property {number} min - The min width
+ * @property {number} [max] - The max width
+ */
+/**
+ * Parses the value of the `width` attribute set on columns in list view archs.
+ * The value can be either:
+ *   - a fixed width, e.g. `width="100px"`,
+ *   - a min width, e.g. `width="[100px]"`,
+ *   - a min and a max widths, e.g. `width="[100px,200px]"`.
+ * Note: the value is always in px, so in all cases above, "px" can be omitted (e.g. `width="100"`).
+ *
+ * @param {string} attr
+ * @returns Widths
+ */
+export function parseWidthAttribute(attr) {
+    const widths = {};
+    const widthAttr = attr.replaceAll("px", "");
+    const match = /\[(?<minWidth>\d+)(,(?<maxWidth>\d+))?\]/.exec(widthAttr);
+    if (match) {
+        widths.min = parseInt(match.groups.minWidth, 10);
+        if (match.groups.maxWidth) {
+            widths.max = parseInt(match.groups.maxWidth, 10);
+        }
+    } else {
+        widths.min = widths.max = parseInt(widthAttr, 10);
+    }
+    return widths;
+}
+
 export function resetDateFieldWidths() {
     // useful for tests
     _dateWidths = null;
@@ -316,7 +347,9 @@ function getWidthSpecs(columns) {
         let minWidth;
         let maxWidth;
         if (column.attrs && column.attrs.width) {
-            minWidth = maxWidth = parseInt(column.attrs.width.split("px")[0]);
+            const { min, max } = parseWidthAttribute(column.attrs.width);
+            minWidth = min;
+            maxWidth = max;
         } else {
             let width;
             if (column.type === "field") {

--- a/addons/web/static/tests/views/list/column_widths.test.js
+++ b/addons/web/static/tests/views/list/column_widths.test.js
@@ -18,7 +18,7 @@ import {
 } from "@web/../tests/web_test_helpers";
 
 import { registry } from "@web/core/registry";
-import { resetDateFieldWidths } from "@web/views/list/column_width_hook";
+import { parseWidthAttribute, resetDateFieldWidths } from "@web/views/list/column_width_hook";
 
 describe.current.tags("desktop");
 
@@ -142,6 +142,15 @@ function expectedColumnWidthsToBeCloseTo(expectedColumnWidths) {
 }
 
 // width computation
+test(`width computation: parseWidthAttribute`, async () => {
+    expect(parseWidthAttribute("40")).toEqual({ min: 40, max: 40 });
+    expect(parseWidthAttribute("75px")).toEqual({ min: 75, max: 75 });
+    expect(parseWidthAttribute("[92]")).toEqual({ min: 92 });
+    expect(parseWidthAttribute("[24px]")).toEqual({ min: 24 });
+    expect(parseWidthAttribute("[120,200]")).toEqual({ min: 120, max: 200 });
+    expect(parseWidthAttribute("[75px,148px]")).toEqual({ min: 75, max: 148 });
+});
+
 test(`width computation: no record, lot of fields`, async () => {
     Foo._records = [];
     await mountView({
@@ -447,7 +456,7 @@ test(`width computation: widget with listViewWidth in its definition`, async () 
     expect(getColumnWidths()).toEqual([40, 180, 580]);
 });
 
-test(`width computation: list with width attribute in arch`, async () => {
+test(`width computation: list with width attribute in arch (fixed widths)`, async () => {
     await mountView({
         type: "list",
         resModel: "foo",
@@ -460,6 +469,21 @@ test(`width computation: list with width attribute in arch`, async () => {
             </list>`,
     });
     expect(getColumnWidths()).toEqual([40, 61, 72, 102, 524]);
+});
+
+test(`width computation: list with width attribute in arch (min/max widths)`, async () => {
+    await mountView({
+        type: "list",
+        resModel: "foo",
+        arch: `
+            <list>
+                <field name="int_field" width="[52,100]"/>
+                <field name="foo"/>
+                <field name="qux" width="[30]"/>
+                <field name="currency_id"/>
+            </list>`,
+    });
+    expect(getColumnWidths()).toEqual([40, 109, 165, 179, 306]);
 });
 
 test(`width computation: datetime in numeric, am/pm format`, async () => {


### PR DESCRIPTION
Before this commit, it was only possible to specify a fixed width in list view archs, e.g. `width="80"`, for columns. However, the column widths logic supported ranges, i.e. min and optionally max widths. This was used as default widths for some field types, and in some field widgets. This couldn't be specified directly in archs though. This commit enables it. One can now write `width="[50]"` to specify a min width, and `width="[50,80]"` to specify a min and a max widths.

task~5194492

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
