### PR TITLE
[FIX] mail: error when reading unknown member persona name

### DIFF
--- a/addons/im_livechat/static/src/core/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/thread_model_patch.js
@@ -74,10 +74,10 @@ patch(Thread.prototype, {
      * @param {import("models").Persona} persona
      */
     getPersonaName(persona) {
-        if (this.channel_type === "livechat" && persona.user_livechat_username) {
+        if (this.channel_type === "livechat" && persona?.user_livechat_username) {
             return persona.user_livechat_username;
         }
-        if (persona.is_public && this.anonymous_name) {
+        if (persona?.is_public && this.anonymous_name) {
             return this.anonymous_name;
         }
         return super.getPersonaName(persona);

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -612,7 +612,7 @@ export class Message extends Record {
      * @returns {string}
      */
     getPersonaName(persona) {
-        return this.thread?.getPersonaName(persona) || persona.displayName || _t("Unnamed");
+        return this.thread?.getPersonaName(persona) || persona?.displayName || _t("Unnamed");
     }
 
     async onClickToggleTranslation() {

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -363,7 +363,7 @@ export class Thread extends Record {
      * @returns {string}
      */
     getPersonaName(persona) {
-        return persona.displayName;
+        return persona?.displayName;
     }
 
     get hasAttachmentPanel() {


### PR DESCRIPTION
Sometimes, channel members are received without their partner/guest because it's not important in the flow. However, some part of the JS code assume the persona is always set, resulting in errors. This PR guards access to persona when computing the member name, a fallback to "unnamed" is already in place.

task-5184408

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
