### PR TITLE
[FIX] l10n_tr_nilvera_einvoice: refresh BytesIO for file resubmission

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice/models/account_move.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_move.py
@@ -135,6 +135,7 @@ class AccountMove(models.Model):
                 # If the sequence/series is not found on Nilvera, add it then retry.
                 if 3009 in error_codes and post_series:
                     self._l10n_tr_nilvera_post_series(endpoint, client)
+                    xml_file.seek(0)    # reset stream before retry, as previous POST moved the buffer to the EOF
                     return self._l10n_tr_nilvera_submit_document(xml_file, endpoint, post_series=False)
                 raise UserError(error_message)
             elif response.status_code == 500:


### PR DESCRIPTION
Resubmitting a Nilvera document reused the same XML stream, leading to an empty file on retries. The issue occurs because `requests.Session. request()` reads the BytesIO buffer, moving its cursor to the end of the file. As a result, subsequent reads return empty content. This fix wraps the XML content in a new BytesIO buffer before each submission to ensure safe recursive resubmissions and prevent 400 errors caused by empty payloads.

task-5163253
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
