### PR TITLE
[FIX] mail: handle deleted records

### DIFF
--- a/addons/crm/tests/test_crm_lead_convert_mass.py
+++ b/addons/crm/tests/test_crm_lead_convert_mass.py
@@ -24,7 +24,7 @@ class TestLeadConvertMass(crm_common.TestLeadConvertMassCommon):
         with self.assertQueryCount(user_sales_manager=0):
             test_leads = self.env['crm.lead'].browse(test_leads.ids)
 
-        with self.assertQueryCount(user_sales_manager=543):  # crm 537 / com 543 / ent 537
+        with self.assertQueryCount(user_sales_manager=597):  # crm 537 / com 543 / ent 591
             test_leads._handle_salesmen_assignment(user_ids=user_ids, team_id=False)
 
         self.assertEqual(test_leads.team_id, self.sales_team_convert | self.sales_team_1)
@@ -42,7 +42,7 @@ class TestLeadConvertMass(crm_common.TestLeadConvertMassCommon):
         with self.assertQueryCount(user_sales_manager=0):
             test_leads = self.env['crm.lead'].browse(test_leads.ids)
 
-        with self.assertQueryCount(user_sales_manager=524):  # crm 521 / com 524
+        with self.assertQueryCount(user_sales_manager=544):  # crm 521 / com 544
             test_leads._handle_salesmen_assignment(user_ids=user_ids, team_id=team_id)
 
         self.assertEqual(test_leads.team_id, self.sales_team_convert)
@@ -167,7 +167,7 @@ class TestLeadConvertMass(crm_common.TestLeadConvertMassCommon):
         user_ids = self.assign_users.ids
 
         # randomness: at least 1 query
-        with self.assertQueryCount(user_sales_manager=1704):  # crm 1410 / com 1697
+        with self.assertQueryCount(user_sales_manager=1754):  # crm 1410 / com 1697
             mass_convert = self.env['crm.lead2opportunity.partner.mass'].with_context({
                 'active_model': 'crm.lead',
                 'active_ids': test_leads.ids,

--- a/addons/mail/models/mail_message_schedule.py
+++ b/addons/mail/models/mail_message_schedule.py
@@ -64,10 +64,13 @@ class MailMessageSchedule(models.Model):
         for model, schedules in self._group_by_model().items():
             if model:
                 records = self.env[model].browse(schedules.mapped('mail_message_id.res_id'))
+                existing = records.exists()
             else:
                 records = [self.env['mail.thread']] * len(schedules)
 
             for record, schedule in zip(records, schedules):
+                if record not in existing:
+                    continue
                 notify_kwargs = dict(default_notify_kwargs or {}, skip_existing=True)
                 try:
                     schedule_notify_kwargs = json.loads(schedule.notification_parameters)

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -1004,13 +1004,18 @@ class MailCase(MockEmail):
                     mbody in message.body and message.message_type == mtype and
                     message.subtype_id == msubtype
                 ))
+                debug_info = '\n'.join(
+                    f'Msg: message_type {message.message_type}, subtype {message.subtype_id.name}, content {message.body}'
+                    for message in messages
+                )
             else:
                 message = self.env['mail.message'].sudo().search([
                     ('body', 'ilike', mbody),
                     ('message_type', '=', mtype),
                     ('subtype_id', '=', msubtype.id)
                 ], limit=1, order='id DESC')
-            self.assertTrue(message, 'Mail: not found message (content: %s, message_type: %s, subtype: %s)' % (mbody, mtype, msubtype.name))
+                debug_info = ''
+            self.assertTrue(message, 'Mail: not found message (content: %s, message_type: %s, subtype: %s\n%s)' % (mbody, mtype, msubtype.name, debug_info))
 
             # check message values
             message_values = message_info.get('message_values', {})

--- a/addons/test_mail/security/test_mail_security.xml
+++ b/addons/test_mail/security/test_mail_security.xml
@@ -1,6 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo noupdate="1">
 
