### PR TITLE
[FIX] purchase_mrp, sale_purchase_stock: track kit bom when receiving without pull rule

### DIFF
--- a/addons/mrp_subcontracting_dropshipping/tests/test_anglo_saxon_valuation.py
+++ b/addons/mrp_subcontracting_dropshipping/tests/test_anglo_saxon_valuation.py
@@ -221,6 +221,7 @@ class TestSubcontractingDropshippingValuation(ValuationReconciliationTestCommon)
             'property_account_expense_id': self.copy_account(self.company_data['default_account_expense']).id,
             'taxes_id': [Command.set((self.tax_sale_a + self.tax_sale_b).ids)],
             'supplier_taxes_id': [Command.set((self.tax_purchase_a + self.tax_purchase_b).ids)],
+            'is_storable': True
         })
         kit_bom = self.env['mrp.bom'].create({
             'product_tmpl_id': kit_final_prod.product_tmpl_id.id,

--- a/addons/purchase_mrp/models/purchase.py
+++ b/addons/purchase_mrp/models/purchase.py
@@ -97,3 +97,22 @@ class PurchaseOrderLine(models.Model):
             filters = {'incoming_moves': lambda m: True, 'outgoing_moves': lambda m: False}
             return move_dests._compute_kit_quantities(self.product_id, self.product_qty, kit_bom, filters)
         return super()._get_move_dests_initial_demand(move_dests)
+
+    def _get_sale_order_line_product(self):
+        return False
+
+    def _prepare_stock_moves(self, picking):
+        res = super()._prepare_stock_moves(picking)
+        sale_line_product = self._get_sale_order_line_product()
+        if sale_line_product:
+            bom = self.env['mrp.bom']._bom_find(self.env['product.product'].browse(sale_line_product.id), company_id=picking.company_id.id, bom_type='phantom')
+            # Was a kit sold?
+            bom_kit = bom.get(sale_line_product)
+            if bom_kit:
+                _dummy, bom_sub_lines = bom_kit.explode(sale_line_product, self.sale_line_id.product_uom_qty)
+                bom_kit_component = {line['product_id'].id: line.id for line, _ in bom_sub_lines}
+                # Find the sml for the kit component
+                for vals in res:
+                    if vals['product_id'] in bom_kit_component:
+                        vals['bom_line_id'] = bom_kit_component[vals['product_id']]
+        return res

--- a/addons/sale_purchase_stock/models/purchase_order.py
+++ b/addons/sale_purchase_stock/models/purchase_order.py
@@ -37,6 +37,9 @@ class PurchaseOrderLine(models.Model):
                 )
         return res
 
+    def _get_sale_order_line_product(self):
+        return self.sale_line_id.product_id
+
     def _find_candidate(self, product_id, product_qty, product_uom, location_id, name, origin, company_id, values):
         # if this is defined, this is a dropshipping line, so no
         # this is to correctly map delivered quantities to the so lines


### PR DESCRIPTION
[FIX] purchase_mrp, sale_purchase_stock: track kit bom when receiving without pull rule

Problem:
If an inventory workflow is completed without any pull rules (only Push or Buy), then `bom_line_id` is never set on the sale order line. The result has two primary impacts: `qty_received` will not be updated upon final transfer, and the COGS line on the invoice will be calculated using the incorrect method, with an incorrect result.

Solution:
Upon confirming a Purchase Order, when the picking is being created, we will try to assign the `bom_line_id` on the Sale Order Line if:
	1. The PO is attached to a Sale Order
	2. The SO line is for the kit
	3. The product on the PO line is component of the BOM for that kit
With the `bom_line_id` assigned on the SO line, `qty_received` will be calculated correctly for kits, and COGS lines on the generated invoice will also be calculated correctly based on the kit.

Steps to Replicate (Runbot 18)
- 2-step receipt, 2-step delivery
- Cross-Dock enabled
- Kit item, fifo auto
	- No routes enabled on kit
	- Two components, fifo auto
		- Enable Buy and Cross-Dock routes
		- Set a vendor and non-zero price

1. Create a sale order for the kit and sell for non-zero price, confirm
2. Confirm the PO
3. Validate the pickings
	1. Receipt
	2. Cross-Dock
	3. Delivery
4. Go back to the sale order, note the first issue of 0 quantity delivered
5. Create an Invoice
6. Confirm the invoice, note the second issue of the COGS lines being triple the total purchase price

opw-5139590
