### PR TITLE
[FIX] mail: channel invite placeholder hints invite by email

### DIFF
--- a/addons/mail/static/src/discuss/core/common/channel_invitation.js
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.js
@@ -111,7 +111,10 @@ export class ChannelInvitation extends Component {
     }
 
     get searchPlaceholder() {
-        return this.props.state?.searchPlaceholder ?? _t("Search people to invite");
+        if (this.props.thread?.allow_invite_by_email) {
+            return _t("Invite people or email");
+        }
+        return _t("Search people to invite");
     }
 
     async fetchPartnersToInvite() {

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.xml
@@ -12,7 +12,7 @@
         <div class="d-flex flex-column flex-grow-1 bg-inherit o-min-height-0" t-att-class="{ 'o-mail-Discuss-threadActionPopover w-100': props.hasSizeConstraints, 'px-1': !props.thread }">
             <t t-if="store.self_partner">
                 <input class="o-discuss-ChannelInvitation-search form-control lh-1 px-2 bg-view" t-att-value="searchStr" t-ref="input" t-att-placeholder="searchPlaceholder" t-on-input="onInput"/>
-                <ul class="d-flex flex-column mx-0 pt-1 pb-0 overflow-auto o-scrollbar-thin list-group border-0 flex-grow-1" t-att-class="{ 'align-items-center justify-content-center': selectablePartners.length === 0 }">
+                <ul class="d-flex flex-column mx-0 pt-1 pb-0 overflow-auto o-scrollbar-thin list-group border-0 flex-grow-1" t-att-class="{ 'align-items-center justify-content-center': selectablePartners.length === 0 and state.selectableEmails.length === 0 }">
                     <div t-if="selectablePartners.length === 0 and state.selectableEmails.length === 0" class="smaller text-muted mx-1 opacity-50">
                         <t t-if="props.thread">No user found that is not already a member of this channel.</t>
                         <t t-else="">No user found.</t>

--- a/addons/mail/static/src/discuss/core/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_model_patch.js
@@ -223,6 +223,13 @@ const threadPatch = {
             (member) => !this.store.onlineMemberStatuses.includes(member.im_status)
         );
     },
+    /** Equivalent to DiscussChannel._allow_invite_by_email */
+    get allow_invite_by_email() {
+        return (
+            this.channel_type === "group" ||
+            (this.channel_type === "channel" && !this.group_public_id)
+        );
+    },
     get areAllMembersLoaded() {
         return this.member_count === this.channel_member_ids.length;
     },

--- a/addons/mail/static/tests/tours/discuss_invite_by_email_tour.js
+++ b/addons/mail/static/tests/tours/discuss_invite_by_email_tour.js
@@ -7,7 +7,7 @@ registry.category("web_tour.tours").add("discuss.invite_by_email", {
             run: "click",
         },
         {
-            trigger: ".o-discuss-ChannelInvitation-search",
+            trigger: ".o-discuss-ChannelInvitation-search[placeholder='Invite people or email']",
             run: "edit john@test.com",
         },
         {


### PR DESCRIPTION
Before this commit, channel invite by email feature had poor discoverability because we had to type a full email address to have selectable item.

This commit changes the placeholder of channel invite to hint for invite by email feature.

Also the selectable invite by email item was misaligned, which this commit also fixes.

Part of Task-5190261

Before
<img width="406" height="613" alt="Screenshot 2025-10-24 at 14 38 05" src="https://github.com/user-attachments/assets/4220af4a-e473-4379-ac9e-80051736e6c0" />
<img width="415" height="613" alt="Screenshot 2025-10-24 at 14 38 12" src="https://github.com/user-attachments/assets/88e013d5-8e0c-4c96-9bde-f15f7b22169c" />


After
<img width="411" height="618" alt="Screenshot 2025-10-24 at 14 37 41" src="https://github.com/user-attachments/assets/343db47c-f8db-4c88-9aa2-bcaa8796cdb2" />
<img width="409" height="612" alt="Screenshot 2025-10-24 at 14 37 47" src="https://github.com/user-attachments/assets/d44d2392-a2bc-4812-a0d7-eafdb68096fa" />


