### PR TITLE
[IMP] payment_adyen: include applicatioInfo

### DIFF
--- a/addons/payment_adyen/controllers/main.py
+++ b/addons/payment_adyen/controllers/main.py
@@ -10,7 +10,7 @@ import pprint
 from werkzeug import urls
 from werkzeug.exceptions import Forbidden
 
-from odoo import _, http
+from odoo import _, http, release
 from odoo.exceptions import ValidationError
 from odoo.http import request
 
@@ -97,6 +97,13 @@ class AdyenController(http.Controller):
             'amount': {
                 'value': converted_amount,
                 'currency': request.env['res.currency'].browse(currency_id).name,  # ISO 4217
+            },
+            'applicationInfo': {
+                'externalPlatform': {
+                    'name': 'Odoo',
+                    'version': release.version,
+                    'integrator': 'Odoo SA',
+                }
             },
             'countryCode': partner_country_code,  # ISO 3166-1 alpha-2 (e.g.: 'BE')
             'reference': reference,

--- a/addons/payment_adyen/models/payment_transaction.py
+++ b/addons/payment_adyen/models/payment_transaction.py
@@ -3,7 +3,7 @@
 import logging
 import pprint
 
-from odoo import _, models
+from odoo import _, models, release
 from odoo.exceptions import UserError, ValidationError
 from odoo.tools import format_amount
 
@@ -72,6 +72,13 @@ class PaymentTransaction(models.Model):
             'amount': {
                 'value': converted_amount,
                 'currency': self.currency_id.name,
+            },
+            'applicationInfo': {
+                'externalPlatform': {
+                    'name': 'Odoo',
+                    'version': release.version,
+                    'integrator': 'Odoo SA',
+                }
             },
             'countryCode': partner_country_code,
             'reference': self.reference,


### PR DESCRIPTION
Add applicationInfo to the payload sent to Adyen, ensuring that externalPlatform is correctly transmitted.

A test was added to verify that applicationInfo is present in the payload and that the payment request succeeds as expected.

task-5157863

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
