### PR TITLE
[IMP] l10n_tr_nilvera_einvoice: enable resetting failed einvoices to …

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice/models/account_move.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_move.py
@@ -32,7 +32,6 @@ class AccountMove(models.Model):
         string="Nilvera Document UUID",
         copy=False,
         readonly=True,
-        default=lambda self: str(uuid.uuid4()),
         help="Universally unique identifier of the Invoice",
     )
 
@@ -81,14 +80,20 @@ class AccountMove(models.Model):
 
     def button_draft(self):
         # EXTENDS account
-        for move in self:
-            if (
-                not move.company_id.l10n_tr_nilvera_use_test_env
-                and move.l10n_tr_nilvera_uuid
-                and move.l10n_tr_nilvera_send_status != 'not_sent'
-            ):
+        for move in self.filtered('l10n_tr_nilvera_uuid'):
+            if move.l10n_tr_nilvera_send_status == 'error':
+                move.message_post(body=_("To preserve accounting integrity and comply with legal requirements, invoices cannot be reused once an error occurs. Please create a new invoice to continue."))
+            elif move.l10n_tr_nilvera_send_status != 'not_sent':
                 raise UserError(_("You cannot reset to draft an entry that has been sent to Nilvera."))
         super().button_draft()
+
+    def _post(self, soft=True):
+        for move in self:
+            if move.l10n_tr_nilvera_send_status == 'error' and move.l10n_tr_nilvera_uuid:
+                raise UserError(_("To preserve accounting integrity and comply with legal requirements, invoices cannot be reused once an error occurs. Please create a new invoice to continue."))
+            if move.country_code == 'TR' and not move.l10n_tr_nilvera_uuid:
+                move.l10n_tr_nilvera_uuid = str(uuid.uuid4())
+        return super()._post(soft=soft)
 
     def _l10n_tr_nilvera_submit_einvoice(self, xml_file, customer_alias):
         self._l10n_tr_nilvera_submit_document(

--- a/addons/l10n_tr_nilvera_einvoice/views/account_move_views.xml
+++ b/addons/l10n_tr_nilvera_einvoice/views/account_move_views.xml
@@ -5,6 +5,14 @@
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
+            <xpath expr="//header" position="after">
+                <div class="alert alert-info" role="alert" invisible="state != 'draft' or l10n_tr_nilvera_send_status != 'error' or not l10n_tr_nilvera_uuid">
+                    To preserve accounting integrity and comply with legal requirements, invoices cannot be reused once an error occurs. Please create a new invoice to continue.
+                </div>
+            </xpath>
+            <xpath expr="//button[@name='action_post'][2]" position="attributes">
+                <attribute name="invisible" separator=" or " add="l10n_tr_nilvera_send_status == 'error' and l10n_tr_nilvera_uuid"/>
+            </xpath>
             <xpath expr="//div[@name='journal_div']" position="after">
                 <label for="l10n_tr_nilvera_send_status" invisible="country_code != 'TR' or state == 'draft' or move_type not in ['out_invoice', 'in_invoice']"/>
                 <div name="nilvera_div"


### PR DESCRIPTION
…draft

This commits allows nilvera einvoices that have an error status to be set to draft. However, they cannot be allowed to be confirmed again because their sequence will have already been registered in nilvera, and will return an error if sent again.

The purpose of this is to undo the accounting effect of failed invoices.

task-5055493

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
