### PR TITLE
 [FIX] website: set image in Masonry blocks

### DIFF
--- a/addons/website/static/src/builder/plugins/layout_option/add_element_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/layout_option/add_element_option_plugin.js
@@ -95,6 +95,9 @@ export class AddGridElementAction extends BuilderAction {
                     noDocuments: true,
                     save: (selectedImageEl) => {
                         imageEl = selectedImageEl;
+                        if (imageEl.complete) {
+                            return;
+                        }
                         imageLoadedPromise = new Promise((resolve) => {
                             imageEl.addEventListener("load", () => resolve(), { once: true });
                         });


### PR DESCRIPTION
Steps to reproduce:
====================
1. Add a snippet with Masonry blocks (e.g., Punchy Image).
2. Edit an image and select an SVG or GIF file.
3. The loading spinner will appear and never disappear.

Cause:
=======
Certain image types like SVG and GIF are not processed by `onImageInfoLoaded`. So the _imageProcess call will be canceled https://github.com/odoo/odoo/blob/3dadb15555b96ad22dfd2799c05415f07b03d027/addons/html_editor/static/src/main/media/image_post_process_plugin.js#L27-L28

The code would then try to add a `load` event listener, but the event had already fired. This caused an unresolved promise.

Solution:
=========
Before attaching the `load` event listener, add a check for the `imageEl.complete` property. If the image is already loaded, we can bypass the listener entirely.

opw-5167545

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
