### PR TITLE
[18.0][IMP] core: JSON operator compatibility with pg_trgm % operator

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2989,9 +2989,11 @@ class BaseModel(metaclass=MetaModel):
 
         if field.translate:
             langs = field.get_translation_fallback_langs(self.env)
+            if len(langs) == 1:
+                # Wrap the ->> operator in parenthesis to ensure correct operator precedence
+                # e.g. when used with the % operator from pg_trgm
+                return SQL("(%s->>%s)", sql_field, langs[0])
             sql_field_langs = [SQL("%s->>%s", sql_field, lang) for lang in langs]
-            if len(sql_field_langs) == 1:
-                return sql_field_langs[0]
             return SQL("COALESCE(%s)", SQL(", ").join(sql_field_langs))
 
         if field.company_dependent:


### PR DESCRIPTION
Wrap the ->> operator to ensure correct operator precedence in WHERE clause with the comparison operator.

Description of the issue/feature this PR addresses:

When building the WHERE clause using only base en_US language, which doesn't use any fallback, the term field->>'en_US' it is not wrapped in any function like COALESCE, thus missing parenthesis for precedence.

This opens the possibility to implement the % operator from pg_trgm.

Without the parenthesis the % is evaluated before the extractor operator ->>.

Current behavior before PR:

```sql
SELECT id FROM product_template WHERE name->>'en_US' % 'foo';
-- evaluated as: name->>('en_US' % 'foo');
```


Desired behavior after PR is merged:

```sql
SELECT id FROM product_template WHERE (name->>'en_US') % 'foo';
```


CLA PR:
https://github.com/odoo/odoo/pull/232991

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