+    <!-- Having rules triggers call to check_access_rules and allow to spot crashes
+    notably when records are unlinked. Without rule, method is not called and
+    some crashes are not trigerred in tests. -->
+    <record id="ir_rule_mail_test_simple_dummy" model="ir.rule">
+        <field name="name">Dummy rule, just to enable rule evaluation, shows some specific errors</field>
+        <field name="model_id" ref="test_mail.model_mail_test_simple"/>
+        <field name="domain_force">[('email_from', '!=', 'donotsetmewiththisvalue')]</field>
+    </record>
+
     <record id="ir_rule_mail_test_access_public" model="ir.rule">
         <field name="name">Public: public only</field>
         <field name="model_id" ref="test_mail.model_mail_test_access"/>

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -272,7 +272,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
             # voip module read activity_type during create leading to one less query in enterprise on action_feedback
             _category = activity.activity_type_id.category
 
-        with self.assertQueryCount(admin=15, employee=15):
+        with self.assertQueryCount(admin=16, employee=16):
             activity.action_feedback(feedback='Zizisse Done !')
 
     @warmup
@@ -307,7 +307,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
 
         record.write({'name': 'Dupe write'})
 
-        with self.assertQueryCount(admin=17, employee=17):
+        with self.assertQueryCount(admin=18, employee=18):
             record.action_close('Dupe feedback')
 
         self.assertEqual(record.activity_ids, self.env['mail.activity'])
@@ -333,7 +333,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
 
         record.write({'name': 'Dupe write'})
 
-        with self.assertQueryCount(admin=21, employee=21):  # com+tm 20/20
+        with self.assertQueryCount(admin=22, employee=22):  # com+tm 20/20
             record.action_close('Dupe feedback', attachment_ids=attachments.ids)
 
         # notifications

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -404,7 +404,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
                 composer_form.attachment_ids.add(attachment)
             composer = composer_form.save()
 
-        with self.assertQueryCount(admin=54, employee=54):  # tm+com 47/47
+        with self.assertQueryCount(admin=55, employee=55):  # tm+com 47/47
             composer._action_send_mail()
 
         # notifications
@@ -525,7 +525,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
             )
             composer = composer_form.save()
 
-        with self.assertQueryCount(admin=50, employee=50):
+        with self.assertQueryCount(admin=51, employee=51):
             composer._action_send_mail()
 
         # notifications
@@ -555,7 +555,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
             )
             composer = composer_form.save()
 
-        with self.assertQueryCount(admin=71, employee=71):
+        with self.assertQueryCount(admin=72, employee=72):
             composer._action_send_mail()
 
         # notifications
@@ -585,7 +585,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     @warmup
     def test_message_assignation_inbox(self):
         record = self.env['mail.test.track'].create({'name': 'Test'})
-        with self.assertQueryCount(admin=20, employee=20):
+        with self.assertQueryCount(admin=21, employee=21):
             record.write({
                 'user_id': self.user_test.id,
             })
@@ -635,7 +635,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     def test_message_log_with_post(self):
         record = self.env['mail.test.simple'].create({'name': 'Test'})
 
-        with self.assertQueryCount(admin=7, employee=7):
+        with self.assertQueryCount(admin=8, employee=8):
             record.message_post(
                 body='<p>Test message_post as log</p>',
                 subtype_xmlid='mail.mt_note',
@@ -646,7 +646,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     def test_message_post_no_notification(self):
         record = self.env['mail.test.simple'].create({'name': 'Test'})
 
-        with self.assertQueryCount(admin=7, employee=7):
+        with self.assertQueryCount(admin=8, employee=8):
             record.message_post(
                 body='<p>Test Post Performances basic</p>',
                 partner_ids=[],
@@ -671,7 +671,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     def test_message_post_one_inbox_notification(self):
         record = self.env['mail.test.simple'].create({'name': 'Test'})
 
-        with self.assertQueryCount(admin=18, employee=18):
+        with self.assertQueryCount(admin=20, employee=20):
             record.message_post(
                 body='<p>Test Post Performances with an inbox ping</p>',
                 partner_ids=self.user_test.partner_id.ids,
@@ -902,7 +902,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
             }).create({})
             composer._onchange_template_id_wrapper()
 
-        with self.assertQueryCount(admin=141, employee=141):
+        with self.assertQueryCount(admin=151, employee=151):
             messages_as_sudo = test_records.message_post_with_view(
                 'test_mail.mail_template_simple_test',
                 values={'partner': self.user_test.partner_id},
@@ -1204,7 +1204,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
             ]
         }])
 
