### PR TITLE
[FIX] web_editor: Make modify_image controller robust to missing image data

### DIFF
--- a/addons/html_editor/controllers/main.py
+++ b/addons/html_editor/controllers/main.py
@@ -398,6 +398,8 @@ class HTML_Editor(http.Controller):
         """
         self._clean_context()
         attachment = request.env['ir.attachment'].browse(attachment.id)
+        if not data and attachment.datas:
+            data = attachment.datas
 
         fields = {
             'original_id': attachment.id,

--- a/addons/html_editor/tests/__init__.py
+++ b/addons/html_editor/tests/__init__.py
@@ -3,3 +3,4 @@ from . import test_converter
 from . import test_tools
 from . import test_views
 from . import test_diff_utils
+from . import test_modify_image_no_data

--- a/addons/html_editor/tests/test_modify_image_no_data.py
+++ b/addons/html_editor/tests/test_modify_image_no_data.py
@@ -1,0 +1,45 @@
+
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import odoo.tests
+from odoo.tests.common import HttpCase
+from odoo.tools.json import scriptsafe as json_safe
+
+
+@odoo.tests.tagged('-at_install', 'post_install')
+class TestModifyImageNoData(HttpCase):
+
+    def setUp(self):
+        super().setUp()
+        self.authenticate('admin', 'admin')
+        self.pixel = 'R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs='
+
+    def test_modify_image_no_data(self):
+        # Create an attachment
+        attachment = self.env['ir.attachment'].create({
+            'name': 'test_image.gif',
+            'datas': self.pixel,
+            'res_model': 'ir.ui.view',
+            'res_id': 0,
+        })
+
+        # Call the modify_image controller without the 'data' parameter
+        response = self.url_open(
+            f'/html_editor/modify_image/{attachment.id}',
+            headers={'Content-Type': 'application/json'},
+            data=json_safe.dumps({'params': {
+                'res_model': 'ir.ui.view',
+                'res_id': 0,
+                'name': 'modified_image.gif',
+            }})
+        )
+        self.assertEqual(response.status_code, 200)
+        response_data = response.json()
+        self.assertNotIn('error', response_data)
+        self.assertIn('result', response_data)
+
+        modified_attachment = self.env['ir.attachment'].search([
+            ('name', '=', 'modified_image.gif'),
+            ('original_id', '=', attachment.id),
+        ])
+        self.assertEqual(len(modified_attachment), 1)


### PR DESCRIPTION

Description of the issue/feature this PR addresses:
Issue reported[ here ](https://github.com/odoo/odoo/issues/233130)

Impacted versions:
19.0 (and likely earlier stable versions: 17.0, 18.0)

Steps to reproduce:

Open the Website Editor or HTML Editor (e.g., editing a website page).
Insert or select an image that has been saved as an attachment (source is a /web/image/... URL, not a Base64 string).
Perform an action that triggers the attachment modification logic (e.g., applying a filter, or a WebP conversion step).


**Current behavior before PR:**
- The client-side JavaScript correctly omits the data parameter in the RPC request to /html_editor/modify_image/<attachment_id>.
- The Python modify_image controller receives data=None, and subsequent image processing fails because it expects the image content, leading to a server-side traceback (e.g., a KeyError or a failure in image manipulation libraries).

**Desired behavior after PR is merged:**
The modify_image controller should successfully retrieve the existing image content from the database and process the modification without error.

- This controller endpoint handles modifications for existing attachments. When the client is modifying a server-stored image (sourced via /web/image/...), the client efficiently omits the image data payload.
- The controller should be resilient to this behavior by retrieving the image content directly from the existing attachment record.
- The fix introduces a conditional check to load the image's base64 content (attachment.datas) into the data variable if the client does not provide a new payload (data is None).
- This is the most robust and performant solution, as it ensures the controller has the necessary image data without forcing the client to re-upload potentially large files


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
