### PR TITLE
[IMP] html_builder, website: prevent being stuck in Operation mutex

### DIFF
--- a/addons/html_builder/static/src/core/builder_action.js
+++ b/addons/html_builder/static/src/core/builder_action.js
@@ -62,6 +62,9 @@ export class BuilderAction {
         this.preview ??= this.reload ? false : true;
         this.withLoadingEffect ??= true;
         this.loadOnClean ??= false;
+        // canTimeout is enabled when no load is used to avoid staying stuck
+        // in the mutex if apply fails silently.
+        this.canTimeout ??= !this.has("load");
     }
 
     /**

--- a/addons/html_builder/static/src/core/builder_overlay/builder_overlay.js
+++ b/addons/html_builder/static/src/core/builder_overlay/builder_overlay.js
@@ -509,7 +509,7 @@ export class BuilderOverlay {
         // Lock the mutex.
         let sizingResolve;
         const sizingProm = new Promise((resolve) => (sizingResolve = () => resolve()));
-        this.next(async () => await sizingProm, { withLoadingEffect: false });
+        this.next(async () => await sizingProm, { withLoadingEffect: false, canTimeout: false });
         const cancelSizing = this.history.makeSavePoint();
 
         const handleEl = ev.currentTarget;

--- a/addons/html_builder/static/src/core/drag_and_drop_plugin.js
+++ b/addons/html_builder/static/src/core/drag_and_drop_plugin.js
@@ -218,6 +218,7 @@ export class DragAndDropPlugin extends Plugin {
                 );
                 this.dependencies.operation.next(async () => await dragAndDropProm, {
                     withLoadingEffect: false,
+                    canTimeout: false,
                 });
                 const restoreDragSavePoint = this.dependencies.history.makeSavePoint();
                 this.cancelDragAndDrop = () => {

--- a/addons/html_builder/static/src/core/utils.js
+++ b/addons/html_builder/static/src/core/utils.js
@@ -459,6 +459,22 @@ function useWithLoadingEffect(getAllActions) {
     return withLoadingEffect;
 }
 
+function useCanTimeout(getAllActions) {
+    const env = useEnv();
+    const getAction = env.editor.shared.builderActions.getAction;
+    let canTimeout = true;
+    for (const descr of getAllActions()) {
+        if (descr.actionId) {
+            const action = getAction(descr.actionId);
+            if (action.canTimeout === false) {
+                canTimeout = false;
+            }
+        }
+    }
+
+    return canTimeout;
+}
+
 export function revertPreview(editor) {
     if (editor.isDestroyed) {
         return;
@@ -485,17 +501,24 @@ export function useClickableBuilderComponent() {
     const operationWithReload = useOperationWithReload(callApply, reload);
 
     const withLoadingEffect = useWithLoadingEffect(getAllActions);
+    const canTimeout = useCanTimeout(getAllActions);
 
     let preventNextPreview = false;
     const operation = {
         commit: () => {
             preventNextPreview = false;
             if (reload) {
-                callOperation(operationWithReload);
+                callOperation(operationWithReload, {
+                    operationParams: {
+                        withLoadingEffect: withLoadingEffect,
+                        canTimeout: canTimeout,
+                    },
+                });
             } else {
                 callOperation(applyOperation.commit, {
                     operationParams: {
                         withLoadingEffect: withLoadingEffect,
+                        canTimeout: canTimeout,
                     },
                 });
             }
@@ -511,6 +534,7 @@ export function useClickableBuilderComponent() {
                 operationParams: {
                     cancellable: true,
                     cancelPrevious: () => applyOperation.revert(),
+                    canTimeout: canTimeout,
                 },
             });
         },
@@ -657,6 +681,7 @@ export function useInputBuilderComponent({
     const { reload } = useReloadAction(getAllActions);
 
     const withLoadingEffect = useWithLoadingEffect(getAllActions);
+    const canTimeout = useCanTimeout(getAllActions);
 
     onWillUpdateProps((nextProps) => {
         if ("default" in nextProps) {
@@ -703,11 +728,20 @@ export function useInputBuilderComponent({
         userInputValue = getValueWithDefault(userInputValue, defaultValue, formatRawValue);
         const rawValue = parseDisplayValue(userInputValue);
         if (reload) {
-            callOperation(operationWithReload, { userInputValue: rawValue });
+            callOperation(operationWithReload, {
+                userInputValue: rawValue,
+                operationParams: {
+                    withLoadingEffect: withLoadingEffect,
+                    canTimeout: canTimeout,
+                },
+            });
         } else {
             callOperation(applyOperation.commit, {
                 userInputValue: rawValue,
-                withLoadingEffect: withLoadingEffect,
+                operationParams: {
+                    withLoadingEffect: withLoadingEffect,
+                    canTimeout: canTimeout,
+                },
             });
         }
         if (rawValue === null || (rawValue === defaultValue && rawValue === state.value)) {
@@ -729,6 +763,7 @@ export function useInputBuilderComponent({
                 operationParams: {
                     cancellable: true,
                     cancelPrevious: () => applyOperation.revert(),
+                    canTimeout: canTimeout,
                 },
             });
         }

--- a/addons/html_builder/static/src/plugins/image/image_tool_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/image_tool_option_plugin.js
@@ -172,6 +172,11 @@ export class ResetCropAction extends BuilderAction {
 export class ReplaceMediaAction extends BuilderAction {
     static id = "replaceMedia";
     static dependencies = ["media_website"];
+
+    setup() {
+        this.canTimeout = false;
+    }
+
     async apply({ editingElement: mediaEl }) {
         await this.dependencies.media_website.replaceMedia(mediaEl);
     }

--- a/addons/html_builder/static/src/sidebar/block_tab.js
+++ b/addons/html_builder/static/src/sidebar/block_tab.js
@@ -128,6 +128,7 @@ export class BlockTab extends Component {
             {
                 withLoadingEffect: false,
                 shouldInterceptClick: true,
+                canTimeout: false,
             }
         );
     }
@@ -258,6 +259,7 @@ export class BlockTab extends Component {
                 );
                 this.shared.operation.next(async () => await dragAndDropProm, {
                     withLoadingEffect: false,
+                    canTimeout: false,
                 });
                 const restoreDragSavePoint = this.shared.history.makeSavePoint();
                 this.cancelDragAndDrop = () => {
@@ -448,6 +450,7 @@ export class BlockTab extends Component {
                             {
                                 withLoadingEffect: false,
                                 shouldInterceptClick: true,
+                                canTimeout: false,
                             }
                         );
                     }

--- a/addons/html_builder/static/tests/builder_action.test.js
+++ b/addons/html_builder/static/tests/builder_action.test.js
@@ -9,7 +9,7 @@ import { BuilderAction } from "@html_builder/core/builder_action";
 import { SavePlugin } from "@html_builder/core/save_plugin";
 import { BaseOptionComponent } from "@html_builder/core/utils";
 import { beforeEach, describe, expect, test } from "@odoo/hoot";
-import { animationFrame, Deferred } from "@odoo/hoot-dom";
+import { advanceTime, animationFrame, Deferred, tick } from "@odoo/hoot-dom";
 import { useState, xml } from "@odoo/owl";
 import {
     contains,
@@ -335,4 +335,34 @@ test("reload action: apply, clean save and reload are called in the right order 
     cleanDef.resolve();
     await reloadDef;
     expect.verifySteps(["clean async", "save sync", "save async", "reload"]);
+});
+
+test("shows notification when a BuilderAction.apply times out", async () => {
+    addBuilderAction({
+        timeoutAction: class extends BuilderAction {
+            static id = "timeoutAction";
+
+            async apply() {
+                expect.step("apply start");
+                await new Promise((resolve) => setTimeout(resolve, 15000));
+                expect.step("apply end");
+            }
+        },
+    });
+    addBuilderOption(
+        class extends BaseOptionComponent {
+            static selector = ".test-options-target";
+            static template = xml`<BuilderButton action="'timeoutAction'"/>`;
+        }
+    );
+
+    await setupHTMLBuilder(`<div class="test-options-target">TEST</div>`);
+    await contains(":iframe .test-options-target").click();
+    await contains("[data-action-id='timeoutAction']").click();
+
+    await advanceTime(15000);
+    await tick();
+
+    expect(".o_notification").toHaveCount(1);
+    expect.verifySteps(["apply start", "apply end"]);
 });


### PR DESCRIPTION
Before this commit, if an error occurred within the mutex that did not
explicitly throw, the mutex could remain locked indefinitely. This
blocked subsequent actions and prevented the user from saving.

This commit introduces a timeout mechanism for Operations. This is
intended for very rare cases as a last resort to prevent the editor from
becoming completely unresponsive.

When a timeout occurs:
- The mutex is released, allowing the user to recover (e.g. by deleting
  the faulty snippet).
- The user is notified of the issue.
- A warning is displayed during saving to indicate that the content
  might be in a corrupted state.

Additionally, the `canTimeout: false` flag is added to options that are
expected to remain open for long periods (such as the snippet modal).

task-5152911
