### PR TITLE
[FIX] mail: shorten display names to prevent miss-fold

### DIFF
--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -843,7 +843,10 @@ def formataddr(pair, charset='utf-8'):
             # ascii name, escape it if needed
             # rfc2822 - Internet Message Format
             #   #section-3.4 - Address Specification
+            # ensure the display-name fits on one line, bpo36041
             name = email_addr_escapes_re.sub(r'\\\g<0>', name)
+            if len(name) > 66:  # 78 - len('Reply-To: ""')
+                name = name[:63].rstrip('\\') + '...'
             return f'"{name}" <{local}@{domain}>'
     return f"{local}@{domain}"
 


### PR DESCRIPTION
In certain edge-case, when having long display names in an email address,
the standard mail library in Python used to have a bug were it would
remove the quotes in the display name of the email address and lead to
miss-folded header values in the final email after serialization of
the message object for SMTP sending. See cpython#80222.

While a fix was deployed in recent Python versions and backported,
given it's non-critical nature, it is not backported my default in
Debian/Ubuntu distribution for Python versions <3.13.
This means that as long as the minimal supported version for Odoo is
below 3.13, we will need to pre-emptively prevent this issues with
an Odoo side fix.

## Bug description:

1) Create a contact with a very long display name:
   `A Name That Is Extremely Long And Will Force The Header Folding Mechanism To Break The Quotes, Which Is The Bug We Are Testing`
2) Send an email message to this contact (capture with a mailcatcher)
3) Analyse the "TO" header an notice that it's miss-folded and RFC non compliant

```
To: A Name That Is Extremely Long And Will Force The Header Folding Mechanism
  To Break The Quotes, Which Is The Bug We Are Testing <test@example.com>
```

Notice that the quotes were wrongly removed, now the single email is
interpreted as multiple ones due to the non-quoted commas.

## After this fix:

```
To: "A Name That Is Extremely Long And Will Force The Header Folding Mec..."
 <test@example.com>
```

OPW-4988762
BPO-36041
BPO-44637