### PR TITLE
[FIX] purchase_stock: keep the smart link PO <-> RO

### DIFF
--- a/addons/purchase_repair/models/purchase_order.py
+++ b/addons/purchase_repair/models/purchase_order.py
@@ -10,11 +10,17 @@ class PurchaseOrder(models.Model):
     @api.depends('order_line.move_dest_ids.repair_id')
     def _compute_repair_count(self):
         for purchase in self:
-            purchase.repair_count = len(purchase.order_line.move_dest_ids.repair_id)
+            purchase.repair_count = len(purchase._get_linked_repair_orders())
+
+    def _get_linked_repair_orders(self):
+        return (
+            self.order_line.move_dest_ids.repair_id |
+            self.order_line.move_ids.move_dest_ids.repair_id
+        )
 
     def action_view_repair_orders(self):
         self.ensure_one()
-        repair_ids = self.order_line.move_dest_ids.repair_id
+        repair_ids = self._get_linked_repair_orders()
         action = {
             'type': 'ir.actions.act_window',
             'res_model': 'repair.order',

--- a/addons/purchase_repair/models/repair_order.py
+++ b/addons/purchase_repair/models/repair_order.py
@@ -10,11 +10,17 @@ class RepairOrder(models.Model):
     @api.depends('move_ids.created_purchase_line_ids.order_id')
     def _compute_purchase_count(self):
         for repair in self:
-            repair.purchase_count = len(repair.move_ids.created_purchase_line_ids.order_id)
+            repair.purchase_count = len(repair._get_linked_purchase_orders())
+
+    def _get_linked_purchase_orders(self):
+        return (
+            self.move_ids.created_purchase_line_ids.order_id |
+            self.move_ids.move_orig_ids.purchase_line_id.order_id
+        )
 
     def action_view_purchase_orders(self):
         self.ensure_one()
-        purchase_ids = self.move_ids.created_purchase_line_ids.order_id
+        purchase_ids = self._get_linked_purchase_orders()
         action = {
             'type': 'ir.actions.act_window',
             'res_model': 'purchase.order',

--- a/addons/purchase_repair/tests/test_repair_purchase_flow.py
+++ b/addons/purchase_repair/tests/test_repair_purchase_flow.py
@@ -62,3 +62,6 @@ class TestRepairPurchaseFlow(TestStockCommon):
         self.assertEqual(purchase.order_line.move_dest_ids.repair_id, repair)
         self.assertEqual(repair.purchase_count, 1)
         self.assertEqual(purchase.repair_count, 1)
+        purchase.button_confirm()
+        self.assertEqual(repair.purchase_count, 1)
+        self.assertEqual(purchase.repair_count, 1)


### PR DESCRIPTION
The link between purchase order and a repair order break at when the PO is confirmed.

### Steps to reproduce:
* Install the Repair and Purchase modules
* Activate multi-steps routes
* Unarchive the MTO route
* Create a product with the MTO route enabled
* Create a Repair
* On the Repair Order, in part add:
	- type : ADD
	- product : mto product
* Save the RO
* Go to Purchase Order
* Confirm the PO
-> Issue Smart link between PO and RO broken.

### Observation:
The smart link is defined on:
RO -> PO:
https://github.com/odoo/odoo/blob/a2be8182010613c6f92f59e686a2fbf066cc6b68/addons/purchase_repair/models/repair_order.py#L15-L17 PO -> RO:
https://github.com/odoo/odoo/blob/a2be8182010613c6f92f59e686a2fbf066cc6b68/addons/purchase_repair/models/purchase_order.py#L15-L17

When we confirm the PO, from the picking information it will create new moves:
https://github.com/odoo/odoo/blob/2c87f3b2b397f268f0e50cb73cd81de992ddd42e/addons/purchase_stock/models/purchase_order.py#L293-L298

To create those stock moves, we go into_create_stock_moves where, for each POL, we will generate their values and erase the smart link:
https://github.com/odoo/odoo/blob/a2be8182010613c6f92f59e686a2fbf066cc6b68/addons/purchase_stock/models/purchase_order_line.py#L362-L365

### Origin:
In this commit https://github.com/odoo/odoo/commit/9d98c43581e2579f43b35541b43264866dede5a5:
"`created_purchase_line_id` is cleared after confirming the RFQ. This
allows to merge more in `_merge_moves`."
This breaks the link between PO <-> RO to maybe merge the move in the future.

This issue is not present in 19.0 since it was solve in this commit :
https://github.com/odoo/odoo/commit/2713876dbc70d3984e584a9037a2206dcda4e84a

### About the fix:
The root cause of this issue remains ambiguous despite the analysis. Therefore, in the interest of stability and caution, we opted to implement the fix in a safer location.

opw-5121816