### PR TITLE
[IMP] account: Improve visibility of payment status on Draft invoices

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1308,11 +1308,16 @@ class AccountMove(models.Model):
     @api.depends('payment_state', 'state', 'is_move_sent')
     def _compute_status_in_payment(self):
         for move in self:
-            if move.state == 'posted' and move.payment_state == 'not_paid' and move.is_move_sent:
-                move.status_in_payment = 'sent'
-            elif move.state == 'posted' and move.payment_state in ('partial', 'in_payment', 'paid', 'reversed'):
-                move.status_in_payment = move.payment_state
-            else:
+            if move.state == 'posted':
+                if move.payment_state in ('partial', 'in_payment', 'paid', 'reversed'):
+                    move.status_in_payment = move.payment_state
+                elif move.is_move_sent:
+                    move.status_in_payment = 'sent'
+            elif move.state == 'draft':
+                if move.payment_state in ('partial', 'in_payment', 'paid'):
+                    move.status_in_payment = move.payment_state
+
+            if not move.status_in_payment:
                 move.status_in_payment = move.state
 
     def _field_to_sql(self, alias: str, fname: str, query=None) -> SQL:


### PR DESCRIPTION
This commit addresses an issue where, after enabling payment/reconciliation of draft invoices, it was difficult to identify which draft invoices had been paid.

The new/improved status computation allows visibility of payment progress without losing the 'Draft' state.

task-5190340

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
