### PR TITLE
[FIX] account,sale: prevent error when applying a zero-amount discount

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -3838,7 +3838,7 @@ class AccountTax(models.Model):
                     'factor': abs(
                         (base_line['tax_details']['total_excluded_currency'] + base_line['tax_details']['delta_total_excluded_currency'])
                         / current_base_amount_currency
-                    ),
+                    ) if current_base_amount_currency else 0.0,
                     'base_line': base_line,
                 }
                 for base_line in sorted_base_lines

--- a/addons/account/static/src/helpers/account_tax.js
+++ b/addons/account/static/src/helpers/account_tax.js
@@ -2406,11 +2406,13 @@ export const accountTaxHelpers = {
             ["", expected_base_amount - current_base_amount, company.currency_id],
         ]) {
             const target_factors = sorted_base_lines.map((base_line) => ({
-                factor: Math.abs(
-                    (base_line.tax_details.total_excluded_currency +
-                        base_line.tax_details.delta_total_excluded_currency) /
-                        current_base_amount_currency
-                ),
+                factor: current_base_amount_currency
+                    ? Math.abs(
+                          (base_line.tax_details.total_excluded_currency +
+                              base_line.tax_details.delta_total_excluded_currency) /
+                              current_base_amount_currency
+                      )
+                    : 0.0,
                 base_line: base_line,
             }));
             const amounts_to_distribute = this.distribute_delta_amount_smoothly(

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -534,6 +534,16 @@ class TestSaleOrder(SaleCommon):
         self.assertEqual(discount_line.invoice_status, 'to invoice')
         self.assertEqual(self.sale_order.invoice_status, 'to invoice')
 
+    def test_so_with_fixed_discount_zero_amount(self):
+        """ Applying a fixed discount of 0.0 should have no effect on the order total. """
+        initial_total = self.sale_order.amount_total
+        self.env['sale.order.discount'].create({
+            'sale_order_id': self.sale_order.id,
+            'discount_amount': 0.0,
+            'discount_type': 'amount',
+        }).action_apply_discount()
+        self.assertEqual(self.sale_order.amount_total, initial_total)
+
     def test_sale_order_line_product_taxes_on_branch(self):
         """ Check taxes populated on SO lines from product on branch company.
             Taxes from the branch company should be taken with a fallback on parent company.


### PR DESCRIPTION
The system raises an error when the user tries to apply a fixed amount discount of 0.0.

**Steps to produce:**
- Install `Sales` module with demo data.
- From the settings enable `discount`.
- Make a sale order with product > click on Discount > click Fixed Amount and set amount as `0.0` > click on apply.

**Error:**
`ZeroDivisionError : float division by zero`

**Cause:**
- When the discount amount is set to 0.0, at [1] we attempt to compute the factor, which causes an error due to a division by zero.

**Solution:**
- Added a condition to check that current_base_amount_currency is not zero, and if it is, set the factor to 0.0.

[1]: https://github.com/odoo/odoo/blob/10887c3081afbfd0734c6a3ac24301c94d14bc24/addons/account/models/account_tax.py#L3718-L3720

**sentry-6967181350**

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
