### PR TITLE
[FIX] website: fix hide_sidebar_header tour

### DIFF
--- a/addons/website/static/tests/tours/hide_sidebar_header.js
+++ b/addons/website/static/tests/tours/hide_sidebar_header.js
@@ -1,5 +1,5 @@
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
-import { clickOnSave, registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
+import { clickOnSave, goToTheme, registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
 
 registerWebsitePreviewTour(
     "hide_sidebar_header",
@@ -24,25 +24,25 @@ registerWebsitePreviewTour(
             run: "click",
         },
         {
-            content: "Check that the header changed to 'Sidebar'",
-            trigger: ":iframe #wrapwrap>header.o_header_sidebar",
+            content: "Check that the loading screen has appeared",
+            trigger: ":iframe .o_loading_screen",
         },
         stepUtils.waitIframeIsReady(),
         {
-            content: "Go to the theme tab",
-            trigger: ".o-website-builder_sidebar .o-snippets-tabs button[data-name='theme']",
-            run: "click",
+            content: "Check that the header changed to 'Sidebar'",
+            trigger: ":iframe #wrapwrap>header.o_header_sidebar",
         },
+        ...goToTheme(),
         {
             content: "Toggle 'Show Header' off",
             trigger: ".hb-row[data-label='Show Header'] input[type='checkbox']",
             run: "click",
         },
+        stepUtils.waitIframeIsReady(),
         {
             content: "Check that the header has been hidden",
             trigger: ":iframe #wrapwrap:not(:has(:scope > header))",
         },
-        stepUtils.waitIframeIsReady(),
         {
             content: "Check that there's no header padding on the #wrapwrap",
             trigger: ":iframe #wrapwrap",


### PR DESCRIPTION
Tour added in that [commit], was previously failing and the earlier [fix] only reduced the frequency of failures. However, it still occasionally fails due to race conditions of the iframe becoming ready and the moment the builder opens the block tab after the iframe has been reloaded.
This commit aims to fix it.

[commit]: https://github.com/odoo/odoo/commit/a5455bf
[fix]: https://github.com/odoo/odoo/commit/0a9522792cc0e18a895c0589f34977123d091d1a

runbot-233438