### PR TITLE
[FIX] barcodes: wait for animationFrame in test

### DIFF
--- a/addons/barcodes/static/tests/barcode.test.js
+++ b/addons/barcodes/static/tests/barcode.test.js
@@ -163,6 +163,7 @@ test("pager buttons", async () => {
     await simulateBarCode(["O", "C", "D", "P", "A", "G", "E", "R", "L", "A", "S", "T", "Enter"]);
     // need to await 2 macro steps
     await macroIsComplete();
+    await animationFrame();
     expect(".o_field_widget input").toHaveValue("Cabinet with Doors");
 
     // OCDPAGERFIRST
@@ -184,5 +185,6 @@ test("pager buttons", async () => {
     ]);
     // need to await 2 macro steps
     await macroIsComplete();
+    await animationFrame();
     expect(".o_field_widget input").toHaveValue("Large Cabinet");
 });


### PR DESCRIPTION
This commit fixes a test that sometimes failed, because we didn't wait for an animationFrame after the macro was complete. As a consequence, there was no guarantee that the form view had been updated before the check.

runbot error~226829

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
