### PR TITLE
[FIX] hr_attendance: typo (maneger -> manager)

### DIFF
--- a/addons/hr_attendance/models/hr_attendance_overtime.py
+++ b/addons/hr_attendance/models/hr_attendance_overtime.py
@@ -78,7 +78,7 @@ class HrAttendanceOvertimeLine(models.Model):
                 has_manager_right or
                 (
                     has_officer_right
-                    and overtime.employee_id.attendance_maneger_id == self.env.user
+                    and overtime.employee_id.attendance_manager_id == self.env.user
                 )
             )
 


### PR DESCRIPTION
Odoo throws a server error without this fix when a non-manager tries to access an attendance record with overtime.

```
RPC_ERROR

Odoo Server Error

Occured on 92006100-19-0-all.runbot132.odoo.com on model hr.attendance on 2025-10-26 13:17:47 GMT

Traceback (most recent call last):
  File "/data/build/odoo/odoo/http.py", line 2266, in _serve_db
    return service_model.retrying(serve_func, env=self.env)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/build/odoo/odoo/service/model.py", line 184, in retrying
    result = func()
             ^^^^^^
  File "/data/build/odoo/odoo/http.py", line 2313, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/build/odoo/odoo/http.py", line 2528, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/build/odoo/odoo/addons/base/models/ir_http.py", line 357, in _dispatch
    result = endpoint(**request.params)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/build/odoo/odoo/http.py", line 788, in route_wrapper
    result = endpoint(self, *args, **params_ok)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/build/odoo/addons/web/controllers/dataset.py", line 32, in call_kw
    return call_kw(request.env[model], method, args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/build/odoo/odoo/service/model.py", line 93, in call_kw
    result = method(recs, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/build/odoo/addons/web/models/models.py", line 192, in web_read
    for vals in co_records.web_read(field_spec['fields'])
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/build/odoo/addons/web/models/models.py", line 113, in web_read
    values_list: list[dict] = self.read(fields_to_read, load=None)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/build/odoo/odoo/orm/models.py", line 3487, in read
    return self._read_format(fnames=fields, load=load)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/build/odoo/odoo/orm/models.py", line 3744, in _read_format
    vals[name] = convert(record[name], record, use_display_name)
                         ~~~~~~^^^^^^
  File "/data/build/odoo/odoo/orm/models.py", line 6680, in __getitem__
    return self._fields[key].__get__(self)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/build/odoo/odoo/orm/fields.py", line 1739, in __get__
    self.compute_value(recs)
  File "/data/build/odoo/odoo/orm/fields.py", line 1910, in compute_value
    records._compute_field_value(self)
  File "/data/build/odoo/odoo/orm/models.py", line 4949, in _compute_field_value
    determine(field.compute, self)
  File "/data/build/odoo/odoo/orm/fields.py", line 81, in determine
    return needle(*args)
           ^^^^^^^^^^^^^
  File "/data/build/odoo/addons/hr_attendance/models/hr_attendance_overtime.py", line 81, in _compute_is_manager
    and overtime.employee_id.attendance_maneger_id == self.env.user
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'hr.employee' object has no attribute 'attendance_maneger_id'

The above server error caused the following client error:
OwlError: An error occured in the owl lifecycle (see this Error's "cause" property)
    Error: An error occured in the owl lifecycle (see this Error's "cause" property)
        at handleError (https://92006100-19-0-all.runbot132.odoo.com/web/assets/d63947b/web.assets_web.min.js:762:101)
        at App.handleError (https://92006100-19-0-all.runbot132.odoo.com/web/assets/d63947b/web.assets_web.min.js:1420:29)
        at ComponentNode.initiateRender (https://92006100-19-0-all.runbot132.odoo.com/web/assets/d63947b/web.assets_web.min.js:854:19)

Caused by: RPC_ERROR: Odoo Server Error
    RPC_ERROR
        at makeErrorFromResponse (https://92006100-19-0-all.runbot132.odoo.com/web/assets/d63947b/web.assets_web.min.js:3183:163)
        at XMLHttpRequest.<anonymous> (https://92006100-19-0-all.runbot132.odoo.com/web/assets/d63947b/web.assets_web.min.js:3189:13)
```

@qrtl

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
