### PR TITLE
[FIX] hr_holidays_attendance: prevent error on fetching extra hours of employee

### DIFF
--- a/addons/hr_holidays_attendance/models/hr_employee.py
+++ b/addons/hr_holidays_attendance/models/hr_employee.py
@@ -1,7 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models, api
-from odoo.fields import Domain
 
 
 class HrEmployee(models.Model):
@@ -10,16 +9,16 @@ class HrEmployee(models.Model):
     @api.model
     def get_overtime_data(self, domain=None, employee_id=None):
         overtime_data = super().get_overtime_data(domain, employee_id)
-        domain = [] if domain is None else domain
+        allocation_domain = [
+            ('holiday_status_id.overtime_deductible', '=', True),
+            ('state', '=', 'confirm'),
+        ]
+        if employee_id:
+            allocation_domain.append(('employee_id', '=', employee_id))
         overtime_adjustments = {
             allocation[0].id: allocation[1]
             for allocation in self.env["hr.leave.allocation"]._read_group(
-                domain=Domain.AND(
-                    domain,
-                    [
-                        ('holiday_status_id.overtime_deductible', '=', True),
-                        ('state', '=', 'confirm'),
-                    ]),
+                domain=allocation_domain,
                 groupby=['employee_id'],
                 aggregates=['number_of_hours_display:sum']
             )


### PR DESCRIPTION
Currently, an error occurs when opening the "Monthly Hours" smart button on an employee record after enabling the "Display Extra Hours" feature.

**Steps to Reproduce:**
1. Install "Attendances" and "Time off" modules with demo data.
2. In Settings, enable the "Display Extra Hours".
3. Open any employee and click on "Monthly Hours" smart button.

**Error:**
`TypeError - Domain.AND() takes 1 positional argument but 2 were given`

**Cause:**
At [1], the domain was incorrectly passed as two separate arguments to `Domain.AND()`, which must be wrapped inside a list. Fixing by-passing a single argument leads to another issue because the ORM call at [2] passes a domain for the `hr.attendance` model, which includes fields like `check_in` and `check_out`. These fields do not exist on the `hr.leave.allocation` model, leading to the `ValueError: Invalid field hr.leave.allocation.check_in in condition ('check_in', '>=', '2025-09-30 18:30:00')`.

**Fix:**
This commit fixes the issue by skipping invalid domain filters that do not exist on the `hr.leave.allocation` model before calling `_read_group` method. 

[1] -  https://github.com/odoo/odoo/blob/041c70150ee50ef58c02dbcec157adb646cfcde5/addons/hr_holidays_attendance/models/hr_employee.py#L17-L22 
[2] - https://github.com/odoo/odoo/blob/041c70150ee50ef58c02dbcec157adb646cfcde5/addons/hr_attendance/static/src/views/extra_hours_list_view.js#L37

sentry-6917312916