### PR TITLE
[IMP] account: improvements accrued orders wizard structure

### DIFF
--- a/addons/account/wizard/accrued_orders.py
+++ b/addons/account/wizard/accrued_orders.py
@@ -236,6 +236,16 @@ class AccruedExpenseRevenue(models.TransientModel):
         }
         return move_vals, orders_with_entries
 
+    def _get_accrual_message_body(self, move, reverse_move):
+        self.ensure_one()
+        return _(
+            'Accrual entry created on %(date)s: %(accrual_entry)s.\
+                And its reverse entry: %(reverse_entry)s.',
+            date=self.date,
+            accrual_entry=move._get_html_link(),
+            reverse_entry=reverse_move._get_html_link(),
+        )
+
     def create_entries(self):
         self.ensure_one()
 
@@ -251,18 +261,11 @@ class AccruedExpenseRevenue(models.TransientModel):
         }])
         reverse_move._post()
         for order in orders_with_entries:
-            body = _(
-                'Accrual entry created on %(date)s: %(accrual_entry)s.\
-                    And its reverse entry: %(reverse_entry)s.',
-                date=self.date,
-                accrual_entry=move._get_html_link(),
-                reverse_entry=reverse_move._get_html_link(),
-            )
-            order.message_post(body=body)
+            order.message_post(body=self._get_accrual_message_body(move, reverse_move))
         return {
             'name': _('Accrual Moves'),
             'type': 'ir.actions.act_window',
             'res_model': 'account.move',
             'view_mode': 'tree,form',
-            'domain': [('id', 'in', (move.id, reverse_move.id))],
+            'domain': [('id', 'in', (move | reverse_move).ids)],
         }


### PR DESCRIPTION
Add a dedicated hook method to facilitate customization of reversal
entry generation in the accrued orders wizard.

Reason:
The current implementation creates a single reversal entry that is
applied in the next period. For scenarios requiring accrual allocation
across multiple periods, modules need the ability to generate multiple
reversal entries (one per period) to properly net-off against actual
invoices

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
