### PR TITLE
[FIX] mrp: prevent starting a blocked work order

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -644,6 +644,8 @@ class MrpWorkorder(models.Model):
                 if raise_on_invalid_state:
                     continue
                 raise UserError(_('You cannot start a work order that is already done or cancelled'))
+            if wo.state == 'blocked':
+                raise UserError(_('You cannot start a work order that is blocked by an other one'))
 
             if wo.product_tracking == 'serial' and wo.qty_producing == 0:
                 wo.qty_producing = 1.0

--- a/addons/mrp/static/tests/tours/mrp_shop_floor.js
+++ b/addons/mrp/static/tests/tours/mrp_shop_floor.js
@@ -1,0 +1,58 @@
+import { registry } from "@web/core/registry";
+import { stepUtils } from "@web_tour/tour_service/tour_utils";
+
+registry.category("web_tour.tours").add("test_work_order_dependency", {
+    steps: () => [
+        stepUtils.showAppsMenuItem(),
+        {
+            content: "Activate work center",
+            run: "click",
+            trigger: '.btn-primary:contains(Activate your Work Centers)'
+        },
+        {
+            content: "Open the Shop Floor app",
+            run: "click",
+            trigger: '.o_workcenter_button:contains(Simple Workcenter)'
+        },
+        {
+            content: "Open the Shop Floor app",
+            run: "click",
+            trigger: '.o_workcenter_button:contains(Nuclear Workcenter)'
+        },
+        {
+            content: "Open the Shop Floor app",
+            run: "click",
+            trigger: '.btn:contains(confirm)'
+        },
+        {
+            content: "Open the Shop Floor app",
+            run: 'click',
+            trigger: '.o_work_center_btn:contains(Simple Workcenter)'
+        },
+        {
+            content: "Open the Shop Floor app",
+            run: 'click',
+            trigger: '.o_searchview_dropdown_toggler'
+        },
+        {
+            content: "Open the Shop Floor app",
+            run: 'click',
+            trigger: '.o-dropdown-item:contains(Blocked)'
+        },
+        {
+            content: "Open the Shop Floor app",
+            run: 'click',
+            trigger: '.o_searchview_dropdown_toggler'
+        },
+        {
+            content: "Open the Shop Floor app",
+            run: 'click',
+            trigger: '.o_mrp_display_record_start_btn'
+        },
+        {
+            content: "Open the Shop Floor app",
+            run: () => {},
+            trigger: '.text-prewrap:contains(You cannot start a work order that is blocked by an other one)'
+        },
+    ],
+});

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -85,7 +85,7 @@
                   invisible="production_state == 'draft'"
                   readonly="is_user_working" sum="real duration"/>
                 <button name="button_start" type="object" title="Start" class="btn-success px-2"
-                  invisible="production_state in ('draft', 'done', 'cancel') or working_state == 'blocked' or state in ('done', 'cancel') or is_user_working" icon="fa-play"/>
+                  invisible="production_state in ('draft', 'done', 'cancel') or working_state == 'blocked' or state in ('done', 'cancel', 'blocked') or is_user_working" icon="fa-play"/>
                 <button name="button_pending" type="object" title="Pause" class="btn-warning px-2" icon="fa-pause"
                   invisible="production_state in ('draft', 'done', 'cancel') or working_state == 'blocked' or not is_user_working"/>
                 <button name="button_finish" type="object" title="Done" class="btn-success px-2" icon="fa-check"


### PR DESCRIPTION
**Issue**
A work order that is blocked by another work order can still be started.

**Steps to reproduce**
1. Go to Settings > Activate Work Order Dependencies.
2. Create a Bill of Material for a product:
   - In the Miscellaneous tab, activate Work Order Dependency.
   - Create two work orders in different work centers where the second depends on the first.
3. Create a manufacturing order for the same product.
4. In the 'Operations' tab, observe that the start button is active for the blocked work order.
5. Click the Shop Floor smart button and observe that the blocked work order can still be started.

**Cause**
The [`state` of the work order](https://github.com/odoo/odoo/blob/dae9b0a906e86a9e26cd1b37bd9b9385804c8e55/addons/mrp/models/mrp_workorder.py#L65C1-L72C49) was not consistently checked before allowing a work order to start.

**Solution**
Follow the existing behaviour for blocked work centers:
- Hide the start button on the manufacturing order if the work order is blocked.
- Trigger an error message if the start button on the Shop Floor is clicked for a blocked work order.

opw-5167644