### PR TITLE
[FIX] website_blog, *: allow editing blog landing title

### DIFF
--- a/addons/html_builder/static/src/core/setup_editor_plugin.js
+++ b/addons/html_builder/static/src/core/setup_editor_plugin.js
@@ -17,6 +17,7 @@ export class SetupEditorPlugin extends Plugin {
             "#wrap .o_homepage_editor_welcome_message"
         );
         welcomeMessageEl?.remove();
+        this.dispatchTo("before_setup_editor_handlers");
         let editableEls = this.getEditableElements(
             this.getResource("o_editable_selectors").join(", ")
         )

--- a/addons/website/static/src/builder/website_builder.js
+++ b/addons/website/static/src/builder/website_builder.js
@@ -139,7 +139,7 @@ export class WebsiteBuilder extends Component {
     get builderProps() {
         const builderProps = Object.assign({}, this.props.builderProps);
         const websitePlugins = this.props.translation
-            ? TRANSLATION_PLUGINS
+            ? [...TRANSLATION_PLUGINS, ...registry.category("website-translation-plugins").getAll()]
             : [
                   ...registry.category("builder-plugins").getAll(),
                   ...registry.category("website-plugins").getAll(),

--- a/addons/website_blog/static/src/website_builder/blog_post_page_title.js
+++ b/addons/website_blog/static/src/website_builder/blog_post_page_title.js
@@ -1,0 +1,21 @@
+import { Plugin } from "@html_editor/plugin";
+import { registry } from "@web/core/registry";
+
+export class BlogPostTitlePlugin extends Plugin {
+    static id = "blogPostTitle";
+    resources = {
+        before_setup_editor_handlers: () => {
+            // TODO: Remove in master and modify the XML
+            // view addons/website_blog/views/website_blog_templates.xml for the
+            // two templates (opt_blog_cover_post_fullwidth_design,
+            // opt_blog_cover_post)
+            const latestPostsEl = this.editable.querySelector(
+                "#o_wblog_blog_top .h1.o_not_editable"
+            );
+            latestPostsEl?.classList.remove("o_not_editable");
+        },
+    };
+}
+
+registry.category("website-plugins").add(BlogPostTitlePlugin.id, BlogPostTitlePlugin);
+registry.category("website-translation-plugins").add(BlogPostTitlePlugin.id, BlogPostTitlePlugin);

--- a/addons/website_blog/static/tests/tours/blog_context.js
+++ b/addons/website_blog/static/tests/tours/blog_context.js
@@ -1,5 +1,6 @@
 import {
     clickOnEditAndWaitEditMode,
+    clickOnSave,
     clickOnSnippet,
     registerWebsitePreviewTour,
 } from "@website/js/tours/tour_utils";
@@ -67,6 +68,35 @@ registerWebsitePreviewTour(
             content: "Click on Discard",
             trigger: ".o-snippets-top-actions [data-action='cancel']",
             run: "click",
+        },
+        {
+            content: "Go to 'All' blogs",
+            trigger: ":iframe a[href='/blog']",
+            run: "click",
+        },
+        ...clickOnEditAndWaitEditMode(),
+        {
+            content: "Open inline editor on blog landing title",
+            trigger: ":iframe #o_wblog_blog_top .h1",
+            run: "dblclick",
+        },
+        {
+            content: "Edit the blog landing title",
+            trigger: ":iframe #o_wblog_blog_top .h1[contenteditable='true']",
+            run: "editor Latest Posts Edited",
+        },
+        {
+            trigger: ":iframe #o_wblog_blog_top .h1:contains('Latest Posts Edited')",
+        },
+        ...clickOnSave(),
+        {
+            content: "Ensure the title was saved and remains editable",
+            trigger: ":iframe #o_wblog_blog_top .h1:contains('Latest Posts Edited')",
+            run() {
+                if (this.anchor.classList.contains("o_not_editable")) {
+                    console.error("Latest Posts heading should not keep the o_not_editable class.");
+                }
+            },
         },
         {
             content: "Click on the first article",


### PR DESCRIPTION
*: html_builder, website

Since [1] and [2] reverting it by mistake, the blog landing title was
not editable anymore.

Steps to reproduce:
- Open /blog in the website editor.
- Try to edit the "Our Latest Posts" heading.

After this commit the heading becomes editable in the website editor.

[1]: https://github.com/odoo/odoo/commit/ec49429d0d405948fcb93228e7350dfea585246f
[2]: https://github.com/odoo/odoo/commit/f503f98915ab39efff80a5904494c879805bb057

