### PR TITLE
[FIX] point_of_sale: fix condition for displaying (proxy) status of hardware devices in PoS NavBar

### DIFF
--- a/addons/point_of_sale/static/src/app/navbar/navbar.xml
+++ b/addons/point_of_sale/static/src/app/navbar/navbar.xml
@@ -36,7 +36,7 @@
                         </button>
                         <t t-set-slot="content">
                             <div t-if="customerFacingDisplayButtonIsShown" class="d-flex gap-2 p-2 border-bottom">
-                                <ProxyStatus t-if="pos.config.use_proxy" />
+                                <ProxyStatus t-if="pos.useProxy()" />
                                 <span t-on-click="openCustomerDisplay" class="btn btn-secondary btn-lg w-100 text-center" title="Customer Display">
                                     <i class="fa fa-fw fa-desktop"/>
                                 </span>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The presence of proxy status of hardware devices depends conditionally on pos.config.use_proxy in template of NavBar.
However, use_proxy was removed in [PR 51000](https://github.com/odoo/enterprise/pull/51000) and [PR 142566](https://github.com/odoo/odoo/pull/142566).
As a consequence, the proxy status is never shown in the NavBar of odoo 18.0. It's already fixed in odoo 19.0

Current behavior before PR:
ProxyStatus is not displayed in PoS NavBar even if proxy is used for hardware devices.

Desired behavior after PR is merged:
ProxyStatus is displayed in PoS NavBar depending on proxy configuration (useProxy() of pos_store.js).



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
