### PR TITLE
[FIX] mrp_subcontracting_dropshipping,stock_account:  create svl with…

### DIFF
--- a/addons/mrp_subcontracting_dropshipping/models/stock_picking.py
+++ b/addons/mrp_subcontracting_dropshipping/models/stock_picking.py
@@ -41,6 +41,9 @@ class StockPicking(models.Model):
                 ).stock_valuation_layer_ids
             else:
                 subcontract_svls = move.move_orig_ids.stock_valuation_layer_ids
+            # the subcontract_svls should not have a remaining_value or remaining_qty because they are part of a dropship
+            subcontract_svls.remaining_value = 0
+            subcontract_svls.remaining_qty = 0
             subcontract_value = sum(subcontract_svls.mapped('value'))
             dropship_value = abs(sum(dropship_svls.mapped('value')))
             diff = subcontract_value - dropship_value

--- a/addons/mrp_subcontracting_dropshipping/tests/test_purchase_subcontracting.py
+++ b/addons/mrp_subcontracting_dropshipping/tests/test_purchase_subcontracting.py
@@ -497,3 +497,50 @@ class TestSubcontractingDropshippingFlows(TestMrpSubcontractingCommon):
         self.env['procurement.group'].run_scheduler()
         delivery = self.env["stock.move"].search([("product_id", "=", self.comp1.id)]).picking_id
         self.assertEqual(delivery.partner_id, p1)
+
+    def test_mrp_subcontracting_dropshipping_svl(self):
+        """Check that svls created from a subcontracted dropshipped product delivery
+        do not a have a remainging value  and quantity (just like svls created from a
+        dropshipped product delivery would not have a remaining value and quantity)
+        """
+
+        dropship_route = self.env['stock.route'].search([('name', '=', 'Dropship')])
+        self.finished.write({'route_ids': [(4, dropship_route.id)]})
+        self.finished.standard_price = 5
+        self.comp1.type = "consu"
+        self.comp2.type = "consu"
+        warehouse = self.env['stock.warehouse'].create({
+            'name': 'Warehouse For subcontract',
+            'code': 'WFS'
+        })
+        self.env['product.supplierinfo'].create({
+            'product_tmpl_id': self.finished.product_tmpl_id.id,
+            'partner_id': self.subcontractor_partner1.id
+        })
+        partner = self.env['res.partner'].create({
+            'name': 'Toto'
+        })
+
+        so_form = Form(self.env['sale.order'])
+        so_form.partner_id = partner
+        so_form.warehouse_id = warehouse
+        with so_form.order_line.new() as line:
+            line.product_id = self.finished
+            line.product_uom_qty = 1
+        so = so_form.save()
+        so.action_confirm()
+
+        po = self.env['purchase.order'].search([('origin', 'ilike', so.name)])
+        self.assertTrue(po)
+        po.button_approve()
+
+        picking_dropshipped = po.picking_ids
+        picking_dropshipped.button_validate()
+        subcontracted_svl = self.env['mrp.production'].search([('incoming_picking', '=', picking_dropshipped.id)]).move_finished_ids.stock_valuation_layer_ids
+        dropship_svl = picking_dropshipped.move_ids.stock_valuation_layer_ids
+        self.assertRecordValues(dropship_svl, [
+            {'product_id': self.finished.id, 'value': -5.0, 'unit_cost': 5.0, 'quantity': -1.0, 'remaining_qty': 0, 'remaining_value': 0},
+        ])
+        self.assertRecordValues(subcontracted_svl, [
+            {'product_id': self.finished.id, 'value': 5.0, 'unit_cost': 5.0, 'quantity': 1.0, 'remaining_qty': 0, 'remaining_value': 0},
+        ])


### PR DESCRIPTION
… correct remaining value when sbc dropship

**Problem:**
When selling and delivering a subcontracted and dropshipped fifo product, 
the incoming stock valuation layer has a remaining_qty and a remaining_value.
(This also happens with 'standard price' and 'avco' but it's mostly problematic for 
fifo products. This being said the fix solves all 3 cases)

Some context: 
When we confirm a SO and validate the delivery of a dropshipped (not sbc) product,
two svls are created, 
   - one with a negative quantity and value.
   - one with positive quantity and value.
 
Both have a zero remaining value and remaining quantity.
The outgoing svl does not trigger run_fifo or decrease the remaining_qty 
and remaining_value on any svl.
In other words the fifo logic is not applied.
If it was the case, the dropship delivery would impact the fifo valuation and 
other layers which we don't want as the product never really entered the stock.
 
In the use case of this PR, a subcontracted dropshipped fifo product being delivered, 
the outgoing svl(s) are linked to the dropship and have the correct values. 
But the incoming svl is linked to the subcontract order and has a remaining value
and remaining quantity which will impact the fifo logic when it shouldn't.

**Steps to reproduce:**
- enable the subcontracting setting and the dropshipping setting.
- create a storable product, with a fifo category and positive cost.
- create a subonctracted bom with a consumable component.
- in the purchase tab of the product set a vendor which is the same
as the subcontractor of the bom.
- in the inventory tab select only the dropship route
- create and confirm a SO for this product.
- on the PO enter a positive unit price and confirm
- validate the dropship delivery
- click on the valuation smart button

**Current behavior:**
the stock valuation layer linked to the subcontract picking (the one with a 
positive quantity) has a positive remaining quantity and remaining value.

**Expected behavior:**
As the product is dropship remaining quantity and remaining value should be 0

**Cause of the issue:**
When action_done is called on the picking:
1) In the super method,
action_done is called on the move.
There, _create_dropshipped_svl is called.
https://github.com/odoo/odoo/blob/3c83171923124c7ea63a4d33262a87cddf004b2b/addons/stock_account/models/stock_move.py#L289
Inside _get_dropshipped_svl_vals only the value for the (first) outgoing svl
is returned because the location_id (subcontrating location) is valued.
https://github.com/odoo/odoo/blob/3c83171923124c7ea63a4d33262a87cddf004b2b/addons/stock_account/models/stock_move.py#L226

2) In the mrp_subcontracting override, button_mark_done is called on 
the mrp.production associated with the picking.
https://github.com/odoo/odoo/blob/3c83171923124c7ea63a4d33262a87cddf004b2b/addons/mrp_subcontracting/models/stock_picking.py#L90
Therefore action_done is called on the finished products move the mrp.production.
https://github.com/odoo/odoo/blob/3c83171923124c7ea63a4d33262a87cddf004b2b/addons/mrp/models/mrp_production.py#L1731
The move is a 'in' move so this lead to the creation of an in svl.
https://github.com/odoo/odoo/blob/3c83171923124c7ea63a4d33262a87cddf004b2b/addons/stock_account/models/stock_move.py#L289
The problem is that there is no mechanism to prevent the in svl from having 
a remaining_value and remaining_qty

**fix**
The mrp_subcontracting_dropshipping override of _action_done (on stock picking)
is where, when needed, the other ougoing layer is created specifically in this 
subcontracting dropshipping use case.
https://github.com/odoo/odoo/blob/3c83171923124c7ea63a4d33262a87cddf004b2b/addons/mrp_subcontracting_dropshipping/models/stock_picking.py#L27-L32
Because the conditions are the same, imo, it's a good place to set the value of 
remaingin_value and remaining_qty of the incoming svl to 0.

opw-5184644