-        with self.assertQueryCount(employee=6):
+        with self.assertQueryCount(employee=7):
             res = messages.message_format()
             self.assertEqual(len(res), 2)
             for message in res:
@@ -1213,7 +1213,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         self.env.flush_all()
         self.env.invalidate_all()
 
-        with self.assertQueryCount(employee=19):
+        with self.assertQueryCount(employee=20):
             res = messages.message_format()
             self.assertEqual(len(res), 2)
             for message in res:
@@ -1234,14 +1234,14 @@ class TestMailComplexPerformance(BaseMailPerformance):
             'res_id': record.id
         } for record in records])
 
-        with self.assertQueryCount(employee=5):
+        with self.assertQueryCount(employee=7):
             res = messages.message_format()
             self.assertEqual(len(res), 6)
 
         self.env.flush_all()
         self.env.invalidate_all()
 
-        with self.assertQueryCount(employee=14):
+        with self.assertQueryCount(employee=16):
             res = messages.message_format()
             self.assertEqual(len(res), 6)
 

--- a/addons/test_mail_full/tests/test_mail_performance.py
+++ b/addons/test_mail_full/tests/test_mail_performance.py
@@ -81,7 +81,7 @@ class TestMailPerformance(BaseMailPerformance):
         record_ticket = self.env['mail.test.ticket.mc'].browse(self.record_ticket.ids)
         attachments = self.env['ir.attachment'].create(self.test_attachments_vals)
 
-        with self.assertQueryCount(employee=91):  # tmf: 60
+        with self.assertQueryCount(employee=92):  # tmf: 60
             new_message = record_ticket.message_post(
                 attachment_ids=attachments.ids,
                 body='<p>Test Content</p>',

--- a/addons/test_mail_full/tests/test_rating.py
+++ b/addons/test_mail_full/tests/test_rating.py
@@ -141,7 +141,7 @@ class TestRatingPerformance(TestRatingCommon):
         partners = self.env['res.partner'].sudo().create([
             {'name': 'Jean-Luc %s' % (idx), 'email': 'jean-luc-%s@opoo.com' % (idx)} for idx in range(RECORD_COUNT)])
 
-        with self.assertQueryCount(employee=1516):  # tmf 1516 / com 5510
+        with self.assertQueryCount(employee=1614):  # tmf 1614
             record_ratings = self.env['mail.test.rating'].create([{
                 'customer_id': partners[idx].id,
                 'name': 'Test Rating',
@@ -149,13 +149,13 @@ class TestRatingPerformance(TestRatingCommon):
             } for idx in range(RECORD_COUNT)])
             self.flush_tracking()
 
-        with self.assertQueryCount(employee=2004):  # tmf 2004
+        with self.assertQueryCount(employee=2104):  # tmf 2104
             for record in record_ratings:
                 access_token = record._rating_get_access_token()
                 record.rating_apply(1, token=access_token)
             self.flush_tracking()
 
-        with self.assertQueryCount(employee=2003):  # tmf 2003
+        with self.assertQueryCount(employee=2103):  # tmf 2103
             for record in record_ratings:
                 access_token = record._rating_get_access_token()
                 record.rating_apply(5, token=access_token)


### PR DESCRIPTION
RATIONALE

When a cascade delete occurs in DB, ORM methods are not called. More
specifically loosely connected records using res_model / res_id pair
are not removed when unlink override exists.

SPECIFICATIONS

Fix various use case in mail

* notifications sent for scheduled messages;
* failure notifications management;
* activities mark as done;

Task-5138556