### PR TITLE
[FIX] l10n_es_edi_facturae: remove ignore in signature template

### DIFF
--- a/addons/l10n_es_edi_facturae/data/signature_templates.xml
+++ b/addons/l10n_es_edi_facturae/data/signature_templates.xml
@@ -58,7 +58,7 @@
                                         </xades:SigPolicyId>
                                         <xades:SigPolicyHash>
                                             <ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
-                                            <ds:DigestValue>___ignore___</ds:DigestValue>
+                                            <ds:DigestValue>Ohixl6upD6av8N7pEvDABhEL6hM=</ds:DigestValue>
                                         </xades:SigPolicyHash>
                                         <xades:SigPolicyQualifiers>
                                             <xades:SigPolicyQualifier>


### PR DESCRIPTION
Commit 051b7bcdd12d669e203296515e57ca8bfdac45e8 introduced an ___ignore___ in the DigestValue tag of signature_templates.xml which does not pass the facturae validation

opw-5111038

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
