### PR TITLE
[FIX] mail: not erase an activity when done

### DIFF
--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -574,7 +574,7 @@ class MailActivity(models.Model):
 
         activity_to_keep = self.filtered('activity_type_id.keep_done')
         activity_to_keep.action_archive()
-        (self - activity_to_keep).unlink()  # will unlink activity, dont access `self` after that
+        (self - activity_to_keep).action_archive() # will unlink activity, dont access `self` after that
 
         return messages, next_activities
 


### PR DESCRIPTION
When doing a search on activities with the filter "done", no activity will appear.

Steps to reproduce:
-------------------
* Go to "View all activities" from clock button on top
* Add filter "Done" -> Issue no activity appears.

Observation:
------------------

The search is made on the field "active" in mail.activity model. But when an activity is marked as done, it's not only marked with that field but also completly erased: https://github.com/odoo/odoo/blob/5207f5f07d00703e5e822852bd5ce212f8051426/addons/mail/models/mail_activity.py#L577

I have juste made all activity archived, but I will try to see if with the keep_done variable added in this commit is possible to solve the problem. https://github.com/odoo/odoo/commit/b6c236df54abb66b30d8643dea797f385d3036f1#diff-37df585509f3129b2a4473822341a8d5af404cd7a50bb7d2876bdf8472b43d87R74

opw-5159884