### PR TITLE
[IMP] product info : reduce timeout of longpress

### DIFF
--- a/addons/point_of_sale/static/src/utils.js
+++ b/addons/point_of_sale/static/src/utils.js
@@ -176,7 +176,7 @@ export function isValidEmail(email) {
     return email && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
 }
 
-export const LONG_PRESS_DURATION = session.test_mode ? 100 : 1000;
+export const LONG_PRESS_DURATION = session.test_mode ? 100 : 500;
 
 export async function getImageDataUrl(imageUrl) {
     const res = await fetch(imageUrl);


### PR DESCRIPTION
Before this PR, in order to reach the product information on the frontend, the user had to longpress the product card for 2 secondes. 

This PR aims to reduce the time necessary to display the product info popup, getting closer to what is done by most mobile OS can provide. 




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
