### PR TITLE
[FIX] uom: add default relative uom on many2x_uom_tags

### DIFF
--- a/addons/uom/static/src/components/many2x_uom_tags/many2x_uom_tags.js
+++ b/addons/uom/static/src/components/many2x_uom_tags/many2x_uom_tags.js
@@ -70,7 +70,12 @@ export class Many2XUomTagsAutocomplete extends Many2XAutocomplete {
         };
         records = records.map((record) => {
             let relativeInfo = this.referenceUnit && this.referenceUnit.id !== record.id ? `${roundPrecision((this.props.productQuantity || 1) * record.factor / this.referenceUnit.factor, this.referenceUnit.rounding)} ${this.referenceUnit.name}` : "";
-            if (this.referenceUnit && record.id !== this.referenceUnit.id && hasCommonReference(record, this.referenceUnit)) {
+            if (
+                this.referenceUnit &&
+                record.id !== this.referenceUnit.id &&
+                hasCommonReference(record, this.referenceUnit) &&
+                record.relative_uom_id
+            ) {
                 relativeInfo = `${roundPrecision((this.props.productQuantity || 1) * record.relative_factor, this.referenceUnit.rounding)} ${record.relative_uom_id[1]}`;
             }
             return {


### PR DESCRIPTION
### Steps to reproduce:

- In the settings enable "Product Packaging"
- Create a product and set its `uom_id` (next to sales price) to "pack of 6"
- In the sales tab click on Packagings
> This opens a list view of units with convertions
#### > The "Units" is converted to "1 Undefined"

### Cause of the issue:

The "Units" uom does not have any set `relative_uom_id` so that `record.relative_uom_id[1] ` is undefined:
https://github.com/odoo/odoo/blob/e44ea4adbe56586349b78ae4796803777d8a782a/addons/uom/static/src/components/many2x_uom_tags/many2x_uom_tags.js#L74

opw-5189284
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
