### PR TITLE
[REF] *: remove unnecessary 'describe' calls

### DIFF
--- a/addons/point_of_sale/static/tests/unit/render_service.test.js
+++ b/addons/point_of_sale/static/tests/unit/render_service.test.js
@@ -1,31 +1,29 @@
-import { describe, expect, test, getFixture } from "@odoo/hoot";
+import { expect, getFixture, test } from "@odoo/hoot";
 import { mockFetch } from "@odoo/hoot-mock";
 import { htmlToCanvas } from "@point_of_sale/app/printer/render_service";
 
-describe("RenderService", () => {
-    test("htmlToCanvas", async () => {
-        // htmlToCanvas fetches some fonts useless for the test, we mock it to avoid warnings
-        mockFetch(() => "");
-        const target = getFixture();
-        const node = document.createElement("div");
-        node.classList.add("render-container");
-        target.appendChild(node);
+test("htmlToCanvas", async () => {
+    // htmlToCanvas fetches some fonts useless for the test, we mock it to avoid warnings
+    mockFetch(() => "");
+    const target = getFixture();
+    const node = document.createElement("div");
+    node.classList.add("render-container");
+    target.appendChild(node);
 
-        const asciiChars = Array.from({ length: 256 }, (_, i) => String.fromCharCode(i)).join("");
-        node.textContent = asciiChars;
+    const asciiChars = Array.from({ length: 256 }, (_, i) => String.fromCharCode(i)).join("");
+    node.textContent = asciiChars;
 
-        let canvas = null;
-        try {
-            canvas = await htmlToCanvas(node, { addClass: "pos-receipt-print" });
-        } catch (error) {
-            // htmlToCanvas create an <img> by setting a svg to its src attribute
-            // if this fails, an Event of type "error" is thrown
-            if (error.constructor.name !== "Event") {
-                throw error;
-            }
+    let canvas = null;
+    try {
+        canvas = await htmlToCanvas(node, { addClass: "pos-receipt-print" });
+    } catch (error) {
+        // htmlToCanvas create an <img> by setting a svg to its src attribute
+        // if this fails, an Event of type "error" is thrown
+        if (error.constructor.name !== "Event") {
+            throw error;
         }
-        expect(canvas).not.toBe(null, {
-            message: "htmlToCanvas should work with all ascii characters",
-        });
+    }
+    expect(canvas).not.toBe(null, {
+        message: "htmlToCanvas should work with all ascii characters",
     });
 });

--- a/addons/spreadsheet/static/tests/pivots/pivot_helpers.test.js
+++ b/addons/spreadsheet/static/tests/pivots/pivot_helpers.test.js
@@ -18,56 +18,54 @@ function stringArg(value) {
 
 describe.current.tags("headless");
 
-describe("pivot_helpers", () => {
-    test("Basic formula extractor", async function () {
-        const formula = `=PIVOT.VALUE("1", "test") + ODOO.LIST("2", "hello", "bla")`;
-        const tokens = tokenize(formula);
-        let functionName;
-        let args;
-        ({ functionName, args } = getFirstPivotFunction(tokens));
-        expect(functionName).toBe("PIVOT.VALUE");
-        expect(args.length).toBe(2);
-        expect(args[0]).toEqual(stringArg("1"));
-        expect(args[1]).toEqual(stringArg("test"));
-        ({ functionName, args } = getFirstListFunction(tokens));
-        expect(functionName).toBe("ODOO.LIST");
-        expect(args.length).toBe(3);
-        expect(args[0]).toEqual(stringArg("2"));
-        expect(args[1]).toEqual(stringArg("hello"));
-        expect(args[2]).toEqual(stringArg("bla"));
-    });
+test("Basic formula extractor", async function () {
+    const formula = `=PIVOT.VALUE("1", "test") + ODOO.LIST("2", "hello", "bla")`;
+    const tokens = tokenize(formula);
+    let functionName;
+    let args;
+    ({ functionName, args } = getFirstPivotFunction(tokens));
+    expect(functionName).toBe("PIVOT.VALUE");
+    expect(args.length).toBe(2);
+    expect(args[0]).toEqual(stringArg("1"));
+    expect(args[1]).toEqual(stringArg("test"));
+    ({ functionName, args } = getFirstListFunction(tokens));
+    expect(functionName).toBe("ODOO.LIST");
+    expect(args.length).toBe(3);
+    expect(args[0]).toEqual(stringArg("2"));
+    expect(args[1]).toEqual(stringArg("hello"));
+    expect(args[2]).toEqual(stringArg("bla"));
+});
 
-    test("Extraction with two PIVOT formulas", async function () {
-        const formula = `=PIVOT.VALUE("1", "test") + PIVOT.VALUE("2", "hello", "bla")`;
-        const tokens = tokenize(formula);
-        const { functionName, args } = getFirstPivotFunction(tokens);
-        expect(functionName).toBe("PIVOT.VALUE");
-        expect(args.length).toBe(2);
-        expect(args[0]).toEqual(stringArg("1"));
-        expect(args[1]).toEqual(stringArg("test"));
-        expect(getFirstListFunction(tokens)).toBe(undefined);
-    });
+test("Extraction with two PIVOT formulas", async function () {
+    const formula = `=PIVOT.VALUE("1", "test") + PIVOT.VALUE("2", "hello", "bla")`;
+    const tokens = tokenize(formula);
+    const { functionName, args } = getFirstPivotFunction(tokens);
+    expect(functionName).toBe("PIVOT.VALUE");
+    expect(args.length).toBe(2);
+    expect(args[0]).toEqual(stringArg("1"));
+    expect(args[1]).toEqual(stringArg("test"));
+    expect(getFirstListFunction(tokens)).toBe(undefined);
+});
 
-    test("Number of formulas", async function () {
-        const formula = `=PIVOT.VALUE("1", "test") + PIVOT.VALUE("2", "hello", "bla") + ODOO.LIST("1", "bla")`;
-        expect(getNumberOfPivotFunctions(tokenize(formula))).toBe(2);
-        expect(getNumberOfListFormulas(tokenize(formula))).toBe(1);
-        expect(getNumberOfPivotFunctions(tokenize("=1+1"))).toBe(0);
-        expect(getNumberOfListFormulas(tokenize("=1+1"))).toBe(0);
-        expect(getNumberOfPivotFunctions(tokenize("=bla"))).toBe(0);
-        expect(getNumberOfListFormulas(tokenize("=bla"))).toBe(0);
-    });
+test("Number of formulas", async function () {
+    const formula = `=PIVOT.VALUE("1", "test") + PIVOT.VALUE("2", "hello", "bla") + ODOO.LIST("1", "bla")`;
+    expect(getNumberOfPivotFunctions(tokenize(formula))).toBe(2);
+    expect(getNumberOfListFormulas(tokenize(formula))).toBe(1);
+    expect(getNumberOfPivotFunctions(tokenize("=1+1"))).toBe(0);
+    expect(getNumberOfListFormulas(tokenize("=1+1"))).toBe(0);
+    expect(getNumberOfPivotFunctions(tokenize("=bla"))).toBe(0);
+    expect(getNumberOfListFormulas(tokenize("=bla"))).toBe(0);
+});
 
-    test("getFirstPivotFunction does not crash when given crap", async function () {
-        expect(getFirstListFunction(tokenize("=SUM(A1)"))).toBe(undefined);
-        expect(getFirstPivotFunction(tokenize("=SUM(A1)"))).toBe(undefined);
-        expect(getFirstListFunction(tokenize("=1+1"))).toBe(undefined);
-        expect(getFirstPivotFunction(tokenize("=1+1"))).toBe(undefined);
-        expect(getFirstListFunction(tokenize("=bla"))).toBe(undefined);
-        expect(getFirstPivotFunction(tokenize("=bla"))).toBe(undefined);
-        expect(getFirstListFunction(tokenize("bla"))).toBe(undefined);
-        expect(getFirstPivotFunction(tokenize("bla"))).toBe(undefined);
-    });
+test("getFirstPivotFunction does not crash when given crap", async function () {
+    expect(getFirstListFunction(tokenize("=SUM(A1)"))).toBe(undefined);
+    expect(getFirstPivotFunction(tokenize("=SUM(A1)"))).toBe(undefined);
+    expect(getFirstListFunction(tokenize("=1+1"))).toBe(undefined);
+    expect(getFirstPivotFunction(tokenize("=1+1"))).toBe(undefined);
+    expect(getFirstListFunction(tokenize("=bla"))).toBe(undefined);
+    expect(getFirstPivotFunction(tokenize("=bla"))).toBe(undefined);
+    expect(getFirstListFunction(tokenize("bla"))).toBe(undefined);
+    expect(getFirstPivotFunction(tokenize("bla"))).toBe(undefined);
 });
 
 describe("toNormalizedPivotValue", () => {


### PR DESCRIPTION
This commit removes test files using a single 'describe' call to wrap its tests, with a name being either redundant with the test file itself or is too misleading.

Regular expression used to find isolated suites:
```js
/^\s*import.*(?:\n(?!describe\()(?!test\().*)+\ndescribe\("[\w\s.]+",.*(?:\n(?!describe\().*)+\n\}\);\n(?!\n)/
```

Tip for reviewers: tick **"Hide whitespace"** when reviewing diff
<img width="237" height="205" alt="image" src="https://github.com/user-attachments/assets/373f7cc6-5e0e-4599-968a-39aad8fac2f0" />


Enterprise: https://github.com/odoo/enterprise/pull/98046

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
