### PR TITLE
[FIX] html_builder: show active shape in selector

### DIFF
--- a/addons/html_builder/static/src/plugins/image/image_shape_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/image_shape_option_plugin.js
@@ -428,6 +428,15 @@ export class SetImageShapeAction extends BuilderAction {
         const imgFilename = img.dataset.originalSrc.split("/").pop().split(".")[0];
         img.dataset.fileName = `${imgFilename}.svg`;
     }
+    isApplied({ editingElement: img, value }) {
+        const datasetShape = img.dataset.shape;
+        if (!datasetShape) {
+            return false;
+        }
+        // Compatibility with old shapes.
+        const currentShape = datasetShape.replace("web_editor", "html_builder");
+        return currentShape === value;
+    }
 }
 export class SetImgShapeColorAction extends BuilderAction {
     static id = "setImgShapeColor";

--- a/addons/html_builder/static/src/plugins/shape/shape_selector.js
+++ b/addons/html_builder/static/src/plugins/shape/shape_selector.js
@@ -3,6 +3,8 @@ import { ImgGroup } from "@html_builder/core/img_group";
 import { BaseOptionComponent } from "@html_builder/core/utils";
 import { useThrottleForAnimation } from "@web/core/utils/timing";
 import { getShapeURL } from "../image/image_helpers";
+import { useHotkey } from "@web/core/hotkeys/hotkey_hook";
+import { useAutofocus } from "@web/core/utils/hooks";
 
 export class ShapeSelector extends BaseOptionComponent {
     static template = "html_builder.shapeSelector";
@@ -23,6 +25,8 @@ export class ShapeSelector extends BaseOptionComponent {
         this.tabsRef = useRef("tabs");
         this.state = useState({ activeGroup: "basic" });
         this.onScroll = useThrottleForAnimation(this._onScroll);
+        useHotkey("escape", () => this.props.onClose());
+        useAutofocus({ refName: "backButton" });
     }
     getShapeUrl(shapePath) {
         return this.props.getShapeUrl ? this.props.getShapeUrl(shapePath) : getShapeURL(shapePath);

--- a/addons/html_builder/static/src/plugins/shape/shape_selector.scss
+++ b/addons/html_builder/static/src/plugins/shape/shape_selector.scss
@@ -44,6 +44,7 @@
             background-color: transparent;
         }
     }
+
     .o-hb-bg-shape-btn {
         grid-column: span 2;
         padding: 0;
@@ -52,9 +53,39 @@
             height: 50px;
         }
     }
+
     .o-hb-img-shape-btn {
         button {
             aspect-ratio: 1;
+        }
+    }
+
+    .o-hb-img-shape-btn,  .o-hb-bg-shape-btn {
+        > .o-hb-btn {
+            --o-highlight-shape-color: var(--o-hb-btn-active-color, #{$o-we-color-accent});
+            --o-highlight-shape-bg-opacity: 0%;
+            --o-highlight-shape-bg-color: color-mix(
+                in srgb,
+                var(--o-highlight-shape-color) var(--o-highlight-shape-bg-opacity),
+                transparent
+            );
+
+            &.active {
+                --o-highlight-shape-bg-opacity: 10%;
+                border-width: 3px;
+                border-color: var(--o-highlight-shape-color);
+                background-color: var(--o-highlight-shape-bg-color);
+
+                &::before {
+                    border-radius: unset;
+                }
+            }
+            &:hover,
+            &:focus-visible {
+                --o-highlight-shape-bg-opacity: 25%;
+                box-shadow: unset;
+                background-color: var(--o-highlight-shape-bg-color);
+            }
         }
     }
 

--- a/addons/html_builder/static/src/plugins/shape/shape_selector.xml
+++ b/addons/html_builder/static/src/plugins/shape/shape_selector.xml
@@ -5,7 +5,7 @@
     <header class="o_pager_nav d-flex flex-column flex-wrap flex-shrink-0 mh-100">
         <div class="d-flex align-items-center mt-2 p-2">
             <button class="o_pager_nav_angle btn btn-secondary bg-transparent border-0"
-                    t-on-click="this.props.onClose">
+                    t-on-click="this.props.onClose" t-ref="backButton">
                     <i class="fa fa-angle-left" aria-hidden="true"/>
                     <span class="visually-hidden">Back</span>
                     <span class="ps-2 text-white" t-out="props.selectorTitle"/>

--- a/addons/website/static/tests/builder/image_shape.test.js
+++ b/addons/website/static/tests/builder/image_shape.test.js
@@ -541,3 +541,18 @@ test("Should reset crop when removing shape with ratio", async () => {
     await waitSidebarUpdated();
     expect(`:iframe .test-options-target img`).not.toHaveAttribute("data-aspect-ratio");
 });
+
+test("Should have the correct active shape in the image shape selector", async () => {
+    const { waitSidebarUpdated } = await setupWebsiteBuilder(`
+        <div class="test-options-target">
+            ${testImg}
+        </div>
+    `);
+
+    await contains(":iframe .test-options-target img").click();
+    await contains("[data-label='Shape'] .dropdown").click();
+    await contains("[data-action-value='html_builder/geometric/geo_tetris']").click();
+    await waitSidebarUpdated();
+    await contains("[data-label='Shape'] .dropdown").click();
+    expect("[data-action-value='html_builder/geometric/geo_tetris']").toHaveClass("active");
+});

--- a/addons/website/static/tests/builder/website_builder/background_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/background_option.test.js
@@ -51,8 +51,11 @@ test("change the background shape of elements", async () => {
         </div>`);
     await contains(":iframe .selector").click();
     await contains("[data-label='Shape'] button").click();
+    expect(
+        ".o_pager_container .o-hb-bg-shape-btn:nth-child(1) .btn.active[data-action-id='setBackgroundShape']"
+    ).toHaveCount();
     await contains(
-        ".o_pager_container .o-hb-bg-shape-btn:nth-child(2) [data-action-id='setBackgroundShape']"
+        ".o_pager_container .o-hb-bg-shape-btn:nth-child(2) .btn:not(.active)[data-action-id='setBackgroundShape']"
     ).click();
     expect(":iframe .selector div#first").toHaveAttribute(
         "data-oe-shape-data",


### PR DESCRIPTION
Before this commit, when a shape was applied to a background or an image, that shape was not highlighted in the shape selector.

After this commit, active shapes are highlighted with a border in the shape selector.

task-5187272