### PR TITLE
[FIX] base_vat: do not reset vies_valid on exception

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -229,7 +229,6 @@ class ResPartner(models.Model):
                         msg = _('The request for VAT validation was not processed. VIES service has responded with the following error: %s', e.message)
                     partner._origin.message_post(body=msg)
                 _logger.warning("The VAT number %s failed VIES check.", partner.vies_vat_to_check)
-                partner.vies_valid = False
 
     @api.model
     def _run_vat_test(self, vat_number, default_country, partner_is_company=True):


### PR DESCRIPTION
When an exception occurs during the VAT validation check, the field `vies_valid` is currently reset to False. This behavior don't seem correct because an error does not necessarily indicate that the VAT number is invalid, it may simply result from a timeout or a temporary issue on the VIES server.

Therefore, this fix ensures that `vies_valid` is only updated based on a valid response from the VIES server and is no longer reset to False when an error occurs.

opw-5148922